### PR TITLE
fix: page.locator.focus() and page.locator(…).type(…) 

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -674,7 +674,7 @@ export class InjectedScript {
 
     const activeElement = (node.getRootNode() as (Document | ShadowRoot)).activeElement;
     const wasFocused = activeElement === node && node.ownerDocument && node.ownerDocument.hasFocus();
-    if (!wasFocused && activeElement && (activeElement as HTMLElement | SVGElement).blur) {
+    if ((node as HTMLElement).isContentEditable && !wasFocused && activeElement && (activeElement as HTMLElement | SVGElement).blur) {
       // Workaround the Firefox bug where focusing the element does not switch current
       // contenteditable to the new element. However, blurring the previous one helps.
       (activeElement as HTMLElement | SVGElement).blur();

--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -671,7 +671,14 @@ export class InjectedScript {
       return 'error:notconnected';
     if (node.nodeType !== Node.ELEMENT_NODE)
       throw this.createStacklessError('Node is not an element');
-    const wasFocused = (node.getRootNode() as (Document | ShadowRoot)).activeElement === node && node.ownerDocument && node.ownerDocument.hasFocus();
+
+    const activeElement = (node.getRootNode() as (Document | ShadowRoot)).activeElement;
+    const wasFocused = activeElement === node && node.ownerDocument && node.ownerDocument.hasFocus();
+    if (!wasFocused && activeElement && (activeElement as HTMLElement | SVGElement).blur) {
+      // Workaround the Firefox bug where focusing the element does not switch current
+      // contenteditable to the new element. However, blurring the previous one helps.
+      (activeElement as HTMLElement | SVGElement).blur();
+    }
     (node as HTMLElement | SVGElement).focus();
 
     if (resetSelectionIfNotFocused && !wasFocused && node.nodeName.toLowerCase() === 'input') {

--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -671,14 +671,7 @@ export class InjectedScript {
       return 'error:notconnected';
     if (node.nodeType !== Node.ELEMENT_NODE)
       throw this.createStacklessError('Node is not an element');
-
-    const activeElement = (node.getRootNode() as (Document | ShadowRoot)).activeElement;
-    const wasFocused = activeElement === node && node.ownerDocument && node.ownerDocument.hasFocus();
-    if (!wasFocused && activeElement && (activeElement as HTMLElement | SVGElement).blur) {
-      // Workaround the Firefox bug where focusing the element does not switch current
-      // contenteditable to the new element. However, blurring the previous one helps.
-      (activeElement as HTMLElement | SVGElement).blur();
-    }
+    const wasFocused = (node.getRootNode() as (Document | ShadowRoot)).activeElement === node && node.ownerDocument && node.ownerDocument.hasFocus();
     (node as HTMLElement | SVGElement).focus();
 
     if (resetSelectionIfNotFocused && !wasFocused && node.nodeName.toLowerCase() === 'input') {

--- a/tests/page/page-focus.spec.ts
+++ b/tests/page/page-focus.spec.ts
@@ -117,3 +117,35 @@ it('clicking checkbox should activate it', async ({ page, browserName, headless,
   const nodeName = await page.evaluate(() => document.activeElement.nodeName);
   expect(nodeName).toBe('INPUT');
 });
+
+it('keeps focus on element when attempting to focus a non-focusable element', async ({ page }) => {
+  it.fail();
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/14254' });
+
+  await page.setContent(`
+      <div id="focusable" tabindex="0">focusable</div>
+      <div id="non-focusable">not focusable</div>
+      <script>
+        window.eventLog = [];
+
+        const focusable = document.getElementById("focusable");
+        focusable.addEventListener('click', () => {
+          focusable.focus();
+        });
+
+        focusable.addEventListener('blur', () => window.eventLog.push('blur focusable'));
+        focusable.addEventListener('focus', () => window.eventLog.push('focus focusable'));
+
+        const nonFocusable = document.getElementById("non-focusable");
+        nonFocusable.addEventListener('blur', () => window.eventLog.push('blur non-focusable'));
+        nonFocusable.addEventListener('focus', () => window.eventLog.push('focus non-focusable'));
+      </script>
+    `);
+  await page.locator('#focusable').click();
+  expect.soft(await page.evaluate(() => document.activeElement?.id)).toBe('focusable');
+  await page.locator('#non-focusable').focus();
+  expect.soft(await page.evaluate(() => document.activeElement?.id)).toBe('focusable');
+  expect.soft(await page.evaluate(() => window['eventLog'])).toEqual([
+    'focus focusable',
+  ]);
+});

--- a/tests/page/page-focus.spec.ts
+++ b/tests/page/page-focus.spec.ts
@@ -128,9 +128,6 @@ it('keeps focus on element when attempting to focus a non-focusable element', as
         window.eventLog = [];
 
         const focusable = document.getElementById("focusable");
-        focusable.addEventListener('click', () => {
-          focusable.focus();
-        });
 
         focusable.addEventListener('blur', () => window.eventLog.push('blur focusable'));
         focusable.addEventListener('focus', () => window.eventLog.push('focus focusable'));

--- a/tests/page/page-focus.spec.ts
+++ b/tests/page/page-focus.spec.ts
@@ -119,7 +119,6 @@ it('clicking checkbox should activate it', async ({ page, browserName, headless,
 });
 
 it('keeps focus on element when attempting to focus a non-focusable element', async ({ page }) => {
-  it.fail();
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/14254' });
 
   await page.setContent(`

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -492,7 +492,6 @@ it('should support undo-redo', async ({ page, isMac, browserName, isLinux }) => 
 
 it('should type repeatedly in contenteditable in shadow dom', async ({ page, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/12941' });
-  it.fail(browserName === 'firefox');
 
   await page.setContent(`
     <html>
@@ -531,6 +530,18 @@ it('should type repeatedly in contenteditable in shadow dom', async ({ page, bro
 
   expect(await editor.textContent()).toBe('This is the first box.');
   expect(await sectionEditor.textContent()).toBe('This is the second box.');
+});
+
+it('type to non-focusable element should maintain old focus', async ({ page }) => {
+  await page.setContent(`
+    <div id="focusable" tabindex="0">focusable div</div>
+    <div id="non-focusable-and-non-editable">non-editable, non-focusable</div>
+  `);
+
+  await page.locator('#focusable').focus();
+  expect(await page.evaluate(() => document.activeElement?.id)).toBe('focusable');
+  await page.locator('#non-focusable-and-non-editable').type('foo');
+  expect(await page.evaluate(() => document.activeElement?.id)).toBe('focusable');
 });
 
 async function captureLastKeydown(page) {

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -490,8 +490,9 @@ it('should support undo-redo', async ({ page, isMac, browserName, isLinux }) => 
   await expect(div).toHaveText('123');
 });
 
-it('should type repeatedly in contenteditable in shadow dom', async ({ page }) => {
+it('should type repeatedly in contenteditable in shadow dom', async ({ page, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/12941' });
+  it.fail(browserName === 'firefox');
 
   await page.setContent(`
     <html>


### PR DESCRIPTION
Fixes focus and blur management when `page.locator(…).focus()`  and  `page.locator(…).type(…)` are used which was regressed by 7a5b070 (#13510).

#13510 relied on an implicit assumption that this (conditional) [`blur`](https://github.com/microsoft/playwright/blob/7a5b070e9507b622877a2af010373585f2184196/packages/playwright-core/src/server/injected/injectedScript.ts#L672) call would always be followed by a call that resulted in a newly focused element via this [`focus`](https://github.com/microsoft/playwright/blob/7a5b070e9507b622877a2af010373585f2184196/packages/playwright-core/src/server/injected/injectedScript.ts#L674) call.

However, some elements are [not focusable](https://html.spec.whatwg.org/multipage/interaction.html#focusable-area), so we were blurring incorrectly, and losing focus that we should have maintained.

Two regression tests were added that pass on the commit prior to 7a5b070e9507b622877a2af010373585f2184196 (and match manual testing/expectations):

* `page.locator(…).focus()`: _keeps focus on element when attempting to focus a non-focusable element_
* `page.locator(…).type(…)`: _should type repeatedly in input in shadow dom_

Additionally, a third test (_should type repeatedly in input in shadow dom_) was added to check the invariant from #13510 that states:

> This affects [contenteditable] elements, but not input elements.

and allows us to introduce the targeted fix (contenteditble check before blur) without breaking FF again.

And _should type repeatedly in contenteditable in shadow dom with nested elements_ was added to ensure the above fix works with nest contenteditble detection.

Fixes #14254.
