### PR TITLE
docs: fix small typo in 'Migrating from Protractor'

### DIFF
--- a/docs/src/protractor-js.md
+++ b/docs/src/protractor-js.md
@@ -5,7 +5,7 @@ title: "Migrating from Protractor"
 
 <!-- TOC -->
 
-## Migration Principes
+## Migration Principles
 
 - No need for "webdriver-manager" / Selenium.
 - Protractor’s [ElementFinder] ⇄ [Playwright Test Locator](./api/class-locator)


### PR DESCRIPTION
Found this small typo when using the docs so thought I'd fix it :)