### PR TITLE
browser(webkit): fix COOP preference after #14087

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1647
-Changed: yurys@chromium.org Wed 18 May 2022 11:49:45 AM PDT
+1648
+Changed: yurys@chromium.org Fri 20 May 2022 01:56:00 PM PDT

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -2058,10 +2058,10 @@ index 2383d5b94b869e13a305571add135a730e15d5b1..9399a38171ba2ed87e10f0944138d148
    type: bool
    humanReadableName: "Private Click Measurement"
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index fd306fb2912e1305984af8cee12906a687ce2cb6..444d736ab4692834ddc78be2adc037fd1c0874b3 100644
+index fd306fb2912e1305984af8cee12906a687ce2cb6..1c751074c4c39e15cdfa202ba67fa746c77f2a80 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-@@ -467,7 +467,7 @@ CrossOriginEmbedderPolicyEnabled:
+@@ -479,7 +479,7 @@ CrossOriginOpenerPolicyEnabled:
      WebKitLegacy:
        default: false
      WebKit:


### PR DESCRIPTION
The recent roll https://github.com/microsoft/playwright/pull/14087 changed CrossOriginOpenerPolicyEnabled preference from false to true (and flipped CrossOriginEmbedderPolicyEnabled instead). This PR reverts that part of the roll and should make our COOP tests pass after the new roll.

Pretty diff: https://github.com/yury-s/WebKit/commit/2a6b8bd41c37190a9241cc34e902f6f7fa92c91b