### PR TITLE
fix(test runner): show tests as interrupted when maxFailures stops them

### DIFF
--- a/tests/playwright-test/max-failures.spec.ts
+++ b/tests/playwright-test/max-failures.spec.ts
@@ -98,7 +98,7 @@ test('max-failures should stop workers', async ({ runInlineTest }) => {
       test('passed short', async () => {
         await new Promise(f => setTimeout(f, 1));
       });
-      test('interrupted counts as skipped', async () => {
+      test('interrupted reported as interrupted', async () => {
         console.log('\\n%%interrupted');
         await new Promise(f => setTimeout(f, 5000));
       });
@@ -110,7 +110,8 @@ test('max-failures should stop workers', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(2);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(2);
+  expect(result.interrupted).toBe(1);
+  expect(result.skipped).toBe(1);
   expect(result.output).toContain('%%interrupted');
   expect(result.output).not.toContain('%%skipped');
 });

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -241,7 +241,7 @@ test('should not override trace file in afterAll', async ({ runInlineTest, serve
   expect(fs.existsSync(testInfo.outputPath('test-results', 'a-test-1', 'trace-1.zip'))).toBeTruthy();
 });
 
-test.fixme('should not retain traces for interrupted tests', async ({ runInlineTest }, testInfo) => {
+test('should retain traces for interrupted tests', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
       module.exports = { use: { trace: 'retain-on-failure' }, maxFailures: 1 };
@@ -261,9 +261,9 @@ test.fixme('should not retain traces for interrupted tests', async ({ runInlineT
 
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.interrupted).toBe(1);
   expect(fs.existsSync(testInfo.outputPath('test-results', 'a-test-1', 'trace.zip'))).toBeTruthy();
-  expect(fs.existsSync(testInfo.outputPath('test-results', 'b-test-2', 'trace.zip'))).toBeFalsy();
+  expect(fs.existsSync(testInfo.outputPath('test-results', 'b-test-2', 'trace.zip'))).toBeTruthy();
 });
 
 async function parseTrace(file: string): Promise<Map<string, Buffer>> {


### PR DESCRIPTION
Previously, we marked these tests as skipped, and it was sometimes
confusing, because they did actually run and produce some output/artifacts.

Fixes #15756.