### PR TITLE
fix(test runner): disallow test.use() in require'd files

### DIFF
--- a/packages/playwright-test/src/globals.ts
+++ b/packages/playwright-test/src/globals.ts
@@ -32,3 +32,11 @@ export function setCurrentlyLoadingFileSuite(suite: Suite | undefined) {
 export function currentlyLoadingFileSuite() {
   return currentFileSuite;
 }
+
+let currentFile: string | undefined;
+export function setCurrentlyLoadingFile(file: string | undefined) {
+  currentFile = file;
+}
+export function currentlyLoadingFile() {
+  return currentFile;
+}

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -17,7 +17,7 @@
 import { installTransform } from './transform';
 import type { Config, Project, ReporterDescription, FullProjectInternal, FullConfigInternal, Fixtures, FixturesWithLocation } from './types';
 import { getPackageJsonPath, mergeObjects, errorWithFile } from './util';
-import { setCurrentlyLoadingFileSuite } from './globals';
+import { setCurrentlyLoadingFileSuite, setCurrentlyLoadingFile } from './globals';
 import { Suite, type TestCase } from './test';
 import type { SerializedLoaderData } from './ipc';
 import * as path from 'path';
@@ -154,6 +154,7 @@ export class Loader {
     suite.location = { file, line: 0, column: 0 };
 
     setCurrentlyLoadingFileSuite(suite);
+    setCurrentlyLoadingFile(file);
     try {
       await this._requireOrImport(file);
       cachedFileSuites.set(file, suite);
@@ -163,6 +164,7 @@ export class Loader {
       suite._loadError = serializeError(e);
     } finally {
       setCurrentlyLoadingFileSuite(undefined);
+      setCurrentlyLoadingFile(undefined);
     }
 
     {

--- a/tests/playwright-test/esm.spec.ts
+++ b/tests/playwright-test/esm.spec.ts
@@ -145,3 +145,128 @@ test('should use source maps w/ ESM', async ({ runInlineTest, nodeVersion }) => 
   expect(result.passed).toBe(1);
   expect(output).toContain('a.test.ts:7:7');
 });
+
+test('should complain about test.use() in esm imported file - 1', async ({ runInlineTest, nodeVersion }) => {
+  // We only support experimental esm mode on Node 16+
+  test.skip(nodeVersion.major < 16);
+  const result = await runInlineTest({
+    'package.json': `{ "type": "module" }`,
+    'playwright.config.ts': `export default {};`,
+    'helper.ts': `
+      pwt.test.use({ headless: true });
+      export function bad() {}
+    `,
+    'test2.spec.ts': `
+      import { bad } from './helper.ts';
+      pwt.test('test', async ({}) => {});
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Call it directly in the test file instead.');
+});
+
+test('should complain about test.use() in esm imported file - 2', async ({ runInlineTest, nodeVersion }) => {
+  // We only support experimental esm mode on Node 16+
+  test.skip(nodeVersion.major < 16);
+  const result = await runInlineTest({
+    'package.json': `{ "type": "module" }`,
+    'playwright.config.ts': `export default {};`,
+    'helper.ts': `
+      export function bad() {
+        pwt.test.use({ headless: true });
+      }
+      bad();
+    `,
+    'test2.spec.ts': `
+      import { bad } from './helper.ts';
+      pwt.test('test', async ({}) => {});
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Call it directly in the test file instead.');
+});
+
+test('should complain about test.use() in esm imported file - 3', async ({ runInlineTest, nodeVersion }) => {
+  // We only support experimental esm mode on Node 16+
+  test.skip(nodeVersion.major < 16);
+  const result = await runInlineTest({
+    'package.json': `{ "type": "module" }`,
+    'playwright.config.ts': `export default {};`,
+    'helper.ts': `
+      export function bad() {
+        pwt.test.use({ headless: true });
+      }
+      await new Promise(f => setTimeout(f, 100)).then(() => bad());
+    `,
+    'test2.spec.ts': `
+      import { bad } from './helper.ts';
+      pwt.test('test', async ({}) => {});
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Call it directly in the test file instead.');
+});
+
+test('should complain about test.use() in esm imported file - 4', async ({ runInlineTest, nodeVersion }) => {
+  // We only support experimental esm mode on Node 16+
+  test.skip(nodeVersion.major < 16);
+  const result = await runInlineTest({
+    'package.json': `{ "type": "module" }`,
+    'playwright.config.ts': `export default {};`,
+    'helper.ts': `
+      export function bad() {
+        pwt.test.use({ headless: true });
+      }
+      await new Promise(f => setTimeout(f, 100))
+      await bad();
+    `,
+    'test2.spec.ts': `
+      import { bad } from './helper.ts';
+      pwt.test('test', async ({}) => {});
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Call it directly in the test file instead.');
+});
+
+test('should complain about test.use() in esm imported file - 5', async ({ runInlineTest, nodeVersion }) => {
+  // We only support experimental esm mode on Node 16+
+  test.skip(nodeVersion.major < 16);
+  const result = await runInlineTest({
+    'package.json': `{ "type": "module" }`,
+    'playwright.config.ts': `export default {};`,
+    'helper.ts': `
+      pwt.test.use({ headless: true });
+    `,
+    'test2.spec.ts': `
+      async function bad() {
+        await import('./helper.ts');
+      }
+      pwt.test('test', async ({}) => {});
+      await bad();
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Call it directly in the test file instead.');
+});
+
+test('should not complain about test.use() in esm imported helper func - 1', async ({ runInlineTest, nodeVersion }) => {
+  // We only support experimental esm mode on Node 16+
+  test.skip(nodeVersion.major < 16);
+  const result = await runInlineTest({
+    'package.json': `{ "type": "module" }`,
+    'playwright.config.ts': `export default {};`,
+    'helper.ts': `
+      export function bad() {
+        pwt.test.use({ headless: true });
+      }
+    `,
+    'test2.spec.ts': `
+      import { bad } from './helper.ts';
+      bad();
+      pwt.test('test', async ({}) => {});
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});


### PR DESCRIPTION
When `test.use()` is called not directly in a test file, but rather in a require'd file, it leads to subtle bugs. Only the first test file that requires the helper with `test.use()` is going to get the use options. This leads to confusion and bugs.

Here we check the stack to detect the situation where `test.use()` is not called directly in the test file and print a nice error message.