### PR TITLE
fix(matchers): repeating values lead to no error

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -1122,18 +1122,14 @@ export class InjectedScript {
         return { received, matches: false };
 
       // Each matcher should get a "received" that matches it, in order.
-      let i = 0;
       const matchers = options.expectedText.map(e => new ExpectedTextMatcher(e));
-      let allMatchesFound = true;
-      for (const matcher of matchers) {
-        while (i < received.length && !matcher.matches(received[i]))
-          i++;
-        if (i >= received.length) {
-          allMatchesFound = false;
-          break;
-        }
+      let mIndex = 0, rIndex = 0;
+      while (mIndex < matchers.length && rIndex < received.length) {
+        if (matchers[mIndex].matches(received[rIndex]))
+          ++mIndex;
+        ++rIndex;
       }
-      return { received, matches: allMatchesFound };
+      return { received, matches: mIndex === matchers.length };
     }
     throw this.createStacklessError('Unknown expect matcher: ' + expression);
   }

--- a/tests/playwright-test/playwright.expect.text.spec.ts
+++ b/tests/playwright-test/playwright.expect.text.spec.ts
@@ -226,7 +226,7 @@ test('should support toHaveText w/ array', async ({ runInlineTest }) => {
       test('fail on repeating array matchers', async ({ page }) => {
         await page.setContent('<div>KekFoo</div>');
         const locator = page.locator('div');
-        await expect(locator).toContainText(['KekFoo', 'KekFoo', 'KekFoo']);
+        await expect(locator).toContainText(['KekFoo', 'KekFoo', 'KekFoo'], { timeout: 1000 });
       });
       `,
   }, { workers: 1 });

--- a/tests/playwright-test/playwright.expect.text.spec.ts
+++ b/tests/playwright-test/playwright.expect.text.spec.ts
@@ -222,6 +222,12 @@ test('should support toHaveText w/ array', async ({ runInlineTest }) => {
         const locator = page.locator('div');
         await expect(locator).toHaveText(['Text 1', /Text \\d/, 'Extra'], { timeout: 1000 });
       });
+
+      test('fail on repeating array matchers', async ({ page }) => {
+        await page.setContent('<div>KekFoo</div>');
+        const locator = page.locator('div');
+        await expect(locator).toContainText(['KekFoo', 'KekFoo', 'KekFoo']);
+      });
       `,
   }, { workers: 1 });
   const output = stripAnsi(result.output);
@@ -231,7 +237,7 @@ test('should support toHaveText w/ array', async ({ runInlineTest }) => {
   expect(output).toContain('waiting for selector "div"');
   expect(output).toContain('selector resolved to 2 elements');
   expect(result.passed).toBe(6);
-  expect(result.failed).toBe(2);
+  expect(result.failed).toBe(3);
   expect(result.exitCode).toBe(1);
 });
 


### PR DESCRIPTION
All the other matchers kept re-trying on the same `i`. Thats why it was possible to have repeating passing matchers.