### PR TITLE
test: mark driver mode as remote

### DIFF
--- a/packages/playwright-core/src/outofprocess.ts
+++ b/packages/playwright-core/src/outofprocess.ts
@@ -48,6 +48,7 @@ class PlaywrightClient {
     this._driverProcess.on('exit', this._onExit.bind(this));
 
     const connection = new Connection();
+    connection.markAsRemote();
     this._transport = new IpcTransport(this._driverProcess);
     connection.onmessage = message => this._transport.send(JSON.stringify(message));
     this._transport.onmessage = message => connection.dispatch(JSON.parse(message));

--- a/tests/library/defaultbrowsercontext-1.spec.ts
+++ b/tests/library/defaultbrowsercontext-1.spec.ts
@@ -172,7 +172,7 @@ it('should support offline option', async ({ server, launchPersistent }) => {
 });
 
 it('should support acceptDownloads option', async ({ server, launchPersistent, mode }) => {
-  it.skip(mode === 'service', 'download.path() is not avaialble in remote mode');
+  it.skip(mode !== 'default', 'download.path() is not avaialble in remote mode');
 
   const { page } = await launchPersistent();
   server.setRoute('/download', (req, res) => {

--- a/tests/library/download.spec.ts
+++ b/tests/library/download.spec.ts
@@ -21,7 +21,7 @@ import crypto from 'crypto';
 import type { Download } from 'playwright-core';
 
 it.describe('download event', () => {
-  it.skip(({ mode }) => mode === 'service', 'download.path() is not available in remote mode');
+  it.skip(({ mode }) => mode !== 'default', 'download.path() is not available in remote mode');
 
   it.beforeEach(async ({ server }) => {
     server.setRoute('/download', (req, res) => {
@@ -651,7 +651,7 @@ it('should save to user-specified path', async ({ browser, server, mode }, testI
     page.waitForEvent('download'),
     page.click('a')
   ]);
-  if (mode === 'service') {
+  if (mode !== 'default') {
     const error = await download.path().catch(e => e);
     expect(error.message).toContain('Path is not available when connecting remotely. Use saveAs() to save a local copy.');
   }

--- a/tests/library/downloads-path.spec.ts
+++ b/tests/library/downloads-path.spec.ts
@@ -19,7 +19,7 @@ import fs from 'fs';
 import path from 'path';
 
 it.describe('downloads path', () => {
-  it.skip(({ mode }) => mode === 'service', 'download.path() is not available in remote mode');
+  it.skip(({ mode }) => mode !== 'default', 'download.path() is not available in remote mode');
 
   it.beforeEach(async ({ server }) => {
     server.setRoute('/download', (req, res) => {

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -154,7 +154,7 @@ function expectRedFrames(videoFile: string, size: { width: number, height: numbe
 
 it.describe('screencast', () => {
   it.slow();
-  it.skip(({ mode }) => mode === 'service', 'video.path() is not avaialble in remote mode');
+  it.skip(({ mode }) => mode !== 'default', 'video.path() is not avaialble in remote mode');
 
   it('videoSize should require videosPath', async ({ browser }) => {
     const error = await browser.newContext({ videoSize: { width: 100, height: 100 } }).catch(e => e);


### PR DESCRIPTION
Otherwise we are passing buffers as objects, not as base64.