### PR TITLE
fix(esm loader): support Node 18.6

### DIFF
--- a/packages/playwright-test/src/experimentalLoader.ts
+++ b/packages/playwright-test/src/experimentalLoader.ts
@@ -18,7 +18,9 @@ import fs from 'fs';
 import url from 'url';
 import { transformHook, resolveHook } from './transform';
 
-async function resolve(specifier: string, context: { parentURL: string }, defaultResolve: any) {
+// Node < 18.6: defaultResolve takes 3 arguments.
+// Node >= 18.6: nextResolve from the chain takes 2 arguments.
+async function resolve(specifier: string, context: { parentURL?: string }, defaultResolve: Function) {
   if (context.parentURL && context.parentURL.startsWith('file://')) {
     const filename = url.fileURLToPath(context.parentURL);
     const resolved = resolveHook(filename, specifier);
@@ -28,12 +30,15 @@ async function resolve(specifier: string, context: { parentURL: string }, defaul
   return defaultResolve(specifier, context, defaultResolve);
 }
 
-async function load(moduleUrl: string, context: any, defaultLoad: any) {
+// Node < 18.6: defaultLoad takes 3 arguments.
+// Node >= 18.6: nextLoad from the chain takes 2 arguments.
+async function load(moduleUrl: string, context: any, defaultLoad: Function) {
   if (moduleUrl.startsWith('file://') && (moduleUrl.endsWith('.ts') || moduleUrl.endsWith('.tsx'))) {
     const filename = url.fileURLToPath(moduleUrl);
     const code = fs.readFileSync(filename, 'utf-8');
     const source = transformHook(code, filename, moduleUrl);
-    return { format: 'module', source };
+    // shortCurcuit is required by Node >= 18.6 to designate no more loaders should be called.
+    return { format: 'module', source, shortCircuit: true };
   }
   return defaultLoad(moduleUrl, context, defaultLoad);
 }


### PR DESCRIPTION
This is a backport of https://github.com/microsoft/playwright/commit/da2fdc2e2e5e89d3d5a959fd6b6aa6fb875170cc to 1.23 branch.

#15717