### PR TITLE
Update docs/src/intro-js.md

### DIFF
--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -208,9 +208,9 @@ test('my test', async ({ page }) => {
   await expect(page).toHaveTitle(/Playwright/);
 
   // Expect an attribute "to be strictly equal" to the value.
-  await expect(page.locator('text=Get Started').first()).toHaveAttribute('href', '/docs/intro');
+  await expect(page.locator('text=Get started').first()).toHaveAttribute('href', '/docs/intro');
 
-  await page.click('text=Get Started');
+  await page.click('text=Get started');
   // Expect some text to be visible on the page.
   await expect(page.locator('text=Introduction').first()).toBeVisible();
 });


### PR DESCRIPTION
Update docs/src/intro-js.md
For selector 'text=Get Started' will not do it since
actual text is 'text=Get started'
Minor fix