### PR TITLE
fix(test-runner): use `configDir` for base in `screenshotsDir` and `outputDir`

### DIFF
--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -20,7 +20,7 @@ import type { Config, TestStatus } from './types';
 export type SerializedLoaderData = {
   defaultConfig: Config;
   overrides: Config;
-  configFile: { file: string } | { rootDir: string };
+  configFile: { file: string } | { configDir: string };
 };
 export type WorkerInitParams = {
   workerIndex: number;

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -1179,6 +1179,7 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
    */
   reportSlowTests: ReportSlowTests;
   rootDir: string;
+  configDir: string;
   /**
    * Whether to suppress stdio and stderr output from the tests.
    */


### PR DESCRIPTION
Turns out `fullConfig.rootDir` is a `testDir` in fact; many places
in our source didn't expect this. Instead, what we want is to have
a `configDir`.

This patch:
- introduces `fullConfig.configDir` that points to the `configDir`
- starts using `configDir` as a default base for `outputDir` and
  `screenshotsDir`
