### PR TITLE
Revert "chore: widen Metadata type (#13942)"

### DIFF
--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -146,9 +146,9 @@ Filter to only run tests with a title **not** matching one of the patterns. This
 `grepInvert` option is also useful for [tagging tests](../test-annotations.md#tag-tests).
 
 ## property: TestProject.metadata
-- type: ?<[Metadata]>
+- type: ?<[any]>
 
-Metadata that will be put directly to the test report serialized as JSON.
+Any JSON-serializable metadata that will be put directly to the test report.
 
 ## property: TestProject.name
 - type: ?<[string]>

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -195,9 +195,9 @@ export interface FullProject<TestArgs = {}, WorkerArgs = {}> {
    */
   grepInvert: RegExp | RegExp[] | null;
   /**
-   * Metadata that will be put directly to the test report serialized as JSON.
+   * Any JSON-serializable metadata that will be put directly to the test report.
    */
-  metadata: Metadata;
+  metadata: any;
   /**
    * Project name is visible in the report and during test execution.
    */
@@ -960,7 +960,7 @@ export interface Config<TestArgs = {}, WorkerArgs = {}> extends TestConfig {
   use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
-export type Metadata = { [key: string]: any };
+export type Metadata = { [key: string]: string | number | boolean };
 
 /**
  * Playwright Test provides many options to configure how your tests are collected and executed, for example `timeout` or
@@ -3910,9 +3910,9 @@ interface TestProject {
   grepInvert?: RegExp|Array<RegExp>;
 
   /**
-   * Metadata that will be put directly to the test report serialized as JSON.
+   * Any JSON-serializable metadata that will be put directly to the test report.
    */
-  metadata?: Metadata;
+  metadata?: any;
 
   /**
    * Project name is visible in the report and during test execution.

--- a/packages/playwright-test/types/testReporter.d.ts
+++ b/packages/playwright-test/types/testReporter.d.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import type { FullConfig, FullProject, TestStatus, TestError, Metadata } from '@playwright/test';
+import type { FullConfig, FullProject, TestStatus, TestError } from '@playwright/test';
 export type { FullConfig, TestStatus, TestError } from '@playwright/test';
 
 /**
@@ -437,7 +437,7 @@ export interface JSONReport {
       outputDir: string,
       repeatEach: number,
       retries: number,
-      metadata: Metadata,
+      metadata: any,
       name: string,
       testDir: string,
       testIgnore: string[],

--- a/tests/config/experimental.d.ts
+++ b/tests/config/experimental.d.ts
@@ -16594,9 +16594,9 @@ export interface FullProject<TestArgs = {}, WorkerArgs = {}> {
    */
   grepInvert: RegExp | RegExp[] | null;
   /**
-   * Metadata that will be put directly to the test report serialized as JSON.
+   * Any JSON-serializable metadata that will be put directly to the test report.
    */
-  metadata: Metadata;
+  metadata: any;
   /**
    * Project name is visible in the report and during test execution.
    */
@@ -17397,7 +17397,7 @@ export interface Config<TestArgs = {}, WorkerArgs = {}> extends TestConfig {
   use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
-export type Metadata = { [key: string]: any };
+export type Metadata = { [key: string]: string | number | boolean };
 
 /**
  * Playwright Test provides many options to configure how your tests are collected and executed, for example `timeout` or
@@ -20339,9 +20339,9 @@ interface TestProject {
   grepInvert?: RegExp|Array<RegExp>;
 
   /**
-   * Metadata that will be put directly to the test report serialized as JSON.
+   * Any JSON-serializable metadata that will be put directly to the test report.
    */
-  metadata?: Metadata;
+  metadata?: any;
 
   /**
    * Project name is visible in the report and during test execution.
@@ -20594,7 +20594,7 @@ declare module '@playwright/test/reporter' {
  * limitations under the License.
  */
 
-import type { FullConfig, FullProject, TestStatus, TestError, Metadata } from '@playwright/test';
+import type { FullConfig, FullProject, TestStatus, TestError } from '@playwright/test';
 export type { FullConfig, TestStatus, TestError } from '@playwright/test';
 
 /**
@@ -21016,7 +21016,7 @@ export interface JSONReport {
       outputDir: string,
       repeatEach: number,
       retries: number,
-      metadata: Metadata,
+      metadata: any,
       name: string,
       testDir: string,
       testIgnore: string[],

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -40,7 +40,7 @@ export interface Project<TestArgs = {}, WorkerArgs = {}> extends TestProject {
 export interface FullProject<TestArgs = {}, WorkerArgs = {}> {
   grep: RegExp | RegExp[];
   grepInvert: RegExp | RegExp[] | null;
-  metadata: Metadata;
+  metadata: any;
   name: string;
   snapshotDir: string;
   outputDir: string;
@@ -66,7 +66,7 @@ export interface Config<TestArgs = {}, WorkerArgs = {}> extends TestConfig {
   use?: UseOptions<TestArgs, WorkerArgs>;
 }
 
-export type Metadata = { [key: string]: any };
+export type Metadata = { [key: string]: string | number | boolean };
 
 // [internal] !!! DO NOT ADD TO THIS !!!
 // [internal] It is part of the public API and is computed from the user's config.

--- a/utils/generate_types/overrides-testReporter.d.ts
+++ b/utils/generate_types/overrides-testReporter.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { FullConfig, FullProject, TestStatus, TestError, Metadata } from '@playwright/test';
+import type { FullConfig, FullProject, TestStatus, TestError } from '@playwright/test';
 export type { FullConfig, TestStatus, TestError } from '@playwright/test';
 
 export interface Suite {
@@ -54,7 +54,7 @@ export interface JSONReport {
       outputDir: string,
       repeatEach: number,
       retries: number,
-      metadata: Metadata,
+      metadata: any,
       name: string,
       testDir: string,
       testIgnore: string[],


### PR DESCRIPTION
This reverts commit 95f7acf1e4890226e66a25196bd822b7d06d97d1.

Reason for revert: follow-up to API review
