### PR TITLE
feat(ct): export component fixture types to enable re-export

### DIFF
--- a/packages/playwright-ct-react/index.d.ts
+++ b/packages/playwright-ct-react/index.d.ts
@@ -34,7 +34,7 @@ export type PlaywrightTestConfig = Omit<BasePlaywrightTestConfig, 'use'> & {
   }
 };
 
-interface ComponentFixtures {
+export interface ComponentFixtures {
   mount(component: JSX.Element, options?: { hooksConfig?: any }): Promise<Locator>;
 }
 

--- a/packages/playwright-ct-svelte/index.d.ts
+++ b/packages/playwright-ct-svelte/index.d.ts
@@ -34,7 +34,7 @@ export type PlaywrightTestConfig = Omit<BasePlaywrightTestConfig, 'use'> & {
   }
 };
 
-interface ComponentFixtures {
+export interface ComponentFixtures {
   mount<Props = { [key: string]: any }>(component: any, options?: {
     props?: Props,
     slots?: { [key: string]: any },

--- a/packages/playwright-ct-vue/index.d.ts
+++ b/packages/playwright-ct-vue/index.d.ts
@@ -34,7 +34,7 @@ export type PlaywrightTestConfig = Omit<BasePlaywrightTestConfig, 'use'> & {
   }
 };
 
-interface ComponentFixtures {
+export interface ComponentFixtures {
   mount(component: JSX.Element): Promise<Locator>;
   mount<Props = { [key: string]: any }>(component: any, options?: {
     props?: Props,

--- a/packages/playwright-ct-vue2/index.d.ts
+++ b/packages/playwright-ct-vue2/index.d.ts
@@ -34,7 +34,7 @@ export type PlaywrightTestConfig = Omit<BasePlaywrightTestConfig, 'use'> & {
   }
 };
 
-interface ComponentFixtures {
+export interface ComponentFixtures {
   mount(component: JSX.Element): Promise<Locator>;
   mount<Props = { [key: string]: any }>(component: any, options?: {
     props?: Props,


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/15352