### PR TITLE
devops: keep one bot for Node.js 12

### DIFF
--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -35,6 +35,9 @@ jobs:
         node-version: [14]
         include:
           - os: ubuntu-20.04
+            node-version: 12
+            browser: chromium
+          - os: ubuntu-20.04
             node-version: 16
             browser: chromium
           - os: ubuntu-20.04


### PR DESCRIPTION
After an offline discussion with pfeldman we agreed that bringing one bot back should be enough to represent our core user-base.

Fixes https://github.com/microsoft/playwright/issues/13773