### PR TITLE
fix(test runner): include test location into unique id

### DIFF
--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -354,9 +354,10 @@ class ProjectSuiteBuilder {
       } else {
         const test = entry._clone();
         test.retries = this._project.retries;
-        // We rely upon relative paths being unique.
-        // See `getClashingTestsPerSuite()` in `runner.ts`.
-        test._id = `${calculateSha1(relativeTitlePath + ' ' + entry.title)}@${entry._requireFile}#run${this._index}-repeat${repeatEachIndex}`;
+        // We rely upon relative paths being unique. See `getClashingTestsPerSuite()` in `runner.ts`.
+        // However, we allow duplicate titles when .only is present, so we additionally distinguish by non-source-mapped call location.
+        const uniqueTestCallId = `${relativeTitlePath} ${entry.title}@${test._jsLocation.file}:${test._jsLocation.line}:${test._jsLocation.column}`;
+        test._id = `${calculateSha1(uniqueTestCallId)}@${entry._requireFile}#run${this._index}-repeat${repeatEachIndex}`;
         test.repeatEachIndex = repeatEachIndex;
         test._projectIndex = this._index;
         to._addTest(test);

--- a/packages/playwright-test/src/test.ts
+++ b/packages/playwright-test/src/test.ts
@@ -130,6 +130,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   repeatEachIndex = 0;
 
   _testType: TestTypeImpl;
+  _jsLocation: Location;
   _id = '';
   _workerHash = '';
   _pool: FixturePool | undefined;
@@ -138,11 +139,12 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   // be re-added each time we retry a test.
   _alreadyInheritedAnnotations: boolean = false;
 
-  constructor(title: string, fn: Function, testType: TestTypeImpl, location: Location) {
+  constructor(title: string, fn: Function, testType: TestTypeImpl, location: Location, jsLocation: Location) {
     super(title);
     this.fn = fn;
     this._testType = testType;
     this.location = location;
+    this._jsLocation = jsLocation;
   }
 
   titlePath(): string[] {
@@ -168,7 +170,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   }
 
   _clone(): TestCase {
-    const test = new TestCase(this.title, this.fn, this._testType, this.location);
+    const test = new TestCase(this.title, this.fn, this._testType, this.location, this._jsLocation);
     test._only = this._only;
     test._requireFile = this._requireFile;
     test.expectedStatus = this.expectedStatus;

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -412,3 +412,18 @@ test('should work with cross-imports - 2', async ({ runInlineTest }) => {
   expect(result.output).toContain('TEST-1');
   expect(result.output).toContain('TEST-2');
 });
+
+test('should not crash with duplicate titles and .only', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'expect-test.spec.ts': `
+      const { test } = pwt;
+      test('non unique title', () => { console.log('do not run me'); });
+      test.skip('non unique title', () => { console.log('do not run me'); });
+      test.only('non unique title', () => { console.log('do run me'); });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(stripAnsi(result.output)).not.toContain('do not run me');
+  expect(stripAnsi(result.output)).toContain('do run me');
+});


### PR DESCRIPTION
Before this change test runner relied upon unique test titles to produce the same id between runner and worker processes.

However, with `.only` present, unique ids might not be enforced universally. To accommodate this case, unique id now also includes non-source-mapped location of the `test()` function call.

Fixes #14034.