### PR TITLE
chore: force localPaths to be resolved

### DIFF
--- a/packages/playwright-core/src/client/elementHandle.ts
+++ b/packages/playwright-core/src/client/elementHandle.ts
@@ -285,7 +285,7 @@ export async function convertInputFiles(files: string | FilePayload | string[] |
       }));
       return { streams };
     }
-    return { localPaths: items as string[] };
+    return { localPaths: items.map(f => path.resolve(f as string)) as string[] };
   }
 
   const filePayloads: SetInputFilesFiles = await Promise.all(items.map(async item => {

--- a/packages/playwright-core/src/server/dispatchers/elementHandlerDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/elementHandlerDispatcher.ts
@@ -24,7 +24,8 @@ import { JSHandleDispatcher, serializeResult, parseArgument } from './jsHandleDi
 import type { FrameDispatcher } from './frameDispatcher';
 import type { CallMetadata } from '../instrumentation';
 import type { WritableStreamDispatcher } from './writableStreamDispatcher';
-
+import { assert } from '../../utils';
+import path from 'path';
 export class ElementHandleDispatcher extends JSHandleDispatcher implements channels.ElementHandleChannel {
   _type_ElementHandle = true;
 
@@ -155,6 +156,8 @@ export class ElementHandleDispatcher extends JSHandleDispatcher implements chann
         throw new Error('Neither localPaths nor streams is specified');
       localPaths = params.streams.map(c => (c as WritableStreamDispatcher).path());
     }
+    for (const p of localPaths)
+      assert(path.isAbsolute(p) && path.resolve(p) === p, 'Paths provided to localPaths must be absolute and fully resolved.');
     return await this._elementHandle.setInputFiles(metadata, { localPaths }, params);
   }
 

--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -25,7 +25,8 @@ import type { ResponseDispatcher } from './networkDispatchers';
 import { RequestDispatcher } from './networkDispatchers';
 import type { CallMetadata } from '../instrumentation';
 import type { WritableStreamDispatcher } from './writableStreamDispatcher';
-
+import { assert } from '../../utils';
+import path from 'path';
 export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel> implements channels.FrameChannel {
   _type_Frame = true;
   private _frame: Frame;
@@ -215,6 +216,8 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel> im
         throw new Error('Neither localPaths nor streams is specified');
       localPaths = params.streams.map(c => (c as WritableStreamDispatcher).path());
     }
+    for (const p of localPaths)
+      assert(path.isAbsolute(p) && path.resolve(p) === p, 'Paths provided to localPaths must be absolute and fully resolved.');
     return await this._frame.setInputFiles(metadata, params.selector, { localPaths }, params);
   }
 

--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -27,6 +27,7 @@ import type { CallMetadata } from '../instrumentation';
 import type { WritableStreamDispatcher } from './writableStreamDispatcher';
 import { assert } from '../../utils';
 import path from 'path';
+
 export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel> implements channels.FrameChannel {
   _type_Frame = true;
   private _frame: Frame;


### PR DESCRIPTION
Relative paths can cause the renderer to crash.

Fixes #13537