### PR TITLE
fix(runner): run afterAll after test fixtures tear down

### DIFF
--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -391,6 +391,11 @@ export class WorkerRunner extends EventEmitter {
         firstAfterHooksError = firstAfterHooksError || afterEachError;
       }
 
+      // Teardown test-scoped fixtures.
+      testInfo._timeoutManager.setCurrentRunnable({ type: 'teardown', slot: afterHooksSlot });
+      const testScopeError = await testInfo._runFn(() => this._fixtureRunner.teardownScope('test', testInfo._timeoutManager));
+      firstAfterHooksError = firstAfterHooksError || testScopeError;
+
       // Run "afterAll" hooks for suites that are not shared with the next test.
       const nextSuites = new Set(getSuites(nextTest));
       for (const suite of reversedSuites) {
@@ -399,11 +404,6 @@ export class WorkerRunner extends EventEmitter {
           firstAfterHooksError = firstAfterHooksError || afterAllError;
         }
       }
-
-      // Teardown test-scoped fixtures.
-      testInfo._timeoutManager.setCurrentRunnable({ type: 'teardown', slot: afterHooksSlot });
-      const testScopeError = await testInfo._runFn(() => this._fixtureRunner.teardownScope('test', testInfo._timeoutManager));
-      firstAfterHooksError = firstAfterHooksError || testScopeError;
     });
 
     const isFailure = testInfo.status !== 'skipped' && testInfo.status !== testInfo.expectedStatus;

--- a/tests/playwright-test/fixtures.spec.ts
+++ b/tests/playwright-test/fixtures.spec.ts
@@ -671,6 +671,32 @@ test('should run tests in order', async ({ runInlineTest }) => {
   ]);
 });
 
+test('should tear down test fixture before afterAll', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      const { test } = pwt;
+      let state = 'afterAll did not run';
+
+      const test1 = test.extend({
+        foo: async ({}, run) => {
+          await run();
+          expect(state).toBe('afterAll did not run');
+        }
+      });
+
+      test1.afterAll(() => {
+        state = 'afterAll finished';
+      });
+
+      test1('test1', async ({ foo }, testInfo) => {
+      });
+    `,
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(0);
+});
+
 test('worker fixture should not receive TestInfo', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `


### PR DESCRIPTION
`afterAll` hooks should run after test fixtures have been torn down.

#14333