### PR TITLE
chore: do not print empty attachments in terminal

### DIFF
--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -250,6 +250,9 @@ export function formatFailure(config: FullConfig, test: TestCase, options: {inde
     if (includeAttachments) {
       for (let i = 0; i < result.attachments.length; ++i) {
         const attachment = result.attachments[i];
+        const hasPrintableContent = attachment.contentType.startsWith('text/') && attachment.body;
+        if (!attachment.path && !hasPrintableContent)
+          continue;
         resultLines.push('');
         resultLines.push(colors.cyan(pad(`    attachment #${i + 1}: ${attachment.name} (${attachment.contentType})`, '-')));
         if (attachment.path) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/12154