### PR TITLE
feat(chromium): roll tot (1003), ignore unknown session error

### DIFF
--- a/packages/playwright-core/src/server/chromium/crConnection.ts
+++ b/packages/playwright-core/src/server/chromium/crConnection.ts
@@ -189,6 +189,8 @@ export class CRSession extends EventEmitter {
         callback.reject(createProtocolError(callback.error, callback.method, object.error));
       else
         callback.resolve(object.result);
+    } else if (object.id && object.error?.code === -32001) {
+      // Message to a closed session, just ignore it.
     } else {
       assert(!object.id);
       Promise.resolve().then(() => {

--- a/packages/playwright-core/src/server/transport.ts
+++ b/packages/playwright-core/src/server/transport.ts
@@ -31,7 +31,7 @@ export type ProtocolResponse = {
   id?: number;
   method?: string;
   sessionId?: string;
-  error?: { message: string; data: any; };
+  error?: { message: string; data: any; code?: number };
   params?: any;
   result?: any;
   pageProxyId?: string;


### PR DESCRIPTION
After https://chromium-review.googlesource.com/c/chromium/src/+/3606712 browser returns an error to messages addressed to unknown session id (previously such messages would never get a response).

#13637
