### PR TITLE
fix(test runner): ensure that hooks run before fixtures teardown after timeout

### DIFF
--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -379,6 +379,7 @@ export class WorkerRunner extends EventEmitter {
     if (testInfo.status === 'timedOut') {
       // A timed-out test gets a full additional timeout to run after hooks.
       afterHooksSlot = { timeout: this._project.timeout, elapsed: 0 };
+      testInfo._timeoutManager.setCurrentRunnable({ type: 'afterEach', slot: afterHooksSlot });
     }
     await testInfo._runWithTimeout(async () => {
       // Note: do not wrap all teardown steps together, because failure in any of them


### PR DESCRIPTION
We had common cleanup exiting early after timeout, because we did not reset the time slot.

Fixes #14027.