### PR TITLE
fix(text selector): ignore non-leading quote when parsing

### DIFF
--- a/packages/playwright-core/src/server/common/selectorParser.ts
+++ b/packages/playwright-core/src/server/common/selectorParser.ts
@@ -173,6 +173,13 @@ function parseSelectorString(selector: string): ParsedSelectorStrings {
     return result;
   }
 
+  const shouldIgnoreTextSelectorQuote = () => {
+    const prefix = selector.substring(start, index);
+    const match = prefix.match(/^\s*text\s*=(.*)$/);
+    // Must be a text selector with some text before the quote.
+    return !!match && !!match[1];
+  };
+
   while (index < selector.length) {
     const c = selector[index];
     if (c === '\\' && index + 1 < selector.length) {
@@ -180,7 +187,7 @@ function parseSelectorString(selector: string): ParsedSelectorStrings {
     } else if (c === quote) {
       quote = undefined;
       index++;
-    } else if (!quote && (c === '"' || c === '\'' || c === '`')) {
+    } else if (!quote && (c === '"' || c === '\'' || c === '`') && !shouldIgnoreTextSelectorQuote()) {
       quote = c;
       index++;
     } else if (!quote && c === '>' && selector[index + 1] === '>') {


### PR DESCRIPTION
Previously, any unpaired quote in the text selector "escaped"
everything till the end of the selector string, and so any
subsequent chained selectors, including ">>" separator were ignored.

An example of misbehaving selector: `text=19" >> nth=1`.

Now, when text selector contains a non-leading quote, selector parser
does not assume it should escape ">>" separator and correctly
tokenizes all selectors from the chain.

Note that this behavior is a workaround for the fact that our
text selectors is somewhat poorly defined in this area. That said,
this workaround seems to be safe enough. It still does not work for
unpaired leading quotes like this: `text="19 >> nth=1`.

Fixes #12719.