### PR TITLE
docs: use selector-based methods in examples

### DIFF
--- a/docs/src/api-testing-java.md
+++ b/docs/src/api-testing-java.md
@@ -403,10 +403,10 @@ it was created:
 @Test
 void lastCreatedIssueShouldBeOnTheServer() {
   page.navigate("https://github.com/" + USER + "/" + REPO + "/issues");
-  page.click("text=New Issue");
-  page.fill("[aria-label='Title']", "Bug report 1");
-  page.fill("[aria-label='Comment body']", "Bug description");
-  page.click("text=Submit new issue");
+  page.locator("text=New Issue").click();
+  page.locator("[aria-label='Title']").fill( "Bug report 1");
+  page.locator("[aria-label='Comment body']").fill( "Bug description");
+  page.locator("text=Submit new issue").click();
   String issueId = page.url().substring(page.url().lastIndexOf('/'));
 
   APIResponse newIssue = request.get("https://github.com/" + USER + "/" + REPO + "/issues/" + issueId);

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -105,28 +105,28 @@ done and its response has started loading in the popup.
 ```js
 const [newPage] = await Promise.all([
   context.waitForEvent('page'),
-  page.click('a[target=_blank]'),
+  page.locator('a[target=_blank]').click(),
 ]);
 console.log(await newPage.evaluate('location.href'));
 ```
 
 ```java
 Page newPage = context.waitForPage(() -> {
-  page.click("a[target=_blank]");
+  page.locator("a[target=_blank]").click();
 });
 System.out.println(newPage.evaluate("location.href"));
 ```
 
 ```python async
 async with context.expect_page() as page_info:
-    await page.click("a[target=_blank]"),
+    await page.locator("a[target=_blank]").click(),
 page = await page_info.value
 print(await page.evaluate("location.href"))
 ```
 
 ```python sync
 with context.expect_page() as page_info:
-    page.click("a[target=_blank]"),
+    page.locator("a[target=_blank]").click(),
 page = page_info.value
 print(page.evaluate("location.href"))
 ```
@@ -412,7 +412,7 @@ const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
     <button onclick="onClick()">Click me</button>
     <div></div>
   `);
-  await page.click('button');
+  await page.locator('button').click();
 })();
 ```
 
@@ -434,7 +434,7 @@ public class Example {
         "</script>\n" +
         "<button onclick=\"onClick()\">Click me</button>\n" +
         "<div></div>");
-      page.click("button");
+      page.locator("button").click();
     }
   }
 }
@@ -633,7 +633,7 @@ const crypto = require('crypto');
     <button onclick="onClick()">Click me</button>
     <div></div>
   `);
-  await page.click('button');
+  await page.locator('button').click();
 })();
 ```
 
@@ -669,7 +669,7 @@ public class Example {
         "</script>\n" +
         "<button onclick=\"onClick()\">Click me</button>\n" +
         "<div></div>\n");
-      page.click("button");
+      page.locator("button").click();
     }
   }
 }
@@ -1206,7 +1206,7 @@ const [page, _] = await Promise.all([
 ```
 
 ```java
-Page newPage = context.waitForPage(() -> page.click("button"));
+Page newPage = context.waitForPage(() -> page.locator("button")).click();
 ```
 
 ```python async

--- a/docs/src/api/class-download.md
+++ b/docs/src/api/class-download.md
@@ -22,7 +22,7 @@ const path = await download.path();
 
 ```java
 // wait for download to start
-Download download  = page.waitForDownload(() -> page.click("a"));
+Download download  = page.waitForDownload(() -> page.locator("a")).click();
 // wait for download to complete
 Path path = download.path();
 ```
@@ -30,7 +30,7 @@ Path path = download.path();
 ```java
 // wait for download to start
 Download download = page.waitForDownload(() -> {
-  page.click("a");
+  page.locator("a").click();
 });
 // wait for download to complete
 Path path = download.path();

--- a/docs/src/api/class-filechooser.md
+++ b/docs/src/api/class-filechooser.md
@@ -15,7 +15,7 @@ await fileChooser.setFiles('myfile.pdf');
 ```
 
 ```java
-FileChooser fileChooser = page.waitForFileChooser(() -> page.click("upload"));
+FileChooser fileChooser = page.waitForFileChooser(() -> page.locator("upload")).click();
 fileChooser.setFiles(Paths.get("myfile.pdf"));
 ```
 

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -178,6 +178,8 @@ Raw CSS content to be injected into frame.
 
 ## async method: Frame.check
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method checks an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
    the DOM.
@@ -206,6 +208,8 @@ When all steps combined have not finished during the specified [`option: timeout
 - returns: <[Array]<[Frame]>>
 
 ## async method: Frame.click
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 This method clicks an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
@@ -241,6 +245,8 @@ Gets the full HTML contents of the frame, including the doctype.
 * langs:
   - alias-csharp: DblClickAsync
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method double clicks an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
    the DOM.
@@ -271,6 +277,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.dblclick.trial = %%-input-trial-%%
 
 ## async method: Frame.dispatchEvent
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.dispatchEvent`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element, `click`
 is dispatched. This is equivalent to calling
@@ -695,6 +703,8 @@ Optional argument to pass to [`param: expression`].
 
 ## async method: Frame.fill
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.fill`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method waits for an element matching [`param: selector`], waits for [actionability](../actionability.md) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
 
 If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
@@ -714,6 +724,8 @@ Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
 ### option: Frame.fill.timeout = %%-input-timeout-%%
 
 ## async method: Frame.focus
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.focus`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 This method fetches an element with [`param: selector`] and focuses it. If there's no element matching
 [`param: selector`], the method waits until a matching element appears in the DOM.
@@ -802,6 +814,8 @@ await locator.ClickAsync();
 ## async method: Frame.getAttribute
 - returns: <[null]|[string]>
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.getAttribute`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns element attribute value.
 
 ### param: Frame.getAttribute.selector = %%-input-selector-%%
@@ -860,6 +874,8 @@ Referer header value. If provided it will take preference over the referer heade
 
 ## async method: Frame.hover
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.hover`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method hovers over an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
    the DOM.
@@ -884,6 +900,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ## async method: Frame.innerHTML
 - returns: <[string]>
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.innerHTML`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns `element.innerHTML`.
 
 ### param: Frame.innerHTML.selector = %%-input-selector-%%
@@ -894,6 +912,8 @@ Returns `element.innerHTML`.
 ## async method: Frame.innerText
 - returns: <[string]>
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.innerText`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns `element.innerText`.
 
 ### param: Frame.innerText.selector = %%-input-selector-%%
@@ -903,6 +923,8 @@ Returns `element.innerText`.
 
 ## async method: Frame.inputValue
 - returns: <[string]>
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.inputValue`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns `input.value` for the selected `<input>` or `<textarea>` or `<select>` element.
 
@@ -915,6 +937,8 @@ Throws for non-input elements. However, if the element is inside the `<label>` e
 
 ## async method: Frame.isChecked
 - returns: <[boolean]>
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isChecked`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
 
@@ -931,6 +955,8 @@ Returns `true` if the frame has been detached, or `false` otherwise.
 ## async method: Frame.isDisabled
 - returns: <[boolean]>
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isDisabled`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns whether the element is disabled, the opposite of [enabled](../actionability.md#enabled).
 
 ### param: Frame.isDisabled.selector = %%-input-selector-%%
@@ -940,6 +966,8 @@ Returns whether the element is disabled, the opposite of [enabled](../actionabil
 
 ## async method: Frame.isEditable
 - returns: <[boolean]>
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isEditable`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns whether the element is [editable](../actionability.md#editable).
 
@@ -951,6 +979,8 @@ Returns whether the element is [editable](../actionability.md#editable).
 ## async method: Frame.isEnabled
 - returns: <[boolean]>
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isEnabled`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns whether the element is [enabled](../actionability.md#enabled).
 
 ### param: Frame.isEnabled.selector = %%-input-selector-%%
@@ -960,6 +990,8 @@ Returns whether the element is [enabled](../actionability.md#enabled).
 
 ## async method: Frame.isHidden
 - returns: <[boolean]>
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isHidden`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns whether the element is hidden, the opposite of [visible](../actionability.md#visible).  [`option: selector`] that does not match any elements is considered hidden.
 
@@ -973,6 +1005,8 @@ Returns whether the element is hidden, the opposite of [visible](../actionabilit
 
 ## async method: Frame.isVisible
 - returns: <[boolean]>
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isVisible`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns whether the element is [visible](../actionability.md#visible). [`option: selector`] that does not match any elements is considered not visible.
 
@@ -1017,6 +1051,8 @@ Returns the page containing this frame.
 Parent frame, if any. Detached frames and main frames return `null`.
 
 ## async method: Frame.press
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.press`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 [`param: key`] can specify the intended
 [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) value or a single character to
@@ -1093,6 +1129,8 @@ returns empty array.
 ## async method: Frame.selectOption
 - returns: <[Array]<[string]>>
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.selectOption`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method waits for an element matching [`param: selector`], waits for [actionability](../actionability.md) checks, waits until all specified options are present in the `<select>` element and selects these options.
 
 If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
@@ -1158,6 +1196,8 @@ await frame.SelectOptionAsync("select#colors", new[] { "red", "green", "blue" })
 
 ## async method: Frame.setChecked
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.setChecked`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method checks or unchecks an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
    the DOM.
@@ -1196,6 +1236,8 @@ HTML markup to assign to the page.
 
 ## async method: Frame.setInputFiles
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.setInputFiles`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then they
 are resolved relative to the current working directory. For empty array, clears the selected files.
 
@@ -1209,6 +1251,8 @@ This method expects [`param: selector`] to point to an
 ### option: Frame.setInputFiles.timeout = %%-input-timeout-%%
 
 ## async method: Frame.tap
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.tap`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 This method taps an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
@@ -1239,6 +1283,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ## async method: Frame.textContent
 - returns: <[null]|[string]>
 
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.textContent`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns `element.textContent`.
 
 ### param: Frame.textContent.selector = %%-input-selector-%%
@@ -1252,6 +1298,8 @@ Returns `element.textContent`.
 Returns the page title.
 
 ## async method: Frame.type
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.type`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text. `frame.type` can be used to
 send fine-grained keyboard events. To fill values in form fields, use [`method: Frame.fill`].
@@ -1302,6 +1350,8 @@ Time to wait between key presses in milliseconds. Defaults to 0.
 ### option: Frame.type.timeout = %%-input-timeout-%%
 
 ## async method: Frame.uncheck
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 This method checks an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
@@ -1558,6 +1608,8 @@ a navigation.
 
 ## async method: Frame.waitForSelector
 - returns: <[null]|[ElementHandle]>
+
+**DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.waitForSelector`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns when element specified by selector satisfies [`option: state`] option. Returns `null` if waiting for `hidden` or
 `detached`.

--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -7,7 +7,7 @@ import { test, expect } from '@playwright/test';
 
 test('status becomes submitted', async ({ page }) => {
   // ...
-  await page.click('#submit-button');
+  await page.locator('#submit-button').click();
   await expect(page.locator('.status')).toHaveText('Submitted');
 });
 ```
@@ -21,7 +21,7 @@ public class TestLocator {
   @Test
   void statusBecomesSubmitted() {
     ...
-    page.click("#submit-button");
+    page.locator("#submit-button").click();
     assertThat(page.locator(".status")).hasText("Submitted");
   }
 }

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -665,6 +665,8 @@ Brings page to front (activates tab).
 
 ## async method: Page.check
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method checks an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
    the DOM.
@@ -692,6 +694,8 @@ Shortcut for main frame's [`method: Frame.check`].
 ### option: Page.check.trial = %%-input-trial-%%
 
 ## async method: Page.click
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 This method clicks an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
@@ -762,6 +766,8 @@ Browser-specific Coverage implementation. See [Coverage](#class-coverage) for mo
 * langs:
   - alias-csharp: DblClickAsync
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method double clicks an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
    the DOM.
@@ -794,6 +800,8 @@ Shortcut for main frame's [`method: Frame.dblclick`].
 ### option: Page.dblclick.trial = %%-input-trial-%%
 
 ## async method: Page.dispatchEvent
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.dispatchEvent`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element, `click`
 is dispatched. This is equivalent to calling
@@ -1837,6 +1845,8 @@ Callback function which will be called in Playwright's context.
 
 ## async method: Page.fill
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.fill`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method waits for an element matching [`param: selector`], waits for [actionability](../actionability.md) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
 
 If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
@@ -1858,6 +1868,8 @@ Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
 ### option: Page.fill.timeout = %%-input-timeout-%%
 
 ## async method: Page.focus
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.focus`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 This method fetches an element with [`param: selector`] and focuses it. If there's no element matching
 [`param: selector`], the method waits until a matching element appears in the DOM.
@@ -1977,6 +1989,8 @@ An array of all frames attached to the page.
 ## async method: Page.getAttribute
 - returns: <[null]|[string]>
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.getAttribute`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns element attribute value.
 
 ### param: Page.getAttribute.selector = %%-input-selector-%%
@@ -2063,6 +2077,8 @@ Referer header value. If provided it will take preference over the referer heade
 
 ## async method: Page.hover
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.hover`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method hovers over an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
    the DOM.
@@ -2089,6 +2105,8 @@ Shortcut for main frame's [`method: Frame.hover`].
 ## async method: Page.innerHTML
 - returns: <[string]>
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.innerHTML`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns `element.innerHTML`.
 
 ### param: Page.innerHTML.selector = %%-input-selector-%%
@@ -2099,6 +2117,8 @@ Returns `element.innerHTML`.
 ## async method: Page.innerText
 - returns: <[string]>
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.innerText`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns `element.innerText`.
 
 ### param: Page.innerText.selector = %%-input-selector-%%
@@ -2108,6 +2128,8 @@ Returns `element.innerText`.
 
 ## async method: Page.inputValue
 - returns: <[string]>
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.inputValue`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns `input.value` for the selected `<input>` or `<textarea>` or `<select>` element.
 
@@ -2120,6 +2142,8 @@ Throws for non-input elements. However, if the element is inside the `<label>` e
 
 ## async method: Page.isChecked
 - returns: <[boolean]>
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isChecked`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
 
@@ -2137,6 +2161,8 @@ Indicates that the page has been closed.
 ## async method: Page.isDisabled
 - returns: <[boolean]>
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isDisabled`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns whether the element is disabled, the opposite of [enabled](../actionability.md#enabled).
 
 ### param: Page.isDisabled.selector = %%-input-selector-%%
@@ -2146,6 +2172,8 @@ Returns whether the element is disabled, the opposite of [enabled](../actionabil
 
 ## async method: Page.isEditable
 - returns: <[boolean]>
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isEditable`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns whether the element is [editable](../actionability.md#editable).
 
@@ -2157,6 +2185,8 @@ Returns whether the element is [editable](../actionability.md#editable).
 ## async method: Page.isEnabled
 - returns: <[boolean]>
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isEnabled`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns whether the element is [enabled](../actionability.md#enabled).
 
 ### param: Page.isEnabled.selector = %%-input-selector-%%
@@ -2166,6 +2196,8 @@ Returns whether the element is [enabled](../actionability.md#enabled).
 
 ## async method: Page.isHidden
 - returns: <[boolean]>
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isHidden`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns whether the element is hidden, the opposite of [visible](../actionability.md#visible).  [`option: selector`] that does not match any elements is considered hidden.
 
@@ -2179,6 +2211,8 @@ Returns whether the element is hidden, the opposite of [visible](../actionabilit
 
 ## async method: Page.isVisible
 - returns: <[boolean]>
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isVisible`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns whether the element is [visible](../actionability.md#visible). [`option: selector`] that does not match any elements is considered not visible.
 
@@ -2416,6 +2450,8 @@ Give any CSS `@page` size declared in the page priority over what is declared in
 size.
 
 ## async method: Page.press
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.press`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Focuses the element, and then uses [`method: Keyboard.down`] and [`method: Keyboard.up`].
 
@@ -2745,6 +2781,8 @@ Returns the buffer with the captured screenshot.
 ## async method: Page.selectOption
 - returns: <[Array]<[string]>>
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.selectOption`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method waits for an element matching [`param: selector`], waits for [actionability](../actionability.md) checks, waits until all specified options are present in the `<select>` element and selects these options.
 
 If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
@@ -2811,6 +2849,8 @@ Shortcut for main frame's [`method: Frame.selectOption`].
 ### option: Page.selectOption.timeout = %%-input-timeout-%%
 
 ## async method: Page.setChecked
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.setChecked`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 This method checks or unchecks an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
@@ -2898,6 +2938,8 @@ An object containing additional HTTP headers to be sent with every request. All 
 
 ## async method: Page.setInputFiles
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.setInputFiles`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then they
 are resolved relative to the current working directory. For empty array, clears the selected files.
 
@@ -2969,6 +3011,8 @@ await page.GotoAsync("https://www.microsoft.com");
 
 ## async method: Page.tap
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.tap`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 This method taps an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
    the DOM.
@@ -3000,6 +3044,8 @@ Shortcut for main frame's [`method: Frame.tap`].
 ## async method: Page.textContent
 - returns: <[null]|[string]>
 
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.textContent`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+
 Returns `element.textContent`.
 
 ### param: Page.textContent.selector = %%-input-selector-%%
@@ -3016,6 +3062,8 @@ Returns the page's title. Shortcut for main frame's [`method: Frame.title`].
 - type: <[Touchscreen]>
 
 ## async method: Page.type
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.type`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text. `page.type` can be used to send
 fine-grained keyboard events. To fill values in form fields, use [`method: Page.fill`].
@@ -3068,6 +3116,8 @@ Time to wait between key presses in milliseconds. Defaults to 0.
 ### option: Page.type.timeout = %%-input-timeout-%%
 
 ## async method: Page.uncheck
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 This method unchecks an element matching [`param: selector`] by performing the following steps:
 1. Find an element matching [`param: selector`]. If there is none, wait until a matching element is attached to
@@ -3753,6 +3803,8 @@ changed by using the [`method: BrowserContext.setDefaultTimeout`] or [`method: P
 
 ## async method: Page.waitForSelector
 - returns: <[null]|[ElementHandle]>
+
+**DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.waitForSelector`] instead. [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
 
 Returns when element specified by selector satisfies [`option: state`] option. Returns `null` if waiting for `hidden` or
 `detached`.

--- a/docs/src/api/class-pageassertions.md
+++ b/docs/src/api/class-pageassertions.md
@@ -7,7 +7,7 @@ import { test, expect } from '@playwright/test';
 
 test('navigates to login', async ({ page }) => {
   // ...
-  await page.click('#login');
+  await page.locator('#login').click();
   await expect(page).toHaveURL(/.*\/login/);
 });
 ```
@@ -21,7 +21,7 @@ public class TestPage {
   @Test
   void navigatesToLoginPage() {
     ...
-    page.click("#login");
+    page.locator("#login").click();
     assertThat(page).hasURL(Pattern.compile(".*/login"));
   }
 }

--- a/docs/src/api/class-playwrightassertions.md
+++ b/docs/src/api/class-playwrightassertions.md
@@ -41,7 +41,7 @@ public class TestExample {
   @Test
   void statusBecomesSubmitted() {
     ...
-    page.click("#submit-button");
+    page.locator("#submit-button").click();
     assertThat(page.locator(".status")).hasText("Submitted");
   }
 }

--- a/docs/src/api/class-selectors.md
+++ b/docs/src/api/class-selectors.md
@@ -34,7 +34,7 @@ const { selectors, firefox } = require('playwright');  // Or 'chromium' or 'webk
   // Use the selector prefixed with its name.
   const button = page.locator('tag=button');
   // Combine it with other selector engines.
-  await page.click('tag=div >> text="Click me"');
+  await page.locator('tag=div >> text="Click me"').click();
   // Can use it in any methods supporting selectors.
   const buttonCount = await page.locator('tag=button').count();
 

--- a/docs/src/api/class-timeouterror.md
+++ b/docs/src/api/class-timeouterror.md
@@ -68,7 +68,7 @@ public class TimeoutErrorExample {
       BrowserContext context = browser.newContext();
       Page page = context.newPage();
       try {
-        page.click("text=Example", new Page.ClickOptions().setTimeout(100));
+        page.locator("text=Example").click( new Page.ClickOptions().setTimeout(100));
       } catch (TimeoutError e) {
         System.out.println("Timeout!");
       }

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -158,7 +158,7 @@ const page = await context.newPage();
 await page.goto('https://playwright.dev');
 
 await context.tracing.startChunk();
-await page.click('text=Get Started');
+await page.locator('text=Get Started').click();
 // Everything between startChunk and stopChunk will be recorded in the trace.
 await context.tracing.stopChunk({ path: 'trace1.zip' });
 

--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -29,10 +29,10 @@ const page = await context.newPage();
 await page.goto('https://github.com/login');
 
 // Interact with login form
-await page.click('text=Login');
-await page.fill('input[name="login"]', USERNAME);
-await page.fill('input[name="password"]', PASSWORD);
-await page.click('text=Submit');
+await page.locator('text=Login').click();
+await page.locator('input[name="login"]').fill( USERNAME);
+await page.locator('input[name="password"]').fill( PASSWORD);
+await page.locator('text=Submit').click();
 // Verify app is logged in
 ```
 

--- a/docs/src/dialogs.md
+++ b/docs/src/dialogs.md
@@ -13,7 +13,7 @@ By default, dialogs are auto-dismissed by Playwright, so you don't have to handl
 
 ```js
 page.on('dialog', dialog => dialog.accept());
-await page.click('button');
+await page.locator('button').click();
 ```
 
 ```java
@@ -48,7 +48,7 @@ WRONG!
 
 ```js
 page.on('dialog', dialog => console.log(dialog.message()));
-await page.click('button'); // Will hang here
+await page.locator('button').click(); // Will hang here
 ```
 
 ```java
@@ -58,7 +58,7 @@ page.click("button"); // Will hang here
 
 ```python async
 page.on("dialog", lambda dialog: print(dialog.message))
-await page.click("button") # Will hang here
+await page.locator("button").click() # Will hang here
 ```
 
 ```python sync

--- a/docs/src/downloads.md
+++ b/docs/src/downloads.md
@@ -34,7 +34,7 @@ const path = await download.path();
 // Wait for the download to start
 Download download = page.waitForDownload(() -> {
     // Perform the action that initiates download
-    page.click("button#delayed-download");
+    page.locator("button#delayed-download").click();
 });
 // Wait for the download process to complete
 Path path = download.path();

--- a/docs/src/extensibility.md
+++ b/docs/src/extensibility.md
@@ -46,7 +46,7 @@ const button = page.locator('tag=button');
 await button.click();
 
 // We can combine it with other selector engines using `>>` combinator.
-await page.click('tag=div >> span >> "Click me"');
+await page.locator('tag=div >> span >> "Click me"').click();
 
 // We can use it in any methods supporting selectors.
 const buttonCount = await page.locator('tag=button').count();

--- a/docs/src/frames.md
+++ b/docs/src/frames.md
@@ -56,7 +56,7 @@ const frame = page.frame('frame-login');
 const frame = page.frame({ url: /.*domain.*/ });
 
 // Interact with the frame
-await frame.fill('#username-input', 'John');
+await frame.locator('#username-input').fill( 'John');
 ```
 
 ```java

--- a/docs/src/handles.md
+++ b/docs/src/handles.md
@@ -60,7 +60,7 @@ APIs wait for the element to be attached and visible.
 
 ```js
 // Get the element handle
-const elementHandle = page.waitForSelector('#box');
+const elementHandle = page.locator('#box').waitForSelector();
 
 // Assert bounding box for the element
 const boundingBox = await elementHandle.boundingBox();
@@ -73,7 +73,7 @@ expect(classNames.includes('highlighted')).toBeTruthy();
 
 ```java
 // Get the element handle
-JSHandle jsHandle = page.waitForSelector("#box");
+JSHandle jsHandle = page.locator("#box").waitForSelector();
 ElementHandle elementHandle = jsHandle.asElement();
 
 // Assert bounding box for the element

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -11,19 +11,19 @@ This is the easiest way to fill out the form fields. It focuses the element and 
 
 ```js
 // Text input
-await page.fill('#name', 'Peter');
+await page.locator('#name').fill( 'Peter');
 
 // Date input
-await page.fill('#date', '2020-02-02');
+await page.locator('#date').fill( '2020-02-02');
 
 // Time input
-await page.fill('#time', '13:15');
+await page.locator('#time').fill( '13:15');
 
 // Local datetime input
-await page.fill('#local', '2020-03-02T05:15');
+await page.locator('#local').fill( '2020-03-02T05:15');
 
 // Input through label
-await page.fill('text=First Name', 'Peter');
+await page.locator('text=First Name').fill( 'Peter');
 ```
 
 ```java
@@ -108,16 +108,16 @@ This is the easiest way to check and uncheck a checkbox or a radio button. This 
 
 ```js
 // Check the checkbox
-await page.check('#agree');
+await page.locator('#agree').check();
 
 // Assert the checked state
-expect(await page.isChecked('#agree')).toBeTruthy()
+expect(await page.locator('#agree')).isChecked().toBeTruthy()
 
 // Uncheck by input <label>.
 await page.uncheck('#subscribe-label');
 
 // Select the radio button
-await page.check('text=XL');
+await page.locator('text=XL').check();
 ```
 
 ```java
@@ -125,7 +125,7 @@ await page.check('text=XL');
 page.check("#agree");
 
 // Assert the checked state
-assertTrue(page.isChecked("#agree"));
+assertTrue(page.locator("#agree")).isChecked();
 
 // Uncheck by input <label>.
 page.uncheck("#subscribe-label");
@@ -194,17 +194,17 @@ You can specify option `value`, `label` or `elementHandle` to select. Multiple o
 
 ```js
 // Single selection matching the value
-await page.selectOption('select#colors', 'blue');
+await page.locator('select#colors').selectOption( 'blue');
 
 // Single selection matching the label
-await page.selectOption('select#colors', { label: 'Blue' });
+await page.locator('select#colors').selectOption( { label: 'Blue' });
 
 // Multiple selected items
-await page.selectOption('select#colors', ['red', 'green', 'blue']);
+await page.locator('select#colors').selectOption( ['red', 'green', 'blue']);
 
 // Select the option via element handle
 const option = await page.$('#best-option');
-await page.selectOption('select#colors', option);
+await page.locator('select#colors').selectOption( option);
 ```
 
 ```java
@@ -281,22 +281,22 @@ Performs a simple human click.
 
 ```js
 // Generic click
-await page.click('button#submit');
+await page.locator('button#submit').click();
 
 // Double click
 await page.dblclick('#item');
 
 // Right click
-await page.click('#item', { button: 'right' });
+await page.locator('#item').click( { button: 'right' });
 
 // Shift + click
-await page.click('#item', { modifiers: ['Shift'] });
+await page.locator('#item').click( { modifiers: ['Shift'] });
 
 // Hover over element
-await page.hover('#item');
+await page.locator('#item').hover();
 
 // Click the top left corner
-await page.click('#item', { position: { x: 0, y: 0} });
+await page.locator('#item').click( { position: { x: 0, y: 0} });
 ```
 
 ```java
@@ -393,7 +393,7 @@ Under the hood, this and other pointer-related methods:
 Sometimes, apps use non-trivial logic where hovering the element overlays it with another element that intercepts the click. This behavior is indistinguishable from a bug where element gets covered and the click is dispatched elsewhere. If you know this is taking place, you can bypass the [actionability](./actionability.md) checks and force the click:
 
 ```js
-await page.click('button#submit', { force: true });
+await page.locator('button#submit').click( { force: true });
 ```
 
 ```java
@@ -417,7 +417,7 @@ await page.ClickAsync("button#submit", new PageClickOptions { Force = true });
 If you are not interested in testing your app under the real conditions and want to simulate the click by any means possible, you can trigger the [`HTMLElement.click()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click) behavior via simply dispatching a click event on the element:
 
 ```js
-await page.dispatchEvent('button#submit', 'click');
+await page.locator('button#submit').dispatchEvent( 'click');
 ```
 
 ```java
@@ -459,7 +459,7 @@ Type into the field character by character, as if it was a user with a real keyb
 
 ```js
 // Type character by character
-await page.type('#area', 'Hello World!');
+await page.locator('#area').type( 'Hello World!');
 ```
 
 ```java
@@ -501,13 +501,13 @@ Most of the time, [`method: Page.fill`] will just work. You only need to type ch
 
 ```js
 // Hit Enter
-await page.press('#submit', 'Enter');
+await page.locator('#submit').press( 'Enter');
 
 // Dispatch Control+Right
-await page.press('#name', 'Control+ArrowRight');
+await page.locator('#name').press( 'Control+ArrowRight');
 
 // Press $ sign on keyboard
-await page.press('#value', '$');
+await page.locator('#value').press( '$');
 ```
 
 ```java
@@ -571,10 +571,10 @@ Simple version produces a single character. This character is case-sensitive, so
 
 ```js
 // <input id=name>
-await page.press('#name', 'Shift+A');
+await page.locator('#name').press( 'Shift+A');
 
 // <input id=name>
-await page.press('#name', 'Shift+ArrowLeft');
+await page.locator('#name').press( 'Shift+ArrowLeft');
 ```
 
 ```java
@@ -629,13 +629,13 @@ You can select input files for upload using the [`method: Page.setInputFiles`] m
 
 ```js
 // Select one file
-await page.setInputFiles('input#upload', 'myfile.pdf');
+await page.locator('input#upload').setInputFiles( 'myfile.pdf');
 
 // Select multiple files
-await page.setInputFiles('input#upload', ['file1.txt', 'file2.txt']);
+await page.locator('input#upload').setInputFiles( ['file1.txt', 'file2.txt']);
 
 // Remove all the selected files
-await page.setInputFiles('input#upload', []);
+await page.locator('input#upload').setInputFiles( []);
 
 // Upload buffer from memory
 await page.setInputFiles('input#upload', {
@@ -733,7 +733,7 @@ await fileChooser.setFiles('myfile.pdf');
 
 ```java
 FileChooser fileChooser = page.waitForFileChooser(() -> {
-  page.click("upload");
+  page.locator("upload").click();
 });
 fileChooser.setFiles(Paths.get("myfile.pdf"));
 ```
@@ -773,7 +773,7 @@ await fileChooser.SetFilesAsync("myfile.pdf");
 For the dynamic pages that handle focus events, you can focus the given element.
 
 ```js
-await page.focus('input#name');
+await page.locator('input#name').focus();
 ```
 
 ```java

--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -210,7 +210,7 @@ test('my test', async ({ page }) => {
   // Expect an attribute "to be strictly equal" to the value.
   await expect(page.locator('text=Get Started').first()).toHaveAttribute('href', '/docs/intro');
 
-  await page.click('text=Get Started');
+  await page.locator('text=Get Started').click();
   // Expect some text to be visible on the page.
   await expect(page.locator('text=Introduction').first()).toBeVisible();
 });
@@ -229,7 +229,7 @@ test('my test', async ({ page }) => {
   // Expect an attribute "to be strictly equal" to the value.
   await expect(page.locator('text=Get Started').first()).toHaveAttribute('href', '/docs/intro');
 
-  await page.click('text=Get Started');
+  await page.locator('text=Get Started').click();
   // Expect some text to be visible on the page.
   await expect(page.locator('text=Introduction').first()).toBeVisible();
 });

--- a/docs/src/navigations.md
+++ b/docs/src/navigations.md
@@ -106,7 +106,7 @@ await page.locator('text=Example Domain').waitFor();
 // Navigate and click element
 // Click will auto-wait for the element
 await page.goto('https://example.com');
-await page.click('text=Example Domain');
+await page.locator('text=Example Domain').click();
 ```
 
 ```java
@@ -170,10 +170,10 @@ the navigated page which would auto-wait for an element.
 
 ```js
 // Click will auto-wait for navigation to complete
-await page.click('text=Login');
+await page.locator('text=Login').click();
 
 // Fill will auto-wait for element on navigated page
-await page.fill('#username', 'John Doe');
+await page.locator('#username').fill( 'John Doe');
 ```
 
 ```java
@@ -213,7 +213,7 @@ await page.FillAsync("#username", "John Doe");
 `page.click` can be combined with [`method: Page.waitForLoadState`] to wait for a loading event.
 
 ```js
-await page.click('button'); // Click triggers navigation
+await page.locator('button').click(); // Click triggers navigation
 await page.waitForLoadState('networkidle'); // This resolves after 'networkidle'
 ```
 
@@ -223,7 +223,7 @@ page.waitForLoadState(LoadState.NETWORKIDLE); // This resolves after "networkidl
 ```
 
 ```python async
-await page.click("button"); # Click triggers navigation
+await page.locator("button").click(); # Click triggers navigation
 await page.wait_for_load_state("networkidle"); # This waits for the "networkidle"
 ```
 
@@ -244,14 +244,14 @@ Alternatively, page interactions like [`method: Page.click`] auto-wait for eleme
 
 ```js
 // Click will auto-wait for the element and trigger navigation
-await page.click('text=Login');
+await page.locator('text=Login').click();
 // Wait for the element
 await page.locator('#username').waitFor();
 
 // Click triggers navigation
-await page.click('text=Login');
+await page.locator('text=Login').click();
 // Fill will auto-wait for element
-await page.fill('#username', 'John Doe');
+await page.locator('#username').fill( 'John Doe');
 ```
 
 ```java
@@ -325,7 +325,7 @@ await Promise.all([
 // Using waitForNavigation with a callback prevents a race condition
 // between clicking and waiting for a navigation.
 page.waitForNavigation(() -> { // Waits for the next navigation
-  page.click("div.delayed-navigation"); // Triggers a navigation after a timeout
+  page.locator("div.delayed-navigation").click(); // Triggers a navigation after a timeout
 });
 ```
 
@@ -377,7 +377,7 @@ await Promise.all([
 // Running action in the callback of waitForNavigation prevents a race
 // condition between clicking and waiting for a navigation.
 page.waitForNavigation(new Page.WaitForNavigationOptions().setUrl("**/login"), () -> {
-  page.click("a"); // Triggers a navigation with a script redirect
+  page.locator("a").click(); // Triggers a navigation with a script redirect
 });
 ```
 
@@ -429,21 +429,21 @@ await popup.waitForLoadState('load');
 
 ```java
 Page popup = page.waitForPopup(() -> {
-  page.click("a[target='_blank']"); // Opens popup
+  page.locator("a[target='_blank']").click(); // Opens popup
 });
 popup.waitForLoadState(LoadState.LOAD);
 ```
 
 ```python async
 async with page.expect_popup() as popup_info:
-    await page.click('a[target="_blank"]') # Opens popup
+    await page.locator('a[target="_blank"]').click() # Opens popup
 popup = await popup_info.value
 await popup.wait_for_load_state("load")
 ```
 
 ```python sync
 with page.expect_popup() as popup_info:
-    page.click('a[target="_blank"]') # Opens popup
+    page.locator('a[target="_blank"]').click() # Opens popup
 popup = popup_info.value
 popup.wait_for_load_state("load")
 ```

--- a/docs/src/network.md
+++ b/docs/src/network.md
@@ -259,14 +259,14 @@ Or wait for a network response after the button click:
 // Use a glob URL pattern
 const [response] = await Promise.all([
   page.waitForResponse('**/api/fetch_data'),
-  page.click('button#update'),
+  page.locator('button#update').click(),
 ]);
 ```
 
 ```java
 // Use a glob URL pattern
 Response response = page.waitForResponse("**/api/fetch_data", () -> {
-  page.click("button#update");
+  page.locator("button#update").click();
 });
 ```
 
@@ -297,25 +297,25 @@ var response = await waitForResponseTask;
 // Use a RegExp
 const [response] = await Promise.all([
   page.waitForResponse(/\.jpeg$/),
-  page.click('button#update'),
+  page.locator('button#update').click(),
 ]);
 
 // Use a predicate taking a Response object
 const [response] = await Promise.all([
   page.waitForResponse(response => response.url().includes(token)),
-  page.click('button#update'),
+  page.locator('button#update').click(),
 ]);
 ```
 
 ```java
 // Use a RegExp
 Response response = page.waitForResponse(Pattern.compile("\\.jpeg$"), () -> {
-  page.click("button#update");
+  page.locator("button#update").click();
 });
 
 // Use a predicate taking a Response object
 Response response = page.waitForResponse(r -> r.url().contains(token), () -> {
-  page.click("button#update");
+  page.locator("button#update").click();
 });
 ```
 

--- a/docs/src/pages.md
+++ b/docs/src/pages.md
@@ -144,7 +144,7 @@ handle new pages opened by `target="_blank"` links.
 // Get page after a specific action (e.g. clicking a link)
 const [newPage] = await Promise.all([
   context.waitForEvent('page'),
-  page.click('a[target="_blank"]') // Opens a new tab
+  page.locator('a[target="_blank"]').click() // Opens a new tab
 ])
 await newPage.waitForLoadState();
 console.log(await newPage.title());
@@ -153,7 +153,7 @@ console.log(await newPage.title());
 ```java
 // Get page after a specific action (e.g. clicking a link)
 Page newPage = context.waitForPage(() -> {
-  page.click("a[target='_blank']"); // Opens a new tab
+  page.locator("a[target='_blank']").click(); // Opens a new tab
 });
 newPage.waitForLoadState();
 System.out.println(newPage.title());
@@ -162,7 +162,7 @@ System.out.println(newPage.title());
 ```python async
 # Get page after a specific action (e.g. clicking a link)
 async with context.expect_page() as new_page_info:
-    await page.click('a[target="_blank"]') # Opens a new tab
+    await page.locator('a[target="_blank"]').click() # Opens a new tab
 new_page = await new_page_info.value
 
 await new_page.wait_for_load_state()
@@ -172,7 +172,7 @@ print(await new_page.title())
 ```python sync
 # Get page after a specific action (e.g. clicking a link)
 with context.expect_page() as new_page_info:
-    page.click('a[target="_blank"]') # Opens a new tab
+    page.locator('a[target="_blank"]').click() # Opens a new tab
 new_page = new_page_info.value
 
 new_page.wait_for_load_state()
@@ -256,7 +256,7 @@ console.log(await popup.title());
 ```java
 // Get popup after a specific action (e.g., click)
 Page popup = page.waitForPopup(() -> {
-  page.click("#open");
+  page.locator("#open").click();
 });
 popup.waitForLoadState();
 System.out.println(popup.title());

--- a/docs/src/selectors.md
+++ b/docs/src/selectors.md
@@ -793,7 +793,7 @@ For example, consider the following DOM structure: `<label for="password">Passwo
 
 ```js
 // Fill the input by targeting the label.
-await page.fill('text=Password', 'secret');
+await page.locator('text=Password').fill( 'secret');
 ```
 
 ```java

--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -224,9 +224,9 @@ module.exports = async config => {
   const browser = await chromium.launch();
   const page = await browser.newPage();
   await page.goto(baseURL);
-  await page.fill('input[name="user"]', 'user');
-  await page.fill('input[name="password"]', 'password');
-  await page.click('text=Sign in');
+  await page.locator('input[name="user"]').fill( 'user');
+  await page.locator('input[name="password"]').fill( 'password');
+  await page.locator('text=Sign in').click();
   await page.context().storageState({ path: storageState });
   await browser.close();
 };
@@ -241,9 +241,9 @@ async function globalSetup(config: FullConfig) {
   const browser = await chromium.launch();
   const page = await browser.newPage();
   await page.goto(baseURL!);
-  await page.fill('input[name="user"]', 'user');
-  await page.fill('input[name="password"]', 'password');
-  await page.click('text=Sign in');
+  await page.locator('input[name="user"]').fill( 'user');
+  await page.locator('input[name="password"]').fill( 'password');
+  await page.locator('text=Sign in').click();
   await page.context().storageState({ path: storageState as string });
   await browser.close();
 }

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -193,7 +193,7 @@ test.beforeEach(async ({ page, isMobile }) => {
 });
 
 test('user profile', async ({ page }) => {
-  await page.click('text=My Profile');
+  await page.locator('text=My Profile').click();
   // ...
 });
 ```
@@ -208,7 +208,7 @@ test.beforeEach(async ({ page, isMobile }) => {
 });
 
 test('user profile', async ({ page }) => {
-  await page.click('text=My Profile');
+  await page.locator('text=My Profile').click();
   // ...
 });
 ```

--- a/docs/src/test-api-testing-js.md
+++ b/docs/src/test-api-testing-js.md
@@ -302,10 +302,10 @@ test.afterAll(async ({ }) => {
 
 test('last created issue should be on the server', async ({ page, request }) => {
   await page.goto(`https://github.com/${USER}/${REPO}/issues`);
-  await page.click('text=New Issue');
-  await page.fill('[aria-label="Title"]', 'Bug report 1');
-  await page.fill('[aria-label="Comment body"]', 'Bug description');
-  await page.click('text=Submit new issue');
+  await page.locator('text=New Issue').click();
+  await page.locator('[aria-label="Title"]').fill( 'Bug report 1');
+  await page.locator('[aria-label="Comment body"]').fill( 'Bug description');
+  await page.locator('text=Submit new issue').click();
   const issueId = page.url().substr(page.url().lastIndexOf('/'));
 
   const newIssue = await request.get(`https://api.github.com/repos/${USER}/${REPO}/issues/${issueId}`);
@@ -347,10 +347,10 @@ test.afterAll(async ({ }) => {
 
 test('last created issue should be on the server', async ({ page, request }) => {
   await page.goto(`https://github.com/${USER}/${REPO}/issues`);
-  await page.click('text=New Issue');
-  await page.fill('[aria-label="Title"]', 'Bug report 1');
-  await page.fill('[aria-label="Comment body"]', 'Bug description');
-  await page.click('text=Submit new issue');
+  await page.locator('text=New Issue').click();
+  await page.locator('[aria-label="Title"]').fill( 'Bug report 1');
+  await page.locator('[aria-label="Comment body"]').fill( 'Bug description');
+  await page.locator('text=Submit new issue').click();
   const issueId = page.url().substr(page.url().lastIndexOf('/'));
 
   const newIssue = await request.get(`https://api.github.com/repos/${USER}/${REPO}/issues/${issueId}`);

--- a/docs/src/test-api/class-fixtures.md
+++ b/docs/src/test-api/class-fixtures.md
@@ -72,9 +72,9 @@ const { test, expect } = require('@playwright/test');
 
 test('basic test', async ({ page }) => {
   await page.goto('/signin');
-  await page.fill('#username', 'User');
-  await page.fill('#password', 'pwd');
-  await page.click('text=Sign in');
+  await page.locator('#username').fill( 'User');
+  await page.locator('#password').fill( 'pwd');
+  await page.locator('text=Sign in').click();
   // ...
 });
 ```
@@ -84,9 +84,9 @@ import { test, expect } from '@playwright/test';
 
 test('basic test', async ({ page }) => {
   await page.goto('/signin');
-  await page.fill('#username', 'User');
-  await page.fill('#password', 'pwd');
-  await page.click('text=Sign in');
+  await page.locator('#username').fill( 'User');
+  await page.locator('#password').fill( 'pwd');
+  await page.locator('text=Sign in').click();
   // ...
 });
 ```

--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -8,7 +8,7 @@ const { test, expect } = require('@playwright/test');
 
 test('basic test', async ({ page }) => {
   await page.goto('https://playwright.dev/');
-  const name = await page.innerText('.navbar__title');
+  const name = await page.locator('.navbar__title').innerText();
   expect(name).toBe('Playwright');
 });
 ```
@@ -18,7 +18,7 @@ import { test, expect } from '@playwright/test';
 
 test('basic test', async ({ page }) => {
   await page.goto('https://playwright.dev/');
-  const name = await page.innerText('.navbar__title');
+  const name = await page.locator('.navbar__title').innerText();
   expect(name).toBe('Playwright');
 });
 ```
@@ -32,7 +32,7 @@ const { test, expect } = require('@playwright/test');
 
 test('basic test', async ({ page }) => {
   await page.goto('https://playwright.dev/');
-  const name = await page.innerText('.navbar__title');
+  const name = await page.locator('.navbar__title').innerText();
   expect(name).toBe('Playwright');
 });
 ```
@@ -42,7 +42,7 @@ import { test, expect } from '@playwright/test';
 
 test('basic test', async ({ page }) => {
   await page.goto('https://playwright.dev/');
-  const name = await page.innerText('.navbar__title');
+  const name = await page.locator('.navbar__title').innerText();
   expect(name).toBe('Playwright');
 });
 ```
@@ -1348,5 +1348,3 @@ test('test with locale', async ({ page }) => {
 - `options` <[TestOptions]>
 
 An object with local options.
-
-

--- a/docs/src/test-auth-js.md
+++ b/docs/src/test-auth-js.md
@@ -23,10 +23,10 @@ import { test } from '@playwright/test';
 test.beforeEach(async ({ page }) => {
   // Runs before each test and signs in each page.
   await page.goto('https://github.com/login');
-  await page.click('text=Login');
-  await page.fill('input[name="login"]', 'username');
-  await page.fill('input[name="password"]', 'password');
-  await page.click('text=Submit');
+  await page.locator('text=Login').click();
+  await page.locator('input[name="login"]').fill( 'username');
+  await page.locator('input[name="password"]').fill( 'password');
+  await page.locator('text=Submit').click();
 });
 
 test('first', async ({ page }) => {
@@ -44,10 +44,10 @@ const { test } = require('@playwright/test');
 test.beforeEach(async ({ page }) => {
   // Runs before each test and signs in each page.
   await page.goto('https://github.com/login');
-  await page.click('text=Login');
-  await page.fill('input[name="login"]', 'username');
-  await page.fill('input[name="password"]', 'password');
-  await page.click('text=Submit');
+  await page.locator('text=Login').click();
+  await page.locator('input[name="login"]').fill( 'username');
+  await page.locator('input[name="password"]').fill( 'password');
+  await page.locator('text=Submit').click();
 });
 
 test('first', async ({ page }) => {
@@ -77,9 +77,9 @@ module.exports = async config => {
   const browser = await chromium.launch();
   const page = await browser.newPage();
   await page.goto('https://github.com/login');
-  await page.fill('input[name="login"]', 'user');
-  await page.fill('input[name="password"]', 'password');
-  await page.click('text=Sign in');
+  await page.locator('input[name="login"]').fill( 'user');
+  await page.locator('input[name="password"]').fill( 'password');
+  await page.locator('text=Sign in').click();
   // Save signed-in state to 'storageState.json'.
   await page.context().storageState({ path: 'storageState.json' });
   await browser.close();
@@ -94,9 +94,9 @@ async function globalSetup(config: FullConfig) {
   const browser = await chromium.launch();
   const page = await browser.newPage();
   await page.goto('https://github.com/login');
-  await page.fill('input[name="login"]', 'user');
-  await page.fill('input[name="password"]', 'password');
-  await page.click('text=Sign in');
+  await page.locator('input[name="login"]').fill( 'user');
+  await page.locator('input[name="password"]').fill( 'password');
+  await page.locator('text=Sign in').click();
   // Save signed-in state to 'storageState.json'.
   await page.context().storageState({ path: 'storageState.json' });
   await browser.close();
@@ -300,9 +300,9 @@ test.beforeAll(async ({ browser }) => {
   // Create page yourself and sign in.
   page = await browser.newPage();
   await page.goto('https://github.com/login');
-  await page.fill('input[name="user"]', 'user');
-  await page.fill('input[name="password"]', 'password');
-  await page.click('text=Sign in');
+  await page.locator('input[name="user"]').fill( 'user');
+  await page.locator('input[name="password"]').fill( 'password');
+  await page.locator('text=Sign in').click();
 });
 
 test.afterAll(async () => {
@@ -331,9 +331,9 @@ test.beforeAll(async ({ browser }) => {
   // Create page once and sign in.
   page = await browser.newPage();
   await page.goto('https://github.com/login');
-  await page.fill('input[name="user"]', 'user');
-  await page.fill('input[name="password"]', 'password');
-  await page.click('text=Sign in');
+  await page.locator('input[name="user"]').fill( 'user');
+  await page.locator('input[name="password"]').fill( 'password');
+  await page.locator('text=Sign in').click();
 });
 
 test.afterAll(async () => {

--- a/docs/src/test-parallel-js.md
+++ b/docs/src/test-parallel-js.md
@@ -144,7 +144,7 @@ test('runs first', async () => {
 });
 
 test('runs second', async () => {
-  await page.click('text=Get Started');
+  await page.locator('text=Get Started').click();
 });
 ```
 
@@ -171,7 +171,7 @@ test('runs first', async () => {
 });
 
 test('runs second', async () => {
-  await page.click('text=Get Started');
+  await page.locator('text=Get Started').click();
 });
 ```
 

--- a/docs/src/test-parameterize-js.md
+++ b/docs/src/test-parameterize-js.md
@@ -146,7 +146,7 @@ exports.test = base.test.extend({
     await page.goto('/chat');
     // We use "person" parameter as a "name" for the chat room.
     await page.locator('#name').fill(person);
-    await page.click('text=Enter chat room');
+    await page.locator('text=Enter chat room').click();
     // Each test will get a "page" that already has the person name.
     await use(page);
   },
@@ -171,7 +171,7 @@ export const test = base.test.extend<TestOptions>({
     await page.goto('/chat');
     // We use "person" parameter as a "name" for the chat room.
     await page.locator('#name').fill(person);
-    await page.click('text=Enter chat room');
+    await page.locator('text=Enter chat room').click();
     // Each test will get a "page" that already has the person name.
     await use(page);
   },

--- a/docs/src/test-retries-js.md
+++ b/docs/src/test-retries-js.md
@@ -213,7 +213,7 @@ test('runs first', async () => {
 });
 
 test('runs second', async () => {
-  await page.click('text=Get Started');
+  await page.locator('text=Get Started').click();
 });
 ```
 
@@ -239,6 +239,6 @@ test('runs first', async () => {
 });
 
 test('runs second', async () => {
-  await page.click('text=Get Started');
+  await page.locator('text=Get Started').click();
 });
 ```

--- a/docs/src/test-runners-java.md
+++ b/docs/src/test-runners-java.md
@@ -63,23 +63,23 @@ public class TestExample {
   @Test
   void shouldClickButton() {
     page.navigate("data:text/html,<script>var result;</script><button onclick='result=\"Clicked\"'>Go</button>");
-    page.click("button");
+    page.locator("button").click();
     assertEquals("Clicked", page.evaluate("result"));
   }
 
   @Test
   void shouldCheckTheBox() {
     page.setContent("<input id='checkbox' type='checkbox'></input>");
-    page.check("input");
+    page.locator("input").check();
     assertTrue((Boolean) page.evaluate("() => window['checkbox'].checked"));
   }
 
   @Test
   void shouldSearchWiki() {
     page.navigate("https://www.wikipedia.org/");
-    page.click("input[name=\"search\"]");
-    page.fill("input[name=\"search\"]", "playwright");
-    page.press("input[name=\"search\"]", "Enter");
+    page.locator("input[name=\"search\"]").click();
+    page.locator("input[name=\"search\"]").fill( "playwright");
+    page.locator("input[name=\"search\"]").press( "Enter");
     assertEquals("https://en.wikipedia.org/wiki/Playwright", page.url());
   }
 }
@@ -137,23 +137,23 @@ class Test1 extends TestFixtures {
   @Test
   void shouldClickButton() {
     page.navigate("data:text/html,<script>var result;</script><button onclick='result=\"Clicked\"'>Go</button>");
-    page.click("button");
+    page.locator("button").click();
     assertEquals("Clicked", page.evaluate("result"));
   }
 
   @Test
   void shouldCheckTheBox() {
     page.setContent("<input id='checkbox' type='checkbox'></input>");
-    page.check("input");
+    page.locator("input").check();
     assertTrue((Boolean) page.evaluate("() => window['checkbox'].checked"));
   }
 
   @Test
   void shouldSearchWiki() {
     page.navigate("https://www.wikipedia.org/");
-    page.click("input[name=\"search\"]");
-    page.fill("input[name=\"search\"]", "playwright");
-    page.press("input[name=\"search\"]", "Enter");
+    page.locator("input[name=\"search\"]").click();
+    page.locator("input[name=\"search\"]").fill( "playwright");
+    page.locator("input[name=\"search\"]").press( "Enter");
     assertEquals("https://en.wikipedia.org/wiki/Playwright", page.url());
   }
 }
@@ -162,7 +162,7 @@ class Test2 extends TestFixtures {
   @Test
   void shouldReturnInnerHTML() {
     page.setContent("<div>hello</div>");
-    assertEquals("hello", page.innerHTML("css=div"));
+    assertEquals("hello", page.locator("css=div")).innerHTML();
   }
 
   @Test

--- a/docs/src/test-snapshots-js.md
+++ b/docs/src/test-snapshots-js.md
@@ -122,7 +122,7 @@ const { test, expect } = require('@playwright/test');
 
 test('example test', async ({ page }) => {
   await page.goto('https://playwright.dev');
-  expect(await page.textContent('.hero__title')).toMatchSnapshot('hero.txt');
+  expect(await page.locator('.hero__title')).toMatchSnapshot('hero.txt').textContent();
 });
 ```
 
@@ -132,7 +132,7 @@ import { test, expect } from '@playwright/test';
 
 test('example test', async ({ page }) => {
   await page.goto('https://playwright.dev');
-  expect(await page.textContent('.hero__title')).toMatchSnapshot('hero.txt');
+  expect(await page.locator('.hero__title')).toMatchSnapshot('hero.txt').textContent();
 });
 ```
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -589,6 +589,9 @@ export interface Page {
   waitForFunction<R>(pageFunction: PageFunction<void, R>, arg?: any, options?: PageWaitForFunctionOptions): Promise<SmartHandle<R>>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -616,11 +619,15 @@ export interface Page {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector<K extends keyof HTMLElementTagNameMap>(selector: K, options?: PageWaitForSelectorOptionsNotHidden): Promise<ElementHandleForTag<K>>;
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -648,11 +655,15 @@ export interface Page {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector(selector: string, options?: PageWaitForSelectorOptionsNotHidden): Promise<ElementHandle<SVGElement | HTMLElement>>;
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -680,11 +691,15 @@ export interface Page {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector<K extends keyof HTMLElementTagNameMap>(selector: K, options: PageWaitForSelectorOptions): Promise<ElementHandleForTag<K> | null>;
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -712,6 +727,7 @@ export interface Page {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -1628,6 +1644,9 @@ export interface Page {
   bringToFront(): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method checks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws. If the element is already
@@ -1643,6 +1662,7 @@ export interface Page {
    * zero timeout disables this.
    *
    * Shortcut for main frame's [frame.check(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-check).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -1691,6 +1711,9 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method clicks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -1704,6 +1727,7 @@ export interface Page {
    * zero timeout disables this.
    *
    * Shortcut for main frame's [frame.click(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-click).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -1808,6 +1832,9 @@ export interface Page {
   coverage: Coverage;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method double clicks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -1825,6 +1852,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.dblclick(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-dblclick).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -1889,6 +1917,9 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.dispatchEvent`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element,
    * `click` is dispatched. This is equivalent to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
@@ -1917,6 +1948,7 @@ export interface Page {
    * await page.dispatchEvent('#source', 'dragstart', { dataTransfer });
    * ```
    *
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param type DOM event type: `"click"`, `"dragstart"`, etc.
    * @param eventInit Optional event-specific initialization properties.
@@ -2103,6 +2135,9 @@ export interface Page {
   exposeFunction(name: string, callback: Function): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.fill`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method waits for an element matching `selector`, waits for [actionability](https://playwright.dev/docs/actionability) checks, focuses the
    * element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input
    * field.
@@ -2117,6 +2152,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.fill(selector, value[, options])](https://playwright.dev/docs/api/class-frame#frame-fill).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param value Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
    * @param options
@@ -2150,10 +2186,14 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.focus`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method fetches an element with `selector` and focuses it. If there's no element matching `selector`, the method
    * waits until a matching element appears in the DOM.
    *
    * Shortcut for main frame's [frame.focus(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-focus).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2218,7 +2258,11 @@ export interface Page {
   frames(): Array<Frame>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.getAttribute`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns element attribute value.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param name Attribute name to get the value for.
    * @param options
@@ -2348,6 +2392,9 @@ export interface Page {
   }): Promise<null|Response>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.hover`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method hovers over an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -2361,6 +2408,7 @@ export interface Page {
    * zero timeout disables this.
    *
    * Shortcut for main frame's [frame.hover(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-hover).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2408,7 +2456,11 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.innerHTML`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.innerHTML`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2429,7 +2481,11 @@ export interface Page {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.innerText`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.innerText`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2450,10 +2506,14 @@ export interface Page {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.inputValue`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `input.value` for the selected `<input>` or `<textarea>` or `<select>` element.
    *
    * Throws for non-input elements. However, if the element is inside the `<label>` element that has an associated
    * [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), returns the value of the control.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2474,7 +2534,11 @@ export interface Page {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isChecked`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2500,7 +2564,11 @@ export interface Page {
   isClosed(): boolean;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isDisabled`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is disabled, the opposite of [enabled](https://playwright.dev/docs/actionability#enabled).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2521,7 +2589,11 @@ export interface Page {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isEditable`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [editable](https://playwright.dev/docs/actionability#editable).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2542,7 +2614,11 @@ export interface Page {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isEnabled`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [enabled](https://playwright.dev/docs/actionability#enabled).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2563,8 +2639,12 @@ export interface Page {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isHidden`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is hidden, the opposite of [visible](https://playwright.dev/docs/actionability#visible).  `selector` that does not
    * match any elements is considered hidden.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2585,8 +2665,12 @@ export interface Page {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isVisible`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [visible](https://playwright.dev/docs/actionability#visible). `selector` that does not match any elements is
    * considered not visible.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2806,6 +2890,9 @@ export interface Page {
   }): Promise<Buffer>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.press`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Focuses the element, and then uses [keyboard.down(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-down)
    * and [keyboard.up(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-up).
    *
@@ -2838,6 +2925,7 @@ export interface Page {
    * await browser.close();
    * ```
    *
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param key Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
    * @param options
@@ -2972,6 +3060,9 @@ export interface Page {
   screenshot(options?: PageScreenshotOptions): Promise<Buffer>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.selectOption`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method waits for an element matching `selector`, waits for [actionability](https://playwright.dev/docs/actionability) checks, waits until
    * all specified options are present in the `<select>` element and selects these options.
    *
@@ -2997,6 +3088,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.selectOption(selector, values[, options])](https://playwright.dev/docs/api/class-frame#frame-select-option).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param values Options to select. If the `<select>` has the `multiple` attribute, all matching options are selected, otherwise only the first option matching one of the passed options is selected. String values are equivalent to `{value:'string'}`. Option
    * is considered matching if all specified properties match.
@@ -3061,6 +3153,9 @@ export interface Page {
   }): Promise<Array<string>>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.setChecked`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method checks or unchecks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws.
@@ -3077,6 +3172,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.setChecked(selector, checked[, options])](https://playwright.dev/docs/api/class-frame#frame-set-checked).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param checked Whether to check or uncheck the checkbox.
    * @param options
@@ -3192,6 +3288,9 @@ export interface Page {
   setExtraHTTPHeaders(headers: { [key: string]: string; }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.setInputFiles`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then they
    * are resolved relative to the current working directory. For empty array, clears the selected files.
    *
@@ -3199,6 +3298,7 @@ export interface Page {
    * [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input). However, if the element is inside the
    * `<label>` element that has an associated
    * [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), targets the control instead.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param files
    * @param options
@@ -3292,6 +3392,9 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.tap`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method taps an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -3308,6 +3411,7 @@ export interface Page {
    * `hasTouch` option of the browser context be set to true.
    *
    * Shortcut for main frame's [frame.tap(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-tap).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -3362,7 +3466,11 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.textContent`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.textContent`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -3391,6 +3499,9 @@ export interface Page {
   touchscreen: Touchscreen;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.type`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text. `page.type` can be used to send
    * fine-grained keyboard events. To fill values in form fields, use
    * [page.fill(selector, value[, options])](https://playwright.dev/docs/api/class-page#page-fill).
@@ -3405,6 +3516,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.type(selector, text[, options])](https://playwright.dev/docs/api/class-frame#frame-type).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param text A text to type into a focused element.
    * @param options
@@ -3438,6 +3550,9 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method unchecks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws. If the element is already
@@ -3454,6 +3569,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.uncheck(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-uncheck).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -4494,6 +4610,9 @@ export interface Frame {
   waitForFunction<R>(pageFunction: PageFunction<void, R>, arg?: any, options?: PageWaitForFunctionOptions): Promise<SmartHandle<R>>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -4521,11 +4640,15 @@ export interface Frame {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector<K extends keyof HTMLElementTagNameMap>(selector: K, options?: PageWaitForSelectorOptionsNotHidden): Promise<ElementHandleForTag<K>>;
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -4553,11 +4676,15 @@ export interface Frame {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector(selector: string, options?: PageWaitForSelectorOptionsNotHidden): Promise<ElementHandle<SVGElement | HTMLElement>>;
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -4585,11 +4712,15 @@ export interface Frame {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector<K extends keyof HTMLElementTagNameMap>(selector: K, options: PageWaitForSelectorOptions): Promise<ElementHandleForTag<K> | null>;
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -4617,6 +4748,7 @@ export interface Frame {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -4677,6 +4809,9 @@ export interface Frame {
   }): Promise<ElementHandle>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method checks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws. If the element is already
@@ -4690,6 +4825,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -4740,6 +4876,9 @@ export interface Frame {
   childFrames(): Array<Frame>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method clicks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -4751,6 +4890,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -4825,6 +4965,9 @@ export interface Frame {
   content(): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method double clicks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -4839,6 +4982,7 @@ export interface Frame {
    * zero timeout disables this.
    *
    * > NOTE: `frame.dblclick()` dispatches two `click` events and a single `dblclick` event.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -4903,6 +5047,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.dispatchEvent`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element,
    * `click` is dispatched. This is equivalent to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
@@ -4931,6 +5078,7 @@ export interface Frame {
    * await frame.dispatchEvent('#source', 'dragstart', { dataTransfer });
    * ```
    *
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param type DOM event type: `"click"`, `"dragstart"`, etc.
    * @param eventInit Optional event-specific initialization properties.
@@ -5012,6 +5160,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.fill`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method waits for an element matching `selector`, waits for [actionability](https://playwright.dev/docs/actionability) checks, focuses the
    * element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input
    * field.
@@ -5023,6 +5174,7 @@ export interface Frame {
    *
    * To send fine-grained keyboard events, use
    * [frame.type(selector, text[, options])](https://playwright.dev/docs/api/class-frame#frame-type).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param value Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
    * @param options
@@ -5056,8 +5208,12 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.focus`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method fetches an element with `selector` and focuses it. If there's no element matching `selector`, the method
    * waits until a matching element appears in the DOM.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5110,7 +5266,11 @@ export interface Frame {
   frameLocator(selector: string): FrameLocator;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.getAttribute`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns element attribute value.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param name Attribute name to get the value for.
    * @param options
@@ -5181,6 +5341,9 @@ export interface Frame {
   }): Promise<null|Response>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.hover`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method hovers over an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -5192,6 +5355,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5239,7 +5403,11 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.innerHTML`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.innerHTML`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5260,7 +5428,11 @@ export interface Frame {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.innerText`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.innerText`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5281,10 +5453,14 @@ export interface Frame {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.inputValue`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `input.value` for the selected `<input>` or `<textarea>` or `<select>` element.
    *
    * Throws for non-input elements. However, if the element is inside the `<label>` element that has an associated
    * [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), returns the value of the control.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5305,7 +5481,11 @@ export interface Frame {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isChecked`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5331,7 +5511,11 @@ export interface Frame {
   isDetached(): boolean;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isDisabled`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is disabled, the opposite of [enabled](https://playwright.dev/docs/actionability#enabled).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5352,7 +5536,11 @@ export interface Frame {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isEditable`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [editable](https://playwright.dev/docs/actionability#editable).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5373,7 +5561,11 @@ export interface Frame {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isEnabled`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [enabled](https://playwright.dev/docs/actionability#enabled).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5394,8 +5586,12 @@ export interface Frame {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isHidden`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is hidden, the opposite of [visible](https://playwright.dev/docs/actionability#visible).  `selector` that does not
    * match any elements is considered hidden.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5416,8 +5612,12 @@ export interface Frame {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isVisible`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [visible](https://playwright.dev/docs/actionability#visible). `selector` that does not match any elements is
    * considered not visible.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5483,6 +5683,9 @@ export interface Frame {
   parentFrame(): null|Frame;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.press`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * `key` can specify the intended [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)
    * value or a single character to generate the text for. A superset of the `key` values can be found
    * [here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values). Examples of the keys are:
@@ -5499,6 +5702,7 @@ export interface Frame {
    *
    * Shortcuts such as `key: "Control+o"` or `key: "Control+Shift+T"` are supported as well. When specified with the
    * modifier, modifier is pressed and being held while the subsequent key is being pressed.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param key Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
    * @param options
@@ -5532,6 +5736,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.selectOption`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method waits for an element matching `selector`, waits for [actionability](https://playwright.dev/docs/actionability) checks, waits until
    * all specified options are present in the `<select>` element and selects these options.
    *
@@ -5554,6 +5761,7 @@ export interface Frame {
    * frame.selectOption('select#colors', 'red', 'green', 'blue');
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param values Options to select. If the `<select>` has the `multiple` attribute, all matching options are selected, otherwise only the first option matching one of the passed options is selected. String values are equivalent to `{value:'string'}`. Option
    * is considered matching if all specified properties match.
@@ -5618,6 +5826,9 @@ export interface Frame {
   }): Promise<Array<string>>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.setChecked`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method checks or unchecks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws.
@@ -5631,6 +5842,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param checked Whether to check or uncheck the checkbox.
    * @param options
@@ -5705,6 +5917,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.setInputFiles`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then they
    * are resolved relative to the current working directory. For empty array, clears the selected files.
    *
@@ -5712,6 +5927,7 @@ export interface Frame {
    * [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input). However, if the element is inside the
    * `<label>` element that has an associated
    * [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), targets the control instead.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param files
    * @param options
@@ -5770,6 +5986,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.tap`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method taps an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -5783,6 +6002,7 @@ export interface Frame {
    * zero timeout disables this.
    *
    * > NOTE: `frame.tap()` requires that the `hasTouch` option of the browser context be set to true.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5837,7 +6057,11 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.textContent`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.textContent`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5863,6 +6087,9 @@ export interface Frame {
   title(): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.type`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text. `frame.type` can be used to
    * send fine-grained keyboard events. To fill values in form fields, use
    * [frame.fill(selector, value[, options])](https://playwright.dev/docs/api/class-frame#frame-fill).
@@ -5875,6 +6102,7 @@ export interface Frame {
    * await frame.type('#mytextarea', 'World', {delay: 100}); // Types slower, like a user
    * ```
    *
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param text A text to type into a focused element.
    * @param options
@@ -5908,6 +6136,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method checks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws. If the element is already
@@ -5921,6 +6152,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -6145,7 +6377,7 @@ export interface BrowserContext {
    *     <button onclick="onClick()">Click me</button>
    *     <div></div>
    *   `);
-   *   await page.click('button');
+   *   await page.locator('button').click();
    * })();
    * ```
    *
@@ -6199,7 +6431,7 @@ export interface BrowserContext {
    *     <button onclick="onClick()">Click me</button>
    *     <div></div>
    *   `);
-   *   await page.click('button');
+   *   await page.locator('button').click();
    * })();
    * ```
    *
@@ -6255,7 +6487,7 @@ export interface BrowserContext {
    * ```js
    * const [newPage] = await Promise.all([
    *   context.waitForEvent('page'),
-   *   page.click('a[target=_blank]'),
+   *   page.locator('a[target=_blank]').click(),
    * ]);
    * console.log(await newPage.evaluate('location.href'));
    * ```
@@ -6382,7 +6614,7 @@ export interface BrowserContext {
    * ```js
    * const [newPage] = await Promise.all([
    *   context.waitForEvent('page'),
-   *   page.click('a[target=_blank]'),
+   *   page.locator('a[target=_blank]').click(),
    * ]);
    * console.log(await newPage.evaluate('location.href'));
    * ```
@@ -6684,7 +6916,7 @@ export interface BrowserContext {
    *     <button onclick="onClick()">Click me</button>
    *     <div></div>
    *   `);
-   *   await page.click('button');
+   *   await page.locator('button').click();
    * })();
    * ```
    *
@@ -6985,7 +7217,7 @@ export interface BrowserContext {
    * ```js
    * const [newPage] = await Promise.all([
    *   context.waitForEvent('page'),
-   *   page.click('a[target=_blank]'),
+   *   page.locator('a[target=_blank]').click(),
    * ]);
    * console.log(await newPage.evaluate('location.href'));
    * ```
@@ -14865,7 +15097,7 @@ export interface Selectors {
    *   // Use the selector prefixed with its name.
    *   const button = page.locator('tag=button');
    *   // Combine it with other selector engines.
-   *   await page.click('tag=div >> text="Click me"');
+   *   await page.locator('tag=div >> text="Click me"').click();
    *   // Can use it in any methods supporting selectors.
    *   const buttonCount = await page.locator('tag=button').count();
    *
@@ -14982,7 +15214,7 @@ export interface Tracing {
    * await page.goto('https://playwright.dev');
    *
    * await context.tracing.startChunk();
-   * await page.click('text=Get Started');
+   * await page.locator('text=Get Started').click();
    * // Everything between startChunk and stopChunk will be recorded in the trace.
    * await context.tracing.stopChunk({ path: 'trace1.zip' });
    *

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -1720,7 +1720,7 @@ interface TestFunction<TestArgs> {
  *
  * test('basic test', async ({ page }) => {
  *   await page.goto('https://playwright.dev/');
- *   const name = await page.innerText('.navbar__title');
+ *   const name = await page.locator('.navbar__title').innerText();
  *   expect(name).toBe('Playwright');
  * });
  * ```
@@ -2853,9 +2853,9 @@ export interface PlaywrightTestArgs {
    *
    * test('basic test', async ({ page }) => {
    *   await page.goto('/signin');
-   *   await page.fill('#username', 'User');
-   *   await page.fill('#password', 'pwd');
-   *   await page.click('text=Sign in');
+   *   await page.locator('#username').fill( 'User');
+   *   await page.locator('#password').fill( 'pwd');
+   *   await page.locator('text=Sign in').click();
    *   // ...
    * });
    * ```
@@ -3017,7 +3017,7 @@ interface APIResponseAssertions {
  *
  * test('status becomes submitted', async ({ page }) => {
  *   // ...
- *   await page.click('#submit-button');
+ *   await page.locator('#submit-button').click();
  *   await expect(page.locator('.status')).toHaveText('Submitted');
  * });
  * ```
@@ -3543,7 +3543,7 @@ interface LocatorAssertions {
  *
  * test('navigates to login', async ({ page }) => {
  *   // ...
- *   await page.click('#login');
+ *   await page.locator('#login').click();
  *   await expect(page).toHaveURL(/.*\/login/);
  * });
  * ```

--- a/tests/config/experimental.d.ts
+++ b/tests/config/experimental.d.ts
@@ -591,6 +591,9 @@ export interface Page {
   waitForFunction<R>(pageFunction: PageFunction<void, R>, arg?: any, options?: PageWaitForFunctionOptions): Promise<SmartHandle<R>>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -618,11 +621,15 @@ export interface Page {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector<K extends keyof HTMLElementTagNameMap>(selector: K, options?: PageWaitForSelectorOptionsNotHidden): Promise<ElementHandleForTag<K>>;
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -650,11 +657,15 @@ export interface Page {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector(selector: string, options?: PageWaitForSelectorOptionsNotHidden): Promise<ElementHandle<SVGElement | HTMLElement>>;
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -682,11 +693,15 @@ export interface Page {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector<K extends keyof HTMLElementTagNameMap>(selector: K, options: PageWaitForSelectorOptions): Promise<ElementHandleForTag<K> | null>;
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -714,6 +729,7 @@ export interface Page {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -1630,6 +1646,9 @@ export interface Page {
   bringToFront(): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method checks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws. If the element is already
@@ -1645,6 +1664,7 @@ export interface Page {
    * zero timeout disables this.
    *
    * Shortcut for main frame's [frame.check(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-check).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -1693,6 +1713,9 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method clicks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -1706,6 +1729,7 @@ export interface Page {
    * zero timeout disables this.
    *
    * Shortcut for main frame's [frame.click(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-click).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -1810,6 +1834,9 @@ export interface Page {
   coverage: Coverage;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method double clicks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -1827,6 +1854,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.dblclick(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-dblclick).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -1891,6 +1919,9 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.dispatchEvent`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element,
    * `click` is dispatched. This is equivalent to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
@@ -1919,6 +1950,7 @@ export interface Page {
    * await page.dispatchEvent('#source', 'dragstart', { dataTransfer });
    * ```
    *
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param type DOM event type: `"click"`, `"dragstart"`, etc.
    * @param eventInit Optional event-specific initialization properties.
@@ -2105,6 +2137,9 @@ export interface Page {
   exposeFunction(name: string, callback: Function): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.fill`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method waits for an element matching `selector`, waits for [actionability](https://playwright.dev/docs/actionability) checks, focuses the
    * element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input
    * field.
@@ -2119,6 +2154,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.fill(selector, value[, options])](https://playwright.dev/docs/api/class-frame#frame-fill).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param value Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
    * @param options
@@ -2152,10 +2188,14 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.focus`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method fetches an element with `selector` and focuses it. If there's no element matching `selector`, the method
    * waits until a matching element appears in the DOM.
    *
    * Shortcut for main frame's [frame.focus(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-focus).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2220,7 +2260,11 @@ export interface Page {
   frames(): Array<Frame>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.getAttribute`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns element attribute value.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param name Attribute name to get the value for.
    * @param options
@@ -2350,6 +2394,9 @@ export interface Page {
   }): Promise<null|Response>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.hover`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method hovers over an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -2363,6 +2410,7 @@ export interface Page {
    * zero timeout disables this.
    *
    * Shortcut for main frame's [frame.hover(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-hover).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2410,7 +2458,11 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.innerHTML`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.innerHTML`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2431,7 +2483,11 @@ export interface Page {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.innerText`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.innerText`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2452,10 +2508,14 @@ export interface Page {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.inputValue`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `input.value` for the selected `<input>` or `<textarea>` or `<select>` element.
    *
    * Throws for non-input elements. However, if the element is inside the `<label>` element that has an associated
    * [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), returns the value of the control.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2476,7 +2536,11 @@ export interface Page {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isChecked`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2502,7 +2566,11 @@ export interface Page {
   isClosed(): boolean;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isDisabled`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is disabled, the opposite of [enabled](https://playwright.dev/docs/actionability#enabled).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2523,7 +2591,11 @@ export interface Page {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isEditable`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [editable](https://playwright.dev/docs/actionability#editable).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2544,7 +2616,11 @@ export interface Page {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isEnabled`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [enabled](https://playwright.dev/docs/actionability#enabled).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2565,8 +2641,12 @@ export interface Page {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isHidden`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is hidden, the opposite of [visible](https://playwright.dev/docs/actionability#visible).  `selector` that does not
    * match any elements is considered hidden.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2587,8 +2667,12 @@ export interface Page {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.isVisible`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [visible](https://playwright.dev/docs/actionability#visible). `selector` that does not match any elements is
    * considered not visible.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -2808,6 +2892,9 @@ export interface Page {
   }): Promise<Buffer>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.press`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Focuses the element, and then uses [keyboard.down(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-down)
    * and [keyboard.up(key)](https://playwright.dev/docs/api/class-keyboard#keyboard-up).
    *
@@ -2840,6 +2927,7 @@ export interface Page {
    * await browser.close();
    * ```
    *
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param key Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
    * @param options
@@ -2974,6 +3062,9 @@ export interface Page {
   screenshot(options?: PageScreenshotOptions): Promise<Buffer>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.selectOption`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method waits for an element matching `selector`, waits for [actionability](https://playwright.dev/docs/actionability) checks, waits until
    * all specified options are present in the `<select>` element and selects these options.
    *
@@ -2999,6 +3090,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.selectOption(selector, values[, options])](https://playwright.dev/docs/api/class-frame#frame-select-option).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param values Options to select. If the `<select>` has the `multiple` attribute, all matching options are selected, otherwise only the first option matching one of the passed options is selected. String values are equivalent to `{value:'string'}`. Option
    * is considered matching if all specified properties match.
@@ -3063,6 +3155,9 @@ export interface Page {
   }): Promise<Array<string>>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.setChecked`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method checks or unchecks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws.
@@ -3079,6 +3174,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.setChecked(selector, checked[, options])](https://playwright.dev/docs/api/class-frame#frame-set-checked).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param checked Whether to check or uncheck the checkbox.
    * @param options
@@ -3194,6 +3290,9 @@ export interface Page {
   setExtraHTTPHeaders(headers: { [key: string]: string; }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.setInputFiles`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then they
    * are resolved relative to the current working directory. For empty array, clears the selected files.
    *
@@ -3201,6 +3300,7 @@ export interface Page {
    * [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input). However, if the element is inside the
    * `<label>` element that has an associated
    * [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), targets the control instead.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param files
    * @param options
@@ -3294,6 +3394,9 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.tap`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method taps an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -3310,6 +3413,7 @@ export interface Page {
    * `hasTouch` option of the browser context be set to true.
    *
    * Shortcut for main frame's [frame.tap(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-tap).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -3364,7 +3468,11 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.textContent`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.textContent`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -3393,6 +3501,9 @@ export interface Page {
   touchscreen: Touchscreen;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.type`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text. `page.type` can be used to send
    * fine-grained keyboard events. To fill values in form fields, use
    * [page.fill(selector, value[, options])](https://playwright.dev/docs/api/class-page#page-fill).
@@ -3407,6 +3518,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.type(selector, text[, options])](https://playwright.dev/docs/api/class-frame#frame-type).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param text A text to type into a focused element.
    * @param options
@@ -3440,6 +3552,9 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Page.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method unchecks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws. If the element is already
@@ -3456,6 +3571,7 @@ export interface Page {
    *
    * Shortcut for main frame's
    * [frame.uncheck(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-uncheck).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -4496,6 +4612,9 @@ export interface Frame {
   waitForFunction<R>(pageFunction: PageFunction<void, R>, arg?: any, options?: PageWaitForFunctionOptions): Promise<SmartHandle<R>>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -4523,11 +4642,15 @@ export interface Frame {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector<K extends keyof HTMLElementTagNameMap>(selector: K, options?: PageWaitForSelectorOptionsNotHidden): Promise<ElementHandleForTag<K>>;
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -4555,11 +4678,15 @@ export interface Frame {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector(selector: string, options?: PageWaitForSelectorOptionsNotHidden): Promise<ElementHandle<SVGElement | HTMLElement>>;
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -4587,11 +4714,15 @@ export interface Frame {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
   waitForSelector<K extends keyof HTMLElementTagNameMap>(selector: K, options: PageWaitForSelectorOptions): Promise<ElementHandleForTag<K> | null>;
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.waitForSelector`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns when element specified by selector satisfies `state` option. Returns `null` if waiting for `hidden` or
    * `detached`.
    *
@@ -4619,6 +4750,7 @@ export interface Frame {
    * })();
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -4679,6 +4811,9 @@ export interface Frame {
   }): Promise<ElementHandle>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method checks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws. If the element is already
@@ -4692,6 +4827,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -4742,6 +4878,9 @@ export interface Frame {
   childFrames(): Array<Frame>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method clicks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -4753,6 +4892,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -4827,6 +4967,9 @@ export interface Frame {
   content(): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.click`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method double clicks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -4841,6 +4984,7 @@ export interface Frame {
    * zero timeout disables this.
    *
    * > NOTE: `frame.dblclick()` dispatches two `click` events and a single `dblclick` event.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -4905,6 +5049,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.dispatchEvent`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element,
    * `click` is dispatched. This is equivalent to calling
    * [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
@@ -4933,6 +5080,7 @@ export interface Frame {
    * await frame.dispatchEvent('#source', 'dragstart', { dataTransfer });
    * ```
    *
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param type DOM event type: `"click"`, `"dragstart"`, etc.
    * @param eventInit Optional event-specific initialization properties.
@@ -5014,6 +5162,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.fill`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method waits for an element matching `selector`, waits for [actionability](https://playwright.dev/docs/actionability) checks, focuses the
    * element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input
    * field.
@@ -5025,6 +5176,7 @@ export interface Frame {
    *
    * To send fine-grained keyboard events, use
    * [frame.type(selector, text[, options])](https://playwright.dev/docs/api/class-frame#frame-type).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param value Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
    * @param options
@@ -5058,8 +5210,12 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.focus`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method fetches an element with `selector` and focuses it. If there's no element matching `selector`, the method
    * waits until a matching element appears in the DOM.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5112,7 +5268,11 @@ export interface Frame {
   frameLocator(selector: string): FrameLocator;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.getAttribute`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns element attribute value.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param name Attribute name to get the value for.
    * @param options
@@ -5183,6 +5343,9 @@ export interface Frame {
   }): Promise<null|Response>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.hover`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method hovers over an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -5194,6 +5357,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5241,7 +5405,11 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.innerHTML`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.innerHTML`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5262,7 +5430,11 @@ export interface Frame {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.innerText`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.innerText`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5283,10 +5455,14 @@ export interface Frame {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.inputValue`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `input.value` for the selected `<input>` or `<textarea>` or `<select>` element.
    *
    * Throws for non-input elements. However, if the element is inside the `<label>` element that has an associated
    * [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), returns the value of the control.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5307,7 +5483,11 @@ export interface Frame {
   }): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isChecked`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5333,7 +5513,11 @@ export interface Frame {
   isDetached(): boolean;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isDisabled`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is disabled, the opposite of [enabled](https://playwright.dev/docs/actionability#enabled).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5354,7 +5538,11 @@ export interface Frame {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isEditable`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [editable](https://playwright.dev/docs/actionability#editable).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5375,7 +5563,11 @@ export interface Frame {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isEnabled`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [enabled](https://playwright.dev/docs/actionability#enabled).
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5396,8 +5588,12 @@ export interface Frame {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isHidden`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is hidden, the opposite of [visible](https://playwright.dev/docs/actionability#visible).  `selector` that does not
    * match any elements is considered hidden.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5418,8 +5614,12 @@ export interface Frame {
   }): Promise<boolean>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.isVisible`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns whether the element is [visible](https://playwright.dev/docs/actionability#visible). `selector` that does not match any elements is
    * considered not visible.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5485,6 +5685,9 @@ export interface Frame {
   parentFrame(): null|Frame;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.press`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * `key` can specify the intended [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)
    * value or a single character to generate the text for. A superset of the `key` values can be found
    * [here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values). Examples of the keys are:
@@ -5501,6 +5704,7 @@ export interface Frame {
    *
    * Shortcuts such as `key: "Control+o"` or `key: "Control+Shift+T"` are supported as well. When specified with the
    * modifier, modifier is pressed and being held while the subsequent key is being pressed.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param key Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
    * @param options
@@ -5534,6 +5738,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.selectOption`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method waits for an element matching `selector`, waits for [actionability](https://playwright.dev/docs/actionability) checks, waits until
    * all specified options are present in the `<select>` element and selects these options.
    *
@@ -5556,6 +5763,7 @@ export interface Frame {
    * frame.selectOption('select#colors', 'red', 'green', 'blue');
    * ```
    *
+   * @deprecated
    * @param selector A selector to query for. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param values Options to select. If the `<select>` has the `multiple` attribute, all matching options are selected, otherwise only the first option matching one of the passed options is selected. String values are equivalent to `{value:'string'}`. Option
    * is considered matching if all specified properties match.
@@ -5620,6 +5828,9 @@ export interface Frame {
   }): Promise<Array<string>>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.setChecked`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method checks or unchecks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws.
@@ -5633,6 +5844,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param checked Whether to check or uncheck the checkbox.
    * @param options
@@ -5707,6 +5919,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.setInputFiles`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then they
    * are resolved relative to the current working directory. For empty array, clears the selected files.
    *
@@ -5714,6 +5929,7 @@ export interface Frame {
    * [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input). However, if the element is inside the
    * `<label>` element that has an associated
    * [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), targets the control instead.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param files
    * @param options
@@ -5772,6 +5988,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.tap`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method taps an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Wait for [actionability](https://playwright.dev/docs/actionability) checks on the matched element, unless `force` option is set. If the
@@ -5785,6 +6004,7 @@ export interface Frame {
    * zero timeout disables this.
    *
    * > NOTE: `frame.tap()` requires that the `hasTouch` option of the browser context be set to true.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5839,7 +6059,11 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.textContent`] instead.
+   * [`Locator`]'s are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Returns `element.textContent`.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -5865,6 +6089,9 @@ export interface Frame {
   title(): Promise<string>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.type`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text. `frame.type` can be used to
    * send fine-grained keyboard events. To fill values in form fields, use
    * [frame.fill(selector, value[, options])](https://playwright.dev/docs/api/class-frame#frame-fill).
@@ -5877,6 +6104,7 @@ export interface Frame {
    * await frame.type('#mytextarea', 'World', {delay: 100}); // Types slower, like a user
    * ```
    *
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param text A text to type into a focused element.
    * @param options
@@ -5910,6 +6138,9 @@ export interface Frame {
   }): Promise<void>;
 
   /**
+   * **DEPRECATED**: Use [`async method: Frame.locator`] combined with [`async method: Locator.check`] instead. [`Locator`]'s
+   * are strict by default, so they help avoid selecting an unexpected element due to an ambiguous selector.
+   *
    * This method checks an element matching `selector` by performing the following steps:
    * 1. Find an element matching `selector`. If there is none, wait until a matching element is attached to the DOM.
    * 1. Ensure that matched element is a checkbox or a radio input. If not, this method throws. If the element is already
@@ -5923,6 +6154,7 @@ export interface Frame {
    *
    * When all steps combined have not finished during the specified `timeout`, this method throws a [TimeoutError]. Passing
    * zero timeout disables this.
+   * @deprecated
    * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](https://playwright.dev/docs/selectors) for more details.
    * @param options
    */
@@ -6147,7 +6379,7 @@ export interface BrowserContext {
    *     <button onclick="onClick()">Click me</button>
    *     <div></div>
    *   `);
-   *   await page.click('button');
+   *   await page.locator('button').click();
    * })();
    * ```
    *
@@ -6201,7 +6433,7 @@ export interface BrowserContext {
    *     <button onclick="onClick()">Click me</button>
    *     <div></div>
    *   `);
-   *   await page.click('button');
+   *   await page.locator('button').click();
    * })();
    * ```
    *
@@ -6257,7 +6489,7 @@ export interface BrowserContext {
    * ```js
    * const [newPage] = await Promise.all([
    *   context.waitForEvent('page'),
-   *   page.click('a[target=_blank]'),
+   *   page.locator('a[target=_blank]').click(),
    * ]);
    * console.log(await newPage.evaluate('location.href'));
    * ```
@@ -6384,7 +6616,7 @@ export interface BrowserContext {
    * ```js
    * const [newPage] = await Promise.all([
    *   context.waitForEvent('page'),
-   *   page.click('a[target=_blank]'),
+   *   page.locator('a[target=_blank]').click(),
    * ]);
    * console.log(await newPage.evaluate('location.href'));
    * ```
@@ -6686,7 +6918,7 @@ export interface BrowserContext {
    *     <button onclick="onClick()">Click me</button>
    *     <div></div>
    *   `);
-   *   await page.click('button');
+   *   await page.locator('button').click();
    * })();
    * ```
    *
@@ -6987,7 +7219,7 @@ export interface BrowserContext {
    * ```js
    * const [newPage] = await Promise.all([
    *   context.waitForEvent('page'),
-   *   page.click('a[target=_blank]'),
+   *   page.locator('a[target=_blank]').click(),
    * ]);
    * console.log(await newPage.evaluate('location.href'));
    * ```
@@ -14867,7 +15099,7 @@ export interface Selectors {
    *   // Use the selector prefixed with its name.
    *   const button = page.locator('tag=button');
    *   // Combine it with other selector engines.
-   *   await page.click('tag=div >> text="Click me"');
+   *   await page.locator('tag=div >> text="Click me"').click();
    *   // Can use it in any methods supporting selectors.
    *   const buttonCount = await page.locator('tag=button').count();
    *
@@ -14984,7 +15216,7 @@ export interface Tracing {
    * await page.goto('https://playwright.dev');
    *
    * await context.tracing.startChunk();
-   * await page.click('text=Get Started');
+   * await page.locator('text=Get Started').click();
    * // Everything between startChunk and stopChunk will be recorded in the trace.
    * await context.tracing.stopChunk({ path: 'trace1.zip' });
    *
@@ -17940,7 +18172,7 @@ interface TestFunction<TestArgs> {
  *
  * test('basic test', async ({ page }) => {
  *   await page.goto('https://playwright.dev/');
- *   const name = await page.innerText('.navbar__title');
+ *   const name = await page.locator('.navbar__title').innerText();
  *   expect(name).toBe('Playwright');
  * });
  * ```
@@ -19073,9 +19305,9 @@ export interface PlaywrightTestArgs {
    *
    * test('basic test', async ({ page }) => {
    *   await page.goto('/signin');
-   *   await page.fill('#username', 'User');
-   *   await page.fill('#password', 'pwd');
-   *   await page.click('text=Sign in');
+   *   await page.locator('#username').fill( 'User');
+   *   await page.locator('#password').fill( 'pwd');
+   *   await page.locator('text=Sign in').click();
    *   // ...
    * });
    * ```
@@ -19229,7 +19461,7 @@ interface APIResponseAssertions {
  *
  * test('status becomes submitted', async ({ page }) => {
  *   // ...
- *   await page.click('#submit-button');
+ *   await page.locator('#submit-button').click();
  *   await expect(page.locator('.status')).toHaveText('Submitted');
  * });
  * ```
@@ -19755,7 +19987,7 @@ interface LocatorAssertions {
  *
  * test('navigates to login', async ({ page }) => {
  *   // ...
- *   await page.click('#login');
+ *   await page.locator('#login').click();
  *   await expect(page).toHaveURL(/.*\/login/);
  * });
  * ```


### PR DESCRIPTION
Deprecates `page.*` and `frame.*` methods that have a corresponding `Locator` method. Updates doc examples accordingly.