### PR TITLE
fix(junit reporter): embedding attachments on report didnt work for tests outside root folder

### DIFF
--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -191,11 +191,10 @@ class JUnitReporter implements Reporter {
             if (!attachment.path)
               continue;
             try {
-              const attachmentPath = path.relative(this.config.rootDir, attachment.path);
               if (fs.existsSync(attachment.path))
                 contents = fs.readFileSync(attachment.path, { encoding: 'base64' });
               else
-                systemErr.push(`\nWarning: attachment ${attachmentPath} is missing`);
+                systemErr.push(`\nWarning: attachment ${attachment.path} is missing`);
             } catch (e) {
             }
           }

--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -192,8 +192,8 @@ class JUnitReporter implements Reporter {
               continue;
             try {
               const attachmentPath = path.relative(this.config.rootDir, attachment.path);
-              if (fs.existsSync(attachmentPath))
-                contents = fs.readFileSync(attachmentPath, { encoding: 'base64' });
+              if (fs.existsSync(attachment.path))
+                contents = fs.readFileSync(attachment.path, { encoding: 'base64' });
               else
                 systemErr.push(`\nWarning: attachment ${attachmentPath} is missing`);
             } catch (e) {


### PR DESCRIPTION
There was a relative path for attachments that could be embed on the junit XML report; it was obtained for logging purposes; however, the actual attachment path is the one to consider (and it's independent from the relative location of the tests).

fixes #15360 by properly checking the attachment path and reading from the correct path