### PR TITLE
fix(process launcher): use spawnSync to cleanup synchronously

### DIFF
--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -29,6 +29,7 @@
     "./lib/utils/manualPromise": "./lib/utils/manualPromise.js",
     "./lib/utils/multimap": "./lib/utils/multimap.js",
     "./lib/utils/processLauncher": "./lib/utils/processLauncher.js",
+    "./lib/utils/processLauncherCleanupEntrypoint": "./lib/utils/processLauncherCleanupEntrypoint.js",
     "./lib/utils/spawnAsync": "./lib/utils/spawnAsync.js",
     "./lib/utils/stackTrace": "./lib/utils/stackTrace.js",
     "./lib/utils/timeoutRunner": "./lib/utils/timeoutRunner.js",

--- a/packages/playwright-core/src/utils/processLauncherCleanupEntrypoint.ts
+++ b/packages/playwright-core/src/utils/processLauncherCleanupEntrypoint.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { removeFolders } from './fileUtils';
+
+(async () => {
+  const dirs = process.argv.slice(2);
+  const errors = await removeFolders(dirs);
+  for (let i = 0; i < dirs.length; ++i) {
+    if (errors[i]) {
+      // eslint-disable-next-line no-console
+      console.error(`exception while removing ${dirs[i]}: ${errors[i]}`);
+    }
+  }
+})();


### PR DESCRIPTION
This allows us to use the full retry logic of rimraf in the `onexit` handler.
Note this is already covered by failing on Windows test `should remove temp dir on process.exit`.