### PR TITLE
chore: add Ubuntu 22 Docker image

### DIFF
--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -1,0 +1,42 @@
+FROM ubuntu:jammy
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=America/Los_Angeles
+ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright:v%version%-jammy"
+
+# === INSTALL Node.js ===
+
+RUN apt-get update && \
+    # Install node16
+    apt-get install -y curl wget && \
+    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt-get install -y nodejs && \
+    # Feature-parity with node.js base images.
+    apt-get install -y --no-install-recommends git openssh-client && \
+    npm install -g yarn && \
+    # clean apt cache
+    rm -rf /var/lib/apt/lists/* && \
+    # Create the pwuser
+    adduser pwuser
+
+# === BAKE BROWSERS INTO IMAGE ===
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# 1. Add tip-of-tree Playwright package to install its browsers.
+#    The package should be built beforehand from tip-of-tree Playwright.
+COPY ./playwright-core.tar.gz /tmp/playwright-core.tar.gz
+
+# 2. Bake in browsers & deps.
+#    Browsers will be downloaded in `/ms-playwright`.
+#    Note: make sure to set 777 to the registry so that any user can access
+#    registry.
+RUN mkdir /ms-playwright && \
+    mkdir /ms-playwright-agent && \
+    cd /ms-playwright-agent && npm init -y && \
+    npm i /tmp/playwright-core.tar.gz && \
+    npx playwright mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    npx playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
+    rm /tmp/playwright-core.tar.gz && \
+    rm -rf /ms-playwright-agent && \
+    chmod -R 777 /ms-playwright

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -3,7 +3,7 @@ set -e
 set +x
 
 if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
-  echo "usage: $(basename $0) {--arm64,--amd64} {bionic,focal} playwright:localbuild-focal"
+  echo "usage: $(basename $0) {--arm64,--amd64} {bionic,focal,jammy} playwright:localbuild-focal"
   echo
   echo "Build Playwright docker image and tag it as 'playwright:localbuild-focal'."
   echo "Once image is built, you can run it with"

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -52,6 +52,15 @@ if [[ "$RELEASE_CHANNEL" == "stable" ]]; then
   FOCAL_TAGS+=("focal")
 fi
 
+JAMMY_TAGS=(
+  "next-jammy"
+  "v${PW_VERSION}-jammy"
+)
+
+if [[ "$RELEASE_CHANNEL" == "stable" ]]; then
+  JAMMY_TAGS+=("jammy")
+fi
+
 tag_and_push() {
   local source="$1"
   local target="$2"
@@ -67,6 +76,9 @@ publish_docker_images_with_arch_suffix() {
     TAGS=("${BIONIC_TAGS[@]}")
   elif [[ "$FLAVOR" == "focal" ]]; then
     TAGS=("${FOCAL_TAGS[@]}")
+  elif [[ "$FLAVOR" == "jammy" ]]; then
+    TAGS=("${JAMMY_TAGS[@]}")
+  else
   else
     echo "ERROR: unknown flavor - $FLAVOR. Must be either 'bionic' or 'focal'"
     exit 1
@@ -119,3 +131,7 @@ publish_docker_manifest bionic amd64
 publish_docker_images_with_arch_suffix focal amd64
 publish_docker_images_with_arch_suffix focal arm64
 publish_docker_manifest focal amd64 arm64
+
+publish_docker_images_with_arch_suffix jammy amd64
+publish_docker_images_with_arch_suffix jammy arm64
+publish_docker_manifest jammy amd64 arm64


### PR DESCRIPTION
This is a "silent release" of the jammy Docker image. It won't change any of the existing tags.

The addition of the Dockerfile is required to add linux/arm64 tests in the playwright-internal repo.

This was essentially a copy of the focal setup Dockerfile.

https://github.com/microsoft/playwright/issues/13738