### PR TITLE
chore: move connect() protocol helper to LocalUtils

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -127,10 +127,10 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
       const deadline = params.timeout ? monotonicTime() + params.timeout : 0;
       let browser: Browser;
       const headers = { 'x-playwright-browser': this.name(), ...params.headers };
-      const connectParams: channels.BrowserTypeConnectParams = { wsEndpoint, headers, slowMo: params.slowMo, timeout: params.timeout };
+      const connectParams: channels.LocalUtilsConnectToWebSocketParams = { wsEndpoint, headers, slowMo: params.slowMo, timeout: params.timeout };
       if ((params as any).__testHookRedirectPortForwarding)
         connectParams.socksProxyRedirectPortForTest = (params as any).__testHookRedirectPortForwarding;
-      const { pipe } = await this._channel.connect(connectParams);
+      const { pipe } = await this._connection.localUtils()._channel.connectToWebSocket(connectParams);
       const closePipe = () => pipe.close().catch(() => {});
       const connection = new Connection(this._connection.localUtils());
       connection.markAsRemote();

--- a/packages/playwright-core/src/protocol/channels.ts
+++ b/packages/playwright-core/src/protocol/channels.ts
@@ -379,12 +379,29 @@ export interface LocalUtilsEventTarget {
 }
 export interface LocalUtilsChannel extends LocalUtilsEventTarget, Channel {
   _type_LocalUtils: boolean;
+  connectToWebSocket(params: LocalUtilsConnectToWebSocketParams, metadata?: Metadata): Promise<LocalUtilsConnectToWebSocketResult>;
   zip(params: LocalUtilsZipParams, metadata?: Metadata): Promise<LocalUtilsZipResult>;
   harOpen(params: LocalUtilsHarOpenParams, metadata?: Metadata): Promise<LocalUtilsHarOpenResult>;
   harLookup(params: LocalUtilsHarLookupParams, metadata?: Metadata): Promise<LocalUtilsHarLookupResult>;
   harClose(params: LocalUtilsHarCloseParams, metadata?: Metadata): Promise<LocalUtilsHarCloseResult>;
   harUnzip(params: LocalUtilsHarUnzipParams, metadata?: Metadata): Promise<LocalUtilsHarUnzipResult>;
 }
+export type LocalUtilsConnectToWebSocketParams = {
+  wsEndpoint: string,
+  headers?: any,
+  slowMo?: number,
+  timeout?: number,
+  socksProxyRedirectPortForTest?: number,
+};
+export type LocalUtilsConnectToWebSocketOptions = {
+  headers?: any,
+  slowMo?: number,
+  timeout?: number,
+  socksProxyRedirectPortForTest?: number,
+};
+export type LocalUtilsConnectToWebSocketResult = {
+  pipe: JsonPipeChannel,
+};
 export type LocalUtilsZipParams = {
   zipFile: string,
   entries: NameValue[],
@@ -657,27 +674,10 @@ export interface BrowserTypeEventTarget {
 }
 export interface BrowserTypeChannel extends BrowserTypeEventTarget, Channel {
   _type_BrowserType: boolean;
-  connect(params: BrowserTypeConnectParams, metadata?: Metadata): Promise<BrowserTypeConnectResult>;
   launch(params: BrowserTypeLaunchParams, metadata?: Metadata): Promise<BrowserTypeLaunchResult>;
   launchPersistentContext(params: BrowserTypeLaunchPersistentContextParams, metadata?: Metadata): Promise<BrowserTypeLaunchPersistentContextResult>;
   connectOverCDP(params: BrowserTypeConnectOverCDPParams, metadata?: Metadata): Promise<BrowserTypeConnectOverCDPResult>;
 }
-export type BrowserTypeConnectParams = {
-  wsEndpoint: string,
-  headers?: any,
-  slowMo?: number,
-  timeout?: number,
-  socksProxyRedirectPortForTest?: number,
-};
-export type BrowserTypeConnectOptions = {
-  headers?: any,
-  slowMo?: number,
-  timeout?: number,
-  socksProxyRedirectPortForTest?: number,
-};
-export type BrowserTypeConnectResult = {
-  pipe: JsonPipeChannel,
-};
 export type BrowserTypeLaunchParams = {
   channel?: string,
   executablePath?: string,

--- a/packages/playwright-core/src/protocol/protocol.yml
+++ b/packages/playwright-core/src/protocol/protocol.yml
@@ -478,6 +478,16 @@ LocalUtils:
 
   commands:
 
+    connectToWebSocket:
+      parameters:
+        wsEndpoint: string
+        headers: json?
+        slowMo: number?
+        timeout: number?
+        socksProxyRedirectPortForTest: number?
+      returns:
+        pipe: JsonPipe
+
     zip:
       parameters:
         zipFile: string
@@ -686,16 +696,6 @@ BrowserType:
     name: string
 
   commands:
-
-    connect:
-      parameters:
-        wsEndpoint: string
-        headers: json?
-        slowMo: number?
-        timeout: number?
-        socksProxyRedirectPortForTest: number?
-      returns:
-        pipe: JsonPipe
 
     launch:
       parameters:

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -207,6 +207,16 @@ scheme.APIResponse = tObject({
 });
 scheme.LifecycleEvent = tEnum(['load', 'domcontentloaded', 'networkidle', 'commit']);
 scheme.LocalUtilsInitializer = tOptional(tObject({}));
+scheme.LocalUtilsConnectToWebSocketParams = tObject({
+  wsEndpoint: tString,
+  headers: tOptional(tAny),
+  slowMo: tOptional(tNumber),
+  timeout: tOptional(tNumber),
+  socksProxyRedirectPortForTest: tOptional(tNumber),
+});
+scheme.LocalUtilsConnectToWebSocketResult = tObject({
+  pipe: tChannel(['JsonPipe']),
+});
 scheme.LocalUtilsZipParams = tObject({
   zipFile: tString,
   entries: tArray(tType('NameValue')),
@@ -355,16 +365,6 @@ scheme.SelectorsRegisterResult = tOptional(tObject({}));
 scheme.BrowserTypeInitializer = tObject({
   executablePath: tString,
   name: tString,
-});
-scheme.BrowserTypeConnectParams = tObject({
-  wsEndpoint: tString,
-  headers: tOptional(tAny),
-  slowMo: tOptional(tNumber),
-  timeout: tOptional(tNumber),
-  socksProxyRedirectPortForTest: tOptional(tNumber),
-});
-scheme.BrowserTypeConnectResult = tObject({
-  pipe: tChannel(['JsonPipe']),
 });
 scheme.BrowserTypeLaunchParams = tObject({
   channel: tOptional(tString),

--- a/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
@@ -21,13 +21,6 @@ import type { DispatcherScope } from './dispatcher';
 import { Dispatcher } from './dispatcher';
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 import type { CallMetadata } from '../instrumentation';
-import { JsonPipeDispatcher } from '../dispatchers/jsonPipeDispatcher';
-import { getUserAgent } from '../../common/userAgent';
-import * as socks from '../../common/socksProxy';
-import EventEmitter from 'events';
-import { ProgressController } from '../progress';
-import { WebSocketTransport } from '../transport';
-import { findValidator, ValidationError, type ValidatorContext } from '../../protocol/validator';
 
 export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.BrowserTypeChannel> implements channels.BrowserTypeChannel {
   _type_BrowserType = true;
@@ -56,101 +49,4 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.Brow
       defaultContext: browser._defaultContext ? new BrowserContextDispatcher(browserDispatcher._scope, browser._defaultContext) : undefined,
     };
   }
-
-  async connect(params: channels.BrowserTypeConnectParams, metadata: CallMetadata): Promise<channels.BrowserTypeConnectResult> {
-    const controller = new ProgressController(metadata, this._object);
-    controller.setLogName('browser');
-    return await controller.run(async progress => {
-      const paramsHeaders = Object.assign({ 'User-Agent': getUserAgent() }, params.headers || {});
-      const transport = await WebSocketTransport.connect(progress, params.wsEndpoint, paramsHeaders, true);
-      let socksInterceptor: SocksInterceptor | undefined;
-      const pipe = new JsonPipeDispatcher(this._scope);
-      transport.onmessage = json => {
-        if (json.method === '__create__' && json.params.type === 'SocksSupport')
-          socksInterceptor = new SocksInterceptor(transport, params.socksProxyRedirectPortForTest, json.params.guid);
-        if (socksInterceptor?.interceptMessage(json))
-          return;
-        const cb = () => {
-          try {
-            pipe.dispatch(json);
-          } catch (e) {
-            transport.close();
-          }
-        };
-        if (params.slowMo)
-          setTimeout(cb, params.slowMo);
-        else
-          cb();
-      };
-      pipe.on('message', message => {
-        transport.send(message);
-      });
-      transport.onclose = () => {
-        socksInterceptor?.cleanup();
-        pipe.wasClosed();
-      };
-      pipe.on('close', () => transport.close());
-      return { pipe };
-    }, params.timeout || 0);
-  }
-}
-
-class SocksInterceptor {
-  private _handler: socks.SocksProxyHandler;
-  private _channel: channels.SocksSupportChannel & EventEmitter;
-  private _socksSupportObjectGuid: string;
-  private _ids = new Set<number>();
-
-  constructor(transport: WebSocketTransport, redirectPortForTest: number | undefined, socksSupportObjectGuid: string) {
-    this._handler = new socks.SocksProxyHandler(redirectPortForTest);
-    this._socksSupportObjectGuid = socksSupportObjectGuid;
-
-    let lastId = -1;
-    this._channel = new Proxy(new EventEmitter(), {
-      get: (obj: any, prop) => {
-        if ((prop in obj) || obj[prop] !== undefined || typeof prop !== 'string')
-          return obj[prop];
-        return (params: any) => {
-          try {
-            const id = --lastId;
-            this._ids.add(id);
-            const validator = findValidator('SocksSupport', prop, 'Params');
-            params = validator(params, '', { tChannelImpl: tChannelForSocks, binary: 'toBase64' });
-            transport.send({ id, guid: socksSupportObjectGuid, method: prop, params, metadata: { stack: [], apiName: '', internal: true } } as any);
-          } catch (e) {
-          }
-        };
-      },
-    }) as channels.SocksSupportChannel & EventEmitter;
-    this._handler.on(socks.SocksProxyHandler.Events.SocksConnected, (payload: socks.SocksSocketConnectedPayload) => this._channel.socksConnected(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksData, (payload: socks.SocksSocketDataPayload) => this._channel.socksData(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksError, (payload: socks.SocksSocketErrorPayload) => this._channel.socksError(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksFailed, (payload: socks.SocksSocketFailedPayload) => this._channel.socksFailed(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksEnd, (payload: socks.SocksSocketEndPayload) => this._channel.socksEnd(payload));
-    this._channel.on('socksRequested', payload => this._handler.socketRequested(payload));
-    this._channel.on('socksClosed', payload => this._handler.socketClosed(payload));
-    this._channel.on('socksData', payload => this._handler.sendSocketData(payload));
-  }
-
-  cleanup() {
-    this._handler.cleanup();
-  }
-
-  interceptMessage(message: any): boolean {
-    if (this._ids.has(message.id)) {
-      this._ids.delete(message.id);
-      return true;
-    }
-    if (message.guid === this._socksSupportObjectGuid) {
-      const validator = findValidator('SocksSupport', message.method, 'Event');
-      const params = validator(message.params, '', { tChannelImpl: tChannelForSocks, binary: 'fromBase64' });
-      this._channel.emit(message.method, params);
-      return true;
-    }
-    return false;
-  }
-}
-
-function tChannelForSocks(names: '*' | string[], arg: any, path: string, context: ValidatorContext) {
-  throw new ValidationError(`${path}: channels are not expected in SocksSupport`);
 }

--- a/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type EventEmitter from 'events';
+import EventEmitter from 'events';
 import fs from 'fs';
 import path from 'path';
 import type * as channels from '../../protocol/channels';
@@ -26,13 +26,26 @@ import { yazl, yauzl } from '../../zipBundle';
 import { ZipFile } from '../../utils/zipFile';
 import type * as har from '../har/har';
 import type { HeadersArray } from '../types';
+import { JsonPipeDispatcher } from '../dispatchers/jsonPipeDispatcher';
+import { getUserAgent } from '../../common/userAgent';
+import { ProgressController } from '../progress';
+import * as socks from '../../common/socksProxy';
+import { WebSocketTransport } from '../transport';
+import { findValidator, ValidationError, type ValidatorContext } from '../../protocol/validator';
+import { type CallMetadata, SdkObject } from '../instrumentation';
 
-export class LocalUtilsDispatcher extends Dispatcher<{ guid: string }, channels.LocalUtilsChannel> implements channels.LocalUtilsChannel {
+class LocalUtilsSdkObject extends SdkObject {
+  constructor(parent: SdkObject) {
+    super(parent, 'localUtils');
+  }
+}
+
+export class LocalUtilsDispatcher extends Dispatcher<LocalUtilsSdkObject, channels.LocalUtilsChannel> implements channels.LocalUtilsChannel {
   _type_LocalUtils: boolean;
   private _harBakends = new Map<string, HarBackend>();
 
-  constructor(scope: DispatcherScope) {
-    super(scope, { guid: 'localUtils@' + createGuid() }, 'LocalUtils', {});
+  constructor(scope: DispatcherScope, parentSdkObject: SdkObject) {
+    super(scope, new LocalUtilsSdkObject(parentSdkObject), 'LocalUtils', {});
     this._type_LocalUtils = true;
   }
 
@@ -137,6 +150,43 @@ export class LocalUtilsDispatcher extends Dispatcher<{ guid: string }, channels.
     }
     zipFile.close();
     await fs.promises.unlink(params.zipFile);
+  }
+
+  async connectToWebSocket(params: channels.LocalUtilsConnectToWebSocketParams, metadata: CallMetadata): Promise<channels.LocalUtilsConnectToWebSocketResult> {
+    const controller = new ProgressController(metadata, this._object);
+    controller.setLogName('browser');
+    return await controller.run(async progress => {
+      const paramsHeaders = Object.assign({ 'User-Agent': getUserAgent() }, params.headers || {});
+      const transport = await WebSocketTransport.connect(progress, params.wsEndpoint, paramsHeaders, true);
+      let socksInterceptor: SocksInterceptor | undefined;
+      const pipe = new JsonPipeDispatcher(this._scope);
+      transport.onmessage = json => {
+        if (json.method === '__create__' && json.params.type === 'SocksSupport')
+          socksInterceptor = new SocksInterceptor(transport, params.socksProxyRedirectPortForTest, json.params.guid);
+        if (socksInterceptor?.interceptMessage(json))
+          return;
+        const cb = () => {
+          try {
+            pipe.dispatch(json);
+          } catch (e) {
+            transport.close();
+          }
+        };
+        if (params.slowMo)
+          setTimeout(cb, params.slowMo);
+        else
+          cb();
+      };
+      pipe.on('message', message => {
+        transport.send(message);
+      });
+      transport.onclose = () => {
+        socksInterceptor?.cleanup();
+        pipe.wasClosed();
+      };
+      pipe.on('close', () => transport.close());
+      return { pipe };
+    }, params.timeout || 0);
   }
 }
 
@@ -272,3 +322,63 @@ function countMatchingHeaders(harHeaders: har.Header[], headers: HeadersArray): 
   return matches;
 }
 
+
+class SocksInterceptor {
+  private _handler: socks.SocksProxyHandler;
+  private _channel: channels.SocksSupportChannel & EventEmitter;
+  private _socksSupportObjectGuid: string;
+  private _ids = new Set<number>();
+
+  constructor(transport: WebSocketTransport, redirectPortForTest: number | undefined, socksSupportObjectGuid: string) {
+    this._handler = new socks.SocksProxyHandler(redirectPortForTest);
+    this._socksSupportObjectGuid = socksSupportObjectGuid;
+
+    let lastId = -1;
+    this._channel = new Proxy(new EventEmitter(), {
+      get: (obj: any, prop) => {
+        if ((prop in obj) || obj[prop] !== undefined || typeof prop !== 'string')
+          return obj[prop];
+        return (params: any) => {
+          try {
+            const id = --lastId;
+            this._ids.add(id);
+            const validator = findValidator('SocksSupport', prop, 'Params');
+            params = validator(params, '', { tChannelImpl: tChannelForSocks, binary: 'toBase64' });
+            transport.send({ id, guid: socksSupportObjectGuid, method: prop, params, metadata: { stack: [], apiName: '', internal: true } } as any);
+          } catch (e) {
+          }
+        };
+      },
+    }) as channels.SocksSupportChannel & EventEmitter;
+    this._handler.on(socks.SocksProxyHandler.Events.SocksConnected, (payload: socks.SocksSocketConnectedPayload) => this._channel.socksConnected(payload));
+    this._handler.on(socks.SocksProxyHandler.Events.SocksData, (payload: socks.SocksSocketDataPayload) => this._channel.socksData(payload));
+    this._handler.on(socks.SocksProxyHandler.Events.SocksError, (payload: socks.SocksSocketErrorPayload) => this._channel.socksError(payload));
+    this._handler.on(socks.SocksProxyHandler.Events.SocksFailed, (payload: socks.SocksSocketFailedPayload) => this._channel.socksFailed(payload));
+    this._handler.on(socks.SocksProxyHandler.Events.SocksEnd, (payload: socks.SocksSocketEndPayload) => this._channel.socksEnd(payload));
+    this._channel.on('socksRequested', payload => this._handler.socketRequested(payload));
+    this._channel.on('socksClosed', payload => this._handler.socketClosed(payload));
+    this._channel.on('socksData', payload => this._handler.sendSocketData(payload));
+  }
+
+  cleanup() {
+    this._handler.cleanup();
+  }
+
+  interceptMessage(message: any): boolean {
+    if (this._ids.has(message.id)) {
+      this._ids.delete(message.id);
+      return true;
+    }
+    if (message.guid === this._socksSupportObjectGuid) {
+      const validator = findValidator('SocksSupport', message.method, 'Event');
+      const params = validator(message.params, '', { tChannelImpl: tChannelForSocks, binary: 'fromBase64' });
+      this._channel.emit(message.method, params);
+      return true;
+    }
+    return false;
+  }
+}
+
+function tChannelForSocks(names: '*' | string[], arg: any, path: string, context: ValidatorContext) {
+  throw new ValidationError(`${path}: channels are not expected in SocksSupport`);
+}

--- a/packages/playwright-core/src/server/dispatchers/playwrightDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/playwrightDispatcher.ts
@@ -47,7 +47,7 @@ export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.Playwr
       webkit: new BrowserTypeDispatcher(scope, playwright.webkit),
       android: new AndroidDispatcher(scope, playwright.android),
       electron: new ElectronDispatcher(scope, playwright.electron),
-      utils: new LocalUtilsDispatcher(scope),
+      utils: new LocalUtilsDispatcher(scope, playwright),
       deviceDescriptors,
       selectors: new SelectorsDispatcher(scope, browserDispatcher?.selectors || playwright.selectors),
       preLaunchedBrowser: browserDispatcher,


### PR DESCRIPTION
This is a local utility, does not make sense for remote connection.