### PR TITLE
fix(reporter): add truthy check for attachment.contentType in formatFailure

### DIFF
--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -249,7 +249,7 @@ export function formatFailure(config: FullConfig, test: TestCase, options: {inde
     if (includeAttachments) {
       for (let i = 0; i < result.attachments.length; ++i) {
         const attachment = result.attachments[i];
-        const hasPrintableContent = attachment.contentType.startsWith('text/') && attachment.body;
+        const hasPrintableContent = attachment.contentType && attachment.contentType.startsWith('text/') && attachment.body;
         if (!attachment.path && !hasPrintableContent)
           continue;
         resultLines.push('');


### PR DESCRIPTION
When some tests fail, report generation crashes if one of the attachments has the contentType equal to the 'undefined'.