### PR TITLE
docs(python): fix missing await in JS evaluation example

### DIFF
--- a/docs/src/evaluating.md
+++ b/docs/src/evaluating.md
@@ -54,7 +54,7 @@ status = await page.evaluate("""async () => {
 
 ```python sync
 status = page.evaluate("""async () => {
-  response = fetch(location.href)
+  response = await fetch(location.href)
   return response.status
 }""")
 ```
@@ -367,6 +367,6 @@ var data = new { text = "some data", value = 1};
 // Pass data as a parameter
 var result = await page.EvaluateAsync(@"data => {
   // There is no |data| in the web page.
-  window.myApp.use(data); 
+  window.myApp.use(data);
 }");
 ```


### PR DESCRIPTION
```python sync
status = page.evaluate("""async () => {
  response = fetch(location.href)
  return response.status
}""")
```

Currently `status` returned to python in this code example is equal to `None`.

Adding the missing `await` makes the promise resolve and `status=200` is properly returned.