### PR TITLE
fix(network): remove races from sizes calculation

### DIFF
--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -304,8 +304,7 @@ export class HarTracer {
       this._addBarrier(page, response.sizes().then(sizes => {
         harEntry.response.bodySize = sizes.responseBodySize;
         harEntry.response.headersSize = sizes.responseHeadersSize;
-        // Fallback for WebKit by calculating it manually
-        harEntry.response._transferSize = response.request().responseSize.transferSize || (sizes.responseHeadersSize + sizes.responseBodySize);
+        harEntry.response._transferSize = sizes.transferSize;
         harEntry.request.headersSize = sizes.requestHeadersSize;
         compressionCalculationBarrier?.setEncodedBodySize(sizes.responseBodySize);
       }));


### PR DESCRIPTION
- Do not resolve raw headers upon `loadingFinished`, since they may still come later in `responseReceivedExtraInfo`.
- Introduce separate promises for `encodedBodySize`, `transferSize` and `responseHeadersSize`.
- Make sure we resolve each of the above with data available from the browser, or fallback to manual calculation.
- Set raw response headers for redirects on WebKit.
- Do not stall on cached responses in Chromium, they have erroneously set `hasExtraInfo` flag.
- Use `transferSize` that is available in Firefox protocol.

Fixes #15017.