### PR TITLE
test: unflake "should truncate long test names"

### DIFF
--- a/packages/playwright-test/src/reporters/list.ts
+++ b/packages/playwright-test/src/reporters/list.ts
@@ -149,6 +149,8 @@ class ListReporter extends BaseReporter {
     // Go down if needed.
     if (testRow !== this._lastRow)
       process.stdout.write(`\u001B[${this._lastRow - testRow}E`);
+    if (process.env.PWTEST_TTY_WIDTH)
+      process.stdout.write('\n');  // For testing.
   }
 
   private _retrySuffix(result: TestResult) {

--- a/tests/playwright-test/reporter-list.spec.ts
+++ b/tests/playwright-test/reporter-list.spec.ts
@@ -124,14 +124,28 @@ test('should truncate long test names', async ({ runInlineTest }) => {
       });
     `,
   }, { reporter: 'list', retries: 0 }, { PWTEST_TTY_WIDTH: 50 });
-  const text = stripAnsi(result.output);
-
-  expect(text).toContain(`${NEGATIVE_STATUS_MARK} …st.ts:6:7 › failure in very long name (`);
-  expect(text).not.toContain(`${NEGATIVE_STATUS_MARK} …est.ts:6:7 › fails very long name (`);
-  expect(text).toContain(`${POSITIVE_STATUS_MARK} [foo] › a.test.ts:9:7 › passes (`);
-  expect(text).toContain(`${POSITIVE_STATUS_MARK} … › a.test.ts:11:7 › passes 2 long name (`);
-  expect(text).not.toContain(`${POSITIVE_STATUS_MARK} …] › a.test.ts:11:7 › passes 2 long name (`);
-  expect(text).toContain(`-  …] › a.test.ts:13:12 › skipped very long nam`);
-  expect(text).not.toContain(`-  …o] › a.test.ts:13:12 › skipped very long nam`);
   expect(result.exitCode).toBe(1);
+
+  const lines = stripAnsi(result.output).split('\n').slice(3, 11);
+  expect(lines.every(line => line.length <= 50)).toBe(true);
+
+  expect(lines[0]).toBe(`     … › a.test.ts:6:7 › failure in very long name`);
+
+  expect(lines[1]).toContain(`${NEGATIVE_STATUS_MARK} …`);
+  expect(lines[1]).toContain(`ts:6:7 › failure in very long name (`);
+  expect(lines[1].length).toBe(50);
+
+  expect(lines[2]).toBe(`     [foo] › a.test.ts:9:7 › passes`);
+
+  expect(lines[3]).toContain(`${POSITIVE_STATUS_MARK} [foo] › a.test.ts:9:7 › passes (`);
+
+  expect(lines[4]).toBe(`     [foo] › a.test.ts:11:7 › passes 2 long name`);
+
+  expect(lines[5]).toContain(`${POSITIVE_STATUS_MARK} …`);
+  expect(lines[5]).toContain(`a.test.ts:11:7 › passes 2 long name (`);
+  expect(lines[5].length).toBe(50);
+
+  expect(lines[6]).toBe(`     …] › a.test.ts:13:12 › skipped very long name`);
+
+  expect(lines[7]).toBe(`  -  …] › a.test.ts:13:12 › skipped very long name`);
 });


### PR DESCRIPTION
Adding `\n` to test output to easier check per-line expectations.