### PR TITLE
chore: remove babel__parser

### DIFF
--- a/packages/playwright-test/bundles/babel/package-lock.json
+++ b/packages/playwright-test/bundles/babel/package-lock.json
@@ -32,7 +32,6 @@
         "@types/babel__code-frame": "^7.0.3",
         "@types/babel__core": "^7.1.18",
         "@types/babel__helper-plugin-utils": "^7.10.0",
-        "@types/babel__parser": "^7.1.1",
         "@types/babel__traverse": "^7.17.0"
       }
     },
@@ -778,16 +777,6 @@
       "dev": true,
       "dependencies": {
         "@types/babel__core": "*"
-      }
-    },
-    "node_modules/@types/babel__parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__parser/-/babel__parser-7.1.1.tgz",
-      "integrity": "sha512-baSzIb0QQOUQSglfR9gwXVSbHH91YvY00C9Zjq6E7sPdnp8oyPyUsonIj3SF4wUl0s96vR/kyWeVv30gmM/xZw==",
-      "deprecated": "Deprecated",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "*"
       }
     },
     "node_modules/@types/babel__template": {
@@ -1680,15 +1669,6 @@
       "dev": true,
       "requires": {
         "@types/babel__core": "*"
-      }
-    },
-    "@types/babel__parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__parser/-/babel__parser-7.1.1.tgz",
-      "integrity": "sha512-baSzIb0QQOUQSglfR9gwXVSbHH91YvY00C9Zjq6E7sPdnp8oyPyUsonIj3SF4wUl0s96vR/kyWeVv30gmM/xZw==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "*"
       }
     },
     "@types/babel__template": {

--- a/packages/playwright-test/bundles/babel/package.json
+++ b/packages/playwright-test/bundles/babel/package.json
@@ -33,7 +33,6 @@
     "@types/babel__code-frame": "^7.0.3",
     "@types/babel__core": "^7.1.18",
     "@types/babel__helper-plugin-utils": "^7.10.0",
-    "@types/babel__parser": "^7.1.1",
     "@types/babel__traverse": "^7.17.0"
   }
 }


### PR DESCRIPTION
Babel parser brings its own types, see here: https://www.npmjs.com/package/@types/babel__parser

We got a warning before.