### PR TITLE
devops: fix Firefox-Beta build the same way we fix FF Stable

### DIFF
--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -282,8 +282,8 @@ elif [[ "$BUILD_FLAVOR" == "firefox-beta-ubuntu-22.04" ]]; then
   BUILD_BLOB_NAME="firefox-beta-ubuntu-22.04.zip"
 elif [[ "$BUILD_FLAVOR" == "firefox-beta-ubuntu-22.04-arm64" ]]; then
   BROWSER_NAME="firefox-beta"
-  EXTRA_BUILD_ARGS="--full --linux-arm64"
-  EXTRA_ARCHIVE_ARGS="--linux-arm64"
+  EXTRA_BUILD_ARGS="--full"
+  EXPECTED_ARCH="aarch64"
   EXPECTED_HOST_OS="Ubuntu"
   EXPECTED_HOST_OS_VERSION="22.04"
   BUILD_BLOB_NAME="firefox-beta-ubuntu-22.04-arm64.zip"

--- a/browser_patches/checkout_build_archive_upload.sh
+++ b/browser_patches/checkout_build_archive_upload.sh
@@ -274,6 +274,13 @@ elif [[ "$BUILD_FLAVOR" == "firefox-beta-ubuntu-20.04" ]]; then
   EXPECTED_HOST_OS="Ubuntu"
   EXPECTED_HOST_OS_VERSION="20.04"
   BUILD_BLOB_NAME="firefox-beta-ubuntu-20.04.zip"
+elif [[ "$BUILD_FLAVOR" == "firefox-beta-ubuntu-20.04-arm64" ]]; then
+  BROWSER_NAME="firefox-beta"
+  EXTRA_BUILD_ARGS="--full"
+  EXPECTED_ARCH="aarch64"
+  EXPECTED_HOST_OS="Ubuntu"
+  EXPECTED_HOST_OS_VERSION="20.04"
+  BUILD_BLOB_NAME="firefox-beta-ubuntu-20.04-arm64.zip"
 elif [[ "$BUILD_FLAVOR" == "firefox-beta-ubuntu-22.04" ]]; then
   BROWSER_NAME="firefox-beta"
   EXTRA_BUILD_ARGS="--full"

--- a/browser_patches/docker_build.sh
+++ b/browser_patches/docker_build.sh
@@ -52,15 +52,13 @@ elif [[ "${BUILD_FLAVOR}" == "firefox-beta-ubuntu-20.04" ]]; then
   DOCKER_PLATFORM="linux/amd64"
   DOCKER_IMAGE_NAME="ubuntu:20.04"
 elif [[ "${BUILD_FLAVOR}" == "firefox-beta-ubuntu-20.04-arm64" ]]; then
-  # We cross-compile from x86_64 to aarch64.
-  DOCKER_PLATFORM="linux/amd64"
+  DOCKER_PLATFORM="linux/arm64"
   DOCKER_IMAGE_NAME="ubuntu:20.04"
 elif [[ "${BUILD_FLAVOR}" == "firefox-beta-ubuntu-22.04" ]]; then
   DOCKER_PLATFORM="linux/amd64"
   DOCKER_IMAGE_NAME="ubuntu:22.04"
 elif [[ "${BUILD_FLAVOR}" == "firefox-beta-ubuntu-22.04-arm64" ]]; then
-  # We cross-compile from x86_64 to aarch64.
-  DOCKER_PLATFORM="linux/amd64"
+  DOCKER_PLATFORM="linux/arm64"
   DOCKER_IMAGE_NAME="ubuntu:22.04"
 elif [[ "${BUILD_FLAVOR}" == "firefox-beta-debian-11" ]]; then
   DOCKER_PLATFORM="linux/amd64"

--- a/browser_patches/firefox-beta/BUILD_NUMBER
+++ b/browser_patches/firefox-beta/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1339
-Changed: dgozman@gmail.com Mon Aug  1 12:43:07 PDT 2022
+1340
+Changed: lushnikov@chromium.org Tue 02 Aug 2022 07:18:19 AM PDT

--- a/browser_patches/firefox-beta/EXPECTED_BUILDS
+++ b/browser_patches/firefox-beta/EXPECTED_BUILDS
@@ -2,6 +2,7 @@ firefox-beta-mac-11.zip
 firefox-beta-mac-11-arm64.zip
 firefox-beta-ubuntu-18.04.zip
 firefox-beta-ubuntu-20.04.zip
+firefox-beta-ubuntu-20.04-arm64.zip
 firefox-beta-ubuntu-22.04.zip
 firefox-beta-ubuntu-22.04-arm64.zip
 firefox-beta-debian-11.zip

--- a/browser_patches/firefox-beta/archive.sh
+++ b/browser_patches/firefox-beta/archive.sh
@@ -42,11 +42,7 @@ cd "${FF_CHECKOUT_PATH}"
 
 export MH_BRANCH=mozilla-beta
 export MOZ_BUILD_DATE=$(date +%Y%m%d%H%M%S)
-if [[ "$2" == "--linux-arm64" ]]; then
-  CMD_STRIP=/usr/bin/aarch64-linux-gnu-strip ./mach package
-else
-  ./mach package
-fi
+./mach package
 node "${SCRIPT_FOLDER}/install-preferences.js" "${OBJ_FOLDER}/dist/firefox"
 
 if ! [[ -d "$OBJ_FOLDER/dist/firefox" ]]; then
@@ -54,11 +50,7 @@ if ! [[ -d "$OBJ_FOLDER/dist/firefox" ]]; then
   exit 1;
 fi
 
-# Copy the libstdc++ version we linked against.
-# TODO(aslushnikov): this won't be needed with official builds.
-if is_linux; then
-  cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 "${OBJ_FOLDER}/dist/firefox/libstdc++.so.6"
-elif is_win; then
+if is_win; then
   # Bundle vcruntime14_1.dll - see https://github.com/microsoft/playwright/issues/9974
   cd "$(printMSVCRedistDir)"
   cp -t "${OBJ_FOLDER}/dist/firefox" vcruntime140_1.dll

--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -21,13 +21,11 @@ fi
 args=("$@")
 IS_FULL=""
 IS_JUGGLER=""
-IS_LINUX_ARM64=""
 IS_DEBUG=""
 for ((i="${#args[@]}"-1; i >= 0; --i)); do
     case ${args[i]} in
         --full) IS_FULL="1"; unset args[i]; ;;
         --juggler) IS_JUGGLER="1"; unset args[i]; ;;
-        --linux-arm64) IS_LINUX_ARM64="1"; unset args[i]; ;;
         --debug) IS_DEBUG="1"; unset args[i]; ;;
     esac
 done
@@ -52,11 +50,6 @@ else
   echo "- debug: NO"
 fi
 
-if [[ -n "${IS_LINUX_ARM64}" ]]; then
-  echo "- linux aarch64: YES"
-else
-  echo "- linux aarch64: NO"
-fi
 echo "========================="
 
 rm -rf .mozconfig
@@ -83,10 +76,6 @@ elif is_win; then
 else
   echo "ERROR: cannot upload on this platform!" 1>&2
   exit 1;
-fi
-
-if [[ -n "${IS_LINUX_ARM64}" ]]; then
-  echo "ac_add_options --target=aarch64-linux-gnu" >> .mozconfig
 fi
 
 # There's no pre-built wasi sysroot on certain platforms.
@@ -117,8 +106,8 @@ if [[ -z "${IS_JUGGLER}" ]]; then
     rustup install "${RUST_VERSION}"
     rustup default "${RUST_VERSION}"
   fi
-
-  # TODO: cargo is not in the PATH on Windows
+  # Firefox on Linux arm64 host does not ship
+  # cbindgen in their default toolchains - install manually.
   if command -v cargo >/dev/null; then
     echo "-- Using cbindgen v${CBINDGEN_VERSION}"
     cargo install cbindgen --version "${CBINDGEN_VERSION}"
@@ -126,26 +115,23 @@ if [[ -z "${IS_JUGGLER}" ]]; then
 fi
 
 if [[ -n "${IS_FULL}" ]]; then
-  if is_mac; then
-    echo "ac_add_options --enable-bootstrap" >> .mozconfig
-  else
-    # This is a slow but sure way to get all the necessary toolchains.
-    # However, it will not work if tree is dirty.
-    # Bail out if git repo is dirty.
-    if [[ -n $(git status -s --untracked-files=no) ]]; then
-      echo "ERROR: dirty GIT state - commit everything and re-run the script."
-      exit 1
-    fi
-
-    # 1. We have a --single-branch checkout, so we have to add a "master" branch and fetch it
-    git remote set-branches --add browser_upstream master
-    git fetch browser_upstream master
-    # 2. Checkout the master branch and run bootstrap from it.
-    git checkout browser_upstream/master
-    SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser
-    git checkout -
-    rm -rf "${OBJ_FOLDER}"
+  # This is a slow but sure way to get all the necessary toolchains.
+  # However, it will not work if tree is dirty.
+  # Bail out if git repo is dirty.
+  if [[ -n $(git status -s --untracked-files=no) ]]; then
+    echo "ERROR: dirty GIT state - commit everything and re-run the script."
+    exit 1
   fi
+
+  # 1. We have a --single-branch checkout, so we have to add a "master" branch and fetch it
+  git remote set-branches --add browser_upstream master
+  git fetch --depth 1 browser_upstream master
+  # 2. Checkout the master branch and run bootstrap from it.
+  git checkout browser_upstream/master
+  echo "ac_add_options --enable-bootstrap" >> .mozconfig
+  SHELL=/bin/sh ./mach --no-interactive bootstrap --application-choice=browser
+  git checkout -
+  rm -rf "${OBJ_FOLDER}"
 
   if [[ -n "${WIN32_REDIST_DIR}" ]]; then
     # Having this option in .mozconfig kills incremental compilation.
@@ -153,26 +139,9 @@ if [[ -n "${IS_FULL}" ]]; then
   fi
 fi
 
-# Remove the cbindgen from mozbuild to rely on the one we install manually.
-# See https://github.com/microsoft/playwright/issues/15174
-if is_win; then
-  rm -rf "${USERPROFILE}\\.mozbuild\\cbindgen"
-else
-  rm -rf "${HOME}/.mozbuild/cbindgen"
-fi
-
-
 if [[ -n "${IS_JUGGLER}" ]]; then
   ./mach build faster
 else
-  export MOZ_AUTOMATION=1
-  # Use winpaths instead of unix paths on Windows.
-  # note: 'cygpath' is not available in MozBuild shell.
-  if is_win; then
-    export MOZ_FETCHES_DIR="${USERPROFILE}\\.mozbuild"
-  else
-    export MOZ_FETCHES_DIR="${HOME}/.mozbuild"
-  fi
   ./mach build
   if is_mac; then
     FF_DEBUG_BUILD="${IS_DEBUG}" node "${SCRIPT_FOLDER}"/install-preferences.js "$PWD"/${OBJ_FOLDER}/dist

--- a/browser_patches/firefox-beta/patches/bootstrap.diff
+++ b/browser_patches/firefox-beta/patches/bootstrap.diff
@@ -2160,19 +2160,6 @@ index d956b3b5c6ecf6a983689d09e491193519f34ceb..826aabb5b794a2d4028950066ca30362
    nsresult rv = NS_OK;
    nsCOMPtr<nsIContentSecurityPolicy> preloadCsp = mDocument->GetPreloadCsp();
    if (!preloadCsp) {
-diff --git a/python/mozbuild/mozpack/executables.py b/python/mozbuild/mozpack/executables.py
-index 4504ade8e6b3be9404e0d72fd30f60939831ed0f..34988ac3ede846d0aaa0d4637439108fd922361f 100644
---- a/python/mozbuild/mozpack/executables.py
-+++ b/python/mozbuild/mozpack/executables.py
-@@ -107,7 +107,7 @@ def strip(path):
-     """
-     from buildconfig import substs
- 
--    strip = substs["STRIP"]
-+    strip = os.getenv("CMD_STRIP") or substs["STRIP"]
-     flags = substs.get("STRIP_FLAGS", [])
-     cmd = [strip] + flags + [path]
-     if subprocess.call(cmd) != 0:
 diff --git a/security/manager/ssl/nsCertOverrideService.cpp b/security/manager/ssl/nsCertOverrideService.cpp
 index 153722c33b9db6475aa5134ad5b665051ac68658..74324d95f7088c65c3d52ab2a7c40e89901d9512 100644
 --- a/security/manager/ssl/nsCertOverrideService.cpp
@@ -2651,7 +2638,7 @@ diff --git a/widget/cocoa/NativeKeyBindings.mm b/widget/cocoa/NativeKeyBindings.
 index d3e5983259053175584254e7ac01ca9ce024f33a..97f5b851c402fea5477c0ee57af451c62b016eec 100644
 --- a/widget/cocoa/NativeKeyBindings.mm
 +++ b/widget/cocoa/NativeKeyBindings.mm
-@@ -492,6 +492,13 @@
+@@ -492,6 +492,13 @@ void NativeKeyBindings::GetEditCommandsForTests(NativeKeyBindingsType aType,
        break;
      case KEY_NAME_INDEX_ArrowLeft:
        if (aEvent.IsAlt()) {
@@ -2665,7 +2652,7 @@ index d3e5983259053175584254e7ac01ca9ce024f33a..97f5b851c402fea5477c0ee57af451c6
          break;
        }
        if (aEvent.IsMeta() || (aEvent.IsControl() && aEvent.IsShift())) {
-@@ -512,6 +519,13 @@
+@@ -512,6 +519,13 @@ void NativeKeyBindings::GetEditCommandsForTests(NativeKeyBindingsType aType,
        break;
      case KEY_NAME_INDEX_ArrowRight:
        if (aEvent.IsAlt()) {
@@ -2679,7 +2666,7 @@ index d3e5983259053175584254e7ac01ca9ce024f33a..97f5b851c402fea5477c0ee57af451c6
          break;
        }
        if (aEvent.IsMeta() || (aEvent.IsControl() && aEvent.IsShift())) {
-@@ -532,6 +546,10 @@
+@@ -532,6 +546,10 @@ void NativeKeyBindings::GetEditCommandsForTests(NativeKeyBindingsType aType,
        break;
      case KEY_NAME_INDEX_ArrowUp:
        if (aEvent.IsControl()) {
@@ -2690,7 +2677,7 @@ index d3e5983259053175584254e7ac01ca9ce024f33a..97f5b851c402fea5477c0ee57af451c6
          break;
        }
        if (aEvent.IsMeta()) {
-@@ -541,7 +559,7 @@
+@@ -541,7 +559,7 @@ void NativeKeyBindings::GetEditCommandsForTests(NativeKeyBindingsType aType,
          instance->AppendEditCommandsForSelector(
              !aEvent.IsShift()
                  ? ToObjcSelectorPtr(@selector(moveToBeginningOfDocument:))
@@ -2699,7 +2686,7 @@ index d3e5983259053175584254e7ac01ca9ce024f33a..97f5b851c402fea5477c0ee57af451c6
              aCommands);
          break;
        }
-@@ -564,6 +582,10 @@
+@@ -564,6 +582,10 @@ void NativeKeyBindings::GetEditCommandsForTests(NativeKeyBindingsType aType,
        break;
      case KEY_NAME_INDEX_ArrowDown:
        if (aEvent.IsControl()) {


### PR DESCRIPTION
Drive-by: add missing `ff-beta-ubuntu-20.04-arm64` build