### PR TITLE
docs: correct instructions for port reuse

### DIFF
--- a/packages/playwright-test/src/webServer.ts
+++ b/packages/playwright-test/src/webServer.ts
@@ -58,7 +58,7 @@ export class WebServer {
     if (isAlreadyAvailable) {
       if (this.config.reuseExistingServer)
         return;
-      throw new Error(`${this.config.url ?? `http://localhost:${this.config.port}`} is already used, make sure that nothing is running on the port/url or set strict:false in config.webServer.`);
+      throw new Error(`${this.config.url ?? `http://localhost:${this.config.port}`} is already used, make sure that nothing is running on the port/url or set reuseExistingServer:true in config.webServer.`);
     }
 
     const { launchedProcess, kill } = await launchProcess({


### PR DESCRIPTION
At least according to typescript there is no `strict:false` 

<img width="1323" alt="image" src="https://user-images.githubusercontent.com/874898/156503539-79fc1a52-796d-49b9-aecd-92c6fb1995bf.png">

But I do know of `reuseExistingServer:true` so that's what was probably meant :rose: