### PR TITLE
chore: show small progress bar in downloader without tty

### DIFF
--- a/packages/playwright-core/src/server/registry/download.ts
+++ b/packages/playwright-core/src/server/registry/download.ts
@@ -115,12 +115,12 @@ export async function download(
 }
 
 function getDownloadProgress(progressBarName: string): OnProgressCallback {
-  if (process.stdout.isTTY)
-    return _getInteractiveDownloadProgress(progressBarName);
-  return _getNonInteractiveDownloadProgress(progressBarName);
+  if (false && process.stdout.isTTY)
+    return _getAnimatedDownloadProgress(progressBarName);
+  return _getBasicDownloadProgress(progressBarName);
 }
 
-function _getInteractiveDownloadProgress(progressBarName: string): OnProgressCallback {
+function _getAnimatedDownloadProgress(progressBarName: string): OnProgressCallback {
   let progressBar: ProgressBar;
   let lastDownloadedBytes = 0;
 
@@ -144,14 +144,12 @@ function _getInteractiveDownloadProgress(progressBarName: string): OnProgressCal
   };
 }
 
-function _getNonInteractiveDownloadProgress(progressBarName: string): OnProgressCallback {
+function _getBasicDownloadProgress(progressBarName: string): OnProgressCallback {
   // eslint-disable-next-line no-console
   console.log(`Downloading ${progressBarName}...`);
   const width = 80;
   const maxLines = 10;
-  const reportedSteps = width / maxLines;
-  const char = '■';
-  const boundary = '|';
+  const reportedSteps = width / (maxLines - 1);
   let nextMinimum = 0;
   return (downloadedBytes: number, totalBytes: number) => {
     const percentage = Math.round(downloadedBytes / totalBytes * 100);
@@ -160,7 +158,7 @@ function _getNonInteractiveDownloadProgress(progressBarName: string): OnProgress
       return;
     nextMinimum = currentWidth + (reportedSteps - currentWidth % reportedSteps);
     // eslint-disable-next-line no-console
-    console.log(`${boundary}${char.repeat(currentWidth)}${' '.repeat(width - currentWidth)}${boundary} ${' '.repeat(3 - percentage.toString().length)}${percentage}% of ${toMegabytes(totalBytes)}`);
+    console.log(`|${'■'.repeat(currentWidth)}${' '.repeat(width - currentWidth)}| ${percentage.toString().padStart(3)}% of ${toMegabytes(totalBytes)}`);
   };
 }
 

--- a/packages/playwright-core/src/server/registry/download.ts
+++ b/packages/playwright-core/src/server/registry/download.ts
@@ -115,7 +115,7 @@ export async function download(
 }
 
 function getDownloadProgress(progressBarName: string): OnProgressCallback {
-  if (false && process.stdout.isTTY)
+  if (process.stdout.isTTY)
     return _getAnimatedDownloadProgress(progressBarName);
   return _getBasicDownloadProgress(progressBarName);
 }
@@ -147,18 +147,18 @@ function _getAnimatedDownloadProgress(progressBarName: string): OnProgressCallba
 function _getBasicDownloadProgress(progressBarName: string): OnProgressCallback {
   // eslint-disable-next-line no-console
   console.log(`Downloading ${progressBarName}...`);
-  const width = 80;
-  const maxLines = 10;
-  const reportedSteps = width / (maxLines - 1);
-  let nextMinimum = 0;
+  const totalRows = 10;
+  const stepWidth = 8;
+  let lastRow = -1;
   return (downloadedBytes: number, totalBytes: number) => {
-    const percentage = Math.round(downloadedBytes / totalBytes * 100);
-    const currentWidth = Math.round(percentage / 100 * width);
-    if (currentWidth < nextMinimum)
-      return;
-    nextMinimum = currentWidth + (reportedSteps - currentWidth % reportedSteps);
-    // eslint-disable-next-line no-console
-    console.log(`|${'■'.repeat(currentWidth)}${' '.repeat(width - currentWidth)}| ${percentage.toString().padStart(3)}% of ${toMegabytes(totalBytes)}`);
+    const percentage = downloadedBytes / totalBytes;
+    const row = Math.floor(totalRows * percentage);
+    if (row > lastRow) {
+      lastRow = row;
+      const percentageString = String(percentage * 100 | 0).padStart(3);
+      // eslint-disable-next-line no-console
+      console.log(`|${'■'.repeat(row * stepWidth)}${' '.repeat((totalRows - row) * stepWidth)}| ${percentageString}% of ${toMegabytes(totalBytes)}`);
+    }
   };
 }
 


### PR DESCRIPTION
Motivation: Sometimes on CI it was hard to tell if browsers are getting downloaded. Also .NET currently not provide an easy way of passing the parent stdout/stderr streams which results in `!isTTY` -> nothing is shown when browsers are getting downloaded when the Playwright CLI via .NET is invoked.

Demo:

```
➜  playwright git:(main) ✗ npx playwright install                                      
Downloading Playwright build of chromium v1003...
|                                                                                |   0% of 119.3 Mb
|■■■■■■■■                                                                        |  10% of 119.3 Mb
|■■■■■■■■■■■■■■■■                                                                |  20% of 119.3 Mb
|■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 119.3 Mb
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 119.3 Mb
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 119.3 Mb
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 119.3 Mb
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 119.3 Mb
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 119.3 Mb
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 119.3 Mb
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 119.3 Mb
```