### PR TITLE
fix: wait for worker to be ready before initializing

### DIFF
--- a/packages/playwright-test/src/dispatcher.ts
+++ b/packages/playwright-test/src/dispatcher.ts
@@ -466,7 +466,7 @@ class Worker extends EventEmitter {
   private _didSendStop = false;
   private _didFail = false;
   private didExit = false;
-  private readonly _ready: Promise<void>;
+  private _ready: Promise<void>;
 
   constructor(hash: string, parallelIndex: number) {
     super();

--- a/packages/playwright-test/src/dispatcher.ts
+++ b/packages/playwright-test/src/dispatcher.ts
@@ -466,7 +466,7 @@ class Worker extends EventEmitter {
   private _didSendStop = false;
   private _didFail = false;
   private didExit = false;
-  private readonly ready: Promise<void>;
+  private readonly _ready: Promise<void>;
 
   constructor(hash: string, parallelIndex: number) {
     super();
@@ -496,14 +496,14 @@ class Worker extends EventEmitter {
       this.emit(method, params);
     });
 
-    this.ready = new Promise((resolve, reject) => {
+    this._ready = new Promise((resolve, reject) => {
       this.process.once('exit', () => reject(new Error('worker exited before it became ready')));
       this.once('ready', () => resolve());
     });
   }
 
   async init(testGroup: TestGroup, loaderData: SerializedLoaderData) {
-    await this.ready;
+    await this._ready;
     const params: WorkerInitParams = {
       workerIndex: this.workerIndex,
       parallelIndex: this.parallelIndex,

--- a/packages/playwright-test/src/dispatcher.ts
+++ b/packages/playwright-test/src/dispatcher.ts
@@ -466,6 +466,7 @@ class Worker extends EventEmitter {
   private _didSendStop = false;
   private _didFail = false;
   private didExit = false;
+  private readonly ready: Promise<void>;
 
   constructor(hash: string, parallelIndex: number) {
     super();
@@ -494,9 +495,15 @@ class Worker extends EventEmitter {
       const { method, params } = message;
       this.emit(method, params);
     });
+
+    this.ready = new Promise((resolve, reject) => {
+      this.process.once('exit', () => reject(new Error('worker exited before it became ready')));
+      this.once('ready', () => resolve());
+    });
   }
 
   async init(testGroup: TestGroup, loaderData: SerializedLoaderData) {
+    await this.ready;
     const params: WorkerInitParams = {
       workerIndex: this.workerIndex,
       parallelIndex: this.parallelIndex,
@@ -505,7 +512,6 @@ class Worker extends EventEmitter {
       loader: loaderData,
     };
     this.send({ method: 'init', params });
-    await new Promise(f => this.process.once('message', f));  // Ready ack
   }
 
   run(testGroup: TestGroup) {

--- a/packages/playwright-test/src/worker.ts
+++ b/packages/playwright-test/src/worker.ts
@@ -23,6 +23,7 @@ import { WorkerRunner } from './workerRunner';
 
 let closed = false;
 
+sendMessageToParent('ready');
 
 global.console = new Console({
   stdout: process.stdout,
@@ -86,8 +87,6 @@ process.on('message', async message => {
     await workerRunner!.runTestGroup(runPayload);
   }
 });
-
-sendMessageToParent('ready');
 
 async function gracefullyCloseAndExit() {
   if (closed)

--- a/packages/playwright-test/src/worker.ts
+++ b/packages/playwright-test/src/worker.ts
@@ -23,7 +23,6 @@ import { WorkerRunner } from './workerRunner';
 
 let closed = false;
 
-sendMessageToParent('ready');
 
 global.console = new Console({
   stdout: process.stdout,
@@ -87,6 +86,8 @@ process.on('message', async message => {
     await workerRunner!.runTestGroup(runPayload);
   }
 });
+
+sendMessageToParent('ready');
 
 async function gracefullyCloseAndExit() {
   if (closed)


### PR DESCRIPTION
The test dispatcher waits until a worker is ready before sending the `init` message. This guarantees that the worker process is listening for the message. Otherwise, the worker process might miss the `init` message and the subsequent `run` message would crash the worker.

I ran into this bug when I set a custom ESM loader with `NODE_OPTIONS=--loader=./esm-loader.mjs`. The following loader delays loading files and can be used to reproduce the issue:
```javascript
// ./esm-loader.mjs
export async function resolve(specifier, context, defaultResolver) {
  await new Promise((resolve) => setTimeout(resolve, 10))
  return defaultResolver(specifier, context)
}
```