### PR TITLE
feat(fixtures): per-fixture timeout

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -880,7 +880,7 @@ Test function that takes one or two arguments: an object with fixtures and optio
 
 ## method: Test.setTimeout
 
-Changes the timeout for the test. Learn more about [various timeouts](./test-timeouts.md).
+Changes the timeout for the test. Zero means no timeout. Learn more about [various timeouts](./test-timeouts.md).
 
 ```js js-flavor=js
 const { test, expect } = require('@playwright/test');

--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -466,6 +466,41 @@ export const test = base.extend<{ saveLogs: void }>({
 export { expect } from '@playwright/test';
 ```
 
+## Fixture timeout
+
+By default, fixture shares timeout with the test. However, for slow fixtures, especially [worker-scoped](#worker-scoped-fixtures) ones, it is convenient to have a separate timeout. This way you can keep the overall test timeout small, and give the slow fixture more time.
+
+```js js-flavor=js
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  slowFixture: [async ({}, use) => {
+    // ... perform a slow operation ...
+    await use('hello');
+  }, { timeout: 60000 }]
+});
+
+test('example test', async ({ slowFixture }) => {
+  // ...
+});
+```
+
+```js js-flavor=ts
+import { test as base, expect } from '@playwright/test';
+
+const test = base.extend<{ slowFixture: string }>({
+  slowFixture: [async ({}, use) => {
+    // ... perform a slow operation ...
+    await use('hello');
+  }, { timeout: 60000 }]
+});
+
+test('example test', async ({ slowFixture }) => {
+  // ...
+});
+```
+
+
 ## Fixtures-options
 
 :::note

--- a/docs/src/test-timeouts-js.md
+++ b/docs/src/test-timeouts-js.md
@@ -16,6 +16,7 @@ Playwright Test has multiple configurable timeouts for various tasks.
 |Action timeout| no timeout |Timeout for each action:<br/><span style={{textTransform:'uppercase',fontSize:'smaller',fontWeight:'bold',opacity:'0.6'}}>Set default</span><br/><code>{`config = { use: { actionTimeout: 10000 } }`}</code><br/><span style={{textTransform: 'uppercase',fontSize: 'smaller', fontWeight: 'bold', opacity: '0.6'}}>Override</span><br/><code>{`locator.click({ timeout: 10000 })`}</code>|
 |Navigation timeout| no timeout |Timeout for each navigation action:<br/><span style={{textTransform:'uppercase',fontSize:'smaller',fontWeight:'bold',opacity:'0.6'}}>Set default</span><br/><code>{`config = { use: { navigationTimeout: 30000 } }`}</code><br/><span style={{textTransform: 'uppercase',fontSize: 'smaller', fontWeight: 'bold', opacity: '0.6'}}>Override</span><br/><code>{`page.goto('/', { timeout: 30000 })`}</code>|
 |Global timeout|no timeout |Global timeout for the whole test run:<br/><span style={{textTransform:'uppercase',fontSize:'smaller',fontWeight:'bold',opacity:'0.6'}}>Set in config</span><br/><code>{`config = { globalTimeout: 60*60*1000 }`}</code><br/>|
+|Fixture timeout|no timeout |Timeout for an individual fixture:<br/><span style={{textTransform:'uppercase',fontSize:'smaller',fontWeight:'bold',opacity:'0.6'}}>Set in fixture</span><br/><code>{`{ scope: 'test', timeout: 30000 }`}</code><br/>|
 
 ## Test timeout
 
@@ -89,7 +90,7 @@ test('very slow test', async ({ page }) => {
 
 API reference: [`method: Test.setTimeout`] and [`method: Test.slow`].
 
-### Change timeout from a hook or fixture
+### Change timeout from a hook
 
 ```js js-flavor=js
 const { test, expect } = require('@playwright/test');
@@ -279,3 +280,39 @@ export default config;
 ```
 
 API reference: [`property: TestConfig.globalTimeout`].
+
+## Fixture timeout
+
+By default, [fixture](./test-fixtures) shares timeout with the test. However, for slow fixtures, especially [worker-scoped](./test-fixtures#worker-scoped-fixtures) ones, it is convenient to have a separate timeout. This way you can keep the overall test timeout small, and give the slow fixture more time.
+
+```js js-flavor=js
+const { test: base, expect } = require('@playwright/test');
+
+const test = base.extend({
+  slowFixture: [async ({}, use) => {
+    // ... perform a slow operation ...
+    await use('hello');
+  }, { timeout: 60000 }]
+});
+
+test('example test', async ({ slowFixture }) => {
+  // ...
+});
+```
+
+```js js-flavor=ts
+import { test as base, expect } from '@playwright/test';
+
+const test = base.extend<{ slowFixture: string }>({
+  slowFixture: [async ({}, use) => {
+    // ... perform a slow operation ...
+    await use('hello');
+  }, { timeout: 60000 }]
+});
+
+test('example test', async ({ slowFixture }) => {
+  // ...
+});
+```
+
+API reference: [`method: Test.extend`].

--- a/packages/playwright-test/src/fixtures.ts
+++ b/packages/playwright-test/src/fixtures.ts
@@ -16,11 +16,13 @@
 
 import { formatLocation, debugTest } from './util';
 import * as crypto from 'crypto';
-import { FixturesWithLocation, Location, WorkerInfo, TestInfo } from './types';
+import { FixturesWithLocation, Location, WorkerInfo } from './types';
 import { ManualPromise } from 'playwright-core/lib/utils/async';
+import { TestInfoImpl } from './testInfo';
+import { FixtureDescription, TimeoutManager } from './timeoutManager';
 
 type FixtureScope = 'test' | 'worker';
-type FixtureOptions = { auto?: boolean, scope?: FixtureScope, option?: boolean };
+type FixtureOptions = { auto?: boolean, scope?: FixtureScope, option?: boolean, timeout?: number | undefined };
 type FixtureTuple = [ value: any, options: FixtureOptions ];
 type FixtureRegistration = {
   location: Location;  // Fixutre registration location.
@@ -29,6 +31,7 @@ type FixtureRegistration = {
   fn: Function | any;  // Either a fixture function, or a fixture value.
   auto: boolean;
   option: boolean;
+  timeout?: number;
   deps: string[];  // Names of the dependencies, ({ foo, bar }) => {...}
   id: string;  // Unique id, to differentiate between fixtures with the same name.
   super?: FixtureRegistration;  // A fixture override can use the previous version of the fixture.
@@ -43,15 +46,24 @@ class Fixture {
   _useFuncFinished: ManualPromise<void> | undefined;
   _selfTeardownComplete: Promise<void> | undefined;
   _teardownWithDepsComplete: Promise<void> | undefined;
+  _runnableDescription: FixtureDescription;
 
   constructor(runner: FixtureRunner, registration: FixtureRegistration) {
     this.runner = runner;
     this.registration = registration;
     this.usages = new Set();
     this.value = null;
+    this._runnableDescription = {
+      fixture: this.registration.name,
+      location: registration.location,
+      slot: this.registration.timeout === undefined ? undefined : {
+        timeout: this.registration.timeout,
+        elapsed: 0,
+      }
+    };
   }
 
-  async setup(testInfo: TestInfo) {
+  async setup(testInfo: TestInfoImpl) {
     if (typeof this.registration.fn !== 'function') {
       this.value = this.registration.fn;
       return;
@@ -79,6 +91,7 @@ class Fixture {
     };
     const workerInfo: WorkerInfo = { config: testInfo.config, parallelIndex: testInfo.parallelIndex, workerIndex: testInfo.workerIndex, project: testInfo.project };
     const info = this.registration.scope === 'worker' ? workerInfo : testInfo;
+    testInfo._timeoutManager.setCurrentFixture(this._runnableDescription);
     this._selfTeardownComplete = Promise.resolve().then(() => this.registration.fn(params, useFunc, info)).catch((e: any) => {
       if (!useFuncStarted.isDone())
         useFuncStarted.reject(e);
@@ -86,25 +99,28 @@ class Fixture {
         throw e;
     });
     await useFuncStarted;
+    testInfo._timeoutManager.setCurrentFixture(undefined);
   }
 
-  async teardown() {
+  async teardown(timeoutManager: TimeoutManager) {
     if (!this._teardownWithDepsComplete)
-      this._teardownWithDepsComplete = this._teardownInternal();
+      this._teardownWithDepsComplete = this._teardownInternal(timeoutManager);
     await this._teardownWithDepsComplete;
   }
 
-  private async _teardownInternal() {
+  private async _teardownInternal(timeoutManager: TimeoutManager) {
     if (typeof this.registration.fn !== 'function')
       return;
     try {
       for (const fixture of this.usages)
-        await fixture.teardown();
+        await fixture.teardown(timeoutManager);
       this.usages.clear();
       if (this._useFuncFinished) {
         debugTest(`teardown ${this.registration.name}`);
+        timeoutManager.setCurrentFixture(this._runnableDescription);
         this._useFuncFinished.resolve();
         await this._selfTeardownComplete;
+        timeoutManager.setCurrentFixture(undefined);
       }
     } finally {
       this.runner.instanceForId.delete(this.registration.id);
@@ -113,7 +129,7 @@ class Fixture {
 }
 
 function isFixtureTuple(value: any): value is FixtureTuple {
-  return Array.isArray(value) && typeof value[1] === 'object' && ('scope' in value[1] || 'auto' in value[1] || 'option' in value[1]);
+  return Array.isArray(value) && typeof value[1] === 'object' && ('scope' in value[1] || 'auto' in value[1] || 'option' in value[1] || 'timeout' in value[1]);
 }
 
 export function isFixtureOption(value: any): value is FixtureTuple {
@@ -131,12 +147,13 @@ export class FixturePool {
       for (const entry of Object.entries(fixtures)) {
         const name = entry[0];
         let value = entry[1];
-        let options: Required<FixtureOptions> | undefined;
+        let options: { auto: boolean, scope: FixtureScope, option: boolean, timeout: number | undefined } | undefined;
         if (isFixtureTuple(value)) {
           options = {
             auto: !!value[1].auto,
             scope: value[1].scope || 'test',
             option: !!value[1].option,
+            timeout: value[1].timeout,
           };
           value = value[0];
         }
@@ -149,9 +166,9 @@ export class FixturePool {
           if (previous.auto !== options.auto)
             throw errorWithLocations(`Fixture "${name}" has already been registered as a { auto: '${previous.scope}' } fixture.`, { location, name }, previous);
         } else if (previous) {
-          options = { auto: previous.auto, scope: previous.scope, option: previous.option };
+          options = { auto: previous.auto, scope: previous.scope, option: previous.option, timeout: previous.timeout };
         } else if (!options) {
-          options = { auto: false, scope: 'test', option: false };
+          options = { auto: false, scope: 'test', option: false, timeout: undefined };
         }
 
         if (options.scope !== 'test' && options.scope !== 'worker')
@@ -160,7 +177,7 @@ export class FixturePool {
           throw errorWithLocations(`Cannot use({ ${name} }) in a describe group, because it forces a new worker.\nMake it top-level in the test file or put in the configuration file.`, { location, name });
 
         const deps = fixtureParameterNames(fn, location);
-        const registration: FixtureRegistration = { id: '', name, location, scope: options.scope, fn, auto: options.auto, option: options.option, deps, super: previous };
+        const registration: FixtureRegistration = { id: '', name, location, scope: options.scope, fn, auto: options.auto, option: options.option, timeout: options.timeout, deps, super: previous };
         registrationId(registration);
         this.registrations.set(name, registration);
       }
@@ -242,14 +259,14 @@ export class FixtureRunner {
     this.pool = pool;
   }
 
-  async teardownScope(scope: FixtureScope) {
+  async teardownScope(scope: FixtureScope, timeoutManager: TimeoutManager) {
     let error: Error | undefined;
     // Teardown fixtures in the reverse order.
     const fixtures = Array.from(this.instanceForId.values()).reverse();
     for (const fixture of fixtures) {
       if (fixture.registration.scope === scope) {
         try {
-          await fixture.teardown();
+          await fixture.teardown(timeoutManager);
         } catch (e) {
           if (error === undefined)
             error = e;
@@ -262,7 +279,7 @@ export class FixtureRunner {
       throw error;
   }
 
-  async resolveParametersForFunction(fn: Function, testInfo: TestInfo): Promise<object> {
+  async resolveParametersForFunction(fn: Function, testInfo: TestInfoImpl): Promise<object> {
     // Install all automatic fixtures.
     for (const registration of this.pool!.registrations.values()) {
       const shouldSkip = !testInfo && registration.scope === 'test';
@@ -281,12 +298,12 @@ export class FixtureRunner {
     return params;
   }
 
-  async resolveParametersAndRunFunction(fn: Function, testInfo: TestInfo) {
+  async resolveParametersAndRunFunction(fn: Function, testInfo: TestInfoImpl) {
     const params = await this.resolveParametersForFunction(fn, testInfo);
     return fn(params, testInfo);
   }
 
-  async setupFixtureForRegistration(registration: FixtureRegistration, testInfo: TestInfo): Promise<Fixture> {
+  async setupFixtureForRegistration(registration: FixtureRegistration, testInfo: TestInfoImpl): Promise<Fixture> {
     if (registration.scope === 'test')
       this.testScopeClean = false;
 

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -510,9 +510,9 @@ function formatStackFrame(frame: StackFrame) {
 }
 
 function hookType(testInfo: TestInfo): 'beforeAll' | 'afterAll' | undefined {
-  if ((testInfo as any)._currentRunnable?.type === 'beforeAll')
+  if ((testInfo as any)._timeoutManager._runnable?.type === 'beforeAll')
     return 'beforeAll';
-  if ((testInfo as any)._currentRunnable?.type === 'afterAll')
+  if ((testInfo as any)._timeoutManager._runnable?.type === 'afterAll')
     return 'afterAll';
 }
 

--- a/packages/playwright-test/src/timeoutManager.ts
+++ b/packages/playwright-test/src/timeoutManager.ts
@@ -1,0 +1,134 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import colors from 'colors/safe';
+import { TimeoutRunner, TimeoutRunnerError } from 'playwright-core/lib/utils/async';
+import type { TestError } from '../types/test';
+import { Location } from './types';
+
+export type TimeSlot = {
+  timeout: number;
+  elapsed: number;
+};
+
+type RunnableDescription = {
+  type: 'test' | 'beforeAll' | 'afterAll' | 'beforeEach' | 'afterEach' | 'slow' | 'skip' | 'fail' | 'fixme' | 'teardown';
+  location?: Location;
+  slot?: TimeSlot;  // Falls back to test slot.
+};
+
+export type FixtureDescription = {
+  fixture: string;
+  location?: Location;
+  slot?: TimeSlot;  // Falls back to current runnable slot.
+};
+
+export class TimeoutManager {
+  private _defaultSlot: TimeSlot;
+  private _runnable: RunnableDescription;
+  private _fixture: FixtureDescription | undefined;
+  private _timeoutRunner: TimeoutRunner;
+
+  constructor(timeout: number) {
+    this._defaultSlot = { timeout, elapsed: 0 };
+    this._runnable = { type: 'test', slot: this._defaultSlot };
+    this._timeoutRunner = new TimeoutRunner(timeout);
+  }
+
+  interrupt() {
+    this._timeoutRunner.interrupt();
+  }
+
+  setCurrentRunnable(runnable: RunnableDescription) {
+    this._updateRunnables(runnable, undefined);
+  }
+
+  setCurrentFixture(fixture: FixtureDescription | undefined) {
+    this._updateRunnables(this._runnable, fixture);
+  }
+
+  defaultTimeout() {
+    return this._defaultSlot.timeout;
+  }
+
+  slow() {
+    const slot = this._currentSlot();
+    slot.timeout = slot.timeout * 3;
+    this._timeoutRunner.updateTimeout(slot.timeout);
+  }
+
+  async runWithTimeout(cb: () => Promise<any>): Promise<TestError | undefined> {
+    try {
+      await this._timeoutRunner.run(cb);
+    } catch (error) {
+      if (!(error instanceof TimeoutRunnerError))
+        throw error;
+      return this._createTimeoutError();
+    }
+  }
+
+  setTimeout(timeout: number) {
+    const slot = this._currentSlot();
+    if (!slot.timeout)
+      return; // Zero timeout means some debug mode - do not set a timeout.
+    slot.timeout = timeout;
+    this._timeoutRunner.updateTimeout(timeout);
+  }
+
+  private _currentSlot() {
+    return this._fixture?.slot || this._runnable.slot || this._defaultSlot;
+  }
+
+  private _updateRunnables(runnable: RunnableDescription, fixture: FixtureDescription | undefined) {
+    let slot = this._currentSlot();
+    slot.elapsed = this._timeoutRunner.elapsed();
+
+    this._runnable = runnable;
+    this._fixture = fixture;
+
+    slot = this._currentSlot();
+    this._timeoutRunner.updateTimeout(slot.timeout, slot.elapsed);
+  }
+
+  private _createTimeoutError(): TestError {
+    let suffix = '';
+    switch (this._runnable.type) {
+      case 'test':
+        suffix = ''; break;
+      case 'beforeAll':
+      case 'beforeEach':
+      case 'afterAll':
+      case 'afterEach':
+        suffix = ` in ${this._runnable.type} hook`; break;
+      case 'teardown':
+        suffix = ` in fixtures teardown`; break;
+      case 'skip':
+      case 'slow':
+      case 'fixme':
+      case 'fail':
+        suffix = ` in ${this._runnable.type} modifier`; break;
+    }
+    if (this._fixture && this._fixture.slot)
+      suffix = ` in fixture "${this._fixture.fixture}"`;
+    const message = colors.red(`Timeout of ${this._currentSlot().timeout}ms exceeded${suffix}.`);
+    const location = (this._fixture || this._runnable).location;
+    return {
+      message,
+      // Include location for hooks, modifiers and fixtures to distinguish between them.
+      stack: location ? message + `\n    at ${location.file}:${location.line}:${location.column}` : undefined,
+    };
+  }
+}

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -2533,7 +2533,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    */
   slow(callback: (args: TestArgs & WorkerArgs) => boolean, description: string): void;
   /**
-   * Changes the timeout for the test. Learn more about [various timeouts](https://playwright.dev/docs/test-timeouts).
+   * Changes the timeout for the test. Zero means no timeout. Learn more about [various timeouts](https://playwright.dev/docs/test-timeouts).
    *
    * ```ts
    * import { test, expect } from '@playwright/test';
@@ -2797,13 +2797,13 @@ export type WorkerFixture<R, Args extends KeyValue> = (args: Args, use: (r: R) =
 type TestFixtureValue<R, Args> = Exclude<R, Function> | TestFixture<R, Args>;
 type WorkerFixtureValue<R, Args> = Exclude<R, Function> | WorkerFixture<R, Args>;
 export type Fixtures<T extends KeyValue = {}, W extends KeyValue = {}, PT extends KeyValue = {}, PW extends KeyValue = {}> = {
-  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker' }];
+  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker', timeout?: number | undefined }];
 } & {
-  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test' }];
+  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined }];
 } & {
-  [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean }];
+  [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined }];
 } & {
-  [K in keyof T]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean }];
+  [K in keyof T]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';

--- a/tests/playwright-test/fixture-errors.spec.ts
+++ b/tests/playwright-test/fixture-errors.spec.ts
@@ -456,7 +456,7 @@ test('should not report fixture teardown error twice', async ({ runInlineTest })
   expect(countTimes(stripAnsi(result.output), 'Oh my error')).toBe(2);
 });
 
-test('should not report fixture teardown timeout twice', async ({ runInlineTest }) => {
+test.fixme('should not report fixture teardown timeout twice', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.ts': `
       const test = pwt.test.extend({
@@ -471,8 +471,8 @@ test('should not report fixture teardown timeout twice', async ({ runInlineTest 
   }, { reporter: 'list', timeout: 1000 });
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.output).toContain('while shutting down environment');
-  expect(countTimes(result.output, 'while shutting down environment')).toBe(1);
+  expect(result.output).toContain('in fixtures teardown');
+  expect(countTimes(result.output, 'in fixtures teardown')).toBe(1);
 });
 
 test('should handle fixture teardown error after test timeout and continue', async ({ runInlineTest }) => {

--- a/tests/playwright-test/timeout.spec.ts
+++ b/tests/playwright-test/timeout.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect } from './playwright-test-fixtures';
+import { test, expect, stripAnsi } from './playwright-test-fixtures';
 
 test('should run fixture teardown on timeout', async ({ runInlineTest }) => {
   const result = await runInlineTest({
@@ -144,8 +144,14 @@ test('should respect test.slow', async ({ runInlineTest }) => {
 test('should ignore test.setTimeout when debugging', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.ts': `
-      const { test } = pwt;
-      test('my test', async ({}) => {
+      const test = pwt.test.extend({
+        fixture: async ({}, use) => {
+          test.setTimeout(100);
+          await new Promise(f => setTimeout(f, 200));
+          await use('hey');
+        },
+      });
+      test('my test', async ({ fixture }) => {
         test.setTimeout(1000);
         await new Promise(f => setTimeout(f, 2000));
       });
@@ -153,4 +159,150 @@ test('should ignore test.setTimeout when debugging', async ({ runInlineTest }) =
   }, { timeout: 0 });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
+});
+
+test('should respect fixture timeout', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const test = pwt.test.extend({
+        fixture: [async ({}, use) => {
+          await new Promise(f => setTimeout(f, 300));
+          await use('hey');
+          await new Promise(f => setTimeout(f, 300));
+        }, { timeout: 1000 }],
+        noTimeout: [async ({}, use) => {
+          await new Promise(f => setTimeout(f, 300));
+          await use('hey');
+          await new Promise(f => setTimeout(f, 300));
+        }, { timeout: 0 }],
+        slowSetup: [async ({}, use) => {
+          await new Promise(f => setTimeout(f, 2000));
+          await use('hey');
+        }, { timeout: 500 }],
+        slowTeardown: [async ({}, use) => {
+          await use('hey');
+          await new Promise(f => setTimeout(f, 2000));
+        }, { timeout: 400 }],
+      });
+      test('test ok', async ({ fixture, noTimeout }) => {
+        await new Promise(f => setTimeout(f, 1000));
+      });
+      test('test setup', async ({ slowSetup }) => {
+      });
+      test('test teardown', async ({ slowTeardown }) => {
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(2);
+  expect(result.output).toContain('Timeout of 500ms exceeded in fixture "slowSetup"');
+  expect(result.output).toContain('Timeout of 400ms exceeded in fixture "slowTeardown"');
+  expect(stripAnsi(result.output)).toContain('> 5 |       const test = pwt.test.extend({');
+});
+
+test('should respect test.setTimeout in the worker fixture', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const test = pwt.test.extend({
+        fixture: [async ({}, use) => {
+          await new Promise(f => setTimeout(f, 300));
+          await use('hey');
+          await new Promise(f => setTimeout(f, 300));
+        }, { scope: 'worker', timeout: 1000 }],
+        noTimeout: [async ({}, use) => {
+          await new Promise(f => setTimeout(f, 300));
+          await use('hey');
+          await new Promise(f => setTimeout(f, 300));
+        }, { scope: 'worker', timeout: 0 }],
+        slowSetup: [async ({}, use) => {
+          await new Promise(f => setTimeout(f, 2000));
+          await use('hey');
+        }, { scope: 'worker', timeout: 500 }],
+        slowTeardown: [async ({}, use) => {
+          await use('hey');
+          await new Promise(f => setTimeout(f, 2000));
+        }, { scope: 'worker', timeout: 400 }],
+      });
+      test('test ok', async ({ fixture, noTimeout }) => {
+        await new Promise(f => setTimeout(f, 1000));
+      });
+      test('test setup', async ({ slowSetup }) => {
+      });
+      test('test teardown', async ({ slowTeardown }) => {
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(2);
+  expect(result.failed).toBe(1);
+  expect(result.output).toContain('Timeout of 500ms exceeded in fixture "slowSetup"');
+  expect(result.output).toContain('Timeout of 400ms exceeded in fixture "slowTeardown"');
+});
+
+test('fixture time in beforeAll hook should not affect test', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const test = pwt.test.extend({
+        fixture: async ({}, use) => {
+          await new Promise(f => setTimeout(f, 500));
+          await use('hey');
+        },
+      });
+      test.beforeAll(async ({ fixture }) => {
+        // Nothing to see here.
+      });
+      test('test ok', async ({}) => {
+        test.setTimeout(1000);
+        await new Promise(f => setTimeout(f, 800));
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
+test('fixture timeout in beforeAll hook should not affect test', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const test = pwt.test.extend({
+        fixture: [async ({}, use) => {
+          await new Promise(f => setTimeout(f, 500));
+          await use('hey');
+        }, { timeout: 800 }],
+      });
+      test.beforeAll(async ({ fixture }) => {
+        // Nothing to see here.
+      });
+      test('test ok', async ({}) => {
+        test.setTimeout(1000);
+        await new Promise(f => setTimeout(f, 800));
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
+test('fixture time in beforeEach hook should affect test', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const test = pwt.test.extend({
+        fixture: async ({}, use) => {
+          await new Promise(f => setTimeout(f, 500));
+          await use('hey');
+        },
+      });
+      test.beforeEach(async ({ fixture }) => {
+        // Nothing to see here.
+      });
+      test('test ok', async ({}) => {
+        test.setTimeout(1000);
+        await new Promise(f => setTimeout(f, 800));
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.output).toContain('Timeout of 1000ms exceeded');
 });

--- a/tests/playwright-test/types.spec.ts
+++ b/tests/playwright-test/types.spec.ts
@@ -22,7 +22,7 @@ test('should check types of fixtures', async ({ runTSC }) => {
       export type MyOptions = { foo: string, bar: number };
       export const test = pwt.test.extend<{ foo: string }, { bar: number }>({
         foo: 'foo',
-        bar: [ 42, { scope: 'worker' } ],
+        bar: [ 42, { scope: 'worker', timeout: 123 } ],
       });
 
       const good1 = test.extend<{}>({ foo: async ({ bar }, run) => run('foo') });
@@ -35,7 +35,7 @@ test('should check types of fixtures', async ({ runTSC }) => {
         foo: async ({ baz }, run) => run('foo')
       });
       const good7 = test.extend<{ baz: boolean }>({
-        baz: [ false, { auto: true } ],
+        baz: [ false, { auto: true, timeout: 0 } ],
       });
       const good8 = test.extend<{ foo: string }>({
         foo: [ async ({}, use) => {
@@ -81,6 +81,12 @@ test('should check types of fixtures', async ({ runTSC }) => {
           await use(42);
         // @ts-expect-error
         }, { scope: 'test' } ],
+      });
+      const fail11 = test.extend<{ yay: string }>({
+        yay: [ async ({}, use) => {
+          await use('foo');
+        // @ts-expect-error
+        }, { scope: 'test', timeout: 'str' } ],
       });
 
       type AssertNotAny<S> = {notRealProperty: number} extends S ? false : true;

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -334,13 +334,13 @@ export type WorkerFixture<R, Args extends KeyValue> = (args: Args, use: (r: R) =
 type TestFixtureValue<R, Args> = Exclude<R, Function> | TestFixture<R, Args>;
 type WorkerFixtureValue<R, Args> = Exclude<R, Function> | WorkerFixture<R, Args>;
 export type Fixtures<T extends KeyValue = {}, W extends KeyValue = {}, PT extends KeyValue = {}, PW extends KeyValue = {}> = {
-  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker' }];
+  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker', timeout?: number | undefined }];
 } & {
-  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test' }];
+  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined }];
 } & {
-  [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean }];
+  [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined }];
 } & {
-  [K in keyof T]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean }];
+  [K in keyof T]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';


### PR DESCRIPTION
By default, fixtures share timeout with the test they are instantiated for. However, for more heavy fixtures, especially worker-scoped ones, it makes sense to have a separate timeout.

This introduces `{ timeout: number }` option to the list of fixture options that opts the fixture into a dedicated timeout rather than sharing it with the test.