### PR TITLE
chore(test-runner): increase jpeg-js max mem allowance

### DIFF
--- a/packages/playwright-core/src/utils/comparators.ts
+++ b/packages/playwright-core/src/utils/comparators.ts
@@ -34,6 +34,8 @@ export function getComparator(mimeType: string): Comparator {
   return compareBuffersOrStrings;
 }
 
+const JPEG_JS_MAX_BUFFER_SIZE_IN_MB = 5 * 1024; // ~5 GB
+
 function compareBuffersOrStrings(actualBuffer: Buffer | string, expectedBuffer: Buffer): ComparatorResult {
   if (typeof actualBuffer === 'string')
     return compareText(actualBuffer, expectedBuffer);
@@ -48,8 +50,8 @@ function compareImages(mimeType: string, actualBuffer: Buffer | string, expected
   if (!actualBuffer || !(actualBuffer instanceof Buffer))
     return { errorMessage: 'Actual result should be a Buffer.' };
 
-  const actual = mimeType === 'image/png' ? PNG.sync.read(actualBuffer) : jpegjs.decode(actualBuffer);
-  const expected = mimeType === 'image/png' ? PNG.sync.read(expectedBuffer) : jpegjs.decode(expectedBuffer);
+  const actual = mimeType === 'image/png' ? PNG.sync.read(actualBuffer) : jpegjs.decode(actualBuffer, { maxMemoryUsageInMB: JPEG_JS_MAX_BUFFER_SIZE_IN_MB });
+  const expected = mimeType === 'image/png' ? PNG.sync.read(expectedBuffer) : jpegjs.decode(expectedBuffer, { maxMemoryUsageInMB: JPEG_JS_MAX_BUFFER_SIZE_IN_MB });
   if (expected.width !== actual.width || expected.height !== actual.height) {
     return {
       errorMessage: `Expected an image ${expected.width}px by ${expected.height}px, received ${actual.width}px by ${actual.height}px. `


### PR DESCRIPTION
Resolves #14255.

PNGs should be preferred as they are deterministic, but increasing this
limit should be fine for JPEG users. (Looking through jpeg-js source code, the actual memory allocation is based on the size of the image—so unless a user is hitting this limit already—this should not impact the memory consumption of Playwright.