### PR TITLE
browser(webkit): fix curl compilation after recent roll

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1653
-Changed: dpino@igalia.com Wed Jun  1 17:53:30 UTC 2022
+1654
+Changed: yurys@chromium.org Thu 02 Jun 2022 03:28:10 PM PDT

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -2238,7 +2238,7 @@ diff --git a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm b/So
 index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d768ace22 100644
 --- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
 +++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
-@@ -198,6 +198,7 @@ NS_ASSUME_NONNULL_BEGIN
+@@ -198,6 +198,7 @@ - (void)sendEndIfNeeded
  
  - (void)speechRecognizer:(SFSpeechRecognizer *)speechRecognizer availabilityDidChange:(BOOL)available
  {
@@ -2246,7 +2246,7 @@ index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d
      ASSERT(isMainThread());
  
      if (available || !_task)
-@@ -211,6 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
+@@ -211,6 +212,7 @@ - (void)speechRecognizer:(SFSpeechRecognizer *)speechRecognizer availabilityDidC
  
  - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didHypothesizeTranscription:(SFTranscription *)transcription
  {
@@ -2254,7 +2254,7 @@ index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d
      ASSERT(isMainThread());
  
      [self sendSpeechStartIfNeeded];
-@@ -219,6 +221,7 @@ NS_ASSUME_NONNULL_BEGIN
+@@ -219,6 +221,7 @@ - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didHypothesizeTran
  
  - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didFinishRecognition:(SFSpeechRecognitionResult *)recognitionResult
  {
@@ -2262,7 +2262,7 @@ index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d
      ASSERT(isMainThread());
      [self callbackWithTranscriptions:recognitionResult.transcriptions isFinal:YES];
  
-@@ -230,6 +233,7 @@ NS_ASSUME_NONNULL_BEGIN
+@@ -230,6 +233,7 @@ - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didFinishRecogniti
  
  - (void)speechRecognitionTaskWasCancelled:(SFSpeechRecognitionTask *)task
  {
@@ -8829,7 +8829,7 @@ diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/
 index f3654db2dff953d825f012af144e1c00130d8251..b8165beb908b307a26c7acc47e3cf52adbaaaff2 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-@@ -720,7 +720,7 @@ void NetworkSessionCocoa::setClientAuditToken(const WebCore::AuthenticationChall
+@@ -720,7 +720,7 @@ - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didRece
  
      if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
          sessionCocoa->setClientAuditToken(challenge);
@@ -8882,6 +8882,54 @@ index 919935044a5b6b24a5d3f8268a0b876065032550..9cfdab46f921fe8b38d6a10e74cb0335
          m_curlRequest->start();
  
          if (m_state != State::Suspended) {
+diff --git a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
+index 892d1b2541e218047c33e88a207aa56e36b7e6bc..04bf128418cce29926d53c1af682485f4162ba03 100644
+--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
++++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
+@@ -61,7 +61,7 @@ NetworkSessionCurl::~NetworkSessionCurl()
+ 
+ std::unique_ptr<WebSocketTask> NetworkSessionCurl::createWebSocketTask(WebPageProxyIdentifier, NetworkSocketChannel& channel, const WebCore::ResourceRequest& request, const String& protocol, const WebCore::ClientOrigin&, bool)
+ {
+-    return makeUnique<WebSocketTask>(channel, request, protocol);
++    return makeUnique<WebSocketTask>(channel, request, protocol, ignoreCertificateErrors());
+ }
+ 
+ } // namespace WebKit
+diff --git a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+index 2c14f606108b1942a5a84ddc833055bea95a37d3..d14839aef6cfca76c3f385651bc3ef3c5af951b2 100644
+--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
++++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+@@ -33,7 +33,7 @@
+ 
+ namespace WebKit {
+ 
+-WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, const WebCore::ResourceRequest& request, const String& protocol)
++WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, const WebCore::ResourceRequest& request, const String& protocol, bool ignoreCertificateErrors)
+     : m_channel(channel)
+     , m_request(request.isolatedCopy())
+     , m_protocol(protocol)
+@@ -42,7 +42,7 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, const WebCore::Resou
+     if (request.url().protocolIs("wss"_s) && WebCore::DeprecatedGlobalSettings::allowsAnySSLCertificate())
+         WebCore::CurlContext::singleton().sslHandle().setIgnoreSSLErrors(true);
+ 
+-    m_streamID = m_scheduler.createStream(request.url(), *this);
++    m_streamID = m_scheduler.createStream(request.url(), ignoreCertificateErrors, *this);
+     m_channel.didSendHandshakeRequest(WebCore::ResourceRequest(m_request));
+ }
+ 
+diff --git a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
+index 2027a4b929fda90b34f46bf563846ca8d4553829..34bfbb236d5f16c8bb34920a2bb01c048d63ab5f 100644
+--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
++++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
+@@ -45,7 +45,7 @@ struct SessionSet;
+ class WebSocketTask : public CanMakeWeakPtr<WebSocketTask>, public WebCore::CurlStream::Client {
+     WTF_MAKE_FAST_ALLOCATED;
+ public:
+-    WebSocketTask(NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol);
++    WebSocketTask(NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, bool ignoreCertificateErrors);
+     ~WebSocketTask();
+ 
+     void sendString(const IPC::DataReference&, CompletionHandler<void()>&&);
 diff --git a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
 index fb70fe2e30abc45508eac1ff7b6fa5b576c22917..6d6404a9fdacf1f5c5f108b860e0e577856b6bf3 100644
 --- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -10191,7 +10239,7 @@ index e6f2fcf02b24fa16021c3be83f6116f989610027..bc2ddd59dd037fe3f52f996124b8cd2d
  #import <WebCore/Credential.h>
  #import <WebCore/RegistrationDatabase.h>
  #import <WebCore/ServiceWorkerClientData.h>
-@@ -234,6 +235,11 @@ static WallTime toSystemClockTime(NSDate *date)
+@@ -234,6 +235,11 @@ - (void)removeDataOfTypes:(NSSet *)dataTypes modifiedSince:(NSDate *)date comple
      });
  }
  
@@ -10370,7 +10418,7 @@ diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm b/
 index 2e235bb880c638a0e74256b6d66cb0244ea0a3f1..3471eebb47e860f7c2071d0e7f2691c9f0a6355d 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
-@@ -257,6 +257,16 @@
+@@ -257,6 +257,16 @@ - (BOOL)processSwapsOnNavigation
      return _processPoolConfiguration->processSwapsOnNavigation();
  }
  
@@ -20606,7 +20654,7 @@ diff --git a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm b/Source/WebKitLegac
 index 9f9c67523b8fac9025d2cec101adf452631ffc61..737d8dab4f7aa1fe446b2dcfdc32fe83e02a4555 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-@@ -4189,7 +4189,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
+@@ -4189,7 +4189,7 @@ - (void)mouseDown:(WebEvent *)event
      _private->handlingMouseDownEvent = NO;
  }
  
@@ -20619,7 +20667,7 @@ diff --git a/Source/WebKitLegacy/mac/WebView/WebView.mm b/Source/WebKitLegacy/ma
 index 09748e5cf07408ec620bb0a151378dbf6590733d..824b2efbfe7c6821ab0913cc7ebeaf960ea79784 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
-@@ -4043,7 +4043,7 @@ IGNORE_WARNINGS_END
+@@ -4043,7 +4043,7 @@ + (void)_doNotStartObservingNetworkReachability
  }
  #endif // PLATFORM(IOS_FAMILY)
  
@@ -20628,7 +20676,7 @@ index 09748e5cf07408ec620bb0a151378dbf6590733d..824b2efbfe7c6821ab0913cc7ebeaf96
  
  - (NSArray *)_touchEventRegions
  {
-@@ -4085,7 +4085,7 @@ IGNORE_WARNINGS_END
+@@ -4085,7 +4085,7 @@ - (NSArray *)_touchEventRegions
      }).autorelease();
  }
  


### PR DESCRIPTION
[WebSocketTaskCurl.cpp](https://github.com/WebKit/WebKit/commit/d726f6c8e4e517f224863044bb7200eeeac40127#diff-8e1df3ab3b752c6d3952d06e4addfc7004bc2b0a3c80feeea7d4bae4f4426e7e) has been implemented upstream since last roll. We now pass ignoreCertificateErrors to it similar to other platforms. This should fix Curl compilation errors on windows.

Pretty-diff: https://github.com/yury-s/WebKit/commit/48cd095db6066ecddd21a36fe9de68633fcd3faf