### PR TITLE
docs: fix js example formatting

### DIFF
--- a/docs/src/test-pom-js.md
+++ b/docs/src/test-pom-js.md
@@ -37,7 +37,8 @@ exports.PlaywrightDevPage = class PlaywrightDevPage {
     await this.getStarted();
     await this.pomLink.click();
   }
-}```
+}
+```
 
 ```js js-flavor=ts
 // playwright-dev-page.ts
@@ -71,7 +72,8 @@ export class PlaywrightDevPage {
     await this.getStarted();
     await this.pomLink.click();
   }
-}```
+}
+```
 
 Now we can use the `PlaywrightDevPage` class in our tests.
 


### PR DESCRIPTION
Fixes roll:
```
Users/yurys/playwright.dev/src/format_utils.js:48
        throw new Error('Bad js tab group: ' + md.render(spec));
        ^

Error: Bad js tab group: ---
id: test-pom
title: "Page Object Model"
---
```