### PR TITLE
chore: listen on localhost for html report

### DIFF
--- a/packages/playwright-core/src/utils/httpServer.ts
+++ b/packages/playwright-core/src/utils/httpServer.ts
@@ -58,7 +58,7 @@ export class HttpServer {
       this._activeSockets.add(socket);
       socket.once('close', () => this._activeSockets.delete(socket));
     });
-    this._server.listen(port, '127.0.0.1');
+    this._server.listen(port, 'localhost');
     await new Promise(cb => this._server!.once('listening', cb));
     const address = this._server.address();
     assert(address, 'Could not bind server socket');
@@ -67,7 +67,7 @@ export class HttpServer {
         this._urlPrefix = address;
       } else {
         this._port = address.port;
-        this._urlPrefix = `http://127.0.0.1:${address.port}`;
+        this._urlPrefix = `http://localhost:${address.port}`;
       }
     }
     return this._urlPrefix;


### PR DESCRIPTION
I came across issue #11568 on my machine. I didn't realize it was fixed, even after reading the code.

This MR is for only for readibility and to harmonize with the rest of the code in `httpServer.ts`
It follows this suggestion https://github.com/microsoft/playwright/issues/11568#issuecomment-1173566316

Also I think localhost is more universally understood than `127.0.0.1` or `::1` for users

