### PR TITLE
feat(browser): close contexts when close browser

### DIFF
--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -96,11 +96,13 @@ were opened).
 In case this browser is connected to, clears all created contexts belonging to this browser and disconnects from the
 browser server.
 
-:::note
-This is similar to force quitting the browser. Therefore, you should call [`method: BrowserContext.close`] on any [BrowserContext]'s you explicitly created earlier with [`method: Browser.newContext`] **before** calling [`method: Browser.close`].
-:::
-
 The [Browser] object itself is considered to be disposed and cannot be used anymore.
+
+### option: Browser.close.force
+* since: v1.25
+- `force` <boolean>
+
+Whether to bypass the closure of the contexts. Defaults to `false`.
 
 ## method: Browser.contexts
 * since: v1.8
@@ -168,11 +170,6 @@ Returns the newly created browser session.
 
 Creates a new browser context. It won't share cookies/cache with other browser contexts.
 
-:::note
-If directly using this method to create [BrowserContext]s, it is best practice to explicilty close the returned context via [`method: BrowserContext.close`] when your code is done with the [BrowserContext],
-and before calling [`method: Browser.close`]. This will ensure the `context` is closed gracefully and any artifacts—like HARs and videos—are fully flushed and saved.
-:::
-
 ```js
 (async () => {
   const browser = await playwright.firefox.launch();  // Or 'chromium' or 'webkit'.
@@ -181,9 +178,6 @@ and before calling [`method: Browser.close`]. This will ensure the `context` is 
   // Create a new page in a pristine context.
   const page = await context.newPage();
   await page.goto('https://example.com');
-
-  // Gracefully close up everything
-  await context.close();
   await browser.close();
 })();
 ```
@@ -195,9 +189,6 @@ BrowserContext context = browser.newContext();
 // Create a new page in a pristine context.
 Page page = context.newPage();
 page.navigate('https://example.com');
-
-// Gracefull close up everything
-context.close();
 browser.close();
 ```
 
@@ -208,9 +199,6 @@ context = await browser.new_context()
 # create a new page in a pristine context.
 page = await context.new_page()
 await page.goto("https://example.com")
-
-# gracefully close up everything
-await context.close()
 await browser.close()
 ```
 
@@ -221,9 +209,6 @@ context = browser.new_context()
 # create a new page in a pristine context.
 page = context.new_page()
 page.goto("https://example.com")
-
-# gracefully close up everything
-context.close()
 browser.close()
 ```
 
@@ -235,9 +220,6 @@ var context = await browser.NewContextAsync();
 // Create a new page in a pristine context.
 var page = await context.NewPageAsync(); ;
 await page.GotoAsync("https://www.bing.com");
-
-// Gracefully close up everything
-await context.CloseAsync();
 await browser.CloseAsync();
 ```
 

--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -116,8 +116,13 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
     return (await this._channel.stopTracing()).binary;
   }
 
-  async close(): Promise<void> {
+  async close(options: { force?: boolean; } = {}): Promise<void> {
     try {
+      if (!options.force) {
+        for (const context of this._contexts)
+          await context.close();
+      }
+
       if (this._shouldCloseConnectionOnClose)
         this._connection.close(kBrowserClosedError);
       else

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -6471,7 +6471,7 @@ export interface BrowserContext {
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   on(event: 'close', listener: (browserContext: BrowserContext) => void): this;
 
@@ -6598,7 +6598,7 @@ export interface BrowserContext {
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   addListener(event: 'close', listener: (browserContext: BrowserContext) => void): this;
 
@@ -6765,7 +6765,7 @@ export interface BrowserContext {
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   prependListener(event: 'close', listener: (browserContext: BrowserContext) => void): this;
 
@@ -7320,7 +7320,7 @@ export interface BrowserContext {
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   waitForEvent(event: 'close', optionsOrPredicate?: { predicate?: (browserContext: BrowserContext) => boolean | Promise<boolean>, timeout?: number } | ((browserContext: BrowserContext) => boolean | Promise<boolean>)): Promise<BrowserContext>;
 
@@ -13178,7 +13178,7 @@ export interface Browser extends EventEmitter {
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   on(event: 'disconnected', listener: (browser: Browser) => void): this;
 
@@ -13190,7 +13190,7 @@ export interface Browser extends EventEmitter {
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   addListener(event: 'disconnected', listener: (browser: Browser) => void): this;
 
@@ -13207,7 +13207,7 @@ export interface Browser extends EventEmitter {
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   prependListener(event: 'disconnected', listener: (browser: Browser) => void): this;
 
@@ -13224,15 +13224,15 @@ export interface Browser extends EventEmitter {
    * In case this browser is connected to, clears all created contexts belonging to this browser and disconnects from the
    * browser server.
    *
-   * > NOTE: This is similar to force quitting the browser. Therefore, you should call
-   * [browserContext.close()](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) on any
-   * [BrowserContext]'s you explicitly created earlier with
-   * [browser.newContext([options])](https://playwright.dev/docs/api/class-browser#browser-new-context) **before** calling
-   * [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close).
-   *
    * The [Browser] object itself is considered to be disposed and cannot be used anymore.
+   * @param options
    */
-  close(): Promise<void>;
+  close(options?: {
+    /**
+     * Whether to bypass the closure of the contexts. Defaults to `false`.
+     */
+    force?: boolean;
+  }): Promise<void>;
 
   /**
    * Returns an array of all open browser contexts. In a newly created browser, this will return zero browser contexts.
@@ -13263,12 +13263,6 @@ export interface Browser extends EventEmitter {
   /**
    * Creates a new browser context. It won't share cookies/cache with other browser contexts.
    *
-   * > NOTE: If directly using this method to create [BrowserContext]s, it is best practice to explicilty close the returned
-   * context via [browserContext.close()](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) when
-   * your code is done with the [BrowserContext], and before calling
-   * [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close). This will ensure the `context` is closed
-   * gracefully and any artifacts—like HARs and videos—are fully flushed and saved.
-   *
    * ```js
    * (async () => {
    *   const browser = await playwright.firefox.launch();  // Or 'chromium' or 'webkit'.
@@ -13277,9 +13271,6 @@ export interface Browser extends EventEmitter {
    *   // Create a new page in a pristine context.
    *   const page = await context.newPage();
    *   await page.goto('https://example.com');
-   *
-   *   // Gracefully close up everything
-   *   await context.close();
    *   await browser.close();
    * })();
    * ```


### PR DESCRIPTION
With this pull request, when the [`browser.close()`](https://playwright.dev/docs/api/class-browser#browser-close) method is called: the contexts are closed cleanly. If you don't want to wait or to hang: you can pass the `force` option.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <pre lang="JavaScript">for (const context of browser.contexts()) {
    await context.close();
}
await browser.close();</pre>
    </td>
    <td><pre lang="JavaScript">await browser.close();</pre></td>
  </tr>
  <tr>
    <td><pre lang="JavaScript">await browser.close();</pre></td>
    <td><pre lang="JavaScript">await browser.close({ force: true });</pre></td>
  </tr>
</table>

Issue related: [_[BUG] `browser.close` doesn't close contexts properly_ #15163](https://github.com/microsoft/playwright/issues/15163)

---

## Edit

Looking at the tests that fail, maybe we need to change the default value of the parameter. Feedback is welcome.

```TypeScript
  async close(options: { closeContexts?: boolean; } = {}): Promise<void> {
    try {
      if (options.closeContexts) {
        for (const context of this._contexts)
          await context.close();
      }
      // ...
    }
  }
```