### PR TITLE
devops: do not dedupe webkit archives

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1680
-Changed: lushnikov@chromium.org Tue Jul 12 00:36:09 MSK 2022
+1681
+Changed: lushnikov@chromium.org Tue Jul 12 14:07:22 MSK 2022

--- a/browser_patches/webkit/build.sh
+++ b/browser_patches/webkit/build.sh
@@ -66,13 +66,12 @@ build_wpe() {
 }
 
 ensure_linux_deps() {
-  SUDO="" ; [ $UID -ne 0 ] && SUDO="sudo"
-
-  # These two packages are needed to de-duplicate files on the GTK+WPE bundle and reduce its size.
-  DEBIAN_FRONTEND=noninteractive ${SUDO} apt-get install -y symlinks rdfind
 
   if [[ -n "${IS_UNIVERSAL_BUILD}" ]]; then
-    DEBIAN_FRONTEND=noninteractive ${SUDO} apt-get install -y flatpak
+    SUDO="" ; [ $UID -ne 0 ] && SUDO="sudo"
+    # - flatpak drives the build
+    # - symlinks and rdfind are needed to de-duplicate files on the GTK+WPE bundle to reduce its size.
+    DEBIAN_FRONTEND=noninteractive ${SUDO} apt-get install -y flatpak symlinks rdfind
   fi
 
   yes | DEBIAN_FRONTEND=noninteractive ./Tools/gtk/install-dependencies


### PR DESCRIPTION
The 2e331715ff7b304529a7ce65a98184681eceaab9 introduced
universal webkit build and tried re-using archive deduping technique
across all our regular JHBuild-based builds.

However, this turns out to be too aggressive and doesn't work. At least
on Ubuntu 18.04:
- `minibrowser-gtk/minibrowser` is identical to
  `minibrowser-wpe/minibrowser`
- WPE gets symlinked into GTK
- Thus we now always start headed
