### PR TITLE
Added excludeDefaultArguments to remove default args from electron launch

### DIFF
--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -3609,6 +3609,7 @@ export type ElectronLaunchParams = {
   },
   strictSelectors?: boolean,
   timezoneId?: string,
+  excludeDefaultArguments?: boolean
 };
 export type ElectronLaunchOptions = {
   executablePath?: string,

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -121,12 +121,13 @@ export class Electron extends SdkObject {
   async launch(options: channels.ElectronLaunchParams): Promise<ElectronApplication> {
     const {
       args = [],
+      excludeDefaultArguments
     } = options;
     const controller = new ProgressController(serverSideCallMetadata(), this);
     controller.setLogName('browser');
     return controller.run(async progress => {
       let app: ElectronApplication | undefined = undefined;
-      const electronArguments = ['--inspect=0', '--remote-debugging-port=0', ...args];
+      const electronArguments = excludeDefaultArguments ? [...args] : ['--inspect=0', '--remote-debugging-port=0', ...args];
 
       if (os.platform() === 'linux') {
         const runningAsRoot = process.geteuid && process.geteuid() === 0;


### PR DESCRIPTION
I've added the `excludeDefaultArguments` argument to allow launching electron process without the default argument list.
This will give better versatile option to test electron-based projects, 
For example [Electron-Forge](https://www.electronforge.io/) which will otherwise crash if any of the default arguments it passed..

Creating electron-forge instance can be done by doing:
```
const electronForgePath = resolve(basePath, 'node_modules', '.bin', 'electron-forge.cmd');
return await electron.launch({
  args: ['start', '--inspect-electron', '--', '--remote-debugging-port=0'],
  executablePath: electronForgePath,
});
```