### PR TITLE
fix windows electron launch enoent error

### DIFF
--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -3589,6 +3589,7 @@ export type ElectronLaunchParams = {
   },
   strictSelectors?: boolean,
   timezoneId?: string,
+  shell?: boolean;
 };
 export type ElectronLaunchOptions = {
   executablePath?: string,

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -178,7 +178,7 @@ export class Electron extends SdkObject {
         handleSIGTERM: true,
         handleSIGHUP: true,
         onExit: () => {},
-        shell: os.platform() === 'win32'
+        shell: options.shell
       });
 
       const waitForXserverError = new Promise(async (resolve, reject) => {

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -178,6 +178,7 @@ export class Electron extends SdkObject {
         handleSIGTERM: true,
         handleSIGHUP: true,
         onExit: () => {},
+        shell: os.platform() === 'win32'
       });
 
       const waitForXserverError = new Promise(async (resolve, reject) => {


### PR DESCRIPTION
Without `shell:true` option on node.js `spawn` option, windows would show `electron. launch: Failed to launch: Error: spawn ..... ENOENT` error


reference:

https://stackoverflow.com/questions/37459717/error-spawn-enoent-on-windows