### PR TITLE
browser(webkit): roll to 2022/04/20

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1631
-Changed: dpino@igalia.com Thu Apr 14 06:07:27 UTC 2022
+1632
+Changed: dkolesa@igalia.com Wed Apr 20 03:58:57 PM CEST 2022

--- a/browser_patches/webkit/UPSTREAM_CONFIG.sh
+++ b/browser_patches/webkit/UPSTREAM_CONFIG.sh
@@ -1,3 +1,3 @@
 REMOTE_URL="https://github.com/WebKit/WebKit.git"
 BASE_BRANCH="main"
-BASE_REVISION="2aa55cf595edfef2ffd838a0f5079d6b2a1d603a"
+BASE_REVISION="70230b87b8baa37f35ed7b58483164c514891c0a"

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -63,12 +63,12 @@ index 667f2c6854f8a1ba13c095f7e154f68e97cbf391..6399b41f2059c96094063c568906128f
      $(JavaScriptCore)/inspector/protocol/ServiceWorker.json \
      $(JavaScriptCore)/inspector/protocol/Target.json \
 diff --git a/Source/JavaScriptCore/bindings/ScriptValue.cpp b/Source/JavaScriptCore/bindings/ScriptValue.cpp
-index 52d955b1e4929f6d0dede53097d275559b29b91d..71c538e57acf3912f9a777f7bc7eba6efb8877eb 100644
+index d28bffd30f21910bb63f515efc6fa9c7749825a4..498ea4b88e0befb9b526c188e079bb5b9882b374 100644
 --- a/Source/JavaScriptCore/bindings/ScriptValue.cpp
 +++ b/Source/JavaScriptCore/bindings/ScriptValue.cpp
 @@ -79,7 +79,10 @@ static RefPtr<JSON::Value> jsToInspectorValue(JSGlobalObject* globalObject, JSVa
          PropertyNameArray propertyNames(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
-         object.methodTable(vm)->getOwnPropertyNames(&object, globalObject, propertyNames, DontEnumPropertiesMode::Exclude);
+         object.methodTable()->getOwnPropertyNames(&object, globalObject, propertyNames, DontEnumPropertiesMode::Exclude);
          for (auto& name : propertyNames) {
 -            auto inspectorValue = jsToInspectorValue(globalObject, object.get(globalObject, name), maxDepth);
 +            JSValue childValue = object.get(globalObject, name);
@@ -1796,7 +1796,7 @@ index 2decf8a83c80e80ca8677f4c787bf79c6c2995fa..9010384a32f7c2ab69a8fb20eb19cd56
      }
  
 diff --git a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
-index 2b27c8820fbc922b9354e6e070df2394280e1557..99854aa23ffd993dcf01015070d7929cf9dabffa 100644
+index aa6ee6b2ad34c05c9056af1931968aa2567abe5b..35693aba5a49956a8326ae5693b6f0e80dbdd066 100644
 --- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
 +++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
 @@ -36,6 +36,7 @@
@@ -1933,7 +1933,7 @@ index 38a4ad6f76932fe5ad6a00689fe60c5b8cc5d042..3cab39566912440255fdbfb765e3a5e7
  PUBLIC_HEADERS_FOLDER_PREFIX = /usr/local/include;
  INSTALL_PUBLIC_HEADER_PREFIX = $(INSTALL_PATH_PREFIX)$(PUBLIC_HEADERS_FOLDER_PREFIX);
 diff --git a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
-index 0d8326fe5dce429851460466cc58687b2ab71b74..817047358946891cd3c1b02b6c01a4f23d4e4db3 100644
+index 8d0fc88c49416514e3c61371664214931fa57566..b3d54a1926996cac1886551afb3a6370c9c274bc 100644
 --- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
 +++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
 @@ -6,6 +6,20 @@
@@ -2024,7 +2024,7 @@ index 0d8326fe5dce429851460466cc58687b2ab71b74..817047358946891cd3c1b02b6c01a4f2
  				DD2E76E827C6B69A00F2A74C /* PBXTargetDependency */,
  				CDEBB4CC24C01AB400ADBD44 /* PBXTargetDependency */,
  				411ED040212E0811004320BA /* PBXTargetDependency */,
-@@ -20090,6 +20129,7 @@
+@@ -20089,6 +20128,7 @@
  				41F77D15215BE45E00E72967 /* yasm */,
  				CDEBB11824C0187400ADBD44 /* webm */,
  				DDF30D0527C5C003006A526F /* absl */,
@@ -2032,7 +2032,7 @@ index 0d8326fe5dce429851460466cc58687b2ab71b74..817047358946891cd3c1b02b6c01a4f2
  			);
  		};
  /* End PBXProject section */
-@@ -20223,6 +20263,23 @@
+@@ -20222,6 +20262,23 @@
  			shellPath = /bin/sh;
  			shellScript = "[ \"${WK_USE_NEW_BUILD_SYSTEM}\" = YES ] && exit 0\nxcodebuild -project \"${PROJECT_FILE_PATH}\" -target \"${TARGET_NAME}\" installhdrs SYMROOT=\"${TARGET_TEMP_DIR}/LegacyNestHeaders-build\" DSTROOT=\"${BUILT_PRODUCTS_DIR}\" SDKROOT=\"${SDKROOT}\" -UseNewBuildSystem=YES\n";
  		};
@@ -2056,7 +2056,7 @@ index 0d8326fe5dce429851460466cc58687b2ab71b74..817047358946891cd3c1b02b6c01a4f2
  /* End PBXShellScriptBuildPhase section */
  
  /* Begin PBXSourcesBuildPhase section */
-@@ -21354,6 +21411,7 @@
+@@ -21353,6 +21410,7 @@
  				419C82F51FE20EB50040C30F /* audio_encoder_opus.cc in Sources */,
  				419C82F31FE20EB50040C30F /* audio_encoder_opus_config.cc in Sources */,
  				4140B8201E4E3383007409E6 /* audio_encoder_pcm.cc in Sources */,
@@ -2064,7 +2064,7 @@ index 0d8326fe5dce429851460466cc58687b2ab71b74..817047358946891cd3c1b02b6c01a4f2
  				5CDD8FFE1E43CE3A00621E92 /* audio_encoder_pcm16b.cc in Sources */,
  				5CD285461E6A61D20094FDC8 /* audio_format.cc in Sources */,
  				41DDB26F212679D200296D47 /* audio_format_to_string.cc in Sources */,
-@@ -21793,6 +21851,7 @@
+@@ -21792,6 +21850,7 @@
  				417953DB216983910028266B /* metrics.cc in Sources */,
  				5CDD865E1E43B8B500621E92 /* min_max_operations.c in Sources */,
  				4189395B242A71F5007FDC41 /* min_video_bitrate_experiment.cc in Sources */,
@@ -2072,7 +2072,7 @@ index 0d8326fe5dce429851460466cc58687b2ab71b74..817047358946891cd3c1b02b6c01a4f2
  				4131C387234B957D0028A615 /* moving_average.cc in Sources */,
  				41FCBB1521B1F7AA00A5DF27 /* moving_average.cc in Sources */,
  				5CD286101E6A64C90094FDC8 /* moving_max.cc in Sources */,
-@@ -22026,6 +22085,7 @@
+@@ -22025,6 +22084,7 @@
  				4131C53B234C8B190028A615 /* rtc_event_rtp_packet_outgoing.cc in Sources */,
  				4131C552234C8B190028A615 /* rtc_event_video_receive_stream_config.cc in Sources */,
  				4131C554234C8B190028A615 /* rtc_event_video_send_stream_config.cc in Sources */,
@@ -2080,7 +2080,7 @@ index 0d8326fe5dce429851460466cc58687b2ab71b74..817047358946891cd3c1b02b6c01a4f2
  				4131C3CF234B98420028A615 /* rtc_stats.cc in Sources */,
  				4131BF2D234B88200028A615 /* rtc_stats_collector.cc in Sources */,
  				4131C3CE234B98420028A615 /* rtc_stats_report.cc in Sources */,
-@@ -22477,6 +22537,11 @@
+@@ -22476,6 +22536,11 @@
  			target = DDF30D0527C5C003006A526F /* absl */;
  			targetProxy = DD2E76E727C6B69A00F2A74C /* PBXContainerItemProxy */;
  		};
@@ -2092,7 +2092,7 @@ index 0d8326fe5dce429851460466cc58687b2ab71b74..817047358946891cd3c1b02b6c01a4f2
  /* End PBXTargetDependency section */
  
  /* Begin XCBuildConfiguration section */
-@@ -22725,6 +22790,27 @@
+@@ -22724,6 +22789,27 @@
  			};
  			name = Production;
  		};
@@ -2120,7 +2120,7 @@ index 0d8326fe5dce429851460466cc58687b2ab71b74..817047358946891cd3c1b02b6c01a4f2
  		FB39D0711200ED9200088E69 /* Debug */ = {
  			isa = XCBuildConfiguration;
  			baseConfigurationReference = 5D7C59C71208C68B001C873E /* DebugRelease.xcconfig */;
-@@ -22857,6 +22943,16 @@
+@@ -22856,6 +22942,16 @@
  			defaultConfigurationIsVisible = 0;
  			defaultConfigurationName = Production;
  		};
@@ -2169,10 +2169,10 @@ index f8edbb7e0638916d22209b9c0baf5b9ed5af9858..aa345b4470460ecfbb33cd301007da5a
    type: bool
    humanReadableName: "Private Click Measurement"
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index c36afc73c97956c167becab023bb4cbb6e52cf62..4985ad839ef85ef825503b30a3ba02e7986634dc 100644
+index 81325855deb728478b86deed54e81ffd0216406a..df1ba70e814b5b730a10dcfea89954600e6af1d6 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-@@ -455,7 +455,7 @@ CrossOriginOpenerPolicyEnabled:
+@@ -467,7 +467,7 @@ CrossOriginOpenerPolicyEnabled:
      WebKitLegacy:
        default: false
      WebKit:
@@ -2181,7 +2181,7 @@ index c36afc73c97956c167becab023bb4cbb6e52cf62..4985ad839ef85ef825503b30a3ba02e7
      WebCore:
        default: false
  
-@@ -832,9 +832,9 @@ MaskWebGLStringsEnabled:
+@@ -844,9 +844,9 @@ MaskWebGLStringsEnabled:
      WebKitLegacy:
        default: true
      WebKit:
@@ -2193,7 +2193,7 @@ index c36afc73c97956c167becab023bb4cbb6e52cf62..4985ad839ef85ef825503b30a3ba02e7
  
  # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
  MediaCapabilitiesExtensionsEnabled:
-@@ -1342,7 +1342,7 @@ SpeechRecognitionEnabled:
+@@ -1354,7 +1354,7 @@ SpeechRecognitionEnabled:
      WebKitLegacy:
        default: false
      WebKit:
@@ -2202,7 +2202,7 @@ index c36afc73c97956c167becab023bb4cbb6e52cf62..4985ad839ef85ef825503b30a3ba02e7
        default: false
      WebCore:
        default: false
-@@ -1457,6 +1457,7 @@ UseGPUProcessForDisplayCapture:
+@@ -1469,6 +1469,7 @@ UseGPUProcessForDisplayCapture:
      WebKit:
        default: false
  
@@ -2210,7 +2210,7 @@ index c36afc73c97956c167becab023bb4cbb6e52cf62..4985ad839ef85ef825503b30a3ba02e7
  UseGPUProcessForWebGLEnabled:
    type: bool
    humanReadableName: "GPU Process: WebGL"
-@@ -1467,7 +1468,7 @@ UseGPUProcessForWebGLEnabled:
+@@ -1479,7 +1480,7 @@ UseGPUProcessForWebGLEnabled:
    defaultValue:
      WebKit:
        "ENABLE(GPU_PROCESS_BY_DEFAULT) && PLATFORM(IOS_FAMILY) && !HAVE(UIKIT_WEBKIT_INTERNALS)": true
@@ -2375,10 +2375,10 @@ index 174e6c07b6f5cf4bcf0469f20f8cf021bed25103..722fff5cdfaf70e2187f96345f78cf44
  WTF_EXPORT_PRIVATE LocalTimeOffset calculateLocalTimeOffset(double utcInMilliseconds, TimeType = UTCTime);
  
 diff --git a/Source/WTF/wtf/PlatformEnable.h b/Source/WTF/wtf/PlatformEnable.h
-index 3550d41b452a9ca149a15ac00f5ef053893108bb..88260d1a36d0e4f62c45c7b61f2e2f953ae79693 100644
+index a2e03f813369da8d01db2bf1176d3fad827a51a7..782975a40591504fed7fa03dc65d5d1c100f9b0d 100644
 --- a/Source/WTF/wtf/PlatformEnable.h
 +++ b/Source/WTF/wtf/PlatformEnable.h
-@@ -416,7 +416,7 @@
+@@ -420,7 +420,7 @@
  #endif
  
  #if !defined(ENABLE_ORIENTATION_EVENTS)
@@ -2387,7 +2387,7 @@ index 3550d41b452a9ca149a15ac00f5ef053893108bb..88260d1a36d0e4f62c45c7b61f2e2f95
  #endif
  
  #if OS(WINDOWS)
-@@ -477,7 +477,7 @@
+@@ -481,7 +481,7 @@
  #endif
  
  #if !defined(ENABLE_TOUCH_EVENTS)
@@ -2446,6 +2446,29 @@ index 09d4af604a835c7c6be1e43c249565bd1053aff4..0d6112342480454ce41a6b56dd925e1d
  )
  
  if (Journald_FOUND)
+diff --git a/Source/WTF/wtf/StdLibExtras.h b/Source/WTF/wtf/StdLibExtras.h
+index cef91ed8e1e484695b0168cfdf625407da0c9933..b67ff2f5c7a46de5f26ea7f09fde8090885bb53a 100644
+--- a/Source/WTF/wtf/StdLibExtras.h
++++ b/Source/WTF/wtf/StdLibExtras.h
+@@ -605,6 +605,18 @@ template<typename OptionalType> auto valueOrDefault(OptionalType&& optionalValue
+ 
+ #define WTFMove(value) std::move<WTF::CheckMoveParameter>(value)
+ 
++#if defined(__GLIBCXX__) && !defined(__cpp_lib_remove_cvref)
++template <typename T>
++struct remove_cvref {
++    using type = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
++};
++
++namespace std {
++template <typename T>
++using remove_cvref_t = typename remove_cvref<T>::type;
++}
++#endif
++
+ using WTF::GB;
+ using WTF::KB;
+ using WTF::MB;
 diff --git a/Source/WebCore/DerivedSources.make b/Source/WebCore/DerivedSources.make
 index d663c323684d1c0f880fb7cf961fc6fa4216e46c..59352ac981e7b9a8053354badafafa379efef72f 100644
 --- a/Source/WebCore/DerivedSources.make
@@ -2548,10 +2571,10 @@ index 9d021a1a887fb06779b063b525ac985f8f4ba37a..8378753eacb14e9fd34e906111352b58
  
  set(CSS_VALUE_PLATFORM_DEFINES "HAVE_OS_DARK_MODE_SUPPORT=1")
 diff --git a/Source/WebCore/SourcesCocoa.txt b/Source/WebCore/SourcesCocoa.txt
-index 2160349b0834db01052c496958b96ce90d700a60..1c28bc44b0ebb19ae49eeae27c7076628e4407ed 100644
+index fe99b3cd1c087cb0d3d965e6a0e32e7a63671389..470828ba028a4c28490b4f4e2eebf7c7d1c443f9 100644
 --- a/Source/WebCore/SourcesCocoa.txt
 +++ b/Source/WebCore/SourcesCocoa.txt
-@@ -631,3 +631,9 @@ platform/graphics/angle/GraphicsContextGLANGLE.cpp @no-unify
+@@ -630,3 +630,9 @@ platform/graphics/angle/GraphicsContextGLANGLE.cpp @no-unify
  platform/graphics/cocoa/ANGLEUtilitiesCocoa.cpp @no-unify
  platform/graphics/cocoa/GraphicsContextGLCocoa.mm @no-unify
  platform/graphics/cv/GraphicsContextGLCVCocoa.cpp @no-unify
@@ -2640,7 +2663,7 @@ index c4898d6db6bf06552f602c4b7f0a7267e64e44f4..7cf2e30729671a89c373870c5691d337
  __ZN7WebCore14DocumentLoaderD2Ev
  __ZN7WebCore14DocumentLoader17clearMainResourceEv
 diff --git a/Source/WebCore/WebCore.xcodeproj/project.pbxproj b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b493e865159 100644
+index c29130ebc767e5783999f7d0687b1f1122ed92b6..d8efde76839d9e3d888e5a58a0fd80b199e751ef 100644
 --- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 +++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 @@ -5525,6 +5525,13 @@
@@ -2657,7 +2680,7 @@ index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b49
  		F12171F616A8CF0B000053CA /* WebVTTElement.h in Headers */ = {isa = PBXBuildFile; fileRef = F12171F416A8BC63000053CA /* WebVTTElement.h */; };
  		F32BDCD92363AACA0073B6AE /* UserGestureEmulationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F32BDCD72363AACA0073B6AE /* UserGestureEmulationScope.h */; };
  		F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
-@@ -17850,6 +17857,14 @@
+@@ -17849,6 +17856,14 @@
  		EDEC98020AED7E170059137F /* WebCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCorePrefix.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
  		EFB7287B2124C73D005C2558 /* CanvasActivityRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasActivityRecord.cpp; sourceTree = "<group>"; };
  		EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasActivityRecord.h; sourceTree = "<group>"; };
@@ -2685,7 +2708,7 @@ index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b49
  				E0FEF371B27C53EAC1C1FBEE /* EventSource.cpp */,
  				E0FEF371B17C53EAC1C1FBEE /* EventSource.h */,
  				E0FEF371B07C53EAC1C1FBEE /* EventSource.idl */,
-@@ -30257,6 +30277,8 @@
+@@ -30286,6 +30306,8 @@
  				29E4D8DF16B0940F00C84704 /* PlatformSpeechSynthesizer.h */,
  				1AD8F81A11CAB9E900E93E54 /* PlatformStrategies.cpp */,
  				1AD8F81911CAB9E900E93E54 /* PlatformStrategies.h */,
@@ -2694,7 +2717,7 @@ index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b49
  				0FD7C21D23CE41E30096D102 /* PlatformWheelEvent.cpp */,
  				935C476A09AC4D4F00A6AAB4 /* PlatformWheelEvent.h */,
  				BCBB8AB513F1AFB000734DF0 /* PODInterval.h */,
-@@ -32585,6 +32607,7 @@
+@@ -32591,6 +32613,7 @@
  				BCCFBAE70B5152ED0001F1D7 /* DocumentParser.h */,
  				AD6E71AA1668899D00320C13 /* DocumentSharedObjectPool.cpp */,
  				AD6E71AB1668899D00320C13 /* DocumentSharedObjectPool.h */,
@@ -2702,7 +2725,7 @@ index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b49
  				6BDB5DC1227BD3B800919770 /* DocumentStorageAccess.cpp */,
  				6BDB5DC0227BD3B800919770 /* DocumentStorageAccess.h */,
  				7CE7FA5B1EF882300060C9D6 /* DocumentTouch.cpp */,
-@@ -33594,6 +33617,7 @@
+@@ -33600,6 +33623,7 @@
  				93C4F6EB1108F9A50099D0DB /* AccessibilityScrollbar.h in Headers */,
  				29489FC712C00F0300D83F0F /* AccessibilityScrollView.h in Headers */,
  				0709FC4E1025DEE30059CDBA /* AccessibilitySlider.h in Headers */,
@@ -2710,7 +2733,7 @@ index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b49
  				29D7BCFA1444AF7D0070619C /* AccessibilitySpinButton.h in Headers */,
  				69A6CBAD1C6BE42C00B836E9 /* AccessibilitySVGElement.h in Headers */,
  				AAC08CF315F941FD00F1E188 /* AccessibilitySVGRoot.h in Headers */,
-@@ -35737,6 +35761,7 @@
+@@ -35743,6 +35767,7 @@
  				6E4ABCD5138EA0B70071D291 /* JSHTMLUnknownElement.h in Headers */,
  				E44614170CD6826900FADA75 /* JSHTMLVideoElement.h in Headers */,
  				81BE20D311F4BC3200915DFA /* JSIDBCursor.h in Headers */,
@@ -2718,7 +2741,7 @@ index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b49
  				7C3D8EF01E0B21430023B084 /* JSIDBCursorDirection.h in Headers */,
  				C585A68311D4FB08004C3E4B /* JSIDBDatabase.h in Headers */,
  				C585A69711D4FB13004C3E4B /* JSIDBFactory.h in Headers */,
-@@ -36858,6 +36883,7 @@
+@@ -36864,6 +36889,7 @@
  				0F7D07331884C56C00B4AF86 /* PlatformTextTrack.h in Headers */,
  				074E82BB18A69F0E007EF54C /* PlatformTimeRanges.h in Headers */,
  				CDD08ABD277E542600EA3755 /* PlatformTrackConfiguration.h in Headers */,
@@ -2726,7 +2749,7 @@ index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b49
  				CD1F9B022700323D00617EB6 /* PlatformVideoColorPrimaries.h in Headers */,
  				CD1F9B01270020B700617EB6 /* PlatformVideoColorSpace.h in Headers */,
  				CD1F9B032700323D00617EB6 /* PlatformVideoMatrixCoefficients.h in Headers */,
-@@ -38952,6 +38978,7 @@
+@@ -38957,6 +38983,7 @@
  				1ABA76CA11D20E50004C201C /* CSSPropertyNames.cpp in Sources */,
  				2D22830323A8470700364B7E /* CursorMac.mm in Sources */,
  				5CBD59592280E926002B22AA /* CustomHeaderFields.cpp in Sources */,
@@ -2734,7 +2757,7 @@ index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b49
  				7CE6CBFD187F394900D46BF5 /* FormatConverter.cpp in Sources */,
  				5130F2F624AEA60A00E1D0A0 /* GameControllerSoftLink.mm in Sources */,
  				51A4BB0A1954D61600FA5C2E /* Gamepad.cpp in Sources */,
-@@ -39028,6 +39055,7 @@
+@@ -39033,6 +39060,7 @@
  				C1692DD223D23ABD006E88F7 /* SystemBattery.mm in Sources */,
  				CE88EE262414467B007F29C2 /* TextAlternativeWithRange.mm in Sources */,
  				51DF6D800B92A18E00C2DC85 /* ThreadCheck.mm in Sources */,
@@ -2742,7 +2765,7 @@ index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b49
  				538EC8031F96AF81004D22A8 /* UnifiedSource1-mm.mm in Sources */,
  				538EC8021F96AF81004D22A8 /* UnifiedSource1.cpp in Sources */,
  				538EC8051F96AF81004D22A8 /* UnifiedSource2-mm.mm in Sources */,
-@@ -39076,6 +39104,7 @@
+@@ -39081,6 +39109,7 @@
  				538EC8881F993F9C004D22A8 /* UnifiedSource23.cpp in Sources */,
  				DE5F85801FA1ABF4006DB63A /* UnifiedSource24-mm.mm in Sources */,
  				538EC8891F993F9D004D22A8 /* UnifiedSource24.cpp in Sources */,
@@ -2750,7 +2773,7 @@ index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b49
  				DE5F85811FA1ABF4006DB63A /* UnifiedSource25-mm.mm in Sources */,
  				538EC88A1F993F9D004D22A8 /* UnifiedSource25.cpp in Sources */,
  				DE5F85821FA1ABF4006DB63A /* UnifiedSource26-mm.mm in Sources */,
-@@ -39608,6 +39637,7 @@
+@@ -39613,6 +39642,7 @@
  				2D8B92F1203D13E1009C868F /* UnifiedSource516.cpp in Sources */,
  				2D8B92F2203D13E1009C868F /* UnifiedSource517.cpp in Sources */,
  				2D8B92F3203D13E1009C868F /* UnifiedSource518.cpp in Sources */,
@@ -2759,7 +2782,7 @@ index 5d511b9df04be69f9c55f6523513e1991f7d3f1f..18536b179b5c1c4ca7f1ef4a738a0b49
  				2D8B92F5203D13E1009C868F /* UnifiedSource520.cpp in Sources */,
  				2D8B92F6203D13E1009C868F /* UnifiedSource521.cpp in Sources */,
 diff --git a/Source/WebCore/accessibility/AccessibilityObject.cpp b/Source/WebCore/accessibility/AccessibilityObject.cpp
-index 89e192d3c8a2dbe6f8cdbb4baeccd43de9317645..920e80b2e91df98398f3a9151eaddcd35d44198a 100644
+index 0f182a4f3c153cb28d3cd70495680e1afed2262b..8b6444bf2b519121adc434046729a1705f91d631 100644
 --- a/Source/WebCore/accessibility/AccessibilityObject.cpp
 +++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
 @@ -61,6 +61,7 @@
@@ -2907,7 +2930,7 @@ index 0000000000000000000000000000000000000000..dd2d8452302999e4a89b0bc18e842645
 +
 +#endif // ENABLE(ACCESSIBILITY) && !USE(ATK) && !USE(ATSPI)
 diff --git a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
-index c128577029f09d0f6a0ce77b2e0d85c19c2e9fc0..934500913a61c2f7763ac1f58100ac17515bc553 100644
+index 63ea7faaf59dd77940293446338fa8b228355fa5..ea522b60acc03e3ff82cb0a4afa2d2317bd2e31d 100644
 --- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
 +++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
 @@ -131,6 +131,8 @@ namespace WebCore {
@@ -3162,10 +3185,10 @@ index 491490579e6b911498449ca829fc9158851ab8d9..725996216e7349784c2c81ba0f619ced
  
  #endif // USE(LIBWPE)
 diff --git a/Source/WebCore/html/FileInputType.cpp b/Source/WebCore/html/FileInputType.cpp
-index ed202a726b20441b72f8cf1ccac7d3fa276de483..d797ef0fc42176711051f54f230a6e5c409663c5 100644
+index ba4ae4b4c2a7b9ac275f54b7b32b49aa03c621f0..01646ff26a370575e47a4aeba0315d47078d8c37 100644
 --- a/Source/WebCore/html/FileInputType.cpp
 +++ b/Source/WebCore/html/FileInputType.cpp
-@@ -36,6 +36,7 @@
+@@ -37,6 +37,7 @@
  #include "HTMLNames.h"
  #include "Icon.h"
  #include "InputTypeNames.h"
@@ -3186,7 +3209,7 @@ index ed202a726b20441b72f8cf1ccac7d3fa276de483..d797ef0fc42176711051f54f230a6e5c
          return;
  
 diff --git a/Source/WebCore/inspector/InspectorController.cpp b/Source/WebCore/inspector/InspectorController.cpp
-index ea02ba6e973b974da0c4a2985ed057a6c62f2b37..8574670b289d5fc5c57b60c8b261199ddc1eb4c3 100644
+index 23b330d6d57226dd0e3e2d19117520097f6baf7f..45531ee0561e8783f245f05f27cd51c175c52b70 100644
 --- a/Source/WebCore/inspector/InspectorController.cpp
 +++ b/Source/WebCore/inspector/InspectorController.cpp
 @@ -285,6 +285,8 @@ void InspectorController::disconnectFrontend(FrontendChannel& frontendChannel)
@@ -3619,7 +3642,7 @@ index 51badf49a6ce08975d655efa01cca9cd877e8f6b..ea4240cf72670cedfbd8b38d4d013676
  {
      return context ? instrumentingAgents(*context) : nullptr;
 diff --git a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
-index 5766244e85d627eea7ab1ccd5d6a6d3688f2be7e..628b102d13b184a8395e387db741e4f9ea5973e1 100644
+index 7d5617c2ad3035b3cc91a3f00bcf35dbeda788c7..02994137d18b1c5ed286edecf1f3b434b3a60b1c 100644
 --- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
 @@ -62,12 +62,16 @@
@@ -3853,7 +3876,7 @@ index 5766244e85d627eea7ab1ccd5d6a6d3688f2be7e..628b102d13b184a8395e387db741e4f9
      if (!object)
          return makeUnexpected("Missing injected script for given nodeId"_s);
  
-@@ -2897,7 +3030,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPath
+@@ -2895,7 +3028,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPath
      return makeUnexpected("Missing node for given path"_s);
  }
  
@@ -3862,7 +3885,7 @@ index 5766244e85d627eea7ab1ccd5d6a6d3688f2be7e..628b102d13b184a8395e387db741e4f9
  {
      Document* document = &node->document();
      if (auto* templateHost = document->templateDocumentHost())
-@@ -2906,12 +3039,18 @@ RefPtr<Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* nod
+@@ -2904,12 +3037,18 @@ RefPtr<Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* nod
      if (!frame)
          return nullptr;
  
@@ -3884,7 +3907,7 @@ index 5766244e85d627eea7ab1ccd5d6a6d3688f2be7e..628b102d13b184a8395e387db741e4f9
  }
  
  Node* InspectorDOMAgent::scriptValueAsNode(JSC::JSValue value)
-@@ -2934,4 +3073,57 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowT
+@@ -2932,4 +3071,57 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowT
      return { };
  }
  
@@ -5649,7 +5672,7 @@ index 982691dd2dfe2f65201370a12302b5086703c126..4af72beb3b1405ffac78e89e7fbb2b14
  protected:
      static SameSiteInfo sameSiteInfo(const Document&, IsForDOMCookieAccess = IsForDOMCookieAccess::No);
 diff --git a/Source/WebCore/loader/DocumentLoader.cpp b/Source/WebCore/loader/DocumentLoader.cpp
-index 55682d0e47cf8aae77f4978341793a35d5540ac1..9f077ab8b27db67a815654be529dfefc0b098a0b 100644
+index 31cf78ca5b143551a3ba75023afca543fce49434..f27238fce970f3da433a3ecc37f9045a7cd8512d 100644
 --- a/Source/WebCore/loader/DocumentLoader.cpp
 +++ b/Source/WebCore/loader/DocumentLoader.cpp
 @@ -1488,8 +1488,6 @@ void DocumentLoader::detachFromFrame()
@@ -5680,10 +5703,10 @@ index c6450d5072d0efd0430b6d3e5420d2d2b3e943cb..74e9c8ea1366c8785f02d5bbd92e0952
      DocumentWriter& writer() const { return m_writer; }
  
 diff --git a/Source/WebCore/loader/FrameLoader.cpp b/Source/WebCore/loader/FrameLoader.cpp
-index 5c42705a52fe4b6a5b7b9177130c1c3fc9a618c3..0edfa805a6c17758bf46a6cf4bd51c42a3c2567c 100644
+index 68c6c52dd77811d5b0ede97b369101715990e181..b14218a86ae0da5e7c8930a78fcd1be166634e4e 100644
 --- a/Source/WebCore/loader/FrameLoader.cpp
 +++ b/Source/WebCore/loader/FrameLoader.cpp
-@@ -1161,6 +1161,7 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
+@@ -1167,6 +1167,7 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
      }
  
      m_client->dispatchDidNavigateWithinPage();
@@ -5691,7 +5714,7 @@ index 5c42705a52fe4b6a5b7b9177130c1c3fc9a618c3..0edfa805a6c17758bf46a6cf4bd51c42
  
      m_frame.document()->statePopped(stateObject ? stateObject.releaseNonNull() : SerializedScriptValue::nullValue());
      m_client->dispatchDidPopStateWithinPage();
-@@ -1597,6 +1598,8 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
+@@ -1603,6 +1604,8 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
      const String& httpMethod = loader->request().httpMethod();
  
      if (shouldPerformFragmentNavigation(isFormSubmission, httpMethod, policyChecker().loadType(), newURL)) {
@@ -5700,7 +5723,7 @@ index 5c42705a52fe4b6a5b7b9177130c1c3fc9a618c3..0edfa805a6c17758bf46a6cf4bd51c42
          RefPtr<DocumentLoader> oldDocumentLoader = m_documentLoader;
          NavigationAction action { *m_frame.document(), loader->request(), InitiatedByMainFrame::Unknown, policyChecker().loadType(), isFormSubmission };
  
-@@ -1626,7 +1629,9 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
+@@ -1632,7 +1635,9 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
      }
  
      RELEASE_ASSERT(!isBackForwardLoadType(policyChecker().loadType()) || history().provisionalItem());
@@ -5710,7 +5733,7 @@ index 5c42705a52fe4b6a5b7b9177130c1c3fc9a618c3..0edfa805a6c17758bf46a6cf4bd51c42
          continueLoadAfterNavigationPolicy(request, formState.get(), navigationPolicyDecision, allowNavigationToInvalidURL);
          completionHandler();
      }, PolicyDecisionMode::Asynchronous);
-@@ -2794,12 +2799,17 @@ String FrameLoader::userAgent(const URL& url) const
+@@ -2800,12 +2805,17 @@ String FrameLoader::userAgent(const URL& url) const
  
  String FrameLoader::navigatorPlatform() const
  {
@@ -5730,7 +5753,7 @@ index 5c42705a52fe4b6a5b7b9177130c1c3fc9a618c3..0edfa805a6c17758bf46a6cf4bd51c42
  }
  
  void FrameLoader::dispatchOnloadEvents()
-@@ -3206,6 +3216,8 @@ void FrameLoader::receivedMainResourceError(const ResourceError& error)
+@@ -3212,6 +3222,8 @@ void FrameLoader::receivedMainResourceError(const ResourceError& error)
      checkCompleted();
      if (m_frame.page())
          checkLoadComplete();
@@ -5739,7 +5762,7 @@ index 5c42705a52fe4b6a5b7b9177130c1c3fc9a618c3..0edfa805a6c17758bf46a6cf4bd51c42
  }
  
  void FrameLoader::continueFragmentScrollAfterNavigationPolicy(const ResourceRequest& request, bool shouldContinue)
-@@ -3973,9 +3985,6 @@ String FrameLoader::referrer() const
+@@ -3979,9 +3991,6 @@ String FrameLoader::referrer() const
  
  void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
  {
@@ -5749,7 +5772,7 @@ index 5c42705a52fe4b6a5b7b9177130c1c3fc9a618c3..0edfa805a6c17758bf46a6cf4bd51c42
      Vector<Ref<DOMWrapperWorld>> worlds;
      ScriptController::getAllWorlds(worlds);
      for (auto& world : worlds)
-@@ -3984,13 +3993,13 @@ void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
+@@ -3990,13 +3999,13 @@ void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
  
  void FrameLoader::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld& world)
  {
@@ -5829,7 +5852,7 @@ index a98d1b590dc79214ca29aef33d49a724f4f9df1f..2a2d362f00998c82419d7878148e0c90
  
  #if ENABLE(INPUT_TYPE_COLOR)
 diff --git a/Source/WebCore/page/EventHandler.cpp b/Source/WebCore/page/EventHandler.cpp
-index 6aa54912ee2817b2637cbefc1d2875b502fcd7be..fb99bc195cbc0a61915a908ece781cb50315ace6 100644
+index b372d51d8a9e8f785262d576776e5dea512547ff..680ad73ef754f84d5d89494cabf2885204baa383 100644
 --- a/Source/WebCore/page/EventHandler.cpp
 +++ b/Source/WebCore/page/EventHandler.cpp
 @@ -141,6 +141,7 @@
@@ -5964,7 +5987,7 @@ index 6aa54912ee2817b2637cbefc1d2875b502fcd7be..fb99bc195cbc0a61915a908ece781cb5
      m_touchPressed = touches->length() > 0;
      if (allTouchReleased)
 diff --git a/Source/WebCore/page/EventHandler.h b/Source/WebCore/page/EventHandler.h
-index de408bfdd161f86de51d9b528a9d27452a76b82a..d9b2374b0f7abf2789729fcc805c65050eba43b4 100644
+index 51d36bd866b1d5f1daea4b02ce86b213eaa44adb..fd3cd3dad309416f41a0a0bcac22c9e50b0abd8d 100644
 --- a/Source/WebCore/page/EventHandler.h
 +++ b/Source/WebCore/page/EventHandler.h
 @@ -135,9 +135,7 @@ public:
@@ -6042,7 +6065,7 @@ index 8d7d9e66d7bc1d429aa5d7ff4668504008aacd4d..a1345e0a432f6b88095bd00de0f2c067
      request.setHTTPHeaderField(HTTPHeaderName::Accept, "text/event-stream"_s);
      request.setHTTPHeaderField(HTTPHeaderName::CacheControl, "no-cache"_s);
 diff --git a/Source/WebCore/page/Frame.cpp b/Source/WebCore/page/Frame.cpp
-index 9faf8adf69b5cc55c2b3afa7aa61ce2bdc0a047f..d28cd6b5b6ad4f1be78a51e218f2627ba57b92bc 100644
+index a2578be89018aa710a8f78baabb05bf348ed19a2..c9b651ff3cdc77ee0b0c58a3f575b6e76833aee0 100644
 --- a/Source/WebCore/page/Frame.cpp
 +++ b/Source/WebCore/page/Frame.cpp
 @@ -39,6 +39,7 @@
@@ -6078,7 +6101,7 @@ index 9faf8adf69b5cc55c2b3afa7aa61ce2bdc0a047f..d28cd6b5b6ad4f1be78a51e218f2627b
      return 0;
  }
  #endif // ENABLE(ORIENTATION_EVENTS)
-@@ -1166,6 +1169,362 @@ DataDetectionResultsStorage& Frame::dataDetectionResults()
+@@ -1167,6 +1170,362 @@ DataDetectionResultsStorage& Frame::dataDetectionResults()
  
  #endif
  
@@ -6442,7 +6465,7 @@ index 9faf8adf69b5cc55c2b3afa7aa61ce2bdc0a047f..d28cd6b5b6ad4f1be78a51e218f2627b
  
  #undef FRAME_RELEASE_LOG_ERROR
 diff --git a/Source/WebCore/page/Frame.h b/Source/WebCore/page/Frame.h
-index c86fe59e30404cd959e08aeaed640558a8abc56e..a44553efaaac5022cd17dd12092e9b2f4dd9f3f4 100644
+index 856ff374f367332ca5ab10a46bff825b8bcb159b..24bbbcd6b51a9ae27c72a0810c97678afb6b018c 100644
 --- a/Source/WebCore/page/Frame.h
 +++ b/Source/WebCore/page/Frame.h
 @@ -113,8 +113,8 @@ enum {
@@ -6572,7 +6595,7 @@ index a782c3be51ca113a52482c5a10583c8fa64724ef..1d82dff81be5c5492efb3bfe77d2f259
      if (stateObjectType == StateObjectType::Push) {
          frame->loader().history().pushState(WTFMove(data), title, fullURL.string());
 diff --git a/Source/WebCore/page/Page.cpp b/Source/WebCore/page/Page.cpp
-index 5d3f68042e72f27f95d56a5be5907d405f05a04f..4df2e553f58ea69de2118865655a3daed7bd5602 100644
+index 9358b8464bb5939105a6898476ff691aef3c3780..30118f620cccc4be27c6b8230883f89d1eb18849 100644
 --- a/Source/WebCore/page/Page.cpp
 +++ b/Source/WebCore/page/Page.cpp
 @@ -488,6 +488,37 @@ void Page::setOverrideViewportArguments(const std::optional<ViewportArguments>&
@@ -6779,7 +6802,7 @@ index 897d2a009752a4030659a88e8b16382e00ac2316..08bb3344c59a0462668762815473659f
  #endif
  
 diff --git a/Source/WebCore/page/RuntimeEnabledFeatures.h b/Source/WebCore/page/RuntimeEnabledFeatures.h
-index 68b7a23d83a3c4effc41e811bd7c3518b4b22d4b..a15562111a57f4b95721fb4951d51e21e8298928 100644
+index fae947611145ce5f79f3a7c846f80a9512e7d25b..f84c9a414aceba10131e0fabf23d3282e2e76603 100644
 --- a/Source/WebCore/page/RuntimeEnabledFeatures.h
 +++ b/Source/WebCore/page/RuntimeEnabledFeatures.h
 @@ -181,6 +181,7 @@ public:
@@ -7247,10 +7270,10 @@ index 0000000000000000000000000000000000000000..f0c3a183e5bc44bdfa4201e0db2067b4
 +
 +#endif // ENABLE(SPEECH_SYNTHESIS)
 diff --git a/Source/WebCore/platform/graphics/FontCascade.h b/Source/WebCore/platform/graphics/FontCascade.h
-index 09f41d601d60cb10fb996540149a1bc652fce835..d69f7dc19d76d2b9174cedb11692b4c0cb1316d7 100644
+index ee63764693bb08b70a4ee6c54bf566f5143182cf..947c9c4f4bde763469e66b915e054f8d6426fe31 100644
 --- a/Source/WebCore/platform/graphics/FontCascade.h
 +++ b/Source/WebCore/platform/graphics/FontCascade.h
-@@ -303,7 +303,8 @@ private:
+@@ -306,7 +306,8 @@ private:
              return true;
          if (textRenderingMode == TextRenderingMode::OptimizeSpeed)
              return false;
@@ -8403,7 +8426,7 @@ index 6e0a3dc7ac5adf22f553f81113633a135ae9271c..16e629a1489bede4f3266253c11077b8
  {
      GUniquePtr<SoupCookie> targetCookie(cookie.toSoupCookie());
 diff --git a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
-index efb4c51f667e2030b0dd119b48542f50d660ede3..af8f59b3084e1721bcac3ad8ff39fe59fb98770b 100644
+index bc819bfda4d07cf04f0d10b7ebf401261c75e3ea..f8c9e6a221409dbc4e5ed10063fc1905c89e55cd 100644
 --- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
 +++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
 @@ -38,6 +38,7 @@
@@ -8475,10 +8498,10 @@ index 05a0d1256a136982507b732c7852bbece201b513..f2c00eca40fbf3a88780610228f60ba6
  
  bool PlatformKeyboardEvent::currentCapsLockState()
 diff --git a/Source/WebCore/platform/win/PasteboardWin.cpp b/Source/WebCore/platform/win/PasteboardWin.cpp
-index 4ce328a831c90bf6bd228e1f072408d64b33a45e..d46934eaaf3b12bf40d2f09d68f1aef9eaf79eab 100644
+index 06dd35f9872cb9af518ab94c557508938ea67fdf..aadcf6f3b9045b6cb4902c5cde30616cd5a10fb8 100644
 --- a/Source/WebCore/platform/win/PasteboardWin.cpp
 +++ b/Source/WebCore/platform/win/PasteboardWin.cpp
-@@ -1130,7 +1130,21 @@ void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
+@@ -1129,7 +1129,21 @@ void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
      }
  
      clear();
@@ -8500,7 +8523,7 @@ index 4ce328a831c90bf6bd228e1f072408d64b33a45e..d46934eaaf3b12bf40d2f09d68f1aef9
      if (::OpenClipboard(m_owner)) {
          const auto& customData = data.first();
          customData.forEachPlatformStringOrBuffer([](auto& type, auto& stringOrBuffer) {
-@@ -1169,4 +1183,25 @@ void Pasteboard::write(const Color&)
+@@ -1168,4 +1182,25 @@ void Pasteboard::write(const Color&)
  {
  }
  
@@ -9062,7 +9085,7 @@ index a2629e4edb214b3d26aca78da845c65d0e5aa341..d034f3a57badda1f34729afd712db7cd
      RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
      LogUserInteraction(WebCore::RegistrableDomain domain)
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.cpp b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
-index 6a875f40242194fa92c689d74d1d42caf936371d..cb6bd6b5449f58c219cd993df9e968725b0191c7 100644
+index 530cbcd5a06e042db665a508a0c6b0cd4d181f19..abd09d51568f1a25c664e38cf325192b6de59cd2 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 @@ -26,7 +26,6 @@
@@ -9164,7 +9187,7 @@ index 531bcbc355cfdf51d0b49048c2149d7038dcf15b..f76ad4d2308d95366e7ad74bdf3848f3
      ClearPrevalentResource(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> ()
      ClearUserInteraction(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> ()
 diff --git a/Source/WebKit/NetworkProcess/NetworkSession.h b/Source/WebKit/NetworkProcess/NetworkSession.h
-index faaacd8608df51e960eab481e27549d0f1323a89..fc90e558145e9957b8db7e5a6c43cd8a8af5ba7d 100644
+index 6cc35141dc21e1fa19b946cfd9d2ffdb67bfb442..6902e2766d28cfe04ea3e39a1d7421f66615bc9a 100644
 --- a/Source/WebKit/NetworkProcess/NetworkSession.h
 +++ b/Source/WebKit/NetworkProcess/NetworkSession.h
 @@ -194,6 +194,9 @@ public:
@@ -9267,7 +9290,7 @@ index f57a72b6bdc3382469d69adb1b1201c7a9f07a84..c501211b094312ca44f0bf92de5d6ebc
      void clear();
  
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-index efd2b139a5888164ae385885910928742308f626..0eacda494b0177370d7d883f2942e19043c7e104 100644
+index 5623a4e3c11dbfa978ecc63f3b762d85fe16ee29..e7e6f789ffd5b70f50bba7bbc8a04bcdebf7c77e 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 @@ -720,7 +720,7 @@ void NetworkSessionCocoa::setClientAuditToken(const WebCore::AuthenticationChall
@@ -9766,6 +9789,28 @@ index 93b9f5f8dbdec3555944d13685486937a3f71eb6..f829a7c9b71c66f1dcf76b954dd8346c
      )
  endif ()
  
+diff --git a/Source/WebKit/Scripts/generate-automation-atom.py b/Source/WebKit/Scripts/generate-automation-atom.py
+index 80fff391c5f79eafa8f8f13c3919bdc3c3105742..1575c9aa2ced5f62e96619a4baf4082bd5710107 100644
+--- a/Source/WebKit/Scripts/generate-automation-atom.py
++++ b/Source/WebKit/Scripts/generate-automation-atom.py
+@@ -75,7 +75,7 @@ def main(args):
+     output = args[1]
+     utils = os.path.join(os.path.dirname(input), "utils.js")
+ 
+-    with open(input, "r") as fd:
++    with open(input, "r", encoding = "utf-8") as fd:
+         input_data = fd.read()
+ 
+     util_functions = collect_utils(input_data)
+@@ -87,7 +87,7 @@ def main(args):
+         append_functions(utils_data, util_functions, util_functions_impl, functions_written)
+         input_data = input_data.replace('"use strict";\n', '"use strict";\n\n' + "\n".join(utils_data))
+ 
+-    with open(output, "w") as fd:
++    with open(output, "w", encoding = "utf-8") as fd:
+         fd.write(input_data)
+ 
+     return 0
 diff --git a/Source/WebKit/Shared/API/c/wpe/WebKit.h b/Source/WebKit/Shared/API/c/wpe/WebKit.h
 index caf67e1dece5b727e43eba780e70814f8fdb0f63..740150d2589d6e16a516daa3bf6ef899ac538c99 100644
 --- a/Source/WebKit/Shared/API/c/wpe/WebKit.h
@@ -10418,10 +10463,10 @@ index 90df093a49c09dc670dfea55077c77d889dd1c1b..6ffd51532e29b941b8dc10f545b7f5b8
      return WebTouchEvent();
  }
 diff --git a/Source/WebKit/Sources.txt b/Source/WebKit/Sources.txt
-index 3ddb0631e102191c775390b5237d78bc0d02322e..150d4674eb1806a9601f3c29b15a0199d3867f27 100644
+index 6757db7b794ecbc0cb246956944d1118ba81ef51..4f6518c6e4087b767f430a263a5048a8c852f50a 100644
 --- a/Source/WebKit/Sources.txt
 +++ b/Source/WebKit/Sources.txt
-@@ -401,11 +401,14 @@ Shared/XR/XRDeviceProxy.cpp
+@@ -402,11 +402,14 @@ Shared/XR/XRDeviceProxy.cpp
  
  UIProcess/AuxiliaryProcessProxy.cpp
  UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -10436,7 +10481,7 @@ index 3ddb0631e102191c775390b5237d78bc0d02322e..150d4674eb1806a9601f3c29b15a0199
  UIProcess/LegacyGlobalSettings.cpp
  UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
  UIProcess/MediaKeySystemPermissionRequestProxy.cpp
-@@ -414,6 +417,7 @@ UIProcess/PageLoadState.cpp
+@@ -415,6 +418,7 @@ UIProcess/PageLoadState.cpp
  UIProcess/ProcessAssertion.cpp
  UIProcess/ProcessThrottler.cpp
  UIProcess/ProvisionalPageProxy.cpp
@@ -10444,7 +10489,7 @@ index 3ddb0631e102191c775390b5237d78bc0d02322e..150d4674eb1806a9601f3c29b15a0199
  UIProcess/ResponsivenessTimer.cpp
  UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
  UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
-@@ -456,6 +460,8 @@ UIProcess/WebOpenPanelResultListenerProxy.cpp
+@@ -457,6 +461,8 @@ UIProcess/WebOpenPanelResultListenerProxy.cpp
  UIProcess/WebPageDiagnosticLoggingClient.cpp
  UIProcess/WebPageGroup.cpp
  UIProcess/WebPageInjectedBundleClient.cpp
@@ -10453,7 +10498,7 @@ index 3ddb0631e102191c775390b5237d78bc0d02322e..150d4674eb1806a9601f3c29b15a0199
  UIProcess/WebPageProxy.cpp
  UIProcess/WebPasteboardProxy.cpp
  UIProcess/WebPreferences.cpp
-@@ -579,7 +585,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
+@@ -580,7 +586,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
  UIProcess/Inspector/WebPageDebuggable.cpp
  UIProcess/Inspector/WebPageInspectorController.cpp
  
@@ -10466,7 +10511,7 @@ index 3ddb0631e102191c775390b5237d78bc0d02322e..150d4674eb1806a9601f3c29b15a0199
  UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
  UIProcess/Media/MediaUsageManager.cpp
 diff --git a/Source/WebKit/SourcesCocoa.txt b/Source/WebKit/SourcesCocoa.txt
-index b34c50dde74bbe490492976023a87d787900dc2d..73983f561fb1289ef0a42abf895fdae0b2bbdb0a 100644
+index 68dc771921149d657f546ca273f4e39537840fa6..ddd68b387a06f54d24373d59229a04340a280d9f 100644
 --- a/Source/WebKit/SourcesCocoa.txt
 +++ b/Source/WebKit/SourcesCocoa.txt
 @@ -276,6 +276,7 @@ UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -10486,10 +10531,10 @@ index b34c50dde74bbe490492976023a87d787900dc2d..73983f561fb1289ef0a42abf895fdae0
  UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
  UIProcess/Inspector/mac/WKInspectorViewController.mm
 diff --git a/Source/WebKit/SourcesGTK.txt b/Source/WebKit/SourcesGTK.txt
-index 98b74854336b34e8487e0adb36cf4a413c6fe63c..11c423a3b7b1629bda15619783ed0a075ade0d8c 100644
+index 3b52d10af68fa9048d93193720fe3068defa8606..089ad9d5e0faf0a34c87dbbaf11abf96e33d8d71 100644
 --- a/Source/WebKit/SourcesGTK.txt
 +++ b/Source/WebKit/SourcesGTK.txt
-@@ -126,6 +126,7 @@ UIProcess/API/glib/WebKitAuthenticationRequest.cpp @no-unify
+@@ -128,6 +128,7 @@ UIProcess/API/glib/WebKitAuthenticationRequest.cpp @no-unify
  UIProcess/API/glib/WebKitAutomationSession.cpp @no-unify
  UIProcess/API/glib/WebKitBackForwardList.cpp @no-unify
  UIProcess/API/glib/WebKitBackForwardListItem.cpp @no-unify
@@ -10497,7 +10542,7 @@ index 98b74854336b34e8487e0adb36cf4a413c6fe63c..11c423a3b7b1629bda15619783ed0a07
  UIProcess/API/glib/WebKitContextMenuClient.cpp @no-unify
  UIProcess/API/glib/WebKitCookieManager.cpp @no-unify
  UIProcess/API/glib/WebKitCredential.cpp @no-unify
-@@ -243,6 +244,7 @@ UIProcess/WebsiteData/unix/WebsiteDataStoreUnix.cpp
+@@ -245,6 +246,7 @@ UIProcess/WebsiteData/unix/WebsiteDataStoreUnix.cpp
  
  UIProcess/cairo/BackingStoreCairo.cpp @no-unify
  
@@ -10505,7 +10550,7 @@ index 98b74854336b34e8487e0adb36cf4a413c6fe63c..11c423a3b7b1629bda15619783ed0a07
  UIProcess/glib/WebPageProxyGLib.cpp
  UIProcess/glib/WebProcessPoolGLib.cpp
  UIProcess/glib/WebProcessProxyGLib.cpp
-@@ -260,6 +262,7 @@ UIProcess/gtk/ClipboardGtk4.cpp @no-unify
+@@ -262,6 +264,7 @@ UIProcess/gtk/ClipboardGtk4.cpp @no-unify
  UIProcess/gtk/WebDateTimePickerGtk.cpp
  UIProcess/gtk/GtkSettingsManager.cpp
  UIProcess/gtk/HardwareAccelerationManager.cpp
@@ -10513,7 +10558,7 @@ index 98b74854336b34e8487e0adb36cf4a413c6fe63c..11c423a3b7b1629bda15619783ed0a07
  UIProcess/gtk/KeyBindingTranslator.cpp
  UIProcess/gtk/PointerLockManager.cpp @no-unify
  UIProcess/gtk/PointerLockManagerWayland.cpp @no-unify
-@@ -272,6 +275,8 @@ UIProcess/gtk/WaylandCompositor.cpp @no-unify
+@@ -274,6 +277,8 @@ UIProcess/gtk/WaylandCompositor.cpp @no-unify
  UIProcess/gtk/WebColorPickerGtk.cpp
  UIProcess/gtk/WebContextMenuProxyGtk.cpp
  UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
@@ -10523,10 +10568,10 @@ index 98b74854336b34e8487e0adb36cf4a413c6fe63c..11c423a3b7b1629bda15619783ed0a07
  UIProcess/gtk/WebPasteboardProxyGtk.cpp
  UIProcess/gtk/WebPopupMenuProxyGtk.cpp
 diff --git a/Source/WebKit/SourcesWPE.txt b/Source/WebKit/SourcesWPE.txt
-index a01e5b20f1fb05a1c057c07f827310a37cf73e3f..4191b10f7a1e5fad2d070659547ece7ae1879393 100644
+index ae2181088f8221594c9a2b4fbe5d99f2b6936d67..0c51c08ebf3352f7ec80aa8490e7e10c119da28a 100644
 --- a/Source/WebKit/SourcesWPE.txt
 +++ b/Source/WebKit/SourcesWPE.txt
-@@ -85,6 +85,7 @@ Shared/glib/ProcessExecutablePathGLib.cpp
+@@ -87,6 +87,7 @@ Shared/glib/ProcessExecutablePathGLib.cpp
  Shared/glib/UserMessage.cpp
  Shared/glib/WebContextMenuItemGlib.cpp
  
@@ -10534,7 +10579,7 @@ index a01e5b20f1fb05a1c057c07f827310a37cf73e3f..4191b10f7a1e5fad2d070659547ece7a
  Shared/libwpe/NativeWebKeyboardEventLibWPE.cpp
  Shared/libwpe/NativeWebMouseEventLibWPE.cpp
  Shared/libwpe/NativeWebTouchEventLibWPE.cpp
-@@ -119,6 +120,7 @@ UIProcess/API/glib/WebKitAuthenticationRequest.cpp @no-unify
+@@ -121,6 +122,7 @@ UIProcess/API/glib/WebKitAuthenticationRequest.cpp @no-unify
  UIProcess/API/glib/WebKitAutomationSession.cpp @no-unify
  UIProcess/API/glib/WebKitBackForwardList.cpp @no-unify
  UIProcess/API/glib/WebKitBackForwardListItem.cpp @no-unify
@@ -10542,7 +10587,7 @@ index a01e5b20f1fb05a1c057c07f827310a37cf73e3f..4191b10f7a1e5fad2d070659547ece7a
  UIProcess/API/glib/WebKitContextMenuClient.cpp @no-unify
  UIProcess/API/glib/WebKitCookieManager.cpp @no-unify
  UIProcess/API/glib/WebKitCredential.cpp @no-unify
-@@ -153,6 +155,7 @@ UIProcess/API/glib/WebKitOptionMenu.cpp @no-unify
+@@ -155,6 +157,7 @@ UIProcess/API/glib/WebKitOptionMenu.cpp @no-unify
  UIProcess/API/glib/WebKitOptionMenuItem.cpp @no-unify
  UIProcess/API/glib/WebKitPermissionRequest.cpp @no-unify
  UIProcess/API/glib/WebKitPlugin.cpp @no-unify
@@ -10550,7 +10595,7 @@ index a01e5b20f1fb05a1c057c07f827310a37cf73e3f..4191b10f7a1e5fad2d070659547ece7a
  UIProcess/API/glib/WebKitPolicyDecision.cpp @no-unify
  UIProcess/API/glib/WebKitPrivate.cpp @no-unify
  UIProcess/API/glib/WebKitProtocolHandler.cpp @no-unify
-@@ -185,6 +188,7 @@ UIProcess/API/wpe/InputMethodFilterWPE.cpp @no-unify
+@@ -187,6 +190,7 @@ UIProcess/API/wpe/InputMethodFilterWPE.cpp @no-unify
  UIProcess/API/wpe/PageClientImpl.cpp @no-unify
  UIProcess/API/wpe/TouchGestureController.cpp @no-unify
  UIProcess/API/wpe/WebKitColor.cpp @no-unify
@@ -10558,7 +10603,7 @@ index a01e5b20f1fb05a1c057c07f827310a37cf73e3f..4191b10f7a1e5fad2d070659547ece7a
  UIProcess/API/wpe/WebKitInputMethodContextWPE.cpp @no-unify
  UIProcess/API/wpe/WebKitPopupMenu.cpp @no-unify
  UIProcess/API/wpe/WebKitRectangle.cpp @no-unify
-@@ -201,6 +205,7 @@ UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+@@ -203,6 +207,7 @@ UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
  
  UIProcess/geoclue/GeoclueGeolocationProvider.cpp
  
@@ -10566,7 +10611,7 @@ index a01e5b20f1fb05a1c057c07f827310a37cf73e3f..4191b10f7a1e5fad2d070659547ece7a
  UIProcess/glib/WebPageProxyGLib.cpp
  UIProcess/glib/WebProcessPoolGLib.cpp
  UIProcess/glib/WebProcessProxyGLib.cpp
-@@ -227,6 +232,11 @@ UIProcess/linux/MemoryPressureMonitor.cpp
+@@ -229,6 +234,11 @@ UIProcess/linux/MemoryPressureMonitor.cpp
  UIProcess/soup/WebCookieManagerProxySoup.cpp
  UIProcess/soup/WebProcessPoolSoup.cpp
  
@@ -10577,8 +10622,8 @@ index a01e5b20f1fb05a1c057c07f827310a37cf73e3f..4191b10f7a1e5fad2d070659547ece7a
 +UIProcess/wpe/WebPageInspectorInputAgentWPE.cpp
  UIProcess/wpe/WebPageProxyWPE.cpp
  
- WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp
-@@ -255,6 +265,8 @@ WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp
+ WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
+@@ -259,6 +269,8 @@ WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp
  
  WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp
  
@@ -12310,7 +12355,7 @@ index 1942490889b8be84160087c0f388302fbc6e96fd..eaa42475b1d56aa8980abd972df116b5
  {
      if (!m_uiDelegate)
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
-index 8c9baa508554d465b2f4d5e29b3a5da021f9c462..4639ffc9e65003eb1329a65aa33feef3111f9b9c 100644
+index 20739e5adb0b77afeb310581eb96d7e3a7802b70..105bb621136ed6fdbfe580083d7c76c608d17492 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
 @@ -37,6 +37,7 @@
@@ -12389,10 +12434,10 @@ index 8c9baa508554d465b2f4d5e29b3a5da021f9c462..4639ffc9e65003eb1329a65aa33feef3
  #if PLATFORM(IOS_FAMILY)
  
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-index 80857323f9d8f9c38f61a921b7deb844b800f270..3e5a397a2b7c8a76d62d6005eb3bd10fa33dede8 100644
+index 06f69768a865ef04a66efdfc88c069a6a1cab04d..e995ae9b7a98095b09740209c209e8235bd748fa 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
-@@ -387,7 +387,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
+@@ -385,7 +385,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
      auto screenProperties = WebCore::collectScreenProperties();
      parameters.screenProperties = WTFMove(screenProperties);
  #if PLATFORM(MAC)
@@ -12401,7 +12446,7 @@ index 80857323f9d8f9c38f61a921b7deb844b800f270..3e5a397a2b7c8a76d62d6005eb3bd10f
  #endif
      
  #if PLATFORM(IOS)
-@@ -691,8 +691,8 @@ void WebProcessPool::registerNotificationObservers()
+@@ -689,8 +689,8 @@ void WebProcessPool::registerNotificationObservers()
      }];
  
      m_scrollerStyleNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSPreferredScrollerStyleDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
@@ -12427,7 +12472,7 @@ index 9faca6d95cdb198961558ffedf2e2ad8e805e08d..9eedff0802bbc01bc14be458df16ae52
      void saveBackForwardSnapshotForCurrentItem();
      void saveBackForwardSnapshotForItem(WebBackForwardListItem&);
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
-index 015a66840dbc8788bd34d79fd7c3bbe59ced1742..3b1fb22e650e00be247a26c54e52a3b849eb4921 100644
+index 7e4e9d603ffe179dfada1fe6fd585f0cdc23e244..41019ab4c9cca47e2d803df4f927078a6e2ab242 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 @@ -2776,6 +2776,11 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
@@ -16080,10 +16125,10 @@ index 35bc45d8c2c7b69ea7de12e6c43942ff1bd12053..a83ba810709466ff402db5a4029ddc6a
      virtual RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) = 0;
  #endif
 diff --git a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
-index 88b2ea838672ac71865eb69bcaf5fb22ca00a87f..d4a2bc93269ce1e127d4fe0dbe5cc8fc5bf7d0f3 100644
+index ed5dfdda478de4116b0fe95306f195ba8451d4fd..72aa9b39747d04f920d9500fa297a6b6ad89c3fe 100644
 --- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
-@@ -631,3 +631,5 @@ bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Option
+@@ -632,3 +632,5 @@ bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Option
  }
  
  } // namespace WebKit
@@ -17097,7 +17142,7 @@ index 0000000000000000000000000000000000000000..48c9ccc420c1b4ae3259e1d5ba17fd8f
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index e68b5922a78dbfd0f7aa564056cd310d34433d07..984ce3203fdbff8c567d47c71ca8dae5c30f9233 100644
+index 0f36cc54ca8273990c0680a9b7d2aca629698bf5..7e76f1967a6ed2b5bef6e0cf6f2a15ec11b32753 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
 @@ -248,6 +248,9 @@
@@ -17556,7 +17601,7 @@ index e68b5922a78dbfd0f7aa564056cd310d34433d07..984ce3203fdbff8c567d47c71ca8dae5
          }
          break;
      }
-@@ -7986,7 +8166,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
+@@ -7965,7 +8145,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
  {
      WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "dispatchProcessDidTerminate: reason=%{public}s", processTerminationReasonToString(reason));
  
@@ -17568,7 +17613,7 @@ index e68b5922a78dbfd0f7aa564056cd310d34433d07..984ce3203fdbff8c567d47c71ca8dae5
      if (m_loaderClient)
          handledByClient = reason != ProcessTerminationReason::RequestedByClient && m_loaderClient->processDidCrash(*this);
      else
-@@ -8313,6 +8496,7 @@ static Span<const ASCIILiteral> gpuMachServices()
+@@ -8292,6 +8475,7 @@ static Span<const ASCIILiteral> gpuMachServices()
  
  WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& process, DrawingAreaProxy& drawingArea, RefPtr<API::WebsitePolicies>&& websitePolicies)
  {
@@ -17576,7 +17621,7 @@ index e68b5922a78dbfd0f7aa564056cd310d34433d07..984ce3203fdbff8c567d47c71ca8dae5
      WebPageCreationParameters parameters;
  
      parameters.processDisplayName = configuration().processDisplayName();
-@@ -8505,6 +8689,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
+@@ -8484,6 +8668,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
  
      parameters.httpsUpgradeEnabled = preferences().upgradeKnownHostsToHTTPSEnabled() ? m_configuration->httpsUpgradeEnabled() : false;
  
@@ -17585,7 +17630,7 @@ index e68b5922a78dbfd0f7aa564056cd310d34433d07..984ce3203fdbff8c567d47c71ca8dae5
  #if PLATFORM(IOS)
      // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
      parameters.allowsDeprecatedSynchronousXMLHttpRequestDuringUnload = allowsDeprecatedSynchronousXMLHttpRequestDuringUnload();
-@@ -8573,6 +8759,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
+@@ -8552,6 +8738,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
  
  void WebPageProxy::didReceiveAuthenticationChallengeProxy(Ref<AuthenticationChallengeProxy>&& authenticationChallenge, NegotiatedLegacyTLS negotiatedLegacyTLS)
  {
@@ -17600,7 +17645,7 @@ index e68b5922a78dbfd0f7aa564056cd310d34433d07..984ce3203fdbff8c567d47c71ca8dae5
      if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes) {
          m_navigationClient->shouldAllowLegacyTLS(*this, authenticationChallenge.get(), [this, protectedThis = Ref { *this }, authenticationChallenge] (bool shouldAllowLegacyTLS) {
              if (shouldAllowLegacyTLS)
-@@ -8666,6 +8860,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
+@@ -8645,6 +8839,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
              request->deny();
      };
  
@@ -17617,7 +17662,7 @@ index e68b5922a78dbfd0f7aa564056cd310d34433d07..984ce3203fdbff8c567d47c71ca8dae5
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6fd5d16db 100644
+index 441ce9454eeeed315df698f531dbe623a1de4a06..0a58164a2fd7f5b3f391a56143e5c4262556ba1a 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -39,6 +39,7 @@
@@ -17671,7 +17716,7 @@ index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6
  class SharedBuffer;
  class SpeechRecognitionRequest;
  class TextIndicator;
-@@ -547,6 +559,8 @@ public:
+@@ -548,6 +560,8 @@ public:
      void setControlledByAutomation(bool);
  
      WebPageInspectorController& inspectorController() { return *m_inspectorController; }
@@ -17680,7 +17725,7 @@ index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6
  
  #if PLATFORM(IOS_FAMILY)
      void showInspectorIndication();
-@@ -653,6 +667,11 @@ public:
+@@ -658,6 +672,11 @@ public:
  
      void setPageLoadStateObserver(std::unique_ptr<PageLoadState::Observer>&&);
  
@@ -17692,7 +17737,7 @@ index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6
      void initializeWebPage();
      void setDrawingArea(std::unique_ptr<DrawingAreaProxy>&&);
  
-@@ -680,6 +699,7 @@ public:
+@@ -685,6 +704,7 @@ public:
      void closePage();
  
      void addPlatformLoadParameters(WebProcessProxy&, LoadParameters&);
@@ -17700,7 +17745,7 @@ index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6
      RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadData(const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
-@@ -1206,6 +1226,7 @@ public:
+@@ -1213,6 +1233,7 @@ public:
  #endif
  
      void pageScaleFactorDidChange(double);
@@ -17708,7 +17753,7 @@ index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6
      void pluginScaleFactorDidChange(double);
      void pluginZoomFactorDidChange(double);
  
-@@ -1293,14 +1314,20 @@ public:
+@@ -1300,14 +1321,20 @@ public:
      void didStartDrag();
      void dragCancelled();
      void setDragCaretRect(const WebCore::IntRect&);
@@ -17730,7 +17775,7 @@ index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6
  #endif
  
      void processDidBecomeUnresponsive();
-@@ -1551,6 +1578,8 @@ public:
+@@ -1558,6 +1585,8 @@ public:
  
  #if PLATFORM(COCOA) || PLATFORM(GTK)
      RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
@@ -17739,7 +17784,7 @@ index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6
  #endif
  
  #if ENABLE(WEB_CRYPTO)
-@@ -2712,6 +2741,7 @@ private:
+@@ -2719,6 +2748,7 @@ private:
      String m_overrideContentSecurityPolicy;
  
      RefPtr<WebInspectorUIProxy> m_inspector;
@@ -17747,7 +17792,7 @@ index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6
  
  #if PLATFORM(COCOA)
      WeakObjCPtr<WKWebView> m_cocoaView;
-@@ -2980,6 +3010,20 @@ private:
+@@ -2987,6 +3017,20 @@ private:
      unsigned m_currentDragNumberOfFilesToBeAccepted { 0 };
      WebCore::IntRect m_currentDragCaretRect;
      WebCore::IntRect m_currentDragCaretEditableElementRect;
@@ -17768,7 +17813,7 @@ index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6
  #endif
  
      PageLoadState m_pageLoadState;
-@@ -3189,6 +3233,9 @@ private:
+@@ -3196,6 +3240,9 @@ private:
          RefPtr<API::Object> messageBody;
      };
      Vector<InjectedBundleMessage> m_pendingInjectedBundleMessages;
@@ -17779,7 +17824,7 @@ index 43f17f26e956f0a62e1dddf9197b5099f7607fdb..fcd6749cd8cc566f70167d23213147a6
  #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
      std::unique_ptr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.messages.in b/Source/WebKit/UIProcess/WebPageProxy.messages.in
-index b4e9141624610497f4391f561f381899e04e35be..0debe3077ab40547828f9d611b64f5d0e4624642 100644
+index e276d3e2f7640986c38fec49d3dc99b1baedafa0..fe8eefde7bde9c00764e43b14acc33b1355b4cc9 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
 +++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
 @@ -29,6 +29,7 @@ messages -> WebPageProxy {
@@ -17814,10 +17859,10 @@ index b4e9141624610497f4391f561f381899e04e35be..0debe3077ab40547828f9d611b64f5d0
      DidPerformDragOperation(bool handled)
  #endif
 diff --git a/Source/WebKit/UIProcess/WebProcessPool.cpp b/Source/WebKit/UIProcess/WebProcessPool.cpp
-index de5d21d53c67de0c500906fa34c458d4db2e5692..70a79cd88acc3403186f3adf53b7dc4dcc8eba35 100644
+index 9ec0e155bd57795ff5edfb6482f04b9c25d8490d..2533299ae9271736b1b14acbea9cc6ff3951dce4 100644
 --- a/Source/WebKit/UIProcess/WebProcessPool.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
-@@ -547,6 +547,14 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
+@@ -548,6 +548,14 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
  
      RefPtr<WebProcessProxy> requestingProcess = requestingProcessIdentifier ? WebProcessProxy::processForIdentifier(*requestingProcessIdentifier) : nullptr;
      WebProcessPool* processPool = requestingProcess ? &requestingProcess->processPool() : processPools()[0];
@@ -17832,7 +17877,7 @@ index de5d21d53c67de0c500906fa34c458d4db2e5692..70a79cd88acc3403186f3adf53b7dc4d
      ASSERT(processPool);
  
      WebProcessProxy* remoteWorkerProcessProxy { nullptr };
-@@ -842,8 +850,12 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
+@@ -843,8 +851,12 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
  #endif
  
      parameters.cacheModel = LegacyGlobalSettings::singleton().cacheModel();
@@ -17848,7 +17893,7 @@ index de5d21d53c67de0c500906fa34c458d4db2e5692..70a79cd88acc3403186f3adf53b7dc4d
      parameters.urlSchemesRegisteredAsEmptyDocument = copyToVector(m_schemesToRegisterAsEmptyDocument);
      parameters.urlSchemesRegisteredAsSecure = copyToVector(LegacyGlobalSettings::singleton().schemesToRegisterAsSecure());
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.cpp b/Source/WebKit/UIProcess/WebProcessProxy.cpp
-index 43821553144d6f326b094ca24cd3f551c7e31205..64ccd8f02dbaf182f80c1a87e17697f48a5c12a7 100644
+index da1542a32c69363871fc041c62079d351bbbf352..a42a5af4afab4a985f0435f7307c2f4b0bdd7dd3 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
 @@ -147,6 +147,11 @@ HashMap<ProcessIdentifier, WebProcessProxy*>& WebProcessProxy::allProcesses()
@@ -17864,7 +17909,7 @@ index 43821553144d6f326b094ca24cd3f551c7e31205..64ccd8f02dbaf182f80c1a87e17697f4
  {
      return allProcesses().get(identifier);
 diff --git a/Source/WebKit/UIProcess/WebProcessProxy.h b/Source/WebKit/UIProcess/WebProcessProxy.h
-index 0555d3d576345bb249610858d69466e49159f1ac..fd5e11b13a7ffd4ebecb11179e4ec864384e0a82 100644
+index 488db9556b5d8b418df98c2cb82f47108a89b13b..010df163d34467cf873860da715bc59a6ddb05df 100644
 --- a/Source/WebKit/UIProcess/WebProcessProxy.h
 +++ b/Source/WebKit/UIProcess/WebProcessProxy.h
 @@ -146,6 +146,7 @@ public:
@@ -17876,10 +17921,10 @@ index 0555d3d576345bb249610858d69466e49159f1ac..fd5e11b13a7ffd4ebecb11179e4ec864
      WebConnection* webConnection() const { return m_webConnection.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-index 216cc47cd127f2ddf9b1efbd8935ddbe5499dcf9..fb7f8bab34e7034f026af6a713a78713848cca59 100644
+index cb623e5e3745fdd91d31844fbd93209886d00e6e..87413c5c1f90da0f9ad0495ac81108b4e0153f37 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-@@ -2027,6 +2027,17 @@ void WebsiteDataStore::originDirectoryForTesting(URL&& origin, URL&& topOrigin,
+@@ -2037,6 +2037,17 @@ void WebsiteDataStore::originDirectoryForTesting(URL&& origin, URL&& topOrigin,
      networkProcess().websiteDataOriginDirectoryForTesting(m_sessionID, WTFMove(origin), WTFMove(topOrigin), type, WTFMove(completionHandler));
  }
  
@@ -18607,10 +18652,10 @@ index 0000000000000000000000000000000000000000..d0f9827544994e450e24e3f7a427c35e
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
-index 920e936763f55068a50faad8311d681592ec82e3..7692d7a5a51554c2c80dfdc43cee3b353165baa2 100644
+index 45b19dedf1a53297bf19a68704912df7ed0ad4bf..f9a83d1954a283411ab74343382b4c948a6550a9 100644
 --- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 +++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
-@@ -440,6 +440,8 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
+@@ -439,6 +439,8 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
      
  void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool eventWasHandled)
  {
@@ -18975,7 +19020,7 @@ index 31bc0797a1b086b9342e5449e48cf5b3050464eb..450b6acf92b31cb40c404e3a8553e263
      void getContextMenuItem(const WebContextMenuItemData&, CompletionHandler<void(NSMenuItem *)>&&);
      void getContextMenuFromItems(const Vector<WebContextMenuItemData>&, CompletionHandler<void(NSMenu *)>&&);
 diff --git a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
-index 6bbb05e0355631b907628ee24c59f57e6cbbcb4b..2a3df261561d0f5835ada5cb065c14842711c6cb 100644
+index 3aa5c7d6f3730d81bbcc54688191f737bf149f65..d3bb1c0ecdbeeb8ee1b1268f670c58d983b1925b 100644
 --- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 +++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
 @@ -438,6 +438,12 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem
@@ -19932,10 +19977,10 @@ index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705e
 + 
 +} // namespace WebKit
 diff --git a/Source/WebKit/WebKit.xcodeproj/project.pbxproj b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e00590e41b 100644
+index 9a3e17e2b54b06817a5c0d32bdfc60893fb65b3b..caf1b665e9b143521e5f8a716845d3686623e961 100644
 --- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 +++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-@@ -1270,6 +1270,7 @@
+@@ -1254,6 +1254,7 @@
  		5CABDC8722C40FED001EDE8E /* APIMessageListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CABDC8322C40FA7001EDE8E /* APIMessageListener.h */; };
  		5CADDE05215046BD0067D309 /* WKWebProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C74300E21500492004BFA17 /* WKWebProcess.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		5CAECB6627465AE400AB78D0 /* UnifiedSource115.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */; };
@@ -19943,7 +19988,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  		5CAF7AA726F93AB00003F19E /* adattributiond.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAF7AA526F93A950003F19E /* adattributiond.cpp */; };
  		5CAFDE452130846300B1F7E1 /* _WKInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE422130843500B1F7E1 /* _WKInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		5CAFDE472130846A00B1F7E1 /* _WKInspectorInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE442130843600B1F7E1 /* _WKInspectorInternal.h */; };
-@@ -2239,6 +2240,18 @@
+@@ -2223,6 +2224,18 @@
  		DF0C5F28252ECB8E00D921DB /* WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F24252ECB8D00D921DB /* WKDownload.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2A252ECB8E00D921DB /* WKDownloadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2B252ED44000D921DB /* WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */; };
@@ -19962,7 +20007,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  		DF462E0F23F22F5500EFF35F /* WKHTTPCookieStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */; };
-@@ -2298,6 +2311,8 @@
+@@ -2282,6 +2295,8 @@
  		E5BEF6822130C48000F31111 /* WebDataListSuggestionsDropdownIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E5BEF6802130C47F00F31111 /* WebDataListSuggestionsDropdownIOS.h */; };
  		E5CB07DC20E1678F0022C183 /* WKFormColorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */; };
  		E5CBA76427A318E100DF7858 /* UnifiedSource120.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */; };
@@ -19971,7 +20016,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  		E5CBA76527A318E100DF7858 /* UnifiedSource118.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */; };
  		E5CBA76627A318E100DF7858 /* UnifiedSource116.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76327A3187B00DF7858 /* UnifiedSource116.cpp */; };
  		E5CBA76727A318E100DF7858 /* UnifiedSource119.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */; };
-@@ -2314,6 +2329,9 @@
+@@ -2298,6 +2313,9 @@
  		EBA8D3B627A5E33F00CB7900 /* MockPushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B027A5E33F00CB7900 /* MockPushServiceConnection.mm */; };
  		EBA8D3B727A5E33F00CB7900 /* PushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B127A5E33F00CB7900 /* PushServiceConnection.mm */; };
  		ED82A7F2128C6FAF004477B3 /* WKBundlePageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22F0FF1289FCD90085E74F /* WKBundlePageOverlay.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -19981,7 +20026,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
  		F42D634122A0EFDF00D2FB3A /* WebAutocorrectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */; };
-@@ -5320,6 +5338,7 @@
+@@ -5282,6 +5300,7 @@
  		5CABDC8522C40FCC001EDE8E /* WKMessageListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKMessageListener.h; sourceTree = "<group>"; };
  		5CADDE0D2151AA010067D309 /* AuthenticationChallengeDisposition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthenticationChallengeDisposition.h; sourceTree = "<group>"; };
  		5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource115.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource115.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -19989,7 +20034,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  		5CAF7AA426F93A750003F19E /* adattributiond */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = adattributiond; sourceTree = BUILT_PRODUCTS_DIR; };
  		5CAF7AA526F93A950003F19E /* adattributiond.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = adattributiond.cpp; sourceTree = "<group>"; };
  		5CAF7AA626F93AA50003F19E /* adattributiond.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = adattributiond.xcconfig; sourceTree = "<group>"; };
-@@ -7019,6 +7038,19 @@
+@@ -6981,6 +7000,19 @@
  		DF0C5F24252ECB8D00D921DB /* WKDownload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownload.h; sourceTree = "<group>"; };
  		DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadInternal.h; sourceTree = "<group>"; };
  		DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadDelegate.h; sourceTree = "<group>"; };
@@ -20009,7 +20054,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  		DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHTTPCookieStorePrivate.h; sourceTree = "<group>"; };
  		DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKContentWorldPrivate.h; sourceTree = "<group>"; };
  		DF58C6311371AC5800F9A37C /* NativeWebWheelEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeWebWheelEvent.h; sourceTree = "<group>"; };
-@@ -7146,6 +7178,8 @@
+@@ -7108,6 +7140,8 @@
  		E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKFormColorControl.h; path = ios/forms/WKFormColorControl.h; sourceTree = "<group>"; };
  		E5CB07DB20E1678F0022C183 /* WKFormColorControl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKFormColorControl.mm; path = ios/forms/WKFormColorControl.mm; sourceTree = "<group>"; };
  		E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource120.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource120.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -20018,7 +20063,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  		E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource119.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource119.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
  		E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource118.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource118.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
  		E5CBA76227A3187900DF7858 /* UnifiedSource117.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource117.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource117.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
-@@ -7167,6 +7201,14 @@
+@@ -7129,6 +7163,14 @@
  		ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtraPrivateSymbolsForTAPI.h; sourceTree = "<group>"; };
  		ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExtraPublicSymbolsForTAPI.h; sourceTree = "<group>"; };
  		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
@@ -20033,7 +20078,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  		F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDragDestinationAction.h; sourceTree = "<group>"; };
  		F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionContext.h; path = ios/WebAutocorrectionContext.h; sourceTree = "<group>"; };
  		F41056612130699A0092281D /* APIAttachmentCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = APIAttachmentCocoa.mm; sourceTree = "<group>"; };
-@@ -7313,6 +7355,7 @@
+@@ -7266,6 +7308,7 @@
  				3766F9EF189A1244003CF19B /* QuartzCore.framework in Frameworks */,
  				37694525184FC6B600CDE21F /* Security.framework in Frameworks */,
  				37BEC4DD1948FC6A008B4286 /* WebCore.framework in Frameworks */,
@@ -20041,7 +20086,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -9409,6 +9452,7 @@
+@@ -9361,6 +9404,7 @@
  		37C4C08318149C2A003688B9 /* Cocoa */ = {
  			isa = PBXGroup;
  			children = (
@@ -20049,7 +20094,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				1A43E826188F38E2009E4D30 /* Deprecated */,
  				37A5E01218BBF937000A081E /* _WKActivatedElementInfo.h */,
  				37A5E01118BBF937000A081E /* _WKActivatedElementInfo.mm */,
-@@ -10603,6 +10647,7 @@
+@@ -10486,6 +10530,7 @@
  				E34B110F27C46D09006D2F2E /* libWebCoreTestSupport.dylib */,
  				DDE992F4278D06D900F60D26 /* libWebKitAdditions.a */,
  				57A9FF15252C6AEF006A2040 /* libWTF.a */,
@@ -20057,7 +20102,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				5750F32A2032D4E500389347 /* LocalAuthentication.framework */,
  				570DAAB0230273D200E8FC04 /* NearField.framework */,
  				51F7BB7E274564A100C45A72 /* Security.framework */,
-@@ -11123,6 +11168,12 @@
+@@ -11000,6 +11045,12 @@
  			children = (
  				9197940423DBC4BB00257892 /* InspectorBrowserAgent.cpp */,
  				9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */,
@@ -20070,7 +20115,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  			);
  			path = Agents;
  			sourceTree = "<group>";
-@@ -11131,6 +11182,7 @@
+@@ -11008,6 +11059,7 @@
  			isa = PBXGroup;
  			children = (
  				A5D3504D1D78F0D2005124A9 /* RemoteWebInspectorUIProxyMac.mm */,
@@ -20078,7 +20123,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */,
  				99A7ACE326012919006D57FD /* WKInspectorResourceURLSchemeHandler.h */,
  				99A7ACE42601291A006D57FD /* WKInspectorResourceURLSchemeHandler.mm */,
-@@ -11674,6 +11726,12 @@
+@@ -11550,6 +11602,12 @@
  		BC032DC310F438260058C15A /* UIProcess */ = {
  			isa = PBXGroup;
  			children = (
@@ -20091,7 +20136,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				BC032DC410F4387C0058C15A /* API */,
  				512F588D12A8836F00629530 /* Authentication */,
  				9955A6E81C79809000EB6A93 /* Automation */,
-@@ -11985,6 +12043,7 @@
+@@ -11861,6 +11919,7 @@
  		BC0C376610F807660076D7CB /* C */ = {
  			isa = PBXGroup;
  			children = (
@@ -20099,7 +20144,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				5123CF18133D25E60056F800 /* cg */,
  				6EE849C41368D9040038D481 /* mac */,
  				BCB63477116BF10600603215 /* WebKit2_C.h */,
-@@ -12575,6 +12634,11 @@
+@@ -12451,6 +12510,11 @@
  		BCCF085C113F3B7500C650C5 /* mac */ = {
  			isa = PBXGroup;
  			children = (
@@ -20111,7 +20156,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				B878B613133428DC006888E9 /* CorrectionPanel.h */,
  				B878B614133428DC006888E9 /* CorrectionPanel.mm */,
  				07EF07592745A8160066EA04 /* DisplayCaptureSessionManager.h */,
-@@ -13788,6 +13852,7 @@
+@@ -13664,6 +13728,7 @@
  				99788ACB1F421DDA00C08000 /* _WKAutomationSessionConfiguration.h in Headers */,
  				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
  				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
@@ -20119,7 +20164,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
  				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
  				1A5704F81BE01FF400874AF1 /* _WKContextMenuElementInfo.h in Headers */,
-@@ -14248,6 +14313,7 @@
+@@ -14124,6 +14189,7 @@
  				1A14F8E21D74C834006CBEC6 /* FrameInfoData.h in Headers */,
  				1AE00D611831792100087DD7 /* FrameLoadState.h in Headers */,
  				5C121E842410208D00486F9B /* FrameTreeNodeData.h in Headers */,
@@ -20127,7 +20172,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				2D4AF0892044C3C4006C8817 /* FrontBoardServicesSPI.h in Headers */,
  				CD78E1151DB7D7ED0014A2DE /* FullscreenClient.h in Headers */,
  				CD19D2EA2046406F0017074A /* FullscreenTouchSecheuristic.h in Headers */,
-@@ -14263,6 +14329,7 @@
+@@ -14139,6 +14205,7 @@
  				410F0D4C2701EFF900F96DFC /* GPUProcessConnectionInitializationParameters.h in Headers */,
  				4614F13225DED875007006E7 /* GPUProcessConnectionParameters.h in Headers */,
  				2DA049B8180CCD0A00AAFA9E /* GraphicsLayerCARemote.h in Headers */,
@@ -20135,7 +20180,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				C0CE72AD1247E78D00BC0EC4 /* HandleMessage.h in Headers */,
  				1AC75A1B1B3368270056745B /* HangDetectionDisabler.h in Headers */,
  				57AC8F50217FEED90055438C /* HidConnection.h in Headers */,
-@@ -14418,6 +14485,7 @@
+@@ -14294,6 +14361,7 @@
  				413075AC1DE85F370039EC69 /* NetworkRTCMonitor.h in Headers */,
  				41DC45961E3D6E2200B11F51 /* NetworkRTCProvider.h in Headers */,
  				5C20CBA01BB1ECD800895BB1 /* NetworkSession.h in Headers */,
@@ -20143,7 +20188,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				532159551DBAE7290054AA3C /* NetworkSessionCocoa.h in Headers */,
  				417915B92257046F00D6F97E /* NetworkSocketChannel.h in Headers */,
  				93085DE026E5BCFD000EC6A7 /* NetworkStorageManager.h in Headers */,
-@@ -14484,6 +14552,7 @@
+@@ -14360,6 +14428,7 @@
  				BC1A7C581136E19C00FB7167 /* ProcessLauncher.h in Headers */,
  				463FD4821EB94EC000A2982C /* ProcessTerminationReason.h in Headers */,
  				86E67A251910B9D100004AB7 /* ProcessThrottler.h in Headers */,
@@ -20151,7 +20196,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				83048AE61ACA45DC0082C832 /* ProcessThrottlerClient.h in Headers */,
  				2D279E1926955768004B3EEB /* PrototypeToolsSPI.h in Headers */,
  				517B5F81275E97B6002DC22D /* PushAppBundle.h in Headers */,
-@@ -14515,6 +14584,7 @@
+@@ -14391,6 +14460,7 @@
  				CDAC20CA23FC2F750021DEE3 /* RemoteCDMInstanceSession.h in Headers */,
  				CDAC20C923FC2F750021DEE3 /* RemoteCDMInstanceSessionIdentifier.h in Headers */,
  				F451C0FE2703B263002BA03B /* RemoteDisplayListRecorderProxy.h in Headers */,
@@ -20159,7 +20204,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				2D47B56D1810714E003A3AEE /* RemoteLayerBackingStore.h in Headers */,
  				2DDF731518E95060004F5A66 /* RemoteLayerBackingStoreCollection.h in Headers */,
  				1AB16AEA164B3A8800290D62 /* RemoteLayerTreeContext.h in Headers */,
-@@ -14937,6 +15007,7 @@
+@@ -14805,6 +14875,7 @@
  				A543E30D215C8A9000279CD9 /* WebPageInspectorTargetController.h in Headers */,
  				A543E307215AD13700279CD9 /* WebPageInspectorTargetFrontendChannel.h in Headers */,
  				C0CE72A11247E71D00BC0EC4 /* WebPageMessages.h in Headers */,
@@ -20167,7 +20212,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				2D5C9D0619C81D8F00B3C5C1 /* WebPageOverlay.h in Headers */,
  				46C392292316EC4D008EED9B /* WebPageProxyIdentifier.h in Headers */,
  				BCBD3915125BB1A800D2C29F /* WebPageProxyMessages.h in Headers */,
-@@ -15118,6 +15189,7 @@
+@@ -14986,6 +15057,7 @@
  				BCD25F1711D6BDE100169B0E /* WKBundleFrame.h in Headers */,
  				BCF049E611FE20F600F86A58 /* WKBundleFramePrivate.h in Headers */,
  				BC49862F124D18C100D834E1 /* WKBundleHitTestResult.h in Headers */,
@@ -20175,7 +20220,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				BC204EF211C83EC8008F3375 /* WKBundleInitialize.h in Headers */,
  				65B86F1E12F11DE300B7DD8A /* WKBundleInspector.h in Headers */,
  				1A8B66B41BC45B010082DF77 /* WKBundleMac.h in Headers */,
-@@ -15172,6 +15244,7 @@
+@@ -15040,6 +15112,7 @@
  				5C795D71229F3757003FF1C4 /* WKContextMenuElementInfoPrivate.h in Headers */,
  				51A555F6128C6C47009ABCEC /* WKContextMenuItem.h in Headers */,
  				51A55601128C6D92009ABCEC /* WKContextMenuItemTypes.h in Headers */,
@@ -20183,7 +20228,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				A1EA02381DABFF7E0096021F /* WKContextMenuListener.h in Headers */,
  				BCC938E11180DE440085E5FE /* WKContextPrivate.h in Headers */,
  				9FB5F395169E6A80002C25BF /* WKContextPrivateMac.h in Headers */,
-@@ -15329,6 +15402,7 @@
+@@ -15197,6 +15270,7 @@
  				1AB8A1F818400BB800E9AE69 /* WKPageContextMenuClient.h in Headers */,
  				8372DB251A674C8F00C697C5 /* WKPageDiagnosticLoggingClient.h in Headers */,
  				1AB8A1F418400B8F00E9AE69 /* WKPageFindClient.h in Headers */,
@@ -20191,7 +20236,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				1AB8A1F618400B9D00E9AE69 /* WKPageFindMatchesClient.h in Headers */,
  				1AB8A1F018400B0000E9AE69 /* WKPageFormClient.h in Headers */,
  				BC7B633712A45ABA00D174A4 /* WKPageGroup.h in Headers */,
-@@ -16945,6 +17019,8 @@
+@@ -16746,6 +16820,8 @@
  				51E9049727BCB3D900929E7E /* ICAppBundle.mm in Sources */,
  				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
  				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
@@ -20200,7 +20245,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
  				C1710CF724AA643200D7C112 /* LaunchServicesDatabaseObserver.mm in Sources */,
  				2984F588164BA095004BC0C6 /* LegacyCustomProtocolManagerMessageReceiver.cpp in Sources */,
-@@ -17284,6 +17360,8 @@
+@@ -17083,6 +17159,8 @@
  				E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */,
  				31BA924D148831260062EDB5 /* WebNotificationManagerMessageReceiver.cpp in Sources */,
  				2DF6FE52212E110900469030 /* WebPage.cpp in Sources */,
@@ -20210,7 +20255,7 @@ index 7eee806befc21875232b44f2481ab0daf44f01f9..2b9fc7d125676664ce08aeacde8ce3e0
  				BCBD3914125BB1A800D2C29F /* WebPageProxyMessageReceiver.cpp in Sources */,
  				7CE9CE101FA0767A000177DE /* WebPageUpdatePreferences.cpp in Sources */,
 diff --git a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
-index 0cbfe8e6596c093a03fab768357293bd8002b4e4..be957c560a5fdcd76723ccf95e96820980e194fe 100644
+index 46f2d99610f9e459fa7dfd0de2f92f4c29388877..e8ec05a7d49d7420e59b2493ec60c2adfce81d51 100644
 --- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 +++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
 @@ -231,6 +231,11 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
@@ -20270,7 +20315,7 @@ index 0cbfe8e6596c093a03fab768357293bd8002b4e4..be957c560a5fdcd76723ccf95e968209
  
      loadParameters.isMainFrameNavigation = resourceLoader.frame() && resourceLoader.frame()->isMainFrame() && resourceLoader.options().mode == FetchOptions::Mode::Navigate;
      if (loadParameters.isMainFrameNavigation && document)
-@@ -470,6 +472,17 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -463,6 +465,17 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
      }
  
      ASSERT((loadParameters.webPageID && loadParameters.webFrameID) || loadParameters.clientCredentialPolicy == ClientCredentialPolicy::CannotAskClientForCredentials);
@@ -20288,7 +20333,7 @@ index 0cbfe8e6596c093a03fab768357293bd8002b4e4..be957c560a5fdcd76723ccf95e968209
  
      std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
      if (loadParameters.isMainFrameNavigation)
-@@ -484,7 +497,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
+@@ -477,7 +490,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
      }
  
      auto loader = WebResourceLoader::create(resourceLoader, trackingParameters);
@@ -20297,7 +20342,7 @@ index 0cbfe8e6596c093a03fab768357293bd8002b4e4..be957c560a5fdcd76723ccf95e968209
  }
  
  void WebLoaderStrategy::scheduleInternallyFailedLoad(WebCore::ResourceLoader& resourceLoader)
-@@ -891,7 +904,7 @@ void WebLoaderStrategy::didFinishPreconnection(WebCore::ResourceLoaderIdentifier
+@@ -884,7 +897,7 @@ void WebLoaderStrategy::didFinishPreconnection(WebCore::ResourceLoaderIdentifier
  
  bool WebLoaderStrategy::isOnLine() const
  {
@@ -20306,7 +20351,7 @@ index 0cbfe8e6596c093a03fab768357293bd8002b4e4..be957c560a5fdcd76723ccf95e968209
  }
  
  void WebLoaderStrategy::addOnlineStateChangeListener(Function<void(bool)>&& listener)
-@@ -911,6 +924,11 @@ void WebLoaderStrategy::isResourceLoadFinished(CachedResource& resource, Complet
+@@ -904,6 +917,11 @@ void WebLoaderStrategy::isResourceLoadFinished(CachedResource& resource, Complet
  
  void WebLoaderStrategy::setOnLineState(bool isOnLine)
  {
@@ -20318,7 +20363,7 @@ index 0cbfe8e6596c093a03fab768357293bd8002b4e4..be957c560a5fdcd76723ccf95e968209
      if (m_isOnLine == isOnLine)
          return;
  
-@@ -919,6 +937,12 @@ void WebLoaderStrategy::setOnLineState(bool isOnLine)
+@@ -912,6 +930,12 @@ void WebLoaderStrategy::setOnLineState(bool isOnLine)
          listener(isOnLine);
  }
  
@@ -20398,10 +20443,10 @@ index e00c722c2be5d505243d45f46001839d4eb8a977..33c0832cde6c292230397a13e70d90fb
  
              auto permissionHandlers = m_requestsPerOrigin.take(securityOrigin);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
-index ea27184060444fb275033fe7721796f93d14ae5d..2d56768cc1e356fe9efd25c422d253ea72a456d6 100644
+index 18da837d1d6725d6e846e1d2f69a3664c3a59ac3..b03a0f3d31356b59f1ae66c5c16ea808e665b342 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
-@@ -417,6 +417,8 @@ void WebChromeClient::setResizable(bool resizable)
+@@ -415,6 +415,8 @@ void WebChromeClient::setResizable(bool resizable)
  
  void WebChromeClient::addMessageToConsole(MessageSource source, MessageLevel level, const String& message, unsigned lineNumber, unsigned columnNumber, const String& sourceID)
  {
@@ -20410,7 +20455,7 @@ index ea27184060444fb275033fe7721796f93d14ae5d..2d56768cc1e356fe9efd25c422d253ea
      // Notify the bundle client.
      m_page.injectedBundleUIClient().willAddMessageToConsole(&m_page, source, level, message, lineNumber, columnNumber, sourceID);
  }
-@@ -847,6 +849,13 @@ std::unique_ptr<DateTimeChooser> WebChromeClient::createDateTimeChooser(DateTime
+@@ -845,6 +847,13 @@ std::unique_ptr<DateTimeChooser> WebChromeClient::createDateTimeChooser(DateTime
  
  #endif
  
@@ -20452,7 +20497,7 @@ index 2eb0886f13ed035a53b8eaa60605de4dfe53fbe3..c46393209cb4f80704bbc9268fad4371
  {
  }
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
-index 7891cd42ac7144b1a18a69cabb8628f5a688fa78..d00372392b6d2aa1ecc647fd08f61be5fedd96cf 100644
+index d9f54aac25cdf77c7d1974b2b9a548406d4af81d..78907a1e727c8e0a1894457961d2b3d524287503 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 @@ -1598,13 +1598,6 @@ void WebFrameLoaderClient::transitionToCommittedForNewPage()
@@ -20748,7 +20793,7 @@ index db2e5d686e6ffff8f5299903c4d42fb3a64607ac..8a4d23bdebe6a7b2f7dea87517de8f0c
  {
      if (m_hasRemovedMessageReceiver)
 diff --git a/Source/WebKit/WebProcess/WebPage/DrawingArea.h b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
-index 21d4658c6c52fdd15444565b9181eec0e6ab0035..c8d1087910fbdddf985edb28114ac5e0889aca25 100644
+index bbd405ae641a84d1979be1f6a8a3ccc5151ca390..0c40a983404eded7b70cf83350fe2e7d743b79ec 100644
 --- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
 +++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
 @@ -148,6 +148,9 @@ public:
@@ -20832,10 +20877,10 @@ index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4
      uint64_t m_navigationID;
  };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc0d03e737 100644
+index f0fc6805fdd7f8b949319fd1f2df9c686dd8f3a7..2a8d890f6e8cf094aa7461703a943f35037f4883 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-@@ -920,6 +920,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
+@@ -924,6 +924,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
          CFPreferencesGetAppIntegerValue(CFSTR("key"), CFSTR("com.apple.WebKit.WebContent.BlockIOKitInWebContentSandbox"), nullptr);
  #endif
  
@@ -20845,7 +20890,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
      updateThrottleState();
  }
  
-@@ -1685,6 +1688,22 @@ void WebPage::platformDidReceiveLoadParameters(const LoadParameters& loadParamet
+@@ -1689,6 +1692,22 @@ void WebPage::platformDidReceiveLoadParameters(const LoadParameters& loadParamet
  }
  #endif
  
@@ -20868,7 +20913,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
  void WebPage::loadRequest(LoadParameters&& loadParameters)
  {
      WEBPAGE_RELEASE_LOG(Loading, "loadRequest: navigationID=%" PRIu64 ", shouldTreatAsContinuingLoad=%u, lastNavigationWasAppInitiated=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, loadParameters.navigationID, static_cast<unsigned>(loadParameters.shouldTreatAsContinuingLoad), loadParameters.request.isAppInitiated(), valueOrDefault(loadParameters.existingNetworkResourceLoadIdentifierToResume).toUInt64());
-@@ -1957,17 +1976,13 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
+@@ -1961,17 +1980,13 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
      view->resize(viewSize);
      m_drawingArea->setNeedsDisplay();
  
@@ -20887,7 +20932,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
  
      // Viewport properties have no impact on zero sized fixed viewports.
      if (m_viewSize.isEmpty())
-@@ -1984,20 +1999,18 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
+@@ -1988,20 +2003,18 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
  
      ViewportAttributes attr = computeViewportAttributes(viewportArguments, minimumLayoutFallbackWidth, deviceWidth, deviceHeight, 1, m_viewSize);
  
@@ -20915,7 +20960,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
  
  #if USE(COORDINATED_GRAPHICS)
      m_drawingArea->didChangeViewportAttributes(WTFMove(attr));
-@@ -2005,7 +2018,6 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
+@@ -2009,7 +2022,6 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
      send(Messages::WebPageProxy::DidChangeViewportProperties(attr));
  #endif
  }
@@ -20923,7 +20968,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
  
  void WebPage::scrollMainFrameIfNotAtMaxScrollPosition(const IntSize& scrollOffset)
  {
-@@ -2297,6 +2309,7 @@ void WebPage::scaleView(double scale)
+@@ -2301,6 +2313,7 @@ void WebPage::scaleView(double scale)
      }
  
      m_page->setViewScaleFactor(scale);
@@ -20931,7 +20976,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
      scalePage(pageScale, scrollPositionAtNewScale);
  }
  
-@@ -2476,17 +2489,13 @@ void WebPage::viewportPropertiesDidChange(const ViewportArguments& viewportArgum
+@@ -2480,17 +2493,13 @@ void WebPage::viewportPropertiesDidChange(const ViewportArguments& viewportArgum
          viewportConfigurationChanged();
  #endif
  
@@ -20950,7 +20995,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
  }
  
  void WebPage::listenForLayoutMilestones(OptionSet<WebCore::LayoutMilestone> milestones)
-@@ -3395,6 +3404,104 @@ void WebPage::touchEvent(const WebTouchEvent& touchEvent)
+@@ -3399,6 +3408,104 @@ void WebPage::touchEvent(const WebTouchEvent& touchEvent)
  
      send(Messages::WebPageProxy::DidReceiveEvent(static_cast<uint32_t>(touchEvent.type()), handled));
  }
@@ -21055,7 +21100,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
  #endif
  
  void WebPage::cancelPointer(WebCore::PointerID pointerId, const WebCore::IntPoint& documentPoint)
-@@ -3471,6 +3578,11 @@ void WebPage::sendMessageToTargetBackend(const String& targetId, const String& m
+@@ -3475,6 +3582,11 @@ void WebPage::sendMessageToTargetBackend(const String& targetId, const String& m
      m_inspectorTargetController->sendMessageToTargetBackend(targetId, message);
  }
  
@@ -21067,7 +21112,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
  void WebPage::insertNewlineInQuotedContent()
  {
      Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-@@ -3715,6 +3827,7 @@ void WebPage::didCompletePageTransition()
+@@ -3719,6 +3831,7 @@ void WebPage::didCompletePageTransition()
  void WebPage::show()
  {
      send(Messages::WebPageProxy::ShowPage());
@@ -21075,7 +21120,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
  }
  
  void WebPage::setIsTakingSnapshotsForApplicationSuspension(bool isTakingSnapshotsForApplicationSuspension)
-@@ -4584,7 +4697,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
+@@ -4568,7 +4681,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
  
  #if ENABLE(DRAG_SUPPORT)
  
@@ -21084,7 +21129,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
  void WebPage::performDragControllerAction(DragControllerAction action, const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation> draggingSourceOperationMask, SelectionData&& selectionData, OptionSet<DragApplicationFlags> flags)
  {
      if (!m_page) {
-@@ -6997,6 +7110,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
+@@ -6983,6 +7096,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
              WebsitePoliciesData::applyToDocumentLoader(WTFMove(*m_pendingWebsitePolicies), documentLoader);
              m_pendingWebsitePolicies = std::nullopt;
          }
@@ -21095,7 +21140,7 @@ index 0a2681d0a386af8635411825be3932c42db41f2f..41d9c533b7a26b40587e9218b05fd2fc
  
      return documentLoader;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.h b/Source/WebKit/WebProcess/WebPage/WebPage.h
-index b2431383b5104c9508416ec1354cc681aac92b33..a44d92e6270785128aea415fe3a29e91934150a4 100644
+index 0e82e1971fd199bbffb76ae4b15a31a0c20ca816..fcbc15fddaf8bcef89358fac541a2118c6eb9449 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
 @@ -117,6 +117,10 @@
@@ -21109,7 +21154,7 @@ index b2431383b5104c9508416ec1354cc681aac92b33..a44d92e6270785128aea415fe3a29e91
  #if PLATFORM(GTK) || PLATFORM(WPE)
  #include "InputMethodState.h"
  #endif
-@@ -1005,11 +1009,11 @@ public:
+@@ -1008,11 +1012,11 @@ public:
      void clearSelection();
      void restoreSelectionInFocusedEditableElement();
  
@@ -21123,7 +21168,7 @@ index b2431383b5104c9508416ec1354cc681aac92b33..a44d92e6270785128aea415fe3a29e91
      void performDragControllerAction(DragControllerAction, const WebCore::DragData&, SandboxExtension::Handle&&, Vector<SandboxExtension::Handle>&&);
  #endif
  
-@@ -1023,6 +1027,9 @@ public:
+@@ -1026,6 +1030,9 @@ public:
      void didStartDrag();
      void dragCancelled();
      OptionSet<WebCore::DragSourceAction> allowedDragSourceActions() const { return m_allowedDragSourceActions; }
@@ -21133,7 +21178,7 @@ index b2431383b5104c9508416ec1354cc681aac92b33..a44d92e6270785128aea415fe3a29e91
  #endif
  
      void beginPrinting(WebCore::FrameIdentifier, const PrintInfo&);
-@@ -1257,6 +1264,7 @@ public:
+@@ -1259,6 +1266,7 @@ public:
      void connectInspector(const String& targetId, Inspector::FrontendChannel::ConnectionType);
      void disconnectInspector(const String& targetId);
      void sendMessageToTargetBackend(const String& targetId, const String& message);
@@ -21141,7 +21186,7 @@ index b2431383b5104c9508416ec1354cc681aac92b33..a44d92e6270785128aea415fe3a29e91
  
      void insertNewlineInQuotedContent();
  
-@@ -1627,6 +1635,7 @@ private:
+@@ -1634,6 +1642,7 @@ private:
      // Actions
      void tryClose(CompletionHandler<void(bool)>&&);
      void platformDidReceiveLoadParameters(const LoadParameters&);
@@ -21149,7 +21194,7 @@ index b2431383b5104c9508416ec1354cc681aac92b33..a44d92e6270785128aea415fe3a29e91
      void loadRequest(LoadParameters&&);
      NO_RETURN void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
      void loadData(LoadParameters&&);
-@@ -1664,6 +1673,7 @@ private:
+@@ -1671,6 +1680,7 @@ private:
      void updatePotentialTapSecurityOrigin(const WebTouchEvent&, bool wasHandled);
  #elif ENABLE(TOUCH_EVENTS)
      void touchEvent(const WebTouchEvent&);
@@ -21157,7 +21202,7 @@ index b2431383b5104c9508416ec1354cc681aac92b33..a44d92e6270785128aea415fe3a29e91
  #endif
  
      void cancelPointer(WebCore::PointerID, const WebCore::IntPoint&);
-@@ -1803,9 +1813,7 @@ private:
+@@ -1810,9 +1820,7 @@ private:
  
      void requestRectForFoundTextRange(const WebFoundTextRange&, CompletionHandler<void(WebCore::FloatRect)>&&);
  
@@ -21167,7 +21212,7 @@ index b2431383b5104c9508416ec1354cc681aac92b33..a44d92e6270785128aea415fe3a29e91
  
      void didChangeSelectedIndexForActivePopupMenu(int32_t newIndex);
      void setTextForActivePopupMenu(int32_t index);
-@@ -2340,6 +2348,7 @@ private:
+@@ -2348,6 +2356,7 @@ private:
      UserActivity m_userActivity;
  
      uint64_t m_pendingNavigationID { 0 };
@@ -21176,10 +21221,10 @@ index b2431383b5104c9508416ec1354cc681aac92b33..a44d92e6270785128aea415fe3a29e91
  
      bool m_mainFrameProgressCompleted { false };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-index 25c28b7cd458c9b272c71cd00a376d26c4e63781..82ed25b5b5e5693b13a2b74de70ea9dec52171c5 100644
+index 4487e02de4ceb41804b16c5bfe84310ccb970aa0..c7e08da1b8069fce1e7ada2ed1bda8cabdd834bb 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-@@ -136,6 +136,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -138,6 +138,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      ConnectInspector(String targetId, Inspector::FrontendChannel::ConnectionType connectionType)
      DisconnectInspector(String targetId)
      SendMessageToTargetBackend(String targetId, String message)
@@ -21187,7 +21232,7 @@ index 25c28b7cd458c9b272c71cd00a376d26c4e63781..82ed25b5b5e5693b13a2b74de70ea9de
  
  #if ENABLE(REMOTE_INSPECTOR)
      SetIndicating(bool indicating);
-@@ -147,6 +148,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -149,6 +150,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
  #endif
  #if !ENABLE(IOS_TOUCH_EVENTS) && ENABLE(TOUCH_EVENTS)
      TouchEvent(WebKit::WebTouchEvent event)
@@ -21195,7 +21240,7 @@ index 25c28b7cd458c9b272c71cd00a376d26c4e63781..82ed25b5b5e5693b13a2b74de70ea9de
  #endif
  
      CancelPointer(WebCore::PointerID pointerId, WebCore::IntPoint documentPoint)
-@@ -176,6 +178,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -178,6 +180,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      LoadURLInFrame(URL url, String referrer, WebCore::FrameIdentifier frameID)
      LoadDataInFrame(IPC::DataReference data, String MIMEType, String encodingName, URL baseURL, WebCore::FrameIdentifier frameID)
      LoadRequest(struct WebKit::LoadParameters loadParameters)
@@ -21203,7 +21248,7 @@ index 25c28b7cd458c9b272c71cd00a376d26c4e63781..82ed25b5b5e5693b13a2b74de70ea9de
      LoadRequestWaitingForProcessLaunch(struct WebKit::LoadParameters loadParameters, URL resourceDirectoryURL, WebKit::WebPageProxyIdentifier pageID, bool checkAssumedReadAccessToResourceURL)
      LoadData(struct WebKit::LoadParameters loadParameters)
      LoadSimulatedRequestAndResponse(struct WebKit::LoadParameters loadParameters, WebCore::ResourceResponse simulatedResponse)
-@@ -340,10 +343,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -342,10 +345,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      AddMIMETypeWithCustomContentProvider(String mimeType)
  
      # Drag and drop.
@@ -21216,7 +21261,7 @@ index 25c28b7cd458c9b272c71cd00a376d26c4e63781..82ed25b5b5e5693b13a2b74de70ea9de
      PerformDragControllerAction(enum:uint8_t WebKit::DragControllerAction action, WebCore::DragData dragData, WebKit::SandboxExtension::Handle sandboxExtensionHandle, Vector<WebKit::SandboxExtension::Handle> sandboxExtensionsForUpload)
  #endif
  #if ENABLE(DRAG_SUPPORT)
-@@ -352,6 +355,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -354,6 +357,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      DragCancelled()
  #endif
  
@@ -21320,7 +21365,7 @@ index c77ff78cd3cd9627d1ae7b930c81457094645200..88746359159a76b169b7e6dcbee4fb34
  }
  
 diff --git a/Source/WebKit/WebProcess/WebProcess.cpp b/Source/WebKit/WebProcess/WebProcess.cpp
-index 53f8a56cd2bf8a380c91f28e27e7b63806b7e339..23c0dc353280d59c11b98aab31ce37593e2dd063 100644
+index d77e03db127a5aaad410916a2d5168a4b124a730..b750307d6b7335c3c092502dd908070c317ac2e4 100644
 --- a/Source/WebKit/WebProcess/WebProcess.cpp
 +++ b/Source/WebKit/WebProcess/WebProcess.cpp
 @@ -92,6 +92,7 @@
@@ -21331,7 +21376,7 @@ index 53f8a56cd2bf8a380c91f28e27e7b63806b7e339..23c0dc353280d59c11b98aab31ce3759
  #include <JavaScriptCore/JSLock.h>
  #include <JavaScriptCore/MemoryStatistics.h>
  #include <JavaScriptCore/WasmFaultSignalHandler.h>
-@@ -368,6 +369,8 @@ void WebProcess::initializeProcess(const AuxiliaryProcessInitializationParameter
+@@ -362,6 +363,8 @@ void WebProcess::initializeProcess(const AuxiliaryProcessInitializationParameter
      
      platformInitializeProcess(parameters);
      updateCPULimit();
@@ -21369,7 +21414,7 @@ index d6b5b19bd5a81b8c041eac72f2d0f65e5f36f11c..293d90cd32c4e827b65fa59d51e90d42
  - (void)touch:(WebEvent *)event
  {
 diff --git a/Source/WebKitLegacy/mac/WebView/WebView.mm b/Source/WebKitLegacy/mac/WebView/WebView.mm
-index 0cc178510b1604ea80f252b6e4e0089f4e2dd4d0..c95b50ef3d4241439f66b0b0f4cde41dfb940e6b 100644
+index 56eb6db6105bfec3771e55338350523b24194878..5e3297ac51926cc4cce13543e24474a150f14521 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
 @@ -4058,7 +4058,7 @@ IGNORE_WARNINGS_END
@@ -21422,7 +21467,7 @@ index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d
 +    LIBVPX_LIBRARIES
 +)
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index 3b5a947f98e2d48f98dc3027ea18d21788862ba1..9fa9863840f3af990c293a282c87971ce99aa2ba 100644
+index 15d2f088c29c3feb29ab8aaedd0fe4fa2ea95b51..6e314722a60c615504ff87ff78a1035c8eb9e5c6 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
 @@ -5,6 +5,7 @@ WEBKIT_OPTION_BEGIN()
@@ -21464,7 +21509,7 @@ index 3b5a947f98e2d48f98dc3027ea18d21788862ba1..9fa9863840f3af990c293a282c87971c
  WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(USE_WPE_RENDERER "Whether to enable WPE rendering" PUBLIC ON)
  
-@@ -120,7 +125,7 @@ endif ()
+@@ -121,7 +126,7 @@ endif ()
  # without approval from a GTK reviewer. There must be strong reason to support
  # changing the value of the option.
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_DRAG_SUPPORT PUBLIC ON)
@@ -21473,7 +21518,7 @@ index 3b5a947f98e2d48f98dc3027ea18d21788862ba1..9fa9863840f3af990c293a282c87971c
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_PDFJS PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SPELLCHECK PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_TOUCH_EVENTS PUBLIC ON)
-@@ -153,10 +158,10 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_INPUT_TYPE_WEEK PRIVATE ON)
+@@ -154,10 +159,10 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_INPUT_TYPE_WEEK PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_INTELLIGENT_TRACKING_PREVENTION PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_LAYER_BASED_SVG_ENGINE PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_LAYOUT_FORMATTING_CONTEXT PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
@@ -21486,7 +21531,7 @@ index 3b5a947f98e2d48f98dc3027ea18d21788862ba1..9fa9863840f3af990c293a282c87971c
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MHTML PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MOUSE_CURSOR_SCALE PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETSCAPE_PLUGIN_API PRIVATE OFF)
-@@ -164,7 +169,7 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETWORK_CACHE_SPECULATIVE_REVALIDATION P
+@@ -165,7 +170,7 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETWORK_CACHE_SPECULATIVE_REVALIDATION P
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETWORK_CACHE_STALE_WHILE_REVALIDATE PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_OFFSCREEN_CANVAS PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_OFFSCREEN_CANVAS_IN_WORKERS PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
@@ -21495,7 +21540,7 @@ index 3b5a947f98e2d48f98dc3027ea18d21788862ba1..9fa9863840f3af990c293a282c87971c
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_PERIODIC_MEMORY_MONITOR PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_POINTER_LOCK PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SERVICE_WORKER PRIVATE ON)
-@@ -172,6 +177,15 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SHAREABLE_RESOURCE PRIVATE ON)
+@@ -173,6 +178,15 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SHAREABLE_RESOURCE PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_API_STATISTICS PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_RTC PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
  
@@ -21511,7 +21556,7 @@ index 3b5a947f98e2d48f98dc3027ea18d21788862ba1..9fa9863840f3af990c293a282c87971c
  include(GStreamerDependencies)
  
  # Finalize the value for all options. Do not attempt to use an option before
-@@ -272,7 +286,8 @@ if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
+@@ -273,7 +287,8 @@ if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
      set(BUILD_REVISION "tarball")
  endif ()
  
@@ -21522,7 +21567,7 @@ index 3b5a947f98e2d48f98dc3027ea18d21788862ba1..9fa9863840f3af990c293a282c87971c
  SET_AND_EXPOSE_TO_BUILD(HAVE_OS_DARK_MODE_SUPPORT 1)
  
 diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
-index 73bb68324ea0f949e3043698b603d0c3b7b3ccd5..41eb3ac554d05d09994cc325629b107b2ff4ba66 100644
+index 9afdc374894bda553a462725dc9a89b521ddc87c..84840f99b75a92079b8fabf81dd8181c59fbb0cc 100644
 --- a/Source/cmake/OptionsWPE.cmake
 +++ b/Source/cmake/OptionsWPE.cmake
 @@ -3,6 +3,7 @@ include(VersioningUtils)
@@ -21594,7 +21639,7 @@ index 73bb68324ea0f949e3043698b603d0c3b7b3ccd5..41eb3ac554d05d09994cc325629b107b
  WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." PUBLIC ON)
  
  # Private options specific to the WPE port.
-@@ -290,7 +309,7 @@ if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
+@@ -291,7 +310,7 @@ if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
  endif ()
  
  SET_AND_EXPOSE_TO_BUILD(HAVE_ACCESSIBILITY ${ENABLE_ACCESSIBILITY})
@@ -22252,10 +22297,10 @@ index ef4407cfc114e602d98ed81724da504f453e258f..448dd483715162baba484f756fbcc1d7
 +    add_subdirectory(Playwright/win)
  endif ()
 diff --git a/Tools/Scripts/build-webkit b/Tools/Scripts/build-webkit
-index 9f32cb6aedc488f36e9c2ddcd3e146e87abf30b9..8ad4ea003aee4c83cec3bcc11c702f9035bbb16c 100755
+index 00664ad09f902ba55d79426ac3c3a472670529d0..1c12f1969fcc5bc0ce9bbd0931febbc01aa60d49 100755
 --- a/Tools/Scripts/build-webkit
 +++ b/Tools/Scripts/build-webkit
-@@ -263,7 +263,7 @@ if (isAppleCocoaWebKit()) {
+@@ -252,7 +252,7 @@ if (isAppleCocoaWebKit()) {
          push @projects, ("Source/WebKit");
  
          if (!isEmbeddedWebKit()) {
@@ -22356,10 +22401,10 @@ index 0000000000000000000000000000000000000000..3618075f10824beb0bc6cd8070772ab8
 +#endif // USE(ATSPI)
 diff --git a/Tools/WebKitTestRunner/InjectedBundle/empty/AccessibilityUIElementEmpty.cpp b/Tools/WebKitTestRunner/InjectedBundle/empty/AccessibilityUIElementEmpty.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..c25ab60262398df7724612cd1397848ff90a572b
+index 0000000000000000000000000000000000000000..c77c7c396f5f0f6b6e26baff61bf4b8de0001247
 --- /dev/null
 +++ b/Tools/WebKitTestRunner/InjectedBundle/empty/AccessibilityUIElementEmpty.cpp
-@@ -0,0 +1,1014 @@
+@@ -0,0 +1,1020 @@
 +/*
 + * Copyright (C) 2022 Microsoft Corporation.
 + *
@@ -22757,6 +22802,12 @@ index 0000000000000000000000000000000000000000..c25ab60262398df7724612cd1397848f
 +}
 +
 +bool AccessibilityUIElement::isDecrementActionSupported()
++{
++    notImplemented();
++    return false;
++}
++
++bool AccessibilityUIElement::isBusy() const
 +{
 +    notImplemented();
 +    return false;
@@ -23419,10 +23470,10 @@ index 4f3640a8b93897d69604ee8ba38cd07561720ad2..00b657a8a585d104afc346dc1126fb71
      InjectedBundle/wpe/InjectedBundleWPE.cpp
      InjectedBundle/wpe/TestRunnerWPE.cpp
 diff --git a/Tools/WebKitTestRunner/TestController.cpp b/Tools/WebKitTestRunner/TestController.cpp
-index 90a14eff3cac2610f7f20e29a7900d07ea071c13..6cef18933cdbe1a01240403823c868e7db31abb7 100644
+index 3ed267075cce314de97b7512226cc930c2366167..05e27645e286455964f6c31d6757ccbd11fd9ce0 100644
 --- a/Tools/WebKitTestRunner/TestController.cpp
 +++ b/Tools/WebKitTestRunner/TestController.cpp
-@@ -871,6 +871,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
+@@ -874,6 +874,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
          0, // requestStorageAccessConfirm
          shouldAllowDeviceOrientationAndMotionAccess,
          runWebAuthenticationPanel,


### PR DESCRIPTION
No 3-way diff, as the patch rebased cleanly and therefore there was no conflict resolution.

Build fixes:

* https://github.com/q66/WebKit/commit/3cab59a5a1babf1c4825acd37256f7a995f64e15 for ubuntu 18.04 (pending upstream)
* https://github.com/q66/WebKit/commit/55871e6f681fe28939e815c8011f5419413fb7dd (not upstreamable as it's a part of the playwright patch; just reflecting upstream API changes)