### PR TITLE
fix(test runner): default workerIndex to -1

### DIFF
--- a/docs/src/test-reporter-api/class-testresult.md
+++ b/docs/src/test-reporter-api/class-testresult.md
@@ -63,6 +63,6 @@ List of steps inside this test run.
 ## property: TestResult.workerIndex
 - type: <[int]>
 
-Index of the worker where the test was run.
+Index of the worker where the test was run. If the test was not run a single time, for example when the user interrupted testing, the only result will have a `workerIndex` equal to `-1`.
 
 Learn more about [parallelism and sharding](../test-parallel.md) with Playwright Test.

--- a/packages/playwright-test/src/test.ts
+++ b/packages/playwright-test/src/test.ts
@@ -176,7 +176,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   _appendTestResult(): reporterTypes.TestResult {
     const result: reporterTypes.TestResult = {
       retry: this.results.length,
-      workerIndex: 0,
+      workerIndex: -1,
       duration: 0,
       startTime: new Date(),
       stdout: [],

--- a/packages/playwright-test/types/testReporter.d.ts
+++ b/packages/playwright-test/types/testReporter.d.ts
@@ -293,7 +293,8 @@ export interface TestResult {
   steps: Array<TestStep>;
 
   /**
-   * Index of the worker where the test was run.
+   * Index of the worker where the test was run. If the test was not run a single time, for example when the user interrupted
+   * testing, the only result will have a `workerIndex` equal to `-1`.
    *
    * Learn more about [parallelism and sharding](https://playwright.dev/docs/test-parallel) with Playwright Test.
    */

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -110,6 +110,14 @@ test('sigint should stop workers', async ({ runInlineTest }) => {
   expect(result.output).toContain('%%SEND-SIGINT%%2');
   expect(result.output).not.toContain('%%skipped1');
   expect(result.output).not.toContain('%%skipped2');
+
+  const interrupted2 = result.report.suites[1].specs[0];
+  expect(interrupted2.title).toBe('interrupted2');
+  expect(interrupted2.tests[0].results[0].workerIndex === 0 || interrupted2.tests[0].results[0].workerIndex === 1).toBe(true);
+
+  const skipped2 = result.report.suites[1].specs[1];
+  expect(skipped2.title).toBe('skipped2');
+  expect(skipped2.tests[0].results[0].workerIndex).toBe(-1);
 });
 
 test('should use the first occurring error when an unhandled exception was thrown', async ({ runInlineTest }) => {


### PR DESCRIPTION
Otherwise we pretend that all skipped tests were actually run in the worker with index `0`.