### PR TITLE
chore: dogfood dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ playwright-report
 /packages/*/NOTICE
 /packages/playwright/README.md
 /packages/playwright-core/api.json
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "copy-webpack-plugin": "^9.1.0",
         "cross-env": "^7.0.3",
         "css-loader": "^6.5.1",
+        "dotenv": "^16.0.0",
         "electron": "^12.2.1",
         "enquirer": "^2.3.6",
         "eslint": "^8.8.0",
@@ -3002,6 +3003,15 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/duplexer3": {
@@ -9752,6 +9762,12 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "copy-webpack-plugin": "^9.1.0",
     "cross-env": "^7.0.3",
     "css-loader": "^6.5.1",
+    "dotenv": "^16.0.0",
     "electron": "^12.2.1",
     "enquirer": "^2.3.6",
     "eslint": "^8.8.0",

--- a/tests/config/android.config.ts
+++ b/tests/config/android.config.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { config as loadEnv } from 'dotenv';
+loadEnv({ path: path.join(__dirname, '..', '..', '.env') });
+
 import type { Config, PlaywrightTestOptions, PlaywrightWorkerOptions } from '@playwright/test';
 import * as path from 'path';
 import { ServerWorkerOptions } from './serverFixtures';

--- a/tests/config/default.playwright.config.ts
+++ b/tests/config/default.playwright.config.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { config as loadEnv } from 'dotenv';
+loadEnv({ path: path.join(__dirname, '..', '..', '.env') });
+
 import type { Config, PlaywrightTestOptions, PlaywrightWorkerOptions } from '@playwright/test';
 import * as path from 'path';
 import { TestModeWorkerOptions } from './testModeFixtures';

--- a/tests/config/electron.config.ts
+++ b/tests/config/electron.config.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { config as loadEnv } from 'dotenv';
+loadEnv({ path: path.join(__dirname, '..', '..', '.env') });
+
 import type { Config, PlaywrightTestOptions, PlaywrightWorkerOptions } from '@playwright/test';
 import * as path from 'path';
 import { CoverageWorkerOptions } from './coverageFixtures';

--- a/tests/playwright-test/playwright-test.config.ts
+++ b/tests/playwright-test/playwright-test.config.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { config as loadEnv } from 'dotenv';
+loadEnv({ path: path.join(__dirname, '..', '..', '.env') });
+
 import { Config } from './stable-test-runner';
 import * as path from 'path';
 


### PR DESCRIPTION
Before this change, I had to use the CLI version of Playwright instead
of fully dogfooding the VSCode extension since I was running with a
custom `CRPATH`.