### PR TITLE
fix(chromium): disable DialMediaRouteProvider in addition to MediaRouter

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -330,7 +330,7 @@ const DEFAULT_ARGS = [
   '--disable-default-apps',
   '--disable-dev-shm-usage',
   '--disable-extensions',
-  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater',
+  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater',
   '--allow-pre-commit-input',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',


### PR DESCRIPTION
This is to avoid “Do you want the application Chromium.app to accept incoming network connections?” dialog on macOS as described in [Chromium docs](https://chromium.googlesource.com/chromium/src/+/9199706abdbc623d193c0df97f6a735eb2dadfed/docs/mac_build_instructions.md#avoiding-the-incoming-network-connections-dialog).

Refs: https://github.com/microsoft/playwright-java/issues/910