### PR TITLE
fix(chromium): disable back-forward cache

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -329,6 +329,7 @@ const DEFAULT_ARGS = [
   '--enable-features=NetworkService,NetworkServiceInProcess',
   '--disable-background-timer-throttling',
   '--disable-backgrounding-occluded-windows',
+  '--disable-back-forward-cache', // Avoids surprises like main request not being intercepted during page.goBack().
   '--disable-breakpad',
   '--disable-client-side-phishing-detection',
   '--disable-component-extensions-with-background-pages',


### PR DESCRIPTION
Otherwise, back/forward navigation does not intercept requests.