### PR TITLE
devops: fix firefox-beta build on Ubuntu 20.04 & 22.04

### DIFF
--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -104,6 +104,15 @@ if [[ $1 == "--full" || $2 == "--full" || $1 == "--bootstrap" ]]; then
   fi
 fi
 
+# Remove the cbindgen from mozbuild to rely on the one we install manually.
+# See https://github.com/microsoft/playwright/issues/15174
+if is_win; then
+  rm -rf "${USERPROFILE}\\.mozbuild\\cbindgen"
+else
+  rm -rf "${HOME}/.mozbuild/cbindgen"
+fi
+
+
 if [[ $1 == "--juggler" ]]; then
   ./mach build faster
 elif [[ $1 == "--bootstrap" ]]; then


### PR DESCRIPTION
References #15174