### PR TITLE
cherry-pick(#12300): chore: best-effort cleanup for output folders that are mounted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7631,7 +7631,6 @@
         "pixelmatch": "5.2.1",
         "playwright-core": "1.19.1",
         "pngjs": "6.0.0",
-        "rimraf": "3.0.2",
         "source-map-support": "0.4.18",
         "stack-utils": "2.0.5",
         "yazl": "2.5.1"
@@ -8448,7 +8447,6 @@
         "pixelmatch": "5.2.1",
         "playwright-core": "1.19.1",
         "pngjs": "6.0.0",
-        "rimraf": "3.0.2",
         "source-map-support": "0.4.18",
         "stack-utils": "2.0.5",
         "yazl": "2.5.1"

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -61,7 +61,6 @@
     "pixelmatch": "5.2.1",
     "playwright-core": "1.19.1",
     "pngjs": "6.0.0",
-    "rimraf": "3.0.2",
     "source-map-support": "0.4.18",
     "stack-utils": "2.0.5",
     "yazl": "2.5.1"

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import rimraf from 'rimraf';
 import * as fs from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';
@@ -38,9 +37,8 @@ import { Minimatch } from 'minimatch';
 import { Config, FullConfig } from './types';
 import { WebServer } from './webServer';
 import { raceAgainstTimeout } from 'playwright-core/lib/utils/async';
-import { SigIntWatcher } from 'playwright-core/lib/utils/utils';
+import { removeFoldersOrDie, SigIntWatcher } from 'playwright-core/lib/utils/utils';
 
-const removeFolderAsync = promisify(rimraf);
 const readDirAsync = promisify(fs.readdir);
 const readFileAsync = promisify(fs.readFile);
 export const kDefaultConfigFiles = ['playwright.config.ts', 'playwright.config.js', 'playwright.config.mjs'];
@@ -352,7 +350,7 @@ export class Runner {
 
     // 12. Remove output directores.
     try {
-      await Promise.all(Array.from(outputDirs).map(outputDir => removeFolderAsync(outputDir)));
+      await removeFoldersOrDie(Array.from(outputDirs));
     } catch (e) {
       this._reporter.onError?.(serializeError(e));
       return { status: 'failed' };

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import rimraf from 'rimraf';
-import util from 'util';
 import colors from 'colors/safe';
 import { EventEmitter } from 'events';
 import { serializeError, prependToTestError, formatLocation } from './util';
@@ -27,9 +25,8 @@ import { Annotations, TestError, TestInfo, TestStepInternal, WorkerInfo } from '
 import { ProjectImpl } from './project';
 import { FixtureRunner } from './fixtures';
 import { raceAgainstTimeout } from 'playwright-core/lib/utils/async';
+import { removeFolders } from 'playwright-core/lib/utils/utils';
 import { TestInfoImpl } from './testInfo';
-
-const removeFolderAsync = util.promisify(rimraf);
 
 export class WorkerRunner extends EventEmitter {
   private _params: WorkerInitParams;
@@ -308,7 +305,7 @@ export class WorkerRunner extends EventEmitter {
     const preserveOutput = this._loader.fullConfig().preserveOutput === 'always' ||
       (this._loader.fullConfig().preserveOutput === 'failures-only' && isFailure);
     if (!preserveOutput)
-      await removeFolderAsync(testInfo.outputDir).catch(e => {});
+      await removeFolders([testInfo.outputDir]);
   }
 
   private async _runTestWithBeforeHooks(test: TestCase, testInfo: TestInfoImpl) {


### PR DESCRIPTION
Fixes #12106
