### PR TITLE
docs: fix typo in soft assertions example

### DIFF
--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -61,7 +61,7 @@ await expect.soft(page.locator('#status')).toHaveText('Success');
 await expect.soft(page.locator('#eta')).toHaveText('1 day');
 
 // Avoid running further if there were soft assertion failures.
-expect(test.info().errors).toBeEmpty();
+expect(test.info().errors).toHaveLength(0);
 ```
 
 ## Custom Expect Message


### PR DESCRIPTION
Fixes #14439