### PR TITLE
devops: use xcode 13.3 on MacOS 12 by default

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -55,8 +55,8 @@ compile_chromium() {
   source "${SCRIPT_FOLDER}/ensure_depot_tools.sh"
 
   if [[ $(uname) == "Darwin" ]]; then
-    # As of Feb, 2022 Chromium mac compilation requires Xcode13.2
-    selectXcodeVersionOrDie "13.2"
+    # As of Apr, 2022 Chromium mac compilation requires Xcode13.3
+    selectXcodeVersionOrDie "13.3"
   fi
 
   cd "${CR_CHECKOUT_PATH}/src"

--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -58,7 +58,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   elif [[ "${CURRENT_HOST_OS_VERSION}" == "11."* ]]; then
     selectXcodeVersionOrDie "12.5"
   elif [[ "${CURRENT_HOST_OS_VERSION}" == "12."* ]]; then
-    selectXcodeVersionOrDie "13.2"
+    selectXcodeVersionOrDie "13.3"
   else
     echo "ERROR: ${CURRENT_HOST_OS_VERSION} is not supported"
     exit 1


### PR DESCRIPTION
- xcode 13.3 is required for chromium
- xcode 13.3 requires MacOS 12, so we can't use it on MacOS 11