### PR TITLE
chore: fix android tests after #12220

### DIFF
--- a/packages/playwright-core/src/client/android.ts
+++ b/packages/playwright-core/src/client/android.ts
@@ -47,7 +47,7 @@ export class Android extends ChannelOwner<channels.AndroidChannel> implements ap
     this._channel.setDefaultTimeoutNoReply({ timeout });
   }
 
-  async devices(options: { port?: number }): Promise<AndroidDevice[]> {
+  async devices(options: { port?: number } = {}): Promise<AndroidDevice[]> {
     const { devices } = await this._channel.devices(options);
     return devices.map(d => AndroidDevice.from(d));
   }


### PR DESCRIPTION
This fixes the following:

```
android.devices: : expected object, got undefined
    at Object._baseTest.baseTest.extend.androidDevice.scope [as fn] (/Users/runner/work/playwright/playwright/tests/android/androidTest.ts:29:47)
<inner error>
Error: : expected object, got undefined
    at /Users/runner/work/playwright/playwright/packages/playwright-core/lib/protocol/validatorPrimitives.js:95:40
    at /Users/runner/work/playwright/playwright/packages/playwright-core/lib/client/channelOwner.js:110:73
    at __PWZONE__[1] (/Users/runner/work/playwright/playwright/packages/playwright-core/lib/client/channelOwner.js:149:22)
    at Zone.run (/Users/runner/work/playwright/playwright/packages/playwright-core/lib/utils/zones.js:77:20)
    at ZoneManager.run (/Users/runner/work/playwright/playwright/packages/playwright-core/lib/utils/zones.js:36:17)
    at Android._wrapApiCall (/Users/runner/work/playwright/playwright/packages/playwright-core/lib/client/channelOwner.js:148:41)
    at Proxy.<anonymous> (/Users/runner/work/playwright/playwright/packages/playwright-core/lib/client/channelOwner.js:98:27)
    at Android.devices (/Users/runner/work/playwright/playwright/packages/playwright-core/lib/client/android.js:63:29)
    at Object._baseTest.baseTest.extend.androidDevice.scope [as fn] (/Users/runner/work/playwright/playwright/tests/android/androidTest.ts:29:47)
    at /Users/runner/work/playwright/playwright/packages/playwright-test/lib/fixtures.js:78:81
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```