### PR TITLE
cherry-pick(#12934): allow toMatchSnapshot to use text comparator for text data

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -31,7 +31,7 @@ import { Progress, ProgressController } from './progress';
 import { assert, isError } from '../utils/utils';
 import { ManualPromise } from '../utils/async';
 import { debugLogger } from '../utils/debugLogger';
-import { mimeTypeToComparator, ImageComparatorOptions, ComparatorResult } from '../utils/comparators';
+import { getComparator, ImageComparatorOptions, ComparatorResult } from '../utils/comparators';
 import { SelectorInfo, Selectors } from './selectors';
 import { CallMetadata, SdkObject } from './instrumentation';
 import { Artifact } from './artifact';
@@ -447,7 +447,7 @@ export class Page extends SdkObject {
       return await this._screenshotter.screenshotPage(progress, options.screenshotOptions || {});
     };
 
-    const comparator = mimeTypeToComparator['image/png'];
+    const comparator = getComparator('image/png');
     const controller = new ProgressController(metadata, this);
     const isGeneratingNewScreenshot = !options.expected;
     if (isGeneratingNewScreenshot && options.isNot)

--- a/packages/playwright-core/src/utils/comparators.ts
+++ b/packages/playwright-core/src/utils/comparators.ts
@@ -26,12 +26,16 @@ const { PNG } = require(require.resolve('pngjs', { paths: [require.resolve('pixe
 export type ImageComparatorOptions = { threshold?: number, maxDiffPixels?: number, maxDiffPixelRatio?: number };
 export type ComparatorResult = { diff?: Buffer; errorMessage?: string; } | null;
 export type Comparator = (actualBuffer: Buffer | string, expectedBuffer: Buffer, options?: any) => ComparatorResult;
-export const mimeTypeToComparator: { [key: string]: Comparator } = {
-  'application/octet-string': compareBuffersOrStrings,
-  'image/png': compareImages.bind(null, 'image/png'),
-  'image/jpeg': compareImages.bind(null, 'image/jpeg'),
-  'text/plain': compareText,
-};
+
+export function getComparator(mimeType: string): Comparator {
+  if (mimeType === 'image/png')
+    return compareImages.bind(null, 'image/png');
+  if (mimeType === 'image/jpeg')
+    return compareImages.bind(null, 'image/jpeg');
+  if (mimeType === 'text/plain')
+    return compareText;
+  return compareBuffersOrStrings;
+}
 
 function compareBuffersOrStrings(actualBuffer: Buffer | string, expectedBuffer: Buffer): ComparatorResult {
   if (typeof actualBuffer === 'string')

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -44,6 +44,22 @@ test('should support golden', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
 });
 
+test('should work with non-txt extensions', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    ...files,
+    'a.spec.js-snapshots/snapshot.csv': `1,2,3`,
+    'a.spec.js': `
+      const { test } = require('./helper');
+      test('is a test', ({}) => {
+        expect('1,2,4').toMatchSnapshot('snapshot.csv');
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(stripAnsi(result.output)).toContain(`1,2,34`);
+});
+
+
 test('should generate default name', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...files,


### PR DESCRIPTION
This was regressed awhile ago.

In v1.17 we shipped the following code: https://github.com/microsoft/playwright/blob/30e15ad36f011c7adf5bad86beadd50ca93b01b8/packages/playwright-test/src/matchers/golden.ts#L122-L131

`toMatchSnapshot` should fallback to text comparator in case of
unknown extension and string data.

Fixes #12862
