### PR TITLE
feat: add serviceWorkerPolicy option

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -636,9 +636,14 @@ contexts override the proxy, global proxy will be never used and can be any stri
 ## context-option-strict
 - `strictSelectors` <[boolean]>
 
-It specified, enables strict selectors mode for this context. In the strict selectors mode all operations
+If specified, enables strict selectors mode for this context. In the strict selectors mode all operations
 on selectors that imply single target DOM element will throw when more than one element matches the selector.
 See [Locator] to learn more about the strict mode.
+
+## context-option-service-worker-policy
+- `serviceWorkerPolicy` <[ServiceWorkerPolicy]<"default"|"disabled">>
+
+If set to `disabled`, all Service Worker registrations will be blocked.
 
 ## select-options-values
 * langs: java, js, csharp
@@ -795,6 +800,7 @@ An acceptable perceived color difference in the [YIQ color space](https://en.wik
 - %%-context-option-recordvideo-dir-%%
 - %%-context-option-recordvideo-size-%%
 - %%-context-option-strict-%%
+- %%-context-option-service-worker-policy-%%
 
 ## browser-option-args
 - `args` <[Array]<[string]>>
@@ -1019,4 +1025,3 @@ When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, 
 - %%-screenshot-option-type-%%
 - %%-screenshot-option-mask-%%
 - %%-input-timeout-%%
-

--- a/docs/src/test-api/class-testoptions.md
+++ b/docs/src/test-api/class-testoptions.md
@@ -215,3 +215,4 @@ Learn more about [recording video](../test-configuration.md#record-video).
 
 ## property: TestOptions.viewport = %%-context-option-viewport-%%
 
+## property: TestOptions.serviceWorkerPolicy = %%-context-option-service-worker-policy-%%

--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -5,39 +5,9 @@ THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 This project incorporates components from the projects listed below. The original copyright notices and the licenses under which Microsoft received such components are set forth below. Microsoft reserves all rights not expressly granted herein, whether by implication, estoppel or otherwise.
 
 -	agent-base@6.0.2 (https://github.com/TooTallNate/node-agent-base)
--	balanced-match@1.0.2 (https://github.com/juliangruber/balanced-match)
--	brace-expansion@1.1.11 (https://github.com/juliangruber/brace-expansion)
--	colors@1.4.0 (https://github.com/Marak/colors.js)
--	commander@8.3.0 (https://github.com/tj/commander.js)
--	concat-map@0.0.1 (https://github.com/substack/node-concat-map)
 -	debug@4.3.4 (https://github.com/debug-js/debug)
--	escape-string-regexp@2.0.0 (https://github.com/sindresorhus/escape-string-regexp)
--	fs.realpath@1.0.0 (https://github.com/isaacs/fs.realpath)
--	glob@7.2.0 (https://github.com/isaacs/node-glob)
--	graceful-fs@4.2.10 (https://github.com/isaacs/node-graceful-fs)
--	https-proxy-agent@5.0.0 (https://github.com/TooTallNate/node-https-proxy-agent)
--	inflight@1.0.6 (https://github.com/npm/inflight)
--	inherits@2.0.4 (https://github.com/isaacs/inherits)
--	ip@1.1.5 (https://github.com/indutny/node-ip)
--	jpeg-js@0.4.3 (https://github.com/eugeneware/jpeg-js)
--	mime@3.0.0 (https://github.com/broofa/mime)
--	minimatch@3.1.2 (https://github.com/isaacs/minimatch)
--	ms@2.1.2 (https://github.com/zeit/ms)
--	once@1.4.0 (https://github.com/isaacs/once)
--	path-is-absolute@1.0.1 (https://github.com/sindresorhus/path-is-absolute)
--	pngjs@6.0.0 (https://github.com/lukeapage/pngjs)
--	progress@2.0.3 (https://github.com/visionmedia/node-progress)
--	proper-lockfile@4.1.2 (https://github.com/moxystudio/node-proper-lockfile)
--	proxy-from-env@1.1.0 (https://github.com/Rob--W/proxy-from-env)
--	retry@0.12.0 (https://github.com/tim-kos/node-retry)
--	rimraf@3.0.2 (https://github.com/isaacs/rimraf)
--	signal-exit@3.0.7 (https://github.com/tapjs/signal-exit)
--	smart-buffer@4.2.0 (https://github.com/JoshGlazebrook/smart-buffer)
 -	socks-proxy-agent@6.1.1 (https://github.com/TooTallNate/node-socks-proxy-agent)
 -	socks@2.6.2 (https://github.com/JoshGlazebrook/socks)
--	stack-utils@2.0.5 (https://github.com/tapjs/stack-utils)
--	wrappy@1.0.2 (https://github.com/npm/wrappy)
--	ws@8.4.2 (https://github.com/websockets/ws)
 -	@types/node@17.0.24 (https://github.com/DefinitelyTyped/DefinitelyTyped)
 -	@types/yauzl@2.10.0 (https://github.com/DefinitelyTyped/DefinitelyTyped)
 -	buffer-crc32@0.2.13 (https://github.com/brianloveswords/buffer-crc32)
@@ -45,8 +15,11 @@ This project incorporates components from the projects listed below. The origina
 -	extract-zip@2.0.1 (https://github.com/maxogden/extract-zip)
 -	fd-slicer@1.1.0 (https://github.com/andrewrk/node-fd-slicer)
 -	get-stream@5.2.0 (https://github.com/sindresorhus/get-stream)
+-	ms@2.1.2 (https://github.com/zeit/ms)
+-	once@1.4.0 (https://github.com/isaacs/once)
 -	pend@1.2.0 (https://github.com/andrewrk/node-pend)
 -	pump@3.0.0 (https://github.com/mafintosh/pump)
+-	wrappy@1.0.2 (https://github.com/npm/wrappy)
 -	yauzl@2.10.0 (https://github.com/thejoshwolfe/yauzl)
 -	yazl@2.5.1 (https://github.com/thejoshwolfe/yazl)
 
@@ -200,138 +173,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF agent-base@6.0.2 AND INFORMATION
 
-%% balanced-match@1.0.2 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-(MIT)
-
-Copyright (c) 2013 Julian Gruber &lt;julian@juliangruber.com&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-=========================================
-END OF balanced-match@1.0.2 AND INFORMATION
-
-%% brace-expansion@1.1.11 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-MIT License
-
-Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-=========================================
-END OF brace-expansion@1.1.11 AND INFORMATION
-
-%% colors@1.4.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-MIT License
-
-Original Library
-  - Copyright (c) Marak Squires
-
-Additional Functionality
- - Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-=========================================
-END OF colors@1.4.0 AND INFORMATION
-
-%% commander@8.3.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-(The MIT License)
-
-Copyright (c) 2011 TJ Holowaychuk <tj@vision-media.ca>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=========================================
-END OF commander@8.3.0 AND INFORMATION
-
-%% concat-map@0.0.1 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-This software is released under the MIT license:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=========================================
-END OF concat-map@0.0.1 AND INFORMATION
-
 %% debug@4.3.4 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 (The MIT License)
@@ -355,734 +196,6 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF debug@4.3.4 AND INFORMATION
-
-%% escape-string-regexp@2.0.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=========================================
-END OF escape-string-regexp@2.0.0 AND INFORMATION
-
-%% fs.realpath@1.0.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-----
-
-This library bundles a version of the `fs.realpath` and `fs.realpathSync`
-methods from Node.js v0.10 under the terms of the Node.js MIT license.
-
-Node's license follows, also included at the header of `old.js` which contains
-the licensed code:
-
-  Copyright Joyent, Inc. and other Node contributors.
-
-  Permission is hereby granted, free of charge, to any person obtaining a
-  copy of this software and associated documentation files (the "Software"),
-  to deal in the Software without restriction, including without limitation
-  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-  and/or sell copies of the Software, and to permit persons to whom the
-  Software is furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-  DEALINGS IN THE SOFTWARE.
-=========================================
-END OF fs.realpath@1.0.0 AND INFORMATION
-
-%% glob@7.2.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-## Glob Logo
-
-Glob's logo created by Tanya Brassie <http://tanyabrassie.com/>, licensed
-under a Creative Commons Attribution-ShareAlike 4.0 International License
-https://creativecommons.org/licenses/by-sa/4.0/
-=========================================
-END OF glob@7.2.0 AND INFORMATION
-
-%% graceful-fs@4.2.10 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) 2011-2022 Isaac Z. Schlueter, Ben Noordhuis, and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-=========================================
-END OF graceful-fs@4.2.10 AND INFORMATION
-
-%% https-proxy-agent@5.0.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-https-proxy-agent
-================
-### An HTTP(s) proxy `http.Agent` implementation for HTTPS
-[![Build Status](https://github.com/TooTallNate/node-https-proxy-agent/workflows/Node%20CI/badge.svg)](https://github.com/TooTallNate/node-https-proxy-agent/actions?workflow=Node+CI)
-
-This module provides an `http.Agent` implementation that connects to a specified
-HTTP or HTTPS proxy server, and can be used with the built-in `https` module.
-
-Specifically, this `Agent` implementation connects to an intermediary "proxy"
-server and issues the [CONNECT HTTP method][CONNECT], which tells the proxy to
-open a direct TCP connection to the destination server.
-
-Since this agent implements the CONNECT HTTP method, it also works with other
-protocols that use this method when connecting over proxies (i.e. WebSockets).
-See the "Examples" section below for more.
-
-
-Installation
-------------
-
-Install with `npm`:
-
-``` bash
-$ npm install https-proxy-agent
-```
-
-
-Examples
---------
-
-#### `https` module example
-
-``` js
-var url = require('url');
-var https = require('https');
-var HttpsProxyAgent = require('https-proxy-agent');
-
-// HTTP/HTTPS proxy to connect to
-var proxy = process.env.http_proxy || 'http://168.63.76.32:3128';
-console.log('using proxy server %j', proxy);
-
-// HTTPS endpoint for the proxy to connect to
-var endpoint = process.argv[2] || 'https://graph.facebook.com/tootallnate';
-console.log('attempting to GET %j', endpoint);
-var options = url.parse(endpoint);
-
-// create an instance of the `HttpsProxyAgent` class with the proxy server information
-var agent = new HttpsProxyAgent(proxy);
-options.agent = agent;
-
-https.get(options, function (res) {
-  console.log('"response" event!', res.headers);
-  res.pipe(process.stdout);
-});
-```
-
-#### `ws` WebSocket connection example
-
-``` js
-var url = require('url');
-var WebSocket = require('ws');
-var HttpsProxyAgent = require('https-proxy-agent');
-
-// HTTP/HTTPS proxy to connect to
-var proxy = process.env.http_proxy || 'http://168.63.76.32:3128';
-console.log('using proxy server %j', proxy);
-
-// WebSocket endpoint for the proxy to connect to
-var endpoint = process.argv[2] || 'ws://echo.websocket.org';
-var parsed = url.parse(endpoint);
-console.log('attempting to connect to WebSocket %j', endpoint);
-
-// create an instance of the `HttpsProxyAgent` class with the proxy server information
-var options = url.parse(proxy);
-
-var agent = new HttpsProxyAgent(options);
-
-// finally, initiate the WebSocket connection
-var socket = new WebSocket(endpoint, { agent: agent });
-
-socket.on('open', function () {
-  console.log('"open" event!');
-  socket.send('hello world');
-});
-
-socket.on('message', function (data, flags) {
-  console.log('"message" event! %j %j', data, flags);
-  socket.close();
-});
-```
-
-API
----
-
-### new HttpsProxyAgent(Object options)
-
-The `HttpsProxyAgent` class implements an `http.Agent` subclass that connects
-to the specified "HTTP(s) proxy server" in order to proxy HTTPS and/or WebSocket
-requests. This is achieved by using the [HTTP `CONNECT` method][CONNECT].
-
-The `options` argument may either be a string URI of the proxy server to use, or an
-"options" object with more specific properties:
-
-  * `host` - String - Proxy host to connect to (may use `hostname` as well). Required.
-  * `port` - Number - Proxy port to connect to. Required.
-  * `protocol` - String - If `https:`, then use TLS to connect to the proxy.
-  * `headers` - Object - Additional HTTP headers to be sent on the HTTP CONNECT method.
-  * Any other options given are passed to the `net.connect()`/`tls.connect()` functions.
-
-
-License
--------
-
-(The MIT License)
-
-Copyright (c) 2013 Nathan Rajlich &lt;nathan@tootallnate.net&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-[CONNECT]: http://en.wikipedia.org/wiki/HTTP_tunnel#HTTP_CONNECT_Tunneling
-=========================================
-END OF https-proxy-agent@5.0.0 AND INFORMATION
-
-%% inflight@1.0.6 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-=========================================
-END OF inflight@1.0.6 AND INFORMATION
-
-%% inherits@2.0.4 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THIS SOFTWARE.
-=========================================
-END OF inherits@2.0.4 AND INFORMATION
-
-%% ip@1.1.5 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-# IP  
-[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)  
-
-IP address utilities for node.js
-
-## Installation
-
-###  npm
-```shell
-npm install ip
-```
-
-### git
-
-```shell
-git clone https://github.com/indutny/node-ip.git
-```
-  
-## Usage
-Get your ip address, compare ip addresses, validate ip addresses, etc.
-
-```js
-var ip = require('ip');
-
-ip.address() // my ip address
-ip.isEqual('::1', '::0:1'); // true
-ip.toBuffer('127.0.0.1') // Buffer([127, 0, 0, 1])
-ip.toString(new Buffer([127, 0, 0, 1])) // 127.0.0.1
-ip.fromPrefixLen(24) // 255.255.255.0
-ip.mask('192.168.1.134', '255.255.255.0') // 192.168.1.0
-ip.cidr('192.168.1.134/26') // 192.168.1.128
-ip.not('255.255.255.0') // 0.0.0.255
-ip.or('192.168.1.134', '0.0.0.255') // 192.168.1.255
-ip.isPrivate('127.0.0.1') // true
-ip.isV4Format('127.0.0.1'); // true
-ip.isV6Format('::ffff:127.0.0.1'); // true
-
-// operate on buffers in-place
-var buf = new Buffer(128);
-var offset = 64;
-ip.toBuffer('127.0.0.1', buf, offset);  // [127, 0, 0, 1] at offset 64
-ip.toString(buf, offset, 4);            // '127.0.0.1'
-
-// subnet information
-ip.subnet('192.168.1.134', '255.255.255.192')
-// { networkAddress: '192.168.1.128',
-//   firstAddress: '192.168.1.129',
-//   lastAddress: '192.168.1.190',
-//   broadcastAddress: '192.168.1.191',
-//   subnetMask: '255.255.255.192',
-//   subnetMaskLength: 26,
-//   numHosts: 62,
-//   length: 64,
-//   contains: function(addr){...} }
-ip.cidrSubnet('192.168.1.134/26')
-// Same as previous.
-
-// range checking
-ip.cidrSubnet('192.168.1.134/26').contains('192.168.1.190') // true
-
-
-// ipv4 long conversion
-ip.toLong('127.0.0.1'); // 2130706433
-ip.fromLong(2130706433); // '127.0.0.1'
-```
-
-### License
-
-This software is licensed under the MIT License.
-
-Copyright Fedor Indutny, 2012.
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to permit
-persons to whom the Software is furnished to do so, subject to the
-following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-USE OR OTHER DEALINGS IN THE SOFTWARE.
-=========================================
-END OF ip@1.1.5 AND INFORMATION
-
-%% jpeg-js@0.4.3 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-Copyright (c) 2014, Eugene Ware
-All rights reserved.
-  
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:  
-
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.  
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.  
-3. Neither the name of Eugene Ware nor the names of its contributors
-   may be used to endorse or promote products derived from this software
-   without specific prior written permission.  
-  
-THIS SOFTWARE IS PROVIDED BY EUGENE WARE ''AS IS'' AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL EUGENE WARE BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-=========================================
-END OF jpeg-js@0.4.3 AND INFORMATION
-
-%% mime@3.0.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The MIT License (MIT)
-
-Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-=========================================
-END OF mime@3.0.0 AND INFORMATION
-
-%% minimatch@3.1.2 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-=========================================
-END OF minimatch@3.1.2 AND INFORMATION
-
-%% ms@2.1.2 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The MIT License (MIT)
-
-Copyright (c) 2016 Zeit, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-=========================================
-END OF ms@2.1.2 AND INFORMATION
-
-%% once@1.4.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-=========================================
-END OF once@1.4.0 AND INFORMATION
-
-%% path-is-absolute@1.0.1 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The MIT License (MIT)
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-=========================================
-END OF path-is-absolute@1.0.1 AND INFORMATION
-
-%% pngjs@6.0.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
-pngjs derived work Copyright (c) 2012 Kuba Niegowski
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-=========================================
-END OF pngjs@6.0.0 AND INFORMATION
-
-%% progress@2.0.3 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-(The MIT License)
-
-Copyright (c) 2017 TJ Holowaychuk <tj@vision-media.ca>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=========================================
-END OF progress@2.0.3 AND INFORMATION
-
-%% proper-lockfile@4.1.2 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The MIT License (MIT)
-
-Copyright (c) 2018 Made With MOXY Lda <hello@moxy.studio>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-=========================================
-END OF proper-lockfile@4.1.2 AND INFORMATION
-
-%% proxy-from-env@1.1.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The MIT License
-
-Copyright (C) 2016-2018 Rob Wu <rob@robwu.nl>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=========================================
-END OF proxy-from-env@1.1.0 AND INFORMATION
-
-%% retry@0.12.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-Copyright (c) 2011:
-Tim Koschützki (tim@debuggable.com)
-Felix Geisendörfer (felix@debuggable.com)
-
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
-
- The above copyright notice and this permission notice shall be included in
- all copies or substantial portions of the Software.
-
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- THE SOFTWARE.
-=========================================
-END OF retry@0.12.0 AND INFORMATION
-
-%% rimraf@3.0.2 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-=========================================
-END OF rimraf@3.0.2 AND INFORMATION
-
-%% signal-exit@3.0.7 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) 2015, Contributors
-
-Permission to use, copy, modify, and/or distribute this software
-for any purpose with or without fee is hereby granted, provided
-that the above copyright notice and this permission notice
-appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE
-LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
-OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
-WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
-ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-=========================================
-END OF signal-exit@3.0.7 AND INFORMATION
-
-%% smart-buffer@4.2.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The MIT License (MIT)
-
-Copyright (c) 2013-2017 Josh Glazebrook
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=========================================
-END OF smart-buffer@4.2.0 AND INFORMATION
 
 %% socks-proxy-agent@6.1.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1243,98 +356,692 @@ END OF socks-proxy-agent@6.1.1 AND INFORMATION
 
 %% socks@2.6.2 NOTICES AND INFORMATION BEGIN HERE
 =========================================
-The MIT License (MIT)
+# socks  [![Build Status](https://travis-ci.org/JoshGlazebrook/socks.svg?branch=master)](https://travis-ci.org/JoshGlazebrook/socks)  [![Coverage Status](https://coveralls.io/repos/github/JoshGlazebrook/socks/badge.svg?branch=master)](https://coveralls.io/github/JoshGlazebrook/socks?branch=v2)
 
-Copyright (c) 2013 Josh Glazebrook
+Fully featured SOCKS proxy client supporting SOCKSv4, SOCKSv4a, and SOCKSv5. Includes Bind and Associate functionality.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
+### Features
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+* Supports SOCKS v4, v4a, v5, and v5h protocols.
+* Supports the CONNECT, BIND, and ASSOCIATE commands.
+* Supports callbacks, promises, and events for proxy connection creation async flow control.
+* Supports proxy chaining (CONNECT only).
+* Supports user/password authentication.
+* Supports custom authentication.
+* Built in UDP frame creation & parse functions.
+* Created with TypeScript, type definitions are provided.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+### Requirements
+
+* Node.js v10.0+  (Please use [v1](https://github.com/JoshGlazebrook/socks/tree/82d83923ad960693d8b774cafe17443ded7ed584) for older versions of Node.js)
+
+### Looking for v1?
+* Docs for v1 are available [here](https://github.com/JoshGlazebrook/socks/tree/82d83923ad960693d8b774cafe17443ded7ed584)
+
+## Installation
+
+`yarn add socks`
+
+or
+
+`npm install --save socks`
+
+## Usage
+
+```typescript
+// TypeScript
+import { SocksClient, SocksClientOptions, SocksClientChainOptions } from 'socks';
+
+// ES6 JavaScript
+import { SocksClient } from 'socks';
+
+// Legacy JavaScript
+const SocksClient = require('socks').SocksClient;
+```
+
+## Quick Start Example
+
+Connect to github.com (192.30.253.113) on port 80, using a SOCKS proxy.
+
+```javascript
+const options = {
+  proxy: {
+    host: '159.203.75.200', // ipv4 or ipv6 or hostname
+    port: 1080,
+    type: 5 // Proxy version (4 or 5)
+  },
+
+  command: 'connect', // SOCKS command (createConnection factory function only supports the connect command)
+
+  destination: {
+    host: '192.30.253.113', // github.com (hostname lookups are supported with SOCKS v4a and 5)
+    port: 80
+  }
+};
+
+// Async/Await
+try {
+  const info = await SocksClient.createConnection(options);
+
+  console.log(info.socket);
+  // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
+} catch (err) {
+  // Handle errors
+}
+
+// Promises
+SocksClient.createConnection(options)
+.then(info => {
+  console.log(info.socket);
+  // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
+})
+.catch(err => {
+  // Handle errors
+});
+
+// Callbacks
+SocksClient.createConnection(options, (err, info) => {
+  if (!err) {
+    console.log(info.socket);
+    // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
+  } else {
+    // Handle errors
+  }
+});
+```
+
+## Chaining Proxies
+
+**Note:** Chaining is only supported when using the SOCKS connect command, and chaining can only be done through the special factory chaining function.
+
+This example makes a proxy chain through two SOCKS proxies to ip-api.com. Once the connection to the destination is established it sends an HTTP request to get a JSON response that returns ip info for the requesting ip.
+
+```javascript
+const options = {
+  destination: {
+    host: 'ip-api.com', // host names are supported with SOCKS v4a and SOCKS v5.
+    port: 80
+  },
+  command: 'connect', // Only the connect command is supported when chaining proxies.
+  proxies: [ // The chain order is the order in the proxies array, meaning the last proxy will establish a connection to the destination.
+    {
+      host: '159.203.75.235', // ipv4, ipv6, or hostname
+      port: 1081,
+      type: 5
+    },
+    {
+      host: '104.131.124.203', // ipv4, ipv6, or hostname
+      port: 1081,
+      type: 5
+    }
+  ]
+}
+
+// Async/Await
+try {
+  const info = await SocksClient.createConnectionChain(options);
+
+  console.log(info.socket);
+  // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy servers)
+
+  console.log(info.socket.remoteAddress) // The remote address of the returned socket is the first proxy in the chain.
+  // 159.203.75.235
+
+  info.socket.write('GET /json HTTP/1.1\nHost: ip-api.com\n\n');
+  info.socket.on('data', (data) => {
+    console.log(data.toString()); // ip-api.com sees that the last proxy in the chain (104.131.124.203) is connected to it.
+    /*
+      HTTP/1.1 200 OK
+      Access-Control-Allow-Origin: *
+      Content-Type: application/json; charset=utf-8
+      Date: Sun, 24 Dec 2017 03:47:51 GMT
+      Content-Length: 300
+
+      {
+        "as":"AS14061 Digital Ocean, Inc.",
+        "city":"Clifton",
+        "country":"United States",
+        "countryCode":"US",
+        "isp":"Digital Ocean",
+        "lat":40.8326,
+        "lon":-74.1307,
+        "org":"Digital Ocean",
+        "query":"104.131.124.203",
+        "region":"NJ",
+        "regionName":"New Jersey",
+        "status":"success",
+        "timezone":"America/New_York",
+        "zip":"07014"
+      }
+    */
+  });
+} catch (err) {
+  // Handle errors
+}
+
+// Promises
+SocksClient.createConnectionChain(options)
+.then(info => {
+  console.log(info.socket);
+  // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
+
+  console.log(info.socket.remoteAddress) // The remote address of the returned socket is the first proxy in the chain.
+  // 159.203.75.235
+
+  info.socket.write('GET /json HTTP/1.1\nHost: ip-api.com\n\n');
+  info.socket.on('data', (data) => {
+    console.log(data.toString()); // ip-api.com sees that the last proxy in the chain (104.131.124.203) is connected to it.
+    /*
+      HTTP/1.1 200 OK
+      Access-Control-Allow-Origin: *
+      Content-Type: application/json; charset=utf-8
+      Date: Sun, 24 Dec 2017 03:47:51 GMT
+      Content-Length: 300
+
+      {
+        "as":"AS14061 Digital Ocean, Inc.",
+        "city":"Clifton",
+        "country":"United States",
+        "countryCode":"US",
+        "isp":"Digital Ocean",
+        "lat":40.8326,
+        "lon":-74.1307,
+        "org":"Digital Ocean",
+        "query":"104.131.124.203",
+        "region":"NJ",
+        "regionName":"New Jersey",
+        "status":"success",
+        "timezone":"America/New_York",
+        "zip":"07014"
+      }
+    */
+  });
+})
+.catch(err => {
+  // Handle errors
+});
+
+// Callbacks
+SocksClient.createConnectionChain(options, (err, info) => {
+  if (!err) {
+    console.log(info.socket);
+    // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
+
+    console.log(info.socket.remoteAddress) // The remote address of the returned socket is the first proxy in the chain.
+  // 159.203.75.235
+
+  info.socket.write('GET /json HTTP/1.1\nHost: ip-api.com\n\n');
+  info.socket.on('data', (data) => {
+    console.log(data.toString()); // ip-api.com sees that the last proxy in the chain (104.131.124.203) is connected to it.
+    /*
+      HTTP/1.1 200 OK
+      Access-Control-Allow-Origin: *
+      Content-Type: application/json; charset=utf-8
+      Date: Sun, 24 Dec 2017 03:47:51 GMT
+      Content-Length: 300
+
+      {
+        "as":"AS14061 Digital Ocean, Inc.",
+        "city":"Clifton",
+        "country":"United States",
+        "countryCode":"US",
+        "isp":"Digital Ocean",
+        "lat":40.8326,
+        "lon":-74.1307,
+        "org":"Digital Ocean",
+        "query":"104.131.124.203",
+        "region":"NJ",
+        "regionName":"New Jersey",
+        "status":"success",
+        "timezone":"America/New_York",
+        "zip":"07014"
+      }
+    */
+  });
+  } else {
+    // Handle errors
+  }
+});
+```
+
+## Bind Example (TCP Relay)
+
+When the bind command is sent to a SOCKS v4/v5 proxy server, the proxy server starts listening on a new TCP port and the proxy relays then remote host information back to the client. When another remote client connects to the proxy server on this port the SOCKS proxy sends a notification that an incoming connection has been accepted to the initial client and a full duplex stream is now established to the initial client and the client that connected to that special port.
+
+```javascript
+const options = {
+  proxy: {
+    host: '159.203.75.235', // ipv4, ipv6, or hostname
+    port: 1081,
+    type: 5
+  },
+
+  command: 'bind',
+
+  // When using BIND, the destination should be the remote client that is expected to connect to the SOCKS proxy. Using 0.0.0.0 makes the Proxy accept any incoming connection on that port.
+  destination: {
+    host: '0.0.0.0',
+    port: 0
+  }
+};
+
+// Creates a new SocksClient instance.
+const client = new SocksClient(options);
+
+// When the SOCKS proxy has bound a new port and started listening, this event is fired.
+client.on('bound', info => {
+  console.log(info.remoteHost);
+  /*
+  {
+    host: "159.203.75.235",
+    port: 57362
+  }
+  */
+});
+
+// When a client connects to the newly bound port on the SOCKS proxy, this event is fired.
+client.on('established', info => {
+  // info.remoteHost is the remote address of the client that connected to the SOCKS proxy.
+  console.log(info.remoteHost);
+  /*
+    host: 67.171.34.23,
+    port: 49823
+  */
+
+  console.log(info.socket);
+  // <Socket ...>  (This is a raw net.Socket that is a connection between the initial client and the remote client that connected to the proxy)
+
+  // Handle received data...
+  info.socket.on('data', data => {
+    console.log('recv', data);
+  });
+});
+
+// An error occurred trying to establish this SOCKS connection.
+client.on('error', err => {
+  console.error(err);
+});
+
+// Start connection to proxy
+client.connect();
+```
+
+## Associate Example (UDP Relay)
+
+When the associate command is sent to a SOCKS v5 proxy server, it sets up a UDP relay that allows the client to send UDP packets to a remote host through the proxy server, and also receive UDP packet responses back through the proxy server.
+
+```javascript
+const options = {
+  proxy: {
+    host: '159.203.75.235', // ipv4, ipv6, or hostname
+    port: 1081,
+    type: 5
+  },
+
+  command: 'associate',
+
+  // When using associate, the destination should be the remote client that is expected to send UDP packets to the proxy server to be forwarded. This should be your local ip, or optionally the wildcard address (0.0.0.0)  UDP Client <-> Proxy <-> UDP Client
+  destination: {
+    host: '0.0.0.0',
+    port: 0
+  }
+};
+
+// Create a local UDP socket for sending packets to the proxy.
+const udpSocket = dgram.createSocket('udp4');
+udpSocket.bind();
+
+// Listen for incoming UDP packets from the proxy server.
+udpSocket.on('message', (message, rinfo) => {
+  console.log(SocksClient.parseUDPFrame(message));
+  /*
+  { frameNumber: 0,
+    remoteHost: { host: '165.227.108.231', port: 4444 }, // The remote host that replied with a UDP packet
+    data: <Buffer 74 65 73 74 0a> // The data
+  }
+  */
+});
+
+let client = new SocksClient(associateOptions);
+
+// When the UDP relay is established, this event is fired and includes the UDP relay port to send data to on the proxy server.
+client.on('established', info => {
+  console.log(info.remoteHost);
+  /*
+    {
+      host: '159.203.75.235',
+      port: 44711
+    }
+  */
+
+  // Send 'hello' to 165.227.108.231:4444
+  const packet = SocksClient.createUDPFrame({
+    remoteHost: { host: '165.227.108.231', port: 4444 },
+    data: Buffer.from(line)
+  });
+  udpSocket.send(packet, info.remoteHost.port, info.remoteHost.host);
+});
+
+// Start connection
+client.connect();
+```
+
+**Note:** The associate TCP connection to the proxy must remain open for the UDP relay to work.
+
+## Additional Examples
+
+[Documentation](docs/index.md)
+
+
+## Migrating from v1
+
+Looking for a guide to migrate from v1? Look [here](docs/migratingFromV1.md)
+
+## Api Reference:
+
+**Note:** socks includes full TypeScript definitions. These can even be used without using TypeScript as most IDEs (such as VS Code) will use these type definition files for auto completion intellisense even in JavaScript files.
+
+* Class: SocksClient
+  * [new SocksClient(options[, callback])](#new-socksclientoptions)
+  * [Class Method: SocksClient.createConnection(options[, callback])](#class-method-socksclientcreateconnectionoptions-callback)
+  * [Class Method: SocksClient.createConnectionChain(options[, callback])](#class-method-socksclientcreateconnectionchainoptions-callback)
+  * [Class Method: SocksClient.createUDPFrame(options)](#class-method-socksclientcreateudpframedetails)
+  * [Class Method: SocksClient.parseUDPFrame(data)](#class-method-socksclientparseudpframedata)
+  * [Event: 'error'](#event-error)
+  * [Event: 'bound'](#event-bound)
+  * [Event: 'established'](#event-established)
+  * [client.connect()](#clientconnect)
+  * [client.socksClientOptions](#clientconnect)
+
+### SocksClient
+
+SocksClient establishes SOCKS proxy connections to remote destination hosts. These proxy connections are fully transparent to the server and once established act as full duplex streams. SOCKS v4, v4a, v5, and v5h are supported, as well as the connect, bind, and associate commands.
+
+SocksClient supports creating connections using callbacks, promises, and async/await flow control using two static factory functions createConnection and createConnectionChain. It also internally extends EventEmitter which results in allowing event handling based async flow control.
+
+**SOCKS Compatibility Table**
+
+Note: When using 4a please specify type: 4, and when using 5h please specify type 5.
+
+| Socks Version | TCP | UDP | IPv4 | IPv6 | Hostname |
+| --- | :---: | :---: | :---: | :---: | :---: |
+| SOCKS v4 | ✅ | ❌ | ✅ | ❌ | ❌ |
+| SOCKS v4a | ✅ | ❌ | ✅ | ❌ | ✅ |
+| SOCKS v5 (includes v5h) | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+### new SocksClient(options)
+
+* ```options``` {SocksClientOptions} - An object describing the SOCKS proxy to use, the command to send and establish, and the destination host to connect to.
+
+### SocksClientOptions
+
+```typescript
+{
+  proxy: {
+    host: '159.203.75.200', // ipv4, ipv6, or hostname
+    port: 1080,
+    type: 5, // Proxy version (4 or 5). For v4a use 4, for v5h use 5.
+
+    // Optional fields
+    userId: 'some username', // Used for SOCKS4 userId auth, and SOCKS5 user/pass auth in conjunction with password.
+    password: 'some password', // Used in conjunction with userId for user/pass auth for SOCKS5 proxies.
+    custom_auth_method: 0x80,  // If using a custom auth method, specify the type here. If this is set, ALL other custom_auth_*** options must be set as well.
+    custom_auth_request_handler: async () =>. {
+      // This will be called when it's time to send the custom auth handshake. You must return a Buffer containing the data to send as your authentication.
+      return Buffer.from([0x01,0x02,0x03]);
+    },
+    // This is the expected size (bytes) of the custom auth response from the proxy server.
+    custom_auth_response_size: 2,
+    // This is called when the auth response is received. The received packet is passed in as a Buffer, and you must return a boolean indicating the response from the server said your custom auth was successful or failed.
+    custom_auth_response_handler: async (data) => {
+      return data[1] === 0x00;
+    }
+  },
+
+  command: 'connect', // connect, bind, associate
+
+  destination: {
+    host: '192.30.253.113', // ipv4, ipv6, hostname. Hostnames work with v4a and v5.
+    port: 80
+  },
+
+  // Optional fields
+  timeout: 30000, // How long to wait to establish a proxy connection. (defaults to 30 seconds)
+
+  set_tcp_nodelay: true // If true, will turn on the underlying sockets TCP_NODELAY option.
+}
+```
+
+### Class Method: SocksClient.createConnection(options[, callback])
+* ```options``` { SocksClientOptions } - An object describing the SOCKS proxy to use, the command to send and establish, and the destination host to connect to.
+* ```callback``` { Function } - Optional callback function that is called when the proxy connection is established, or an error occurs.
+* ```returns``` { Promise } - A Promise is returned that is resolved when the proxy connection is established, or rejected when an error occurs.
+
+Creates a new proxy connection through the given proxy to the given destination host. This factory function supports callbacks and promises for async flow control.
+
+**Note:** If a callback function is provided, the promise will always resolve regardless of an error occurring. Please be sure to exclusively use either promises or callbacks when using this factory function.
+
+```typescript
+const options = {
+  proxy: {
+    host: '159.203.75.200', // ipv4, ipv6, or hostname
+    port: 1080,
+    type: 5 // Proxy version (4 or 5)
+  },
+
+  command: 'connect', // connect, bind, associate
+
+  destination: {
+    host: '192.30.253.113', // ipv4, ipv6, or hostname
+    port: 80
+  }
+}
+
+// Await/Async (uses a Promise)
+try {
+  const info = await SocksClient.createConnection(options);
+  console.log(info);
+  /*
+  {
+    socket: <Socket ...>,  // Raw net.Socket
+  }
+  */
+  / <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
+
+} catch (err) {
+  // Handle error...
+}
+
+// Promise
+SocksClient.createConnection(options)
+.then(info => {
+  console.log(info);
+  /*
+  {
+    socket: <Socket ...>,  // Raw net.Socket
+  }
+  */
+})
+.catch(err => {
+  // Handle error...
+});
+
+// Callback
+SocksClient.createConnection(options, (err, info) => {
+  if (!err) {
+    console.log(info);
+  /*
+  {
+    socket: <Socket ...>,  // Raw net.Socket
+  }
+  */
+  } else {
+    // Handle error...
+  }
+});
+```
+
+### Class Method: SocksClient.createConnectionChain(options[, callback])
+* ```options``` { SocksClientChainOptions } - An object describing a list of SOCKS proxies to use, the command to send and establish, and the destination host to connect to.
+* ```callback``` { Function } - Optional callback function that is called when the proxy connection chain is established, or an error occurs.
+* ```returns``` { Promise } - A Promise is returned that is resolved when the proxy connection chain is established, or rejected when an error occurs.
+
+Creates a new proxy connection chain through a list of at least two SOCKS proxies to the given destination host. This factory method supports callbacks and promises for async flow control.
+
+**Note:** If a callback function is provided, the promise will always resolve regardless of an error occurring. Please be sure to exclusively use either promises or callbacks when using this factory function.
+
+**Note:** At least two proxies must be provided for the chain to be established.
+
+```typescript
+const options = {
+  proxies: [ // The chain order is the order in the proxies array, meaning the last proxy will establish a connection to the destination.
+    {
+      host: '159.203.75.235', // ipv4, ipv6, or hostname
+      port: 1081,
+      type: 5
+    },
+    {
+      host: '104.131.124.203', // ipv4, ipv6, or hostname
+      port: 1081,
+      type: 5
+    }
+  ]
+
+  command: 'connect', // Only connect is supported in chaining mode.
+
+  destination: {
+    host: '192.30.253.113', // ipv4, ipv6, hostname
+    port: 80
+  }
+}
+```
+
+### Class Method: SocksClient.createUDPFrame(details)
+* ```details``` { SocksUDPFrameDetails } - An object containing the remote host, frame number, and frame data to use when creating a SOCKS UDP frame packet.
+* ```returns``` { Buffer } - A Buffer containing all of the UDP frame data.
+
+Creates a SOCKS UDP frame relay packet that is sent and received via a SOCKS proxy when using the associate command for UDP packet forwarding.
+
+**SocksUDPFrameDetails**
+
+```typescript
+{
+  frameNumber: 0, // The frame number (used for breaking up larger packets)
+
+  remoteHost: { // The remote host to have the proxy send data to, or the remote host that send this data.
+    host: '1.2.3.4',
+    port: 1234
+  },
+
+  data: <Buffer 01 02 03 04...> // A Buffer instance of data to include in the packet (actual data sent to the remote host)
+}
+interface SocksUDPFrameDetails {
+  // The frame number of the packet.
+  frameNumber?: number;
+
+  // The remote host.
+  remoteHost: SocksRemoteHost;
+
+  // The packet data.
+  data: Buffer;
+}
+```
+
+### Class Method: SocksClient.parseUDPFrame(data)
+* ```data``` { Buffer } - A Buffer instance containing SOCKS UDP frame data to parse.
+* ```returns``` { SocksUDPFrameDetails } - An object containing the remote host, frame number, and frame data of the SOCKS UDP frame.
+
+```typescript
+const frame = SocksClient.parseUDPFrame(data);
+console.log(frame);
+/*
+{
+  frameNumber: 0,
+  remoteHost: {
+    host: '1.2.3.4',
+    port: 1234
+  },
+  data: <Buffer 01 02 03 04 ...>
+}
+*/
+```
+
+Parses a Buffer instance and returns the parsed SocksUDPFrameDetails object.
+
+## Event: 'error'
+* ```err``` { SocksClientError } - An Error object containing an error message and the original SocksClientOptions.
+
+This event is emitted if an error occurs when trying to establish the proxy connection.
+
+## Event: 'bound'
+* ```info``` { SocksClientBoundEvent } An object containing a Socket and SocksRemoteHost info.
+
+This event is emitted when using the BIND command on a remote SOCKS proxy server. This event indicates the proxy server is now listening for incoming connections on a specified port.
+
+**SocksClientBoundEvent**
+```typescript
+{
+  socket: net.Socket, // The underlying raw Socket
+  remoteHost: {
+    host: '1.2.3.4', // The remote host that is listening (usually the proxy itself)
+    port: 4444 // The remote port the proxy is listening on for incoming connections (when using BIND).
+  }
+}
+```
+
+## Event: 'established'
+* ```info``` { SocksClientEstablishedEvent } An object containing a Socket and SocksRemoteHost info.
+
+This event is emitted when the following conditions are met:
+1. When using the CONNECT command, and a proxy connection has been established to the remote host.
+2. When using the BIND command, and an incoming connection has been accepted by the proxy and a TCP relay has been established.
+3. When using the ASSOCIATE command, and a UDP relay has been established.
+
+When using BIND, 'bound' is first emitted to indicate the SOCKS server is waiting for an incoming connection, and provides the remote port the SOCKS server is listening on.
+
+When using ASSOCIATE, 'established' is emitted with the remote UDP port the SOCKS server is accepting UDP frame packets on.
+
+**SocksClientEstablishedEvent**
+```typescript
+{
+  socket: net.Socket, // The underlying raw Socket
+  remoteHost: {
+    host: '1.2.3.4', // The remote host that is listening (usually the proxy itself)
+    port: 52738 // The remote port the proxy is listening on for incoming connections (when using BIND).
+  }
+}
+```
+
+## client.connect()
+
+Starts connecting to the remote SOCKS proxy server to establish a proxy connection to the destination host.
+
+## client.socksClientOptions
+* ```returns``` { SocksClientOptions } The options that were passed to the SocksClient.
+
+Gets the options that were passed to the SocksClient when it was created.
+
+
+**SocksClientError**
+```typescript
+{ // Subclassed from Error.
+  message: 'An error has occurred',
+  options: {
+    // SocksClientOptions
+  }
+}
+```
+
+# Further Reading:
+
+Please read the SOCKS 5 specifications for more information on how to use BIND and Associate.
+http://www.ietf.org/rfc/rfc1928.txt
+
+# License
+
+This work is licensed under the [MIT license](http://en.wikipedia.org/wiki/MIT_License).
 =========================================
 END OF socks@2.6.2 AND INFORMATION
-
-%% stack-utils@2.0.5 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The MIT License (MIT)
-
-Copyright (c) Isaac Z. Schlueter <i@izs.me>, James Talmage <james@talmage.io> (github.com/jamestalmage), and Contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-=========================================
-END OF stack-utils@2.0.5 AND INFORMATION
-
-%% wrappy@1.0.2 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-=========================================
-END OF wrappy@1.0.2 AND INFORMATION
-
-%% ws@8.4.2 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-=========================================
-END OF ws@8.4.2 AND INFORMATION
 
 %% @types/node@17.0.24 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1506,6 +1213,52 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 =========================================
 END OF get-stream@5.2.0 AND INFORMATION
 
+%% ms@2.1.2 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Zeit, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF ms@2.1.2 AND INFORMATION
+
+%% once@1.4.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+=========================================
+END OF once@1.4.0 AND INFORMATION
+
 %% pend@1.2.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 The MIT License (Expat)
@@ -1559,6 +1312,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 =========================================
 END OF pump@3.0.0 AND INFORMATION
+
+%% wrappy@1.0.2 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+=========================================
+END OF wrappy@1.0.2 AND INFORMATION
 
 %% yauzl@2.10.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1614,6 +1387,6 @@ END OF yazl@2.5.1 AND INFORMATION
 
 SUMMARY BEGIN HERE
 =========================================
-Total Packages: 45
+Total Packages: 18
 =========================================
 END OF SUMMARY

--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -5,9 +5,39 @@ THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 This project incorporates components from the projects listed below. The original copyright notices and the licenses under which Microsoft received such components are set forth below. Microsoft reserves all rights not expressly granted herein, whether by implication, estoppel or otherwise.
 
 -	agent-base@6.0.2 (https://github.com/TooTallNate/node-agent-base)
+-	balanced-match@1.0.2 (https://github.com/juliangruber/balanced-match)
+-	brace-expansion@1.1.11 (https://github.com/juliangruber/brace-expansion)
+-	colors@1.4.0 (https://github.com/Marak/colors.js)
+-	commander@8.3.0 (https://github.com/tj/commander.js)
+-	concat-map@0.0.1 (https://github.com/substack/node-concat-map)
 -	debug@4.3.4 (https://github.com/debug-js/debug)
+-	escape-string-regexp@2.0.0 (https://github.com/sindresorhus/escape-string-regexp)
+-	fs.realpath@1.0.0 (https://github.com/isaacs/fs.realpath)
+-	glob@7.2.0 (https://github.com/isaacs/node-glob)
+-	graceful-fs@4.2.10 (https://github.com/isaacs/node-graceful-fs)
+-	https-proxy-agent@5.0.0 (https://github.com/TooTallNate/node-https-proxy-agent)
+-	inflight@1.0.6 (https://github.com/npm/inflight)
+-	inherits@2.0.4 (https://github.com/isaacs/inherits)
+-	ip@1.1.5 (https://github.com/indutny/node-ip)
+-	jpeg-js@0.4.3 (https://github.com/eugeneware/jpeg-js)
+-	mime@3.0.0 (https://github.com/broofa/mime)
+-	minimatch@3.1.2 (https://github.com/isaacs/minimatch)
+-	ms@2.1.2 (https://github.com/zeit/ms)
+-	once@1.4.0 (https://github.com/isaacs/once)
+-	path-is-absolute@1.0.1 (https://github.com/sindresorhus/path-is-absolute)
+-	pngjs@6.0.0 (https://github.com/lukeapage/pngjs)
+-	progress@2.0.3 (https://github.com/visionmedia/node-progress)
+-	proper-lockfile@4.1.2 (https://github.com/moxystudio/node-proper-lockfile)
+-	proxy-from-env@1.1.0 (https://github.com/Rob--W/proxy-from-env)
+-	retry@0.12.0 (https://github.com/tim-kos/node-retry)
+-	rimraf@3.0.2 (https://github.com/isaacs/rimraf)
+-	signal-exit@3.0.7 (https://github.com/tapjs/signal-exit)
+-	smart-buffer@4.2.0 (https://github.com/JoshGlazebrook/smart-buffer)
 -	socks-proxy-agent@6.1.1 (https://github.com/TooTallNate/node-socks-proxy-agent)
 -	socks@2.6.2 (https://github.com/JoshGlazebrook/socks)
+-	stack-utils@2.0.5 (https://github.com/tapjs/stack-utils)
+-	wrappy@1.0.2 (https://github.com/npm/wrappy)
+-	ws@8.4.2 (https://github.com/websockets/ws)
 -	@types/node@17.0.24 (https://github.com/DefinitelyTyped/DefinitelyTyped)
 -	@types/yauzl@2.10.0 (https://github.com/DefinitelyTyped/DefinitelyTyped)
 -	buffer-crc32@0.2.13 (https://github.com/brianloveswords/buffer-crc32)
@@ -15,11 +45,8 @@ This project incorporates components from the projects listed below. The origina
 -	extract-zip@2.0.1 (https://github.com/maxogden/extract-zip)
 -	fd-slicer@1.1.0 (https://github.com/andrewrk/node-fd-slicer)
 -	get-stream@5.2.0 (https://github.com/sindresorhus/get-stream)
--	ms@2.1.2 (https://github.com/zeit/ms)
--	once@1.4.0 (https://github.com/isaacs/once)
 -	pend@1.2.0 (https://github.com/andrewrk/node-pend)
 -	pump@3.0.0 (https://github.com/mafintosh/pump)
--	wrappy@1.0.2 (https://github.com/npm/wrappy)
 -	yauzl@2.10.0 (https://github.com/thejoshwolfe/yauzl)
 -	yazl@2.5.1 (https://github.com/thejoshwolfe/yazl)
 
@@ -173,6 +200,138 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF agent-base@6.0.2 AND INFORMATION
 
+%% balanced-match@1.0.2 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+(MIT)
+
+Copyright (c) 2013 Julian Gruber &lt;julian@juliangruber.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF balanced-match@1.0.2 AND INFORMATION
+
+%% brace-expansion@1.1.11 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+MIT License
+
+Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF brace-expansion@1.1.11 AND INFORMATION
+
+%% colors@1.4.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+MIT License
+
+Original Library
+  - Copyright (c) Marak Squires
+
+Additional Functionality
+ - Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+=========================================
+END OF colors@1.4.0 AND INFORMATION
+
+%% commander@8.3.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+(The MIT License)
+
+Copyright (c) 2011 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF commander@8.3.0 AND INFORMATION
+
+%% concat-map@0.0.1 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF concat-map@0.0.1 AND INFORMATION
+
 %% debug@4.3.4 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 (The MIT License)
@@ -196,6 +355,734 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF debug@4.3.4 AND INFORMATION
+
+%% escape-string-regexp@2.0.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF escape-string-regexp@2.0.0 AND INFORMATION
+
+%% fs.realpath@1.0.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----
+
+This library bundles a version of the `fs.realpath` and `fs.realpathSync`
+methods from Node.js v0.10 under the terms of the Node.js MIT license.
+
+Node's license follows, also included at the header of `old.js` which contains
+the licensed code:
+
+  Copyright Joyent, Inc. and other Node contributors.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+=========================================
+END OF fs.realpath@1.0.0 AND INFORMATION
+
+%% glob@7.2.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+## Glob Logo
+
+Glob's logo created by Tanya Brassie <http://tanyabrassie.com/>, licensed
+under a Creative Commons Attribution-ShareAlike 4.0 International License
+https://creativecommons.org/licenses/by-sa/4.0/
+=========================================
+END OF glob@7.2.0 AND INFORMATION
+
+%% graceful-fs@4.2.10 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) 2011-2022 Isaac Z. Schlueter, Ben Noordhuis, and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+=========================================
+END OF graceful-fs@4.2.10 AND INFORMATION
+
+%% https-proxy-agent@5.0.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+https-proxy-agent
+================
+### An HTTP(s) proxy `http.Agent` implementation for HTTPS
+[![Build Status](https://github.com/TooTallNate/node-https-proxy-agent/workflows/Node%20CI/badge.svg)](https://github.com/TooTallNate/node-https-proxy-agent/actions?workflow=Node+CI)
+
+This module provides an `http.Agent` implementation that connects to a specified
+HTTP or HTTPS proxy server, and can be used with the built-in `https` module.
+
+Specifically, this `Agent` implementation connects to an intermediary "proxy"
+server and issues the [CONNECT HTTP method][CONNECT], which tells the proxy to
+open a direct TCP connection to the destination server.
+
+Since this agent implements the CONNECT HTTP method, it also works with other
+protocols that use this method when connecting over proxies (i.e. WebSockets).
+See the "Examples" section below for more.
+
+
+Installation
+------------
+
+Install with `npm`:
+
+``` bash
+$ npm install https-proxy-agent
+```
+
+
+Examples
+--------
+
+#### `https` module example
+
+``` js
+var url = require('url');
+var https = require('https');
+var HttpsProxyAgent = require('https-proxy-agent');
+
+// HTTP/HTTPS proxy to connect to
+var proxy = process.env.http_proxy || 'http://168.63.76.32:3128';
+console.log('using proxy server %j', proxy);
+
+// HTTPS endpoint for the proxy to connect to
+var endpoint = process.argv[2] || 'https://graph.facebook.com/tootallnate';
+console.log('attempting to GET %j', endpoint);
+var options = url.parse(endpoint);
+
+// create an instance of the `HttpsProxyAgent` class with the proxy server information
+var agent = new HttpsProxyAgent(proxy);
+options.agent = agent;
+
+https.get(options, function (res) {
+  console.log('"response" event!', res.headers);
+  res.pipe(process.stdout);
+});
+```
+
+#### `ws` WebSocket connection example
+
+``` js
+var url = require('url');
+var WebSocket = require('ws');
+var HttpsProxyAgent = require('https-proxy-agent');
+
+// HTTP/HTTPS proxy to connect to
+var proxy = process.env.http_proxy || 'http://168.63.76.32:3128';
+console.log('using proxy server %j', proxy);
+
+// WebSocket endpoint for the proxy to connect to
+var endpoint = process.argv[2] || 'ws://echo.websocket.org';
+var parsed = url.parse(endpoint);
+console.log('attempting to connect to WebSocket %j', endpoint);
+
+// create an instance of the `HttpsProxyAgent` class with the proxy server information
+var options = url.parse(proxy);
+
+var agent = new HttpsProxyAgent(options);
+
+// finally, initiate the WebSocket connection
+var socket = new WebSocket(endpoint, { agent: agent });
+
+socket.on('open', function () {
+  console.log('"open" event!');
+  socket.send('hello world');
+});
+
+socket.on('message', function (data, flags) {
+  console.log('"message" event! %j %j', data, flags);
+  socket.close();
+});
+```
+
+API
+---
+
+### new HttpsProxyAgent(Object options)
+
+The `HttpsProxyAgent` class implements an `http.Agent` subclass that connects
+to the specified "HTTP(s) proxy server" in order to proxy HTTPS and/or WebSocket
+requests. This is achieved by using the [HTTP `CONNECT` method][CONNECT].
+
+The `options` argument may either be a string URI of the proxy server to use, or an
+"options" object with more specific properties:
+
+  * `host` - String - Proxy host to connect to (may use `hostname` as well). Required.
+  * `port` - Number - Proxy port to connect to. Required.
+  * `protocol` - String - If `https:`, then use TLS to connect to the proxy.
+  * `headers` - Object - Additional HTTP headers to be sent on the HTTP CONNECT method.
+  * Any other options given are passed to the `net.connect()`/`tls.connect()` functions.
+
+
+License
+-------
+
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich &lt;nathan@tootallnate.net&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+[CONNECT]: http://en.wikipedia.org/wiki/HTTP_tunnel#HTTP_CONNECT_Tunneling
+=========================================
+END OF https-proxy-agent@5.0.0 AND INFORMATION
+
+%% inflight@1.0.6 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+=========================================
+END OF inflight@1.0.6 AND INFORMATION
+
+%% inherits@2.0.4 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+=========================================
+END OF inherits@2.0.4 AND INFORMATION
+
+%% ip@1.1.5 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+# IP  
+[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)  
+
+IP address utilities for node.js
+
+## Installation
+
+###  npm
+```shell
+npm install ip
+```
+
+### git
+
+```shell
+git clone https://github.com/indutny/node-ip.git
+```
+  
+## Usage
+Get your ip address, compare ip addresses, validate ip addresses, etc.
+
+```js
+var ip = require('ip');
+
+ip.address() // my ip address
+ip.isEqual('::1', '::0:1'); // true
+ip.toBuffer('127.0.0.1') // Buffer([127, 0, 0, 1])
+ip.toString(new Buffer([127, 0, 0, 1])) // 127.0.0.1
+ip.fromPrefixLen(24) // 255.255.255.0
+ip.mask('192.168.1.134', '255.255.255.0') // 192.168.1.0
+ip.cidr('192.168.1.134/26') // 192.168.1.128
+ip.not('255.255.255.0') // 0.0.0.255
+ip.or('192.168.1.134', '0.0.0.255') // 192.168.1.255
+ip.isPrivate('127.0.0.1') // true
+ip.isV4Format('127.0.0.1'); // true
+ip.isV6Format('::ffff:127.0.0.1'); // true
+
+// operate on buffers in-place
+var buf = new Buffer(128);
+var offset = 64;
+ip.toBuffer('127.0.0.1', buf, offset);  // [127, 0, 0, 1] at offset 64
+ip.toString(buf, offset, 4);            // '127.0.0.1'
+
+// subnet information
+ip.subnet('192.168.1.134', '255.255.255.192')
+// { networkAddress: '192.168.1.128',
+//   firstAddress: '192.168.1.129',
+//   lastAddress: '192.168.1.190',
+//   broadcastAddress: '192.168.1.191',
+//   subnetMask: '255.255.255.192',
+//   subnetMaskLength: 26,
+//   numHosts: 62,
+//   length: 64,
+//   contains: function(addr){...} }
+ip.cidrSubnet('192.168.1.134/26')
+// Same as previous.
+
+// range checking
+ip.cidrSubnet('192.168.1.134/26').contains('192.168.1.190') // true
+
+
+// ipv4 long conversion
+ip.toLong('127.0.0.1'); // 2130706433
+ip.fromLong(2130706433); // '127.0.0.1'
+```
+
+### License
+
+This software is licensed under the MIT License.
+
+Copyright Fedor Indutny, 2012.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF ip@1.1.5 AND INFORMATION
+
+%% jpeg-js@0.4.3 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright (c) 2014, Eugene Ware
+All rights reserved.
+  
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:  
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.  
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.  
+3. Neither the name of Eugene Ware nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.  
+  
+THIS SOFTWARE IS PROVIDED BY EUGENE WARE ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL EUGENE WARE BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+=========================================
+END OF jpeg-js@0.4.3 AND INFORMATION
+
+%% mime@3.0.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+=========================================
+END OF mime@3.0.0 AND INFORMATION
+
+%% minimatch@3.1.2 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+=========================================
+END OF minimatch@3.1.2 AND INFORMATION
+
+%% ms@2.1.2 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Zeit, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF ms@2.1.2 AND INFORMATION
+
+%% once@1.4.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+=========================================
+END OF once@1.4.0 AND INFORMATION
+
+%% path-is-absolute@1.0.1 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+=========================================
+END OF path-is-absolute@1.0.1 AND INFORMATION
+
+%% pngjs@6.0.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
+pngjs derived work Copyright (c) 2012 Kuba Niegowski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+=========================================
+END OF pngjs@6.0.0 AND INFORMATION
+
+%% progress@2.0.3 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+(The MIT License)
+
+Copyright (c) 2017 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF progress@2.0.3 AND INFORMATION
+
+%% proper-lockfile@4.1.2 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) 2018 Made With MOXY Lda <hello@moxy.studio>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+=========================================
+END OF proper-lockfile@4.1.2 AND INFORMATION
+
+%% proxy-from-env@1.1.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License
+
+Copyright (C) 2016-2018 Rob Wu <rob@robwu.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF proxy-from-env@1.1.0 AND INFORMATION
+
+%% retry@0.12.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright (c) 2011:
+Tim Koschützki (tim@debuggable.com)
+Felix Geisendörfer (felix@debuggable.com)
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+=========================================
+END OF retry@0.12.0 AND INFORMATION
+
+%% rimraf@3.0.2 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+=========================================
+END OF rimraf@3.0.2 AND INFORMATION
+
+%% signal-exit@3.0.7 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) 2015, Contributors
+
+Permission to use, copy, modify, and/or distribute this software
+for any purpose with or without fee is hereby granted, provided
+that the above copyright notice and this permission notice
+appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE
+LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+=========================================
+END OF signal-exit@3.0.7 AND INFORMATION
+
+%% smart-buffer@4.2.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) 2013-2017 Josh Glazebrook
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF smart-buffer@4.2.0 AND INFORMATION
 
 %% socks-proxy-agent@6.1.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -356,692 +1243,98 @@ END OF socks-proxy-agent@6.1.1 AND INFORMATION
 
 %% socks@2.6.2 NOTICES AND INFORMATION BEGIN HERE
 =========================================
-# socks  [![Build Status](https://travis-ci.org/JoshGlazebrook/socks.svg?branch=master)](https://travis-ci.org/JoshGlazebrook/socks)  [![Coverage Status](https://coveralls.io/repos/github/JoshGlazebrook/socks/badge.svg?branch=master)](https://coveralls.io/github/JoshGlazebrook/socks?branch=v2)
-
-Fully featured SOCKS proxy client supporting SOCKSv4, SOCKSv4a, and SOCKSv5. Includes Bind and Associate functionality.
-
-### Features
-
-* Supports SOCKS v4, v4a, v5, and v5h protocols.
-* Supports the CONNECT, BIND, and ASSOCIATE commands.
-* Supports callbacks, promises, and events for proxy connection creation async flow control.
-* Supports proxy chaining (CONNECT only).
-* Supports user/password authentication.
-* Supports custom authentication.
-* Built in UDP frame creation & parse functions.
-* Created with TypeScript, type definitions are provided.
-
-### Requirements
-
-* Node.js v10.0+  (Please use [v1](https://github.com/JoshGlazebrook/socks/tree/82d83923ad960693d8b774cafe17443ded7ed584) for older versions of Node.js)
-
-### Looking for v1?
-* Docs for v1 are available [here](https://github.com/JoshGlazebrook/socks/tree/82d83923ad960693d8b774cafe17443ded7ed584)
-
-## Installation
-
-`yarn add socks`
-
-or
-
-`npm install --save socks`
-
-## Usage
-
-```typescript
-// TypeScript
-import { SocksClient, SocksClientOptions, SocksClientChainOptions } from 'socks';
-
-// ES6 JavaScript
-import { SocksClient } from 'socks';
-
-// Legacy JavaScript
-const SocksClient = require('socks').SocksClient;
-```
-
-## Quick Start Example
-
-Connect to github.com (192.30.253.113) on port 80, using a SOCKS proxy.
-
-```javascript
-const options = {
-  proxy: {
-    host: '159.203.75.200', // ipv4 or ipv6 or hostname
-    port: 1080,
-    type: 5 // Proxy version (4 or 5)
-  },
-
-  command: 'connect', // SOCKS command (createConnection factory function only supports the connect command)
-
-  destination: {
-    host: '192.30.253.113', // github.com (hostname lookups are supported with SOCKS v4a and 5)
-    port: 80
-  }
-};
-
-// Async/Await
-try {
-  const info = await SocksClient.createConnection(options);
-
-  console.log(info.socket);
-  // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
-} catch (err) {
-  // Handle errors
-}
-
-// Promises
-SocksClient.createConnection(options)
-.then(info => {
-  console.log(info.socket);
-  // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
-})
-.catch(err => {
-  // Handle errors
-});
-
-// Callbacks
-SocksClient.createConnection(options, (err, info) => {
-  if (!err) {
-    console.log(info.socket);
-    // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
-  } else {
-    // Handle errors
-  }
-});
-```
-
-## Chaining Proxies
-
-**Note:** Chaining is only supported when using the SOCKS connect command, and chaining can only be done through the special factory chaining function.
-
-This example makes a proxy chain through two SOCKS proxies to ip-api.com. Once the connection to the destination is established it sends an HTTP request to get a JSON response that returns ip info for the requesting ip.
-
-```javascript
-const options = {
-  destination: {
-    host: 'ip-api.com', // host names are supported with SOCKS v4a and SOCKS v5.
-    port: 80
-  },
-  command: 'connect', // Only the connect command is supported when chaining proxies.
-  proxies: [ // The chain order is the order in the proxies array, meaning the last proxy will establish a connection to the destination.
-    {
-      host: '159.203.75.235', // ipv4, ipv6, or hostname
-      port: 1081,
-      type: 5
-    },
-    {
-      host: '104.131.124.203', // ipv4, ipv6, or hostname
-      port: 1081,
-      type: 5
-    }
-  ]
-}
-
-// Async/Await
-try {
-  const info = await SocksClient.createConnectionChain(options);
-
-  console.log(info.socket);
-  // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy servers)
-
-  console.log(info.socket.remoteAddress) // The remote address of the returned socket is the first proxy in the chain.
-  // 159.203.75.235
-
-  info.socket.write('GET /json HTTP/1.1\nHost: ip-api.com\n\n');
-  info.socket.on('data', (data) => {
-    console.log(data.toString()); // ip-api.com sees that the last proxy in the chain (104.131.124.203) is connected to it.
-    /*
-      HTTP/1.1 200 OK
-      Access-Control-Allow-Origin: *
-      Content-Type: application/json; charset=utf-8
-      Date: Sun, 24 Dec 2017 03:47:51 GMT
-      Content-Length: 300
-
-      {
-        "as":"AS14061 Digital Ocean, Inc.",
-        "city":"Clifton",
-        "country":"United States",
-        "countryCode":"US",
-        "isp":"Digital Ocean",
-        "lat":40.8326,
-        "lon":-74.1307,
-        "org":"Digital Ocean",
-        "query":"104.131.124.203",
-        "region":"NJ",
-        "regionName":"New Jersey",
-        "status":"success",
-        "timezone":"America/New_York",
-        "zip":"07014"
-      }
-    */
-  });
-} catch (err) {
-  // Handle errors
-}
-
-// Promises
-SocksClient.createConnectionChain(options)
-.then(info => {
-  console.log(info.socket);
-  // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
-
-  console.log(info.socket.remoteAddress) // The remote address of the returned socket is the first proxy in the chain.
-  // 159.203.75.235
-
-  info.socket.write('GET /json HTTP/1.1\nHost: ip-api.com\n\n');
-  info.socket.on('data', (data) => {
-    console.log(data.toString()); // ip-api.com sees that the last proxy in the chain (104.131.124.203) is connected to it.
-    /*
-      HTTP/1.1 200 OK
-      Access-Control-Allow-Origin: *
-      Content-Type: application/json; charset=utf-8
-      Date: Sun, 24 Dec 2017 03:47:51 GMT
-      Content-Length: 300
-
-      {
-        "as":"AS14061 Digital Ocean, Inc.",
-        "city":"Clifton",
-        "country":"United States",
-        "countryCode":"US",
-        "isp":"Digital Ocean",
-        "lat":40.8326,
-        "lon":-74.1307,
-        "org":"Digital Ocean",
-        "query":"104.131.124.203",
-        "region":"NJ",
-        "regionName":"New Jersey",
-        "status":"success",
-        "timezone":"America/New_York",
-        "zip":"07014"
-      }
-    */
-  });
-})
-.catch(err => {
-  // Handle errors
-});
-
-// Callbacks
-SocksClient.createConnectionChain(options, (err, info) => {
-  if (!err) {
-    console.log(info.socket);
-    // <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
-
-    console.log(info.socket.remoteAddress) // The remote address of the returned socket is the first proxy in the chain.
-  // 159.203.75.235
-
-  info.socket.write('GET /json HTTP/1.1\nHost: ip-api.com\n\n');
-  info.socket.on('data', (data) => {
-    console.log(data.toString()); // ip-api.com sees that the last proxy in the chain (104.131.124.203) is connected to it.
-    /*
-      HTTP/1.1 200 OK
-      Access-Control-Allow-Origin: *
-      Content-Type: application/json; charset=utf-8
-      Date: Sun, 24 Dec 2017 03:47:51 GMT
-      Content-Length: 300
-
-      {
-        "as":"AS14061 Digital Ocean, Inc.",
-        "city":"Clifton",
-        "country":"United States",
-        "countryCode":"US",
-        "isp":"Digital Ocean",
-        "lat":40.8326,
-        "lon":-74.1307,
-        "org":"Digital Ocean",
-        "query":"104.131.124.203",
-        "region":"NJ",
-        "regionName":"New Jersey",
-        "status":"success",
-        "timezone":"America/New_York",
-        "zip":"07014"
-      }
-    */
-  });
-  } else {
-    // Handle errors
-  }
-});
-```
-
-## Bind Example (TCP Relay)
-
-When the bind command is sent to a SOCKS v4/v5 proxy server, the proxy server starts listening on a new TCP port and the proxy relays then remote host information back to the client. When another remote client connects to the proxy server on this port the SOCKS proxy sends a notification that an incoming connection has been accepted to the initial client and a full duplex stream is now established to the initial client and the client that connected to that special port.
-
-```javascript
-const options = {
-  proxy: {
-    host: '159.203.75.235', // ipv4, ipv6, or hostname
-    port: 1081,
-    type: 5
-  },
-
-  command: 'bind',
-
-  // When using BIND, the destination should be the remote client that is expected to connect to the SOCKS proxy. Using 0.0.0.0 makes the Proxy accept any incoming connection on that port.
-  destination: {
-    host: '0.0.0.0',
-    port: 0
-  }
-};
-
-// Creates a new SocksClient instance.
-const client = new SocksClient(options);
-
-// When the SOCKS proxy has bound a new port and started listening, this event is fired.
-client.on('bound', info => {
-  console.log(info.remoteHost);
-  /*
-  {
-    host: "159.203.75.235",
-    port: 57362
-  }
-  */
-});
-
-// When a client connects to the newly bound port on the SOCKS proxy, this event is fired.
-client.on('established', info => {
-  // info.remoteHost is the remote address of the client that connected to the SOCKS proxy.
-  console.log(info.remoteHost);
-  /*
-    host: 67.171.34.23,
-    port: 49823
-  */
-
-  console.log(info.socket);
-  // <Socket ...>  (This is a raw net.Socket that is a connection between the initial client and the remote client that connected to the proxy)
-
-  // Handle received data...
-  info.socket.on('data', data => {
-    console.log('recv', data);
-  });
-});
-
-// An error occurred trying to establish this SOCKS connection.
-client.on('error', err => {
-  console.error(err);
-});
-
-// Start connection to proxy
-client.connect();
-```
-
-## Associate Example (UDP Relay)
-
-When the associate command is sent to a SOCKS v5 proxy server, it sets up a UDP relay that allows the client to send UDP packets to a remote host through the proxy server, and also receive UDP packet responses back through the proxy server.
-
-```javascript
-const options = {
-  proxy: {
-    host: '159.203.75.235', // ipv4, ipv6, or hostname
-    port: 1081,
-    type: 5
-  },
-
-  command: 'associate',
-
-  // When using associate, the destination should be the remote client that is expected to send UDP packets to the proxy server to be forwarded. This should be your local ip, or optionally the wildcard address (0.0.0.0)  UDP Client <-> Proxy <-> UDP Client
-  destination: {
-    host: '0.0.0.0',
-    port: 0
-  }
-};
-
-// Create a local UDP socket for sending packets to the proxy.
-const udpSocket = dgram.createSocket('udp4');
-udpSocket.bind();
-
-// Listen for incoming UDP packets from the proxy server.
-udpSocket.on('message', (message, rinfo) => {
-  console.log(SocksClient.parseUDPFrame(message));
-  /*
-  { frameNumber: 0,
-    remoteHost: { host: '165.227.108.231', port: 4444 }, // The remote host that replied with a UDP packet
-    data: <Buffer 74 65 73 74 0a> // The data
-  }
-  */
-});
-
-let client = new SocksClient(associateOptions);
-
-// When the UDP relay is established, this event is fired and includes the UDP relay port to send data to on the proxy server.
-client.on('established', info => {
-  console.log(info.remoteHost);
-  /*
-    {
-      host: '159.203.75.235',
-      port: 44711
-    }
-  */
-
-  // Send 'hello' to 165.227.108.231:4444
-  const packet = SocksClient.createUDPFrame({
-    remoteHost: { host: '165.227.108.231', port: 4444 },
-    data: Buffer.from(line)
-  });
-  udpSocket.send(packet, info.remoteHost.port, info.remoteHost.host);
-});
-
-// Start connection
-client.connect();
-```
-
-**Note:** The associate TCP connection to the proxy must remain open for the UDP relay to work.
-
-## Additional Examples
-
-[Documentation](docs/index.md)
-
-
-## Migrating from v1
-
-Looking for a guide to migrate from v1? Look [here](docs/migratingFromV1.md)
-
-## Api Reference:
-
-**Note:** socks includes full TypeScript definitions. These can even be used without using TypeScript as most IDEs (such as VS Code) will use these type definition files for auto completion intellisense even in JavaScript files.
-
-* Class: SocksClient
-  * [new SocksClient(options[, callback])](#new-socksclientoptions)
-  * [Class Method: SocksClient.createConnection(options[, callback])](#class-method-socksclientcreateconnectionoptions-callback)
-  * [Class Method: SocksClient.createConnectionChain(options[, callback])](#class-method-socksclientcreateconnectionchainoptions-callback)
-  * [Class Method: SocksClient.createUDPFrame(options)](#class-method-socksclientcreateudpframedetails)
-  * [Class Method: SocksClient.parseUDPFrame(data)](#class-method-socksclientparseudpframedata)
-  * [Event: 'error'](#event-error)
-  * [Event: 'bound'](#event-bound)
-  * [Event: 'established'](#event-established)
-  * [client.connect()](#clientconnect)
-  * [client.socksClientOptions](#clientconnect)
-
-### SocksClient
-
-SocksClient establishes SOCKS proxy connections to remote destination hosts. These proxy connections are fully transparent to the server and once established act as full duplex streams. SOCKS v4, v4a, v5, and v5h are supported, as well as the connect, bind, and associate commands.
-
-SocksClient supports creating connections using callbacks, promises, and async/await flow control using two static factory functions createConnection and createConnectionChain. It also internally extends EventEmitter which results in allowing event handling based async flow control.
-
-**SOCKS Compatibility Table**
-
-Note: When using 4a please specify type: 4, and when using 5h please specify type 5.
-
-| Socks Version | TCP | UDP | IPv4 | IPv6 | Hostname |
-| --- | :---: | :---: | :---: | :---: | :---: |
-| SOCKS v4 | ✅ | ❌ | ✅ | ❌ | ❌ |
-| SOCKS v4a | ✅ | ❌ | ✅ | ❌ | ✅ |
-| SOCKS v5 (includes v5h) | ✅ | ✅ | ✅ | ✅ | ✅ |
-
-### new SocksClient(options)
-
-* ```options``` {SocksClientOptions} - An object describing the SOCKS proxy to use, the command to send and establish, and the destination host to connect to.
-
-### SocksClientOptions
-
-```typescript
-{
-  proxy: {
-    host: '159.203.75.200', // ipv4, ipv6, or hostname
-    port: 1080,
-    type: 5, // Proxy version (4 or 5). For v4a use 4, for v5h use 5.
-
-    // Optional fields
-    userId: 'some username', // Used for SOCKS4 userId auth, and SOCKS5 user/pass auth in conjunction with password.
-    password: 'some password', // Used in conjunction with userId for user/pass auth for SOCKS5 proxies.
-    custom_auth_method: 0x80,  // If using a custom auth method, specify the type here. If this is set, ALL other custom_auth_*** options must be set as well.
-    custom_auth_request_handler: async () =>. {
-      // This will be called when it's time to send the custom auth handshake. You must return a Buffer containing the data to send as your authentication.
-      return Buffer.from([0x01,0x02,0x03]);
-    },
-    // This is the expected size (bytes) of the custom auth response from the proxy server.
-    custom_auth_response_size: 2,
-    // This is called when the auth response is received. The received packet is passed in as a Buffer, and you must return a boolean indicating the response from the server said your custom auth was successful or failed.
-    custom_auth_response_handler: async (data) => {
-      return data[1] === 0x00;
-    }
-  },
-
-  command: 'connect', // connect, bind, associate
-
-  destination: {
-    host: '192.30.253.113', // ipv4, ipv6, hostname. Hostnames work with v4a and v5.
-    port: 80
-  },
-
-  // Optional fields
-  timeout: 30000, // How long to wait to establish a proxy connection. (defaults to 30 seconds)
-
-  set_tcp_nodelay: true // If true, will turn on the underlying sockets TCP_NODELAY option.
-}
-```
-
-### Class Method: SocksClient.createConnection(options[, callback])
-* ```options``` { SocksClientOptions } - An object describing the SOCKS proxy to use, the command to send and establish, and the destination host to connect to.
-* ```callback``` { Function } - Optional callback function that is called when the proxy connection is established, or an error occurs.
-* ```returns``` { Promise } - A Promise is returned that is resolved when the proxy connection is established, or rejected when an error occurs.
-
-Creates a new proxy connection through the given proxy to the given destination host. This factory function supports callbacks and promises for async flow control.
-
-**Note:** If a callback function is provided, the promise will always resolve regardless of an error occurring. Please be sure to exclusively use either promises or callbacks when using this factory function.
-
-```typescript
-const options = {
-  proxy: {
-    host: '159.203.75.200', // ipv4, ipv6, or hostname
-    port: 1080,
-    type: 5 // Proxy version (4 or 5)
-  },
-
-  command: 'connect', // connect, bind, associate
-
-  destination: {
-    host: '192.30.253.113', // ipv4, ipv6, or hostname
-    port: 80
-  }
-}
-
-// Await/Async (uses a Promise)
-try {
-  const info = await SocksClient.createConnection(options);
-  console.log(info);
-  /*
-  {
-    socket: <Socket ...>,  // Raw net.Socket
-  }
-  */
-  / <Socket ...>  (this is a raw net.Socket that is established to the destination host through the given proxy server)
-
-} catch (err) {
-  // Handle error...
-}
-
-// Promise
-SocksClient.createConnection(options)
-.then(info => {
-  console.log(info);
-  /*
-  {
-    socket: <Socket ...>,  // Raw net.Socket
-  }
-  */
-})
-.catch(err => {
-  // Handle error...
-});
-
-// Callback
-SocksClient.createConnection(options, (err, info) => {
-  if (!err) {
-    console.log(info);
-  /*
-  {
-    socket: <Socket ...>,  // Raw net.Socket
-  }
-  */
-  } else {
-    // Handle error...
-  }
-});
-```
-
-### Class Method: SocksClient.createConnectionChain(options[, callback])
-* ```options``` { SocksClientChainOptions } - An object describing a list of SOCKS proxies to use, the command to send and establish, and the destination host to connect to.
-* ```callback``` { Function } - Optional callback function that is called when the proxy connection chain is established, or an error occurs.
-* ```returns``` { Promise } - A Promise is returned that is resolved when the proxy connection chain is established, or rejected when an error occurs.
-
-Creates a new proxy connection chain through a list of at least two SOCKS proxies to the given destination host. This factory method supports callbacks and promises for async flow control.
-
-**Note:** If a callback function is provided, the promise will always resolve regardless of an error occurring. Please be sure to exclusively use either promises or callbacks when using this factory function.
-
-**Note:** At least two proxies must be provided for the chain to be established.
-
-```typescript
-const options = {
-  proxies: [ // The chain order is the order in the proxies array, meaning the last proxy will establish a connection to the destination.
-    {
-      host: '159.203.75.235', // ipv4, ipv6, or hostname
-      port: 1081,
-      type: 5
-    },
-    {
-      host: '104.131.124.203', // ipv4, ipv6, or hostname
-      port: 1081,
-      type: 5
-    }
-  ]
-
-  command: 'connect', // Only connect is supported in chaining mode.
-
-  destination: {
-    host: '192.30.253.113', // ipv4, ipv6, hostname
-    port: 80
-  }
-}
-```
-
-### Class Method: SocksClient.createUDPFrame(details)
-* ```details``` { SocksUDPFrameDetails } - An object containing the remote host, frame number, and frame data to use when creating a SOCKS UDP frame packet.
-* ```returns``` { Buffer } - A Buffer containing all of the UDP frame data.
-
-Creates a SOCKS UDP frame relay packet that is sent and received via a SOCKS proxy when using the associate command for UDP packet forwarding.
-
-**SocksUDPFrameDetails**
-
-```typescript
-{
-  frameNumber: 0, // The frame number (used for breaking up larger packets)
-
-  remoteHost: { // The remote host to have the proxy send data to, or the remote host that send this data.
-    host: '1.2.3.4',
-    port: 1234
-  },
-
-  data: <Buffer 01 02 03 04...> // A Buffer instance of data to include in the packet (actual data sent to the remote host)
-}
-interface SocksUDPFrameDetails {
-  // The frame number of the packet.
-  frameNumber?: number;
-
-  // The remote host.
-  remoteHost: SocksRemoteHost;
-
-  // The packet data.
-  data: Buffer;
-}
-```
-
-### Class Method: SocksClient.parseUDPFrame(data)
-* ```data``` { Buffer } - A Buffer instance containing SOCKS UDP frame data to parse.
-* ```returns``` { SocksUDPFrameDetails } - An object containing the remote host, frame number, and frame data of the SOCKS UDP frame.
-
-```typescript
-const frame = SocksClient.parseUDPFrame(data);
-console.log(frame);
-/*
-{
-  frameNumber: 0,
-  remoteHost: {
-    host: '1.2.3.4',
-    port: 1234
-  },
-  data: <Buffer 01 02 03 04 ...>
-}
-*/
-```
-
-Parses a Buffer instance and returns the parsed SocksUDPFrameDetails object.
-
-## Event: 'error'
-* ```err``` { SocksClientError } - An Error object containing an error message and the original SocksClientOptions.
-
-This event is emitted if an error occurs when trying to establish the proxy connection.
-
-## Event: 'bound'
-* ```info``` { SocksClientBoundEvent } An object containing a Socket and SocksRemoteHost info.
-
-This event is emitted when using the BIND command on a remote SOCKS proxy server. This event indicates the proxy server is now listening for incoming connections on a specified port.
-
-**SocksClientBoundEvent**
-```typescript
-{
-  socket: net.Socket, // The underlying raw Socket
-  remoteHost: {
-    host: '1.2.3.4', // The remote host that is listening (usually the proxy itself)
-    port: 4444 // The remote port the proxy is listening on for incoming connections (when using BIND).
-  }
-}
-```
-
-## Event: 'established'
-* ```info``` { SocksClientEstablishedEvent } An object containing a Socket and SocksRemoteHost info.
-
-This event is emitted when the following conditions are met:
-1. When using the CONNECT command, and a proxy connection has been established to the remote host.
-2. When using the BIND command, and an incoming connection has been accepted by the proxy and a TCP relay has been established.
-3. When using the ASSOCIATE command, and a UDP relay has been established.
-
-When using BIND, 'bound' is first emitted to indicate the SOCKS server is waiting for an incoming connection, and provides the remote port the SOCKS server is listening on.
-
-When using ASSOCIATE, 'established' is emitted with the remote UDP port the SOCKS server is accepting UDP frame packets on.
-
-**SocksClientEstablishedEvent**
-```typescript
-{
-  socket: net.Socket, // The underlying raw Socket
-  remoteHost: {
-    host: '1.2.3.4', // The remote host that is listening (usually the proxy itself)
-    port: 52738 // The remote port the proxy is listening on for incoming connections (when using BIND).
-  }
-}
-```
-
-## client.connect()
-
-Starts connecting to the remote SOCKS proxy server to establish a proxy connection to the destination host.
-
-## client.socksClientOptions
-* ```returns``` { SocksClientOptions } The options that were passed to the SocksClient.
-
-Gets the options that were passed to the SocksClient when it was created.
-
-
-**SocksClientError**
-```typescript
-{ // Subclassed from Error.
-  message: 'An error has occurred',
-  options: {
-    // SocksClientOptions
-  }
-}
-```
-
-# Further Reading:
-
-Please read the SOCKS 5 specifications for more information on how to use BIND and Associate.
-http://www.ietf.org/rfc/rfc1928.txt
-
-# License
-
-This work is licensed under the [MIT license](http://en.wikipedia.org/wiki/MIT_License).
+The MIT License (MIT)
+
+Copyright (c) 2013 Josh Glazebrook
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF socks@2.6.2 AND INFORMATION
+
+%% stack-utils@2.0.5 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) Isaac Z. Schlueter <i@izs.me>, James Talmage <james@talmage.io> (github.com/jamestalmage), and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+=========================================
+END OF stack-utils@2.0.5 AND INFORMATION
+
+%% wrappy@1.0.2 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+=========================================
+END OF wrappy@1.0.2 AND INFORMATION
+
+%% ws@8.4.2 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF ws@8.4.2 AND INFORMATION
 
 %% @types/node@17.0.24 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1213,52 +1506,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 =========================================
 END OF get-stream@5.2.0 AND INFORMATION
 
-%% ms@2.1.2 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The MIT License (MIT)
-
-Copyright (c) 2016 Zeit, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-=========================================
-END OF ms@2.1.2 AND INFORMATION
-
-%% once@1.4.0 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-=========================================
-END OF once@1.4.0 AND INFORMATION
-
 %% pend@1.2.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 The MIT License (Expat)
@@ -1312,26 +1559,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 =========================================
 END OF pump@3.0.0 AND INFORMATION
-
-%% wrappy@1.0.2 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-=========================================
-END OF wrappy@1.0.2 AND INFORMATION
 
 %% yauzl@2.10.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1387,6 +1614,6 @@ END OF yazl@2.5.1 AND INFORMATION
 
 SUMMARY BEGIN HERE
 =========================================
-Total Packages: 18
+Total Packages: 45
 =========================================
 END OF SUMMARY

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -741,6 +741,7 @@ export type BrowserTypeLaunchPersistentContextParams = {
     path: string,
   },
   strictSelectors?: boolean,
+  serviceWorkerPolicy?: 'default' | 'disabled',
   userDataDir: string,
   slowMo?: number,
 };
@@ -813,6 +814,7 @@ export type BrowserTypeLaunchPersistentContextOptions = {
     path: string,
   },
   strictSelectors?: boolean,
+  serviceWorkerPolicy?: 'default' | 'disabled',
   slowMo?: number,
 };
 export type BrowserTypeLaunchPersistentContextResult = {
@@ -909,6 +911,7 @@ export type BrowserNewContextParams = {
     path: string,
   },
   strictSelectors?: boolean,
+  serviceWorkerPolicy?: 'default' | 'disabled',
   proxy?: {
     server: string,
     bypass?: string,
@@ -968,6 +971,7 @@ export type BrowserNewContextOptions = {
     path: string,
   },
   strictSelectors?: boolean,
+  serviceWorkerPolicy?: 'default' | 'disabled',
   proxy?: {
     server: string,
     bypass?: string,
@@ -3995,6 +3999,7 @@ export type AndroidDeviceLaunchBrowserParams = {
     path: string,
   },
   strictSelectors?: boolean,
+  serviceWorkerPolicy?: 'default' | 'disabled',
   pkg?: string,
   proxy?: {
     server: string,
@@ -4051,6 +4056,7 @@ export type AndroidDeviceLaunchBrowserOptions = {
     path: string,
   },
   strictSelectors?: boolean,
+  serviceWorkerPolicy?: 'default' | 'disabled',
   pkg?: string,
   proxy?: {
     server: string,

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -447,6 +447,11 @@ ContextOptions:
         omitContent: boolean?
         path: string
     strictSelectors: boolean?
+    serviceWorkerPolicy:
+      type: enum?
+      literals:
+      - default
+      - disabled
 
 LocalUtils:
   type: interface

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -349,6 +349,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
       path: tString,
     })),
     strictSelectors: tOptional(tBoolean),
+    serviceWorkerPolicy: tOptional(tEnum(['default', 'disabled'])),
     userDataDir: tString,
     slowMo: tOptional(tNumber),
   });
@@ -408,6 +409,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
       path: tString,
     })),
     strictSelectors: tOptional(tBoolean),
+    serviceWorkerPolicy: tOptional(tEnum(['default', 'disabled'])),
     proxy: tOptional(tObject({
       server: tString,
       bypass: tOptional(tString),
@@ -1445,6 +1447,7 @@ export function createScheme(tChannel: (name: string) => Validator): Scheme {
       path: tString,
     })),
     strictSelectors: tOptional(tBoolean),
+    serviceWorkerPolicy: tOptional(tEnum(['default', 'disabled'])),
     pkg: tOptional(tString),
     proxy: tOptional(tObject({
       server: tString,

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -122,6 +122,21 @@ export abstract class BrowserContext extends SdkObject {
 
     if (debugMode() === 'console')
       await this.extendInjectedScript(consoleApiSource.source);
+
+    if (this._options.serviceWorkerPolicy === 'disabled') {
+      await this.addInitScript(`
+
+        // Service Worker Policy Injected Script
+
+        navigator.serviceWorker.register = () => {
+          console.warn('Service Worker registration disabled by Playwright');
+          return Promise.reject('Service Worker registration disabled by Playwright');
+        };
+
+        // END Service Worker Policy Injected Script
+
+      `);
+    }
   }
 
   async _ensureVideosPath() {
@@ -455,6 +470,8 @@ export function validateBrowserContextOptions(options: types.BrowserContextOptio
     throw new Error(`"isMobile" option is not supported with null "viewport"`);
   if (options.acceptDownloads === undefined)
     options.acceptDownloads = true;
+  if (options.serviceWorkerPolicy === undefined)
+    options.serviceWorkerPolicy = 'default';
   if (!options.viewport && !options.noDefaultViewport)
     options.viewport = { width: 1280, height: 720 };
   if (options.recordVideo) {

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -261,6 +261,7 @@ export type BrowserContextOptions = {
   strictSelectors?: boolean,
   proxy?: ProxySettings,
   baseURL?: string,
+  serviceWorkerPolicy?: ServiceWorkerPolicy,
 };
 
 export type EnvArray = { name: string, value: string }[];
@@ -373,3 +374,5 @@ export type AndroidDeviceOptions = {
   port?: number,
   omitDriverInstall?: boolean,
 };
+
+export type ServiceWorkerPolicy = 'default' | 'disabled';

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -10365,12 +10365,17 @@ export interface BrowserType<Unused = {}> {
     };
 
     /**
+     * If set to `disabled`, all Service Worker registrations will be blocked.
+     */
+    serviceWorkerPolicy?: "default"|"disabled";
+
+    /**
      * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going on.
      */
     slowMo?: number;
 
     /**
-     * It specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
+     * If specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
      * that imply single target DOM element will throw when more than one element matches the selector. See [Locator] to learn
      * more about the strict mode.
      */
@@ -11514,7 +11519,12 @@ export interface AndroidDevice {
     };
 
     /**
-     * It specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
+     * If set to `disabled`, all Service Worker registrations will be blocked.
+     */
+    serviceWorkerPolicy?: "default"|"disabled";
+
+    /**
+     * If specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
      * that imply single target DOM element will throw when more than one element matches the selector. See [Locator] to learn
      * more about the strict mode.
      */
@@ -13035,6 +13045,11 @@ export interface Browser extends EventEmitter {
     };
 
     /**
+     * If set to `disabled`, all Service Worker registrations will be blocked.
+     */
+    serviceWorkerPolicy?: "default"|"disabled";
+
+    /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
      * obtained via
      * [browserContext.storageState([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state).
@@ -13089,7 +13104,7 @@ export interface Browser extends EventEmitter {
     };
 
     /**
-     * It specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
+     * If specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
      * that imply single target DOM element will throw when more than one element matches the selector. See [Locator] to learn
      * more about the strict mode.
      */
@@ -15476,6 +15491,11 @@ export interface BrowserContextOptions {
   };
 
   /**
+   * If set to `disabled`, all Service Worker registrations will be blocked.
+   */
+  serviceWorkerPolicy?: "default"|"disabled";
+
+  /**
    * Populates context with given storage state. This option can be used to initialize context with logged-in information
    * obtained via
    * [browserContext.storageState([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state).
@@ -15530,7 +15550,7 @@ export interface BrowserContextOptions {
   };
 
   /**
-   * It specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
+   * If specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
    * that imply single target DOM element will throw when more than one element matches the selector. See [Locator] to learn
    * more about the strict mode.
    */

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -159,6 +159,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
   baseURL: [ async ({ }, use) => {
     await use(process.env.PLAYWRIGHT_TEST_BASE_URL);
   }, { option: true } ],
+  serviceWorkerPolicy: [ undefined, { option: true } ],
   contextOptions: [ {}, { option: true } ],
 
   _combinedContextOptions: async ({

--- a/packages/playwright-test/src/mount.ts
+++ b/packages/playwright-test/src/mount.ts
@@ -134,6 +134,7 @@ function contextHash(context: BrowserContextOptions): string {
     timezoneId: context.timezoneId,
     userAgent: context.userAgent,
     deviceScaleFactor: context.deviceScaleFactor,
+    serviceWorkerPolicy: context.serviceWorkerPolicy,
   };
   return JSON.stringify(hash);
 }

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -2464,6 +2464,7 @@ type ColorScheme = Exclude<BrowserContextOptions['colorScheme'], undefined>;
 type ExtraHTTPHeaders = Exclude<BrowserContextOptions['extraHTTPHeaders'], undefined>;
 type Proxy = Exclude<BrowserContextOptions['proxy'], undefined>;
 type StorageState = Exclude<BrowserContextOptions['storageState'], undefined>;
+type ServiceWorkerPolicy = Exclude<BrowserContextOptions['serviceWorkerPolicy'], undefined>;
 type ConnectOptions = {
   /**
    * A browser websocket endpoint to connect to.
@@ -2768,6 +2769,10 @@ export interface PlaywrightTestOptions {
    * Learn more about [various timeouts](https://playwright.dev/docs/test-timeouts).
    */
   navigationTimeout: number | undefined;
+  /**
+   * If set to `disabled`, all Service Worker registrations will be blocked.
+   */
+  serviceWorkerPolicy: ServiceWorkerPolicy | undefined;
 }
 
 

--- a/tests/config/experimental.d.ts
+++ b/tests/config/experimental.d.ts
@@ -10367,12 +10367,17 @@ export interface BrowserType<Unused = {}> {
     };
 
     /**
+     * If set to `disabled`, all Service Worker registrations will be blocked.
+     */
+    serviceWorkerPolicy?: "default"|"disabled";
+
+    /**
      * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going on.
      */
     slowMo?: number;
 
     /**
-     * It specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
+     * If specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
      * that imply single target DOM element will throw when more than one element matches the selector. See [Locator] to learn
      * more about the strict mode.
      */
@@ -11516,7 +11521,12 @@ export interface AndroidDevice {
     };
 
     /**
-     * It specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
+     * If set to `disabled`, all Service Worker registrations will be blocked.
+     */
+    serviceWorkerPolicy?: "default"|"disabled";
+
+    /**
+     * If specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
      * that imply single target DOM element will throw when more than one element matches the selector. See [Locator] to learn
      * more about the strict mode.
      */
@@ -13037,6 +13047,11 @@ export interface Browser extends EventEmitter {
     };
 
     /**
+     * If set to `disabled`, all Service Worker registrations will be blocked.
+     */
+    serviceWorkerPolicy?: "default"|"disabled";
+
+    /**
      * Populates context with given storage state. This option can be used to initialize context with logged-in information
      * obtained via
      * [browserContext.storageState([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state).
@@ -13091,7 +13106,7 @@ export interface Browser extends EventEmitter {
     };
 
     /**
-     * It specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
+     * If specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
      * that imply single target DOM element will throw when more than one element matches the selector. See [Locator] to learn
      * more about the strict mode.
      */
@@ -15478,6 +15493,11 @@ export interface BrowserContextOptions {
   };
 
   /**
+   * If set to `disabled`, all Service Worker registrations will be blocked.
+   */
+  serviceWorkerPolicy?: "default"|"disabled";
+
+  /**
    * Populates context with given storage state. This option can be used to initialize context with logged-in information
    * obtained via
    * [browserContext.storageState([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state).
@@ -15532,7 +15552,7 @@ export interface BrowserContextOptions {
   };
 
   /**
-   * It specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
+   * If specified, enables strict selectors mode for this context. In the strict selectors mode all operations on selectors
    * that imply single target DOM element will throw when more than one element matches the selector. See [Locator] to learn
    * more about the strict mode.
    */
@@ -18684,6 +18704,7 @@ type ColorScheme = Exclude<BrowserContextOptions['colorScheme'], undefined>;
 type ExtraHTTPHeaders = Exclude<BrowserContextOptions['extraHTTPHeaders'], undefined>;
 type Proxy = Exclude<BrowserContextOptions['proxy'], undefined>;
 type StorageState = Exclude<BrowserContextOptions['storageState'], undefined>;
+type ServiceWorkerPolicy = Exclude<BrowserContextOptions['serviceWorkerPolicy'], undefined>;
 type ConnectOptions = {
   /**
    * A browser websocket endpoint to connect to.
@@ -18988,6 +19009,10 @@ export interface PlaywrightTestOptions {
    * Learn more about [various timeouts](https://playwright.dev/docs/test-timeouts).
    */
   navigationTimeout: number | undefined;
+  /**
+   * If set to `disabled`, all Service Worker registrations will be blocked.
+   */
+  serviceWorkerPolicy: ServiceWorkerPolicy | undefined;
 }
 
 

--- a/tests/library/browsercontext-service-worker-policy.spec.ts
+++ b/tests/library/browsercontext-service-worker-policy.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { browserTest as it, expect } from '../config/browserTest';
+
+it('should allow service workers by default', async ({ contextFactory, server }) => {
+  const context = await contextFactory();
+  const page = await context.newPage();
+  await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+  await expect(page.evaluate(() => window['registrationPromise'])).resolves.toBeTruthy();
+  await context.close();
+});
+
+
+it('should fail service worker registrations', async ({ contextFactory, server, browserName }) => {
+  const context = await contextFactory({
+    serviceWorkerPolicy: 'disabled',
+  });
+  const page = await context.newPage();
+  await Promise.all([
+    page.waitForEvent('console', evt => evt.text() === 'Service Worker registration disabled by Playwright'),
+    page.goto(server.PREFIX + '/serviceworkers/empty/sw.html'),
+  ]);
+  const err = await page.evaluate(() => window['registrationPromise']).catch(e => `REJECTED: ${e}`);
+  if (browserName === 'firefox')
+    expect(err).toMatch(/^REJECTED:.*undefined/);
+  else
+    expect(err).toMatch(/^REJECTED:.*Service Worker registration disabled by Playwright/);
+  await context.close();
+});

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -175,6 +175,7 @@ type ColorScheme = Exclude<BrowserContextOptions['colorScheme'], undefined>;
 type ExtraHTTPHeaders = Exclude<BrowserContextOptions['extraHTTPHeaders'], undefined>;
 type Proxy = Exclude<BrowserContextOptions['proxy'], undefined>;
 type StorageState = Exclude<BrowserContextOptions['storageState'], undefined>;
+type ServiceWorkerPolicy = Exclude<BrowserContextOptions['serviceWorkerPolicy'], undefined>;
 type ConnectOptions = {
   /**
    * A browser websocket endpoint to connect to.
@@ -231,6 +232,7 @@ export interface PlaywrightTestOptions {
   contextOptions: BrowserContextOptions;
   actionTimeout: number | undefined;
   navigationTimeout: number | undefined;
+  serviceWorkerPolicy: ServiceWorkerPolicy | undefined;
 }
 
 


### PR DESCRIPTION
Anecdotally, it's common for users to want to disable Service Workers
while testing, so this provides a simple context option to do so.

It also prepares us to land #14321 which requires us to have a point for
folks to enable seeing Service Worker Requests as events (and allow for
routing).

Resolves #14522