### PR TITLE
fix(test runner): do not run automatic test fixtures for beforeAll hooks

### DIFF
--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -609,3 +609,144 @@ const config: PlaywrightTestConfig<MyOptions> = {
 };
 export default config;
 ```
+
+## Execution order
+
+Each fixture has a setup and teardown phase separated by the `await use()` call in the fixture. Setup is executed before the fixture is used by the test/hook, and teardown is executed when the fixture will not be used by the test/hook anymore.
+
+Fixtures follow these rules to determine the execution order:
+* When fixture A depends on fixture B: B is always set up before A and teared down after A.
+* Non-automatic fixtures are executed lazily, only when the test/hook needs them.
+* Test-scoped fixtures are teared down after each test, while worker-scoped fixtures are only teared down when the worker process executing tests is shutdown.
+
+Consider the following example:
+
+```js js-flavor=js
+const { test: base } = require('@playwright/test');
+
+const test = base.extend({
+  workerFixture: [async ({ browser }) => {
+    // workerFixture setup...
+    await use('workerFixture');
+    // workerFixture teardown...
+  }, { scope: 'worker' }],
+
+  autoWorkerFixture: [async ({ browser }) => {
+    // autoWorkerFixture setup...
+    await use('autoWorkerFixture');
+    // autoWorkerFixture teardown...
+  }, { scope: 'worker', auto: true }],
+
+  testFixture: [async ({ page, workerFixture }) => {
+    // testFixture setup...
+    await use('testFixture');
+    // testFixture teardown...
+  }, { scope: 'test' }],
+
+  autoTestFixture: [async () => {
+    // autoTestFixture setup...
+    await use('autoTestFixture');
+    // autoTestFixture teardown...
+  }, { scope: 'test', auto: true }],
+
+  unusedFixture: [async ({ page }) => {
+    // unusedFixture setup...
+    await use('unusedFixture');
+    // unusedFixture teardown...
+  }, { scope: 'test' }],
+});
+
+test.beforeAll(async () => { /* ... */ });
+test.beforeEach(async ({ page }) => { /* ... */ });
+test('first test', async ({ page }) => { /* ... */ });
+test('second test', async ({ testFixture }) => { /* ... */ });
+test.afterEach(async () => { /* ... */ });
+test.afterAll(async () => { /* ... */ });
+```
+
+```js js-flavor=ts
+import { test as base } from '@playwright/test';
+
+const test = base.extend<{
+  testFixture: string,
+  autoTestFixture: string,
+  unusedFixture: string,
+}, {
+  workerFixture: string,
+  autoWorkerFixture: string,
+}>({
+  workerFixture: [async ({ browser }) => {
+    // workerFixture setup...
+    await use('workerFixture');
+    // workerFixture teardown...
+  }, { scope: 'worker' }],
+
+  autoWorkerFixture: [async ({ browser }) => {
+    // autoWorkerFixture setup...
+    await use('autoWorkerFixture');
+    // autoWorkerFixture teardown...
+  }, { scope: 'worker', auto: true }],
+
+  testFixture: [async ({ page, workerFixture }) => {
+    // testFixture setup...
+    await use('testFixture');
+    // testFixture teardown...
+  }, { scope: 'test' }],
+
+  autoTestFixture: [async () => {
+    // autoTestFixture setup...
+    await use('autoTestFixture');
+    // autoTestFixture teardown...
+  }, { scope: 'test', auto: true }],
+
+  unusedFixture: [async ({ page }) => {
+    // unusedFixture setup...
+    await use('unusedFixture');
+    // unusedFixture teardown...
+  }, { scope: 'test' }],
+});
+
+test.beforeAll(async () => { /* ... */ });
+test.beforeEach(async ({ page }) => { /* ... */ });
+test('first test', async ({ page }) => { /* ... */ });
+test('second test', async ({ testFixture }) => { /* ... */ });
+test.afterEach(async () => { /* ... */ });
+test.afterAll(async () => { /* ... */ });
+```
+
+Normally, if all tests pass and no errors are thrown, the order of execution is as following.
+* worker setup and `beforeAll` section:
+  * `browser` setup because it is required by `autoWorkerFixture`.
+  * `autoWorkerFixture` setup because automatic worker fixtures are always set up before anything else.
+  * `beforeAll` runs.
+* `first test` section:
+  * `autoTestFixture` setup because automatic test fixtures are always set up before test and `beforeEach` hooks.
+  * `page` setup because it is required in `beforeEach` hook.
+  * `beforeEach` runs.
+  * `first test` runs.
+  * `afterEach` runs.
+  * `page` teardown because it is a test-scoped fixture and should be teared down after the test finishes.
+  * `autoTestFixture` teardown because it is a test-scoped fixture and should be teared down after the test finishes.
+* `second test` section:
+  * `autoTestFixture` setup because automatic test fixtures are always set up before test and `beforeEach` hooks.
+  * `page` setup because it is required in `beforeEach` hook.
+  * `beforeEach` runs.
+  * `workerFixture` setup because it is required by `testFixture` that is required by the `second test`.
+  * `testFixture` setup because it is required by the `second test`.
+  * `second test` runs.
+  * `afterEach` runs.
+  * `testFixture` teardown because it is a test-scoped fixture and should be teared down after the test finishes.
+  * `page` teardown because it is a test-scoped fixture and should be teared down after the test finishes.
+  * `autoTestFixture` teardown because it is a test-scoped fixture and should be teared down after the test finishes.
+* `afterAll` and worker teardown section:
+  * `afterAll` runs.
+  * `workerFixture` teardown because it is a workers-scoped fixture and should be teared down once at the end.
+  * `autoWorkerFixture` teardown because it is a workers-scoped fixture and should be teared down once at the end.
+  * `browser` teardown because it is a workers-scoped fixture and should be teared down once at the end.
+
+A few observations:
+* `page` and `autoTestFixture` are set up and teared down for each test, as test-scoped fixtures.
+* `unusedFixture` is never set up because it is not used by any tests/hooks.
+* `testFixture` depends on `workerFixture` and triggers its setup.
+* `workerFixture` is lazily set up before the second test, but teared down once during worker shutdown, as a worker-scoped fixture.
+* `autoWorkerFixture` is set up for `beforeAll` hook, but `autoTestFixture` is not.

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -429,7 +429,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
       else
         await fs.promises.unlink(file).catch(() => {});
     }));
-  }, { auto: true,  _title: 'built-in playwright configuration' } as any],
+  }, { auto: 'all-hooks-included',  _title: 'built-in playwright configuration' } as any],
 
   _contextFactory: [async ({ browser, video, _artifactsDir }, use, testInfo) => {
     let videoMode = typeof video === 'string' ? video : video.mode;

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -349,7 +349,7 @@ export class WorkerRunner extends EventEmitter {
 
         // Setup fixtures required by the test.
         testInfo._timeoutManager.setCurrentRunnable({ type: 'test' });
-        const params = await this._fixtureRunner.resolveParametersForFunction(test.fn, testInfo);
+        const params = await this._fixtureRunner.resolveParametersForFunction(test.fn, testInfo, 'test');
         beforeHooksStep.complete({}); // Report fixture hooks step as completed.
 
         // Now run the test itself.
@@ -447,7 +447,7 @@ export class WorkerRunner extends EventEmitter {
       if (actualScope !== scope)
         continue;
       testInfo._timeoutManager.setCurrentRunnable({ type: modifier.type, location: modifier.location, slot: timeSlot });
-      const result = await testInfo._runAsStep(() => this._fixtureRunner.resolveParametersAndRunFunction(modifier.fn, testInfo), {
+      const result = await testInfo._runAsStep(() => this._fixtureRunner.resolveParametersAndRunFunction(modifier.fn, testInfo, scope), {
         category: 'hook',
         title: `${modifier.type} modifier`,
         canHaveChildren: true,
@@ -472,7 +472,7 @@ export class WorkerRunner extends EventEmitter {
         // Separate time slot for each "beforeAll" hook.
         const timeSlot = { timeout: this._project.timeout, elapsed: 0 };
         testInfo._timeoutManager.setCurrentRunnable({ type: 'beforeAll', location: hook.location, slot: timeSlot });
-        await testInfo._runAsStep(() => this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo), {
+        await testInfo._runAsStep(() => this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo, 'all-hooks-only'), {
           category: 'hook',
           title: `${hook.type} hook`,
           canHaveChildren: true,
@@ -500,7 +500,7 @@ export class WorkerRunner extends EventEmitter {
         // Separate time slot for each "afterAll" hook.
         const timeSlot = { timeout: this._project.timeout, elapsed: 0 };
         testInfo._timeoutManager.setCurrentRunnable({ type: 'afterAll', location: hook.location, slot: timeSlot });
-        await testInfo._runAsStep(() => this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo), {
+        await testInfo._runAsStep(() => this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo, 'all-hooks-only'), {
           category: 'hook',
           title: `${hook.type} hook`,
           canHaveChildren: true,
@@ -519,7 +519,7 @@ export class WorkerRunner extends EventEmitter {
     for (const hook of hooks) {
       try {
         testInfo._timeoutManager.setCurrentRunnable({ type, location: hook.location, slot: timeSlot });
-        await testInfo._runAsStep(() => this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo), {
+        await testInfo._runAsStep(() => this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo, 'test'), {
           category: 'hook',
           title: `${hook.type} hook`,
           canHaveChildren: true,

--- a/tests/playwright-test/fixtures.spec.ts
+++ b/tests/playwright-test/fixtures.spec.ts
@@ -297,6 +297,7 @@ test('automatic fixtures should work', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
       let counterTest = 0;
+      let counterHooksIncluded = 0;
       let counterWorker = 0;
       const test = pwt.test;
       test.use({
@@ -305,6 +306,11 @@ test('automatic fixtures should work', async ({ runInlineTest }) => {
           await runTest();
         }, { auto: true } ],
 
+        automaticTestFixtureHooksIncluded: [ async ({}, runTest) => {
+          ++counterHooksIncluded;
+          await runTest();
+        }, { auto: 'all-hooks-included' } ],
+
         automaticWorkerFixture: [ async ({}, runTest) => {
           ++counterWorker;
           await runTest();
@@ -312,26 +318,32 @@ test('automatic fixtures should work', async ({ runInlineTest }) => {
       });
       test.beforeAll(async ({}) => {
         expect(counterWorker).toBe(1);
-        expect(counterTest).toBe(1);
+        expect(counterHooksIncluded).toBe(1);
+        expect(counterTest).toBe(0);
       });
       test.beforeEach(async ({}) => {
         expect(counterWorker).toBe(1);
         expect(counterTest === 1 || counterTest === 2).toBe(true);
+        expect(counterHooksIncluded === 1 || counterHooksIncluded === 2).toBe(true);
       });
       test('test 1', async ({}) => {
         expect(counterWorker).toBe(1);
+        expect(counterHooksIncluded).toBe(1);
         expect(counterTest).toBe(1);
       });
       test('test 2', async ({}) => {
         expect(counterWorker).toBe(1);
+        expect(counterHooksIncluded).toBe(2);
         expect(counterTest).toBe(2);
       });
       test.afterEach(async ({}) => {
         expect(counterWorker).toBe(1);
         expect(counterTest === 1 || counterTest === 2).toBe(true);
+        expect(counterHooksIncluded === 1 || counterHooksIncluded === 2).toBe(true);
       });
       test.afterAll(async ({}) => {
         expect(counterWorker).toBe(1);
+        expect(counterHooksIncluded).toBe(2);
         expect(counterTest).toBe(2);
       });
     `


### PR DESCRIPTION
There are a few issues this covers:
- Some fixtures like `page` and `context` are not allowed in `beforeAll` hooks, so using them in automatic fixture makes it throw.
- Running automatic fixture solely for `afterAll` is unexpected. This currently happens when `afterAll` is run for cleanup after fixture timeout/throw.

For built-in playwright fixture, we keep `'all-hooks-included'` auto mode.
This does not affect automatic worker fixtures - these run first thing before any user callback in the worker.

Fixes #13186.
References #13920.