### PR TITLE
Detects React 17+ first

### DIFF
--- a/packages/playwright-core/src/server/injected/reactSelectorEngine.ts
+++ b/packages/playwright-core/src/server/injected/reactSelectorEngine.ts
@@ -145,17 +145,17 @@ function findReactRoots(root: Document | ShadowRoot, roots: ReactVNode[] = []): 
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
   do {
     const node = walker.currentNode;
-    // ReactDOM Legacy client API:
-    // @see https://github.com/baruchvlz/resq/blob/5c15a5e04d3f7174087248f5a158c3d6dcc1ec72/src/utils.js#L329
-    if (node.hasOwnProperty('_reactRootContainer')) {
+
+    // React 17+
+    // React sets rootKey when mounting
+    // @see https://github.com/facebook/react/blob/a724a3b578dce77d427bef313102a4d0e978d9b4/packages/react-dom/src/client/ReactDOMComponentTree.js#L62-L64
+    const rootKey = Object.keys(node).find(key => key.startsWith('__reactContainer'));
+    if (rootKey) {
+      roots.push((node as any)[rootKey].stateNode.current);
+    } else if (node.hasOwnProperty('_reactRootContainer')) {
+      // ReactDOM Legacy client API:
+      // @see https://github.com/baruchvlz/resq/blob/5c15a5e04d3f7174087248f5a158c3d6dcc1ec72/src/utils.js#L329
       roots.push((node as any)._reactRootContainer._internalRoot.current);
-    } else {
-      // React 17+
-      // React sets rootKey when mounting
-      // @see https://github.com/facebook/react/blob/a724a3b578dce77d427bef313102a4d0e978d9b4/packages/react-dom/src/client/ReactDOMComponentTree.js#L62-L64
-      const rootKey = Object.keys(node).find(key => key.startsWith('__reactContainer'));
-      if (rootKey)
-        roots.push((node as any)[rootKey].stateNode.current);
     }
 
     // Pre-react 16: rely on `data-reactroot`


### PR DESCRIPTION
My Next.js application built for production (with minification disabled, so that React selectors work) cannot run the Playwright tests, they crash with:

```
    expect.toBeVisible: TypeError: Cannot read properties of undefined (reading 'current')

        at findReactRoots (<anonymous>:1740:57)
        at Object.queryAll (<anonymous>:1761:24)
        at InjectedScript._queryEngineAll (<anonymous>:3907:49)
        at InjectedScript.querySelectorAll (<anonymous>:3894:30)
        at InjectedScript.querySelector (<anonymous>:3841:25)
        at eval (eval at evaluate (:178:30), <anonymous>:22:34)
        at next (<anonymous>:4032:27)
```

After investigating, I saw that the problem comes from the modified lines: the React root in the production application has seemingly both a new-style `__reactContainer` key, and a legacy `_reactRootContainer` one. The legacy one is caused by some internal Next.js components which [still use the legacy APIs](https://github.com/vercel/next.js/blob/122899bd37c70e12e6ac3d9503931bd0d4ac424b/packages/next/client/index.tsx#L566-L572).

One fix is to set the `__NEXT_REACT_ROOT=1` environment variable, but given it seems to be a hidden setting I think it wouldn't hurt to implement the fix in this PR regardless, which just involves preferring React 18 roots when available (rather than the other way around).