### PR TITLE
docs(dotnet): migrate to top-level style code snippets

### DIFF
--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -63,20 +63,13 @@ with sync_playwright() as playwright:
 
 ```csharp
 using Microsoft.Playwright;
-using System.Threading.Tasks;
 
-class Program
-{
-    public static async Task Main()
-    {
-        using var playwright = await Playwright.CreateAsync();
-        var firefox = playwright.Firefox;
-        var browser = await firefox.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
-        var page = await browser.NewPageAsync();
-        await page.GotoAsync("https://www.bing.com");
-        await browser.CloseAsync();
-    }
-}
+using var playwright = await Playwright.CreateAsync();
+var firefox = playwright.Firefox;
+var browser = await firefox.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+var page = await browser.NewPageAsync();
+await page.GotoAsync("https://www.bing.com");
+await browser.CloseAsync();
 ```
 
 ## event: Browser.disconnected

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -493,28 +493,21 @@ with sync_playwright() as playwright:
 
 ```csharp
 using Microsoft.Playwright;
-using System.Threading.Tasks;
 
-class Program
-{
-    public static async Task Main()
-    {
-        using var playwright = await Playwright.CreateAsync();
-        var browser = await playwright.Webkit.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
-        var context = await browser.NewContextAsync();
+using var playwright = await Playwright.CreateAsync();
+var browser = await playwright.Webkit.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+var context = await browser.NewContextAsync();
 
-        await context.ExposeBindingAsync("pageURL", source => source.Page.Url);
-        var page = await context.NewPageAsync();
-        await page.SetContentAsync("<script>\n" +
-        "  async function onClick() {\n" +
-        "    document.querySelector('div').textContent = await window.pageURL();\n" +
-        "  }\n" +
-        "</script>\n" +
-        "<button onclick=\"onClick()\">Click me</button>\n" +
-        "<div></div>");
-        await page.ClickAsync("button");
-    }
-}
+await context.ExposeBindingAsync("pageURL", source => source.Page.Url);
+var page = await context.NewPageAsync();
+await page.SetContentAsync("<script>\n" +
+"  async function onClick() {\n" +
+"    document.querySelector('div').textContent = await window.pageURL();\n" +
+"  }\n" +
+"</script>\n" +
+"<button onclick=\"onClick()\">Click me</button>\n" +
+"<div></div>");
+await page.ClickAsync("button");
 ```
 
 An example of passing an element handle:

--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -51,17 +51,16 @@ using System.Threading.Tasks;
 using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
 
-namespace PlaywrightTests
+namespace PlaywrightTests;
+
+public class ExampleTests : PageTest
 {
-    public class ExampleTests : PageTest
+    [Test]
+    public async Task StatusBecomesSubmitted()
     {
-        [Test]
-        public async Task StatusBecomesSubmitted()
-        {
-            // ..
-            await Page.ClickAsync("#submit-button");
-            await Expect(Page.Locator(".status")).ToHaveTextAsync("Submitted");
-        }
+        // ..
+        await Page.ClickAsync("#submit-button");
+        await Expect(Page.Locator(".status")).ToHaveTextAsync("Submitted");
     }
 }
 ```

--- a/docs/src/api/class-pageassertions.md
+++ b/docs/src/api/class-pageassertions.md
@@ -53,17 +53,16 @@ using System.Threading.Tasks;
 using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
 
-namespace PlaywrightTests
+namespace PlaywrightTests;
+
+public class ExampleTests : PageTest
 {
-    public class ExampleTests : PageTest
+    [Test]
+    public async Task NavigatetoLoginPage()
     {
-        [Test]
-        public async Task NavigatetoLoginPage()
-        {
-            // ..
-            await Page.ClickAsync("#login");
-            await Expect(Page.Locator("div#foobar")).ToHaveURL(new Regex(".*/login"));
-        }
+        // ..
+        await Page.ClickAsync("#login");
+        await Expect(Page.Locator("div#foobar")).ToHaveURL(new Regex(".*/login"));
     }
 }
 ```

--- a/docs/src/api/class-playwrightassertions.md
+++ b/docs/src/api/class-playwrightassertions.md
@@ -52,15 +52,14 @@ using System.Threading.Tasks;
 using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
 
-namespace Playwright.TestingHarnessTest.NUnit
+namespace Playwright.TestingHarnessTest.NUnit;
+
+public class ExampleTests : PageTest
 {
-    public class ExampleTests : PageTest
+    [Test]
+    public async Task StatusBecomesSubmitted()
     {
-        [Test]
-        public async Task StatusBecomesSubmitted()
-        {
-            await Expect(Page.Locator(".status")).ToHaveTextAsync("Submitted");
-        }
+        await Expect(Page.Locator(".status")).ToHaveTextAsync("Submitted");
     }
 }
 ```

--- a/docs/src/api/class-timeouterror.md
+++ b/docs/src/api/class-timeouterror.md
@@ -78,25 +78,17 @@ public class TimeoutErrorExample {
 ```
 
 ```csharp
-using System.Threading.Tasks;
 using Microsoft.Playwright;
-using System;
 
-class Program
+using var playwright = await Playwright.CreateAsync();
+await using var browser = await playwright.Chromium.LaunchAsync();
+var page = await browser.NewPageAsync();
+try
 {
-    public static async Task Main()
-    {
-        using var playwright = await Playwright.CreateAsync();
-        await using var browser = await playwright.Chromium.LaunchAsync();
-        var page = await browser.NewPageAsync();
-        try
-        {
-            await page.ClickAsync("text=Example", new() { Timeout = 100 });
-        }
-        catch (TimeoutException)
-        {
-            Console.WriteLine("Timeout!");
-        }
-    }
+    await page.ClickAsync("text=Example", new() { Timeout = 100 });
+}
+catch (TimeoutException)
+{
+    Console.WriteLine("Timeout!");
 }
 ```

--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -90,7 +90,6 @@ browser = playwright.chromium.launch(channel="chrome")
 
 ```csharp
 using Microsoft.Playwright;
-using System.Threading.Tasks;
 
 using var playwright = await Playwright.CreateAsync();
 var chromium = playwright.Chromium;

--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -92,16 +92,10 @@ browser = playwright.chromium.launch(channel="chrome")
 using Microsoft.Playwright;
 using System.Threading.Tasks;
 
-class Program
-{
-    public static async Task Main()
-    {
-        using var playwright = await Playwright.CreateAsync();
-        var chromium = playwright.Chromium;
-        // Can be "msedge", "chrome-beta", "msedge-beta", "msedge-dev", etc.
-        var browser = await chromium.LaunchAsync(new BrowserTypeLaunchOptions { Channel = "chrome" });
-    }
-}
+using var playwright = await Playwright.CreateAsync();
+var chromium = playwright.Chromium;
+// Can be "msedge", "chrome-beta", "msedge-beta", "msedge-dev", etc.
+var browser = await chromium.LaunchAsync(new BrowserTypeLaunchOptions { Channel = "chrome" });
 ```
 
 ### When to use Google Chrome & Microsoft Edge and when not to?

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -313,19 +313,12 @@ with sync_playwright() as p:
 
 ```csharp
 using Microsoft.Playwright;
-using System.Threading.Tasks;
 
-class Program
+using var playwright = await Playwright.CreateAsync();
+await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
 {
-    public static async Task Main()
-    {
-        using var playwright = await Playwright.CreateAsync();
-        await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
-        {
-            Headless = false
-        });
-    }
-}
+    Headless = false
+});
 ```
 
 On Linux agents, headed execution requires [Xvfb](https://en.wikipedia.org/wiki/Xvfb) to be installed. Our [Docker image](./docker.md) and GitHub Action have Xvfb pre-installed. To run browsers in headed mode with Xvfb, add `xvfb-run` before the Node.js command.

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -255,26 +255,19 @@ with sync_playwright() as p:
 
 ```csharp
 using Microsoft.Playwright;
-using System.Threading.Tasks;
 
-class Program
-{
-    public static async Task Main()
-    {
-        using var playwright = await Playwright.CreateAsync();
-        var chromium = playwright.Chromium;
-        // Make sure to run headed.
-        var browser = await chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+using var playwright = await Playwright.CreateAsync();
+var chromium = playwright.Chromium;
+// Make sure to run headed.
+var browser = await chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
 
-        // Setup context however you like.
-        var context = await browser.NewContextAsync(); // Pass any options
-        await context.RouteAsync('**/*', route => route.ContinueAsync());
+// Setup context however you like.
+var context = await browser.NewContextAsync(); // Pass any options
+await context.RouteAsync('**/*', route => route.ContinueAsync());
 
-        // Pause the page, and start recording manually.
-        var page = await context.NewPageAsync();
-        await page.PauseAsync();
-    }
-}
+// Pause the page, and start recording manually.
+var page = await context.NewPageAsync();
+await page.PauseAsync();
 ```
 
 ## Open pages

--- a/docs/src/codegen.md
+++ b/docs/src/codegen.md
@@ -163,26 +163,19 @@ with sync_playwright() as p:
 
 ```csharp
 using Microsoft.Playwright;
-using System.Threading.Tasks;
 
-class Program
-{
-    public static async Task Main()
-    {
-        using var playwright = await Playwright.CreateAsync();
-        var chromium = playwright.Chromium;
-        // Make sure to run headed.
-        var browser = await chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+using var playwright = await Playwright.CreateAsync();
+var chromium = playwright.Chromium;
+// Make sure to run headed.
+var browser = await chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
 
-        // Setup context however you like.
-        var context = await browser.NewContextAsync(); // Pass any options
-        await context.RouteAsync('**/*', route => route.ContinueAsync());
+// Setup context however you like.
+var context = await browser.NewContextAsync(); // Pass any options
+await context.RouteAsync('**/*', route => route.ContinueAsync());
 
-        // Pause the page, and start recording manually.
-        var page = await context.NewPageAsync();
-        await page.PauseAsync();
-    }
-}
+// Pause the page, and start recording manually.
+var page = await context.NewPageAsync();
+await page.PauseAsync();
 ```
 
 ## Emulate devices

--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -71,7 +71,7 @@ Install dependencies, build project and download necessary browsers. This is onl
 dotnet add package Microsoft.Playwright.NUnit
 # Build the project
 dotnet build
-# Install required browsers
+# Install required browsers - replace netX with actual output folder name, f.ex. net6.0.
 pwsh bin\Debug\netX\playwright.ps1 install
 ```
 
@@ -81,24 +81,23 @@ using System.Threading.Tasks;
 using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
 
-namespace PlaywrightTests
-{
-    [Parallelizable(ParallelScope.Self)]
-    public class Tests : PageTest
-    {
-        [Test]
-        public async Task ShouldAdd()
-        {
-            int result = await Page.EvaluateAsync<int>("() => 7 + 3");
-            Assert.AreEqual(10, result);
-        }
+namespace PlaywrightTests;
 
-        [Test]
-        public async Task ShouldMultiply()
-        {
-            int result = await Page.EvaluateAsync<int>("() => 7 * 3");
-            Assert.AreEqual(21, result);
-        }
+[Parallelizable(ParallelScope.Self)]
+public class Tests : PageTest
+{
+    [Test]
+    public async Task ShouldAdd()
+    {
+        int result = await Page.EvaluateAsync<int>("() => 7 + 3");
+        Assert.AreEqual(10, result);
+    }
+
+    [Test]
+    public async Task ShouldMultiply()
+    {
+        int result = await Page.EvaluateAsync<int>("() => 7 * 3");
+        Assert.AreEqual(21, result);
     }
 }
 ```

--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -30,19 +30,12 @@ Create a `Program.cs` that will navigate to `https://playwright.dev/dotnet` and 
 
 ```csharp
 using Microsoft.Playwright;
-using System.Threading.Tasks;
 
-class Program
-{
-    public static async Task Main()
-    {
-        using var playwright = await Playwright.CreateAsync();
-        await using var browser = await playwright.Chromium.LaunchAsync();
-        var page = await browser.NewPageAsync();
-        await page.GotoAsync("https://playwright.dev/dotnet");
-        await page.ScreenshotAsync(new PageScreenshotOptions { Path = "screenshot.png" });
-    }
-}
+using var playwright = await Playwright.CreateAsync();
+await using var browser = await playwright.Chromium.LaunchAsync();
+var page = await browser.NewPageAsync();
+await page.GotoAsync("https://playwright.dev/dotnet");
+await page.ScreenshotAsync(new PageScreenshotOptions { Path = "screenshot.png" });
 ```
 
 Now run it.

--- a/docs/src/network.md
+++ b/docs/src/network.md
@@ -244,20 +244,13 @@ with sync_playwright() as playwright:
 
 ```csharp
 using Microsoft.Playwright;
-using System;
 
-class Program
-{
-    public static async Task Main()
-    {
-        using var playwright = await Playwright.CreateAsync();
-        await using var browser = await playwright.Chromium.LaunchAsync();
-        var page = await browser.NewPageAsync();
-        page.Request += (_, request) => Console.WriteLine(">> " + request.Method + " " + request.Url);
-        page.Response += (_, response) => Console.WriteLine("<< " + response.Status + " " + response.Url);
-        await page.GotoAsync("https://example.com");
-    }
-}
+using var playwright = await Playwright.CreateAsync();
+await using var browser = await playwright.Chromium.LaunchAsync();
+var page = await browser.NewPageAsync();
+page.Request += (_, request) => Console.WriteLine(">> " + request.Method + " " + request.Url);
+page.Response += (_, response) => Console.WriteLine("<< " + response.Status + " " + response.Url);
+await page.GotoAsync("https://example.com");
 ```
 
 Or wait for a network response after the button click:

--- a/docs/src/pom.md
+++ b/docs/src/pom.md
@@ -103,29 +103,28 @@ class SearchPage:
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 
-namespace BigEcommerceApp.Tests.Models
+namespace BigEcommerceApp.Tests.Models;
+
+public class SearchPage
 {
-  public class SearchPage
+  private readonly IPage _page;
+  private readonly ILocator _searchTermInput;
+
+  public SearchPage(IPage page)
   {
-    private readonly IPage _page;
-    private readonly ILocator _searchTermInput;
+    _page = page;
+    _searchTermInput = page.Locator("[aria-label='Enter your search term']");
+  }
 
-    public SearchPage(IPage page)
-    {
-      _page = page;
-      _searchTermInput = page.Locator("[aria-label='Enter your search term']");
-    }
+  public async Task Goto()
+  {
+    await _page.GotoAsync("https://bing.com");
+  }
 
-    public async Task Goto()
-    {
-      await _page.GotoAsync("https://bing.com");
-    }
-
-    public async Task Search(string text)
-    {
-      await _searchTermInput.FillAsync(text);
-      await _searchTermInput.PressAsync("Enter");
-    }
+  public async Task Search(string text)
+  {
+    await _searchTermInput.FillAsync(text);
+    await _searchTermInput.PressAsync("Enter");
   }
 }
 ```

--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -52,15 +52,14 @@ using System.Threading.Tasks;
 using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
 
-namespace Playwright.TestingHarnessTest.NUnit
+namespace Playwright.TestingHarnessTest.NUnit;
+
+public class ExampleTests : PageTest
 {
-    public class ExampleTests : PageTest
+    [Test]
+    public async Task StatusBecomesSubmitted()
     {
-        [Test]
-        public async Task StatusBecomesSubmitted()
-        {
-            await Expect(Page.Locator(".status")).ToHaveTextAsync("Submitted");
-        }
+        await Expect(Page.Locator(".status")).ToHaveTextAsync("Submitted");
     }
 }
 ```

--- a/docs/src/test-runners-csharp.md
+++ b/docs/src/test-runners-csharp.md
@@ -34,24 +34,23 @@ using System.Threading.Tasks;
 using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
 
-namespace PlaywrightTests
-{
-    [Parallelizable(ParallelScope.Self)]
-    public class MyTest : PageTest
-    {
-        [Test]
-        public async Task ShouldAdd()
-        {
-            int result = await Page.EvaluateAsync<int>("() => 7 + 3");
-            Assert.AreEqual(10, result);
-        }
+namespace PlaywrightTests;
 
-        [Test]
-        public async Task ShouldMultiply()
-        {
-            int result = await Page.EvaluateAsync<int>("() => 7 * 3");
-            Assert.AreEqual(21, result);
-        }
+[Parallelizable(ParallelScope.Self)]
+public class MyTest : PageTest
+{
+    [Test]
+    public async Task ShouldAdd()
+    {
+        int result = await Page.EvaluateAsync<int>("() => 7 + 3");
+        Assert.AreEqual(10, result);
+    }
+
+    [Test]
+    public async Task ShouldMultiply()
+    {
+        int result = await Page.EvaluateAsync<int>("() => 7 * 3");
+        Assert.AreEqual(21, result);
     }
 }
 ```


### PR DESCRIPTION
I converted examples found in top-level style. Omitted some usings base on implicit usings and converted namespace into file-scoped.