### PR TITLE
feat(locator): layout options (leftOf, rightOf, above, below, near)

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -897,9 +897,59 @@ For example, `article` that has `text=Playwright` matches `<article><div>Playwri
 
 Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
 
+## locator-option-left-of
+- `leftOf` <[Locator]|[Object]>
+  - `locator` <[Locator]> The inner locator.
+  - `maxDistance` ?<[float]> Maximum horizontal distance between the elements in pixels, unlimited by default.
+
+Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator is queried against the same root as the outer one. More details in [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
+
+Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+
+## locator-option-right-of
+- `rightOf` <[Locator]|[Object]>
+  - `locator` <[Locator]> The inner locator.
+  - `maxDistance` ?<[float]> Maximum horizontal distance between the elements in pixels, unlimited by default.
+
+Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner locator is queried against the same root as the outer one. More details in [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
+
+Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+
+## locator-option-above
+- `above` <[Locator]|[Object]>
+  - `locator` <[Locator]> The inner locator.
+  - `maxDistance` ?<[float]> Maximum vertical distance between the elements in pixels, unlimited by default.
+
+Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner locator is queried against the same root as the outer one. More details in [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
+
+Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+
+## locator-option-below
+- `below` <[Locator]|[Object]>
+  - `locator` <[Locator]> The inner locator.
+  - `maxDistance` ?<[float]> Maximum vertical distance between the elements in pixels, unlimited by default.
+
+Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner locator is queried against the same root as the outer one. More details in [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
+
+Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+
+## locator-option-near
+- `near` <[Locator]|[Object]>
+  - `locator` <[Locator]> The inner locator.
+  - `maxDistance` ?<[float]> Maximum distance between the elements in pixels, 50 by default.
+
+Matches elements that are near any of the elements matching the inner locator. Inner locator is queried against the same root as the outer one. More details in [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
+
+Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+
 ## locator-options-list
 - %%-locator-option-has-text-%%
 - %%-locator-option-has-%%
+- %%-locator-option-left-of-%%
+- %%-locator-option-right-of-%%
+- %%-locator-option-above-%%
+- %%-locator-option-below-%%
+- %%-locator-option-near-%%
 
 ## screenshot-option-animations
 - `animations` <[ScreenshotAnimations]<"disabled"|"allow">>

--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -18,7 +18,7 @@
 import { assert } from '../utils';
 import type * as channels from '../protocol/channels';
 import { ChannelOwner } from './channelOwner';
-import { FrameLocator, Locator } from './locator';
+import { FrameLocator, Locator, type LocatorOptions } from './locator';
 import { ElementHandle, convertSelectOptionValues, convertInputFiles } from './elementHandle';
 import { assertMaxArguments, JSHandle, serializeArgument, parseResult } from './jsHandle';
 import fs from 'fs';
@@ -290,7 +290,7 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
     return await this._channel.highlight({ selector });
   }
 
-  locator(selector: string, options?: { hasText?: string | RegExp, has?: Locator }): Locator {
+  locator(selector: string, options?: LocatorOptions): Locator {
     return new Locator(this, selector, options);
   }
 

--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -26,11 +26,21 @@ import type { FilePayload, FrameExpectOptions, Rect, SelectOption, SelectOptionO
 import { parseResult, serializeArgument } from './jsHandle';
 import { escapeWithQuotes } from '../utils/isomorphic/stringUtils';
 
+export type LocatorOptions = {
+  hasText?: string | RegExp;
+  has?: Locator;
+  leftOf?: Locator | { locator: Locator, maxDistance?: number };
+  rightOf?: Locator | { locator: Locator, maxDistance?: number };
+  above?: Locator | { locator: Locator, maxDistance?: number };
+  below?: Locator | { locator: Locator, maxDistance?: number };
+  near?: Locator | { locator: Locator, maxDistance?: number };
+};
+
 export class Locator implements api.Locator {
   _frame: Frame;
   _selector: string;
 
-  constructor(frame: Frame, selector: string, options?: { hasText?: string | RegExp, has?: Locator }) {
+  constructor(frame: Frame, selector: string, options?: LocatorOptions) {
     this._frame = frame;
     this._selector = selector;
 
@@ -46,6 +56,26 @@ export class Locator implements api.Locator {
       if (options.has._frame !== frame)
         throw new Error(`Inner "has" locator must belong to the same frame.`);
       this._selector += ` >> has=` + JSON.stringify(options.has._selector);
+    }
+
+    for (const inner of ['leftOf', 'rightOf', 'above', 'below', 'near'] as const) {
+      const value = options?.[inner];
+      if (!value)
+        continue;
+      let maxDistance: number | undefined;
+      let locator: Locator;
+      if (value instanceof Locator) {
+        locator = value;
+      } else {
+        locator = value.locator;
+        maxDistance = value.maxDistance;
+      }
+      if (locator._frame !== frame)
+        throw new Error(`Inner "${inner}" locator must belong to the same frame.`);
+      if (maxDistance !== undefined && typeof maxDistance !== 'number')
+        throw new Error(`"${inner}.maxDistance" must be a number, found ${typeof maxDistance}.`);
+      const engineName = inner === 'leftOf' ? 'left-of' : (inner === 'rightOf' ? 'right-of' : inner);
+      this._selector += ` >> ${engineName}=` + JSON.stringify(locator._selector) + (maxDistance === undefined ? '' : ',' + maxDistance);
     }
   }
 
@@ -122,7 +152,7 @@ export class Locator implements api.Locator {
     return this._frame._highlight(this._selector);
   }
 
-  locator(selector: string, options?: { hasText?: string | RegExp, has?: Locator }): Locator {
+  locator(selector: string, options?: LocatorOptions): Locator {
     return new Locator(this._frame, this._selector + ' >> ' + selector, options);
   }
 
@@ -130,7 +160,7 @@ export class Locator implements api.Locator {
     return new FrameLocator(this._frame, this._selector + ' >> ' + selector);
   }
 
-  that(options?: { hasText?: string | RegExp, has?: Locator }): Locator {
+  that(options?: LocatorOptions): Locator {
     return new Locator(this._frame, this._selector, options);
   }
 

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -28,7 +28,7 @@ import { ConsoleMessage } from './consoleMessage';
 import { Dialog } from './dialog';
 import { Download } from './download';
 import { ElementHandle, determineScreenshotType } from './elementHandle';
-import type { Locator, FrameLocator } from './locator';
+import type { Locator, FrameLocator, LocatorOptions } from './locator';
 import { Worker } from './worker';
 import type { WaitForNavigationOptions } from './frame';
 import { Frame, verifyLoadState } from './frame';
@@ -578,7 +578,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     return this._mainFrame.fill(selector, value, options);
   }
 
-  locator(selector: string, options?: { hasText?: string | RegExp, has?: Locator }): Locator {
+  locator(selector: string, options?: LocatorOptions): Locator {
     return this.mainFrame().locator(selector, options);
   }
 

--- a/packages/playwright-core/src/server/injected/layoutSelectorUtils.ts
+++ b/packages/playwright-core/src/server/injected/layoutSelectorUtils.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function boxRightOf(box1: DOMRect, box2: DOMRect, maxDistance: number | undefined): number | undefined {
+  const distance = box1.left - box2.right;
+  if (distance < 0 || (maxDistance !== undefined && distance > maxDistance))
+    return;
+  return distance + Math.max(box2.bottom - box1.bottom, 0) + Math.max(box1.top - box2.top, 0);
+}
+
+function boxLeftOf(box1: DOMRect, box2: DOMRect, maxDistance: number | undefined): number | undefined {
+  const distance = box2.left - box1.right;
+  if (distance < 0 || (maxDistance !== undefined && distance > maxDistance))
+    return;
+  return distance + Math.max(box2.bottom - box1.bottom, 0) + Math.max(box1.top - box2.top, 0);
+}
+
+function boxAbove(box1: DOMRect, box2: DOMRect, maxDistance: number | undefined): number | undefined {
+  const distance = box2.top - box1.bottom;
+  if (distance < 0 || (maxDistance !== undefined && distance > maxDistance))
+    return;
+  return distance + Math.max(box1.left - box2.left, 0) + Math.max(box2.right - box1.right, 0);
+}
+
+function boxBelow(box1: DOMRect, box2: DOMRect, maxDistance: number | undefined): number | undefined {
+  const distance = box1.top - box2.bottom;
+  if (distance < 0 || (maxDistance !== undefined && distance > maxDistance))
+    return;
+  return distance + Math.max(box1.left - box2.left, 0) + Math.max(box2.right - box1.right, 0);
+}
+
+function boxNear(box1: DOMRect, box2: DOMRect, maxDistance: number | undefined): number | undefined {
+  const kThreshold = maxDistance === undefined ? 50 : maxDistance;
+  let score = 0;
+  if (box1.left - box2.right >= 0)
+    score += box1.left - box2.right;
+  if (box2.left - box1.right >= 0)
+    score += box2.left - box1.right;
+  if (box2.top - box1.bottom >= 0)
+    score += box2.top - box1.bottom;
+  if (box1.top - box2.bottom >= 0)
+    score += box1.top - box2.bottom;
+  return score > kThreshold ? undefined : score;
+}
+
+export type LayoutSelectorName = 'left-of' | 'right-of' | 'above' | 'below' | 'near';
+export const kLayoutSelectorNames: LayoutSelectorName[] = ['left-of', 'right-of', 'above', 'below', 'near'];
+
+export function layoutSelectorScore(name: LayoutSelectorName, element: Element, inner: Element[], maxDistance: number | undefined): number | undefined {
+  const box = element.getBoundingClientRect();
+  const scorer = { 'left-of': boxLeftOf, 'right-of': boxRightOf, 'above': boxAbove, 'below': boxBelow, 'near': boxNear }[name];
+  let bestScore: number | undefined;
+  for (const e of inner) {
+    if (e === element)
+      continue;
+    const score = scorer(box, e.getBoundingClientRect(), maxDistance);
+    if (score === undefined)
+      continue;
+    if (bestScore === undefined || score < bestScore)
+      bestScore = score;
+  }
+  return bestScore;
+}

--- a/packages/playwright-core/src/server/selectors.ts
+++ b/packages/playwright-core/src/server/selectors.ts
@@ -46,6 +46,7 @@ export class Selectors {
       'data-test-id', 'data-test-id:light',
       'data-test', 'data-test:light',
       'nth', 'visible', 'control', 'has',
+      'left-of', 'right-of', 'above', 'below', 'near',
     ]);
     this._builtinEnginesInMainWorld = new Set([
       '_react', '_vue',

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2620,6 +2620,44 @@ export interface Page {
    */
   locator(selector: string, options?: {
     /**
+     * Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    above?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    below?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
      * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
      * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
      *
@@ -2633,6 +2671,62 @@ export interface Page {
      * `<article><div>Playwright</div></article>`.
      */
     hasText?: string|RegExp;
+
+    /**
+     * Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
+     * is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    leftOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are near any of the elements matching the inner locator. Inner locator is queried against the same
+     * root as the outer one. More details in [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    near?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum distance between the elements in pixels, 50 by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    rightOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
   }): Locator;
 
   /**
@@ -5444,6 +5538,44 @@ export interface Frame {
    */
   locator(selector: string, options?: {
     /**
+     * Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    above?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    below?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
      * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
      * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
      *
@@ -5457,6 +5589,62 @@ export interface Frame {
      * `<article><div>Playwright</div></article>`.
      */
     hasText?: string|RegExp;
+
+    /**
+     * Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
+     * is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    leftOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are near any of the elements matching the inner locator. Inner locator is queried against the same
+     * root as the outer one. More details in [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    near?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum distance between the elements in pixels, 50 by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    rightOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
   }): Locator;
 
   /**
@@ -9414,6 +9602,44 @@ export interface Locator {
    */
   locator(selector: string, options?: {
     /**
+     * Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    above?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    below?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
      * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
      * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
      *
@@ -9427,6 +9653,62 @@ export interface Locator {
      * `<article><div>Playwright</div></article>`.
      */
     hasText?: string|RegExp;
+
+    /**
+     * Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
+     * is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    leftOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are near any of the elements matching the inner locator. Inner locator is queried against the same
+     * root as the outer one. More details in [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    near?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum distance between the elements in pixels, 50 by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    rightOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
   }): Locator;
 
   /**
@@ -9805,6 +10087,44 @@ export interface Locator {
    */
   that(options?: {
     /**
+     * Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    above?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    below?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
      * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
      * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
      *
@@ -9818,6 +10138,62 @@ export interface Locator {
      * `<article><div>Playwright</div></article>`.
      */
     hasText?: string|RegExp;
+
+    /**
+     * Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
+     * is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    leftOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are near any of the elements matching the inner locator. Inner locator is queried against the same
+     * root as the outer one. More details in [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    near?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum distance between the elements in pixels, 50 by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    rightOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
   }): Locator;
 
   /**
@@ -13916,6 +14292,44 @@ export interface FrameLocator {
    */
   locator(selector: string, options?: {
     /**
+     * Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    above?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    below?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
      * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
      * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
      *
@@ -13929,6 +14343,62 @@ export interface FrameLocator {
      * `<article><div>Playwright</div></article>`.
      */
     hasText?: string|RegExp;
+
+    /**
+     * Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
+     * is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    leftOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are near any of the elements matching the inner locator. Inner locator is queried against the same
+     * root as the outer one. More details in [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    near?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum distance between the elements in pixels, 50 by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    rightOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
   }): Locator;
 
   /**

--- a/tests/config/experimental.d.ts
+++ b/tests/config/experimental.d.ts
@@ -2622,6 +2622,44 @@ export interface Page {
    */
   locator(selector: string, options?: {
     /**
+     * Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    above?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    below?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
      * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
      * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
      *
@@ -2635,6 +2673,62 @@ export interface Page {
      * `<article><div>Playwright</div></article>`.
      */
     hasText?: string|RegExp;
+
+    /**
+     * Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
+     * is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    leftOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are near any of the elements matching the inner locator. Inner locator is queried against the same
+     * root as the outer one. More details in [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    near?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum distance between the elements in pixels, 50 by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    rightOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
   }): Locator;
 
   /**
@@ -5446,6 +5540,44 @@ export interface Frame {
    */
   locator(selector: string, options?: {
     /**
+     * Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    above?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    below?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
      * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
      * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
      *
@@ -5459,6 +5591,62 @@ export interface Frame {
      * `<article><div>Playwright</div></article>`.
      */
     hasText?: string|RegExp;
+
+    /**
+     * Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
+     * is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    leftOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are near any of the elements matching the inner locator. Inner locator is queried against the same
+     * root as the outer one. More details in [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    near?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum distance between the elements in pixels, 50 by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    rightOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
   }): Locator;
 
   /**
@@ -9423,6 +9611,44 @@ export interface Locator {
    */
   locator(selector: string, options?: {
     /**
+     * Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    above?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    below?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
      * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
      * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
      *
@@ -9436,6 +9662,62 @@ export interface Locator {
      * `<article><div>Playwright</div></article>`.
      */
     hasText?: string|RegExp;
+
+    /**
+     * Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
+     * is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    leftOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are near any of the elements matching the inner locator. Inner locator is queried against the same
+     * root as the outer one. More details in [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    near?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum distance between the elements in pixels, 50 by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    rightOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
   }): Locator;
 
   /**
@@ -9814,6 +10096,44 @@ export interface Locator {
    */
   that(options?: {
     /**
+     * Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    above?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    below?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
      * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
      * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
      *
@@ -9827,6 +10147,62 @@ export interface Locator {
      * `<article><div>Playwright</div></article>`.
      */
     hasText?: string|RegExp;
+
+    /**
+     * Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
+     * is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    leftOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are near any of the elements matching the inner locator. Inner locator is queried against the same
+     * root as the outer one. More details in [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    near?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum distance between the elements in pixels, 50 by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    rightOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
   }): Locator;
 
   /**
@@ -13925,6 +14301,44 @@ export interface FrameLocator {
    */
   locator(selector: string, options?: {
     /**
+     * Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    above?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    below?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum vertical distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
      * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer one.
      * For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
      *
@@ -13938,6 +14352,62 @@ export interface FrameLocator {
      * `<article><div>Playwright</div></article>`.
      */
     hasText?: string|RegExp;
+
+    /**
+     * Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
+     * is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    leftOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are near any of the elements matching the inner locator. Inner locator is queried against the same
+     * root as the outer one. More details in [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    near?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum distance between the elements in pixels, 50 by default.
+       */
+      maxDistance?: number;
+    };
+
+    /**
+     * Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
+     * locator is queried against the same root as the outer one. More details in
+     * [layout selectors](https://playwright.dev/docs/selectors#selecting-elements-based-on-layout) guide.
+     *
+     * Note that outer and inner locators must belong to the same frame. Inner locator must not contain [FrameLocator]s.
+     */
+    rightOf?: Locator|{
+      /**
+       * The inner locator.
+       */
+      locator: Locator;
+
+      /**
+       * Maximum horizontal distance between the elements in pixels, unlimited by default.
+       */
+      maxDistance?: number;
+    };
   }): Locator;
 
   /**

--- a/tests/page/locator-query.spec.ts
+++ b/tests/page/locator-query.spec.ts
@@ -141,14 +141,26 @@ it('should support locator.that', async ({ page, trace }) => {
   })).toHaveCount(1);
 });
 
-it('should enforce same frame for has:locator', async ({ page, server }) => {
+it('should enforce same frame for has/leftOf/rightOf/above/below/near', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/frames/two-frames.html');
   const child = page.frames()[1];
+  for (const option of ['has', 'leftOf', 'rightOf', 'above', 'below', 'near']) {
+    let error;
+    try {
+      page.locator('div', { [option]: child.locator('span') });
+    } catch (e) {
+      error = e;
+    }
+    expect(error.message).toContain(`Inner "${option}" locator must belong to the same frame.`);
+  }
+});
+
+it('should check leftOf options', async ({ page }) => {
   let error;
   try {
-    page.locator('div', { has: child.locator('span') });
+    page.locator('div', { leftOf: { locator: page.locator('span'), maxDistance: 'abc' } as any });
   } catch (e) {
     error = e;
   }
-  expect(error.message).toContain('Inner "has" locator must belong to the same frame.');
+  expect(error.message).toContain(`"leftOf.maxDistance" must be a number, found string.`);
 });

--- a/tests/page/selectors-misc.spec.ts
+++ b/tests/page/selectors-misc.spec.ts
@@ -162,7 +162,9 @@ it('should work with strict mode and chaining', async ({ page }) => {
   expect(await page.locator('div >> div >> span').textContent()).toBe('hi');
 });
 
-it('should work with position selectors', async ({ page }) => {
+it('should work with layout selectors', async ({ page, trace }) => {
+  it.skip(trace === 'on');
+
   /*
 
        +--+  +--+
@@ -214,60 +216,130 @@ it('should work with position selectors', async ({ page }) => {
       div.style.width = box[2] + 'px';
       div.style.height = box[3] + 'px';
       container.appendChild(div);
+      const span = document.createElement('span');
+      span.textContent = '' + i;
+      div.appendChild(span);
     }
   }, boxes);
 
   expect(await page.$eval('div:right-of(#id6)', e => e.id)).toBe('id7');
+  expect(await page.$eval('div >> right-of="#id6"', e => e.id)).toBe('id7');
+  expect(await page.locator('div', { rightOf: page.locator('#id6') }).first().evaluate(e => e.id)).toBe('id7');
   expect(await page.$eval('div:right-of(#id1)', e => e.id)).toBe('id2');
+  expect(await page.$eval('div >> right-of="#id1"', e => e.id)).toBe('id2');
   expect(await page.$eval('div:right-of(#id3)', e => e.id)).toBe('id4');
+  expect(await page.$eval('div >> right-of="#id3"', e => e.id)).toBe('id4');
   expect(await page.$('div:right-of(#id4)')).toBe(null);
+  expect(await page.$('div >> right-of="#id4"')).toBe(null);
   expect(await page.$eval('div:right-of(#id0)', e => e.id)).toBe('id7');
+  expect(await page.$eval('div >> right-of="#id0"', e => e.id)).toBe('id7');
   expect(await page.$eval('div:right-of(#id8)', e => e.id)).toBe('id9');
+  expect(await page.$eval('div >> right-of="#id8"', e => e.id)).toBe('id9');
   expect(await page.$$eval('div:right-of(#id3)', els => els.map(e => e.id).join(','))).toBe('id4,id2,id5,id7,id8,id9');
+  expect(await page.$$eval('div >> right-of="#id3"', els => els.map(e => e.id).join(','))).toBe('id4,id2,id5,id7,id8,id9');
+  expect(await page.locator('div', { rightOf: page.locator('#id3') }).locator('span').evaluateAll(els => els.map(e => e.textContent).join(','))).toBe('4,2,5,7,8,9');
   expect(await page.$$eval('div:right-of(#id3, 50)', els => els.map(e => e.id).join(','))).toBe('id2,id5,id7,id8');
+  expect(await page.$$eval('div >> right-of="#id3",50', els => els.map(e => e.id).join(','))).toBe('id2,id5,id7,id8');
+  expect(await page.$$eval('div >> right-of="#id3",50 >> span', els => els.map(e => e.textContent).join(','))).toBe('2,5,7,8');
+  expect(await page.locator('div', {
+    rightOf: { locator: page.locator('#id3'), maxDistance: 50 },
+  }).locator('span').evaluateAll(els => els.map(e => e.textContent).join(','))).toBe('2,5,7,8');
   expect(await page.$$eval('div:right-of(#id3, 49)', els => els.map(e => e.id).join(','))).toBe('id7,id8');
+  expect(await page.$$eval('div >> right-of="#id3",49', els => els.map(e => e.id).join(','))).toBe('id7,id8');
+  expect(await page.$$eval('div >> right-of="#id3",49 >> span', els => els.map(e => e.textContent).join(','))).toBe('7,8');
+  expect(await page.locator('div', {
+    rightOf: { locator: page.locator('#id3'), maxDistance: 49 },
+  }).locator('span').evaluateAll(els => els.map(e => e.textContent).join(','))).toBe('7,8');
 
   expect(await page.$eval('div:left-of(#id2)', e => e.id)).toBe('id1');
+  expect(await page.$eval('div >> left-of="#id2"', e => e.id)).toBe('id1');
+  expect(await page.locator('div', { leftOf: page.locator('#id2') }).first().evaluate(e => e.id)).toBe('id1');
   expect(await page.$('div:left-of(#id0)')).toBe(null);
+  expect(await page.$('div >> left-of="#id0"')).toBe(null);
   expect(await page.$eval('div:left-of(#id5)', e => e.id)).toBe('id0');
+  expect(await page.$eval('div >> left-of="#id5"', e => e.id)).toBe('id0');
   expect(await page.$eval('div:left-of(#id9)', e => e.id)).toBe('id8');
+  expect(await page.$eval('div >> left-of="#id9"', e => e.id)).toBe('id8');
   expect(await page.$eval('div:left-of(#id4)', e => e.id)).toBe('id3');
+  expect(await page.$eval('div >> left-of="#id4"', e => e.id)).toBe('id3');
   expect(await page.$$eval('div:left-of(#id5)', els => els.map(e => e.id).join(','))).toBe('id0,id7,id3,id1,id6,id8');
+  expect(await page.$$eval('div >> left-of="#id5"', els => els.map(e => e.id).join(','))).toBe('id0,id7,id3,id1,id6,id8');
   expect(await page.$$eval('div:left-of(#id5, 3)', els => els.map(e => e.id).join(','))).toBe('id7,id8');
+  expect(await page.$$eval('div >> left-of="#id5",3', els => els.map(e => e.id).join(','))).toBe('id7,id8');
+  expect(await page.$$eval('div >> left-of="#id5",3 >> span', els => els.map(e => e.textContent).join(','))).toBe('7,8');
 
   expect(await page.$eval('div:above(#id0)', e => e.id)).toBe('id3');
+  expect(await page.$eval('div >> above="#id0"', e => e.id)).toBe('id3');
+  expect(await page.locator('div', { above: page.locator('#id0') }).first().evaluate(e => e.id)).toBe('id3');
   expect(await page.$eval('div:above(#id5)', e => e.id)).toBe('id4');
+  expect(await page.$eval('div >> above="#id5"', e => e.id)).toBe('id4');
   expect(await page.$eval('div:above(#id7)', e => e.id)).toBe('id5');
+  expect(await page.$eval('div >> above="#id7"', e => e.id)).toBe('id5');
   expect(await page.$eval('div:above(#id8)', e => e.id)).toBe('id0');
+  expect(await page.$eval('div >> above="#id8"', e => e.id)).toBe('id0');
   expect(await page.$eval('div:above(#id9)', e => e.id)).toBe('id8');
+  expect(await page.$eval('div >> above="#id9"', e => e.id)).toBe('id8');
   expect(await page.$('div:above(#id2)')).toBe(null);
+  expect(await page.$('div >> above="#id2"')).toBe(null);
   expect(await page.$$eval('div:above(#id5)', els => els.map(e => e.id).join(','))).toBe('id4,id2,id3,id1');
+  expect(await page.$$eval('div >> above="#id5"', els => els.map(e => e.id).join(','))).toBe('id4,id2,id3,id1');
   expect(await page.$$eval('div:above(#id5, 20)', els => els.map(e => e.id).join(','))).toBe('id4,id3');
+  expect(await page.$$eval('div >> above="#id5",20', els => els.map(e => e.id).join(','))).toBe('id4,id3');
 
   expect(await page.$eval('div:below(#id4)', e => e.id)).toBe('id5');
+  expect(await page.$eval('div >> below="#id4"', e => e.id)).toBe('id5');
+  expect(await page.locator('div', { below: page.locator('#id4') }).first().evaluate(e => e.id)).toBe('id5');
   expect(await page.$eval('div:below(#id3)', e => e.id)).toBe('id0');
+  expect(await page.$eval('div >> below="#id3"', e => e.id)).toBe('id0');
   expect(await page.$eval('div:below(#id2)', e => e.id)).toBe('id4');
+  expect(await page.$eval('div >> below="#id2"', e => e.id)).toBe('id4');
   expect(await page.$eval('div:below(#id6)', e => e.id)).toBe('id8');
+  expect(await page.$eval('div >> below="#id6"', e => e.id)).toBe('id8');
   expect(await page.$eval('div:below(#id7)', e => e.id)).toBe('id8');
+  expect(await page.$eval('div >> below="#id7"', e => e.id)).toBe('id8');
   expect(await page.$eval('div:below(#id8)', e => e.id)).toBe('id9');
+  expect(await page.$eval('div >> below="#id8"', e => e.id)).toBe('id9');
   expect(await page.$('div:below(#id9)')).toBe(null);
+  expect(await page.$('div >> below="#id9"')).toBe(null);
   expect(await page.$$eval('div:below(#id3)', els => els.map(e => e.id).join(','))).toBe('id0,id5,id6,id7,id8,id9');
+  expect(await page.$$eval('div >> below="#id3"', els => els.map(e => e.id).join(','))).toBe('id0,id5,id6,id7,id8,id9');
   expect(await page.$$eval('div:below(#id3, 105)', els => els.map(e => e.id).join(','))).toBe('id0,id5,id6,id7');
+  expect(await page.$$eval('div >> below="#id3" , 105', els => els.map(e => e.id).join(','))).toBe('id0,id5,id6,id7');
 
   expect(await page.$eval('div:near(#id0)', e => e.id)).toBe('id3');
+  expect(await page.$eval('div >> near="#id0"', e => e.id)).toBe('id3');
+  expect(await page.locator('div', { near: page.locator('#id0') }).first().evaluate(e => e.id)).toBe('id3');
   expect(await page.$$eval('div:near(#id7)', els => els.map(e => e.id).join(','))).toBe('id0,id5,id3,id6');
+  expect(await page.$$eval('div >> near="#id7"', els => els.map(e => e.id).join(','))).toBe('id0,id5,id3,id6');
   expect(await page.$$eval('div:near(#id0)', els => els.map(e => e.id).join(','))).toBe('id3,id6,id7,id8,id1,id5');
+  expect(await page.$$eval('div >> near="#id0"', els => els.map(e => e.id).join(','))).toBe('id3,id6,id7,id8,id1,id5');
   expect(await page.$$eval('div:near(#id6)', els => els.map(e => e.id).join(','))).toBe('id0,id3,id7');
+  expect(await page.$$eval('div >> near="#id6"', els => els.map(e => e.id).join(','))).toBe('id0,id3,id7');
   expect(await page.$$eval('div:near(#id6, 10)', els => els.map(e => e.id).join(','))).toBe('id0');
+  expect(await page.$$eval('div >> near="#id6",10', els => els.map(e => e.id).join(','))).toBe('id0');
   expect(await page.$$eval('div:near(#id0, 100)', els => els.map(e => e.id).join(','))).toBe('id3,id6,id7,id8,id1,id5,id4,id2');
+  expect(await page.$$eval('div >> near="#id0",100', els => els.map(e => e.id).join(','))).toBe('id3,id6,id7,id8,id1,id5,id4,id2');
 
   expect(await page.$$eval('div:below(#id5):above(#id8)', els => els.map(e => e.id).join(','))).toBe('id7,id6');
+  expect(await page.$$eval('div >> below="#id5" >> above="#id8"', els => els.map(e => e.id).join(','))).toBe('id7,id6');
   expect(await page.$eval('div:below(#id5):above(#id8)', e => e.id)).toBe('id7');
+  expect(await page.$eval('div >> below="#id5" >> above="#id8"', e => e.id)).toBe('id7');
+  expect(await page.locator('div', { below: page.locator('#id5'), above: page.locator('#id8') }).first().evaluate(e => e.id)).toBe('id7');
 
   expect(await page.$$eval('div:right-of(#id0) + div:above(#id8)', els => els.map(e => e.id).join(','))).toBe('id5,id6,id3');
 
   const error = await page.$(':near(50)').catch(e => e);
   expect(error.message).toContain('"near" engine expects a selector list and optional maximum distance in pixels');
+  const error1 = await page.$(`div >> left-of=abc`).catch(e => e);
+  expect(error1.message).toContain('Malformed selector: left-of=abc');
+  const error2 = await page.$(`left-of="div"`).catch(e => e);
+  expect(error2.message).toContain('"left-of" selector cannot be first');
+  const error3 = await page.$(`div >> left-of=33`).catch(e => e);
+  expect(error3.message).toContain('Malformed selector: left-of=33');
+  const error4 = await page.$(`div >> left-of="span","foo"`).catch(e => e);
+  expect(error4.message).toContain('Malformed selector: left-of="span","foo"');
+  const error5 = await page.$(`div >> left-of="span",3,4`).catch(e => e);
+  expect(error5.message).toContain('Malformed selector: left-of="span",3,4');
 });
 
 it('should escape the scope with >>', async ({ page }) => {


### PR DESCRIPTION
This also includes corresponding selector engines `left-of` and others, modeled after existing `has` selector engine.

Fixes #12542.