### PR TITLE
chore: fix installation-tests type error warning

### DIFF
--- a/installation-tests/initialize_test.sh
+++ b/installation-tests/initialize_test.sh
@@ -124,6 +124,7 @@ function initialize_test {
   export npm_config_cache="$TEST_TMP_NPM_SCRATCH_SPACE/npm_cache"
   export npm_config_registry="$(local-playwright-registry wait-for-ready)"
   export EXPECTED_NODE_MODULES_PARENT="$(pwd -P)"
+  echo '.playwright-registry/' >> .gitignore
 
   # Enable bash lines logging.
   set -x


### PR DESCRIPTION
This should fix the following:

```
  
  Running 2 tests using 1 worker
  
  Error: /tmp/playwright-installation-tests/test_playwright_test_should_work/.playwright-registry/.staging-package-tMQ83I/package/types/test.d.ts: Missing initializer in const declaration. (3069:119)
  
    3067 |  * and provides a fresh page to each test.
    3068 |  */
  > 3069 | export const test: TestType<PlaywrightTestArgs & PlaywrightTestOptions, PlaywrightWorkerArgs & PlaywrightWorkerOptions>;
         |                                                                                                                        ^
    3070 | export default test;
    3071 |
    3072 | export const _baseTest: TestType<{}, {}>;
```