### PR TITLE
feat: detect docker version and Playwright version mismatch

### DIFF
--- a/packages/playwright-core/src/cli/cli.ts
+++ b/packages/playwright-core/src/cli/cli.ts
@@ -33,6 +33,7 @@ import { BrowserContextOptions, LaunchOptions } from '../client/types';
 import { spawn } from 'child_process';
 import { registry, Executable } from '../utils/registry';
 import { spawnAsync, getPlaywrightVersion } from '../utils/utils';
+import { writeDockerVersion } from '../utils/dependencies';
 import { launchGridAgent } from '../grid/gridAgent';
 import { GridServer, GridFactory } from '../grid/gridServer';
 
@@ -41,6 +42,14 @@ const packageJSON = require('../../package.json');
 program
     .version('Version ' + (process.env.PW_CLI_DISPLAY_VERSION || packageJSON.version))
     .name(buildBasePlaywrightCLICommand(process.env.PW_LANG_NAME));
+
+program
+    .command('mark-docker-image > [args...]', { hidden: true })
+    .description('mark docker image')
+    .allowUnknownOption(true)
+    .action(function(dockerImageNameTemplate) {
+      writeDockerVersion(dockerImageNameTemplate);
+    });
 
 commandWithOpenOptions('open [url]', 'open page in browser specified via -b, --browser', [])
     .action(function(url, options) {

--- a/packages/playwright-core/src/utils/dependencies.ts
+++ b/packages/playwright-core/src/utils/dependencies.ts
@@ -207,7 +207,7 @@ export async function validateDependenciesLinux(sdkLanguage: string, linuxLddDir
   ];
   // Ignore patch versions when comparing docker container version and Playwright version:
   // we **NEVER** roll browsers in patch releases, so native dependencies do not change.
-  if (dockerInfo && !dockerInfo.driverVersion.startsWith(utils.getPlaywrightVersion(true /* majorMinorOnly */))) {
+  if (dockerInfo && !dockerInfo.driverVersion.startsWith(utils.getPlaywrightVersion(true /* majorMinorOnly */) + '.')) {
     // We are running in a docker container with unmatching version.
     // In this case, we know how to install dependencies in it.
     const pwVersion = utils.getPlaywrightVersion();

--- a/utils/docker/Dockerfile.bionic
+++ b/utils/docker/Dockerfile.bionic
@@ -2,6 +2,7 @@ FROM ubuntu:bionic
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=America/Los_Angeles
+ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright:v%version%-bionic"
 
 # === INSTALL Node.js ===
 
@@ -34,7 +35,9 @@ RUN mkdir /ms-playwright && \
     mkdir /ms-playwright-agent && \
     cd /ms-playwright-agent && npm init -y && \
     npm i /tmp/playwright-core.tar.gz && \
+    npx playwright mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
     npx playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
     rm /tmp/playwright-core.tar.gz && \
     rm -rf /ms-playwright-agent && \
     chmod -R 777 /ms-playwright
+

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -2,6 +2,7 @@ FROM ubuntu:focal
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=America/Los_Angeles
+ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright:v%version%-focal"
 
 # === INSTALL Node.js ===
 
@@ -34,6 +35,7 @@ RUN mkdir /ms-playwright && \
     mkdir /ms-playwright-agent && \
     cd /ms-playwright-agent && npm init -y && \
     npm i /tmp/playwright-core.tar.gz && \
+    npx playwright mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
     npx playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
     rm /tmp/playwright-core.tar.gz && \
     rm -rf /ms-playwright-agent && \

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -7,7 +7,7 @@ trap "cd $(pwd -P)" EXIT
 cd "$(dirname "$0")"
 
 MCR_IMAGE_NAME="playwright"
-PW_VERSION=$(node -e 'console.log(require("../../package.json").version)')
+PW_VERSION=$(node ../../utils/workspace.js --get-version)
 
 RELEASE_CHANNEL="$1"
 if [[ "${RELEASE_CHANNEL}" == "stable" ]]; then

--- a/utils/workspace.js
+++ b/utils/workspace.js
@@ -56,6 +56,11 @@ class Workspace {
     return this._packages;
   }
 
+  async version() {
+    const workspacePackageJSON = await readJSON(path.join(this._rootDir, 'package.json'));
+    return workspacePackageJSON.version;
+  }
+
   /**
    * @param {string} version
    */
@@ -209,6 +214,9 @@ async function parseCLI() {
         if (!pkg.isPrivate)
           console.log(pkg.path);
       }
+    },
+    '--get-version': async (version) => {
+      console.log(await workspace.version());
     },
     '--set-version': async (version) => {
       if (!version)


### PR DESCRIPTION
This patch prints a friendly instructions in case Docker image version
mismatches Playwright version and there are missing browser
dependencies.

With this patch, Playwright will yield the following error:

```
root@f0774d2b2097:~# node a.mjs
node:internal/process/promises:279
            triggerUncaughtException(err, true /* fromPromise */);
            ^

browserType.launch:
╔════════════════════════════════════════════════════════════════════════════════════════════╗
║ Host system is missing dependencies to run browsers.                                       ║
║ This is most likely due to docker image version not matching Playwright version:           ║
║ - Playwright: 1.22.0                                                                       ║
║ -     Docker: 1.21.0                                                                       ║
║                                                                                            ║
║ Either:                                                                                    ║
║ - (recommended) use docker image "mcr.microsoft.com/playwright:v1.22.0-focal"              ║
║ - (alternative 1) run the following command inside docker to install missing dependencies: ║
║                                                                                            ║
║     npx playwright install-deps                                                            ║
║                                                                                            ║
║ - (alternative 2) use Aptitude inside docker:                                              ║
║                                                                                            ║
║     apt-get install libgbm1                                                                ║
║                                                                                            ║
║ <3 Playwright Team                                                                         ║
╚════════════════════════════════════════════════════════════════════════════════════════════╝
    at file:///root/a.mjs:3:10 {
  name: 'Error'
}```

References #12796
