### PR TITLE
devops: more compact commits for the flakiness dashboard

### DIFF
--- a/utils/flakiness-dashboard/processing/dashboard_compressed_v1.js
+++ b/utils/flakiness-dashboard/processing/dashboard_compressed_v1.js
@@ -43,14 +43,12 @@ function compressReports(reports) {
           delete project.metadata.mode;
         if (project.metadata.platform && project.metadata.platform.toLowerCase() !== 'android')
           delete project.metadata.platform;
-        // Cleanup a bunch of data from report.
-        delete project.metadata['ci.link'];
-        delete project.metadata['revision.id'];
-        delete project.metadata['revision.author'];
-        delete project.metadata['revision.email'];
-        delete project.metadata['revision.subject'];
-        delete project.metadata['revision.timestamp'];
-        delete project.metadata['revision.link'];
+        // Cleanup a bunch of data from report that
+        // comes from CI plugin.
+        for (const key of Object.keys(project.metadata)) {
+          if (key.startsWith('ci.') || key.startsWith('revision.'))
+            delete project.metadata[key];
+        }
         delete project.metadata['timestamp'];
 
         projectNameToMetadata.set(project.name, project.metadata);

--- a/utils/flakiness-dashboard/processing/dashboard_compressed_v1.js
+++ b/utils/flakiness-dashboard/processing/dashboard_compressed_v1.js
@@ -43,6 +43,16 @@ function compressReports(reports) {
           delete project.metadata.mode;
         if (project.metadata.platform && project.metadata.platform.toLowerCase() !== 'android')
           delete project.metadata.platform;
+        // Cleanup a bunch of data from report.
+        delete project.metadata['ci.link'];
+        delete project.metadata['revision.id'];
+        delete project.metadata['revision.author'];
+        delete project.metadata['revision.email'];
+        delete project.metadata['revision.subject'];
+        delete project.metadata['revision.timestamp'];
+        delete project.metadata['revision.link'];
+        delete project.metadata['timestamp'];
+
         projectNameToMetadata.set(project.name, project.metadata);
       }
     }
@@ -108,11 +118,6 @@ function compressReports(reports) {
         }
 
         for (const run of test.results) {
-          // Record duration of slow tests only, i.e. > 1s.
-          if (run.status === 'passed' && run.duration > 1000) {
-            testObject.minTime = Math.min((testObject.minTime || Number.MAX_VALUE), run.duration);
-            testObject.maxTime = Math.max((testObject.maxTime || 0), run.duration);
-          }
           if (run.status === 'failed') {
             if (!Array.isArray(testObject.failed))
               testObject.failed = [];

--- a/utils/upload_flakiness_dashboard.sh
+++ b/utils/upload_flakiness_dashboard.sh
@@ -50,13 +50,6 @@ if [[ $# == 0 ]]; then
   exit 1
 fi
 
-export BUILD_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-export COMMIT_SHA=$(git rev-parse HEAD)
-export COMMIT_TITLE=$(git show -s --format=%s HEAD)
-export COMMIT_AUTHOR_NAME=$(git show -s --format=%an HEAD)
-export COMMIT_AUTHOR_EMAIL=$(git show -s --format=%ae HEAD)
-export COMMIT_TIMESTAMP=$(git show -s --format=%ct HEAD)
-
 export HOST_OS_NAME="$(uname)"
 export HOST_ARCH="$(uname -m)"
 export HOST_OS_VERSION=""
@@ -67,19 +60,12 @@ elif [[ "$HOST_OS_NAME" == "Linux" ]]; then
   HOST_OS_VERSION="$(bash -c 'source /etc/os-release && echo $VERSION_ID')"
 fi
 
-
 EMBED_METADATA_SCRIPT=$(cat <<EOF
   const json = require('./' + process.argv[1]);
   json.metadata = {
-    runURL: process.env.BUILD_URL,
     osName: process.env.HOST_OS_NAME,
     arch: process.env.HOST_ARCH,
     osVersion: process.env.HOST_OS_VERSION,
-    commitSHA: process.env.COMMIT_SHA,
-    commitTimestamp: process.env.COMMIT_TIMESTAMP,
-    commitTitle: process.env.COMMIT_TITLE,
-    commitAuthorName: process.env.COMMIT_AUTHOR_NAME,
-    commitAuthorEmail: process.env.COMMIT_AUTHOR_EMAIL,
   };
   console.log(JSON.stringify(json));
 EOF


### PR DESCRIPTION
- do not collect commit info since we don't use
- do not store CI plugin information
- do not store test timings
