### PR TITLE
fix(test-runner): experimental ESM TS support did not work on Windows

### DIFF
--- a/packages/playwright-core/src/cli/cli.ts
+++ b/packages/playwright-core/src/cli/cli.ts
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 import { fork } from 'child_process';
+import url from 'url';
 
 if (process.env.PW_EXPERIMENTAL_TS_ESM) {
-  const NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + ` --experimental-loader=${require.resolve('@playwright/test/lib/experimentalLoader')}`;
+  const NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + ` --experimental-loader=${url.pathToFileURL(require.resolve('@playwright/test/lib/experimentalLoader'))}`;
   const innerProcess = fork(require.resolve('./innerCli'), process.argv.slice(2), {
     env: { ...process.env, NODE_OPTIONS }
   });


### PR DESCRIPTION
There were two issues on Windows.

a) The first one was that require.resolve did resolve the 'experimentalLoader.js' file with the drive letter prefix: `C:\` which ended up in [this](https://github.com/nodejs/node/blob/6c77fd3a5359b16d472c23cd1be2c208b7bcb1d2/lib/internal/modules/esm/resolve.js#L777) if condition -> error was thrown.
b) The path got incorrectly extracted out of the file URL. 

Fixes https://github.com/microsoft/playwright/issues/12307