### PR TITLE
fix(core): use import for whatwg url usage

### DIFF
--- a/packages/playwright-core/src/client/clientHelper.ts
+++ b/packages/playwright-core/src/client/clientHelper.ts
@@ -17,6 +17,7 @@
 
 import type * as types from './types';
 import fs from 'fs';
+import { URL } from 'url';
 import { isString, isRegExp, constructURLBasedOnBaseURL } from '../utils';
 
 export function envObjectToArray(env: types.Env): { name: string, value: string }[] {

--- a/packages/playwright-core/src/common/types.ts
+++ b/packages/playwright-core/src/common/types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { URL } from 'url';
+
 export type Size = { width: number, height: number };
 export type Point = { x: number, y: number };
 export type Rect = Size & Point;

--- a/packages/playwright-core/src/grid/gridAgent.ts
+++ b/packages/playwright-core/src/grid/gridAgent.ts
@@ -17,6 +17,7 @@
 import { debug } from '../utilsBundle';
 import { ws as WebSocket } from '../utilsBundle';
 import { fork } from 'child_process';
+import { URLSearchParams } from 'url';
 import { getPlaywrightVersion } from '../common/userAgent';
 
 export function launchGridAgent(agentId: string, gridURL: string, runId: string | undefined) {

--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -17,6 +17,7 @@
 import { debug, wsServer } from '../utilsBundle';
 import type { WebSocketServer } from '../utilsBundle';
 import * as http from 'http';
+import { URL } from 'url';
 import type { Browser } from '../server/browser';
 import { PlaywrightConnection } from './playwrightConnection';
 

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -31,6 +31,7 @@ import type { Selectors } from './selectors';
 import type * as types from './types';
 import path from 'path';
 import fs from 'fs';
+import { URL } from 'url';
 import type { CallMetadata } from './instrumentation';
 import { serverSideCallMetadata, SdkObject } from './instrumentation';
 import { Debugger } from './debugger';

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -18,6 +18,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { URL } from 'url';
 import { CRBrowser } from './crBrowser';
 import type { Env } from '../../utils/processLauncher';
 import { gracefullyCloseSet } from '../../utils/processLauncher';

--- a/packages/playwright-core/src/server/cookieStore.ts
+++ b/packages/playwright-core/src/server/cookieStore.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { URL } from 'url';
 import type * as types from './types';
 
 class Cookie {

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -18,7 +18,7 @@ import * as http from 'http';
 import * as https from 'https';
 import type { Readable, TransformCallback } from 'stream';
 import { pipeline, Transform } from 'stream';
-import url from 'url';
+import { parse as urlParse, URL, URLSearchParams } from 'url';
 import zlib from 'zlib';
 import type { HTTPCredentials } from '../../types/types';
 import type * as channels from '../protocol/channels';
@@ -142,7 +142,7 @@ export abstract class APIRequestContext extends SdkObject {
     let agent;
     if (proxy && proxy.server !== 'per-context') {
       // TODO: support bypass proxy
-      const proxyOpts = url.parse(proxy.server);
+      const proxyOpts = urlParse(proxy.server);
       if (proxyOpts.protocol?.startsWith('socks')) {
         agent = new SocksProxyAgent({
           host: proxyOpts.hostname,

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { URL } from 'url';
 import { kBrowserClosedError } from '../../common/errors';
 import { assert } from '../../utils';
 import type { BrowserOptions } from '../browser';

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { URL } from 'url';
+import { URLSearchParams } from 'url';
 import { BrowserContext } from '../browserContext';
 import type { APIRequestEvent, APIRequestFinishedEvent } from '../fetch';
 import { APIRequestContext } from '../fetch';

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { URL } from 'url';
 import type * as frames from './frames';
 import type * as types from './types';
 import type * as channels from '../protocol/channels';

--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { URL } from 'url';
 import type { NodeSnapshot } from '../common/snapshotTypes';
 
 export type SnapshotData = {

--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -16,6 +16,7 @@
 
 import path from 'path';
 import fs from 'fs';
+import { URL } from 'url';
 import * as consoleApiSource from '../../../generated/consoleApiSource';
 import { HttpServer } from '../../../utils/httpServer';
 import { findChromiumChannel } from '../../registry';

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -16,6 +16,7 @@
  */
 
 import path from 'path';
+import { URL } from 'url';
 import { PNG, jpegjs } from '../../utilsBundle';
 import { splitErrorMessage } from '../../utils/stackTrace';
 import { assert, createGuid, debugAssert, headersArrayToObject, headersObjectToArray } from '../../utils';

--- a/packages/playwright-core/src/utils/httpServer.ts
+++ b/packages/playwright-core/src/utils/httpServer.ts
@@ -17,6 +17,7 @@
 import * as http from 'http';
 import fs from 'fs';
 import path from 'path';
+import { URL } from 'url';
 import { mime, wsServer } from '../utilsBundle';
 import type { WebSocketServer } from '../utilsBundle';
 import { assert } from './';

--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -15,6 +15,7 @@
  */
 
 import path from 'path';
+import { URL } from 'url';
 import { StackUtils } from '../utilsBundle';
 import { isUnderTest } from './';
 


### PR DESCRIPTION
Useful when working with playwright-core in an environment like jsdom