### PR TITLE
docs(examples/components-vue/README.md): updated installation steps

### DIFF
--- a/examples/components-vue/README.md
+++ b/examples/components-vue/README.md
@@ -32,84 +32,14 @@ npm run test
     npm init vue@latest
     ```
 
-- Install Playwright Text w/ component testing as dev dependencies.
+- Install Playwright Text with component testing as dev dependencies.
 
     ```sh
     npm i --save-dev @playwright/test @playwright/experimental-ct-vue
     ```
 
-- `tests.js` file was added that registers all the components to be tested.
+- [playwright/index.html](playwright/index.html) file was added that defines theming for the components through importing [playwright/index.js](playwright/index.js) .
 
-    ```js
-    import register from '@playwright/experimental-ct-vue/register'
-
-    import Counter from './src/components/Counter.vue'
-    import DocumentationIcon from './src/components/icons/IconDocumentation.vue'
-    import HelloWorld from './src/components/HelloWorld.vue'
-    import NamedSlots from './src/components/NamedSlots.vue'
-    import TheWelcome from './src/components/TheWelcome.vue'
-    import WelcomeItem from './src/components/WelcomeItem.vue'
-
-    register({
-      Counter,
-      DocumentationIcon,
-      HelloWorld,
-      NamedSlots,
-      TheWelcome,
-      WelcomeItem,
-    })
-    ```
-- `tests.html` file was added that defines theming for the components and references `tests.js`.
-    ```html
-    <html>
-    <head>
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <style>@import '/src/assets/base.css';</style>
-    </head>
-    <body>
-      <div id="root"></div>
-      <script type="module" src="/tests.js"></script>
-    </body>
-    </html>
-    ```
-- `playwright.config.ts` was added that executes `npm run dev` before running tests if it is not already running.
-    ```js
-    import { PlaywrightTestConfig, devices } from '@playwright/test';
-
-    const config: PlaywrightTestConfig = {
-      testDir: 'src',
-      forbidOnly: !!process.env.CI,
-      retries: process.env.CI ? 2 : 0,
-      reporter: process.env.CI ? [
-        ['html', { open: 'never' }],
-      ] : [
-        ['html', { open: 'on-failure' }]
-      ],
-      webServer: {
-        url: 'http://localhost:3000/tests.html',
-        command: 'npm run dev',
-        reuseExistingServer: !process.env.CI,
-      },
-      use: {
-        baseURL: 'http://localhost:3000/tests.html',
-        trace: 'on-first-retry',
-      },
-      projects: [
-        {
-          name: 'chromium',
-          use: { ...devices['Desktop Chrome'] },
-        },
-        {
-          name: 'firefox',
-          use: { ...devices['Desktop Firefox'] },
-        },
-        {
-          name: 'webkit',
-          use: { ...devices['Desktop Safari'] },
-        },
-      ],
-    };
-
-    export default config;
-    ```
+- [playwright.config.ts](playwright.config.ts) was added that executes `npm run dev` before running tests if it is not already running.
+  
 - A bunch of `.spec.ts` and `.spec.tsx` files were added to `src` that demonstrate Vue3 component testing with and without the use of JSX syntax.

--- a/examples/components-vue/README.md
+++ b/examples/components-vue/README.md
@@ -32,7 +32,7 @@ npm run test
     npm init vue@latest
     ```
 
-- Install Playwright Text with component testing as dev dependencies.
+- Install Playwright Test with component testing as dev dependencies.
 
     ```sh
     npm i --save-dev @playwright/test @playwright/experimental-ct-vue


### PR DESCRIPTION
Great project! Read through the source code and found out that the docs were not up to date. [This post seems to be outdated as well](https://github.com/microsoft/playwright/issues/12799). Not sure if it is still necessary to register the components as they have been removed in [this PR](https://github.com/microsoft/playwright/pull/13750/files#diff-91c18708ef49e3c75aa2e08e6c22283ba637e4a4e153f9f1bc7e46880aea6024)?:

```typescript
import register from '@playwright/experimental-ct-vue/register'

import Counter from './src/components/Counter.vue'
import DocumentationIcon from './src/components/icons/IconDocumentation.vue'
import HelloWorld from './src/components/HelloWorld.vue'
import NamedSlots from './src/components/NamedSlots.vue'
import TheWelcome from './src/components/TheWelcome.vue'
import WelcomeItem from './src/components/WelcomeItem.vue'

register({
  Counter,
  DocumentationIcon,
  HelloWorld,
  NamedSlots,
  TheWelcome,
  WelcomeItem,
})
```