### PR TITLE
chore: remove Python from main Docker image

### DIFF
--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -13,11 +13,6 @@ RUN apt-get update && \
     # Feature-parity with node.js base images.
     apt-get install -y --no-install-recommends git openssh-client && \
     npm install -g yarn && \
-    # Install Python 3.8
-    apt-get install -y python3.8 python3-pip && \
-    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 && \
     # clean apt cache
     rm -rf /var/lib/apt/lists/* && \
     # Create the pwuser (we internally create a symlink for the pwuser and the root user)
@@ -41,5 +36,6 @@ RUN mkdir /ms-playwright && \
     npm i /tmp/playwright-core.tar.gz && \
     npx playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
     rm /tmp/playwright-core.tar.gz && \
+    npm cache clean --force && \
     rm -rf /ms-playwright-agent && \
     chmod -R 777 /ms-playwright

--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -36,6 +36,5 @@ RUN mkdir /ms-playwright && \
     npm i /tmp/playwright-core.tar.gz && \
     npx playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
     rm /tmp/playwright-core.tar.gz && \
-    npm cache clean --force && \
     rm -rf /ms-playwright-agent && \
     chmod -R 777 /ms-playwright

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -13,11 +13,6 @@ RUN apt-get update && \
     # Feature-parity with node.js base images.
     apt-get install -y --no-install-recommends git openssh-client && \
     npm install -g yarn && \
-    # Install Python 3.8
-    apt-get install -y python3.8 python3-pip && \
-    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 && \
     # clean apt cache
     rm -rf /var/lib/apt/lists/* && \
     # Create the pwuser
@@ -41,5 +36,6 @@ RUN mkdir /ms-playwright && \
     npm i /tmp/playwright-core.tar.gz && \
     npx playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
     rm /tmp/playwright-core.tar.gz && \
+    npm cache clean --force && \
     rm -rf /ms-playwright-agent && \
     chmod -R 777 /ms-playwright

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -36,6 +36,5 @@ RUN mkdir /ms-playwright && \
     npm i /tmp/playwright-core.tar.gz && \
     npx playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
     rm /tmp/playwright-core.tar.gz && \
-    npm cache clean --force && \
     rm -rf /ms-playwright-agent && \
     chmod -R 777 /ms-playwright


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/1130

This marks having a dedicated Python Docker image as done and reduces the upstream image size by 209.79MB.

drive-by: clean npm cache which gives us another 15mb.