### PR TITLE
docs(test-auth-js): added missing static keyword to pages create method

### DIFF
--- a/docs/src/test-auth-js.md
+++ b/docs/src/test-auth-js.md
@@ -418,7 +418,7 @@ class AdminPage {
     this.page = page;
   }
 
-  async create(browser: Browser) {
+  static async create(browser: Browser) {
     const context = await browser.newContext({ storageState: 'adminStorageState.json' });
     const page = await context.newPage();
     return new AdminPage(page);
@@ -439,7 +439,7 @@ class UserPage {
     this.greeting = page.locator('#greeting');
   }
 
-  async create(browser: Browser) {
+  static async create(browser: Browser) {
     const context = await browser.newContext({ storageState: 'userStorageState.json' });
     const page = await context.newPage();
     return new UserPage(page);
@@ -488,7 +488,7 @@ class AdminPage {
     this.page = page;
   }
 
-  async create(browser) {
+  static async create(browser) {
     const context = await browser.newContext({ storageState: 'adminStorageState.json' });
     const page = await context.newPage();
     return new AdminPage(page);
@@ -505,7 +505,7 @@ class UserPage {
     this.greeting = page.locator('#greeting');
   }
 
-  async create(browser) {
+  static async create(browser) {
     const context = await browser.newContext({ storageState: 'userStorageState.json' });
     const page = await context.newPage();
     return new UserPage(page);


### PR DESCRIPTION
`AdminPage.create` and `UserPage.create` used as static methods, but don't have `static` keyword, which might confuse younglings