### PR TITLE
test: mark enum babel test as failing

### DIFF
--- a/tests/playwright-test/babel.spec.ts
+++ b/tests/playwright-test/babel.spec.ts
@@ -39,6 +39,7 @@ test('should succeed', async ({ runInlineTest }) => {
 
 test('should treat enums equally', async ({ runInlineTest }) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/13265' });
+  test.fail();
   const result = await runInlineTest({
     'component.tsx': `
       export enum MyEnum {


### PR DESCRIPTION
This got dropped via the GitHub commit suggestion UI during merge of https://github.com/microsoft/playwright/pull/13272.