### PR TITLE
devops: fix firefox-beta build

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1324
-Changed: lushnikov@chromium.org Mon 16 May 2022 08:24:55 AM PDT
+1325
+Changed: lushnikov@chromium.org Thu May 19 17:56:07 +03 2022

--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -82,10 +82,22 @@ if [[ $1 != "--juggler" ]]; then
 fi
 
 if [[ $1 == "--full" || $2 == "--full" || $1 == "--bootstrap" ]]; then
-  echo "ac_add_options --enable-bootstrap" >> .mozconfig
-  if is_mac || is_linux; then
-    SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser
+  # This is a slow but sure way to get all the necessary toolchains.
+  # However, it will not work if tree is dirty.
+  # Bail out if git repo is dirty.
+  if [[ -n $(git status -s --untracked-files=no) ]]; then
+    echo "ERROR: dirty GIT state - commit everything and re-run the script."
+    exit 1
   fi
+
+  # 1. We have a --single-branch checkout, so we have to add a "master" branch and fetch it
+  git remote set-branches --add browser_upstream master
+  git fetch browser_upstream master
+  # 2. Checkout the master branch and run bootstrap from it.
+  git checkout browser_upstream/master
+  SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser
+  git checkout -
+
   if [[ ! -z "${WIN32_REDIST_DIR}" ]]; then
     # Having this option in .mozconfig kills incremental compilation.
     echo "export WIN32_REDIST_DIR=\"$WIN32_REDIST_DIR\"" >> .mozconfig


### PR DESCRIPTION
It turns out that we can only bootstrap Firefox toolchains
from latest commits.

So in case of a full build, we have to fetch latest commit
from `master`, bootstrap from it, and then build the commit we'd like.
