### PR TITLE
browser(webkit): build Playwright.app in workspace mode

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1671
-Changed: dpino@igalia.com Mon Jun 27 17:53:44 CEST 2022
+1672
+Changed: yurys@chromium.org Mon Jun 27 16:23:58 PDT 2022

--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -53,7 +53,7 @@ fi
 
 if is_mac; then
   selectXcodeVersionOrDie $(node "$SCRIPT_FOLDER/../get_xcode_version.js" webkit)
-  ./Tools/Scripts/build-webkit --release --touch-events --orientation-events --no-use-workspace
+  ./Tools/Scripts/build-webkit --release --touch-events --orientation-events
 elif is_linux; then
   if [[ $# == 0 || (-z "$1") ]]; then
     echo

--- a/browser_patches/webkit/embedder/Playwright/Playwright.xcodeproj/project.pbxproj
+++ b/browser_patches/webkit/embedder/Playwright/Playwright.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		51E244F811EFCE07008228D2 /* MBToolbarItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBToolbarItem.h; sourceTree = "<group>"; };
 		51E244F911EFCE07008228D2 /* MBToolbarItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBToolbarItem.m; sourceTree = "<group>"; };
 		5C9332AE24C1349C0036DECF /* SecurityInterface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SecurityInterface.framework; path = System/Library/Frameworks/SecurityInterface.framework; sourceTree = SDKROOT; };
-		7A8E843D26858D80008EC0B1 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Images.xcassets; sourceTree = "<group>"; };
+		7A8E843D26858D80008EC0B1 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		8D1107320486CEB800E47091 /* Playwright.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Playwright.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B89B95221E027A00EB4CEB /* SDKVariant.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = SDKVariant.xcconfig; sourceTree = "<group>"; };
 		BC329486116A92E2008635D1 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = mac/main.m; sourceTree = "<group>"; };
@@ -41,6 +41,7 @@
 		BCA8CBDD11E578A000812FB8 /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		BCA8CBDE11E578A000812FB8 /* DebugRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = DebugRelease.xcconfig; sourceTree = "<group>"; };
 		BCA8CBDF11E578A000812FB8 /* Playwright.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Playwright.xcconfig; sourceTree = "<group>"; };
+		F393B1A6286A71AE007B8F61 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = WebKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +119,7 @@
 				1058C7A2FEA54F0111CA2CBC /* Other Frameworks */,
 				1AFFEF761860EE6800DA465F /* Cocoa.framework */,
 				5C9332AE24C1349C0036DECF /* SecurityInterface.framework */,
+				F393B1A6286A71AE007B8F61 /* WebKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -23106,3 +23106,42 @@ index 8b8ba5b934075fe53e231a418db17ddcf7ba92aa..08aba0aa37ffbbd5878befe05e2950ab
      </branch>
      <dependencies>
        <dep package="glib"/>
+diff --git a/WebKit.xcworkspace/contents.xcworkspacedata b/WebKit.xcworkspace/contents.xcworkspacedata
+index 8660306662de6faabab78662034958811e3e4a67..979c470d97950007ad990564eba18de965c295b2 100644
+--- a/WebKit.xcworkspace/contents.xcworkspacedata
++++ b/WebKit.xcworkspace/contents.xcworkspacedata
+@@ -1,6 +1,9 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <Workspace
+    version = "1.0">
++   <FileRef
++      location = "group:Tools/Playwright/Playwright.xcodeproj">
++   </FileRef>
+    <FileRef
+       location = "group:Source/bmalloc/bmalloc.xcodeproj">
+    </FileRef>
+diff --git a/WebKit.xcworkspace/xcshareddata/xcschemes/All Modules.xcscheme b/WebKit.xcworkspace/xcshareddata/xcschemes/All Modules.xcscheme
+index 0a7672a9d18fead0f7c0b451683835beff4f94a1..87ccc0e4fcb4a386165392fe8df6acade41b755e 100644
+--- a/WebKit.xcworkspace/xcshareddata/xcschemes/All Modules.xcscheme	
++++ b/WebKit.xcworkspace/xcshareddata/xcschemes/All Modules.xcscheme	
+@@ -188,6 +188,20 @@
+                ReferencedContainer = "container:Tools/MiniBrowser/MiniBrowser.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
++         <BuildActionEntry
++            buildForTesting = "YES"
++            buildForRunning = "YES"
++            buildForProfiling = "YES"
++            buildForArchiving = "YES"
++            buildForAnalyzing = "YES">
++            <BuildableReference
++               BuildableIdentifier = "primary"
++               BlueprintIdentifier = "8D1107260486CEB800E47091"
++               BuildableName = "Playwright.app"
++               BlueprintName = "Playwright"
++               ReferencedContainer = "container:Tools/Playwright/Playwright.xcodeproj">
++            </BuildableReference>
++         </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"


### PR DESCRIPTION
WebKit switched to workspace builds by default upstream in https://github.com/WebKit/WebKit/commit/c67ee46115278a11d7a489f8229d16af31097cbb and Playwright.app project (forked from MiniBrowser.app xcode project) was not a part of the workspace. This PR:

* Adds Tools/Playwright project to the WebKit workspace;
* Adds WebKit.framework to the list of dependencies of Playwright.app (I managed to successfully build without this modification but decided to added to be on the safe side as that was done upstream too);
* Removes `--no-use-workspace` in order to use workspace build mode which is the default upstream.

Pretty-diff: https://github.com/yury-s/WebKit/commit/75f1e79447d1f4b95e9296e0d40a1c56eab324d5