### PR TITLE
wip: fix cycle errors in ct code

### DIFF
--- a/tests/components/ct-react/src/App.spec.tsx
+++ b/tests/components/ct-react/src/App.spec.tsx
@@ -7,3 +7,10 @@ test('should work', async ({ mount }) => {
   const component = await mount(<App></App>);
   await expect(component).toContainText('Learn React');
 });
+
+test('should work with function', async ({ mount }) => {
+    let clicked = true;
+    const component = await mount(<div onClick={() => clicked}>hi</div>);
+    await component.click();
+    expect(clicked).toBe(true);
+})


### PR DESCRIPTION
Without this change, the newly added ct-react test does not work, and
react-dom logs a complaint about cyclic JSON.

The code here, however:

1. creates regressions in the event tests (so it's not viable)
2. is likely an attempt to fix the issue in the incorrect place