### PR TITLE
feat(route): fulfill with HARResponse

### DIFF
--- a/docs/src/api/class-route.md
+++ b/docs/src/api/class-route.md
@@ -508,9 +508,9 @@ File path to respond with. The content type will be inferred from file extension
 is resolved relative to the current working directory.
 
 ### option: Route.fulfill.response
-- `response` <[APIResponse]>
+- `response` <[APIResponse]|[HARResponse]>
 
-[APIResponse] to fulfill route's request with. Individual fields of the response (such as headers) can be overridden using fulfill options.
+[APIResponse] or [HARResponse] to fulfill route's request with. Individual fields of the response (such as headers) can be overridden using fulfill options.
 
 ## method: Route.request
 - returns: <[Request]>

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -38,6 +38,7 @@
     "./lib/server": "./lib/server/index.js",
     "./lib/utilsBundle": "./lib/utilsBundle.js",
     "./lib/zipBundle": "./lib/zipBundle.js",
+    "./types/har": "./types/har.d.ts",
     "./types/protocol": "./types/protocol.d.ts",
     "./types/structs": "./types/structs.d.ts"
   },

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -307,7 +307,7 @@ export class Route extends ChannelOwner<channels.RouteChannel> implements api.Ro
 
   private async _innerFulfill(options: { response?: api.APIResponse | HARResponse, status?: number, headers?: Headers, contentType?: string, body?: string | Buffer, path?: string, har?: RouteHAR } = {}): Promise<'abort' | 'continue' | 'done'> {
     let fetchResponseUid;
-    let { status: statusOption, headers: headersOption, body } = options;
+    let { status: statusOption, headers: headersOption, body, contentType } = options;
 
     if (options.har && options.response)
       throw new Error(`At most one of "har" and "response" options should be present`);
@@ -351,6 +351,7 @@ export class Route extends ChannelOwner<channels.RouteChannel> implements api.Ro
       headersOption ??= headersArrayToObject(harResponse.headers, false);
       if (body === undefined && options.path === undefined) {
         body = harResponse.content.text;
+        contentType ??= harResponse.content.mimeType;
         if (body !== undefined && harResponse.content.encoding === 'base64')
           body = Buffer.from(body, 'base64');
       }
@@ -375,8 +376,8 @@ export class Route extends ChannelOwner<channels.RouteChannel> implements api.Ro
     const headers: Headers = {};
     for (const header of Object.keys(headersOption || {}))
       headers[header.toLowerCase()] = String(headersOption![header]);
-    if (options.contentType)
-      headers['content-type'] = String(options.contentType);
+    if (contentType)
+      headers['content-type'] = String(contentType);
     else if (options.path)
       headers['content-type'] = mime.getType(options.path) || 'application/octet-stream';
     if (length && !('content-length' in headers))

--- a/packages/playwright-core/src/server/har/har.ts
+++ b/packages/playwright-core/src/server/har/har.ts
@@ -15,6 +15,10 @@
  */
 
 // see http://www.softwareishard.com/blog/har-12-spec/
+export type HAR = {
+  log: Log;
+};
+
 export type Log = {
   version: string;
   creator: Creator;

--- a/packages/playwright-core/src/server/har/har.ts
+++ b/packages/playwright-core/src/server/har/har.ts
@@ -15,7 +15,7 @@
  */
 
 // see http://www.softwareishard.com/blog/har-12-spec/
-export type HAR = {
+export type HARFile = {
   log: Log;
 };
 

--- a/packages/playwright-core/types/har.d.ts
+++ b/packages/playwright-core/types/har.d.ts
@@ -15,26 +15,29 @@
  */
 
 // see http://www.softwareishard.com/blog/har-12-spec/
-export type HAR = {
+export type HARFile = {
   log: HARLog;
 }
 
 export type HARLog = {
   version: string;
   creator: HARCreator;
-  browser: HARBrowser;
-  pages: HARPage[];
+  browser?: HARBrowser;
+  pages?: HARPage[];
   entries: HAREntry[];
+  comment?: string;
 };
 
 export type HARCreator = {
   name: string;
   version: string;
+  comment?: string;
 };
 
 export type HARBrowser = {
   name: string;
   version: string;
+  comment?: string;
 };
 
 export type HARPage = {
@@ -42,11 +45,13 @@ export type HARPage = {
   id: string;
   title: string;
   pageTimings: HARPageTimings;
+  comment?: string;
 };
 
 export type HARPageTimings = {
-  onContentLoad: number;
-  onLoad: number;
+  onContentLoad?: number;
+  onLoad?: number;
+  comment?: string;
 };
 
 export type HAREntry = {
@@ -59,6 +64,7 @@ export type HAREntry = {
   timings: HARTimings;
   serverIPAddress?: string;
   connection?: string;
+  comment?: string;
 };
 
 export type HARRequest = {
@@ -71,6 +77,7 @@ export type HARRequest = {
   postData?: HARPostData;
   headersSize: number;
   bodySize: number;
+  comment?: string;
 };
 
 export type HARResponse = {
@@ -83,6 +90,7 @@ export type HARResponse = {
   redirectURL: string;
   headersSize: number;
   bodySize: number;
+  comment?: string;
 };
 
 export type HARCookie = {
@@ -94,22 +102,26 @@ export type HARCookie = {
   httpOnly?: boolean;
   secure?: boolean;
   sameSite?: string;
+  comment?: string;
 };
 
 export type HARHeader = {
   name: string;
   value: string;
+  comment?: string;
 };
 
 export type HARQueryParameter = {
   name: string;
   value: string;
+  comment?: string;
 };
 
 export type HARPostData = {
   mimeType: string;
   params: HARParam[];
   text: string;
+  comment?: string;
 };
 
 export type HARParam = {
@@ -117,6 +129,7 @@ export type HARParam = {
   value?: string;
   fileName?: string;
   contentType?: string;
+  comment?: string;
 };
 
 export type HARContent = {
@@ -125,11 +138,13 @@ export type HARContent = {
   mimeType: string;
   text?: string;
   encoding?: string;
+  comment?: string;
 };
 
 export type HARCache = {
-  beforeRequest: HARCacheState | null;
-  afterRequest: HARCacheState | null;
+  beforeRequest?: HARCacheState;
+  afterRequest?: HARCacheState;
+  comment?: string;
 };
 
 export type HARCacheState = {
@@ -137,6 +152,7 @@ export type HARCacheState = {
   lastAccess: string;
   eTag: string;
   hitCount: number;
+  comment?: string;
 };
 
 export type HARTimings = {
@@ -147,12 +163,5 @@ export type HARTimings = {
   wait: number;
   receive: number;
   ssl?: number;
-};
-
-export type HARSecurityDetails = {
-  protocol?: string;
-  subjectName?: string;
-  issuer?: string;
-  validFrom?: number;
-  validTo?: number;
+  comment?: string;
 };

--- a/packages/playwright-core/types/har.d.ts
+++ b/packages/playwright-core/types/har.d.ts
@@ -15,6 +15,10 @@
  */
 
 // see http://www.softwareishard.com/blog/har-12-spec/
+export type HAR = {
+  log: HARLog;
+}
+
 export type HARLog = {
   version: string;
   creator: HARCreator;

--- a/packages/playwright-core/types/har.d.ts
+++ b/packages/playwright-core/types/har.d.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// see http://www.softwareishard.com/blog/har-12-spec/
+export type HARLog = {
+  version: string;
+  creator: HARCreator;
+  browser: HARBrowser;
+  pages: HARPage[];
+  entries: HAREntry[];
+};
+
+export type HARCreator = {
+  name: string;
+  version: string;
+};
+
+export type HARBrowser = {
+  name: string;
+  version: string;
+};
+
+export type HARPage = {
+  startedDateTime: string;
+  id: string;
+  title: string;
+  pageTimings: HARPageTimings;
+};
+
+export type HARPageTimings = {
+  onContentLoad: number;
+  onLoad: number;
+};
+
+export type HAREntry = {
+  pageref?: string;
+  startedDateTime: string;
+  time: number;
+  request: HARRequest;
+  response: HARResponse;
+  cache: HARCache;
+  timings: HARTimings;
+  serverIPAddress?: string;
+  connection?: string;
+};
+
+export type HARRequest = {
+  method: string;
+  url: string;
+  httpVersion: string;
+  cookies: HARCookie[];
+  headers: HARHeader[];
+  queryString: HARQueryParameter[];
+  postData?: HARPostData;
+  headersSize: number;
+  bodySize: number;
+};
+
+export type HARResponse = {
+  status: number;
+  statusText: string;
+  httpVersion: string;
+  cookies: HARCookie[];
+  headers: HARHeader[];
+  content: HARContent;
+  redirectURL: string;
+  headersSize: number;
+  bodySize: number;
+};
+
+export type HARCookie = {
+  name: string;
+  value: string;
+  path?: string;
+  domain?: string;
+  expires?: string;
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: string;
+};
+
+export type HARHeader = {
+  name: string;
+  value: string;
+};
+
+export type HARQueryParameter = {
+  name: string;
+  value: string;
+};
+
+export type HARPostData = {
+  mimeType: string;
+  params: HARParam[];
+  text: string;
+};
+
+export type HARParam = {
+  name: string;
+  value?: string;
+  fileName?: string;
+  contentType?: string;
+};
+
+export type HARContent = {
+  size: number;
+  compression?: number;
+  mimeType: string;
+  text?: string;
+  encoding?: string;
+};
+
+export type HARCache = {
+  beforeRequest: HARCacheState | null;
+  afterRequest: HARCacheState | null;
+};
+
+export type HARCacheState = {
+  expires?: string;
+  lastAccess: string;
+  eTag: string;
+  hitCount: number;
+};
+
+export type HARTimings = {
+  blocked?: number;
+  dns?: number;
+  connect?: number;
+  send: number;
+  wait: number;
+  receive: number;
+  ssl?: number;
+};
+
+export type HARSecurityDetails = {
+  protocol?: string;
+  subjectName?: string;
+  issuer?: string;
+  validFrom?: number;
+  validTo?: number;
+};

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -22,6 +22,8 @@ import { Readable } from 'stream';
 import { ReadStream } from 'fs';
 import { Serializable, EvaluationArgument, PageFunction, PageFunctionOn, SmartHandle, ElementHandleForTag, BindingSource } from 'playwright-core/types/structs';
 
+export * from 'playwright-core/types/har';
+
 type PageWaitForSelectorOptionsNotHidden = PageWaitForSelectorOptions & {
   state?: 'visible'|'attached';
 };

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -17,6 +17,7 @@
 import { Protocol } from 'playwright-core/types/protocol';
 import { ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
+import { HARResponse } from 'playwright-core/types/har';
 import { Readable } from 'stream';
 import { ReadStream } from 'fs';
 import { Serializable, EvaluationArgument, PageFunction, PageFunctionOn, SmartHandle, ElementHandleForTag, BindingSource } from 'playwright-core/types/structs';
@@ -14980,10 +14981,10 @@ export interface Route {
     path?: string;
 
     /**
-     * [APIResponse] to fulfill route's request with. Individual fields of the response (such as headers) can be overridden
-     * using fulfill options.
+     * [APIResponse] or [HARResponse] to fulfill route's request with. Individual fields of the response (such as headers) can
+     * be overridden using fulfill options.
      */
-    response?: APIResponse;
+    response?: APIResponse|HARResponse;
 
     /**
      * Response status code, defaults to `200`.

--- a/tests/page/page-request-fulfill.spec.ts
+++ b/tests/page/page-request-fulfill.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as base, expect } from './pageTest';
 import fs from 'fs';
-import type { HARLog } from 'playwright-core/types/har';
+import type { HARLog } from '@playwright/test';
 
 const it = base.extend<{
   // We access test servers at 10.0.2.2 from inside the browser on Android,

--- a/tests/page/page-request-fulfill.spec.ts
+++ b/tests/page/page-request-fulfill.spec.ts
@@ -17,7 +17,7 @@
 
 import { test as base, expect } from './pageTest';
 import fs from 'fs';
-import type { HAR } from '@playwright/test';
+import type { HARFile } from '@playwright/test';
 
 const it = base.extend<{
   // We access test servers at 10.0.2.2 from inside the browser on Android,
@@ -424,7 +424,7 @@ it('should fulfill with har response', async ({ page, isAndroid, asset }) => {
   it.fixme(isAndroid);
 
   const harPath = asset('har-fulfill.har');
-  const har = JSON.parse(await fs.promises.readFile(harPath, 'utf-8')) as HAR;
+  const har = JSON.parse(await fs.promises.readFile(harPath, 'utf-8')) as HARFile;
   await page.route('**/*', async route => {
     const response = findResponse(har, route.request().url());
     await route.fulfill({ response });
@@ -440,7 +440,7 @@ it('should override status when fulfill with response from har', async ({ page, 
   it.fixme(isAndroid);
 
   const harPath = asset('har-fulfill.har');
-  const har = JSON.parse(await fs.promises.readFile(harPath, 'utf-8')) as HAR;
+  const har = JSON.parse(await fs.promises.readFile(harPath, 'utf-8')) as HARFile;
   await page.route('**/*', async route => {
     const response = findResponse(har, route.request().url());
     await route.fulfill({ response, status: route.request().url().endsWith('.css') ? 404 : undefined });
@@ -452,7 +452,7 @@ it('should override status when fulfill with response from har', async ({ page, 
   await expect(page.locator('body')).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
 });
 
-function findResponse(har: HAR, url: string) {
+function findResponse(har: HARFile, url: string) {
   let entry;
   const originalUrl = url;
   while (url.trim()) {

--- a/tests/page/page-request-fulfill.spec.ts
+++ b/tests/page/page-request-fulfill.spec.ts
@@ -436,7 +436,7 @@ it('should fulfill with har response', async ({ page, isAndroid, asset }) => {
   await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(0, 255, 255)');
 });
 
-it('should should override status when fulfill with response from har', async ({ page, isAndroid, asset }) => {
+it('should override status when fulfill with response from har', async ({ page, isAndroid, asset }) => {
   it.fixme(isAndroid);
 
   const harPath = asset('har-fulfill.har');

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -21,6 +21,8 @@ import { Readable } from 'stream';
 import { ReadStream } from 'fs';
 import { Serializable, EvaluationArgument, PageFunction, PageFunctionOn, SmartHandle, ElementHandleForTag, BindingSource } from 'playwright-core/types/structs';
 
+export * from 'playwright-core/types/har';
+
 type PageWaitForSelectorOptionsNotHidden = PageWaitForSelectorOptions & {
   state?: 'visible'|'attached';
 };

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -16,6 +16,7 @@
 import { Protocol } from 'playwright-core/types/protocol';
 import { ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
+import { HARResponse } from 'playwright-core/types/har';
 import { Readable } from 'stream';
 import { ReadStream } from 'fs';
 import { Serializable, EvaluationArgument, PageFunction, PageFunctionOn, SmartHandle, ElementHandleForTag, BindingSource } from 'playwright-core/types/structs';


### PR DESCRIPTION
`har.d.ts` is copied from `packages/playwright-core/src/server/har/har.ts` with all private fields removed and Date type replaced with string so that it can be used to type cast result of `JSON.parse` to `HARLog`.