### PR TITLE
feat(webkit): roll to r1658

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "webkit",
-      "revision": "1648",
+      "revision": "1658",
       "installByDefault": true,
       "revisionOverrides": {
         "mac10.14": "1446",

--- a/packages/playwright-core/src/server/webkit/protocol.d.ts
+++ b/packages/playwright-core/src/server/webkit/protocol.d.ts
@@ -1559,6 +1559,10 @@ export module Protocol {
        * Identifier of the network request associated with this message.
        */
       networkRequestId?: Network.RequestId;
+      /**
+       * Time when this message was added. Currently only used when an expensive operation happens to make sure that the frontend can account for it.
+       */
+      timestamp?: number;
     }
     /**
      * Stack entry for console errors and assertions.
@@ -2384,7 +2388,7 @@ export module Protocol {
       /**
        * Query selector result.
        */
-      nodeId: NodeId;
+      nodeId?: NodeId;
     }
     /**
      * Executes <code>querySelectorAll</code> on a given node.
@@ -8564,11 +8568,11 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     /**
      * Timeline record type.
      */
-    export type EventType = "EventDispatch"|"ScheduleStyleRecalculation"|"RecalculateStyles"|"InvalidateLayout"|"Layout"|"Paint"|"Composite"|"RenderingFrame"|"TimerInstall"|"TimerRemove"|"TimerFire"|"EvaluateScript"|"TimeStamp"|"Time"|"TimeEnd"|"FunctionCall"|"ProbeSample"|"ConsoleProfile"|"RequestAnimationFrame"|"CancelAnimationFrame"|"FireAnimationFrame"|"ObserverCallback";
+    export type EventType = "EventDispatch"|"ScheduleStyleRecalculation"|"RecalculateStyles"|"InvalidateLayout"|"Layout"|"Paint"|"Composite"|"RenderingFrame"|"TimerInstall"|"TimerRemove"|"TimerFire"|"EvaluateScript"|"TimeStamp"|"Time"|"TimeEnd"|"FunctionCall"|"ProbeSample"|"ConsoleProfile"|"RequestAnimationFrame"|"CancelAnimationFrame"|"FireAnimationFrame"|"ObserverCallback"|"Screenshot";
     /**
      * Instrument types.
      */
-    export type Instrument = "ScriptProfiler"|"Timeline"|"CPU"|"Memory"|"Heap"|"Animation";
+    export type Instrument = "ScriptProfiler"|"Timeline"|"CPU"|"Memory"|"Heap"|"Animation"|"Screenshot";
     /**
      * Timeline record contains information about the recorded activity.
      */

--- a/tests/library/browsercontext-locale.spec.ts
+++ b/tests/library/browsercontext-locale.spec.ts
@@ -28,10 +28,10 @@ it('should affect accept-language header @smoke', async ({ browser, server }) =>
   await context.close();
 });
 
-it('should affect navigator.language', async ({ browser, server }) => {
-  const context = await browser.newContext({ locale: 'fr-CH' });
+it('should affect navigator.language', async ({ browser }) => {
+  const context = await browser.newContext({ locale: 'fr-FR' });
   const page = await context.newPage();
-  expect(await page.evaluate(() => navigator.language)).toBe('fr-CH');
+  expect(await page.evaluate(() => navigator.language)).toBe('fr-FR');
   await context.close();
 });
 
@@ -87,7 +87,7 @@ it('should format number in popups', async ({ browser, server }) => {
 });
 
 it('should affect navigator.language in popups', async ({ browser, server }) => {
-  const context = await browser.newContext({ locale: 'fr-CH' });
+  const context = await browser.newContext({ locale: 'fr-FR' });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
   const [popup] = await Promise.all([
@@ -96,7 +96,7 @@ it('should affect navigator.language in popups', async ({ browser, server }) => 
   ]);
   await popup.waitForLoadState('domcontentloaded');
   const result = await popup.evaluate('window.initialNavigatorLanguage');
-  expect(result).toBe('fr-CH');
+  expect(result).toBe('fr-FR');
   await context.close();
 });
 
@@ -138,7 +138,7 @@ it('should be isolated between contexts', async ({ browser, server }) => {
   ]);
 });
 
-it('should not change default locale in another context', async ({ browser, server }) => {
+it('should not change default locale in another context', async ({ browser }) => {
   async function getContextLocale(context) {
     const page = await context.newPage();
     return await page.evaluate(() => (new Intl.NumberFormat()).resolvedOptions().locale);
@@ -150,7 +150,7 @@ it('should not change default locale in another context', async ({ browser, serv
     defaultLocale = await getContextLocale(context);
     await context.close();
   }
-  const localeOverride = defaultLocale === 'ru-RU' ? 'de-DE' : 'ru-RU';
+  const localeOverride = defaultLocale === 'es-MX' ? 'de-DE' : 'es-MX';
   {
     const context = await browser.newContext({ locale: localeOverride });
     expect(await getContextLocale(context)).toBe(localeOverride);
@@ -164,13 +164,13 @@ it('should not change default locale in another context', async ({ browser, serv
 });
 
 it('should format number in workers', async ({ browser, server }) => {
-  const context = await browser.newContext({ locale: 'ru-RU' });
+  const context = await browser.newContext({ locale: 'es-MX' });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
   const [worker] = await Promise.all([
     page.waitForEvent('worker'),
     page.evaluate(() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], { type: 'application/javascript' })))),
   ]);
-  expect(await worker.evaluate(() => (10000.20).toLocaleString())).toBe('10\u00A0000,2');
+  expect(await worker.evaluate(() => (10000.20).toLocaleString())).toBe('10,000.2');
   await context.close();
 });

--- a/tests/library/defaultbrowsercontext-2.spec.ts
+++ b/tests/library/defaultbrowsercontext-2.spec.ts
@@ -58,8 +58,8 @@ it('should support timezoneId option', async ({ launchPersistent, browserName })
 });
 
 it('should support locale option', async ({ launchPersistent }) => {
-  const { page } = await launchPersistent({ locale: 'fr-CH' });
-  expect(await page.evaluate(() => navigator.language)).toBe('fr-CH');
+  const { page } = await launchPersistent({ locale: 'fr-FR' });
+  expect(await page.evaluate(() => navigator.language)).toBe('fr-FR');
 });
 
 it('should support geolocation and permissions options', async ({ server, launchPersistent }) => {


### PR DESCRIPTION
Language override behavior changed upstream in https://github.com/WebKit/WebKit/commit/039ebd9db2a695fef5b67d38da258851ed81086c
New logic is closer to the actual behavior of WebKit on macOS, meaning that when the user changes system language the actual locale changes according to some weird OS rules:
ru-RU => navigator.language === 'ru'
fr-CH =>  navigator.language === 'fr-FR'
es-MX =>  navigator.language === 'es-MX'
Our locale emulation is aligned with that, so setting locale to fr-CH will result in fr-FR etc.
