### PR TITLE
fix(firefox): add missing dependency on Ubuntu 18.04

### DIFF
--- a/packages/playwright-core/src/utils/nativeDeps.ts
+++ b/packages/playwright-core/src/utils/nativeDeps.ts
@@ -88,6 +88,7 @@ export const deps: any = {
       'libxi6',
       'libxrender1',
       'libxt6',
+      'libxtst6',
     ],
     webkit: [
       'gstreamer1.0-libav',


### PR DESCRIPTION
#12613