### PR TITLE
cherry-pick(#15723): docs: clarify toHaveURL parameter semantics

### DIFF
--- a/docs/src/api/class-pageassertions.md
+++ b/docs/src/api/class-pageassertions.md
@@ -116,7 +116,7 @@ The opposite of [`method: PageAssertions.toHaveURL`].
 * since: v1.18
 - `urlOrRegExp` <[string]|[RegExp]>
 
-Expected substring or RegExp.
+Expected URL string or RegExp.
 
 ### option: PageAssertions.NotToHaveURL.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
@@ -285,7 +285,7 @@ await Expect(page).ToHaveURL(new Regex(".*checkout"));
 * since: v1.18
 - `urlOrRegExp` <[string]|[RegExp]>
 
-Expected substring or RegExp.
+Expected URL string or RegExp.
 
 ### option: PageAssertions.toHaveURL.timeout = %%-js-assertions-timeout-%%
 * since: v1.18

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -3987,7 +3987,7 @@ interface PageAssertions {
    * await expect(page).toHaveURL(/.*checkout/);
    * ```
    *
-   * @param urlOrRegExp Expected substring or RegExp.
+   * @param urlOrRegExp Expected URL string or RegExp.
    * @param options
    */
   toHaveURL(urlOrRegExp: string|RegExp, options?: {


### PR DESCRIPTION
582b5e08b2313a47cb24429a6b8f710d9bb9b86f

Fixes #15703