### PR TITLE
docs(ci): improve docs around ci, sharing and docker

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -244,54 +244,6 @@ pipeline {
 }
 ```
 
-### Buildkite
-
-Buildkite supports [containerized builds with Docker](https://buildkite.com/docs/tutorials/docker-containerized-builds) using either their [Docker Compose plugin](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin) or their [Docker plugin](https://github.com/buildkite-plugins/docker-buildkite-plugin).
-
-The simpler of the two approaches is to use the [Docker plugin](https://github.com/buildkite-plugins/docker-buildkite-plugin) which simply runs the command(s) within the docker container, similar to GitHub Actions and Jenkins.
-
-```yml
-steps:
-  - label: ':playwright: Playwright tests'
-    plugins:
-      - docker#v3.13.0:
-          image: mcr.microsoft.com/playwright:v1.24.0-focal
-          workdir: /app
-          propagate-environment: true
-          environment:
-            # list any non-buildkite env vars you want to propagate to the container
-            - MY_SPECIAL_TOKEN
-    artifact_paths:
-      - my/playwright/reports/*
-    key: playwright
-    commands:
-      - npx playwright test
-```
-
-> Note: The `:playwright:` syntax in the label is used to define [emojis](https://github.com/buildkite/emojis#emoji-reference).
-
-#### Sharding
-
-The [`parallelism`](https://buildkite.com/docs/tutorials/parallel-builds#parallel-jobs) option allows you to run playwright tests across multiple agents/jobs where you can use the provided environment variables `BUILDKITE_PARALLEL_JOB` and `BUILDKITE_PARALLEL_JOB_COUNT` to defined the `--shard` flag as shown below.
-
-```yml
-steps:
-  - label: ':playwright: Playwright tests'
-    plugins:
-      - docker#v3.13.0:
-          image: mcr.microsoft.com/playwright:v1.24.0-focal
-          workdir: /app
-          propagate-environment: true
-    parallelism: 10 # runs 10 jobs in parallel agents
-    key: playwright
-    command: |
-      jobIndex=$$BUILDKITE_PARALLEL_JOB
-      shardIndex=$$((jobIndex + 1))
-      jobCount=$$BUILDKITE_PARALLEL_JOB_COUNT
-
-      npx playwright test --shard=$$shardIndex/$$jobCount
-```
-
 > Note: The `$$` is used to escape the `$` and the `shardIndex` is incremented by one to convert the 0-based `jobIndex` to the 1-based `shardIndex`.
 
 ### Bitbucket Pipelines

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -154,7 +154,7 @@ steps:
 
 #### Sharding
 
-GitHub Actions supports [sharding tests between multiple jobs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) using the  [`jobs.<job_id>.strategy.matrix`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) option. The `matrix` option will run a seperate job for every possible combination of the provided option. In the example below, we have 2 `project` values, 10 `shardIndex` values and 1 `shardTotal` value, resulting in a total of 20 jobs to be run.
+GitHub Actions supports [sharding tests between multiple jobs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) using the  [`jobs.<job_id>.strategy.matrix`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) option. The `matrix` option will run a seperate job for every possible combination of the provided options. In the example below, we have 2 `project` values, 10 `shardIndex` values and 1 `shardTotal` value, resulting in a total of 20 jobs to be run.
 
 ```yml js
 steps:

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -118,7 +118,7 @@ jobs:
         PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url }}
 ```
 
-## Docker
+### Docker
 
 We have a [pre-built Docker image](./docker.md) which can either be used directly, or as a reference to update your existing Docker definitions.
 
@@ -130,7 +130,7 @@ Suggested configuration
 1. Using `--init` Docker flag or [dumb-init](https://github.com/Yelp/dumb-init) is recommended to avoid special
    treatment for processes with PID=1. This is a common reason for zombie processes.
 
-### GitHub Actions
+### GitHub Actions (via containers)
 
 GitHub Actions support [running jobs in a container](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container) by using the [`jobs.<job_id>.container`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontainer) option.
 

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -153,8 +153,9 @@ steps:
 ```
 
 #### Sharding
+* langs: js
 
-GitHub Actions supports [sharding tests between multiple jobs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) using the  [`jobs.<job_id>.strategy.matrix`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) option. The `matrix` option will run a seperate job for every possible combination of the provided options. In the example below, we have 2 `project` values, 10 `shardIndex` values and 1 `shardTotal` value, resulting in a total of 20 jobs to be run.
+GitHub Actions supports [sharding tests between multiple jobs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) using the [`jobs.<job_id>.strategy.matrix`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) option. The `matrix` option will run a seperate job for every possible combination of the provided options. In the example below, we have 2 `project` values, 10 `shardIndex` values and 1 `shardTotal` value, resulting in a total of 20 jobs to be run.
 
 ```yml js
 steps:

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -244,8 +244,6 @@ pipeline {
 }
 ```
 
-> Note: The `$$` is used to escape the `$` and the `shardIndex` is incremented by one to convert the 0-based `jobIndex` to the 1-based `shardIndex`.
-
 ### Bitbucket Pipelines
 
 Bitbucket Pipelines can use public [Docker images as build environments](https://confluence.atlassian.com/bitbucket/use-docker-images-as-build-environments-792298897.html). To run Playwright tests on Bitbucket, use our public Docker image ([see Dockerfile](./docker.md)).

--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -302,7 +302,7 @@ Or if there is a custom folder name:
 npx playwright show-report my-report
 ```
 
-> The `html` reporter currently does not support merging reports generated across multple [`--shards`](./test-parallel.md#shard-tests-between-multiple-machines). In the meantime, the [`playwright-merge-html-reports`](https://www.npmjs.com/package/playwright-merge-html-reports) npm package can be used to merge any number of reports into one.
+> The `html` reporter currently does not support merging reports generated across multiple [`--shards`](./test-parallel.md#shard-tests-between-multiple-machines) into a single report. See [this](https://github.com/microsoft/playwright/issues/10437) issue for available third party solutions.
 
 
 ### JSON reporter

--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -302,6 +302,8 @@ Or if there is a custom folder name:
 npx playwright show-report my-report
 ```
 
+> The `html` reporter currently does not support merging reports generated across multple [`--shards`](./test-parallel.md#shard-tests-between-multiple-machines). In the meantime, the [`playwright-merge-html-reports`](https://www.npmjs.com/package/playwright-merge-html-reports) npm package can be used to merge any number of reports into one.
+
 
 ### JSON reporter
 


### PR DESCRIPTION
After using playwright extensively in GitHub actions and Buildkite (in docker 🐳) I thought I'd add my knowledge to the docs for the next adventurers.

Additions include:

- Creating a logical separation in `ci.md` between generic ci configurations and those run inside docker.
- Adds GitHub action ci example using docker image.
- Adds GitHub action ci example runing in docker with `shard` and `matrix`.
- Adds Buildkite ci example running in docker.
- Adds Buildkite ci example running in docker with `shard` and `parallelism` option.
- Adds note about using [`playwright-merge-html-reports`](https://www.npmjs.com/package/playwright-merge-html-reports) to merge multiple `html` reports across `shard`s until it's natively supported.