### PR TITLE
reland(hooks): separate test timeout from beforeAll/afterAll timeouts

### DIFF
--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -519,10 +519,9 @@ function formatStackFrame(frame: StackFrame) {
 }
 
 function hookType(testInfo: TestInfo): 'beforeAll' | 'afterAll' | undefined {
-  const impl = testInfo as import('./testInfo').TestInfoImpl;
-  if (impl._currentRunnable?.type === 'beforeAll')
+  if ((testInfo as any)._currentRunnable?.type === 'beforeAll')
     return 'beforeAll';
-  if (impl._currentRunnable?.type === 'afterAll')
+  if ((testInfo as any)._currentRunnable?.type === 'afterAll')
     return 'afterAll';
 }
 

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -274,7 +274,7 @@ export class WorkerRunner extends EventEmitter {
         forceNoParent: true
       });
 
-      // Note: wrap all preparation steps together, because failure in any of them
+      // Note: wrap all preparation steps together, because failure/skip in any of them
       // prevents further setup and/or test from running.
       const maybeError = await testInfo._runFn(async () => {
         // Run "beforeAll" modifiers on parent suites, unless already run during previous tests.
@@ -301,7 +301,7 @@ export class WorkerRunner extends EventEmitter {
         await this._runEachHooksForSuites(suites, 'beforeEach', testInfo);
 
         // Setup fixtures required by the test.
-        testInfo._currentRunnable = { type: 'test' };
+        testInfo._setCurrentRunnable({ type: 'test' });
         const params = await this._fixtureRunner.resolveParametersForFunction(test.fn, testInfo);
         beforeHooksStep.complete(); // Report fixture hooks step as completed.
 
@@ -330,7 +330,7 @@ export class WorkerRunner extends EventEmitter {
 
     if (testInfo.status === 'timedOut') {
       // A timed-out test gets a full additional timeout to run after hooks.
-      testInfo._timeoutRunner.resetTimeout(testInfo.timeout);
+      testInfo._timeoutRunner.updateTimeout(testInfo.timeout, 0);
     }
     await testInfo._runWithTimeout(async () => {
       // Note: do not wrap all teardown steps together, because failure in any of them
@@ -352,7 +352,7 @@ export class WorkerRunner extends EventEmitter {
       }
 
       // Teardown test-scoped fixtures.
-      testInfo._currentRunnable = { type: 'teardown' };
+      testInfo._setCurrentRunnable({ type: 'teardown' });
       const testScopeError = await testInfo._runFn(() => this._fixtureRunner.teardownScope('test'));
       firstAfterHooksError = firstAfterHooksError || testScopeError;
     });
@@ -367,13 +367,13 @@ export class WorkerRunner extends EventEmitter {
       this._didRunFullCleanup = true;
 
       // Give it more time for the full cleanup.
-      testInfo._timeoutRunner.resetTimeout(this._project.config.timeout);
+      testInfo._timeoutRunner.updateTimeout(this._project.config.timeout, 0);
       await testInfo._runWithTimeout(async () => {
         for (const suite of reversedSuites) {
           const afterAllError = await this._runAfterAllHooksForSuite(suite, testInfo);
           firstAfterHooksError = firstAfterHooksError || afterAllError;
         }
-        testInfo._currentRunnable = { type: 'teardown' };
+        testInfo._setCurrentRunnable({ type: 'teardown', timeout: this._project.config.timeout });
         const testScopeError = await testInfo._runFn(() => this._fixtureRunner.teardownScope('test'));
         firstAfterHooksError = firstAfterHooksError || testScopeError;
         const workerScopeError = await testInfo._runFn(() => this._fixtureRunner.teardownScope('worker'));
@@ -397,7 +397,7 @@ export class WorkerRunner extends EventEmitter {
       const actualScope = this._fixtureRunner.dependsOnWorkerFixturesOnly(modifier.fn, modifier.location) ? 'worker' : 'test';
       if (actualScope !== scope)
         continue;
-      testInfo._currentRunnable = { type: modifier.type, location: modifier.location };
+      testInfo._setCurrentRunnable({ type: modifier.type, location: modifier.location, timeout: scope === 'worker' ? this._project.config.timeout : undefined });
       const result = await this._fixtureRunner.resolveParametersAndRunFunction(modifier.fn, testInfo);
       if (result && extraAnnotations)
         extraAnnotations.push({ type: modifier.type, description: modifier.description });
@@ -414,7 +414,7 @@ export class WorkerRunner extends EventEmitter {
       if (hook.type !== 'beforeAll')
         continue;
       try {
-        testInfo._currentRunnable = { type: 'beforeAll', location: hook.location };
+        testInfo._setCurrentRunnable({ type: 'beforeAll', location: hook.location, timeout: this._project.config.timeout });
         await this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo);
       } catch (e) {
         // Always run all the hooks, and capture the first error.
@@ -434,7 +434,7 @@ export class WorkerRunner extends EventEmitter {
       if (hook.type !== 'afterAll')
         continue;
       const afterAllError = await testInfo._runFn(async () => {
-        testInfo._currentRunnable = { type: 'afterAll', location: hook.location };
+        testInfo._setCurrentRunnable({ type: 'afterAll', location: hook.location, timeout: this._project.config.timeout });
         await this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo);
       });
       firstError = firstError || afterAllError;
@@ -447,7 +447,7 @@ export class WorkerRunner extends EventEmitter {
     let error: Error | undefined;
     for (const hook of hooks) {
       try {
-        testInfo._currentRunnable = { type, location: hook.location };
+        testInfo._setCurrentRunnable({ type, location: hook.location });
         await this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo);
       } catch (e) {
         // Always run all the hooks, and capture the first error.

--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -496,6 +496,7 @@ test('afterAll timeout should be reported, run other afterAll hooks, and continu
           await new Promise(f => setTimeout(f, 5000));
         });
         test('runs', () => {
+          test.setTimeout(2000);
           console.log('\\n%%test1');
         });
       });
@@ -669,4 +670,85 @@ test('unhandled rejection during beforeAll should be reported and prevent more t
   ]);
   expect(result.output).toContain('Error: Oh my');
   expect(stripAnsi(result.output)).toContain(`>  9 |           throw new Error('Oh my');`);
+});
+
+test('beforeAll and afterAll should have a separate timeout', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test.beforeAll(async () => {
+        console.log('\\n%%beforeAll');
+        await new Promise(f => setTimeout(f, 300));
+      });
+      test.beforeAll(async () => {
+        console.log('\\n%%beforeAll2');
+        await new Promise(f => setTimeout(f, 300));
+      });
+      test('passed', async () => {
+        console.log('\\n%%test');
+        await new Promise(f => setTimeout(f, 300));
+      });
+      test.afterAll(async () => {
+        console.log('\\n%%afterAll');
+        await new Promise(f => setTimeout(f, 300));
+      });
+      test.afterAll(async () => {
+        console.log('\\n%%afterAll2');
+        await new Promise(f => setTimeout(f, 300));
+      });
+    `,
+  }, { timeout: '500' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.output.split('\n').filter(line => line.startsWith('%%'))).toEqual([
+    '%%beforeAll',
+    '%%beforeAll2',
+    '%%test',
+    '%%afterAll',
+    '%%afterAll2',
+  ]);
+});
+
+test('test.setTimeout should work separately in beforeAll', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test.beforeAll(async () => {
+        console.log('\\n%%beforeAll');
+        test.setTimeout(100);
+      });
+      test('passed', async () => {
+        console.log('\\n%%test');
+        await new Promise(f => setTimeout(f, 800));
+      });
+    `,
+  }, { timeout: '1000' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.output.split('\n').filter(line => line.startsWith('%%'))).toEqual([
+    '%%beforeAll',
+    '%%test',
+  ]);
+});
+
+test('test.setTimeout should work separately in afterAll', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test('passed', async () => {
+        console.log('\\n%%test');
+      });
+      test.afterAll(async () => {
+        console.log('\\n%%afterAll');
+        test.setTimeout(1000);
+        await new Promise(f => setTimeout(f, 800));
+      });
+    `,
+  }, { timeout: '100' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.output.split('\n').filter(line => line.startsWith('%%'))).toEqual([
+    '%%test',
+    '%%afterAll',
+  ]);
 });


### PR DESCRIPTION
This makes it possible to have longer `beforeAll`/`afterAll` and not affect first/last test timeout.

Relands #12413.