### PR TITLE
docs(docker.md): correct seccomp_profile.json

### DIFF
--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -78,20 +78,18 @@ docker run -it --rm --ipc=host --user pwuser --security-opt seccomp=seccomp_prof
 [`seccomp_profile.json`](https://github.com/microsoft/playwright/blob/main/utils/docker/seccomp_profile.json) is needed to run Chromium with sandbox. This is a [default Docker seccomp profile](https://github.com/docker/engine/blob/d0d99b04cf6e00ed3fc27e81fc3d94e7eda70af3/profiles/seccomp/default.json) with extra user namespace cloning permissions:
 
 ```json
-[
-  {
-    "comment": "Allow create user namespaces",
-    "names": [
-      "clone",
-      "setns",
-      "unshare"
-    ],
-    "action": "SCMP_ACT_ALLOW",
-    "args": [],
-    "includes": {},
-    "excludes": {}
-  }
-]
+{
+  "comment": "Allow create user namespaces",
+  "names": [
+    "clone",
+    "setns",
+    "unshare"
+  ],
+  "action": "SCMP_ACT_ALLOW",
+  "args": [],
+  "includes": {},
+  "excludes": {}
+}
 ```
 
 :::note


### PR DESCRIPTION
seccomp_profile.json should be a JSON object. A JSON array would produce this error message:

```
docker: Error response from daemon: Decoding seccomp profile failed: json: cannot unmarshal array into Go value of type seccomp.Seccomp.
```

CR: https://codereviewvideos.com/blog/how-i-fixed-docker-error-response-from-daemon-decoding-seccomp-profile-failed-json-cannot-unmarshal-array-into-go-value-of-type-seccomp-seccomp/