### PR TITLE
chore: follow-up to animations default option

### DIFF
--- a/packages/playwright-core/src/server/screenshotter.ts
+++ b/packages/playwright-core/src/server/screenshotter.ts
@@ -36,7 +36,7 @@ export type ScreenshotOptions = {
   type?: 'png' | 'jpeg',
   quality?: number,
   omitBackground?: boolean,
-  animations?: 'disabled',
+  animations?: 'disabled' | 'allow',
   mask?: { frame: Frame, selector: string}[],
   fullPage?: boolean,
   clip?: Rect,

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8070,7 +8070,7 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
      * - finite animations are fast-forwarded to completion, so they'll fire `transitionend` event.
      * - infinite animations are canceled to initial state, and then played over after the screenshot.
      *
-     * Defaults to `"allow"`.
+     * Defaults to `"allow"` that leaves animations untouched.
      */
     animations?: "disabled"|"allow";
 
@@ -15600,7 +15600,7 @@ export interface LocatorScreenshotOptions {
    * - finite animations are fast-forwarded to completion, so they'll fire `transitionend` event.
    * - infinite animations are canceled to initial state, and then played over after the screenshot.
    *
-   * Defaults to `"allow"`.
+   * Defaults to `"allow"` that leaves animations untouched.
    */
   animations?: "disabled"|"allow";
 
@@ -15753,7 +15753,7 @@ export interface PageScreenshotOptions {
    * - finite animations are fast-forwarded to completion, so they'll fire `transitionend` event.
    * - infinite animations are canceled to initial state, and then played over after the screenshot.
    *
-   * Defaults to `"allow"`.
+   * Defaults to `"allow"` that leaves animations untouched.
    */
   animations?: "disabled"|"allow";
 


### PR DESCRIPTION
This is a follow-up to 42765804bcabd35d7c185006b0ce16f9c8676c18
that was landed without bots.

I ran the bots manually on Linux & Mac.
