### PR TITLE
fix(testrunner): explicitly define viewport size fixture

### DIFF
--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -152,7 +152,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
   storageState: [ undefined, { option: true } ],
   timezoneId: [ undefined, { option: true } ],
   userAgent: [ undefined, { option: true } ],
-  viewport: [ undefined, { option: true } ],
+  viewport: [ { width: 1280, height: 720 }, { option: true } ],
   actionTimeout: [ undefined, { option: true } ],
   navigationTimeout: [ undefined, { option: true } ],
   baseURL: [ async ({ }, use) => {


### PR DESCRIPTION
Instead of relying on library defaults, let's explicitly define
viewport size fixture so that users can rely on its existance.
