### PR TITLE
fix: hide DeprecationWarning of fd-slicer

### DIFF
--- a/packages/playwright-core/bundles/zip/build.js
+++ b/packages/playwright-core/bundles/zip/build.js
@@ -1,0 +1,33 @@
+// @ts-check
+const path = require('path');
+const fs = require('fs');
+const esbuild = require('esbuild');
+
+// Can be removed once https://github.com/thejoshwolfe/yauzl/issues/114 is fixed.
+/** @type{import('esbuild').Plugin} */
+let patchFdSlicerToHideBufferDeprecationWarning = {
+  name: 'patch-fd-slicer-deprecation',
+  setup(build) {
+    build.onResolve({ filter: /fd-slicer/ }, () => {
+      const originalPath = require.resolve('fd-slicer');
+      const patchedPath = path.join(path.dirname(originalPath), path.basename(originalPath, '.js') + '.pw-patched.js');
+      let sourceFileContent = fs.readFileSync(originalPath, 'utf8')
+      sourceFileContent = sourceFileContent.replace(/new Buffer\(toRead\)/g, 'Buffer.alloc(toRead)');
+      fs.writeFileSync(patchedPath, sourceFileContent);
+      return { path: patchedPath }
+    });
+  },
+}
+
+esbuild.build({
+  entryPoints: [path.join(__dirname, 'src/zipBundleImpl.ts')],
+  bundle: true,
+  outdir: path.join(__dirname, '../../lib'),
+  plugins: [patchFdSlicerToHideBufferDeprecationWarning],
+  format: 'cjs',
+  platform: 'node',
+  target: 'ES2019',
+  watch: process.argv.includes('--watch'),
+  sourcemap: process.argv.includes('--sourcemap'),
+  minify: process.argv.includes('--minify'),
+}).catch(() => process.exit(1));

--- a/packages/playwright-core/bundles/zip/build.js
+++ b/packages/playwright-core/bundles/zip/build.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @ts-check
 const path = require('path');
 const fs = require('fs');

--- a/packages/playwright-core/bundles/zip/package.json
+++ b/packages/playwright-core/bundles/zip/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "esbuild": "esbuild ./src/zipBundleImpl.ts --bundle --outdir=../../lib --format=cjs --platform=node --target=ES2019",
+    "esbuild": "node build.js",
     "build": "npm ci && npm run esbuild -- --minify",
     "watch": "npm ci && npm run esbuild -- --watch --sourcemap",
     "generate-license": "node ../../../../utils/generate_third_party_notice.js"


### PR DESCRIPTION
This patch fixes the deprecation warning which got emitted by `fd-slicer` during installation phase:

```
(node:336) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

Instead of rewriting all the `new Buffer(...)` usages of the bundle, only the `new Buffer(...)` usages inside `fd-slicer` gets rewritten. This is better since `new Buffer(...)` accepts `number` and `array` and replacing it all with `Buffer.alloc` or `Buffer.from` does not work. Needs to be done case by case.

Fixes https://github.com/microsoft/playwright/issues/14065