### PR TITLE
docs: describe test.setTimeout inside beforeAll/afterAll

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -943,7 +943,7 @@ test('very slow test', async ({ page }) => {
 });
 ```
 
-Changing timeout from a slow hook:
+Changing timeout from a slow `beforeEach` or `afterEach` hook. Note that this affects the test timeout that is shared with `beforeEach`/`afterEach` hooks.
 
 ```js js-flavor=js
 const { test, expect } = require('@playwright/test');
@@ -960,6 +960,54 @@ import { test, expect } from '@playwright/test';
 test.beforeEach(async ({ page }, testInfo) => {
   // Extend timeout for all tests running this hook by 30 seconds.
   test.setTimeout(testInfo.timeout + 30000);
+});
+```
+
+Changing timeout for a `beforeAll` or `afterAll` hook. Note this affects the hook's timeout, not the test timeout.
+
+```js js-flavor=js
+const { test, expect } = require('@playwright/test');
+
+test.beforeAll(async () => {
+  // Set timeout for this hook.
+  test.setTimeout(60000);
+});
+```
+
+```js js-flavor=ts
+import { test, expect } from '@playwright/test';
+
+test.beforeAll(async () => {
+  // Set timeout for this hook.
+  test.setTimeout(60000);
+});
+```
+
+Changing timeout for all tests in a [`method: Test.describe`] group.
+
+```js js-flavor=js
+const { test, expect } = require('@playwright/test');
+
+test.describe('group', () => {
+  // Applies to all tests in this group.
+  test.setTimeout(60000);
+
+  test('test one', async () => { /* ... */ });
+  test('test two', async () => { /* ... */ });
+  test('test three', async () => { /* ... */ });
+});
+```
+
+```js js-flavor=ts
+import { test, expect } from '@playwright/test';
+
+test.describe('group', () => {
+  // Applies to all tests in this group.
+  test.setTimeout(60000);
+
+  test('test one', async () => { /* ... */ });
+  test('test two', async () => { /* ... */ });
+  test('test three', async () => { /* ... */ });
 });
 ```
 
@@ -1174,6 +1222,10 @@ test('slow test', async ({ page }) => {
   // ...
 });
 ```
+
+:::note
+[`method: Test.slow#1`] cannot be used in a `beforeAll` or `afterAll` hook. Use [`method: Test.setTimeout`] instead.
+:::
 
 ## method: Test.slow#2
 

--- a/docs/src/test-timeouts-js.md
+++ b/docs/src/test-timeouts-js.md
@@ -16,6 +16,7 @@ Playwright Test has multiple configurable timeouts for various tasks.
 |Action timeout| no timeout |Timeout for each action:<br/><span style={{textTransform:'uppercase',fontSize:'smaller',fontWeight:'bold',opacity:'0.6'}}>Set default</span><br/><code>{`config = { use: { actionTimeout: 10000 } }`}</code><br/><span style={{textTransform: 'uppercase',fontSize: 'smaller', fontWeight: 'bold', opacity: '0.6'}}>Override</span><br/>`locator.click({ timeout: 10000 })` |
 |Navigation timeout| no timeout |Timeout for each navigation action:<br/><span style={{textTransform:'uppercase',fontSize:'smaller',fontWeight:'bold',opacity:'0.6'}}>Set default</span><br/><code>{`config = { use: { navigationTimeout: 30000 } }`}</code><br/><span style={{textTransform: 'uppercase',fontSize: 'smaller', fontWeight: 'bold', opacity: '0.6'}}>Override</span><br/>`page.goto('/', { timeout: 30000 })` |
 |Global timeout|no timeout |Global timeout for the whole test run:<br/><span style={{textTransform:'uppercase',fontSize:'smaller',fontWeight:'bold',opacity:'0.6'}}>Set in config</span><br/>`config = { globalTimeout: 60*60*1000 }`<br/> |
+|`beforeAll`/`afterAll` timeout|30000 ms|Timeout for the hook:<br/><span style={{textTransform:'uppercase',fontSize:'smaller',fontWeight:'bold',opacity:'0.6'}}>Set in hook</span><br/>`test.setTimeout(60000)`<br/> |
 |Fixture timeout|no timeout |Timeout for an individual fixture:<br/><span style={{textTransform:'uppercase',fontSize:'smaller',fontWeight:'bold',opacity:'0.6'}}>Set in fixture</span><br/>`{ scope: 'test', timeout: 30000 }`<br/> |
 
 ## Test timeout
@@ -30,7 +31,7 @@ example.spec.ts:3:1 › basic test ===========================
 Timeout of 30000ms exceeded.
 ```
 
-The same test timeout also applies to `beforeAll` and `afterAll` hooks.
+The same timeout value also applies to `beforeAll` and `afterAll` hooks, but they do not share time with any test.
 
 ### Set test timeout in the config
 
@@ -90,7 +91,7 @@ test('very slow test', async ({ page }) => {
 
 API reference: [`method: Test.setTimeout`] and [`method: Test.slow#1`].
 
-### Change timeout from a hook
+### Change timeout from a slow hook
 
 ```js js-flavor=js
 const { test, expect } = require('@playwright/test');
@@ -107,6 +108,30 @@ import { test, expect } from '@playwright/test';
 test.beforeEach(async ({ page }, testInfo) => {
   // Extend timeout for all tests running this hook by 30 seconds.
   testInfo.setTimeout(testInfo.timeout + 30000);
+});
+```
+
+API reference: [`method: TestInfo.setTimeout`].
+
+### Change timeout for `beforeAll`/`afterAll` hook
+
+`beforeAll` and `afterAll` hooks have a separate timeout, by default equal to test timeout. You can change it separately for each hook by calling [`method: TestInfo.setTimeout`] inside the hook.
+
+```js js-flavor=js
+const { test, expect } = require('@playwright/test');
+
+test.beforeAll(async () => {
+  // Set timeout for this hook.
+  test.setTimeout(60000);
+});
+```
+
+```js js-flavor=ts
+import { test, expect } from '@playwright/test';
+
+test.beforeAll(async () => {
+  // Set timeout for this hook.
+  test.setTimeout(60000);
 });
 ```
 

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -2144,6 +2144,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * });
    * ```
    *
+   * > NOTE: [test.slow()](https://playwright.dev/docs/api/class-test#test-slow-1) cannot be used in a `beforeAll` or
+   * `afterAll` hook. Use [test.setTimeout(timeout)](https://playwright.dev/docs/api/class-test#test-set-timeout) instead.
    */
   slow(): void;
   /**
@@ -2196,7 +2198,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * });
    * ```
    *
-   * Changing timeout from a slow hook:
+   * Changing timeout from a slow `beforeEach` or `afterEach` hook. Note that this affects the test timeout that is shared
+   * with `beforeEach`/`afterEach` hooks.
    *
    * ```ts
    * import { test, expect } from '@playwright/test';
@@ -2204,6 +2207,33 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * test.beforeEach(async ({ page }, testInfo) => {
    *   // Extend timeout for all tests running this hook by 30 seconds.
    *   test.setTimeout(testInfo.timeout + 30000);
+   * });
+   * ```
+   *
+   * Changing timeout for a `beforeAll` or `afterAll` hook. Note this affects the hook's timeout, not the test timeout.
+   *
+   * ```ts
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.beforeAll(async () => {
+   *   // Set timeout for this hook.
+   *   test.setTimeout(60000);
+   * });
+   * ```
+   *
+   * Changing timeout for all tests in a
+   * [test.describe(title, callback)](https://playwright.dev/docs/api/class-test#test-describe) group.
+   *
+   * ```ts
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.describe('group', () => {
+   *   // Applies to all tests in this group.
+   *   test.setTimeout(60000);
+   *
+   *   test('test one', async () => { /* ... *\/ });
+   *   test('test two', async () => { /* ... *\/ });
+   *   test('test three', async () => { /* ... *\/ });
    * });
    * ```
    *


### PR DESCRIPTION
Adding documentation that `test.setTimeout()` call from the `beforeAll`/`afterAll` hook changes the timeout of the hook itself.

References #14190.