### PR TITLE
devops: install Python 3.8 on Ubuntu 18.04

### DIFF
--- a/browser_patches/docker_build.sh
+++ b/browser_patches/docker_build.sh
@@ -131,15 +131,24 @@ function ensure_docker_container {
 
     apt-get update && apt-get install -y wget \
                                          git-core \
-                                         python3 \
-                                         python3-pip \
                                          curl \
                                          autoconf2.13 \
                                          tzdata \
                                          sudo \
                                          zip \
-                                         unzip \
-                                         python3-distutils
+                                         unzip
+
+    # Ubuntu 18 installs Python 3.6 as Python3 by default; this, however,
+    # fails to run Firefox build scripts.
+    # Install Python3.8 instead on Ubuntu 18.04 as Python3.
+    if [[ "${BUILD_FLAVOR}" == *ubuntu-18.04* ]]; then
+      apt-get install -y python3.8 python3.8-pip python3.8-distutils
+      # Point python3 to python3.8
+      update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2
+    else
+      apt-get install -y python3 python3-pip python3-distutils
+    fi
+
 
     # Create the pwuser and make it passwordless sudoer.
     adduser --disabled-password --gecos "" pwuser


### PR DESCRIPTION
Ubuntu 18.04 ships Python 3.6 by default on Ubuntu18.04; this python,
however, fails to run Firefox build system, so we have to install
Python 3.8 and default it to `python3`.
