### PR TITLE
fix(test-runner): improve documentation for `rootDir`

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -256,7 +256,7 @@ Any JSON-serializable metadata that will be put directly to the test report.
 ## property: TestConfig.outputDir
 - type: <[string]>
 
-The output directory for files created during test execution. Defaults to `test-results`.
+The output directory for files created during test execution. Defaults to `<rootDir>/test-results`.
 
 ```js js-flavor=js
 // playwright.config.js
@@ -310,7 +310,7 @@ test('example test', async ({}, testInfo) => {
 The base directory, relative to the config file, for screenshot files created with `toHaveScreenshot`. Defaults to
 
 ```
-<directory-of-configuration-file>/__screenshots__/<platform name>/<project name>
+<rootDir>/__screenshots__/<platform name>/<project name>
 ```
 
 This path will serve as the base directory for each test file screenshot directory. For example, the following test structure:
@@ -454,6 +454,35 @@ export default config;
 Shard tests and execute only the selected shard. Specify in the one-based form like `{ total: 5, current: 2 }`.
 
 Learn more about [parallelism and sharding](./test-parallel.md) with Playwright Test.
+
+## property: TestConfig.rootDir
+- type: <[string]>
+
+All test paths will be shown relative to this dir. `rootDir` also affects the following defaults:
+- [`property: TestConfig.outputDir`] defaults to `<rootDir>/test-results`
+- [`property: TestConfig.screenshotsDir`] defaults to `<rootDir>/__screenshots__/<platform>/<project>`
+
+```js js-flavor=js
+// playwright.config.js
+// @ts-check
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  rootDir: './',
+};
+
+module.exports = config;
+```
+
+```js js-flavor=ts
+// playwright.config.ts
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  rootDir: './',
+};
+export default config;
+```
 
 ## property: TestConfig.testDir
 - type: <[string]>

--- a/tests/config/android.config.ts
+++ b/tests/config/android.config.ts
@@ -26,6 +26,7 @@ process.env.PWPAGE_IMPL = 'android';
 const outputDir = path.join(__dirname, '..', '..', 'test-results');
 const testDir = path.join(__dirname, '..');
 const config: Config<ServerWorkerOptions & PlaywrightWorkerOptions & PlaywrightTestOptions> = {
+  rootDir: path.join(__dirname, '..', '..'),
   testDir,
   outputDir,
   timeout: 120000,

--- a/tests/config/default.playwright.config.ts
+++ b/tests/config/default.playwright.config.ts
@@ -44,6 +44,7 @@ const trace = !!process.env.PWTEST_TRACE;
 const outputDir = path.join(__dirname, '..', '..', 'test-results');
 const testDir = path.join(__dirname, '..');
 const config: Config<CoverageWorkerOptions & PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeWorkerOptions> = {
+  rootDir: path.join(__dirname, '..', '..');
   testDir,
   outputDir,
   expect: {

--- a/tests/config/electron.config.ts
+++ b/tests/config/electron.config.ts
@@ -26,6 +26,7 @@ process.env.PWPAGE_IMPL = 'electron';
 const outputDir = path.join(__dirname, '..', '..', 'test-results');
 const testDir = path.join(__dirname, '..');
 const config: Config<CoverageWorkerOptions & PlaywrightWorkerOptions & PlaywrightTestOptions> = {
+  rootDir: path.join(__dirname, '..', '..'),
   testDir,
   outputDir,
   timeout: 30000,


### PR DESCRIPTION
Drive-by: fix playwright configs to correctly specify `rootDir`.
