### PR TITLE
fix: explicitly ignore maxDiffPixels in toMatchSnapshot

### DIFF
--- a/packages/playwright-test/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright-test/src/matchers/toMatchSnapshot.ts
@@ -236,7 +236,11 @@ export function toMatchSnapshot(
     return helper.handleMissing(received);
 
   const expected = fs.readFileSync(helper.snapshotPath);
-  const result = comparator(received, expected, helper.comparatorOptions);
+  const result = comparator(received, expected, {
+    ...helper.comparatorOptions,
+    maxDiffPixels: undefined,
+    maxDiffPixelRatio: undefined,
+  });
   if (!result)
     return helper.handleMatching();
 

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -417,7 +417,11 @@ test('should compare different PNG images', async ({ runInlineTest }, testInfo) 
     'a.spec.js': `
       const { test } = require('./helper');
       test('is a test', ({}) => {
-        expect(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII==', 'base64')).toMatchSnapshot('snapshot.png');
+        expect(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII==', 'base64')).toMatchSnapshot('snapshot.png', {
+          // make sure maxDiffPixelRatio is *not* respected.
+          // See https://github.com/microsoft/playwright/issues/12564
+          maxDiffPixelRatio: 1.0,
+        });
       });
     `
   });


### PR DESCRIPTION
Fixes #12564
