### PR TITLE
feat(expect): add 'subset' option for toHaveText and toContainText

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -192,6 +192,9 @@ Expected substring or RegExp or a list of those.
 
 Whether to perform case-insensitive match. [`option: ignoreCase`] option takes precedence over the corresponding regular expression flag if specified.
 
+### option: LocatorAssertions.NotToContainText.subset = %%-assertions-subset-%%
+* since: v1.24
+
 ### option: LocatorAssertions.NotToContainText.useInnerText
 * since: v1.18
 - `useInnerText` <[boolean]>
@@ -340,6 +343,9 @@ Expected substring or RegExp or a list of those.
 - `ignoreCase` <[boolean]>
 
 Whether to perform case-insensitive match. [`option: ignoreCase`] option takes precedence over the corresponding regular expression flag if specified.
+
+### option: LocatorAssertions.NotToHaveText.subset = %%-assertions-subset-%%
+* since: v1.24
 
 ### option: LocatorAssertions.NotToHaveText.useInnerText
 * since: v1.18
@@ -813,6 +819,9 @@ Expected substring or RegExp or a list of those.
 - `ignoreCase` <[boolean]>
 
 Whether to perform case-insensitive match. [`option: ignoreCase`] option takes precedence over the corresponding regular expression flag if specified.
+
+### option: LocatorAssertions.toContainText.subset = %%-assertions-subset-%%
+* since: v1.24
 
 ### option: LocatorAssertions.toContainText.useInnerText
 * since: v1.18
@@ -1316,6 +1325,40 @@ var locator = Page.Locator("list > .component");
 await Expect(locator).toHaveTextAsync(new string[]{ "Text 1", "Text 2", "Text 3" });
 ```
 
+You can also check just a subset of the elements matching the [Locator]. For example, in the list of ten items from `Item 1` to `Item 10`, only check the text of `Item 2`, `Item 4` and `Item 5`:
+
+```js
+const locator = page.locator('list > .component');
+await expect(locator).toHaveText(['Item 2', 'Item 4', 'Item 5'], { subset: true });
+```
+
+```java
+assertThat(page.locator("list > .component")).hasText(
+    new String[] {"Item 2", "Item 4", "Item 5"},
+    new LocatorAssertions.HasTextOptions().setSubset(true));
+```
+
+```python async
+from playwright.async_api import expect
+
+locator = page.locator("list > .component")
+await expect(locator).to_have_text(["Item 2", "Item 4", "Item 5"], subset=True)
+```
+
+```python sync
+from playwright.sync_api import expect
+
+locator = page.locator("list > .component")
+expect(locator).to_have_text(["Item 2", "Item 4", "Item 5"], subset=True)
+```
+
+```csharp
+var locator = Page.Locator("list > .component");
+await Expect(locator).toHaveTextAsync(
+    new string[]{ "Item 2", "Item 4", "Item 5" },
+    new LocatorAssertionsToHaveTextOptions() { Subset = true });
+```
+
 ### param: LocatorAssertions.toHaveText.expected
 * since: v1.18
 * langs: python, js
@@ -1335,6 +1378,9 @@ Expected substring or RegExp or a list of those.
 - `ignoreCase` <[boolean]>
 
 Whether to perform case-insensitive match. [`option: ignoreCase`] option takes precedence over the corresponding regular expression flag if specified.
+
+### option: LocatorAssertions.toHaveText.subset = %%-assertions-subset-%%
+* since: v1.24
 
 ### option: LocatorAssertions.toHaveText.useInnerText
 * since: v1.18

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -792,6 +792,11 @@ An acceptable ratio of pixels that are different to the total amount of pixels, 
 
 An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the same pixel in compared images, between zero (strict) and one (lax), default is configurable with `TestConfig.expect`. Defaults to `0.2`.
 
+## assertions-subset
+- `subset` <[boolean]>
+
+Only applies when [`param: expected`] is a list. When set to `false`, the list of elements found by the locator must contain the same number of items as [`param: expected`]. When set to `true`, the list of elements may be larger, but it must contain the items matching [`param: expected`] in the same order as listed. Defaults to `true`.
+
 ## shared-context-params-list-v1.8
 - %%-context-option-acceptdownloads-%%
 - %%-context-option-ignorehttpserrors-%%

--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -238,7 +238,7 @@ test.beforeEach(async ({ settingsPage }) => {
 
 test('basic test', async ({ todoPage, page }) => {
   await todoPage.addToDo('something nice');
-  await expect(page.locator('.todo-item')).toContainText(['something nice']);
+  await expect(page.locator('.todo-item')).toHaveText(['something nice']);
 });
 ```
 
@@ -251,7 +251,7 @@ test.beforeEach(async ({ settingsPage }) => {
 
 test('basic test', async ({ todoPage, page }) => {
   await todoPage.addToDo('something nice');
-  await expect(page.locator('.todo-item')).toContainText(['something nice']);
+  await expect(page.locator('.todo-item')).toHaveText(['something nice']);
 });
 ```
 

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -2674,6 +2674,7 @@ export type FrameExpectParams = {
   expectedNumber?: number,
   expectedValue?: SerializedArgument,
   useInnerText?: boolean,
+  subset?: boolean,
   isNot: boolean,
   timeout?: number,
 };
@@ -2683,6 +2684,7 @@ export type FrameExpectOptions = {
   expectedNumber?: number,
   expectedValue?: SerializedArgument,
   useInnerText?: boolean,
+  subset?: boolean,
   timeout?: number,
 };
 export type FrameExpectResult = {

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -1979,6 +1979,7 @@ Frame:
         expectedNumber: number?
         expectedValue: SerializedArgument?
         useInnerText: boolean?
+        subset: boolean?
         isNot: boolean
         timeout: number?
       returns:

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1489,6 +1489,7 @@ scheme.FrameExpectParams = tObject({
   expectedNumber: tOptional(tNumber),
   expectedValue: tOptional(tType('SerializedArgument')),
   useInnerText: tOptional(tBoolean),
+  subset: tOptional(tBoolean),
   isNot: tBoolean,
   timeout: tOptional(tNumber),
 });

--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -1117,7 +1117,7 @@ export class InjectedScript {
 
     if (received && options.expectedText) {
       // "To match an array" is "to contain an array" + "equal length"
-      const lengthShouldMatch = expression !== 'to.contain.text.array';
+      const lengthShouldMatch = !options.subset;
       const matchesLength = received.length === options.expectedText.length || !lengthShouldMatch;
       if (!matchesLength)
         return { received, matches: false };

--- a/packages/playwright-test/src/matchers/matchers.ts
+++ b/packages/playwright-test/src/matchers/matchers.ts
@@ -117,17 +117,17 @@ export function toContainText(
   this: ReturnType<Expect['getState']>,
   locator: LocatorEx,
   expected: string | RegExp | (string | RegExp)[],
-  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean } = {},
+  options: { timeout?: number, useInnerText?: boolean, subset?: boolean, ignoreCase?: boolean } = {},
 ) {
   if (Array.isArray(expected)) {
     return toEqual.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout, customStackTrace) => {
       const expectedText = toExpectedTextValues(expected, { matchSubstring: true, normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect(customStackTrace, 'to.contain.text.array', { expectedText, isNot, useInnerText: options.useInnerText, timeout });
+      return await locator._expect(customStackTrace, 'to.contain.text.array', { expectedText, isNot, useInnerText: options.useInnerText, subset: options.subset, timeout });
     }, expected, { ...options, contains: true });
   } else {
     return toMatchText.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout, customStackTrace) => {
       const expectedText = toExpectedTextValues([expected], { matchSubstring: true, normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect(customStackTrace, 'to.have.text', { expectedText, isNot, useInnerText: options.useInnerText, timeout });
+      return await locator._expect(customStackTrace, 'to.have.text', { expectedText, isNot, useInnerText: options.useInnerText, subset: options.subset, timeout });
     }, expected, options);
   }
 }
@@ -216,17 +216,17 @@ export function toHaveText(
   this: ReturnType<Expect['getState']>,
   locator: LocatorEx,
   expected: string | RegExp | (string | RegExp)[],
-  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean } = {},
+  options: { timeout?: number, useInnerText?: boolean, subset?: boolean, ignoreCase?: boolean } = {},
 ) {
   if (Array.isArray(expected)) {
     return toEqual.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, customStackTrace) => {
       const expectedText = toExpectedTextValues(expected, { normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect(customStackTrace, 'to.have.text.array', { expectedText, isNot, useInnerText: options?.useInnerText, timeout });
+      return await locator._expect(customStackTrace, 'to.have.text.array', { expectedText, isNot, useInnerText: options.useInnerText, subset: options.subset, timeout });
     }, expected, options);
   } else {
     return toMatchText.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, customStackTrace) => {
       const expectedText = toExpectedTextValues([expected], { normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect(customStackTrace, 'to.have.text', { expectedText, isNot, useInnerText: options?.useInnerText, timeout });
+      return await locator._expect(customStackTrace, 'to.have.text', { expectedText, isNot, useInnerText: options.useInnerText, subset: options.subset, timeout });
     }, expected, options);
   }
 }

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -3355,6 +3355,13 @@ interface LocatorAssertions {
     ignoreCase?: boolean;
 
     /**
+     * Only applies when `expected` is a list. When set to `false`, the list of elements found by the locator must contain the
+     * same number of items as `expected`. When set to `true`, the list of elements may be larger, but it must contain the
+     * items matching `expected` in the same order as listed. Defaults to `true`.
+     */
+    subset?: boolean;
+
+    /**
      * Time to retry the assertion for. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -3655,6 +3662,14 @@ interface LocatorAssertions {
    * await expect(locator).toHaveText(['Text 1', 'Text 2', 'Text 3']);
    * ```
    *
+   * You can also check just a subset of the elements matching the [Locator]. For example, in the list of ten items from
+   * `Item 1` to `Item 10`, only check the text of `Item 2`, `Item 4` and `Item 5`:
+   *
+   * ```js
+   * const locator = page.locator('list > .component');
+   * await expect(locator).toHaveText(['Item 2', 'Item 4', 'Item 5'], { subset: true });
+   * ```
+   *
    * @param expected Expected substring or RegExp or a list of those.
    * @param options
    */
@@ -3664,6 +3679,13 @@ interface LocatorAssertions {
      * expression flag if specified.
      */
     ignoreCase?: boolean;
+
+    /**
+     * Only applies when `expected` is a list. When set to `false`, the list of elements found by the locator must contain the
+     * same number of items as `expected`. When set to `true`, the list of elements may be larger, but it must contain the
+     * items matching `expected` in the same order as listed. Defaults to `true`.
+     */
+    subset?: boolean;
 
     /**
      * Time to retry the assertion for. Defaults to `timeout` in `TestConfig.expect`.

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -554,7 +554,7 @@ test('should show action source', async ({ showTraceViewer }) => {
   await expect(page.locator('.source-line')).toContainText([
     /async.*function.*doClick/,
     /page\.click/
-  ]);
+  ], { subset: true });
   await expect(page.locator('.source-line-running')).toContainText('page.click');
   await expect(page.locator('.stack-trace-frame.selected')).toHaveText(/doClick.*trace-viewer\.spec\.ts:[\d]+/);
 });


### PR DESCRIPTION
This removes the default 'subset' behavior from `toContainText` and adds an explicit option.

Fixes #15666.