### PR TITLE
chore: remove elementsFromPoint workaround

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -813,10 +813,7 @@ export class InjectedScript {
       // elementFromPoint works incorrectly in Chromium (http://crbug.com/1188919),
       // so we use elementsFromPoint instead.
       const elements: Element[] = container.elementsFromPoint(x, y);
-      let innerElement = elements[0] as Element | undefined;
-      // Workaround https://bugs.chromium.org/p/chromium/issues/detail?id=1307458.
-      if (elements[0] && elements[1] && elements[0].contains(elements[1]) && container.elementFromPoint(x, y) === elements[1])
-        innerElement = elements[1];
+      const innerElement = elements[0] as Element | undefined;
       if (!innerElement || element === innerElement)
         break;
       element = innerElement;


### PR DESCRIPTION
The issue was fixed upstream in r982637, and merged to beta v101.