### PR TITLE
Update class-coverage.md

### DIFF
--- a/docs/src/api/class-coverage.md
+++ b/docs/src/api/class-coverage.md
@@ -20,7 +20,7 @@ const v8toIstanbul = require('v8-to-istanbul');
   await page.goto('https://chromium.org');
   const coverage = await page.coverage.stopJSCoverage();
   for (const entry of coverage) {
-    const converter = new v8toIstanbul('', 0, { source: entry.source });
+    const converter = v8toIstanbul('', 0, { source: entry.source });
     await converter.load();
     converter.applyCoverage(entry.functions);
     console.log(JSON.stringify(converter.toIstanbul()));

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -13267,7 +13267,7 @@ export interface ConsoleMessage {
  *   await page.goto('https://chromium.org');
  *   const coverage = await page.coverage.stopJSCoverage();
  *   for (const entry of coverage) {
- *     const converter = new v8toIstanbul('', 0, { source: entry.source });
+ *     const converter = v8toIstanbul('', 0, { source: entry.source });
  *     await converter.load();
  *     converter.applyCoverage(entry.functions);
  *     console.log(JSON.stringify(converter.toIstanbul()));


### PR DESCRIPTION
Based on the api, v8toIstanbul is a function instead of class. When I compile this code snippet, I got compiler error, after I removed the `new` keyword, then build is successful