### PR TITLE
docs: list all extension testing requirements

### DIFF
--- a/docs/src/chrome-extensions-js-python.md
+++ b/docs/src/chrome-extensions-js-python.md
@@ -4,7 +4,7 @@ title: "Chrome Extensions"
 ---
 
 :::note
-Extensions only work in Chrome / Chromium in non-headless mode.
+Extensions only work in Chrome / Chromium in non-headless mode, launched with a persistent context.
 :::
 
 The following is code for getting a handle to the [background page](https://developer.chrome.com/extensions/background_pages) of an extension whose source is located in `./my-extension`:


### PR DESCRIPTION
Based on other playwright code as well as experimenting with puppeteer (same API but not requiring a persistent context), it was not obvious to me that the persistent context here is a requirement and so I found myself wondering why it didn't work.