### PR TITLE
Fix compilation error in TypeScript 4.8

### DIFF
--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -56,7 +56,7 @@ class Root extends ChannelOwner<channels.RootChannel> {
   }
 }
 
-class DummyChannelOwner<T> extends ChannelOwner<T> {
+class DummyChannelOwner extends ChannelOwner {
 }
 
 export class Connection extends EventEmitter {


### PR DESCRIPTION
TypeScript 4.8 will include stricter assignability rules for unconstrained type parameters. Our [error detection infrastructure](https://github.com/microsoft/TypeScript/issues/49461) caught a build failure in your codebase due to that change.

This unconstrained `T` in `DummyChannelOwner` can’t be the type argument for `ChannelOwner` because the type parameter in `ChannelOwner` is constrained to `channels.Channel` which must be non-null/undefined, but an unconstrained `T` could be instantiated with null/undefined.

It looks like this type parameter was never used, so I just removed it.