### PR TITLE
fix: make fetch api work with connectOverCDP

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -141,7 +141,7 @@ export abstract class APIRequestContext extends SdkObject {
     const method = params.method?.toUpperCase() || 'GET';
     const proxy = defaults.proxy;
     let agent;
-    if (proxy) {
+    if (proxy && proxy.server !== 'per-context') {
       // TODO: support bypass proxy
       const proxyOpts = url.parse(proxy.server);
       if (proxyOpts.protocol?.startsWith('socks')) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/13520

Maybe there is a better way to fix it, we set it here to make proxies work on Windows:

https://github.com/microsoft/playwright/blob/4b85f924ccbbee2fb647ab21b1af48e94eb1108a/packages/playwright-core/src/server/chromium/chromium.ts#L108-L113