### PR TITLE
docs: Add chrome extension testing example

### DIFF
--- a/docs/src/chrome-extensions-js-python.md
+++ b/docs/src/chrome-extensions-js-python.md
@@ -115,17 +115,16 @@ export const test = base.extend<{
   extensionId: async ({ context }, use) => {
     /*
     // for manifest v2:
-    let background = context.backgroundPages()[0]
-    if (background == null) {
-      background = await context.waitForEvent('backgroundpage')
-    }
+    let [background] = context.backgroundPages()
+    if (!background)
+      background = await context.waitForEvent("backgroundpage")
     */
 
     // for manifest v3:
-    let background = context.serviceWorkers()[0];
-    if (background == null) {
+    let [background] = context.serviceWorkers();
+    if (!background)
       background = await context.waitForEvent("serviceworker");
-    }
+
 
     const extensionId = background.url().split("/")[2];
     await use(extensionId);

--- a/docs/src/chrome-extensions-js-python.md
+++ b/docs/src/chrome-extensions-js-python.md
@@ -13,7 +13,7 @@ The following is code for getting a handle to the [background page](https://deve
 const { chromium } = require('playwright');
 
 (async () => {
-  const pathToExtension = require('path').join(process.cwd(), 'my-extension');
+  const pathToExtension = require('path').join(__dirname, 'my-extension');
   const userDataDir = '/tmp/test-user-data-dir';
   const browserContext = await chromium.launchPersistentContext(userDataDir,{
     headless: false,
@@ -97,7 +97,7 @@ export const test = base.extend<{
 }>({
   context: async ({ browserName }, use) => {
     const browserTypes = { chromium };
-    const pathToExtension = path.join(process.cwd(), "my-extension");
+   const pathToExtension = path.join(__dirname, "my-extension");
     const context = await browserTypes[browserName].launchPersistentContext(
       '',
       {

--- a/docs/src/chrome-extensions-js-python.md
+++ b/docs/src/chrome-extensions-js-python.md
@@ -97,17 +97,14 @@ export const test = base.extend<{
 }>({
   context: async ({ browserName }, use) => {
     const browserTypes = { chromium };
-   const pathToExtension = path.join(__dirname, "my-extension");
-    const context = await browserTypes[browserName].launchPersistentContext(
-      '',
-      {
-        headless: false,
-        args: [
-          `--disable-extensions-except=${pathToExtension}`,
-          `--load-extension=${pathToExtension}`,
-        ],
-      }
-    );
+    const pathToExtension = path.join(__dirname, "my-extension");
+    const context = await browserTypes[browserName].launchPersistentContext("", {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+      ],
+    });
     await use(context);
     await context.close();
   },
@@ -123,7 +120,6 @@ export const test = base.extend<{
     let [background] = context.serviceWorkers();
     if (!background)
       background = await context.waitForEvent("serviceworker");
-
 
     const extensionId = background.url().split("/")[2];
     await use(extensionId);

--- a/docs/src/chrome-extensions-js-python.md
+++ b/docs/src/chrome-extensions-js-python.md
@@ -87,11 +87,14 @@ with sync_playwright() as playwright:
 
 To have the extension loaded when running tests you can use a test fixture to set the context. You can also dynamically retrieve the extension id and use it that to load and test the popup page for example.
 
-```js
-import { test as base, expect, chromium } from "@playwright/test";
+```typescript
+import { test as base, expect, chromium, BrowserContext } from "@playwright/test";
 import path from "path";
 
-export const test = base.extend({
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
   context: async ({ browserName }, use) => {
     const browserTypes = { chromium };
     const pathToExtension = path.join(process.cwd(), "my-extension");

--- a/docs/src/chrome-extensions-js-python.md
+++ b/docs/src/chrome-extensions-js-python.md
@@ -98,9 +98,8 @@ export const test = base.extend<{
   context: async ({ browserName }, use) => {
     const browserTypes = { chromium };
     const pathToExtension = path.join(process.cwd(), "my-extension");
-    const userDataDir = '/tmp/test-user-data-dir';
     const context = await browserTypes[browserName].launchPersistentContext(
-      userDataDir,
+      '',
       {
         headless: false,
         args: [


### PR DESCRIPTION
Found how to do this by perusing the issues. Would be helpful to have this in the docs. 