### PR TITLE
docs: add example for global setup process.env

### DIFF
--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -301,7 +301,7 @@ test('test', async ({ page }) => {
 });
 ```
 
-You can make arbitary data available in your tests from your global setup file by attaching it to `process.env`.
+You can make arbitrary data available in your tests from your global setup file by setting them as environment variables via `process.env`.
 
 ```js js-flavor=js
 // global-setup.js

--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -211,7 +211,7 @@ test('test', async ({ page }) => {
 
 To set something up once before running all tests, use `globalSetup` option in the [configuration file](#configuration-object). Global setup file must export a single function that takes a config object. This function will be run once before all the tests.
 
-Similarly, use `globalTeardown` to run something once after all the tests. Alternatively, let `globalSetup` return a function that will be used as a global teardown. You can pass data such as port number, authentication tokens, etc. from your global setup to your tests using environment.
+Similarly, use `globalTeardown` to run something once after all the tests. Alternatively, let `globalSetup` return a function that will be used as a global teardown. You can pass data such as port number, authentication tokens, etc. from your global setup to your tests using environment variables.
 
 Here is a global setup example that authenticates once and reuses authentication state in tests. It uses `baseURL` and `storageState` options from the configuration file.
 

--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -336,7 +336,9 @@ const { FOO, BAR } = process.env;
 test('test', async ({ page }) => {
   // FOO and BAR properties are populated.
   expect(FOO).toEqual('some data');
-  expect(BAR).toEqual('{"some":"data"}');
+
+  const complexData = JSON.parse(BAR);
+  expect(BAR).toEqual({ some: "data" });
 });
 ```
 
@@ -347,7 +349,9 @@ const { FOO, BAR } = process.env;
 test('test', async ({ page }) => {
   // FOO and BAR properties are populated.
   expect(FOO).toEqual('some data');
-  expect(BAR).toEqual('{"some":"data"}');
+
+  const complexData = JSON.parse(BAR);
+  expect(BAR).toEqual({ some: "data" });
 });
 ```
 

--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -301,6 +301,56 @@ test('test', async ({ page }) => {
 });
 ```
 
+You can make arbitary data available in your tests from your global setup file by attaching it to `process.env`.
+
+```js js-flavor=js
+// global-setup.js
+const { chromium } = require('@playwright/test');
+
+module.exports = async config => {
+  process.env.foo = 'some data';
+  // Or a more complicated data structure as JSON:
+  process.env.bar = JSON.stringify({ some: 'data' });
+};
+```
+
+```js js-flavor=ts
+// global-setup.ts
+import { chromium, FullConfig } from '@playwright/test';
+
+async function globalSetup(config: FullConfig) {
+  process.env.foo = 'some data';
+  // Or a more complicated data structure as JSON:
+  process.env.bar = JSON.stringify({ some: 'data' });
+}
+
+export default globalSetup;
+```
+
+Tests have access to the `process.env` properties set in the global setup.
+
+```js js-flavor=ts
+import { test } from '@playwright/test';
+const { foo, bar } = process.env;
+
+test('test', async ({ page }) => {
+  // foo and bar properties are populated.
+  expect(foo).toEqual('some data')
+  expect(bar).toEqual('{"some":"data"}')
+});
+```
+
+```js js-flavor=js
+const { test } = require('@playwright/test');
+const { foo, bar } = process.env;
+
+test('test', async ({ page }) => {
+  // foo and bar properties are populated.
+  expect(foo).toEqual('some data')
+  expect(bar).toEqual('{"some":"data"}')
+});
+```
+
 ## Projects
 
 Playwright Test supports running multiple test projects at the same time. This is useful for running the same or different tests in multiple configurations.

--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -308,9 +308,9 @@ You can make arbitrary data available in your tests from your global setup file 
 const { chromium } = require('@playwright/test');
 
 module.exports = async config => {
-  process.env.foo = 'some data';
+  process.env.FOO = 'some data';
   // Or a more complicated data structure as JSON:
-  process.env.bar = JSON.stringify({ some: 'data' });
+  process.env.BAR = JSON.stringify({ some: 'data' });
 };
 ```
 
@@ -319,9 +319,9 @@ module.exports = async config => {
 import { chromium, FullConfig } from '@playwright/test';
 
 async function globalSetup(config: FullConfig) {
-  process.env.foo = 'some data';
+  process.env.FOO = 'some data';
   // Or a more complicated data structure as JSON:
-  process.env.bar = JSON.stringify({ some: 'data' });
+  process.env.BAR = JSON.stringify({ some: 'data' });
 }
 
 export default globalSetup;
@@ -331,23 +331,23 @@ Tests have access to the `process.env` properties set in the global setup.
 
 ```js js-flavor=ts
 import { test } from '@playwright/test';
-const { foo, bar } = process.env;
+const { FOO, BAR } = process.env;
 
 test('test', async ({ page }) => {
-  // foo and bar properties are populated.
-  expect(foo).toEqual('some data')
-  expect(bar).toEqual('{"some":"data"}')
+  // FOO and BAR properties are populated.
+  expect(FOO).toEqual('some data')
+  expect(BAR).toEqual('{"some":"data"}')
 });
 ```
 
 ```js js-flavor=js
 const { test } = require('@playwright/test');
-const { foo, bar } = process.env;
+const { FOO, BAR } = process.env;
 
 test('test', async ({ page }) => {
-  // foo and bar properties are populated.
-  expect(foo).toEqual('some data')
-  expect(bar).toEqual('{"some":"data"}')
+  // FOO and BAR properties are populated.
+  expect(FOO).toEqual('some data')
+  expect(BAR).toEqual('{"some":"data"}')
 });
 ```
 

--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -305,8 +305,6 @@ You can make arbitrary data available in your tests from your global setup file 
 
 ```js js-flavor=js
 // global-setup.js
-const { chromium } = require('@playwright/test');
-
 module.exports = async config => {
   process.env.FOO = 'some data';
   // Or a more complicated data structure as JSON:
@@ -316,7 +314,7 @@ module.exports = async config => {
 
 ```js js-flavor=ts
 // global-setup.ts
-import { chromium, FullConfig } from '@playwright/test';
+import { FullConfig } from '@playwright/test';
 
 async function globalSetup(config: FullConfig) {
   process.env.FOO = 'some data';
@@ -338,7 +336,7 @@ test('test', async ({ page }) => {
   expect(FOO).toEqual('some data');
 
   const complexData = JSON.parse(BAR);
-  expect(BAR).toEqual({ some: "data" });
+  expect(BAR).toEqual({ some: 'data' });
 });
 ```
 
@@ -351,7 +349,7 @@ test('test', async ({ page }) => {
   expect(FOO).toEqual('some data');
 
   const complexData = JSON.parse(BAR);
-  expect(BAR).toEqual({ some: "data" });
+  expect(BAR).toEqual({ some: 'data' });
 });
 ```
 

--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -335,8 +335,8 @@ const { FOO, BAR } = process.env;
 
 test('test', async ({ page }) => {
   // FOO and BAR properties are populated.
-  expect(FOO).toEqual('some data')
-  expect(BAR).toEqual('{"some":"data"}')
+  expect(FOO).toEqual('some data');
+  expect(BAR).toEqual('{"some":"data"}');
 });
 ```
 
@@ -346,8 +346,8 @@ const { FOO, BAR } = process.env;
 
 test('test', async ({ page }) => {
   // FOO and BAR properties are populated.
-  expect(FOO).toEqual('some data')
-  expect(BAR).toEqual('{"some":"data"}')
+  expect(FOO).toEqual('some data');
+  expect(BAR).toEqual('{"some":"data"}');
 });
 ```
 

--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -329,9 +329,11 @@ Tests have access to the `process.env` properties set in the global setup.
 
 ```js js-flavor=ts
 import { test } from '@playwright/test';
-const { FOO, BAR } = process.env;
 
 test('test', async ({ page }) => {
+  // environment variables which are set in globalSetup are only available inside test().
+  const { FOO, BAR } = process.env;
+
   // FOO and BAR properties are populated.
   expect(FOO).toEqual('some data');
 
@@ -342,9 +344,11 @@ test('test', async ({ page }) => {
 
 ```js js-flavor=js
 const { test } = require('@playwright/test');
-const { FOO, BAR } = process.env;
 
 test('test', async ({ page }) => {
+  // environment variables which are set in globalSetup are only available inside test().
+  const { FOO, BAR } = process.env;
+
   // FOO and BAR properties are populated.
   expect(FOO).toEqual('some data');
 


### PR DESCRIPTION
Add an example for how to attach data to `process.env` in the global setup step to be available in test files. This addresses the confusion I had in #13337 