### PR TITLE
tests(chromium): service worker main request/response should be marked correctly

### DIFF
--- a/tests/library/chromium/chromium.spec.ts
+++ b/tests/library/chromium/chromium.spec.ts
@@ -101,6 +101,8 @@ test('should intercept service worker requests (main and within)', async ({ cont
 
   const [ sw ] = await Promise.all([
     context.waitForEvent('serviceworker'),
+    context.waitForEvent('request', r => r.url().endsWith('sw.js') && !!r.serviceWorker()),
+    context.waitForEvent('response', r => r.url().endsWith('sw.js') && !r.fromServiceWorker()),
     page.goto(server.PREFIX + '/serviceworkers/empty/sw.html'),
   ]);
 


### PR DESCRIPTION
This can be seen in the devtools (navigate to https://meir017.github.io/service-worker-examples/ and open the devtools)
![image](https://user-images.githubusercontent.com/9786571/177925893-01476540-bd87-4972-a5e2-eeceec8f1049.png)

* The main service-worker request should be marked as sent from service-worker
* The response should not be served from a service worker