### PR TITLE
Fixing example code in `accessibility` API docs

### DIFF
--- a/docs/src/api/class-accessibility.md
+++ b/docs/src/api/class-accessibility.md
@@ -91,7 +91,8 @@ function findFocusedNode(node) {
     return node;
   for (const child of node.children || []) {
     const foundNode = findFocusedNode(child);
-    return foundNode;
+    if (foundNode)
+      return foundNode;
   }
   return null;
 }
@@ -113,7 +114,8 @@ def find_focused_node(node):
         return node
     for child in (node.get("children") or []):
         found_node = find_focused_node(child)
-        return found_node
+        if (found_node)
+            return found_node
     return None
 
 snapshot = await page.accessibility.snapshot()
@@ -128,7 +130,8 @@ def find_focused_node(node):
         return node
     for child in (node.get("children") or []):
         found_node = find_focused_node(child)
-        return found_node
+        if (found_node)
+            return found_node
     return None
 
 snapshot = page.accessibility.snapshot()

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -10580,7 +10580,8 @@ export interface Accessibility {
    *     return node;
    *   for (const child of node.children || []) {
    *     const foundNode = findFocusedNode(child);
-   *     return foundNode;
+   *     if (foundNode)
+   *       return foundNode;
    *   }
    *   return null;
    * }


### PR DESCRIPTION
The example code for finding the focused node doesn't work as described. While this is not a particularly big deal, it should probably do what it says it does!

This patch updates the existing JS/Python examples to work as intended, but does't add any new code for missing languages.