### PR TITLE
devops: follow-up with installation tests on flakienss dashbaord

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -136,6 +136,9 @@ jobs:
       if: matrix.os != 'ubuntu-latest'
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run itest
       if: matrix.os == 'ubuntu-latest'
+    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+      if: always()
+      shell: bash
 
   headful_linux:
     name: "Headful Linux"

--- a/tests/installation/playwright.config.ts
+++ b/tests/installation/playwright.config.ts
@@ -19,12 +19,17 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 import { config as loadEnv } from 'dotenv';
 loadEnv({ path: path.join(__dirname, '..', '..', '.env') });
 
+const outputDir = path.join(__dirname, '..', '..', 'test-results');
 const config: PlaywrightTestConfig = {
   globalSetup: path.join(__dirname, 'globalSetup'),
+  outputDir,
   testIgnore: '**\/fixture-scripts/**',
   timeout: 5 * 60 * 1000,
   retries: 0,
-  reporter: process.env.CI ? 'dot' : [['list'], ['html', { open: 'on-failure' }]],
+  reporter: process.env.CI ? [
+    ['dot'],
+    ['json', { outputFile: path.join(outputDir, 'report.json') }],
+  ] : [['list'], ['html', { open: 'on-failure' }]],
   forbidOnly: !!process.env.CI,
   workers: 1,
   projects: [


### PR DESCRIPTION
- upload more installation tests to the dashboard
- use json reporter on CI
