### PR TITLE
chore(fixtures): do not force-close contexts in beforeAll

### DIFF
--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -421,15 +421,6 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
       else
         await fs.promises.unlink(file).catch(() => {});
     }));
-
-    // 7. Cleanup created contexts when we know it's safe - this will produce nice error message.
-    if (testInfo.status === 'timedOut' && testInfo.errors.some(error => error.message?.match(/Timeout of \d+ms exceeded in beforeAll hook./))) {
-      const anyContext = leftoverContexts[0];
-      const pendingCalls = anyContext ? formatPendingCalls((anyContext as any)._connection.pendingProtocolCalls()) : '';
-      await Promise.all(leftoverContexts.filter(c => createdContexts.has(c)).map(c => c.close()));
-      if (pendingCalls)
-        testInfo.errors.push({ message: pendingCalls });
-    }
   }, { auto: true }],
 
   _contextFactory: async ({ browser, video, _artifactsDir }, use, testInfo) => {

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -353,7 +353,7 @@ test('should report error on timeout with shared page', async ({ runInlineTest }
   expect(stripAnsi(result.output)).toContain(`14 |         await page.click('text=Missing');`);
 });
 
-test('should report error and pending operations from beforeAll timeout', async ({ runInlineTest }, testInfo) => {
+test('should report error from beforeAll timeout', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'a.test.ts': `
       const { test } = pwt;
@@ -373,9 +373,6 @@ test('should report error and pending operations from beforeAll timeout', async 
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);
   expect(result.output).toContain('Timeout of 2000ms exceeded in beforeAll hook.');
-  expect(result.output).toContain('Pending operations:');
-  expect(result.output).toContain('- page.click at a.test.ts:10:16');
-  expect(result.output).toContain('- page.textContent at a.test.ts:11:16');
   expect(result.output).toContain('waiting for selector');
   expect(stripAnsi(result.output)).toContain(`11 |           page.textContent('text=More missing'),`);
 });


### PR DESCRIPTION
This now happens the same way as for the test, in the worker cleanup
when browser closes, which is reported as a part of the test.