### PR TITLE
chore: adjust gha agent params

### DIFF
--- a/packages/playwright-core/src/grid/githubGridFactory.ts
+++ b/packages/playwright-core/src/grid/githubGridFactory.ts
@@ -30,9 +30,10 @@ const log = debug(`pw:grid:server`);
 
 const githubFactory: GridFactory = {
   name: 'Agents hosted on Github',
-  capacity: 10,
-  launchTimeout: 30000,
-  retireTimeout: 600000,
+  // Standard VM is 3-core on mac and 2-core on win and lin
+  capacity: 4,
+  launchTimeout: 10 * 60_000,
+  retireTimeout: 1 * 60 * 60_000,
   launch: async (options: GridAgentLaunchOptions) => {
     await createWorkflow(options);
   },

--- a/packages/playwright-core/src/grid/gridServer.ts
+++ b/packages/playwright-core/src/grid/gridServer.ts
@@ -248,18 +248,12 @@ export class GridServer {
 
     this._wsServer.shouldHandle = request => {
       this._log(request.url);
-      if (request.url!.startsWith(this._securePath('/claimWorker'))) {
+      if (request.url!.startsWith(this._securePath('/claimWorker')) ||
+          request.url!.startsWith(this._securePath('/registerAgent')) ||
+          request.url!.startsWith(this._securePath('/registerWorker'))) {
         // shouldHandle claims it accepts promise, except it doesn't.
         return true;
       }
-
-      if (request.url!.startsWith(this._securePath('/registerAgent'))
-       || request.url!.startsWith(this._securePath('/registerWorker'))) {
-        const params = new URL('http://localhost/' + request.url).searchParams;
-        const agentId = params.get('agentId');
-        return !!agentId && this._agents.has(agentId);
-      }
-
       return false;
     };
 


### PR DESCRIPTION
* Accept websocket connections even for retired agents, this provides clearer diagnostics on the worker/agent side
* Adjust params for default runners hardware: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
* Increase both launch and retire timeouts