### PR TITLE
feat(test-runner): more default workers for M1

### DIFF
--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -27,7 +27,7 @@ import { FilePatternFilter } from './util';
 import { showHTMLReport } from './reporters/html';
 import { GridServer } from 'playwright-core/lib/grid/gridServer';
 import dockerFactory from 'playwright-core/lib/grid/dockerGridFactory';
-import { createGuid } from 'playwright-core/lib/utils/utils';
+import { createGuid, hostPlatform } from 'playwright-core/lib/utils/utils';
 import { fileIsModule } from './loader';
 
 const defaultTimeout = 30000;
@@ -109,8 +109,7 @@ async function runTests(args: string[], opts: { [key: string]: any }) {
 
   const os = require('os');
   const cpus = os.cpus().length;
-  const isLikelyM1 = os.arch() === 'arm64' && os.platform() === 'darwin';
-  const workers = isLikelyM1 ? cpus : Math.ceil(cpus / 2);
+  const workers = hostPlatform.startsWith('mac') && hostPlatform.endsWith('arm64') ? cpus : Math.ceil(cpus / 2);
 
   const defaultConfig: Config = {
     preserveOutput: 'always',

--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -20,6 +20,7 @@ import { Command } from 'commander';
 import fs from 'fs';
 import url from 'url';
 import path from 'path';
+import os from 'os';
 import type { Config } from './types';
 import { Runner, builtInReporters, BuiltInReporter, kDefaultConfigFiles } from './runner';
 import { stopProfiling, startProfiling } from './profiler';
@@ -107,7 +108,6 @@ Examples:
 async function runTests(args: string[], opts: { [key: string]: any }) {
   await startProfiling();
 
-  const os = require('os');
   const cpus = os.cpus().length;
   const workers = hostPlatform.startsWith('mac') && hostPlatform.endsWith('arm64') ? cpus : Math.ceil(cpus / 2);
 

--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -107,13 +107,18 @@ Examples:
 async function runTests(args: string[], opts: { [key: string]: any }) {
   await startProfiling();
 
+  const os = require('os');
+  const cpus = os.cpus().length;
+  const isLikelyM1 = os.arch() === 'arm64' && os.platform() === 'darwin';
+  const workers = isLikelyM1 ? cpus : Math.ceil(cpus / 2);
+
   const defaultConfig: Config = {
     preserveOutput: 'always',
     reporter: [ [defaultReporter] ],
     reportSlowTests: { max: 5, threshold: 15000 },
     timeout: defaultTimeout,
     updateSnapshots: 'missing',
-    workers: Math.ceil(require('os').cpus().length / 2),
+    workers,
   };
 
   if (opts.browser) {


### PR DESCRIPTION
New default is based on the very (unscientific) output of the following repeated a few
times:

```
$ for i in `seq 5 13`; do time npm run ctest -- --reporter=line --workers=$i 'page/*' 'selector*' 'channels*' 'resource-timing*'; done
```

NB: Depending on the user's version of Node, their platform will be
reported as x86 and not arm, so this won't make a difference for them.