### PR TITLE
fix(test runner): toHaveScreenshot should not overwrite matching expectations

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -578,7 +578,7 @@ export default config;
 - type: ?<[UpdateSnapshots]<"all"|"none"|"missing">>
 
 Whether to update expected snapshots with the actual results produced by the test run. Defaults to `'missing'`.
-* `'all'` - All tests that are executed will update snapshots.
+* `'all'` - All tests that are executed will update snapshots that did not match. Matching snapshots will not be updated.
 * `'none'` - No snapshots are updated.
 * `'missing'` - Missing snapshots are created, for example when authoring a new test and running it for the first time. This is the default.
 

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -881,7 +881,8 @@ interface TestConfig {
 
   /**
    * Whether to update expected snapshots with the actual results produced by the test run. Defaults to `'missing'`.
-   * - `'all'` - All tests that are executed will update snapshots.
+   * - `'all'` - All tests that are executed will update snapshots that did not match. Matching snapshots will not be
+   *   updated.
    * - `'none'` - No snapshots are updated.
    * - `'missing'` - Missing snapshots are created, for example when authoring a new test and running it for the first
    *   time. This is the default.
@@ -1155,7 +1156,8 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
   shard: { total: number, current: number } | null;
   /**
    * Whether to update expected snapshots with the actual results produced by the test run. Defaults to `'missing'`.
-   * - `'all'` - All tests that are executed will update snapshots.
+   * - `'all'` - All tests that are executed will update snapshots that did not match. Matching snapshots will not be
+   *   updated.
    * - `'none'` - No snapshots are updated.
    * - `'missing'` - Missing snapshots are created, for example when authoring a new test and running it for the first
    *   time. This is the default.


### PR DESCRIPTION
Even in the `--update-snapshots` mode we should keep existing files if they are matching under the threshold, to avoid needless churn.

Fixes #14833.