### PR TITLE
fix(test runner): handle istty in line reporter

### DIFF
--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -20,6 +20,7 @@ import path from 'path';
 import type { FullConfig, TestCase, Suite, TestResult, TestError, Reporter, FullResult, TestStep, Location } from '../../types/testReporter';
 import type { FullConfigInternal } from '../types';
 import { codeFrameColumns } from '../babelBundle';
+import { getAsBooleanFromENV } from 'playwright-core/lib/utils';
 
 export type TestResultOutput = { chunk: string | Buffer, type: 'stdout' | 'stderr' };
 export const kOutputSymbol = Symbol('output');
@@ -54,10 +55,12 @@ export class BaseReporter implements Reporter  {
   private monotonicStartTime: number = 0;
   private _omitFailures: boolean;
   private readonly _ttyWidthForTest: number;
+  readonly liveTerminal: boolean;
 
   constructor(options: { omitFailures?: boolean } = {}) {
     this._omitFailures = options.omitFailures || false;
     this._ttyWidthForTest = parseInt(process.env.PWTEST_TTY_WIDTH || '', 10);
+    this.liveTerminal = process.stdout.isTTY || getAsBooleanFromENV('PLAYWRIGHT_LIVE_TERMINAL');
   }
 
   onBegin(config: FullConfig, suite: Suite) {

--- a/packages/playwright-test/src/reporters/list.ts
+++ b/packages/playwright-test/src/reporters/list.ts
@@ -28,11 +28,9 @@ class ListReporter extends BaseReporter {
   private _lastRow = 0;
   private _testRows = new Map<TestCase, number>();
   private _needNewLine = false;
-  private readonly _liveTerminal: string | boolean | undefined;
 
   constructor(options: { omitFailures?: boolean } = {}) {
     super(options);
-    this._liveTerminal = process.stdout.isTTY || !!process.env.PWTEST_TTY_WIDTH;
   }
 
   printsToStdio() {
@@ -46,7 +44,7 @@ class ListReporter extends BaseReporter {
   }
 
   onTestBegin(test: TestCase, result: TestResult) {
-    if (this._liveTerminal) {
+    if (this.liveTerminal) {
       if (this._needNewLine) {
         this._needNewLine = false;
         process.stdout.write('\n');
@@ -70,7 +68,7 @@ class ListReporter extends BaseReporter {
   }
 
   onStepBegin(test: TestCase, result: TestResult, step: TestStep) {
-    if (!this._liveTerminal)
+    if (!this.liveTerminal)
       return;
     if (step.category !== 'test.step')
       return;
@@ -78,7 +76,7 @@ class ListReporter extends BaseReporter {
   }
 
   onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
-    if (!this._liveTerminal)
+    if (!this.liveTerminal)
       return;
     if (step.category !== 'test.step')
       return;
@@ -90,7 +88,7 @@ class ListReporter extends BaseReporter {
       return;
     const text = chunk.toString('utf-8');
     this._needNewLine = text[text.length - 1] !== '\n';
-    if (this._liveTerminal) {
+    if (this.liveTerminal) {
       const newLineCount = text.split('\n').length - 1;
       this._lastRow += newLineCount;
     }
@@ -119,7 +117,7 @@ class ListReporter extends BaseReporter {
       text += this._retrySuffix(result) + colors.dim(` (${milliseconds(result.duration)})`);
     }
 
-    if (this._liveTerminal) {
+    if (this.liveTerminal) {
       this._updateTestLine(test, text, prefix);
     } else {
       if (this._needNewLine) {

--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -631,7 +631,7 @@ test('should not hang and report results when worker process suddenly exits duri
       test('failing due to afterall', () => {});
       test.afterAll(() => { process.exit(0); });
     `
-  }, { reporter: 'line' });
+  }, { reporter: 'line' }, { PLAYWRIGHT_LIVE_TERMINAL: '1' });
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -284,6 +284,10 @@ export function stripAnsi(str: string): string {
   return str.replace(asciiRegex, '');
 }
 
+export function trimLineEnds(text: string): string {
+  return text.split('\n').map(line => line.trimEnd()).join('\n');
+}
+
 export function countTimes(s: string, sub: string): number {
   let result = 0;
   for (let index = 0; index !== -1;) {

--- a/tests/playwright-test/reporter-json.spec.ts
+++ b/tests/playwright-test/reporter-json.spec.ts
@@ -230,7 +230,7 @@ test('should add line in addition to file json without CI', async ({ runInlineTe
         expect(1).toBe(1);
       });
     `,
-  }, { reporter: '' }, { PW_TEST_DEBUG_REPORTERS: '1' });
+  }, { reporter: '' }, { PLAYWRIGHT_LIVE_TERMINAL: '1' });
   expect(result.exitCode).toBe(0);
   expect(stripAnsi(result.output)).toContain('[1/1] a.test.js:6:7 › one');
   expect(fs.existsSync(testInfo.outputPath('a.json'))).toBeTruthy();

--- a/tests/playwright-test/reporter-list.spec.ts
+++ b/tests/playwright-test/reporter-list.spec.ts
@@ -66,7 +66,7 @@ test('render steps', async ({ runInlineTest }) => {
         });
       });
     `,
-  }, { reporter: 'list' }, { PW_TEST_DEBUG_REPORTERS: '1', PWTEST_TTY_WIDTH: '80' });
+  }, { reporter: 'list' }, { PW_TEST_DEBUG_REPORTERS: '1', PLAYWRIGHT_LIVE_TERMINAL: '1' });
   const text = stripAnsi(result.output);
   const lines = text.split('\n').filter(l => l.startsWith('0 :'));
   lines.pop(); // Remove last item that contains [v] and time in ms.
@@ -94,7 +94,7 @@ test('render retries', async ({ runInlineTest }) => {
         expect(testInfo.retry).toBe(1);
       });
     `,
-  }, { reporter: 'list', retries: '1' }, { PW_TEST_DEBUG_REPORTERS: '1', PWTEST_TTY_WIDTH: '80' });
+  }, { reporter: 'list', retries: '1' }, { PW_TEST_DEBUG_REPORTERS: '1', PLAYWRIGHT_LIVE_TERMINAL: '1' });
   const text = stripAnsi(result.output);
   const lines = text.split('\n').filter(l => l.startsWith('0 :') || l.startsWith('1 :')).map(l => l.replace(/[\dm]+s/, 'XXms'));
 
@@ -123,7 +123,7 @@ test('should truncate long test names', async ({ runInlineTest }) => {
       test.skip('skipped very long name', async () => {
       });
     `,
-  }, { reporter: 'list', retries: 0 }, { PWTEST_TTY_WIDTH: 50 });
+  }, { reporter: 'list', retries: 0 }, { PLAYWRIGHT_LIVE_TERMINAL: '1', PWTEST_TTY_WIDTH: 50 });
   expect(result.exitCode).toBe(1);
 
   const lines = stripAnsi(result.output).split('\n').slice(3, 11);


### PR DESCRIPTION
When running without tty, line reporter outputs a line for each percent of the tests, thus limiting the output to ~100 lines.

In addition, reporters now support `PLAYWRIGHT_LIVE_TERMINAL` env variable to force tty mode.