### PR TITLE
fix(): export remote/playwrightConnection from playwright-core

### DIFF
--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -35,6 +35,7 @@
     "./lib/utils/stackTrace": "./lib/utils/stackTrace.js",
     "./lib/utils/timeoutRunner": "./lib/utils/timeoutRunner.js",
     "./lib/remote/playwrightServer": "./lib/remote/playwrightServer.js",
+    "./lib/remote/playwrightConnection": "./lib/remote/playwrightConnection.js",
     "./lib/server": "./lib/server/index.js",
     "./lib/utilsBundle": "./lib/utilsBundle.js",
     "./lib/zipBundle": "./lib/zipBundle.js",


### PR DESCRIPTION
Previously remote/playwrightClient was exported from playwright-core however with the recent update to playwrightConnection it has been removed from the package.json in playwright-core.