### PR TITLE
tests: attempt to fix WebKit headed tests

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -158,6 +158,12 @@ jobs:
       env:
         DEBUG: pw:install
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+    - name: set high screen resolution
+      run: |
+        system_profiler SPDisplaysDataType | grep Resolution
+        "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1280 1024
+        system_profiler SPDisplaysDataType | grep Resolution
+      if: matrix.os == 'macos-latest'
     - run: npm run build
     - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }} --headed


### PR DESCRIPTION
It looks like GitHub Actions have default screen resolution of 1176 x 694, so
we can't open a browser window larger than this size.

This patch sets screen resolution to be at least 1280 x 1024.
