### PR TITLE
docs(test-runner): add note about custom annotations

### DIFF
--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -212,3 +212,25 @@ test('user profile', async ({ page }) => {
   // ...
 });
 ```
+
+## Custom annotations
+
+It's also possible to add custom metadata in the form of annotations to your tests. This is key/value-based and gets reflected inside the HTML report. During the test execution it's accessible via [`test.info().annotations`](./api/class-testinfo#test-info-annotations) and after the test execution by reading [`testCase.annotations`](./api/class-testcase#test-case-annotations) inside a custom reporter.
+
+```js js-flavor=js
+// example.spec.js
+
+test('user profile', async ({ page }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/12600' });
+  // ...
+});
+```
+
+```js js-flavor=ts
+// example.spec.ts
+
+test('user profile', async ({ page }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/12600' });
+  // ...
+});
+```

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -215,7 +215,7 @@ test('user profile', async ({ page }) => {
 
 ## Custom annotations
 
-It's also possible to add custom metadata in the form of annotations to your tests. This is key/value-based and gets reflected inside the HTML report. During the test execution it's accessible via [`test.info().annotations`](./api/class-testinfo#test-info-annotations) and after the test execution by reading [`testCase.annotations`](./api/class-testcase#test-case-annotations) inside a custom reporter.
+It's also possible to add custom metadata in the form of annotations to your tests. Annotations are key/value pairs accessible via [`test.info().annotations`](./api/class-testinfo#test-info-annotations). Many reporters show annotations, for example `'html'`.```
 
 ```js js-flavor=js
 // example.spec.js

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -215,13 +215,13 @@ test('user profile', async ({ page }) => {
 
 ## Custom annotations
 
-It's also possible to add custom metadata in the form of annotations to your tests. Annotations are key/value pairs accessible via [`test.info().annotations`](./api/class-testinfo#test-info-annotations). Many reporters show annotations, for example `'html'`.```
+It's also possible to add custom metadata in the form of annotations to your tests. Annotations are key/value pairs accessible via [`test.info().annotations`](./api/class-testinfo#test-info-annotations). Many reporters show annotations, for example `'html'`.
 
 ```js js-flavor=js
 // example.spec.js
 
 test('user profile', async ({ page }) => {
-  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/12600' });
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/<some-issue>' });
   // ...
 });
 ```
@@ -230,7 +230,7 @@ test('user profile', async ({ page }) => {
 // example.spec.ts
 
 test('user profile', async ({ page }) => {
-  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/12600' });
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/<some-issue>' });
   // ...
 });
 ```


### PR DESCRIPTION
We did not have it yet in the docs I guess and people keep asking.