### PR TITLE
fix(parallel): minimize the number of beforeAll/afterAll hooks in parallel mode

### DIFF
--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -314,7 +314,7 @@ export class Runner {
       fatalErrors.push(createNoTestsError());
 
     // 8. Compute shards.
-    let testGroups = createTestGroups(rootSuite);
+    let testGroups = createTestGroups(rootSuite, config.workers);
 
     const shard = config.shard;
     if (shard) {
@@ -620,7 +620,7 @@ function buildItemLocation(rootDir: string, testOrSuite: Suite | TestCase) {
   return `${path.relative(rootDir, testOrSuite.location.file)}:${testOrSuite.location.line}`;
 }
 
-function createTestGroups(rootSuite: Suite): TestGroup[] {
+function createTestGroups(rootSuite: Suite, workers: number): TestGroup[] {
   // This function groups tests that can be run together.
   // Tests cannot be run together when:
   // - They belong to different projects - requires different workers.
@@ -631,7 +631,15 @@ function createTestGroups(rootSuite: Suite): TestGroup[] {
 
   // Using the map "workerHash -> requireFile -> group" makes us preserve the natural order
   // of worker hashes and require files for the simple cases.
-  const groups = new Map<string, Map<string, { general: TestGroup, parallel: TestGroup[] }>>();
+  const groups = new Map<string, Map<string, {
+    // Tests that must be run in order are in the same group.
+    general: TestGroup,
+    // Tests that may be run independently each has a dedicated group with a single test.
+    parallel: TestGroup[],
+    // Tests that are marked as parallel but have beforeAll/afterAll hooks should be grouped
+    // as much as possible. We split them into equally sized groups, one per worker.
+    parallelWithHooks: TestGroup,
+  }>>();
 
   const createGroup = (test: TestCase): TestGroup => {
     return {
@@ -655,18 +663,26 @@ function createTestGroups(rootSuite: Suite): TestGroup[] {
         withRequireFile = {
           general: createGroup(test),
           parallel: [],
+          parallelWithHooks: createGroup(test),
         };
         withWorkerHash.set(test._requireFile, withRequireFile);
       }
 
       let insideParallel = false;
-      for (let parent: Suite | undefined = test.parent; parent; parent = parent.parent)
+      let hasAllHooks = false;
+      for (let parent: Suite | undefined = test.parent; parent; parent = parent.parent) {
         insideParallel = insideParallel || parent._parallelMode === 'parallel';
+        hasAllHooks = hasAllHooks || parent._hooks.some(hook => hook.type === 'beforeAll' || hook.type === 'afterAll');
+      }
 
       if (insideParallel) {
-        const group = createGroup(test);
-        group.tests.push(test);
-        withRequireFile.parallel.push(group);
+        if (hasAllHooks) {
+          withRequireFile.parallelWithHooks.tests.push(test);
+        } else {
+          const group = createGroup(test);
+          group.tests.push(test);
+          withRequireFile.parallel.push(group);
+        }
       } else {
         withRequireFile.general.tests.push(test);
       }
@@ -679,6 +695,16 @@ function createTestGroups(rootSuite: Suite): TestGroup[] {
       if (withRequireFile.general.tests.length)
         result.push(withRequireFile.general);
       result.push(...withRequireFile.parallel);
+
+      const parallelWithHooksGroupSize = Math.ceil(withRequireFile.parallelWithHooks.tests.length / workers);
+      let lastGroup: TestGroup | undefined;
+      for (const test of withRequireFile.parallelWithHooks.tests) {
+        if (!lastGroup || lastGroup.tests.length >= parallelWithHooksGroupSize) {
+          lastGroup = createGroup(test);
+          result.push(lastGroup);
+        }
+        lastGroup.tests.push(test);
+      }
     }
   }
   return result;


### PR DESCRIPTION
Previously, we always formed groups consisting of a single test. Now, we group tests that share `beforeAll`/`afterAll` hooks into `config.workers` equally-sized groups.

Fixes #13099.