### PR TITLE
fix(test-runner): mark attach as async

### DIFF
--- a/docs/src/test-api/class-globalinfo.md
+++ b/docs/src/test-api/class-globalinfo.md
@@ -98,7 +98,7 @@ The list of files or buffers attached to the overall test run. Some reporters sh
 
 To add an attachment, use [`method: GlobalInfo.attach`]. See [`property: TestInfo.attachments`] if you are looking for test-scoped attachments.
 
-## method: GlobalInfo.attach
+## async method: GlobalInfo.attach
 
 Attach a value or a file from disk to the overall test run. Some reporters show global attachments. Either [`option: path`] or [`option: body`] must be specified, but not both.
 

--- a/docs/src/test-api/class-testinfo.md
+++ b/docs/src/test-api/class-testinfo.md
@@ -42,7 +42,7 @@ The list of files or buffers attached to the current test. Some reporters show t
 
 To add an attachment, use [`method: TestInfo.attach`] instead of directly pushing onto this array.
 
-## method: TestInfo.attach
+## async method: TestInfo.attach
 
 Attach a value or a file from disk to the current test. Some reporters show test attachments. Either [`option: path`] or [`option: body`] must be specified, but not both.
 

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -1474,7 +1474,7 @@ export interface TestInfo {
     contentType?: string;
 
     path?: string;
-  }): void;
+  }): Promise<void>;
 
   /**
    * Column number where the currently running test is declared.

--- a/tests/config/experimental.d.ts
+++ b/tests/config/experimental.d.ts
@@ -17143,7 +17143,7 @@ interface TestConfig {
     reuseExistingServer?: boolean;
 
     /**
-     * Current working directory of the spawned process, `process.cwd()` by default.
+     * Current working directory of the spawned process, defaults to the directory of the configuration file.
      */
     cwd?: string;
 
@@ -17687,7 +17687,7 @@ export interface TestInfo {
     contentType?: string;
 
     path?: string;
-  }): void;
+  }): Promise<void>;
 
   /**
    * Column number where the currently running test is declared.

--- a/tests/config/experimental.d.ts
+++ b/tests/config/experimental.d.ts
@@ -11118,12 +11118,17 @@ export interface Android {
    */
   devices(options?: {
     /**
+     * Optional host to establish ADB server connection. Default to `127.0.0.1`.
+     */
+    host?: string;
+
+    /**
      * Prevents automatic playwright driver installation on attach. Assumes that the drivers have been installed already.
      */
     omitDriverInstall?: boolean;
 
     /**
-     * Optional port to establish ADB server connection.
+     * Optional port to establish ADB server connection. Default to `5037`.
      */
     port?: number;
   }): Promise<Array<AndroidDevice>>;

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -658,6 +658,7 @@ class TypesGenerator {
   writeFile(path.join(coreTypesDir, 'types.d.ts'), await generateCoreTypes(false), true);
   writeFile(path.join(testTypesDir, 'test.d.ts'), await generateTestTypes(false), true);
   writeFile(path.join(testTypesDir, 'testReporter.d.ts'), await generateReporterTypes(false), true);
+  writeFile(path.join(__dirname, '..', '..', 'tests', 'config', 'experimental.d.ts'), await generateExperimentalTypes(), true);
   process.exit(hadChanges && process.argv.includes('--check-clean') ? 1 : 0);
 })().catch(e => {
   console.error(e);


### PR DESCRIPTION
Noticed this while writing new fixtures. This has been wrong in the docs all along (the types had been fine until https://github.com/microsoft/playwright/pull/13358/files#diff-69583b434e25c5c454472fca02f61a2f7caa0233032e79934e6e69525c622721L237), since the override was overriding the incorrect doc-based-typing.