### PR TITLE
chore: make LocalUtils easily available on the client

### DIFF
--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -24,7 +24,6 @@ import { isSafeCloseError, kBrowserClosedError } from '../common/errors';
 import type * as api from '../../types/types';
 import { CDPSession } from './cdpSession';
 import type { BrowserType } from './browserType';
-import type { LocalUtils } from './localUtils';
 
 export class Browser extends ChannelOwner<channels.BrowserChannel> implements api.Browser {
   readonly _contexts = new Set<BrowserContext>();
@@ -33,7 +32,6 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
   _shouldCloseConnectionOnClose = false;
   private _browserType!: BrowserType;
   readonly _name: string;
-  _localUtils!: LocalUtils;
 
   static from(browser: channels.BrowserChannel): Browser {
     return (browser as any)._object;
@@ -68,7 +66,6 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
     this._contexts.add(context);
     context._logger = options.logger || this._logger;
     context._setBrowserType(this._browserType);
-    context.tracing._localUtils = this._localUtils;
     await this._browserType._onDidCreateContext?.(context);
     return context;
   }

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -80,7 +80,6 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
     const browser = Browser.from((await this._channel.launch(launchOptions)).browser);
     browser._logger = logger;
     browser._setBrowserType(this);
-    browser._localUtils = this._playwright._utils;
     return browser;
   }
 
@@ -109,7 +108,6 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
     context._options = contextParams;
     context._logger = logger;
     context._setBrowserType(this);
-    context.tracing._localUtils = this._playwright._utils;
     await this._onDidCreateContext?.(context);
     return context;
   }
@@ -134,7 +132,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
         connectParams.socksProxyRedirectPortForTest = (params as any).__testHookRedirectPortForwarding;
       const { pipe } = await this._channel.connect(connectParams);
       const closePipe = () => pipe.close().catch(() => {});
-      const connection = new Connection();
+      const connection = new Connection(this._connection.localUtils());
       connection.markAsRemote();
       connection.on('close', closePipe);
 
@@ -176,7 +174,6 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
         browser._logger = logger;
         browser._shouldCloseConnectionOnClose = true;
         browser._setBrowserType(this);
-        browser._localUtils = this._playwright._utils;
         browser.on(Events.Browser.Disconnected, closePipe);
         return browser;
       }, deadline ? deadline - monotonicTime() : 0);
@@ -214,7 +211,6 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
       browser._contexts.add(BrowserContext.from(result.defaultContext));
     browser._logger = params.logger;
     browser._setBrowserType(this);
-    browser._localUtils = this._playwright._utils;
     return browser;
   }
 }

--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -67,12 +67,14 @@ export class Connection extends EventEmitter {
   private _rootObject: Root;
   private _closedErrorMessage: string | undefined;
   private _isRemote = false;
+  private _localUtils?: LocalUtils;
   // Some connections allow resolving in-process dispatchers.
   toImpl: ((client: ChannelOwner) => any) | undefined;
 
-  constructor() {
+  constructor(localUtils?: LocalUtils) {
     super();
     this._rootObject = new Root(this);
+    this._localUtils = localUtils;
   }
 
   markAsRemote() {
@@ -81,6 +83,10 @@ export class Connection extends EventEmitter {
 
   isRemote() {
     return this._isRemote;
+  }
+
+  localUtils(): LocalUtils {
+    return this._localUtils!;
   }
 
   async initializePlaywright(): Promise<Playwright> {
@@ -238,6 +244,8 @@ export class Connection extends EventEmitter {
         break;
       case 'LocalUtils':
         result = new LocalUtils(parent, type, guid, initializer);
+        if (!this._localUtils)
+          this._localUtils = result as LocalUtils;
         break;
       case 'Page':
         result = new Page(parent, type, guid, initializer);

--- a/packages/playwright-core/src/client/fetch.ts
+++ b/packages/playwright-core/src/client/fetch.ts
@@ -73,7 +73,6 @@ export class APIRequest implements api.APIRequest {
       extraHTTPHeaders: options.extraHTTPHeaders ? headersObjectToArray(options.extraHTTPHeaders) : undefined,
       storageState,
     })).request);
-    context._tracing._localUtils = this._playwright._utils;
     this._contexts.add(context);
     context._request = this;
     await this._onDidCreateContext?.(context);

--- a/packages/playwright-core/src/client/localUtils.ts
+++ b/packages/playwright-core/src/client/localUtils.ts
@@ -18,10 +18,6 @@ import type * as channels from '../protocol/channels';
 import { ChannelOwner } from './channelOwner';
 
 export class LocalUtils extends ChannelOwner<channels.LocalUtilsChannel> {
-  static from(channel: channels.LocalUtilsChannel): LocalUtils {
-    return (channel as any)._object;
-  }
-
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.LocalUtilsInitializer) {
     super(parent, type, guid, initializer);
   }

--- a/packages/playwright-core/src/client/playwright.ts
+++ b/packages/playwright-core/src/client/playwright.ts
@@ -22,7 +22,6 @@ import { BrowserType } from './browserType';
 import { ChannelOwner } from './channelOwner';
 import { Electron } from './electron';
 import { APIRequest } from './fetch';
-import { LocalUtils } from './localUtils';
 import { Selectors, SelectorsOwner } from './selectors';
 import type { Size } from './types';
 
@@ -46,7 +45,6 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel> {
   selectors: Selectors;
   readonly request: APIRequest;
   readonly errors: { TimeoutError: typeof TimeoutError };
-  _utils: LocalUtils;
   private _socksProxyHandler: socks.SocksProxyHandler | undefined;
 
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.PlaywrightInitializer) {
@@ -65,7 +63,6 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel> {
       this.devices[name] = descriptor;
     this.selectors = new Selectors();
     this.errors = { TimeoutError };
-    this._utils = LocalUtils.from(initializer.utils);
 
     const selectorsOwner = SelectorsOwner.from(initializer.selectors);
     this.selectors._addChannel(selectorsOwner);

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -18,11 +18,8 @@ import type * as api from '../../types/types';
 import type * as channels from '../protocol/channels';
 import { Artifact } from './artifact';
 import { ChannelOwner } from './channelOwner';
-import type { LocalUtils } from './localUtils';
 
 export class Tracing extends ChannelOwner<channels.TracingChannel> implements api.Tracing {
-  _localUtils!: LocalUtils;
-
   static from(channel: channels.TracingChannel): Tracing {
     return (channel as any)._object;
   }
@@ -81,6 +78,6 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
 
     // Add local sources to the remote trace if necessary.
     if (result.sourceEntries?.length)
-      await this._localUtils.zip(filePath, result.sourceEntries);
+      await this._connection.localUtils().zip(filePath, result.sourceEntries);
   }
 }


### PR DESCRIPTION
Instead of plumbing it around, expose it through Connection.