### PR TITLE
feat(testinfo): enhance attach function

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -33,6 +33,52 @@ const config: PlaywrightTestConfig = {
 export default config;
 ```
 
+## property: TestConfig.attachmentConfig
+- type: <[Object]>
+  - `useNameAsPrefix` <[boolean]>: Whether to use the attachment name as prefix for the attachment filename, defaults to false.
+  - `useOriginalFilenameAsPrefix` <[boolean]>: Whether to use original filename as saved filename prefix, defaults to false.
+  - `saveBodyAsFile` <[boolean]>: Whether to save body as file. This is useful for reporters such as junit, defaults to false.
+
+Configuration for the [`method: TestInfo.attach`] behaviour.
+
+By default, attachments are saved to the test result directory with hashed path as filename. `useNameAsPrefix` and `useOriginalFilenameAsPrefix` control whether to append the attachment name or the original filename to the filename.
+
+If `useNameAsPrefix` is true, the filename will be `${attach name}-${hashed path}.${extension}`. If `useOriginalFilenameAsPrefix` is true, the filename will be `${original filename}-${hashed path}.${extension}`.
+
+If `saveBodyAsFile` is set to true, the attachment body will be saved to a file. This is useful for reporters such as junit, and if you need to upload all attachments to another service. Be noted that if you have this enabled, the reporter will no longer report the body, but the saved path instead.
+
+
+```js js-flavor=js
+// playwright.config.js
+// @ts-check
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  attachmentConfig: {
+    useNameAsPrefix: true,
+    useOriginalFilenameAsPrefix: true,
+    saveBodyAsFile: true,
+  },
+};
+
+module.exports = config;
+```
+
+```js js-flavor=ts
+// playwright.config.ts
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  attachmentConfig: {
+    useNameAsPrefix: true,
+    useOriginalFilenameAsPrefix: true,
+    saveBodyAsFile: true,
+  },
+};
+
+export default config;
+```
+
 ## property: TestConfig.expect
 - type: <[Object]>
   - `timeout` <[int]> Default timeout for async expect matchers in milliseconds, defaults to 5000ms.

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -104,6 +104,20 @@ const config: PlaywrightTestConfig = {
 export default config;
 ```
 
+## property: TestProject.attachmentConfig
+- type: <[Object]>
+  - `useNameAsPrefix` <[boolean]>: Whether to use the attachment name as prefix for the attachment filename, defaults to false.
+  - `useOriginalFilenameAsPrefix` <[boolean]>: Whether to use original filename as saved filename prefix, defaults to false.
+  - `saveBodyAsFile` <[boolean]>: Whether to save body as file. This is useful for reporters such as junit, defaults to false.
+
+Configuration for the [`method: TestInfo.attach`] behaviour. Use [`property: TestConfig.attachmentConfig`] to change this option for all projects.
+
+By default, attachments are saved to the test result directory with hashed filename. `useNameAsPrefix` and `useOriginalFilenameAsPrefix` control whether to append the attachment name or the original filename to the filename.
+
+If `useNameAsPrefix` is true, the filename will be `${attach name}-${hashed path}.${extension}`. If `useOriginalFilenameAsPrefix` is true, the filename will be `${original filename}-${hashed path}.${extension}`.
+
+If `saveBodyAsFile` is set to true, the attachment body will be saved to a file. This is useful for reporters such as junit, and if you need to upload all attachments to another service. Be noted that if you have this enabled, the reporter will no longer report the body, but the saved path instead.
+
 ## property: TestProject.expect
 - type: <[Object]>
   - `timeout` <[int]> Default timeout for async expect matchers in milliseconds, defaults to 5000ms.

--- a/packages/playwright-core/src/utils/utils.ts
+++ b/packages/playwright-core/src/utils/utils.ts
@@ -624,3 +624,9 @@ export class SigIntWatcher {
   }
 }
 
+export function getFilenameWithoutExtension(filename: string) {
+  if (filename.includes('.'))
+    return filename.split('.').slice(0, -1).join('.');
+  else
+    return filename;
+}

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -278,7 +278,7 @@ function toReporters(reporters: BuiltInReporter | ReporterDescription[] | undefi
   if (!reporters)
     return;
   if (typeof reporters === 'string')
-    return [[reporters]];
+    return [ [reporters] ];
   return reporters;
 }
 
@@ -469,7 +469,7 @@ const baseFullConfig: FullConfig = {
   maxFailures: 0,
   preserveOutput: 'always',
   projects: [],
-  reporter: [['list']],
+  reporter: [ ['list'] ],
   reportSlowTests: null,
   rootDir: path.resolve(process.cwd()),
   quiet: false,
@@ -481,11 +481,11 @@ const baseFullConfig: FullConfig = {
   attachments: [],
 };
 
-function resolveReporters(reporters: Config['reporter'], rootDir: string): ReporterDescription[] | undefined {
+function resolveReporters(reporters: Config['reporter'], rootDir: string): ReporterDescription[]|undefined {
   return toReporters(reporters as any)?.map(([id, arg]) => {
     if (builtInReporters.includes(id as any))
       return [id, arg];
-    return [require.resolve(id, { paths: [rootDir] }), arg];
+    return [require.resolve(id, { paths: [ rootDir ] }), arg];
   });
 }
 

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -153,6 +153,23 @@ type ExpectSettings = {
  */
 interface TestProject {
   /**
+   * Configuration for the
+   * [testInfo.attach(name[, options])](https://playwright.dev/docs/api/class-testinfo#test-info-attach) behaviour. Use
+   * [testConfig.attachmentConfig](https://playwright.dev/docs/api/class-testconfig#test-config-attachment-config) to change
+   * this option for all projects.
+   *
+   * By default, attachments are saved to the test result directory with hashed filename. `useNameAsPrefix` and
+   * `useOriginalFilenameAsPrefix` control whether to append the attachment name or the original filename to the filename.
+   *
+   * If `useNameAsPrefix` is true, the filename will be `${attach name}-${hashed path}.${extension}`. If
+   * `useOriginalFilenameAsPrefix` is true, the filename will be `${original filename}-${hashed path}.${extension}`.
+   *
+   * If `saveBodyAsFile` is set to true, the attachment body will be saved to a file. This is useful for reporters such as
+   * junit, and if you need to upload all attachments to another service. Be noted that if you have this enabled, the
+   * reporter will no longer report the body, but the saved path instead.
+   */
+  attachmentConfig?: AttachmentConfig;
+  /**
    * Configuration for the `expect` assertion library.
    *
    * Use [testConfig.expect](https://playwright.dev/docs/api/class-testconfig#test-config-expect) to change this option for
@@ -487,6 +504,15 @@ export type WebServerConfig = {
   cwd?: string,
 };
 
+export type AttachmentConfig = {
+  // Whether to add name to attachment filename.
+  useNameAsPrefix?: boolean;
+  // Whether to use original filename as saved filename prefix.
+  useOriginalFilenameAsPrefix?: boolean;
+  // Whether to save body as file. This is useful for reporters such as junit.
+  saveBodyAsFile?: boolean;
+}
+
 type LiteralUnion<T extends U, U = string> = T | (U & { zz_IGNORE_ME?: never });
 
 /**
@@ -512,6 +538,37 @@ type LiteralUnion<T extends U, U = string> = T | (U & { zz_IGNORE_ME?: never });
  *
  */
 interface TestConfig {
+  /**
+   * Configuration for the
+   * [testInfo.attach(name[, options])](https://playwright.dev/docs/api/class-testinfo#test-info-attach) behaviour.
+   *
+   * By default, attachments are saved to the test result directory with hashed path as filename. `useNameAsPrefix` and
+   * `useOriginalFilenameAsPrefix` control whether to append the attachment name or the original filename to the filename.
+   *
+   * If `useNameAsPrefix` is true, the filename will be `${attach name}-${hashed path}.${extension}`. If
+   * `useOriginalFilenameAsPrefix` is true, the filename will be `${original filename}-${hashed path}.${extension}`.
+   *
+   * If `saveBodyAsFile` is set to true, the attachment body will be saved to a file. This is useful for reporters such as
+   * junit, and if you need to upload all attachments to another service. Be noted that if you have this enabled, the
+   * reporter will no longer report the body, but the saved path instead.
+   *
+   * ```ts
+   * // playwright.config.ts
+   * import { PlaywrightTestConfig } from '@playwright/test';
+   *
+   * const config: PlaywrightTestConfig = {
+   *   attachmentConfig: {
+   *     useNameAsPrefix: true,
+   *     useOriginalFilenameAsPrefix: true,
+   *     saveBodyAsFile: true,
+   *   },
+   * };
+   *
+   * export default config;
+   * ```
+   *
+   */
+  attachmentConfig?: AttachmentConfig;
   /**
    * Whether to exit with an error if any tests or groups are marked as
    * [test.only(title, testFunction)](https://playwright.dev/docs/api/class-test#test-only) or

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -92,6 +92,7 @@ type ExpectSettings = {
 };
 
 interface TestProject {
+  attachmentConfig?: AttachmentConfig;
   expect?: ExpectSettings;
   fullyParallel?: boolean;
   grep?: RegExp | RegExp[];
@@ -151,9 +152,19 @@ export type WebServerConfig = {
   cwd?: string,
 };
 
+export type AttachmentConfig = {
+  // Whether to add name to attachment filename.
+  useNameAsPrefix?: boolean;
+  // Whether to use original filename as saved filename prefix.
+  useOriginalFilenameAsPrefix?: boolean;
+  // Whether to save body as file. This is useful for reporters such as junit.
+  saveBodyAsFile?: boolean;
+}
+
 type LiteralUnion<T extends U, U = string> = T | (U & { zz_IGNORE_ME?: never });
 
 interface TestConfig {
+  attachmentConfig?: AttachmentConfig;
   forbidOnly?: boolean;
   fullyParallel?: boolean;
   globalSetup?: string;


### PR DESCRIPTION
- Add ability to save body as file, this is useful for reporters like JUnit and other.
- Add filename or name to saved filename (#12145)