### PR TITLE
chore: widen Metadata type

### DIFF
--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -147,9 +147,9 @@ Filter to only run tests with a title **not** matching one of the patterns. This
 `grepInvert` option is also useful for [tagging tests](../test-annotations.md#tag-tests).
 
 ## property: TestProject.metadata
-- type: ?<[any]>
+- type: ?<[Metadata]>
 
-Any JSON-serializable metadata that will be put directly to the test report.
+Metadata that will be put directly to the test report serialized as JSON.
 
 ## property: TestProject.name
 - type: ?<[string]>

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -195,9 +195,9 @@ export interface FullProject<TestArgs = {}, WorkerArgs = {}> {
    */
   grepInvert: RegExp | RegExp[] | null;
   /**
-   * Any JSON-serializable metadata that will be put directly to the test report.
+   * Metadata that will be put directly to the test report serialized as JSON.
    */
-  metadata: any;
+  metadata: Metadata;
   /**
    * Project name is visible in the report and during test execution.
    */
@@ -919,7 +919,7 @@ export interface Config<TestArgs = {}, WorkerArgs = {}> extends TestConfig {
   use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
-export type Metadata = { [key: string]: string | number | boolean };
+export type Metadata = { [key: string]: any };
 
 /**
  * Playwright Test provides many options to configure how your tests are collected and executed, for example `timeout` or
@@ -3648,9 +3648,9 @@ interface TestProject {
   grepInvert?: RegExp|Array<RegExp>;
 
   /**
-   * Any JSON-serializable metadata that will be put directly to the test report.
+   * Metadata that will be put directly to the test report serialized as JSON.
    */
-  metadata?: any;
+  metadata?: Metadata;
 
   /**
    * Project name is visible in the report and during test execution.

--- a/packages/playwright-test/types/testReporter.d.ts
+++ b/packages/playwright-test/types/testReporter.d.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import type { FullConfig, FullProject, TestStatus, TestError } from '@playwright/test';
+import type { FullConfig, FullProject, TestStatus, TestError, Metadata } from '@playwright/test';
 export type { FullConfig, TestStatus, TestError } from '@playwright/test';
 
 /**
@@ -437,7 +437,7 @@ export interface JSONReport {
       outputDir: string,
       repeatEach: number,
       retries: number,
-      metadata: any,
+      metadata: Metadata,
       name: string,
       testDir: string,
       testIgnore: string[],

--- a/tests/config/experimental.d.ts
+++ b/tests/config/experimental.d.ts
@@ -16855,9 +16855,9 @@ export interface FullProject<TestArgs = {}, WorkerArgs = {}> {
    */
   grepInvert: RegExp | RegExp[] | null;
   /**
-   * Any JSON-serializable metadata that will be put directly to the test report.
+   * Metadata that will be put directly to the test report serialized as JSON.
    */
-  metadata: any;
+  metadata: Metadata;
   /**
    * Project name is visible in the report and during test execution.
    */
@@ -17664,7 +17664,7 @@ export interface Config<TestArgs = {}, WorkerArgs = {}> extends TestConfig {
   use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
-export type Metadata = { [key: string]: string | number | boolean };
+export type Metadata = { [key: string]: any };
 
 /**
  * Playwright Test provides many options to configure how your tests are collected and executed, for example `timeout` or
@@ -20626,9 +20626,9 @@ interface TestProject {
   grepInvert?: RegExp|Array<RegExp>;
 
   /**
-   * Any JSON-serializable metadata that will be put directly to the test report.
+   * Metadata that will be put directly to the test report serialized as JSON.
    */
-  metadata?: any;
+  metadata?: Metadata;
 
   /**
    * Project name is visible in the report and during test execution.
@@ -20881,7 +20881,7 @@ declare module '@playwright/test/reporter' {
  * limitations under the License.
  */
 
-import type { FullConfig, FullProject, TestStatus, TestError } from '@playwright/test';
+import type { FullConfig, FullProject, TestStatus, TestError, Metadata } from '@playwright/test';
 export type { FullConfig, TestStatus, TestError } from '@playwright/test';
 
 /**
@@ -21303,7 +21303,7 @@ export interface JSONReport {
       outputDir: string,
       repeatEach: number,
       retries: number,
-      metadata: any,
+      metadata: Metadata,
       name: string,
       testDir: string,
       testIgnore: string[],

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -40,7 +40,7 @@ export interface Project<TestArgs = {}, WorkerArgs = {}> extends TestProject {
 export interface FullProject<TestArgs = {}, WorkerArgs = {}> {
   grep: RegExp | RegExp[];
   grepInvert: RegExp | RegExp[] | null;
-  metadata: any;
+  metadata: Metadata;
   name: string;
   snapshotDir: string;
   outputDir: string;
@@ -66,7 +66,7 @@ export interface Config<TestArgs = {}, WorkerArgs = {}> extends TestConfig {
   use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
-export type Metadata = { [key: string]: string | number | boolean };
+export type Metadata = { [key: string]: any };
 
 // [internal] !!! DO NOT ADD TO THIS !!!
 // [internal] It is part of the public API and is computed from the user's config.

--- a/utils/generate_types/overrides-testReporter.d.ts
+++ b/utils/generate_types/overrides-testReporter.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { FullConfig, FullProject, TestStatus, TestError } from '@playwright/test';
+import type { FullConfig, FullProject, TestStatus, TestError, Metadata } from '@playwright/test';
 export type { FullConfig, TestStatus, TestError } from '@playwright/test';
 
 export interface Suite {
@@ -54,7 +54,7 @@ export interface JSONReport {
       outputDir: string,
       repeatEach: number,
       retries: number,
-      metadata: any,
+      metadata: Metadata,
       name: string,
       testDir: string,
       testIgnore: string[],


### PR DESCRIPTION
@dgozman pointed out it was a bit odd we didn't allow for array's as values.
We discsussed and decided that while we Metadta to at least be Key-Value (object)
at the top-level, its inner shape shall be less constrained.