### PR TITLE
docs: add set expect timeout for all langs

### DIFF
--- a/docs/src/api/class-playwrightassertions.md
+++ b/docs/src/api/class-playwrightassertions.md
@@ -145,12 +145,20 @@ await Expect(page).ToHaveTitleAsync("News");
 
 ## method: PlaywrightAssertions.setDefaultTimeout
 * since: v1.25
-* langs: java
+* langs: java, python, csharp
 
 Changes default timeout for Playwright assertions from 5 seconds to the speicified value.
 
 ```java
 PlaywrightAssertions.setDefaultTimeout(30_000);
+```
+
+```csharp
+Assertions.SetDefaultTimeout(30_000);
+```
+
+```python
+expect_set_default_timeout(30_000)
 ```
 
 ### param: PlaywrightAssertions.setDefaultTimeout.timeout


### PR DESCRIPTION
https://github.com/microsoft/playwright-dotnet/issues/2237
https://github.com/microsoft/playwright-python/issues/1358

I like the .NET way of doing it, but not sure about the Python one.