### PR TITLE
chore(dotnet): do not rely on auto camel case for channel initializers

### DIFF
--- a/utils/generate_dotnet_channels.js
+++ b/utils/generate_dotnet_channels.js
@@ -114,6 +114,7 @@ function properties(properties, indent, onlyOptional) {
       if (onlyOptional && !inner.optional)
         continue;
       ts.push('');
+      ts.push(`${indent}[JsonPropertyName("${name}")]`)
       ts.push(`${indent}public ${inner.ts}${nullableSuffix(inner)} ${toTitleCase(name)} { get; set; }`);
       const wrapped = inner.optional ? `tOptional(${inner.scheme})` : inner.scheme;
       scheme.push(`${indent}${name}: ${wrapped},`);
@@ -183,6 +184,7 @@ for (const [name, item] of Object.entries(protocol)) {
  */
 `)
     channels_ts.push('using System.Collections.Generic;');
+    channels_ts.push('using System.Text.Json.Serialization;')
     channels_ts.push(``);
     channels_ts.push(`namespace Microsoft.Playwright.Transport.Protocol`);
     channels_ts.push(`{`);


### PR DESCRIPTION
Motivation: In our JSON serializer options we have "auto use camel case" enabled, it works in most of the cases, but not in all. Let's be more verbose and define them explicitly.

Corresponding roll: https://github.com/microsoft/playwright-dotnet/pull/2121