### PR TITLE
chore(test-runner): throw if the config has no default export

### DIFF
--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -61,8 +61,12 @@ export class Loader {
     if (this._configFile)
       throw new Error('Cannot load two config files');
     let config = await this._requireOrImport(file);
-    if (config && typeof config === 'object' && ('default' in config))
-      config = config['default'];
+    if (config && typeof config === 'object') {
+      if ('default' in config)
+        config = config['default'];
+      else if (Object.keys(config).length === 0)
+        throw new Error('No default export found in config file!');
+    }
     this._config = config;
     this._configFile = file;
     const rawConfig = { ...config };

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -391,3 +391,11 @@ test('should work with undefined values and base', async ({ runInlineTest }) => 
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
 });
+
+test('should throw when the config does not have a default export', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': '',
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('No default export found in config file!');
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/12349

Hmm it breaks the `module.exports = {};` config's but I think its fine tho.