### PR TITLE
chore: print error if install-deps is used != ubuntu

### DIFF
--- a/packages/playwright-core/src/utils/dependencies.ts
+++ b/packages/playwright-core/src/utils/dependencies.ts
@@ -21,6 +21,7 @@ import childProcess from 'child_process';
 import * as utils from './utils';
 import { buildPlaywrightCLICommand } from './registry';
 import { deps } from './nativeDeps';
+import { getUbuntuVersion } from './ubuntuVersion';
 
 const BIN_DIRECTORY = path.join(__dirname, '..', '..', 'bin');
 
@@ -53,6 +54,8 @@ export async function installDependenciesWindows(targets: Set<DependencyGroup>, 
 }
 
 export async function installDependenciesLinux(targets: Set<DependencyGroup>, dryRun: boolean) {
+  if (await getUbuntuVersion() === '')
+    throw new Error(`Unsupported Linux distribution, only Ubuntu is supported!`);
   const libraries: string[] = [];
   for (const target of targets) {
     const info = deps[utils.hostPlatform];


### PR DESCRIPTION
We've seen a plenty of users trying to install-deps on != ubuntu like debian. This prints a pretty error for them instead of "package xyz not found".

Fixes https://github.com/microsoft/playwright/issues/12845
Fixes https://github.com/microsoft/playwright/issues/12859