### PR TITLE
docs: automatically test examples

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,3 +15,4 @@ output/
 test-results/
 tests-components/
 examples/
+/docs/tests/generated/**/*

--- a/.github/workflows/tests_primary_embedded_doc_tests.yml
+++ b/.github/workflows/tests_primary_embedded_doc_tests.yml
@@ -1,0 +1,44 @@
+name: "tests - embedded doc tests"
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request:
+    paths-ignore:
+      - 'browser_patches/**'
+    branches:
+      - main
+      - release-*
+
+env:
+  # Force terminal colors. @see https://www.npmjs.com/package/colors
+  FORCE_COLOR: 1
+  FLAKINESS_CONNECTION_STRING: ${{ secrets.FLAKINESS_CONNECTION_STRING }}
+
+jobs:
+  test_embedded_doc_tests:
+    name: Embedded Doc Tests
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 12
+    - run: npm i -g npm@8.3
+    - run: npm ci
+      env:
+        DEBUG: pw:install
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+    - run: npm run build
+    - run: npx playwright install --with-deps chromium
+    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run dtest
+    # - run: node tests/config/checkCoverage.js ${{ matrix.browser }}
+    # - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+    #   if: always()
+    # - uses: actions/upload-artifact@v1
+    #   if: always()
+    #   with:
+    #     name: ${{ matrix.browser }}-${{ matrix.os }}-test-results
+    #     path: test-results

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ playwright-report
 /packages/playwright/README.md
 /packages/playwright-core/api.json
 .env
+/docs/tests/generated

--- a/docs/src/api/class-download.md
+++ b/docs/src/api/class-download.md
@@ -10,7 +10,7 @@ Download event is emitted once the download starts. Download path becomes availa
 ```js js-flavor=js RUNNABLE
 const { test, expect } = require('@playwright/test');
 
-test('downlad example', async ({ page }) => {
+test('download example', async ({ page }) => {
   await page.setContent(`<a href='data:application/json;base64,ImV4YW1wbGUgZGF0YSIK' download>Download file</a>`);
   // Note that Promise.all prevents a race condition
   // between clicking and waiting for the download.
@@ -28,7 +28,7 @@ test('downlad example', async ({ page }) => {
 ```js js-flavor=ts RUNNABLE
 import { test, expect } from '@playwright/test';
 
-test('downlad example', async ({ page }) => {
+test('download example', async ({ page }) => {
   await page.setContent(`<a href='data:application/json;base64,ImV4YW1wbGUgZGF0YSIK' download>Download file</a>`);
   // Note that Promise.all prevents a race condition
   // between clicking and waiting for the download.

--- a/docs/src/api/class-download.md
+++ b/docs/src/api/class-download.md
@@ -7,17 +7,40 @@ browser context is closed.
 
 Download event is emitted once the download starts. Download path becomes available once download completes:
 
-```js
-// Note that Promise.all prevents a race condition
-// between clicking and waiting for the download.
-const [ download ] = await Promise.all([
-  // It is important to call waitForEvent before click to set up waiting.
-  page.waitForEvent('download'),
-  // Triggers the download.
-  page.locator('text=Download file').click(),
-]);
-// wait for download to complete
-const path = await download.path();
+```js js-flavor=js RUNNABLE
+const { test, expect } = require('@playwright/test');
+
+test('downlad example', async ({ page }) => {
+  await page.setContent(`<a href='data:application/json;base64,ImV4YW1wbGUgZGF0YSIK' download>Download file</a>`);
+  // Note that Promise.all prevents a race condition
+  // between clicking and waiting for the download.
+  const [ download ] = await Promise.all([
+    // It is important to call waitForEvent before click to set up waiting.
+    page.waitForEvent('download'),
+    // Triggers the download.
+    page.locator('text=Download file').click(),
+  ]);
+  // wait for download to complete
+  await expect(download.path()).resolves.toBeTruthy();
+});
+```
+
+```js js-flavor=ts RUNNABLE
+import { test, expect } from '@playwright/test';
+
+test('downlad example', async ({ page }) => {
+  await page.setContent(`<a href='data:application/json;base64,ImV4YW1wbGUgZGF0YSIK' download>Download file</a>`);
+  // Note that Promise.all prevents a race condition
+  // between clicking and waiting for the download.
+  const [ download ] = await Promise.all([
+    // It is important to call waitForEvent before click to set up waiting.
+    page.waitForEvent('download'),
+    // Triggers the download.
+    page.locator('text=Download file').click(),
+  ]);
+  // wait for download to complete
+  await expect(download.path()).resolves.toBeTruthy();
+});
 ```
 
 ```java

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -9,21 +9,50 @@ title: "Input"
 
 This is the easiest way to fill out the form fields. It focuses the element and triggers an `input` event with the entered text. It works for `<input>`, `<textarea>`, `[contenteditable]` and `<label>` associated with an input or textarea.
 
-```js
-// Text input
-await page.fill('#name', 'Peter');
+```js js-flavor=ts RUNNABLE
+import { test, expect } from '@playwright/test';
 
-// Date input
-await page.fill('#date', '2020-02-02');
+test('form examples', async ({ page }) => {
+  await page.goto('https://rwoll.github.io/gh-pages-examples/');
 
-// Time input
-await page.fill('#time', '13:15');
+  // Text input
+  await page.fill('#input-text', 'Peter');
 
-// Local datetime input
-await page.fill('#local', '2020-03-02T05:15');
+  // Date input
+  await page.fill('#input-date', '2020-02-02');
 
-// Input through label
-await page.fill('text=First Name', 'Peter');
+  // Time input
+  await page.fill('#input-time', '13:15');
+
+  // Local datetime input
+  await page.fill('#input-local-datetime', '2020-03-02T05:15');
+
+  // Input through label
+  await page.fill('text=Text Input', 'Peter');
+});
+```
+
+```js js-flavor=js RUNNABLE
+const { test, expect } = require('@playwright/test');
+
+test('form examples', async ({ page }) => {
+  await page.goto('https://rwoll.github.io/gh-pages-examples/');
+
+  // Text input
+  await page.fill('#input-text', 'Peter');
+
+  // Date input
+  await page.fill('#input-date', '2020-02-02');
+
+  // Time input
+  await page.fill('#input-time', '13:15');
+
+  // Local datetime input
+  await page.fill('#input-local-datetime', '2020-03-02T05:15');
+
+  // Input through label
+  await page.fill('text=Text Input', 'Peter');
+});
 ```
 
 ```java
@@ -106,19 +135,46 @@ await page.FillAsync("text=First Name", "Peter");
 
 This is the easiest way to check and uncheck a checkbox or a radio button. This method can be used with `input[type=checkbox]`, `input[type=radio]`, `[role=checkbox]` or `label` associated with checkbox or radio button.
 
-```js
-// Check the checkbox
-await page.check('#agree');
+```js js-flavor=ts RUNNABLE
+import { test, expect } from '@playwright/test';
 
-// Assert the checked state
-expect(await page.isChecked('#agree')).toBeTruthy()
+test('form examples', async ({ page }) => {
+  await page.goto('https://rwoll.github.io/gh-pages-examples/');
 
-// Uncheck by input <label>.
-await page.uncheck('#subscribe-label');
+  // Check the checkbox
+  await page.check('#input-checkbox');
 
-// Select the radio button
-await page.check('text=XL');
+  // Assert the checked state
+  expect(await page.isChecked('#input-checkbox')).toBeTruthy()
+
+  // Uncheck by input <label>.
+  await page.uncheck('text=Checkbox Input');
+
+  // Select the radio button
+  // await page.check('text=XL');
+});
 ```
+
+```js js-flavor=js RUNNABLE
+const { test, expect } = require('@playwright/test');
+
+test('form examples', async ({ page }) => {
+  await page.goto('https://rwoll.github.io/gh-pages-examples/');
+
+  // Check the checkbox
+  await page.check('#input-checkbox');
+
+  // Assert the checked state
+  expect(await page.isChecked('#input-checkbox')).toBeTruthy()
+
+  // Uncheck by input <label>.
+  await page.uncheck('text=Checkbox Input');
+
+  // Select the radio button
+  // await page.check('text=XL');
+});
+```
+
 
 ```java
 // Check the checkbox
@@ -192,19 +248,46 @@ await page.CheckAsync("text=XL");
 Selects one or multiple options in the `<select>` element.
 You can specify option `value`, `label` or `elementHandle` to select. Multiple options can be selected.
 
-```js
-// Single selection matching the value
-await page.selectOption('select#colors', 'blue');
+```js js-flavor=js RUNNABLE
+const { test, expect } = require('@playwright/test');
 
-// Single selection matching the label
-await page.selectOption('select#colors', { label: 'Blue' });
+test('form examples', async ({ page }) => {
+  await page.goto('https://rwoll.github.io/gh-pages-examples/');
 
-// Multiple selected items
-await page.selectOption('select#colors', ['red', 'green', 'blue']);
+  // Single selection matching the value
+  await page.selectOption('select#favorite-color', 'blue');
 
-// Select the option via element handle
-const option = await page.$('#best-option');
-await page.selectOption('select#colors', option);
+  // Single selection matching the label
+  await page.selectOption('select#favorite-color', { label: 'Blue' });
+
+  // Multiple selected items
+  await page.selectOption('select#favorite-color', ['red', 'green', 'blue']);
+
+  // Select the option via element handle
+  // const option = await page.$('#best-option');
+  // await page.selectOption('select#colors', option);
+});
+```
+
+```js js-flavor=ts RUNNABLE
+import { test, expect } from '@playwright/test';
+
+test('form examples', async ({ page }) => {
+  await page.goto('https://rwoll.github.io/gh-pages-examples/');
+
+  // Single selection matching the value
+  await page.selectOption('select#favorite-color', 'blue');
+
+  // Single selection matching the label
+  await page.selectOption('select#favorite-color', { label: 'Blue' });
+
+  // Multiple selected items
+  await page.selectOption('select#favorite-color', ['red', 'green', 'blue']);
+
+  // Select the option via element handle
+  // const option = await page.$('#best-option');
+  // await page.selectOption('select#colors', option);
+});
 ```
 
 ```java

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "htest": "playwright test --config=packages/html-reporter",
     "ttest": "node ./tests/playwright-test/stable-test-runner/node_modules/@playwright/test/cli test --config=tests/playwright-test/playwright-test.config.ts",
     "vtest": "cross-env PLAYWRIGHT_DOCKER=1 node ./tests/playwright-test/stable-test-runner/node_modules/@playwright/test/cli test --config=tests/playwright-test/playwright-test.config.ts",
+    "dtest": "PWTEST_DISABLE_AUTOIGNORE=1 npx playwright test docs/tests/generated/**",
     "ct": "npx playwright test tests-components/test-all.spec.js --reporter=list",
     "test": "playwright test --config=tests/config/default.playwright.config.ts",
     "eslint": "eslint --ext ts,tsx .",

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -13409,17 +13409,22 @@ export interface Dialog {
  *
  * Download event is emitted once the download starts. Download path becomes available once download completes:
  *
- * ```js
- * // Note that Promise.all prevents a race condition
- * // between clicking and waiting for the download.
- * const [ download ] = await Promise.all([
- *   // It is important to call waitForEvent before click to set up waiting.
- *   page.waitForEvent('download'),
- *   // Triggers the download.
- *   page.locator('text=Download file').click(),
- * ]);
- * // wait for download to complete
- * const path = await download.path();
+ * ```ts
+ * import { test, expect } from '@playwright/test';
+ *
+ * test('downlad example', async ({ page }) => {
+ *   await page.setContent(`<a href='data:application/json;base64,ImV4YW1wbGUgZGF0YSIK' download>Download file</a>`);
+ *   // Note that Promise.all prevents a race condition
+ *   // between clicking and waiting for the download.
+ *   const [ download ] = await Promise.all([
+ *     // It is important to call waitForEvent before click to set up waiting.
+ *     page.waitForEvent('download'),
+ *     // Triggers the download.
+ *     page.locator('text=Download file').click(),
+ *   ]);
+ *   // wait for download to complete
+ *   await expect(download.path()).resolves.toBeTruthy();
+ * });
  * ```
  *
  */

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -13412,7 +13412,7 @@ export interface Dialog {
  * ```ts
  * import { test, expect } from '@playwright/test';
  *
- * test('downlad example', async ({ page }) => {
+ * test('download example', async ({ page }) => {
  *   await page.setContent(`<a href='data:application/json;base64,ImV4YW1wbGUgZGF0YSIK' download>Download file</a>`);
  *   // Note that Promise.all prevents a race condition
  *   // between clicking and waiting for the download.

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -557,7 +557,7 @@ async function collectFiles(testDir: string): Promise<string[]> {
     entries.sort((a, b) => a.name.localeCompare(b.name));
 
     const gitignore = entries.find(e => e.isFile() && e.name === '.gitignore');
-    if (gitignore) {
+    if (gitignore && !process.env.PWTEST_DISABLE_AUTOIGNORE) {
       const content = await readFileAsync(path.join(dir, gitignore.name), 'utf8');
       const newRules: Rule[] = content.split(/\r?\n/).map(s => {
         s = s.trim();

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -236,6 +236,14 @@ onChanges.push({
   script: 'utils/generate_types/index.js',
 });
 
+onChanges.push({
+  committed: false,
+  inputs: [
+    'docs/src/',
+  ],
+  script: 'utils/generate_doc_tests/index.js',
+});
+
 // The recorder and trace viewer have an app_icon.png that needs to be copied.
 copyFiles.push({
   files: 'packages/playwright-core/src/server/chromium/*.png',

--- a/utils/generate_doc_tests/index.js
+++ b/utils/generate_doc_tests/index.js
@@ -1,0 +1,73 @@
+// @ts-check
+
+/** @typedef {import('../markdown').MarkdownNode} MarkdownNode */
+const md = require('../markdown');
+
+const fs = require('fs').promises;
+const path = require('path');
+const { promisify } = require('util');
+const glob = promisify(require('glob').glob);
+const rimraf = require('rimraf');
+
+const DOCS_DIR = path.normalize(path.join(__dirname, '..', '..', 'docs', 'src'));
+const OUT_DIR = path.normalize(path.join(DOCS_DIR, "..", "tests", "generated"));
+
+/**
+ *
+ * @param {string} src
+ * @param {string} dst
+ */
+async function generateExamples(src, dst) {
+    const contents = await fs.readFile(src);
+    const ast = md.parse(contents.toString());
+
+    let madeDir = false;
+
+    /**
+     *
+     * @param {MarkdownNode} node
+     */
+    const walk = async (node) => {
+        if (node.type === 'code' && node.codeLang.includes('RUNNABLE')) {
+            const match = /js-flavor=(ts|js)/.exec(node.codeLang);
+            if (!match)
+                throw new Error(`
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+The following code block on line ${node.lineNo}, was marked RUNNABLE, but did
+not have a valid js-flavor annotation:
+-----------------------------------------------------------------------------
+${JSON.stringify(node, null, '  ')}
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+`);
+
+            const extension = match[1]
+            if (node.lineNo === undefined)
+                throw new Error(`Unexpected missing lineNo: ${JSON.stringify(node, null, '  ')}`);
+            if (!node.lines || node.lines.length < 1)
+                throw new Error(`Unexpected missing content: ${JSON.stringify(node, null, '  ')}`);
+
+            if (!madeDir) {
+                await fs.mkdir(path.dirname(dst), { recursive: true });
+                madeDir = true;
+            }
+
+            await fs.writeFile(`${dst}-${node.lineNo}-${extension}.spec.${extension}`, [`// generated from ${src}:${node.lineNo}`, ...node.lines].join('\n'))
+        }
+
+        for (const c of (node.children || []))
+            await walk(c);
+    }
+
+    for (const c of ast)
+        await walk(c);
+}
+
+
+(async () => {
+    const docs = await glob('./**/*.md', { cwd: DOCS_DIR });
+    rimraf.sync(OUT_DIR);
+    for (const doc of docs) {
+        const fullPath = path.join(DOCS_DIR, doc);
+        await generateExamples(fullPath, path.join(OUT_DIR, doc));
+    }
+})();

--- a/utils/generate_doc_tests/index.js
+++ b/utils/generate_doc_tests/index.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @ts-check
 
 /** @typedef {import('../markdown').MarkdownNode} MarkdownNode */

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -313,7 +313,7 @@ class TypesGenerator {
         let flavor = 'ts';
         if (match[3]) {
           flavor = match[3];
-          line = line.replace(/js-flavor=\w+/, '').replace(/```\w+/, '```ts');
+          line = line.replace(/js-flavor=\w+/, '').replace('RUNNABLE', '').replace(/```\w+/, '```ts');
         }
         skipExample = !["html", "yml", "bash", "js"].includes(lang) || flavor !== 'ts';
       } else if (skipExample && line.trim().startsWith('```')) {

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -22,6 +22,7 @@
  *    codeLang?: string,
  *    noteType?: string,
  *    lines?: string[],
+ *    lineNo?: number,
  *    liType?: 'default' | 'bullet' | 'ordinal',
  *    children?: MarkdownNode[]
  *  }} MarkdownNode */
@@ -122,7 +123,8 @@ function buildTree(lines) {
       const node = {
         type: 'code',
         lines: [],
-        codeLang: content.substring(3)
+        codeLang: content.substring(3),
+        lineNo: i + 1,
       };
       line = lines[++i];
       while (!line.trim().startsWith('```')) {
@@ -205,9 +207,10 @@ function buildTree(lines) {
 
 /**
  * @param {string} content
+ * @param {boolean?} flatten
  */
-function parse(content) {
-  return buildTree(flattenWrappedLines(content));
+function parse(content, flatten = true) {
+  return buildTree(flatten ? flattenWrappedLines(content) : content.replace(/\r\n/g, '\n').split('\n'));
 }
 
 /**


### PR DESCRIPTION
This change intends to help us make our docs and examples:

1. more `@playwright/test` centric since many users consume the APIs via
   test runner
2. self-contained: many of our docs show example API usage, but don't
   show the corresponding DOM that the API is being exercised against
3. working out of the box: there is nothing more frustrating than trying
   an example only to get an error

This introduces:

```
$ npm run dtest
```

which will run all (annotated) code samples from the docs.

See the diffs of the `*.md` files for examples.

The current annotation/generation assumes the example is completely
self-contained, but since importing `test`/`expect` into each example
can get verbose (for both doc contributors and users/readers), we might
consider having that part implied and just including it as part of the
generation. Currently, runnable blocks are annotated with `RUNNABLE`,
so maybe we could introduce variations of this that indicate to the
generation step whether the example is self-container or requires
auto-adding of the common imports.