### PR TITLE
feat(role selector): allow unquoted name attribute

### DIFF
--- a/packages/playwright-core/src/server/injected/reactSelectorEngine.ts
+++ b/packages/playwright-core/src/server/injected/reactSelectorEngine.ts
@@ -167,7 +167,7 @@ function findReactRoots(root: Document | ShadowRoot, roots: ReactVNode[] = []): 
 
 export const ReactEngine: SelectorEngine = {
   queryAll(scope: SelectorRoot, selector: string): Element[] {
-    const { name, attributes } = parseComponentSelector(selector);
+    const { name, attributes } = parseComponentSelector(selector, false);
 
     const reactRoots = findReactRoots(document);
     const trees = reactRoots.map(reactRoot => buildComponentsTree(reactRoot));

--- a/packages/playwright-core/src/server/injected/roleSelectorEngine.ts
+++ b/packages/playwright-core/src/server/injected/roleSelectorEngine.ts
@@ -75,7 +75,10 @@ function validateAttributes(attrs: ParsedComponentAttribute[], role: string) {
       }
       case 'level': {
         validateSupportedRole(attr.name, kAriaLevelRoles, role);
-        if (attr.op !== '=' || typeof attr.value !== 'number')
+        // Level is a number, convert it from string.
+        if (typeof attr.value === 'string')
+          attr.value = +attr.value;
+        if (attr.op !== '=' || typeof attr.value !== 'number' || Number.isNaN(attr.value))
           throw new Error(`"level" attribute must be compared to a number`);
         break;
       }
@@ -105,7 +108,7 @@ function validateAttributes(attrs: ParsedComponentAttribute[], role: string) {
 
 export const RoleEngine: SelectorEngine = {
   queryAll(scope: SelectorRoot, selector: string): Element[] {
-    const parsed = parseComponentSelector(selector);
+    const parsed = parseComponentSelector(selector, true);
     const role = parsed.name.toLowerCase();
     if (!role)
       throw new Error(`Role must not be empty`);

--- a/packages/playwright-core/src/server/injected/vueSelectorEngine.ts
+++ b/packages/playwright-core/src/server/injected/vueSelectorEngine.ts
@@ -232,7 +232,7 @@ function findVueRoots(root: Document | ShadowRoot, roots: VueRoot[] = []): VueRo
 
 export const VueEngine: SelectorEngine = {
   queryAll(scope: SelectorRoot, selector: string): Element[] {
-    const { name, attributes } = parseComponentSelector(selector);
+    const { name, attributes } = parseComponentSelector(selector, false);
     const vueRoots = findVueRoots(document);
     const trees = vueRoots.map(vueRoot => vueRoot.version === 3 ? buildComponentsTreeVue3(vueRoot.root) : buildComponentsTreeVue2(vueRoot.root));
     const treeNodes = trees.map(tree => filterComponentsTree(tree, treeNode => {

--- a/tests/page/selectors-role.spec.ts
+++ b/tests/page/selectors-role.spec.ts
@@ -16,6 +16,8 @@
 
 import { test, expect } from './pageTest';
 
+test.skip(({ mode }) => mode !== 'default', 'Experimental features only work in default mode');
+
 test('should detect roles', async ({ page }) => {
   await page.setContent(`
     <button>Hello</button>
@@ -267,6 +269,7 @@ test('should support name', async ({ page }) => {
     <div role="button" aria-label="Hello"></div>
     <div role="button" aria-label="Hallo"></div>
     <div role="button" aria-label="Hello" aria-hidden="true"></div>
+    <div role="button" aria-label="123" aria-hidden="true"></div>
   `);
   expect(await page.$$eval(`role=button[name="Hello"]`, els => els.map(e => e.outerHTML))).toEqual([
     `<div role="button" aria-label="Hello"></div>`,
@@ -285,6 +288,12 @@ test('should support name', async ({ page }) => {
   expect(await page.$$eval(`role=button[name="Hello"][include-hidden]`, els => els.map(e => e.outerHTML))).toEqual([
     `<div role="button" aria-label="Hello"></div>`,
     `<div role="button" aria-label="Hello" aria-hidden="true"></div>`,
+  ]);
+  expect(await page.$$eval(`role=button[name=Hello]`, els => els.map(e => e.outerHTML))).toEqual([
+    `<div role="button" aria-label="Hello"></div>`,
+  ]);
+  expect(await page.$$eval(`role=button[name=123][include-hidden]`, els => els.map(e => e.outerHTML))).toEqual([
+    `<div role="button" aria-label="123" aria-hidden="true"></div>`,
   ]);
 });
 


### PR DESCRIPTION
- This supports `role=button[name=Hello]` similarly to CSS selectors.
- Does not change `_react` or `_vue` behavior that insist on quoting the string.
- Uses CSS notion of "identifier" characters.

References #11182.