### PR TITLE
tests: Enable "SharedArrayBuffer should work @smoke"

### DIFF
--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -19,7 +19,6 @@ import url from 'url';
 import { contextTest as it, expect } from '../config/browserTest';
 
 it('SharedArrayBuffer should work @smoke', async function({ contextFactory, httpsServer, browserName }) {
-  it.fail(browserName === 'webkit', 'no shared array buffer on webkit');
   const context = await contextFactory({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
   httpsServer.setRoute('/sharedarraybuffer', (req, res) => {


### PR DESCRIPTION
SharedArrayBuffer is enabled in version https://webkit.org/blog/12140/new-webkit-features-in-safari-15-2/

also in MDN https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#browser_compatibility