### PR TITLE
feat(android) add webview pages method

### DIFF
--- a/docs/src/api/class-androidwebview.md
+++ b/docs/src/api/class-androidwebview.md
@@ -12,6 +12,11 @@ Emitted when the WebView is closed.
 
 Connects to the WebView and returns a regular Playwright [Page] to interact with.
 
+## async method: AndroidWebView.pages
+- returns: <[Page[]]>
+
+Connects to the WebView and returns multiple Playwright [Page] objects to interact with.
+
 ## method: AndroidWebView.pid
 - returns: <[int]>
 

--- a/packages/playwright-core/src/client/android.ts
+++ b/packages/playwright-core/src/client/android.ts
@@ -343,13 +343,16 @@ export class AndroidWebView extends EventEmitter implements api.AndroidWebView {
   }
 
   async page(): Promise<Page> {
-    if (!this._pagePromise)
-      this._pagePromise = this._fetchPage();
-    return this._pagePromise;
+    const pages = await this.pages();
+    return pages[0];
   }
 
-  private async _fetchPage(): Promise<Page> {
+  async pages(): Promise<Page[]> {
+    return this._fetchPages();
+  }
+
+  private async _fetchPages(): Promise<Page[]> {
     const { context } = await this._device._channel.connectToWebView({ socketName: this._data.socketName });
-    return BrowserContext.from(context).pages()[0];
+    return BrowserContext.from(context).pages();
   }
 }

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -11910,6 +11910,11 @@ export interface AndroidWebView {
   page(): Promise<Page>;
 
   /**
+   * Connects to the WebView and returns multiple Playwright [Page] objects to interact with.
+   */
+  pages(): Promise<Page[]>;
+
+  /**
    * WebView process PID.
    */
   pid(): number;

--- a/tests/android/webview.spec.ts
+++ b/tests/android/webview.spec.ts
@@ -78,3 +78,21 @@ test('select webview from socketName', async function({ androidDevice }) {
   await newPage.close();
   await context.close();
 });
+
+test('webview.pages', async function({ androidDevice }) {
+  test.slow();
+  // open first page
+  const context = await androidDevice.launchBrowser();
+  // open second page
+  const newPage = await context.newPage();
+  newPage.goto('about:blank');
+
+  const webview = await androidDevice.webView({ socketName: 'webview_devtools_remote_playwright_test' });
+  expect(webview.pkg()).toBe('');
+  const pages = await webview.pages();
+  expect(pages.length).toBe(2);
+  expect(pages[0].url()).toBe('about:blank');
+
+  await newPage.close();
+  await context.close();
+});


### PR DESCRIPTION

## why 
In mobile phone,  in order to save cpus and memory,  only a webview process exist and load many pages.   there are also some preloaded pages in a app webview.  so I need get all pages to test business logics.

## how
```
const pages = await webview.pages();
```