### PR TITLE
chore: support Pop!_OS 22.04 versioning

### DIFF
--- a/packages/playwright-core/src/utils/ubuntuVersion.ts
+++ b/packages/playwright-core/src/utils/ubuntuVersion.ts
@@ -81,6 +81,10 @@ function parseUbuntuVersion(osReleaseText: string): string {
   if (fields.get('distrib_id') && fields.get('distrib_id')?.toLowerCase() === 'ubuntu')
     return fields.get('distrib_release') || '';
 
+  // For Pop!_OS
+  if (fields.get('id') && fields.get('id')?.toLowerCase() === 'pop')
+    return fields.get('version_id') || '';
+
   if (!fields.get('name') || fields.get('name')?.toLowerCase() !== 'ubuntu')
     return '';
   return fields.get('version_id') || '';


### PR DESCRIPTION
Pop!_OS 22.04 should use same packages as Ubuntu 22.04, but due to not checking for Pop!_OS, it receives the generic linux package list (which is Ubuntu 20.04).

Check for Pop!_OS in `ubuntuVersion.ts` to make sure that packages are installed correctly on 22.04.

`cat /etc/os-release` looks like this on Pop!_OS 22.04:
```
NAME="Pop!_OS"
VERSION="22.04 LTS"
ID=pop
ID_LIKE="ubuntu debian"
PRETTY_NAME="Pop!_OS 22.04 LTS"
VERSION_ID="22.04"
HOME_URL="https://pop.system76.com"
SUPPORT_URL="https://support.system76.com"
BUG_REPORT_URL="https://github.com/pop-os/pop/issues"
PRIVACY_POLICY_URL="https://system76.com/privacy"
VERSION_CODENAME=jammy
UBUNTU_CODENAME=jammy
LOGO=distributor-logo-pop-os
```