### PR TITLE
chore: set minimum version to Node.js 14

### DIFF
--- a/docs/src/library-js.md
+++ b/docs/src/library-js.md
@@ -97,7 +97,7 @@ let page: import('playwright').Page;
 
 ## System requirements
 
-Playwright requires Node.js version 12 or above. The browser binaries for Chromium,
+Playwright requires Node.js version 14 or above. The browser binaries for Chromium,
 Firefox and WebKit work across the 3 platforms (Windows, macOS, Linux):
 
 ### Windows

--- a/docs/src/troubleshooting-js.md
+++ b/docs/src/troubleshooting-js.md
@@ -30,7 +30,7 @@ await page.evaluate(`(async() => {
 
 ### ReferenceError: URL is not defined
 
-Playwright requires Node.js 12 or higher. Node.js 8 is not supported, and will cause you to receive this error.
+Playwright requires Node.js 14 or higher. Node.js 8 is not supported, and will cause you to receive this error.
 
 # Please file an issue
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-chromium/package.json
+++ b/packages/playwright-chromium/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-firefox/package.json
+++ b/packages/playwright-firefox/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "main": "index.js",
   "exports": {

--- a/packages/playwright-webkit/package.json
+++ b/packages/playwright-webkit/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
Node.js 12 EOL is on the 2022-04-30, this is before our next release. So in our next release we can stop supporting Node.js 12 officially.