### PR TITLE
chore: generate types always with LF

### DIFF
--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -615,8 +615,6 @@ class TypesGenerator {
     content = content.replace(/\r\n/g, '\n');
     if (removeTrailingWhiteSpace)
       content = content.replace(/( +)\n/g, '\n'); // remove trailing whitespace
-    if (os.platform() === 'win32')
-      content = content.replace(/\n/g, '\r\n');
     const existing = fs.readFileSync(filePath, 'utf8');
     if (existing === content)
       return;


### PR DESCRIPTION
Back in the days we checked out the repository with the preferred new line separator from the OS.

This got changed in https://github.com/microsoft/playwright/pull/10292

since then when building on Windows it always generated a delta:

![image](https://user-images.githubusercontent.com/17984549/176534328-8ef0e82e-1aa7-41b3-8b42-857b1ca02f1e.png)

Which got in the end also "normalized" by git, but this was still very confusing.

This PR fixes it.