### PR TITLE
docs: fix markdown links

### DIFF
--- a/packages/playwright-chromium/README.md
+++ b/packages/playwright-chromium/README.md
@@ -1,3 +1,3 @@
 # playwright-chromium
 
-This package contains the [Chromium](https://www.chromium.org/) flavor of the [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [`@playwright/test](https://playwright.dev/docs/intro).
+This package contains the [Chromium](https://www.chromium.org/) flavor of the [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [@playwright/test](https://playwright.dev/docs/intro).

--- a/packages/playwright-firefox/README.md
+++ b/packages/playwright-firefox/README.md
@@ -1,3 +1,3 @@
 # playwright-firefox
 
-This package contains the [Firefox](https://www.mozilla.org/firefox/) flavor of the [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [`@playwright/test](https://playwright.dev/docs/intro).
+This package contains the [Firefox](https://www.mozilla.org/firefox/) flavor of the [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [@playwright/test](https://playwright.dev/docs/intro).

--- a/packages/playwright-webkit/README.md
+++ b/packages/playwright-webkit/README.md
@@ -1,3 +1,3 @@
 # playwright-webkit
 
-This package contains the [WebKit](https://www.webkit.org/) flavor of the [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [`@playwright/test](https://playwright.dev/docs/intro).
+This package contains the [WebKit](https://www.webkit.org/) flavor of the [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [@playwright/test](https://playwright.dev/docs/intro).


### PR DESCRIPTION
I noticed on the npm package page, that there are some unwanted backticks for the flavored-Playwright builds so I fixed that.

## Screenshot of bug

![image](https://user-images.githubusercontent.com/469989/158680788-09d0025b-2bf1-467e-9e9f-71ac93fd640d.png)
