### PR TITLE
docs(accessibility-testing): fix syntax issues in example 1

### DIFF
--- a/docs/src/accessibility-testing-js.md
+++ b/docs/src/accessibility-testing-js.md
@@ -30,10 +30,10 @@ The following examples demonstrate a few basic accessibility testing scenarios.
 
 This example demonstrates how to test an entire page for automatically detectable accessibility violations. The test:
 1. Imports the `@axe-core/playwright` package
-2. Uses normal Playwright Test syntax to define a test case
-3. Uses normal Playwright syntax to navigate to the page under test
-4. Awaits `AxeBuilder.analyze()` to run the accessibility scan against the page
-5. Uses normal Playwright Test [expect] syntax to verify that there are no violations in the returned scan results
+1. Uses normal Playwright Test syntax to define a test case
+1. Uses normal Playwright syntax to navigate to the page under test
+1. Awaits `AxeBuilder.analyze()` to run the accessibility scan against the page
+1. Uses normal Playwright Test [test assertions](./test-assertions) to verify that there are no violations in the returned scan results
 
 ```js tab=js-ts
 import { test, expect } from '@playwright/test';

--- a/docs/src/accessibility-testing-js.md
+++ b/docs/src/accessibility-testing-js.md
@@ -33,7 +33,7 @@ This example demonstrates how to test an entire page for automatically detectabl
 1. Uses normal Playwright Test syntax to define a test case
 1. Uses normal Playwright syntax to navigate to the page under test
 1. Awaits `AxeBuilder.analyze()` to run the accessibility scan against the page
-1. Uses normal Playwright Test [test assertions](./test-assertions) to verify that there are no violations in the returned scan results
+1. Uses normal Playwright Test [assertions](./test-assertions) to verify that there are no violations in the returned scan results
 
 ```js tab=js-ts
 import { test, expect } from '@playwright/test';


### PR DESCRIPTION
This PR fixes two syntax issues from #15154:

* A numbered list was represented as `1. ... \n 2. ... \n 3. ...` instead of `1. ... \n 1. ... \n 1. ...`. The former is valid in GitHub-flavored markdown but not Docusaurus-flavored markdown
* A word within the list was intended to link to the Test assertions guide but missed half the link syntax

I found both of these while testing a `microsoft/playwright.dev` PR to add the new guide to the sidebar - in retrospect, it would have been good to test as-rendered in docusaurus before sending #15154. I'll follow up with a separate PR updating `CONTRIBUTING.md`'s "Writing Documentation" section to suggest this.