### PR TITLE
docs(test-annotations): add isMobile to typescript snippet

### DIFF
--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -201,7 +201,7 @@ test('user profile', async ({ page }) => {
 ```js js-flavor=ts
 // example.spec.ts
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page, isMobile }) => {
   test.fixme(isMobile, 'Settings page does not work in mobile yet');
 
   await page.goto('http://localhost:3000/settings');


### PR DESCRIPTION
The Typescript example was missing the `isMobile` variable. The variable is present in the JavaScript snippet.

Page: https://playwright.dev/docs/test-annotations#use-fixme-in-beforeeach-hook