### PR TITLE
chore: follow-up to fix docs

### DIFF
--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8074,7 +8074,7 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
     /**
      * When set to `"ready"`, screenshot will wait for
-     * [`document.fonts.ready()`](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/ready) promise to resolve in all
+     * [`document.fonts.ready`](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/ready) promise to resolve in all
      * frames. Defaults to `"nowait"`.
      */
     fonts?: "ready"|"nowait";
@@ -15602,7 +15602,7 @@ export interface LocatorScreenshotOptions {
 
   /**
    * When set to `"ready"`, screenshot will wait for
-   * [`document.fonts.ready()`](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/ready) promise to resolve in all
+   * [`document.fonts.ready`](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/ready) promise to resolve in all
    * frames. Defaults to `"nowait"`.
    */
   fonts?: "ready"|"nowait";
@@ -15778,7 +15778,7 @@ export interface PageScreenshotOptions {
 
   /**
    * When set to `"ready"`, screenshot will wait for
-   * [`document.fonts.ready()`](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/ready) promise to resolve in all
+   * [`document.fonts.ready`](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/ready) promise to resolve in all
    * frames. Defaults to `"nowait"`.
    */
   fonts?: "ready"|"nowait";


### PR DESCRIPTION
This is a follow-up to 49e66c7f08c192f8b79664f8ccb032eeaf665b84 that was landed without bots.

I ran bots manually on Mac & Linux.