### PR TITLE
fix(test-runner): ESM compatibly on Windows 

### DIFF
--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -56,9 +56,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12]
-        include:
-        - os: ubuntu-latest
-          node-version: 16
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -78,9 +75,13 @@ jobs:
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
 
-  test_test_runner_windows_esm:
-    name: Test Runner Windows ESM
-    runs-on: windows-latest
+  test_test_runner_esm:
+    name: Test Runner ESM
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
@@ -92,7 +93,7 @@ jobs:
         DEBUG: pw:install
     - run: npm run build
     - run: npx playwright install --with-deps
-    - run: npm run ttest -- --grep=esm
+    - run: npm run ttest -- --grep=@esm
 
   test_html_report:
     name: HTML Report

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -78,6 +78,22 @@ jobs:
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
 
+  test_test_runner_windows_esm:
+    name: Test Runner Windows ESM
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16
+    - run: npm i -g npm@8.3
+    - run: npm ci
+      env:
+        DEBUG: pw:install
+    - run: npm run build
+    - run: npx playwright install --with-deps
+    - run: npm run ttest -- --grep=esm
+
   test_html_report:
     name: HTML Report
     runs-on: ubuntu-latest

--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -18,6 +18,7 @@
 
 import { Command } from 'commander';
 import fs from 'fs';
+import url from 'url';
 import path from 'path';
 import type { Config } from './types';
 import { Runner, builtInReporters, BuiltInReporter, kDefaultConfigFiles } from './runner';
@@ -245,7 +246,7 @@ function restartWithExperimentalTsEsm(configFile: string | null): boolean {
     return false;
   if (!fileIsModule(configFile))
     return false;
-  const NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + ` --experimental-loader=${require.resolve('@playwright/test/lib/experimentalLoader')}`;
+  const NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + ` --experimental-loader=${url.pathToFileURL(require.resolve('@playwright/test/lib/experimentalLoader')).toString()}`;
   const innerProcess = require('child_process').fork(require.resolve('playwright-core/cli'), process.argv.slice(2), {
     env: {
       ...process.env,

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -241,7 +241,7 @@ test('should fail to load ts from esm when package.json has type module', async 
   expect(result.output).toContain('Cannot import a typescript file from an esmodule');
 });
 
-test('should import esm from ts when package.json has type module in experimental mode #esm', async ({ runInlineTest }) => {
+test('should import esm from ts when package.json has type module in experimental mode @esm', async ({ runInlineTest }) => {
   // We only support experimental esm mode on Node 16+
   test.skip(parseInt(process.version.slice(1), 10) < 16);
   const result = await runInlineTest({
@@ -267,7 +267,7 @@ test('should import esm from ts when package.json has type module in experimenta
   expect(result.exitCode).toBe(0);
 });
 
-test('should propagate subprocess exit code in experimental mode #esm', async ({ runInlineTest }) => {
+test('should propagate subprocess exit code in experimental mode @esm', async ({ runInlineTest }) => {
   // We only support experimental esm mode on Node 16+
   test.skip(parseInt(process.version.slice(1), 10) < 16);
   const result = await runInlineTest({

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -241,7 +241,7 @@ test('should fail to load ts from esm when package.json has type module', async 
   expect(result.output).toContain('Cannot import a typescript file from an esmodule');
 });
 
-test('should import esm from ts when package.json has type module in experimental mode', async ({ runInlineTest }) => {
+test('should import esm from ts when package.json has type module in experimental mode #esm', async ({ runInlineTest }) => {
   // We only support experimental esm mode on Node 16+
   test.skip(parseInt(process.version.slice(1), 10) < 16);
   const result = await runInlineTest({
@@ -267,7 +267,7 @@ test('should import esm from ts when package.json has type module in experimenta
   expect(result.exitCode).toBe(0);
 });
 
-test('should propagate subprocess exit code in experimental mode', async ({ runInlineTest }) => {
+test('should propagate subprocess exit code in experimental mode #esm', async ({ runInlineTest }) => {
   // We only support experimental esm mode on Node 16+
   test.skip(parseInt(process.version.slice(1), 10) < 16);
   const result = await runInlineTest({

--- a/tests/playwright-test/resolver.spec.ts
+++ b/tests/playwright-test/resolver.spec.ts
@@ -164,7 +164,7 @@ test('should respect baseurl w/o paths', async ({ runInlineTest }) => {
   expect(result.output).not.toContain(`Could not`);
 });
 
-test('should respect path resolver in experimental mode #esm', async ({ runInlineTest }) => {
+test('should respect path resolver in experimental mode @esm', async ({ runInlineTest }) => {
   // We only support experimental esm mode on Node 16+
   test.skip(parseInt(process.version.slice(1), 10) < 16);
   const result = await runInlineTest({

--- a/tests/playwright-test/resolver.spec.ts
+++ b/tests/playwright-test/resolver.spec.ts
@@ -164,7 +164,7 @@ test('should respect baseurl w/o paths', async ({ runInlineTest }) => {
   expect(result.output).not.toContain(`Could not`);
 });
 
-test('should respect path resolver in experimental mode', async ({ runInlineTest }) => {
+test('should respect path resolver in experimental mode #esm', async ({ runInlineTest }) => {
   // We only support experimental esm mode on Node 16+
   test.skip(parseInt(process.version.slice(1), 10) < 16);
   const result = await runInlineTest({


### PR DESCRIPTION
Lets keep ensuring that ESM and its friends are working because currently they are broken and users are affected.

Relates: 
- https://github.com/microsoft/playwright/discussions/11624#discussioncomment-2069146
- https://github.com/microsoft/playwright/issues/12307
- https://github.com/sveltejs/kit/issues/4194