### PR TITLE
feat(list reporter): show testing progress

### DIFF
--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -130,6 +130,13 @@ export class BaseReporter implements Reporter  {
     return fitToWidth(line, ttyWidth, prefix);
   }
 
+  protected fillsEntireScreen(line: string) {
+    const ttyWidth = this._ttyWidthForTest || process.stdout.columns || 0;
+    if (!ttyWidth)
+      return false;
+    return stripAnsiEscapes(line).length >= ttyWidth;
+  }
+
   protected generateStartingMessage() {
     const jobs = Math.min(this.config.workers, this.config._testGroupsCount);
     const shardDetails = this.config.shard ? `, shard ${this.config.shard.current} of ${this.config.shard.total}` : '';
@@ -145,11 +152,11 @@ export class BaseReporter implements Reporter  {
     const message = [
       `[${count}/${this.stats.total}${retriesSuffix}]`,
       `${(this.stats.passed ? colors.green : colors.gray)('Passed: ' + this.stats.passed)}`,
-      `${(this.stats.flaky ? colors.red : colors.gray)('Flaky: ' + this.stats.flaky)}`,
+      `${(this.stats.flaky ? colors.yellow : colors.gray)('Flaky: ' + this.stats.flaky)}`,
       `${(this.stats.failed ? colors.red : colors.gray)('Failed: ' + this.stats.failed)}`,
       `${(this.stats.skipped ? colors.yellow : colors.gray)('Skipped: ' + this.stats.skipped)}`,
       colors.gray(process.env.PW_TEST_DEBUG_REPORTERS ? `(XXms)` : `(${milliseconds((monotonicTime() - this.monotonicStartTime) | 0)})`),
-    ].join(' ');
+    ].join('  ');
     return { percent, message };
   }
 

--- a/packages/playwright-test/src/reporters/list.ts
+++ b/packages/playwright-test/src/reporters/list.ts
@@ -21,13 +21,17 @@ import type { FullConfig, FullResult, Suite, TestCase, TestResult, TestStep } fr
 
 // Allow it in the Visual Studio Code Terminal and the new Windows Terminal
 const DOES_NOT_SUPPORT_UTF8_IN_TERMINAL = process.platform === 'win32' && process.env.TERM_PROGRAM !== 'vscode' && !process.env.WT_SESSION;
-const POSITIVE_STATUS_MARK = DOES_NOT_SUPPORT_UTF8_IN_TERMINAL ? 'ok' : '✓';
-const NEGATIVE_STATUS_MARK = DOES_NOT_SUPPORT_UTF8_IN_TERMINAL ? 'x' : '✘';
+const USE_SIMPLE_MARKS = process.env.PW_TEST_DEBUG_REPORTERS || DOES_NOT_SUPPORT_UTF8_IN_TERMINAL;
+const POSITIVE_STATUS_MARK = USE_SIMPLE_MARKS ? 'ok' : '✓';
+const NEGATIVE_STATUS_MARK = USE_SIMPLE_MARKS ? 'x' : '✘';
+
+const lineUp = (count: number) => process.env.PW_TEST_DEBUG_REPORTERS ? `<lineup${count}>` : `\u001B[${count}A`;
+const lineDown = (count: number) => process.env.PW_TEST_DEBUG_REPORTERS ? `<linedown${count}>` : `\u001B[${count}E`;
+const erase = () => process.env.PW_TEST_DEBUG_REPORTERS ? '<erase>' : '\u001B[2K\u001B[0G';
 
 class ListReporter extends BaseReporter {
   private _lastRow = 0;
   private _testRows = new Map<TestCase, number>();
-  private _needNewLine = false;
 
   constructor(options: { omitFailures?: boolean } = {}) {
     super(options);
@@ -46,16 +50,16 @@ class ListReporter extends BaseReporter {
   override onTestBegin(test: TestCase, result: TestResult) {
     super.onTestBegin(test, result);
     if (this.liveTerminal) {
-      if (this._needNewLine) {
-        this._needNewLine = false;
-        process.stdout.write('\n');
-        this._lastRow++;
-      }
+      this._eraseStats();
       const prefix = '     ';
       const line = colors.gray(formatTestTitle(this.config, test)) + this._retrySuffix(result);
-      process.stdout.write(prefix + this.fitToScreen(line, prefix) + '\n');
+      const formatted = prefix + this.fitToScreen(line, prefix);
+      process.stdout.write(formatted);
+      if (!this.fillsEntireScreen(formatted) || process.env.PW_TEST_DEBUG_REPORTERS)
+        process.stdout.write('\n');
+      this._testRows.set(test, this._lastRow++);
+      this._writeStats();
     }
-    this._testRows.set(test, this._lastRow++);
   }
 
   override onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
@@ -84,16 +88,36 @@ class ListReporter extends BaseReporter {
     this._updateTestLine(test, colors.gray(formatTestTitle(this.config, test, step.parent)) + this._retrySuffix(result), '     ');
   }
 
+  private _eraseStats() {
+    if (process.env.PW_TEST_DEBUG_REPORTERS)
+      process.stdout.write('<erase stats>\n');
+    else
+      process.stdout.write(lineUp(1) + erase());
+  }
+
+  private _writeStats() {
+    const stats = this.fitToScreen(this.generateStatsMessage('completed', false).message);
+    if (process.env.PW_TEST_DEBUG_REPORTERS)
+      process.stdout.write(stats + '\n');
+    else
+      process.stdout.write(erase() + stats + '\n');
+  }
+
   private _dumpToStdio(test: TestCase | undefined, chunk: string | Buffer, stream: NodeJS.WriteStream) {
     if (this.config.quiet)
       return;
     const text = chunk.toString('utf-8');
-    this._needNewLine = text[text.length - 1] !== '\n';
+    const addNewLine = text[chunk.length - 1] !== '\n';
     if (this.liveTerminal) {
+      this._eraseStats();
       const newLineCount = text.split('\n').length - 1;
-      this._lastRow += newLineCount;
+      this._lastRow += newLineCount + (addNewLine ? 1 : 0);
     }
     stream.write(chunk);
+    if (addNewLine)
+      stream.write('\n');
+    if (this.liveTerminal)
+      this._writeStats();
   }
 
   override onTestEnd(test: TestCase, result: TestResult) {
@@ -115,54 +139,45 @@ class ListReporter extends BaseReporter {
         prefix = colors.red(statusMark);
         text = colors.red(title);
       }
-      text += this._retrySuffix(result) + colors.dim(` (${milliseconds(result.duration)})`);
+      const ms = process.env.PW_TEST_DEBUG_REPORTERS ? 'XXms' : milliseconds(result.duration);
+      text += this._retrySuffix(result) + colors.dim(` (${ms})`);
     }
 
     if (this.liveTerminal) {
       this._updateTestLine(test, text, prefix);
     } else {
-      if (this._needNewLine) {
-        this._needNewLine = false;
-        process.stdout.write('\n');
-      }
       process.stdout.write(prefix + text);
       process.stdout.write('\n');
     }
   }
 
   private _updateTestLine(test: TestCase, line: string, prefix: string) {
-    if (process.env.PW_TEST_DEBUG_REPORTERS)
-      this._updateTestLineForTest(test, line, prefix);
-    else
-      this._updateTestLineForTTY(test, line, prefix);
-  }
-
-  private _updateTestLineForTTY(test: TestCase, line: string, prefix: string) {
     const testRow = this._testRows.get(test)!;
-    // Go up if needed
-    if (testRow !== this._lastRow)
-      process.stdout.write(`\u001B[${this._lastRow - testRow}A`);
-    // Erase line, go to the start
-    process.stdout.write('\u001B[2K\u001B[0G');
-    process.stdout.write(prefix + this.fitToScreen(line, prefix));
-    // Go down if needed.
-    if (testRow !== this._lastRow)
-      process.stdout.write(`\u001B[${this._lastRow - testRow}E`);
-    if (process.env.PWTEST_TTY_WIDTH)
-      process.stdout.write('\n');  // For testing.
+    const formatted = prefix + this.fitToScreen(line, prefix);
+    this._eraseStats();
+    if (process.env.PW_TEST_DEBUG_REPORTERS) {
+      process.stdout.write(testRow + ' : ' + formatted + '\n');
+    } else {
+      // Go up to the test line and erase it.
+      process.stdout.write(lineUp(this._lastRow - testRow) + erase());
+      // Write the test line.
+      process.stdout.write(formatted);
+      if (this.fillsEntireScreen(formatted))
+        process.stdout.write(lineUp(1));
+      // Go down to the stats line.
+      process.stdout.write(lineDown(this._lastRow - testRow));
+    }
+    this._writeStats();
   }
 
   private _retrySuffix(result: TestResult) {
-    return (result.retry ? colors.yellow(` (retry #${result.retry})`) : '');
-  }
-
-  private _updateTestLineForTest(test: TestCase, line: string, prefix: string) {
-    const testRow = this._testRows.get(test)!;
-    process.stdout.write(testRow + ' : ' + prefix + line + '\n');
+    return result.retry ? colors.yellow(` (retry #${result.retry})`) : '';
   }
 
   override async onEnd(result: FullResult) {
     await super.onEnd(result);
+    if (this.liveTerminal)
+      this._eraseStats();
     process.stdout.write('\n');
     this.epilogue(true);
   }

--- a/tests/playwright-test/reporter-line.spec.ts
+++ b/tests/playwright-test/reporter-line.spec.ts
@@ -38,11 +38,11 @@ test('should work with tty', async ({ runInlineTest }, testInfo) => {
   });
   expect(result.exitCode).toBe(1);
   expect(trimLineEnds(result.output)).toContain(trimLineEnds(`<lineup><erase><lineup><erase>a.test.js:6:12 › skipped test
-[1/4] Passed: 0 Flaky: 0 Failed: 0 Skipped: 0 (XXms)
+[1/4]  Passed: 0  Flaky: 0  Failed: 0  Skipped: 0  (XXms)
 <lineup><erase><lineup><erase>a.test.js:8:7 › flaky test
-[2/4] Passed: 0 Flaky: 0 Failed: 0 Skipped: 1 (XXms)
+[2/4]  Passed: 0  Flaky: 0  Failed: 0  Skipped: 1  (XXms)
 <lineup><erase><lineup><erase>a.test.js:8:7 › flaky test (retry #1)
-[3/4] Passed: 0 Flaky: 0 Failed: 0 Skipped: 1 (XXms)
+[3/4]  Passed: 0  Flaky: 0  Failed: 0  Skipped: 1  (XXms)
 <lineup><erase><lineup><erase>  1) a.test.js:8:7 › flaky test ====================================================================
 
     Error: expect(received).toBe(expected) // Object.is equality
@@ -61,13 +61,13 @@ test('should work with tty', async ({ runInlineTest }, testInfo) => {
         at ${testInfo.outputPath('a.test.js')}:9:32
 
 
-[3/4] Passed: 0 Flaky: 1 Failed: 0 Skipped: 1 (XXms)
+[3/4]  Passed: 0  Flaky: 1  Failed: 0  Skipped: 1  (XXms)
 <lineup><erase><lineup><erase>a.test.js:11:7 › passing test
-[4/4] Passed: 0 Flaky: 1 Failed: 0 Skipped: 1 (XXms)
+[4/4]  Passed: 0  Flaky: 1  Failed: 0  Skipped: 1  (XXms)
 <lineup><erase><lineup><erase>a.test.js:13:7 › failing test
-[5/4+retries] Passed: 1 Flaky: 1 Failed: 0 Skipped: 1 (XXms)
+[5/4+retries]  Passed: 1  Flaky: 1  Failed: 0  Skipped: 1  (XXms)
 <lineup><erase><lineup><erase>a.test.js:13:7 › failing test (retry #1)
-[6/4+retries] Passed: 1 Flaky: 1 Failed: 0 Skipped: 1 (XXms)
+[6/4+retries]  Passed: 1  Flaky: 1  Failed: 0  Skipped: 1  (XXms)
 <lineup><erase><lineup><erase>  2) a.test.js:13:7 › failing test =================================================================
 
     Error: expect(received).toBe(expected) // Object.is equality
@@ -101,7 +101,7 @@ test('should work with tty', async ({ runInlineTest }, testInfo) => {
         at ${testInfo.outputPath('a.test.js')}:14:19
 
 
-[6/4+retries] Passed: 1 Flaky: 1 Failed: 1 Skipped: 1 (XXms)
+[6/4+retries]  Passed: 1  Flaky: 1  Failed: 1  Skipped: 1  (XXms)
 <lineup><erase><lineup><erase>
   1 failed
     a.test.js:13:7 › failing test ==================================================================
@@ -132,9 +132,9 @@ test('should work with non-tty', async ({ runInlineTest }, testInfo) => {
   });
   expect(result.exitCode).toBe(1);
   expect(trimLineEnds(result.output)).toContain(trimLineEnds(`Running 4 tests using 1 worker
-[1/4] Passed: 0 Flaky: 0 Failed: 0 Skipped: 0 (XXms)
-[2/4] Passed: 0 Flaky: 0 Failed: 0 Skipped: 1 (XXms)
-[3/4] Passed: 0 Flaky: 0 Failed: 0 Skipped: 1 (XXms)
+[1/4]  Passed: 0  Flaky: 0  Failed: 0  Skipped: 0  (XXms)
+[2/4]  Passed: 0  Flaky: 0  Failed: 0  Skipped: 1  (XXms)
+[3/4]  Passed: 0  Flaky: 0  Failed: 0  Skipped: 1  (XXms)
   1) a.test.js:8:7 › flaky test ====================================================================
 
     Error: expect(received).toBe(expected) // Object.is equality
@@ -153,7 +153,7 @@ test('should work with non-tty', async ({ runInlineTest }, testInfo) => {
         at ${testInfo.outputPath('a.test.js')}:9:32
 
 
-[4/4] Passed: 0 Flaky: 1 Failed: 0 Skipped: 1 (XXms)
+[4/4]  Passed: 0  Flaky: 1  Failed: 0  Skipped: 1  (XXms)
   2) a.test.js:13:7 › failing test =================================================================
 
     Error: expect(received).toBe(expected) // Object.is equality
@@ -187,7 +187,7 @@ test('should work with non-tty', async ({ runInlineTest }, testInfo) => {
         at ${testInfo.outputPath('a.test.js')}:14:19
 
 
-[6/4+retries] Passed: 1 Flaky: 1 Failed: 1 Skipped: 1 (XXms)
+[6/4+retries]  Passed: 1  Flaky: 1  Failed: 1  Skipped: 1  (XXms)
 
   1 failed
     a.test.js:13:7 › failing test ==================================================================
@@ -210,10 +210,10 @@ test('should spare status updates in non-tty mode', async ({ runInlineTest }) =>
     PW_TEST_DEBUG_REPORTERS: '1',
   });
   expect(result.exitCode).toBe(0);
-  const lines = [`Running 300 tests using 1 worker`, `[1/300] Passed: 0 Flaky: 0 Failed: 0 Skipped: 0 (XXms)`];
+  const lines = [`Running 300 tests using 1 worker`, `[1/300]  Passed: 0  Flaky: 0  Failed: 0  Skipped: 0  (XXms)`];
   for (let i = 0; i < 99; i++)
-    lines.push(`[${3 * i + 2}/300] Passed: ${3 * i + 1} Flaky: 0 Failed: 0 Skipped: 0 (XXms)`);
-  lines.push('[300/300] Passed: 300 Flaky: 0 Failed: 0 Skipped: 0 (XXms)');
+    lines.push(`[${3 * i + 2}/300]  Passed: ${3 * i + 1}  Flaky: 0  Failed: 0  Skipped: 0  (XXms)`);
+  lines.push('[300/300]  Passed: 300  Flaky: 0  Failed: 0  Skipped: 0  (XXms)');
   lines.push('');
   lines.push('  300 passed');
   expect(trimLineEnds(result.output)).toContain(lines.join('\n'));
@@ -235,14 +235,14 @@ test('should print output', async ({ runInlineTest }) => {
   }, { reporter: 'line' }, { PW_TEST_DEBUG_REPORTERS: '1' });
   expect(result.exitCode).toBe(0);
   expect(stripAnsi(result.output)).toContain([
-    '[1/2] Passed: 0 Flaky: 0 Failed: 0 Skipped: 0 (XXms)',
+    '[1/2]  Passed: 0  Flaky: 0  Failed: 0  Skipped: 0  (XXms)',
     'a.spec.ts:6:7 › foobar',
     'one',
     'two',
     'full-line',
-    '[2/2] Passed: 1 Flaky: 0 Failed: 0 Skipped: 0 (XXms)',
+    '[2/2]  Passed: 1  Flaky: 0  Failed: 0  Skipped: 0  (XXms)',
     'a.spec.ts:11:7 › one more',
     'yay',
-    '[2/2] Passed: 2 Flaky: 0 Failed: 0 Skipped: 0 (XXms)',
+    '[2/2]  Passed: 2  Flaky: 0  Failed: 0  Skipped: 0  (XXms)',
   ].join('\n'));
 });


### PR DESCRIPTION
List reporter now shows stats at the end:

```
Running 93 tests using 3 workers
  ✓  example.spec.ts:8:3 › test
     example.spec.ts:8:3 › test 3 › step #2
  -  example.spec.ts:8:3 › test 2
     example.spec.ts:8:3 › test 4 › step #2
     example.spec.ts:8:3 › test 5 › step #1
[2/93]  Passed: 1  Flaky: 0  Failed: 0  Skipped: 1  (2s)
```