### PR TITLE
fix(test runner): more friendly test duration

### DIFF
--- a/packages/playwright-test/src/testInfo.ts
+++ b/packages/playwright-test/src/testInfo.ts
@@ -76,7 +76,7 @@ export class TestInfoImpl implements TestInfo {
   }
 
   get timeout(): number {
-    return this._timeoutManager.defaultTimeout();
+    return this._timeoutManager.defaultSlotTimings().timeout;
   }
 
   set timeout(timeout: number) {
@@ -178,7 +178,7 @@ export class TestInfoImpl implements TestInfo {
       this.status = 'timedOut';
       this.errors.push(timeoutError);
     }
-    this.duration = (monotonicTime() - this._startTime) | 0;
+    this.duration = this._timeoutManager.defaultSlotTimings().elapsed | 0;
   }
 
   async _runFn(fn: Function, skips?: 'allowSkips'): Promise<TestError | undefined> {

--- a/packages/playwright-test/src/timeoutManager.ts
+++ b/packages/playwright-test/src/timeoutManager.ts
@@ -60,8 +60,10 @@ export class TimeoutManager {
     this._updateRunnables(this._runnable, fixture);
   }
 
-  defaultTimeout() {
-    return this._defaultSlot.timeout;
+  defaultSlotTimings() {
+    const slot = this._currentSlot();
+    slot.elapsed = this._timeoutRunner.elapsed();
+    return this._defaultSlot;
   }
 
   slow() {


### PR DESCRIPTION
Reported test duration now does not include time spent in `beforeAll`, `afterAll` and fixtures that have a separate timeout.
This is to avoid different reported test execution time, depending on the test execution order.

Fixes #15338.