### PR TITLE
cherry-pick(#15675): fix: add missing gstreamer dependencies for wk on debian 11

### DIFF
--- a/packages/playwright-core/src/server/registry/nativeDeps.ts
+++ b/packages/playwright-core/src/server/registry/nativeDeps.ts
@@ -717,6 +717,10 @@ export const deps: any = {
       'libxtst6'
     ],
     webkit: [
+      'gstreamer1.0-libav',
+      'gstreamer1.0-plugins-bad',
+      'gstreamer1.0-plugins-base',
+      'gstreamer1.0-plugins-good',
       'libatk-bridge2.0-0',
       'libatk1.0-0',
       'libcairo2',


### PR DESCRIPTION
SHA: 173ea04b0279ab1da9b72b1d61d33e278e704fde
