### PR TITLE
fix: delete headers with undefined value

### DIFF
--- a/packages/playwright-core/src/utils/index.ts
+++ b/packages/playwright-core/src/utils/index.ts
@@ -132,6 +132,8 @@ export function headersObjectToArray(headers: HeadersObject, separator?: string,
   const result: HeadersArray = [];
   for (const name in headers) {
     const values = headers[name];
+    if (values === undefined)
+      continue;
     if (separator) {
       const sep = name.toLowerCase() === 'set-cookie' ? setCookieSeparator : separator;
       for (const value of values.split(sep!))


### PR DESCRIPTION
https://github.com/microsoft/playwright/issues/13106

Instead of throwing 'route.continue: headers[5].value: expected string, got undefined' on the server side, just treat such headers as if they were deleted from the map via `delete headers['name']`