### PR TITLE
browser(webkit): rebase to 03/16/22 (r291344)

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1620
-Changed: yurys@chromium.org Tue Mar 22 15:23:41 PDT 2022
+1621
+Changed: dpino@igalia.com Thu Mar 24 15:05:11 UTC 2022

--- a/browser_patches/webkit/UPSTREAM_CONFIG.sh
+++ b/browser_patches/webkit/UPSTREAM_CONFIG.sh
@@ -1,3 +1,3 @@
 REMOTE_URL="https://github.com/WebKit/WebKit.git"
 BASE_BRANCH="main"
-BASE_REVISION="196fcd71682fd2f6a2319bca077b8e7ff0f0daac"
+BASE_REVISION="6863b71663b3194fa7a650d6cc91039674bca189"

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -31,10 +31,10 @@ index 74e23df54de6fc8840423325e48101d63e87c681..b21a6bf6bd8671bf4c9ff27eca527689
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/ServiceWorker.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Target.json
 diff --git a/Source/JavaScriptCore/DerivedSources.make b/Source/JavaScriptCore/DerivedSources.make
-index 0f48ad56c9fc6d5a81f4bec94e4d8e9825ce1c81..950e03340d28e116e67abeb54e540b131f34298c 100644
+index 667f2c6854f8a1ba13c095f7e154f68e97cbf391..6399b41f2059c96094063c568906128f83d974db 100644
 --- a/Source/JavaScriptCore/DerivedSources.make
 +++ b/Source/JavaScriptCore/DerivedSources.make
-@@ -286,22 +286,27 @@ INSPECTOR_DOMAINS := \
+@@ -291,22 +291,27 @@ INSPECTOR_DOMAINS := \
      $(JavaScriptCore)/inspector/protocol/CSS.json \
      $(JavaScriptCore)/inspector/protocol/Canvas.json \
      $(JavaScriptCore)/inspector/protocol/Console.json \
@@ -1841,34 +1841,6 @@ index fc6fd38ecb392e9d5ea54d5702578562289434fb..6d4be8e5288a5a3307d7803246dcc16b
      // Do not use icu::TimeZone::createDefault. ICU internally has a cache for timezone and createDefault returns this cached value.
      m_timeZoneCache = std::unique_ptr<OpaqueICUTimeZone, OpaqueICUTimeZoneDeleter>(bitwise_cast<OpaqueICUTimeZone*>(icu::TimeZone::detectHostTimeZone()));
  #endif
-diff --git a/Source/JavaScriptCore/wasm/WasmCompilationMode.h b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
-index 6f134e33eb8ebdd3888fdb068df7bfcd0c4225fd..1e3f2f08ee3bcb1d4a52009907a2dd9e622c4c67 100644
---- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
-+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
-@@ -50,7 +50,6 @@ constexpr inline bool isOSREntry(CompilationMode compilationMode)
-     case CompilationMode::OMGForOSREntryMode:
-         return true;
-     }
--    RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(false);
- }
- 
- constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
-@@ -65,7 +64,6 @@ constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
-     case CompilationMode::EmbedderEntrypointMode:
-         return false;
-     }
--    RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(false);
- }
- 
- constexpr inline bool isAnyOMG(CompilationMode compilationMode)
-@@ -80,7 +78,6 @@ constexpr inline bool isAnyOMG(CompilationMode compilationMode)
-     case CompilationMode::EmbedderEntrypointMode:
-         return false;
-     }
--    RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(false);
- }
- 
- } } // namespace JSC::Wasm
 diff --git a/Source/PlatformWPE.cmake b/Source/PlatformWPE.cmake
 index 277feac7ce8f20ac94b6a02351f1c29f221fcef7..d9c39df7db565545108c765407ce1cda544856f7 100644
 --- a/Source/PlatformWPE.cmake
@@ -1962,10 +1934,10 @@ index fa280a4a4fd86851ccb31f3c9de76b8ea88958dc..f995e6a5a747d2c10fb29e1fe991b11d
 +_vpx_codec_version_str
 +_vpx_codec_vp8_cx
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
-index 9e4e9d694a47a3a25859688e431437b3ec7841a5..71d64cc3da4dfb098ed8fc96840216b5588e4c5b 100644
+index 705982f5ec9e1580193d5681a60045b35344684d..be0ea385d08191e46b75f5b07fd6868ad467dfa2 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
-@@ -50,7 +50,7 @@ DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_ = $(NORMAL_WEBCORE_FRAMEWORKS
+@@ -52,7 +52,7 @@ DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_ = $(NORMAL_WEBCORE_FRAMEWORKS
  DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_YES = @loader_path/../../../;
  
  GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
@@ -2088,7 +2060,7 @@ index 4aa67a3129804da9ff8e6a4494596c4661ff9e16..4fcf5dd448703b5d6a2d738f3cd5c88e
    type: bool
    humanReadableName: "Private Click Measurement"
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index d0ee99cf4c39c77045472e089e12ffed746ced7e..65b81de88aa2b362d0d15f40973e3fc172b7c462 100644
+index 0f63c8cb02277bcdc49b1afe7b5e531fe89ce2d5..dacc476d98100047329679cd31dc0758df2d9d4e 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 @@ -455,7 +455,7 @@ CrossOriginOpenerPolicyEnabled:
@@ -2100,7 +2072,7 @@ index d0ee99cf4c39c77045472e089e12ffed746ced7e..65b81de88aa2b362d0d15f40973e3fc1
      WebCore:
        default: false
  
-@@ -834,9 +834,9 @@ MaskWebGLStringsEnabled:
+@@ -846,9 +846,9 @@ MaskWebGLStringsEnabled:
      WebKitLegacy:
        default: true
      WebKit:
@@ -2112,7 +2084,7 @@ index d0ee99cf4c39c77045472e089e12ffed746ced7e..65b81de88aa2b362d0d15f40973e3fc1
  
  # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
  MediaCapabilitiesExtensionsEnabled:
-@@ -1332,7 +1332,7 @@ SpeechRecognitionEnabled:
+@@ -1344,7 +1344,7 @@ SpeechRecognitionEnabled:
      WebKitLegacy:
        default: false
      WebKit:
@@ -2303,7 +2275,7 @@ index 3901bfb0f5479064f4e7b67c90621ff26d74b580..5b3615a871d0d7123822394c94d5ce10
  
  if (Journald_FOUND)
 diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
-index e2ef4570b4e1480895a7d9fb5e3dbd49181ea783..a730dea80a09dee033abd0896feb89875ddcbbc5 100644
+index 16d7aca4d82abf2f836c4bba36bf770464276f23..bd48e77956a09dae4814afb558e1dab89ff4390e 100644
 --- a/Source/WTF/wtf/PlatformHave.h
 +++ b/Source/WTF/wtf/PlatformHave.h
 @@ -416,7 +416,7 @@
@@ -2327,11 +2299,27 @@ index f8bedf1af5d20d9c93a96af565e416bfb0df6faa..a072e5e130822d3658cbab453aef8d16
  )
  
  if (Journald_FOUND)
+diff --git a/Source/WebCore/CMakeLists.txt b/Source/WebCore/CMakeLists.txt
+index f84b68f71946aca630d138d068f1d38d47c9cc5e..d07f228ef9404cf711380f34b8be9b9573e495fd 100644
+--- a/Source/WebCore/CMakeLists.txt
++++ b/Source/WebCore/CMakeLists.txt
+@@ -545,7 +545,11 @@ set(WebCore_NON_SVG_IDL_FILES
+ 
+     Modules/speech/DOMWindow+SpeechSynthesis.idl
+     Modules/speech/SpeechSynthesis.idl
++    Modules/speech/SpeechSynthesisErrorCode.idl
++    Modules/speech/SpeechSynthesisErrorEvent.idl
++    Modules/speech/SpeechSynthesisErrorEventInit.idl
+     Modules/speech/SpeechSynthesisEvent.idl
++    Modules/speech/SpeechSynthesisEventInit.idl
+     Modules/speech/SpeechSynthesisUtterance.idl
+     Modules/speech/SpeechSynthesisVoice.idl
+ 
 diff --git a/Source/WebCore/DerivedSources.make b/Source/WebCore/DerivedSources.make
-index 26803270d67a774559ecf23d75b6bb05b0693885..8a711a7028c7d9dc08e401ecb9f1c85606b63fb2 100644
+index 1ec22835adece9c3b2bc6aba6c53c4fec0027430..46ea0bfbcd6e9617efbba223b3a725d79ab7e715 100644
 --- a/Source/WebCore/DerivedSources.make
 +++ b/Source/WebCore/DerivedSources.make
-@@ -960,6 +960,10 @@ JS_BINDING_IDLS := \
+@@ -965,6 +965,10 @@ JS_BINDING_IDLS := \
      $(WebCore)/dom/Slotable.idl \
      $(WebCore)/dom/StaticRange.idl \
      $(WebCore)/dom/StringCallback.idl \
@@ -2342,7 +2330,7 @@ index 26803270d67a774559ecf23d75b6bb05b0693885..8a711a7028c7d9dc08e401ecb9f1c856
      $(WebCore)/dom/Text.idl \
      $(WebCore)/dom/TextDecoder.idl \
      $(WebCore)/dom/TextDecoderStream.idl \
-@@ -1502,9 +1506,6 @@ JS_BINDING_IDLS := \
+@@ -1507,9 +1511,6 @@ JS_BINDING_IDLS := \
  ADDITIONAL_BINDING_IDLS = \
      DocumentTouch.idl \
      GestureEvent.idl \
@@ -2429,10 +2417,10 @@ index f8b6c3578e152679a2e72bfd69313f6f4aa783e1..c12f77e371169058b022ca30ca13f2fb
  
  set(CSS_VALUE_PLATFORM_DEFINES "HAVE_OS_DARK_MODE_SUPPORT=1")
 diff --git a/Source/WebCore/SourcesCocoa.txt b/Source/WebCore/SourcesCocoa.txt
-index f9e0abaf4b922b89372f9ba9725409fbc7b7f85f..e8b3c986ebb45c9905237c32edbb60d8496214c7 100644
+index 029f6e18e1dbcc85ffd3f40fd7a6ad630fc3c236..4794ba2b029c8488f20d6d24df029b435391bfa7 100644
 --- a/Source/WebCore/SourcesCocoa.txt
 +++ b/Source/WebCore/SourcesCocoa.txt
-@@ -625,3 +625,9 @@ platform/graphics/angle/GraphicsContextGLANGLE.cpp @no-unify
+@@ -629,3 +629,9 @@ platform/graphics/angle/GraphicsContextGLANGLE.cpp @no-unify
  platform/graphics/cocoa/ANGLEUtilitiesCocoa.cpp @no-unify
  platform/graphics/cocoa/GraphicsContextGLCocoa.mm @no-unify
  platform/graphics/cv/GraphicsContextGLCVCocoa.cpp @no-unify
@@ -2442,8 +2430,23 @@ index f9e0abaf4b922b89372f9ba9725409fbc7b7f85f..e8b3c986ebb45c9905237c32edbb60d8
 +JSTouchEvent.cpp
 +JSTouchList.cpp
 +// Playwright end
+diff --git a/Source/WebCore/SourcesGTK.txt b/Source/WebCore/SourcesGTK.txt
+index b5e58ccd7619e47c77cb7b2c6d7ba581cab02563..39521adf049731c1dc584bbe37f5451fd98f3842 100644
+--- a/Source/WebCore/SourcesGTK.txt
++++ b/Source/WebCore/SourcesGTK.txt
+@@ -152,3 +152,10 @@ platform/xdg/MIMETypeRegistryXdg.cpp
+ 
+ rendering/RenderThemeAdwaita.cpp
+ rendering/RenderThemeGtk.cpp
++
++// Playwright: begin.
++JSSpeechSynthesisErrorCode.cpp
++JSSpeechSynthesisErrorEvent.cpp
++JSSpeechSynthesisErrorEventInit.cpp
++JSSpeechSynthesisEventInit.cpp
++// Playwright: end.
 diff --git a/Source/WebCore/SourcesWPE.txt b/Source/WebCore/SourcesWPE.txt
-index 57fa7ca67c4dea4a9e5b9845e72ae25873d8cf55..80b49517655ef1dae7f6e21c3672431d90c7ecf0 100644
+index f8c8c70492fb09d109aed1184b7c69ca25eb2f27..8cfe779213514131a74079514f96812375896ff3 100644
 --- a/Source/WebCore/SourcesWPE.txt
 +++ b/Source/WebCore/SourcesWPE.txt
 @@ -61,6 +61,8 @@ editing/libwpe/EditorLibWPE.cpp
@@ -2455,7 +2458,7 @@ index 57fa7ca67c4dea4a9e5b9845e72ae25873d8cf55..80b49517655ef1dae7f6e21c3672431d
  page/linux/ResourceUsageOverlayLinux.cpp
  page/linux/ResourceUsageThreadLinux.cpp
  
-@@ -104,8 +106,12 @@ platform/text/LocaleICU.cpp
+@@ -105,8 +107,19 @@ platform/text/LocaleICU.cpp
  
  platform/unix/LoggingUnix.cpp
  
@@ -2468,6 +2471,13 @@ index 57fa7ca67c4dea4a9e5b9845e72ae25873d8cf55..80b49517655ef1dae7f6e21c3672431d
  rendering/RenderThemeAdwaita.cpp
 +
 +platform/wpe/SelectionData.cpp
++
++// Playwright: begin.
++JSSpeechSynthesisErrorCode.cpp
++JSSpeechSynthesisErrorEvent.cpp
++JSSpeechSynthesisErrorEventInit.cpp
++JSSpeechSynthesisEventInit.cpp
++// Playwright: end.
 diff --git a/Source/WebCore/WebCore.order b/Source/WebCore/WebCore.order
 index c4898d6db6bf06552f602c4b7f0a7267e64e44f4..7cf2e30729671a89c373870c5691d337ec3f8a59 100644
 --- a/Source/WebCore/WebCore.order
@@ -2481,10 +2491,10 @@ index c4898d6db6bf06552f602c4b7f0a7267e64e44f4..7cf2e30729671a89c373870c5691d337
  __ZN7WebCore14DocumentLoaderD2Ev
  __ZN7WebCore14DocumentLoader17clearMainResourceEv
 diff --git a/Source/WebCore/WebCore.xcodeproj/project.pbxproj b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3f12a4725 100644
+index d8dc8686c498145fba37b2456617a840a27c25a6..df7c15fcd1a1fe34b6596e3d1f4d2a4a26611155 100644
 --- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 +++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-@@ -5512,6 +5512,13 @@
+@@ -5506,6 +5506,13 @@
  		EDE3A5000C7A430600956A37 /* ColorMac.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE3A4FF0C7A430600956A37 /* ColorMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		EDEC98030AED7E170059137F /* WebCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEC98020AED7E170059137F /* WebCorePrefix.h */; };
  		EFCC6C8F20FE914400A2321B /* CanvasActivityRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2498,7 +2508,7 @@ index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3
  		F12171F616A8CF0B000053CA /* WebVTTElement.h in Headers */ = {isa = PBXBuildFile; fileRef = F12171F416A8BC63000053CA /* WebVTTElement.h */; };
  		F32BDCD92363AACA0073B6AE /* UserGestureEmulationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F32BDCD72363AACA0073B6AE /* UserGestureEmulationScope.h */; };
  		F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
-@@ -17804,6 +17811,14 @@
+@@ -17772,6 +17779,14 @@
  		EDEC98020AED7E170059137F /* WebCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCorePrefix.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
  		EFB7287B2124C73D005C2558 /* CanvasActivityRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasActivityRecord.cpp; sourceTree = "<group>"; };
  		EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasActivityRecord.h; sourceTree = "<group>"; };
@@ -2513,7 +2523,7 @@ index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3
  		F12171F316A8BC63000053CA /* WebVTTElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebVTTElement.cpp; sourceTree = "<group>"; };
  		F12171F416A8BC63000053CA /* WebVTTElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebVTTElement.h; sourceTree = "<group>"; };
  		F32BDCD52363AAC90073B6AE /* UserGestureEmulationScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserGestureEmulationScope.cpp; sourceTree = "<group>"; };
-@@ -24185,7 +24200,12 @@
+@@ -24143,7 +24158,12 @@
  				1AF326770D78B9440068F0C4 /* EditorClient.h */,
  				E36D701E27B71F04006531B7 /* EmptyAttachmentElementClient.h */,
  				93C09A800B064F00005ABD4D /* EventHandler.cpp */,
@@ -2526,7 +2536,7 @@ index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3
  				E0FEF371B27C53EAC1C1FBEE /* EventSource.cpp */,
  				E0FEF371B17C53EAC1C1FBEE /* EventSource.h */,
  				E0FEF371B07C53EAC1C1FBEE /* EventSource.idl */,
-@@ -30145,6 +30165,8 @@
+@@ -30112,6 +30132,8 @@
  				29E4D8DF16B0940F00C84704 /* PlatformSpeechSynthesizer.h */,
  				1AD8F81A11CAB9E900E93E54 /* PlatformStrategies.cpp */,
  				1AD8F81911CAB9E900E93E54 /* PlatformStrategies.h */,
@@ -2535,7 +2545,7 @@ index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3
  				0FD7C21D23CE41E30096D102 /* PlatformWheelEvent.cpp */,
  				935C476A09AC4D4F00A6AAB4 /* PlatformWheelEvent.h */,
  				BCBB8AB513F1AFB000734DF0 /* PODInterval.h */,
-@@ -32466,6 +32488,7 @@
+@@ -32433,6 +32455,7 @@
  				BCCFBAE70B5152ED0001F1D7 /* DocumentParser.h */,
  				AD6E71AA1668899D00320C13 /* DocumentSharedObjectPool.cpp */,
  				AD6E71AB1668899D00320C13 /* DocumentSharedObjectPool.h */,
@@ -2543,7 +2553,7 @@ index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3
  				6BDB5DC1227BD3B800919770 /* DocumentStorageAccess.cpp */,
  				6BDB5DC0227BD3B800919770 /* DocumentStorageAccess.h */,
  				7CE7FA5B1EF882300060C9D6 /* DocumentTouch.cpp */,
-@@ -33476,6 +33499,7 @@
+@@ -33443,6 +33466,7 @@
  				93C4F6EB1108F9A50099D0DB /* AccessibilityScrollbar.h in Headers */,
  				29489FC712C00F0300D83F0F /* AccessibilityScrollView.h in Headers */,
  				0709FC4E1025DEE30059CDBA /* AccessibilitySlider.h in Headers */,
@@ -2551,7 +2561,7 @@ index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3
  				29D7BCFA1444AF7D0070619C /* AccessibilitySpinButton.h in Headers */,
  				69A6CBAD1C6BE42C00B836E9 /* AccessibilitySVGElement.h in Headers */,
  				AAC08CF315F941FD00F1E188 /* AccessibilitySVGRoot.h in Headers */,
-@@ -35611,6 +35635,7 @@
+@@ -35578,6 +35602,7 @@
  				6E4ABCD5138EA0B70071D291 /* JSHTMLUnknownElement.h in Headers */,
  				E44614170CD6826900FADA75 /* JSHTMLVideoElement.h in Headers */,
  				81BE20D311F4BC3200915DFA /* JSIDBCursor.h in Headers */,
@@ -2559,7 +2569,7 @@ index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3
  				7C3D8EF01E0B21430023B084 /* JSIDBCursorDirection.h in Headers */,
  				C585A68311D4FB08004C3E4B /* JSIDBDatabase.h in Headers */,
  				C585A69711D4FB13004C3E4B /* JSIDBFactory.h in Headers */,
-@@ -36722,6 +36747,7 @@
+@@ -36691,6 +36716,7 @@
  				0F7D07331884C56C00B4AF86 /* PlatformTextTrack.h in Headers */,
  				074E82BB18A69F0E007EF54C /* PlatformTimeRanges.h in Headers */,
  				CDD08ABD277E542600EA3755 /* PlatformTrackConfiguration.h in Headers */,
@@ -2567,7 +2577,7 @@ index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3
  				CD1F9B022700323D00617EB6 /* PlatformVideoColorPrimaries.h in Headers */,
  				CD1F9B01270020B700617EB6 /* PlatformVideoColorSpace.h in Headers */,
  				CD1F9B032700323D00617EB6 /* PlatformVideoMatrixCoefficients.h in Headers */,
-@@ -38817,6 +38843,7 @@
+@@ -38761,6 +38787,7 @@
  				1ABA76CA11D20E50004C201C /* CSSPropertyNames.cpp in Sources */,
  				2D22830323A8470700364B7E /* CursorMac.mm in Sources */,
  				5CBD59592280E926002B22AA /* CustomHeaderFields.cpp in Sources */,
@@ -2575,7 +2585,7 @@ index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3
  				7CE6CBFD187F394900D46BF5 /* FormatConverter.cpp in Sources */,
  				5130F2F624AEA60A00E1D0A0 /* GameControllerSoftLink.mm in Sources */,
  				51A4BB0A1954D61600FA5C2E /* Gamepad.cpp in Sources */,
-@@ -38890,6 +38917,7 @@
+@@ -38834,6 +38861,7 @@
  				C1692DD223D23ABD006E88F7 /* SystemBattery.mm in Sources */,
  				CE88EE262414467B007F29C2 /* TextAlternativeWithRange.mm in Sources */,
  				51DF6D800B92A18E00C2DC85 /* ThreadCheck.mm in Sources */,
@@ -2583,7 +2593,7 @@ index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3
  				538EC8031F96AF81004D22A8 /* UnifiedSource1-mm.mm in Sources */,
  				538EC8021F96AF81004D22A8 /* UnifiedSource1.cpp in Sources */,
  				538EC8051F96AF81004D22A8 /* UnifiedSource2-mm.mm in Sources */,
-@@ -38938,6 +38966,7 @@
+@@ -38882,6 +38910,7 @@
  				538EC8881F993F9C004D22A8 /* UnifiedSource23.cpp in Sources */,
  				DE5F85801FA1ABF4006DB63A /* UnifiedSource24-mm.mm in Sources */,
  				538EC8891F993F9D004D22A8 /* UnifiedSource24.cpp in Sources */,
@@ -2591,7 +2601,7 @@ index eaea38295c9af4416f38a569acc6ce499e001ce6..5ec27a5b4305f92fe544853a6a0a64b3
  				DE5F85811FA1ABF4006DB63A /* UnifiedSource25-mm.mm in Sources */,
  				538EC88A1F993F9D004D22A8 /* UnifiedSource25.cpp in Sources */,
  				DE5F85821FA1ABF4006DB63A /* UnifiedSource26-mm.mm in Sources */,
-@@ -39470,6 +39499,7 @@
+@@ -39414,6 +39443,7 @@
  				2D8B92F1203D13E1009C868F /* UnifiedSource516.cpp in Sources */,
  				2D8B92F2203D13E1009C868F /* UnifiedSource517.cpp in Sources */,
  				2D8B92F3203D13E1009C868F /* UnifiedSource518.cpp in Sources */,
@@ -2629,7 +2639,7 @@ index 50509d6026dfacde3822a2dc6f76528a1dcf02ec..b0eedb83ddd98d560700a1573742aeb2
  {
      AXComputedObjectAttributeCache* attributeCache = nullptr;
 diff --git a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
-index 632190ae73d71caed24cf043de0efe1e495e6e3f..f9e0feb6a03f7a24c49d2a6470f4290f5a41cae3 100644
+index 8fcf8f5bb6e9e4dc91af731b86bfeefdb29c3fc8..1d9b0bd63fb7bb1a82967a0076fbf27fb2c9926a 100644
 --- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
 +++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
 @@ -122,6 +122,8 @@ namespace WebCore {
@@ -2640,7 +2650,7 @@ index 632190ae73d71caed24cf043de0efe1e495e6e3f..f9e0feb6a03f7a24c49d2a6470f4290f
 +    macro(DeviceOrientationEvent) \
      macro(DocumentTimeline) \
      macro(DynamicsCompressorNode) \
-     macro(EnterPictureInPictureEvent) \
+     macro(ExtendableEvent) \
 diff --git a/Source/WebCore/css/MediaQueryEvaluator.cpp b/Source/WebCore/css/MediaQueryEvaluator.cpp
 index 345cc24534bc0451867035faa033bdf5cd0604f6..59f4a45331219709e98bbc35c479e78b4726714b 100644
 --- a/Source/WebCore/css/MediaQueryEvaluator.cpp
@@ -5386,7 +5396,7 @@ index 982691dd2dfe2f65201370a12302b5086703c126..4af72beb3b1405ffac78e89e7fbb2b14
  protected:
      static SameSiteInfo sameSiteInfo(const Document&, IsForDOMCookieAccess = IsForDOMCookieAccess::No);
 diff --git a/Source/WebCore/loader/DocumentLoader.cpp b/Source/WebCore/loader/DocumentLoader.cpp
-index f18db8695b397c1b2a3bd303111deb9e55e49442..df8091ebfb6cace493b23e4b5a04b84cba35f75b 100644
+index 36c7091678ff764ea4fe4e7a7e59075566a1f361..a4cf6541690741232034880433b16e973a017fa1 100644
 --- a/Source/WebCore/loader/DocumentLoader.cpp
 +++ b/Source/WebCore/loader/DocumentLoader.cpp
 @@ -1479,8 +1479,6 @@ void DocumentLoader::detachFromFrame()
@@ -5417,7 +5427,7 @@ index 0b079f88ff3326ed24d31c8f0c00a654e290494c..d6308c79c13e08503ba0e18dc8ce5bdc
      DocumentWriter& writer() const { return m_writer; }
  
 diff --git a/Source/WebCore/loader/FrameLoader.cpp b/Source/WebCore/loader/FrameLoader.cpp
-index f8ab45de9af3ee0c03464cf3c988a888a4f4ad85..a5affb040099a492d739ec92e9078f6ab1126388 100644
+index 60f9b0b5bc8469e2066a477a0387c998f19492aa..58470be488c8a92c9d7d4b026baeecea8aef7885 100644
 --- a/Source/WebCore/loader/FrameLoader.cpp
 +++ b/Source/WebCore/loader/FrameLoader.cpp
 @@ -1157,6 +1157,7 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
@@ -5553,7 +5563,7 @@ index a2c6d72b5ba0f04a49ca6dc710ef6fa5e0125c33..759b0d34b7db839027063a1b6ce8fb0f
  
  void ProgressTracker::incrementProgress(ResourceLoaderIdentifier identifier, const ResourceResponse& response)
 diff --git a/Source/WebCore/page/ChromeClient.h b/Source/WebCore/page/ChromeClient.h
-index c1f81dddc87add596a0a9a3b46ec8f2f2bd98fa5..1ae543793c1a5d063e064d134448f55fdcc6fb96 100644
+index ad62cbc6fbc026b2c57e9e2dc6a4ebd31d6db010..a7245b12da012cbe1469e496db016c1a1b75c8c9 100644
 --- a/Source/WebCore/page/ChromeClient.h
 +++ b/Source/WebCore/page/ChromeClient.h
 @@ -318,7 +318,7 @@ public:
@@ -6863,10 +6873,10 @@ index ba50b688ab6d0bae5d199fa0bac4b7e2004baf81..0b83a798b00835635a95a0db22173de0
 +} // namespace WebCore
 +#endif
 diff --git a/Source/WebCore/platform/PlatformScreen.h b/Source/WebCore/platform/PlatformScreen.h
-index be373f080140728d3e0bfc1e7db9f163ed3aedc8..12f49cdf02ec892acef95e524e72929c12c3b8d3 100644
+index 44799e0b2a93cbcf25f4315d62a3d95896c02f3d..29277223448a0936a16f975970ab60d739b000cd 100644
 --- a/Source/WebCore/platform/PlatformScreen.h
 +++ b/Source/WebCore/platform/PlatformScreen.h
-@@ -155,12 +155,14 @@ WEBCORE_EXPORT float screenScaleFactor(UIScreen * = nullptr);
+@@ -151,12 +151,14 @@ WEBCORE_EXPORT float screenScaleFactor(UIScreen * = nullptr);
  #endif
  
  #if ENABLE(TOUCH_EVENTS)
@@ -8799,7 +8809,7 @@ index a5a2fd628c6da1ffb0b048aacfbae06aeef9943f..625cc6b1f23c83bcd26c52a976121c39
      RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
      LogUserInteraction(WebCore::RegistrableDomain domain)
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.cpp b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
-index 6b9ef10bef918579cf4c8193441e7f24001fd6eb..4afd63efa53d78c0611c8ca0c8b2065c100f844b 100644
+index c74406a558af4e684fa4047c6083485a1e561268..eeaa0d5b75b0578f24cc41afab580f0b5579561a 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 @@ -26,7 +26,6 @@
@@ -8810,7 +8820,7 @@ index 6b9ef10bef918579cf4c8193441e7f24001fd6eb..4afd63efa53d78c0611c8ca0c8b2065c
  #include "ArgumentCoders.h"
  #include "Attachment.h"
  #include "AuthenticationManager.h"
-@@ -513,6 +512,41 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID)
+@@ -517,6 +516,41 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID)
      m_sessionsControlledByAutomation.remove(sessionID);
  }
  
@@ -8853,7 +8863,7 @@ index 6b9ef10bef918579cf4c8193441e7f24001fd6eb..4afd63efa53d78c0611c8ca0c8b2065c
  void NetworkProcess::dumpResourceLoadStatistics(PAL::SessionID sessionID, CompletionHandler<void(String)>&& completionHandler)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.h b/Source/WebKit/NetworkProcess/NetworkProcess.h
-index 42ce08bf350cfcba3b5a752293269ae778b9517b..d3a6ab307c8dee70699824d837929631d63595f2 100644
+index 063965a16a9414cc847572a21db2418b47bea18f..91119312d66c23157b56f323970203eae3f756e2 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
 @@ -37,6 +37,7 @@
@@ -8872,7 +8882,7 @@ index 42ce08bf350cfcba3b5a752293269ae778b9517b..d3a6ab307c8dee70699824d837929631
  class CurlProxySettings;
  class ProtectionSpace;
  class NetworkStorageSession;
-@@ -200,6 +202,11 @@ public:
+@@ -199,6 +201,11 @@ public:
  
      void addWebsiteDataStore(WebsiteDataStoreParameters&&);
  
@@ -8885,7 +8895,7 @@ index 42ce08bf350cfcba3b5a752293269ae778b9517b..d3a6ab307c8dee70699824d837929631
      void clearPrevalentResource(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);
      void clearUserInteraction(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
-index 781fc4720d4f0217523e170d8ca667266d6df278..be056f687a488e92f3b199eb096f5a6741254fb9 100644
+index 1cf32ead60bb34fa22ef4dd39e985608f7e66b24..9e4ca8305c6dadd872f2bdfc239679bfb708527f 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 @@ -79,6 +79,11 @@ messages -> NetworkProcess LegacyReceiver {
@@ -9004,7 +9014,7 @@ index f57a72b6bdc3382469d69adb1b1201c7a9f07a84..c501211b094312ca44f0bf92de5d6ebc
      void clear();
  
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-index f121d5ef899c06b712b3f2855a930fda62379972..aa910e95a1a7126435cfe2d96d63a46840ffc14e 100644
+index 5dd1bc8a936ad814649218d9b40921b07bd6bf3b..63e4b225ba0fcc3424817969801c6c6a8835ed54 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 @@ -719,7 +719,7 @@ void NetworkSessionCocoa::setClientAuditToken(const WebCore::AuthenticationChall
@@ -9852,7 +9862,7 @@ index cb741693db30a7502b489c8397cef6c739feda91..276471905c38eba40c841240789dbf77
      bool allowsDeprecatedSynchronousXMLHttpRequestDuringUnload { false };
  #endif
 diff --git a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
-index d4e9bef48c5ddd2795b2c00f77dbfe2ba1b1dbad..7d08a48ca354962598dbca62bc52e8fa672add04 100644
+index 1a68d7b463d7eab44136f874d9e7579fd59d60dd..0ae6d3a802ab010f7c9ae8a4bee7cc1164ca385e 100644
 --- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
 +++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
 @@ -161,7 +161,9 @@ bool defaultOfflineWebApplicationCacheEnabled()
@@ -9866,10 +9876,10 @@ index d4e9bef48c5ddd2795b2c00f77dbfe2ba1b1dbad..7d08a48ca354962598dbca62bc52e8fa
      bool defaultValue = true;
  #else
      bool defaultValue = false;
-@@ -188,9 +190,10 @@ bool defaultUseGPUProcessForMediaEnabled()
- 
- bool defaultUseGPUProcessForWebGLEnabled()
- {
+@@ -195,9 +197,10 @@ bool defaultUseGPUProcessForWebGLEnabled()
+ #if HAVE(UIKIT_WEBKIT_INTERNALS)
+     return false;
+ #else
 -#if (ENABLE(GPU_PROCESS_BY_DEFAULT) && PLATFORM(IOS_FAMILY)) || PLATFORM(WIN)
 +#if (ENABLE(GPU_PROCESS_BY_DEFAULT) && PLATFORM(IOS_FAMILY))
      bool defaultValue = true;
@@ -10230,7 +10240,7 @@ index bec1a3f134e2dd3923612752a89d881579e20f84..70b02cf6e97779d1f0ca261edc59b275
  UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
  UIProcess/Media/MediaUsageManager.cpp
 diff --git a/Source/WebKit/SourcesCocoa.txt b/Source/WebKit/SourcesCocoa.txt
-index 01be8d7dad9b63b7b7b537205a59c7550c226663..a54bbef4a18ff5db03db49b0d39f06b5a7d8e6f6 100644
+index b08d1fddac0a593cad545a8ca536129fa22a9def..5fcd862dbcfa516f23957c8252c87b7cdd908793 100644
 --- a/Source/WebKit/SourcesCocoa.txt
 +++ b/Source/WebKit/SourcesCocoa.txt
 @@ -276,6 +276,7 @@ UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -12087,7 +12097,7 @@ index 7659b1c9ff0d2f9bc50aee7ed437a759bf6e9200..2c75e4b0fae4584136cf4d649945864f
  {
      if (!m_uiDelegate)
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
-index 746cdf1b1dc401953d94372e25415e12ece7e319..9acfbb92d7e0581b5347dcf7926565485f9e9a2b 100644
+index 58dff442a07233dbbfe23806cdaa8d059b662a7d..cf1cfa75643ef594dff085ce61c03b58a40f0cc9 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 @@ -37,6 +37,7 @@
@@ -12166,7 +12176,7 @@ index 746cdf1b1dc401953d94372e25415e12ece7e319..9acfbb92d7e0581b5347dcf792656548
  #if PLATFORM(IOS_FAMILY)
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-index 53a6ba439903cdd9bfa715c700a4dfb327fae71a..bee325ad03a12272b44ef938302380a0146eea0d 100644
+index 6998970b1f45c5756b86a005ba53faceb51d225b..6cfb54837201aba091822ecb1bd0d4007450a3c1 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
 @@ -402,7 +402,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
@@ -12178,7 +12188,7 @@ index 53a6ba439903cdd9bfa715c700a4dfb327fae71a..bee325ad03a12272b44ef938302380a0
  #endif
      
  #if PLATFORM(IOS)
-@@ -704,8 +704,8 @@ void WebProcessPool::registerNotificationObservers()
+@@ -707,8 +707,8 @@ void WebProcessPool::registerNotificationObservers()
      }];
  
      m_scrollerStyleNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSPreferredScrollerStyleDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
@@ -12190,7 +12200,7 @@ index 53a6ba439903cdd9bfa715c700a4dfb327fae71a..bee325ad03a12272b44ef938302380a0
  
      m_activationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidBecomeActiveNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
-index f4a6a3391c1d20c74be263a7273f45620bdb2e15..5dba3f40ed7aad87562cd804130e1c45d3c16087 100644
+index 86fd890db49f302f6b007e406e41808a8ec2bfb8..f3a77e41a6f3a5a68bbd89f220d1040e3ac48ee4 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
 @@ -504,6 +504,9 @@ public:
@@ -12204,7 +12214,7 @@ index f4a6a3391c1d20c74be263a7273f45620bdb2e15..5dba3f40ed7aad87562cd804130e1c45
      void saveBackForwardSnapshotForCurrentItem();
      void saveBackForwardSnapshotForItem(WebBackForwardListItem&);
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
-index 727abb26ced4a1e27b33bec8964f1407430ced7a..9206844bbe962282a66b0bd89310b20f7d129b95 100644
+index 8103a69bf8f4205020f592b8831cd4d3ac5979e6..c41894b1b99dbd812b77599cce9fc513033b474b 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 @@ -2682,6 +2682,11 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
@@ -12219,7 +12229,7 @@ index 727abb26ced4a1e27b33bec8964f1407430ced7a..9206844bbe962282a66b0bd89310b20f
  
      ASSERT(m_colorSpace);
      return WebCore::DestinationColorSpace { [m_colorSpace CGColorSpace] };
-@@ -4666,6 +4671,18 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
+@@ -4685,6 +4690,18 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
      return adoptCF(CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
  }
  
@@ -15841,7 +15851,7 @@ index 7a14cfba15c103a2d4fe263fa49d25af3c396ec2..3ee0e154349661632799057c71f1d1f1
      BOOL result = ::CreateProcess(0, commandLine.data(), 0, 0, true, 0, 0, 0, &startupInfo, &processInformation);
  
 diff --git a/Source/WebKit/UIProcess/PageClient.h b/Source/WebKit/UIProcess/PageClient.h
-index d02bb7cc80f7071a13c7f2b3641bc7baf0bab098..f3027ec3a284fbbe2ef3a1a56f71c10574a98d89 100644
+index af3151879ac0dac34c563bdefeb6904d5c504b1f..3bd07470de38cfa206a78f2ed716f5b3616a46b7 100644
 --- a/Source/WebKit/UIProcess/PageClient.h
 +++ b/Source/WebKit/UIProcess/PageClient.h
 @@ -325,6 +325,11 @@ public:
@@ -16874,7 +16884,7 @@ index 0000000000000000000000000000000000000000..48c9ccc420c1b4ae3259e1d5ba17fd8f
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267cf294a177 100644
+index 6fd132d7173f5b8c5850f419e4fba5e17846b38e..94d105016e0a7e3adffe8073cfcec9ce2a70be36 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
 @@ -248,6 +248,9 @@
@@ -17195,7 +17205,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
  }
  
  void WebPageProxy::didStartProvisionalLoadForFrame(FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, uint64_t navigationID, URL&& url, URL&& unreachableURL, const UserData& userData)
-@@ -4872,6 +5025,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
+@@ -4873,6 +5026,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
  
      m_failingProvisionalLoadURL = { };
  
@@ -17204,7 +17214,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
      // If the provisional page's load fails then we destroy the provisional page.
      if (m_provisionalPage && m_provisionalPage->mainFrame() == &frame && willContinueLoading == WillContinueLoading::No)
          m_provisionalPage = nullptr;
-@@ -5343,7 +5498,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
+@@ -5346,7 +5501,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
      NavigationActionData&& navigationActionData, FrameInfoData&& originatingFrameInfo, std::optional<WebPageProxyIdentifier> originatingPageID, const WebCore::ResourceRequest& originalRequest, WebCore::ResourceRequest&& request,
      IPC::FormDataReference&& requestBody, WebCore::ResourceResponse&& redirectResponse, const UserData& userData, uint64_t listenerID)
  {
@@ -17220,7 +17230,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
  }
  
  void WebPageProxy::decidePolicyForNavigationActionAsyncShared(Ref<WebProcessProxy>&& process, PageIdentifier webPageID, FrameIdentifier frameID, FrameInfoData&& frameInfo,
-@@ -5915,6 +6077,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -5918,6 +6080,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
      if (originatingPage)
          openerAppInitiatedState = originatingPage->lastNavigationWasAppInitiated();
  
@@ -17228,7 +17238,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
      auto completionHandler = [this, protectedThis = Ref { *this }, mainFrameURL, request, reply = WTFMove(reply), privateClickMeasurement = navigationActionData.privateClickMeasurement, openerAppInitiatedState = WTFMove(openerAppInitiatedState)] (RefPtr<WebPageProxy> newPage) mutable {
          if (!newPage) {
              reply(std::nullopt, std::nullopt);
-@@ -5961,6 +6124,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -5964,6 +6127,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
  void WebPageProxy::showPage()
  {
      m_uiClient->showPage(this);
@@ -17236,7 +17246,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
  }
  
  void WebPageProxy::exitFullscreenImmediately()
-@@ -6018,6 +6182,10 @@ void WebPageProxy::closePage()
+@@ -6021,6 +6185,10 @@ void WebPageProxy::closePage()
      if (isClosed())
          return;
  
@@ -17247,7 +17257,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
      WEBPAGEPROXY_RELEASE_LOG(Process, "closePage:");
      pageClient().clearAllEditCommands();
      m_uiClient->close(this);
-@@ -6054,6 +6222,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
+@@ -6057,6 +6225,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
      }
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
@@ -17256,7 +17266,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
          page.m_uiClient->runJavaScriptAlert(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)]() mutable {
              reply();
              completion();
-@@ -6075,6 +6245,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
+@@ -6078,6 +6248,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17265,7 +17275,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptConfirm(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](bool result) mutable {
-@@ -6098,6 +6270,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
+@@ -6101,6 +6273,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17274,7 +17284,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply), defaultValue](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptPrompt(page, message, defaultValue, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](auto& result) mutable {
-@@ -6225,6 +6399,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
+@@ -6228,6 +6402,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
              return;
          }
      }
@@ -17283,7 +17293,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
  
      // Since runBeforeUnloadConfirmPanel() can spin a nested run loop we need to turn off the responsiveness timer and the tryClose timer.
      m_process->stopResponsivenessTimer();
-@@ -7476,6 +7652,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7479,6 +7655,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->mouseEventsFlushedForPage(*this);
              didFinishProcessingAllPendingMouseEvents();
@@ -17292,7 +17302,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
          }
          break;
      }
-@@ -7490,10 +7668,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7493,10 +7671,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              pageClient().wheelEventWasNotHandledByWebCore(oldestProcessedEvent);
          }
  
@@ -17309,7 +17319,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
          break;
      }
  
-@@ -7502,7 +7683,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7505,7 +7686,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
      case WebEvent::RawKeyDown:
      case WebEvent::Char: {
          LOG(KeyHandling, "WebPageProxy::didReceiveEvent: %s (queue empty %d)", webKeyboardEventTypeString(type), m_keyEventQueue.isEmpty());
@@ -17317,7 +17327,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
          MESSAGE_CHECK(m_process, !m_keyEventQueue.isEmpty());
          auto event = m_keyEventQueue.takeFirst();
          MESSAGE_CHECK(m_process, type == event.type());
-@@ -7521,7 +7701,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7524,7 +7704,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          // The call to doneWithKeyEvent may close this WebPage.
          // Protect against this being destroyed.
          Ref<WebPageProxy> protect(*this);
@@ -17325,7 +17335,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
          pageClient().doneWithKeyEvent(event, handled);
          if (!handled)
              m_uiClient->didNotHandleKeyEvent(this, event);
-@@ -7530,6 +7709,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7533,6 +7712,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          if (!canProcessMoreKeyEvents) {
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->keyboardEventsFlushedForPage(*this);
@@ -17333,7 +17343,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
          }
          break;
      }
-@@ -7884,7 +8064,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
+@@ -7887,7 +8067,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
  {
      WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "dispatchProcessDidTerminate: reason=%{public}s", processTerminationReasonToString(reason));
  
@@ -17345,7 +17355,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
      if (m_loaderClient)
          handledByClient = reason != ProcessTerminationReason::RequestedByClient && m_loaderClient->processDidCrash(*this);
      else
-@@ -8216,6 +8399,7 @@ static Span<const ASCIILiteral> gpuMachServices()
+@@ -8219,6 +8402,7 @@ static Span<const ASCIILiteral> gpuMachServices()
  
  WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& process, DrawingAreaProxy& drawingArea, RefPtr<API::WebsitePolicies>&& websitePolicies)
  {
@@ -17353,7 +17363,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
      WebPageCreationParameters parameters;
  
      parameters.processDisplayName = configuration().processDisplayName();
-@@ -8406,6 +8590,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
+@@ -8409,6 +8593,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
  
      parameters.httpsUpgradeEnabled = preferences().upgradeKnownHostsToHTTPSEnabled() ? m_configuration->httpsUpgradeEnabled() : false;
  
@@ -17362,7 +17372,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
  #if PLATFORM(IOS)
      // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
      parameters.allowsDeprecatedSynchronousXMLHttpRequestDuringUnload = allowsDeprecatedSynchronousXMLHttpRequestDuringUnload();
-@@ -8474,6 +8660,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
+@@ -8477,6 +8663,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
  
  void WebPageProxy::didReceiveAuthenticationChallengeProxy(Ref<AuthenticationChallengeProxy>&& authenticationChallenge, NegotiatedLegacyTLS negotiatedLegacyTLS)
  {
@@ -17377,7 +17387,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
      if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes) {
          m_navigationClient->shouldAllowLegacyTLS(*this, authenticationChallenge.get(), [this, protectedThis = Ref { *this }, authenticationChallenge] (bool shouldAllowLegacyTLS) {
              if (shouldAllowLegacyTLS)
-@@ -8567,6 +8761,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
+@@ -8570,6 +8764,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
              request->deny();
      };
  
@@ -17394,7 +17404,7 @@ index 40dbda4f825ab17444068985725890d42710b464..22d0233bcd95d2bbb35e36da644b267c
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index 916cdff4b966c1c74fbb90753a56477b44e080b8..bcb334707ee21c9cc8151f9f43fa7f17e3e239ef 100644
+index 06b737ae03ae2f3c1b2cd3a26b39bacb1c4e252d..786737c313a75e295dff77d9a5ee0ac65506cf3c 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -39,6 +39,7 @@
@@ -17477,7 +17487,7 @@ index 916cdff4b966c1c74fbb90753a56477b44e080b8..bcb334707ee21c9cc8151f9f43fa7f17
      RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadData(const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
-@@ -1197,6 +1217,7 @@ public:
+@@ -1201,6 +1221,7 @@ public:
  #endif
  
      void pageScaleFactorDidChange(double);
@@ -17485,7 +17495,7 @@ index 916cdff4b966c1c74fbb90753a56477b44e080b8..bcb334707ee21c9cc8151f9f43fa7f17
      void pluginScaleFactorDidChange(double);
      void pluginZoomFactorDidChange(double);
  
-@@ -1283,14 +1304,20 @@ public:
+@@ -1287,14 +1308,20 @@ public:
      void didStartDrag();
      void dragCancelled();
      void setDragCaretRect(const WebCore::IntRect&);
@@ -17507,7 +17517,7 @@ index 916cdff4b966c1c74fbb90753a56477b44e080b8..bcb334707ee21c9cc8151f9f43fa7f17
  #endif
  
      void processDidBecomeUnresponsive();
-@@ -1541,6 +1568,8 @@ public:
+@@ -1543,6 +1570,8 @@ public:
  
  #if PLATFORM(COCOA) || PLATFORM(GTK)
      RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
@@ -17516,7 +17526,7 @@ index 916cdff4b966c1c74fbb90753a56477b44e080b8..bcb334707ee21c9cc8151f9f43fa7f17
  #endif
  
  #if ENABLE(WEB_CRYPTO)
-@@ -2684,6 +2713,7 @@ private:
+@@ -2686,6 +2715,7 @@ private:
      String m_overrideContentSecurityPolicy;
  
      RefPtr<WebInspectorUIProxy> m_inspector;
@@ -17524,7 +17534,7 @@ index 916cdff4b966c1c74fbb90753a56477b44e080b8..bcb334707ee21c9cc8151f9f43fa7f17
  
  #if PLATFORM(COCOA)
      WeakObjCPtr<WKWebView> m_cocoaView;
-@@ -2948,6 +2978,20 @@ private:
+@@ -2950,6 +2980,20 @@ private:
      unsigned m_currentDragNumberOfFilesToBeAccepted { 0 };
      WebCore::IntRect m_currentDragCaretRect;
      WebCore::IntRect m_currentDragCaretEditableElementRect;
@@ -17545,7 +17555,7 @@ index 916cdff4b966c1c74fbb90753a56477b44e080b8..bcb334707ee21c9cc8151f9f43fa7f17
  #endif
  
      PageLoadState m_pageLoadState;
-@@ -3157,6 +3201,9 @@ private:
+@@ -3159,6 +3203,9 @@ private:
          RefPtr<API::Object> messageBody;
      };
      Vector<InjectedBundleMessage> m_pendingInjectedBundleMessages;
@@ -17625,7 +17635,7 @@ index f153458805ec95479284d5b6bce34875882e897b..d7e9135341d8150f1b1726540b6d5892
      parameters.urlSchemesRegisteredAsEmptyDocument = copyToVector(m_schemesToRegisterAsEmptyDocument);
      parameters.urlSchemesRegisteredAsSecure = copyToVector(LegacyGlobalSettings::singleton().schemesToRegisterAsSecure());
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.cpp b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-index be96b41de2752fc635934163e5b02055afedc299..24570635349635c7e41e5b385cd66c662f766865 100644
+index 2f1e6936be6145812d477faba7dc2a803784e7af..169c47ffc6e9841d735682c9c65950f5bca3b925 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
 @@ -147,6 +147,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
@@ -18063,7 +18073,7 @@ index 0000000000000000000000000000000000000000..8006336003a4512b4c63bc8272d4b350
 +
 +#endif // ENABLE(REMOTE_INSPECTOR)
 diff --git a/Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp b/Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp
-index 521df7840ab6d376c25130e87ea500942398c8b6..c733d9d5cd304889640e5af4423860717be94725 100644
+index 521df7840ab6d376c25130e87ea500942398c8b6..da198916beb0d0b46661f5209db3967ba5f9f776 100644
 --- a/Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp
 +++ b/Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp
 @@ -57,4 +57,34 @@ void WebPageProxy::loadRecentSearches(const String&, CompletionHandler<void(Vect
@@ -18091,7 +18101,7 @@ index 521df7840ab6d376c25130e87ea500942398c8b6..c733d9d5cd304889640e5af442386071
 +{
 +}
 +
-+void WebPageProxy::boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary speechBoundary, unsigned charIndex)
++void WebPageProxy::boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary speechBoundary, unsigned charIndex, unsigned charLength)
 +{
 +}
 +
@@ -18752,10 +18762,10 @@ index 31bc0797a1b086b9342e5449e48cf5b3050464eb..450b6acf92b31cb40c404e3a8553e263
      void getContextMenuItem(const WebContextMenuItemData&, CompletionHandler<void(NSMenuItem *)>&&);
      void getContextMenuFromItems(const Vector<WebContextMenuItemData>&, CompletionHandler<void(NSMenu *)>&&);
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-index de3e60150826948ea082232327e3ace5dea9a0f9..8c8bb0c53de3ea6b8538ba367354657ee32c430a 100644
+index dec88e7833f63527f1d6d8fbe7415f2fcc578b68..22c1f21c5ff6164ead19455319476d962bdb687f 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-@@ -446,6 +446,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
+@@ -443,6 +443,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
  }
  #endif
  
@@ -19709,10 +19719,10 @@ index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705e
 + 
 +} // namespace WebKit
 diff --git a/Source/WebKit/WebKit.xcodeproj/project.pbxproj b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d9297457143128e2d6c6e 100644
+index d207ba581ebd35a89a52f1f647d92249d9da210d..33f970f3c41c000c1ab8d8ef29545bd2e27cfa6a 100644
 --- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 +++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-@@ -1269,6 +1269,7 @@
+@@ -1270,6 +1270,7 @@
  		5CABDC8722C40FED001EDE8E /* APIMessageListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CABDC8322C40FA7001EDE8E /* APIMessageListener.h */; };
  		5CADDE05215046BD0067D309 /* WKWebProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C74300E21500492004BFA17 /* WKWebProcess.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		5CAECB6627465AE400AB78D0 /* UnifiedSource115.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */; };
@@ -19720,7 +19730,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  		5CAF7AA726F93AB00003F19E /* adattributiond.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAF7AA526F93A950003F19E /* adattributiond.cpp */; };
  		5CAFDE452130846300B1F7E1 /* _WKInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE422130843500B1F7E1 /* _WKInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		5CAFDE472130846A00B1F7E1 /* _WKInspectorInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE442130843600B1F7E1 /* _WKInspectorInternal.h */; };
-@@ -1968,6 +1969,18 @@
+@@ -1969,6 +1970,18 @@
  		DF0C5F28252ECB8E00D921DB /* WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F24252ECB8D00D921DB /* WKDownload.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2A252ECB8E00D921DB /* WKDownloadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2B252ED44000D921DB /* WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */; };
@@ -19739,7 +19749,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  		DF462E0F23F22F5500EFF35F /* WKHTTPCookieStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */; };
-@@ -2025,6 +2038,8 @@
+@@ -2026,6 +2039,8 @@
  		E5BEF6822130C48000F31111 /* WebDataListSuggestionsDropdownIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E5BEF6802130C47F00F31111 /* WebDataListSuggestionsDropdownIOS.h */; };
  		E5CB07DC20E1678F0022C183 /* WKFormColorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */; };
  		E5CBA76427A318E100DF7858 /* UnifiedSource120.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */; };
@@ -19748,7 +19758,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  		E5CBA76527A318E100DF7858 /* UnifiedSource118.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */; };
  		E5CBA76627A318E100DF7858 /* UnifiedSource116.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76327A3187B00DF7858 /* UnifiedSource116.cpp */; };
  		E5CBA76727A318E100DF7858 /* UnifiedSource119.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */; };
-@@ -2041,6 +2056,9 @@
+@@ -2042,6 +2057,9 @@
  		EBA8D3B627A5E33F00CB7900 /* MockPushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B027A5E33F00CB7900 /* MockPushServiceConnection.mm */; };
  		EBA8D3B727A5E33F00CB7900 /* PushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B127A5E33F00CB7900 /* PushServiceConnection.mm */; };
  		ED82A7F2128C6FAF004477B3 /* WKBundlePageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22F0FF1289FCD90085E74F /* WKBundlePageOverlay.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -19758,7 +19768,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
  		F42D634122A0EFDF00D2FB3A /* WebAutocorrectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */; };
-@@ -5008,6 +5026,7 @@
+@@ -5009,6 +5027,7 @@
  		5CABDC8522C40FCC001EDE8E /* WKMessageListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKMessageListener.h; sourceTree = "<group>"; };
  		5CADDE0D2151AA010067D309 /* AuthenticationChallengeDisposition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthenticationChallengeDisposition.h; sourceTree = "<group>"; };
  		5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource115.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource115.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -19818,7 +19828,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -8835,6 +8878,7 @@
+@@ -8836,6 +8879,7 @@
  		37C4C08318149C2A003688B9 /* Cocoa */ = {
  			isa = PBXGroup;
  			children = (
@@ -19826,7 +19836,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				1A43E826188F38E2009E4D30 /* Deprecated */,
  				37A5E01218BBF937000A081E /* _WKActivatedElementInfo.h */,
  				37A5E01118BBF937000A081E /* _WKActivatedElementInfo.mm */,
-@@ -10018,6 +10062,7 @@
+@@ -10019,6 +10063,7 @@
  			children = (
  				DDE992F4278D06D900F60D26 /* libWebKitAdditions.a */,
  				57A9FF15252C6AEF006A2040 /* libWTF.a */,
@@ -19834,7 +19844,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				5750F32A2032D4E500389347 /* LocalAuthentication.framework */,
  				570DAAB0230273D200E8FC04 /* NearField.framework */,
  				51F7BB7E274564A100C45A72 /* Security.framework */,
-@@ -10537,6 +10582,12 @@
+@@ -10536,6 +10581,12 @@
  			children = (
  				9197940423DBC4BB00257892 /* InspectorBrowserAgent.cpp */,
  				9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */,
@@ -19847,7 +19857,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  			);
  			path = Agents;
  			sourceTree = "<group>";
-@@ -10545,6 +10596,7 @@
+@@ -10544,6 +10595,7 @@
  			isa = PBXGroup;
  			children = (
  				A5D3504D1D78F0D2005124A9 /* RemoteWebInspectorUIProxyMac.mm */,
@@ -19855,7 +19865,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */,
  				99A7ACE326012919006D57FD /* WKInspectorResourceURLSchemeHandler.h */,
  				99A7ACE42601291A006D57FD /* WKInspectorResourceURLSchemeHandler.mm */,
-@@ -11091,6 +11143,12 @@
+@@ -11090,6 +11142,12 @@
  		BC032DC310F438260058C15A /* UIProcess */ = {
  			isa = PBXGroup;
  			children = (
@@ -19868,7 +19878,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				BC032DC410F4387C0058C15A /* API */,
  				512F588D12A8836F00629530 /* Authentication */,
  				9955A6E81C79809000EB6A93 /* Automation */,
-@@ -11402,6 +11460,7 @@
+@@ -11401,6 +11459,7 @@
  		BC0C376610F807660076D7CB /* C */ = {
  			isa = PBXGroup;
  			children = (
@@ -19876,7 +19886,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				5123CF18133D25E60056F800 /* cg */,
  				6EE849C41368D9040038D481 /* mac */,
  				BCB63477116BF10600603215 /* WebKit2_C.h */,
-@@ -11992,6 +12051,11 @@
+@@ -11991,6 +12050,11 @@
  		BCCF085C113F3B7500C650C5 /* mac */ = {
  			isa = PBXGroup;
  			children = (
@@ -19888,7 +19898,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				B878B613133428DC006888E9 /* CorrectionPanel.h */,
  				B878B614133428DC006888E9 /* CorrectionPanel.mm */,
  				07EF07592745A8160066EA04 /* DisplayCaptureSessionManager.h */,
-@@ -12916,6 +12980,7 @@
+@@ -12915,6 +12979,7 @@
  				99788ACB1F421DDA00C08000 /* _WKAutomationSessionConfiguration.h in Headers */,
  				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
  				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
@@ -19936,7 +19946,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				2D47B56D1810714E003A3AEE /* RemoteLayerBackingStore.h in Headers */,
  				2DDF731518E95060004F5A66 /* RemoteLayerBackingStoreCollection.h in Headers */,
  				1AB16AEA164B3A8800290D62 /* RemoteLayerTreeContext.h in Headers */,
-@@ -13830,6 +13900,7 @@
+@@ -13829,6 +13899,7 @@
  				A543E30D215C8A9000279CD9 /* WebPageInspectorTargetController.h in Headers */,
  				A543E307215AD13700279CD9 /* WebPageInspectorTargetFrontendChannel.h in Headers */,
  				C0CE72A11247E71D00BC0EC4 /* WebPageMessages.h in Headers */,
@@ -19944,7 +19954,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				2D5C9D0619C81D8F00B3C5C1 /* WebPageOverlay.h in Headers */,
  				46C392292316EC4D008EED9B /* WebPageProxyIdentifier.h in Headers */,
  				BCBD3915125BB1A800D2C29F /* WebPageProxyMessages.h in Headers */,
-@@ -13973,6 +14044,7 @@
+@@ -13972,6 +14043,7 @@
  				BCD25F1711D6BDE100169B0E /* WKBundleFrame.h in Headers */,
  				BCF049E611FE20F600F86A58 /* WKBundleFramePrivate.h in Headers */,
  				BC49862F124D18C100D834E1 /* WKBundleHitTestResult.h in Headers */,
@@ -19952,7 +19962,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				BC204EF211C83EC8008F3375 /* WKBundleInitialize.h in Headers */,
  				65B86F1E12F11DE300B7DD8A /* WKBundleInspector.h in Headers */,
  				1A8B66B41BC45B010082DF77 /* WKBundleMac.h in Headers */,
-@@ -14026,6 +14098,7 @@
+@@ -14025,6 +14097,7 @@
  				5C795D71229F3757003FF1C4 /* WKContextMenuElementInfoPrivate.h in Headers */,
  				51A555F6128C6C47009ABCEC /* WKContextMenuItem.h in Headers */,
  				51A55601128C6D92009ABCEC /* WKContextMenuItemTypes.h in Headers */,
@@ -19960,7 +19970,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				A1EA02381DABFF7E0096021F /* WKContextMenuListener.h in Headers */,
  				BCC938E11180DE440085E5FE /* WKContextPrivate.h in Headers */,
  				9FB5F395169E6A80002C25BF /* WKContextPrivateMac.h in Headers */,
-@@ -14182,6 +14255,7 @@
+@@ -14181,6 +14254,7 @@
  				1AB8A1F818400BB800E9AE69 /* WKPageContextMenuClient.h in Headers */,
  				8372DB251A674C8F00C697C5 /* WKPageDiagnosticLoggingClient.h in Headers */,
  				1AB8A1F418400B8F00E9AE69 /* WKPageFindClient.h in Headers */,
@@ -19968,7 +19978,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				1AB8A1F618400B9D00E9AE69 /* WKPageFindMatchesClient.h in Headers */,
  				1AB8A1F018400B0000E9AE69 /* WKPageFormClient.h in Headers */,
  				BC7B633712A45ABA00D174A4 /* WKPageGroup.h in Headers */,
-@@ -15853,6 +15927,8 @@
+@@ -15852,6 +15926,8 @@
  				51E9049727BCB3D900929E7E /* ICAppBundle.mm in Sources */,
  				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
  				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
@@ -19977,7 +19987,7 @@ index 77a599b53409cb8d5bf6b69f34bbd1902178fbfd..e1da4e04bff17b35372d929745714312
  				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
  				C1710CF724AA643200D7C112 /* LaunchServicesDatabaseObserver.mm in Sources */,
  				2984F588164BA095004BC0C6 /* LegacyCustomProtocolManagerMessageReceiver.cpp in Sources */,
-@@ -16190,6 +16266,8 @@
+@@ -16189,6 +16265,8 @@
  				51F060E11654318500F3282F /* WebMDNSRegisterMessageReceiver.cpp in Sources */,
  				31BA924D148831260062EDB5 /* WebNotificationManagerMessageReceiver.cpp in Sources */,
  				2DF6FE52212E110900469030 /* WebPage.cpp in Sources */,
@@ -20139,10 +20149,10 @@ index e07a15c59ed7378b08069a4a9b930e1825357083..8b9e151e172657e772e3d977d0a0d9de
  
  } // namespace WebKit
 diff --git a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
-index 70f810ffb7f1d5cd564740008a81b69cc1153eb0..04e8d69a1aae019bb60964c469c2340178fabf1f 100644
+index 99049de024b120b57cbdac531502e193a72f2ac5..a1bb45542adeb1a31db7321a52a4991f2cae264a 100644
 --- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
-@@ -192,9 +192,6 @@ void WebResourceLoader::didReceiveResponse(const ResourceResponse& response, Pri
+@@ -195,9 +195,6 @@ void WebResourceLoader::didReceiveResponse(ResourceResponse&& response, PrivateR
              }
  
              m_coreLoader->didReceiveResponse(inspectorResponse, [this, protectedThis = WTFMove(protectedThis), interceptedRequestIdentifier, policyDecisionCompletionHandler = WTFMove(policyDecisionCompletionHandler), overrideData = WTFMove(overrideData)]() mutable {
@@ -20152,7 +20162,7 @@ index 70f810ffb7f1d5cd564740008a81b69cc1153eb0..04e8d69a1aae019bb60964c469c23401
                  if (!m_coreLoader || !m_coreLoader->identifier()) {
                      m_interceptController.continueResponse(interceptedRequestIdentifier);
                      return;
-@@ -212,6 +209,8 @@ void WebResourceLoader::didReceiveResponse(const ResourceResponse& response, Pri
+@@ -215,6 +212,8 @@ void WebResourceLoader::didReceiveResponse(ResourceResponse&& response, PrivateR
                  }
              });
          });
@@ -20175,7 +20185,7 @@ index e00c722c2be5d505243d45f46001839d4eb8a977..33c0832cde6c292230397a13e70d90fb
  
              auto permissionHandlers = m_requestsPerOrigin.take(securityOrigin);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
-index 05e3f3f1b8d4ccda25fd7b457525e23c5c281f23..6a91b5bf2849807719c2b476eda87dd144454342 100644
+index dadcecb8c083e5cd31ca3a3669f2d01049436419..7682b7016a944d213fffb584fc7911c079dcf9d3 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 @@ -417,6 +417,8 @@ void WebChromeClient::setResizable(bool resizable)
@@ -20609,7 +20619,7 @@ index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4
      uint64_t m_navigationID;
  };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index 01de4dbf5b778b75c9120229d5aa70ab9578ec20..4f6865a414fcd59d2e2c8a8d2f50d35efa520caa 100644
+index eb48c7b2d138392abbf14118f8e253c0ae9f4e22..5efc0f1b847d071d7adac9f5041e4aab349675db 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 @@ -905,6 +905,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
@@ -20872,7 +20882,7 @@ index 01de4dbf5b778b75c9120229d5aa70ab9578ec20..4f6865a414fcd59d2e2c8a8d2f50d35e
  
      return documentLoader;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.h b/Source/WebKit/WebProcess/WebPage/WebPage.h
-index 1e14752504fad540b9875e5dc722be4d4ce8db77..46096768ca4f5d845460efc720f5149468255703 100644
+index 6e5f8f0a5116e1aa262ba0ad31b2c927bc36fdcf..a69fa8c8196ae88e896c17f1d838e271f66dea06 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
 @@ -122,6 +122,10 @@ typedef struct _AtkObject AtkObject;
@@ -20886,7 +20896,7 @@ index 1e14752504fad540b9875e5dc722be4d4ce8db77..46096768ca4f5d845460efc720f51494
  #if PLATFORM(GTK) || PLATFORM(WPE)
  #include "InputMethodState.h"
  #endif
-@@ -1005,11 +1009,11 @@ public:
+@@ -1008,11 +1012,11 @@ public:
      void clearSelection();
      void restoreSelectionInFocusedEditableElement();
  
@@ -20900,7 +20910,7 @@ index 1e14752504fad540b9875e5dc722be4d4ce8db77..46096768ca4f5d845460efc720f51494
      void performDragControllerAction(DragControllerAction, const WebCore::DragData&, SandboxExtension::Handle&&, Vector<SandboxExtension::Handle>&&);
  #endif
  
-@@ -1023,6 +1027,9 @@ public:
+@@ -1026,6 +1030,9 @@ public:
      void didStartDrag();
      void dragCancelled();
      OptionSet<WebCore::DragSourceAction> allowedDragSourceActions() const { return m_allowedDragSourceActions; }
@@ -20910,7 +20920,7 @@ index 1e14752504fad540b9875e5dc722be4d4ce8db77..46096768ca4f5d845460efc720f51494
  #endif
  
      void beginPrinting(WebCore::FrameIdentifier, const PrintInfo&);
-@@ -1261,6 +1268,7 @@ public:
+@@ -1262,6 +1269,7 @@ public:
      void connectInspector(const String& targetId, Inspector::FrontendChannel::ConnectionType);
      void disconnectInspector(const String& targetId);
      void sendMessageToTargetBackend(const String& targetId, const String& message);
@@ -20918,7 +20928,7 @@ index 1e14752504fad540b9875e5dc722be4d4ce8db77..46096768ca4f5d845460efc720f51494
  
      void insertNewlineInQuotedContent();
  
-@@ -1631,6 +1639,7 @@ private:
+@@ -1632,6 +1640,7 @@ private:
      // Actions
      void tryClose(CompletionHandler<void(bool)>&&);
      void platformDidReceiveLoadParameters(const LoadParameters&);
@@ -20926,7 +20936,7 @@ index 1e14752504fad540b9875e5dc722be4d4ce8db77..46096768ca4f5d845460efc720f51494
      void loadRequest(LoadParameters&&);
      NO_RETURN void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
      void loadData(LoadParameters&&);
-@@ -1668,6 +1677,7 @@ private:
+@@ -1669,6 +1678,7 @@ private:
      void updatePotentialTapSecurityOrigin(const WebTouchEvent&, bool wasHandled);
  #elif ENABLE(TOUCH_EVENTS)
      void touchEvent(const WebTouchEvent&);
@@ -20934,7 +20944,7 @@ index 1e14752504fad540b9875e5dc722be4d4ce8db77..46096768ca4f5d845460efc720f51494
  #endif
  
      void cancelPointer(WebCore::PointerID, const WebCore::IntPoint&);
-@@ -1802,9 +1812,7 @@ private:
+@@ -1803,9 +1813,7 @@ private:
  
      void requestRectForFoundTextRange(const WebFoundTextRange&, CompletionHandler<void(WebCore::FloatRect)>&&);
  
@@ -20944,7 +20954,7 @@ index 1e14752504fad540b9875e5dc722be4d4ce8db77..46096768ca4f5d845460efc720f51494
  
      void didChangeSelectedIndexForActivePopupMenu(int32_t newIndex);
      void setTextForActivePopupMenu(int32_t index);
-@@ -2341,6 +2349,7 @@ private:
+@@ -2342,6 +2350,7 @@ private:
      UserActivity m_userActivity;
  
      uint64_t m_pendingNavigationID { 0 };
@@ -20953,7 +20963,7 @@ index 1e14752504fad540b9875e5dc722be4d4ce8db77..46096768ca4f5d845460efc720f51494
  
      bool m_mainFrameProgressCompleted { false };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-index cff0aa91a0bc2f4afee6ecf14da7d2e111a3a454..1bcda592029d7fe375daeb1a0d637d956421bc40 100644
+index fcc5b7e03425d28ec8e7b6242fd8d452b31d72dc..1e6cf482936d04ece44fe96088788a60f0ee0f99 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 @@ -144,6 +144,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
@@ -21133,10 +21143,10 @@ index 8987c3964a9308f2454759de7f8972215a3ae416..bcac0afeb94ed8123d1f9fb0b932c849
              SetProcessDPIAware();
          return true;
 diff --git a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-index 4eb3f83d7d6a9c6df19dbf53792691d9e6714d44..70f0f1681de45cef6d96acf8f69603566eb6aa94 100644
+index 877ff287a76c315f1197391d26c04c3eb25e605a..b6c627f9fe8b979528573f03bfa61601c1579792 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-@@ -4170,7 +4170,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
+@@ -4189,7 +4189,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
      _private->handlingMouseDownEvent = NO;
  }
  


### PR DESCRIPTION
Rebase `webkit/patches/bootstrap.diff` to [r291344](https://trac.webkit.org/changeset/291344/webkit):

  * [3way diff](https://github.com/dpino/WebKit/commit/caa508873edf3e19774b9cec093b9f9defcac23b)
  * [Resolve conflicts](https://github.com/dpino/WebKit/commit/35036974e0e58e92116c0308493a0c90fe0e6d7c)
  * [Fix build errors](https://github.com/dpino/WebKit/commit/77a42f11058f67a622ad847e10d21bb50be5a1e4)

When trying to build after resolving the conflicts, I got the following build error:

```
In file included from WebCore/DerivedSources/unified-sources/UnifiedSource-3a52ce78-135.cpp:5:
WebCore/DerivedSources/JSSpeechSynthesisEvent.cpp:41:10: fatal error: JSSpeechSynthesisEventInit.h: No such file or directory
   41 | #include "JSSpeechSynthesisEventInit.h"
	  |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

SpeechSynthesis is not supported in upstream WebKitGTK/WPE, but it seems it's enabled in Playwright which also features a minimal implementation. To resolve the build error, I added the new SpeechSynthesis files introduced in [r291124](https://trac.webkit.org/changeset/291124/webkit) to GTK and WPE sources.