### PR TITLE
fix(default context): remove first page re-creation workaround for isMobile and locale

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -231,30 +231,13 @@ export abstract class BrowserContext extends SdkObject {
     this._timeoutSettings.setDefaultTimeout(timeout);
   }
 
-  async _loadDefaultContextAsIs(progress: Progress): Promise<Page[]> {
+  async _loadDefaultContextAsIs(progress: Progress) {
     if (!this.pages().length) {
       const waitForEvent = helper.waitForEvent(progress, this, BrowserContext.Events.Page);
       progress.cleanupWhenAborted(() => waitForEvent.dispose);
       const page = (await waitForEvent.promise) as Page;
       if (page._pageIsError)
         throw page._pageIsError;
-    }
-    const pages = this.pages();
-    if (pages[0]._pageIsError)
-      throw pages[0]._pageIsError;
-    await pages[0].mainFrame()._waitForLoadState(progress, 'load');
-    return pages;
-  }
-
-  async _loadDefaultContext(progress: Progress) {
-    const pages = await this._loadDefaultContextAsIs(progress);
-    if (this._options.isMobile || this._options.locale) {
-      // Workaround for:
-      // - chromium fails to change isMobile for existing page;
-      // - webkit fails to change locale for existing page.
-      const oldPage = pages[0];
-      await this.newPage(progress.metadata);
-      await oldPage.close(progress.metadata);
     }
   }
 

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -130,7 +130,7 @@ export abstract class BrowserType extends SdkObject {
     (browser as any)._userDataDirForTest = userDataDir;
     // We assume no control when using custom arguments, and do not prepare the default context in that case.
     if (persistent && !options.ignoreAllDefaultArgs)
-      await browser._defaultContext!._loadDefaultContext(progress);
+      await browser._defaultContext!._loadDefaultContextAsIs(progress);
     return browser;
   }
 

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -87,11 +87,8 @@ it('should have pages in persistent context', async ({ launchPersistent }, testI
   await page.waitForLoadState('domcontentloaded');
   await context.close();
   const log = JSON.parse(fs.readFileSync(harPath).toString())['log'];
-  // Explicit locale emulation forces a new page creation when
-  // doing a new context.
-  // See https://github.com/microsoft/playwright/blob/13dd41c2e36a63f35ddef5dc5dec322052d670c6/packages/playwright-core/src/server/browserContext.ts#L232-L242
-  expect(log.pages.length).toBe(2);
-  const pageEntry = log.pages[1];
+  expect(log.pages.length).toBe(1);
+  const pageEntry = log.pages[0];
   expect(pageEntry.id).toBeTruthy();
   expect(pageEntry.title).toBe('Hello');
 });


### PR DESCRIPTION
This patch removes a workaround that was added in https://github.com/microsoft/playwright/pull/2177, about 2 years ago. The workaround fixed a couple of bugs in chrome and webkit:

> Workaround for:
> - chromium fails to change isMobile for existing page;
> - webkit fails to change locale for existing page.

No reference to the bugs in the browsers' bug-trackers was provided so it is impossible to know if the bugs were fixed by now so I simply removed that workaround code and ran the full tests suite, and no regression was observed.