### PR TITLE
feat(test runner): describe.skip

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -459,6 +459,38 @@ A callback that is run immediately when calling [`method: Test.describe.serial.o
 
 
 
+## method: Test.describe.skip
+
+Declares a skipped test group, similarly to [`method: Test.describe`]. Tests in the skipped group are never run.
+
+```js js-flavor=js
+test.describe.skip('skipped group', () => {
+  test('example', async ({ page }) => {
+    // This test will not run
+  });
+});
+```
+
+```js js-flavor=ts
+test.describe.skip('skipped group', () => {
+  test('example', async ({ page }) => {
+    // This test will not run
+  });
+});
+```
+
+### param: Test.describe.skip.title
+- `title` <[string]>
+
+Group title.
+
+### param: Test.describe.skip.callback
+- `callback` <[function]>
+
+A callback that is run immediately when calling [`method: Test.describe.skip`]. Any tests added in this callback will belong to the group, and will not be run.
+
+
+
 ## property: Test.expect
 - type: <[Object]>
 

--- a/packages/playwright-test/src/test.ts
+++ b/packages/playwright-test/src/test.ts
@@ -44,6 +44,7 @@ export class Suite extends Base implements reporterTypes.Suite {
   parent?: Suite;
   _use: FixturesWithLocation[] = [];
   _isDescribe = false;
+  _skipped = false;
   _entries: (Suite | TestCase)[] = [];
   _hooks: { type: 'beforeEach' | 'afterEach' | 'beforeAll' | 'afterAll', fn: Function, location: Location }[] = [];
   _timeout: number | undefined;
@@ -108,6 +109,7 @@ export class Suite extends Base implements reporterTypes.Suite {
     suite._isDescribe = this._isDescribe;
     suite._parallelMode = this._parallelMode;
     suite._projectConfig = this._projectConfig;
+    suite._skipped = this._skipped;
     return suite;
   }
 

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -1795,6 +1795,24 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    */
   only: SuiteFunction;
     /**
+   * Declares a skipped test group, similarly to
+   * [test.describe(title, callback)](https://playwright.dev/docs/api/class-test#test-describe). Tests in the skipped group
+   * are never run.
+   *
+   * ```ts
+   * test.describe.skip('skipped group', () => {
+   *   test('example', async ({ page }) => {
+   *     // This test will not run
+   *   });
+   * });
+   * ```
+   *
+   * @param title Group title.
+   * @param callback A callback that is run immediately when calling [test.describe.skip(title, callback)](https://playwright.dev/docs/api/class-test#test-describe-skip). Any tests added in
+   * this callback will belong to the group, and will not be run.
+   */
+  skip: SuiteFunction;
+    /**
    * Declares a group of tests that should always be run serially. If one of the tests fails, all subsequent tests are
    * skipped. All tests in a group are retried together.
    *

--- a/tests/playwright-test/basic.spec.ts
+++ b/tests/playwright-test/basic.spec.ts
@@ -442,3 +442,29 @@ test('should allow unhandled expects in test.fail', async ({ runInlineTest }) =>
   expect(result.passed).toBe(1);
   expect(result.output).not.toContain(`Error: expect`);
 });
+
+test('should support describe.skip', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'nested-skip.spec.js': `
+      const { test } = pwt;
+      test.describe.skip('skipped', () => {
+        test.describe('nested', () => {
+          test('test1', () => {});
+        });
+        test('test2', () => {});
+      });
+      test.describe('not skipped', () => {
+        test.describe.skip('skipped', () => {
+          test('test4', () => {});
+        });
+        test('test4', () => {
+          console.log('heytest4');
+        });
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.skipped).toBe(3);
+  expect(result.output).toContain('heytest4');
+});

--- a/tests/playwright-test/types-2.spec.ts
+++ b/tests/playwright-test/types-2.spec.ts
@@ -22,11 +22,21 @@ test('basics should work', async ({ runTSC }) => {
       const { test } = pwt;
       test.describe('suite', () => {
         test.beforeEach(async () => {});
+        test.afterEach(async () => {});
+        test.beforeAll(async () => {});
+        test.afterAll(async () => {});
         test('my test', async({}, testInfo) => {
           expect(testInfo.title).toBe('my test');
           testInfo.annotations[0].type;
         });
+        test.skip('my test', async () => {});
+        test.fixme('my test', async () => {});
       });
+      test.describe.parallel('suite', () => {});
+      test.describe.parallel.only('suite', () => {});
+      test.describe.serial('suite', () => {});
+      test.describe.serial.only('suite', () => {});
+      test.describe.skip('suite', () => {});
       // @ts-expect-error
       test.foo();
     `

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -290,6 +290,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
   only: TestFunction<TestArgs & WorkerArgs>;
   describe: SuiteFunction & {
     only: SuiteFunction;
+    skip: SuiteFunction;
     serial: SuiteFunction & {
       only: SuiteFunction;
     };


### PR DESCRIPTION
`describe.skip` declares a test group that is skipped.

Fixes #12453.