### PR TITLE
devops: do not bundle `libstdc++` with Firefox builds

### DIFF
--- a/browser_patches/firefox/archive.sh
+++ b/browser_patches/firefox/archive.sh
@@ -50,11 +50,7 @@ if ! [[ -d "$OBJ_FOLDER/dist/firefox" ]]; then
   exit 1;
 fi
 
-# Copy the libstdc++ version we linked against.
-# TODO(aslushnikov): this won't be needed with official builds.
-if is_linux; then
-  cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 "${OBJ_FOLDER}/dist/firefox/libstdc++.so.6"
-elif is_win; then
+if is_win; then
   # Bundle vcruntime14_1.dll - see https://github.com/microsoft/playwright/issues/9974
   cd "$(printMSVCRedistDir)"
   cp -t "${OBJ_FOLDER}/dist/firefox" vcruntime140_1.dll


### PR DESCRIPTION
Turns out we were bundling x86_64 `libstdc++` with aarch64
builds on Ubuntu, which was useless and implies that this
library might not be needed at all.
