### PR TITLE
feat(matchers): support null/undefined with toHaveProperty

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -1046,6 +1046,8 @@ export class InjectedScript {
       // JS property
       if (expression === 'to.have.property') {
         const received = (element as any)[options.expressionArg];
+        if (options.expectedValue === 'PLAYWRIGHT_ACCEPT_NULL_OR_UNDEFINED')
+          return { received, matches: received === null || received === undefined };
         const matches = deepEquals(received, options.expectedValue);
         return { received, matches };
       }

--- a/tests/playwright-test/playwright.expect.misc.spec.ts
+++ b/tests/playwright-test/playwright.expect.misc.spec.ts
@@ -116,6 +116,32 @@ test('should support toHaveJSProperty', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
 });
 
+test('should support toHaveJSProperty and accept null/undefined for language bindings', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      const { test } = pwt;
+
+      test('pass', async ({ page }) => {
+        await page.setContent('<div></div>');
+        await page.$eval('div', e => {
+          e.iAmNull = null;
+          e.iAmUndefined = undefined;
+          e.iAmAString = 'foobar';
+          e.iAmAnObject = { a: 1 };
+        });
+        const locator = page.locator('div');
+        await expect(locator).toHaveJSProperty('iAmNull', 'PLAYWRIGHT_ACCEPT_NULL_OR_UNDEFINED');
+        await expect(locator).toHaveJSProperty('iAmUndefined', 'PLAYWRIGHT_ACCEPT_NULL_OR_UNDEFINED');
+        await expect(locator).toHaveJSProperty('iAmNotThere', 'PLAYWRIGHT_ACCEPT_NULL_OR_UNDEFINED');
+        await expect(locator).not.toHaveJSProperty('iAmAString', 'PLAYWRIGHT_ACCEPT_NULL_OR_UNDEFINED');
+        await expect(locator).not.toHaveJSProperty('iAmAnObject', 'PLAYWRIGHT_ACCEPT_NULL_OR_UNDEFINED');
+      });
+      `,
+  }, { workers: 1 });
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(0);
+  expect(result.exitCode).toBe(0);
+});
 
 test('should support toHaveJSProperty with builtin types', async ({ runInlineTest }) => {
   const result = await runInlineTest({


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/14909

Inside the language ports we then use this token when null gets passed over.