### PR TITLE
cherry-pick(1.20): docs: fix broken release-notes links

### DIFF
--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -9,7 +9,7 @@ title: "Release notes"
 
 ### Web-First Assertions
 
-Playwright for .NET 1.20 introduces [Web-First Assertions](./api/class-playwrightassertions).
+Playwright for .NET 1.20 introduces [Web-First Assertions](./test-assertions).
 
 Consider the following example:
 
@@ -36,7 +36,7 @@ fetched Node has the `"Submitted"` text. It will be re-fetching the node and
 checking it over and over, until the condition is met or until the timeout is
 reached. You can pass this timeout as an option.
 
-Read more in [our documentation](./api/class-playwrightassertions).
+Read more in [our documentation](./test-assertions).
 
 ### Other Updates
 

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -12,7 +12,7 @@ title: "Release notes"
 - New options for methods [`method: Page.screenshot`], [`method: Locator.screenshot`] and [`method: ElementHandle.screenshot`]:
   * Option `ScreenshotAnimations.DISABLED` rewinds all CSS animations and transitions to a consistent state
   * Option `mask: Locator[]` masks given elements, overlaying them with pink `#FF00FF` boxes.
-- [Trace Viewer](./trace-viewer) now shows [API testing requests](./src/test-api-testing).
+- [Trace Viewer](./trace-viewer) now shows [API testing requests](./api-testing).
 - [`method: Locator.highlight`] visually reveals element(s) for easier debugging.
 
 ### Announcements

--- a/docs/src/release-notes-python.md
+++ b/docs/src/release-notes-python.md
@@ -12,7 +12,7 @@ title: "Release notes"
 - New options for methods [`method: Page.screenshot`], [`method: Locator.screenshot`] and [`method: ElementHandle.screenshot`]:
   * Option `animations: "disabled"` rewinds all CSS animations and transitions to a consistent state
   * Option `mask: Locator[]` masks given elements, overlaying them with pink `#FF00FF` boxes.
-- [Trace Viewer](./trace-viewer) now shows [API testing requests](./src/test-api-testing).
+- [Trace Viewer](./trace-viewer) now shows [API testing requests](./api-testing).
 - [`method: Locator.highlight`] visually reveals element(s) for easier debugging.
 
 ### Announcements


### PR DESCRIPTION
PR: #12747