### PR TITLE
chore: hide stackTrace.js from recorded frames

### DIFF
--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -130,7 +130,7 @@ export function captureStackTrace(rawStack?: string): ParsedStackTrace {
       return true;
     if (f.frame.file.startsWith(TEST_DIR_SRC) || f.frame.file.startsWith(TEST_DIR_LIB))
       return false;
-    if (i && f.frame.file.startsWith(CORE_DIR))
+    if (f.frame.file.startsWith(CORE_DIR))
       return false;
     return true;
   });


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/16200