### PR TITLE
fix(selenium): Use ms:edgeOptions with Edge

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -159,7 +159,10 @@ export class Chromium extends BrowserType {
     const args = this._innerDefaultArgs(options);
     args.push('--remote-debugging-port=0');
     const isEdge = options.channel && options.channel.startsWith('msedge');
-    let desiredCapabilities = { 'browserName': isEdge ? 'MicrosoftEdge' : 'chrome', 'goog:chromeOptions': { args } };
+    let desiredCapabilities = {
+      'browserName': isEdge ? 'MicrosoftEdge' : 'chrome',
+      [isEdge ? 'ms:edgeOptions' : 'goog:chromeOptions']: { args }
+    };
     try {
       if (process.env.SELENIUM_REMOTE_CAPABILITIES) {
         const parsed = JSON.parse(process.env.SELENIUM_REMOTE_CAPABILITIES);


### PR DESCRIPTION
Updating Selenium Grid support to use the `ms:edgeOptions` capability when connecting to Microsoft Edge. Edge WebDriver doesn't recognize `goog:chromeOptions`.