### PR TITLE
feat(chromium-tip-of-tree): roll to r1025

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -15,9 +15,9 @@
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1024",
+      "revision": "1025",
       "installByDefault": false,
-      "browserVersion": "105.0.5175.0"
+      "browserVersion": "105.0.5179.0"
     },
     {
       "name": "firefox",


### PR DESCRIPTION
Chromium ToT is failing with the latest roll.
Test: npm run ctest -- --reporter=list page/elementhandle-scroll-into-view.spec.ts:63:1
Range: https://chromium.googlesource.com/chromium/src/+/7df34f9d82533b797c9156e746e1a6b6d871ccd0
I guess its that: https://chromium.googlesource.com/chromium/src/+/7df34f9d82533b797c9156e746e1a6b6d871ccd0