### PR TITLE
devops: align Node.js versions on CI and add 16/18 bots

### DIFF
--- a/.github/workflows/component_tests.yml
+++ b/.github/workflows/component_tests.yml
@@ -29,6 +29,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 16
+    - run: npm i -g npm@8.3
     - run: npm ci
     - run: npm run build
     - run: npx playwright install --with-deps

--- a/.github/workflows/component_tests.yml
+++ b/.github/workflows/component_tests.yml
@@ -28,6 +28,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
+        # Component tests require Node.js 16+ (they require ESM via TS)
         node-version: 16
     - run: npm i -g npm@8.3
     - run: npm ci

--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -72,7 +72,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 18
+        node-version: 14
     - run: npm i -g npm@7
     - name: Deploy Canary
       run: bash utils/build/deploy-trace-viewer.sh --canary

--- a/.github/workflows/publish_release_traceviewer.yml
+++ b/.github/workflows/publish_release_traceviewer.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 18
+        node-version: 14
     - run: npm i -g npm@7
     - name: Deploy Stable
       run: bash utils/build/deploy-trace-viewer.sh --stable

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 18
+        node-version: 14
     - run: npm i -g npm@8.3
     - run: npm ci
     - run: npm run build

--- a/.github/workflows/tests_android.yml
+++ b/.github/workflows/tests_android.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 16
+        node-version: 14
     - run: npm i -g npm@8.3
     - run: npm ci
       env:

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -26,18 +26,26 @@ env:
 
 jobs:
   test_linux:
-    name: ${{ matrix.os }} (${{ matrix.browser }})
+    name: ${{ matrix.os }} (${{ matrix.browser }} - Node.js ${{ matrix.node-version }})
     strategy:
       fail-fast: false
       matrix:
         browser: [chromium, firefox, webkit]
         os: [ubuntu-20.04]
+        node-version: [14]
+        include:
+          - os: ubuntu-20.04
+            node-version: 16
+            browser: chromium
+          - os: ubuntu-20.04
+            node-version: 18
+            browser: chromium
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 14
+        node-version: ${{ matrix.node-version }}
     - run: npm i -g npm@8.3
     - run: npm ci
       env:
@@ -123,7 +131,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 18
+        node-version: 16
     - run: npm i -g npm@8.3
     - run: npm ci
       env:
@@ -139,7 +147,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 18
+        node-version: 16
+    - run: npm i -g npm@8.3
     - run: npm ci
       env:
         DEBUG: pw:install

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -131,6 +131,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
+        # ESM tests rely on the experimental loader in Node.js 16+
         node-version: 16
     - run: npm i -g npm@8.3
     - run: npm ci
@@ -147,6 +148,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
+        # Component tests require Node.js 16+ (they require ESM via TS)
         node-version: 16
     - run: npm i -g npm@8.3
     - run: npm ci


### PR DESCRIPTION
- use 14 everywhere 
- add 16/18 bot
- component testing needs to stay 16 (no 14) because it imports ESM from TS.

#13469
