### PR TITLE
chore: use helper functions to define platforms

### DIFF
--- a/browser_patches/chromium/build.sh
+++ b/browser_patches/chromium/build.sh
@@ -5,6 +5,7 @@ set +x
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname "$0")"
 SCRIPT_FOLDER=$(pwd -P)
+source "${SCRIPT_FOLDER}/../utils.sh"
 
 USAGE=$(cat<<EOF
   usage: $(basename "$0") [--arm64] [--symbols] [--full] [--goma] <custom targets to compile>
@@ -54,7 +55,7 @@ compile_chromium() {
 
   source "${SCRIPT_FOLDER}/ensure_depot_tools.sh"
 
-  if [[ $(uname) == "Darwin" ]]; then
+  if is_mac; then
     # As of Apr, 2022 Chromium mac compilation requires Xcode13.3
     selectXcodeVersionOrDie "13.3"
   fi
@@ -85,7 +86,7 @@ compile_chromium() {
   echo "===== ======= ====="
 
   if [[ -n "$IS_FULL" ]]; then
-    if [[ $(uname) == "Linux" ]]; then
+    if is_linux; then
       ./build/install-build-deps.sh
       if [[ -n "$IS_ARM64" ]]; then
         # Install sysroot image, see https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/linux/chromium_arm.md
@@ -95,7 +96,7 @@ compile_chromium() {
   fi
 
   TARGETS="${args[@]}"
-  if [[ $(uname) == "MINGW"* || "$(uname)" == MSYS* ]]; then
+  if is_win; then
     if [[ -n "$TARGETS" ]]; then
       echo "ERROR: cannot compile custom targets on windows yet."
       echo "Requested to compile chromium targets - ${TARGETS}"
@@ -108,7 +109,7 @@ compile_chromium() {
     fi
   else
     if [[ -z "$TARGETS" ]]; then
-      if [[ $(uname) == "Linux" ]]; then
+      if is_linux; then
         TARGETS="chrome chrome_sandbox clear_key_cdm"
       else
         TARGETS="chrome"

--- a/browser_patches/chromium/goma.sh
+++ b/browser_patches/chromium/goma.sh
@@ -5,6 +5,7 @@ set +x
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname "$0")"
 SCRIPT_FOLDER=$(pwd -P)
+source "${SCRIPT_FOLDER}/../utils.sh"
 
 ELECTRON_BUILD_TOOLS_REQUIRED_VERSION=6ba8962529c37727a778691b89c92ab0eb1d9d87
 if [[ -d ./electron-build-tools ]]; then
@@ -35,7 +36,7 @@ export GOMA_START_COMPILER_PROXY=true
 
 function print_gn_args() {
   PLAYWRIGHT_GOMA_PATH="${SCRIPT_FOLDER}/electron-build-tools/third_party/goma"
-  if [[ $(uname) == MINGW* || "$(uname)" == MSYS* ]]; then
+  if is_win; then
     PLAYWRIGHT_GOMA_PATH=$(cygpath -w "${PLAYWRIGHT_GOMA_PATH}")
   fi
   echo 'use_goma = true'
@@ -48,7 +49,7 @@ if [[ $1 == "--help" ]]; then
 elif [[ $1 == "args" ]]; then
   print_gn_args
 elif [[ $1 == "login" ]]; then
-  if [[ $(uname) == "MINGW"* || "$(uname)" == MSYS* ]]; then
+  if is_win; then
     /c/Windows/System32/cmd.exe "/c $(cygpath -w $(pwd)/goma_auth.bat) login"
   else
     python ./goma_auth.py login
@@ -67,7 +68,7 @@ elif [[ $1 == "start" ]]; then
     echo "run '$(basename "$0") login'"
     exit 1
   fi
-  if [[ $(uname) == "MINGW"* || "$(uname)" == MSYS* ]]; then
+  if is_win; then
     /c/Windows/System32/cmd.exe "/c $(cygpath -w $(pwd)/goma_ctl.bat) ensure_start"
   else
     python ./goma_ctl.py ensure_start
@@ -82,7 +83,7 @@ elif [[ $1 == "start" ]]; then
   print_gn_args
   echo "===== ======= ====="
 elif [[ $1 == "stop" ]]; then
-  if [[ $(uname) == "MINGW"* || "$(uname)" == MSYS* ]]; then
+  if is_win; then
     /c/Windows/System32/cmd.exe "/c $(cygpath -w $(pwd)/goma_ctl.bat) stop"
   else
     python ./goma_ctl.py stop

--- a/browser_patches/firefox-beta/archive.sh
+++ b/browser_patches/firefox-beta/archive.sh
@@ -54,9 +54,9 @@ fi
 
 # Copy the libstdc++ version we linked against.
 # TODO(aslushnikov): this won't be needed with official builds.
-if [[ "$(uname)" == "Linux" ]]; then
+if is_linux; then
   cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 "${OBJ_FOLDER}/dist/firefox/libstdc++.so.6"
-elif [[ "$(uname)" == MINGW* || "$(uname)" == MSYS* ]]; then
+elif is_win; then
   # Bundle vcruntime14_1.dll - see https://github.com/microsoft/playwright/issues/9974
   cd "$(printMSVCRedistDir)"
   cp -t "${OBJ_FOLDER}/dist/firefox" vcruntime140_1.dll

--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -20,7 +20,7 @@ fi
 
 rm -rf .mozconfig
 
-if [[ "$(uname)" == "Darwin" ]]; then
+if is_mac; then
   CURRENT_HOST_OS_VERSION=$(getMacVersion)
   # As of Oct 2021, building Firefox requires XCode 13
   if [[ "${CURRENT_HOST_OS_VERSION}" != "10."* ]]; then
@@ -30,9 +30,9 @@ if [[ "$(uname)" == "Darwin" ]]; then
     exit 1
   fi
   echo "-- building on Mac"
-elif [[ "$(uname)" == "Linux" ]]; then
+elif is_linux; then
   echo "-- building on Linux"
-elif [[ "$(uname)" == MINGW* || "$(uname)" == MSYS* ]]; then
+elif is_win; then
   echo "ac_add_options --disable-update-agent" >> .mozconfig
   echo "ac_add_options --disable-default-browser-agent" >> .mozconfig
   echo "ac_add_options --disable-maintenance-service" >> .mozconfig
@@ -67,7 +67,7 @@ else
   echo "ac_add_options --enable-release" >> .mozconfig
 fi
 
-if [[ "$(uname)" == MINGW* || "$(uname)" == "Darwin" || "$(uname)" == MSYS* ]]; then
+if is_mac || is_win; then
   # This options is only available on win and mac.
   echo "ac_add_options --disable-update-agent" >> .mozconfig
 fi
@@ -90,7 +90,7 @@ fi
 
 if [[ $1 == "--full" || $2 == "--full" || $1 == "--bootstrap" ]]; then
   echo "ac_add_options --enable-bootstrap" >> .mozconfig
-  if [[ "$(uname)" == "Darwin" || "$(uname)" == "Linux" ]]; then
+  if is_mac || is_linux; then
     SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser
   fi
   if [[ ! -z "${WIN32_REDIST_DIR}" ]]; then
@@ -105,7 +105,7 @@ elif [[ $1 == "--bootstrap" ]]; then
   ./mach configure
 else
   ./mach build
-  if [[ "$(uname)" == "Darwin" ]]; then
+  if is_mac; then
     node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/${OBJ_FOLDER}/dist
   else
     node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/${OBJ_FOLDER}/dist/bin

--- a/browser_patches/firefox/archive.sh
+++ b/browser_patches/firefox/archive.sh
@@ -56,9 +56,9 @@ fi
 
 # Copy the libstdc++ version we linked against.
 # TODO(aslushnikov): this won't be needed with official builds.
-if [[ "$(uname)" == "Linux" ]]; then
+if is_linux; then
   cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 "${OBJ_FOLDER}/dist/firefox/libstdc++.so.6"
-elif [[ "$(uname)" == MINGW* || "$(uname)" == MSYS* ]]; then
+elif is_win; then
   # Bundle vcruntime14_1.dll - see https://github.com/microsoft/playwright/issues/9974
   cd "$(printMSVCRedistDir)"
   cp -t "${OBJ_FOLDER}/dist/firefox" vcruntime140_1.dll

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -67,7 +67,7 @@ else
   echo "ac_add_options --enable-release" >> .mozconfig
 fi
 
-if is_win || is_linux; then
+if is_win || is_mac; then
   # This options is only available on win and mac.
   echo "ac_add_options --disable-update-agent" >> .mozconfig
 fi

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -20,7 +20,7 @@ fi
 
 rm -rf .mozconfig
 
-if [[ "$(uname)" == "Darwin" ]]; then
+if is_mac; then
   CURRENT_HOST_OS_VERSION=$(getMacVersion)
   # As of Oct 2021, building Firefox requires XCode 13
   if [[ "${CURRENT_HOST_OS_VERSION}" != "10."* ]]; then
@@ -30,9 +30,9 @@ if [[ "$(uname)" == "Darwin" ]]; then
     exit 1
   fi
   echo "-- building on Mac"
-elif [[ "$(uname)" == "Linux" ]]; then
+elif is_linux; then
   echo "-- building on Linux"
-elif [[ "$(uname)" == MINGW* || "$(uname)" == MSYS* ]]; then
+elif is_win; then
   echo "ac_add_options --disable-update-agent" >> .mozconfig
   echo "ac_add_options --disable-default-browser-agent" >> .mozconfig
   echo "ac_add_options --disable-maintenance-service" >> .mozconfig
@@ -67,7 +67,7 @@ else
   echo "ac_add_options --enable-release" >> .mozconfig
 fi
 
-if [[ "$(uname)" == MINGW* || "$(uname)" == "Darwin" || "$(uname)" == MSYS* ]]; then
+if is_win || is_linux; then
   # This options is only available on win and mac.
   echo "ac_add_options --disable-update-agent" >> .mozconfig
 fi
@@ -89,7 +89,7 @@ if [[ $1 != "--juggler" ]]; then
 fi
 
 if [[ $1 == "--full" || $2 == "--full" ]]; then
-  if [[ "$(uname)" == "Linux" ]]; then
+  if is_linux; then
     echo "ac_add_options --enable-bootstrap" >> .mozconfig
     SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser
   fi
@@ -99,7 +99,7 @@ if [[ $1 == "--full" || $2 == "--full" ]]; then
   fi
 fi
 
-if [[ "$(uname)" == "Darwin" ]]; then
+if is_mac; then
   if [[ ! -d "$HOME/.mozbuild/clang" ]]; then
     echo "ERROR: build toolchains are not found, specifically \$HOME/.mozbuild/clang is not there!"
     echo "Since December, 2021, build toolchains have to be predownloaded (see https://github.com/microsoft/playwright/pull/10929)"
@@ -118,7 +118,7 @@ if [[ $1 == "--juggler" ]]; then
   ./mach build faster
 else
   ./mach build
-  if [[ "$(uname)" == "Darwin" ]]; then
+  if is_mac; then
     node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/${OBJ_FOLDER}/dist
   else
     node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/${OBJ_FOLDER}/dist/bin

--- a/browser_patches/prepare_checkout.sh
+++ b/browser_patches/prepare_checkout.sh
@@ -6,6 +6,8 @@ trap "cd $(pwd -P)" EXIT
 cd "$(dirname "$0")"
 SCRIPT_PATH=$(pwd -P)
 
+source "${SCRIPT_PATH}/utils.sh"
+
 REMOTE_BROWSER_UPSTREAM="browser_upstream"
 BUILD_BRANCH="playwright-build"
 
@@ -28,7 +30,7 @@ if [[ $# == 0 ]]; then
 fi
 
 function maybe_cmd {
-  if [[ $(uname) == MINGW* || "$(uname)" == MSYS* ]]; then
+  if is_win; then
     local args="$@"
     /c/Windows/System32/cmd.exe "/c $args"
   else
@@ -62,7 +64,7 @@ function prepare_chromium_checkout {
     cd "${CR_CHECKOUT_PATH}"
     maybe_cmd fetch --nohooks chromium
     cd src
-    if [[ $(uname) == "Linux" ]]; then
+    if is_linux; then
       ./build/install-build-deps.sh
     fi
     maybe_cmd gclient runhooks

--- a/browser_patches/upload.sh
+++ b/browser_patches/upload.sh
@@ -5,6 +5,8 @@ set +x
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname "$0")"
 
+source "./utils.sh"
+
 if [[ ($1 == '--help') || ($1 == '-h') ]]; then
   echo "usage: $(basename "$0") [BLOB-PATH] [--check|ZIP-PATH]"
   echo
@@ -62,7 +64,7 @@ if [[ "${ZIP_PATH}" != *.zip && "${ZIP_PATH}" != *.gz ]]; then
   echo "ERROR: ${ZIP_PATH} is not an archive (must have a .zip or .gz extension)"
   exit 1
 fi
-if [[ $(uname) == MINGW* || "$(uname)" == MSYS* ]]; then
+if is_win; then
   # Convert POSIX path to MSYS
   WIN_PATH=$({ cd $(dirname "$ZIP_PATH") && pwd -W; } | sed 's|/|\\|g')
   WIN_PATH="${WIN_PATH}\\$(basename "$ZIP_PATH")"

--- a/browser_patches/utils.sh
+++ b/browser_patches/utils.sh
@@ -42,3 +42,27 @@ function printMSVCRedistDir() {
   fi
   echo "$redist_dir"
 }
+
+function is_win() {
+  if [[ "$(uname)" == MINGW* || "$(uname)" == MSYS* ]]; then
+    return 0;
+  else
+    return 1;
+  fi
+}
+
+function is_mac() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    return 0;
+  else
+    return 1;
+  fi
+}
+
+function is_linux() {
+  if [[ "$(uname)" == "Linux" ]]; then
+    return 0;
+  else
+    return 1;
+  fi
+}

--- a/browser_patches/webkit/archive.sh
+++ b/browser_patches/webkit/archive.sh
@@ -37,11 +37,11 @@ main() {
   fi
 
   set -x
-  if [[ "$(uname)" == "Darwin" ]]; then
+  if is_mac; then
     createZipForMac
-  elif [[ "$(uname)" == "Linux" ]]; then
+  elif is_linux; then
     createZipForLinux
-  elif [[ "$(uname)" == MINGW* || "$(uname)" == MSYS* ]]; then
+  elif is_win; then
     createZipForWindows
   else
     echo "ERROR: cannot upload on this platform!" 1>&2

--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -51,7 +51,7 @@ else
   cd "$HOME/webkit"
 fi
 
-if [[ "$(uname)" == "Darwin" ]]; then
+if is_mac; then
   CURRENT_HOST_OS_VERSION=$(getMacVersion)
   if [[ "${CURRENT_HOST_OS_VERSION}" == "10.15" ]]; then
     selectXcodeVersionOrDie "11.7"
@@ -64,7 +64,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
     exit 1
   fi
   ./Tools/Scripts/build-webkit --release --touch-events --orientation-events
-elif [[ "$(uname)" == "Linux" ]]; then
+elif is_linux; then
   if [[ $# == 0 || (-z "$1") ]]; then
     echo
     echo BUILDING: GTK and WPE
@@ -89,7 +89,7 @@ elif [[ "$(uname)" == "Linux" ]]; then
     echo
     build_wpe
   fi
-elif [[ "$(uname)" == MINGW* || "$(uname)" == MSYS* ]]; then
+elif is_win; then
   /c/Windows/System32/cmd.exe "/c $(cygpath -w "${SCRIPT_FOLDER}"/buildwin.bat)"
 else
   echo "ERROR: cannot upload on this platform!" 1>&2

--- a/browser_patches/webkit/clean.sh
+++ b/browser_patches/webkit/clean.sh
@@ -5,6 +5,8 @@ set +x
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname "$0")"
 
+source "../utils.sh"
+
 if [[ ! -z "${WK_CHECKOUT_PATH}" ]]; then
   cd "${WK_CHECKOUT_PATH}"
   echo "WARNING: checkout path from WK_CHECKOUT_PATH env: ${WK_CHECKOUT_PATH}"
@@ -12,7 +14,7 @@ else
   cd "$HOME/webkit"
 fi
 
-if [[ "$(uname)" == "Darwin" ]]; then
+if is_mac; then
   rm -rf ./WebKitBuild
 else
   if [[ -d ./WebKitBuild ]]; then

--- a/browser_patches/winldd/archive.sh
+++ b/browser_patches/winldd/archive.sh
@@ -10,11 +10,6 @@ if [[ ("$1" == "-h") || ("$1" == "--help") ]]; then
   exit 0
 fi
 
-if [[ "$(uname)" != MINGW* || "$(uname)" == MSYS* ]]; then
-  echo "ERROR: this script only supports MINGW (windows)"
-  exit 1
-fi
-
 ZIP_PATH=$1
 if [[ $ZIP_PATH != /* ]]; then
   echo "ERROR: path $ZIP_PATH is not absolute"
@@ -35,6 +30,12 @@ fi
 
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname "$0")"
+
+if [[ "$(uname)" != MINGW* ]]; then
+  echo "ERROR: this script only supports MINGW (windows)"
+  exit 1
+fi
+
 
 # create a TMP directory to copy all necessary files
 cd ./x64/Release

--- a/browser_patches/winldd/build.sh
+++ b/browser_patches/winldd/build.sh
@@ -4,8 +4,9 @@ set +x
 
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname $0)"
+source "../utils.sh"
 
-if [[ "$(uname)" == MINGW* || "$(uname)" == MSYS* ]]; then
+if is_win; then
   /c/Windows/System32/cmd.exe "/c buildwin.bat"
 else
   echo "ERROR: cannot upload on this platform!" 1>&2


### PR DESCRIPTION
This is to make code less error-prone due to involved windows
detection.
