### PR TITLE
browser(webkit): fix mac build - remove unused variable

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1662
-Changed: yurys@chromium.org Thu 09 Jun 2022 11:53:07 AM PDT
+1663
+Changed: yurys@chromium.org Thu 09 Jun 2022 12:18:53 PM PDT

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -14195,10 +14195,10 @@ index 0000000000000000000000000000000000000000..d0e11ed81a6257c011df23d5870da740
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..20fd6c8be329f6f18787715736e422821973623f
+index 0000000000000000000000000000000000000000..d9f566a6cce6433c2cfbb25fd6793f65a4ec1f23
 --- /dev/null
 +++ b/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
-@@ -0,0 +1,957 @@
+@@ -0,0 +1,956 @@
 +/*
 + * Copyright (C) 2019 Microsoft Corporation.
 + *
@@ -14940,7 +14940,6 @@ index 0000000000000000000000000000000000000000..20fd6c8be329f6f18787715736e42282
 +        return;
 +    }
 +
-+    NetworkProcessProxy& networkProcess = browserContext->dataStore->networkProcess();
 +    browserContext->dataStore->cookieStore().cookies(
 +        [callback = WTFMove(callback)](const Vector<WebCore::Cookie>& allCookies) {
 +            if (!callback->isActive())


### PR DESCRIPTION
Fixes:
```
In file included from /Users/yurys/playwright/browser_patches/webkit/checkout/WebKitBuild/Release/DerivedSources/WebKit/unified-sources/UnifiedSource63.cpp:2:
/Users/yurys/playwright/browser_patches/webkit/checkout/Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp:742:26: error: unused variable 'networkProcess'
      [-Werror,-Wunused-variable]
    NetworkProcessProxy& networkProcess = browserContext->dataStore->networkProcess();
                         ^
1 error generated.
```

Pretty-diff: https://github.com/yury-s/WebKit/commit/2174713f73cd49834c491afad3ce7235e4ad61ed