### PR TITLE
devops: build WebKit for Mac using --no-use-workspace flag

### DIFF
--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -53,7 +53,7 @@ fi
 
 if is_mac; then
   selectXcodeVersionOrDie $(node "$SCRIPT_FOLDER/../get_xcode_version.js" webkit)
-  ./Tools/Scripts/build-webkit --release --touch-events --orientation-events
+  ./Tools/Scripts/build-webkit --release --touch-events --orientation-events --no-use-workspace
 elif is_linux; then
   if [[ $# == 0 || (-z "$1") ]]; then
     echo


### PR DESCRIPTION
Currently, Mac WebKit builds are failing in CI. It seems this is a regression in upstream WebKit as I'm able to reproduce it in my local environment. 

The error is the following:

``` 
usr/bin/codesign --force --sign - --timestamp\=none --preserve-metadata\=identifier,entitlements,flags --generate-entitlement-der /Users/playwright/webkit/WebKitBuild/Release/InjectedBundleTestWebKitAPI.bundle/Contents/Resources/WebKit.framework
/Users/playwright/webkit/WebKitBuild/Release/InjectedBundleTestWebKitAPI.bundle/Contents/Resources/WebKit.framework: replacing existing signature
/Users/playwright/webkit/WebKitBuild/Release/InjectedBundleTestWebKitAPI.bundle/Contents/Resources/WebKit.framework: unsealed contents present in the root directory of an embedded framework
Command CodeSign failed with a nonzero exit code
```

Bisecting the regression it seems the build started failing on [r295496](https://trac.webkit.org/changeset/295496/webkit)

This changeset also introduced a new flag, _--no-use-workspace__, which allows to build not using WebKit.xcworkspace (I understand this is how builds were done before this changeset). Building with  _--no-use-workspace_ fixes builds for Mac.