### PR TITLE
feat(android): support socketName selector and control installing driver

### DIFF
--- a/docs/src/api/class-android.md
+++ b/docs/src/api/class-android.md
@@ -87,6 +87,11 @@ Returns the list of detected Android devices.
 
 Optional port to establish ADB server connection.
 
+### option: Android.devices.autoInstallDriver
+- `autoInstallDriver` <[boolean]>
+
+Optional install latest playwright driver automatically. if false, firstly you should install android-driver.apk and android-driver-target.apk which are in bin directory of playwright-core.  Default to true.
+
 ## method: Android.setDefaultTimeout
 
 This setting will change the default maximum time for all the methods accepting [`param: timeout`] option.

--- a/docs/src/api/class-androiddevice.md
+++ b/docs/src/api/class-androiddevice.md
@@ -358,7 +358,8 @@ This method waits until [AndroidWebView] matching the [`option: selector`] is op
 
 ### param: AndroidDevice.webView.selector
 - `selector` <[Object]>
-  - `pkg` <[string]> Package identifier.
+  - `pkg` <[string]> Optional Package identifier.
+  - `socketName` <[string]> Optional webview socket name.
 
 ### option: AndroidDevice.webView.timeout = %%-android-timeout-%%
 

--- a/docs/src/api/class-androidwebview.md
+++ b/docs/src/api/class-androidwebview.md
@@ -12,6 +12,11 @@ Emitted when the WebView is closed.
 
 Connects to the WebView and returns a regular Playwright [Page] to interact with.
 
+## async method: AndroidWebView.pages
+- returns: <[Page[]]>
+
+Connects to the WebView and returns many regular Playwright [Page] to interact with.
+
 ## method: AndroidWebView.pid
 - returns: <[int]>
 
@@ -21,3 +26,8 @@ WebView process PID.
 - returns: <[string]>
 
 WebView package identifier.
+
+## method: AndroidWebView.socketName
+- returns: <[string]>
+
+WebView socket name.

--- a/packages/playwright-core/src/dispatchers/androidDispatcher.ts
+++ b/packages/playwright-core/src/dispatchers/androidDispatcher.ts
@@ -55,7 +55,7 @@ export class AndroidDeviceDispatcher extends Dispatcher<AndroidDevice, channels.
     for (const webView of device.webViews())
       this._dispatchEvent('webViewAdded', { webView });
     device.on(AndroidDevice.Events.WebViewAdded, webView => this._dispatchEvent('webViewAdded', { webView }));
-    device.on(AndroidDevice.Events.WebViewRemoved, pid => this._dispatchEvent('webViewRemoved', { pid }));
+    device.on(AndroidDevice.Events.WebViewRemoved, socketName => this._dispatchEvent('webViewRemoved', { socketName }));
   }
 
   async wait(params: channels.AndroidDeviceWaitParams) {
@@ -168,7 +168,7 @@ export class AndroidDeviceDispatcher extends Dispatcher<AndroidDevice, channels.
   }
 
   async connectToWebView(params: channels.AndroidDeviceConnectToWebViewParams): Promise<channels.AndroidDeviceConnectToWebViewResult> {
-    return { context: new BrowserContextDispatcher(this._scope, await this._object.connectToWebView(params.pid)) };
+    return { context: new BrowserContextDispatcher(this._scope, await this._object.connectToWebView(params.socketName)) };
   }
 }
 

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -3678,9 +3678,11 @@ export interface AndroidChannel extends AndroidEventTarget, Channel {
 }
 export type AndroidDevicesParams = {
   port?: number,
+  autoInstallDriver?: boolean,
 };
 export type AndroidDevicesOptions = {
   port?: number,
+  autoInstallDriver?: boolean,
 };
 export type AndroidDevicesResult = {
   devices: AndroidDeviceChannel[],
@@ -3768,7 +3770,7 @@ export type AndroidDeviceWebViewAddedEvent = {
   webView: AndroidWebView,
 };
 export type AndroidDeviceWebViewRemovedEvent = {
-  pid: number,
+  socketName: string,
 };
 export type AndroidDeviceWaitParams = {
   selector: AndroidSelector,
@@ -4085,7 +4087,7 @@ export type AndroidDeviceSetDefaultTimeoutNoReplyOptions = {
 };
 export type AndroidDeviceSetDefaultTimeoutNoReplyResult = void;
 export type AndroidDeviceConnectToWebViewParams = {
-  pid: number,
+  socketName: string,
 };
 export type AndroidDeviceConnectToWebViewOptions = {
 
@@ -4105,6 +4107,7 @@ export interface AndroidDeviceEvents {
 export type AndroidWebView = {
   pid: number,
   pkg: string,
+  socketName: string,
 };
 
 export type AndroidSelector = {

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -2846,6 +2846,7 @@ Android:
     devices:
       parameters:
         port: number?
+        autoInstallDriver: boolean?
       returns:
         devices:
           type: array
@@ -3050,7 +3051,7 @@ AndroidDevice:
 
     connectToWebView:
       parameters:
-        pid: number
+        socketName: string
       returns:
         context: BrowserContext
 
@@ -3063,7 +3064,7 @@ AndroidDevice:
 
     webViewRemoved:
       parameters:
-        pid: number
+        socketName: string
 
 
 AndroidWebView:
@@ -3071,6 +3072,7 @@ AndroidWebView:
   properties:
     pid: number
     pkg: string
+    socketName: string
 
 
 AndroidSelector:

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1301,6 +1301,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
   scheme.ElectronApplicationCloseParams = tOptional(tObject({}));
   scheme.AndroidDevicesParams = tObject({
     port: tOptional(tNumber),
+    autoInstallDriver: tOptional(tBoolean),
   });
   scheme.AndroidSetDefaultTimeoutNoReplyParams = tObject({
     timeout: tNumber,
@@ -1463,12 +1464,13 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     timeout: tNumber,
   });
   scheme.AndroidDeviceConnectToWebViewParams = tObject({
-    pid: tNumber,
+    socketName: tString,
   });
   scheme.AndroidDeviceCloseParams = tOptional(tObject({}));
   scheme.AndroidWebView = tObject({
     pid: tNumber,
     pkg: tString,
+    socketName: tString,
   });
   scheme.AndroidSelector = tObject({
     checkable: tOptional(tBoolean),

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -22,7 +22,7 @@ import os from 'os';
 import path from 'path';
 import * as stream from 'stream';
 import * as ws from 'ws';
-import { createGuid, makeWaitForNextTask, removeFolders } from '../../utils/utils';
+import { makeWaitForNextTask, removeFolders } from '../../utils/utils';
 import { BrowserOptions, BrowserProcess, PlaywrightOptions } from '../browser';
 import { BrowserContext, validateBrowserContextOptions } from '../browserContext';
 import { ProgressController } from '../progress';

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -80,7 +80,7 @@ export class Android extends SdkObject {
       newSerials.add(d.serial);
       if (this._devices.has(d.serial))
         continue;
-      const device = await AndroidDevice.create(this, d);
+      const device = await AndroidDevice.create(this, d, options);
       this._devices.set(d.serial, device);
     }
     for (const d of this._devices.keys()) {
@@ -99,12 +99,13 @@ export class AndroidDevice extends SdkObject {
   readonly _backend: DeviceBackend;
   readonly model: string;
   readonly serial: string;
+  private _options: types.AndroidDeviceOptions;
   private _driverPromise: Promise<PipeTransport> | undefined;
   private _lastId = 0;
   private _callbacks = new Map<number, { fulfill: (result: any) => void, reject: (error: Error) => void }>();
   private _pollingWebViews: NodeJS.Timeout | undefined;
   readonly _timeoutSettings: TimeoutSettings;
-  private _webViews = new Map<number, AndroidWebView>();
+  private _webViews = new Map<string, AndroidWebView>();
 
   static Events = {
     WebViewAdded: 'webViewAdded',
@@ -116,19 +117,20 @@ export class AndroidDevice extends SdkObject {
   private _android: Android;
   private _isClosed = false;
 
-  constructor(android: Android, backend: DeviceBackend, model: string) {
+  constructor(android: Android, backend: DeviceBackend, model: string, options: types.AndroidDeviceOptions) {
     super(android, 'android-device');
     this._android = android;
     this._backend = backend;
     this.model = model;
     this.serial = backend.serial;
+    this._options = options;
     this._timeoutSettings = new TimeoutSettings(android._timeoutSettings);
   }
 
-  static async create(android: Android, backend: DeviceBackend): Promise<AndroidDevice> {
+  static async create(android: Android, backend: DeviceBackend, options: types.AndroidDeviceOptions): Promise<AndroidDevice> {
     await backend.init();
     const model = await backend.runCommand('shell:getprop ro.product.model');
-    const device = new AndroidDevice(android, backend, model.toString().trim());
+    const device = new AndroidDevice(android, backend, model.toString().trim(), options);
     await device._init();
     return device;
   }
@@ -169,13 +171,16 @@ export class AndroidDevice extends SdkObject {
     debug('pw:android')('Stopping the old driver');
     await this.shell(`am force-stop com.microsoft.playwright.androiddriver`);
 
-    debug('pw:android')('Uninstalling the old driver');
-    await this.shell(`cmd package uninstall com.microsoft.playwright.androiddriver`);
-    await this.shell(`cmd package uninstall com.microsoft.playwright.androiddriver.test`);
+    // uninstall and install driver on every excution
+    if (this._options.autoInstallDriver !== false) {
+      debug('pw:android')('Uninstalling the old driver');
+      await this.shell(`cmd package uninstall com.microsoft.playwright.androiddriver`);
+      await this.shell(`cmd package uninstall com.microsoft.playwright.androiddriver.test`);
 
-    debug('pw:android')('Installing the new driver');
-    for (const file of ['android-driver.apk', 'android-driver-target.apk'])
-      await this.installApk(await fs.promises.readFile(require.resolve(`../../../bin/${file}`)));
+      debug('pw:android')('Installing the new driver');
+      for (const file of ['android-driver.apk', 'android-driver-target.apk'])
+        await this.installApk(await fs.promises.readFile(require.resolve(`../../../bin/${file}`)));
+    }
 
     debug('pw:android')('Starting the new driver');
     this.shell('am instrument -w com.microsoft.playwright.androiddriver.test/androidx.test.runner.AndroidJUnitRunner').catch(e => debug('pw:android')(e));
@@ -238,8 +243,8 @@ export class AndroidDevice extends SdkObject {
   async launchBrowser(pkg: string = 'com.android.chrome', options: types.BrowserContextOptions): Promise<BrowserContext> {
     debug('pw:android')('Force-stopping', pkg);
     await this._backend.runCommand(`shell:am force-stop ${pkg}`);
-
-    const socketName = 'playwright-' + createGuid();
+    // need not non-root devices
+    const socketName = 'chrome_devtools_remote';
     const commandLine = `_ --disable-fre --no-default-browser-check --no-first-run --remote-debugging-socket-name=${socketName}`;
     debug('pw:android')('Starting', pkg, commandLine);
     await this._backend.runCommand(`shell:echo "${commandLine}" > /data/local/tmp/chrome-command-line`);
@@ -247,11 +252,11 @@ export class AndroidDevice extends SdkObject {
     return await this._connectToBrowser(socketName, options);
   }
 
-  async connectToWebView(pid: number): Promise<BrowserContext> {
-    const webView = this._webViews.get(pid);
+  async connectToWebView(socketName: string): Promise<BrowserContext> {
+    const webView = this._webViews.get(socketName);
     if (!webView)
       throw new Error('WebView has been closed');
-    return await this._connectToBrowser(`webview_devtools_remote_${pid}`);
+    return await this._connectToBrowser(socketName, { hasTouch: true });
   }
 
   private async _connectToBrowser(socketName: string, options: types.BrowserContextOptions = {}): Promise<BrowserContext> {
@@ -336,42 +341,61 @@ export class AndroidDevice extends SdkObject {
   }
 
   private async _refreshWebViews() {
-    const sockets = (await this._backend.runCommand(`shell:cat /proc/net/unix | grep webview_devtools_remote`)).toString().split('\n');
+    const sockets = (await this._backend.runCommand(`shell:cat /proc/net/unix | grep devtools_remote`)).toString().split('\n');
     if (this._isClosed)
       return;
 
     const newPids = new Set<number>();
+    const socketNames = new Set<string>();
     for (const line of sockets) {
-      const match = line.match(/[^@]+@webview_devtools_remote_(\d+)/);
-      if (!match)
+      const match = line.match(/[^@]+@.*?devtools_remote_?(\d*)/);
+      const macthSocketName = line.match(/[^@]+@(.*?_devtools_remote_?.*)/);
+
+      if (!macthSocketName)
         continue;
+
+      const socketName = macthSocketName[1];
+      socketNames.add(socketName);
+
+      if (!match) {
+        if (this._webViews.has(socketName))
+          continue;
+        const webView = { pid: -1, pkg: '', socketName };
+        this._webViews.set(socketName, webView);
+        this.emit(AndroidDevice.Events.WebViewAdded, webView);
+        continue;
+      }
+
+
       const pid = +match[1];
+      if (!newPids.has(pid)) {
+
+        if (this._webViews.has(socketName))
+          continue;
+
+        const procs = (await this._backend.runCommand(`shell:ps -A | grep ${pid}`)).toString().split('\n');
+        if (this._isClosed)
+          return;
+        let pkg = '';
+        for (const proc of procs) {
+          const match = proc.match(/[^\s]+\s+(\d+).*$/);
+          if (!match)
+            continue;
+          const p = match[1];
+          if (+p !== pid)
+            continue;
+          pkg = proc.substring(proc.lastIndexOf(' ') + 1);
+        }
+        const webView = { pid, pkg, socketName };
+        this._webViews.set(socketName, webView);
+
+        this.emit(AndroidDevice.Events.WebViewAdded, webView);
+      }
+
       newPids.add(pid);
     }
-    for (const pid of newPids) {
-      if (this._webViews.has(pid))
-        continue;
-
-      const procs = (await this._backend.runCommand(`shell:ps -A | grep ${pid}`)).toString().split('\n');
-      if (this._isClosed)
-        return;
-      let pkg = '';
-      for (const proc of procs) {
-        const match = proc.match(/[^\s]+\s+(\d+).*$/);
-        if (!match)
-          continue;
-        const p = match[1];
-        if (+p !== pid)
-          continue;
-        pkg = proc.substring(proc.lastIndexOf(' ') + 1);
-      }
-      const webView = { pid, pkg };
-      this._webViews.set(pid, webView);
-      this.emit(AndroidDevice.Events.WebViewAdded, webView);
-    }
-
     for (const p of this._webViews.keys()) {
-      if (!newPids.has(p)) {
+      if (!socketNames.has(p)) {
         this._webViews.delete(p);
         this.emit(AndroidDevice.Events.WebViewRemoved, p);
       }

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -369,5 +369,6 @@ export type APIResponse = {
 };
 
 export type AndroidDeviceOptions = {
-  port?: number
+  port?: number,
+  autoInstallDriver?: boolean,
 };

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -11112,6 +11112,12 @@ export interface Android {
    */
   devices(options?: {
     /**
+     * Optional install latest playwright driver automatically. if false, firstly you should install android-driver.apk and
+     * android-driver-target.apk which are in bin directory of playwright-core.  Default to true.
+     */
+    autoInstallDriver?: boolean;
+
+    /**
      * Optional port to establish ADB server connection.
      */
     port?: number;
@@ -11725,9 +11731,14 @@ export interface AndroidDevice {
    */
   webView(selector: {
     /**
-     * Package identifier.
+     * Optional Package identifier.
      */
-    pkg: string;
+    pkg?: string;
+
+    /**
+     * Optional webview socket name.
+     */
+    socketName?: string;
   }, options?: {
     /**
      * Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by
@@ -11903,6 +11914,11 @@ export interface AndroidWebView {
   page(): Promise<Page>;
 
   /**
+   * Connects to the WebView and returns many regular Playwright [Page] to interact with.
+   */
+  pages(): Promise<Page[]>;
+
+  /**
    * WebView process PID.
    */
   pid(): number;
@@ -11911,6 +11927,11 @@ export interface AndroidWebView {
    * WebView package identifier.
    */
   pkg(): string;
+
+  /**
+   * WebView socket name.
+   */
+  socketName(): string;
 }
 
 /**

--- a/tests/android/device.spec.ts
+++ b/tests/android/device.spec.ts
@@ -59,50 +59,40 @@ test('androidDevice.fill', async function({ androidDevice }) {
   expect((await androidDevice.info({ res: 'org.chromium.webview_shell:id/url_field' })).text).toBe('Hello');
 });
 
-test('androidDevice.options.autoInstallDriver', async function({ playwright }) {
+function wait(ms: number) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve('');
+    }, ms);
+  });
+}
+
+test.only('androidDevice.options.autoInstallDriver', async function({ playwright }) {
   const devices = await playwright._android.devices({ autoInstallDriver: false });
 
   const androidDevice = devices[0];
   await androidDevice.shell(`cmd package uninstall com.microsoft.playwright.androiddriver`);
-  await androidDevice.shell(`cmd package uninstall com.microsoft.playwright.androiddriver.test`)
+  await androidDevice.shell(`cmd package uninstall com.microsoft.playwright.androiddriver.test`);
+
+  await androidDevice.shell('am start -n com.android.chrome/com.google.android.apps.chrome.Main about:blank');
 
   let fillEnd = false;
-  try {
-    await androidDevice.shell('am start -n com.android.chrome/com.google.android.apps.chrome.Main about:blank');
+  const fillPromise = androidDevice.fill({ res: 'com.android.chrome:id/url_bar' }, 'Hello').then(() => {
+    fillEnd = true;
+  });
 
-    // parallel
-    await Promise.all([
-      // 1. hang on opening socket
-      // 2. install and start driver
-      // 3. finish operation
-      androidDevice.fill({ res: 'com.android.chrome:id/url_bar' }, 'Hello').then(() => {
-        fillEnd = true
-      }),
+  await wait(2000);
+  expect(fillEnd).toBe(false);
 
-      // 1. check false
-      // 2. install and start driver
-      // 3. check true
-      new Promise(resolve => {
-        setTimeout(async () => {
-          expect(fillEnd).toBe(false);
-
-          // install and start driver
-          for (const file of ['android-driver.apk', 'android-driver-target.apk']) {
-            const filePath = join(require.resolve('playwright-core'), '..', 'bin', file);
-            console.log('file', filePath);
-            await androidDevice.installApk(await fs.promises.readFile(filePath));
-          }
-          androidDevice.shell('am instrument -w com.microsoft.playwright.androiddriver.test/androidx.test.runner.AndroidJUnitRunner').catch(e => console.error);
-
-          setTimeout(() => {
-            resolve('');
-          }, 4000)
-        }, 2000)
-      })
-    ])
+  // install and start driver
+  for (const file of ['android-driver.apk', 'android-driver-target.apk']) {
+    const filePath = join(require.resolve('playwright-core'), '..', 'bin', file);
+    console.log('file', filePath);
+    await androidDevice.installApk(await fs.promises.readFile(filePath));
   }
-  catch (e) {
-    console.error(e);
-  }
+  androidDevice.shell('am instrument -w com.microsoft.playwright.androiddriver.test/androidx.test.runner.AndroidJUnitRunner').catch(e => console.error);
+
+  await wait(2000);
+  await fillPromise;
   expect(fillEnd).toBe(true);
 });

--- a/tests/android/webview.spec.ts
+++ b/tests/android/webview.spec.ts
@@ -18,6 +18,7 @@ import { androidTest as test, expect } from './androidTest';
 
 test.afterEach(async ({ androidDevice }) => {
   await androidDevice.shell('am force-stop org.chromium.webview_shell');
+  await androidDevice.shell('am force-stop com.android.chrome');
 });
 
 test('androidDevice.webView', async function({ androidDevice }) {
@@ -61,3 +62,23 @@ test('should navigate page externally', async function({ androidDevice }) {
   ]);
   expect(await page.title()).toBe('Hello world!');
 });
+
+test('select webview from socketName', async function({ androidDevice }) {
+  test.slow();
+  await androidDevice.shell('am start -n com.android.chrome/com.google.android.apps.chrome.Main about:blank');
+  const webview = await androidDevice.webView({ socketName: 'chrome_devtools_remote' });
+  expect(webview.pkg()).toBe('');
+  expect(webview.socketName()).toBe('chrome_devtools_remote');
+  const page = await webview.page();
+  expect(page.url()).toBe('about:blank');
+});
+
+test('webview.pages', async function({ androidDevice }) {
+  test.slow();
+  await androidDevice.shell('am start -n com.android.chrome/com.google.android.apps.chrome.Main about:blank');
+  const webview = await androidDevice.webView({ socketName: 'chrome_devtools_remote' });
+  const pages = await webview.pages();
+  expect(pages.length).toBe(1);
+  expect(pages[0].url()).toBe('about:blank');
+});
+


### PR DESCRIPTION
## 1. support socketName selector

### Why
Some apps includes custom chromium version and socket names. Can not get webviews only by `pid`. eg:
```
0000000000000000: 00000002 00000000 00010000 0001 01 17073592 @webview_devtools_remote_zeus
0000000000000000: 00000002 00000000 00010000 0001 01 17123419 @webview_devtools_remote_32327_zeus
0000000000000000: 00000002 00000000 00010000 0001 01 17194878 @chrome_devtools_remote
0000000000000000: 00000002 00000000 00010000 0001 01 22537480 @content_shell_devtools_remote
```
Chromedriver also supports `androidDeviceSocket` param to set custom socket name.

### How
```
const webview = await device.webView({ socketName: 'chrome_devtools_remote' });
```
## 2. Control installing drivers
Drivers are installed on every execution. But some phones must input password to install apps and can not be bypassed.
So Let user install driver for the first time ,  and providing  ` autoInstallDriver: false` avoid installing drivers
```
const [device] = await _android.devices({
      autoInstallDriver: false
});
```
