### PR TITLE
devops: fix firefox-beta build on Windows 10

### DIFF
--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -249,6 +249,8 @@ elif [[ "$BUILD_FLAVOR" == "firefox-beta-win64" ]]; then
   EXTRA_BUILD_ARGS="--full"
   EXPECTED_HOST_OS="MINGW"
   BUILD_BLOB_NAME="firefox-beta-win64.zip"
+  # This is the architecture that is set by mozilla-build bash.
+  EXPECTED_ARCH="i686"
 
 # ===========================
 #    WEBKIT COMPILATION

--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -96,8 +96,6 @@ if [[ $1 == "--full" || $2 == "--full" || $1 == "--bootstrap" ]]; then
   if [[ ! -z "${WIN32_REDIST_DIR}" ]]; then
     # Having this option in .mozconfig kills incremental compilation.
     echo "export WIN32_REDIST_DIR=\"$WIN32_REDIST_DIR\"" >> .mozconfig
-    echo "export MSVC_C_RUNTIME_DLL=vcruntime140.dll" >> .mozconfig
-    echo "export MSVC_CXX_RUNTIME_DLL=msvcp140.dll" >> .mozconfig
   fi
 fi
 


### PR DESCRIPTION
Instead of using 64-bit version of MINGW that comes with Git Bash,
we now switch to the one provided by the mozilla-build on windows,
which is 32-bit.

This patch also reverts the previous attempt that was defining the library names
for redistribution. It should work without them as well.

References #12225
