### PR TITLE
fix(screenshot): avoid unnecessary work

### DIFF
--- a/packages/playwright-core/src/server/screenshotter.ts
+++ b/packages/playwright-core/src/server/screenshotter.ts
@@ -140,6 +140,9 @@ export class Screenshotter {
   }
 
   async _preparePageForScreenshot(progress: Progress, hideCaret: boolean, disableAnimations: boolean) {
+    if (!hideCaret && !disableAnimations)
+      return;
+
     if (disableAnimations)
       progress.log('  disabled all CSS animations');
     await Promise.all(this._page.frames().map(async frame => {


### PR DESCRIPTION
Do not evaluate when not hiding caret nor disabling animations.

References #15773.