### PR TITLE
feat(browser): close contexts when close browser

### DIFF
--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -97,10 +97,16 @@ In case this browser is connected to, clears all created contexts belonging to t
 browser server.
 
 :::note
-This is similar to force quitting the browser. Therefore, you should call [`method: BrowserContext.close`] on any [BrowserContext]'s you explicitly created earlier with [`method: Browser.newContext`] **before** calling [`method: Browser.close`].
+This is similar to force quitting the browser. Therefore, you should add `closeContexts` option. Or you should call [`method: BrowserContext.close`] on any [BrowserContext]'s you explicitly created earlier with [`method: Browser.newContext`] **before** calling [`method: Browser.close`].
 :::
 
 The [Browser] object itself is considered to be disposed and cannot be used anymore.
+
+### option: Browser.close.closeContexts
+* since: v1.25
+- `force` <boolean>
+
+If the contexts have to be closed. Defaults to `false`.
 
 ## method: Browser.contexts
 * since: v1.8

--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -116,8 +116,13 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
     return (await this._channel.stopTracing()).binary;
   }
 
-  async close(): Promise<void> {
+  async close(options: { closeContexts?: boolean; } = {}): Promise<void> {
     try {
+      if (options.closeContexts) {
+        for (const context of this._contexts)
+          await context.close();
+      }
+
       if (this._shouldCloseConnectionOnClose)
         this._connection.close(kBrowserClosedError);
       else

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -6471,7 +6471,7 @@ export interface BrowserContext {
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   on(event: 'close', listener: (browserContext: BrowserContext) => void): this;
 
@@ -6598,7 +6598,7 @@ export interface BrowserContext {
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   addListener(event: 'close', listener: (browserContext: BrowserContext) => void): this;
 
@@ -6765,7 +6765,7 @@ export interface BrowserContext {
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   prependListener(event: 'close', listener: (browserContext: BrowserContext) => void): this;
 
@@ -7320,7 +7320,7 @@ export interface BrowserContext {
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   waitForEvent(event: 'close', optionsOrPredicate?: { predicate?: (browserContext: BrowserContext) => boolean | Promise<boolean>, timeout?: number } | ((browserContext: BrowserContext) => boolean | Promise<boolean>)): Promise<BrowserContext>;
 
@@ -13178,7 +13178,7 @@ export interface Browser extends EventEmitter {
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   on(event: 'disconnected', listener: (browser: Browser) => void): this;
 
@@ -13190,7 +13190,7 @@ export interface Browser extends EventEmitter {
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   addListener(event: 'disconnected', listener: (browser: Browser) => void): this;
 
@@ -13207,7 +13207,7 @@ export interface Browser extends EventEmitter {
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
    * - Browser application is closed or crashed.
-   * - The [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
+   * - The [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close) method was called.
    */
   prependListener(event: 'disconnected', listener: (browser: Browser) => void): this;
 
@@ -13224,15 +13224,21 @@ export interface Browser extends EventEmitter {
    * In case this browser is connected to, clears all created contexts belonging to this browser and disconnects from the
    * browser server.
    *
-   * > NOTE: This is similar to force quitting the browser. Therefore, you should call
-   * [browserContext.close()](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) on any
+   * > NOTE: This is similar to force quitting the browser. Therefore, you should add `closeContexts` option. Or you should
+   * call [browserContext.close()](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) on any
    * [BrowserContext]'s you explicitly created earlier with
    * [browser.newContext([options])](https://playwright.dev/docs/api/class-browser#browser-new-context) **before** calling
-   * [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close).
+   * [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close).
    *
    * The [Browser] object itself is considered to be disposed and cannot be used anymore.
+   * @param options
    */
-  close(): Promise<void>;
+  close(options?: {
+    /**
+     * If the contexts have to be closed. Defaults to `false`.
+     */
+    force?: boolean;
+  }): Promise<void>;
 
   /**
    * Returns an array of all open browser contexts. In a newly created browser, this will return zero browser contexts.
@@ -13266,8 +13272,8 @@ export interface Browser extends EventEmitter {
    * > NOTE: If directly using this method to create [BrowserContext]s, it is best practice to explicilty close the returned
    * context via [browserContext.close()](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) when
    * your code is done with the [BrowserContext], and before calling
-   * [browser.close()](https://playwright.dev/docs/api/class-browser#browser-close). This will ensure the `context` is closed
-   * gracefully and any artifacts—like HARs and videos—are fully flushed and saved.
+   * [browser.close([options])](https://playwright.dev/docs/api/class-browser#browser-close). This will ensure the `context`
+   * is closed gracefully and any artifacts—like HARs and videos—are fully flushed and saved.
    *
    * ```js
    * (async () => {

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -256,6 +256,19 @@ test('should reject navigation when browser closes', async ({ browserType, start
   expect(error.message).toContain('has been closed');
 });
 
+test('should reject navigation when browser and contexts close', async ({ browserType, startRemoteServer, server }) => {
+  const remoteServer = await startRemoteServer();
+  server.setRoute('/one-style.css', () => {});
+  const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
+  const page = await browser.newPage();
+  const navigationPromise = page.goto(server.PREFIX + '/one-style.html', { timeout: 60000 }).catch(e => e);
+  await server.waitForRequest('/one-style.css');
+  await browser.close({ closeContexts: true });
+  const error = await navigationPromise;
+  console.log(error.message);
+  expect(error.message).toContain('was closed');
+});
+
 test('should reject waitForSelector when browser closes', async ({ browserType, startRemoteServer, server }) => {
   const remoteServer = await startRemoteServer();
   server.setRoute('/empty.html', () => {});
@@ -269,6 +282,21 @@ test('should reject waitForSelector when browser closes', async ({ browserType, 
   await browser.close();
   const error = await watchdog;
   expect(error.message).toContain('has been closed');
+});
+
+test('should reject waitForSelector when browser and contexts close', async ({ browserType, startRemoteServer, server }) => {
+  const remoteServer = await startRemoteServer();
+  server.setRoute('/empty.html', () => {});
+  const browser = await browserType.connect({ wsEndpoint: remoteServer.wsEndpoint() });
+  const page = await browser.newPage();
+  const watchdog = page.waitForSelector('div', { state: 'attached', timeout: 60000 }).catch(e => e);
+
+  // Make sure the previous waitForSelector has time to make it to the browser before we disconnect.
+  await page.waitForSelector('body', { state: 'attached' });
+
+  await browser.close({ closeContexts: true });
+  const error = await watchdog;
+  expect(error.message).toContain('closed');
 });
 
 test('should emit close events on pages and contexts', async ({ browserType, startRemoteServer }) => {


### PR DESCRIPTION
I reversed the default value of the [`browser.close()`](https://playwright.dev/docs/api/class-browser#browser-close) option so as not to change the default behavior. I added the `closeContexts` option which simplifies closing the browser and its contexts.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><pre lang="JavaScript">await browser.close();</pre></td>
    <td><pre lang="JavaScript">await browser.close();</pre></td>
  </tr>
  <tr>
    <td>
      <pre lang="JavaScript">for (const context of browser.contexts()) {
    await context.close();
}
await browser.close();</pre>
    </td>
    <td><pre lang="JavaScript">await browser.close({ closeContexts: true });</pre></td>
  </tr>
</table>

- Issue related: [_[BUG] `browser.close` doesn't close contexts properly_ #15163](https://github.com/microsoft/playwright/issues/15163)
- Pull request related: #16073. I pushed on this pull request, but my modification does not go up (probably because it is closed). So I created a new pull request. 😕