### PR TITLE
devops: auto-publish experimental CT packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5707,47 +5707,41 @@
     },
     "packages/playwright-ct-react": {
       "name": "@playwright/experimental-ct-react",
-      "version": "0.0.13",
+      "version": "1.22.0-next",
       "license": "Apache-2.0",
       "dependencies": {
+        "@playwright/test": "1.22.0-next",
         "@vitejs/plugin-react": "^1.0.7",
         "vite": "^2.9.5"
       },
-      "devDependencies": {
-        "@playwright/test": "1.22.0-next"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "packages/playwright-ct-svelte": {
       "name": "@playwright/experimental-ct-svelte",
-      "version": "0.0.13",
+      "version": "1.22.0-next",
       "license": "Apache-2.0",
       "dependencies": {
+        "@playwright/test": "1.22.0-next",
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",
         "vite": "^2.9.5"
       },
-      "devDependencies": {
-        "@playwright/test": "1.22.0-next"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "packages/playwright-ct-vue": {
       "name": "@playwright/experimental-ct-vue",
-      "version": "0.0.13",
+      "version": "1.22.0-next",
       "license": "Apache-2.0",
       "dependencies": {
+        "@playwright/test": "1.22.0-next",
         "@vitejs/plugin-vue": "^2.3.1",
         "vite": "^2.9.5"
       },
-      "devDependencies": {
-        "@playwright/test": "1.22.0-next"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "packages/playwright-firefox": {

--- a/packages/playwright-ct-react/package.json
+++ b/packages/playwright-ct-react/package.json
@@ -1,12 +1,11 @@
 {
   "name": "@playwright/experimental-ct-react",
-  "private": true,
-  "version": "0.0.13",
+  "version": "1.22.0-next",
   "description": "Playwright Component Testing for React",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "author": {
     "name": "Microsoft Corporation"
@@ -18,9 +17,7 @@
   },
   "dependencies": {
     "@vitejs/plugin-react": "^1.0.7",
+    "@playwright/test": "1.22.0-next",
     "vite": "^2.9.5"
-  },
-  "devDependencies": {
-    "@playwright/test": "1.22.0-next"
   }
 }

--- a/packages/playwright-ct-svelte/package.json
+++ b/packages/playwright-ct-svelte/package.json
@@ -1,12 +1,11 @@
 {
   "name": "@playwright/experimental-ct-svelte",
-  "private": true,
-  "version": "0.0.13",
+  "version": "1.22.0-next",
   "description": "Playwright Component Testing for Svelte",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "author": {
     "name": "Microsoft Corporation"
@@ -18,9 +17,7 @@
   },
   "dependencies": {
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",
+    "@playwright/test": "1.22.0-next",
     "vite": "^2.9.5"
-  },
-  "devDependencies": {
-    "@playwright/test": "1.22.0-next"
   }
 }

--- a/packages/playwright-ct-vue/package.json
+++ b/packages/playwright-ct-vue/package.json
@@ -1,12 +1,11 @@
 {
   "name": "@playwright/experimental-ct-vue",
-  "private": true,
-  "version": "0.0.13",
+  "version": "1.22.0-next",
   "description": "Playwright Component Testing for Vue",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "author": {
     "name": "Microsoft Corporation"
@@ -18,9 +17,7 @@
   },
   "dependencies": {
     "@vitejs/plugin-vue": "^2.3.1",
+    "@playwright/test": "1.22.0-next",
     "vite": "^2.9.5"
-  },
-  "devDependencies": {
-    "@playwright/test": "1.22.0-next"
   }
 }


### PR DESCRIPTION
This patch:
- adds a hard dependency from `experimental-ct-*` packages to the
  same-version of `@playwright/test`
- aligns `experimental-ct-*` package versions with main package
  version
- starts publishing experimental CT packages together with other
  packages
