### PR TITLE
feat(ct): typesafe mount props

### DIFF
--- a/packages/playwright-ct-svelte/index.d.ts
+++ b/packages/playwright-ct-svelte/index.d.ts
@@ -35,8 +35,8 @@ export type PlaywrightTestConfig = Omit<BasePlaywrightTestConfig, 'use'> & {
 };
 
 interface ComponentFixtures {
-  mount(component: any, options?: {
-    props?: { [key: string]: any },
+  mount<Props = { [key: string]: any }>(component: any, options?: {
+    props?: Props,
     slots?: { [key: string]: any },
     on?: { [key: string]: Function },
   }): Promise<Locator>;

--- a/packages/playwright-ct-vue/index.d.ts
+++ b/packages/playwright-ct-vue/index.d.ts
@@ -36,8 +36,8 @@ export type PlaywrightTestConfig = Omit<BasePlaywrightTestConfig, 'use'> & {
 
 interface ComponentFixtures {
   mount(component: JSX.Element): Promise<Locator>;
-  mount(component: any, options?: {
-    props?: { [key: string]: any },
+  mount<Props = { [key: string]: any }>(component: any, options?: {
+    props?: Props,
     slots?: { [key: string]: any },
     on?: { [key: string]: Function },
   }): Promise<Locator>;

--- a/packages/playwright-ct-vue2/index.d.ts
+++ b/packages/playwright-ct-vue2/index.d.ts
@@ -36,8 +36,8 @@ export type PlaywrightTestConfig = Omit<BasePlaywrightTestConfig, 'use'> & {
 
 interface ComponentFixtures {
   mount(component: JSX.Element): Promise<Locator>;
-  mount(component: any, options?: {
-    props?: { [key: string]: any },
+  mount<Props = { [key: string]: any }>(component: any, options?: {
+    props?: Props,
     slots?: { [key: string]: any },
     on?: { [key: string]: Function },
   }): Promise<Locator>;


### PR DESCRIPTION
Use case using `"@playwright-testing-library/test": "4.3.0-beta.1",` and `"vue": "^3.2.37"`:

```typescript
// SomeComponent.vue
<script lang="ts" setup>
const props = defineProps<SomeComponentProps>();
</script>
```

```typescript
// SomeComponenProps.ts
export type SomeComponentProps = {
   id: string;
   name: string;
   image: string;
}
```

```typescript
// SomeComponent.test.ts
test('display a image', async ({ mount, queries }) => {
   await mount<SomeComponentProps>(SomeComponent, { 
      props: {
         id: '1337',
         name: 'test',
         image: '/42.jpg',
      }
   });

   await expect(queries.getByAltText(props.name)).toHaveAttribute('src', '/42.jpg');
});
```