### PR TITLE
fix(fixtures): do not run user function when required fixture has failed

### DIFF
--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -351,6 +351,10 @@ export class WorkerRunner extends EventEmitter {
         testInfo._timeoutManager.setCurrentRunnable({ type: 'test' });
         const params = await this._fixtureRunner.resolveParametersForFunction(test.fn, testInfo, 'test');
         beforeHooksStep.complete({}); // Report fixture hooks step as completed.
+        if (params === null) {
+          // Fixture setup failed, we should not run the test now.
+          return;
+        }
 
         // Now run the test itself.
         const fn = test.fn; // Extract a variable to get a better stack trace ("myTest" vs "TestCase.myTest [as fn]").


### PR DESCRIPTION
Currently, it is possible to run a function, e.g. a second `beforeEach` hook, that will receive `null` for the fixture that has already failed before.

This PR skips running any user function that uses a fixture that has already failed, just like if the fixture would be initialized again and failing for the second time.

Fixes #15071.