### PR TITLE
docs(test-auth-js.md): remove unnecessary export

### DIFF
--- a/docs/src/test-auth-js.md
+++ b/docs/src/test-auth-js.md
@@ -178,8 +178,6 @@ module.exports = async () => {
   await requestContext.storageState({ path: 'storageState.json' });
   await requestContext.dispose();
 }
-
-export default globalSetup;
 ```
 
 ```js js-flavor=ts


### PR DESCRIPTION
I ran into an issue when using the example code from the docs. I believe the export statement should not be there for the js version. It must have been copied over accidentally from the ts code which is very similiar.