### PR TITLE
chore: do not double trim in trace viewer

### DIFF
--- a/packages/playwright-core/src/web/traceViewer/ui/callTab.tsx
+++ b/packages/playwright-core/src/web/traceViewer/ui/callTab.tsx
@@ -68,7 +68,7 @@ export const CallTab: React.FunctionComponent<{
 
 function renderLine(metadata: CallMetadata, name: string, value: any, key: string) {
   const { title, type } = toString(metadata, name, value);
-  let text = trimRight(title.replace(/\n/g, '↵'), 80);
+  let text = title.replace(/\n/g, '↵');
   if (type === 'string')
     text = `"${text}"`;
   return <div key={key} className='call-line'>{name}: <span className={type} title={title}>{text}</span></div>;
@@ -87,10 +87,4 @@ function toString(metadata: CallMetadata, name: string, value: any): { title: st
   if (value.guid)
     return { title: '<handle>', type: 'handle' };
   return { title: JSON.stringify(value), type: 'object' };
-}
-
-function trimRight(text: string, max: number): string {
-  if (text.length > max)
-    return text.substr(0, max) + '\u2026';
-  return text;
 }

--- a/tests/trace-viewer/trace-viewer.spec.ts
+++ b/tests/trace-viewer/trace-viewer.spec.ts
@@ -250,7 +250,7 @@ test('should show params and return value', async ({ showTraceViewer, browserNam
     /page.evaluate/,
     /wall time: [0-9/:,APM ]+/,
     /duration: [\d]+ms/,
-    'expression: "({↵    a↵  }) => {↵    console.log(\'Info\');↵    console.warn(\'Warning\');↵    con…"',
+    /expression: "\({↵    a↵  }\) => {↵    console\.log\(\'Info\'\);↵    console\.warn\(\'Warning\'\);↵    console/,
     'isFunction: true',
     'arg: {"a":"paramA","b":4}',
     'value: "return paramA"'


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/12278

Deleting code seems wrong, but lets see. We already trim on CSS level, so it should be fine.