### PR TITLE
devops: run test-runner tests on Node 16

### DIFF
--- a/.github/workflows/test_test_runner.yml
+++ b/.github/workflows/test_test_runner.yml
@@ -1,0 +1,50 @@
+name: "Test Runner"
+on:
+  push:
+    branches:
+      - main
+      - release-*
+    paths:
+      - ".github/workflows/test_test_runner.yml"
+      - "!browser_patches/**"
+      - "!docs/**"
+      - "tests/playwright-test/**/*"
+      - "packages/playwright-test/**/*"
+      - "package.json"
+  pull_request:
+    branches:
+      - main
+      - release-*
+    paths:
+      - ".github/workflows/test_test_runner.yml"
+      - "!browser_patches/**"
+      - "!docs/**"
+      - "tests/playwright-test/**/*"
+      - "packages/playwright-test/**/*"
+      - "package.json"
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [12, 16]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: ${{matrix.node-version}}
+    - run: npm i -g npm@8.3
+    - run: npm ci
+      env:
+        DEBUG: pw:install
+    - run: npm run build
+    - run: npx playwright install --with-deps
+    - run: npm run ttest
+      if: matrix.os != 'ubuntu-latest'
+    - run: xvfb-run npm run ttest
+      if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -49,33 +49,6 @@ jobs:
         name: ${{ matrix.browser }}-${{ matrix.os }}-test-results
         path: test-results
 
-  test_test_runner:
-    name: Test Runner
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [12]
-        include:
-        - os: ubuntu-latest
-          node-version: 16
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: ${{matrix.node-version}}
-    - run: npm i -g npm@8.3
-    - run: npm ci
-      env:
-        DEBUG: pw:install
-    - run: npm run build
-    - run: npx playwright install --with-deps
-    - run: npm run ttest
-      if: matrix.os != 'ubuntu-latest'
-    - run: xvfb-run npm run ttest
-      if: matrix.os == 'ubuntu-latest'
-
   test_html_report:
     name: HTML Report
     runs-on: ubuntu-latest


### PR DESCRIPTION
Turns out we run some tests, especially the fancy ESM tests only on Node.js 16. So we never ran them.

https://github.com/microsoft/playwright/issues/12307