### PR TITLE
devops: fix `//utils/workspace.js --set-version` script

### DIFF
--- a/utils/workspace.js
+++ b/utils/workspace.js
@@ -123,10 +123,14 @@ class Workspace {
       for (const otherPackage of this._packages) {
         if (pkgLockEntry.dependencies && pkgLockEntry.dependencies[otherPackage.name])
           pkgLockEntry.dependencies[otherPackage.name] = version;
+        if (pkgLockEntry.devDependencies && pkgLockEntry.devDependencies[otherPackage.name])
+          pkgLockEntry.devDependencies[otherPackage.name] = version;
         if (depLockEntry.requires && depLockEntry.requires[otherPackage.name])
           depLockEntry.requires[otherPackage.name] = version;
         if (pkg.packageJSON.dependencies && pkg.packageJSON.dependencies[otherPackage.name])
           pkg.packageJSON.dependencies[otherPackage.name] = version;
+        if (pkg.packageJSON.devDependencies && pkg.packageJSON.devDependencies[otherPackage.name])
+          pkg.packageJSON.devDependencies[otherPackage.name] = version;
       }
       await maybeWriteJSON(pkg.packageJSONPath, pkg.packageJSON);
     }


### PR DESCRIPTION
We use this script to update packages version across our repository.
It was broken because it did not account for the devDependencies.
