### PR TITLE
feat(remote): handle timeout manually in `browser` fixture

### DIFF
--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -90,7 +90,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
   _browserOptions: [async ({ playwright, headless, channel, launchOptions }, use) => {
     const options: LaunchOptions = {
       handleSIGINT: false,
-      timeout: 0,
+      timeout: 30000,  // 30 seconds
       ...launchOptions,
     };
     if (headless !== undefined)
@@ -109,14 +109,13 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
     if (!['chromium', 'firefox', 'webkit'].includes(browserName))
       throw new Error(`Unexpected browserName "${browserName}", must be one of "chromium", "firefox" or "webkit"`);
     if (connectOptions) {
-      const browser = await playwright[browserName].connect({
-        wsEndpoint: connectOptions.wsEndpoint,
+      const browser = await playwright[browserName].connect(connectOptions.wsEndpoint, {
         headers: {
           'x-playwright-browser': channel || browserName,
           'x-playwright-headless': headless ? '1' : '0',
           ...connectOptions.headers,
         },
-        timeout: connectOptions.timeout,
+        timeout: connectOptions.timeout ?? 3 * 60 * 1000, // 3 minutes
       });
       await use(browser);
       await browser.close();
@@ -126,7 +125,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
     const browser = await playwright[browserName].launch();
     await use(browser);
     await browser.close();
-  }, { scope: 'worker' } ],
+  }, { scope: 'worker', timeout: 0 } ],
 
   acceptDownloads: [ undefined, { option: true } ],
   bypassCSP: [ undefined, { option: true } ],


### PR DESCRIPTION
To make launch/connect not affect the test timeout:
- `browser` fixture is declared with `timeout: 0`.
- Default timeouts are set to 30sec for launch and 3min for connect.

NOTE: this changes previous behavior of browser launch. When test timeout was specified (e.g. 120 seconds), but no launch timeout was specified, browser launch could take as long as 120 seconds. Now, it will be defaulted to 30 seconds instead.