### PR TITLE
test: typo fix

### DIFF
--- a/tests/browsercontext-fetch.spec.ts
+++ b/tests/browsercontext-fetch.spec.ts
@@ -570,7 +570,7 @@ it('should support gzip compression', async function({ context, server }) {
   expect(await response.text()).toBe('Hello, world!');
 });
 
-it('should throw informatibe error on corrupted gzip body', async function({ context, server }) {
+it('should throw informative error on corrupted gzip body', async function({ context, server }) {
   server.setRoute('/corrupted', (req, res) => {
     res.writeHead(200, {
       'Content-Encoding': 'gzip',
@@ -604,7 +604,7 @@ it('should support brotli compression', async function({ context, server }) {
   expect(await response.text()).toBe('Hello, world!');
 });
 
-it('should throw informatibe error on corrupted brotli body', async function({ context, server }) {
+it('should throw informative error on corrupted brotli body', async function({ context, server }) {
   server.setRoute('/corrupted', (req, res) => {
     res.writeHead(200, {
       'Content-Encoding': 'br',
@@ -638,7 +638,7 @@ it('should support deflate compression', async function({ context, server }) {
   expect(await response.text()).toBe('Hello, world!');
 });
 
-it('should throw informatibe error on corrupted deflate body', async function({ context, server }) {
+it('should throw informative error on corrupted deflate body', async function({ context, server }) {
   server.setRoute('/corrupted', (req, res) => {
     res.writeHead(200, {
       'Content-Encoding': 'deflate',


### PR DESCRIPTION
Noticed this only because this test was failing under Node v17.4.0.

Failure is:

```
  1) [chromium] › browsercontext-fetch.spec.ts:573:4 › should throw informatibe error on corrupted gzip body

    Error: expect(received).toContain(expected) // indexOf

    Expected substring: "failed to decompress 'gzip' encoding"
    Received string:    "apiRequestContext.get: incorrect header check
    =========================== logs ===========================
    → GET http://localhost:8907/corrupted
      user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/101.0.4921.0 Safari/537.36
      accept: */*
      accept-encoding: gzip,deflate,br
    ← 200 OK
      content-encoding: gzip
      content-type: text/plain
      date: Fri, 04 Mar 2022 21:53:18 GMT
      connection: close
      transfer-encoding: chunked
    ============================================================"
```