### PR TITLE
devops: move everyone to use xcode 13.2

### DIFF
--- a/browser_patches/ffmpeg/build-mac.sh
+++ b/browser_patches/ffmpeg/build-mac.sh
@@ -33,7 +33,7 @@ if [[ "${CURRENT_HOST_OS_VERSION}" == "10."* ]]; then
   echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"
   exit 1
 else
-  selectXcodeVersionOrDie "13"
+  selectXcodeVersionOrDie "13.2"
 fi
 
 source ./CONFIG.sh

--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -24,7 +24,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   CURRENT_HOST_OS_VERSION=$(getMacVersion)
   # As of Oct 2021, building Firefox requires XCode 13
   if [[ "${CURRENT_HOST_OS_VERSION}" != "10."* ]]; then
-    selectXcodeVersionOrDie "13"
+    selectXcodeVersionOrDie "13.2"
   else
     echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"
     exit 1

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -24,7 +24,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   CURRENT_HOST_OS_VERSION=$(getMacVersion)
   # As of Oct 2021, building Firefox requires XCode 13
   if [[ "${CURRENT_HOST_OS_VERSION}" != "10."* ]]; then
-    selectXcodeVersionOrDie "13"
+    selectXcodeVersionOrDie "13.2"
   else
     echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"
     exit 1


### PR DESCRIPTION
We don't have too much free space on bots so we have to align
on some set of Xcode's.
