### PR TITLE
browser(webkit): clear extra http headers on successive calls

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1642
-Changed: dpino@igalia.com Wed May 11 06:54:33 UTC 2022
+1643
+Changed: yurys@chromium.org Fri 13 May 2022 02:10:13 PM PDT

--- a/browser_patches/webkit/UPSTREAM_CONFIG.sh
+++ b/browser_patches/webkit/UPSTREAM_CONFIG.sh
@@ -1,3 +1,3 @@
 REMOTE_URL="https://github.com/WebKit/WebKit.git"
 BASE_BRANCH="main"
-BASE_REVISION="38f99b1251a27027b3eeea66ae7ae4a57b4144f2"
+BASE_REVISION="c2469dd6baa0034fe1ad0159788267d17f0bc7c2"


### PR DESCRIPTION
This fixes [webkit flakiness](https://devops.aslushnikov.com/flakiness2.html#filter_spec=should+override+extra+headers+from+browser+context&show_flaky=false&timestamp=1652476305017) of [library/browsercontext-set-extra-http-headers.spec.ts - should override extra headers from browser context](https://github.com/microsoft/playwright/blob/634ba85c83ae19de1e1610e5b393e35eb03012e4/tests/library/browsercontext-set-extra-http-headers.spec.ts#L20) test. The test is flaky because actual headers depend on the order of the header names ('fOo' and 'Foo') in the hash map.

https://github.com/yury-s/WebKit/commit/7a26d29af953181aac39f86f20b689381f90a779