### PR TITLE
fix(click): no element should intercept events over the target frame

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -715,7 +715,7 @@ export class InjectedScript {
     input.dispatchEvent(new Event('change', { 'bubbles': true }));
   }
 
-  private _expectHitTargetParent(hitElement: Element | undefined, targetElement: Element) {
+  expectHitTargetParent(hitElement: Element | undefined, targetElement: Element) {
     targetElement = targetElement.closest('button, [role=button], a, [role=link]') || targetElement;
     const hitParents: Element[] = [];
     while (hitElement && hitElement !== targetElement) {
@@ -782,7 +782,7 @@ export class InjectedScript {
     // First do a preliminary check, to reduce the possibility of some iframe
     // intercepting the action.
     const preliminaryHitElement = this.deepElementFromPoint(document, hitPoint.x, hitPoint.y);
-    const preliminaryResult = this._expectHitTargetParent(preliminaryHitElement, element);
+    const preliminaryResult = this.expectHitTargetParent(preliminaryHitElement, element);
     if (preliminaryResult !== 'done')
       return preliminaryResult.hitTargetDescription;
 
@@ -817,7 +817,7 @@ export class InjectedScript {
       // subsequent events will be fine.
       if (result === undefined && point) {
         const hitElement = this.deepElementFromPoint(document, point.clientX, point.clientY);
-        result = this._expectHitTargetParent(hitElement, element);
+        result = this.expectHitTargetParent(hitElement, element);
       }
 
       if (blockAllEvents || (result !== 'done' && result !== undefined)) {

--- a/tests/library/hit-target.spec.ts
+++ b/tests/library/hit-target.spec.ts
@@ -254,3 +254,22 @@ it('should not click iframe overlaying the target', async ({ page, server }) => 
   expect(await page.evaluate('window._clicked')).toBe(undefined);
   expect(error.message).toContain(`<iframe srcdoc="<body onclick='window.top._clicked=2' st…></iframe> from <div>…</div> subtree intercepts pointer events`);
 });
+
+it('should not click an element overlaying iframe with the target', async ({ page, server }) => {
+  await page.goto(server.EMPTY_PAGE);
+  await page.setContent(`
+    <div onclick='window.top._clicked=1'>padding</div>
+    <iframe width=600 height=600 srcdoc="<iframe srcdoc='<div onclick=&quot;window.top._clicked=2&quot;>padding</div><div onclick=&quot;window.top._clicked=3&quot;>inner</div>'></iframe><div onclick='window.top._clicked=4'>outer</div>"></iframe>
+    <div onclick='window.top._clicked=5' style="position: absolute; left: 0; right: 0; top: 0; bottom: 0; background: rgba(255, 0, 0, 0.1); padding: 200px;">PINK OVERLAY</div>
+  `);
+
+  const target = page.frameLocator('iframe').frameLocator('iframe').locator('text=inner');
+  const error = await target.click({ timeout: 500 }).catch(e => e);
+  expect(await page.evaluate('window._clicked')).toBe(undefined);
+  expect(error.message).toContain(`<div onclick="window.top._clicked=5">PINK OVERLAY</div> intercepts pointer events`);
+
+  await page.locator('text=overlay').evaluate(e => e.style.display = 'none');
+
+  await target.click();
+  expect(await page.evaluate('window._clicked')).toBe(3);
+});


### PR DESCRIPTION
When target element is inside a non-main frame, there could be an overlay in some of the parent frames that intercepts pointer events. However, we never detected this case.

Fixes #14752.