### PR TITLE
fix: include @types/node in pwt deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -981,8 +981,7 @@
     "node_modules/@types/node": {
       "version": "14.17.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.15.tgz",
-      "integrity": "sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==",
-      "dev": true
+      "integrity": "sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -5763,6 +5762,7 @@
       "version": "1.23.0-next",
       "license": "Apache-2.0",
       "dependencies": {
+        "@types/node": "*",
         "playwright-core": "1.23.0-next"
       },
       "bin": {
@@ -6409,6 +6409,7 @@
     "@playwright/test": {
       "version": "file:packages/playwright-test",
       "requires": {
+        "@types/node": "*",
         "playwright-core": "1.23.0-next"
       }
     },
@@ -6466,8 +6467,7 @@
     "@types/node": {
       "version": "14.17.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.15.tgz",
-      "integrity": "sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==",
-      "dev": true
+      "integrity": "sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -31,6 +31,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@types/node": "*",
     "playwright-core": "1.23.0-next"
   }
 }


### PR DESCRIPTION
Considering it to be the right thing to do since @playwright/test is itself being a dev dependency in the recommended setting.