### PR TITLE
fix(text selector): ignore NOSCRIPT elements

### DIFF
--- a/packages/playwright-core/src/server/injected/selectorUtils.ts
+++ b/packages/playwright-core/src/server/injected/selectorUtils.ts
@@ -76,7 +76,7 @@ export function createRegexTextMatcher(source: string, flags?: string): TextMatc
 }
 
 export function shouldSkipForTextMatching(element: Element | ShadowRoot) {
-  return element.nodeName === 'SCRIPT' || element.nodeName === 'STYLE' || document.head && document.head.contains(element);
+  return element.nodeName === 'SCRIPT' || element.nodeName === 'NOSCRIPT' || element.nodeName === 'STYLE' || document.head && document.head.contains(element);
 }
 
 export type ElementText = { full: string, immediate: string[] };


### PR DESCRIPTION
These are usually not rendered, and some sites have very big content inside, for example full page markup.

Fixes #15874.