### PR TITLE
devops: allow building webkit runder root

### DIFF
--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -7,6 +7,9 @@ cd "$(dirname "$0")"
 SCRIPT_FOLDER="$(pwd -P)"
 source "${SCRIPT_FOLDER}/../utils.sh"
 
+# Allow building under root
+export JHBUILD_RUN_AS_ROOT=
+
 build_gtk() {
   if ! [[ -d ./WebKitBuild/GTK/DependenciesGTK ]]; then
     yes | WEBKIT_JHBUILD=1 WEBKIT_JHBUILD_MODULESET=minimal WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/GTK DEBIAN_FRONTEND=noninteractive ./Tools/Scripts/update-webkitgtk-libs


### PR DESCRIPTION
Always have to google it and Codespaces etc. gives you root by default.