### PR TITLE
devops: fix canary publishing

### DIFF
--- a/utils/publish_all_packages.sh
+++ b/utils/publish_all_packages.sh
@@ -94,7 +94,7 @@ echo "==================== Publishing version ${VERSION} ================"
 node ./utils/workspace.js --ensure-consistent
 node ./utils/workspace.js --list-public-package-paths | while read package
 do
-  npm publish ${package} --tag="${NPM_PUBLISH_TAG}"
+  npm publish --access=public ${package} --tag="${NPM_PUBLISH_TAG}"
 done
 
 echo "Done."


### PR DESCRIPTION
The first time a scoped package is published, it is considered to be
private.

See https://stackoverflow.com/a/44862841/314883
