### PR TITLE
chore(default context): Apply context workaround only when browser and scenario match

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -295,7 +295,8 @@ export abstract class BrowserContext extends SdkObject {
 
   async _loadDefaultContext(progress: Progress) {
     const pages = await this._loadDefaultContextAsIs(progress);
-    if (this._options.isMobile || this._options.locale) {
+    const browserName = this._browser.options.name;
+    if ((this._options.isMobile && browserName === 'chromium') || (this._options.locale && browserName === 'webkit')) {
       // Workaround for:
       // - chromium fails to change isMobile for existing page;
       // - webkit fails to change locale for existing page.

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -79,7 +79,7 @@ it('should have pages', async ({ contextFactory, server }, testInfo) => {
   expect(pageEntry.pageTimings.onLoad).toBeGreaterThan(0);
 });
 
-it('should have pages in persistent context', async ({ launchPersistent }, testInfo) => {
+it('should have pages in persistent context', async ({ launchPersistent, browserName }, testInfo) => {
   const harPath = testInfo.outputPath('test.har');
   const { context, page } = await launchPersistent({ recordHar: { path: harPath } });
   await page.goto('data:text/html,<title>Hello</title>');
@@ -87,11 +87,17 @@ it('should have pages in persistent context', async ({ launchPersistent }, testI
   await page.waitForLoadState('domcontentloaded');
   await context.close();
   const log = JSON.parse(fs.readFileSync(harPath).toString())['log'];
+  let pageEntry;
+  if (browserName === 'webkit') {
   // Explicit locale emulation forces a new page creation when
   // doing a new context.
   // See https://github.com/microsoft/playwright/blob/13dd41c2e36a63f35ddef5dc5dec322052d670c6/packages/playwright-core/src/server/browserContext.ts#L232-L242
-  expect(log.pages.length).toBe(2);
-  const pageEntry = log.pages[1];
+    expect(log.pages.length).toBe(2);
+    pageEntry = log.pages[1];
+  } else {
+    expect(log.pages.length).toBe(1);
+    pageEntry = log.pages[0];
+  }
   expect(pageEntry.id).toBeTruthy();
   expect(pageEntry.title).toBe('Hello');
 });


### PR DESCRIPTION
The workaround to isMobile and locale that was introduced in https://github.com/microsoft/playwright/pull/2177 was applied to all instances, regardless of the browser type and options.

This uncommon behavior, re-opening the page, that is caused by the workaround, may cause unexpected behavior by applications that are leveraging Playwright for testings.

In this pull request I suggest narrowing the amount of instances that are affected by the workaround by only applying it when it is required, and let instances that doesn't match the criteria run naturally, as expected.

Fixes #15965.