### PR TITLE
fix: wait for cleanup on double SIGINT

### DIFF
--- a/packages/playwright-core/src/browserServerImpl.ts
+++ b/packages/playwright-core/src/browserServerImpl.ts
@@ -63,6 +63,7 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
     browserServer.close = () => browser.options.browserProcess.close();
     browserServer.kill = () => browser.options.browserProcess.kill();
     (browserServer as any)._disconnectForTest = () => server.close();
+    (browserServer as any)._artifactsDirForTest = browser.options.artifactsDir;
     browser.options.browserProcess.onclose = async (exitCode, signal) => {
       server.close();
       browserServer.emit('close', exitCode, signal);

--- a/tests/config/remote-server-impl.js
+++ b/tests/config/remote-server-impl.js
@@ -21,6 +21,7 @@ async function start() {
     console.log(`(exitCode=>${exitCode})`);
     console.log(`(signal=>${signal})`);
   });
+  console.log(`(tempDir=>${browserServer._artifactsDirForTest})`);
   console.log(`(pid=>${browserServer.process().pid})`);
   console.log(`(wsEndpoint=>${browserServer.wsEndpoint()})`);
 }


### PR DESCRIPTION
This is a speculative fix to leftover tmp directories. When users issues SIGINT twice, we enter `gracefullyClose()` twice, and shortcut the second time. It turns out, we do not wait for directories removal.

Note: it is unknown how often we reach this codepath in practice.