### PR TITLE
feat(trace-viewer): show request time in trace viewer network tab

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -96,3 +96,7 @@
   margin: 3px 0;
   font-weight: bold;
 }
+
+.network-request-details-time {
+  float: right;
+}

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -127,6 +127,7 @@ export const NetworkResourceDetails: React.FunctionComponent<{
     className={'network-request ' + (selected ? 'selected' : '')} onClick={() => setSelected(index)}>
     <Expandable expanded={expanded} setExpanded={setExpanded} style={{ width: '100%' }} title={ renderTitle() }>
       <div className='network-request-details'>
+        <div className='network-request-details-time'>{resource.time}ms</div>
         <div className='network-request-details-header'>URL</div>
         <div className='network-request-details-url'>{resource.request.url}</div>
         <div className='network-request-details-header'>Request Headers</div>


### PR DESCRIPTION
Fixes: #11893. Added resource time in the expanded details view. 

<img width="293" alt="Screenshot 2022-05-23 at 10 02 16 PM" src="https://user-images.githubusercontent.com/2058170/169866043-14b4b7ff-8f93-47aa-9e64-89a84c56d591.png">