### PR TITLE
test: out-of-viewport should be considered visible

### DIFF
--- a/tests/page/page-wait-for-selector-2.spec.ts
+++ b/tests/page/page-wait-for-selector-2.spec.ts
@@ -100,6 +100,29 @@ it('hidden should wait for removal', async ({ page, server }) => {
   expect(divRemoved).toBe(true);
 });
 
+it('hidden should wait for out-of-viewport', async ({ page }) => {
+  it.fail(true, 'https://github.com/microsoft/playwright/issues/13131');
+  await page.setContent(`
+    <style>
+      .cover {
+        position: fixed;
+        left: 0;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        background-color: red;
+        transform: translateX(-200px);
+      }
+    </style>
+    <div class="cover">cover</div>
+  `);
+
+  const cover = page.locator('.cover');
+  await expect.soft(cover).not.toBeVisible();
+  // Below is not web-first, but is included to mirror original snippet from https://github.com/microsoft/playwright/issues/13131
+  await cover.waitFor({ state: 'hidden' });
+});
+
 it('should return null if waiting to hide non-existing element', async ({ page, server }) => {
   const handle = await page.waitForSelector('non-existing', { state: 'hidden' });
   expect(handle).toBe(null);

--- a/tests/page/page-wait-for-selector-2.spec.ts
+++ b/tests/page/page-wait-for-selector-2.spec.ts
@@ -67,6 +67,27 @@ it('should wait for visible recursively', async ({ page, server }) => {
   expect(divVisible).toBe(true);
 });
 
+it('should consider outside of viewport visible', async ({ page }) => {
+  await page.setContent(`
+    <style>
+      .cover {
+        position: fixed;
+        left: 0;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        background-color: red;
+        transform: translateX(-200px);
+      }
+    </style>
+    <div class="cover">cover</div>
+  `);
+
+  const cover = page.locator('.cover');
+  await cover.waitFor({ state: 'visible' });
+  await expect(cover).toBeVisible();
+});
+
 it('hidden should wait for hidden', async ({ page, server }) => {
   let divHidden = false;
   await page.setContent(`<div style='display: block;'>content</div>`);
@@ -98,30 +119,6 @@ it('hidden should wait for removal', async ({ page, server }) => {
   await page.evaluate(() => document.querySelector('div').remove());
   expect(await waitForSelector).toBe(true);
   expect(divRemoved).toBe(true);
-});
-
-it('hidden should wait for out-of-viewport', async ({ page }) => {
-  it.setTimeout(3000);
-  it.fail(true, 'https://github.com/microsoft/playwright/issues/13131');
-  await page.setContent(`
-    <style>
-      .cover {
-        position: fixed;
-        left: 0;
-        top: 0;
-        width: 100px;
-        height: 100px;
-        background-color: red;
-        transform: translateX(-200px);
-      }
-    </style>
-    <div class="cover">cover</div>
-  `);
-
-  const cover = page.locator('.cover');
-  await expect(cover).not.toBeVisible();
-  // Below is not web-first, but is included to mirror original snippet from https://github.com/microsoft/playwright/issues/13131
-  await cover.waitFor({ state: 'hidden' });
 });
 
 it('should return null if waiting to hide non-existing element', async ({ page, server }) => {

--- a/tests/page/page-wait-for-selector-2.spec.ts
+++ b/tests/page/page-wait-for-selector-2.spec.ts
@@ -101,6 +101,7 @@ it('hidden should wait for removal', async ({ page, server }) => {
 });
 
 it('hidden should wait for out-of-viewport', async ({ page }) => {
+  it.setTimeout(3000);
   it.fail(true, 'https://github.com/microsoft/playwright/issues/13131');
   await page.setContent(`
     <style>
@@ -118,7 +119,7 @@ it('hidden should wait for out-of-viewport', async ({ page }) => {
   `);
 
   const cover = page.locator('.cover');
-  await expect.soft(cover).not.toBeVisible();
+  await expect(cover).not.toBeVisible();
   // Below is not web-first, but is included to mirror original snippet from https://github.com/microsoft/playwright/issues/13131
   await cover.waitFor({ state: 'hidden' });
 });


### PR DESCRIPTION
Closes #13131.

Per the visibility spec on https://playwright.dev/docs/next/actionability#visible:

> Element is considered visible when it has non-empty bounding box and does not have visibility:hidden computed style. Note that elements of zero size or with display:none are not considered visible.

✅ non-empty bounding box
✅ does not have visibility:hidden

Given the above conditions are satisfied, the locator is considered visible.

https://github.com/microsoft/playwright/issues/8740 proposes something like `isInViewport()` that would be better suited for checking if an element is offscreen.