### PR TITLE
chore: bump 'ip' peer dependency

### DIFF
--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -25,7 +25,7 @@ This project incorporates components from the projects listed below. The origina
 -	https-proxy-agent@5.0.0 (https://github.com/TooTallNate/node-https-proxy-agent)
 -	inflight@1.0.6 (https://github.com/npm/inflight)
 -	inherits@2.0.4 (https://github.com/isaacs/inherits)
--	ip@1.1.5 (https://github.com/indutny/node-ip)
+-	ip@2.0.0 (https://github.com/indutny/node-ip)
 -	jpeg-js@0.4.4 (https://github.com/eugeneware/jpeg-js)
 -	mime@3.0.0 (https://github.com/broofa/mime)
 -	minimatch@3.1.2 (https://github.com/isaacs/minimatch)
@@ -43,7 +43,7 @@ This project incorporates components from the projects listed below. The origina
 -	signal-exit@3.0.7 (https://github.com/tapjs/signal-exit)
 -	smart-buffer@4.2.0 (https://github.com/JoshGlazebrook/smart-buffer)
 -	socks-proxy-agent@6.1.1 (https://github.com/TooTallNate/node-socks-proxy-agent)
--	socks@2.6.2 (https://github.com/JoshGlazebrook/socks)
+-	socks@2.7.0 (https://github.com/JoshGlazebrook/socks)
 -	stack-utils@2.0.5 (https://github.com/tapjs/stack-utils)
 -	wrappy@1.0.2 (https://github.com/npm/wrappy)
 -	ws@8.4.2 (https://github.com/websockets/ws)
@@ -816,7 +816,7 @@ PERFORMANCE OF THIS SOFTWARE.
 =========================================
 END OF inherits@2.0.4 AND INFORMATION
 
-%% ip@1.1.5 NOTICES AND INFORMATION BEGIN HERE
+%% ip@2.0.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 # IP  
 [![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)  
@@ -909,7 +909,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
-END OF ip@1.1.5 AND INFORMATION
+END OF ip@2.0.0 AND INFORMATION
 
 %% jpeg-js@0.4.4 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1465,7 +1465,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF socks-proxy-agent@6.1.1 AND INFORMATION
 
-%% socks@2.6.2 NOTICES AND INFORMATION BEGIN HERE
+%% socks@2.7.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 The MIT License (MIT)
 
@@ -1488,7 +1488,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
-END OF socks@2.6.2 AND INFORMATION
+END OF socks@2.7.0 AND INFORMATION
 
 %% stack-utils@2.0.5 NOTICES AND INFORMATION BEGIN HERE
 =========================================

--- a/packages/playwright-core/bundles/utils/package-lock.json
+++ b/packages/playwright-core/bundles/utils/package-lock.json
@@ -277,9 +277,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "node_modules/jpeg-js": {
       "version": "0.4.4",
@@ -397,11 +397,11 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
       "dependencies": {
-        "ip": "^1.1.5",
+        "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -667,9 +667,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "jpeg-js": {
       "version": "0.4.4",
@@ -756,11 +756,11 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "socks": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
       "requires": {
-        "ip": "^1.1.5",
+        "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
       }
     },

--- a/packages/playwright-core/bundles/zip/build.js
+++ b/packages/playwright-core/bundles/zip/build.js
@@ -46,4 +46,7 @@ esbuild.build({
   watch: process.argv.includes('--watch'),
   sourcemap: process.argv.includes('--sourcemap'),
   minify: process.argv.includes('--minify'),
-}).catch(() => process.exit(1));
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/playwright-test/bundles/utils/build.js
+++ b/packages/playwright-test/bundles/utils/build.js
@@ -49,4 +49,7 @@ esbuild.build({
   watch: process.argv.includes('--watch'),
   sourcemap: process.argv.includes('--sourcemap'),
   minify: process.argv.includes('--minify'),
-}).catch(() => process.exit(1));
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Since https://github.com/JoshGlazebrook/socks/pull/85 got merged we can get rid of that extra complexity. Keeping the `build.js` for the future.

drive-by: log the exception when esbuild would throw.