### PR TITLE
fix(html-reporter): do not verbose yell when opening report without gui

### DIFF
--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -218,8 +218,11 @@ export async function showHTMLReport(reportFolder: string | undefined, testId?: 
   console.log(colors.cyan(`  Serving HTML report at ${url}. Press Ctrl+C to quit.`));
   if (testId)
     url += `#?testId=${testId}`;
-  open(url);
-  await new Promise(() => {});
+  try {
+    await open(url, { wait: true });
+  } catch (error) {
+    console.log(`Failed to open browser on ${url}`);
+  }
 }
 
 export function startHtmlReportServer(folder: string): HttpServer {

--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -218,12 +218,8 @@ export async function showHTMLReport(reportFolder: string | undefined, testId?: 
   console.log(colors.cyan(`  Serving HTML report at ${url}. Press Ctrl+C to quit.`));
   if (testId)
     url += `#?testId=${testId}`;
-  try {
-    await open(url, { wait: true });
-    await new Promise(() => {});
-  } catch (error) {
-    console.log(`Failed to open browser on ${url}`);
-  }
+  await open(url, { wait: true }).catch(() => console.log(`Failed to open browser on ${url}`));
+  await new Promise(() => {});
 }
 
 export function startHtmlReportServer(folder: string): HttpServer {

--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -220,6 +220,7 @@ export async function showHTMLReport(reportFolder: string | undefined, testId?: 
     url += `#?testId=${testId}`;
   try {
     await open(url, { wait: true });
+    await new Promise(() => {});
   } catch (error) {
     console.log(`Failed to open browser on ${url}`);
   }


### PR DESCRIPTION
Before it yelled with a lot of noise:

```
node:events:505
      throw er; // Unhandled 'error' event
      ^

Error: spawn xdg-open ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:283:19)
    at onErrorNT (node:internal/child_process:478:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
Emitted 'error' event on ChildProcess instance at:
    at Process.ChildProcess._handle.onexit (node:internal/child_process:289:12)
    at onErrorNT (node:internal/child_process:478:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn xdg-open',
  path: 'xdg-open',
  spawnargs: [
    'http://127.0.0.1:9323#?testId=2c6f87b50045c9a35c5b1292df81f1b83219d91d-ae3472cbf3c1300fd4873f3611e4be44c8dcf70c'
  ]
}
```

After that its not that loud anymore and the `open`  module will wait for us instead until the process has terminated or in case of macOS it will be open forever (since programs there are always running).