### PR TITLE
fix: support installing dependencies on non-ubuntu.

### DIFF
--- a/packages/playwright-core/src/server/registry/dependencies.ts
+++ b/packages/playwright-core/src/server/registry/dependencies.ts
@@ -75,8 +75,13 @@ export async function installDependenciesWindows(targets: Set<DependencyGroup>, 
 
 export async function installDependenciesLinux(targets: Set<DependencyGroup>, dryRun: boolean) {
   const libraries: string[] = [];
+  let platform = hostPlatform;
+  if (platform === 'generic-linux' || platform === 'generic-linux-arm64') {
+    console.warn('BEWARE: your OS is not officially supported by Playwright; installing dependencies for Ubuntu as a fallback.');
+    platform = hostPlatform === 'generic-linux' ? 'ubuntu20.04' : 'ubuntu20.04-arm64';
+  }
   for (const target of targets) {
-    const info = deps[hostPlatform];
+    let info = deps[platform];
     if (!info) {
       console.warn('Cannot install dependencies for this linux distribution!');  // eslint-disable-line no-console
       return;
@@ -85,7 +90,7 @@ export async function installDependenciesLinux(targets: Set<DependencyGroup>, dr
   }
   const uniqueLibraries = Array.from(new Set(libraries));
   if (!dryRun)
-    console.log('Installing Ubuntu dependencies...');  // eslint-disable-line no-console
+    console.log(`Installing dependencies...`);  // eslint-disable-line no-console
   const commands: string[] = [];
   commands.push('apt-get update');
   commands.push(['apt-get', 'install', '-y', '--no-install-recommends',
@@ -187,10 +192,10 @@ export async function validateDependenciesLinux(sdkLanguage: string, linuxLddDir
   // Check Ubuntu version.
   const missingPackages = new Set();
 
-  const libraryToPackageNameMapping = {
+  const libraryToPackageNameMapping = deps[hostPlatform] ? {
     ...(deps[hostPlatform]?.lib2package || {}),
     ...MANUAL_LIBRARY_TO_PACKAGE_NAME_UBUNTU,
-  };
+  } : {};
   // Translate missing dependencies to package names to install with apt.
   for (const missingDep of missingDeps) {
     const packageName = libraryToPackageNameMapping[missingDep];

--- a/packages/playwright-core/src/server/registry/dependencies.ts
+++ b/packages/playwright-core/src/server/registry/dependencies.ts
@@ -77,11 +77,11 @@ export async function installDependenciesLinux(targets: Set<DependencyGroup>, dr
   const libraries: string[] = [];
   let platform = hostPlatform;
   if (platform === 'generic-linux' || platform === 'generic-linux-arm64') {
-    console.warn('BEWARE: your OS is not officially supported by Playwright; installing dependencies for Ubuntu as a fallback.');
+    console.warn('BEWARE: your OS is not officially supported by Playwright; installing dependencies for Ubuntu as a fallback.'); // eslint-disable-line no-console
     platform = hostPlatform === 'generic-linux' ? 'ubuntu20.04' : 'ubuntu20.04-arm64';
   }
   for (const target of targets) {
-    let info = deps[platform];
+    const info = deps[platform];
     if (!info) {
       console.warn('Cannot install dependencies for this linux distribution!');  // eslint-disable-line no-console
       return;


### PR DESCRIPTION
We should not fast-return if someone tries to run
`npx playwright install-deps` on Debian. We regressed this in our last release.

Instead, we should warn users, fallback to Ubuntu 20.04 dependencies,
and proceed.
