### PR TITLE
test: update macos 12 test expectations

### DIFF
--- a/tests/library/modernizr.spec.ts
+++ b/tests/library/modernizr.spec.ts
@@ -30,7 +30,7 @@ async function checkFeatures(name: string, context: any, server: any) {
   }
 }
 
-it('safari-14-1', async ({ browser, browserName, platform, server, headless }) => {
+it('safari-14-1', async ({ browser, browserName, platform, server, headless, isMac }) => {
   it.skip(browserName !== 'webkit');
   it.skip(browserName === 'webkit' && parseInt(os.release(), 10) < 20, 'WebKit for macOS 10.15 is frozen.');
   const context = await browser.newContext({
@@ -70,10 +70,15 @@ it('safari-14-1', async ({ browser, browserName, platform, server, headless }) =
     expected.inputtypes['datetime-local'] = false;
     expected.inputtypes.time = false;
   }
+
+  if (isMac && parseInt(os.release(), 10) > 20) {
+    expected.applicationcache = false;
+  }
+
   expect(actual).toEqual(expected);
 });
 
-it('mobile-safari-14-1', async ({ playwright, browser, browserName, platform, server, headless }) => {
+it('mobile-safari-14-1', async ({ playwright, browser, browserName, platform, isMac, server, headless }) => {
   it.skip(browserName !== 'webkit');
   it.skip(browserName === 'webkit' && parseInt(os.release(), 10) < 20, 'WebKit for macOS 10.15 is frozen.');
   const iPhone = playwright.devices['iPhone 12'];
@@ -123,6 +128,10 @@ it('mobile-safari-14-1', async ({ playwright, browser, browserName, platform, se
     expected.inputtypes.time = false;
     expected.inputtypes['datetime-local'] = false;
     expected.inputtypes.time = false;
+  }
+
+  if (isMac && parseInt(os.release(), 10) > 20) {
+    expected.applicationcache = false;
   }
 
   expect(actual).toEqual(expected);

--- a/tests/library/modernizr.spec.ts
+++ b/tests/library/modernizr.spec.ts
@@ -71,9 +71,8 @@ it('safari-14-1', async ({ browser, browserName, platform, server, headless, isM
     expected.inputtypes.time = false;
   }
 
-  if (isMac && parseInt(os.release(), 10) > 20) {
+  if (isMac && parseInt(os.release(), 10) > 20)
     expected.applicationcache = false;
-  }
 
   expect(actual).toEqual(expected);
 });
@@ -130,9 +129,8 @@ it('mobile-safari-14-1', async ({ playwright, browser, browserName, platform, is
     expected.inputtypes.time = false;
   }
 
-  if (isMac && parseInt(os.release(), 10) > 20) {
+  if (isMac && parseInt(os.release(), 10) > 20)
     expected.applicationcache = false;
-  }
 
   expect(actual).toEqual(expected);
 });

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -20,7 +20,6 @@ import { verifyViewport, attachFrame } from '../config/utils';
 import type { Route } from 'playwright-core';
 import path from 'path';
 import fs from 'fs';
-import os from 'os';
 
 it.describe('page screenshot', () => {
   it.skip(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -231,7 +231,7 @@ it.describe('page screenshot', () => {
   });
 
   it('should capture canvas changes', async ({ page, isElectron, browserName, isMac }) => {
-    it.fixme(browserName === 'webkit' && isMac && parseInt(os.release(), 10) < 21, 'https://github.com/microsoft/playwright/issues/8796,https://github.com/microsoft/playwright/issues/16180');
+    it.fixme(browserName === 'webkit' && isMac, 'https://github.com/microsoft/playwright/issues/8796,https://github.com/microsoft/playwright/issues/16180');
     it.skip(isElectron);
     await page.goto('data:text/html,<canvas></canvas>');
     await page.evaluate(() => {


### PR DESCRIPTION
'should capture canvas changes' always passes locally but fails on the bots, it probably has to do with how the display is mocked on the CI.

https://github.com/microsoft/playwright/issues/16180