### PR TITLE
test: mark failing android tests as fixme / fix them

### DIFF
--- a/tests/browsercontext-viewport-mobile.spec.ts
+++ b/tests/browsercontext-viewport-mobile.spec.ts
@@ -173,4 +173,20 @@ it.describe('mobile viewport', () => {
     expect(await page.evaluate('result')).toEqual({ x: 30, y: 40 });
     await context.close();
   });
+
+  it('should scroll when emulating a mobile viewport', async ({ browser, server, browserName }) => {
+    const context = await browser.newContext({
+      viewport: { 'width': 1000, 'height': 600 },
+      isMobile: true,
+    });
+    const page = await context.newPage();
+    await page.goto(server.PREFIX + '/input/scrollable.html');
+    await page.mouse.move(50, 60);
+    const error = await page.mouse.wheel(0, 100).catch(e => e);
+    if (browserName === 'webkit')
+      expect(error.message).toContain('Mouse wheel is not supported in mobile WebKit');
+    else
+      await page.waitForFunction('window.scrollY === 100');
+    await context.close();
+  });
 });

--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -235,9 +235,9 @@ it('should report multiple set-cookie headers', async ({ page, server }) => {
   expect(await response.headerValues('set-cookie')).toEqual(['a=b', 'c=d']);
 });
 
-it('should behave the same way for headers and allHeaders', async ({ page, server, browserName, channel, platform }) => {
+it('should behave the same way for headers and allHeaders', async ({ page, server, browserName, channel, platform, isAndroid }) => {
   it.fixme(browserName === 'webkit' && platform === 'win32', 'libcurl does not support non-set-cookie multivalue headers');
-  it.skip(!!channel, 'Stable chrome uses \n as a header separator in non-raw headers');
+  it.fixme(isAndroid, 'Android uses \n as a header separator in non-raw headers');
   server.setRoute('/headers', (req, res) => {
     const headers = {
       'Set-Cookie': ['a=b', 'c=d'],

--- a/tests/page/wheel.spec.ts
+++ b/tests/page/wheel.spec.ts
@@ -15,11 +15,10 @@
  */
 import type { Page } from 'playwright-core';
 import { test as it, expect } from './pageTest';
-import { contextTest } from '../config/browserTest';
 
-it.skip(({ isElectron, browserMajorVersion }) => {
+it.skip(({ isElectron, browserMajorVersion, isAndroid }) => {
   // Old Electron has flaky wheel events.
-  return isElectron && browserMajorVersion <= 11;
+  return (isElectron && browserMajorVersion <= 11) || isAndroid;
 });
 it('should dispatch wheel events #smoke', async ({ page, server }) => {
   await page.setContent(`<div style="width: 5000px; height: 5000px;"></div>`);
@@ -108,22 +107,6 @@ it('should work when the event is canceled', async ({ page }) => {
   await page.waitForTimeout(100);
   // Ensure that it did not.
   expect(await page.evaluate('window.scrollY')).toBe(0);
-});
-
-contextTest('should scroll when emulating a mobile viewport', async ({ contextFactory, server, browserName }) => {
-  contextTest.skip(browserName === 'firefox');
-  const context = await contextFactory({
-    viewport: { 'width': 1000, 'height': 600 },
-    isMobile: true,
-  });
-  const page = await context.newPage();
-  await page.goto(server.PREFIX + '/input/scrollable.html');
-  await page.mouse.move(50, 60);
-  const error = await page.mouse.wheel(0, 100).catch(e => e);
-  if (browserName === 'webkit')
-    expect(error.message).toContain('Mouse wheel is not supported in mobile WebKit');
-  else
-    await page.waitForFunction('window.scrollY === 100');
 });
 
 async function listenForWheelEvents(page: Page, selector: string) {


### PR DESCRIPTION
This should reduce failing android tests to only the following three:
```
    [android] › page/page-screenshot.spec.ts:481:3 › page screenshot animations › should not capture css animations in shadow DOM 
    [android] › page/page-screenshot.spec.ts:495:3 › page screenshot animations › should stop animations that happen right before screenshot 
    [android] › page/page-screenshot.spec.ts:609:3 › page screenshot animations › should not change animation with playbackRate equal to 0 
```