### PR TITLE
docs: selectOption actionability checks

### DIFF
--- a/docs/src/actionability.md
+++ b/docs/src/actionability.md
@@ -35,7 +35,7 @@ Here is the complete list of actionability checks performed for each action:
 | innerHTML | Yes | - | - | - | - | - |
 | press | Yes | - | - | - | - | - |
 | setInputFiles | Yes | - | - | - | - | - |
-| selectOption | Yes | - | - | - | - | - |
+| selectOption | Yes | Yes | - | - | Yes | - |
 | textContent | Yes | - | - | - | - | - |
 | type | Yes | - | - | - | - | - |
 


### PR DESCRIPTION
Based on anecdotal testing, and the code:

https://github.com/microsoft/playwright/blob/dd0eb5fb1d7438d76034cb7b2034ed761eaa41eb/packages/playwright-core/src/server/dom.ts#L557

it looks like `selectOption` documentation failed to note it waits on
`visible` and `enabled`.

NB: I did **not** audit the other APIs listed in the table. 