### PR TITLE
docs: fix previos -> previous

### DIFF
--- a/docs/src/api/class-route.md
+++ b/docs/src/api/class-route.md
@@ -117,7 +117,7 @@ If set changes the request HTTP headers. Header values will be converted to a st
 ## async method: Route.fallback
 
 When several routes match the given pattern, they run in the order opposite to their registration.
-That way the last registered route can always override all the previos ones. In the example below,
+That way the last registered route can always override all the previous ones. In the example below,
 request will be handled by the bottom-most handler first, then it'll fall back to the previous one and
 in the end will be aborted by the first registered route.
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -15287,7 +15287,7 @@ export interface Route {
 
   /**
    * When several routes match the given pattern, they run in the order opposite to their registration. That way the last
-   * registered route can always override all the previos ones. In the example below, request will be handled by the
+   * registered route can always override all the previous ones. In the example below, request will be handled by the
    * bottom-most handler first, then it'll fall back to the previous one and in the end will be aborted by the first
    * registered route.
    *


### PR DESCRIPTION
Fix a typo in [`route.fallback([options])`](https://playwright.dev/docs/api/class-route#route-fallback) : _previos_.