### PR TITLE
devops: use xcode 12 on macOS 11 for webkit

### DIFF
--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -48,7 +48,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   if [[ "${CURRENT_HOST_OS_VERSION}" == "10.15" ]]; then
     selectXcodeVersionOrDie "11.7"
   elif [[ "${CURRENT_HOST_OS_VERSION}" == "11."* ]]; then
-    selectXcodeVersionOrDie "13.2"
+    selectXcodeVersionOrDie "12.5"
   elif [[ "${CURRENT_HOST_OS_VERSION}" == "12."* ]]; then
     selectXcodeVersionOrDie "13.2"
   else


### PR DESCRIPTION
This is what is used [upstream](https://build.webkit.org/#/builders/29/builds/11174/steps/2/logs/stdio), otherwise we get an error that lib ANGLE was built for macOS 12.1

#12739