### PR TITLE
cherry-pick(#12820): chore: restore expect.any()/expect.anything()

### DIFF
--- a/packages/playwright-test/types/testExpect.d.ts
+++ b/packages/playwright-test/types/testExpect.d.ts
@@ -34,6 +34,8 @@ export declare type Expect = {
   extend(arg0: any): void;
   getState(): expect.MatcherState;
   setState(state: Partial<expect.MatcherState>): void;
+  any(expectedObject: any): AsymmetricMatcher;
+  anything(): AsymmetricMatcher;
   arrayContaining(sample: Array<unknown>): AsymmetricMatcher;
   objectContaining(sample: Record<string, unknown>): AsymmetricMatcher;
   stringContaining(expected: string): AsymmetricMatcher;
@@ -43,8 +45,6 @@ export declare type Expect = {
    * - assertions()
    * - extractExpectedAssertionsErrors()
    * – hasAssertions()
-   * - any()
-   * - anything()
    */
 };
 

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -118,17 +118,31 @@ test('should include custom error message with web-first assertions', async ({ r
   ].join('\n'));
 });
 
-test('should work with default expect prototype functions', async ({ runTSC }) => {
-  const result = await runTSC({
-    'a.spec.ts': `
-      const { test } = pwt;
+test('should work with default expect prototype functions', async ({ runTSC, runInlineTest }) => {
+  const spec = `
+    const { test } = pwt;
+    test('pass', async () => {
       const expected = [1, 2, 3, 4, 5, 6];
       test.expect([4, 1, 6, 7, 3, 5, 2, 5, 4, 6]).toEqual(
         expect.arrayContaining(expected),
       );
-    `
-  });
-  expect(result.exitCode).toBe(0);
+      expect('foo').toEqual(expect.any(String));
+      expect('foo').toEqual(expect.anything());
+    });
+  `;
+  {
+    const result = await runTSC({
+      'a.spec.ts': spec,
+    });
+    expect(result.exitCode).toBe(0);
+  }
+  {
+    const result = await runInlineTest({
+      'a.spec.ts': spec,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.passed).toBe(1);
+  }
 });
 
 test('should work with default expect matchers', async ({ runTSC }) => {

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -241,7 +241,8 @@ const TSCONFIG = {
     'esModuleInterop': true,
     'allowSyntheticDefaultImports': true,
     'rootDir': '.',
-    'lib': ['esnext', 'dom', 'DOM.Iterable']
+    'lib': ['esnext', 'dom', 'DOM.Iterable'],
+    'noEmit': true,
   },
   'exclude': [
     'node_modules'


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/12814