### PR TITLE
docs: remove unsupported permission "push" from docs

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -805,7 +805,6 @@ A permission or an array of permissions to grant. Permissions can be one of the 
 * `'midi'`
 * `'midi-sysex'` (system-exclusive midi)
 * `'notifications'`
-* `'push'`
 * `'camera'`
 * `'microphone'`
 * `'background-sync'`

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -6612,7 +6612,6 @@ export interface BrowserContext {
    * - `'midi'`
    * - `'midi-sysex'` (system-exclusive midi)
    * - `'notifications'`
-   * - `'push'`
    * - `'camera'`
    * - `'microphone'`
    * - `'background-sync'`


### PR DESCRIPTION
Fixes #12649