### PR TITLE
browser(webkit): fix build on Ubuntu 18.04

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1678
-Changed: yurys@chromium.org Fri 08 Jul 2022 02:52:19 PM PDT
+1679
+Changed: lushnikov@chromium.org Mon Jul 11 15:30:32 MSK 2022

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -2296,7 +2296,7 @@ diff --git a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm b/So
 index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d768ace22 100644
 --- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
 +++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
-@@ -198,6 +198,7 @@ - (void)sendEndIfNeeded
+@@ -198,6 +198,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  - (void)speechRecognizer:(SFSpeechRecognizer *)speechRecognizer availabilityDidChange:(BOOL)available
  {
@@ -2304,7 +2304,7 @@ index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d
      ASSERT(isMainThread());
  
      if (available || !_task)
-@@ -211,6 +212,7 @@ - (void)speechRecognizer:(SFSpeechRecognizer *)speechRecognizer availabilityDidC
+@@ -211,6 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didHypothesizeTranscription:(SFTranscription *)transcription
  {
@@ -2312,7 +2312,7 @@ index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d
      ASSERT(isMainThread());
  
      [self sendSpeechStartIfNeeded];
-@@ -219,6 +221,7 @@ - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didHypothesizeTran
+@@ -219,6 +221,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didFinishRecognition:(SFSpeechRecognitionResult *)recognitionResult
  {
@@ -2320,7 +2320,7 @@ index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d
      ASSERT(isMainThread());
      [self callbackWithTranscriptions:recognitionResult.transcriptions isFinal:YES];
  
-@@ -230,6 +233,7 @@ - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didFinishRecogniti
+@@ -230,6 +233,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  - (void)speechRecognitionTaskWasCancelled:(SFSpeechRecognitionTask *)task
  {
@@ -9150,7 +9150,7 @@ diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/
 index 1dc6df3e1145332a0aeb902c0f5d7d5d727593be..230d268489a52391f7d4f336d22311e35c9f8278 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-@@ -720,7 +720,7 @@ - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didRece
+@@ -720,7 +720,7 @@ void NetworkSessionCocoa::setClientAuditToken(const WebCore::AuthenticationChall
  
      if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
          sessionCocoa->setClientAuditToken(challenge);
@@ -10560,7 +10560,7 @@ index b8bf936e2eb8ca4dc0f445099dfb899395950bdb..30a2af76de0daac450c7afbb8a2dfe81
  #import <WebCore/Credential.h>
  #import <WebCore/RegistrationDatabase.h>
  #import <WebCore/ServiceWorkerClientData.h>
-@@ -234,6 +235,11 @@ - (void)removeDataOfTypes:(NSSet *)dataTypes modifiedSince:(NSDate *)date comple
+@@ -234,6 +235,11 @@ static WallTime toSystemClockTime(NSDate *date)
      });
  }
  
@@ -10739,7 +10739,7 @@ diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm b/
 index 2e235bb880c638a0e74256b6d66cb0244ea0a3f1..3471eebb47e860f7c2071d0e7f2691c9f0a6355d 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
-@@ -257,6 +257,16 @@ - (BOOL)processSwapsOnNavigation
+@@ -257,6 +257,16 @@
      return _processPoolConfiguration->processSwapsOnNavigation();
  }
  
@@ -20988,7 +20988,7 @@ diff --git a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm b/Source/WebKitLegac
 index 294e83317c044f75927ab868cf5b821b4f1fe157..08fcf9bd9d064fa78ac32d9808ffc3bce6c8dbbe 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-@@ -4189,7 +4189,7 @@ - (void)mouseDown:(WebEvent *)event
+@@ -4189,7 +4189,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
      _private->handlingMouseDownEvent = NO;
  }
  
@@ -21001,7 +21001,7 @@ diff --git a/Source/WebKitLegacy/mac/WebView/WebView.mm b/Source/WebKitLegacy/ma
 index f57ff1862f7bc2d2e88710c7b43d62b78b1765a0..fdcf7866546515473fe579333184d9400d1f6bb6 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
-@@ -4038,7 +4038,7 @@ + (void)_doNotStartObservingNetworkReachability
+@@ -4038,7 +4038,7 @@ IGNORE_WARNINGS_END
  }
  #endif // PLATFORM(IOS_FAMILY)
  
@@ -21010,7 +21010,7 @@ index f57ff1862f7bc2d2e88710c7b43d62b78b1765a0..fdcf7866546515473fe579333184d940
  
  - (NSArray *)_touchEventRegions
  {
-@@ -4080,7 +4080,7 @@ - (NSArray *)_touchEventRegions
+@@ -4080,7 +4080,7 @@ IGNORE_WARNINGS_END
      }).autorelease();
  }
  
@@ -23343,7 +23343,7 @@ index a08c829f49b43d494a09c40f71606735c172b6a5..49403c27d67b40e5ae0fb4cf294d835c
      <dependencies>
        <dep package="glib"/>
 diff --git a/Tools/jhbuild/jhbuildrc_common.py b/Tools/jhbuild/jhbuildrc_common.py
-index 814abef097120d8f0b99ce7b05a43dc014597248..d691310642588977ee12f5f74d90735f19725143 100644
+index 814abef097120d8f0b99ce7b05a43dc014597248..8dbf674c859c10be5430892e71ceb502a5c6cc16 100644
 --- a/Tools/jhbuild/jhbuildrc_common.py
 +++ b/Tools/jhbuild/jhbuildrc_common.py
 @@ -19,7 +19,7 @@ import multiprocessing
@@ -23355,7 +23355,7 @@ index 814abef097120d8f0b99ce7b05a43dc014597248..d691310642588977ee12f5f74d90735f
  
  script_dir = None
  
-@@ -35,6 +35,24 @@ def top_level_path(*args):
+@@ -35,6 +35,25 @@ def top_level_path(*args):
      return os.path.join(*((os.path.join(os.path.dirname(__file__), '..', '..'),) + args))
  
  
@@ -23374,13 +23374,14 @@ index 814abef097120d8f0b99ce7b05a43dc014597248..d691310642588977ee12f5f74d90735f
 +
 +def use_openssl_backend():
 +    v = gnutls_version()
-+    return v["major"] <= 3 and v["minor"] <= 6 and v["patch"] < 13
++    # Use Open SSL if gnu TLS version is less then 3.6.13
++    return v["major"] * 100000 + v["minor"] * 1000 + v["patch"] < 3 * 100000 + 6 * 1000 + 13
 +
 +
  def init(jhbuildrc_globals, jhbuild_platform):
  
      __tools_directory = os.path.join(os.path.dirname(__file__), "../", jhbuild_platform)
-@@ -100,3 +118,7 @@ def init(jhbuildrc_globals, jhbuild_platform):
+@@ -100,3 +119,7 @@ def init(jhbuildrc_globals, jhbuild_platform):
          jhbuild_enable_thunder = os.environ['JHBUILD_ENABLE_THUNDER'].lower()
          if jhbuild_enable_thunder == 'yes' or jhbuild_enable_thunder == '1' or jhbuild_enable_thunder == 'true':
              jhbuildrc_globals['conditions'].add('Thunder')


### PR DESCRIPTION
Turns out default GnuTLS on Ubuntu 18.04 is 3.5.18, so we should
use OpenSSL.

The glib-networking backend selector condition is thus incorrectly
compares version triplets.

Pretty diff: https://github.com/aslushnikov/WebKit/commit/332032ddc10a32b9c9ffb24b68904cddee4aff46