### PR TITLE
fix(hooks): separate test timeout from beforeAll/afterAll timeouts

### DIFF
--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -519,10 +519,9 @@ function formatStackFrame(frame: StackFrame) {
 }
 
 function hookType(testInfo: TestInfo): 'beforeAll' | 'afterAll' | undefined {
-  const impl = testInfo as import('./testInfo').TestInfoImpl;
-  if (impl._currentRunnable?.type === 'beforeAll')
+  if ((testInfo as any)._currentRunnable?.type === 'beforeAll')
     return 'beforeAll';
-  if (impl._currentRunnable?.type === 'afterAll')
+  if ((testInfo as any)._currentRunnable?.type === 'afterAll')
     return 'afterAll';
 }
 

--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -496,6 +496,7 @@ test('afterAll timeout should be reported, run other afterAll hooks, and continu
           await new Promise(f => setTimeout(f, 5000));
         });
         test('runs', () => {
+          test.setTimeout(2000);
           console.log('\\n%%test1');
         });
       });
@@ -669,4 +670,85 @@ test('unhandled rejection during beforeAll should be reported and prevent more t
   ]);
   expect(result.output).toContain('Error: Oh my');
   expect(stripAnsi(result.output)).toContain(`>  9 |           throw new Error('Oh my');`);
+});
+
+test('beforeAll and afterAll should have a separate timeout', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test.beforeAll(async () => {
+        console.log('\\n%%beforeAll');
+        await new Promise(f => setTimeout(f, 300));
+      });
+      test.beforeAll(async () => {
+        console.log('\\n%%beforeAll2');
+        await new Promise(f => setTimeout(f, 300));
+      });
+      test('passed', async () => {
+        console.log('\\n%%test');
+        await new Promise(f => setTimeout(f, 300));
+      });
+      test.afterAll(async () => {
+        console.log('\\n%%afterAll');
+        await new Promise(f => setTimeout(f, 300));
+      });
+      test.afterAll(async () => {
+        console.log('\\n%%afterAll2');
+        await new Promise(f => setTimeout(f, 300));
+      });
+    `,
+  }, { timeout: '500' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.output.split('\n').filter(line => line.startsWith('%%'))).toEqual([
+    '%%beforeAll',
+    '%%beforeAll2',
+    '%%test',
+    '%%afterAll',
+    '%%afterAll2',
+  ]);
+});
+
+test('test.setTimeout should work separately in beforeAll', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test.beforeAll(async () => {
+        console.log('\\n%%beforeAll');
+        test.setTimeout(100);
+      });
+      test('passed', async () => {
+        console.log('\\n%%test');
+        await new Promise(f => setTimeout(f, 800));
+      });
+    `,
+  }, { timeout: '1000' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.output.split('\n').filter(line => line.startsWith('%%'))).toEqual([
+    '%%beforeAll',
+    '%%test',
+  ]);
+});
+
+test('test.setTimeout should work separately in afterAll', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test('passed', async () => {
+        console.log('\\n%%test');
+      });
+      test.afterAll(async () => {
+        console.log('\\n%%afterAll');
+        test.setTimeout(1000);
+        await new Promise(f => setTimeout(f, 800));
+      });
+    `,
+  }, { timeout: '100' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.output.split('\n').filter(line => line.startsWith('%%'))).toEqual([
+    '%%test',
+    '%%afterAll',
+  ]);
 });


### PR DESCRIPTION
This makes it possible to have longer `beforeAll`/`afterAll` and not
affect first/last test timeout.