### PR TITLE
fix: sanitize URLs with vbscript:

### DIFF
--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -218,7 +218,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string) {
     }
 
     private _sanitizeUrl(url: string): string {
-      if (url.startsWith('javascript:'))
+      if (url.startsWith('javascript:') || url.startsWith('data:') || url.startsWith('vbscript:'))
         return '';
       return url;
     }

--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -218,7 +218,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string) {
     }
 
     private _sanitizeUrl(url: string): string {
-      if (url.startsWith('javascript:') || url.startsWith('data:') || url.startsWith('vbscript:'))
+      if (url.startsWith('javascript:') || url.startsWith('vbscript:'))
         return '';
       return url;
     }

--- a/packages/trace-viewer/src/snapshotRenderer.ts
+++ b/packages/trace-viewer/src/snapshotRenderer.ts
@@ -297,7 +297,7 @@ export function rewriteURLForCustomProtocol(href: string): string {
   try {
     const url = new URL(href);
     // Sanitize URL.
-    if (url.protocol === 'javascript:')
+    if (url.protocol === 'javascript:' || url.protocol === 'vbscript:')
       return 'javascript:void(0)';
 
     // Pass through if possible.


### PR DESCRIPTION
The vbscript: protocols can be used to run scripts in much the same way as the javascript: protocol. This PR adds in validation for those aforementioned protocols in snapshotterInjected.ts and snapshotRenderer.ts.