### PR TITLE
fix(network): make allHeaders wait until all headers are available

### DIFF
--- a/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
+++ b/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
@@ -113,6 +113,8 @@ export class FFNetworkManager {
       validFrom: event?.securityDetails?.validFrom,
       validTo: event?.securityDetails?.validTo,
     });
+    // "raw" headers are the same as "provisional" headers in Firefox.
+    response.setRawResponseHeaders(null);
     this._page._frameManager.requestReceivedResponse(response);
   }
 
@@ -194,6 +196,8 @@ class InterceptableRequest {
       postDataBuffer = Buffer.from(payload.postData, 'base64');
     this.request = new network.Request(frame, redirectedFrom ? redirectedFrom.request : null, payload.navigationId,
         payload.url, internalCauseToResourceType[payload.internalCause] || causeToResourceType[payload.cause] || 'other', payload.method, postDataBuffer, payload.headers);
+    // "raw" headers are the same as "provisional" headers in Firefox.
+    this.request.setRawRequestHeaders(null);
   }
 
   _finalRequest(): InterceptableRequest {

--- a/packages/playwright-core/src/server/webkit/wkInterceptableRequest.ts
+++ b/packages/playwright-core/src/server/webkit/wkInterceptableRequest.ts
@@ -88,7 +88,10 @@ export class WKInterceptableRequest {
       responseStart: timingPayload ? wkMillisToRoundishMillis(timingPayload.responseStart) : -1,
     };
     const setCookieSeparator = process.platform === 'darwin' ? ',' : '\n';
-    return new network.Response(this.request, responsePayload.status, responsePayload.statusText, headersObjectToArray(responsePayload.headers, ',', setCookieSeparator), timing, getResponseBody, responsePayload.source === 'service-worker');
+    const response = new network.Response(this.request, responsePayload.status, responsePayload.statusText, headersObjectToArray(responsePayload.headers, ',', setCookieSeparator), timing, getResponseBody, responsePayload.source === 'service-worker');
+    // No raw response headers in WebKit, use "provisional" ones.
+    response.setRawResponseHeaders(null);
+    return response;
   }
 }
 

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -1034,6 +1034,9 @@ export class WKPage implements PageDelegate {
       session.sendMayFail('Network.interceptRequestWithError', { errorType: 'Cancellation', requestId: event.requestId });
       return;
     }
+    // There is no point in waiting for the raw headers in Network.responseReceived when intercepting.
+    // Use provisional headers as raw headers, so that client can call allHeaders() from the route handler.
+    request.request.setRawRequestHeaders(null);
     if (!request._route) {
       // Intercepted, although we do not intend to allow interception.
       // Just continue.
@@ -1055,6 +1058,9 @@ export class WKPage implements PageDelegate {
       if (!headers['host'])
         headers['Host'] = new URL(request.request.url()).host;
       request.request.setRawRequestHeaders(headersObjectToArray(headers));
+    } else {
+      // No raw headers avaialable, use provisional ones.
+      request.request.setRawRequestHeaders(null);
     }
     this._page._frameManager.requestReceivedResponse(response);
 


### PR DESCRIPTION
Before, calling `allHeaders()` from `page.on('request')` would yield provisional headers instead.

With these changes:
- In Firefox, all headers are available immediately.
- In Chromium, all headers are available upon requestWillBeSentExtraInfo.
- In WebKit, all headers are available upon responseReceived.
- In all browsers, intercepted requests use "provisional" headers
  as all headers, since there is no network stack to change the headers.

Drive-by: migrated Chromium to `hasExtraInfo` flags that simplifies the logic quite a bit.

Fixes #14944.