### PR TITLE
feat(selectors): support regular expressions in attribute selectors

### DIFF
--- a/docs/src/selectors.md
+++ b/docs/src/selectors.md
@@ -765,7 +765,7 @@ Selector examples:
 - match by component and property value **prefix**: `_react=BookItem[author ^= "Steven"]`
 - match by component and property value **suffix**: `_react=BookItem[author $= "Steven"]`
 - match by component and **key**: `_react=BookItem[key = '2']`
-
+- match by property value **regex**: `_react=[author = /Steven(\\s+King)?/i]`
 
 
 To find React element names in a tree use [React DevTools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi).
@@ -801,6 +801,7 @@ Selector examples:
 - match by **nested** property value: `_vue=[some.nested.value = 12]`
 - match by component and property value **prefix**: `_vue=book-item[author ^= "Steven"]`
 - match by component and property value **suffix**: `_vue=book-item[author $= "Steven"]`
+- match by property value **regex**: `_vue=[author = /Steven(\\s+King)?/i]`
 
 To find Vue element names in a tree use [Vue DevTools](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd?hl=en).
 

--- a/tests/page/selectors-react.spec.ts
+++ b/tests/page/selectors-react.spec.ts
@@ -102,6 +102,15 @@ for (const [name, url] of Object.entries(reacts)) {
       expect(await page.$$eval(`_react=BookItem[name *= " gatsby" i]`, els => els.length)).toBe(1);
     });
 
+    it('should support regex', async ({ page }) => {
+      expect(await page.$$eval(`_react=ColorButton[color = /red/]`, els => els.length)).toBe(3);
+      expect(await page.$$eval(`_react=ColorButton[color = /^red$/]`, els => els.length)).toBe(3);
+      expect(await page.$$eval(`_react=ColorButton[color = /RED/i]`, els => els.length)).toBe(3);
+      expect(await page.$$eval(`_react=ColorButton[color = /[pqr]ed/]`, els => els.length)).toBe(3);
+      expect(await page.$$eval(`_react=ColorButton[color = /[pq]ed/]`, els => els.length)).toBe(0);
+      expect(await page.$$eval(`_react=BookItem[name = /gat.by/i]`, els => els.length)).toBe(1);
+    });
+
     it('should support truthy querying', async ({ page }) => {
       expect(await page.$$eval(`_react=ColorButton[enabled]`, els => els.length)).toBe(5);
     });

--- a/tests/page/selectors-vue.spec.ts
+++ b/tests/page/selectors-vue.spec.ts
@@ -102,6 +102,15 @@ for (const [name, url] of Object.entries(vues)) {
       expect(await page.$$eval(`_vue=book-item[name *= " gatsby" i]`, els => els.length)).toBe(1);
     });
 
+    it('should support regex', async ({ page }) => {
+      expect(await page.$$eval(`_vue=color-button[color = /red/]`, els => els.length)).toBe(3);
+      expect(await page.$$eval(`_vue=color-button[color = /^red$/]`, els => els.length)).toBe(3);
+      expect(await page.$$eval(`_vue=color-button[color = /RED/i]`, els => els.length)).toBe(3);
+      expect(await page.$$eval(`_vue=color-button[color = /[pqr]ed/]`, els => els.length)).toBe(3);
+      expect(await page.$$eval(`_vue=color-button[color = /[pq]ed/]`, els => els.length)).toBe(0);
+      expect(await page.$$eval(`_vue=book-item[name = /gat.by/i]`, els => els.length)).toBe(1);
+    });
+
     it('should support truthy querying', async ({ page }) => {
       expect(await page.$$eval(`_vue=color-button[enabled]`, els => els.length)).toBe(5);
     });


### PR DESCRIPTION
Supports inline regex in addition to string: `_react=BookItem[author = /Ann?a/i]`.

This is similar to `text=` selector, but applies to `_react` and `_vue` selectors. In the future will also apply to `role=` selector.