### PR TITLE
fix(firefox): launch races

### DIFF
--- a/packages/playwright-core/src/server/chromium/crConnection.ts
+++ b/packages/playwright-core/src/server/chromium/crConnection.ts
@@ -49,10 +49,11 @@ export class CRConnection extends EventEmitter {
     this._transport = transport;
     this._protocolLogger = protocolLogger;
     this._browserLogsCollector = browserLogsCollector;
-    this._transport.onmessage = this._onMessage.bind(this);
-    this._transport.onclose = this._onClose.bind(this);
     this.rootSession = new CRSession(this, '', 'browser', '');
     this._sessions.set('', this.rootSession);
+    this._transport.onmessage = this._onMessage.bind(this);
+    // onclose should be set last, since it can be immediately called.
+    this._transport.onclose = this._onClose.bind(this);
   }
 
   static fromSession(session: CRSession): CRConnection {

--- a/packages/playwright-core/src/server/firefox/ffConnection.ts
+++ b/packages/playwright-core/src/server/firefox/ffConnection.ts
@@ -58,8 +58,6 @@ export class FFConnection extends EventEmitter {
     this._lastId = 0;
     this._callbacks = new Map();
 
-    this._transport.onmessage = this._onMessage.bind(this);
-    this._transport.onclose = this._onClose.bind(this);
     this._sessions = new Map();
     this._closed = false;
 
@@ -68,6 +66,10 @@ export class FFConnection extends EventEmitter {
     this.off = super.removeListener;
     this.removeListener = super.removeListener;
     this.once = super.once;
+
+    this._transport.onmessage = this._onMessage.bind(this);
+    // onclose should be set last, since it can be immediately called.
+    this._transport.onclose = this._onClose.bind(this);
   }
 
   async send<T extends keyof Protocol.CommandParameters>(

--- a/packages/playwright-core/src/server/webkit/wkConnection.ts
+++ b/packages/playwright-core/src/server/webkit/wkConnection.ts
@@ -47,14 +47,15 @@ export class WKConnection {
 
   constructor(transport: ConnectionTransport, onDisconnect: () => void, protocolLogger: ProtocolLogger, browserLogsCollector: RecentLogsCollector) {
     this._transport = transport;
-    this._transport.onmessage = this._dispatchMessage.bind(this);
-    this._transport.onclose = this._onClose.bind(this);
     this._onDisconnect = onDisconnect;
     this._protocolLogger = protocolLogger;
     this._browserLogsCollector = browserLogsCollector;
     this.browserSession = new WKSession(this, '', kBrowserClosedError, (message: any) => {
       this.rawSend(message);
     });
+    this._transport.onmessage = this._dispatchMessage.bind(this);
+    // onclose should be set last, since it can be immediately called.
+    this._transport.onclose = this._onClose.bind(this);
   }
 
   nextMessageId(): number {

--- a/tests/library/browsertype-launch.spec.ts
+++ b/tests/library/browsertype-launch.spec.ts
@@ -63,6 +63,7 @@ it('should reject if launched browser fails immediately', async ({ browserType, 
   let waitError = null;
   await browserType.launch({ executablePath: asset('dummy_bad_browser_executable.js') }).catch(e => waitError = e);
   expect(waitError.message).toContain('== logs ==');
+  expect(waitError.message).toContain('Browser process did exit unexpectedly: exitCode=1');
 });
 
 it('should reject if executable path is invalid', async ({ browserType }) => {

--- a/tests/library/browsertype-launch.spec.ts
+++ b/tests/library/browsertype-launch.spec.ts
@@ -63,7 +63,6 @@ it('should reject if launched browser fails immediately', async ({ browserType, 
   let waitError = null;
   await browserType.launch({ executablePath: asset('dummy_bad_browser_executable.js') }).catch(e => waitError = e);
   expect(waitError.message).toContain('== logs ==');
-  expect(waitError.message).toContain('Browser process did exit unexpectedly: exitCode=1');
 });
 
 it('should reject if executable path is invalid', async ({ browserType }) => {


### PR DESCRIPTION
Potential fixes to avoid startup races:
- Wait for "juggler listening" message.
- Make sure `transport.onclose` is called when connecting to the transport after the actual pipe closure.