### PR TITLE
fix(toHaveScreenshot): round ratio up

### DIFF
--- a/packages/playwright-core/src/utils/comparators.ts
+++ b/packages/playwright-core/src/utils/comparators.ts
@@ -66,7 +66,7 @@ function compareImages(mimeType: string, actualBuffer: Buffer | string, expected
     maxDiffPixels = Math.min(maxDiffPixels1, maxDiffPixels2);
   else
     maxDiffPixels = maxDiffPixels1 ?? maxDiffPixels2 ?? 0;
-  const ratio = count / (expected.width * expected.height);
+  const ratio = Math.ceil(count / (expected.width * expected.height) * 100) / 100;
   return count > maxDiffPixels ? {
     errorMessage: `${count} pixels (ratio ${ratio.toFixed(2)} of all image pixels) are different`,
     diff: PNG.sync.write(diff),

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -245,7 +245,7 @@ test('should fail when screenshot is different size', async ({ runInlineTest }) 
 test('should fail when screenshot is different pixels', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,
-    'a.spec.js-snapshots/snapshot.png': blueImage,
+    'a.spec.js-snapshots/snapshot.png': paintBlackPixels(whiteImage, 12345),
     'a.spec.js': `
       const { test } = require('./helper');
       test('is a test', async ({ page }) => {
@@ -255,9 +255,9 @@ test('should fail when screenshot is different pixels', async ({ runInlineTest }
   });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('Screenshot comparison failed');
-  expect(result.output).toContain('921600 pixels');
+  expect(result.output).toContain('12345 pixels');
   expect(result.output).not.toContain('Call log');
-  expect(result.output).toContain('ratio 1.00');
+  expect(result.output).toContain('ratio 0.02');
   expect(result.output).toContain('Expected:');
   expect(result.output).toContain('Received:');
 });


### PR DESCRIPTION
This way the ratio value could be used right away in configuation.
