### PR TITLE
feat(list reporter): number test runs to see testing progress

### DIFF
--- a/packages/playwright-test/src/reporters/line.ts
+++ b/packages/playwright-test/src/reporters/line.ts
@@ -50,7 +50,7 @@ class LineReporter extends BaseReporter {
       stream.write(`\u001B[1A\u001B[2K`);
     if (test && this._lastTest !== test) {
       // Write new header for the output.
-      const title = colors.gray(formatTestTitle(this.config, test));
+      const title = colors.dim(formatTestTitle(this.config, test));
       stream.write(this.fitToScreen(title) + `\n`);
       this._lastTest = test;
     }

--- a/packages/playwright-test/src/reporters/list.ts
+++ b/packages/playwright-test/src/reporters/list.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable no-console */
 import { colors, ms as milliseconds } from 'playwright-core/lib/utilsBundle';
-import { BaseReporter, formatTestTitle } from './base';
+import { BaseReporter, formatTestTitle, stripAnsiEscapes } from './base';
 import type { FullConfig, FullResult, Suite, TestCase, TestResult, TestStep } from '../../types/testReporter';
 
 // Allow it in the Visual Studio Code Terminal and the new Windows Terminal
@@ -27,6 +27,7 @@ const NEGATIVE_STATUS_MARK = DOES_NOT_SUPPORT_UTF8_IN_TERMINAL ? 'x' : '✘';
 class ListReporter extends BaseReporter {
   private _lastRow = 0;
   private _testRows = new Map<TestCase, number>();
+  private _resultIndex = new Map<TestResult, number>();
   private _needNewLine = false;
   private readonly _liveTerminal: string | boolean | undefined;
 
@@ -46,17 +47,18 @@ class ListReporter extends BaseReporter {
   }
 
   onTestBegin(test: TestCase, result: TestResult) {
+    if (this._liveTerminal && this._needNewLine) {
+      this._needNewLine = false;
+      process.stdout.write('\n');
+      this._lastRow++;
+    }
+    this._resultIndex.set(result, this._resultIndex.size + 1);
+    this._testRows.set(test, this._lastRow++);
     if (this._liveTerminal) {
-      if (this._needNewLine) {
-        this._needNewLine = false;
-        process.stdout.write('\n');
-        this._lastRow++;
-      }
-      const prefix = '     ';
-      const line = colors.gray(formatTestTitle(this.config, test)) + this._retrySuffix(result);
+      const prefix = this._testPrefix(result, '');
+      const line = colors.dim(formatTestTitle(this.config, test)) + this._retrySuffix(result);
       process.stdout.write(prefix + this.fitToScreen(line, prefix) + '\n');
     }
-    this._testRows.set(test, this._lastRow++);
   }
 
   override onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
@@ -74,7 +76,7 @@ class ListReporter extends BaseReporter {
       return;
     if (step.category !== 'test.step')
       return;
-    this._updateTestLine(test, colors.gray(formatTestTitle(this.config, test, step)) + this._retrySuffix(result), '     ');
+    this._updateTestLine(test, colors.dim(formatTestTitle(this.config, test, step)) + this._retrySuffix(result), this._testPrefix(result, ''));
   }
 
   onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
@@ -82,7 +84,7 @@ class ListReporter extends BaseReporter {
       return;
     if (step.category !== 'test.step')
       return;
-    this._updateTestLine(test, colors.gray(formatTestTitle(this.config, test, step.parent)) + this._retrySuffix(result), '     ');
+    this._updateTestLine(test, colors.dim(formatTestTitle(this.config, test, step.parent)) + this._retrySuffix(result), this._testPrefix(result, ''));
   }
 
   private _dumpToStdio(test: TestCase | undefined, chunk: string | Buffer, stream: NodeJS.WriteStream) {
@@ -104,16 +106,16 @@ class ListReporter extends BaseReporter {
     let prefix = '';
     let text = '';
     if (result.status === 'skipped') {
-      prefix = colors.green('  -  ');
+      prefix = this._testPrefix(result, colors.green('-'));
       // Do not show duration for skipped.
       text = colors.cyan(title) + this._retrySuffix(result);
     } else {
-      const statusMark = ('  ' + (result.status === 'passed' ? POSITIVE_STATUS_MARK : NEGATIVE_STATUS_MARK)).padEnd(5);
+      const statusMark = result.status === 'passed' ? POSITIVE_STATUS_MARK : NEGATIVE_STATUS_MARK;
       if (result.status === test.expectedStatus) {
-        prefix = colors.green(statusMark);
-        text = colors.gray(title);
+        prefix = this._testPrefix(result, colors.green(statusMark));
+        text = colors.dim(title);
       } else {
-        prefix = colors.red(statusMark);
+        prefix = this._testPrefix(result, colors.red(statusMark));
         text = colors.red(title);
       }
       text += this._retrySuffix(result) + colors.dim(` (${milliseconds(result.duration)})`);
@@ -151,6 +153,12 @@ class ListReporter extends BaseReporter {
       process.stdout.write(`\u001B[${this._lastRow - testRow}E`);
     if (process.env.PWTEST_TTY_WIDTH)
       process.stdout.write('\n');  // For testing.
+  }
+
+  private _testPrefix(result: TestResult, statusMark: string) {
+    const index = this._resultIndex.get(result)!;
+    const statusMarkLength = stripAnsiEscapes(statusMark).length;
+    return '  ' + statusMark + ' '.repeat(3 - statusMarkLength) + colors.dim(String(index) + ' ');
   }
 
   private _retrySuffix(result: TestResult) {

--- a/tests/playwright-test/reporter-list.spec.ts
+++ b/tests/playwright-test/reporter-list.spec.ts
@@ -39,15 +39,15 @@ test('render each test with project name', async ({ runInlineTest }) => {
       test.skip('skipped', async () => {
       });
     `,
-  }, { reporter: 'list' });
+  }, { reporter: 'list', workers: '1' });
   const text = stripAnsi(result.output);
 
-  expect(text).toContain(`${NEGATIVE_STATUS_MARK} [foo] › a.test.ts:6:7 › fails`);
-  expect(text).toContain(`${NEGATIVE_STATUS_MARK} [bar] › a.test.ts:6:7 › fails`);
-  expect(text).toContain(`${POSITIVE_STATUS_MARK} [foo] › a.test.ts:9:7 › passes`);
-  expect(text).toContain(`${POSITIVE_STATUS_MARK} [bar] › a.test.ts:9:7 › passes`);
-  expect(text).toContain(`-  [foo] › a.test.ts:12:12 › skipped`);
-  expect(text).toContain(`-  [bar] › a.test.ts:12:12 › skipped`);
+  expect(text).toContain(`${NEGATIVE_STATUS_MARK} 1 [foo] › a.test.ts:6:7 › fails`);
+  expect(text).toContain(`${POSITIVE_STATUS_MARK} 2 [foo] › a.test.ts:9:7 › passes`);
+  expect(text).toContain(`-  3 [foo] › a.test.ts:12:12 › skipped`);
+  expect(text).toContain(`${NEGATIVE_STATUS_MARK} 4 [bar] › a.test.ts:6:7 › fails`);
+  expect(text).toContain(`${POSITIVE_STATUS_MARK} 5 [bar] › a.test.ts:9:7 › passes`);
+  expect(text).toContain(`-  6 [bar] › a.test.ts:12:12 › skipped`);
   expect(result.exitCode).toBe(1);
 });
 
@@ -71,18 +71,18 @@ test('render steps', async ({ runInlineTest }) => {
   const lines = text.split('\n').filter(l => l.startsWith('0 :'));
   lines.pop(); // Remove last item that contains [v] and time in ms.
   expect(lines).toEqual([
-    '0 :      a.test.ts:6:7 › passes › outer 1.0',
-    '0 :      a.test.ts:6:7 › passes › outer 1.0 › inner 1.1',
-    '0 :      a.test.ts:6:7 › passes › outer 1.0',
-    '0 :      a.test.ts:6:7 › passes › outer 1.0 › inner 1.1',
-    '0 :      a.test.ts:6:7 › passes › outer 1.0',
-    '0 :      a.test.ts:6:7 › passes',
-    '0 :      a.test.ts:6:7 › passes › outer 2.0',
-    '0 :      a.test.ts:6:7 › passes › outer 2.0 › inner 2.1',
-    '0 :      a.test.ts:6:7 › passes › outer 2.0',
-    '0 :      a.test.ts:6:7 › passes › outer 2.0 › inner 2.1',
-    '0 :      a.test.ts:6:7 › passes › outer 2.0',
-    '0 :      a.test.ts:6:7 › passes',
+    '0 :      1 a.test.ts:6:7 › passes › outer 1.0',
+    '0 :      1 a.test.ts:6:7 › passes › outer 1.0 › inner 1.1',
+    '0 :      1 a.test.ts:6:7 › passes › outer 1.0',
+    '0 :      1 a.test.ts:6:7 › passes › outer 1.0 › inner 1.1',
+    '0 :      1 a.test.ts:6:7 › passes › outer 1.0',
+    '0 :      1 a.test.ts:6:7 › passes',
+    '0 :      1 a.test.ts:6:7 › passes › outer 2.0',
+    '0 :      1 a.test.ts:6:7 › passes › outer 2.0 › inner 2.1',
+    '0 :      1 a.test.ts:6:7 › passes › outer 2.0',
+    '0 :      1 a.test.ts:6:7 › passes › outer 2.0 › inner 2.1',
+    '0 :      1 a.test.ts:6:7 › passes › outer 2.0',
+    '0 :      1 a.test.ts:6:7 › passes',
   ]);
 });
 
@@ -99,8 +99,8 @@ test('render retries', async ({ runInlineTest }) => {
   const lines = text.split('\n').filter(l => l.startsWith('0 :') || l.startsWith('1 :')).map(l => l.replace(/[\dm]+s/, 'XXms'));
 
   expect(lines).toEqual([
-    `0 :   ${NEGATIVE_STATUS_MARK} a.test.ts:6:7 › flaky (XXms)`,
-    `1 :   ${POSITIVE_STATUS_MARK} a.test.ts:6:7 › flaky (retry #1) (XXms)`,
+    `0 :   ${NEGATIVE_STATUS_MARK} 1 a.test.ts:6:7 › flaky (XXms)`,
+    `1 :   ${POSITIVE_STATUS_MARK} 2 a.test.ts:6:7 › flaky (retry #1) (XXms)`,
   ]);
 });
 
@@ -129,23 +129,23 @@ test('should truncate long test names', async ({ runInlineTest }) => {
   const lines = stripAnsi(result.output).split('\n').slice(3, 11);
   expect(lines.every(line => line.length <= 50)).toBe(true);
 
-  expect(lines[0]).toBe(`     … › a.test.ts:6:7 › failure in very long name`);
+  expect(lines[0]).toBe(`     1 … a.test.ts:6:7 › failure in very long name`);
 
-  expect(lines[1]).toContain(`${NEGATIVE_STATUS_MARK} …`);
-  expect(lines[1]).toContain(`ts:6:7 › failure in very long name (`);
+  expect(lines[1]).toContain(`${NEGATIVE_STATUS_MARK} 1 …`);
+  expect(lines[1]).toContain(`:6:7 › failure in very long name (`);
   expect(lines[1].length).toBe(50);
 
-  expect(lines[2]).toBe(`     [foo] › a.test.ts:9:7 › passes`);
+  expect(lines[2]).toBe(`     2 [foo] › a.test.ts:9:7 › passes`);
 
-  expect(lines[3]).toContain(`${POSITIVE_STATUS_MARK} [foo] › a.test.ts:9:7 › passes (`);
+  expect(lines[3]).toContain(`${POSITIVE_STATUS_MARK} 2 [foo] › a.test.ts:9:7 › passes (`);
 
-  expect(lines[4]).toBe(`     [foo] › a.test.ts:11:7 › passes 2 long name`);
+  expect(lines[4]).toBe(`     3 [foo] › a.test.ts:11:7 › passes 2 long name`);
 
-  expect(lines[5]).toContain(`${POSITIVE_STATUS_MARK} …`);
-  expect(lines[5]).toContain(`a.test.ts:11:7 › passes 2 long name (`);
+  expect(lines[5]).toContain(`${POSITIVE_STATUS_MARK} 3 …`);
+  expect(lines[5]).toContain(`test.ts:11:7 › passes 2 long name (`);
   expect(lines[5].length).toBe(50);
 
-  expect(lines[6]).toBe(`     …] › a.test.ts:13:12 › skipped very long name`);
+  expect(lines[6]).toBe(`     4 …› a.test.ts:13:12 › skipped very long name`);
 
-  expect(lines[7]).toBe(`  -  …] › a.test.ts:13:12 › skipped very long name`);
+  expect(lines[7]).toBe(`  -  4 …› a.test.ts:13:12 › skipped very long name`);
 });


### PR DESCRIPTION
Sample output on a large terminal:

<img width="1066" alt="list-numbers-large" src="https://user-images.githubusercontent.com/9881434/179125274-e0b38327-21e2-4b5b-909e-afa10e699313.png">

Sample output on a small terminal:

<img width="881" alt="list-numbers-small" src="https://user-images.githubusercontent.com/9881434/179125172-7d2c99f9-aa55-4a85-8ff6-bf4e972bd9e7.png">

Drive-by: replace a few `colors.gray` with `colors.dim` for better contrast.

Fixes #14953.