### PR TITLE
feat(test-runner): implement `expect.poll`

### DIFF
--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -96,6 +96,25 @@ The same works with soft assertions:
 expect.soft(value, 'my soft assertion').toBe(56);
 ```
 
+## Polling
+
+You can convert any synchronous `expect` to an asynchronous polling one using `expect.poll`.
+
+The following method will poll given function until it returns HTTP status 200:
+
+```js
+expect.poll(async () => {
+  const response = await page.request.get('https://api.example.com');
+  return response.status();
+}, {
+  // Custom error message
+  message: 'make sure API eventually succeeds', // custom error message
+  // Poll for 10 seconds; defaults to 5 seconds. Pass 0 to disable timeout.
+  timeout: 10000,
+}).toBe(200);
+```
+
+
 ## API reference
 See the following pages for Playwright-specific assertions:
 - [APIResponseAssertions] assertions for [APIResponse]

--- a/packages/playwright-test/types/testExpect.d.ts
+++ b/packages/playwright-test/types/testExpect.d.ts
@@ -28,8 +28,9 @@ type MakeMatchers<T, ReturnValue = T> = PlaywrightTest.Matchers<ReturnValue> &
   ExtraMatchers<T, APIResponse, APIResponseMatchers>
 
 export declare type Expect = {
-  <T = unknown>(actual: T, message?: string): MakeMatchers<T>;
-  soft: <T = unknown>(actual: T, message?: string) => MakeMatchers<T>;
+  <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }): MakeMatchers<T>;
+  soft: <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }) => MakeMatchers<T>;
+  poll: <T = unknown>(actual: () => T | Promise<T>, messageOrOptions?: string | { message?: string, timeout?: number }) => Omit<PlaywrightTest.Matchers<T>, 'rejects' | 'resolves'>;
 
   extend(arg0: any): void;
   getState(): expect.MatcherState;

--- a/tests/playwright-test/expect-poll.spec.ts
+++ b/tests/playwright-test/expect-poll.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, stripAnsi } from './playwright-test-fixtures';
+
+test('should poll predicate', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('should poll sync predicate', async () => {
+        let i = 0;
+        await test.expect.poll(() => ++i).toBe(3);
+      });
+      test('should poll async predicate', async () => {
+        let i = 0;
+        await test.expect.poll(async () => {
+          await new Promise(x => setTimeout(x, 50));
+          return ++i;
+        }).toBe(3);
+      });
+      test('should poll predicate that returns a promise', async () => {
+        let i = 0;
+        await test.expect.poll(() => Promise.resolve(++i)).toBe(3);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+});
+
+test('should compile', async ({ runTSC }) => {
+  const result = await runTSC({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('should poll sync predicate', () => {
+        let i = 0;
+        test.expect.poll(() => ++i).toBe(3);
+        test.expect.poll(() => ++i, 'message').toBe(3);
+        test.expect.poll(() => ++i, { message: 'message' }).toBe(3);
+        test.expect.poll(() => ++i, { timeout: 100 }).toBe(3);
+        test.expect.poll(() => ++i, { message: 'message', timeout: 100 }).toBe(3);
+        test.expect.poll(async () => {
+          await new Promise(x => setTimeout(x, 50));
+          return ++i;
+        }).toBe(3);
+        test.expect.poll(() => Promise.resolve(++i)).toBe(3);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+});
+
+test('should respect timeout', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('should fail', async () => {
+        await test.expect.poll(() => false, { timeout: 100 }).toBe(3);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(stripAnsi(result.output)).toContain('Timeout 100ms exceeded while waiting on the predicate');
+  expect(stripAnsi(result.output)).toContain(`
+  7 |         await test.expect.poll(() => false, { timeout: 100 }).
+  `.trim());
+});
+
+test('should fail when passed in non-function', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('should fail', async () => {
+        await test.expect.poll(false).toBe(3);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(stripAnsi(result.output)).toContain('Error: `expect.poll()` accepts only function as a first argument');
+});
+
+test('should fail when used with web-first assertion', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('should fail', async ({ page }) => {
+        await test.expect.poll(() => page.locator('body')).toHaveText('foo');
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(stripAnsi(result.output)).toContain('Error: `expect.poll()` does not support "toHaveText" matcher');
+});
+
+test('should time out when running infinite predicate', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('should fail', async ({ page }) => {
+        await test.expect.poll(() => new Promise(x => {}), { timeout: 100 }).toBe(42);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(stripAnsi(result.output)).toContain('Timeout 100ms exceeded');
+});
+
+test('should show error that is thrown from predicate', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('should fail', async ({ page }) => {
+        await test.expect.poll(() => { throw new Error('foo bar baz'); }, { timeout: 100 }).toBe(42);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(stripAnsi(result.output)).toContain('foo bar baz');
+});
+
+test('should support .not predicate', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('should fail', async ({ page }) => {
+        let i = 0;
+        await test.expect.poll(() => ++i).not.toBeLessThan(3);
+        expect(i).toBe(3);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+});

--- a/tests/playwright-test/expect-soft.spec.ts
+++ b/tests/playwright-test/expect-soft.spec.ts
@@ -23,6 +23,7 @@ test('soft expects should compile', async ({ runTSC }) => {
       test('should work', () => {
         test.expect.soft(1+1).toBe(3);
         test.expect.soft(1+1, 'custom error message').toBe(3);
+        test.expect.soft(1+1, { message: 'custom error message' }).toBe(3);
       });
     `
   });
@@ -43,6 +44,19 @@ test('soft expects should work', async ({ runInlineTest }) => {
   expect(stripAnsi(result.output)).toContain('woof-woof');
 });
 
+test('should fail when passed in function', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('should work', () => {
+        test.expect.soft(() => 1+1).toBe(2);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(stripAnsi(result.output)).toContain('Error: Cannot accept function as a first argument; use `expect.poll()` instead');
+});
+
 test('should report a mixture of soft and non-soft errors', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.ts': `
@@ -51,7 +65,7 @@ test('should report a mixture of soft and non-soft errors', async ({ runInlineTe
         test.expect.soft(1+1, 'one plus one').toBe(3);
         test.expect.soft(2*2, 'two times two').toBe(5);
         test.expect(3/3, 'three div three').toBe(7);
-        test.expect.soft(6-4, 'six minus four').toBe(3);
+        test.expect.soft(6-4, { message: 'six minus four' }).toBe(3);
       });
     `
   });

--- a/tests/playwright-test/expect-soft.spec.ts
+++ b/tests/playwright-test/expect-soft.spec.ts
@@ -54,7 +54,7 @@ test('should fail when passed in function', async ({ runInlineTest }) => {
     `
   });
   expect(result.exitCode).toBe(1);
-  expect(stripAnsi(result.output)).toContain('Error: Cannot accept function as a first argument; use `expect.poll()` instead');
+  expect(stripAnsi(result.output)).toContain('Cannot accept function as a first argument; did you mean to use `expect.poll()`?');
 });
 
 test('should report a mixture of soft and non-soft errors', async ({ runInlineTest }) => {

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -67,20 +67,6 @@ test('should not expand huge arrays', async ({ runInlineTest }) => {
   expect(result.output.length).toBeLessThan(100000);
 });
 
-test('should fail when passed `null` instead of message', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'expect-test.spec.ts': `
-      const { test } = pwt;
-      test('custom expect message', () => {
-        test.expect(1+1, null).toEqual(3);
-      });
-    `
-  });
-  expect(result.exitCode).toBe(1);
-  expect(result.passed).toBe(0);
-  expect(stripAnsi(result.output)).toContain(`optional error message must be a string.`);
-});
-
 test('should include custom error message', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'expect-test.spec.ts': `
@@ -105,7 +91,7 @@ test('should include custom error message with web-first assertions', async ({ r
     'expect-test.spec.ts': `
       const { test } = pwt;
       test('custom expect message', async ({page}) => {
-        await expect(page.locator('x-foo'), 'x-foo must be visible').toBeVisible({timeout: 1});
+        await expect(page.locator('x-foo'), { message: 'x-foo must be visible' }).toBeVisible({timeout: 1});
       });
     `
   });


### PR DESCRIPTION
This patch implements `expect.poll()` method that polls given
predicate until a given synchronous matcher succeeds.

Usage:

```js
// wait until page gets 3 frames.
await expect.poll(() => page.frames().length, {
  timeout: 1000,
  message: 'custom error message',
}).toBe(3);
```

Fixes #10235
