### PR TITLE
fix(lifecycle): recalculate lifecycle on iframe detach

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -277,8 +277,11 @@ export class FrameManager {
 
   frameDetached(frameId: string) {
     const frame = this._frames.get(frameId);
-    if (frame)
+    if (frame) {
       this._removeFramesRecursively(frame);
+      // Recalculate subtree lifecycle for the whole tree - it should not be that big.
+      this._page.mainFrame()._recalculateLifecycle();
+    }
   }
 
   frameStoppedLoading(frameId: string) {
@@ -590,7 +593,7 @@ export class Frame extends SdkObject {
     });
   }
 
-  private _recalculateLifecycle() {
+  _recalculateLifecycle() {
     const events = new Set<types.LifecycleEvent>(this._firedLifecycleEvents);
     for (const child of this._childFrames) {
       child._recalculateLifecycle();

--- a/tests/page/page-network-idle.spec.ts
+++ b/tests/page/page-network-idle.spec.ts
@@ -157,3 +157,18 @@ it('should wait for networkidle from the popup', async ({ page, server, isAndroi
     await popup.waitForLoadState('networkidle');
   }
 });
+
+it('should wait for networkidle when iframe attaches and detaches', async ({ page }) => {
+  await page.setContent(`
+    <body>
+      <script>
+        setTimeout(() => {
+          const iframe = document.createElement('iframe');
+          document.body.appendChild(iframe);
+          setTimeout(() => iframe.remove(), 400);
+        }, 400);
+      </script>
+    </body>
+  `, { waitUntil: 'networkidle' });
+  expect(await page.$('iframe')).toBe(null);
+});


### PR DESCRIPTION
It could be that iframe was blocking some event, like load or networkidle, and we never updated the lifecycle after the iframe was detached. This lead to goto and other navigation commands to never resolve.

Fixes #15084.