### PR TITLE
fix(list mode): print errors to stderr

### DIFF
--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -25,6 +25,7 @@ import { TestCase, Suite } from './test';
 import { Loader } from './loader';
 import { FullResult, Reporter, TestError } from '../types/testReporter';
 import { Multiplexer } from './reporters/multiplexer';
+import { formatError } from './reporters/base';
 import DotReporter from './reporters/dot';
 import GitHubReporter from './reporters/github';
 import LineReporter from './reporters/line';
@@ -684,7 +685,10 @@ function createTestGroups(rootSuite: Suite): TestGroup[] {
 }
 
 class ListModeReporter implements Reporter {
+  private config!: FullConfig;
+
   onBegin(config: FullConfig, suite: Suite): void {
+    this.config = config;
     // eslint-disable-next-line no-console
     console.log(`Listing tests:`);
     const tests = suite.allTests();
@@ -700,6 +704,11 @@ class ListModeReporter implements Reporter {
     }
     // eslint-disable-next-line no-console
     console.log(`Total: ${tests.length} ${tests.length === 1 ? 'test' : 'tests'} in ${files.size} ${files.size === 1 ? 'file' : 'files'}`);
+  }
+
+  onError(error: TestError) {
+    // eslint-disable-next-line no-console
+    console.error('\n' + formatError(this.config, error, false).message);
   }
 }
 

--- a/tests/playwright-test/list-mode.spec.ts
+++ b/tests/playwright-test/list-mode.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect } from './playwright-test-fixtures';
+import { test, expect, stripAnsi } from './playwright-test-fixtures';
 import path from 'path';
 import fs from 'fs';
 
@@ -139,4 +139,15 @@ test('outputDir should not be removed', async ({ runInlineTest }, testInfo) => {
   }, { list: true }, {}, { usesCustomOutputDir: true });
   expect(result2.exitCode).toBe(0);
   expect(fs.existsSync(path.join(outputDir, 'a-my-test', 'myfile.txt'))).toBe(true);
+});
+
+test('should report errors', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const oh = '';
+      oh = 2;
+    `
+  }, { 'list': true });
+  expect(result.exitCode).toBe(1);
+  expect(stripAnsi(result.output)).toContain('> 6 |       oh = 2;');
 });


### PR DESCRIPTION
`--list` mode now prints any errors encountered during test collection, for example syntax errors, to `stderr`.