### PR TITLE
chore: remove/rename FullConfig._attachments

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -720,16 +720,3 @@ const config: PlaywrightTestConfig = {
 };
 export default config;
 ```
-
-## property: TestConfig.attachments
-- type: <[Array]<[Object]>>
-  - `name` <[string]> Attachment name.
-  - `contentType` <[string]> Content type of this attachment to properly present in the report, for example `'application/json'` or `'image/png'`.
-  - `path` <[void]|[string]> Optional path on the filesystem to the attached file.
-  - `body` <[void]|[Buffer]> Optional attachment body used instead of a file.
-
-:::note
-This does not include test-level attachments. See [`method: TestInfo.attach`] and [`property: TestInfo.attachments`] for working with test-level attachments.
-:::
-
-The list of files or buffers attached for the overall Playwright Test run. Some reporters show attachments.

--- a/packages/playwright-test/src/DEPS
+++ b/packages/playwright-test/src/DEPS
@@ -14,6 +14,7 @@ module.exports = {
   ],
   'reporters': [
     '../types/testReporter.d.ts',
+    './types.ts',
     'util.ts',
   ],
 };

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -473,7 +473,7 @@ const baseFullConfig: FullConfigInternal = {
   version: require('../package.json').version,
   workers: 1,
   webServer: null,
-  attachments: [],
+  _attachments: [],
 };
 
 function resolveReporters(reporters: Config['reporter'], rootDir: string): ReporterDescription[]|undefined {

--- a/packages/playwright-test/src/reporters/json.ts
+++ b/packages/playwright-test/src/reporters/json.ts
@@ -20,13 +20,7 @@ import { FullConfig, TestCase, Suite, TestResult, TestError, TestStep, FullResul
 import { prepareErrorStack } from './base';
 
 export interface JSONReport {
-  config: Omit<FullConfig, 'projects' | 'attachments'> & {
-    attachments: {
-      name: string;
-      path?: string;
-      body?: string;
-      contentType: string;
-    }[];
+  config: Omit<FullConfig, 'projects'> & {
     projects: {
       outputDir: string,
       repeatEach: number,
@@ -127,12 +121,6 @@ class JSONReporter implements Reporter {
     return {
       config: {
         ...this.config,
-        attachments: this.config.attachments.map(a => ({
-          name: a.name,
-          contentType: a.contentType,
-          path: a.path,
-          body: a.body?.toString('base64')
-        })),
         rootDir: toPosixPath(this.config.rootDir),
         projects: this.config.projects.map(project => {
           return {

--- a/packages/playwright-test/src/reporters/raw.ts
+++ b/packages/playwright-test/src/reporters/raw.ts
@@ -23,6 +23,7 @@ import { formatResultFailure } from './base';
 import { toPosixPath, serializePatterns } from './json';
 import { MultiMap } from 'playwright-core/lib/utils/multimap';
 import { codeFrameColumns } from '@babel/code-frame';
+import { FullConfigInternal } from '../types';
 
 export type JsonLocation = Location;
 export type JsonError = string;
@@ -134,7 +135,7 @@ class RawReporter {
   }
 
   generateAttachments(config: FullConfig): JsonAttachment[] {
-    return this._createAttachments(config.attachments);
+    return this._createAttachments((config as FullConfigInternal)._attachments);
   }
 
   generateProjectReport(config: FullConfig, suite: Suite): JsonReport {

--- a/packages/playwright-test/src/types.ts
+++ b/packages/playwright-test/src/types.ts
@@ -40,4 +40,5 @@ export interface TestStepInternal {
  * increasing the surface area of the public API type called FullConfig.
  */
 export interface FullConfigInternal extends FullConfigPublic {
+  _attachments: { name: string, path?: string, body?: Buffer, contentType: string }[];
 }

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -1277,15 +1277,6 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
    *
    */
   webServer: WebServerConfig | null;
-  /**
-   * > NOTE: This does not include test-level attachments. See
-   * [testInfo.attach(name[, options])](https://playwright.dev/docs/api/class-testinfo#test-info-attach) and
-   * [testInfo.attachments](https://playwright.dev/docs/api/class-testinfo#test-info-attachments) for working with test-level
-   * attachments.
-   *
-   * The list of files or buffers attached for the overall Playwright Test run. Some reporters show attachments.
-   */
-  attachments: { name: string, path?: string, body?: Buffer, contentType: string }[];
 }
 
 export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped';

--- a/tests/config/globalSetup.ts
+++ b/tests/config/globalSetup.ts
@@ -19,7 +19,7 @@ import { FullConfig } from '@playwright/test';
 import * as ci from '@playwright/test/lib/ci';
 
 async function globalSetup(config: FullConfig) {
-  config.attachments = [
+  (config as any)._attachments = [
     ...await ci.generationTimestamp(),
     ...await ci.gitStatusFromCLI(config.rootDir),
     ...await ci.githubEnv(),

--- a/tests/playwright-test/reporter-attachment.spec.ts
+++ b/tests/playwright-test/reporter-attachment.spec.ts
@@ -193,7 +193,7 @@ test(`TestConfig.attachments works`, async ({ runInlineTest }) => {
       import { FullConfig } from '@playwright/test';
 
       async function globalSetup(config: FullConfig) {
-        config.attachments = [{ contentType: 'text/plain', body: Buffer.from('example data'), name: 'my-attachment.txt' }];
+        (config as any)._attachments = [{ contentType: 'text/plain', body: Buffer.from('example data'), name: 'my-attachment.txt' }];
       };
 
       export default globalSetup;
@@ -213,7 +213,7 @@ test(`TestConfig.attachments works`, async ({ runInlineTest }) => {
   }, { reporter: 'json' });
 
   expect(result.exitCode).toBe(0);
-  expect(result.report.config.attachments).toHaveLength(1);
-  expect(result.report.config.attachments[0].name).toBe('my-attachment.txt');
-  expect(Buffer.from(result.report.config.attachments[0].body, 'base64').toString()).toBe('example data');
+  expect((result.report.config as any)._attachments).toHaveLength(1);
+  expect((result.report.config as any)._attachments[0].name).toBe('my-attachment.txt');
+  expect(Buffer.from((result.report.config as any)._attachments[0].body, 'base64').toString()).toBe('example data');
 });

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -711,7 +711,7 @@ test('should include metadata', async ({ runInlineTest, showReport, page }) => {
       import { FullConfig } from '@playwright/test';
 
       async function globalSetup(config: FullConfig) {
-        config.attachments = [
+        (config as any)._attachments = [
           ...await ci.generationTimestamp(),
           ...await ci.gitStatusFromCLI(config.rootDir),
           ...await ci.githubEnv(),

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -223,7 +223,6 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
   updateSnapshots: UpdateSnapshots;
   workers: number;
   webServer: WebServerConfig | null;
-  attachments: { name: string, path?: string, body?: Buffer, contentType: string }[];
   // [internal] !!! DO NOT ADD TO THIS !!! See prior note.
 }
 


### PR DESCRIPTION
This was originally introduced in #12734.

It will be replaced with GlobalInfo (#13083), but not before the 1.21
release.