### PR TITLE
docs: fix typo

### DIFF
--- a/docs/src/api/class-apirequestcontext.md
+++ b/docs/src/api/class-apirequestcontext.md
@@ -16,7 +16,7 @@ values from the browser context. If the API response contains `Set-Cookie` heade
 [BrowserContext] cookies and requests made from the page will pick them up. This means that if you log in using
 this API, your e2e test will be logged in and vice versa.
 
-If you want API requests to not interfere with the browser cookies you shoud create a new [APIRequestContext] by
+If you want API requests to not interfere with the browser cookies you should create a new [APIRequestContext] by
 calling [`method: APIRequest.newContext`]. Such `APIRequestContext` object will have its own isolated cookie
 storage.
 

--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -169,7 +169,7 @@ Returns the newly created browser session.
 Creates a new browser context. It won't share cookies/cache with other browser contexts.
 
 :::note
-If directly using this method to create [BrowserContext]s, it is best practice to explicilty close the returned context via [`method: BrowserContext.close`] when your code is done with the [BrowserContext],
+If directly using this method to create [BrowserContext]s, it is best practice to explicitly close the returned context via [`method: BrowserContext.close`] when your code is done with the [BrowserContext],
 and before calling [`method: Browser.close`]. This will ensure the `context` is closed gracefully and any artifacts—like HARs and videos—are fully flushed and saved.
 :::
 

--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -196,7 +196,7 @@ BrowserContext context = browser.newContext();
 Page page = context.newPage();
 page.navigate('https://example.com');
 
-// Gracefull close up everything
+// Gracefully close up everything
 context.close();
 browser.close();
 ```


### PR DESCRIPTION
1. Fixed "shoud" to "should".
2. Fixed "explicilty" to "explicitly".
3. Fixed "Gracefull" to "Gracefully".