### PR TITLE
Add example for running tests against a project

### DIFF
--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -14,11 +14,6 @@ Here are the most common options available in the command line.
   npx playwright test
   ```
 
-- Run all the tests against a specific [project](./test-configuration-js.md#multiple-browsers)
-  ```bash
-  npx playwright test --project=chromium
-  ```
-
 - Run a single test file
   ```bash
   npx playwright test tests/todo-page.spec.ts
@@ -49,14 +44,9 @@ Here are the most common options available in the command line.
   npx playwright test --headed
   ```
 
-- Run tests in a particular browser (config-less mode)
+- Run all the tests against a specific project
   ```bash
-  npx playwright test --browser=webkit
-  ```
-
-- Run tests in all browsers (config-less mode)
-  ```bash
-  npx playwright test --browser=all
+  npx playwright test --project=chromium
   ```
 
 - Disable [parallelization](./test-parallel.md)

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -14,6 +14,11 @@ Here are the most common options available in the command line.
   npx playwright test
   ```
 
+- Run all the tests against a specific [project](./test-configuration-js.md#multiple-browsers)
+  ```bash
+  npx playwright test --project=chromium
+  ```
+
 - Run a single test file
   ```bash
   npx playwright test tests/todo-page.spec.ts


### PR DESCRIPTION
This PR updates the `Playwright Test > Command line` documentation to add an example command for running all tests against a specific project, as defined in `playwright.config.ts`.