### PR TITLE
browser(webkit): fix mac build after roll

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1661
-Changed: yurys@chromium.org Thu 09 Jun 2022 09:27:30 AM PDT
+1662
+Changed: yurys@chromium.org Thu 09 Jun 2022 11:53:07 AM PDT

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -16924,7 +16924,7 @@ index 51eb4833d140baef40501790ef05906c1f5285a0..86434813aebe0e5e1955a19c70a1e63c
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index f69420b0b67e1d9d37b4af1feb3cea731f1f3285..73b45e8248cb08ef2a4c55081de1e244b566b911 100644
+index f69420b0b67e1d9d37b4af1feb3cea731f1f3285..00d99f5b7b192c650817302b5e38bc786f047d05 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -39,6 +39,7 @@
@@ -16978,7 +16978,15 @@ index f69420b0b67e1d9d37b4af1feb3cea731f1f3285..73b45e8248cb08ef2a4c55081de1e244
  class SharedBuffer;
  class SpeechRecognitionRequest;
  class TextIndicator;
-@@ -543,6 +555,8 @@ public:
+@@ -399,7 +411,6 @@ struct EditingRange;
+ struct EditorState;
+ struct FrameTreeNodeData;
+ struct FocusedElementInformation;
+-struct FontInfo;
+ struct FrameInfoData;
+ struct InputMethodState;
+ struct InsertTextOptions;
+@@ -543,6 +554,8 @@ public:
      void setControlledByAutomation(bool);
  
      WebPageInspectorController& inspectorController() { return *m_inspectorController; }
@@ -16987,7 +16995,7 @@ index f69420b0b67e1d9d37b4af1feb3cea731f1f3285..73b45e8248cb08ef2a4c55081de1e244
  
  #if PLATFORM(IOS_FAMILY)
      void showInspectorIndication();
-@@ -653,6 +667,11 @@ public:
+@@ -653,6 +666,11 @@ public:
  
      void setPageLoadStateObserver(std::unique_ptr<PageLoadState::Observer>&&);
  
@@ -16999,7 +17007,7 @@ index f69420b0b67e1d9d37b4af1feb3cea731f1f3285..73b45e8248cb08ef2a4c55081de1e244
      void initializeWebPage();
      void setDrawingArea(std::unique_ptr<DrawingAreaProxy>&&);
  
-@@ -680,6 +699,7 @@ public:
+@@ -680,6 +698,7 @@ public:
      void closePage();
  
      void addPlatformLoadParameters(WebProcessProxy&, LoadParameters&);
@@ -17007,7 +17015,7 @@ index f69420b0b67e1d9d37b4af1feb3cea731f1f3285..73b45e8248cb08ef2a4c55081de1e244
      RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
      RefPtr<API::Navigation> loadData(const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
-@@ -1213,6 +1233,7 @@ public:
+@@ -1213,6 +1232,7 @@ public:
  #endif
  
      void pageScaleFactorDidChange(double);
@@ -17015,7 +17023,7 @@ index f69420b0b67e1d9d37b4af1feb3cea731f1f3285..73b45e8248cb08ef2a4c55081de1e244
      void pluginScaleFactorDidChange(double);
      void pluginZoomFactorDidChange(double);
  
-@@ -1300,14 +1321,20 @@ public:
+@@ -1300,14 +1320,20 @@ public:
      void didStartDrag();
      void dragCancelled();
      void setDragCaretRect(const WebCore::IntRect&);
@@ -17037,7 +17045,7 @@ index f69420b0b67e1d9d37b4af1feb3cea731f1f3285..73b45e8248cb08ef2a4c55081de1e244
  #endif
  
      void processDidBecomeUnresponsive();
-@@ -1558,6 +1585,8 @@ public:
+@@ -1558,6 +1584,8 @@ public:
  
  #if PLATFORM(COCOA) || PLATFORM(GTK)
      RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
@@ -17046,7 +17054,7 @@ index f69420b0b67e1d9d37b4af1feb3cea731f1f3285..73b45e8248cb08ef2a4c55081de1e244
  #endif
  
  #if ENABLE(WEB_CRYPTO)
-@@ -2734,6 +2763,7 @@ private:
+@@ -2734,6 +2762,7 @@ private:
      String m_overrideContentSecurityPolicy;
  
      RefPtr<WebInspectorUIProxy> m_inspector;
@@ -17054,7 +17062,7 @@ index f69420b0b67e1d9d37b4af1feb3cea731f1f3285..73b45e8248cb08ef2a4c55081de1e244
  
  #if PLATFORM(COCOA)
      WeakObjCPtr<WKWebView> m_cocoaView;
-@@ -3003,6 +3033,20 @@ private:
+@@ -3003,6 +3032,20 @@ private:
      unsigned m_currentDragNumberOfFilesToBeAccepted { 0 };
      WebCore::IntRect m_currentDragCaretRect;
      WebCore::IntRect m_currentDragCaretEditableElementRect;
@@ -17075,7 +17083,7 @@ index f69420b0b67e1d9d37b4af1feb3cea731f1f3285..73b45e8248cb08ef2a4c55081de1e244
  #endif
  
      PageLoadState m_pageLoadState;
-@@ -3213,6 +3257,9 @@ private:
+@@ -3213,6 +3256,9 @@ private:
          RefPtr<API::Object> messageBody;
      };
      Vector<InjectedBundleMessage> m_pendingInjectedBundleMessages;


### PR DESCRIPTION
Speculative build fix for:

```
CompileC /Users/administrator/webkit/WebKitBuild/WebKit.build/Release/WebKit.build/Objects-normal/x86_64/UnifiedSource82.o /Users/administrator/webkit/WebKitBuild/Release/DerivedSources/WebKit/unified-sources/UnifiedSource82.cpp normal x86_64 c++ com.apple.compilers.llvm.cl
ang.1_0.compiler (in target 'WebKit' from project 'WebKit')
    cd /Users/administrator/webkit/Source/WebKit
    export LANG\=en_US.US-ASCII
    /Applications/Xcode13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -target x86_64-apple-macos12.1 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -std\=c++2a -stdlib\=libc++ -gmodules -Wno-trigr
aphs -fno-exceptions -fno-rtti -fno-sanitize\=vptr -fpascal-strings -Os -fno-common -Werror -Wno-missing-field-initializers -Wmissing-prototypes -Wunreachable-code -Wnon-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswit
ch -Wunused-function -Wno-unused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wuninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -W
no-float-conversion -Wnon-literal-null-conversion -Wobjc-literal-conversion -Wsign-compare -Wno-shorten-64-to-32 -Wnewline-eof -Wno-c++11-extensions -DNDEBUG -DHAVE_CORE_PREDICTION -DENABLE_LOWER_FORMATREADERBUNDLE_CODESIGNING_REQUIREMENTS -DFRAMEWORK_NAME\=WebKit -isysroot
 /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility\=hidden -fvisibility-inlines-hidden -fno-threadsafe-statics -Wno-sign-conver
sion -Winfinite-recursion -Wmove -Wcomma -Wblock-capture-autoreleasing -Wstrict-prototypes -Wrange-loop-analysis -Wno-semicolon-before-method-body -iquote /Users/administrator/webkit/WebKitBuild/WebKit.build/Release/WebKit.build/WebKit-generated-files.hmap -I/Users/administ
rator/webkit/WebKitBuild/WebKit.build/Release/WebKit.build/WebKit-own-target-headers.hmap -I/Users/administrator/webkit/WebKitBuild/WebKit.build/Release/WebKit.build/WebKit-all-target-headers.hmap -iquote /Users/administrator/webkit/WebKitBuild/WebKit.build/Release/WebKit.b
uild/WebKit-project-headers.hmap -I/Users/administrator/webkit/WebKitBuild/Release/include -I/Users/administrator/webkit/WebKitBuild/Release/usr/local/include -I/Users/administrator/webkit/WebKitBuild/Release/WebCore.framework/Versions/A/PrivateHeaders/ForwardingHeaders -I/
Users/administrator/webkit/WebKitBuild/Release/DerivedSources/WebKit -I/Users/administrator/webkit/WebKitBuild/Release/usr/local/include/pal/graphics/WebGPU -I/Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/local/
include/pal/graphics/WebGPU -I/Users/administrator/webkit/WebKitBuild/Release/usr/local/include/WebKitAdditions -I/Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/local/include/WebKitAdditions -I/Users/administrato
r/webkit/WebKitBuild/Release/usr/local/include/webrtc -I/Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/local/include/webrtc -I/Users/administrator/webkit/Source/WebKit -isystem /Applications/Xcode13.2.1.app/Conte
nts/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/local/include -I/Users/administrator/webkit/WebKitBuild/WebKit.build/Release/WebKit.build/DerivedSources-normal/x86_64 -I/Users/administrator/webkit/WebKitBuild/WebKit.build/Release/WebKit.build/Deriv
edSources/x86_64 -I/Users/administrator/webkit/WebKitBuild/WebKit.build/Release/WebKit.build/DerivedSources -Wall -Wextra -Wcast-qual -Wchar-subscripts -Wconditional-uninitialized -Wextra-tokens -Wformat\=2 -Winit-self -Wmissing-format-attribute -Wmissing-noreturn -Wno-unus
ed-parameter -Wpacked -Wpointer-arith -Wredundant-decls -Wundef -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-profile-instr-out-of-date -Wno-profile-instr-unprofile
d -F/Users/administrator/webkit/WebKitBuild/Release -F/Users/administrator/webkit/WebKitBuild/Release -F/Users/administrator/webkit/WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/120000 -iframework /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/PrivateFrameworks -iframework /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks -iframework /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/PrivateFrameworks -D__STDC_WANT_LIB_EXT1__\=1 -fprofile-instr-use\=/Users/administrator/webkit/WebKitBuild/Release/DerivedSources/WebKit/WebKit.profdata -isystem /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/System.framework/PrivateHeaders -include /Users/administrator/webkit/WebKitBuild/PrecompiledHeaders/SharedPrecompiledHeaders/9300323727089741043/WebKit2Prefix.h -MMD -MT dependencies -MF /Users/administrator/webkit/WebKitBuild/WebKit.build/Release/WebKit.build/Objects-normal/x86_64/UnifiedSource82.d --serialize-diagnostics /Users/administrator/webkit/WebKitBuild/WebKit.build/Release/WebKit.build/Objects-normal/x86_64/UnifiedSource82.dia -c /Users/administrator/webkit/WebKitBuild/Release/DerivedSources/WebKit/unified-sources/UnifiedSource82.cpp -o /Users/administrator/webkit/WebKitBuild/WebKit.build/Release/WebKit.build/Objects-normal/x86_64/UnifiedSource82.o
In file included from /Users/administrator/webkit/WebKitBuild/Release/DerivedSources/WebKit/unified-sources/UnifiedSource82.cpp:8:
In file included from /Users/administrator/webkit/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:32:
In file included from /Users/administrator/webkit/WebKitBuild/Release/DerivedSources/WebKit/RemoteCaptureSampleManagerMessages.h:37:
In file included from /Users/administrator/webkit/WebKitBuild/Release/WebCore.framework/PrivateHeaders/CVUtilities.h:28:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/CoreVideo.framework/Headers/CoreVideo.h:29:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/CoreVideo.framework/Headers/CVPixelBuffer.h:23:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/CoreVideo.framework/Headers/CVImageBuffer.h:28:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/ApplicationServices.framework/Headers/ApplicationServices.h:43:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/ApplicationServices.framework/Frameworks/HIServices.framework/Headers/HIServices.h:26:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/ApplicationServices.framework/Frameworks/HIServices.framework/Headers/HIShape.h:22:
/Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/ApplicationServices.framework/Frameworks/QD.framework/Headers/Quickdraw.h:209:16: error: reference to 'FontInfo' is ambiguous
typedef struct FontInfo                 FontInfo;
               ^
/Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/ApplicationServices.framework/Frameworks/QD.framework/Headers/Quickdraw.h:203:8: note: candidate found by name lookup is 'FontInfo'
struct FontInfo {
       ^
In file included from /Users/administrator/webkit/WebKitBuild/Release/DerivedSources/WebKit/unified-sources/UnifiedSource82.cpp:4:
In file included from /Users/administrator/webkit/Source/WebKit/UIProcess/Authentication/AuthenticationDecisionListener.cpp:35:
/Users/administrator/webkit/Source/WebKit/UIProcess/WebPageProxy.h:414:8: note: candidate found by name lookup is 'WebKit::FontInfo'
struct FontInfo;
       ^
In file included from /Users/administrator/webkit/WebKitBuild/Release/DerivedSources/WebKit/unified-sources/UnifiedSource82.cpp:8:
In file included from /Users/administrator/webkit/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:32:
In file included from /Users/administrator/webkit/WebKitBuild/Release/DerivedSources/WebKit/RemoteCaptureSampleManagerMessages.h:37:
In file included from /Users/administrator/webkit/WebKitBuild/Release/WebCore.framework/PrivateHeaders/CVUtilities.h:28:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/CoreVideo.framework/Headers/CoreVideo.h:29:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/CoreVideo.framework/Headers/CVPixelBuffer.h:23:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/CoreVideo.framework/Headers/CVImageBuffer.h:28:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/ApplicationServices.framework/Headers/ApplicationServices.h:43:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/ApplicationServices.framework/Frameworks/HIServices.framework/Headers/HIServices.h:26:
In file included from /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/ApplicationServices.framework/Frameworks/HIServices.framework/Headers/HIShape.h:22:
/Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/ApplicationServices.framework/Frameworks/QD.framework/Headers/Quickdraw.h:282:116: error: reference to 'FontInfo' is ambiguous
typedef CALLBACK_API( short , QDTxMeasProcPtr )(short byteCount, const void *textAddr, Point *numer, Point *denom, FontInfo *info);
                                                                                                                   ^
In file included from /Users/administrator/webkit/WebKitBuild/Release/DerivedSources/WebKit/unified-sources/UnifiedSource82.cpp:4:
In file included from /Users/administrator/webkit/Source/WebKit/UIProcess/Authentication/AuthenticationDecisionListener.cpp:35:
/Users/administrator/webkit/Source/WebKit/UIProcess/WebPageProxy.h:414:8: note: candidate found by name lookup is 'WebKit::FontInfo'
struct FontInfo;
       ^
```
which was introduced by https://github.com/microsoft/playwright/pull/14756

The error is likely caused by `using namespace WebKit;` in one of the .cpp files compiled as part of the same UnifiedSource82.cpp.

Pretty-diff: https://github.com/yury-s/WebKit/commit/fda476d518d9d9d64effcdb1c672bf77d17ebf4d