### PR TITLE
fix(devops): list dependencies error

### DIFF
--- a/utils/linux-browser-dependencies/inside_docker/list_dependencies.js
+++ b/utils/linux-browser-dependencies/inside_docker/list_dependencies.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const util = require('util');
 const path = require('path');
 const {spawn} = require('child_process');
-const {registryDirectory} = require('playwright-core/lib/utils/registry.js');
+const {registryDirectory} = require('playwright-core/lib/utils/registry');
 
 const readdirAsync = util.promisify(fs.readdir.bind(fs));
 const readFileAsync = util.promisify(fs.readFile.bind(fs));


### PR DESCRIPTION
Fixes this:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/utils/registry.js' is not defined by "exports" in /root/tmp/node_modules/playwright-core/package.json
```