### PR TITLE
feat(touchscreen): add Touchscreen move down up methods

### DIFF
--- a/docs/src/api/class-touchscreen.md
+++ b/docs/src/api/class-touchscreen.md
@@ -3,14 +3,13 @@
 The Touchscreen class operates in main-frame CSS pixels relative to the top-left corner of the viewport. Methods on the
 touchscreen can only be used in browser contexts that have been initialized with `hasTouch` set to true.
 
-## async method: Touchscreen.tap
+## async method: Touchscreen.down
+Dispatches a `touchstart` event with a single touch at the position ([`param: x`],[`param: y`]).
 
-Dispatches a `touchstart` and `touchend` event with a single touch at the position ([`param: x`],[`param: y`]).
-
-### param: Touchscreen.tap.x
+### param: Touchscreen.down.x
 - `x` <[float]>
 
-### param: Touchscreen.tap.y
+### param: Touchscreen.down.y
 - `y` <[float]>
 
 ## async method: Touchscreen.move
@@ -27,11 +26,16 @@ Dispatches a `touchstart` and `touchmove` and `touchend` event with a single tou
 ### param: Touchscreen.move.endY
 - `endY` <[float]>
 
-## async method: Touchscreen.down
-### param: Touchscreen.down.x
+## async method: Touchscreen.tap
+
+Dispatches a `touchstart` and `touchend` event with a single touch at the position ([`param: x`],[`param: y`]).
+
+### param: Touchscreen.tap.x
 - `x` <[float]>
 
-### param: Touchscreen.down.y
+### param: Touchscreen.tap.y
 - `y` <[float]>
 
 ## async method: Touchscreen.up
+
+Dispatches a `touchend` event

--- a/docs/src/api/class-touchscreen.md
+++ b/docs/src/api/class-touchscreen.md
@@ -12,3 +12,26 @@ Dispatches a `touchstart` and `touchend` event with a single touch at the positi
 
 ### param: Touchscreen.tap.y
 - `y` <[float]>
+
+## async method: Touchscreen.move
+Dispatches a `touchstart` and `touchmove` and `touchend` event with a single touch at the position ([`param: x`],[`param: y`],[`param: endX`],[`param: endY`]).
+
+### param: Touchscreen.move.x
+- `x` <[float]>
+
+### param: Touchscreen.move.y
+- `y` <[float]>
+### param: Touchscreen.move.endX
+- `endX` <[float]>
+
+### param: Touchscreen.move.endY
+- `endY` <[float]>
+
+## async method: Touchscreen.down
+### param: Touchscreen.down.x
+- `x` <[float]>
+
+### param: Touchscreen.down.y
+- `y` <[float]>
+
+## async method: Touchscreen.up

--- a/packages/playwright-core/src/client/input.ts
+++ b/packages/playwright-core/src/client/input.ts
@@ -89,4 +89,19 @@ export class Touchscreen implements api.Touchscreen {
   async tap(x: number, y: number) {
     await this._page._channel.touchscreenTap({ x, y });
   }
+
+  async move(x: number, y: number, endX: number, endY: number) {
+    await this._page._channel.touchscreenMove({ x, y, endX, endY });
+  }
+
+  async down(x: number, y: number) {
+    await this._page._channel.touchscreenDown({
+      x,
+      y
+    });
+  }
+
+  async up() {
+    await this._page._channel.touchscreenUp({});
+  }
 }

--- a/packages/playwright-core/src/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/dispatchers/pageDispatcher.ts
@@ -238,6 +238,18 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel> imple
     await this._page.touchscreen.tap(params.x, params.y);
   }
 
+  async touchscreenMove(params: channels.PageTouchscreenMoveParams, metadata?: CallMetadata): Promise<void> {
+    await this._page.touchscreen.move(params.x, params.y, params.endX, params.endY);
+  }
+
+  async touchscreenDown(params: channels.PageTouchscreenDownParams, metadata?: CallMetadata): Promise<void> {
+    await this._page.touchscreen.down(params.x, params.y);
+  }
+
+  async touchscreenUp(params: channels.PageTouchscreenUpParams, metadata?: CallMetadata): Promise<void> {
+    await this._page.touchscreen.up();
+  }
+
   async accessibilitySnapshot(params: channels.PageAccessibilitySnapshotParams, metadata: CallMetadata): Promise<channels.PageAccessibilitySnapshotResult> {
     const rootAXNode = await this._page.accessibility.snapshot({
       interestingOnly: params.interestingOnly,

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -1359,6 +1359,9 @@ export interface PageChannel extends PageEventTarget, EventTargetChannel {
   mouseClick(params: PageMouseClickParams, metadata?: Metadata): Promise<PageMouseClickResult>;
   mouseWheel(params: PageMouseWheelParams, metadata?: Metadata): Promise<PageMouseWheelResult>;
   touchscreenTap(params: PageTouchscreenTapParams, metadata?: Metadata): Promise<PageTouchscreenTapResult>;
+  touchscreenMove(params: PageTouchscreenMoveParams, metadata?: Metadata): Promise<PageTouchscreenMoveResult>;
+  touchscreenDown(params: PageTouchscreenDownParams, metadata?: Metadata): Promise<PageTouchscreenDownResult>;
+  touchscreenUp(params?: PageTouchscreenUpParams, metadata?: Metadata): Promise<PageTouchscreenUpResult>;
   accessibilitySnapshot(params: PageAccessibilitySnapshotParams, metadata?: Metadata): Promise<PageAccessibilitySnapshotResult>;
   pdf(params: PagePdfParams, metadata?: Metadata): Promise<PagePdfResult>;
   startJSCoverage(params: PageStartJSCoverageParams, metadata?: Metadata): Promise<PageStartJSCoverageResult>;
@@ -1708,6 +1711,28 @@ export type PageTouchscreenTapOptions = {
 
 };
 export type PageTouchscreenTapResult = void;
+export type PageTouchscreenMoveParams = {
+  x: number,
+  y: number,
+  endX: number,
+  endY: number,
+};
+export type PageTouchscreenMoveOptions = {
+
+};
+export type PageTouchscreenMoveResult = void;
+export type PageTouchscreenDownParams = {
+  x: number,
+  y: number,
+};
+export type PageTouchscreenDownOptions = {
+
+};
+export type PageTouchscreenDownResult = void;
+export type PageTouchscreenUpParams = {};
+export type PageTouchscreenUpOptions = {};
+export type PageTouchscreenUpResult = void;
+
 export type PageAccessibilitySnapshotParams = {
   interestingOnly?: boolean,
   root?: ElementHandleChannel,

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -1732,7 +1732,6 @@ export type PageTouchscreenDownResult = void;
 export type PageTouchscreenUpParams = {};
 export type PageTouchscreenUpOptions = {};
 export type PageTouchscreenUpResult = void;
-
 export type PageAccessibilitySnapshotParams = {
   interestingOnly?: boolean,
   root?: ElementHandleChannel,

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -1186,6 +1186,20 @@ Page:
       tracing:
         snapshot: true
 
+    touchscreenMove:
+      parameters:
+        x: number
+        y: number
+        endX: number
+        endY: number
+
+    touchscreenDown:
+      parameters:
+        x: number
+        y: number
+
+    touchscreenUp:
+
     accessibilitySnapshot:
       parameters:
         interestingOnly: boolean?

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -641,6 +641,17 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     x: tNumber,
     y: tNumber,
   });
+  scheme.PageTouchscreenMoveParams = tObject({
+    x: tNumber,
+    y: tNumber,
+    endX: tNumber,
+    endY: tNumber,
+  });
+  scheme.PageTouchscreenDownParams = tObject({
+    x: tNumber,
+    y: tNumber,
+  });
+  scheme.PageTouchscreenUpParams = tOptional(tObject({}));
   scheme.PageAccessibilitySnapshotParams = tObject({
     interestingOnly: tOptional(tBoolean),
     root: tOptional(tChannel('ElementHandle')),

--- a/packages/playwright-core/src/server/chromium/crInput.ts
+++ b/packages/playwright-core/src/server/chromium/crInput.ts
@@ -179,14 +179,14 @@ export class RawTouchscreenImpl implements input.RawTouchscreen {
       }),
     ]);
   }
-  async move(startX: number, startY: number, endX: number, endY: number, modifiers: Set<types.KeyboardModifier>) {
+  async move(x: number, y: number, endX: number, endY: number, modifiers: Set<types.KeyboardModifier>) {
     await Promise.all([
       this._client.send('Input.dispatchTouchEvent', {
         type: 'touchStart',
         modifiers: toModifiersMask(modifiers),
         touchPoints: [{
-          x: startX,
-          y: startY
+          x: x,
+          y: y
         }]
       }),
       this._client.send('Input.dispatchTouchEvent', {
@@ -194,7 +194,8 @@ export class RawTouchscreenImpl implements input.RawTouchscreen {
         modifiers: toModifiersMask(modifiers),
         touchPoints: [{
           x: endX,
-          y: endY
+          y: endY,
+          tangentialPressure: -1
         }]
       }),
       this._client.send('Input.dispatchTouchEvent', {

--- a/packages/playwright-core/src/server/chromium/crInput.ts
+++ b/packages/playwright-core/src/server/chromium/crInput.ts
@@ -179,4 +179,47 @@ export class RawTouchscreenImpl implements input.RawTouchscreen {
       }),
     ]);
   }
+  async move(startX: number, startY: number, endX: number, endY: number, modifiers: Set<types.KeyboardModifier>) {
+    await Promise.all([
+      this._client.send('Input.dispatchTouchEvent', {
+        type: 'touchStart',
+        modifiers: toModifiersMask(modifiers),
+        touchPoints: [{
+          x: startX,
+          y: startY
+        }]
+      }),
+      this._client.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        modifiers: toModifiersMask(modifiers),
+        touchPoints: [{
+          x: endX,
+          y: endY
+        }]
+      }),
+      this._client.send('Input.dispatchTouchEvent', {
+        type: 'touchEnd',
+        modifiers: toModifiersMask(modifiers),
+        touchPoints: []
+      }),
+    ]);
+  }
+
+  async down(x: number, y: number, modifiers: Set<types.KeyboardModifier>) {
+    await this._client.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      modifiers: toModifiersMask(modifiers),
+      touchPoints: [{
+        x, y
+      }]
+    });
+  }
+
+  async up(modifiers: Set<types.KeyboardModifier>) {
+    await this._client.send('Input.dispatchTouchEvent', {
+      type: 'touchEnd',
+      modifiers: toModifiersMask(modifiers),
+      touchPoints: []
+    });
+  }
 }

--- a/packages/playwright-core/src/server/input.ts
+++ b/packages/playwright-core/src/server/input.ts
@@ -302,6 +302,9 @@ function buildLayoutClosure(layout: keyboardLayout.KeyboardLayout): Map<string, 
 
 export interface RawTouchscreen {
   tap(x: number, y: number, modifiers: Set<types.KeyboardModifier>): Promise<void>;
+  move?(x: number, y: number, endX: number, endY: number, modifiers: Set<types.KeyboardModifier>): Promise<void>;
+  down?(x: number, y: number, modifiers: Set<types.KeyboardModifier>): Promise<void>;
+  up?(modifiers: Set<types.KeyboardModifier>): Promise<void>;
 }
 
 export class Touchscreen {
@@ -317,6 +320,32 @@ export class Touchscreen {
     if (!this._page._browserContext._options.hasTouch)
       throw new Error('hasTouch must be enabled on the browser context before using the touchscreen.');
     await this._raw.tap(x, y, this._page.keyboard._modifiers());
+    await this._page._doSlowMo();
+  }
+
+  async move(x: number, y: number, endX: number, endY: number) {
+    if (!this._page._browserContext._options.hasTouch)
+      throw new Error('hasTouch must be enabled on the browser context before using the touchscreen.');
+    if (!this._raw.move)
+      throw new Error('move not support');
+    await this._raw.move(x, y, endX, endY, this._page.keyboard._modifiers());
+    await this._page._doSlowMo();
+  }
+  async down(x: number, y: number) {
+    if (!this._page._browserContext._options.hasTouch)
+      throw new Error('hasTouch must be enabled on the browser context before using the touchscreen.');
+    if (!this._raw.down)
+      throw new Error('down not support');
+    await this._raw.down(x, y, this._page.keyboard._modifiers());
+    await this._page._doSlowMo();
+  }
+
+  async up() {
+    if (!this._page._browserContext._options.hasTouch)
+      throw new Error('hasTouch must be enabled on the browser context before using the touchscreen.');
+    if (!this._raw.up)
+      throw new Error('up not support');
+    await this._raw.up(this._page.keyboard._modifiers());
     await this._page._doSlowMo();
   }
 }

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14834,11 +14834,11 @@ export interface Selectors {
  */
 export interface Touchscreen {
   /**
-   * Dispatches a `touchstart` and `touchend` event with a single touch at the position (`x`,`y`).
+   * Dispatches a `touchstart` event with a single touch at the position (`x`,`y`).
    * @param x
    * @param y
    */
-  tap(x: number, y: number): Promise<void>;
+  down(x: number, y: number): Promise<void>;
 
   /**
    * Dispatches a `touchstart` and `touchmove` and `touchend` event with a single touch at the position
@@ -14851,11 +14851,15 @@ export interface Touchscreen {
   move(x: number, y: number, endX: number, endY: number): Promise<void>;
 
   /**
+   * Dispatches a `touchstart` and `touchend` event with a single touch at the position (`x`,`y`).
    * @param x
    * @param y
    */
-  down(x: number, y: number): Promise<void>;
+  tap(x: number, y: number): Promise<void>;
 
+  /**
+   * Dispatches a `touchend` event
+   */
   up(): Promise<void>;
 }
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14839,6 +14839,24 @@ export interface Touchscreen {
    * @param y
    */
   tap(x: number, y: number): Promise<void>;
+
+  /**
+   * Dispatches a `touchstart` and `touchmove` and `touchend` event with a single touch at the position
+   * (`x`,`y`,`endX`,`endY`).
+   * @param x
+   * @param y
+   * @param endX
+   * @param endY
+   */
+  move(x: number, y: number, endX: number, endY: number): Promise<void>;
+
+  /**
+   * @param x
+   * @param y
+   */
+  down(x: number, y: number): Promise<void>;
+
+  up(): Promise<void>;
 }
 
 /**

--- a/tests/library/tap.spec.ts
+++ b/tests/library/tap.spec.ts
@@ -28,7 +28,7 @@ it('should send all of the correct events @smoke', async ({ page }) => {
   await page.tap('#a');
   const eventsHandle = await trackEvents(await page.$('#b'));
   await page.tap('#b');
-  // webkit doesnt send pointerenter or pointerleave or mouseout
+  // webkit doesnt saend pointerenter or pointerleave or mouseout
   expect(await eventsHandle.jsonValue()).toEqual([
     'pointerover',  'pointerenter',
     'pointerdown',  'touchstart',
@@ -188,7 +188,7 @@ it('should wait until an element is visible to tap it', async ({ page }) => {
   expect(await div.textContent()).toBe('clicked');
 });
 
-it.only('should move in touchscreen.move', async ({ page }) => {
+it('should move in touchscreen.move', async ({ page }) => {
 
   await page.setContent(`
     <div id="a" style="background: lightblue; width: 300px; height: 5000px">a</div>
@@ -227,7 +227,7 @@ it.only('should move in touchscreen.move', async ({ page }) => {
 });
 
 
-it.only('should send all of the correct events @touchscreen.down', async ({ page }) => {
+it('should send all of the correct events @touchscreen.down', async ({ page }) => {
 
   await page.setContent(`
     <div id="a" style="background: lightblue; width: 200px; height: 2000px">a</div>
@@ -245,7 +245,7 @@ it.only('should send all of the correct events @touchscreen.down', async ({ page
   ]);
 });
 
-it.only('should send all of the correct events @touchscreen.up', async ({ page }) => {
+it('should send all of the correct events @touchscreen.up', async ({ page }) => {
 
   await page.setContent(`
     <div id="a" style="background: lightblue; width: 200px; height: 2000px">a</div>

--- a/tests/library/tap.spec.ts
+++ b/tests/library/tap.spec.ts
@@ -262,12 +262,12 @@ it('should send all of the correct events @touchscreen.up', async ({ page }) => 
     'pointerup',
     'pointerout',
     'pointerleave',
-    "mouseover",
-    "mouseenter",
-    "mousemove",
-    "mousedown",
-    "mouseup",
-    "click",
+    'mouseover',
+    'mouseenter',
+    'mousemove',
+    'mousedown',
+    'mouseup',
+    'click',
   ]);
 });
 
@@ -287,16 +287,16 @@ async function trackEvents(target: ElementHandle) {
 }
 
 function wait(ms: number) {
-  return new Promise(re => {
+  return new Promise(resolve => {
     setTimeout(() => {
-      re('');
-    }, ms)
-  })
+      resolve('');
+    }, ms);
+  });
 }
 
 async function getRect(page: Page) {
   return page.evaluate(() => {
-    const {x, y} = document.documentElement.getBoundingClientRect();
+    const { x, y } = document.documentElement.getBoundingClientRect();
     return {
       x, y
     };

--- a/tests/library/tap.spec.ts
+++ b/tests/library/tap.spec.ts
@@ -28,7 +28,7 @@ it('should send all of the correct events @smoke', async ({ page }) => {
   await page.tap('#a');
   const eventsHandle = await trackEvents(await page.$('#b'));
   await page.tap('#b');
-  // webkit doesnt saend pointerenter or pointerleave or mouseout
+  // webkit doesnt send pointerenter or pointerleave or mouseout
   expect(await eventsHandle.jsonValue()).toEqual([
     'pointerover',  'pointerenter',
     'pointerdown',  'touchstart',


### PR DESCRIPTION
## add page.touchscreen.move/down/up method
### Why

Some business logics is valid when a page is pressed down  by user and Once the page is pressed up, the logics changes. So  I need to validate this logic under `down`. 

On touch move, I need to record user scroll behavior and send log.

### How 
```javascript
await page.touchscreen.down(100, 100);

await page.touchscreen.up();

await page.touchscreen.move(200, 200, 200, 180);
```
