### PR TITLE
devops: fix firefox-beta build

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1326
-Changed: lushnikov@chromium.org Tue May 31 10:19:28 +03 2022
+1327
+Changed: lushnikov@chromium.org Tue May 31 11:00:16 +03 2022

--- a/browser_patches/firefox-beta/archive.sh
+++ b/browser_patches/firefox-beta/archive.sh
@@ -40,6 +40,8 @@ OBJ_FOLDER="${FF_CHECKOUT_PATH}/obj-build-playwright"
 
 cd "${FF_CHECKOUT_PATH}"
 
+export MH_BRANCH=mozilla-beta
+export MOZ_BUILD_DATE=$(date +%Y%m%d%H%M%S)
 if [[ "$2" == "--linux-arm64" ]]; then
   CMD_STRIP=/usr/bin/aarch64-linux-gnu-strip ./mach package
 else

--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -109,7 +109,15 @@ if [[ $1 == "--juggler" ]]; then
 elif [[ $1 == "--bootstrap" ]]; then
   ./mach configure
 else
-  MOZ_AUTOMATION=1 MOZ_FETCHES_DIR=$HOME/.mozbuild ./mach build
+  export MOZ_AUTOMATION=1
+  # Use winpaths instead of unix paths on Windows.
+  # note: 'cygpath' is not available in MozBuild shell.
+  if is_win; then
+    export MOZ_FETCHES_DIR="${USERPROFILE}\\.mozbuild"
+  else
+    export MOZ_FETCHES_DIR="${HOME}/.mozbuild"
+  fi
+  ./mach build
   if is_mac; then
     node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/${OBJ_FOLDER}/dist
   else


### PR DESCRIPTION
This patch:
- fixes firefox-beta archiving that requires 2 extra env variables
- attempts to use windows paths to specify `MOZ_FETCHES_DIR` on
  Windows to point to the toolchains folder.