### PR TITLE
feat(test runner): on beforeAll failure, precisely skip the tests

### DIFF
--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -76,7 +76,7 @@ export type RunPayload = {
 
 export type DonePayload = {
   fatalErrors: TestError[];
-  skipRemaining: boolean;
+  skipTestsDueToSetupFailure: string[];  // test ids
 };
 
 export type TestOutputPayload = {

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -284,10 +284,10 @@ export function createWhiteImage(width: number, height: number) {
 }
 
 export function paintBlackPixels(image: Buffer, blackPixelsCount: number): Buffer {
-  image = PNG.sync.read(image);
+  const png = PNG.sync.read(image);
   for (let i = 0; i < blackPixelsCount; ++i) {
     for (let j = 0; j < 3; ++j)
-      image.data[i * 4 + j] = 0;
+      png.data[i * 4 + j] = 0;
   }
-  return PNG.sync.write(image);
+  return PNG.sync.write(png);
 }


### PR DESCRIPTION
Previously, we used to skip all the tests from the same file when any `beforeAll` fails in the file.

Now, we only skip the rest of the tests affected by this particular `beforeAll` and continue with other tests in the new worker.