### PR TITLE
feat(test runner): show the number of fatal errors at the end

### DIFF
--- a/packages/playwright-test/src/reporters/dot.ts
+++ b/packages/playwright-test/src/reporters/dot.ts
@@ -15,8 +15,8 @@
  */
 
 import { colors } from 'playwright-core/lib/utilsBundle';
-import { BaseReporter } from './base';
-import type { FullResult, TestCase, TestResult, FullConfig, Suite } from '../../types/testReporter';
+import { BaseReporter, formatError } from './base';
+import type { FullResult, TestCase, TestResult, FullConfig, Suite, TestError } from '../../types/testReporter';
 
 class DotReporter extends BaseReporter {
   private _counter = 0;
@@ -62,6 +62,12 @@ class DotReporter extends BaseReporter {
       case 'unexpected': process.stdout.write(colors.red(result.status === 'timedOut' ? 'T' : 'F')); break;
       case 'flaky': process.stdout.write(colors.yellow('±')); break;
     }
+  }
+
+  override onError(error: TestError): void {
+    super.onError(error);
+    console.log('\n' + formatError(this.config, error, colors.enabled).message);
+    this._counter = 0;
   }
 
   override async onEnd(result: FullResult) {

--- a/packages/playwright-test/src/reporters/line.ts
+++ b/packages/playwright-test/src/reporters/line.ts
@@ -15,8 +15,8 @@
  */
 
 import { colors } from 'playwright-core/lib/utilsBundle';
-import { BaseReporter, formatFailure, formatTestTitle } from './base';
-import type { FullConfig, TestCase, Suite, TestResult, FullResult, TestStep } from '../../types/testReporter';
+import { BaseReporter, formatError, formatFailure, formatTestTitle } from './base';
+import type { FullConfig, TestCase, Suite, TestResult, FullResult, TestStep, TestError } from '../../types/testReporter';
 
 class LineReporter extends BaseReporter {
   private _current = 0;
@@ -98,6 +98,16 @@ class LineReporter extends BaseReporter {
       process.stdout.write(`${prefix + title}\n`);
     else
       process.stdout.write(`\u001B[1A\u001B[2K${prefix + this.fitToScreen(title, prefix)}\n`);
+  }
+
+  override onError(error: TestError): void {
+    super.onError(error);
+
+    const message = formatError(this.config, error, colors.enabled).message + '\n\n';
+    if (!process.env.PW_TEST_DEBUG_REPORTERS)
+      process.stdout.write(`\u001B[1A\u001B[2K`);
+    process.stdout.write(message);
+    console.log();
   }
 
   override async onEnd(result: FullResult) {

--- a/packages/playwright-test/src/worker.ts
+++ b/packages/playwright-test/src/worker.ts
@@ -99,7 +99,9 @@ async function gracefullyCloseAndExit() {
       await stopProfiling(workerIndex);
   } catch (e) {
     try {
-      const payload: TeardownErrorsPayload = { fatalErrors: [serializeError(e)] };
+      const error = serializeError(e);
+      workerRunner.appendWorkerTeardownDiagnostics(error);
+      const payload: TeardownErrorsPayload = { fatalErrors: [error] };
       process.send!({ method: 'teardownErrors', params: payload });
     } catch {
     }

--- a/tests/playwright-test/fixture-errors.spec.ts
+++ b/tests/playwright-test/fixture-errors.spec.ts
@@ -517,7 +517,9 @@ test('should report worker fixture teardown with debug info', async ({ runInline
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(20);
   expect(stripAnsi(result.output)).toContain([
-    'Worker teardown error. This worker ran 20 tests, last 10 tests were:',
+    'Worker teardown timeout of 1000ms exceeded while tearing down "fixture".',
+    '',
+    'Failed worker ran 20 tests, last 10 tests were:',
     'a.spec.ts:12:9 › good10',
     'a.spec.ts:12:9 › good11',
     'a.spec.ts:12:9 › good12',
@@ -528,8 +530,6 @@ test('should report worker fixture teardown with debug info', async ({ runInline
     'a.spec.ts:12:9 › good17',
     'a.spec.ts:12:9 › good18',
     'a.spec.ts:12:9 › good19',
-    '',
-    'Worker teardown timeout of 1000ms exceeded while tearing down "fixture".',
   ].join('\n'));
 });
 

--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -290,3 +290,31 @@ test('should not crash on undefined body with manual attachments', async ({ runI
   expect(result.failed).toBe(1);
   expect(result.exitCode).toBe(1);
 });
+
+test('should report fatal errors at the end', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const test = pwt.test.extend({
+        fixture: [async ({ }, use) => {
+          await use();
+          throw new Error('oh my!');
+        }, { scope: 'worker' }],
+      });
+      test('good', async ({ fixture }) => {
+      });
+    `,
+    'b.spec.ts': `
+      const test = pwt.test.extend({
+        fixture: [async ({ }, use) => {
+          await use();
+          throw new Error('oh my!');
+        }, { scope: 'worker' }],
+      });
+      test('good', async ({ fixture }) => {
+      });
+    `,
+  }, { reporter: 'list' });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(2);
+  expect(stripAnsi(result.output)).toContain('2 fatal errors');
+});


### PR DESCRIPTION
Example output from the `dot` reporter:

```bash
Running 8 tests using 1 worker
···
Worker teardown timeout of 2000ms exceeded while tearing down "worker".

Failed worker ran 4 tests:
output/a.spec.ts:11:1 › test1
output/a.spec.ts:17:3 › good0
output/a.spec.ts:17:3 › good1
output/a.spec.ts:22:1 › test2
·····

  1 fatal error
  8 passed (3s)
```