### PR TITLE
docs(dotnet): fix EvalueHandleAsync typo

### DIFF
--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -646,7 +646,7 @@ a_handle = page.evaluate_handle("document") # handle for the "document"
 ```
 
 ```csharp
-var docHandle = await frame.EvalueHandleAsync("document"); // Handle for the `document`
+var docHandle = await frame.EvaluateHandleAsync("document"); // Handle for the `document`
 ```
 
 [JSHandle] instances can be passed as an argument to the [`method: Frame.evaluateHandle`]:

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1372,7 +1372,7 @@ a_handle = page.evaluate_handle("document") # handle for the "document"
 ```
 
 ```csharp
-var docHandle = await page.EvalueHandleAsync("document"); // Handle for the `document`
+var docHandle = await page.EvaluateHandleAsync("document"); // Handle for the `document`
 ```
 
 [JSHandle] instances can be passed as an argument to the [`method: Page.evaluateHandle`]:


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright.dev/issues/520