### PR TITLE
fix: demand `--force` to re-install stable browser channels

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -234,7 +234,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps chrome
+    - run: npx playwright install --with-deps --force chrome
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
       env:
         PWTEST_CHANNEL: chrome
@@ -259,7 +259,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps chrome
+    - run: npx playwright install --with-deps --force chrome
     - run: npm run ctest
       shell: bash
       env:
@@ -286,7 +286,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps chrome
+    - run: npx playwright install --with-deps --force chrome
     - run: npm run ctest
       env:
         PWTEST_CHANNEL: chrome
@@ -388,7 +388,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps msedge
+    - run: npx playwright install --with-deps --force msedge
     - run: npm run ctest
       env:
         PWTEST_CHANNEL: msedge
@@ -414,7 +414,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps msedge
+    - run: npx playwright install --with-deps --force msedge
     - run: npm run ctest
       shell: bash
       env:
@@ -438,7 +438,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps msedge
+    - run: npx playwright install --with-deps --force msedge
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
       env:
         PWTEST_CHANNEL: msedge
@@ -463,7 +463,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps msedge-beta
+    - run: npx playwright install --with-deps --force msedge-beta
     - run: npm run ctest
       env:
         PWTEST_CHANNEL: msedge-beta
@@ -488,7 +488,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps msedge-beta
+    - run: npx playwright install --with-deps --force msedge-beta
     - run: npm run ctest
       shell: bash
       env:
@@ -512,7 +512,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps msedge-beta
+    - run: npx playwright install --with-deps --force msedge-beta
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
       env:
         PWTEST_CHANNEL: msedge-beta
@@ -537,7 +537,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps msedge-dev
+    - run: npx playwright install --with-deps --force msedge-dev
     - run: npm run ctest
       env:
         PWTEST_CHANNEL: msedge-dev
@@ -562,7 +562,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps msedge-dev
+    - run: npx playwright install --with-deps --force msedge-dev
     - run: npm run ctest
       shell: bash
       env:
@@ -586,7 +586,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps msedge-dev
+    - run: npx playwright install --with-deps --force msedge-dev
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
       env:
         PWTEST_CHANNEL: msedge-dev
@@ -611,7 +611,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps chrome-beta
+    - run: npx playwright install --with-deps --force chrome-beta
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run ctest
       env:
         PWTEST_CHANNEL: chrome-beta
@@ -636,7 +636,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps chrome-beta
+    - run: npx playwright install --with-deps --force chrome-beta
     - run: npm run ctest
       shell: bash
       env:
@@ -663,7 +663,7 @@ jobs:
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps chrome-beta
+    - run: npx playwright install --with-deps --force chrome-beta
     - run: npm run ctest
       env:
         PWTEST_CHANNEL: chrome-beta

--- a/packages/playwright-core/src/cli/cli.ts
+++ b/packages/playwright-core/src/cli/cli.ts
@@ -113,13 +113,14 @@ program
     .command('install [browser...]')
     .description('ensure browsers necessary for this version of Playwright are installed')
     .option('--with-deps', 'install system dependencies for browsers')
-    .action(async function(args: string[], options: { withDeps?: boolean }) {
+    .option('--force', 'force reinstall of stable browser channels')
+    .action(async function(args: string[], options: { withDeps?: boolean, force?: boolean }) {
       try {
         if (!args.length) {
           const executables = registry.defaultExecutables();
           if (options.withDeps)
             await registry.installDeps(executables, false);
-          await registry.install(executables);
+          await registry.install(executables, false /* forceReinstall */);
         } else {
           const installDockerImage = args.some(arg => arg === 'docker-image');
           args = args.filter(arg => arg !== 'docker-image');
@@ -135,7 +136,7 @@ program
           const executables = checkBrowsersToInstall(args);
           if (options.withDeps)
             await registry.installDeps(executables, false);
-          await registry.install(executables);
+          await registry.install(executables, !!options.force /* forceReinstall */);
         }
       } catch (e) {
         console.log(`Failed to install browsers\n${e}`);

--- a/packages/playwright-core/src/utils/utils.ts
+++ b/packages/playwright-core/src/utils/utils.ts
@@ -479,6 +479,11 @@ function determineUserAgent(): string {
     }
   }
 
+  const { langName, langVersion } = getClientLanguage();
+  return `Playwright/${getPlaywrightVersion()} (${os.arch()}; ${osIdentifier} ${osVersion}) ${langName}/${langVersion}`;
+}
+
+export function getClientLanguage(): { langName: string, langVersion: string } {
   let langName = 'unknown';
   let langVersion = 'unknown';
   if (!process.env.PW_LANG_NAME) {
@@ -488,8 +493,7 @@ function determineUserAgent(): string {
     langName = process.env.PW_LANG_NAME;
     langVersion = process.env.PW_LANG_NAME_VERSION ?? 'unknown';
   }
-
-  return `Playwright/${getPlaywrightVersion()} (${os.arch()}; ${osIdentifier} ${osVersion}) ${langName}/${langVersion}`;
+  return { langName, langVersion };
 }
 
 export function getPlaywrightVersion(majorMinorOnly = false) {


### PR DESCRIPTION
This patch will check if browser channel is already installed.
If it is, it'll abort installation with the following error:

```
aslushnikov:~/prog/playwright$ npx playwright install msedge
Failed to install browsers
Error:
╔═════════════════════════════════════════════════════════════════╗
║ ATTENTION: "msedge" is already installed on the system!         ║
║                                                                 ║
║ "msedge" installation is not hermetic; installing newer version ║
║ requires *removal* of a current installation first.             ║
║                                                                 ║
║ To *uninstall* current version and re-install latest "msedge":  ║
║                                                                 ║
║ - Close all running instances of "msedge", if any               ║
║ - Use "--force" to install browser:                             ║
║                                                                 ║
║     npx playwright install --force msedge                       ║
║                                                                 ║
║ <3 Playwright Team                                              ║
╚═════════════════════════════════════════════════════════════════╝
```

To re-install browser channel, use `--force`.

Fixes https://github.com/microsoft/playwright/issues/13061
