### PR TITLE
devops: fallback to xcode 13.2 for webkit

### DIFF
--- a/browser_patches/get_xcode_version.js
+++ b/browser_patches/get_xcode_version.js
@@ -12,7 +12,7 @@ const XCODE_VERSIONS = {
       ffmpeg: '13.2',
   },
   "macos-12": {
-      webkit: '13.3',
+      webkit: '13.2', // WebKit requires xcode 13.2 to work on MacOS 12.2. 
      firefox: '13.2', // As of Oct 2021 building Firefox requires XCode 13
     chromium: '13.3', // As of Apr 2022 Chromium requires Xcode13.3
       ffmpeg: '13.2',

--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1640
-Changed: yurys@chromium.org Thu 05 May 2022 12:43:18 PM PDT
+1641
+Changed: aslushnikov@gmail.com Tue May 10 11:50:04 BST 2022


### PR DESCRIPTION
Turns out we should use minimal possible xcode on MacOS 12
to compile WebKit: if we use xcode 13.3, then webkit fails
on MacOS 12.2.
