### PR TITLE
devops: do not compile NaCL for chromium

### DIFF
--- a/browser_patches/chromium/archive.sh
+++ b/browser_patches/chromium/archive.sh
@@ -70,7 +70,7 @@ function archive_compiled_chromium() {
     unset IFS
   elif [[ $1 == "--compile-linux-arm64" ]]; then
     CHROMIUM_FOLDER_NAME="chrome-linux"
-    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($(node "${SCRIPT_PATH}/compute_files_to_archive.js" "${CR_CHECKOUT_PATH}/src/infra/archive_config/linux-archive-rel.json" --linux-arm64))
+    IFS=$'\n' CHROMIUM_FILES_TO_ARCHIVE=($(node "${SCRIPT_PATH}/compute_files_to_archive.js" "${CR_CHECKOUT_PATH}/src/infra/archive_config/linux-archive-rel.json"))
     unset IFS
   elif [[ $1 == "--compile-win64" ]]; then
     CHROMIUM_FOLDER_NAME="chrome-win"

--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -77,6 +77,7 @@ compile_chromium() {
     echo 'use_goma = true' >> ./out/Default/args.gn
     echo "goma_dir = \"${PLAYWRIGHT_GOMA_PATH}\"" >> ./out/Default/args.gn
   fi
+  echo 'enable_nacl = false' >> ./out/Default/args.gn
 
   echo "===== args.gn ====="
   cat ./out/Default/args.gn

--- a/browser_patches/chromium/compute_files_to_archive.js
+++ b/browser_patches/chromium/compute_files_to_archive.js
@@ -11,20 +11,16 @@ const config = configs.find(config => config.gcs_path.includes('chrome-linux.zip
 const excludeList = new Set([
   // We do not need interactive tests in our archive.
   'interactive_ui_tests.exe',
+  // We no longer compile nacl with Chromium.
+  'nacl_helper_bootstrap',
+  'nacl_helper',
+  'nacl_irt_x86_64.nexe',
 ]);
-
-// There is no upstream configuration for packaging Linux Arm64 builds,
-// so we build one by replacing x86_64-specific nacl binary with arm one.
-const replaceMap = {
-  '--linux-arm64': {
-    'nacl_irt_x86_64.nexe': 'nacl_irt_arm.nexe',
-  },
-}[process.argv[3]] || {};
 
 const entries = [
   ...(config.files || []),
   ...(config.dirs || []),
-].filter(entry => !excludeList.has(entry)).map(entry => replaceMap[entry] || entry);
+].filter(entry => !excludeList.has(entry));
 
 for (const entry of entries)
   console.log(entry);


### PR DESCRIPTION
NaCL support was ended in June 2021: https://developer.chrome.com/docs/native-client/