### PR TITLE
feat(test-runner): introduce `rootDir` configuration option

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -256,7 +256,7 @@ Any JSON-serializable metadata that will be put directly to the test report.
 ## property: TestConfig.outputDir
 - type: <[string]>
 
-The output directory for files created during test execution. Defaults to `test-results`.
+The output directory for files created during test execution. Defaults to `<rootDir>/test-results`.
 
 ```js js-flavor=js
 // playwright.config.js
@@ -310,7 +310,7 @@ test('example test', async ({}, testInfo) => {
 The base directory, relative to the config file, for screenshot files created with `toHaveScreenshot`. Defaults to
 
 ```
-<directory-of-configuration-file>/__screenshots__/<platform name>/<project name>
+<rootDir>/__screenshots__/<platform name>/<project name>
 ```
 
 This path will serve as the base directory for each test file screenshot directory. For example, the following test structure:
@@ -455,10 +455,40 @@ Shard tests and execute only the selected shard. Specify in the one-based form l
 
 Learn more about [parallelism and sharding](./test-parallel.md) with Playwright Test.
 
+## property: TestConfig.rootDir
+- type: <[string]>
+
+All test paths will be shown relative to this dir. `rootDir` also affects the following defaults:
+* [`property: TestConfig.outputDir`] defaults to `<rootDir>/test-results`
+* [`property: TestConfig.screenshotsDir`] defaults to `<rootDir>/__screenshots__/<platform>/<project>`
+* [`property: TestConfig.testDir`] defaults to `<rootDir>`
+
+```js js-flavor=js
+// playwright.config.js
+// @ts-check
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  rootDir: './',
+};
+
+module.exports = config;
+```
+
+```js js-flavor=ts
+// playwright.config.ts
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  rootDir: './',
+};
+export default config;
+```
+
 ## property: TestConfig.testDir
 - type: <[string]>
 
-Directory that will be recursively scanned for test files. Defaults to the directory of the configuration file.
+Directory that will be recursively scanned for test files. Defaults to [`property: TestConfig.rootDir`].
 
 ```js js-flavor=js
 // playwright.config.js

--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -20,7 +20,7 @@ import type { Config, TestStatus } from './types';
 export type SerializedLoaderData = {
   defaultConfig: Config;
   overrides: Config;
-  configFile: { file: string } | { rootDir: string };
+  configFile: { file: string } | { configDir: string };
 };
 export type WorkerInitParams = {
   workerIndex: number;

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -37,7 +37,7 @@ export class Loader {
   private _defaultConfig: Config;
   private _configOverrides: Config;
   private _fullConfig: FullConfig;
-  private _config: Config = {};
+  private _configDir: string = '';
   private _configFile: string | undefined;
   private _projects: ProjectImpl[] = [];
 
@@ -52,7 +52,7 @@ export class Loader {
     if ('file' in data.configFile)
       await loader.loadConfigFile(data.configFile.file);
     else
-      loader.loadEmptyConfig(data.configFile.rootDir);
+      loader.loadEmptyConfig(data.configFile.configDir);
     return loader;
   }
 
@@ -62,55 +62,62 @@ export class Loader {
     let config = await this._requireOrImport(file);
     if (config && typeof config === 'object' && ('default' in config))
       config = config['default'];
-    this._config = config;
     this._configFile = file;
     const rawConfig = { ...config };
-    this._processConfigObject(path.dirname(file));
+    this._processConfigObject(config, path.dirname(file));
     return rawConfig;
   }
 
-  loadEmptyConfig(rootDir: string): Config {
-    this._config = {};
-    this._processConfigObject(rootDir);
+  loadEmptyConfig(configDir: string): Config {
+    this._processConfigObject({}, configDir);
     return {};
   }
 
-  private _processConfigObject(rootDir: string) {
-    validateConfig(this._configFile || '<default config>', this._config);
+  private _processConfigObject(config: Config, configDir: string) {
+    this._configDir = configDir;
+    validateConfig(this._configFile || '<default config>', config);
 
     // Resolve script hooks relative to the root dir.
-    if (this._config.globalSetup)
-      this._config.globalSetup = resolveScript(this._config.globalSetup, rootDir);
-    if (this._config.globalTeardown)
-      this._config.globalTeardown = resolveScript(this._config.globalTeardown, rootDir);
+    if (config.globalSetup)
+      config.globalSetup = resolveScript(config.globalSetup, configDir);
+    if (config.globalTeardown)
+      config.globalTeardown = resolveScript(config.globalTeardown, configDir);
+    // Resolve all config dirs relative to configDir.
+    if (config.rootDir !== undefined)
+      config.rootDir = path.resolve(configDir, config.rootDir);
+    if (config.testDir !== undefined)
+      config.testDir = path.resolve(configDir, config.testDir);
+    if (config.outputDir !== undefined)
+      config.outputDir = path.resolve(configDir, config.outputDir);
+    if (config.screenshotsDir !== undefined)
+      config.screenshotsDir = path.resolve(configDir, config.screenshotsDir);
+    if (config.snapshotDir !== undefined)
+      config.snapshotDir = path.resolve(configDir, config.snapshotDir);
 
-    const configUse = mergeObjects(this._defaultConfig.use, this._config.use);
-    this._config = mergeObjects(mergeObjects(this._defaultConfig, this._config), { use: configUse });
+    const configUse = mergeObjects(this._defaultConfig.use, config.use);
+    config = mergeObjects(mergeObjects(this._defaultConfig, config), { use: configUse });
 
-    if (this._config.testDir !== undefined)
-      this._config.testDir = path.resolve(rootDir, this._config.testDir);
-    const projects: Project[] = ('projects' in this._config) && this._config.projects !== undefined ? this._config.projects : [this._config];
+    this._fullConfig.rootDir = takeFirst(this._configOverrides.rootDir, config.rootDir, configDir);
+    this._fullConfig.forbidOnly = takeFirst(this._configOverrides.forbidOnly, config.forbidOnly, baseFullConfig.forbidOnly);
+    this._fullConfig.fullyParallel = takeFirst(this._configOverrides.fullyParallel, config.fullyParallel, baseFullConfig.fullyParallel);
+    this._fullConfig.globalSetup = takeFirst(this._configOverrides.globalSetup, config.globalSetup, baseFullConfig.globalSetup);
+    this._fullConfig.globalTeardown = takeFirst(this._configOverrides.globalTeardown, config.globalTeardown, baseFullConfig.globalTeardown);
+    this._fullConfig.globalTimeout = takeFirst(this._configOverrides.globalTimeout, this._configOverrides.globalTimeout, config.globalTimeout, baseFullConfig.globalTimeout);
+    this._fullConfig.grep = takeFirst(this._configOverrides.grep, config.grep, baseFullConfig.grep);
+    this._fullConfig.grepInvert = takeFirst(this._configOverrides.grepInvert, config.grepInvert, baseFullConfig.grepInvert);
+    this._fullConfig.maxFailures = takeFirst(this._configOverrides.maxFailures, config.maxFailures, baseFullConfig.maxFailures);
+    this._fullConfig.preserveOutput = takeFirst<PreserveOutput>(this._configOverrides.preserveOutput, config.preserveOutput, baseFullConfig.preserveOutput);
+    this._fullConfig.reporter = takeFirst(toReporters(this._configOverrides.reporter as any), resolveReporters(config.reporter, configDir), baseFullConfig.reporter);
+    this._fullConfig.reportSlowTests = takeFirst(this._configOverrides.reportSlowTests, config.reportSlowTests, baseFullConfig.reportSlowTests);
+    this._fullConfig.quiet = takeFirst(this._configOverrides.quiet, config.quiet, baseFullConfig.quiet);
+    this._fullConfig.shard = takeFirst(this._configOverrides.shard, config.shard, baseFullConfig.shard);
+    this._fullConfig.updateSnapshots = takeFirst(this._configOverrides.updateSnapshots, config.updateSnapshots, baseFullConfig.updateSnapshots);
+    this._fullConfig.workers = takeFirst(this._configOverrides.workers, config.workers, baseFullConfig.workers);
+    this._fullConfig.webServer = takeFirst(this._configOverrides.webServer, config.webServer, baseFullConfig.webServer);
 
-    this._fullConfig.rootDir = this._config.testDir || rootDir;
-    this._fullConfig.forbidOnly = takeFirst(this._configOverrides.forbidOnly, this._config.forbidOnly, baseFullConfig.forbidOnly);
-    this._fullConfig.fullyParallel = takeFirst(this._configOverrides.fullyParallel, this._config.fullyParallel, baseFullConfig.fullyParallel);
-    this._fullConfig.globalSetup = takeFirst(this._configOverrides.globalSetup, this._config.globalSetup, baseFullConfig.globalSetup);
-    this._fullConfig.globalTeardown = takeFirst(this._configOverrides.globalTeardown, this._config.globalTeardown, baseFullConfig.globalTeardown);
-    this._fullConfig.globalTimeout = takeFirst(this._configOverrides.globalTimeout, this._configOverrides.globalTimeout, this._config.globalTimeout, baseFullConfig.globalTimeout);
-    this._fullConfig.grep = takeFirst(this._configOverrides.grep, this._config.grep, baseFullConfig.grep);
-    this._fullConfig.grepInvert = takeFirst(this._configOverrides.grepInvert, this._config.grepInvert, baseFullConfig.grepInvert);
-    this._fullConfig.maxFailures = takeFirst(this._configOverrides.maxFailures, this._config.maxFailures, baseFullConfig.maxFailures);
-    this._fullConfig.preserveOutput = takeFirst<PreserveOutput>(this._configOverrides.preserveOutput, this._config.preserveOutput, baseFullConfig.preserveOutput);
-    this._fullConfig.reporter = takeFirst(toReporters(this._configOverrides.reporter as any), resolveReporters(this._config.reporter, rootDir), baseFullConfig.reporter);
-    this._fullConfig.reportSlowTests = takeFirst(this._configOverrides.reportSlowTests, this._config.reportSlowTests, baseFullConfig.reportSlowTests);
-    this._fullConfig.quiet = takeFirst(this._configOverrides.quiet, this._config.quiet, baseFullConfig.quiet);
-    this._fullConfig.shard = takeFirst(this._configOverrides.shard, this._config.shard, baseFullConfig.shard);
-    this._fullConfig.updateSnapshots = takeFirst(this._configOverrides.updateSnapshots, this._config.updateSnapshots, baseFullConfig.updateSnapshots);
-    this._fullConfig.workers = takeFirst(this._configOverrides.workers, this._config.workers, baseFullConfig.workers);
-    this._fullConfig.webServer = takeFirst(this._configOverrides.webServer, this._config.webServer, baseFullConfig.webServer);
-
+    const projects: Project[] = ('projects' in config) && config.projects !== undefined ? config.projects : [config];
     for (const project of projects)
-      this._addProject(project, this._fullConfig.rootDir, rootDir);
+      this._addProject(config, project, this._fullConfig.rootDir);
     this._fullConfig.projects = this._projects.map(p => p.config);
   }
 
@@ -187,46 +194,47 @@ export class Loader {
   serialize(): SerializedLoaderData {
     return {
       defaultConfig: this._defaultConfig,
-      configFile: this._configFile ? { file: this._configFile } : { rootDir: this._fullConfig.rootDir },
+      configFile: this._configFile ? { file: this._configFile } : { configDir: this._configDir },
       overrides: this._configOverrides,
     };
   }
 
-  private _addProject(projectConfig: Project, rootDir: string, configDir: string) {
-    let testDir = takeFirst(projectConfig.testDir, rootDir);
-    if (!path.isAbsolute(testDir))
-      testDir = path.resolve(configDir, testDir);
-    let outputDir = takeFirst(this._configOverrides.outputDir, projectConfig.outputDir, this._config.outputDir, path.resolve(rootDir, 'test-results'));
-    if (!path.isAbsolute(outputDir))
-      outputDir = path.resolve(configDir, outputDir);
-    let snapshotDir = takeFirst(this._configOverrides.snapshotDir, projectConfig.snapshotDir, this._config.snapshotDir, testDir);
-    if (!path.isAbsolute(snapshotDir))
-      snapshotDir = path.resolve(configDir, snapshotDir);
-    const name = takeFirst(this._configOverrides.name, projectConfig.name, this._config.name, '');
-    let screenshotsDir = takeFirst(this._configOverrides.screenshotsDir, projectConfig.screenshotsDir, this._config.screenshotsDir, path.join(rootDir, '__screenshots__', process.platform, name));
-    if (!path.isAbsolute(screenshotsDir))
-      screenshotsDir = path.resolve(configDir, screenshotsDir);
+  private _addProject(config: Config, projectConfig: Project, rootDir: string) {
+    // Resolve all config dirs relative to configDir.
+    if (projectConfig.testDir !== undefined)
+      projectConfig.testDir = path.resolve(this._configDir, projectConfig.testDir);
+    if (projectConfig.outputDir !== undefined)
+      projectConfig.outputDir = path.resolve(this._configDir, projectConfig.outputDir);
+    if (projectConfig.screenshotsDir !== undefined)
+      projectConfig.screenshotsDir = path.resolve(this._configDir, projectConfig.screenshotsDir);
+    if (projectConfig.snapshotDir !== undefined)
+      projectConfig.snapshotDir = path.resolve(this._configDir, projectConfig.snapshotDir);
+
+    const testDir = takeFirst(this._configOverrides.testDir, projectConfig.testDir, config.testDir, rootDir);
+    const outputDir = takeFirst(this._configOverrides.outputDir, projectConfig.outputDir, config.outputDir, path.join(rootDir, 'test-results'));
+    const snapshotDir = takeFirst(this._configOverrides.snapshotDir, projectConfig.snapshotDir, config.snapshotDir, testDir);
+    const name = takeFirst(this._configOverrides.name, projectConfig.name, config.name, '');
+    const screenshotsDir = takeFirst(this._configOverrides.screenshotsDir, projectConfig.screenshotsDir, config.screenshotsDir, path.join(rootDir, '__screenshots__', process.platform, name));
     const fullProject: FullProject = {
-      fullyParallel: takeFirst(this._configOverrides.fullyParallel, projectConfig.fullyParallel, this._config.fullyParallel, undefined),
-      expect: takeFirst(this._configOverrides.expect, projectConfig.expect, this._config.expect, undefined),
-      grep: takeFirst(this._configOverrides.grep, projectConfig.grep, this._config.grep, baseFullConfig.grep),
-      grepInvert: takeFirst(this._configOverrides.grepInvert, projectConfig.grepInvert, this._config.grepInvert, baseFullConfig.grepInvert),
+      fullyParallel: takeFirst(this._configOverrides.fullyParallel, projectConfig.fullyParallel, config.fullyParallel, undefined),
+      expect: takeFirst(this._configOverrides.expect, projectConfig.expect, config.expect, undefined),
+      grep: takeFirst(this._configOverrides.grep, projectConfig.grep, config.grep, baseFullConfig.grep),
+      grepInvert: takeFirst(this._configOverrides.grepInvert, projectConfig.grepInvert, config.grepInvert, baseFullConfig.grepInvert),
       outputDir,
-      repeatEach: takeFirst(this._configOverrides.repeatEach, projectConfig.repeatEach, this._config.repeatEach, 1),
-      retries: takeFirst(this._configOverrides.retries, projectConfig.retries, this._config.retries, 0),
-      metadata: takeFirst(this._configOverrides.metadata, projectConfig.metadata, this._config.metadata, undefined),
+      repeatEach: takeFirst(this._configOverrides.repeatEach, projectConfig.repeatEach, config.repeatEach, 1),
+      retries: takeFirst(this._configOverrides.retries, projectConfig.retries, config.retries, 0),
+      metadata: takeFirst(this._configOverrides.metadata, projectConfig.metadata, config.metadata, undefined),
       name,
       testDir,
       snapshotDir,
       screenshotsDir,
-      testIgnore: takeFirst(this._configOverrides.testIgnore, projectConfig.testIgnore, this._config.testIgnore, []),
-      testMatch: takeFirst(this._configOverrides.testMatch, projectConfig.testMatch, this._config.testMatch, '**/?(*.)@(spec|test).*'),
-      timeout: takeFirst(this._configOverrides.timeout, projectConfig.timeout, this._config.timeout, 10000),
-      use: mergeObjects(mergeObjects(this._config.use, projectConfig.use), this._configOverrides.use),
+      testIgnore: takeFirst(this._configOverrides.testIgnore, projectConfig.testIgnore, config.testIgnore, []),
+      testMatch: takeFirst(this._configOverrides.testMatch, projectConfig.testMatch, config.testMatch, '**/?(*.)@(spec|test).*'),
+      timeout: takeFirst(this._configOverrides.timeout, projectConfig.timeout, config.timeout, 10000),
+      use: mergeObjects(mergeObjects(config.use, projectConfig.use), this._configOverrides.use),
     };
     this._projects.push(new ProjectImpl(fullProject, this._projects.length));
   }
-
 
   private async _requireOrImport(file: string) {
     const revertBabelRequire = installTransform();

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -796,7 +796,7 @@ interface TestConfig {
    * The base directory, relative to the config file, for screenshot files created with `toHaveScreenshot`. Defaults to
    *
    * ```
-   * <directory-of-configuration-file>/__screenshots__/<platform name>/<project name>
+   * <rootDir>/__screenshots__/<platform name>/<project name>
    * ```
    *
    * This path will serve as the base directory for each test file screenshot directory. For example, the following test
@@ -828,7 +828,7 @@ interface TestConfig {
    */
   screenshotsDir?: string;
   /**
-   * The output directory for files created during test execution. Defaults to `test-results`.
+   * The output directory for files created during test execution. Defaults to `<rootDir>/test-results`.
    *
    * ```ts
    * // playwright.config.ts
@@ -883,7 +883,8 @@ interface TestConfig {
    */
   retries?: number;
   /**
-   * Directory that will be recursively scanned for test files. Defaults to the directory of the configuration file.
+   * Directory that will be recursively scanned for test files. Defaults to
+   * [testConfig.rootDir](https://playwright.dev/docs/api/class-testconfig#test-config-root-dir).
    *
    * ```ts
    * // playwright.config.ts
@@ -897,6 +898,26 @@ interface TestConfig {
    *
    */
   testDir?: string;
+  /**
+   * All test paths will be shown relative to this dir. `rootDir` also affects the following defaults:
+   * - [testConfig.outputDir](https://playwright.dev/docs/api/class-testconfig#test-config-output-dir) defaults to
+   *   `<rootDir>/test-results`
+   * - [testConfig.screenshotsDir](https://playwright.dev/docs/api/class-testconfig#test-config-screenshots-dir) defaults
+   *   to `<rootDir>/__screenshots__/<platform>/<project>`
+   * - [testConfig.testDir](https://playwright.dev/docs/api/class-testconfig#test-config-test-dir) defaults to `<rootDir>`
+   *
+   * ```ts
+   * // playwright.config.ts
+   * import { PlaywrightTestConfig } from '@playwright/test';
+   *
+   * const config: PlaywrightTestConfig = {
+   *   rootDir: './',
+   * };
+   * export default config;
+   * ```
+   *
+   */
+  rootDir?: string;
   /**
    * Files matching one of these patterns are not executed as test files. Matching is performed against the absolute file
    * path. Strings are treated as glob patterns.
@@ -1178,6 +1199,25 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
    * than `max` number of them. Passing zero as `max` reports all test files that exceed the threshold.
    */
   reportSlowTests: ReportSlowTests;
+  /**
+   * All test paths will be shown relative to this dir. `rootDir` also affects the following defaults:
+   * - [testConfig.outputDir](https://playwright.dev/docs/api/class-testconfig#test-config-output-dir) defaults to
+   *   `<rootDir>/test-results`
+   * - [testConfig.screenshotsDir](https://playwright.dev/docs/api/class-testconfig#test-config-screenshots-dir) defaults
+   *   to `<rootDir>/__screenshots__/<platform>/<project>`
+   * - [testConfig.testDir](https://playwright.dev/docs/api/class-testconfig#test-config-test-dir) defaults to `<rootDir>`
+   *
+   * ```ts
+   * // playwright.config.ts
+   * import { PlaywrightTestConfig } from '@playwright/test';
+   *
+   * const config: PlaywrightTestConfig = {
+   *   rootDir: './',
+   * };
+   * export default config;
+   * ```
+   *
+   */
   rootDir: string;
   /**
    * Whether to suppress stdio and stderr output from the tests.

--- a/tests/config/android.config.ts
+++ b/tests/config/android.config.ts
@@ -26,6 +26,7 @@ process.env.PWPAGE_IMPL = 'android';
 const outputDir = path.join(__dirname, '..', '..', 'test-results');
 const testDir = path.join(__dirname, '..');
 const config: Config<ServerWorkerOptions & PlaywrightWorkerOptions & PlaywrightTestOptions> = {
+  rootDir: path.join(__dirname, '..', '..'),
   testDir,
   outputDir,
   timeout: 120000,

--- a/tests/config/default.playwright.config.ts
+++ b/tests/config/default.playwright.config.ts
@@ -44,6 +44,7 @@ const trace = !!process.env.PWTEST_TRACE;
 const outputDir = path.join(__dirname, '..', '..', 'test-results');
 const testDir = path.join(__dirname, '..');
 const config: Config<CoverageWorkerOptions & PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeWorkerOptions> = {
+  rootDir: path.join('..', '..'),
   testDir,
   outputDir,
   expect: {

--- a/tests/config/electron.config.ts
+++ b/tests/config/electron.config.ts
@@ -26,6 +26,7 @@ process.env.PWPAGE_IMPL = 'electron';
 const outputDir = path.join(__dirname, '..', '..', 'test-results');
 const testDir = path.join(__dirname, '..');
 const config: Config<CoverageWorkerOptions & PlaywrightWorkerOptions & PlaywrightTestOptions> = {
+  rootDir: path.join(__dirname, '..', '..'),
   testDir,
   outputDir,
   timeout: 30000,

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -95,7 +95,7 @@ test('should read config from --config, resolve relative testDir', async ({ runI
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
   expect(result.report.suites.length).toBe(1);
-  expect(result.report.suites[0].file).toBe('b.test.ts');
+  expect(result.report.suites[0].file).toBe(path.join('dir', '/b.test.ts'));
 });
 
 test('should default testDir to the config file', async ({ runInlineTest }) => {
@@ -203,7 +203,7 @@ test('should allow root testDir and use it for relative paths', async ({ runInli
   expect(result.passed).toBe(0);
   expect(result.skipped).toBe(0);
   expect(result.failed).toBe(1);
-  expect(result.output).toContain(`1) ${path.join('dir', 'a.test.ts')}:6:7 › fails`);
+  expect(result.output).toContain(`1) ${path.join('..', 'dir', 'a.test.ts')}:6:7 › fails`);
 });
 
 test('should throw when test() is called in config file', async ({ runInlineTest }) => {

--- a/tests/playwright-test/test-ignore.spec.ts
+++ b/tests/playwright-test/test-ignore.spec.ts
@@ -163,7 +163,7 @@ test('should match absolute path', async ({ runInlineTest }) => {
     `
   });
   expect(result.passed).toBe(1);
-  expect(result.report.suites.map(s => s.file).sort()).toEqual(['a.test.ts']);
+  expect(result.report.suites.map(s => s.file).sort()).toEqual([path.join('dir', 'a.test.ts')]);
   expect(result.exitCode).toBe(0);
 });
 
@@ -187,7 +187,7 @@ test('should match cli string argument', async ({ runInlineTest }) => {
     `
   }, {}, {}, { additionalArgs: [`dir\\${path.sep}a`] });
   expect(result.passed).toBe(1);
-  expect(result.report.suites.map(s => s.file).sort()).toEqual(['a.test.ts']);
+  expect(result.report.suites.map(s => s.file).sort()).toEqual([path.join('dir', 'a.test.ts')]);
   expect(result.exitCode).toBe(0);
 });
 
@@ -368,6 +368,6 @@ test('should always work with unix separators', async ({ runInlineTest }) => {
     `
   }, {}, {}, { additionalArgs: [`dir/a`] });
   expect(result.passed).toBe(1);
-  expect(result.report.suites.map(s => s.file).sort()).toEqual(['a.test.ts']);
+  expect(result.report.suites.map(s => s.file).sort()).toEqual([path.join('dir', 'a.test.ts')]);
   expect(result.exitCode).toBe(0);
 });

--- a/tests/playwright-test/test-output-dir.spec.ts
+++ b/tests/playwright-test/test-output-dir.spec.ts
@@ -67,6 +67,29 @@ test('should work and remove non-failures', async ({ runInlineTest }, testInfo) 
   expect(fs.existsSync(testInfo.outputPath('test-results', 'my-test-test-1-chromium-retry2'))).toBe(false);
 });
 
+test('rootDir should define defaults', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'playwright.config.js': `
+      module.exports = {
+        rootDir: 'rootdir',
+        testDir: '.',
+      };
+    `,
+    'a.spec.js': `
+      const { test } = pwt;
+      test('test', async ({ page }, testInfo) => {
+        await expect(page).toHaveScreenshot();
+        console.log(testInfo.outputPath());
+      });
+    `
+  }, { 'reporter': '', 'update-snapshots': true }, {}, { usesCustomOutputDir: true });
+  expect(result.exitCode).toBe(0);
+  expect(fs.existsSync(testInfo.outputPath('test-results'))).toBe(false);
+  expect(fs.existsSync(testInfo.outputPath('rootdir'))).toBe(true);
+  expect(fs.existsSync(testInfo.outputPath('rootdir', 'test-results'))).toBe(true);
+  expect(fs.existsSync(testInfo.outputPath('rootdir', '__screenshots__'))).toBe(true);
+});
+
 test('should include repeat token', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.js': `

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -181,6 +181,7 @@ interface TestConfig {
   repeatEach?: number;
   retries?: number;
   testDir?: string;
+  rootDir?: string;
   testIgnore?: string | RegExp | (string | RegExp)[];
   testMatch?: string | RegExp | (string | RegExp)[];
   timeout?: number;


### PR DESCRIPTION
In our latest release, v1.20, we have the following defaults
for essential folders for test runner:

- `testDir` defaults to `<configDir>`
- `outputDir` defaults to `<process.cwd>/test-results`
- HTML report defaults to `<process.cwd>/playright-report`
- `screenshotsDir` defaults to
  `<testDir>/__screenshots__/<platform>/<project>`.
- all paths are computed relatively to `<testDir>`

In an attempt to get rid of `process.cwd` in `outputDir`, we landed
e3bd7ce11 that changed default for `outputDir` to `<testDir>`.

However, turned out this is not what we want: defining `testDir` now changes defaults for `outputDir` and `screenshotsDir` to unreasonable.
For example, consider the config we ship with `create-playwright`:

```js
module.exports = {
  testDir: `tests/`,
};
```

That will result in the following directories structure (note
unfortunate nesting of `test-results/` and `__screenshots__`):

```
playwright.config.ts
tests/
├── test-results/
└── __screenshots__
```

---

This patch aims to sort out all the issues with our directories
configuration [by introducing a `rootDir` configuration option](https://xkcd.com/927/).

`rootDir`defaults to **configuration directory** and defines default
values for all the essential directories:
- `testDir` defaults to `<rootDir>`.
- `outputDir` defaults to `<rootDir>/test-results`.
- `screenshotsDir` defaults to
  `<rootDir>/__screenshots__/<platform>/<project>`.

Additionally:
- HTML reporter **will** default to `<rootDir>/playwright-report`.
- All paths are computed relatively to `rootDir`.

Pros:
- In case of top-level configs, the following config now produces expected
  directories structure:
  ```js
  module.exports = {
    testDir: 'tests/',
  };
   ```

   ```
   playwright.config.ts
   tests/
   test-results/
   __screenshots__
   ```
- In case of nested configs (like we have for ourselves), configuring
  `rootDir` to point to git root will produce relative paths that match
  git paths and will result in all the by-product directories in a
  well-established location.

Cons:
- This patch introduces a new configuration option
- This patch introduces behavior changes
  * relative paths in reporters are now computed wrt `<rootDir>`, not
    `<testDir>`.
  * `<outputDir>` will now default to `<configDir>/test-results`

P.S. The reason I started touching all this is to figure out treatment
for both `screenshotsPath` and default HTML report location.
