### PR TITLE
Remove `chromium` switch

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -39,7 +39,7 @@ jobs:
         DEBUG: pw:install
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
-    - run: npx playwright install --with-deps ${{ matrix.browser }} chromium
+    - run: npx playwright install --with-deps ${{ matrix.browser }}
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --project=${{ matrix.browser }}
     - run: node tests/config/checkCoverage.js ${{ matrix.browser }}
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json


### PR DESCRIPTION
Removing hardcoded `chromium` CLI switch/option, as it comes from the `${{ matrix.browser }}` expression. Otherwise, at runtime this would evaluate as follows:

- 0: `npx playwright install --with-deps chromium chromium`
- 1: `npx playwright install --with-deps firefox chromium`
- 2: `npx playwright install --with-deps webkit chromium`