### PR TITLE
test: skip fonts test on Windows

### DIFF
--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -711,7 +711,8 @@ it.describe('page screenshot animations', () => {
     ]);
   });
 
-  it('should respect fonts option', async ({ page, server }) => {
+  it('should respect fonts option', async ({ page, server, isWindows }) => {
+    it.skip(isWindows, 'This requires a windows-specific test expectations. https://github.com/microsoft/playwright/issues/12707');
     await page.setViewportSize({ width: 500, height: 500 });
     let serverRequest, serverResponse;
     // Stall font loading.

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -712,7 +712,7 @@ it.describe('page screenshot animations', () => {
   });
 
   it('should respect fonts option', async ({ page, server, isWindows }) => {
-    it.skip(isWindows, 'This requires a windows-specific test expectations. https://github.com/microsoft/playwright/issues/12707');
+    it.fixme(isWindows, 'This requires a windows-specific test expectations. https://github.com/microsoft/playwright/issues/12707');
     await page.setViewportSize({ width: 500, height: 500 });
     let serverRequest, serverResponse;
     // Stall font loading.


### PR DESCRIPTION
This test requires windows-specific test expectations. We'll use
it as a playground for the rebaseline workflow.

References #12707
