### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/docs/src/test-api-testing-js.md
+++ b/docs/src/test-api-testing-js.md
@@ -306,7 +306,7 @@ test('last created issue should be on the server', async ({ page, request }) => 
   await page.fill('[aria-label="Title"]', 'Bug report 1');
   await page.fill('[aria-label="Comment body"]', 'Bug description');
   await page.click('text=Submit new issue');
-  const issueId = page.url().substr(page.url().lastIndexOf('/'));
+  const issueId = page.url().slice(page.url().lastIndexOf('/'));
 
   const newIssue = await request.get(`https://api.github.com/repos/${USER}/${REPO}/issues/${issueId}`);
   expect(newIssue.ok()).toBeTruthy();
@@ -351,7 +351,7 @@ test('last created issue should be on the server', async ({ page, request }) => 
   await page.fill('[aria-label="Title"]', 'Bug report 1');
   await page.fill('[aria-label="Comment body"]', 'Bug description');
   await page.click('text=Submit new issue');
-  const issueId = page.url().substr(page.url().lastIndexOf('/'));
+  const issueId = page.url().slice(page.url().lastIndexOf('/'));
 
   const newIssue = await request.get(`https://api.github.com/repos/${USER}/${REPO}/issues/${issueId}`);
   expect(newIssue.ok()).toBeTruthy();

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -196,7 +196,7 @@ export abstract class APIRequestContext extends SdkObject {
       return [];
     const url = new URL(responseUrl);
     // https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4
-    const defaultPath = '/' + url.pathname.substr(1).split('/').slice(0, -1).join('/');
+    const defaultPath = '/' + url.pathname.slice(1).split('/').slice(0, -1).join('/');
     const cookies: types.NetworkCookie[] = [];
     for (const header of setCookie) {
       // Decode cookie value?

--- a/packages/playwright-core/src/server/supplements/har/harTracer.ts
+++ b/packages/playwright-core/src/server/supplements/har/harTracer.ts
@@ -489,8 +489,8 @@ function parseCookie(c: string): har.Cookie {
   let first = true;
   for (const pair of c.split(/; */)) {
     const indexOfEquals = pair.indexOf('=');
-    const name = indexOfEquals !== -1 ? pair.substr(0, indexOfEquals).trim() : pair.trim();
-    const value = indexOfEquals !== -1 ? pair.substr(indexOfEquals + 1, pair.length).trim() : '';
+    const name = indexOfEquals !== -1 ? pair.slice(0, indexOfEquals).trim() : pair.trim();
+    const value = indexOfEquals !== -1 ? pair.slice(indexOfEquals + 1).trim() : '';
     if (first) {
       first = false;
       cookie.name = name;

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -825,7 +825,7 @@ export class WKPage implements PageDelegate {
     const rect = (documentRect || viewportRect)!;
     const result = await this._session.send('Page.snapshotRect', { ...rect, coordinateSystem: documentRect ? 'Page' : 'Viewport', omitDeviceScaleFactor: size === 'css' });
     const prefix = 'data:image/png;base64,';
-    let buffer = Buffer.from(result.dataURL.substr(prefix.length), 'base64');
+    let buffer = Buffer.from(result.dataURL.slice(prefix.length), 'base64');
     if (format === 'jpeg')
       buffer = jpeg.encode(png.PNG.sync.read(buffer), quality).data;
     return buffer;

--- a/packages/playwright-core/src/third_party/highlightjs/highlightjs/core.js
+++ b/packages/playwright-core/src/third_party/highlightjs/highlightjs/core.js
@@ -1433,7 +1433,7 @@ function mergeStreams(original, highlighted, value) {
       render(stream.splice(0, 1)[0]);
     }
   }
-  return result + escapeHTML(value.substr(processed));
+  return result + escapeHTML(value.slice(processed));
 }
 
 /*
@@ -1635,7 +1635,7 @@ const HLJS = function(hljs) {
         lastIndex = top.keywordPatternRe.lastIndex;
         match = top.keywordPatternRe.exec(modeBuffer);
       }
-      buf += modeBuffer.substr(lastIndex);
+      buf += modeBuffer.slice(lastIndex);
       emitter.addText(buf);
     }
 
@@ -1783,7 +1783,7 @@ const HLJS = function(hljs) {
      */
     function doEndMatch(match) {
       const lexeme = match[0];
-      const matchPlusRemainder = codeToHighlight.substr(match.index);
+      const matchPlusRemainder = codeToHighlight.slice(match.index);
 
       const endMode = endOfMode(top, match, matchPlusRemainder);
       if (!endMode) { return NO_MATCH; }
@@ -1957,7 +1957,7 @@ const HLJS = function(hljs) {
         const processedCount = processLexeme(beforeMatch, match);
         index = match.index + processedCount;
       }
-      processLexeme(codeToHighlight.substr(index));
+      processLexeme(codeToHighlight.slice(index));
       emitter.closeAllNodes();
       emitter.finalize();
       result = emitter.toHTML();

--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -450,5 +450,5 @@ function fitToWidth(line: string, width: number, suffix?: string): string {
     ansiLen += m[0].length;
   }
   // Truncate and reset all colors.
-  return line.substr(0, width + ansiLen) + '\u001b[0m';
+  return line.slice(0, width + ansiLen) + '\u001b[0m';
 }

--- a/tests/assets/background-color.html
+++ b/tests/assets/background-color.html
@@ -1,7 +1,7 @@
 <html>
 <script>
 function changeBackground() {
-  const color = location.hash.substr(1);
+  const color = location.hash.slice(1);
   document.body.style.backgroundColor = color;
 }
 </script>

--- a/tests/assets/checkerboard.html
+++ b/tests/assets/checkerboard.html
@@ -1,7 +1,7 @@
 <html>
 <script>
 function changeBackground() {
-  const color = location.hash.substr(1);
+  const color = location.hash.slice(1);
   document.body.style.backgroundColor = color;
 }
 </script>

--- a/tests/assets/reading-list/react-dom_15.7.0.js
+++ b/tests/assets/reading-list/react-dom_15.7.0.js
@@ -12400,7 +12400,7 @@ function makeNativeSimulator(eventType) {
 
 Object.keys(topLevelTypes).forEach(function (eventType) {
   // Event type is stored as 'topClick' - we transform that to 'click'
-  var convenienceName = eventType.indexOf('top') === 0 ? eventType.charAt(3).toLowerCase() + eventType.substr(4) : eventType;
+  var convenienceName = eventType.indexOf('top') === 0 ? eventType.charAt(3).toLowerCase() + eventType.slice(4) : eventType;
   /**
    * @param {!Element|ReactDOMComponent} domComponentOrNode
    * @param {?Event} nativeEventData Fake native event to use in SyntheticEvent.

--- a/tests/assets/reading-list/react_15.7.0.js
+++ b/tests/assets/reading-list/react_15.7.0.js
@@ -722,7 +722,7 @@ if (canUseCollections) {
     return '.' + id;
   };
   var getIDFromKey = function (key) {
-    return parseInt(key.substr(1), 10);
+    return parseInt(key.slice(1), 10);
   };
 
   setItem = function (id, item) {

--- a/tests/assets/reading-list/vue_3.1.5.js
+++ b/tests/assets/reading-list/vue_3.1.5.js
@@ -10708,7 +10708,7 @@ var Vue = (function (exports) {
       return !currentOpenBracketCount && !currentOpenParensCount;
   };
   function getInnerRange(loc, offset, length) {
-      const source = loc.source.substr(offset, length);
+      const source = loc.source.slice(offset, offset + length);
       const newLoc = {
           source,
           start: advancePositionWithClone(loc.start, loc.source, offset),
@@ -11441,7 +11441,7 @@ var Vue = (function (exports) {
                   if (!content.endsWith(']')) {
                       emitError(context, 26 /* X_MISSING_DYNAMIC_DIRECTIVE_ARGUMENT_END */);
                   }
-                  content = content.substr(1, content.length - 2);
+                  content = content.slice(1, -1);
               }
               else if (isSlot) {
                   // #1241 special case for v-slot: vuetify relies extensively on slot
@@ -11466,7 +11466,7 @@ var Vue = (function (exports) {
               valueLoc.end = advancePositionWithClone(valueLoc.start, value.content);
               valueLoc.source = valueLoc.source.slice(1, -1);
           }
-          const modifiers = match[3] ? match[3].substr(1).split('.') : [];
+          const modifiers = match[3] ? match[3].slice(1).split('.') : [];
           return {
               type: 7 /* DIRECTIVE */,
               name: dirName,
@@ -11673,7 +11673,7 @@ var Vue = (function (exports) {
   }
   function startsWithEndTagOpen(source, tag) {
       return (startsWith(source, '</') &&
-          source.substr(2, tag.length).toLowerCase() === tag.toLowerCase() &&
+          source.slice(2, 2 + tag.length).toLowerCase() === tag.toLowerCase() &&
           /[\t\r\n\f />]/.test(source[2 + tag.length] || '>'));
   }
 

--- a/tests/browsercontext-fetch.spec.ts
+++ b/tests/browsercontext-fetch.spec.ts
@@ -142,7 +142,7 @@ for (const method of ['fetch', 'delete', 'get', 'head', 'patch', 'post', 'put'] 
         }
       }),
     ]);
-    const params = new URLSearchParams(request.url.substr(request.url.indexOf('?')));
+    const params = new URLSearchParams(request.url.slice(request.url.indexOf('?')));
     expect(params.get('p1')).toEqual('v1');
     expect(params.get('парам2')).toEqual('знач2');
   });
@@ -932,7 +932,7 @@ it('should accept bool and numeric params', async ({ page, server }) => {
       'bool2': false,
     }
   });
-  const params = new URLSearchParams(request.url.substr(request.url.indexOf('?')));
+  const params = new URLSearchParams(request.url.slice(request.url.indexOf('?')));
   expect(params.get('str')).toEqual('s');
   expect(params.get('num')).toEqual('10');
   expect(params.get('bool')).toEqual('true');

--- a/tests/browsercontext-locale.spec.ts
+++ b/tests/browsercontext-locale.spec.ts
@@ -24,7 +24,7 @@ it('should affect accept-language header @smoke', async ({ browser, server }) =>
     server.waitForRequest('/empty.html'),
     page.goto(server.EMPTY_PAGE),
   ]);
-  expect((request.headers['accept-language'] as string).substr(0, 5)).toBe('fr-CH');
+  expect((request.headers['accept-language'] as string).slice(0, 5)).toBe('fr-CH');
   await context.close();
 });
 

--- a/tests/inspector/inspectorTest.ts
+++ b/tests/inspector/inspectorTest.ts
@@ -143,7 +143,7 @@ class Recorder {
       const prefix = 'Highlight updated for test: ';
       if (msg.text().startsWith(prefix)) {
         this.page.off('console', listener);
-        callback(msg.text().substr(prefix.length));
+        callback(msg.text().slice(prefix.length));
       }
     };
     this.page.on('console', listener);
@@ -160,7 +160,7 @@ class Recorder {
       const prefix = 'Action performed for test: ';
       if (msg.text().startsWith(prefix)) {
         this.page.off('console', listener);
-        const arg = JSON.parse(msg.text().substr(prefix.length));
+        const arg = JSON.parse(msg.text().slice(prefix.length));
         callback(arg);
       }
     };

--- a/tests/port-forwarding-server.spec.ts
+++ b/tests/port-forwarding-server.spec.ts
@@ -41,7 +41,7 @@ class OutOfProcessPlaywrightServer {
         const prefix = 'Listening on ';
         const line = data.toString();
         if (line.startsWith(prefix))
-          resolve(line.substr(prefix.length));
+          resolve(line.slice(prefix.length));
       });
       this._driverProcess.stderr.on('data', (data: Buffer) => {
         console.log(data.toString());


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.