### PR TITLE
browser(webkit): rebase to 05/31/22 (r295073)

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1652
-Changed: dpino@igalia.com Thu May 26 09:36:11 UTC 2022
+1653
+Changed: dpino@igalia.com Wed Jun  1 17:53:30 UTC 2022

--- a/browser_patches/webkit/UPSTREAM_CONFIG.sh
+++ b/browser_patches/webkit/UPSTREAM_CONFIG.sh
@@ -1,3 +1,3 @@
 REMOTE_URL="https://github.com/WebKit/WebKit.git"
 BASE_BRANCH="main"
-BASE_REVISION="0e798281d3ad557900b890a1ffdee2984b05c227"
+BASE_REVISION="b443fbf87d8dcbaabdd9bde259a812a2e5622906"

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -1,5 +1,5 @@
 diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
-index cc949e8304d49f72552cc4f11f5806f9ac8c313f..3b5137abf27276f2506a944f71e9f3bd6d0a7e6d 100644
+index bb4ad01e4262640d9d6dad18655be08468f073ce..5697dfc37cabe285f975b9f0e13d48251dde7803 100644
 --- a/Source/JavaScriptCore/CMakeLists.txt
 +++ b/Source/JavaScriptCore/CMakeLists.txt
 @@ -1352,22 +1352,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
@@ -31,10 +31,10 @@ index cc949e8304d49f72552cc4f11f5806f9ac8c313f..3b5137abf27276f2506a944f71e9f3bd
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/ServiceWorker.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Target.json
 diff --git a/Source/JavaScriptCore/DerivedSources.make b/Source/JavaScriptCore/DerivedSources.make
-index 1fb623cd6f6e8d8987f94804544f0d44e5b35f08..98a74d2b1ca19b044f2f75960e1b5134773f3c14 100644
+index 19f09213a6f7ddade2380ac3d60d24aab99ade5a..5f049b829ec3fd1b87c9130ddaca14fc1844c741 100644
 --- a/Source/JavaScriptCore/DerivedSources.make
 +++ b/Source/JavaScriptCore/DerivedSources.make
-@@ -291,22 +291,27 @@ INSPECTOR_DOMAINS := \
+@@ -292,22 +292,27 @@ INSPECTOR_DOMAINS := \
      $(JavaScriptCore)/inspector/protocol/CSS.json \
      $(JavaScriptCore)/inspector/protocol/Canvas.json \
      $(JavaScriptCore)/inspector/protocol/Console.json \
@@ -1802,7 +1802,7 @@ index 4157c0a95fa332ac85a295814fda2fb61f3da434..6edd90d2c5fc3b16d19f4d73edacf8b3
 +_vpx_codec_version_str
 +_vpx_codec_vp8_cx
 diff --git a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
-index cc89d13e8e007737e4325392a9d7bb81ea88d566..7a08f298defd4c9dd77354f5b892a03928bbb711 100644
+index 64433d3d2a0be3d9b83bde060700af8ce57a0b9d..14e35310c06a3add1cbe951287706be705761580 100644
 --- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 +++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
 @@ -50,7 +50,7 @@ DYLIB_INSTALL_NAME_BASE_WK_RELOCATABLE_FRAMEWORKS_ = $(NORMAL_WEBCORE_FRAMEWORKS
@@ -1812,7 +1812,7 @@ index cc89d13e8e007737e4325392a9d7bb81ea88d566..7a08f298defd4c9dd77354f5b892a039
 -HEADER_SEARCH_PATHS = Source Source/third_party/libsrtp/crypto/include Source/third_party/libsrtp/include Source/third_party/boringssl/src/include Source/third_party/libyuv/include Source/third_party/usrsctp Source/third_party/usrsctp/usrsctplib Source/third_party/usrsctp/usrsctplib/usrsctplib Source/webrtc/sdk/objc/Framework/Headers Source/webrtc/common_audio/signal_processing/include Source/webrtc/modules/audio_coding/codecs/isac/main/include Source/third_party/opus/src/celt Source/third_party/opus/src/include Source/third_party/opus/src/src Source/webrtc/modules/audio_device/mac Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet Source/webrtc/modules/audio_device/ios Source/webrtc Source/webrtc/sdk/objc Source/webrtc/sdk/objc/base Source/webrtc/sdk/objc/Framework/Classes Source/third_party/libsrtp/config Source/webrtc/sdk/objc/Framework/Classes/Common Source/webrtc/sdk/objc/Framework/Classes/Video Source/webrtc/sdk/objc/Framework/Classes/PeerConnection Source/third_party/abseil-cpp Source/third_party/libvpx/source/libvpx Source/third_party/libwebm/webm_parser/include;
 +HEADER_SEARCH_PATHS = Source Source/third_party/libsrtp/crypto/include Source/third_party/libsrtp/include Source/third_party/boringssl/src/include Source/third_party/libyuv/include Source/third_party/usrsctp Source/third_party/usrsctp/usrsctplib Source/third_party/usrsctp/usrsctplib/usrsctplib Source/webrtc/sdk/objc/Framework/Headers Source/webrtc/common_audio/signal_processing/include Source/webrtc/modules/audio_coding/codecs/isac/main/include Source/third_party/opus/src/celt Source/third_party/opus/src/include Source/third_party/opus/src/src Source/webrtc/modules/audio_device/mac Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet Source/webrtc/modules/audio_device/ios Source/webrtc Source/webrtc/sdk/objc Source/webrtc/sdk/objc/base Source/webrtc/sdk/objc/Framework/Classes Source/third_party/libsrtp/config Source/webrtc/sdk/objc/Framework/Classes/Common Source/webrtc/sdk/objc/Framework/Classes/Video Source/webrtc/sdk/objc/Framework/Classes/PeerConnection Source/third_party/abseil-cpp Source/third_party/libvpx/source/libvpx Source/third_party/libwebm/webm_parser/include Source/third_party/libvpx/source/libvpx/third_party/libwebm;
  
- PUBLIC_HEADERS_FOLDER_PREFIX = /usr/local/include;
+ PUBLIC_HEADERS_FOLDER_PREFIX = $(WK_LIBRARY_HEADERS_FOLDER_PATH);
  INSTALL_PUBLIC_HEADER_PREFIX = $(INSTALL_PATH_PREFIX)$(PUBLIC_HEADERS_FOLDER_PREFIX);
 diff --git a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
 index e4b94b59216277aae01696e6d4846abf8f287dce..86dd35168450f2d9ab91c2b2d0f6ca954ecf8ba7 100644
@@ -2051,10 +2051,10 @@ index 2383d5b94b869e13a305571add135a730e15d5b1..9399a38171ba2ed87e10f0944138d148
    type: bool
    humanReadableName: "Private Click Measurement"
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index d14f8687510aa4f2a7ec2d0b41055e7cde58031f..e9d07bc57b77ca6acca110a39359e565fc1e4a47 100644
+index 766be08177248750e8cbbddff798bfd4e3a81ba1..11ca05a55357ff757719a1e5f62729e7aaadb74d 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-@@ -479,7 +479,7 @@ CrossOriginOpenerPolicyEnabled:
+@@ -503,7 +503,7 @@ CrossOriginOpenerPolicyEnabled:
      WebKitLegacy:
        default: false
      WebKit:
@@ -2063,7 +2063,7 @@ index d14f8687510aa4f2a7ec2d0b41055e7cde58031f..e9d07bc57b77ca6acca110a39359e565
      WebCore:
        default: false
  
-@@ -856,9 +856,9 @@ MaskWebGLStringsEnabled:
+@@ -880,9 +880,9 @@ MaskWebGLStringsEnabled:
      WebKitLegacy:
        default: true
      WebKit:
@@ -2075,7 +2075,7 @@ index d14f8687510aa4f2a7ec2d0b41055e7cde58031f..e9d07bc57b77ca6acca110a39359e565
  
  # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
  MediaCapabilitiesExtensionsEnabled:
-@@ -1366,7 +1366,7 @@ SpeechRecognitionEnabled:
+@@ -1390,7 +1390,7 @@ SpeechRecognitionEnabled:
      WebKitLegacy:
        default: false
      WebKit:
@@ -2084,7 +2084,7 @@ index d14f8687510aa4f2a7ec2d0b41055e7cde58031f..e9d07bc57b77ca6acca110a39359e565
        default: false
      WebCore:
        default: false
-@@ -1481,6 +1481,7 @@ UseGPUProcessForDisplayCapture:
+@@ -1505,6 +1505,7 @@ UseGPUProcessForDisplayCapture:
      WebKit:
        default: false
  
@@ -2092,7 +2092,7 @@ index d14f8687510aa4f2a7ec2d0b41055e7cde58031f..e9d07bc57b77ca6acca110a39359e565
  UseGPUProcessForWebGLEnabled:
    type: bool
    humanReadableName: "GPU Process: WebGL"
-@@ -1491,7 +1492,7 @@ UseGPUProcessForWebGLEnabled:
+@@ -1515,7 +1516,7 @@ UseGPUProcessForWebGLEnabled:
    defaultValue:
      WebKit:
        "ENABLE(GPU_PROCESS_BY_DEFAULT) && PLATFORM(IOS_FAMILY) && !HAVE(UIKIT_WEBKIT_INTERNALS)": true
@@ -2123,10 +2123,10 @@ index 78b806ade5ac37c3b4b075aa39a3962888a217da..de4f57b6e10141d78ad77ae5cd754740
  
  UseGPUProcessForMediaEnabled:
 diff --git a/Source/WTF/wtf/PlatformEnable.h b/Source/WTF/wtf/PlatformEnable.h
-index 4867c7ea9d2f6e08c66692e26a8c29641b03297d..6ca27cacb2869d6aeeba4c69ca7bd94f685c1762 100644
+index 2af5d10c7741eb4b6b33dfcd3ac807f1d0c30461..1c681372cf061b6b14600fae8540f40ca1451d28 100644
 --- a/Source/WTF/wtf/PlatformEnable.h
 +++ b/Source/WTF/wtf/PlatformEnable.h
-@@ -420,7 +420,7 @@
+@@ -416,7 +416,7 @@
  #endif
  
  #if !defined(ENABLE_ORIENTATION_EVENTS)
@@ -2135,7 +2135,7 @@ index 4867c7ea9d2f6e08c66692e26a8c29641b03297d..6ca27cacb2869d6aeeba4c69ca7bd94f
  #endif
  
  #if OS(WINDOWS)
-@@ -481,7 +481,7 @@
+@@ -477,7 +477,7 @@
  #endif
  
  #if !defined(ENABLE_TOUCH_EVENTS)
@@ -2170,7 +2170,7 @@ index bb01bfeeac63f854fa656ec6b8d262fafc4c9df5..f8376ea8aada69d2e53734ba8fd234c2
  
  if (Journald_FOUND)
 diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
-index 5fa4d36f5d7f6a997c85dbf23f38918b659c7e6c..71958e68e2442c387a9c764f6659cb6bf27ff627 100644
+index ba64118161e8fc6f9ef9334354dc057c020e9045..0e69cc066acf8afb12dfaa2ed81c76d55aafbdee 100644
 --- a/Source/WTF/wtf/PlatformHave.h
 +++ b/Source/WTF/wtf/PlatformHave.h
 @@ -414,7 +414,7 @@
@@ -2195,7 +2195,7 @@ index 09d4af604a835c7c6be1e43c249565bd1053aff4..0d6112342480454ce41a6b56dd925e1d
  
  if (Journald_FOUND)
 diff --git a/Source/WebCore/DerivedSources.make b/Source/WebCore/DerivedSources.make
-index b123abf93e2758d21148c101c9d1734d0496f9a4..b0f076df5692925a4f93c67f2dca9bc86e3cdf53 100644
+index b8892d2a1791c0a01a0468eb9efb6d8aac08f26a..f90f1d42d6d8e07d6006cf5c0f033b2e03f0d121 100644
 --- a/Source/WebCore/DerivedSources.make
 +++ b/Source/WebCore/DerivedSources.make
 @@ -976,6 +976,10 @@ JS_BINDING_IDLS := \
@@ -2209,7 +2209,7 @@ index b123abf93e2758d21148c101c9d1734d0496f9a4..b0f076df5692925a4f93c67f2dca9bc8
      $(WebCore)/dom/Text.idl \
      $(WebCore)/dom/TextDecoder.idl \
      $(WebCore)/dom/TextDecoderStream.idl \
-@@ -1519,9 +1523,6 @@ JS_BINDING_IDLS := \
+@@ -1521,9 +1525,6 @@ JS_BINDING_IDLS := \
  ADDITIONAL_BINDING_IDLS = \
      DocumentTouch.idl \
      GestureEvent.idl \
@@ -2375,10 +2375,10 @@ index c4898d6db6bf06552f602c4b7f0a7267e64e44f4..7cf2e30729671a89c373870c5691d337
  __ZN7WebCore14DocumentLoaderD2Ev
  __ZN7WebCore14DocumentLoader17clearMainResourceEv
 diff --git a/Source/WebCore/WebCore.xcodeproj/project.pbxproj b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4cecc6351 100644
+index a08974f0a5d579995e18571c83c60c7a88a038a5..60819585f2ddb831509d3b6365875b062a0637c4 100644
 --- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 +++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-@@ -5531,6 +5531,13 @@
+@@ -5537,6 +5537,13 @@
  		EDE3A5000C7A430600956A37 /* ColorMac.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE3A4FF0C7A430600956A37 /* ColorMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		EDEC98030AED7E170059137F /* WebCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEC98020AED7E170059137F /* WebCorePrefix.h */; };
  		EFCC6C8F20FE914400A2321B /* CanvasActivityRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2392,7 +2392,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  		F12171F616A8CF0B000053CA /* WebVTTElement.h in Headers */ = {isa = PBXBuildFile; fileRef = F12171F416A8BC63000053CA /* WebVTTElement.h */; };
  		F32BDCD92363AACA0073B6AE /* UserGestureEmulationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F32BDCD72363AACA0073B6AE /* UserGestureEmulationScope.h */; };
  		F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
-@@ -17870,6 +17877,14 @@
+@@ -17886,6 +17893,14 @@
  		EDEC98020AED7E170059137F /* WebCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCorePrefix.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
  		EFB7287B2124C73D005C2558 /* CanvasActivityRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasActivityRecord.cpp; sourceTree = "<group>"; };
  		EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasActivityRecord.h; sourceTree = "<group>"; };
@@ -2407,7 +2407,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  		F12171F316A8BC63000053CA /* WebVTTElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebVTTElement.cpp; sourceTree = "<group>"; };
  		F12171F416A8BC63000053CA /* WebVTTElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebVTTElement.h; sourceTree = "<group>"; };
  		F32BDCD52363AAC90073B6AE /* UserGestureEmulationScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserGestureEmulationScope.cpp; sourceTree = "<group>"; };
-@@ -24293,7 +24308,12 @@
+@@ -24315,7 +24330,12 @@
  				1AF326770D78B9440068F0C4 /* EditorClient.h */,
  				E36D701E27B71F04006531B7 /* EmptyAttachmentElementClient.h */,
  				93C09A800B064F00005ABD4D /* EventHandler.cpp */,
@@ -2420,7 +2420,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  				E0FEF371B27C53EAC1C1FBEE /* EventSource.cpp */,
  				E0FEF371B17C53EAC1C1FBEE /* EventSource.h */,
  				E0FEF371B07C53EAC1C1FBEE /* EventSource.idl */,
-@@ -30328,6 +30348,8 @@
+@@ -30354,6 +30374,8 @@
  				29E4D8DF16B0940F00C84704 /* PlatformSpeechSynthesizer.h */,
  				1AD8F81A11CAB9E900E93E54 /* PlatformStrategies.cpp */,
  				1AD8F81911CAB9E900E93E54 /* PlatformStrategies.h */,
@@ -2429,7 +2429,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  				0FD7C21D23CE41E30096D102 /* PlatformWheelEvent.cpp */,
  				935C476A09AC4D4F00A6AAB4 /* PlatformWheelEvent.h */,
  				BCBB8AB513F1AFB000734DF0 /* PODInterval.h */,
-@@ -32636,6 +32658,7 @@
+@@ -32662,6 +32684,7 @@
  				BCCFBAE70B5152ED0001F1D7 /* DocumentParser.h */,
  				AD6E71AA1668899D00320C13 /* DocumentSharedObjectPool.cpp */,
  				AD6E71AB1668899D00320C13 /* DocumentSharedObjectPool.h */,
@@ -2437,7 +2437,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  				6BDB5DC1227BD3B800919770 /* DocumentStorageAccess.cpp */,
  				6BDB5DC0227BD3B800919770 /* DocumentStorageAccess.h */,
  				7CE7FA5B1EF882300060C9D6 /* DocumentTouch.cpp */,
-@@ -33645,6 +33668,7 @@
+@@ -33671,6 +33694,7 @@
  				93C4F6EB1108F9A50099D0DB /* AccessibilityScrollbar.h in Headers */,
  				29489FC712C00F0300D83F0F /* AccessibilityScrollView.h in Headers */,
  				0709FC4E1025DEE30059CDBA /* AccessibilitySlider.h in Headers */,
@@ -2445,7 +2445,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  				29D7BCFA1444AF7D0070619C /* AccessibilitySpinButton.h in Headers */,
  				69A6CBAD1C6BE42C00B836E9 /* AccessibilitySVGElement.h in Headers */,
  				AAC08CF315F941FD00F1E188 /* AccessibilitySVGRoot.h in Headers */,
-@@ -35792,6 +35816,7 @@
+@@ -35823,6 +35847,7 @@
  				6E4ABCD5138EA0B70071D291 /* JSHTMLUnknownElement.h in Headers */,
  				E44614170CD6826900FADA75 /* JSHTMLVideoElement.h in Headers */,
  				81BE20D311F4BC3200915DFA /* JSIDBCursor.h in Headers */,
@@ -2453,7 +2453,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  				7C3D8EF01E0B21430023B084 /* JSIDBCursorDirection.h in Headers */,
  				C585A68311D4FB08004C3E4B /* JSIDBDatabase.h in Headers */,
  				C585A69711D4FB13004C3E4B /* JSIDBFactory.h in Headers */,
-@@ -36915,6 +36940,7 @@
+@@ -36946,6 +36971,7 @@
  				0F7D07331884C56C00B4AF86 /* PlatformTextTrack.h in Headers */,
  				074E82BB18A69F0E007EF54C /* PlatformTimeRanges.h in Headers */,
  				CDD08ABD277E542600EA3755 /* PlatformTrackConfiguration.h in Headers */,
@@ -2461,7 +2461,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  				CD1F9B022700323D00617EB6 /* PlatformVideoColorPrimaries.h in Headers */,
  				CD1F9B01270020B700617EB6 /* PlatformVideoColorSpace.h in Headers */,
  				CD1F9B032700323D00617EB6 /* PlatformVideoMatrixCoefficients.h in Headers */,
-@@ -39009,6 +39035,7 @@
+@@ -39041,6 +39067,7 @@
  				1ABA76CA11D20E50004C201C /* CSSPropertyNames.cpp in Sources */,
  				2D22830323A8470700364B7E /* CursorMac.mm in Sources */,
  				5CBD59592280E926002B22AA /* CustomHeaderFields.cpp in Sources */,
@@ -2469,7 +2469,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  				7CE6CBFD187F394900D46BF5 /* FormatConverter.cpp in Sources */,
  				5130F2F624AEA60A00E1D0A0 /* GameControllerSoftLink.mm in Sources */,
  				51A4BB0A1954D61600FA5C2E /* Gamepad.cpp in Sources */,
-@@ -39085,6 +39112,7 @@
+@@ -39117,6 +39144,7 @@
  				C1692DD223D23ABD006E88F7 /* SystemBattery.mm in Sources */,
  				CE88EE262414467B007F29C2 /* TextAlternativeWithRange.mm in Sources */,
  				51DF6D800B92A18E00C2DC85 /* ThreadCheck.mm in Sources */,
@@ -2477,7 +2477,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  				538EC8031F96AF81004D22A8 /* UnifiedSource1-mm.mm in Sources */,
  				538EC8021F96AF81004D22A8 /* UnifiedSource1.cpp in Sources */,
  				538EC8051F96AF81004D22A8 /* UnifiedSource2-mm.mm in Sources */,
-@@ -39133,6 +39161,7 @@
+@@ -39165,6 +39193,7 @@
  				538EC8881F993F9C004D22A8 /* UnifiedSource23.cpp in Sources */,
  				DE5F85801FA1ABF4006DB63A /* UnifiedSource24-mm.mm in Sources */,
  				538EC8891F993F9D004D22A8 /* UnifiedSource24.cpp in Sources */,
@@ -2485,7 +2485,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  				DE5F85811FA1ABF4006DB63A /* UnifiedSource25-mm.mm in Sources */,
  				538EC88A1F993F9D004D22A8 /* UnifiedSource25.cpp in Sources */,
  				DE5F85821FA1ABF4006DB63A /* UnifiedSource26-mm.mm in Sources */,
-@@ -39665,6 +39694,7 @@
+@@ -39697,6 +39726,7 @@
  				2D8B92F1203D13E1009C868F /* UnifiedSource516.cpp in Sources */,
  				2D8B92F2203D13E1009C868F /* UnifiedSource517.cpp in Sources */,
  				2D8B92F3203D13E1009C868F /* UnifiedSource518.cpp in Sources */,
@@ -2494,7 +2494,7 @@ index ff8a77bde312abf01cdb79e0ffc225b1df757138..77d30b0e110a10d7c7f260d82d35c9f4
  				2D8B92F5203D13E1009C868F /* UnifiedSource520.cpp in Sources */,
  				2D8B92F6203D13E1009C868F /* UnifiedSource521.cpp in Sources */,
 diff --git a/Source/WebCore/accessibility/AccessibilityObject.cpp b/Source/WebCore/accessibility/AccessibilityObject.cpp
-index e7cd6584978e30c2149784d302af997f3a65c8e3..82f51cd262be3dcf3a5c3f9a97d62269f4d09985 100644
+index e7b992a4fa4a711639d7089c6508d782fb128fd5..e5c4ff499af4abcb6e3877844ae74df5760a102b 100644
 --- a/Source/WebCore/accessibility/AccessibilityObject.cpp
 +++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
 @@ -61,6 +61,7 @@
@@ -2523,7 +2523,7 @@ index e7cd6584978e30c2149784d302af997f3a65c8e3..82f51cd262be3dcf3a5c3f9a97d62269
  {
      AXComputedObjectAttributeCache* attributeCache = nullptr;
 diff --git a/Source/WebCore/accessibility/AccessibilityObjectInterface.h b/Source/WebCore/accessibility/AccessibilityObjectInterface.h
-index fc43cb10a804186f754dc27cd3d1d5884a8dc6f7..047af6938869ccf5fedb19973d67402bcd940901 100644
+index f74784a950c349f692298ede02ab3e4fdad4cdf3..d77d4e8eb557f07ec65fac01c529616f71f397bd 100644
 --- a/Source/WebCore/accessibility/AccessibilityObjectInterface.h
 +++ b/Source/WebCore/accessibility/AccessibilityObjectInterface.h
 @@ -57,7 +57,7 @@ typedef const struct __AXTextMarkerRange* AXTextMarkerRangeRef;
@@ -2535,7 +2535,7 @@ index fc43cb10a804186f754dc27cd3d1d5884a8dc6f7..047af6938869ccf5fedb19973d67402b
  #endif
  
  namespace PAL {
-@@ -1529,6 +1529,8 @@ private:
+@@ -1552,6 +1552,8 @@ private:
      COMPtr<AccessibilityObjectWrapper> m_wrapper;
  #elif USE(ATSPI)
      RefPtr<AccessibilityObjectAtspi> m_wrapper;
@@ -2642,10 +2642,10 @@ index 0000000000000000000000000000000000000000..dd2d8452302999e4a89b0bc18e842645
 +
 +#endif // ENABLE(ACCESSIBILITY) && !USE(ATK) && !USE(ATSPI)
 diff --git a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
-index 63ea7faaf59dd77940293446338fa8b228355fa5..ea522b60acc03e3ff82cb0a4afa2d2317bd2e31d 100644
+index 2cc6674df51634daa275a34828b832212ade9b2a..697cf75e301cae080c8fcc8ad749142e33f14683 100644
 --- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
 +++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
-@@ -131,6 +131,8 @@ namespace WebCore {
+@@ -132,6 +132,8 @@ namespace WebCore {
      macro(DataTransferItem) \
      macro(DataTransferItemList) \
      macro(DelayNode) \
@@ -3869,7 +3869,7 @@ index 1a4779cbc9f388434295a94fd9da566d6ff4e3f7..c4712dd9f1319c205b97e5afa0a903b7
      // InspectorInstrumentation
      void willRecalculateStyle();
 diff --git a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
-index 258429e97b12ddf52aa2d23b1dd541a5ddcf532f..e5be0d69facff68cef5311f4fd2ca4b68aa1c660 100644
+index 78c340d26e07205fa467ac93f068423ea23e99d7..315887ccd675e5f1726668486deaaa9f1f1775b0 100644
 --- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
 +++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
 @@ -32,20 +32,28 @@
@@ -5300,7 +5300,7 @@ index 11bda04703c38c0ac3c81ca8d575c453ed3430a2..d1d0d7c2002e3e4021584e6493d91ac2
  class UserGestureEmulationScope {
      WTF_MAKE_NONCOPYABLE(UserGestureEmulationScope);
 diff --git a/Source/WebCore/loader/CookieJar.h b/Source/WebCore/loader/CookieJar.h
-index 982691dd2dfe2f65201370a12302b5086703c126..4af72beb3b1405ffac78e89e7fbb2b14d6647903 100644
+index 21e33e46bdb1af8434527747e3c308cbe53f60f0..c17c4de17f439c04d27caa532771934cb2f62abd 100644
 --- a/Source/WebCore/loader/CookieJar.h
 +++ b/Source/WebCore/loader/CookieJar.h
 @@ -43,6 +43,7 @@ struct CookieRequestHeaderFieldProxy;
@@ -7804,7 +7804,7 @@ index f169677e661510b225b899c79b68d040179a097a..420e101c7bb7a49b5c644076a8a2ffab
          m_commonHeaders.append(CommonHeader { name, value });
  }
 diff --git a/Source/WebCore/platform/network/NetworkStorageSession.h b/Source/WebCore/platform/network/NetworkStorageSession.h
-index deca176523b8838fd9d0cf365aa49c24be02dde6..f81f51906bd226554e75ef495f90c24942e4ae36 100644
+index 8e3cb385825b5d3f9b045bbd93d099324bec2912..51d451aaec8e2f799272efc8b3f4feeb0bc3bff7 100644
 --- a/Source/WebCore/platform/network/NetworkStorageSession.h
 +++ b/Source/WebCore/platform/network/NetworkStorageSession.h
 @@ -155,6 +155,8 @@ public:
@@ -7817,7 +7817,7 @@ index deca176523b8838fd9d0cf365aa49c24be02dde6..f81f51906bd226554e75ef495f90c249
      WEBCORE_EXPORT void setCookie(const Cookie&);
      WEBCORE_EXPORT void setCookies(const Vector<Cookie>&, const URL&, const URL& mainDocumentURL);
 diff --git a/Source/WebCore/platform/network/ResourceResponseBase.h b/Source/WebCore/platform/network/ResourceResponseBase.h
-index b1e38001d2338d8ddb393ac6c8758a34d7c4008b..84228abb4b8188440c2443be0c198814968d19e8 100644
+index f5558f3b6b822e80bfb731e3ad40b2e515a8ff17..081a3bfa4dc18c7ad3d40f07e252992845287781 100644
 --- a/Source/WebCore/platform/network/ResourceResponseBase.h
 +++ b/Source/WebCore/platform/network/ResourceResponseBase.h
 @@ -223,6 +223,8 @@ public:
@@ -7851,10 +7851,10 @@ index b1e38001d2338d8ddb393ac6c8758a34d7c4008b..84228abb4b8188440c2443be0c198814
      if constexpr (Decoder::isIPCDecoder) {
          std::optional<Box<NetworkLoadMetrics>> networkLoadMetrics;
 diff --git a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
-index 49993be7ccaab3a7dd7e4b62a945df732b7608c4..d421683e2332b47849fef5a18d25f4e480f25962 100644
+index 8f3f4ad592fb624f406d6244dcab766940496b7a..1db5f443608b0387ff0b9b19dab78847bd20be34 100644
 --- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
 +++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
-@@ -477,6 +477,22 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
+@@ -471,6 +471,22 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
      END_BLOCK_OBJC_EXCEPTIONS
  }
  
@@ -7971,7 +7971,7 @@ index 0c39c90aac884fca48849388acc1b42bad16d620..dd8e50686c348b46d5ae92fd67a31eb0
      void send(CurlStreamID, UniqueArray<uint8_t>&&, size_t);
  
 diff --git a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
-index cacf84fa9eb9c4fddd315f03d014cac7c28b84c1..d20f930485115e7735cb362c57ced87195d5130c 100644
+index e52e4ce08c038f2da84925db03478e271d741465..fc2a9acb1e3e2805d57f7f86de046f8b676cda26 100644
 --- a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
 +++ b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
 @@ -118,6 +118,12 @@ void NetworkStorageSession::setCookieAcceptPolicy(CookieAcceptPolicy policy) con
@@ -8032,7 +8032,7 @@ index e106d2e9c4bdf2f099c34d61270ab1ab12e1b1bc..d1ffe11e4fc2a0bece55c4a70f4d1eef
  
  SocketStreamHandleImpl::~SocketStreamHandleImpl()
 diff --git a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
-index 7ec08a674d15678dbbb80c755a8df253a9f545be..7b34d110779af23497ed937bbd3dd1800f269d33 100644
+index 9bd65a464e6d669f6cc51f9a149ebafd58d5ffe8..5eb404f32629599adc40b367b9220535f946d2af 100644
 --- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
 +++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
 @@ -410,6 +410,30 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
@@ -8063,7 +8063,7 @@ index 7ec08a674d15678dbbb80c755a8df253a9f545be..7b34d110779af23497ed937bbd3dd180
 +    }
 +}
 +
- void NetworkStorageSession::deleteCookie(const Cookie& cookie)
+ void NetworkStorageSession::deleteCookie(const Cookie& cookie, CompletionHandler<void()>&& completionHandler)
  {
      GUniquePtr<SoupCookie> targetCookie(cookie.toSoupCookie());
 diff --git a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -8657,45 +8657,15 @@ index fac9402820702989bf72ed2425678bfb82bd6523..40b5a6441d22714fd370ce1a7c2f534e
      // Returns the line height of the inner renderer.
      int innerLineHeight() const override;
  #endif
-diff --git a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
-index 3b7fd04ff503a71b9e53b3d0a25764f839005602..d0af8634fbff3f32cb713900386e125faae1dace 100644
---- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
-+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
-@@ -69,10 +69,11 @@ void WebCookieManager::deleteCookiesForHostnames(PAL::SessionID sessionID, const
-         storageSession->deleteCookiesForHostnames(hostnames);
- }
- 
--void WebCookieManager::deleteAllCookies(PAL::SessionID sessionID)
-+void WebCookieManager::deleteAllCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
- {
-     if (auto* storageSession = m_process.storageSession(sessionID))
-         storageSession->deleteAllCookies();
-+    completionHandler();
- }
- 
- void WebCookieManager::deleteCookie(PAL::SessionID sessionID, const Cookie& cookie, CompletionHandler<void()>&& completionHandler)
-diff --git a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
-index 35ce8a9ecfc294cd6de1e7ff9310e0a57ea49d7e..6b03f334763e5c46e7d35064e3a169a8308a1b46 100644
---- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
-+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
-@@ -73,7 +73,7 @@ private:
- 
-     void deleteCookie(PAL::SessionID, const WebCore::Cookie&, CompletionHandler<void()>&&);
-     void deleteCookiesForHostnames(PAL::SessionID, const Vector<String>&);
--    void deleteAllCookies(PAL::SessionID);
-+    void deleteAllCookies(PAL::SessionID, CompletionHandler<void()>&&);
-     void deleteAllCookiesModifiedSince(PAL::SessionID, WallTime, CompletionHandler<void()>&&);
- 
-     void setCookie(PAL::SessionID, const Vector<WebCore::Cookie>&, CompletionHandler<void()>&&);
 diff --git a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
-index 46d9708bdb8ea74213a4636ca319a09de87f249e..d785669417f8e32f39d422ac1698b303aee5190a 100644
+index 2081154f90fac8f7b9f7c6061cf5dc6da1af44b5..e7c6071a6f2e05e76e0fd1cb4661ebd32a5bb3fd 100644
 --- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
 +++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
 @@ -26,13 +26,13 @@
  messages -> WebCookieManager NotRefCounted {
      void GetHostnamesWithCookies(PAL::SessionID sessionID) -> (Vector<String> hostnames)
-     void DeleteCookiesForHostnames(PAL::SessionID sessionID, Vector<String> hostnames)
--    void DeleteAllCookies(PAL::SessionID sessionID)
+     void DeleteCookiesForHostnames(PAL::SessionID sessionID, Vector<String> hostnames) -> ()
+-    void DeleteAllCookies(PAL::SessionID sessionID) -> ()
  
      void SetCookie(PAL::SessionID sessionID, Vector<WebCore::Cookie> cookie) -> ()
      void SetCookies(PAL::SessionID sessionID, Vector<WebCore::Cookie> cookies, URL url, URL mainDocumentURL) -> ()
@@ -8707,7 +8677,7 @@ index 46d9708bdb8ea74213a4636ca319a09de87f249e..d785669417f8e32f39d422ac1698b303
  
      void SetHTTPCookieAcceptPolicy(enum:uint8_t WebCore::HTTPCookieAcceptPolicy policy) -> ()
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
-index 61a609b6f9394d53f610c7e9673ada3f1e5da0de..7f317fb6da663e64ea935fb4567613315e567aa4 100644
+index 24e9d0eecb5730ad96c625b114b9c7360adcac52..e0b0218bbf37222fc581d19d6ec3f688445aa9c5 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
 @@ -83,6 +83,11 @@
@@ -8749,7 +8719,7 @@ index 61a609b6f9394d53f610c7e9673ada3f1e5da0de..7f317fb6da663e64ea935fb456761331
  void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier frameID, PageIdentifier pageID)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
-index 02fbed766529dca1c047832dfc85f9506ca8f6cd..7094f82ee6f6220e0ff2793edd8e0589468b1869 100644
+index 35deb0171bee03d36acd1abad195e9450a54d6fc..90c118158c336763c98132abdded326d9339d8ff 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
 @@ -312,6 +312,8 @@ private:
@@ -8762,7 +8732,7 @@ index 02fbed766529dca1c047832dfc85f9506ca8f6cd..7094f82ee6f6220e0ff2793edd8e0589
      void removeStorageAccessForFrame(WebCore::FrameIdentifier, WebCore::PageIdentifier);
  
 diff --git a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
-index a2629e4edb214b3d26aca78da845c65d0e5aa341..d034f3a57badda1f34729afd712db7cddbfce8bf 100644
+index 77597632a0e3f5dbac4ed45312c401496cf2387d..c3861e47242b15234101ca02a83f2766c8220de2 100644
 --- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 @@ -66,6 +66,8 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
@@ -8775,7 +8745,7 @@ index a2629e4edb214b3d26aca78da845c65d0e5aa341..d034f3a57badda1f34729afd712db7cd
      RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
      LogUserInteraction(WebCore::RegistrableDomain domain)
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.cpp b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
-index b038697a228ad13e4b2183638c123ae9427f364d..26de8d2ed663fa760c5e244c6795bfb4c088ff5d 100644
+index 75f5fe9a094503648bdd1ef3231154a0f92314ae..ef46091d7cf93f2a80acaa11d37270748d0df001 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 @@ -530,6 +530,12 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID)
@@ -8856,7 +8826,7 @@ index 11b3fc7c4267ef9e412d7d48bb6cfbe70b2bdfeb..af1fb6660696cf9c91d319670d554272
      HashSet<Ref<NetworkResourceLoader>> m_keptAliveLoads;
  
 diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-index ba33be375f926e0f5d71a9bb6ca8663f13ba59be..80c781b0e7a39b130311d090d7ccf1c233af1261 100644
+index f3654db2dff953d825f012af144e1c00130d8251..b8165beb908b307a26c7acc47e3cf52adbaaaff2 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 @@ -720,7 +720,7 @@ void NetworkSessionCocoa::setClientAuditToken(const WebCore::AuthenticationChall
@@ -9071,7 +9041,7 @@ index 93c194b1e3c2462fee6b8c66ecbb9323c4841350..51e0f52c363ecd4b1d64c78834473ceb
      Cairo::Cairo
      Freetype::Freetype
 diff --git a/Source/WebKit/PlatformWin.cmake b/Source/WebKit/PlatformWin.cmake
-index e0093e70915eed9eb74fd48a7f62192e97ceaa9b..81a30f0256a8b8b9bec2cd52894ff2ab3ab60032 100644
+index 737f761d4595df39fc4a1877f7f95fb5aa506c47..885921ea5c771e2728ef39a652c59cf144dc4d83 100644
 --- a/Source/WebKit/PlatformWin.cmake
 +++ b/Source/WebKit/PlatformWin.cmake
 @@ -64,8 +64,12 @@ list(APPEND WebKit_SOURCES
@@ -9168,7 +9138,7 @@ index e0093e70915eed9eb74fd48a7f62192e97ceaa9b..81a30f0256a8b8b9bec2cd52894ff2ab
  set(WebKitCommonIncludeDirectories ${WebKit_INCLUDE_DIRECTORIES})
  set(WebKitCommonSystemIncludeDirectories ${WebKit_SYSTEM_INCLUDE_DIRECTORIES})
  
-@@ -195,6 +266,7 @@ if (${WTF_PLATFORM_WIN_CAIRO})
+@@ -196,6 +267,7 @@ if (${WTF_PLATFORM_WIN_CAIRO})
          OpenSSL::SSL
          mfuuid.lib
          strmiids.lib
@@ -9997,21 +9967,6 @@ index ae2181088f8221594c9a2b4fbe5d99f2b6936d67..0c51c08ebf3352f7ec80aa8490e7e10c
  WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
  
  WebProcess/WebPage/AcceleratedSurface.cpp
-diff --git a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
-index 3311eedbb49db7d2cc15b275a8bd9db34d3be119..ed3e1a6b0b1c676d93a1bd8f75591bbaf2fa7d7a 100644
---- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
-+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
-@@ -119,9 +119,7 @@ void HTTPCookieStore::deleteAllCookies(CompletionHandler<void()>&& completionHan
-     if (!m_owningDataStore)
-         return completionHandler();
-     auto& cookieManager = m_owningDataStore->networkProcess().cookieManager();
--    cookieManager.deleteAllCookies(m_owningDataStore->sessionID());
--    // FIXME: The CompletionHandler should be passed to WebCookieManagerProxy::deleteAllCookies.
--    RunLoop::main().dispatch(WTFMove(completionHandler));
-+    cookieManager.deleteAllCookies(m_owningDataStore->sessionID(), WTFMove(completionHandler));
- }
- 
- void HTTPCookieStore::setHTTPCookieAcceptPolicy(WebCore::HTTPCookieAcceptPolicy policy, CompletionHandler<void()>&& completionHandler)
 diff --git a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
 index a16fe13c08576194ec8c43e9dae62a20566904be..f1bc17b878c3103475fa371e05f53cce3a27cff1 100644
 --- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
@@ -11758,7 +11713,7 @@ index a4d0e7c10ffe1cfd50203c996cec083f167ac03f..95cfb310026746a10d36c50bbbcbc40e
      void saveBackForwardSnapshotForCurrentItem();
      void saveBackForwardSnapshotForItem(WebBackForwardListItem&);
 diff --git a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
-index f8f4a3ffe656dfbc72ee12425deb72adbd024566..03d6d358d6101eb926174c78cbbe18eededd16c1 100644
+index 301c5369280e278a5cd21b231ef6041425a120f7..1a2f7fb51740c54931c8690281399e0346bea2ed 100644
 --- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 +++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
 @@ -2776,6 +2776,11 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
@@ -15385,7 +15340,7 @@ index 7a14cfba15c103a2d4fe263fa49d25af3c396ec2..3ee0e154349661632799057c71f1d1f1
      BOOL result = ::CreateProcess(0, commandLine.data(), 0, 0, true, 0, 0, 0, &startupInfo, &processInformation);
  
 diff --git a/Source/WebKit/UIProcess/PageClient.h b/Source/WebKit/UIProcess/PageClient.h
-index 195b11a248fb2f2fcd0ee270a1d478caa37c708d..78fbe6d3c4d2b0944c3ef979a52e14bc3da4f625 100644
+index 87ec521ac54382bb1365d961a0f69d61b44bbff7..a37b2602e6ee5458951a0d204ed41759471bcf5c 100644
 --- a/Source/WebKit/UIProcess/PageClient.h
 +++ b/Source/WebKit/UIProcess/PageClient.h
 @@ -321,6 +321,11 @@ public:
@@ -15743,38 +15698,6 @@ index 8a506c2f4b96185560c8ee198f9af9575152b15a..2e76e28266dfd71061373e8ee4211653
  
      WebPageProxy* page() const { return m_page.get(); }
  
-diff --git a/Source/WebKit/UIProcess/WebCookieManagerProxy.cpp b/Source/WebKit/UIProcess/WebCookieManagerProxy.cpp
-index 42c66d2b0dcd180258c5b90d13f663de1f893316..e0ccafdecb4e31301c51cdd10f5db6bcfdd026fa 100644
---- a/Source/WebKit/UIProcess/WebCookieManagerProxy.cpp
-+++ b/Source/WebKit/UIProcess/WebCookieManagerProxy.cpp
-@@ -67,10 +67,12 @@ void WebCookieManagerProxy::deleteCookiesForHostnames(PAL::SessionID sessionID,
-         m_networkProcess->send(Messages::WebCookieManager::DeleteCookiesForHostnames(sessionID, hostnames), 0);
- }
- 
--void WebCookieManagerProxy::deleteAllCookies(PAL::SessionID sessionID)
-+void WebCookieManagerProxy::deleteAllCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& callbackFunction)
- {
-     if (m_networkProcess)
--        m_networkProcess->send(Messages::WebCookieManager::DeleteAllCookies(sessionID), 0);
-+        m_networkProcess->sendWithAsyncReply(Messages::WebCookieManager::DeleteAllCookies(sessionID), WTFMove(callbackFunction));
-+    else
-+        callbackFunction();
- }
- 
- void WebCookieManagerProxy::deleteCookie(PAL::SessionID sessionID, const Cookie& cookie, CompletionHandler<void()>&& callbackFunction)
-diff --git a/Source/WebKit/UIProcess/WebCookieManagerProxy.h b/Source/WebKit/UIProcess/WebCookieManagerProxy.h
-index 3dcf54ad7c8bab1b5ab6a6ec28f5a1f871a4191c..b80849fa2604e63f837f35141ee61b62cb926869 100644
---- a/Source/WebKit/UIProcess/WebCookieManagerProxy.h
-+++ b/Source/WebKit/UIProcess/WebCookieManagerProxy.h
-@@ -61,7 +61,7 @@ public:
-     void getHostnamesWithCookies(PAL::SessionID, CompletionHandler<void(Vector<String>&&)>&&);
-     void deleteCookie(PAL::SessionID, const WebCore::Cookie&, CompletionHandler<void()>&&);
-     void deleteCookiesForHostnames(PAL::SessionID, const Vector<String>&);
--    void deleteAllCookies(PAL::SessionID);
-+    void deleteAllCookies(PAL::SessionID, CompletionHandler<void()>&&);
-     void deleteAllCookiesModifiedSince(PAL::SessionID, WallTime, CompletionHandler<void()>&&);
- 
-     void setCookies(PAL::SessionID, const Vector<WebCore::Cookie>&, CompletionHandler<void()>&&);
 diff --git a/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp b/Source/WebKit/UIProcess/WebPageInspectorEmulationAgent.cpp
 new file mode 100644
 index 0000000000000000000000000000000000000000..ae45b4212bdb3f6a004cc80a1d91146b540f86f5
@@ -16440,7 +16363,7 @@ index 0000000000000000000000000000000000000000..48c9ccc420c1b4ae3259e1d5ba17fd8f
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a60266661e 100644
+index 09d9f1cc093aa5539b5be90304781a27fb784300..3d8bf100bc1d041137b58bb7af776a2022354595 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
 @@ -247,6 +247,9 @@
@@ -16785,7 +16708,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
  }
  
  void WebPageProxy::decidePolicyForNavigationActionAsyncShared(Ref<WebProcessProxy>&& process, PageIdentifier webPageID, FrameIdentifier frameID, FrameInfoData&& frameInfo,
-@@ -6015,6 +6177,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -6017,6 +6179,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
      if (originatingPage)
          openerAppInitiatedState = originatingPage->lastNavigationWasAppInitiated();
  
@@ -16793,7 +16716,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
      auto completionHandler = [this, protectedThis = Ref { *this }, mainFrameURL, request, reply = WTFMove(reply), privateClickMeasurement = navigationActionData.privateClickMeasurement, openerAppInitiatedState = WTFMove(openerAppInitiatedState)] (RefPtr<WebPageProxy> newPage) mutable {
          if (!newPage) {
              reply(std::nullopt, std::nullopt);
-@@ -6061,6 +6224,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -6063,6 +6226,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
  void WebPageProxy::showPage()
  {
      m_uiClient->showPage(this);
@@ -16801,7 +16724,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
  }
  
  void WebPageProxy::exitFullscreenImmediately()
-@@ -6118,6 +6282,10 @@ void WebPageProxy::closePage()
+@@ -6122,6 +6286,10 @@ void WebPageProxy::closePage()
      if (isClosed())
          return;
  
@@ -16812,7 +16735,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
      WEBPAGEPROXY_RELEASE_LOG(Process, "closePage:");
      pageClient().clearAllEditCommands();
      m_uiClient->close(this);
-@@ -6154,6 +6322,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
+@@ -6158,6 +6326,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
      }
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
@@ -16821,7 +16744,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
          page.m_uiClient->runJavaScriptAlert(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)]() mutable {
              reply();
              completion();
-@@ -6175,6 +6345,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
+@@ -6179,6 +6349,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -16830,7 +16753,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptConfirm(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](bool result) mutable {
-@@ -6198,6 +6370,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
+@@ -6202,6 +6374,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -16839,7 +16762,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply), defaultValue](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptPrompt(page, message, defaultValue, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](auto& result) mutable {
-@@ -6325,6 +6499,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
+@@ -6329,6 +6503,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
              return;
          }
      }
@@ -16848,7 +16771,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
  
      // Since runBeforeUnloadConfirmPanel() can spin a nested run loop we need to turn off the responsiveness timer and the tryClose timer.
      m_process->stopResponsivenessTimer();
-@@ -7589,6 +7765,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7593,6 +7769,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->mouseEventsFlushedForPage(*this);
              didFinishProcessingAllPendingMouseEvents();
@@ -16857,7 +16780,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
          }
          break;
      }
-@@ -7603,10 +7781,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7607,10 +7785,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              pageClient().wheelEventWasNotHandledByWebCore(oldestProcessedEvent);
          }
  
@@ -16874,7 +16797,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
          break;
      }
  
-@@ -7615,7 +7796,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7619,7 +7800,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
      case WebEvent::RawKeyDown:
      case WebEvent::Char: {
          LOG(KeyHandling, "WebPageProxy::didReceiveEvent: %s (queue empty %d)", webKeyboardEventTypeString(type), m_keyEventQueue.isEmpty());
@@ -16882,7 +16805,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
          MESSAGE_CHECK(m_process, !m_keyEventQueue.isEmpty());
          auto event = m_keyEventQueue.takeFirst();
          MESSAGE_CHECK(m_process, type == event.type());
-@@ -7634,7 +7814,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7638,7 +7818,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          // The call to doneWithKeyEvent may close this WebPage.
          // Protect against this being destroyed.
          Ref<WebPageProxy> protect(*this);
@@ -16890,7 +16813,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
          pageClient().doneWithKeyEvent(event, handled);
          if (!handled)
              m_uiClient->didNotHandleKeyEvent(this, event);
-@@ -7643,6 +7822,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7647,6 +7826,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          if (!canProcessMoreKeyEvents) {
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->keyboardEventsFlushedForPage(*this);
@@ -16898,7 +16821,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
          }
          break;
      }
-@@ -7976,7 +8156,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
+@@ -7980,7 +8160,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
  {
      WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "dispatchProcessDidTerminate: reason=%{public}s", processTerminationReasonToString(reason));
  
@@ -16910,7 +16833,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
      if (m_loaderClient)
          handledByClient = reason != ProcessTerminationReason::RequestedByClient && m_loaderClient->processDidCrash(*this);
      else
-@@ -8310,6 +8493,7 @@ static Span<const ASCIILiteral> gpuMachServices()
+@@ -8314,6 +8497,7 @@ static Span<const ASCIILiteral> gpuMachServices()
  
  WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& process, DrawingAreaProxy& drawingArea, RefPtr<API::WebsitePolicies>&& websitePolicies)
  {
@@ -16918,7 +16841,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
      WebPageCreationParameters parameters;
  
      parameters.processDisplayName = configuration().processDisplayName();
-@@ -8502,6 +8686,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
+@@ -8506,6 +8690,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
  
      parameters.httpsUpgradeEnabled = preferences().upgradeKnownHostsToHTTPSEnabled() ? m_configuration->httpsUpgradeEnabled() : false;
  
@@ -16927,7 +16850,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
  #if PLATFORM(IOS)
      // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
      parameters.allowsDeprecatedSynchronousXMLHttpRequestDuringUnload = allowsDeprecatedSynchronousXMLHttpRequestDuringUnload();
-@@ -8574,6 +8760,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
+@@ -8578,6 +8764,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
  
  void WebPageProxy::didReceiveAuthenticationChallengeProxy(Ref<AuthenticationChallengeProxy>&& authenticationChallenge, NegotiatedLegacyTLS negotiatedLegacyTLS)
  {
@@ -16942,7 +16865,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
      if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes) {
          m_navigationClient->shouldAllowLegacyTLS(*this, authenticationChallenge.get(), [this, protectedThis = Ref { *this }, authenticationChallenge] (bool shouldAllowLegacyTLS) {
              if (shouldAllowLegacyTLS)
-@@ -8667,6 +8861,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
+@@ -8671,6 +8865,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
              request->deny();
      };
  
@@ -16959,7 +16882,7 @@ index 0a74e844e0780c2f701f03b09fe6387cb0390ff4..0fbb1e047a52a2e362824dd6a08b83a6
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index 7a06458c72ba0a87daed94ffb316b8e58a8dcb3c..da11c29f0c0a634d06755ff17b389e5a81ba6265 100644
+index d0fe14a2e4e169845706abfda163f4da24dd349d..77b735a23b630caa7e3825deafff51645ae61e48 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -39,6 +39,7 @@
@@ -17013,7 +16936,7 @@ index 7a06458c72ba0a87daed94ffb316b8e58a8dcb3c..da11c29f0c0a634d06755ff17b389e5a
  class SharedBuffer;
  class SpeechRecognitionRequest;
  class TextIndicator;
-@@ -546,6 +558,8 @@ public:
+@@ -543,6 +555,8 @@ public:
      void setControlledByAutomation(bool);
  
      WebPageInspectorController& inspectorController() { return *m_inspectorController; }
@@ -17022,7 +16945,7 @@ index 7a06458c72ba0a87daed94ffb316b8e58a8dcb3c..da11c29f0c0a634d06755ff17b389e5a
  
  #if PLATFORM(IOS_FAMILY)
      void showInspectorIndication();
-@@ -656,6 +670,11 @@ public:
+@@ -653,6 +667,11 @@ public:
  
      void setPageLoadStateObserver(std::unique_ptr<PageLoadState::Observer>&&);
  
@@ -17034,7 +16957,7 @@ index 7a06458c72ba0a87daed94ffb316b8e58a8dcb3c..da11c29f0c0a634d06755ff17b389e5a
      void initializeWebPage();
      void setDrawingArea(std::unique_ptr<DrawingAreaProxy>&&);
  
-@@ -683,6 +702,7 @@ public:
+@@ -680,6 +699,7 @@ public:
      void closePage();
  
      void addPlatformLoadParameters(WebProcessProxy&, LoadParameters&);
@@ -17042,7 +16965,7 @@ index 7a06458c72ba0a87daed94ffb316b8e58a8dcb3c..da11c29f0c0a634d06755ff17b389e5a
      RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadData(const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
-@@ -1211,6 +1231,7 @@ public:
+@@ -1213,6 +1233,7 @@ public:
  #endif
  
      void pageScaleFactorDidChange(double);
@@ -17050,7 +16973,7 @@ index 7a06458c72ba0a87daed94ffb316b8e58a8dcb3c..da11c29f0c0a634d06755ff17b389e5a
      void pluginScaleFactorDidChange(double);
      void pluginZoomFactorDidChange(double);
  
-@@ -1298,14 +1319,20 @@ public:
+@@ -1300,14 +1321,20 @@ public:
      void didStartDrag();
      void dragCancelled();
      void setDragCaretRect(const WebCore::IntRect&);
@@ -17072,7 +16995,7 @@ index 7a06458c72ba0a87daed94ffb316b8e58a8dcb3c..da11c29f0c0a634d06755ff17b389e5a
  #endif
  
      void processDidBecomeUnresponsive();
-@@ -1556,6 +1583,8 @@ public:
+@@ -1558,6 +1585,8 @@ public:
  
  #if PLATFORM(COCOA) || PLATFORM(GTK)
      RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
@@ -17081,7 +17004,7 @@ index 7a06458c72ba0a87daed94ffb316b8e58a8dcb3c..da11c29f0c0a634d06755ff17b389e5a
  #endif
  
  #if ENABLE(WEB_CRYPTO)
-@@ -2728,6 +2757,7 @@ private:
+@@ -2734,6 +2763,7 @@ private:
      String m_overrideContentSecurityPolicy;
  
      RefPtr<WebInspectorUIProxy> m_inspector;
@@ -17089,7 +17012,7 @@ index 7a06458c72ba0a87daed94ffb316b8e58a8dcb3c..da11c29f0c0a634d06755ff17b389e5a
  
  #if PLATFORM(COCOA)
      WeakObjCPtr<WKWebView> m_cocoaView;
-@@ -2997,6 +3027,20 @@ private:
+@@ -3003,6 +3033,20 @@ private:
      unsigned m_currentDragNumberOfFilesToBeAccepted { 0 };
      WebCore::IntRect m_currentDragCaretRect;
      WebCore::IntRect m_currentDragCaretEditableElementRect;
@@ -17110,7 +17033,7 @@ index 7a06458c72ba0a87daed94ffb316b8e58a8dcb3c..da11c29f0c0a634d06755ff17b389e5a
  #endif
  
      PageLoadState m_pageLoadState;
-@@ -3207,6 +3251,9 @@ private:
+@@ -3213,6 +3257,9 @@ private:
          RefPtr<API::Object> messageBody;
      };
      Vector<InjectedBundleMessage> m_pendingInjectedBundleMessages;
@@ -17203,10 +17126,10 @@ index 56789958133037207df23dffd42a5144132e3219..06c9a3d31cf2a08c187087b07f4141d7
      WebConnection* webConnection() const { return m_webConnection.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-index 6663c05d9108da2fa4bd0a5a414a805cad417038..5b77abace61c8f1e2c7c26df26421c3b2b29a08e 100644
+index d972449851175209109506b3842f8c35d43f0094..b19c0dfc5f55e05d74ee947325acb938faf6555f 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-@@ -2040,6 +2040,12 @@ void WebsiteDataStore::originDirectoryForTesting(URL&& origin, URL&& topOrigin,
+@@ -2011,6 +2011,12 @@ void WebsiteDataStore::originDirectoryForTesting(URL&& origin, URL&& topOrigin,
      networkProcess().websiteDataOriginDirectoryForTesting(m_sessionID, WTFMove(origin), WTFMove(topOrigin), type, WTFMove(completionHandler));
  }
  
@@ -17220,7 +17143,7 @@ index 6663c05d9108da2fa4bd0a5a414a805cad417038..5b77abace61c8f1e2c7c26df26421c3b
  void WebsiteDataStore::hasAppBoundSession(CompletionHandler<void(bool)>&& completionHandler) const
  {
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
-index 6d5126aef4433fbeba5e7b70a3586e41d933f671..49562cd02dc72290fb1010dea6102d240ecf1fd0 100644
+index 22ad4ca93d1e4645d838178a12a5eab30167f573..f20741ec7f9b7a09e86c045783176584d587f3ff 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
 @@ -88,6 +88,7 @@ class SecKeyProxyStore;
@@ -17254,7 +17177,7 @@ index 6d5126aef4433fbeba5e7b70a3586e41d933f671..49562cd02dc72290fb1010dea6102d24
  class WebsiteDataStore : public API::ObjectImpl<API::Object::Type::WebsiteDataStore>, public Identified<WebsiteDataStore>, public CanMakeWeakPtr<WebsiteDataStore>  {
  public:
      static Ref<WebsiteDataStore> defaultDataStore();
-@@ -295,11 +305,13 @@ public:
+@@ -294,11 +304,13 @@ public:
      const WebCore::CurlProxySettings& networkProxySettings() const { return m_proxySettings; }
  #endif
  
@@ -17269,7 +17192,7 @@ index 6d5126aef4433fbeba5e7b70a3586e41d933f671..49562cd02dc72290fb1010dea6102d24
      void setNetworkProxySettings(WebCore::SoupNetworkProxySettings&&);
      const WebCore::SoupNetworkProxySettings& networkProxySettings() const { return m_networkProxySettings; }
      void setCookiePersistentStorage(const String&, SoupCookiePersistentStorageType);
-@@ -363,6 +375,12 @@ public:
+@@ -362,6 +374,12 @@ public:
      static constexpr uint64_t defaultPerOriginQuota() { return 1000 * MB; }
      static bool defaultShouldUseCustomStoragePaths();
  
@@ -17282,7 +17205,7 @@ index 6d5126aef4433fbeba5e7b70a3586e41d933f671..49562cd02dc72290fb1010dea6102d24
      void resetQuota(CompletionHandler<void()>&&);
      void clearStorage(CompletionHandler<void()>&&);
  
-@@ -457,9 +475,11 @@ private:
+@@ -456,9 +474,11 @@ private:
      WebCore::CurlProxySettings m_proxySettings;
  #endif
  
@@ -17295,7 +17218,7 @@ index 6d5126aef4433fbeba5e7b70a3586e41d933f671..49562cd02dc72290fb1010dea6102d24
      WebCore::SoupNetworkProxySettings m_networkProxySettings;
      String m_cookiePersistentStoragePath;
      SoupCookiePersistentStorageType m_cookiePersistentStorageType { SoupCookiePersistentStorageType::SQLite };
-@@ -487,6 +507,10 @@ private:
+@@ -486,6 +506,10 @@ private:
      RefPtr<API::HTTPCookieStore> m_cookieStore;
      RefPtr<NetworkProcessProxy> m_networkProcess;
  
@@ -17931,7 +17854,7 @@ index 0000000000000000000000000000000000000000..d0f9827544994e450e24e3f7a427c35e
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
-index f31db8d38d19e975216c941d13802bc2b3fb592d..abc38b6ae330112e486c753dce217ab3cf3752fc 100644
+index c38053cab644397a4aaa31d8819b10dec2549fd1..dcdf39a2cff9f719e2a503e1a5b6120add32e94f 100644
 --- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 +++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
 @@ -439,6 +439,8 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
@@ -18132,7 +18055,7 @@ index 0000000000000000000000000000000000000000..721826c8c98fc85b68a4f45deaee69c1
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/mac/PageClientImplMac.h b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
-index d5953b04a4c8277264664c36e106fa26a704b44a..42623b410edd37d926d630d09af1b02c90d17964 100644
+index 3034718c90afa349dc2109654b6338540f7dcbc3..a94412a42547378a33d3fb6897632d472724218d 100644
 --- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
 +++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
 @@ -53,6 +53,8 @@ class PageClientImpl final : public PageClientImplCocoa
@@ -19256,7 +19179,7 @@ index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705e
 + 
 +} // namespace WebKit
 diff --git a/Source/WebKit/WebKit.xcodeproj/project.pbxproj b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b926247499c0cd94b 100644
+index 207a9ed1837312396e61ce3eae67f2161a96f66e..1c219e5c6e6051de2746e2e9e797b38085a739f0 100644
 --- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 +++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 @@ -1246,6 +1246,7 @@
@@ -19267,7 +19190,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  		5CAF7AA726F93AB00003F19E /* adattributiond.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAF7AA526F93A950003F19E /* adattributiond.cpp */; };
  		5CAFDE452130846300B1F7E1 /* _WKInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE422130843500B1F7E1 /* _WKInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		5CAFDE472130846A00B1F7E1 /* _WKInspectorInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE442130843600B1F7E1 /* _WKInspectorInternal.h */; };
-@@ -2221,6 +2222,18 @@
+@@ -2223,6 +2224,18 @@
  		DF0C5F28252ECB8E00D921DB /* WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F24252ECB8D00D921DB /* WKDownload.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2A252ECB8E00D921DB /* WKDownloadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2B252ED44000D921DB /* WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */; };
@@ -19286,7 +19209,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  		DF462E0F23F22F5500EFF35F /* WKHTTPCookieStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */; };
-@@ -2282,6 +2295,8 @@
+@@ -2284,6 +2297,8 @@
  		E5BEF6822130C48000F31111 /* WebDataListSuggestionsDropdownIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E5BEF6802130C47F00F31111 /* WebDataListSuggestionsDropdownIOS.h */; };
  		E5CB07DC20E1678F0022C183 /* WKFormColorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */; };
  		E5CBA76427A318E100DF7858 /* UnifiedSource120.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */; };
@@ -19295,7 +19218,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  		E5CBA76527A318E100DF7858 /* UnifiedSource118.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */; };
  		E5CBA76627A318E100DF7858 /* UnifiedSource116.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76327A3187B00DF7858 /* UnifiedSource116.cpp */; };
  		E5CBA76727A318E100DF7858 /* UnifiedSource119.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */; };
-@@ -2298,6 +2313,9 @@
+@@ -2300,6 +2315,9 @@
  		EBA8D3B627A5E33F00CB7900 /* MockPushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B027A5E33F00CB7900 /* MockPushServiceConnection.mm */; };
  		EBA8D3B727A5E33F00CB7900 /* PushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B127A5E33F00CB7900 /* PushServiceConnection.mm */; };
  		ED82A7F2128C6FAF004477B3 /* WKBundlePageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22F0FF1289FCD90085E74F /* WKBundlePageOverlay.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -19305,7 +19228,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
  		F42D634122A0EFDF00D2FB3A /* WebAutocorrectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */; };
-@@ -5265,6 +5283,7 @@
+@@ -5267,6 +5285,7 @@
  		5CABDC8522C40FCC001EDE8E /* WKMessageListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKMessageListener.h; sourceTree = "<group>"; };
  		5CADDE0D2151AA010067D309 /* AuthenticationChallengeDisposition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthenticationChallengeDisposition.h; sourceTree = "<group>"; };
  		5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource115.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource115.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -19313,7 +19236,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  		5CAF7AA426F93A750003F19E /* adattributiond */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = adattributiond; sourceTree = BUILT_PRODUCTS_DIR; };
  		5CAF7AA526F93A950003F19E /* adattributiond.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = adattributiond.cpp; sourceTree = "<group>"; };
  		5CAF7AA626F93AA50003F19E /* adattributiond.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = adattributiond.xcconfig; sourceTree = "<group>"; };
-@@ -6966,6 +6985,19 @@
+@@ -6970,6 +6989,19 @@
  		DF0C5F24252ECB8D00D921DB /* WKDownload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownload.h; sourceTree = "<group>"; };
  		DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadInternal.h; sourceTree = "<group>"; };
  		DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadDelegate.h; sourceTree = "<group>"; };
@@ -19333,7 +19256,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  		DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHTTPCookieStorePrivate.h; sourceTree = "<group>"; };
  		DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKContentWorldPrivate.h; sourceTree = "<group>"; };
  		DF58C6311371AC5800F9A37C /* NativeWebWheelEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeWebWheelEvent.h; sourceTree = "<group>"; };
-@@ -7094,6 +7126,8 @@
+@@ -7098,6 +7130,8 @@
  		E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKFormColorControl.h; path = ios/forms/WKFormColorControl.h; sourceTree = "<group>"; };
  		E5CB07DB20E1678F0022C183 /* WKFormColorControl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKFormColorControl.mm; path = ios/forms/WKFormColorControl.mm; sourceTree = "<group>"; };
  		E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource120.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource120.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -19342,7 +19265,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  		E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource119.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource119.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
  		E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource118.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource118.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
  		E5CBA76227A3187900DF7858 /* UnifiedSource117.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource117.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource117.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
-@@ -7115,6 +7149,14 @@
+@@ -7119,6 +7153,14 @@
  		ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtraPrivateSymbolsForTAPI.h; sourceTree = "<group>"; };
  		ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExtraPublicSymbolsForTAPI.h; sourceTree = "<group>"; };
  		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
@@ -19357,7 +19280,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  		F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDragDestinationAction.h; sourceTree = "<group>"; };
  		F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionContext.h; path = ios/WebAutocorrectionContext.h; sourceTree = "<group>"; };
  		F41056612130699A0092281D /* APIAttachmentCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = APIAttachmentCocoa.mm; sourceTree = "<group>"; };
-@@ -7251,6 +7293,7 @@
+@@ -7255,6 +7297,7 @@
  				3766F9EF189A1244003CF19B /* QuartzCore.framework in Frameworks */,
  				37694525184FC6B600CDE21F /* Security.framework in Frameworks */,
  				37BEC4DD1948FC6A008B4286 /* WebCore.framework in Frameworks */,
@@ -19365,7 +19288,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -9356,6 +9399,7 @@
+@@ -9351,6 +9394,7 @@
  		37C4C08318149C2A003688B9 /* Cocoa */ = {
  			isa = PBXGroup;
  			children = (
@@ -19373,7 +19296,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				1A43E826188F38E2009E4D30 /* Deprecated */,
  				37A5E01218BBF937000A081E /* _WKActivatedElementInfo.h */,
  				37A5E01118BBF937000A081E /* _WKActivatedElementInfo.mm */,
-@@ -10479,6 +10523,7 @@
+@@ -10475,6 +10519,7 @@
  				E34B110F27C46D09006D2F2E /* libWebCoreTestSupport.dylib */,
  				DDE992F4278D06D900F60D26 /* libWebKitAdditions.a */,
  				57A9FF15252C6AEF006A2040 /* libWTF.a */,
@@ -19381,7 +19304,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				5750F32A2032D4E500389347 /* LocalAuthentication.framework */,
  				570DAAB0230273D200E8FC04 /* NearField.framework */,
  				51F7BB7E274564A100C45A72 /* Security.framework */,
-@@ -11005,6 +11050,12 @@
+@@ -11001,6 +11046,12 @@
  			children = (
  				9197940423DBC4BB00257892 /* InspectorBrowserAgent.cpp */,
  				9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */,
@@ -19394,7 +19317,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  			);
  			path = Agents;
  			sourceTree = "<group>";
-@@ -11013,6 +11064,7 @@
+@@ -11009,6 +11060,7 @@
  			isa = PBXGroup;
  			children = (
  				A5D3504D1D78F0D2005124A9 /* RemoteWebInspectorUIProxyMac.mm */,
@@ -19402,7 +19325,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */,
  				99A7ACE326012919006D57FD /* WKInspectorResourceURLSchemeHandler.h */,
  				99A7ACE42601291A006D57FD /* WKInspectorResourceURLSchemeHandler.mm */,
-@@ -11532,6 +11584,12 @@
+@@ -11528,6 +11580,12 @@
  		BC032DC310F438260058C15A /* UIProcess */ = {
  			isa = PBXGroup;
  			children = (
@@ -19415,7 +19338,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				BC032DC410F4387C0058C15A /* API */,
  				512F588D12A8836F00629530 /* Authentication */,
  				9955A6E81C79809000EB6A93 /* Automation */,
-@@ -11843,6 +11901,7 @@
+@@ -11839,6 +11897,7 @@
  		BC0C376610F807660076D7CB /* C */ = {
  			isa = PBXGroup;
  			children = (
@@ -19423,7 +19346,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				5123CF18133D25E60056F800 /* cg */,
  				6EE849C41368D9040038D481 /* mac */,
  				BCB63477116BF10600603215 /* WebKit2_C.h */,
-@@ -12433,6 +12492,11 @@
+@@ -12429,6 +12488,11 @@
  		BCCF085C113F3B7500C650C5 /* mac */ = {
  			isa = PBXGroup;
  			children = (
@@ -19435,7 +19358,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				B878B613133428DC006888E9 /* CorrectionPanel.h */,
  				B878B614133428DC006888E9 /* CorrectionPanel.mm */,
  				07EF07592745A8160066EA04 /* DisplayCaptureSessionManager.h */,
-@@ -13652,6 +13716,7 @@
+@@ -13649,6 +13713,7 @@
  				99788ACB1F421DDA00C08000 /* _WKAutomationSessionConfiguration.h in Headers */,
  				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
  				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
@@ -19443,7 +19366,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
  				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
  				1A5704F81BE01FF400874AF1 /* _WKContextMenuElementInfo.h in Headers */,
-@@ -14119,6 +14184,7 @@
+@@ -14116,6 +14181,7 @@
  				1A14F8E21D74C834006CBEC6 /* FrameInfoData.h in Headers */,
  				1AE00D611831792100087DD7 /* FrameLoadState.h in Headers */,
  				5C121E842410208D00486F9B /* FrameTreeNodeData.h in Headers */,
@@ -19451,7 +19374,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				2D4AF0892044C3C4006C8817 /* FrontBoardServicesSPI.h in Headers */,
  				CD78E1151DB7D7ED0014A2DE /* FullscreenClient.h in Headers */,
  				CD19D2EA2046406F0017074A /* FullscreenTouchSecheuristic.h in Headers */,
-@@ -14133,6 +14199,7 @@
+@@ -14130,6 +14196,7 @@
  				2DA944A41884E4F000ED86DB /* GestureTypes.h in Headers */,
  				4614F13225DED875007006E7 /* GPUProcessConnectionParameters.h in Headers */,
  				2DA049B8180CCD0A00AAFA9E /* GraphicsLayerCARemote.h in Headers */,
@@ -19459,7 +19382,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				C0CE72AD1247E78D00BC0EC4 /* HandleMessage.h in Headers */,
  				1AC75A1B1B3368270056745B /* HangDetectionDisabler.h in Headers */,
  				57AC8F50217FEED90055438C /* HidConnection.h in Headers */,
-@@ -14288,6 +14355,7 @@
+@@ -14285,6 +14352,7 @@
  				413075AC1DE85F370039EC69 /* NetworkRTCMonitor.h in Headers */,
  				41DC45961E3D6E2200B11F51 /* NetworkRTCProvider.h in Headers */,
  				5C20CBA01BB1ECD800895BB1 /* NetworkSession.h in Headers */,
@@ -19467,7 +19390,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				532159551DBAE7290054AA3C /* NetworkSessionCocoa.h in Headers */,
  				417915B92257046F00D6F97E /* NetworkSocketChannel.h in Headers */,
  				93085DE026E5BCFD000EC6A7 /* NetworkStorageManager.h in Headers */,
-@@ -14354,6 +14422,7 @@
+@@ -14350,6 +14418,7 @@
  				93E05E40282CD560000B69EB /* ProcessStateMonitor.h in Headers */,
  				463FD4821EB94EC000A2982C /* ProcessTerminationReason.h in Headers */,
  				86E67A251910B9D100004AB7 /* ProcessThrottler.h in Headers */,
@@ -19475,7 +19398,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				83048AE61ACA45DC0082C832 /* ProcessThrottlerClient.h in Headers */,
  				2D279E1926955768004B3EEB /* PrototypeToolsSPI.h in Headers */,
  				517B5F81275E97B6002DC22D /* PushAppBundle.h in Headers */,
-@@ -14385,6 +14454,7 @@
+@@ -14381,6 +14450,7 @@
  				CDAC20CA23FC2F750021DEE3 /* RemoteCDMInstanceSession.h in Headers */,
  				CDAC20C923FC2F750021DEE3 /* RemoteCDMInstanceSessionIdentifier.h in Headers */,
  				F451C0FE2703B263002BA03B /* RemoteDisplayListRecorderProxy.h in Headers */,
@@ -19483,7 +19406,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				2D47B56D1810714E003A3AEE /* RemoteLayerBackingStore.h in Headers */,
  				2DDF731518E95060004F5A66 /* RemoteLayerBackingStoreCollection.h in Headers */,
  				1AB16AEA164B3A8800290D62 /* RemoteLayerTreeContext.h in Headers */,
-@@ -14795,6 +14865,7 @@
+@@ -14792,6 +14862,7 @@
  				A543E30D215C8A9000279CD9 /* WebPageInspectorTargetController.h in Headers */,
  				A543E307215AD13700279CD9 /* WebPageInspectorTargetFrontendChannel.h in Headers */,
  				C0CE72A11247E71D00BC0EC4 /* WebPageMessages.h in Headers */,
@@ -19491,7 +19414,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				2D5C9D0619C81D8F00B3C5C1 /* WebPageOverlay.h in Headers */,
  				46C392292316EC4D008EED9B /* WebPageProxyIdentifier.h in Headers */,
  				BCBD3915125BB1A800D2C29F /* WebPageProxyMessages.h in Headers */,
-@@ -14976,6 +15047,7 @@
+@@ -14973,6 +15044,7 @@
  				BCD25F1711D6BDE100169B0E /* WKBundleFrame.h in Headers */,
  				BCF049E611FE20F600F86A58 /* WKBundleFramePrivate.h in Headers */,
  				BC49862F124D18C100D834E1 /* WKBundleHitTestResult.h in Headers */,
@@ -19499,7 +19422,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				BC204EF211C83EC8008F3375 /* WKBundleInitialize.h in Headers */,
  				65B86F1E12F11DE300B7DD8A /* WKBundleInspector.h in Headers */,
  				1A8B66B41BC45B010082DF77 /* WKBundleMac.h in Headers */,
-@@ -15030,6 +15102,7 @@
+@@ -15027,6 +15099,7 @@
  				5C795D71229F3757003FF1C4 /* WKContextMenuElementInfoPrivate.h in Headers */,
  				51A555F6128C6C47009ABCEC /* WKContextMenuItem.h in Headers */,
  				51A55601128C6D92009ABCEC /* WKContextMenuItemTypes.h in Headers */,
@@ -19507,7 +19430,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				A1EA02381DABFF7E0096021F /* WKContextMenuListener.h in Headers */,
  				BCC938E11180DE440085E5FE /* WKContextPrivate.h in Headers */,
  				9FB5F395169E6A80002C25BF /* WKContextPrivateMac.h in Headers */,
-@@ -15188,6 +15261,7 @@
+@@ -15186,6 +15259,7 @@
  				1AB8A1F818400BB800E9AE69 /* WKPageContextMenuClient.h in Headers */,
  				8372DB251A674C8F00C697C5 /* WKPageDiagnosticLoggingClient.h in Headers */,
  				1AB8A1F418400B8F00E9AE69 /* WKPageFindClient.h in Headers */,
@@ -19515,7 +19438,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				1AB8A1F618400B9D00E9AE69 /* WKPageFindMatchesClient.h in Headers */,
  				1AB8A1F018400B0000E9AE69 /* WKPageFormClient.h in Headers */,
  				BC7B633712A45ABA00D174A4 /* WKPageGroup.h in Headers */,
-@@ -16716,6 +16790,8 @@
+@@ -16694,6 +16768,8 @@
  				51E9049727BCB3D900929E7E /* ICAppBundle.mm in Sources */,
  				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
  				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
@@ -19524,7 +19447,7 @@ index 1ec0320d114bfdddc23fbcdb7a113dc07aebd7e6..4af0fbc556e46c99f622961b92624749
  				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
  				C1710CF724AA643200D7C112 /* LaunchServicesDatabaseObserver.mm in Sources */,
  				2984F588164BA095004BC0C6 /* LegacyCustomProtocolManagerMessageReceiver.cpp in Sources */,
-@@ -17051,6 +17127,8 @@
+@@ -17029,6 +17105,8 @@
  				E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */,
  				31BA924D148831260062EDB5 /* WebNotificationManagerMessageReceiver.cpp in Sources */,
  				2DF6FE52212E110900469030 /* WebPage.cpp in Sources */,
@@ -19722,7 +19645,7 @@ index e00c722c2be5d505243d45f46001839d4eb8a977..33c0832cde6c292230397a13e70d90fb
  
              auto permissionHandlers = m_requestsPerOrigin.take(securityOrigin);
 diff --git a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
-index e23555a46142970f11975f554802f07a749913d9..78565bc1289ab742f800c75c7a58d9b93f6471e1 100644
+index 62fb577af7fef5dd25e896d0f2677f24098805b8..c2cea276fab97695642f3beb25a4885f6bf988b5 100644
 --- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 +++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
 @@ -415,6 +415,8 @@ void WebChromeClient::setResizable(bool resizable)
@@ -19734,7 +19657,7 @@ index e23555a46142970f11975f554802f07a749913d9..78565bc1289ab742f800c75c7a58d9b9
      // Notify the bundle client.
      m_page.injectedBundleUIClient().willAddMessageToConsole(&m_page, source, level, message, lineNumber, columnNumber, sourceID);
  }
-@@ -843,6 +845,13 @@ std::unique_ptr<DateTimeChooser> WebChromeClient::createDateTimeChooser(DateTime
+@@ -823,6 +825,13 @@ std::unique_ptr<DateTimeChooser> WebChromeClient::createDateTimeChooser(DateTime
  
  #endif
  
@@ -20086,7 +20009,7 @@ index 3f6b9304dd08fbcc1fba7086163c753f0ad50785..165f22b4c3043cff7c9fbfb70fdc56f1
      virtual void adoptLayersFromDrawingArea(DrawingArea&) { }
      virtual void adoptDisplayRefreshMonitorsFromDrawingArea(DrawingArea&) { }
 diff --git a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
-index 1c0857116c24ebfc0fd30360431f97c52e39ab0f..5e608356e81976de094729d6b4b4674acb633675 100644
+index 51afcf721a21c6b073b84f55dbceba45909e2000..233a6b023d27cd7d4b3579e8d006d34edc4ea91f 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
 @@ -38,6 +38,7 @@
@@ -20098,7 +20021,7 @@ index 1c0857116c24ebfc0fd30360431f97c52e39ab0f..5e608356e81976de094729d6b4b4674a
  #include <WebCore/StorageSessionProvider.h>
  
 @@ -256,4 +257,10 @@ void WebCookieJar::deleteCookie(const WebCore::Document& document, const URL& ur
-     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::DeleteCookie(url, cookieName), 0);
+     WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::DeleteCookie(url, cookieName), WTFMove(completionHandler));
  }
  
 +void WebCookieJar::setCookieFromResponse(ResourceLoader& loader, const String& setCookieValue)
@@ -20109,7 +20032,7 @@ index 1c0857116c24ebfc0fd30360431f97c52e39ab0f..5e608356e81976de094729d6b4b4674a
 +
  } // namespace WebKit
 diff --git a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
-index bc78502b18b994a3ffa47b933273ebdb84fafde9..f4c95fcbc0a1d618cc51f748a0df82b7ebe20cab 100644
+index 4dca404d993dbcbafeac3cf175b45201db3857f8..9d1025bd52589de93f00139791f924b85a8c30ca 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
 @@ -52,6 +52,8 @@ public:
@@ -20156,7 +20079,7 @@ index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4
      uint64_t m_navigationID;
  };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index 1ad2fc2225e60d148e7bee0241a1a167c4731881..ce0fc16d413fc294aea32828bf8e87da647a5168 100644
+index f838fffe1d121d94051cd3f5a5866e0a3d4f175c..7cfe5aca5d4ed46cfe2a53cf4d8814fec368d135 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 @@ -934,6 +934,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
@@ -20419,7 +20342,7 @@ index 1ad2fc2225e60d148e7bee0241a1a167c4731881..ce0fc16d413fc294aea32828bf8e87da
  
      return documentLoader;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.h b/Source/WebKit/WebProcess/WebPage/WebPage.h
-index b6d64e5f6c1a97a0c6e0a2476da7193859d9c36c..95944c93a3e78f534bdae0d37c685402da592949 100644
+index 88e937bd7b988632081ef8a7435ddf251899aef0..475a01b48a12f7a56229321c9a6dcc3f9c6394aa 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
 @@ -117,6 +117,10 @@
@@ -20465,7 +20388,7 @@ index b6d64e5f6c1a97a0c6e0a2476da7193859d9c36c..95944c93a3e78f534bdae0d37c685402
  
      void insertNewlineInQuotedContent();
  
-@@ -1652,6 +1660,7 @@ private:
+@@ -1654,6 +1662,7 @@ private:
      // Actions
      void tryClose(CompletionHandler<void(bool)>&&);
      void platformDidReceiveLoadParameters(const LoadParameters&);
@@ -20473,7 +20396,7 @@ index b6d64e5f6c1a97a0c6e0a2476da7193859d9c36c..95944c93a3e78f534bdae0d37c685402
      void loadRequest(LoadParameters&&);
      NO_RETURN void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
      void loadData(LoadParameters&&);
-@@ -1689,6 +1698,7 @@ private:
+@@ -1691,6 +1700,7 @@ private:
      void updatePotentialTapSecurityOrigin(const WebTouchEvent&, bool wasHandled);
  #elif ENABLE(TOUCH_EVENTS)
      void touchEvent(const WebTouchEvent&);
@@ -20481,7 +20404,7 @@ index b6d64e5f6c1a97a0c6e0a2476da7193859d9c36c..95944c93a3e78f534bdae0d37c685402
  #endif
  
      void cancelPointer(WebCore::PointerID, const WebCore::IntPoint&);
-@@ -1832,9 +1842,7 @@ private:
+@@ -1834,9 +1844,7 @@ private:
  
      void requestRectForFoundTextRange(const WebFoundTextRange&, CompletionHandler<void(WebCore::FloatRect)>&&);
  
@@ -20491,7 +20414,7 @@ index b6d64e5f6c1a97a0c6e0a2476da7193859d9c36c..95944c93a3e78f534bdae0d37c685402
  
      void didChangeSelectedIndexForActivePopupMenu(int32_t newIndex);
      void setTextForActivePopupMenu(int32_t index);
-@@ -2377,6 +2385,7 @@ private:
+@@ -2379,6 +2387,7 @@ private:
      UserActivity m_userActivity;
  
      uint64_t m_pendingNavigationID { 0 };
@@ -20644,7 +20567,7 @@ index c77ff78cd3cd9627d1ae7b930c81457094645200..88746359159a76b169b7e6dcbee4fb34
  }
  
 diff --git a/Source/WebKit/WebProcess/WebProcess.cpp b/Source/WebKit/WebProcess/WebProcess.cpp
-index 81cbbc08ff732882e867565284f8a65299c0c2c0..617ac7b3248ceb63d7b803d80c3ca2f045ebf184 100644
+index 4f818395cb940e76ae58ec19a59e3358cf8138ac..ec0235ccbde767fb0d802fe71d339b66f68f68ad 100644
 --- a/Source/WebKit/WebProcess/WebProcess.cpp
 +++ b/Source/WebKit/WebProcess/WebProcess.cpp
 @@ -92,6 +92,7 @@
@@ -20746,10 +20669,10 @@ index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d
 +    LIBVPX_LIBRARIES
 +)
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index 8dc57e7d0395edee5667eceada38bd3b56668151..e944f55214844cf35e6a80a600a9773cf5d49ef6 100644
+index 0b46274ec42f24ec201f5bd8771cdf751781a381..5ae927b66bfbd065ff6d2752671cf35f92182d9a 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
-@@ -11,6 +11,8 @@ if (${CMAKE_VERSION} VERSION_LESS "3.20" AND NOT ${CMAKE_GENERATOR} STREQUAL "Ni
+@@ -11,8 +11,13 @@ if (${CMAKE_VERSION} VERSION_LESS "3.20" AND NOT ${CMAKE_GENERATOR} STREQUAL "Ni
      message(FATAL_ERROR "Building with Makefiles requires CMake 3.20 or newer. Either enable Ninja by passing -GNinja, or upgrade CMake.")
  endif ()
  
@@ -20757,8 +20680,13 @@ index 8dc57e7d0395edee5667eceada38bd3b56668151..e944f55214844cf35e6a80a600a9773c
 +
  set(USER_AGENT_BRANDING "" CACHE STRING "Branding to add to user agent string")
  
++set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
++set(THREADS_PREFER_PTHREAD_FLAG TRUE)
++
  find_package(Cairo 1.14.0 REQUIRED)
-@@ -32,6 +34,10 @@ find_package(EGL)
+ find_package(Fontconfig 2.8.0 REQUIRED)
+ find_package(Freetype 2.4.2 REQUIRED)
+@@ -32,6 +37,10 @@ find_package(EGL)
  find_package(OpenGL)
  find_package(OpenGLES2)
  
@@ -20769,7 +20697,7 @@ index 8dc57e7d0395edee5667eceada38bd3b56668151..e944f55214844cf35e6a80a600a9773c
  include(GStreamerDefinitions)
  
  SET_AND_EXPOSE_TO_BUILD(USE_CAIRO TRUE)
-@@ -65,16 +71,16 @@ WEBKIT_OPTION_DEFINE(ENABLE_QUARTZ_TARGET "Whether to enable support for the Qua
+@@ -65,16 +74,16 @@ WEBKIT_OPTION_DEFINE(ENABLE_QUARTZ_TARGET "Whether to enable support for the Qua
  WEBKIT_OPTION_DEFINE(ENABLE_WAYLAND_TARGET "Whether to enable support for the Wayland windowing target." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(ENABLE_X11_TARGET "Whether to enable support for the X11 windowing target." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(USE_ANGLE_WEBGL "Whether to use ANGLE as WebGL backend." PUBLIC OFF)
@@ -20789,7 +20717,7 @@ index 8dc57e7d0395edee5667eceada38bd3b56668151..e944f55214844cf35e6a80a600a9773c
  WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(USE_WPE_RENDERER "Whether to enable WPE rendering" PUBLIC ON)
  
-@@ -124,7 +130,7 @@ endif ()
+@@ -124,7 +133,7 @@ endif ()
  # without approval from a GTK reviewer. There must be strong reason to support
  # changing the value of the option.
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_DRAG_SUPPORT PUBLIC ON)
@@ -20798,7 +20726,7 @@ index 8dc57e7d0395edee5667eceada38bd3b56668151..e944f55214844cf35e6a80a600a9773c
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MINIBROWSER PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_PDFJS PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SPELLCHECK PUBLIC ON)
-@@ -158,10 +164,10 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_INPUT_TYPE_WEEK PRIVATE ON)
+@@ -159,10 +168,10 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_INPUT_TYPE_WEEK PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_INTELLIGENT_TRACKING_PREVENTION PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_LAYER_BASED_SVG_ENGINE PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_LAYOUT_FORMATTING_CONTEXT PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
@@ -20811,7 +20739,7 @@ index 8dc57e7d0395edee5667eceada38bd3b56668151..e944f55214844cf35e6a80a600a9773c
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MHTML PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MOUSE_CURSOR_SCALE PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETSCAPE_PLUGIN_API PRIVATE OFF)
-@@ -169,7 +175,7 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETWORK_CACHE_SPECULATIVE_REVALIDATION P
+@@ -170,7 +179,7 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETWORK_CACHE_SPECULATIVE_REVALIDATION P
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETWORK_CACHE_STALE_WHILE_REVALIDATE PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_OFFSCREEN_CANVAS PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_OFFSCREEN_CANVAS_IN_WORKERS PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
@@ -20820,7 +20748,7 @@ index 8dc57e7d0395edee5667eceada38bd3b56668151..e944f55214844cf35e6a80a600a9773c
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_PERIODIC_MEMORY_MONITOR PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_POINTER_LOCK PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SERVICE_WORKER PRIVATE ON)
-@@ -177,6 +183,15 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SHAREABLE_RESOURCE PRIVATE ON)
+@@ -178,6 +187,15 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SHAREABLE_RESOURCE PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_API_STATISTICS PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_RTC PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
  
@@ -20836,7 +20764,7 @@ index 8dc57e7d0395edee5667eceada38bd3b56668151..e944f55214844cf35e6a80a600a9773c
  include(GStreamerDependencies)
  
  # Finalize the value for all options. Do not attempt to use an option before
-@@ -277,7 +292,8 @@ if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
+@@ -279,7 +297,8 @@ if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
      set(BUILD_REVISION "tarball")
  endif ()
  
@@ -20847,10 +20775,10 @@ index 8dc57e7d0395edee5667eceada38bd3b56668151..e944f55214844cf35e6a80a600a9773c
  SET_AND_EXPOSE_TO_BUILD(HAVE_OS_DARK_MODE_SUPPORT 1)
  
 diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
-index 7b2389bcee6a781b01debbd2d3d2d3bcf4b2bea6..54f099bb5a89c6c282d1ec58a3261830728c7ffb 100644
+index 42c335562733a8813a434880d74b0b4ed9232694..55600800f9bf05f8c9e4d9a9577d9e7681660fb3 100644
 --- a/Source/cmake/OptionsWPE.cmake
 +++ b/Source/cmake/OptionsWPE.cmake
-@@ -9,6 +9,8 @@ if (${CMAKE_VERSION} VERSION_LESS "3.20" AND NOT ${CMAKE_GENERATOR} STREQUAL "Ni
+@@ -9,8 +9,13 @@ if (${CMAKE_VERSION} VERSION_LESS "3.20" AND NOT ${CMAKE_GENERATOR} STREQUAL "Ni
      message(FATAL_ERROR "Building with Makefiles requires CMake 3.20 or newer. Either enable Ninja by passing -GNinja, or upgrade CMake.")
  endif ()
  
@@ -20858,8 +20786,13 @@ index 7b2389bcee6a781b01debbd2d3d2d3bcf4b2bea6..54f099bb5a89c6c282d1ec58a3261830
 +
  set(USER_AGENT_BRANDING "" CACHE STRING "Branding to add to user agent string")
  
++set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
++set(THREADS_PREFER_PTHREAD_FLAG TRUE)
++
  find_package(Cairo 1.14.0 REQUIRED)
-@@ -61,10 +63,10 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_GPU_PROCESS PRIVATE OFF)
+ find_package(Fontconfig 2.8.0 REQUIRED)
+ find_package(Freetype 2.4.2 REQUIRED)
+@@ -62,10 +67,10 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_GPU_PROCESS PRIVATE OFF)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_INTELLIGENT_TRACKING_PREVENTION PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_LAYER_BASED_SVG_ENGINE PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_LAYOUT_FORMATTING_CONTEXT PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
@@ -20872,7 +20805,7 @@ index 7b2389bcee6a781b01debbd2d3d2d3bcf4b2bea6..54f099bb5a89c6c282d1ec58a3261830
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MHTML PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETSCAPE_PLUGIN_API PRIVATE OFF)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NOTIFICATIONS PRIVATE ON)
-@@ -74,24 +76,42 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_OFFSCREEN_CANVAS_IN_WORKERS PRIVATE ${EN
+@@ -75,24 +80,42 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_OFFSCREEN_CANVAS_IN_WORKERS PRIVATE ${EN
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_PERIODIC_MEMORY_MONITOR PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SERVICE_WORKER PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SHAREABLE_RESOURCE PRIVATE ON)
@@ -20902,7 +20835,7 @@ index 7b2389bcee6a781b01debbd2d3d2d3bcf4b2bea6..54f099bb5a89c6c282d1ec58a3261830
 +
  # Public options specific to the WPE port. Do not add any options here unless
  # there is a strong reason we should support changing the value of the option,
- # and the option is not relevant to any other WebKit ports.
+ # and the option is not relevant to other WebKit ports.
  WEBKIT_OPTION_DEFINE(ENABLE_DOCUMENTATION "Whether to generate documentation." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(ENABLE_INTROSPECTION "Whether to enable GObject introspection." PUBLIC ON)
  WEBKIT_OPTION_DEFINE(ENABLE_JOURNALD_LOG "Whether to enable journald logging" PUBLIC ON)
@@ -20920,7 +20853,7 @@ index 7b2389bcee6a781b01debbd2d3d2d3bcf4b2bea6..54f099bb5a89c6c282d1ec58a3261830
  WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." PUBLIC ON)
  
  # Private options specific to the WPE port.
-@@ -297,7 +317,7 @@ if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
+@@ -299,7 +322,7 @@ if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
  endif ()
  
  SET_AND_EXPOSE_TO_BUILD(HAVE_ACCESSIBILITY ${ENABLE_ACCESSIBILITY})
@@ -20930,7 +20863,7 @@ index 7b2389bcee6a781b01debbd2d3d2d3bcf4b2bea6..54f099bb5a89c6c282d1ec58a3261830
  SET_AND_EXPOSE_TO_BUILD(USE_EGL TRUE)
  SET_AND_EXPOSE_TO_BUILD(USE_GCRYPT TRUE)
 diff --git a/Source/cmake/OptionsWin.cmake b/Source/cmake/OptionsWin.cmake
-index 113f0203c76d1e589f086d719bde700c487050e6..f96a2b304b153d74dcafc616271d7b0823eae177 100644
+index dfc46c968213532914e88e1c65e3f3852f29c2a1..4ae88adbba3f5b37d009aabaaf89652ee1f9d88a 100644
 --- a/Source/cmake/OptionsWin.cmake
 +++ b/Source/cmake/OptionsWin.cmake
 @@ -7,8 +7,9 @@ add_definitions(-D_WINDOWS -DWINVER=0x601 -D_WIN32_WINNT=0x601)
@@ -20944,7 +20877,7 @@ index 113f0203c76d1e589f086d719bde700c487050e6..f96a2b304b153d74dcafc616271d7b08
      set(ENABLE_WEBKIT OFF)
  endif ()
  
-@@ -27,11 +28,9 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_CSS_BOX_DECORATION_BREAK PUBLIC ON)
+@@ -26,11 +27,9 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_CSS_BOX_DECORATION_BREAK PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_CSS_SELECTORS_LEVEL4 PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_CURSOR_VISIBILITY PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_DATALIST_ELEMENT PUBLIC OFF)
@@ -20956,7 +20889,7 @@ index 113f0203c76d1e589f086d719bde700c487050e6..f96a2b304b153d74dcafc616271d7b08
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_GEOLOCATION PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_INPUT_TYPE_COLOR PUBLIC OFF)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_INPUT_TYPE_DATE PUBLIC OFF)
-@@ -47,7 +46,6 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MEDIA_CONTROLS_SCRIPT PUBLIC ON)
+@@ -46,7 +45,6 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MEDIA_CONTROLS_SCRIPT PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MEDIA_SOURCE PUBLIC OFF)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MEDIA_STATISTICS PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MOUSE_CURSOR_SCALE PUBLIC ON)
@@ -20964,7 +20897,7 @@ index 113f0203c76d1e589f086d719bde700c487050e6..f96a2b304b153d74dcafc616271d7b08
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_VIDEO PUBLIC ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEBASSEMBLY PRIVATE OFF)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_AUDIO PUBLIC OFF)
-@@ -91,6 +89,16 @@ if (${WTF_PLATFORM_WIN_CAIRO})
+@@ -90,6 +88,16 @@ if (${WTF_PLATFORM_WIN_CAIRO})
      # No support planned
      WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_FTPDIR PRIVATE OFF)
  
@@ -22711,7 +22644,7 @@ index 0000000000000000000000000000000000000000..b52141c28ad89e0486d3bbdae5f9f86d
 +
 +#endif // !USE(ATSPI) && !USE(ATK)
 diff --git a/Tools/WebKitTestRunner/PlatformGTK.cmake b/Tools/WebKitTestRunner/PlatformGTK.cmake
-index a87adedcc0e1b67220f04e517097aae8fc640340..497777c13d0d083bee65710ced9fc6f03eac3778 100644
+index 8e434fbb2d6c04528922d50b3e1dd36bf945557e..35231da4eb73a9d99e004b3e1d649fc9fa30ec6f 100644
 --- a/Tools/WebKitTestRunner/PlatformGTK.cmake
 +++ b/Tools/WebKitTestRunner/PlatformGTK.cmake
 @@ -25,6 +25,7 @@ list(APPEND WebKitTestRunner_LIBRARIES
@@ -22722,7 +22655,7 @@ index a87adedcc0e1b67220f04e517097aae8fc640340..497777c13d0d083bee65710ced9fc6f0
  )
  
  list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES
-@@ -42,6 +43,9 @@ list(APPEND WebKitTestRunnerInjectedBundle_SOURCES
+@@ -38,6 +39,9 @@ list(APPEND WebKitTestRunnerInjectedBundle_SOURCES
      InjectedBundle/atspi/AccessibilityNotificationHandler.cpp
      InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
  


### PR DESCRIPTION
Rebase `webkit/patches/bootstrap.diff` to [r295073](https://trac.webkit.org/changeset/r295073/webkit). Changes:

- [Rebase patch to r295073](https://github.com/dpino/webkit/commit/010967bd7fba937aaa5416ba511828db3590b419)
- [Resolve conflicts](https://github.com/dpino/webkit/commit/994ab58958fe491aac0045e516efe7609926313c)
- [Fix linking error pthread](https://github.com/dpino/webkit/commit/5f572cea0f8cb26774b976c6ad91292425dc3452)

About the linking error, after resolving the conflicts the build finished with a linking error. The output was:

```
[27/72] Linking CXX shared library lib/libTestRunnerInjectedBundle.so
FAILED: lib/libTestRunnerInjectedBundle.so
: && /usr/lib/ccache/c++ -fPIC -fdiagnostics-color=always -Wextra -Wall -pipe -Wno-expansion-to-defined -Wno-odr -Wno-noexcept-type -Wno-psabi -Wno-misleading-indentation -Wno-maybe-uninitialized -Wwrite-strings -Wundef -Wpointer-arith -Wmissing-format-attribute -Wformat-security -Wcast-align -Wno-tautological-compare  -fno-stric
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `thread_local_init':
thread_pthread.c:(.text+0x17): undefined reference to `pthread_key_create'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_MUTEX_init':
thread_pthread.c:(.text+0xfb): undefined reference to `pthread_rwlock_init'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_MUTEX_lock_read':
thread_pthread.c:(.text+0x119): undefined reference to `pthread_rwlock_rdlock'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_MUTEX_lock_write':
thread_pthread.c:(.text+0x139): undefined reference to `pthread_rwlock_wrlock'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_MUTEX_unlock_read':
thread_pthread.c:(.text+0x159): undefined reference to `pthread_rwlock_unlock'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_MUTEX_unlock_write':
thread_pthread.c:(.text+0x179): undefined reference to `pthread_rwlock_unlock'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_STATIC_MUTEX_lock_read':
thread_pthread.c:(.text+0x1a9): undefined reference to `pthread_rwlock_rdlock'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_STATIC_MUTEX_lock_write':
thread_pthread.c:(.text+0x1c9): undefined reference to `pthread_rwlock_wrlock'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_STATIC_MUTEX_unlock_read':
thread_pthread.c:(.text+0x1e9): undefined reference to `pthread_rwlock_unlock'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_STATIC_MUTEX_unlock_write':
thread_pthread.c:(.text+0x209): undefined reference to `pthread_rwlock_unlock'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_once':
thread_pthread.c:(.text+0x229): undefined reference to `pthread_once'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_get_thread_local':
thread_pthread.c:(.text+0x256): undefined reference to `pthread_once'
/usr/bin/ld: thread_pthread.c:(.text+0x273): undefined reference to `pthread_getspecific'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_set_thread_local':
thread_pthread.c:(.text+0x2b4): undefined reference to `pthread_once'
/usr/bin/ld: thread_pthread.c:(.text+0x2e7): undefined reference to `pthread_getspecific'
/usr/bin/ld: thread_pthread.c:(.text+0x357): undefined reference to `pthread_setspecific'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/third_party/boringssl/src/crypto/thread_pthread.c.o: in function `CRYPTO_MUTEX_cleanup':
thread_pthread.c:(.text+0x195): undefined reference to `pthread_rwlock_destroy'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/webrtc/rtc_base/logging.cc.o: in function `rtc::LogMessage::SetLogOutput(rtc::LoggingSeverity, void (*)(rtc::LoggingSeverity, char const*))':
logging.cc:(.text+0x101): undefined reference to `pthread_mutexattr_init'
/usr/bin/ld: logging.cc:(.text+0x118): undefined reference to `pthread_mutexattr_destroy'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/webrtc/rtc_base/logging.cc.o: in function `rtc::LogMessage::LogToDebug(rtc::LoggingSeverity)':
logging.cc:(.text+0x2e9): undefined reference to `pthread_mutexattr_init'
/usr/bin/ld: logging.cc:(.text+0x300): undefined reference to `pthread_mutexattr_destroy'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/webrtc/rtc_base/logging.cc.o: in function `rtc::LogMessage::GetLogToStream(rtc::LogSink*)':
logging.cc:(.text+0x40d): undefined reference to `pthread_mutexattr_init'
/usr/bin/ld: logging.cc:(.text+0x424): undefined reference to `pthread_mutexattr_destroy'
/usr/bin/ld: lib/../Source/ThirdParty/libwebrtc/CMakeFiles/webrtc.dir/Source/webrtc/rtc_base/logging.cc.o: in function `rtc::LogMessage::AddLogToStream(rtc::LogSink*, rtc::LoggingSeverity)':
logging.cc:(.text+0x51d): undefined reference to `pthread_mutexattr_init'
...
```

So basically this was a linking error due to missing linkage to pthread from libraries `webrtc` and `boringssl`. I inspected several commits and found out the linking error started happening since this commit https://bugs.webkit.org/show_bug.cgi?id=240755

This patch fixed a linking error in non-unified builds. The patch reintroduced a CMake setting that had created some problems in the past (there's a lof of discussion in the bug ticket about whether to enable this setting or not). The setting is `set(WebCore_LIBRARY_TYPE OBJECT)`. My understanding is that this change makes WebCore be built as dynamic library instead of statically.

I didn't manage to reproduce this linking error upstream.

To solve the linking error I enforced linking to pthread. Probably this is not the right fix and there's a better way to fix it than introducing a change in Options{GTK,WPE}.cmake.

About the tests, I got the following failures:

```	
[webkit] › library/browsercontext-locale.spec.ts:31:1 › should affect navigator.language =======
[webkit] › library/browsercontext-locale.spec.ts:89:1 › should affect navigator.language in popups 
[webkit] › library/browsercontext-locale.spec.ts:141:1 › should not change default locale in another context 
[webkit] › library/defaultbrowsercontext-2.spec.ts:60:1 › should support locale option =========
```

These tests have been failing since #1649. They started failing due to [fast/text/international/system-language/navigator-language/navigator-language-fr.html is a flaky failure](https://bugs.webkit.org/show_bug.cgi?id=240104). It seems to me these tests need to get their expectations updated after that change.

```
[webkit] › library/modernizr.spec.ts:32:1 › safari-14-1 ========================================
[webkit] › library/modernizr.spec.ts:74:1 › mobile-safari-14-1 =================================
```

Likely a regression introduced by [Stop exposing ApplicationCache API if it is not enabled](https://bugs.webkit.org/show_bug.cgi?id=241000). Probably can be fixed by updating expectations or enabling this setting.