### PR TITLE
chore: use `package.json` directory to resolve output directory

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -256,7 +256,7 @@ Any JSON-serializable metadata that will be put directly to the test report.
 ## property: TestConfig.outputDir
 - type: <[string]>
 
-The output directory for files created during test execution. Defaults to `test-results`.
+The output directory for files created during test execution. Defaults to `<package.json-directory>/test-results`.
 
 ```js js-flavor=js
 // playwright.config.js

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -202,7 +202,7 @@ This path will serve as the base directory for each test file snapshot directory
 ## property: TestProject.outputDir
 - type: <[string]>
 
-The output directory for files created during test execution. Defaults to `test-results`.
+The output directory for files created during test execution. Defaults to `<package.json-directory>/test-results`.
 
 This directory is cleaned at the start. When running a test, a unique subdirectory inside the [`property: TestProject.outputDir`] is created, guaranteeing that test running in parallel do not conflict. This directory can be accessed by [`property: TestInfo.outputDir`] and [`method: TestInfo.outputPath`].
 

--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -20,7 +20,7 @@ import type { Config, TestStatus } from './types';
 export type SerializedLoaderData = {
   defaultConfig: Config;
   overrides: Config;
-  configFile: { file: string } | { rootDir: string };
+  configFile: { file: string } | { configDir: string };
 };
 export type WorkerInitParams = {
   workerIndex: number;

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -239,7 +239,7 @@ interface TestProject {
    */
   screenshotsDir?: string;
   /**
-   * The output directory for files created during test execution. Defaults to `test-results`.
+   * The output directory for files created during test execution. Defaults to `<package.json-directory>/test-results`.
    *
    * This directory is cleaned at the start. When running a test, a unique subdirectory inside the
    * [testProject.outputDir](https://playwright.dev/docs/api/class-testproject#test-project-output-dir) is created,
@@ -828,7 +828,7 @@ interface TestConfig {
    */
   screenshotsDir?: string;
   /**
-   * The output directory for files created during test execution. Defaults to `test-results`.
+   * The output directory for files created during test execution. Defaults to `<package.json-directory>/test-results`.
    *
    * ```ts
    * // playwright.config.ts

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -69,6 +69,12 @@ async function writeFiles(testInfo: TestInfo, files: Files) {
       `,
     };
   }
+  if (!Object.keys(files).some(name => name.includes('package.json'))) {
+    files = {
+      ...files,
+      'package.json': `{ "name": "test-project" }`,
+    };
+  }
 
   await Promise.all(Object.keys(files).map(async name => {
     const fullName = path.join(baseDir, name);
@@ -142,7 +148,7 @@ async function runPlaywrightTest(childProcess: CommonFixtures['childProcess'], b
       NODE_OPTIONS: undefined,
       ...env,
     },
-    cwd: baseDir,
+    cwd: options.cwd ? path.resolve(baseDir, options.cwd) : baseDir,
   });
   let didSendSigint = false;
   testProcess.onOutput = () => {
@@ -206,6 +212,7 @@ type RunOptions = {
   sendSIGINTAfter?: number;
   usesCustomOutputDir?: boolean;
   additionalArgs?: string[];
+  cwd?: string,
 };
 type Fixtures = {
   writeFiles: (files: Files) => Promise<string>;


### PR DESCRIPTION
This patch:
- starts using directory of `package.json` to resolve default
  output directory path
- starts using either `package.json` directory or configuration
  directory to resolve all relative paths

References #12970