### PR TITLE
fix(runner): globalTeardown without globalSetup should work

### DIFF
--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -473,12 +473,17 @@ export class Runner {
       }
 
       // The do global setup.
-      if (!sigintWatcher.hadSignal() && config.globalSetup) {
-        const hook = await this._loader.loadGlobalHook(config.globalSetup, 'globalSetup');
-        await Promise.race([
-          Promise.resolve().then(() => hook(this._loader.fullConfig())).then((r: any) => globalSetupResult = r || '<noop>'),
-          sigintWatcher.promise(),
-        ]);
+      if (!sigintWatcher.hadSignal()) {
+        if (config.globalSetup) {
+          const hook = await this._loader.loadGlobalHook(config.globalSetup, 'globalSetup');
+          await Promise.race([
+            Promise.resolve().then(() => hook(this._loader.fullConfig())).then((r: any) => globalSetupResult = r || '<noop>'),
+            sigintWatcher.promise(),
+          ]);
+        } else {
+          // Make sure we run globalTeardown.
+          globalSetupResult = '<noop>';
+        }
       }
     }, result);
 

--- a/tests/playwright-test/global-setup.spec.ts
+++ b/tests/playwright-test/global-setup.spec.ts
@@ -48,6 +48,29 @@ test('globalSetup and globalTeardown should work', async ({ runInlineTest }) => 
   expect(output).toContain('teardown=42');
 });
 
+test('standalone globalTeardown should work', async ({ runInlineTest }) => {
+  const { results, output } = await runInlineTest({
+    'playwright.config.ts': `
+      import * as path from 'path';
+      module.exports = {
+        globalTeardown: './globalTeardown.ts',
+      };
+    `,
+    'globalTeardown.ts': `
+      module.exports = async () => {
+        console.log('got my teardown');
+      };
+    `,
+    'a.test.js': `
+      const { test } = pwt;
+      test('should work', async ({}, testInfo) => {
+      });
+    `,
+  });
+  expect(results[0].status).toBe('passed');
+  expect(output).toContain('got my teardown');
+});
+
 test('globalTeardown runs after failures', async ({ runInlineTest }) => {
   const { results, output } = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
Fixes #15794.
Regressed in #14805.
