### PR TITLE
browser(webkit): rebase to 04/13/22 r292830

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1630
-Changed: yurys@chromium.org Fri 08 Apr 2022 01:14:10 PM PDT
+1631
+Changed: dpino@igalia.com Thu Apr 14 06:07:27 UTC 2022

--- a/browser_patches/webkit/UPSTREAM_CONFIG.sh
+++ b/browser_patches/webkit/UPSTREAM_CONFIG.sh
@@ -1,3 +1,3 @@
 REMOTE_URL="https://github.com/WebKit/WebKit.git"
 BASE_BRANCH="main"
-BASE_REVISION="7a58e66ff4b54177b5d8ef24993d6c3fa2c07d09"
+BASE_REVISION="2aa55cf595edfef2ffd838a0f5079d6b2a1d603a"

--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -11,22 +11,30 @@ build_gtk() {
   if ! [[ -d ./WebKitBuild/GTK/DependenciesGTK ]]; then
     yes | WEBKIT_JHBUILD=1 WEBKIT_JHBUILD_MODULESET=minimal WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/GTK DEBIAN_FRONTEND=noninteractive ./Tools/Scripts/update-webkitgtk-libs
   fi
-  local CMAKE_ARGS=""
+  local CMAKE_ARGS=(
+    --cmakeargs=-DENABLE_INTROSPECTION=OFF
+    --cmakeargs=-DUSE_GSTREAMER_WEBRTC=FALSE
+  )
   if [[ -n "${EXPORT_COMPILE_COMMANDS}" ]]; then
-    CMAKE_ARGS="--cmakeargs=\"-DCMAKE_EXPORT_COMPILE_COMMANDS=1\""
+    CMAKE_ARGS+=("--cmakeargs=-DCMAKE_EXPORT_COMPILE_COMMANDS=1")
   fi
-  WEBKIT_JHBUILD=1 WEBKIT_JHBUILD_MODULESET=minimal WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/GTK ./Tools/Scripts/build-webkit --gtk --release "${CMAKE_ARGS}" --touch-events --orientation-events --no-bubblewrap-sandbox --no-webxr --cmakeargs=-DUSE_GSTREAMER_WEBRTC=FALSE --cmakeargs=-DENABLE_INTROSPECTION=OFF MiniBrowser
+  WEBKIT_JHBUILD=1 WEBKIT_JHBUILD_MODULESET=minimal WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/GTK ./Tools/Scripts/build-webkit --gtk --release "${CMAKE_ARGS}" --touch-events --orientation-events --no-bubblewrap-sandbox "${CMAKE_ARGS[@]}" MiniBrowser
 }
 
 build_wpe() {
   if ! [[ -d ./WebKitBuild/WPE/DependenciesWPE ]]; then
     yes | WEBKIT_JHBUILD=1 WEBKIT_JHBUILD_MODULESET=minimal WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/WPE DEBIAN_FRONTEND=noninteractive ./Tools/Scripts/update-webkitwpe-libs
   fi
-  local CMAKE_ARGS=""
+  local CMAKE_ARGS=(
+    --cmakeargs=-DENABLE_COG=OFF
+    --cmakeargs=-DENABLE_INTROSPECTION=OFF
+    --cmakeargs=-DENABLE_WEBXR=OFF
+    --cmakeargs=-DUSE_GSTREAMER_WEBRTC=FALSE
+  )
   if [[ -n "${EXPORT_COMPILE_COMMANDS}" ]]; then
-    CMAKE_ARGS="--cmakeargs=\"-DCMAKE_EXPORT_COMPILE_COMMANDS=1\""
+    CMAKE_ARGS+=("--cmakeargs=-DCMAKE_EXPORT_COMPILE_COMMANDS=1")
   fi
-  WEBKIT_JHBUILD=1 WEBKIT_JHBUILD_MODULESET=minimal WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/WPE ./Tools/Scripts/build-webkit --wpe --release "${CMAKE_ARGS}" --touch-events --orientation-events --no-bubblewrap-sandbox --no-webxr --cmakeargs=-DENABLE_COG=OFF --cmakeargs=-DUSE_GSTREAMER_WEBRTC=FALSE --cmakeargs=-DENABLE_INTROSPECTION=OFF MiniBrowser
+  WEBKIT_JHBUILD=1 WEBKIT_JHBUILD_MODULESET=minimal WEBKIT_OUTPUTDIR=$(pwd)/WebKitBuild/WPE ./Tools/Scripts/build-webkit --wpe --release "${CMAKE_ARGS}" --touch-events --orientation-events --no-bubblewrap-sandbox "${CMAKE_ARGS[@]}" MiniBrowser
 }
 
 ensure_linux_deps() {

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -1,5 +1,5 @@
 diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
-index 29a7af9a2de68629b78f020f1d9d81709da3b25e..641ce3ac2f06c8bf07b6b7282896e009ccc0cba7 100644
+index 23c4a74f886863a1efce0b3ca36bf16613ef4954..ec583d281065eaaf6034c00dc533c4a3e572dd92 100644
 --- a/Source/JavaScriptCore/CMakeLists.txt
 +++ b/Source/JavaScriptCore/CMakeLists.txt
 @@ -1345,22 +1345,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
@@ -1796,7 +1796,7 @@ index 2decf8a83c80e80ca8677f4c787bf79c6c2995fa..9010384a32f7c2ab69a8fb20eb19cd56
      }
  
 diff --git a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
-index 01941453ee989a064587592202a36c9adfc02761..9ae20416c6895abe42f24e2444273e651d28010a 100644
+index 2b27c8820fbc922b9354e6e070df2394280e1557..99854aa23ffd993dcf01015070d7929cf9dabffa 100644
 --- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
 +++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
 @@ -36,6 +36,7 @@
@@ -1892,13 +1892,13 @@ index 0d42c17c6a85b2a9f6af319431332f7f8a709188..8899c8e85b11db81d1da14c7f2781488
      Source/third_party/opus/src/celt
      Source/third_party/opus/src/include
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
-index fa280a4a4fd86851ccb31f3c9de76b8ea88958dc..f995e6a5a747d2c10fb29e1fe991b11d3f909241 100644
+index 9767ed562334cb55a44d2b63c3284171b35fcd05..5fd2cb8df95a2c24156f738a3ee03d7cce5869d6 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.mac.exp
-@@ -336,3 +336,23 @@ __ZTVN6webrtc30WrappingAsyncDnsResolverResultE
- __ZN6webrtc20pixelBufferFromFrameERKNS_10VideoFrameE
- __ZN6webrtc20copyVideoFrameBufferERNS_16VideoFrameBufferEPh
+@@ -337,3 +337,23 @@ __ZN6webrtc20copyVideoFrameBufferERNS_16VideoFrameBufferEPh
  __ZN6webrtc32createPixelBufferFromFrameBufferERNS_16VideoFrameBufferERKNSt3__18functionIFP10__CVBuffermmNS_10BufferTypeEEEE
+ __ZN6webrtc25CreateTaskQueueGcdFactoryEv
+ __ZN6webrtc27CreatePeerConnectionFactoryEPN3rtc6ThreadES2_S2_NS0_13scoped_refptrINS_17AudioDeviceModuleEEENS3_INS_19AudioEncoderFactoryEEENS3_INS_19AudioDecoderFactoryEEENSt3__110unique_ptrINS_19VideoEncoderFactoryENSA_14default_deleteISC_EEEENSB_INS_19VideoDecoderFactoryENSD_ISG_EEEENS3_INS_10AudioMixerEEENS3_INS_15AudioProcessingEEEPNS_19AudioFrameProcessorENSB_INS_16TaskQueueFactoryENSD_ISP_EEEE
 +__ZN8mkvmuxer11SegmentInfo15set_writing_appEPKc
 +__ZN8mkvmuxer11SegmentInfo4InitEv
 +__ZN8mkvmuxer7Segment10OutputCuesEb
@@ -1920,7 +1920,7 @@ index fa280a4a4fd86851ccb31f3c9de76b8ea88958dc..f995e6a5a747d2c10fb29e1fe991b11d
 +_vpx_codec_version_str
 +_vpx_codec_vp8_cx
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
-index 4fa76966397a86dd9563e54e79677a15e1127306..4a83720f9a0550a337dcc8297dc0dbba4f6ef8c8 100644
+index 38a4ad6f76932fe5ad6a00689fe60c5b8cc5d042..3cab39566912440255fdbfb765e3a5e7acc0491a 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 @@ -52,7 +52,7 @@ DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_ = $(NORMAL_WEBCORE_FRAMEWORKS
@@ -1933,11 +1933,11 @@ index 4fa76966397a86dd9563e54e79677a15e1127306..4a83720f9a0550a337dcc8297dc0dbba
  PUBLIC_HEADERS_FOLDER_PREFIX = /usr/local/include;
  INSTALL_PUBLIC_HEADER_PREFIX = $(INSTALL_PATH_PREFIX)$(PUBLIC_HEADERS_FOLDER_PREFIX);
 diff --git a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
-index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec897359be8324a 100644
+index 0d8326fe5dce429851460466cc58687b2ab71b74..817047358946891cd3c1b02b6c01a4f23d4e4db3 100644
 --- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
 +++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
 @@ -6,6 +6,20 @@
- 	objectVersion = 46;
+ 	objectVersion = 52;
  	objects = {
  
 +/* Begin PBXAggregateTarget section */
@@ -1957,7 +1957,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  /* Begin PBXBuildFile section */
  		410091CF242CFD6500C5EDA2 /* internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 41A391FA1EFC493000C4516A /* internal.h */; };
  		410091D2242CFF6F00C5EDA2 /* gcm_nohw.c in Sources */ = {isa = PBXBuildFile; fileRef = 410091D0242CFD8200C5EDA2 /* gcm_nohw.c */; };
-@@ -4527,6 +4541,9 @@
+@@ -4529,6 +4543,9 @@
  		DDF30D9127C5C725006A526F /* receive_side_congestion_controller.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF30D9027C5C725006A526F /* receive_side_congestion_controller.h */; };
  		DDF30D9527C5C756006A526F /* bwe_defines.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF30D9327C5C756006A526F /* bwe_defines.h */; };
  		DDF30D9627C5C756006A526F /* remote_bitrate_estimator.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF30D9427C5C756006A526F /* remote_bitrate_estimator.h */; };
@@ -1967,7 +1967,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  /* End PBXBuildFile section */
  
  /* Begin PBXBuildRule section */
-@@ -4777,6 +4794,13 @@
+@@ -4779,6 +4796,13 @@
  			remoteGlobalIDString = DDF30D0527C5C003006A526F;
  			remoteInfo = absl;
  		};
@@ -1981,7 +1981,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  /* End PBXContainerItemProxy section */
  
  /* Begin PBXCopyFilesBuildPhase section */
-@@ -9554,6 +9578,9 @@
+@@ -9558,6 +9582,9 @@
  		DDF30D9027C5C725006A526F /* receive_side_congestion_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = receive_side_congestion_controller.h; sourceTree = "<group>"; };
  		DDF30D9327C5C756006A526F /* bwe_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bwe_defines.h; sourceTree = "<group>"; };
  		DDF30D9427C5C756006A526F /* remote_bitrate_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remote_bitrate_estimator.h; sourceTree = "<group>"; };
@@ -1991,7 +1991,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  		FB39D0D11200F0E300088E69 /* libwebrtc.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libwebrtc.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
  /* End PBXFileReference section */
  
-@@ -16870,6 +16897,7 @@
+@@ -16876,6 +16903,7 @@
  			isa = PBXGroup;
  			children = (
  				CDFD2F9224C4B2F90048DAC3 /* common */,
@@ -1999,7 +1999,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  				CDEBB19224C0191800ADBD44 /* webm_parser */,
  			);
  			path = libwebm;
-@@ -17337,6 +17365,16 @@
+@@ -17343,6 +17371,16 @@
  			path = include;
  			sourceTree = "<group>";
  		};
@@ -2016,7 +2016,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  		FB39D06E1200ED9200088E69 = {
  			isa = PBXGroup;
  			children = (
-@@ -20023,6 +20061,7 @@
+@@ -20029,6 +20067,7 @@
  				DDF30CFA27C5A98F006A526F /* PBXBuildRule */,
  			);
  			dependencies = (
@@ -2024,7 +2024,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  				DD2E76E827C6B69A00F2A74C /* PBXTargetDependency */,
  				CDEBB4CC24C01AB400ADBD44 /* PBXTargetDependency */,
  				411ED040212E0811004320BA /* PBXTargetDependency */,
-@@ -20084,6 +20123,7 @@
+@@ -20090,6 +20129,7 @@
  				41F77D15215BE45E00E72967 /* yasm */,
  				CDEBB11824C0187400ADBD44 /* webm */,
  				DDF30D0527C5C003006A526F /* absl */,
@@ -2032,7 +2032,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  			);
  		};
  /* End PBXProject section */
-@@ -20217,6 +20257,23 @@
+@@ -20223,6 +20263,23 @@
  			shellPath = /bin/sh;
  			shellScript = "[ \"${WK_USE_NEW_BUILD_SYSTEM}\" = YES ] && exit 0\nxcodebuild -project \"${PROJECT_FILE_PATH}\" -target \"${TARGET_NAME}\" installhdrs SYMROOT=\"${TARGET_TEMP_DIR}/LegacyNestHeaders-build\" DSTROOT=\"${BUILT_PRODUCTS_DIR}\" SDKROOT=\"${SDKROOT}\" -UseNewBuildSystem=YES\n";
  		};
@@ -2056,7 +2056,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  /* End PBXShellScriptBuildPhase section */
  
  /* Begin PBXSourcesBuildPhase section */
-@@ -21348,6 +21405,7 @@
+@@ -21354,6 +21411,7 @@
  				419C82F51FE20EB50040C30F /* audio_encoder_opus.cc in Sources */,
  				419C82F31FE20EB50040C30F /* audio_encoder_opus_config.cc in Sources */,
  				4140B8201E4E3383007409E6 /* audio_encoder_pcm.cc in Sources */,
@@ -2064,7 +2064,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  				5CDD8FFE1E43CE3A00621E92 /* audio_encoder_pcm16b.cc in Sources */,
  				5CD285461E6A61D20094FDC8 /* audio_format.cc in Sources */,
  				41DDB26F212679D200296D47 /* audio_format_to_string.cc in Sources */,
-@@ -21786,6 +21844,7 @@
+@@ -21793,6 +21851,7 @@
  				417953DB216983910028266B /* metrics.cc in Sources */,
  				5CDD865E1E43B8B500621E92 /* min_max_operations.c in Sources */,
  				4189395B242A71F5007FDC41 /* min_video_bitrate_experiment.cc in Sources */,
@@ -2072,7 +2072,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  				4131C387234B957D0028A615 /* moving_average.cc in Sources */,
  				41FCBB1521B1F7AA00A5DF27 /* moving_average.cc in Sources */,
  				5CD286101E6A64C90094FDC8 /* moving_max.cc in Sources */,
-@@ -22019,6 +22078,7 @@
+@@ -22026,6 +22085,7 @@
  				4131C53B234C8B190028A615 /* rtc_event_rtp_packet_outgoing.cc in Sources */,
  				4131C552234C8B190028A615 /* rtc_event_video_receive_stream_config.cc in Sources */,
  				4131C554234C8B190028A615 /* rtc_event_video_send_stream_config.cc in Sources */,
@@ -2080,7 +2080,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  				4131C3CF234B98420028A615 /* rtc_stats.cc in Sources */,
  				4131BF2D234B88200028A615 /* rtc_stats_collector.cc in Sources */,
  				4131C3CE234B98420028A615 /* rtc_stats_report.cc in Sources */,
-@@ -22469,6 +22529,11 @@
+@@ -22477,6 +22537,11 @@
  			target = DDF30D0527C5C003006A526F /* absl */;
  			targetProxy = DD2E76E727C6B69A00F2A74C /* PBXContainerItemProxy */;
  		};
@@ -2092,7 +2092,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  /* End PBXTargetDependency section */
  
  /* Begin XCBuildConfiguration section */
-@@ -22717,6 +22782,27 @@
+@@ -22725,6 +22790,27 @@
  			};
  			name = Production;
  		};
@@ -2120,7 +2120,7 @@ index 589133f4e501728e62836b75b88dc58ec89e9da2..9c6a36f10ce1cad52cda27a5eec89735
  		FB39D0711200ED9200088E69 /* Debug */ = {
  			isa = XCBuildConfiguration;
  			baseConfigurationReference = 5D7C59C71208C68B001C873E /* DebugRelease.xcconfig */;
-@@ -22849,6 +22935,16 @@
+@@ -22857,6 +22943,16 @@
  			defaultConfigurationIsVisible = 0;
  			defaultConfigurationName = Production;
  		};
@@ -2169,7 +2169,7 @@ index f8edbb7e0638916d22209b9c0baf5b9ed5af9858..aa345b4470460ecfbb33cd301007da5a
    type: bool
    humanReadableName: "Private Click Measurement"
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index 6b5f33fc5c9e1dc0dedecf0f2070e0483c197f21..5c44cde5ed6626c6a34e6dff062bd49ba76857b2 100644
+index c36afc73c97956c167becab023bb4cbb6e52cf62..4985ad839ef85ef825503b30a3ba02e7986634dc 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 @@ -455,7 +455,7 @@ CrossOriginOpenerPolicyEnabled:
@@ -2193,7 +2193,7 @@ index 6b5f33fc5c9e1dc0dedecf0f2070e0483c197f21..5c44cde5ed6626c6a34e6dff062bd49b
  
  # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
  MediaCapabilitiesExtensionsEnabled:
-@@ -1341,7 +1341,7 @@ SpeechRecognitionEnabled:
+@@ -1342,7 +1342,7 @@ SpeechRecognitionEnabled:
      WebKitLegacy:
        default: false
      WebKit:
@@ -2202,7 +2202,7 @@ index 6b5f33fc5c9e1dc0dedecf0f2070e0483c197f21..5c44cde5ed6626c6a34e6dff062bd49b
        default: false
      WebCore:
        default: false
-@@ -1456,6 +1456,7 @@ UseGPUProcessForDisplayCapture:
+@@ -1457,6 +1457,7 @@ UseGPUProcessForDisplayCapture:
      WebKit:
        default: false
  
@@ -2210,7 +2210,7 @@ index 6b5f33fc5c9e1dc0dedecf0f2070e0483c197f21..5c44cde5ed6626c6a34e6dff062bd49b
  UseGPUProcessForWebGLEnabled:
    type: bool
    humanReadableName: "GPU Process: WebGL"
-@@ -1466,7 +1467,7 @@ UseGPUProcessForWebGLEnabled:
+@@ -1467,7 +1468,7 @@ UseGPUProcessForWebGLEnabled:
    defaultValue:
      WebKit:
        "ENABLE(GPU_PROCESS_BY_DEFAULT) && PLATFORM(IOS_FAMILY) && !HAVE(UIKIT_WEBKIT_INTERNALS)": true
@@ -2220,10 +2220,10 @@ index 6b5f33fc5c9e1dc0dedecf0f2070e0483c197f21..5c44cde5ed6626c6a34e6dff062bd49b
  
  UseScreenCaptureKit:
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
-index 65aca5319527cb7c4d67e80b6974362dbb7ef472..30aad4af22a17034ddb2876d348a024661257abe 100644
+index ea8e5b28bb6c71d5b214a855332302168bc75460..05491fb0f43a7950e09eddbdfaf156de02a4df49 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
-@@ -968,6 +968,7 @@ UseCGDisplayListsForDOMRendering:
+@@ -958,6 +958,7 @@ UseCGDisplayListsForDOMRendering:
      WebKit:
        default: true
  
@@ -2231,7 +2231,7 @@ index 65aca5319527cb7c4d67e80b6974362dbb7ef472..30aad4af22a17034ddb2876d348a0246
  UseGPUProcessForCanvasRenderingEnabled:
    type: bool
    humanReadableName: "GPU Process: Canvas Rendering"
-@@ -978,7 +979,7 @@ UseGPUProcessForCanvasRenderingEnabled:
+@@ -968,7 +969,7 @@ UseGPUProcessForCanvasRenderingEnabled:
    defaultValue:
      WebKit:
        "ENABLE(GPU_PROCESS_BY_DEFAULT)": true
@@ -2241,7 +2241,7 @@ index 65aca5319527cb7c4d67e80b6974362dbb7ef472..30aad4af22a17034ddb2876d348a0246
  
  UseGPUProcessForMediaEnabled:
 diff --git a/Source/WTF/wtf/DateMath.cpp b/Source/WTF/wtf/DateMath.cpp
-index 01976e039682c467765ef77d54925dd84a4b7da1..b8c108fc4a165256f7fed2572fadac70a64770eb 100644
+index b5f228308d161b6e16c9c45abf82b152b576cc6e..65d4ab303887d7c96928d9f24d2696c417092f2c 100644
 --- a/Source/WTF/wtf/DateMath.cpp
 +++ b/Source/WTF/wtf/DateMath.cpp
 @@ -76,9 +76,14 @@
@@ -2277,7 +2277,7 @@ index 01976e039682c467765ef77d54925dd84a4b7da1..b8c108fc4a165256f7fed2572fadac70
 +
  /* Constants */
  
- const char* const weekdayName[7] = { "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" };
+ const ASCIILiteral weekdayName[7] = { "Mon"_s, "Tue"_s, "Wed"_s, "Thu"_s, "Fri"_s, "Sat"_s, "Sun"_s };
 @@ -318,6 +335,14 @@ static double calculateDSTOffset(time_t localTime, double utcOffset)
  // Returns combined offset in millisecond (UTC + DST).
  LocalTimeOffset calculateLocalTimeOffset(double ms, TimeType inputTimeType)
@@ -2360,7 +2360,7 @@ index 01976e039682c467765ef77d54925dd84a4b7da1..b8c108fc4a165256f7fed2572fadac70
 +
  } // namespace WTF
 diff --git a/Source/WTF/wtf/DateMath.h b/Source/WTF/wtf/DateMath.h
-index 07ddf3854633cb5e4ca9679359c048f13395e4ab..a0be72ba35e7afa09e8ea5976ebf600b9f35269a 100644
+index 174e6c07b6f5cf4bcf0469f20f8cf021bed25103..722fff5cdfaf70e2187f96345f78cf4428dcedda 100644
 --- a/Source/WTF/wtf/DateMath.h
 +++ b/Source/WTF/wtf/DateMath.h
 @@ -393,6 +393,10 @@ inline double timeToMS(double hour, double min, double sec, double ms)
@@ -2375,7 +2375,7 @@ index 07ddf3854633cb5e4ca9679359c048f13395e4ab..a0be72ba35e7afa09e8ea5976ebf600b
  WTF_EXPORT_PRIVATE LocalTimeOffset calculateLocalTimeOffset(double utcInMilliseconds, TimeType = UTCTime);
  
 diff --git a/Source/WTF/wtf/PlatformEnable.h b/Source/WTF/wtf/PlatformEnable.h
-index 411354f6c11f941d73d35c62aadd0da73ec4a5d3..853d4131e0b698465f3179a548e7653caaa5f435 100644
+index 3550d41b452a9ca149a15ac00f5ef053893108bb..88260d1a36d0e4f62c45c7b61f2e2f953ae79693 100644
 --- a/Source/WTF/wtf/PlatformEnable.h
 +++ b/Source/WTF/wtf/PlatformEnable.h
 @@ -416,7 +416,7 @@
@@ -2447,7 +2447,7 @@ index 09d4af604a835c7c6be1e43c249565bd1053aff4..0d6112342480454ce41a6b56dd925e1d
  
  if (Journald_FOUND)
 diff --git a/Source/WebCore/DerivedSources.make b/Source/WebCore/DerivedSources.make
-index 71a8ce7086fa79daa8b751315bf43a443a619afb..fec3566469dc5566641b65421b83010cfacf046f 100644
+index d663c323684d1c0f880fb7cf961fc6fa4216e46c..59352ac981e7b9a8053354badafafa379efef72f 100644
 --- a/Source/WebCore/DerivedSources.make
 +++ b/Source/WebCore/DerivedSources.make
 @@ -976,6 +976,10 @@ JS_BINDING_IDLS := \
@@ -2461,7 +2461,7 @@ index 71a8ce7086fa79daa8b751315bf43a443a619afb..fec3566469dc5566641b65421b83010c
      $(WebCore)/dom/Text.idl \
      $(WebCore)/dom/TextDecoder.idl \
      $(WebCore)/dom/TextDecoderStream.idl \
-@@ -1518,9 +1522,6 @@ JS_BINDING_IDLS := \
+@@ -1519,9 +1523,6 @@ JS_BINDING_IDLS := \
  ADDITIONAL_BINDING_IDLS = \
      DocumentTouch.idl \
      GestureEvent.idl \
@@ -2472,7 +2472,7 @@ index 71a8ce7086fa79daa8b751315bf43a443a619afb..fec3566469dc5566641b65421b83010c
  
  vpath %.in $(WEBKITADDITIONS_HEADER_SEARCH_PATHS)
 diff --git a/Source/WebCore/Modules/geolocation/Geolocation.cpp b/Source/WebCore/Modules/geolocation/Geolocation.cpp
-index cd372f43691add4d7df0c9e52570eaffd2934037..55ee984ef83a06ba7cc47b0d3beee2540587575c 100644
+index a0f3a2f50826db31cf7d6c133e4dfc47bac27528..a09ba013dc815b3f14f67ce799c2edb4bf77134b 100644
 --- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
 +++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
 @@ -371,8 +371,9 @@ bool Geolocation::shouldBlockGeolocationRequests()
@@ -2480,7 +2480,7 @@ index cd372f43691add4d7df0c9e52570eaffd2934037..55ee984ef83a06ba7cc47b0d3beee254
      bool hasMixedContent = !document()->foundMixedContent().isEmpty();
      bool isLocalOrigin = securityOrigin()->isLocal();
 +    bool isPotentiallyTrustworthy = securityOrigin()->isPotentiallyTrustworthy();
-     if (securityOrigin()->canRequestGeolocation()) {
+     if (document()->canAccessResource(ScriptExecutionContext::ResourceType::Geolocation) != ScriptExecutionContext::HasResourceAccess::No) {
 -        if (isLocalOrigin || (isSecure && !hasMixedContent) || isRequestFromIBooks())
 +        if (isLocalOrigin || isPotentiallyTrustworthy || (isSecure && !hasMixedContent) || isRequestFromIBooks())
              return false;
@@ -2562,7 +2562,7 @@ index 2160349b0834db01052c496958b96ce90d700a60..1c28bc44b0ebb19ae49eeae27c707662
 +JSTouchList.cpp
 +// Playwright end
 diff --git a/Source/WebCore/SourcesGTK.txt b/Source/WebCore/SourcesGTK.txt
-index c6386a65d471071f7cc3b401898fb615afd6aa95..291cc59b1014205579ebbd772b840877f92ff3f0 100644
+index 2322e2fd1686832942465614051db738cabfe9e4..d9e3cbe7d54e54b84c4293937b948b4161937574 100644
 --- a/Source/WebCore/SourcesGTK.txt
 +++ b/Source/WebCore/SourcesGTK.txt
 @@ -37,6 +37,9 @@ accessibility/atspi/AccessibilityObjectValueAtspi.cpp
@@ -2575,7 +2575,7 @@ index c6386a65d471071f7cc3b401898fb615afd6aa95..291cc59b1014205579ebbd772b840877
  editing/atspi/FrameSelectionAtspi.cpp
  
  editing/gtk/EditorGtk.cpp
-@@ -132,3 +135,10 @@ platform/xdg/MIMETypeRegistryXdg.cpp
+@@ -134,3 +137,10 @@ platform/xdg/MIMETypeRegistryXdg.cpp
  
  rendering/RenderThemeAdwaita.cpp
  rendering/RenderThemeGtk.cpp
@@ -2587,7 +2587,7 @@ index c6386a65d471071f7cc3b401898fb615afd6aa95..291cc59b1014205579ebbd772b840877
 +JSSpeechSynthesisEventInit.cpp
 +// Playwright: end.
 diff --git a/Source/WebCore/SourcesWPE.txt b/Source/WebCore/SourcesWPE.txt
-index 16d35344a30865a01257d7f9ac544e6131ddce67..88b786dd55afc9edfd4b47e033e8dfbcb770f8a4 100644
+index 3c64bfd9e2a5ed56ffd61f6c0e1a42f78c9e726b..1e01d0a3f3d71021661f9b43238e9c1f5289e7ae 100644
 --- a/Source/WebCore/SourcesWPE.txt
 +++ b/Source/WebCore/SourcesWPE.txt
 @@ -37,11 +37,16 @@ accessibility/atspi/AccessibilityObjectValueAtspi.cpp
@@ -2607,7 +2607,7 @@ index 16d35344a30865a01257d7f9ac544e6131ddce67..88b786dd55afc9edfd4b47e033e8dfbc
  page/linux/ResourceUsageOverlayLinux.cpp
  page/linux/ResourceUsageThreadLinux.cpp
  
-@@ -86,8 +91,19 @@ platform/text/LocaleICU.cpp
+@@ -88,8 +93,19 @@ platform/text/LocaleICU.cpp
  
  platform/unix/LoggingUnix.cpp
  
@@ -2640,10 +2640,10 @@ index c4898d6db6bf06552f602c4b7f0a7267e64e44f4..7cf2e30729671a89c373870c5691d337
  __ZN7WebCore14DocumentLoaderD2Ev
  __ZN7WebCore14DocumentLoader17clearMainResourceEv
 diff --git a/Source/WebCore/WebCore.xcodeproj/project.pbxproj b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff94f802117 100644
+index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b493e865159 100644
 --- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 +++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-@@ -5523,6 +5523,13 @@
+@@ -5525,6 +5525,13 @@
  		EDE3A5000C7A430600956A37 /* ColorMac.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE3A4FF0C7A430600956A37 /* ColorMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		EDEC98030AED7E170059137F /* WebCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEC98020AED7E170059137F /* WebCorePrefix.h */; };
  		EFCC6C8F20FE914400A2321B /* CanvasActivityRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2657,7 +2657,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  		F12171F616A8CF0B000053CA /* WebVTTElement.h in Headers */ = {isa = PBXBuildFile; fileRef = F12171F416A8BC63000053CA /* WebVTTElement.h */; };
  		F32BDCD92363AACA0073B6AE /* UserGestureEmulationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F32BDCD72363AACA0073B6AE /* UserGestureEmulationScope.h */; };
  		F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
-@@ -17842,6 +17849,14 @@
+@@ -17850,6 +17857,14 @@
  		EDEC98020AED7E170059137F /* WebCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCorePrefix.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
  		EFB7287B2124C73D005C2558 /* CanvasActivityRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasActivityRecord.cpp; sourceTree = "<group>"; };
  		EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasActivityRecord.h; sourceTree = "<group>"; };
@@ -2672,7 +2672,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  		F12171F316A8BC63000053CA /* WebVTTElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebVTTElement.cpp; sourceTree = "<group>"; };
  		F12171F416A8BC63000053CA /* WebVTTElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebVTTElement.h; sourceTree = "<group>"; };
  		F32BDCD52363AAC90073B6AE /* UserGestureEmulationScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserGestureEmulationScope.cpp; sourceTree = "<group>"; };
-@@ -24252,7 +24267,12 @@
+@@ -24264,7 +24279,12 @@
  				1AF326770D78B9440068F0C4 /* EditorClient.h */,
  				E36D701E27B71F04006531B7 /* EmptyAttachmentElementClient.h */,
  				93C09A800B064F00005ABD4D /* EventHandler.cpp */,
@@ -2685,7 +2685,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  				E0FEF371B27C53EAC1C1FBEE /* EventSource.cpp */,
  				E0FEF371B17C53EAC1C1FBEE /* EventSource.h */,
  				E0FEF371B07C53EAC1C1FBEE /* EventSource.idl */,
-@@ -30245,6 +30265,8 @@
+@@ -30257,6 +30277,8 @@
  				29E4D8DF16B0940F00C84704 /* PlatformSpeechSynthesizer.h */,
  				1AD8F81A11CAB9E900E93E54 /* PlatformStrategies.cpp */,
  				1AD8F81911CAB9E900E93E54 /* PlatformStrategies.h */,
@@ -2694,7 +2694,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  				0FD7C21D23CE41E30096D102 /* PlatformWheelEvent.cpp */,
  				935C476A09AC4D4F00A6AAB4 /* PlatformWheelEvent.h */,
  				BCBB8AB513F1AFB000734DF0 /* PODInterval.h */,
-@@ -32571,6 +32593,7 @@
+@@ -32585,6 +32607,7 @@
  				BCCFBAE70B5152ED0001F1D7 /* DocumentParser.h */,
  				AD6E71AA1668899D00320C13 /* DocumentSharedObjectPool.cpp */,
  				AD6E71AB1668899D00320C13 /* DocumentSharedObjectPool.h */,
@@ -2702,7 +2702,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  				6BDB5DC1227BD3B800919770 /* DocumentStorageAccess.cpp */,
  				6BDB5DC0227BD3B800919770 /* DocumentStorageAccess.h */,
  				7CE7FA5B1EF882300060C9D6 /* DocumentTouch.cpp */,
-@@ -33580,6 +33603,7 @@
+@@ -33594,6 +33617,7 @@
  				93C4F6EB1108F9A50099D0DB /* AccessibilityScrollbar.h in Headers */,
  				29489FC712C00F0300D83F0F /* AccessibilityScrollView.h in Headers */,
  				0709FC4E1025DEE30059CDBA /* AccessibilitySlider.h in Headers */,
@@ -2710,7 +2710,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  				29D7BCFA1444AF7D0070619C /* AccessibilitySpinButton.h in Headers */,
  				69A6CBAD1C6BE42C00B836E9 /* AccessibilitySVGElement.h in Headers */,
  				AAC08CF315F941FD00F1E188 /* AccessibilitySVGRoot.h in Headers */,
-@@ -35722,6 +35746,7 @@
+@@ -35737,6 +35761,7 @@
  				6E4ABCD5138EA0B70071D291 /* JSHTMLUnknownElement.h in Headers */,
  				E44614170CD6826900FADA75 /* JSHTMLVideoElement.h in Headers */,
  				81BE20D311F4BC3200915DFA /* JSIDBCursor.h in Headers */,
@@ -2718,7 +2718,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  				7C3D8EF01E0B21430023B084 /* JSIDBCursorDirection.h in Headers */,
  				C585A68311D4FB08004C3E4B /* JSIDBDatabase.h in Headers */,
  				C585A69711D4FB13004C3E4B /* JSIDBFactory.h in Headers */,
-@@ -36843,6 +36868,7 @@
+@@ -36858,6 +36883,7 @@
  				0F7D07331884C56C00B4AF86 /* PlatformTextTrack.h in Headers */,
  				074E82BB18A69F0E007EF54C /* PlatformTimeRanges.h in Headers */,
  				CDD08ABD277E542600EA3755 /* PlatformTrackConfiguration.h in Headers */,
@@ -2726,7 +2726,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  				CD1F9B022700323D00617EB6 /* PlatformVideoColorPrimaries.h in Headers */,
  				CD1F9B01270020B700617EB6 /* PlatformVideoColorSpace.h in Headers */,
  				CD1F9B032700323D00617EB6 /* PlatformVideoMatrixCoefficients.h in Headers */,
-@@ -38936,6 +38962,7 @@
+@@ -38952,6 +38978,7 @@
  				1ABA76CA11D20E50004C201C /* CSSPropertyNames.cpp in Sources */,
  				2D22830323A8470700364B7E /* CursorMac.mm in Sources */,
  				5CBD59592280E926002B22AA /* CustomHeaderFields.cpp in Sources */,
@@ -2734,7 +2734,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  				7CE6CBFD187F394900D46BF5 /* FormatConverter.cpp in Sources */,
  				5130F2F624AEA60A00E1D0A0 /* GameControllerSoftLink.mm in Sources */,
  				51A4BB0A1954D61600FA5C2E /* Gamepad.cpp in Sources */,
-@@ -39012,6 +39039,7 @@
+@@ -39028,6 +39055,7 @@
  				C1692DD223D23ABD006E88F7 /* SystemBattery.mm in Sources */,
  				CE88EE262414467B007F29C2 /* TextAlternativeWithRange.mm in Sources */,
  				51DF6D800B92A18E00C2DC85 /* ThreadCheck.mm in Sources */,
@@ -2742,7 +2742,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  				538EC8031F96AF81004D22A8 /* UnifiedSource1-mm.mm in Sources */,
  				538EC8021F96AF81004D22A8 /* UnifiedSource1.cpp in Sources */,
  				538EC8051F96AF81004D22A8 /* UnifiedSource2-mm.mm in Sources */,
-@@ -39060,6 +39088,7 @@
+@@ -39076,6 +39104,7 @@
  				538EC8881F993F9C004D22A8 /* UnifiedSource23.cpp in Sources */,
  				DE5F85801FA1ABF4006DB63A /* UnifiedSource24-mm.mm in Sources */,
  				538EC8891F993F9D004D22A8 /* UnifiedSource24.cpp in Sources */,
@@ -2750,7 +2750,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  				DE5F85811FA1ABF4006DB63A /* UnifiedSource25-mm.mm in Sources */,
  				538EC88A1F993F9D004D22A8 /* UnifiedSource25.cpp in Sources */,
  				DE5F85821FA1ABF4006DB63A /* UnifiedSource26-mm.mm in Sources */,
-@@ -39592,6 +39621,7 @@
+@@ -39608,6 +39637,7 @@
  				2D8B92F1203D13E1009C868F /* UnifiedSource516.cpp in Sources */,
  				2D8B92F2203D13E1009C868F /* UnifiedSource517.cpp in Sources */,
  				2D8B92F3203D13E1009C868F /* UnifiedSource518.cpp in Sources */,
@@ -2759,7 +2759,7 @@ index f978f52fde6df80de39a34adb6535a4202743240..22f76c7f990652193c4bc9cb3f4faff9
  				2D8B92F5203D13E1009C868F /* UnifiedSource520.cpp in Sources */,
  				2D8B92F6203D13E1009C868F /* UnifiedSource521.cpp in Sources */,
 diff --git a/Source/WebCore/accessibility/AccessibilityObject.cpp b/Source/WebCore/accessibility/AccessibilityObject.cpp
-index 8081e9adc499d8e314c69a0e31fd04fc4e5bdc7b..1c2e7cfe4d4d6717710cf1312f69f154664f3294 100644
+index 89e192d3c8a2dbe6f8cdbb4baeccd43de9317645..920e80b2e91df98398f3a9151eaddcd35d44198a 100644
 --- a/Source/WebCore/accessibility/AccessibilityObject.cpp
 +++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
 @@ -61,6 +61,7 @@
@@ -2770,7 +2770,7 @@ index 8081e9adc499d8e314c69a0e31fd04fc4e5bdc7b..1c2e7cfe4d4d6717710cf1312f69f154
  #include "LocalizedStrings.h"
  #include "MathMLNames.h"
  #include "NodeList.h"
-@@ -3708,9 +3709,14 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
+@@ -3710,9 +3711,14 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
      if (roleValue() == AccessibilityRole::ApplicationDialog)
          return AccessibilityObjectInclusion::IncludeObject;
  
@@ -2788,7 +2788,7 @@ index 8081e9adc499d8e314c69a0e31fd04fc4e5bdc7b..1c2e7cfe4d4d6717710cf1312f69f154
  {
      AXComputedObjectAttributeCache* attributeCache = nullptr;
 diff --git a/Source/WebCore/accessibility/AccessibilityObjectInterface.h b/Source/WebCore/accessibility/AccessibilityObjectInterface.h
-index 9745720d2af33481ae6ed33723d08b06ee0d97f7..35269a4daca7bd541321426b272c223505bfb35f 100644
+index ee0ccd5818f8912fb83fb10a02dba47036b3798f..35cef177c5e71ce3f152f66abbaaf93635695f07 100644
 --- a/Source/WebCore/accessibility/AccessibilityObjectInterface.h
 +++ b/Source/WebCore/accessibility/AccessibilityObjectInterface.h
 @@ -57,7 +57,7 @@ typedef const struct __AXTextMarkerRange* AXTextMarkerRangeRef;
@@ -2945,7 +2945,7 @@ index 6c87e4f8941abc8da9829833a9275975ddc2c96d..0119365699fe02326102de0cf1aea741
      if (!value)
          return userPrefersReducedMotion;
 diff --git a/Source/WebCore/dom/DataTransfer.cpp b/Source/WebCore/dom/DataTransfer.cpp
-index acaf08cbd1585893d268af9ccbeab346c00a9365..31e458d7dc73de7ea1683f6b0cba1cb57c36f956 100644
+index 0ed2bed9623204f9a0beb9fcb15a10dd7e5d8f39..b98885f72147fdd3d5226028beba4668777584ed 100644
 --- a/Source/WebCore/dom/DataTransfer.cpp
 +++ b/Source/WebCore/dom/DataTransfer.cpp
 @@ -494,6 +494,14 @@ Ref<DataTransfer> DataTransfer::createForDrag(const Document& document)
@@ -3619,7 +3619,7 @@ index 51badf49a6ce08975d655efa01cca9cd877e8f6b..ea4240cf72670cedfbd8b38d4d013676
  {
      return context ? instrumentingAgents(*context) : nullptr;
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
-index d389ec07ae87bc95b56809e8db8259088e052a06..bfe286f6638ad8417dfa22310ef70a68093e9782 100644
+index 5766244e85d627eea7ab1ccd5d6a6d3688f2be7e..628b102d13b184a8395e387db741e4f9ea5973e1 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 @@ -62,12 +62,16 @@
@@ -3673,7 +3673,7 @@ index d389ec07ae87bc95b56809e8db8259088e052a06..bfe286f6638ad8417dfa22310ef70a68
  }
  
  static bool parseQuad(Ref<JSON::Array>&& quadArray, FloatQuad* quad)
-@@ -451,6 +458,20 @@ Node* InspectorDOMAgent::assertNode(Protocol::ErrorString& errorString, Protocol
+@@ -417,6 +424,20 @@ Node* InspectorDOMAgent::assertNode(Protocol::ErrorString& errorString, Protocol
      return node;
  }
  
@@ -3694,7 +3694,7 @@ index d389ec07ae87bc95b56809e8db8259088e052a06..bfe286f6638ad8417dfa22310ef70a68
  Document* InspectorDOMAgent::assertDocument(Protocol::ErrorString& errorString, Protocol::DOM::NodeId nodeId)
  {
      Node* node = assertNode(errorString, nodeId);
-@@ -1437,16 +1458,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(Ref<JSON::Obj
+@@ -1403,16 +1424,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(Ref<JSON::Obj
  Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNode(Ref<JSON::Object>&& highlightInspectorObject, std::optional<Protocol::DOM::NodeId>&& nodeId, const Protocol::Runtime::RemoteObjectId& objectId)
  {
      Protocol::ErrorString errorString;
@@ -3712,7 +3712,7 @@ index d389ec07ae87bc95b56809e8db8259088e052a06..bfe286f6638ad8417dfa22310ef70a68
      if (!node)
          return makeUnexpected(errorString);
  
-@@ -1684,15 +1696,136 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Protocol::DOM:
+@@ -1650,15 +1662,136 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Protocol::DOM:
      return { };
  }
  
@@ -3853,7 +3853,7 @@ index d389ec07ae87bc95b56809e8db8259088e052a06..bfe286f6638ad8417dfa22310ef70a68
      if (!object)
          return makeUnexpected("Missing injected script for given nodeId"_s);
  
-@@ -2952,7 +3085,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPath
+@@ -2897,7 +3030,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPath
      return makeUnexpected("Missing node for given path"_s);
  }
  
@@ -3862,7 +3862,7 @@ index d389ec07ae87bc95b56809e8db8259088e052a06..bfe286f6638ad8417dfa22310ef70a68
  {
      Document* document = &node->document();
      if (auto* templateHost = document->templateDocumentHost())
-@@ -2961,12 +3094,18 @@ RefPtr<Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* nod
+@@ -2906,12 +3039,18 @@ RefPtr<Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* nod
      if (!frame)
          return nullptr;
  
@@ -3884,7 +3884,7 @@ index d389ec07ae87bc95b56809e8db8259088e052a06..bfe286f6638ad8417dfa22310ef70a68
  }
  
  Node* InspectorDOMAgent::scriptValueAsNode(JSC::JSValue value)
-@@ -2989,4 +3128,57 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowT
+@@ -2934,4 +3073,57 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowT
      return { };
  }
  
@@ -3943,7 +3943,7 @@ index d389ec07ae87bc95b56809e8db8259088e052a06..bfe286f6638ad8417dfa22310ef70a68
 +
  } // namespace WebCore
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.h b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
-index 2d073147ff54937b4ea0ce3f8ea3af61ad9761c4..373ea5f0205a7bb7ec2cac6c1aca8e663226f2e3 100644
+index 12dc38a0bb33578e0c468c690b4ae6d77f0cd1e6..8402d34f8099fa040e5ebdefc217b06054733054 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
 @@ -57,6 +57,7 @@ namespace WebCore {
@@ -4007,7 +4007,7 @@ index 2d073147ff54937b4ea0ce3f8ea3af61ad9761c4..373ea5f0205a7bb7ec2cac6c1aca8e66
  private:
  #if ENABLE(VIDEO)
      void mediaMetricsTimerFired();
-@@ -246,7 +255,6 @@ private:
+@@ -245,7 +254,6 @@ private:
      void processAccessibilityChildren(AXCoreObject&, JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>&);
      
      Node* nodeForPath(const String& path);
@@ -5487,7 +5487,7 @@ index fe1cc2dbb9863cd4480476d2e21a5a229dc8a0e8..35dd7ca4cabe0d0ec76d44e260870a99
  
  void InspectorWorkerAgent::disconnectFromWorkerInspectorProxy(WorkerInspectorProxy& proxy)
 diff --git a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
-index 3dd1baf1e375db6058f32dfe7fac5723bcf7eb40..dd493b99dbcbc4b0850245d5b1fa04d3dd27ea8d 100644
+index 31ca79d6410560456c89a5be62560fc33e082cee..4a1e4dbc2ff3c13761014ae614ebf4b7199dbdcd 100644
 --- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
 +++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
 @@ -38,6 +38,7 @@
@@ -5649,7 +5649,7 @@ index 982691dd2dfe2f65201370a12302b5086703c126..4af72beb3b1405ffac78e89e7fbb2b14
  protected:
      static SameSiteInfo sameSiteInfo(const Document&, IsForDOMCookieAccess = IsForDOMCookieAccess::No);
 diff --git a/Source/WebCore/loader/DocumentLoader.cpp b/Source/WebCore/loader/DocumentLoader.cpp
-index fd9e36c475452f6f963aa25d96fffc6defc1dce2..9e5daf8d8ca46b3716852f02a0b654df962bcf35 100644
+index 55682d0e47cf8aae77f4978341793a35d5540ac1..9f077ab8b27db67a815654be529dfefc0b098a0b 100644
 --- a/Source/WebCore/loader/DocumentLoader.cpp
 +++ b/Source/WebCore/loader/DocumentLoader.cpp
 @@ -1488,8 +1488,6 @@ void DocumentLoader::detachFromFrame()
@@ -6502,7 +6502,7 @@ index c86fe59e30404cd959e08aeaed640558a8abc56e..a44553efaaac5022cd17dd12092e9b2f
  
      ViewportArguments m_viewportArguments;
 diff --git a/Source/WebCore/page/FrameSnapshotting.cpp b/Source/WebCore/page/FrameSnapshotting.cpp
-index 5d2876a5dfda5d65efc29ad8004da9c0317ff54b..24dc3ff8792d18f0e011674133a3a718b5484307 100644
+index 0b4b556d9714e0bc2a56e09c0b829776ff509e67..12a22d69154f09ecbb60ffe71997c2ec243c1112 100644
 --- a/Source/WebCore/page/FrameSnapshotting.cpp
 +++ b/Source/WebCore/page/FrameSnapshotting.cpp
 @@ -106,7 +106,7 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(Frame& frame, const IntRect& image
@@ -6515,7 +6515,7 @@ index 5d2876a5dfda5d65efc29ad8004da9c0317ff54b..24dc3ff8792d18f0e011674133a3a718
      if (frame.page()->delegatesScaling())
          scaleFactor *= frame.page()->pageScaleFactor();
 @@ -117,7 +117,12 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(Frame& frame, const IntRect& image
-     auto buffer = ImageBuffer::create(imageRect.size(), RenderingMode::Unaccelerated, scaleFactor, options.colorSpace, options.pixelFormat);
+     auto buffer = ImageBuffer::create(imageRect.size(), RenderingPurpose::Unspecified, scaleFactor, options.colorSpace, options.pixelFormat);
      if (!buffer)
          return nullptr;
 +#if !PLATFORM(MAC)
@@ -6572,7 +6572,7 @@ index a782c3be51ca113a52482c5a10583c8fa64724ef..1d82dff81be5c5492efb3bfe77d2f259
      if (stateObjectType == StateObjectType::Push) {
          frame->loader().history().pushState(WTFMove(data), title, fullURL.string());
 diff --git a/Source/WebCore/page/Page.cpp b/Source/WebCore/page/Page.cpp
-index e0ee73790f0b64c7b0582cfc8a4b934ffe8005d0..ad880a862daaf50055c8955970997ba4588cb770 100644
+index 5d3f68042e72f27f95d56a5be5907d405f05a04f..4df2e553f58ea69de2118865655a3daed7bd5602 100644
 --- a/Source/WebCore/page/Page.cpp
 +++ b/Source/WebCore/page/Page.cpp
 @@ -488,6 +488,37 @@ void Page::setOverrideViewportArguments(const std::optional<ViewportArguments>&
@@ -6831,7 +6831,7 @@ index 7ac11c8289347e3a2f3e7316cf9e32932b9544ed..764b2d4fe36ac2e5588bd22595424ac1
  }
  
 diff --git a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
-index 0d8a9c765246d5702758ce9f1e6e79a2ff964b1f..a8d6b7ecab8b137718504ce32dad390a678ef023 100644
+index 9f20887ff6d2b12934bb2822953520671d10c903..bd3cf5ff391c7934260a4b148871033e077dfbc2 100644
 --- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
 +++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
 @@ -298,6 +298,8 @@ bool ContentSecurityPolicy::allowContentSecurityPolicySourceStarToMatchAnyProtoc
@@ -7445,7 +7445,7 @@ index 6d6820fc22f9a7102bbdad6c4b5e3e7e9645f66c..f44797b8c197bf1b3daaa9b59dad2a8e
          // Determine the string for this item.
          const UChar* str = cp + items[i].iCharPos;
 diff --git a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
-index c017f21fbd84f2b842e01f248cc440723cb1aab8..8eb4204454a3d48a2ba7c5cc10ee1fb234c01a2a 100644
+index dd5fb8634277baea92be6ecaf6d2fbc7ce7ee9f0..9aa9e4d923d487cd4003e7396ebe61c7df51057d 100644
 --- a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
 +++ b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
 @@ -37,8 +37,10 @@
@@ -7861,7 +7861,7 @@ index ae439e30f1fb239d18e1164e8896dfb272c75673..93bbf2bdfc99df151c9b82df07eb5a07
  
  #endif // USE(LIBWPE)
 diff --git a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
-index 843231d3b58a02fd9d93d3a37b86997be56d0f30..01a2775d31801cdf6a404bfb9f321bb7a64b0464 100644
+index a724f126f8f389d46ba5c1a941eef76fdc59c94c..aa40f6c3ee81213074639cce1d18eb21c6e204f4 100644
 --- a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
 +++ b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
 @@ -30,8 +30,10 @@
@@ -8123,10 +8123,10 @@ index 843231d3b58a02fd9d93d3a37b86997be56d0f30..01a2775d31801cdf6a404bfb9f321bb7
  {
      switch (val) {
 diff --git a/Source/WebCore/platform/network/HTTPHeaderMap.cpp b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
-index bd516cf6c65f2db40518f0cd1d7e97e8f74e3850..8ef0703e518cac2b7c45b534115038b883ed48a3 100644
+index f169677e661510b225b899c79b68d040179a097a..420e101c7bb7a49b5c644076a8a2ffab2282d758 100644
 --- a/Source/WebCore/platform/network/HTTPHeaderMap.cpp
 +++ b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
-@@ -214,8 +214,11 @@ void HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
+@@ -229,8 +229,11 @@ void HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
      auto index = m_commonHeaders.findIf([&](auto& header) {
          return header.key == name;
      });
@@ -8153,10 +8153,10 @@ index 3309945bd49a690a65f73ec3ed3d7b245ac0272d..603d36fbf22900b4e9ee0b9b43baab48
      WEBCORE_EXPORT void setCookie(const Cookie&);
      WEBCORE_EXPORT void setCookies(const Vector<Cookie>&, const URL&, const URL& mainDocumentURL);
 diff --git a/Source/WebCore/platform/network/ResourceResponseBase.h b/Source/WebCore/platform/network/ResourceResponseBase.h
-index 262e53180d6dd7c4d133ddc1daf5652bd6f31c76..d09aed9c9c58afe3c2040e1d5d683374365e65f8 100644
+index 93827d309ca9293486a3eccbe3e0c5ab54943900..27ed848fbdf042caa31d0a6228ece0628ba0cb57 100644
 --- a/Source/WebCore/platform/network/ResourceResponseBase.h
 +++ b/Source/WebCore/platform/network/ResourceResponseBase.h
-@@ -221,6 +221,8 @@ public:
+@@ -223,6 +223,8 @@ public:
  
      WEBCORE_EXPORT static ResourceResponse dataURLResponse(const URL&, const DataURLDecoder::Result&);
  
@@ -8165,7 +8165,7 @@ index 262e53180d6dd7c4d133ddc1daf5652bd6f31c76..d09aed9c9c58afe3c2040e1d5d683374
  protected:
      enum InitLevel {
          Uninitialized,
-@@ -300,6 +302,7 @@ void ResourceResponseBase::encode(Encoder& encoder) const
+@@ -302,6 +304,7 @@ void ResourceResponseBase::encode(Encoder& encoder) const
      encoder << m_httpStatusText;
      encoder << m_httpVersion;
      encoder << m_httpHeaderFields;
@@ -8173,7 +8173,7 @@ index 262e53180d6dd7c4d133ddc1daf5652bd6f31c76..d09aed9c9c58afe3c2040e1d5d683374
  
      // We don't want to put the networkLoadMetrics info
      // into the disk cache, because we will never use the old info.
-@@ -372,6 +375,12 @@ bool ResourceResponseBase::decode(Decoder& decoder, ResourceResponseBase& respon
+@@ -374,6 +377,12 @@ bool ResourceResponseBase::decode(Decoder& decoder, ResourceResponseBase& respon
          return false;
      response.m_httpHeaderFields = WTFMove(*httpHeaderFields);
  
@@ -8307,7 +8307,7 @@ index 0c39c90aac884fca48849388acc1b42bad16d620..dd8e50686c348b46d5ae92fd67a31eb0
      void send(CurlStreamID, UniqueArray<uint8_t>&&, size_t);
  
 diff --git a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
-index 4f89d973ec911a5d909ddd7e2eba97a5d4fbcb0f..7f8dc398efe49c57f82d36582f780e9d710e218c 100644
+index a3be8be8329320a56fae4205fa9ba9ec38ec8580..ca1d7d1b7bbd8686b0c5458b25e0f82c3ae06c22 100644
 --- a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
 +++ b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
 @@ -118,6 +118,12 @@ void NetworkStorageSession::setCookieAcceptPolicy(CookieAcceptPolicy policy) con
@@ -8368,7 +8368,7 @@ index a8f57a72d0eacca7755be84fcaa1c9bf10958c0b..a5d67b8016a86b9184ded0904e317048
  
  SocketStreamHandleImpl::~SocketStreamHandleImpl()
 diff --git a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
-index a8d2370648d2468812ce5b6f9539aab0962e86bc..8a95ec2369e20777f2db828406a2d193c2516fc5 100644
+index 6e0a3dc7ac5adf22f553f81113633a135ae9271c..16e629a1489bede4f3266253c11077b82524e576 100644
 --- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
 +++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
 @@ -410,6 +410,30 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
@@ -8403,7 +8403,7 @@ index a8d2370648d2468812ce5b6f9539aab0962e86bc..8a95ec2369e20777f2db828406a2d193
  {
      GUniquePtr<SoupCookie> targetCookie(cookie.toSoupCookie());
 diff --git a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
-index 4093537da5579db54326cc88b54e4ab17a2e22e3..0beae7659ed600fc9900d758884c1d70c86bd53e 100644
+index efb4c51f667e2030b0dd119b48542f50d660ede3..af8f59b3084e1721bcac3ad8ff39fe59fb98770b 100644
 --- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
 +++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
 @@ -38,6 +38,7 @@
@@ -8475,7 +8475,7 @@ index 05a0d1256a136982507b732c7852bbece201b513..f2c00eca40fbf3a88780610228f60ba6
  
  bool PlatformKeyboardEvent::currentCapsLockState()
 diff --git a/Source/WebCore/platform/win/PasteboardWin.cpp b/Source/WebCore/platform/win/PasteboardWin.cpp
-index 6685ed9936469fd0a43fbe2412bbc38bcff8d56d..59af3a6654e569eb5e8ab7592c64292a25ba8262 100644
+index 4ce328a831c90bf6bd228e1f072408d64b33a45e..d46934eaaf3b12bf40d2f09d68f1aef9eaf79eab 100644
 --- a/Source/WebCore/platform/win/PasteboardWin.cpp
 +++ b/Source/WebCore/platform/win/PasteboardWin.cpp
 @@ -1130,7 +1130,21 @@ void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
@@ -8994,7 +8994,7 @@ index fac9402820702989bf72ed2425678bfb82bd6523..40b5a6441d22714fd370ce1a7c2f534e
      int innerLineHeight() const override;
  #endif
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
-index e4ea03c11b6bb3ffe3f80d2f3b78fb9a398c56a0..4007429dcd3cabf4c69b8f38f35863d0384d4b08 100644
+index 61a609b6f9394d53f610c7e9673ada3f1e5da0de..7f317fb6da663e64ea935fb4567613315e567aa4 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 @@ -83,6 +83,11 @@
@@ -9062,7 +9062,7 @@ index a2629e4edb214b3d26aca78da845c65d0e5aa341..d034f3a57badda1f34729afd712db7cd
      RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
      LogUserInteraction(WebCore::RegistrableDomain domain)
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.cpp b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
-index 29c75f80478b5f9158da8cf8aa333e86edf47c5a..601cc36264d368f9b99d8119e335ae0bf19ac055 100644
+index 6a875f40242194fa92c689d74d1d42caf936371d..cb6bd6b5449f58c219cd993df9e968725b0191c7 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 @@ -26,7 +26,6 @@
@@ -9073,7 +9073,7 @@ index 29c75f80478b5f9158da8cf8aa333e86edf47c5a..601cc36264d368f9b99d8119e335ae0b
  #include "ArgumentCoders.h"
  #include "Attachment.h"
  #include "AuthenticationManager.h"
-@@ -529,6 +528,41 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID)
+@@ -528,6 +527,41 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID)
      m_sessionsControlledByAutomation.remove(sessionID);
  }
  
@@ -9148,10 +9148,10 @@ index 8e92fc2c135714a16dfbc635c753931a64baa9ef..b75b3dbc7a16e4e55246421d22abe477
      void clearPrevalentResource(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);
      void clearUserInteraction(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
-index 45e7559e6cfab2bc14d0c5918040ce4483448872..71470c682d422cee2ce12a4e56dfc938e4008d4f 100644
+index 531bcbc355cfdf51d0b49048c2149d7038dcf15b..f76ad4d2308d95366e7ad74bdf3848f354c513de 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
-@@ -80,6 +80,11 @@ messages -> NetworkProcess LegacyReceiver {
+@@ -77,6 +77,11 @@ messages -> NetworkProcess LegacyReceiver {
  
      PreconnectTo(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier webPageID, URL url, String userAgent, enum:uint8_t WebCore::StoredCredentialsPolicy storedCredentialsPolicy, enum:bool std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, enum:bool WebKit::LastNavigationWasAppInitiated lastNavigationWasAppInitiated);
  
@@ -9267,7 +9267,7 @@ index f57a72b6bdc3382469d69adb1b1201c7a9f07a84..c501211b094312ca44f0bf92de5d6ebc
      void clear();
  
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-index 33816a8d3bd885f98d12c4934bea6af69d85a125..182fb89472e7fe85e3040fc243782a1431e5b02b 100644
+index efd2b139a5888164ae385885910928742308f626..0eacda494b0177370d7d883f2942e19043c7e104 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 @@ -720,7 +720,7 @@ void NetworkSessionCocoa::setClientAuditToken(const WebCore::AuthenticationChall
@@ -9469,7 +9469,7 @@ index e55864a95f7bcbc085c46628bff058573573286c..d82268c1877a29e3e9e848185e4df4e7
  
      WebCore::ShouldRelaxThirdPartyCookieBlocking m_shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
 diff --git a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
-index e67f7ed29bc52eac926fea756e7a58af5cc61a57..a240fafe24d726385dcb5cbe92e36978eb787683 100644
+index 309dac079dd287b841a820173b574c758e509f69..da2d6af7d58c53cbe15a7786bda14c17dcb8bcb1 100644
 --- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 +++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 @@ -494,6 +494,8 @@ void NetworkDataTaskSoup::didSendRequest(GRefPtr<GInputStream>&& inputStream)
@@ -9586,7 +9586,7 @@ index bc06eb37854c1ec72b30568e95dba6ef60c132a4..7b8fd54b740c828be204d4fedba0286f
      }
      return makeUnique<WebSocketTask>(channel, request, soupSession(), soupMessage.get(), protocol);
 diff --git a/Source/WebKit/PlatformGTK.cmake b/Source/WebKit/PlatformGTK.cmake
-index 5e0683eab256821c17ac8a338de83fdcc21d4e56..3e3e3d214b3a867e0a8dfe0fdfc058ba124e7eef 100644
+index 505c95d1310f142dd311d8151468d02ac71a73ed..0038a0608e9fa380ecafc2c236128bbd02213b57 100644
 --- a/Source/WebKit/PlatformGTK.cmake
 +++ b/Source/WebKit/PlatformGTK.cmake
 @@ -476,6 +476,9 @@ list(APPEND WebKit_SYSTEM_INCLUDE_DIRECTORIES
@@ -9857,7 +9857,7 @@ index f2f3979fcac9dfd97d0e0ead600fe35eb8defd40..ac91412e1a96bdf521b1890a66e465dc
      NSEvent* nativeEvent() const { return m_nativeEvent.get(); }
  #elif PLATFORM(GTK)
 diff --git a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
-index 409e98105e7e12593aa3402d5d97fb813d10ce72..c5e69f9c2e695cf80ff4ff8587d3b6e263b18a13 100644
+index f748bdf373618083eadc95bf8a6bb32b637b0bad..6ed8e9f6775a658940e1bcbeffb686a6b49f7de8 100644
 --- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 +++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
 @@ -122,6 +122,10 @@
@@ -10405,7 +10405,7 @@ index 0000000000000000000000000000000000000000..789a0d7cf69704c8f665a9ed79348fbc
 +
 +} // namespace IPC
 diff --git a/Source/WebKit/Shared/win/WebEventFactory.cpp b/Source/WebKit/Shared/win/WebEventFactory.cpp
-index 0fb307c6647ff86eb1c068bc06c6b1a0b32c5770..c8f0be7050fffcf32abd6b5db2cd84afecd0304c 100644
+index 90df093a49c09dc670dfea55077c77d889dd1c1b..6ffd51532e29b941b8dc10f545b7f5b81e9407b4 100644
 --- a/Source/WebKit/Shared/win/WebEventFactory.cpp
 +++ b/Source/WebKit/Shared/win/WebEventFactory.cpp
 @@ -473,7 +473,7 @@ WebKeyboardEvent WebEventFactory::createWebKeyboardEvent(HWND hwnd, UINT message
@@ -10418,10 +10418,10 @@ index 0fb307c6647ff86eb1c068bc06c6b1a0b32c5770..c8f0be7050fffcf32abd6b5db2cd84af
      return WebTouchEvent();
  }
 diff --git a/Source/WebKit/Sources.txt b/Source/WebKit/Sources.txt
-index bec1a3f134e2dd3923612752a89d881579e20f84..70b02cf6e97779d1f0ca261edc59b2759512c30b 100644
+index 3ddb0631e102191c775390b5237d78bc0d02322e..150d4674eb1806a9601f3c29b15a0199d3867f27 100644
 --- a/Source/WebKit/Sources.txt
 +++ b/Source/WebKit/Sources.txt
-@@ -402,11 +402,14 @@ Shared/XR/XRDeviceProxy.cpp
+@@ -401,11 +401,14 @@ Shared/XR/XRDeviceProxy.cpp
  
  UIProcess/AuxiliaryProcessProxy.cpp
  UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -10436,7 +10436,7 @@ index bec1a3f134e2dd3923612752a89d881579e20f84..70b02cf6e97779d1f0ca261edc59b275
  UIProcess/LegacyGlobalSettings.cpp
  UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
  UIProcess/MediaKeySystemPermissionRequestProxy.cpp
-@@ -415,6 +418,7 @@ UIProcess/PageLoadState.cpp
+@@ -414,6 +417,7 @@ UIProcess/PageLoadState.cpp
  UIProcess/ProcessAssertion.cpp
  UIProcess/ProcessThrottler.cpp
  UIProcess/ProvisionalPageProxy.cpp
@@ -10444,7 +10444,7 @@ index bec1a3f134e2dd3923612752a89d881579e20f84..70b02cf6e97779d1f0ca261edc59b275
  UIProcess/ResponsivenessTimer.cpp
  UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
  UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
-@@ -457,6 +461,8 @@ UIProcess/WebOpenPanelResultListenerProxy.cpp
+@@ -456,6 +460,8 @@ UIProcess/WebOpenPanelResultListenerProxy.cpp
  UIProcess/WebPageDiagnosticLoggingClient.cpp
  UIProcess/WebPageGroup.cpp
  UIProcess/WebPageInjectedBundleClient.cpp
@@ -10453,7 +10453,7 @@ index bec1a3f134e2dd3923612752a89d881579e20f84..70b02cf6e97779d1f0ca261edc59b275
  UIProcess/WebPageProxy.cpp
  UIProcess/WebPasteboardProxy.cpp
  UIProcess/WebPreferences.cpp
-@@ -580,7 +586,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
+@@ -579,7 +585,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
  UIProcess/Inspector/WebPageDebuggable.cpp
  UIProcess/Inspector/WebPageInspectorController.cpp
  
@@ -10683,7 +10683,7 @@ index 026121d114c5fcad84c1396be8d692625beaa3bd..edd6e5cae033124c589959a42522fde0
  }
  #endif
 diff --git a/Source/WebKit/UIProcess/API/C/WKPage.cpp b/Source/WebKit/UIProcess/API/C/WKPage.cpp
-index 5ebc5b8a749bfecb4cb527c5d42c8c958f673f88..3a5174565b28ea03a327c59f828f624cf8975cb0 100644
+index 2d2ca701c9092613f96c7ab102fe2a2f224d8e65..2358414be2644a4157723a8b0f69ba47d78a19d0 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
 +++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
 @@ -1762,6 +1762,13 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
@@ -10800,7 +10800,7 @@ index afa925f36c29db9c23921298dead9cce737500d6..42d396342acdb6d39830f611df0ee40e
  
  NS_ASSUME_NONNULL_END
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
-index 56a0e0d839928dae812f06cb2828c22365b67ce9..d440e2315481c5a1ec2c73c541c4c9db9ca0b976 100644
+index e09380361479885612f48afadb3c74bae3551161..7a84f8801d3220fc1f852fb280a21c0b1e0d4c2f 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 @@ -46,6 +46,7 @@
@@ -11515,10 +11515,10 @@ index fbab1afe9ca09f5e6a6793f5065f08fc76bfedaf..23f66f4da6229d88271e4b732414088b
  bool webkitWebViewIsScriptDialogRunning(WebKitWebView*, WebKitScriptDialog*);
  String webkitWebViewGetCurrentScriptDialogMessage(WebKitWebView*);
 diff --git a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
-index 0d43178565055539ed8c2f88dedae97ba455bc42..f687eafa80270bebe13297e482ae48ebbd7534c9 100644
+index 5a44624f8d2fc8fb7f8871c97c8ffd3cd73c3b5e..39751c87230dee3e800b8c1c8a54fbe86efc5b3f 100644
 --- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
 +++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
-@@ -251,6 +251,8 @@ void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool
+@@ -252,6 +252,8 @@ void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool
  {
      if (wasEventHandled || event.type() != WebEvent::Type::KeyDown || !event.nativeEvent())
          return;
@@ -11661,7 +11661,7 @@ index 5cd9524252a97d4ea64dfeb22e5a47b55f36c887..45da62b4ffe54d5cfd680dd40cabd6f4
  #include <webkit2/WebKitContextMenu.h>
  #include <webkit2/WebKitContextMenuActions.h>
 diff --git a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
-index 806993ca73a9cce37753d805a9ab9f4cb6bd1a7b..349a21bbc00c419da7c7e65671c2a6b424b9bcdb 100644
+index cfe3689f22c6659ceab3950e40b686e9b97b4254..d2de92105afecd8e1a5ffb6de16965aad74c71a0 100644
 --- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
 +++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
 @@ -32,8 +32,11 @@
@@ -12282,7 +12282,7 @@ index 20b08ac2df75f589bbbe29e2f924c92f33cf2242..2aaa37a18eb31ade4ff8d7fb8b85fee6
          bool webViewRunBeforeUnloadConfirmPanelWithMessageInitiatedByFrameCompletionHandler : 1;
          bool webViewRequestGeolocationPermissionForFrameDecisionHandler : 1;
 diff --git a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
-index f39e16cb046646a6fe37ed3e66de682ae1bac2ad..e9c9c0f5d9fa7e35d7c6ff5341ea0e6dfe7ff78f 100644
+index 1942490889b8be84160087c0f388302fbc6e96fd..eaa42475b1d56aa8980abd972df116b5aa72ba44 100644
 --- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
 @@ -111,6 +111,7 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
@@ -12389,10 +12389,10 @@ index 8c9baa508554d465b2f4d5e29b3a5da021f9c462..4639ffc9e65003eb1329a65aa33feef3
  #if PLATFORM(IOS_FAMILY)
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-index f0c556d1e59feefc963f1405c634bb1204efbfa3..937773e18277a203e46e8b5c73866765da07683f 100644
+index 80857323f9d8f9c38f61a921b7deb844b800f270..3e5a397a2b7c8a76d62d6005eb3bd10fa33dede8 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-@@ -376,7 +376,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
+@@ -387,7 +387,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
      auto screenProperties = WebCore::collectScreenProperties();
      parameters.screenProperties = WTFMove(screenProperties);
  #if PLATFORM(MAC)
@@ -12401,7 +12401,7 @@ index f0c556d1e59feefc963f1405c634bb1204efbfa3..937773e18277a203e46e8b5c73866765
  #endif
      
  #if PLATFORM(IOS)
-@@ -677,8 +677,8 @@ void WebProcessPool::registerNotificationObservers()
+@@ -691,8 +691,8 @@ void WebProcessPool::registerNotificationObservers()
      }];
  
      m_scrollerStyleNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSPreferredScrollerStyleDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
@@ -12427,7 +12427,7 @@ index 9faca6d95cdb198961558ffedf2e2ad8e805e08d..9eedff0802bbc01bc14be458df16ae52
      void saveBackForwardSnapshotForCurrentItem();
      void saveBackForwardSnapshotForItem(WebBackForwardListItem&);
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
-index 066b8b05573bac600d4df41004e622f00fff932c..ce7611ac99b94843107d0e4c424a0ec18b1c1648 100644
+index 015a66840dbc8788bd34d79fd7c3bbe59ced1742..3b1fb22e650e00be247a26c54e52a3b849eb4921 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 @@ -2776,6 +2776,11 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
@@ -16064,7 +16064,7 @@ index 7a14cfba15c103a2d4fe263fa49d25af3c396ec2..3ee0e154349661632799057c71f1d1f1
      BOOL result = ::CreateProcess(0, commandLine.data(), 0, 0, true, 0, 0, 0, &startupInfo, &processInformation);
  
 diff --git a/Source/WebKit/UIProcess/PageClient.h b/Source/WebKit/UIProcess/PageClient.h
-index d9c0f8b85de7452f8e6ea0a82c07a59562e12812..76e21a3090d98170e9e4ab77d5ba196c1942a2b8 100644
+index 35bc45d8c2c7b69ea7de12e6c43942ff1bd12053..a83ba810709466ff402db5a4029ddc6a1b31c42a 100644
 --- a/Source/WebKit/UIProcess/PageClient.h
 +++ b/Source/WebKit/UIProcess/PageClient.h
 @@ -325,6 +325,11 @@ public:
@@ -16080,10 +16080,10 @@ index d9c0f8b85de7452f8e6ea0a82c07a59562e12812..76e21a3090d98170e9e4ab77d5ba196c
      virtual RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) = 0;
  #endif
 diff --git a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
-index 62b85b7263f2a8124444f0fe25cb220220427c8a..dca1d4d6d695f57a610dcbe80463c0234f6823be 100644
+index 88b2ea838672ac71865eb69bcaf5fb22ca00a87f..d4a2bc93269ce1e127d4fe0dbe5cc8fc5bf7d0f3 100644
 --- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
-@@ -629,3 +629,5 @@ bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Option
+@@ -631,3 +631,5 @@ bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Option
  }
  
  } // namespace WebKit
@@ -17097,7 +17097,7 @@ index 0000000000000000000000000000000000000000..48c9ccc420c1b4ae3259e1d5ba17fd8f
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0af94bd42f 100644
+index e68b5922a78dbfd0f7aa564056cd310d34433d07..984ce3203fdbff8c567d47c71ca8dae5c30f9233 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
 @@ -248,6 +248,9 @@
@@ -17410,7 +17410,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
  void WebPageProxy::pluginScaleFactorDidChange(double pluginScaleFactor)
  {
      m_pluginScaleFactor = pluginScaleFactor;
-@@ -4708,6 +4860,7 @@ void WebPageProxy::didDestroyNavigation(uint64_t navigationID)
+@@ -4713,6 +4865,7 @@ void WebPageProxy::didDestroyNavigation(uint64_t navigationID)
          return;
  
      m_navigationState->didDestroyNavigation(navigationID);
@@ -17418,7 +17418,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
  }
  
  void WebPageProxy::didStartProvisionalLoadForFrame(FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, uint64_t navigationID, URL&& url, URL&& unreachableURL, const UserData& userData)
-@@ -4933,6 +5086,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
+@@ -4938,6 +5091,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
  
      m_failingProvisionalLoadURL = { };
  
@@ -17427,7 +17427,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
      // If the provisional page's load fails then we destroy the provisional page.
      if (m_provisionalPage && m_provisionalPage->mainFrame() == &frame && willContinueLoading == WillContinueLoading::No)
          m_provisionalPage = nullptr;
-@@ -5411,7 +5566,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
+@@ -5416,7 +5571,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
      NavigationActionData&& navigationActionData, FrameInfoData&& originatingFrameInfo, std::optional<WebPageProxyIdentifier> originatingPageID, const WebCore::ResourceRequest& originalRequest, WebCore::ResourceRequest&& request,
      IPC::FormDataReference&& requestBody, WebCore::ResourceResponse&& redirectResponse, const UserData& userData, uint64_t listenerID)
  {
@@ -17443,7 +17443,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
  }
  
  void WebPageProxy::decidePolicyForNavigationActionAsyncShared(Ref<WebProcessProxy>&& process, PageIdentifier webPageID, FrameIdentifier frameID, FrameInfoData&& frameInfo,
-@@ -5998,6 +6160,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -6003,6 +6165,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
      if (originatingPage)
          openerAppInitiatedState = originatingPage->lastNavigationWasAppInitiated();
  
@@ -17451,7 +17451,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
      auto completionHandler = [this, protectedThis = Ref { *this }, mainFrameURL, request, reply = WTFMove(reply), privateClickMeasurement = navigationActionData.privateClickMeasurement, openerAppInitiatedState = WTFMove(openerAppInitiatedState)] (RefPtr<WebPageProxy> newPage) mutable {
          if (!newPage) {
              reply(std::nullopt, std::nullopt);
-@@ -6044,6 +6207,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -6049,6 +6212,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
  void WebPageProxy::showPage()
  {
      m_uiClient->showPage(this);
@@ -17459,7 +17459,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
  }
  
  void WebPageProxy::exitFullscreenImmediately()
-@@ -6101,6 +6265,10 @@ void WebPageProxy::closePage()
+@@ -6106,6 +6270,10 @@ void WebPageProxy::closePage()
      if (isClosed())
          return;
  
@@ -17470,7 +17470,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
      WEBPAGEPROXY_RELEASE_LOG(Process, "closePage:");
      pageClient().clearAllEditCommands();
      m_uiClient->close(this);
-@@ -6137,6 +6305,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
+@@ -6142,6 +6310,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
      }
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
@@ -17479,7 +17479,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
          page.m_uiClient->runJavaScriptAlert(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)]() mutable {
              reply();
              completion();
-@@ -6158,6 +6328,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
+@@ -6163,6 +6333,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17488,7 +17488,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptConfirm(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](bool result) mutable {
-@@ -6181,6 +6353,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
+@@ -6186,6 +6358,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17497,7 +17497,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply), defaultValue](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptPrompt(page, message, defaultValue, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](auto& result) mutable {
-@@ -6308,6 +6482,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
+@@ -6313,6 +6487,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
              return;
          }
      }
@@ -17568,7 +17568,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
      if (m_loaderClient)
          handledByClient = reason != ProcessTerminationReason::RequestedByClient && m_loaderClient->processDidCrash(*this);
      else
-@@ -8318,6 +8501,7 @@ static Span<const ASCIILiteral> gpuMachServices()
+@@ -8313,6 +8496,7 @@ static Span<const ASCIILiteral> gpuMachServices()
  
  WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& process, DrawingAreaProxy& drawingArea, RefPtr<API::WebsitePolicies>&& websitePolicies)
  {
@@ -17576,7 +17576,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
      WebPageCreationParameters parameters;
  
      parameters.processDisplayName = configuration().processDisplayName();
-@@ -8510,6 +8694,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
+@@ -8505,6 +8689,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
  
      parameters.httpsUpgradeEnabled = preferences().upgradeKnownHostsToHTTPSEnabled() ? m_configuration->httpsUpgradeEnabled() : false;
  
@@ -17585,7 +17585,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
  #if PLATFORM(IOS)
      // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
      parameters.allowsDeprecatedSynchronousXMLHttpRequestDuringUnload = allowsDeprecatedSynchronousXMLHttpRequestDuringUnload();
-@@ -8578,6 +8764,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
+@@ -8573,6 +8759,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
  
  void WebPageProxy::didReceiveAuthenticationChallengeProxy(Ref<AuthenticationChallengeProxy>&& authenticationChallenge, NegotiatedLegacyTLS negotiatedLegacyTLS)
  {
@@ -17600,7 +17600,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
      if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes) {
          m_navigationClient->shouldAllowLegacyTLS(*this, authenticationChallenge.get(), [this, protectedThis = Ref { *this }, authenticationChallenge] (bool shouldAllowLegacyTLS) {
              if (shouldAllowLegacyTLS)
-@@ -8671,6 +8865,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
+@@ -8666,6 +8860,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
              request->deny();
      };
  
@@ -17617,7 +17617,7 @@ index 9073696a25dc9e915b325d7d6c39df3291e3f9e3..39e01e0bad1fa5a3d572ab68fed6cb0a
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index ad77bb68bf4cb619ce05d08bb8daa40b0801ba1e..79cf97e24132f4490cf616a29eddfadb73866d5f 100644
+index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6fd5d16db 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -39,6 +39,7 @@
@@ -17730,7 +17730,7 @@ index ad77bb68bf4cb619ce05d08bb8daa40b0801ba1e..79cf97e24132f4490cf616a29eddfadb
  #endif
  
      void processDidBecomeUnresponsive();
-@@ -1552,6 +1579,8 @@ public:
+@@ -1551,6 +1578,8 @@ public:
  
  #if PLATFORM(COCOA) || PLATFORM(GTK)
      RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
@@ -17739,7 +17739,7 @@ index ad77bb68bf4cb619ce05d08bb8daa40b0801ba1e..79cf97e24132f4490cf616a29eddfadb
  #endif
  
  #if ENABLE(WEB_CRYPTO)
-@@ -2713,6 +2742,7 @@ private:
+@@ -2712,6 +2741,7 @@ private:
      String m_overrideContentSecurityPolicy;
  
      RefPtr<WebInspectorUIProxy> m_inspector;
@@ -17747,7 +17747,7 @@ index ad77bb68bf4cb619ce05d08bb8daa40b0801ba1e..79cf97e24132f4490cf616a29eddfadb
  
  #if PLATFORM(COCOA)
      WeakObjCPtr<WKWebView> m_cocoaView;
-@@ -2981,6 +3011,20 @@ private:
+@@ -2980,6 +3010,20 @@ private:
      unsigned m_currentDragNumberOfFilesToBeAccepted { 0 };
      WebCore::IntRect m_currentDragCaretRect;
      WebCore::IntRect m_currentDragCaretEditableElementRect;
@@ -17768,7 +17768,7 @@ index ad77bb68bf4cb619ce05d08bb8daa40b0801ba1e..79cf97e24132f4490cf616a29eddfadb
  #endif
  
      PageLoadState m_pageLoadState;
-@@ -3190,6 +3234,9 @@ private:
+@@ -3189,6 +3233,9 @@ private:
          RefPtr<API::Object> messageBody;
      };
      Vector<InjectedBundleMessage> m_pendingInjectedBundleMessages;
@@ -17779,7 +17779,7 @@ index ad77bb68bf4cb619ce05d08bb8daa40b0801ba1e..79cf97e24132f4490cf616a29eddfadb
  #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
      std::unique_ptr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.messages.in b/Source/WebKit/UIProcess/WebPageProxy.messages.in
-index c303bb32184697976b1a15915d03cea76152ab05..de7bb33ba3fc1ca2bab43189cfdf867f5b5e5b39 100644
+index b4e9141624610497f4391f561f381899e04e35be..0debe3077ab40547828f9d611b64f5d0e4624642 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
 +++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
 @@ -29,6 +29,7 @@ messages -> WebPageProxy {
@@ -17814,7 +17814,7 @@ index c303bb32184697976b1a15915d03cea76152ab05..de7bb33ba3fc1ca2bab43189cfdf867f
      DidPerformDragOperation(bool handled)
  #endif
 diff --git a/Source/WebKit/UIProcess/WebProcessPool.cpp b/Source/WebKit/UIProcess/WebProcessPool.cpp
-index 1b2b851e9724ac50fe398f904fb3ec57ae509a05..b5136bb39098f374bac975163cd2d5d06c24758b 100644
+index de5d21d53c67de0c500906fa34c458d4db2e5692..70a79cd88acc3403186f3adf53b7dc4dcc8eba35 100644
 --- a/Source/WebKit/UIProcess/WebProcessPool.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
 @@ -547,6 +547,14 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
@@ -17848,7 +17848,7 @@ index 1b2b851e9724ac50fe398f904fb3ec57ae509a05..b5136bb39098f374bac975163cd2d5d0
      parameters.urlSchemesRegisteredAsEmptyDocument = copyToVector(m_schemesToRegisterAsEmptyDocument);
      parameters.urlSchemesRegisteredAsSecure = copyToVector(LegacyGlobalSettings::singleton().schemesToRegisterAsSecure());
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.cpp b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-index 170450a95ba6e8a49ee5fc81e11b55091bb94b62..e000d5cb27eaf2eb14bdd790efada4e0623c8674 100644
+index 43821553144d6f326b094ca24cd3f551c7e31205..64ccd8f02dbaf182f80c1a87e17697f48a5c12a7 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
 @@ -147,6 +147,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
@@ -17876,7 +17876,7 @@ index 0555d3d576345bb249610858d69466e49159f1ac..fd5e11b13a7ffd4ebecb11179e4ec864
      WebConnection* webConnection() const { return m_webConnection.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-index b700c999e4b0eadd517226561d8d310fadd0b5c0..d07fe92acd396b2d026671e632cf1d19f6a18536 100644
+index 216cc47cd127f2ddf9b1efbd8935ddbe5499dcf9..fb7f8bab34e7034f026af6a713a78713848cca59 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 @@ -2027,6 +2027,17 @@ void WebsiteDataStore::originDirectoryForTesting(URL&& origin, URL&& topOrigin,
@@ -18607,7 +18607,7 @@ index 0000000000000000000000000000000000000000..d0f9827544994e450e24e3f7a427c35e
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
-index a76a3324913e2c3cf7356df3e06808863e29017c..70b11aeccf98a564e5427def69d385739ef558ab 100644
+index 920e936763f55068a50faad8311d681592ec82e3..7692d7a5a51554c2c80dfdc43cee3b353165baa2 100644
 --- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 +++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 @@ -440,6 +440,8 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
@@ -18975,10 +18975,10 @@ index 31bc0797a1b086b9342e5449e48cf5b3050464eb..450b6acf92b31cb40c404e3a8553e263
      void getContextMenuItem(const WebContextMenuItemData&, CompletionHandler<void(NSMenuItem *)>&&);
      void getContextMenuFromItems(const Vector<WebContextMenuItemData>&, CompletionHandler<void(NSMenu *)>&&);
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-index dec88e7833f63527f1d6d8fbe7415f2fcc578b68..22c1f21c5ff6164ead19455319476d962bdb687f 100644
+index 6bbb05e0355631b907628ee24c59f57e6cbbcb4b..2a3df261561d0f5835ada5cb065c14842711c6cb 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-@@ -443,6 +443,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
+@@ -438,6 +438,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
  }
  #endif
  
@@ -19932,7 +19932,7 @@ index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705e
 + 
 +} // namespace WebKit
 diff --git a/Source/WebKit/WebKit.xcodeproj/project.pbxproj b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde325518a8be57 100644
+index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e00590e41b 100644
 --- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 +++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 @@ -1270,6 +1270,7 @@
@@ -19943,7 +19943,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  		5CAF7AA726F93AB00003F19E /* adattributiond.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAF7AA526F93A950003F19E /* adattributiond.cpp */; };
  		5CAFDE452130846300B1F7E1 /* _WKInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE422130843500B1F7E1 /* _WKInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		5CAFDE472130846A00B1F7E1 /* _WKInspectorInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE442130843600B1F7E1 /* _WKInspectorInternal.h */; };
-@@ -2241,6 +2242,18 @@
+@@ -2239,6 +2240,18 @@
  		DF0C5F28252ECB8E00D921DB /* WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F24252ECB8D00D921DB /* WKDownload.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2A252ECB8E00D921DB /* WKDownloadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2B252ED44000D921DB /* WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */; };
@@ -19962,7 +19962,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  		DF462E0F23F22F5500EFF35F /* WKHTTPCookieStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */; };
-@@ -2300,6 +2313,8 @@
+@@ -2298,6 +2311,8 @@
  		E5BEF6822130C48000F31111 /* WebDataListSuggestionsDropdownIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E5BEF6802130C47F00F31111 /* WebDataListSuggestionsDropdownIOS.h */; };
  		E5CB07DC20E1678F0022C183 /* WKFormColorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */; };
  		E5CBA76427A318E100DF7858 /* UnifiedSource120.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */; };
@@ -19971,7 +19971,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  		E5CBA76527A318E100DF7858 /* UnifiedSource118.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */; };
  		E5CBA76627A318E100DF7858 /* UnifiedSource116.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76327A3187B00DF7858 /* UnifiedSource116.cpp */; };
  		E5CBA76727A318E100DF7858 /* UnifiedSource119.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */; };
-@@ -2316,6 +2331,9 @@
+@@ -2314,6 +2329,9 @@
  		EBA8D3B627A5E33F00CB7900 /* MockPushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B027A5E33F00CB7900 /* MockPushServiceConnection.mm */; };
  		EBA8D3B727A5E33F00CB7900 /* PushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B127A5E33F00CB7900 /* PushServiceConnection.mm */; };
  		ED82A7F2128C6FAF004477B3 /* WKBundlePageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22F0FF1289FCD90085E74F /* WKBundlePageOverlay.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -19981,7 +19981,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
  		F42D634122A0EFDF00D2FB3A /* WebAutocorrectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */; };
-@@ -5322,6 +5340,7 @@
+@@ -5320,6 +5338,7 @@
  		5CABDC8522C40FCC001EDE8E /* WKMessageListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKMessageListener.h; sourceTree = "<group>"; };
  		5CADDE0D2151AA010067D309 /* AuthenticationChallengeDisposition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthenticationChallengeDisposition.h; sourceTree = "<group>"; };
  		5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource115.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource115.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -19989,7 +19989,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  		5CAF7AA426F93A750003F19E /* adattributiond */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = adattributiond; sourceTree = BUILT_PRODUCTS_DIR; };
  		5CAF7AA526F93A950003F19E /* adattributiond.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = adattributiond.cpp; sourceTree = "<group>"; };
  		5CAF7AA626F93AA50003F19E /* adattributiond.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = adattributiond.xcconfig; sourceTree = "<group>"; };
-@@ -7025,6 +7044,19 @@
+@@ -7019,6 +7038,19 @@
  		DF0C5F24252ECB8D00D921DB /* WKDownload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownload.h; sourceTree = "<group>"; };
  		DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadInternal.h; sourceTree = "<group>"; };
  		DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadDelegate.h; sourceTree = "<group>"; };
@@ -20009,7 +20009,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  		DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHTTPCookieStorePrivate.h; sourceTree = "<group>"; };
  		DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKContentWorldPrivate.h; sourceTree = "<group>"; };
  		DF58C6311371AC5800F9A37C /* NativeWebWheelEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeWebWheelEvent.h; sourceTree = "<group>"; };
-@@ -7152,6 +7184,8 @@
+@@ -7146,6 +7178,8 @@
  		E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKFormColorControl.h; path = ios/forms/WKFormColorControl.h; sourceTree = "<group>"; };
  		E5CB07DB20E1678F0022C183 /* WKFormColorControl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKFormColorControl.mm; path = ios/forms/WKFormColorControl.mm; sourceTree = "<group>"; };
  		E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource120.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource120.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -20018,7 +20018,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  		E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource119.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource119.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
  		E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource118.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource118.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
  		E5CBA76227A3187900DF7858 /* UnifiedSource117.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource117.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource117.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
-@@ -7173,6 +7207,14 @@
+@@ -7167,6 +7201,14 @@
  		ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtraPrivateSymbolsForTAPI.h; sourceTree = "<group>"; };
  		ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExtraPublicSymbolsForTAPI.h; sourceTree = "<group>"; };
  		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
@@ -20033,7 +20033,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  		F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDragDestinationAction.h; sourceTree = "<group>"; };
  		F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionContext.h; path = ios/WebAutocorrectionContext.h; sourceTree = "<group>"; };
  		F41056612130699A0092281D /* APIAttachmentCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = APIAttachmentCocoa.mm; sourceTree = "<group>"; };
-@@ -7319,6 +7361,7 @@
+@@ -7313,6 +7355,7 @@
  				3766F9EF189A1244003CF19B /* QuartzCore.framework in Frameworks */,
  				37694525184FC6B600CDE21F /* Security.framework in Frameworks */,
  				37BEC4DD1948FC6A008B4286 /* WebCore.framework in Frameworks */,
@@ -20041,7 +20041,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -9414,6 +9457,7 @@
+@@ -9409,6 +9452,7 @@
  		37C4C08318149C2A003688B9 /* Cocoa */ = {
  			isa = PBXGroup;
  			children = (
@@ -20049,7 +20049,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				1A43E826188F38E2009E4D30 /* Deprecated */,
  				37A5E01218BBF937000A081E /* _WKActivatedElementInfo.h */,
  				37A5E01118BBF937000A081E /* _WKActivatedElementInfo.mm */,
-@@ -10608,6 +10652,7 @@
+@@ -10603,6 +10647,7 @@
  				E34B110F27C46D09006D2F2E /* libWebCoreTestSupport.dylib */,
  				DDE992F4278D06D900F60D26 /* libWebKitAdditions.a */,
  				57A9FF15252C6AEF006A2040 /* libWTF.a */,
@@ -20057,7 +20057,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				5750F32A2032D4E500389347 /* LocalAuthentication.framework */,
  				570DAAB0230273D200E8FC04 /* NearField.framework */,
  				51F7BB7E274564A100C45A72 /* Security.framework */,
-@@ -11128,6 +11173,12 @@
+@@ -11123,6 +11168,12 @@
  			children = (
  				9197940423DBC4BB00257892 /* InspectorBrowserAgent.cpp */,
  				9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */,
@@ -20070,7 +20070,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  			);
  			path = Agents;
  			sourceTree = "<group>";
-@@ -11136,6 +11187,7 @@
+@@ -11131,6 +11182,7 @@
  			isa = PBXGroup;
  			children = (
  				A5D3504D1D78F0D2005124A9 /* RemoteWebInspectorUIProxyMac.mm */,
@@ -20078,7 +20078,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */,
  				99A7ACE326012919006D57FD /* WKInspectorResourceURLSchemeHandler.h */,
  				99A7ACE42601291A006D57FD /* WKInspectorResourceURLSchemeHandler.mm */,
-@@ -11682,6 +11734,12 @@
+@@ -11674,6 +11726,12 @@
  		BC032DC310F438260058C15A /* UIProcess */ = {
  			isa = PBXGroup;
  			children = (
@@ -20091,7 +20091,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				BC032DC410F4387C0058C15A /* API */,
  				512F588D12A8836F00629530 /* Authentication */,
  				9955A6E81C79809000EB6A93 /* Automation */,
-@@ -11993,6 +12051,7 @@
+@@ -11985,6 +12043,7 @@
  		BC0C376610F807660076D7CB /* C */ = {
  			isa = PBXGroup;
  			children = (
@@ -20099,7 +20099,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				5123CF18133D25E60056F800 /* cg */,
  				6EE849C41368D9040038D481 /* mac */,
  				BCB63477116BF10600603215 /* WebKit2_C.h */,
-@@ -12583,6 +12642,11 @@
+@@ -12575,6 +12634,11 @@
  		BCCF085C113F3B7500C650C5 /* mac */ = {
  			isa = PBXGroup;
  			children = (
@@ -20111,7 +20111,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				B878B613133428DC006888E9 /* CorrectionPanel.h */,
  				B878B614133428DC006888E9 /* CorrectionPanel.mm */,
  				07EF07592745A8160066EA04 /* DisplayCaptureSessionManager.h */,
-@@ -13798,6 +13862,7 @@
+@@ -13788,6 +13852,7 @@
  				99788ACB1F421DDA00C08000 /* _WKAutomationSessionConfiguration.h in Headers */,
  				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
  				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
@@ -20119,7 +20119,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
  				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
  				1A5704F81BE01FF400874AF1 /* _WKContextMenuElementInfo.h in Headers */,
-@@ -14258,6 +14323,7 @@
+@@ -14248,6 +14313,7 @@
  				1A14F8E21D74C834006CBEC6 /* FrameInfoData.h in Headers */,
  				1AE00D611831792100087DD7 /* FrameLoadState.h in Headers */,
  				5C121E842410208D00486F9B /* FrameTreeNodeData.h in Headers */,
@@ -20127,7 +20127,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				2D4AF0892044C3C4006C8817 /* FrontBoardServicesSPI.h in Headers */,
  				CD78E1151DB7D7ED0014A2DE /* FullscreenClient.h in Headers */,
  				CD19D2EA2046406F0017074A /* FullscreenTouchSecheuristic.h in Headers */,
-@@ -14273,6 +14339,7 @@
+@@ -14263,6 +14329,7 @@
  				410F0D4C2701EFF900F96DFC /* GPUProcessConnectionInitializationParameters.h in Headers */,
  				4614F13225DED875007006E7 /* GPUProcessConnectionParameters.h in Headers */,
  				2DA049B8180CCD0A00AAFA9E /* GraphicsLayerCARemote.h in Headers */,
@@ -20135,7 +20135,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				C0CE72AD1247E78D00BC0EC4 /* HandleMessage.h in Headers */,
  				1AC75A1B1B3368270056745B /* HangDetectionDisabler.h in Headers */,
  				57AC8F50217FEED90055438C /* HidConnection.h in Headers */,
-@@ -14428,6 +14495,7 @@
+@@ -14418,6 +14485,7 @@
  				413075AC1DE85F370039EC69 /* NetworkRTCMonitor.h in Headers */,
  				41DC45961E3D6E2200B11F51 /* NetworkRTCProvider.h in Headers */,
  				5C20CBA01BB1ECD800895BB1 /* NetworkSession.h in Headers */,
@@ -20143,7 +20143,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				532159551DBAE7290054AA3C /* NetworkSessionCocoa.h in Headers */,
  				417915B92257046F00D6F97E /* NetworkSocketChannel.h in Headers */,
  				93085DE026E5BCFD000EC6A7 /* NetworkStorageManager.h in Headers */,
-@@ -14494,6 +14562,7 @@
+@@ -14484,6 +14552,7 @@
  				BC1A7C581136E19C00FB7167 /* ProcessLauncher.h in Headers */,
  				463FD4821EB94EC000A2982C /* ProcessTerminationReason.h in Headers */,
  				86E67A251910B9D100004AB7 /* ProcessThrottler.h in Headers */,
@@ -20151,7 +20151,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				83048AE61ACA45DC0082C832 /* ProcessThrottlerClient.h in Headers */,
  				2D279E1926955768004B3EEB /* PrototypeToolsSPI.h in Headers */,
  				517B5F81275E97B6002DC22D /* PushAppBundle.h in Headers */,
-@@ -14524,6 +14593,7 @@
+@@ -14515,6 +14584,7 @@
  				CDAC20CA23FC2F750021DEE3 /* RemoteCDMInstanceSession.h in Headers */,
  				CDAC20C923FC2F750021DEE3 /* RemoteCDMInstanceSessionIdentifier.h in Headers */,
  				F451C0FE2703B263002BA03B /* RemoteDisplayListRecorderProxy.h in Headers */,
@@ -20159,7 +20159,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				2D47B56D1810714E003A3AEE /* RemoteLayerBackingStore.h in Headers */,
  				2DDF731518E95060004F5A66 /* RemoteLayerBackingStoreCollection.h in Headers */,
  				1AB16AEA164B3A8800290D62 /* RemoteLayerTreeContext.h in Headers */,
-@@ -14948,6 +15018,7 @@
+@@ -14937,6 +15007,7 @@
  				A543E30D215C8A9000279CD9 /* WebPageInspectorTargetController.h in Headers */,
  				A543E307215AD13700279CD9 /* WebPageInspectorTargetFrontendChannel.h in Headers */,
  				C0CE72A11247E71D00BC0EC4 /* WebPageMessages.h in Headers */,
@@ -20167,7 +20167,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				2D5C9D0619C81D8F00B3C5C1 /* WebPageOverlay.h in Headers */,
  				46C392292316EC4D008EED9B /* WebPageProxyIdentifier.h in Headers */,
  				BCBD3915125BB1A800D2C29F /* WebPageProxyMessages.h in Headers */,
-@@ -15129,6 +15200,7 @@
+@@ -15118,6 +15189,7 @@
  				BCD25F1711D6BDE100169B0E /* WKBundleFrame.h in Headers */,
  				BCF049E611FE20F600F86A58 /* WKBundleFramePrivate.h in Headers */,
  				BC49862F124D18C100D834E1 /* WKBundleHitTestResult.h in Headers */,
@@ -20175,7 +20175,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				BC204EF211C83EC8008F3375 /* WKBundleInitialize.h in Headers */,
  				65B86F1E12F11DE300B7DD8A /* WKBundleInspector.h in Headers */,
  				1A8B66B41BC45B010082DF77 /* WKBundleMac.h in Headers */,
-@@ -15183,6 +15255,7 @@
+@@ -15172,6 +15244,7 @@
  				5C795D71229F3757003FF1C4 /* WKContextMenuElementInfoPrivate.h in Headers */,
  				51A555F6128C6C47009ABCEC /* WKContextMenuItem.h in Headers */,
  				51A55601128C6D92009ABCEC /* WKContextMenuItemTypes.h in Headers */,
@@ -20183,7 +20183,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				A1EA02381DABFF7E0096021F /* WKContextMenuListener.h in Headers */,
  				BCC938E11180DE440085E5FE /* WKContextPrivate.h in Headers */,
  				9FB5F395169E6A80002C25BF /* WKContextPrivateMac.h in Headers */,
-@@ -15340,6 +15413,7 @@
+@@ -15329,6 +15402,7 @@
  				1AB8A1F818400BB800E9AE69 /* WKPageContextMenuClient.h in Headers */,
  				8372DB251A674C8F00C697C5 /* WKPageDiagnosticLoggingClient.h in Headers */,
  				1AB8A1F418400B8F00E9AE69 /* WKPageFindClient.h in Headers */,
@@ -20191,7 +20191,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				1AB8A1F618400B9D00E9AE69 /* WKPageFindMatchesClient.h in Headers */,
  				1AB8A1F018400B0000E9AE69 /* WKPageFormClient.h in Headers */,
  				BC7B633712A45ABA00D174A4 /* WKPageGroup.h in Headers */,
-@@ -16956,6 +17030,8 @@
+@@ -16945,6 +17019,8 @@
  				51E9049727BCB3D900929E7E /* ICAppBundle.mm in Sources */,
  				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
  				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
@@ -20200,7 +20200,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
  				C1710CF724AA643200D7C112 /* LaunchServicesDatabaseObserver.mm in Sources */,
  				2984F588164BA095004BC0C6 /* LegacyCustomProtocolManagerMessageReceiver.cpp in Sources */,
-@@ -17296,6 +17372,8 @@
+@@ -17284,6 +17360,8 @@
  				E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */,
  				31BA924D148831260062EDB5 /* WebNotificationManagerMessageReceiver.cpp in Sources */,
  				2DF6FE52212E110900469030 /* WebPage.cpp in Sources */,
@@ -20210,7 +20210,7 @@ index fd388d10a3ffa45dc3dd2f0efcf8e8bfe476c3f3..133b69d9d183fd8e4590591cfbde3255
  				BCBD3914125BB1A800D2C29F /* WebPageProxyMessageReceiver.cpp in Sources */,
  				7CE9CE101FA0767A000177DE /* WebPageUpdatePreferences.cpp in Sources */,
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
-index 408083c9737709f82ff0ab79c822322d21c8a938..c54d894a254d995b871a6857f93f444313522201 100644
+index 0cbfe8e6596c093a03fab768357293bd8002b4e4..be957c560a5fdcd76723ccf95e96820980e194fe 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 @@ -231,6 +231,11 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
@@ -20236,8 +20236,8 @@ index 408083c9737709f82ff0ab79c822322d21c8a938..c54d894a254d995b871a6857f93f4443
      auto identifier = resourceLoader.identifier();
      ASSERT(identifier);
 @@ -329,7 +335,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
-             RunLoop::main().dispatch([resourceLoader = Ref { resourceLoader }] {
-                 resourceLoader->didFail(resourceLoader->blockedError());
+             RunLoop::main().dispatch([resourceLoader = Ref { resourceLoader }, error = blockedError(request)] {
+                 resourceLoader->didFail(error);
              });
 -            return;
 +            return false;
@@ -20398,7 +20398,7 @@ index e00c722c2be5d505243d45f46001839d4eb8a977..33c0832cde6c292230397a13e70d90fb
  
              auto permissionHandlers = m_requestsPerOrigin.take(securityOrigin);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
-index ec83bcae7dce003bc95f0b849b75a244aa5b29a2..8bc6c3aec3eb93549b502948ce6b15b445dd54ae 100644
+index ea27184060444fb275033fe7721796f93d14ae5d..2d56768cc1e356fe9efd25c422d253ea72a456d6 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 @@ -417,6 +417,8 @@ void WebChromeClient::setResizable(bool resizable)
@@ -20452,7 +20452,7 @@ index 2eb0886f13ed035a53b8eaa60605de4dfe53fbe3..c46393209cb4f80704bbc9268fad4371
  {
  }
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
-index 70efcd24f3da2b3e83b44077628d62601fa7be45..7ef1e3643215f59ab4f02639e7b7d0947c5c2571 100644
+index 7891cd42ac7144b1a18a69cabb8628f5a688fa78..d00372392b6d2aa1ecc647fd08f61be5fedd96cf 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 @@ -1598,13 +1598,6 @@ void WebFrameLoaderClient::transitionToCommittedForNewPage()
@@ -20832,7 +20832,7 @@ index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4
      uint64_t m_navigationID;
  };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index a2e1c13150527a2e01650712b49de7ee91e6950c..09c9193bf2ac53f208dd0eee5da1b365f68c16fd 100644
+index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc0d03e737 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 @@ -920,6 +920,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
@@ -20950,7 +20950,7 @@ index a2e1c13150527a2e01650712b49de7ee91e6950c..09c9193bf2ac53f208dd0eee5da1b365
  }
  
  void WebPage::listenForLayoutMilestones(OptionSet<WebCore::LayoutMilestone> milestones)
-@@ -3399,6 +3408,104 @@ void WebPage::touchEvent(const WebTouchEvent& touchEvent)
+@@ -3395,6 +3404,104 @@ void WebPage::touchEvent(const WebTouchEvent& touchEvent)
  
      send(Messages::WebPageProxy::DidReceiveEvent(static_cast<uint32_t>(touchEvent.type()), handled));
  }
@@ -21055,7 +21055,7 @@ index a2e1c13150527a2e01650712b49de7ee91e6950c..09c9193bf2ac53f208dd0eee5da1b365
  #endif
  
  void WebPage::cancelPointer(WebCore::PointerID pointerId, const WebCore::IntPoint& documentPoint)
-@@ -3475,6 +3582,11 @@ void WebPage::sendMessageToTargetBackend(const String& targetId, const String& m
+@@ -3471,6 +3578,11 @@ void WebPage::sendMessageToTargetBackend(const String& targetId, const String& m
      m_inspectorTargetController->sendMessageToTargetBackend(targetId, message);
  }
  
@@ -21067,7 +21067,7 @@ index a2e1c13150527a2e01650712b49de7ee91e6950c..09c9193bf2ac53f208dd0eee5da1b365
  void WebPage::insertNewlineInQuotedContent()
  {
      Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-@@ -3719,6 +3831,7 @@ void WebPage::didCompletePageTransition()
+@@ -3715,6 +3827,7 @@ void WebPage::didCompletePageTransition()
  void WebPage::show()
  {
      send(Messages::WebPageProxy::ShowPage());
@@ -21075,7 +21075,7 @@ index a2e1c13150527a2e01650712b49de7ee91e6950c..09c9193bf2ac53f208dd0eee5da1b365
  }
  
  void WebPage::setIsTakingSnapshotsForApplicationSuspension(bool isTakingSnapshotsForApplicationSuspension)
-@@ -4588,7 +4701,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
+@@ -4584,7 +4697,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
  
  #if ENABLE(DRAG_SUPPORT)
  
@@ -21084,7 +21084,7 @@ index a2e1c13150527a2e01650712b49de7ee91e6950c..09c9193bf2ac53f208dd0eee5da1b365
  void WebPage::performDragControllerAction(DragControllerAction action, const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation> draggingSourceOperationMask, SelectionData&& selectionData, OptionSet<DragApplicationFlags> flags)
  {
      if (!m_page) {
-@@ -6985,6 +7098,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
+@@ -6997,6 +7110,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
              WebsitePoliciesData::applyToDocumentLoader(WTFMove(*m_pendingWebsitePolicies), documentLoader);
              m_pendingWebsitePolicies = std::nullopt;
          }
@@ -21095,7 +21095,7 @@ index a2e1c13150527a2e01650712b49de7ee91e6950c..09c9193bf2ac53f208dd0eee5da1b365
  
      return documentLoader;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.h b/Source/WebKit/WebProcess/WebPage/WebPage.h
-index 1ee74f4d9237ea089c289fc114a609738c35925c..498f0070f18b9a8b48ade95681f67e228f88542e 100644
+index b2431383b5104c9508416ec1354cc681aac92b33..a44d92e6270785128aea415fe3a29e91934150a4 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
 @@ -117,6 +117,10 @@
@@ -21109,7 +21109,7 @@ index 1ee74f4d9237ea089c289fc114a609738c35925c..498f0070f18b9a8b48ade95681f67e22
  #if PLATFORM(GTK) || PLATFORM(WPE)
  #include "InputMethodState.h"
  #endif
-@@ -1009,11 +1013,11 @@ public:
+@@ -1005,11 +1009,11 @@ public:
      void clearSelection();
      void restoreSelectionInFocusedEditableElement();
  
@@ -21123,7 +21123,7 @@ index 1ee74f4d9237ea089c289fc114a609738c35925c..498f0070f18b9a8b48ade95681f67e22
      void performDragControllerAction(DragControllerAction, const WebCore::DragData&, SandboxExtension::Handle&&, Vector<SandboxExtension::Handle>&&);
  #endif
  
-@@ -1027,6 +1031,9 @@ public:
+@@ -1023,6 +1027,9 @@ public:
      void didStartDrag();
      void dragCancelled();
      OptionSet<WebCore::DragSourceAction> allowedDragSourceActions() const { return m_allowedDragSourceActions; }
@@ -21133,7 +21133,7 @@ index 1ee74f4d9237ea089c289fc114a609738c35925c..498f0070f18b9a8b48ade95681f67e22
  #endif
  
      void beginPrinting(WebCore::FrameIdentifier, const PrintInfo&);
-@@ -1261,6 +1268,7 @@ public:
+@@ -1257,6 +1264,7 @@ public:
      void connectInspector(const String& targetId, Inspector::FrontendChannel::ConnectionType);
      void disconnectInspector(const String& targetId);
      void sendMessageToTargetBackend(const String& targetId, const String& message);
@@ -21141,7 +21141,7 @@ index 1ee74f4d9237ea089c289fc114a609738c35925c..498f0070f18b9a8b48ade95681f67e22
  
      void insertNewlineInQuotedContent();
  
-@@ -1636,6 +1644,7 @@ private:
+@@ -1627,6 +1635,7 @@ private:
      // Actions
      void tryClose(CompletionHandler<void(bool)>&&);
      void platformDidReceiveLoadParameters(const LoadParameters&);
@@ -21149,7 +21149,7 @@ index 1ee74f4d9237ea089c289fc114a609738c35925c..498f0070f18b9a8b48ade95681f67e22
      void loadRequest(LoadParameters&&);
      NO_RETURN void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
      void loadData(LoadParameters&&);
-@@ -1673,6 +1682,7 @@ private:
+@@ -1664,6 +1673,7 @@ private:
      void updatePotentialTapSecurityOrigin(const WebTouchEvent&, bool wasHandled);
  #elif ENABLE(TOUCH_EVENTS)
      void touchEvent(const WebTouchEvent&);
@@ -21157,7 +21157,7 @@ index 1ee74f4d9237ea089c289fc114a609738c35925c..498f0070f18b9a8b48ade95681f67e22
  #endif
  
      void cancelPointer(WebCore::PointerID, const WebCore::IntPoint&);
-@@ -1812,9 +1822,7 @@ private:
+@@ -1803,9 +1813,7 @@ private:
  
      void requestRectForFoundTextRange(const WebFoundTextRange&, CompletionHandler<void(WebCore::FloatRect)>&&);
  
@@ -21167,7 +21167,7 @@ index 1ee74f4d9237ea089c289fc114a609738c35925c..498f0070f18b9a8b48ade95681f67e22
  
      void didChangeSelectedIndexForActivePopupMenu(int32_t newIndex);
      void setTextForActivePopupMenu(int32_t index);
-@@ -2351,6 +2359,7 @@ private:
+@@ -2340,6 +2348,7 @@ private:
      UserActivity m_userActivity;
  
      uint64_t m_pendingNavigationID { 0 };
@@ -21176,10 +21176,10 @@ index 1ee74f4d9237ea089c289fc114a609738c35925c..498f0070f18b9a8b48ade95681f67e22
  
      bool m_mainFrameProgressCompleted { false };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-index 2fbdec8b8cc24ea212ba2eac25cc9e3dedae5666..f0ada6d6f61b3bec55fdca7488709a16e6872fff 100644
+index 25c28b7cd458c9b272c71cd00a376d26c4e63781..82ed25b5b5e5693b13a2b74de70ea9dec52171c5 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-@@ -142,6 +142,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -136,6 +136,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      ConnectInspector(String targetId, Inspector::FrontendChannel::ConnectionType connectionType)
      DisconnectInspector(String targetId)
      SendMessageToTargetBackend(String targetId, String message)
@@ -21187,7 +21187,7 @@ index 2fbdec8b8cc24ea212ba2eac25cc9e3dedae5666..f0ada6d6f61b3bec55fdca7488709a16
  
  #if ENABLE(REMOTE_INSPECTOR)
      SetIndicating(bool indicating);
-@@ -153,6 +154,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -147,6 +148,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
  #endif
  #if !ENABLE(IOS_TOUCH_EVENTS) && ENABLE(TOUCH_EVENTS)
      TouchEvent(WebKit::WebTouchEvent event)
@@ -21195,7 +21195,7 @@ index 2fbdec8b8cc24ea212ba2eac25cc9e3dedae5666..f0ada6d6f61b3bec55fdca7488709a16
  #endif
  
      CancelPointer(WebCore::PointerID pointerId, WebCore::IntPoint documentPoint)
-@@ -182,6 +184,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -176,6 +178,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      LoadURLInFrame(URL url, String referrer, WebCore::FrameIdentifier frameID)
      LoadDataInFrame(IPC::DataReference data, String MIMEType, String encodingName, URL baseURL, WebCore::FrameIdentifier frameID)
      LoadRequest(struct WebKit::LoadParameters loadParameters)
@@ -21203,7 +21203,7 @@ index 2fbdec8b8cc24ea212ba2eac25cc9e3dedae5666..f0ada6d6f61b3bec55fdca7488709a16
      LoadRequestWaitingForProcessLaunch(struct WebKit::LoadParameters loadParameters, URL resourceDirectoryURL, WebKit::WebPageProxyIdentifier pageID, bool checkAssumedReadAccessToResourceURL)
      LoadData(struct WebKit::LoadParameters loadParameters)
      LoadSimulatedRequestAndResponse(struct WebKit::LoadParameters loadParameters, WebCore::ResourceResponse simulatedResponse)
-@@ -346,10 +349,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -340,10 +343,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      AddMIMETypeWithCustomContentProvider(String mimeType)
  
      # Drag and drop.
@@ -21216,7 +21216,7 @@ index 2fbdec8b8cc24ea212ba2eac25cc9e3dedae5666..f0ada6d6f61b3bec55fdca7488709a16
      PerformDragControllerAction(enum:uint8_t WebKit::DragControllerAction action, WebCore::DragData dragData, WebKit::SandboxExtension::Handle sandboxExtensionHandle, Vector<WebKit::SandboxExtension::Handle> sandboxExtensionsForUpload)
  #endif
  #if ENABLE(DRAG_SUPPORT)
-@@ -358,6 +361,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -352,6 +355,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      DragCancelled()
  #endif
  
@@ -21270,7 +21270,7 @@ index 1a789f99d89f67f80215fd1661509ce334db1861..8a8e515effd36e277e3390a9cfa82922
  }
  
 diff --git a/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp b/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
-index 76443a94254ae4fe8e58f807baa52156c367d11d..08b2550eb12bce9ac1fb809c520de6babdf7a50f 100644
+index c77ff78cd3cd9627d1ae7b930c81457094645200..88746359159a76b169b7e6dcbee4fb34db5f246a 100644
 --- a/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
 @@ -43,6 +43,7 @@
@@ -21320,7 +21320,7 @@ index 76443a94254ae4fe8e58f807baa52156c367d11d..08b2550eb12bce9ac1fb809c520de6ba
  }
  
 diff --git a/Source/WebKit/WebProcess/WebProcess.cpp b/Source/WebKit/WebProcess/WebProcess.cpp
-index 272105032407261021a87c32cdb7bc1285431127..f353ac384ae7ab9326f3df94087e7bcb910110b7 100644
+index 53f8a56cd2bf8a380c91f28e27e7b63806b7e339..23c0dc353280d59c11b98aab31ce37593e2dd063 100644
 --- a/Source/WebKit/WebProcess/WebProcess.cpp
 +++ b/Source/WebKit/WebProcess/WebProcess.cpp
 @@ -92,6 +92,7 @@
@@ -21356,7 +21356,7 @@ index 8987c3964a9308f2454759de7f8972215a3ae416..bcac0afeb94ed8123d1f9fb0b932c849
              SetProcessDPIAware();
          return true;
 diff --git a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-index bfd5d09e98adf739ab8f377bcb7e4d54e2e8075f..c3ac49a5a84382d484b9274b599f9d50cc8ecff8 100644
+index d6b5b19bd5a81b8c041eac72f2d0f65e5f36f11c..293d90cd32c4e827b65fa59d51e90d429f34d794 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 @@ -4189,7 +4189,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
@@ -21369,7 +21369,7 @@ index bfd5d09e98adf739ab8f377bcb7e4d54e2e8075f..c3ac49a5a84382d484b9274b599f9d50
  - (void)touch:(WebEvent *)event
  {
 diff --git a/Source/WebKitLegacy/mac/WebView/WebView.mm b/Source/WebKitLegacy/mac/WebView/WebView.mm
-index f14fa3994f4afabbce5b01b9945752da99a811f9..d583e448422414ecfc0819521db9f0f90da8fdb5 100644
+index 0cc178510b1604ea80f252b6e4e0089f4e2dd4d0..c95b50ef3d4241439f66b0b0f4cde41dfb940e6b 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
 @@ -4058,7 +4058,7 @@ IGNORE_WARNINGS_END
@@ -21422,7 +21422,7 @@ index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d
 +    LIBVPX_LIBRARIES
 +)
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index d523bea45e7da223d2703249aa4a07db70c3656b..ae587ecd29a787c3eccda2994f82ae41941b9ce2 100644
+index 3b5a947f98e2d48f98dc3027ea18d21788862ba1..9fa9863840f3af990c293a282c87971ce99aa2ba 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
 @@ -5,6 +5,7 @@ WEBKIT_OPTION_BEGIN()
@@ -22252,7 +22252,7 @@ index ef4407cfc114e602d98ed81724da504f453e258f..448dd483715162baba484f756fbcc1d7
 +    add_subdirectory(Playwright/win)
  endif ()
 diff --git a/Tools/Scripts/build-webkit b/Tools/Scripts/build-webkit
-index faad78e101e3bb91dc45ae55abf90c7f6dbe4dc6..94af5f57c389d8403991ee45c95a2ff46c0208cb 100755
+index 9f32cb6aedc488f36e9c2ddcd3e146e87abf30b9..8ad4ea003aee4c83cec3bcc11c702f9035bbb16c 100755
 --- a/Tools/Scripts/build-webkit
 +++ b/Tools/Scripts/build-webkit
 @@ -263,7 +263,7 @@ if (isAppleCocoaWebKit()) {
@@ -22264,23 +22264,6 @@ index faad78e101e3bb91dc45ae55abf90c7f6dbe4dc6..94af5f57c389d8403991ee45c95a2ff4
  
              # WebInspectorUI must come after JavaScriptCore and WebCore but before WebKit and WebKit2
              my $webKitIndex = first { $projects[$_] eq "Source/WebKitLegacy" } 0..$#projects;
-diff --git a/Tools/Scripts/webkitpy/binary_bundling/bundle.py b/Tools/Scripts/webkitpy/binary_bundling/bundle.py
-index a0de1c33380c4b6c6d22d081f9ca87d16c090293..cf16a562fe27f1f8e8153efc2703c2961635a9cb 100644
---- a/Tools/Scripts/webkitpy/binary_bundling/bundle.py
-+++ b/Tools/Scripts/webkitpy/binary_bundling/bundle.py
-@@ -214,10 +214,7 @@ class BinaryBundler:
-             if os.path.isfile(os.path.join(lib_dir, dlopenwrap_libname)):
-                 script_handle.write('export LD_PRELOAD="${%s}/lib/%s"\n' % (self.VAR_MYDIR, dlopenwrap_libname))
-             # If we have patched the binaries to use a relative relpath then load the binary directly without prefixing it with the interpreter (it allows the process to use the correct progname)
--            if self._has_patched_interpreter_relpath:
--                script_handle.write('exec "${%s}/bin/%s" "$@"\n' % (self.VAR_MYDIR, binary_to_wrap))
--            else:
--                script_handle.write('INTERPRETER="${%s}/lib/%s"\n' % (self.VAR_MYDIR, os.path.basename(interpreter)))
--                script_handle.write('exec "${INTERPRETER}" "${%s}/bin/%s" "$@"\n' % (self.VAR_MYDIR, binary_to_wrap))
-+            # Playwright: always exec directly for now as it was previously; the dynamic linker is not bundled
-+            script_handle.write('exec "${%s}/bin/%s" "$@"\n' % (self.VAR_MYDIR, binary_to_wrap))
- 
-         os.chmod(script_file, 0o755)
 diff --git a/Tools/WebKitTestRunner/InjectedBundle/empty/AccessibilityControllerEmpty.cpp b/Tools/WebKitTestRunner/InjectedBundle/empty/AccessibilityControllerEmpty.cpp
 new file mode 100644
 index 0000000000000000000000000000000000000000..3618075f10824beb0bc6cd8070772ab88f4e51c8
@@ -23436,7 +23419,7 @@ index 4f3640a8b93897d69604ee8ba38cd07561720ad2..00b657a8a585d104afc346dc1126fb71
      InjectedBundle/wpe/InjectedBundleWPE.cpp
      InjectedBundle/wpe/TestRunnerWPE.cpp
 diff --git a/Tools/WebKitTestRunner/TestController.cpp b/Tools/WebKitTestRunner/TestController.cpp
-index 46aff08139489032aaaf002ec638b669a0218b3c..49563910a054f52e19c3b8a7bdc02fef43bafd36 100644
+index 90a14eff3cac2610f7f20e29a7900d07ea071c13..6cef18933cdbe1a01240403823c868e7db31abb7 100644
 --- a/Tools/WebKitTestRunner/TestController.cpp
 +++ b/Tools/WebKitTestRunner/TestController.cpp
 @@ -871,6 +871,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
@@ -23504,7 +23487,7 @@ index 3a231b168583cfc378fb67ff42b108c747dd0733..2b0971a411f87be622cf53536f107a44
 +
  } // namespace WTR
 diff --git a/Tools/glib/dependencies/apt b/Tools/glib/dependencies/apt
-index 178e74ac90708b9571330c216a1ee07f7db3dff2..f33f29a9a26d1219aa5780b1860792353a70f4ee 100644
+index 017c992209e39859a0b56c1145bb79d9fdc6e939..5bf0744cfdcca58f6ecab6a9838abacfdea24fdb 100644
 --- a/Tools/glib/dependencies/apt
 +++ b/Tools/glib/dependencies/apt
 @@ -45,9 +45,11 @@ PACKAGES=(
@@ -23519,6 +23502,20 @@ index 178e74ac90708b9571330c216a1ee07f7db3dff2..f33f29a9a26d1219aa5780b186079235
      ruby
  
      # These are dependencies necessary for running tests.
+diff --git a/Tools/jhbuild/jhbuild-minimal.modules b/Tools/jhbuild/jhbuild-minimal.modules
+index 77755b7fa816283c5e738c4e82c9a822499ef353..348eb67028791bf13e333299f521de2fc7a020c1 100644
+--- a/Tools/jhbuild/jhbuild-minimal.modules
++++ b/Tools/jhbuild/jhbuild-minimal.modules
+@@ -175,7 +175,8 @@
+     </branch>
+   </meson>
+ 
+-  <meson id="glib-networking">
++  <meson id="glib-networking"
++         mesonargs="-Dgnutls=disabled -Dopenssl=enabled">
+     <dependencies>
+       <dep package="glib"/>
+     </dependencies>
 diff --git a/Tools/win/DLLLauncher/DLLLauncherMain.cpp b/Tools/win/DLLLauncher/DLLLauncherMain.cpp
 index 52605867b9302d1afcc56c5e9b0c54acf0827900..6edf24ab60249241ba2969531ef55f4b495dce9e 100644
 --- a/Tools/win/DLLLauncher/DLLLauncherMain.cpp


### PR DESCRIPTION
Rebase `webkit/patches/bootstrap.diff` to [r292830](https://trac.webkit.org/changeset/292830/webkit). Changes:

* [Rebase #1630 to r292830](https://github.com/dpino/WebKit/commit/44b3c43a6dd905d13d1838734fe766b01a0cb30b)
* [Resolve conflicts](https://github.com/dpino/WebKit/commit/ad91be6494dbcb26cef8327ec7642d54379b6353)
* [[JHBuild] Disable gnutls backend in glib-networking and enabled openssl](https://github.com/dpino/WebKit/commit/fdbfbe4c87d39fad09d2a12d1235a93dc4cce2d6)
  - This patch should go upstream. Ubuntu 18.04 features a gnutls version that is not compatible with glib-networking 2.70.   