### PR TITLE
test: unskip viewport size test on ToT CR bots

### DIFF
--- a/tests/library/popup.spec.ts
+++ b/tests/library/popup.spec.ts
@@ -127,7 +127,6 @@ it('should inherit viewport size from browser context', async function({ browser
 });
 
 it('should use viewport size from window features', async function({ browser, server, channel }) {
-  it.fixme(channel === 'chromium-tip-of-tree', 'https://github.com/microsoft/playwright/issues/14787');
   const context = await browser.newContext({
     viewport: { width: 700, height: 700 }
   });

--- a/tests/library/popup.spec.ts
+++ b/tests/library/popup.spec.ts
@@ -126,7 +126,7 @@ it('should inherit viewport size from browser context', async function({ browser
   expect(size).toEqual({ width: 400, height: 500 });
 });
 
-it('should use viewport size from window features', async function({ browser, server, channel }) {
+it('should use viewport size from window features', async function({ browser, server }) {
   const context = await browser.newContext({
     viewport: { width: 700, height: 700 }
   });


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/14787

seems ok now.