### PR TITLE
devops: use Android SDK 33 instead of 32

### DIFF
--- a/.github/workflows/tests_android.yml
+++ b/.github/workflows/tests_android.yml
@@ -11,7 +11,7 @@ on:
       - release-*
     paths:
       - "**android**"
-      - "utils/avd_*.js"
+      - "utils/avd_*"
       - ".github/workflows/tests_android.yml"
 
 env:

--- a/.github/workflows/tests_android.yml
+++ b/.github/workflows/tests_android.yml
@@ -38,7 +38,6 @@ jobs:
       env:
         DEBUG: pw:install
     - run: npm run build
-    - run: npx playwright install-deps
     - name: Create Android Emulator
       run: utils/avd_recreate.sh
     - name: Start Android Emulator

--- a/utils/avd_install.sh
+++ b/utils/avd_install.sh
@@ -13,7 +13,7 @@ mkdir ${SDKDIR}/cmdline-tools
 echo Downloading Android SDK...
 cd ${SDKDIR}/cmdline-tools
 COMMAND_LINE_TOOLS_ZIP=${SDKDIR}/commandlinetools.zip
-curl https://dl.google.com/android/repository/commandlinetools-mac-7583922_latest.zip -o ${COMMAND_LINE_TOOLS_ZIP}
+curl https://dl.google.com/android/repository/commandlinetools-mac-8512546_latest.zip -o ${COMMAND_LINE_TOOLS_ZIP}
 unzip ${COMMAND_LINE_TOOLS_ZIP}
 rm ${COMMAND_LINE_TOOLS_ZIP}
 mv cmdline-tools latest
@@ -23,7 +23,7 @@ echo Installing emulator...
 yes | ${ANDROID_HOME}/tools/bin/sdkmanager --install platform-tools emulator
 
 echo Installing platform SDK...
-yes | ${ANDROID_HOME}/tools/bin/sdkmanager --install "platforms;android-32"
+yes | ${ANDROID_HOME}/tools/bin/sdkmanager --install "platforms;android-33"
 
 echo Starting ADB...
 ${ANDROID_HOME}/platform-tools/adb devices

--- a/utils/avd_recreate.sh
+++ b/utils/avd_recreate.sh
@@ -8,7 +8,7 @@ if [[ -z "${ANDROID_HOME}" ]]; then
     export ANDROID_SDK_ROOT=${SDKDIR}
 fi
 
-${ANDROID_HOME}/tools/bin/avdmanager delete avd --name android32 || true
-echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager --install "system-images;android-32;google_apis;x86_64"
-echo "no" | ${ANDROID_HOME}/tools/bin/avdmanager create avd --force --name android32 --device "Nexus 5X" --package "system-images;android-32;google_apis;x86_64"
+${ANDROID_HOME}/tools/bin/avdmanager delete avd --name android33 || true
+echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager --install "system-images;android-33;google_apis;x86_64"
+echo "no" | ${ANDROID_HOME}/tools/bin/avdmanager create avd --force --name android33 --device "Nexus 5X" --package "system-images;android-33;google_apis;x86_64"
 ${ANDROID_HOME}/emulator/emulator -list-avds

--- a/utils/avd_start.sh
+++ b/utils/avd_start.sh
@@ -17,7 +17,7 @@ if [[ -n "${GITHUB_ACTIONS}" ]]; then
 fi
 
 echo "Starting emulator"
-nohup ${ANDROID_HOME}/emulator/emulator -avd android32 -no-audio -no-window -gpu ${EMULATOR_GPU} -no-boot-anim &
+nohup ${ANDROID_HOME}/emulator/emulator -avd android33 -no-audio -no-window -gpu ${EMULATOR_GPU} -no-boot-anim &
 ${ANDROID_HOME}/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
 ${ANDROID_HOME}/platform-tools/adb devices
 echo "Emulator started"


### PR DESCRIPTION
This should give us a more recent Chrome.

Blocked by an upstream bug: https://issuetracker.google.com/issues/236862869