### PR TITLE
fix: fix folder traversal for isModule check (#12836)

### DIFF
--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -494,7 +494,7 @@ export function folderIsModule(folder: string): boolean {
   if (fs.existsSync(packageJson)) {
     isModule = require(packageJson).type === 'module';
   } else {
-    const parentFolder = path.basename(folder);
+    const parentFolder = path.dirname(folder);
     if (parentFolder !== folder)
       isModule = folderIsModule(parentFolder);
     else


### PR DESCRIPTION
This change fixed the error shown in #12836, where tests in an ES module don't get detected as such and therefore break test execution in v1.20 because they are loaded with `require()` instead of `import`.

By using `path.dirname(folder)` instead of `path.basename(folder)`, `folderIsModule` is able to correctly iterate through all parent folders and detect the correct project type.