### PR TITLE
feat(test runner): TestProject.projectSetup

### DIFF
--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -359,6 +359,8 @@ test('test', async ({ page }) => {
 });
 ```
 
+You can also have project-specific setup with [`property: TestProject.projectSetup`]. It will only be executed if at least one test from a specific project should be run, while global setup is always executed at the start of the test session.
+
 ### Capturing trace of failures during global setup
 
 In some instances, it may be useful to capture a trace of failures encountered during the global setup. In order to do this, you must [start tracing](./api/class-tracing.md#tracing-start) in your setup, and you must ensure that you [stop tracing](./api/class-tracing.md#tracing-stop) if an error occurs before that error is thrown. This can be achieved by wrapping your setup in a `try...catch` block.  Here is an example that expands the global setup example to capture a trace.

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -163,6 +163,63 @@ Metadata that will be put directly to the test report serialized as JSON.
 Project name is visible in the report and during test execution.
 
 
+## property: TestProject.projectSetup
+* since: v1.25
+- type: ?<[string]>
+
+Path to the project-specifc setup file. This file will be required and run before all the tests from this project. It must export a single function that takes a [`TestConfig`] argument.
+
+Project setup is similar to [`property: TestConfig.globalSetup`], but it is only executed if at least one test from this particular project should be run. Learn more about [global setup and teardown](../test-advanced.md#global-setup-and-teardown).
+
+```js tab=js-js
+// playwright.config.js
+// @ts-check
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  projects: [
+    {
+      name: 'Admin Portal',
+      projectSetup: './setup-admin',
+    },
+    {
+      name: 'Customer Portal',
+      projectSetup: './setup-customer',
+    },
+  ],
+};
+
+module.exports = config;
+```
+
+```js tab=js-ts
+// playwright.config.ts
+import { type PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  projects: [
+    {
+      name: 'Admin Portal',
+      projectSetup: './setup-admin',
+    },
+    {
+      name: 'Customer Portal',
+      projectSetup: './setup-customer',
+    },
+  ],
+};
+export default config;
+```
+
+## property: TestProject.projectTeardown
+* since: v1.25
+- type: ?<[string]>
+
+Path to the project-specifc teardown file. This file will be required and run after all the tests from this project. It must export a single function. See also [`property: TestProject.projectSetup`].
+
+Project teardown is similar to [`property: TestConfig.globalTeardown`], but it is only executed if at least one test from this particular project did run. Learn more about [global setup and teardown](../test-advanced.md#global-setup-and-teardown).
+
+
 ## property: TestProject.screenshotsDir
 * since: v1.10
 * experimental

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -212,7 +212,7 @@ export class Loader {
     return suite;
   }
 
-  async loadGlobalHook(file: string, name: string): Promise<(config: FullConfigInternal) => any> {
+  async loadGlobalHook(file: string): Promise<(config: FullConfigInternal) => any> {
     return this._requireOrImportDefaultFunction(path.resolve(this._fullConfig.rootDir, file), false);
   }
 
@@ -257,6 +257,10 @@ export class Loader {
       projectConfig.testDir = path.resolve(this._configDir, projectConfig.testDir);
     if (projectConfig.outputDir !== undefined)
       projectConfig.outputDir = path.resolve(this._configDir, projectConfig.outputDir);
+    if (projectConfig.projectSetup)
+      projectConfig.projectSetup = resolveScript(projectConfig.projectSetup, this._configDir);
+    if (projectConfig.projectTeardown)
+      projectConfig.projectTeardown = resolveScript(projectConfig.projectTeardown, this._configDir);
     if ((projectConfig as any).screenshotsDir !== undefined)
       (projectConfig as any).screenshotsDir = path.resolve(this._configDir, (projectConfig as any).screenshotsDir);
     if (projectConfig.snapshotDir !== undefined)
@@ -281,6 +285,8 @@ export class Loader {
       retries: takeFirst(projectConfig.retries, config.retries, 0),
       metadata: takeFirst(projectConfig.metadata, config.metadata, undefined),
       name,
+      _projectSetup: projectConfig.projectSetup,
+      _projectTeardown: projectConfig.projectTeardown,
       testDir,
       _respectGitIgnore: respectGitIgnore,
       snapshotDir,

--- a/packages/playwright-test/src/types.ts
+++ b/packages/playwright-test/src/types.ts
@@ -65,4 +65,6 @@ export interface FullProjectInternal extends FullProjectPublic {
   _expect: Project['expect'];
   _screenshotsDir: string;
   _respectGitIgnore: boolean;
+  _projectSetup?: string;
+  _projectTeardown?: string;
 }

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -4315,6 +4315,49 @@ interface TestProject {
   name?: string;
 
   /**
+   * Path to the project-specifc setup file. This file will be required and run before all the tests from this project. It
+   * must export a single function that takes a [`TestConfig`] argument.
+   *
+   * Project setup is similar to
+   * [testConfig.globalSetup](https://playwright.dev/docs/api/class-testconfig#test-config-global-setup), but it is only
+   * executed if at least one test from this particular project should be run. Learn more about
+   * [global setup and teardown](https://playwright.dev/docs/test-advanced#global-setup-and-teardown).
+   *
+   * ```js
+   * // playwright.config.ts
+   * import { type PlaywrightTestConfig } from '@playwright/test';
+   *
+   * const config: PlaywrightTestConfig = {
+   *   projects: [
+   *     {
+   *       name: 'Admin Portal',
+   *       projectSetup: './setup-admin',
+   *     },
+   *     {
+   *       name: 'Customer Portal',
+   *       projectSetup: './setup-customer',
+   *     },
+   *   ],
+   * };
+   * export default config;
+   * ```
+   *
+   */
+  projectSetup?: string;
+
+  /**
+   * Path to the project-specifc teardown file. This file will be required and run after all the tests from this project. It
+   * must export a single function. See also
+   * [testProject.projectSetup](https://playwright.dev/docs/api/class-testproject#test-project-project-setup).
+   *
+   * Project teardown is similar to
+   * [testConfig.globalTeardown](https://playwright.dev/docs/api/class-testconfig#test-config-global-teardown), but it is
+   * only executed if at least one test from this particular project did run. Learn more about
+   * [global setup and teardown](https://playwright.dev/docs/test-advanced#global-setup-and-teardown).
+   */
+  projectTeardown?: string;
+
+  /**
    * The base directory, relative to the config file, for snapshot files created with `toMatchSnapshot`. Defaults to
    * [testProject.testDir](https://playwright.dev/docs/api/class-testproject#test-project-test-dir).
    *

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -410,8 +410,18 @@ test('should have correct types for the config', async ({ runTSC }) => {
             port: 8082,
           },
         ],
+        globalSetup: './globalSetup',
+        // @ts-expect-error
+        globalTeardown: null,
+        projects: [
+          {
+            name: 'project name',
+            projectSetup: './projectSetup',
+            projectTeardown: './projectTeardown',
+          }
+        ],
       };
-      
+
       export default config;
   `
   });

--- a/tests/playwright-test/reporter.spec.ts
+++ b/tests/playwright-test/reporter.spec.ts
@@ -557,8 +557,8 @@ test('should report correct tests/suites when using grep', async ({ runInlineTes
   expect(result.output).toContain('%%test2');
   expect(result.output).not.toContain('%%test3');
   const fileSuite = result.report.suites[0];
-  expect(fileSuite.suites.length).toBe(1);
-  expect(fileSuite.suites[0].specs.length).toBe(2);
+  expect(fileSuite.suites!.length).toBe(1);
+  expect(fileSuite.suites![0].specs.length).toBe(2);
   expect(fileSuite.specs.length).toBe(0);
 });
 


### PR DESCRIPTION
New `projectSetup` is a project-scoped alternative to `globalSetup`. It is only executed if at least one test from the project is scheduled to run.

Fixes #16008.