### PR TITLE
devops: fix "ensure-depot-tools" script

### DIFF
--- a/browser_patches/chromium/ensure_depot_tools.sh
+++ b/browser_patches/chromium/ensure_depot_tools.sh
@@ -11,18 +11,22 @@ if [[ $sourced == 0 ]]; then
   exit 1
 fi
 
-# Install depot_tools if they are not in system, and modify $PATH
-# to include depot_tools
-if ! command -v autoninja >/dev/null; then
-  if [[ $(uname) == "MINGW"* ]]; then
-    # NOTE: as of Feb 8, 2021, windows requires manual and separate
-    # installation of depot_tools.
-    echo "ERROR: cannot automatically install depot_tools on windows. Please, install manually"
-    exit 1
+function ensure_depot_tools() {
+  # Install depot_tools if they are not in system, and modify $PATH
+  # to include depot_tools
+  if ! command -v autoninja >/dev/null; then
+    if [[ $(uname) == "MINGW"* ]]; then
+      # NOTE: as of Feb 8, 2021, windows requires manual and separate
+      # installation of depot_tools.
+      echo "ERROR: cannot automatically install depot_tools on windows. Please, install manually"
+      exit 1
+    fi
+    local SCRIPT_PATH=$(cd "$(dirname "$BASH_SOURCE")"; pwd -P)
+    if [[ ! -d "${SCRIPT_PATH}/depot_tools" ]]; then
+      git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "${SCRIPT_PATH}/depot_tools"
+    fi
+    export PATH="${SCRIPT_PATH}/depot_tools:$PATH"
   fi
-  SCRIPT_PATH=$(cd "$(dirname "$BASH_SOURCE")"; pwd -P)
-  if [[ ! -d "${SCRIPT_PATH}/depot_tools" ]]; then
-    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "${SCRIPT_PATH}/depot_tools"
-  fi
-  export PATH="${SCRIPT_PATH}/depot_tools:$PATH"
-fi
+}
+
+ensure_depot_tools

--- a/browser_patches/prepare_checkout.sh
+++ b/browser_patches/prepare_checkout.sh
@@ -30,6 +30,7 @@ fi
 function prepare_chromium_checkout {
   cd "${SCRIPT_PATH}"
 
+  source "${SCRIPT_PATH}/chromium/UPSTREAM_CONFIG.sh"
   source "${SCRIPT_PATH}/chromium/ensure_depot_tools.sh"
 
   if [[ -z "${CR_CHECKOUT_PATH}" ]]; then
@@ -55,7 +56,6 @@ function prepare_chromium_checkout {
     exit 1
   fi
 
-  source "${SCRIPT_PATH}/chromium/UPSTREAM_CONFIG.sh"
   cd "${CR_CHECKOUT_PATH}/src"
   gclient sync --with_branch_heads
   git fetch origin


### PR DESCRIPTION
The script should is supposed to be sourced and thus
should not change any env variables of parent script
besides `$PATH`.