### PR TITLE
feat(toHaveScreenshot): enhance messaging in case of failures

### DIFF
--- a/packages/playwright-test/src/matchers/matchers.ts
+++ b/packages/playwright-test/src/matchers/matchers.ts
@@ -18,7 +18,7 @@ import { Locator, Page, APIResponse } from 'playwright-core';
 import { FrameExpectOptions } from 'playwright-core/lib/client/types';
 import { constructURLBasedOnBaseURL } from 'playwright-core/lib/utils/utils';
 import type { Expect } from '../types';
-import { expectType, callLogText } from '../util';
+import { expectTypes, callLogText } from '../util';
 import { toBeTruthy } from './toBeTruthy';
 import { toEqual } from './toEqual';
 import { toExpectedTextValues, toMatchText } from './toMatchText';
@@ -275,7 +275,7 @@ export async function toBeOK(
   response: APIResponseEx
 ) {
   const matcherName = 'toBeOK';
-  expectType(response, 'APIResponse', matcherName);
+  expectTypes(response, ['APIResponse'], matcherName);
   const log = (this.isNot === response.ok()) ? await response._fetchLog() : [];
   const message = () => this.utils.matcherHint(matcherName, undefined, '', { isNot: this.isNot }) + callLogText(log);
   const pass = response.ok();

--- a/packages/playwright-test/src/matchers/toBeTruthy.ts
+++ b/packages/playwright-test/src/matchers/toBeTruthy.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Expect } from '../types';
-import { expectType, callLogText, currentExpectTimeout } from '../util';
+import { expectTypes, callLogText, currentExpectTimeout } from '../util';
 
 export async function toBeTruthy(
   this: ReturnType<Expect['getState']>,
@@ -25,7 +25,7 @@ export async function toBeTruthy(
   query: (isNot: boolean, timeout: number) => Promise<{ matches: boolean, log?: string[] }>,
   options: { timeout?: number } = {},
 ) {
-  expectType(receiver, receiverType, matcherName);
+  expectTypes(receiver, [receiverType], matcherName);
 
   const matcherOptions = {
     isNot: this.isNot,

--- a/packages/playwright-test/src/matchers/toEqual.ts
+++ b/packages/playwright-test/src/matchers/toEqual.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Expect } from '../types';
-import { expectType } from '../util';
+import { expectTypes } from '../util';
 import { callLogText, currentExpectTimeout } from '../util';
 
 // Omit colon and one or more spaces, so can call getLabelPrinter.
@@ -34,7 +34,7 @@ export async function toEqual<T>(
   expected: T,
   options: { timeout?: number, contains?: boolean } = {},
 ) {
-  expectType(receiver, receiverType, matcherName);
+  expectTypes(receiver, [receiverType], matcherName);
 
   const matcherOptions = {
     comment: options.contains ? '' : 'deep equality',

--- a/packages/playwright-test/src/matchers/toMatchText.ts
+++ b/packages/playwright-test/src/matchers/toMatchText.ts
@@ -18,7 +18,7 @@
 import type { ExpectedTextValue } from 'playwright-core/lib/protocol/channels';
 import { isRegExp, isString } from 'playwright-core/lib/utils/utils';
 import type { Expect } from '../types';
-import { expectType, callLogText, currentExpectTimeout } from '../util';
+import { expectTypes, callLogText, currentExpectTimeout } from '../util';
 import {
   printReceivedStringContainExpectedResult,
   printReceivedStringContainExpectedSubstring
@@ -33,7 +33,7 @@ export async function toMatchText(
   expected: string | RegExp,
   options: { timeout?: number, matchSubstring?: boolean } = {},
 ) {
-  expectType(receiver, receiverType, matcherName);
+  expectTypes(receiver, [receiverType], matcherName);
 
   const matcherOptions = {
     isNot: this.isNot,

--- a/packages/playwright-test/src/util.ts
+++ b/packages/playwright-test/src/util.ts
@@ -170,9 +170,13 @@ export function errorWithLocation(location: Location, message: string) {
   return new Error(`${formatLocation(location)}: ${message}`);
 }
 
-export function expectType(receiver: any, type: string, matcherName: string) {
-  if (typeof receiver !== 'object' || receiver.constructor.name !== type)
-    throw new Error(`${matcherName} can be only used with ${type} object`);
+export function expectTypes(receiver: any, types: string[], matcherName: string) {
+  if (typeof receiver !== 'object' || !types.includes(receiver.constructor.name)) {
+    const commaSeparated = types.slice();
+    const lastType = commaSeparated.pop();
+    const typesString = commaSeparated.length ? commaSeparated.join(', ') + ' or ' + lastType : lastType;
+    throw new Error(`${matcherName} can be only used with ${typesString} object${types.length > 1 ? 's' : ''}`);
+  }
 }
 
 export function sanitizeForFilePath(s: string) {

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -724,6 +724,13 @@ it.describe('page screenshot animations', () => {
     });
     // Make sure we can take screenshot.
     const noIconsScreenshot = await page.screenshot();
+    // Make sure screenshot times out while webfont is stalled.
+    const error = await page.screenshot({
+      fonts: 'ready',
+      timeout: 200,
+    }).catch(e => e);
+    expect(error.message).toContain('waiting for fonts to load...');
+    expect(error.message).toContain('Timeout 200ms exceeded');
     const [iconsScreenshot] = await Promise.all([
       page.screenshot({ fonts: 'ready' }),
       server.serveFile(serverRequest, serverResponse),

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -194,7 +194,7 @@ test('should include image diff when screenshot failed to generate due to animat
   await page.click('text=fails');
   await expect(page.locator('text=Image mismatch')).toHaveCount(1);
   await expect(page.locator('text=Snapshot mismatch')).toHaveCount(0);
-  await expect(page.locator('text=Screenshots')).toHaveCount(0);
+  await expect(page.locator('.chip-header', { hasText: 'Screenshots' })).toHaveCount(0);
   const imageDiff = page.locator('data-testid=test-result-image-mismatch');
   const image = imageDiff.locator('img');
   await expect(image).toHaveAttribute('src', /.*png/);


### PR DESCRIPTION
This patch:
- adds call logs to track screenshot timeouts, e.g. due to
  waiting for web fonts
- makes sure all snapshot expectations have `.png` extension
- throws a polite error when given a buffer or a string instead of a
  page or a locator
- removes stray NL between error description and call log

<img width="981" alt="image" src="https://user-images.githubusercontent.com/746130/157974016-95fee40c-8dca-4121-be1e-d7e5544009d0.png">

Fixes #12563