### PR TITLE
feat(remote): support headless/x-playwright-headless

### DIFF
--- a/packages/playwright-core/src/grid/gridBrowserWorker.ts
+++ b/packages/playwright-core/src/grid/gridBrowserWorker.ts
@@ -23,7 +23,7 @@ function launchGridBrowserWorker(gridURL: string, agentId: string, workerId: str
   const log = debug(`pw:grid:worker:${workerId}`);
   log('created');
   const ws = new WebSocket(gridURL.replace('http://', 'ws://') + `/registerWorker?agentId=${agentId}&workerId=${workerId}`);
-  new PlaywrightConnection(ws, true, browserAlias, undefined, log, async () => {
+  new PlaywrightConnection(ws, true, browserAlias, true, undefined, log, async () => {
     log('exiting process');
     setTimeout(() => process.exit(0), 30000);
     // Meanwhile, try to gracefully close all browsers.

--- a/packages/playwright-core/src/remote/playwrightConnection.ts
+++ b/packages/playwright-core/src/remote/playwrightConnection.ts
@@ -31,7 +31,7 @@ export class PlaywrightConnection {
   private _debugLog: (m: string) => void;
   private _disconnected = false;
 
-  constructor(ws: WebSocket, enableSocksProxy: boolean, browserAlias: string | undefined, browser: Browser | undefined, log: (m: string) => void, onClose: () => void) {
+  constructor(ws: WebSocket, enableSocksProxy: boolean, browserAlias: string | undefined, headless: boolean, browser: Browser | undefined, log: (m: string) => void, onClose: () => void) {
     this._ws = ws;
     this._onClose = onClose;
     this._debugLog = log;
@@ -53,7 +53,7 @@ export class PlaywrightConnection {
         return await this._initPreLaunchedBrowserMode(scope, browser);
       if (!browserAlias)
         return await this._initPlaywrightConnectMode(scope, enableSocksProxy);
-      return await this._initLaunchBrowserMode(scope, enableSocksProxy, browserAlias);
+      return await this._initLaunchBrowserMode(scope, enableSocksProxy, browserAlias, headless);
     });
   }
 
@@ -67,7 +67,7 @@ export class PlaywrightConnection {
     return new PlaywrightDispatcher(scope, playwright, socksProxy);
   }
 
-  private async _initLaunchBrowserMode(scope: DispatcherScope, enableSocksProxy: boolean, browserAlias: string) {
+  private async _initLaunchBrowserMode(scope: DispatcherScope, enableSocksProxy: boolean, browserAlias: string, headless: boolean) {
     this._debugLog(`engaged launch mode for "${browserAlias}"`);
     const executable = registry.findExecutable(browserAlias);
     if (!executable || !executable.browserName)
@@ -77,6 +77,7 @@ export class PlaywrightConnection {
     const socksProxy = enableSocksProxy ? await this._enableSocksProxy(playwright) : undefined;
     const browser = await playwright[executable.browserName].launch(serverSideCallMetadata(), {
       channel: executable.type === 'browser' ? undefined : executable.name,
+      headless,
     });
 
     // Close the browser on disconnect.

--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -81,13 +81,15 @@ export class PlaywrightServer {
       const url = new URL('http://localhost' + (request.url || ''));
       const browserHeader = request.headers['x-playwright-browser'];
       const browserAlias = url.searchParams.get('browser') || (Array.isArray(browserHeader) ? browserHeader[0] : browserHeader);
+      const headlessHeader = request.headers['x-playwright-headless'];
+      const headlessValue = url.searchParams.get('headless') || (Array.isArray(headlessHeader) ? headlessHeader[0] : headlessHeader);
       const proxyHeader = request.headers['x-playwright-proxy'];
       const proxyValue = url.searchParams.get('proxy') || (Array.isArray(proxyHeader) ? proxyHeader[0] : proxyHeader);
       const enableSocksProxy = this._enableSocksProxy && proxyValue === '*';
       this._clientsCount++;
       const log = newLogger();
       log(`serving connection: ${request.url}`);
-      const connection = new PlaywrightConnection(ws, enableSocksProxy, browserAlias, this._browser, log, () => this._clientsCount--);
+      const connection = new PlaywrightConnection(ws, enableSocksProxy, browserAlias, headlessValue !== '0', this._browser, log, () => this._clientsCount--);
       (ws as any)[kConnectionSymbol] = connection;
     });
 


### PR DESCRIPTION
This only applies when remote launches the browser.