### PR TITLE
devops(ff-beta): fix build to use bootstrapped toolchains

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1325
-Changed: lushnikov@chromium.org Thu May 19 17:56:07 +03 2022
+1326
+Changed: lushnikov@chromium.org Tue May 31 10:19:28 +03 2022

--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -109,7 +109,7 @@ if [[ $1 == "--juggler" ]]; then
 elif [[ $1 == "--bootstrap" ]]; then
   ./mach configure
 else
-  ./mach build
+  MOZ_AUTOMATION=1 MOZ_FETCHES_DIR=$HOME/.mozbuild ./mach build
   if is_mac; then
     node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/${OBJ_FOLDER}/dist
   else


### PR DESCRIPTION
This is a follow-up to a7a7644bebd69d68d1803bd7b4cf9771bec4d185
that started bootstrapping toolchains from `master` branch.

Now, we have to explicitly use these toolchains when building
Firefox.
