### PR TITLE
chore: use channels types instead of a copy in server

### DIFF
--- a/packages/playwright-core/src/server/accessibility.ts
+++ b/packages/playwright-core/src/server/accessibility.ts
@@ -16,13 +16,13 @@
  */
 
 import type * as dom from './dom';
-import type * as types from './types';
+import type * as channels from '../protocol/channels';
 
 export interface AXNode {
     isInteresting(insideControl: boolean): boolean;
     isLeafNode(): boolean;
     isControl(): boolean;
-    serialize(): types.SerializedAXNode;
+    serialize(): channels.AXNode;
     children(): Iterable<AXNode>;
 }
 
@@ -35,7 +35,7 @@ export class Accessibility {
   async snapshot(options: {
       interestingOnly?: boolean;
       root?: dom.ElementHandle;
-    } = {}): Promise<types.SerializedAXNode | null> {
+    } = {}): Promise<channels.AXNode | null> {
     const {
       interestingOnly = true,
       root = null,
@@ -65,8 +65,8 @@ function collectInterestingNodes(collection: Set<AXNode>, node: AXNode, insideCo
     collectInterestingNodes(collection, child, insideControl);
 }
 
-function serializeTree(node: AXNode, whitelistedNodes?: Set<AXNode>): types.SerializedAXNode[] {
-  const children: types.SerializedAXNode[] = [];
+function serializeTree(node: AXNode, whitelistedNodes?: Set<AXNode>): channels.AXNode[] {
+  const children: channels.AXNode[] = [];
   for (const child of node.children())
     children.push(...serializeTree(child, whitelistedNodes));
 

--- a/packages/playwright-core/src/server/android/backendAdb.ts
+++ b/packages/playwright-core/src/server/android/backendAdb.ts
@@ -15,14 +15,14 @@
  */
 
 import { debug } from '../../utilsBundle';
-import type * as types from '../types';
+import type * as channels from '../../protocol/channels';
 import * as net from 'net';
 import { EventEmitter } from 'events';
 import type { Backend, DeviceBackend, SocketBackend } from './android';
 import { assert, createGuid } from '../../utils';
 
 export class AdbBackend implements Backend {
-  async devices(options: types.AndroidDeviceOptions = {}): Promise<DeviceBackend[]> {
+  async devices(options: channels.AndroidDevicesOptions = {}): Promise<DeviceBackend[]> {
     const result = await runCommand('host:devices', options.host, options.port);
     const lines = result.toString().trim().split('\n');
     return lines.map(line => {

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -15,6 +15,7 @@
  */
 
 import type * as types from './types';
+import type * as channels from '../protocol/channels';
 import { BrowserContext, validateBrowserContextOptions } from './browserContext';
 import { Page } from './page';
 import { Download } from './download';
@@ -48,7 +49,7 @@ export type BrowserOptions = PlaywrightOptions & {
   downloadsPath: string,
   tracesDir: string,
   headful?: boolean,
-  persistent?: types.BrowserContextOptions,  // Undefined means no persistent context.
+  persistent?: channels.BrowserNewContextParams,  // Undefined means no persistent context.
   browserProcess: BrowserProcess,
   customExecutablePath?: string;
   proxy?: ProxySettings,
@@ -75,13 +76,13 @@ export abstract class Browser extends SdkObject {
     this.options = options;
   }
 
-  abstract doCreateNewContext(options: types.BrowserContextOptions): Promise<BrowserContext>;
+  abstract doCreateNewContext(options: channels.BrowserNewContextParams): Promise<BrowserContext>;
   abstract contexts(): BrowserContext[];
   abstract isConnected(): boolean;
   abstract version(): string;
   abstract userAgent(): string;
 
-  async newContext(metadata: CallMetadata, options: types.BrowserContextOptions): Promise<BrowserContext> {
+  async newContext(metadata: CallMetadata, options: channels.BrowserNewContextParams): Promise<BrowserContext> {
     validateBrowserContextOptions(options, this.options);
     const context = await this.doCreateNewContext(options);
     if (options.storageState)

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -30,6 +30,7 @@ import { PipeTransport } from './pipeTransport';
 import type { Progress } from './progress';
 import { ProgressController } from './progress';
 import type * as types from './types';
+import type * as channels from '../protocol/channels';
 import { DEFAULT_TIMEOUT, TimeoutSettings } from '../common/timeoutSettings';
 import { debugMode } from '../utils';
 import { existsAsync } from '../utils/fileUtils';
@@ -73,10 +74,10 @@ export abstract class BrowserType extends SdkObject {
     return browser;
   }
 
-  async launchPersistentContext(metadata: CallMetadata, userDataDir: string, options: types.LaunchPersistentOptions): Promise<BrowserContext> {
+  async launchPersistentContext(metadata: CallMetadata, userDataDir: string, options: channels.BrowserTypeLaunchPersistentContextOptions & { useWebSocket?: boolean }): Promise<BrowserContext> {
     options = this._validateLaunchOptions(options);
     const controller = new ProgressController(metadata, this);
-    const persistent: types.BrowserContextOptions = options;
+    const persistent: channels.BrowserNewContextParams = options;
     controller.setLogName('browser');
     const browser = await controller.run(progress => {
       return this._innerLaunchWithRetries(progress, options, persistent, helper.debugProtocolLogger(), userDataDir).catch(e => { throw this._rewriteStartupError(e); });
@@ -84,7 +85,7 @@ export abstract class BrowserType extends SdkObject {
     return browser._defaultContext!;
   }
 
-  async _innerLaunchWithRetries(progress: Progress, options: types.LaunchOptions, persistent: types.BrowserContextOptions | undefined, protocolLogger: types.ProtocolLogger, userDataDir?: string): Promise<Browser> {
+  async _innerLaunchWithRetries(progress: Progress, options: types.LaunchOptions, persistent: channels.BrowserNewContextParams | undefined, protocolLogger: types.ProtocolLogger, userDataDir?: string): Promise<Browser> {
     try {
       return await this._innerLaunch(progress, options, persistent, protocolLogger, userDataDir);
     } catch (error) {
@@ -98,7 +99,7 @@ export abstract class BrowserType extends SdkObject {
     }
   }
 
-  async _innerLaunch(progress: Progress, options: types.LaunchOptions, persistent: types.BrowserContextOptions | undefined, protocolLogger: types.ProtocolLogger, maybeUserDataDir?: string): Promise<Browser> {
+  async _innerLaunch(progress: Progress, options: types.LaunchOptions, persistent: channels.BrowserNewContextParams | undefined, protocolLogger: types.ProtocolLogger, maybeUserDataDir?: string): Promise<Browser> {
     options.proxy = options.proxy ? normalizeProxySettings(options.proxy) : undefined;
     const browserLogsCollector = new RecentLogsCollector();
     const { browserProcess, userDataDir, artifactsDir, transport } = await this._launchProcess(progress, options, !!persistent, browserLogsCollector, maybeUserDataDir);

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -30,6 +30,7 @@ import { CRDevTools } from './crDevTools';
 import type { BrowserOptions, BrowserProcess, PlaywrightOptions } from '../browser';
 import { Browser } from '../browser';
 import type * as types from '../types';
+import type * as channels from '../../protocol/channels';
 import type { HTTPRequestParams } from '../../common/netUtils';
 import { fetchData } from '../../common/netUtils';
 import { getUserAgent } from '../../common/userAgent';
@@ -94,7 +95,7 @@ export class Chromium extends BrowserType {
       await cleanedUp;
     };
     const browserProcess: BrowserProcess = { close: doClose, kill: doClose };
-    const persistent: types.BrowserContextOptions = { noDefaultViewport: true };
+    const persistent: channels.BrowserNewContextParams = { noDefaultViewport: true };
     const browserOptions: BrowserOptions = {
       ...this._playwrightOptions,
       slowMo: options.slowMo,

--- a/packages/playwright-core/src/server/chromium/crAccessibility.ts
+++ b/packages/playwright-core/src/server/chromium/crAccessibility.ts
@@ -19,7 +19,7 @@ import type { CRSession } from './crConnection';
 import type { Protocol } from './protocol';
 import type * as dom from '../dom';
 import type * as accessibility from '../accessibility';
-import type * as types from '../types';
+import type * as channels from '../../protocol/channels';
 
 export async function getAccessibilityTree(client: CRSession, needle?: dom.ElementHandle): Promise<{tree: accessibility.AXNode, needle: accessibility.AXNode | null}> {
   const { nodes } = await client.send('Accessibility.getFullAXTree');
@@ -210,19 +210,19 @@ class CRAXNode implements accessibility.AXNode {
     }
   }
 
-  serialize(): types.SerializedAXNode {
+  serialize(): channels.AXNode {
     const properties: Map<string, number | string | boolean> = new Map();
     for (const property of this._payload.properties || [])
       properties.set(property.name.toLowerCase(), property.value.value);
     if (this._payload.description)
       properties.set('description', this._payload.description.value);
 
-    const node: {[x in keyof types.SerializedAXNode]: any} = {
+    const node: {[x in keyof channels.AXNode]: any} = {
       role: this.normalizedRole(),
       name: this._payload.name ? (this._payload.name.value || '') : '',
     };
 
-    const userStringProperties: Array<keyof types.SerializedAXNode> = [
+    const userStringProperties: Array<keyof channels.AXNode> = [
       'description',
       'keyshortcuts',
       'roledescription',
@@ -233,7 +233,7 @@ class CRAXNode implements accessibility.AXNode {
         continue;
       node[userStringProperty] = properties.get(userStringProperty);
     }
-    const booleanProperties: Array<keyof types.SerializedAXNode> = [
+    const booleanProperties: Array<keyof channels.AXNode> = [
       'disabled',
       'expanded',
       'focused',
@@ -254,7 +254,7 @@ class CRAXNode implements accessibility.AXNode {
         continue;
       node[booleanProperty] = value;
     }
-    const numericalProperties: Array<keyof types.SerializedAXNode> = [
+    const numericalProperties: Array<keyof channels.AXNode> = [
       'level',
       'valuemax',
       'valuemin',
@@ -264,7 +264,7 @@ class CRAXNode implements accessibility.AXNode {
         continue;
       node[numericalProperty] = properties.get(numericalProperty);
     }
-    const tokenProperties: Array<keyof types.SerializedAXNode> = [
+    const tokenProperties: Array<keyof channels.AXNode> = [
       'autocomplete',
       'haspopup',
       'invalid',
@@ -277,7 +277,7 @@ class CRAXNode implements accessibility.AXNode {
       node[tokenProperty] = value;
     }
 
-    const axNode = node as types.SerializedAXNode;
+    const axNode = node as channels.AXNode;
     if (this._payload.value) {
       if (typeof this._payload.value.value === 'string')
         axNode.valueString = this._payload.value.value;

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -26,6 +26,7 @@ import { Frame } from '../frames';
 import type { Dialog } from '../dialog';
 import type { ConnectionTransport } from '../transport';
 import type * as types from '../types';
+import type * as channels from '../../protocol/channels';
 import type { CRSession } from './crConnection';
 import { ConnectionEvents, CRConnection } from './crConnection';
 import { CRPage } from './crPage';
@@ -95,7 +96,7 @@ export class CRBrowser extends Browser {
     this._session.on('Browser.downloadProgress', this._onDownloadProgress.bind(this));
   }
 
-  async doCreateNewContext(options: types.BrowserContextOptions): Promise<BrowserContext> {
+  async doCreateNewContext(options: channels.BrowserNewContextParams): Promise<BrowserContext> {
     let proxyBypassList = undefined;
     if (options.proxy) {
       if (process.env.PLAYWRIGHT_DISABLE_FORCED_CHROMIUM_PROXIED_LOOPBACK)
@@ -327,7 +328,7 @@ export class CRBrowserContext extends BrowserContext {
 
   declare readonly _browser: CRBrowser;
 
-  constructor(browser: CRBrowser, browserContextId: string | undefined, options: types.BrowserContextOptions) {
+  constructor(browser: CRBrowser, browserContextId: string | undefined, options: channels.BrowserNewContextParams) {
     super(browser, options, browserContextId);
     this._authenticateProxyViaCredentials();
   }
@@ -383,7 +384,7 @@ export class CRBrowserContext extends BrowserContext {
     return this._browser._crPages.get(targetId)!;
   }
 
-  async doGetCookies(urls: string[]): Promise<types.NetworkCookie[]> {
+  async doGetCookies(urls: string[]): Promise<channels.NetworkCookie[]> {
     const { cookies } = await this._browser._session.send('Storage.getCookies', { browserContextId: this._browserContextId });
     return network.filterCookies(cookies.map(c => {
       const copy: any = { sameSite: 'Lax', ...c };
@@ -393,11 +394,11 @@ export class CRBrowserContext extends BrowserContext {
       delete copy.sameParty;
       delete copy.sourceScheme;
       delete copy.sourcePort;
-      return copy as types.NetworkCookie;
+      return copy as channels.NetworkCookie;
     }), urls);
   }
 
-  async addCookies(cookies: types.SetNetworkCookieParam[]) {
+  async addCookies(cookies: channels.SetNetworkCookie[]) {
     await this._browser._session.send('Storage.setCookies', { cookies: network.rewriteCookies(cookies), browserContextId: this._browserContextId });
   }
 

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -30,6 +30,7 @@ import type { PageBinding, PageDelegate } from '../page';
 import { Page, Worker } from '../page';
 import type { Progress } from '../progress';
 import type * as types from '../types';
+import type * as channels from '../../protocol/channels';
 import { getAccessibilityTree } from './crAccessibility';
 import { CRBrowserContext } from './crBrowser';
 import type { CRSession } from './crConnection';
@@ -356,7 +357,7 @@ export class CRPage implements PageDelegate {
     await this._mainFrameSession._client.send('Page.enable').catch(e => {});
   }
 
-  async pdf(options?: types.PDFOptions): Promise<Buffer> {
+  async pdf(options: channels.PagePdfParams): Promise<Buffer> {
     return this._pdf.generate(options);
   }
 

--- a/packages/playwright-core/src/server/chromium/crPdf.ts
+++ b/packages/playwright-core/src/server/chromium/crPdf.ts
@@ -16,7 +16,7 @@
  */
 
 import { assert } from '../../utils';
-import type * as types from '../types';
+import type * as channels from '../../protocol/channels';
 import type { CRSession } from './crConnection';
 import { readProtocolStream } from './crProtocolHelper';
 
@@ -67,7 +67,7 @@ export class CRPDF {
     this._client = client;
   }
 
-  async generate(options: types.PDFOptions = {}): Promise<Buffer> {
+  async generate(options: channels.PagePdfParams): Promise<Buffer> {
     const {
       scale = 1,
       displayHeaderFooter = false,

--- a/packages/playwright-core/src/server/cookieStore.ts
+++ b/packages/playwright-core/src/server/cookieStore.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import type * as types from './types';
+import type * as channels from '../protocol/channels';
 
 class Cookie {
-  private _raw: types.NetworkCookie;
-  constructor(data: types.NetworkCookie) {
+  private _raw: channels.NetworkCookie;
+  constructor(data: channels.NetworkCookie) {
     this._raw = data;
   }
 
@@ -43,7 +43,7 @@ class Cookie {
       this._raw.path === other._raw.path;
   }
 
-  networkCookie(): types.NetworkCookie {
+  networkCookie(): channels.NetworkCookie {
     return this._raw;
   }
 
@@ -61,12 +61,12 @@ class Cookie {
 export class CookieStore {
   private readonly _nameToCookies: Map<string, Set<Cookie>> = new Map();
 
-  addCookies(cookies: types.NetworkCookie[]) {
+  addCookies(cookies: channels.NetworkCookie[]) {
     for (const cookie of cookies)
       this._addCookie(new Cookie(cookie));
   }
 
-  cookies(url: URL): types.NetworkCookie[] {
+  cookies(url: URL): channels.NetworkCookie[] {
     const result = [];
     for (const cookie of this._cookiesIterator()) {
       if (cookie.matches(url))
@@ -75,7 +75,7 @@ export class CookieStore {
     return result;
   }
 
-  allCookies(): types.NetworkCookie[] {
+  allCookies(): channels.NetworkCookie[] {
     const result = [];
     for (const cookie of this._cookiesIterator())
       result.push(cookie.networkCookie());

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -274,7 +274,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel> imple
 
   async stopJSCoverage(params: channels.PageStopJSCoverageParams, metadata: CallMetadata): Promise<channels.PageStopJSCoverageResult> {
     const coverage = this._page.coverage as CRCoverage;
-    return { entries: await coverage.stopJSCoverage() };
+    return await coverage.stopJSCoverage();
   }
 
   async startCSSCoverage(params: channels.PageStartCSSCoverageParams, metadata: CallMetadata): Promise<void> {
@@ -284,7 +284,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel> imple
 
   async stopCSSCoverage(params: channels.PageStopCSSCoverageParams, metadata: CallMetadata): Promise<channels.PageStopCSSCoverageResult> {
     const coverage = this._page.coverage as CRCoverage;
-    return { entries: await coverage.stopCSSCoverage() };
+    return await coverage.stopCSSCoverage();
   }
 
   _onFrameAttached(frame: Frame) {

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -41,7 +41,6 @@ import * as readline from 'readline';
 import { RecentLogsCollector } from '../../common/debugLogger';
 import { serverSideCallMetadata, SdkObject } from '../instrumentation';
 import type * as channels from '../../protocol/channels';
-import type { BrowserContextOptions } from '../types';
 
 const ARTIFACTS_FOLDER = path.join(os.tmpdir(), 'playwright-artifacts-');
 
@@ -211,7 +210,7 @@ export class Electron extends SdkObject {
         close: gracefullyClose,
         kill
       };
-      const contextOptions: BrowserContextOptions = {
+      const contextOptions: channels.BrowserNewContextParams = {
         ...options,
         noDefaultViewport: true,
       };

--- a/packages/playwright-core/src/server/firefox/ffAccessibility.ts
+++ b/packages/playwright-core/src/server/firefox/ffAccessibility.ts
@@ -19,7 +19,7 @@ import type * as accessibility from '../accessibility';
 import type { FFSession } from './ffConnection';
 import type { Protocol } from './protocol';
 import type * as dom from '../dom';
-import type * as types from '../types';
+import type * as channels from '../../protocol/channels';
 
 export async function getAccessibilityTree(session: FFSession, needle?: dom.ElementHandle): Promise<{tree: accessibility.AXNode, needle: accessibility.AXNode | null}> {
   const objectId = needle ? needle._objectId : undefined;
@@ -198,12 +198,12 @@ class FFAXNode implements accessibility.AXNode {
     return this.isLeafNode() && !!this._name.trim();
   }
 
-  serialize(): types.SerializedAXNode {
-    const node: {[x in keyof types.SerializedAXNode]: any} = {
+  serialize(): channels.AXNode {
+    const node: {[x in keyof channels.AXNode]: any} = {
       role: FFRoleToARIARole.get(this._role) || this._role,
       name: this._name || '',
     };
-    const userStringProperties: Array<keyof types.SerializedAXNode & keyof Protocol.Accessibility.AXTree> = [
+    const userStringProperties: Array<keyof channels.AXNode & keyof Protocol.Accessibility.AXTree> = [
       'name',
       'description',
       'roledescription',
@@ -215,7 +215,7 @@ class FFAXNode implements accessibility.AXNode {
         continue;
       node[userStringProperty] = this._payload[userStringProperty];
     }
-    const booleanProperties: Array<keyof types.SerializedAXNode & keyof Protocol.Accessibility.AXTree> = [
+    const booleanProperties: Array<keyof channels.AXNode & keyof Protocol.Accessibility.AXTree> = [
       'disabled',
       'expanded',
       'focused',
@@ -234,7 +234,7 @@ class FFAXNode implements accessibility.AXNode {
         continue;
       node[booleanProperty] = value;
     }
-    const numericalProperties: Array<keyof types.SerializedAXNode & keyof Protocol.Accessibility.AXTree> = [
+    const numericalProperties: Array<keyof channels.AXNode & keyof Protocol.Accessibility.AXTree> = [
       'level'
     ];
     for (const numericalProperty of numericalProperties) {
@@ -242,7 +242,7 @@ class FFAXNode implements accessibility.AXNode {
         continue;
       node[numericalProperty] = this._payload[numericalProperty];
     }
-    const tokenProperties: Array<keyof types.SerializedAXNode & keyof Protocol.Accessibility.AXTree> = [
+    const tokenProperties: Array<keyof channels.AXNode & keyof Protocol.Accessibility.AXTree> = [
       'autocomplete',
       'haspopup',
       'invalid',
@@ -255,7 +255,7 @@ class FFAXNode implements accessibility.AXNode {
       node[tokenProperty] = value;
     }
 
-    const axNode = node as types.SerializedAXNode;
+    const axNode = node as channels.AXNode;
     axNode.valueString = this._payload.value;
     if ('checked' in this._payload)
       axNode.checked = this._payload.checked === true ? 'checked' : this._payload.checked === 'mixed' ? 'mixed' : 'unchecked';

--- a/packages/playwright-core/src/server/har/harRecorder.ts
+++ b/packages/playwright-core/src/server/har/harRecorder.ts
@@ -20,16 +20,16 @@ import { Artifact } from '../artifact';
 import type { BrowserContext } from '../browserContext';
 import type * as har from './har';
 import { HarTracer } from './harTracer';
-import type { HarOptions } from '../types';
+import type * as channels from '../../protocol/channels';
 
 export class HarRecorder {
   private _artifact: Artifact;
   private _isFlushed: boolean = false;
-  private _options: HarOptions;
+  private _options: channels.RecordHarOptions;
   private _tracer: HarTracer;
   private _entries: har.Entry[] = [];
 
-  constructor(context: BrowserContext | APIRequestContext, options: HarOptions) {
+  constructor(context: BrowserContext | APIRequestContext, options: channels.RecordHarOptions) {
     this._artifact = new Artifact(context, options.path);
     this._options = options;
     const urlFilterRe = options.urlRegexSource !== undefined && options.urlRegexFlags !== undefined ? new RegExp(options.urlRegexSource, options.urlRegexFlags) : undefined;

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -23,7 +23,7 @@ import { SdkObject } from './instrumentation';
 import type { NameValue } from '../common/types';
 import { APIRequestContext } from './fetch';
 
-export function filterCookies(cookies: types.NetworkCookie[], urls: string[]): types.NetworkCookie[] {
+export function filterCookies(cookies: channels.NetworkCookie[], urls: string[]): channels.NetworkCookie[] {
   const parsedURLs = urls.map(s => new URL(s));
   // Chromiums's cookies are missing sameSite when it is 'None'
   return cookies.filter(c => {
@@ -50,7 +50,7 @@ export function filterCookies(cookies: types.NetworkCookie[], urls: string[]): t
 // 253402300800 == Sat,  1 Jan 1000 00:00:00 +0000 (UTC)
 const kMaxCookieExpiresDateInSeconds = 253402300799;
 
-export function rewriteCookies(cookies: types.SetNetworkCookieParam[]): types.SetNetworkCookieParam[] {
+export function rewriteCookies(cookies: channels.SetNetworkCookie[]): channels.SetNetworkCookie[] {
   return cookies.map(c => {
     assert(c.url || (c.domain && c.path), 'Cookie should have a url or a domain/path pair');
     assert(!(c.url && c.domain), 'Cookie should have either url or domain');

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -20,6 +20,7 @@ import * as frames from './frames';
 import * as input from './input';
 import * as js from './javascript';
 import * as network from './network';
+import type * as channels from '../protocol/channels';
 import type { ScreenshotOptions } from './screenshotter';
 import { Screenshotter, validateScreenshotOptions } from './screenshotter';
 import { TimeoutSettings } from '../common/timeoutSettings';
@@ -86,7 +87,7 @@ export interface PageDelegate {
   setScreencastOptions(options: { width: number, height: number, quality: number } | null): Promise<void>;
 
   getAccessibilityTree(needle?: dom.ElementHandle): Promise<{tree: accessibility.AXNode, needle: accessibility.AXNode | null}>;
-  pdf?: (options?: types.PDFOptions) => Promise<Buffer>;
+  pdf?: (options: channels.PagePdfParams) => Promise<Buffer>;
   coverage?: () => any;
 
   // Work around WebKit's raf issues on Windows.
@@ -160,7 +161,7 @@ export class Page extends SdkObject {
   readonly _frameManager: frames.FrameManager;
   readonly accessibility: accessibility.Accessibility;
   private _workers = new Map<string, Worker>();
-  readonly pdf: ((options?: types.PDFOptions) => Promise<Buffer>) | undefined;
+  readonly pdf: ((options: channels.PagePdfParams) => Promise<Buffer>) | undefined;
   readonly coverage: any;
   private _clientRequestInterceptor: network.RouteHandler | undefined;
   private _serverRequestInterceptor: network.RouteHandler | undefined;

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -17,6 +17,7 @@
 
 import type { Size, Point, TimeoutOptions } from '../common/types';
 export type { Size, Point, Rect, Quad, URLMatch, TimeoutOptions } from '../common/types';
+import type * as channels from '../protocol/channels';
 
 export type StrictOptions = {
   strict?: boolean,
@@ -77,16 +78,12 @@ export type FilePayload = {
 };
 
 export type MediaType = 'screen' | 'print';
-export const mediaTypes: Set<MediaType> = new Set(['screen', 'print']);
 
 export type ColorScheme = 'dark' | 'light' | 'no-preference';
-export const colorSchemes: Set<ColorScheme> = new Set(['dark', 'light', 'no-preference']);
 
 export type ReducedMotion = 'no-preference' | 'reduce';
-export const reducedMotions: Set<ReducedMotion> = new Set(['no-preference', 'reduce']);
 
 export type ForcedColors = 'active' | 'none';
-export const forcedColors: Set<ForcedColors> = new Set(['active', 'none']);
 
 export type DeviceDescriptor = {
   userAgent: string,
@@ -97,56 +94,6 @@ export type DeviceDescriptor = {
   defaultBrowserType: 'chromium' | 'firefox' | 'webkit'
 };
 export type Devices = { [name: string]: DeviceDescriptor };
-
-export type PDFOptions = {
-  scale?: number,
-  displayHeaderFooter?: boolean,
-  headerTemplate?: string,
-  footerTemplate?: string,
-  printBackground?: boolean,
-  landscape?: boolean,
-  pageRanges?: string,
-  format?: string,
-  width?: string,
-  height?: string,
-  preferCSSPageSize?: boolean,
-  margin?: {top?: string, bottom?: string, left?: string, right?: string},
-};
-
-export type CSSCoverageOptions = {
-  resetOnNavigation?: boolean,
-};
-
-export type JSCoverageOptions = {
-  resetOnNavigation?: boolean,
-  reportAnonymousScripts?: boolean,
-};
-
-export type JSRange = {
-  startOffset: number,
-  endOffset: number,
-  count: number
-};
-
-export type CSSCoverageEntry = {
-  url: string,
-  text?: string,
-  ranges: {
-    start: number,
-    end: number
-  }[]
-};
-
-export type JSCoverageEntry = {
-  url: string,
-  scriptId: string,
-  source?: string,
-  functions: {
-    functionName: string,
-    isBlockCoverage: boolean,
-    ranges: JSRange[]
-  }[]
-};
 
 export type ProxySettings = {
   server: string,
@@ -202,180 +149,14 @@ export type NormalizedContinueOverrides = {
   postData?: Buffer,
 };
 
-export type NetworkCookie = {
-  name: string,
-  value: string,
-  domain: string,
-  path: string,
-  expires: number,
-  httpOnly: boolean,
-  secure: boolean,
-  sameSite: 'Strict' | 'Lax' | 'None'
-};
-
-export type SetNetworkCookieParam = {
-  name: string,
-  value: string,
-  url?: string,
-  domain?: string,
-  path?: string,
-  expires?: number,
-  httpOnly?: boolean,
-  secure?: boolean,
-  sameSite?: 'Strict' | 'Lax' | 'None'
-};
-
 export type EmulatedSize = { viewport: Size, screen: Size };
 
-export type HarOptions = {
-  omitContent?: boolean,
-  path: string,
-  urlGlob?: string,
-  urlRegexSource?: string,
-  urlRegexFlags?: string,
-};
-
-export type BrowserContextOptions = {
-  viewport?: Size,
-  screen?: Size,
-  noDefaultViewport?: boolean,
-  ignoreHTTPSErrors?: boolean,
-  javaScriptEnabled?: boolean,
-  bypassCSP?: boolean,
-  userAgent?: string,
-  locale?: string,
-  timezoneId?: string,
-  geolocation?: Geolocation,
-  permissions?: string[],
-  extraHTTPHeaders?: HeadersArray,
-  offline?: boolean,
-  httpCredentials?: Credentials,
-  deviceScaleFactor?: number,
-  isMobile?: boolean,
-  hasTouch?: boolean,
-  colorScheme?: ColorScheme,
-  reducedMotion?: ReducedMotion,
-  forcedColors?: ForcedColors,
-  acceptDownloads?: boolean,
-  recordVideo?: {
-    dir: string,
-    size?: Size,
-  },
-  recordHar?: HarOptions,
-  storageState?: SetStorageState,
-  strictSelectors?: boolean,
-  proxy?: ProxySettings,
-  baseURL?: string,
-  serviceWorkers?: 'allow' | 'block',
-};
-
-export type EnvArray = { name: string, value: string }[];
-
-type LaunchOptionsBase = {
-  channel?: string,
-  executablePath?: string,
-  args?: string[],
-  ignoreDefaultArgs?: string[],
-  ignoreAllDefaultArgs?: boolean,
-  handleSIGINT?: boolean,
-  handleSIGTERM?: boolean,
-  handleSIGHUP?: boolean,
-  timeout?: number,
-  env?: EnvArray,
-  headless?: boolean,
-  devtools?: boolean,
-  proxy?: ProxySettings,
-  downloadsPath?: string,
-  chromiumSandbox?: boolean,
-  slowMo?: number,
-  useWebSocket?: boolean,
-  tracesDir?: string,
-};
-export type LaunchOptions = LaunchOptionsBase & {
-  firefoxUserPrefs?: { [key: string]: string | number | boolean },
-};
-export type LaunchPersistentOptions = LaunchOptionsBase & BrowserContextOptions;
+export type LaunchOptions = channels.BrowserTypeLaunchOptions & { useWebSocket?: boolean };
 
 export type ProtocolLogger = (direction: 'send' | 'receive', message: object) => void;
-
-export type SerializedAXNode = {
-  role: string,
-  name: string,
-  valueString?: string,
-  valueNumber?: number,
-  description?: string,
-
-  keyshortcuts?: string,
-  roledescription?: string,
-  valuetext?: string,
-
-  disabled?: boolean,
-  expanded?: boolean,
-  focused?: boolean,
-  modal?: boolean,
-  multiline?: boolean,
-  multiselectable?: boolean,
-  readonly?: boolean,
-  required?: boolean,
-  selected?: boolean,
-
-  checked?: 'checked' | 'unchecked' | 'mixed',
-  pressed?: 'pressed' | 'released' | 'mixed',
-
-  level?: number,
-  valuemin?: number,
-  valuemax?: number,
-
-  autocomplete?: string,
-  haspopup?: string,
-  invalid?: string,
-  orientation?: string,
-
-  children?: SerializedAXNode[]
-};
 
 export type ConsoleMessageLocation = {
   url: string,
   lineNumber: number,
   columnNumber: number,
-};
-
-export type Error = {
-  message: string,
-  name: string,
-  stack?: string,
-};
-
-export type NameValueList = {
-  name: string;
-  value: string;
-}[];
-
-export type OriginStorage = {
-  origin: string;
-  localStorage: NameValueList;
-};
-
-export type StorageState = {
-  cookies: NetworkCookie[],
-  origins: OriginStorage[]
-};
-
-export type SetStorageState = {
-  cookies?: SetNetworkCookieParam[],
-  origins?: OriginStorage[]
-};
-
-export type APIResponse = {
-  url: string,
-  status: number,
-  statusText: string,
-  headers: HeadersArray,
-  body: Buffer,
-};
-
-export type AndroidDeviceOptions = {
-  host?: string,
-  port?: number,
-  omitDriverInstall?: boolean,
 };

--- a/packages/playwright-core/src/server/webkit/wkAccessibility.ts
+++ b/packages/playwright-core/src/server/webkit/wkAccessibility.ts
@@ -17,7 +17,7 @@ import type * as accessibility from '../accessibility';
 import type { WKSession } from './wkConnection';
 import type { Protocol } from './protocol';
 import type * as dom from '../dom';
-import type * as types from '../types';
+import type * as channels from '../../protocol/channels';
 
 export async function getAccessibilityTree(session: WKSession, needle?: dom.ElementHandle) {
   const objectId = needle ? needle._objectId : undefined;
@@ -167,8 +167,8 @@ class WKAXNode implements accessibility.AXNode {
     return false;
   }
 
-  serialize(): types.SerializedAXNode {
-    const node: types.SerializedAXNode = {
+  serialize(): channels.AXNode {
+    const node: channels.AXNode = {
       role: WKRoleToARIARole.get(this._payload.role) || this._payload.role,
       name: this._name(),
     };
@@ -195,7 +195,7 @@ class WKAXNode implements accessibility.AXNode {
     if ('pressed' in this._payload)
       node.pressed = this._payload.pressed === 'true' ? 'pressed' : this._payload.pressed === 'false' ? 'released' : 'mixed';
 
-    const userStringProperties: Array<keyof types.SerializedAXNode & keyof Protocol.Page.AXNode> = [
+    const userStringProperties: Array<keyof channels.AXNode & keyof Protocol.Page.AXNode> = [
       'keyshortcuts',
       'valuetext'
     ];
@@ -205,7 +205,7 @@ class WKAXNode implements accessibility.AXNode {
       (node as any)[userStringProperty] = this._payload[userStringProperty];
     }
 
-    const booleanProperties: Array<keyof types.SerializedAXNode & keyof Protocol.Page.AXNode> = [
+    const booleanProperties: Array<keyof channels.AXNode & keyof Protocol.Page.AXNode> = [
       'disabled',
       'expanded',
       'focused',
@@ -227,7 +227,7 @@ class WKAXNode implements accessibility.AXNode {
       (node as any)[booleanProperty] = value;
     }
 
-    const numericalProperties: Array<keyof types.SerializedAXNode & keyof Protocol.Page.AXNode> = [
+    const numericalProperties: Array<keyof channels.AXNode & keyof Protocol.Page.AXNode> = [
       'level',
       'valuemax',
       'valuemin',
@@ -237,7 +237,7 @@ class WKAXNode implements accessibility.AXNode {
         continue;
       (node as any)[numericalProperty] = (this._payload as any)[numericalProperty];
     }
-    const tokenProperties: Array<keyof types.SerializedAXNode & keyof Protocol.Page.AXNode> = [
+    const tokenProperties: Array<keyof channels.AXNode & keyof Protocol.Page.AXNode> = [
       'autocomplete',
       'haspopup',
       'invalid',


### PR DESCRIPTION
This is to avoid duplicating types for no reason.