### PR TITLE
browser(firefox): fix racy browser.newPage() method

### DIFF
--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1331
-Changed: lushnikov@chromium.org Wed Jun 29 23:40:49 MSK 2022
+1332
+Changed: lushnikov@chromium.org Thu Jun 30 02:06:47 MSK 2022

--- a/browser_patches/firefox-beta/juggler/TargetRegistry.js
+++ b/browser_patches/firefox-beta/juggler/TargetRegistry.js
@@ -323,7 +323,11 @@ class TargetRegistry {
     if (window.gBrowser.browsers.length !== 1)
       throw new Error(`Unexpected number of tabs in the new window: ${window.gBrowser.browsers.length}`);
     const browser = window.gBrowser.browsers[0];
-    const target = this._browserToTarget.get(browser);
+    let target = this._browserToTarget.get(browser);
+    while (!target) {
+      await helper.awaitEvent(this, TargetRegistry.Events.TargetCreated);
+      target = this._browserToTarget.get(browser);
+    }
     browser.focus();
     if (browserContext.settings.timezoneId) {
       if (await target.hasFailedToOverrideTimezone())

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1330
-Changed: lushnikov@chromium.org Wed Jun 29 23:40:12 MSK 2022
+1331
+Changed: lushnikov@chromium.org Thu Jun 30 02:09:30 MSK 2022

--- a/browser_patches/firefox/juggler/TargetRegistry.js
+++ b/browser_patches/firefox/juggler/TargetRegistry.js
@@ -323,7 +323,11 @@ class TargetRegistry {
     if (window.gBrowser.browsers.length !== 1)
       throw new Error(`Unexpected number of tabs in the new window: ${window.gBrowser.browsers.length}`);
     const browser = window.gBrowser.browsers[0];
-    const target = this._browserToTarget.get(browser);
+    let target = this._browserToTarget.get(browser);
+    while (!target) {
+      await helper.awaitEvent(this, TargetRegistry.Events.TargetCreated);
+      target = this._browserToTarget.get(browser);
+    }
     browser.focus();
     if (browserContext.settings.timezoneId) {
       if (await target.hasFailedToOverrideTimezone())


### PR DESCRIPTION
It looks like the tabopen callback is async, so we must
make sure it is called when opening new pages.
