### PR TITLE
fix: add stdio option to make it possible to debug electron applications

### DIFF
--- a/docs/src/api/class-electron.md
+++ b/docs/src/api/class-electron.md
@@ -77,6 +77,11 @@ Current working directory to launch application from.
 
 Specifies environment variables that will be visible to Electron. Defaults to `process.env`.
 
+### option: Electron.launch.stdio
+- `stdio` <[string]>
+
+Specifies where output is printed to.
+
 ### option: Electron.launch.timeout
 - `timeout` <[float]>
 

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -3541,6 +3541,7 @@ export type ElectronLaunchParams = {
   acceptDownloads?: boolean,
   bypassCSP?: boolean,
   colorScheme?: 'dark' | 'light' | 'no-preference',
+  stdio?: 'inherit',
   extraHTTPHeaders?: NameValue[],
   geolocation?: {
     longitude: number,
@@ -3577,6 +3578,7 @@ export type ElectronLaunchOptions = {
   acceptDownloads?: boolean,
   bypassCSP?: boolean,
   colorScheme?: 'dark' | 'light' | 'no-preference',
+  stdio?: 'inherit',
   extraHTTPHeaders?: NameValue[],
   geolocation?: {
     longitude: number,

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -3541,7 +3541,7 @@ export type ElectronLaunchParams = {
   acceptDownloads?: boolean,
   bypassCSP?: boolean,
   colorScheme?: 'dark' | 'light' | 'no-preference',
-  stdio?: 'inherit',
+  stdio?: string,
   extraHTTPHeaders?: NameValue[],
   geolocation?: {
     longitude: number,
@@ -3578,7 +3578,7 @@ export type ElectronLaunchOptions = {
   acceptDownloads?: boolean,
   bypassCSP?: boolean,
   colorScheme?: 'dark' | 'light' | 'no-preference',
-  stdio?: 'inherit',
+  stdio?: string,
   extraHTTPHeaders?: NameValue[],
   geolocation?: {
     longitude: number,

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -2757,6 +2757,10 @@ Electron:
           - dark
           - light
           - no-preference
+        stdio:
+          type: enum?
+          literals:
+          - inherit
         extraHTTPHeaders:
           type: array?
           items: NameValue

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -2757,10 +2757,7 @@ Electron:
           - dark
           - light
           - no-preference
-        stdio:
-          type: enum?
-          literals:
-          - inherit
+        stdio: string?
         extraHTTPHeaders:
           type: array?
           items: NameValue

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1257,6 +1257,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     acceptDownloads: tOptional(tBoolean),
     bypassCSP: tOptional(tBoolean),
     colorScheme: tOptional(tEnum(['dark', 'light', 'no-preference'])),
+    stdio: tOptional(tEnum(['inherit'])),
     extraHTTPHeaders: tOptional(tArray(tType('NameValue'))),
     geolocation: tOptional(tObject({
       longitude: tNumber,

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1257,7 +1257,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
     acceptDownloads: tOptional(tBoolean),
     bypassCSP: tOptional(tBoolean),
     colorScheme: tOptional(tEnum(['dark', 'light', 'no-preference'])),
-    stdio: tOptional(tEnum(['inherit'])),
+    stdio: tOptional(tString),
     extraHTTPHeaders: tOptional(tArray(tType('NameValue'))),
     geolocation: tOptional(tObject({
       longitude: tNumber,

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -111,6 +111,7 @@ export class Electron extends SdkObject {
   async launch(options: channels.ElectronLaunchParams): Promise<ElectronApplication> {
     const {
       args = [],
+      stdio = undefined
     } = options;
     const controller = new ProgressController(serverSideCallMetadata(), this);
     controller.setLogName('browser');
@@ -149,6 +150,19 @@ export class Electron extends SdkObject {
         handleSIGHUP: true,
         onExit: () => {},
       });
+
+      if(stdio === 'inherit'){
+        if(launchedProcess.stdout){
+          launchedProcess.stdout.on('data', data=>{
+            process.stdout.write(data)
+          })
+        }
+        if(launchedProcess.stderr){
+          launchedProcess.stderr.on('data', data=>{
+            process.stderr.write(data)
+          })
+        }
+      }
 
       const waitForXserverError = new Promise(async (resolve, reject) => {
         waitForLine(progress, launchedProcess, /Unable to open X display/).then(() => reject(new Error([

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -151,16 +151,16 @@ export class Electron extends SdkObject {
         onExit: () => {},
       });
 
-      if(stdio === 'inherit'){
-        if(launchedProcess.stdout){
-          launchedProcess.stdout.on('data', data=>{
-            process.stdout.write(data)
-          })
+      if (stdio === 'inherit'){
+        if (launchedProcess.stdout){
+          launchedProcess.stdout.on('data', data => {
+            process.stdout.write(data);
+          });
         }
-        if(launchedProcess.stderr){
-          launchedProcess.stderr.on('data', data=>{
-            process.stderr.write(data)
-          })
+        if (launchedProcess.stderr){
+          launchedProcess.stderr.on('data', data => {
+            process.stderr.write(data);
+          });
         }
       }
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -13671,6 +13671,11 @@ export interface Electron {
     };
 
     /**
+     * Specifies where output is printed to.
+     */
+    stdio?: string;
+
+    /**
      * Maximum time in milliseconds to wait for the application to start. Defaults to `30000` (30 seconds). Pass `0` to disable
      * timeout.
      */

--- a/tests/electron/electron-app-error.js
+++ b/tests/electron/electron-app-error.js
@@ -1,0 +1,3 @@
+const { app } = require('electron');
+
+throw new TypeError(`Cannot read properties of undefined (reading 'close')`)

--- a/tests/electron/electron-app-error.spec.ts
+++ b/tests/electron/electron-app-error.spec.ts
@@ -18,18 +18,18 @@ import path from 'path';
 import { electronTest as test, expect } from './electronTest';
 
 test('should print errors to stderr', async ({ playwright }) => {
-  let stderr=''
-  const originalWrite = process.stderr.write.bind(process.stderr)
-  process.stderr.write = (buffer,)=>{
-    stderr += buffer
-    return true
-  }
+  let stderr = '';
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = buffer => {
+    stderr += buffer;
+    return true;
+  };
   await playwright._electron.launch({
     args: [path.join(__dirname, 'electron-app-error.js')],
     stdio: 'inherit',
-    executablePath:''
+    executablePath: ''
 
   });
-  expect(stderr).toContain('TypeError: Cannot read properties of undefined (reading \'close\')')
-  process.stderr.write = originalWrite
+  expect(stderr).toContain('TypeError: Cannot read properties of undefined (reading \'close\')');
+  process.stderr.write = originalWrite;
 });

--- a/tests/electron/electron-app-error.spec.ts
+++ b/tests/electron/electron-app-error.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from 'path';
+import { electronTest as test, expect } from './electronTest';
+
+test('should print errors to stderr', async ({ playwright }) => {
+  let stderr=''
+  const originalWrite = process.stderr.write.bind(process.stderr)
+  process.stderr.write = (buffer,)=>{
+    stderr += buffer
+    return true
+  }
+  await playwright._electron.launch({
+    args: [path.join(__dirname, 'electron-app-error.js')],
+    stdio: 'inherit',
+    executablePath:''
+
+  });
+  expect(stderr).toContain('TypeError: Cannot read properties of undefined (reading \'close\')')
+  process.stderr.write = originalWrite
+});


### PR DESCRIPTION
Currently it is very hard to debug when an electron test fails because no stdout or stderr is printed (see also https://github.com/microsoft/playwright/issues/5905#issuecomment-966598268)

This adds an stdio option which prints to stdout and stderr just like a normal electron app would. 

## before
it is very unclear why the test is failing:
![before](https://user-images.githubusercontent.com/23744935/160933785-3be9fca4-ae49-4e00-8baa-aba04c43914e.png)

## after
it is very clear why and where the test is failing:
![after](https://user-images.githubusercontent.com/23744935/160933870-df37956a-8444-46c7-9124-7445bfbc9a7f.png)

