### PR TITLE
cherry-pick(#14174): fix(types): fix the toHaveScreenshot types

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -1002,7 +1002,36 @@ Property value.
 ### option: LocatorAssertions.toHaveJSProperty.timeout = %%-csharp-java-python-assertions-timeout-%%
 
 
-## async method: LocatorAssertions.toHaveScreenshot
+## async method: LocatorAssertions.toHaveScreenshot#1
+* langs: js
+
+Ensures that [Locator] resolves to a given screenshot. This function will re-take
+screenshots until it matches with the saved expectation.
+
+If there's no expectation yet, it will wait until two consecutive screenshots
+yield the same result, and save the last one as an expectation.
+
+```js
+const locator = page.locator('button');
+await expect(locator).toHaveScreenshot('image.png');
+```
+
+### param: LocatorAssertions.toHaveScreenshot#1.name
+- `name` <[string]|[Array]<[string]>>
+
+Snapshot name.
+
+### option: LocatorAssertions.toHaveScreenshot#1.timeout = %%-js-assertions-timeout-%%
+### option: LocatorAssertions.toHaveScreenshot#1.animations = %%-screenshot-option-animations-%%
+### option: LocatorAssertions.toHaveScreenshot#1.caret = %%-screenshot-option-caret-%%
+### option: LocatorAssertions.toHaveScreenshot#1.mask = %%-screenshot-option-mask-%%
+### option: LocatorAssertions.toHaveScreenshot#1.omitBackground = %%-screenshot-option-omit-background-%%
+### option: LocatorAssertions.toHaveScreenshot#1.scale = %%-screenshot-option-scale-%%
+### option: LocatorAssertions.toHaveScreenshot#1.maxDiffPixels = %%-assertions-max-diff-pixels-%%
+### option: LocatorAssertions.toHaveScreenshot#1.maxDiffPixelRatio = %%-assertions-max-diff-pixel-ratio-%%
+### option: LocatorAssertions.toHaveScreenshot#1.threshold = %%-assertions-threshold-%%
+
+## async method: LocatorAssertions.toHaveScreenshot#2
 * langs: js
 
 Ensures that [Locator] resolves to a given screenshot. This function will re-take
@@ -1016,24 +1045,15 @@ const locator = page.locator('button');
 await expect(locator).toHaveScreenshot();
 ```
 
-### option: LocatorAssertions.toHaveScreenshot.timeout = %%-js-assertions-timeout-%%
-### option: LocatorAssertions.toHaveScreenshot.timeout = %%-csharp-java-python-assertions-timeout-%%
-
-### option: LocatorAssertions.toHaveScreenshot.animations = %%-screenshot-option-animations-%%
-
-### option: LocatorAssertions.toHaveScreenshot.caret = %%-screenshot-option-caret-%%
-
-### option: LocatorAssertions.toHaveScreenshot.mask = %%-screenshot-option-mask-%%
-
-### option: LocatorAssertions.toHaveScreenshot.omitBackground = %%-screenshot-option-omit-background-%%
-
-### option: LocatorAssertions.toHaveScreenshot.scale = %%-screenshot-option-scale-%%
-
-### option: LocatorAssertions.toHaveScreenshot.maxDiffPixels = %%-assertions-max-diff-pixels-%%
-
-### option: LocatorAssertions.toHaveScreenshot.maxDiffPixelRatio = %%-assertions-max-diff-pixel-ratio-%%
-
-### option: LocatorAssertions.toHaveScreenshot.threshold = %%-assertions-threshold-%%
+### option: LocatorAssertions.toHaveScreenshot#2.timeout = %%-js-assertions-timeout-%%
+### option: LocatorAssertions.toHaveScreenshot#2.animations = %%-screenshot-option-animations-%%
+### option: LocatorAssertions.toHaveScreenshot#2.caret = %%-screenshot-option-caret-%%
+### option: LocatorAssertions.toHaveScreenshot#2.mask = %%-screenshot-option-mask-%%
+### option: LocatorAssertions.toHaveScreenshot#2.omitBackground = %%-screenshot-option-omit-background-%%
+### option: LocatorAssertions.toHaveScreenshot#2.scale = %%-screenshot-option-scale-%%
+### option: LocatorAssertions.toHaveScreenshot#2.maxDiffPixels = %%-assertions-max-diff-pixels-%%
+### option: LocatorAssertions.toHaveScreenshot#2.maxDiffPixelRatio = %%-assertions-max-diff-pixel-ratio-%%
+### option: LocatorAssertions.toHaveScreenshot#2.threshold = %%-assertions-threshold-%%
 
 
 ## async method: LocatorAssertions.toHaveText

--- a/docs/src/api/class-pageassertions.md
+++ b/docs/src/api/class-pageassertions.md
@@ -114,7 +114,38 @@ Expected substring or RegExp.
 ### option: PageAssertions.NotToHaveURL.timeout = %%-csharp-java-python-assertions-timeout-%%
 
 
-## async method: PageAssertions.toHaveScreenshot
+## async method: PageAssertions.toHaveScreenshot#1
+* langs: js
+
+Ensures that the page resolves to a given screenshot. This function will re-take
+screenshots until it matches with the saved expectation.
+
+If there's no expectation yet, it will wait until two consecutive screenshots
+yield the same result, and save the last one as an expectation.
+
+```js
+await expect(page).toHaveScreenshot('image.png');
+```
+
+### param: PageAssertions.toHaveScreenshot#1.name
+- `name` <[string]|[Array]<[string]>>
+
+Snapshot name.
+
+### option: PageAssertions.toHaveScreenshot#1.timeout = %%-js-assertions-timeout-%%
+### option: PageAssertions.toHaveScreenshot#1.animations = %%-screenshot-option-animations-%%
+### option: PageAssertions.toHaveScreenshot#1.caret = %%-screenshot-option-caret-%%
+### option: PageAssertions.toHaveScreenshot#1.clip = %%-screenshot-option-clip-%%
+### option: PageAssertions.toHaveScreenshot#1.fullPage = %%-screenshot-option-full-page-%%
+### option: PageAssertions.toHaveScreenshot#1.mask = %%-screenshot-option-mask-%%
+### option: PageAssertions.toHaveScreenshot#1.omitBackground = %%-screenshot-option-omit-background-%%
+### option: PageAssertions.toHaveScreenshot#1.scale = %%-screenshot-option-scale-%%
+### option: PageAssertions.toHaveScreenshot#1.maxDiffPixels = %%-assertions-max-diff-pixels-%%
+### option: PageAssertions.toHaveScreenshot#1.maxDiffPixelRatio = %%-assertions-max-diff-pixel-ratio-%%
+### option: PageAssertions.toHaveScreenshot#1.threshold = %%-assertions-threshold-%%
+
+
+## async method: PageAssertions.toHaveScreenshot#2
 * langs: js
 
 Ensures that the page resolves to a given screenshot. This function will re-take
@@ -127,28 +158,17 @@ yield the same result, and save the last one as an expectation.
 await expect(page).toHaveScreenshot();
 ```
 
-### option: PageAssertions.toHaveScreenshot.timeout = %%-js-assertions-timeout-%%
-### option: PageAssertions.toHaveScreenshot.timeout = %%-csharp-java-python-assertions-timeout-%%
-
-### option: PageAssertions.toHaveScreenshot.animations = %%-screenshot-option-animations-%%
-
-### option: PageAssertions.toHaveScreenshot.caret = %%-screenshot-option-caret-%%
-
-### option: PageAssertions.toHaveScreenshot.clip = %%-screenshot-option-clip-%%
-
-### option: PageAssertions.toHaveScreenshot.fullPage = %%-screenshot-option-full-page-%%
-
-### option: PageAssertions.toHaveScreenshot.mask = %%-screenshot-option-mask-%%
-
-### option: PageAssertions.toHaveScreenshot.omitBackground = %%-screenshot-option-omit-background-%%
-
-### option: PageAssertions.toHaveScreenshot.scale = %%-screenshot-option-scale-%%
-
-### option: PageAssertions.toHaveScreenshot.maxDiffPixels = %%-assertions-max-diff-pixels-%%
-
-### option: PageAssertions.toHaveScreenshot.maxDiffPixelRatio = %%-assertions-max-diff-pixel-ratio-%%
-
-### option: PageAssertions.toHaveScreenshot.threshold = %%-assertions-threshold-%%
+### option: PageAssertions.toHaveScreenshot#2.timeout = %%-js-assertions-timeout-%%
+### option: PageAssertions.toHaveScreenshot#2.animations = %%-screenshot-option-animations-%%
+### option: PageAssertions.toHaveScreenshot#2.caret = %%-screenshot-option-caret-%%
+### option: PageAssertions.toHaveScreenshot#2.clip = %%-screenshot-option-clip-%%
+### option: PageAssertions.toHaveScreenshot#2.fullPage = %%-screenshot-option-full-page-%%
+### option: PageAssertions.toHaveScreenshot#2.mask = %%-screenshot-option-mask-%%
+### option: PageAssertions.toHaveScreenshot#2.omitBackground = %%-screenshot-option-omit-background-%%
+### option: PageAssertions.toHaveScreenshot#2.scale = %%-screenshot-option-scale-%%
+### option: PageAssertions.toHaveScreenshot#2.maxDiffPixels = %%-assertions-max-diff-pixels-%%
+### option: PageAssertions.toHaveScreenshot#2.maxDiffPixelRatio = %%-assertions-max-diff-pixel-ratio-%%
+### option: PageAssertions.toHaveScreenshot#2.threshold = %%-assertions-threshold-%%
 
 
 ## async method: PageAssertions.toHaveTitle

--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -59,7 +59,7 @@ title: "Release notes"
   await submitButton.click();
   ```
 
-- New web-first assertions [`method: PageAssertions.toHaveScreenshot`] and [`method: LocatorAssertions.toHaveScreenshot`] that
+- New web-first assertions [`method: PageAssertions.toHaveScreenshot#1`] and [`method: LocatorAssertions.toHaveScreenshot#1`] that
   wait for screenshot stabilization and enhances test reliability.
 
   The new assertions has screenshot-specific defaults, such as:
@@ -71,7 +71,7 @@ title: "Release notes"
   await expect(page).toHaveScreenshot();
   ```
 
-  The new [`method: PageAssertions.toHaveScreenshot`] saves screenshots at the same
+  The new [`method: PageAssertions.toHaveScreenshot#1`] saves screenshots at the same
   location as [`method: ScreenshotAssertions.toMatchSnapshot#1`].
 
 

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -36,7 +36,7 @@ export default config;
 ## property: TestConfig.expect
 - type: ?<[Object]>
   - `timeout` ?<[int]> Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
-  - `toHaveScreenshot` ?<[Object]> Configuration for the [`method: PageAssertions.toHaveScreenshot`] method.
+  - `toHaveScreenshot` ?<[Object]> Configuration for the [`method: PageAssertions.toHaveScreenshot#1`] method.
     - `threshold` ?<[float]> an acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the same pixel in compared images, between zero (strict) and one (lax). Defaults to `0.2`.
     - `maxDiffPixels` ?<[int]> an acceptable amount of pixels that could be different, unset by default.
     - `maxDiffPixelRatio` ?<[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
@@ -419,7 +419,7 @@ export default config;
 * experimental
 - type: ?<[string]>
 
-The base directory, relative to the config file, for screenshot files created with [`method: PageAssertions.toHaveScreenshot`]. Defaults to
+The base directory, relative to the config file, for screenshot files created with [`method: PageAssertions.toHaveScreenshot#1`]. Defaults to
 
 ```
 <directory-of-configuration-file>/__screenshots__/<platform name>/<project name>

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -107,7 +107,7 @@ export default config;
 ## property: TestProject.expect
 - type: ?<[Object]>
   - `timeout` ?<[int]> Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
-  - `toHaveScreenshot` ?<[Object]> Configuration for the [`method: PageAssertions.toHaveScreenshot`] method.
+  - `toHaveScreenshot` ?<[Object]> Configuration for the [`method: PageAssertions.toHaveScreenshot#1`] method.
     - `threshold` ?<[float]> an acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the same pixel in compared images, between zero (strict) and one (lax). Defaults to `0.2`.
     - `maxDiffPixels` ?<[int]> an acceptable amount of pixels that could be different, unset by default.
     - `maxDiffPixelRatio` ?<[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -486,7 +486,7 @@ interface TestConfig {
 
     /**
      * Configuration for the
-     * [pageAssertions.toHaveScreenshot([options])](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot)
+     * [pageAssertions.toHaveScreenshot(name[, options])](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1)
      * method.
      */
     toHaveScreenshot?: {
@@ -3336,6 +3336,82 @@ interface LocatorAssertions {
    *
    * ```js
    * const locator = page.locator('button');
+   * await expect(locator).toHaveScreenshot('image.png');
+   * ```
+   *
+   * @param name Snapshot name.
+   * @param options
+   */
+  toHaveScreenshot(name: string|Array<string>, options?: {
+    /**
+     * When set to `"disabled"`, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment
+     * depending on their duration:
+     * - finite animations are fast-forwarded to completion, so they'll fire `transitionend` event.
+     * - infinite animations are canceled to initial state, and then played over after the screenshot.
+     *
+     * Defaults to `"allow"` that leaves animations untouched.
+     */
+    animations?: "disabled"|"allow";
+
+    /**
+     * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be changed.
+     * Defaults to `"hide"`.
+     */
+    caret?: "hide"|"initial";
+
+    /**
+     * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlayed with a pink box
+     * `#FF00FF` that completely covers its bounding box.
+     */
+    mask?: Array<Locator>;
+
+    /**
+     * An acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1`. Default is
+     * configurable with `TestConfig.expect`. Unset by default.
+     */
+    maxDiffPixelRatio?: number;
+
+    /**
+     * An acceptable amount of pixels that could be different, default is configurable with `TestConfig.expect`. Default is
+     * configurable with `TestConfig.expect`. Unset by default.
+     */
+    maxDiffPixels?: number;
+
+    /**
+     * Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
+     * Defaults to `false`.
+     */
+    omitBackground?: boolean;
+
+    /**
+     * When set to `"css"`, screenshot will have a single pixel per each css pixel on the page. For high-dpi devices, this will
+     * keep screenshots small. Using `"device"` option will produce a single pixel per each device pixel, so screenhots of
+     * high-dpi devices will be twice as large or even larger. Defaults to `"device"`.
+     */
+    scale?: "css"|"device";
+
+    /**
+     * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the same
+     * pixel in compared images, between zero (strict) and one (lax), default is configurable with `TestConfig.expect`.
+     * Defaults to `0.2`.
+     */
+    threshold?: number;
+
+    /**
+     * Time to retry the assertion for. Defaults to `timeout` in `TestConfig.expect`.
+     */
+    timeout?: number;
+  }): Promise<void>;
+
+  /**
+   * Ensures that [Locator] resolves to a given screenshot. This function will re-take screenshots until it matches with the
+   * saved expectation.
+   *
+   * If there's no expectation yet, it will wait until two consecutive screenshots yield the same result, and save the last
+   * one as an expectation.
+   *
+   * ```js
+   * const locator = page.locator('button');
    * await expect(locator).toHaveScreenshot();
    * ```
    *
@@ -3480,6 +3556,112 @@ interface PageAssertions {
    *
    */
   not: PageAssertions;
+
+  /**
+   * Ensures that the page resolves to a given screenshot. This function will re-take screenshots until it matches with the
+   * saved expectation.
+   *
+   * If there's no expectation yet, it will wait until two consecutive screenshots yield the same result, and save the last
+   * one as an expectation.
+   *
+   * ```js
+   * await expect(page).toHaveScreenshot('image.png');
+   * ```
+   *
+   * @param name Snapshot name.
+   * @param options
+   */
+  toHaveScreenshot(name: string|Array<string>, options?: {
+    /**
+     * When set to `"disabled"`, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment
+     * depending on their duration:
+     * - finite animations are fast-forwarded to completion, so they'll fire `transitionend` event.
+     * - infinite animations are canceled to initial state, and then played over after the screenshot.
+     *
+     * Defaults to `"allow"` that leaves animations untouched.
+     */
+    animations?: "disabled"|"allow";
+
+    /**
+     * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be changed.
+     * Defaults to `"hide"`.
+     */
+    caret?: "hide"|"initial";
+
+    /**
+     * An object which specifies clipping of the resulting image. Should have the following fields:
+     */
+    clip?: {
+      /**
+       * x-coordinate of top-left corner of clip area
+       */
+      x: number;
+
+      /**
+       * y-coordinate of top-left corner of clip area
+       */
+      y: number;
+
+      /**
+       * width of clipping area
+       */
+      width: number;
+
+      /**
+       * height of clipping area
+       */
+      height: number;
+    };
+
+    /**
+     * When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to
+     * `false`.
+     */
+    fullPage?: boolean;
+
+    /**
+     * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlayed with a pink box
+     * `#FF00FF` that completely covers its bounding box.
+     */
+    mask?: Array<Locator>;
+
+    /**
+     * An acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1`. Default is
+     * configurable with `TestConfig.expect`. Unset by default.
+     */
+    maxDiffPixelRatio?: number;
+
+    /**
+     * An acceptable amount of pixels that could be different, default is configurable with `TestConfig.expect`. Default is
+     * configurable with `TestConfig.expect`. Unset by default.
+     */
+    maxDiffPixels?: number;
+
+    /**
+     * Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
+     * Defaults to `false`.
+     */
+    omitBackground?: boolean;
+
+    /**
+     * When set to `"css"`, screenshot will have a single pixel per each css pixel on the page. For high-dpi devices, this will
+     * keep screenshots small. Using `"device"` option will produce a single pixel per each device pixel, so screenhots of
+     * high-dpi devices will be twice as large or even larger. Defaults to `"device"`.
+     */
+    scale?: "css"|"device";
+
+    /**
+     * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the same
+     * pixel in compared images, between zero (strict) and one (lax), default is configurable with `TestConfig.expect`.
+     * Defaults to `0.2`.
+     */
+    threshold?: number;
+
+    /**
+     * Time to retry the assertion for. Defaults to `timeout` in `TestConfig.expect`.
+     */
+    timeout?: number;
+  }): Promise<void>;
 
   /**
    * Ensures that the page resolves to a given screenshot. This function will re-take screenshots until it matches with the
@@ -3820,7 +4002,7 @@ interface TestProject {
 
     /**
      * Configuration for the
-     * [pageAssertions.toHaveScreenshot([options])](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot)
+     * [pageAssertions.toHaveScreenshot(name[, options])](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1)
      * method.
      */
     toHaveScreenshot?: {

--- a/tests/config/experimental.d.ts
+++ b/tests/config/experimental.d.ts
@@ -16662,7 +16662,7 @@ interface TestConfig {
 
     /**
      * Configuration for the
-     * [pageAssertions.toHaveScreenshot([options])](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot)
+     * [pageAssertions.toHaveScreenshot(name[, options])](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1)
      * method.
      */
     toHaveScreenshot?: {
@@ -16966,7 +16966,7 @@ interface TestConfig {
 
   /**
    * The base directory, relative to the config file, for screenshot files created with
-   * [pageAssertions.toHaveScreenshot([options])](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot).
+   * [pageAssertions.toHaveScreenshot(name[, options])](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1).
    * Defaults to
    *
    * ```
@@ -19542,6 +19542,82 @@ interface LocatorAssertions {
    *
    * ```js
    * const locator = page.locator('button');
+   * await expect(locator).toHaveScreenshot('image.png');
+   * ```
+   *
+   * @param name Snapshot name.
+   * @param options
+   */
+  toHaveScreenshot(name: string|Array<string>, options?: {
+    /**
+     * When set to `"disabled"`, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment
+     * depending on their duration:
+     * - finite animations are fast-forwarded to completion, so they'll fire `transitionend` event.
+     * - infinite animations are canceled to initial state, and then played over after the screenshot.
+     *
+     * Defaults to `"allow"` that leaves animations untouched.
+     */
+    animations?: "disabled"|"allow";
+
+    /**
+     * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be changed.
+     * Defaults to `"hide"`.
+     */
+    caret?: "hide"|"initial";
+
+    /**
+     * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlayed with a pink box
+     * `#FF00FF` that completely covers its bounding box.
+     */
+    mask?: Array<Locator>;
+
+    /**
+     * An acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1`. Default is
+     * configurable with `TestConfig.expect`. Unset by default.
+     */
+    maxDiffPixelRatio?: number;
+
+    /**
+     * An acceptable amount of pixels that could be different, default is configurable with `TestConfig.expect`. Default is
+     * configurable with `TestConfig.expect`. Unset by default.
+     */
+    maxDiffPixels?: number;
+
+    /**
+     * Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
+     * Defaults to `false`.
+     */
+    omitBackground?: boolean;
+
+    /**
+     * When set to `"css"`, screenshot will have a single pixel per each css pixel on the page. For high-dpi devices, this will
+     * keep screenshots small. Using `"device"` option will produce a single pixel per each device pixel, so screenhots of
+     * high-dpi devices will be twice as large or even larger. Defaults to `"device"`.
+     */
+    scale?: "css"|"device";
+
+    /**
+     * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the same
+     * pixel in compared images, between zero (strict) and one (lax), default is configurable with `TestConfig.expect`.
+     * Defaults to `0.2`.
+     */
+    threshold?: number;
+
+    /**
+     * Time to retry the assertion for. Defaults to `timeout` in `TestConfig.expect`.
+     */
+    timeout?: number;
+  }): Promise<void>;
+
+  /**
+   * Ensures that [Locator] resolves to a given screenshot. This function will re-take screenshots until it matches with the
+   * saved expectation.
+   *
+   * If there's no expectation yet, it will wait until two consecutive screenshots yield the same result, and save the last
+   * one as an expectation.
+   *
+   * ```js
+   * const locator = page.locator('button');
    * await expect(locator).toHaveScreenshot();
    * ```
    *
@@ -19686,6 +19762,112 @@ interface PageAssertions {
    *
    */
   not: PageAssertions;
+
+  /**
+   * Ensures that the page resolves to a given screenshot. This function will re-take screenshots until it matches with the
+   * saved expectation.
+   *
+   * If there's no expectation yet, it will wait until two consecutive screenshots yield the same result, and save the last
+   * one as an expectation.
+   *
+   * ```js
+   * await expect(page).toHaveScreenshot('image.png');
+   * ```
+   *
+   * @param name Snapshot name.
+   * @param options
+   */
+  toHaveScreenshot(name: string|Array<string>, options?: {
+    /**
+     * When set to `"disabled"`, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment
+     * depending on their duration:
+     * - finite animations are fast-forwarded to completion, so they'll fire `transitionend` event.
+     * - infinite animations are canceled to initial state, and then played over after the screenshot.
+     *
+     * Defaults to `"allow"` that leaves animations untouched.
+     */
+    animations?: "disabled"|"allow";
+
+    /**
+     * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be changed.
+     * Defaults to `"hide"`.
+     */
+    caret?: "hide"|"initial";
+
+    /**
+     * An object which specifies clipping of the resulting image. Should have the following fields:
+     */
+    clip?: {
+      /**
+       * x-coordinate of top-left corner of clip area
+       */
+      x: number;
+
+      /**
+       * y-coordinate of top-left corner of clip area
+       */
+      y: number;
+
+      /**
+       * width of clipping area
+       */
+      width: number;
+
+      /**
+       * height of clipping area
+       */
+      height: number;
+    };
+
+    /**
+     * When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to
+     * `false`.
+     */
+    fullPage?: boolean;
+
+    /**
+     * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlayed with a pink box
+     * `#FF00FF` that completely covers its bounding box.
+     */
+    mask?: Array<Locator>;
+
+    /**
+     * An acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1`. Default is
+     * configurable with `TestConfig.expect`. Unset by default.
+     */
+    maxDiffPixelRatio?: number;
+
+    /**
+     * An acceptable amount of pixels that could be different, default is configurable with `TestConfig.expect`. Default is
+     * configurable with `TestConfig.expect`. Unset by default.
+     */
+    maxDiffPixels?: number;
+
+    /**
+     * Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images.
+     * Defaults to `false`.
+     */
+    omitBackground?: boolean;
+
+    /**
+     * When set to `"css"`, screenshot will have a single pixel per each css pixel on the page. For high-dpi devices, this will
+     * keep screenshots small. Using `"device"` option will produce a single pixel per each device pixel, so screenhots of
+     * high-dpi devices will be twice as large or even larger. Defaults to `"device"`.
+     */
+    scale?: "css"|"device";
+
+    /**
+     * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the same
+     * pixel in compared images, between zero (strict) and one (lax), default is configurable with `TestConfig.expect`.
+     * Defaults to `0.2`.
+     */
+    threshold?: number;
+
+    /**
+     * Time to retry the assertion for. Defaults to `timeout` in `TestConfig.expect`.
+     */
+    timeout?: number;
+  }): Promise<void>;
 
   /**
    * Ensures that the page resolves to a given screenshot. This function will re-take screenshots until it matches with the
@@ -20026,7 +20208,7 @@ interface TestProject {
 
     /**
      * Configuration for the
-     * [pageAssertions.toHaveScreenshot([options])](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot)
+     * [pageAssertions.toHaveScreenshot(name[, options])](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1)
      * method.
      */
     toHaveScreenshot?: {

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -403,6 +403,8 @@ test('should compile with different option combinations', async ({ runTSC }) => 
       const { test } = pwt;
       test('is a test', async ({ page }) => {
         await expect(page).toHaveScreenshot();
+        await expect(page).toHaveScreenshot('img.png');
+        await expect(page).toHaveScreenshot('img.png', { threshold: 0.2, caret: 'initial' });
         await expect(page.locator('body')).toHaveScreenshot({ threshold: 0.2 });
         await expect(page).toHaveScreenshot({ maxDiffPixelRatio: 0.2 });
         await expect(page).toHaveScreenshot({


### PR DESCRIPTION
Co-authored-by: Andrey Lushnikov <aslushnikov@gmail.com>
