### PR TITLE
fix: respect min allowed firefox width in video tests

### DIFF
--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -345,10 +345,8 @@ it.describe('screencast', () => {
   it('should capture css transformation', async ({ browser, server, headless, browserName, platform, trace }, testInfo) => {
     it.fixme(!headless, 'Fails on headed');
     it.fixme(browserName === 'webkit' && platform === 'win32');
-    it.fixme(browserName === 'firefox' && trace === 'on', 'https://github.com/microsoft/playwright/issues/10060');
-    it.fixme(browserName === 'firefox', 'https://github.com/microsoft/playwright/issues/14405');
 
-    const size = { width: 320, height: 240 };
+    const size = { width: 600, height: 400 };
     // Set viewport equal to screencast frame size to avoid scaling.
     const context = await browser.newContext({
       recordVideo: {
@@ -376,9 +374,9 @@ it.describe('screencast', () => {
 
   it('should work for popups', async ({ browser, server, browserName, trace }, testInfo) => {
     it.fixme(browserName === 'firefox' && trace === 'on', 'https://github.com/microsoft/playwright/issues/10060');
-    it.fixme(browserName === 'firefox', 'https://github.com/microsoft/playwright/issues/14405');
+    it.fixme(browserName === 'firefox', 'https://github.com/microsoft/playwright/issues/14557');
     const videosPath = testInfo.outputPath('');
-    const size = { width: 450, height: 240 };
+    const size = { width: 600, height: 400 };
     const context = await browser.newContext({
       recordVideo: {
         dir: videosPath,
@@ -516,7 +514,7 @@ it.describe('screencast', () => {
 
   it('should capture static page in persistent context @smoke', async ({ launchPersistent, browserName, trace }, testInfo) => {
     it.fixme(browserName === 'firefox' && trace === 'on', 'https://github.com/microsoft/playwright/issues/10060');
-    const size = { width: 320, height: 240 };
+    const size = { width: 600, height: 400 };
     const { context, page } = await launchPersistent({
       recordVideo: {
         dir: testInfo.outputPath(''),
@@ -534,8 +532,8 @@ it.describe('screencast', () => {
     const duration = videoPlayer.duration;
     expect(duration).toBeGreaterThan(0);
 
-    expect(videoPlayer.videoWidth).toBe(320);
-    expect(videoPlayer.videoHeight).toBe(240);
+    expect(videoPlayer.videoWidth).toBe(600);
+    expect(videoPlayer.videoHeight).toBe(400);
 
     {
       const pixels = videoPlayer.seekLastFrame().data;
@@ -659,10 +657,9 @@ it.describe('screencast', () => {
   });
 
   it('should capture full viewport', async ({ browserType, browserName, headless }, testInfo) => {
-    it.fail(browserName === 'firefox', 'The actual picture is smaller than video frame');
     it.fail(browserName === 'chromium' && !headless, 'The square is not on the video');
 
-    const size = { width: 400, height: 400 };
+    const size = { width: 600, height: 400 };
     const browser = await browserType.launch();
 
     const videoDir = testInfo.outputPath('');
@@ -693,10 +690,8 @@ it.describe('screencast', () => {
   });
 
   it('should capture full viewport on hidpi', async ({ browserType, browserName, headless }, testInfo) => {
-    it.fixme(browserName === 'firefox', 'https://github.com/microsoft/playwright/issues/14405');
-    it.fail(browserName === 'firefox', 'The actual picture is smaller than video frame');
     it.fail(browserName === 'chromium' && !headless, 'The square is not on the video');
-    const size = { width: 400, height: 400 };
+    const size = { width: 600, height: 400 };
     const browser = await browserType.launch();
 
     const videoDir = testInfo.outputPath('');

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -345,6 +345,7 @@ it.describe('screencast', () => {
   it('should capture css transformation', async ({ browser, server, headless, browserName, platform, trace }, testInfo) => {
     it.fixme(!headless, 'Fails on headed');
     it.fixme(browserName === 'webkit' && platform === 'win32');
+    it.fixme(browserName === 'firefox' && trace === 'on', 'https://github.com/microsoft/playwright/issues/10060');
 
     const size = { width: 600, height: 400 };
     // Set viewport equal to screencast frame size to avoid scaling.
@@ -656,9 +657,9 @@ it.describe('screencast', () => {
     expect(files.length).toBe(1);
   });
 
-  it('should capture full viewport', async ({ browserType, browserName, headless }, testInfo) => {
+  it('should capture full viewport', async ({ browserType, browserName, headless, isWindows }, testInfo) => {
     it.fail(browserName === 'chromium' && !headless, 'The square is not on the video');
-
+    it.fail(browserName === 'firefox' && isWindows, 'https://github.com/microsoft/playwright/issues/14405');
     const size = { width: 600, height: 400 };
     const browser = await browserType.launch();
 
@@ -689,8 +690,9 @@ it.describe('screencast', () => {
     expectAll(pixels, almostRed);
   });
 
-  it('should capture full viewport on hidpi', async ({ browserType, browserName, headless }, testInfo) => {
+  it('should capture full viewport on hidpi', async ({ browserType, browserName, headless, isWindows }, testInfo) => {
     it.fail(browserName === 'chromium' && !headless, 'The square is not on the video');
+    it.fail(browserName === 'firefox' && isWindows, 'https://github.com/microsoft/playwright/issues/14405');
     const size = { width: 600, height: 400 };
     const browser = await browserType.launch();
 


### PR DESCRIPTION
In firefox browser window min width is 450, setting viewport to smaller value in the tests led to unexpected image in the video.

References #14405