### PR TITLE
browser(webkit): skip gpu availability check on mac

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1688
-Changed: dgozman@gmail.com Mon Jul 25 17:06:24 PDT 2022
+1689
+Changed: yurys@chromium.org Mon Jul 25 17:55:49 PDT 2022

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -2216,7 +2216,7 @@ index f2b30930c44473be6bf087fde5fd75b074b190c7..fcdfd21fc73ce584f7976d381d91bae4
  #endif
  
 diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
-index 30078593883c7440a90add36e762555587a69136..27f478a69b045c33b4b293f2c16752581e889ee2 100644
+index 30078593883c7440a90add36e762555587a69136..19e9495403f77f1866e92f1560d1033895c33536 100644
 --- a/Source/WTF/wtf/PlatformHave.h
 +++ b/Source/WTF/wtf/PlatformHave.h
 @@ -430,7 +430,7 @@
@@ -2228,6 +2228,16 @@ index 30078593883c7440a90add36e762555587a69136..27f478a69b045c33b4b293f2c1675258
  #define HAVE_OS_DARK_MODE_SUPPORT 1
  #endif
  
+@@ -1310,7 +1310,8 @@
+ #endif
+ 
+ #if PLATFORM(MAC)
+-#define HAVE_GPU_AVAILABILITY_CHECK 1
++// Playwright: disable the check to make WebGL always work.
++#define HAVE_GPU_AVAILABILITY_CHECK 0
+ #endif
+ 
+ #if (!defined(HAVE_LOCKDOWN_MODE_PDF_ADDITIONS) && \
 diff --git a/Source/WebCore/DerivedSources.make b/Source/WebCore/DerivedSources.make
 index 8e0fa01deda72cb7abde61793297f8073077f93a..441d7c0fca693c5c187f1d129e7d5bdcaa280f14 100644
 --- a/Source/WebCore/DerivedSources.make


### PR DESCRIPTION
WebGL tests started failing on CI after the recent rolls (https://cs.github.com/microsoft/playwright/blob/dfd6fa356a0cd43354fb172fdad8e3a6b0650d36/tests/library/capabilities.spec.ts#L98 in particular).  This PR turns off the check introduced upstream in https://github.com/WebKit/WebKit/commit/6ed0df1df12a2ae89b0937a49030f6e97ec1b2d4 which should fix WebGL context creation on GitHub Actions.

Pretty-diff: https://github.com/yury-s/WebKit/commit/b4d2e0ddc183a9cc95c0dce64fe00e632ac57eca