### PR TITLE
Add constraint to `DummyChannelOwner` for (upcoming) TypeScript 4.8

### DIFF
--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -56,7 +56,7 @@ class Root extends ChannelOwner<channels.RootChannel> {
   }
 }
 
-class DummyChannelOwner<T> extends ChannelOwner<T> {
+class DummyChannelOwner<T extends channels.Channel> extends ChannelOwner<T> {
 }
 
 export class Connection extends EventEmitter {


### PR DESCRIPTION
Hi there! 👋

TypeScript recently added some stricter checking around unconstrained generics being incompatible with emptyish object types. The changes are only in nightly versions of TypeScript right now, but we've been exploring how open-source projects have been impacted [here](https://github.com/microsoft/TypeScript/issues/49461). In TypeScript 4.8, you'll get the following error without this change.

```
error TS2344: Type 'T' does not satisfy the constraint 'Channel'.
```