### PR TITLE
fix(esm): show codeframe when errors get reported

### DIFF
--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -15,6 +15,7 @@
  */
 
 import path from 'path';
+import url from 'url';
 import { StackUtils } from '../utilsBundle';
 import { isUnderTest } from './';
 
@@ -87,12 +88,8 @@ export function captureStackTrace(rawStack?: string): ParsedStackTrace {
       return null;
     if (isInternalFileName(frame.file, frame.function))
       return null;
-    // Workaround for https://github.com/tapjs/stack-utils/issues/60
-    let fileName: string;
-    if (frame.file.startsWith('file://'))
-      fileName = new URL(frame.file).pathname;
-    else
-      fileName = path.resolve(process.cwd(), frame.file);
+    // ESM files return file:// URLs, see here: https://github.com/tapjs/stack-utils/issues/60
+    const fileName = frame.file.startsWith('file://') ? url.fileURLToPath(frame.file) : path.resolve(process.cwd(), frame.file);
     if (isTesting && fileName.includes(COVERAGE_PATH))
       return null;
     const inCore = fileName.startsWith(CORE_LIB) || fileName.startsWith(CORE_SRC);

--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -15,11 +15,8 @@
  */
 
 import path from 'path';
-import url from 'url';
-import { StackUtils } from '../utilsBundle';
+import { parseStackTraceLine } from '../utilsBundle';
 import { isUnderTest } from './';
-
-const stackUtils = new StackUtils();
 
 export function rewriteErrorMessage<E extends Error>(e: E, newMessage: string): E {
   const lines: string[] = (e.stack?.split('\n') || []).filter(l => l.startsWith('    at '));
@@ -83,13 +80,11 @@ export function captureStackTrace(rawStack?: string): ParsedStackTrace {
     inCore: boolean;
   };
   let parsedFrames = stack.split('\n').map(line => {
-    const frame = stackUtils.parseLine(line);
-    if (!frame || !frame.file)
+    const { frame, fileName } = parseStackTraceLine(line);
+    if (!frame || !frame.file || !fileName)
       return null;
     if (isInternalFileName(frame.file, frame.function))
       return null;
-    // ESM files return file:// URLs, see here: https://github.com/tapjs/stack-utils/issues/60
-    const fileName = frame.file.startsWith('file://') ? url.fileURLToPath(frame.file) : path.resolve(process.cwd(), frame.file);
     if (isTesting && fileName.includes(COVERAGE_PATH))
       return null;
     const inCore = fileName.startsWith(CORE_LIB) || fileName.startsWith(CORE_SRC);

--- a/packages/playwright-core/src/utilsBundle.ts
+++ b/packages/playwright-core/src/utilsBundle.ts
@@ -46,9 +46,10 @@ export function parseStackTraceLine(line: string): { frame: import('../bundles/u
   if (!frame)
     return { frame: null, fileName: null };
   let fileName = null;
-  if (frame.file)
+  if (frame.file) {
     // ESM files return file:// URLs, see here: https://github.com/tapjs/stack-utils/issues/60
     fileName = frame.file.startsWith('file://') ? url.fileURLToPath(frame.file) : path.resolve(process.cwd(), frame.file);
+  }
   return {
     frame,
     fileName,

--- a/packages/playwright-core/src/utilsBundle.ts
+++ b/packages/playwright-core/src/utilsBundle.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import url from 'url';
+import path from 'path';
+
 export const colors: typeof import('../bundles/utils/node_modules/colors/safe') = require('./utilsBundleImpl').colors;
 export const debug: typeof import('../bundles/utils/node_modules/@types/debug') = require('./utilsBundleImpl').debug;
 export const getProxyForUrl: typeof import('../bundles/utils/node_modules/@types/proxy-from-env').getProxyForUrl = require('./utilsBundleImpl').getProxyForUrl;
@@ -28,10 +31,26 @@ export const program: typeof import('../bundles/utils/node_modules/commander').p
 export const progress: typeof import('../bundles/utils/node_modules/@types/progress') = require('./utilsBundleImpl').progress;
 export const rimraf: typeof import('../bundles/utils/node_modules/@types/rimraf') = require('./utilsBundleImpl').rimraf;
 export const SocksProxyAgent: typeof import('../bundles/utils/node_modules/socks-proxy-agent').SocksProxyAgent = require('./utilsBundleImpl').SocksProxyAgent;
-export const StackUtils: typeof import('../bundles/utils/node_modules/@types/stack-utils') = require('./utilsBundleImpl').StackUtils;
 export const ws: typeof import('../bundles/utils/node_modules/@types/ws') = require('./utilsBundleImpl').ws;
 export const wsServer: typeof import('../bundles/utils/node_modules/@types/ws').WebSocketServer = require('./utilsBundleImpl').wsServer;
 export const wsReceiver = require('./utilsBundleImpl').wsReceiver;
 export const wsSender = require('./utilsBundleImpl').wsSender;
 export type { Command } from '../bundles/utils/node_modules/commander';
 export type { WebSocket, WebSocketServer, RawData as WebSocketRawData, EventEmitter as WebSocketEventEmitter } from '../bundles/utils/node_modules/@types/ws';
+
+const StackUtils: typeof import('../bundles/utils/node_modules/@types/stack-utils') = require('./utilsBundleImpl').StackUtils;
+const stackUtils = new StackUtils();
+
+export function parseStackTraceLine(line: string): { frame: import('../bundles/utils/node_modules/@types/stack-utils').StackLineData | null, fileName: string | null } {
+  const frame = stackUtils.parseLine(line);
+  if (!frame)
+    return { frame: null, fileName: null };
+  let fileName = null;
+  if (frame.file)
+    // ESM files return file:// URLs, see here: https://github.com/tapjs/stack-utils/issues/60
+    fileName = frame.file.startsWith('file://') ? url.fileURLToPath(frame.file) : path.resolve(process.cwd(), frame.file);
+  return {
+    frame,
+    fileName,
+  };
+}

--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -16,6 +16,7 @@
 
 import { colors, ms as milliseconds } from 'playwright-core/lib/utilsBundle';
 import fs from 'fs';
+import url from 'url';
 import path from 'path';
 import { StackUtils } from 'playwright-core/lib/utilsBundle';
 import type { FullConfig, TestCase, Suite, TestResult, TestError, Reporter, FullResult, TestStep, Location } from '../../types/testReporter';
@@ -414,7 +415,8 @@ export function prepareErrorStack(stack: string, file?: string): {
     const parsed = stackUtils.parseLine(line);
     if (!parsed || !parsed.file)
       continue;
-    const resolvedFile = path.join(process.cwd(), parsed.file);
+    // ESM files return file:// URLs, see here: https://github.com/tapjs/stack-utils/issues/60
+    const resolvedFile = parsed.file.startsWith('file://') ? url.fileURLToPath(parsed.file) : path.resolve(process.cwd(), parsed.file);
     if (!file || resolvedFile === file) {
       location = { file: resolvedFile, column: parsed.column || 0, line: parsed.line || 0 };
       break;


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/15244

Abstract: stack-utils return file locations as `file://` in ESM mode. We handled this case already correctly inside `playwright-core`, and this patch applies the same fix inside `playwright-test`.

drive-by: replace `new URL(frame.file).pathname` with `url.fileURLToPath`