### PR TITLE
feat: make scrollIntoView work with zero-sized elements

### DIFF
--- a/docs/src/actionability.md
+++ b/docs/src/actionability.md
@@ -24,7 +24,7 @@ Here is the complete list of actionability checks performed for each action:
 | tap | Yes | Yes | Yes | Yes | Yes | - |
 | uncheck | Yes | Yes | Yes | Yes | Yes | - |
 | hover | Yes | Yes | Yes | Yes | - | - |
-| scrollIntoViewIfNeeded | Yes | Yes | Yes | - | - | - |
+| scrollIntoViewIfNeeded | Yes | - | Yes | - | - | - |
 | screenshot | Yes | Yes | Yes | - | - | - |
 | fill | Yes | Yes | - | - | Yes | Yes |
 | selectText | Yes | Yes | - | - | - | - |

--- a/packages/playwright-core/src/server/screenshotter.ts
+++ b/packages/playwright-core/src/server/screenshotter.ts
@@ -119,7 +119,7 @@ export class Screenshotter {
       await this._preparePageForScreenshot(progress, options.caret !== 'initial', options.animations === 'disabled', options.fonts === 'ready');
       progress.throwIfAborted(); // Do not do extra work.
 
-      await handle._waitAndScrollIntoViewIfNeeded(progress);
+      await handle._waitAndScrollIntoViewIfNeeded(progress, true /* waitForVisible */);
 
       progress.throwIfAborted(); // Do not do extra work.
       const boundingBox = await handle.boundingBox();

--- a/tests/page/elementhandle-scroll-into-view.spec.ts
+++ b/tests/page/elementhandle-scroll-into-view.spec.ts
@@ -54,6 +54,7 @@ async function testWaiting(page, after) {
   await promise;
   expect(done).toBe(true);
 }
+
 it('should wait for display:none to become visible', async ({ page, server }) => {
   await page.setContent('<div style="display:none">Hello</div>');
   await testWaiting(page, div => div.style.display = 'block');
@@ -64,14 +65,16 @@ it('should wait for display:contents to become visible', async ({ page, server }
   await testWaiting(page, div => div.style.display = 'block');
 });
 
-it('should wait for visibility:hidden to become visible', async ({ page, server }) => {
+it('should work for visibility:hidden element', async ({ page }) => {
   await page.setContent('<div style="visibility:hidden">Hello</div>');
-  await testWaiting(page, div => div.style.visibility = 'visible');
+  const div = await page.$('div');
+  await div.scrollIntoViewIfNeeded();
 });
 
-it('should wait for zero-sized element to become visible', async ({ page, server }) => {
+it('should work for zero-sized element', async ({ page }) => {
   await page.setContent('<div style="height:0">Hello</div>');
-  await testWaiting(page, div => div.style.height = '100px');
+  const div = await page.$('div');
+  await div.scrollIntoViewIfNeeded();
 });
 
 it('should wait for nested display:none to become visible', async ({ page, server }) => {
@@ -99,5 +102,5 @@ it('should timeout waiting for visible', async ({ page, server }) => {
   await page.setContent('<div style="display:none">Hello</div>');
   const div = await page.$('div');
   const error = await div.scrollIntoViewIfNeeded({ timeout: 3000 }).catch(e => e);
-  expect(error.message).toContain('element is not visible');
+  expect(error.message).toContain('element is not displayed, retrying in 100ms');
 });

--- a/tests/page/locator-misc-2.spec.ts
+++ b/tests/page/locator-misc-2.spec.ts
@@ -42,6 +42,34 @@ it('should scroll into view', async ({ page, server, isAndroid }) => {
   }
 });
 
+it('should scroll zero-sized element into view', async ({ page, isAndroid }) => {
+  it.fixme(isAndroid);
+
+  await page.setContent(`
+    <style>html,body { margin: 0; padding: 0; }</style>
+    <div style="height: 2000px; text-align: center; border: 10px solid blue;">
+      <h1>SCROLL DOWN</h1>
+    </div>
+    <div id=lazyload style="font-size:75px; background-color: green;"></div>
+    <script>
+      const lazyLoadElement = document.querySelector('#lazyload');
+      const observer = new IntersectionObserver((entries) => {
+        if (entries.some(entry => entry.isIntersecting)) {
+          lazyLoadElement.textContent = 'LAZY LOADED CONTENT';
+          lazyLoadElement.style.height = '20px';
+          observer.disconnect();
+        }
+      });
+      observer.observe(lazyLoadElement);
+    </script>
+  `);
+  expect(await page.locator('#lazyload').boundingBox()).toEqual({ x: 0, y: 2020, width: 1280, height: 0 });
+  await page.locator('#lazyload').scrollIntoViewIfNeeded();
+  await page.evaluate(() => new Promise(requestAnimationFrame));
+  expect(await page.locator('#lazyload').textContent()).toBe('LAZY LOADED CONTENT');
+  expect(await page.locator('#lazyload').boundingBox()).toEqual({ x: 0, y: 720, width: 1280, height: 20 });
+});
+
 it('should select textarea', async ({ page, server, browserName }) => {
   await page.goto(server.PREFIX + '/input/textarea.html');
   const textarea = page.locator('textarea');


### PR DESCRIPTION
We skip waiting for "visible" state that enforces non-zero size. Other invisible conditions like "display:none" fail during the actual "scrolling" step and will retry after short timeout.

Fixes #13508.