### PR TITLE
devops: fix prepare_checkout script

### DIFF
--- a/browser_patches/prepare_checkout.sh
+++ b/browser_patches/prepare_checkout.sh
@@ -189,8 +189,8 @@ else
   git remote rename origin $REMOTE_BROWSER_UPSTREAM
 fi
 
-# Check if our checkout contains BASE_REVISION.
-if ! git cat-file -e "$BASE_REVISION"^{commit} 2>/dev/null; then
+# if our remote branch does not contains "BASE_REVISION" - then fetch more stuff.
+if [[ -z $(git branch -r --contains "${BASE_REVISION}" --list "${REMOTE_BROWSER_UPSTREAM}/${BASE_BRANCH}") ]]; then
   # Detach git head so that we can fetch into branch.
   git checkout --detach >/dev/null 2>/dev/null
 


### PR DESCRIPTION
Instead of checking repository for the existance of a commit sha,
we should make sure that our remote branch has the commit.

This situation might happen if there's another branch in the repo
that contains the SHA.

Otherwise, the `export.sh` script later on would not work!
