### PR TITLE
chore: add workdir to installation tests

### DIFF
--- a/installation-tests/initialize_test.sh
+++ b/installation-tests/initialize_test.sh
@@ -111,6 +111,7 @@ function initialize_test {
 
   cecho "YELLOW" ">>>>>>>>>>>>"
   cecho "YELLOW" "  Running test - '${TEST_FILE}'"
+  cecho "YELLOW" "  Workdir - ${PWD}/${TEST_NAME}"
   cecho "YELLOW" ">>>>>>>>>>>>"
   mkdir ${TEST_NAME} && cd ${TEST_NAME} && npm init -y 1>/dev/null 2>/dev/null
 


### PR DESCRIPTION
This is helpful to debug installation test
