### PR TITLE
devops: compile Firefox natively on Ubuntu aarch64

### DIFF
--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -212,8 +212,8 @@ elif [[ "$BUILD_FLAVOR" == "firefox-ubuntu-20.04" ]]; then
   BUILD_BLOB_NAME="firefox-ubuntu-20.04.zip"
 elif [[ "$BUILD_FLAVOR" == "firefox-ubuntu-20.04-arm64" ]]; then
   BROWSER_NAME="firefox"
-  EXTRA_BUILD_ARGS="--full --linux-arm64"
-  EXTRA_ARCHIVE_ARGS="--linux-arm64"
+  EXTRA_BUILD_ARGS="--full"
+  EXPECTED_ARCH="arm64"
   EXPECTED_HOST_OS="Ubuntu"
   EXPECTED_HOST_OS_VERSION="20.04"
   BUILD_BLOB_NAME="firefox-ubuntu-20.04-arm64.zip"
@@ -225,8 +225,8 @@ elif [[ "$BUILD_FLAVOR" == "firefox-ubuntu-22.04" ]]; then
   BUILD_BLOB_NAME="firefox-ubuntu-22.04.zip"
 elif [[ "$BUILD_FLAVOR" == "firefox-ubuntu-22.04-arm64" ]]; then
   BROWSER_NAME="firefox"
-  EXTRA_BUILD_ARGS="--full --linux-arm64"
-  EXTRA_ARCHIVE_ARGS="--linux-arm64"
+  EXTRA_BUILD_ARGS="--full"
+  EXPECTED_ARCH="arm64"
   EXPECTED_HOST_OS="Ubuntu"
   EXPECTED_HOST_OS_VERSION="22.04"
   BUILD_BLOB_NAME="firefox-ubuntu-22.04-arm64.zip"

--- a/browser_patches/docker_build.sh
+++ b/browser_patches/docker_build.sh
@@ -29,15 +29,13 @@ elif [[ "${BUILD_FLAVOR}" == "firefox-ubuntu-20.04" ]]; then
   DOCKER_PLATFORM="linux/amd64"
   DOCKER_IMAGE_NAME="ubuntu:20.04"
 elif [[ "${BUILD_FLAVOR}" == "firefox-ubuntu-20.04-arm64" ]]; then
-  # We cross-compile from x86_64 to aarch64.
-  DOCKER_PLATFORM="linux/amd64"
+  DOCKER_PLATFORM="linux/arm64"
   DOCKER_IMAGE_NAME="ubuntu:20.04"
 elif [[ "${BUILD_FLAVOR}" == "firefox-ubuntu-22.04" ]]; then
   DOCKER_PLATFORM="linux/amd64"
   DOCKER_IMAGE_NAME="ubuntu:22.04"
 elif [[ "${BUILD_FLAVOR}" == "firefox-ubuntu-22.04-arm64" ]]; then
-  # We cross-compile from x86_64 to aarch64.
-  DOCKER_PLATFORM="linux/amd64"
+  DOCKER_PLATFORM="linux/arm64"
   DOCKER_IMAGE_NAME="ubuntu:22.04"
 elif [[ "${BUILD_FLAVOR}" == "firefox-debian-11" ]]; then
   DOCKER_PLATFORM="linux/amd64"
@@ -174,7 +172,9 @@ function ensure_docker_container {
 
       # Ubuntu 18.04 specific: install GCC-8. WebKit requires gcc 8.3+ to compile.
       apt-get install -y gcc-8 g++-8
-    elif [[ "${BUILD_FLAVOR}" == webkit-*-arm64 ]]; then
+    fi
+
+    if [[ "${BUILD_FLAVOR}" == *"-arm64" ]]; then
       apt-get install -y clang-12
     fi
 
@@ -201,7 +201,7 @@ elif [[ "$2" == "compile" ]]; then
     if [[ "${BUILD_FLAVOR}" == "webkit-ubuntu-18.04" ]]; then
       export CC=/usr/bin/gcc-8
       export CXX=/usr/bin/g++-8
-    elif [[ "${BUILD_FLAVOR}" == webkit-*-arm64 ]]; then
+    elif [[ "${BUILD_FLAVOR}" == "*-arm64" ]]; then
       export CC=/usr/bin/clang-12
       export CXX=/usr/bin/clang++-12
     fi

--- a/browser_patches/firefox/BUILD_NUMBER
+++ b/browser_patches/firefox/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1339
-Changed: yurys@chromium.org Fri Jul 29 16:50:33 PDT 2022
+1340
+Changed: lushnikov@chromium.org Mon Aug  1 17:56:53 MSK 2022

--- a/browser_patches/firefox/archive.sh
+++ b/browser_patches/firefox/archive.sh
@@ -42,11 +42,7 @@ cd "${FF_CHECKOUT_PATH}"
 
 export MH_BRANCH=mozilla-release
 export MOZ_BUILD_DATE=$(date +%Y%m%d%H%M%S)
-if [[ "$2" == "--linux-arm64" ]]; then
-  CMD_STRIP=/usr/bin/aarch64-linux-gnu-strip ./mach package
-else
-  ./mach package
-fi
+./mach package
 node "${SCRIPT_FOLDER}/install-preferences.js" "${OBJ_FOLDER}/dist/firefox"
 
 if ! [[ -d "$OBJ_FOLDER/dist/firefox" ]]; then

--- a/browser_patches/firefox/build.sh
+++ b/browser_patches/firefox/build.sh
@@ -3,6 +3,7 @@ set -e
 set +x
 
 RUST_VERSION="1.59.0"
+CBINDGEN_VERSION="0.24.3"
 
 trap "cd $(pwd -P)" EXIT
 
@@ -20,13 +21,11 @@ fi
 args=("$@")
 IS_FULL=""
 IS_JUGGLER=""
-IS_LINUX_ARM64=""
 IS_DEBUG=""
 for ((i="${#args[@]}"-1; i >= 0; --i)); do
     case ${args[i]} in
         --full) IS_FULL="1"; unset args[i]; ;;
         --juggler) IS_JUGGLER="1"; unset args[i]; ;;
-        --linux-arm64) IS_LINUX_ARM64="1"; unset args[i]; ;;
         --debug) IS_DEBUG="1"; unset args[i]; ;;
     esac
 done
@@ -51,11 +50,6 @@ else
   echo "- debug: NO"
 fi
 
-if [[ -n "${IS_LINUX_ARM64}" ]]; then
-  echo "- linux aarch64: YES"
-else
-  echo "- linux aarch64: NO"
-fi
 echo "========================="
 
 rm -rf .mozconfig
@@ -82,10 +76,6 @@ elif is_win; then
 else
   echo "ERROR: cannot upload on this platform!" 1>&2
   exit 1;
-fi
-
-if [[ -n "${IS_LINUX_ARM64}" ]]; then
-  echo "ac_add_options --target=aarch64-linux-gnu" >> .mozconfig
 fi
 
 # There's no pre-built wasi sysroot on certain platforms.
@@ -115,6 +105,12 @@ if [[ -z "${IS_JUGGLER}" ]]; then
     echo "-- Using rust v${RUST_VERSION}"
     rustup install "${RUST_VERSION}"
     rustup default "${RUST_VERSION}"
+  fi
+  # Firefox on Linux arm64 host does not ship
+  # cbindgen in their default toolchains - install manually.
+  if command -v cargo >/dev/null; then
+    echo "-- Using cbindgen v${CBINDGEN_VERSION}"
+    cargo install cbindgen --version "${CBINDGEN_VERSION}"
   fi
 fi
 

--- a/browser_patches/firefox/patches/bootstrap.diff
+++ b/browser_patches/firefox/patches/bootstrap.diff
@@ -2088,19 +2088,6 @@ index d956b3b5c6ecf6a983689d09e491193519f34ceb..826aabb5b794a2d4028950066ca30362
    nsresult rv = NS_OK;
    nsCOMPtr<nsIContentSecurityPolicy> preloadCsp = mDocument->GetPreloadCsp();
    if (!preloadCsp) {
-diff --git a/python/mozbuild/mozpack/executables.py b/python/mozbuild/mozpack/executables.py
-index 4504ade8e6b3be9404e0d72fd30f60939831ed0f..34988ac3ede846d0aaa0d4637439108fd922361f 100644
---- a/python/mozbuild/mozpack/executables.py
-+++ b/python/mozbuild/mozpack/executables.py
-@@ -107,7 +107,7 @@ def strip(path):
-     """
-     from buildconfig import substs
- 
--    strip = substs["STRIP"]
-+    strip = os.getenv("CMD_STRIP") or substs["STRIP"]
-     flags = substs.get("STRIP_FLAGS", [])
-     cmd = [strip] + flags + [path]
-     if subprocess.call(cmd) != 0:
 diff --git a/security/manager/ssl/nsCertOverrideService.cpp b/security/manager/ssl/nsCertOverrideService.cpp
 index 153722c33b9db6475aa5134ad5b665051ac68658..74324d95f7088c65c3d52ab2a7c40e89901d9512 100644
 --- a/security/manager/ssl/nsCertOverrideService.cpp


### PR DESCRIPTION
We used to cross-compile Firefox for aarch64, but this no longer
works.

This patch switches to native build inside Ubuntu aarch.
