### PR TITLE
browser(webkit): add missing header to fix linux build

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1624
-Changed: dpino@igalia.com Tue 05 Apr 2022 10:51:05 AM UTC
+1625
+Changed: yurys@chromium.org Tue 05 Apr 2022 10:51:30 AM PDT

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -7340,6 +7340,18 @@ index b60f9a64bacc8282860da6de299b75aeb295b9b5..55bd017c03c6478ca334bd5ef164160f
  
  namespace WebCore {
  
+diff --git a/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp b/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp
+index 6f18826e06382c4d915607dbe5d6d16666a6c8e4..f1ab10953b92713da029f19de76ea2338336312a 100644
+--- a/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp
++++ b/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp
+@@ -32,6 +32,7 @@
+ #include <fcntl.h>
+ #include <gbm.h>
+ #include <mutex>
++#include <unistd.h>
+ #include <wtf/StdLibExtras.h>
+ #include <xf86drm.h>
+ 
 diff --git a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
 index d6942ce22541d8ec4eda1edf50c4735eaa6af644..e8aa707257aaf8bfe00fc8fd0ed9e31994b0b42d 100644
 --- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp


### PR DESCRIPTION
Fix for this error:
```
In file included from <WK_CHECKOUT_PATH>/WebKitBuild/WPE/Release/WebCore/DerivedSources/unified-sources/UnifiedSource-3c72abbe-43.cpp:1:
<WK_CHECKOUT_PATH>/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp: In destructor ‘WebCore::GBMDevice::~GBMDevice()’:
<WK_CHECKOUT_PATH>/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp:83:9: error: ‘close’ was not declared in this scope
         close(m_fd);
         ^~~~~
```

It's been fixed upstream already: https://github.com/WebKit/WebKit/commit/f336d008023f40443c74962b78fd67135527128e