### PR TITLE
browser(webkit): rebase to 08/03/22 (253090@main)

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1696
-Changed: dpino@igalia.com Tue Aug  2 10:40:41 PM HKT 2022
+1697
+Changed: dpino@igalia.com Thu Aug  4 19:20:29 HKT 2022

--- a/browser_patches/webkit/UPSTREAM_CONFIG.sh
+++ b/browser_patches/webkit/UPSTREAM_CONFIG.sh
@@ -1,3 +1,3 @@
 REMOTE_URL="https://github.com/WebKit/WebKit.git"
 BASE_BRANCH="main"
-BASE_REVISION="65e2837a04b395fb0ba10e33a1bb4565ceed2995"
+BASE_REVISION="df7f18952ccf0421dbdc7ee63587f59dbc7bd8ef"

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -1,8 +1,8 @@
 diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
-index f777a49444dc3b2065b18d8ee25e62d68aa10d7c..190c731d96640838be47036736704efd3279108f 100644
+index b71df073763105a7a12865ba208ea44fe16dbcb1..df26de1579b2c0806c16b205736daf46df42ebe5 100644
 --- a/Source/JavaScriptCore/CMakeLists.txt
 +++ b/Source/JavaScriptCore/CMakeLists.txt
-@@ -1357,22 +1357,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
+@@ -1358,22 +1358,27 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/CSS.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Canvas.json
      ${JAVASCRIPTCORE_DIR}/inspector/protocol/Console.json
@@ -2079,7 +2079,7 @@ index e4b94b59216277aae01696e6d4846abf8f287dce..8cbe085788ba582ee4615faef20769b6
  			isa = XCConfigurationList;
  			buildConfigurations = (
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferences.yaml b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
-index 704adf1bb71721cebd3e20341e3e625511bfd0dd..9bb4573b65d2c6f80661687f3e446786c4aa9eb0 100644
+index a5b4d51f561db15f1b65c5ce06bfd543abe2acbb..fcd47eee3d2b5e48958d90e93ec46b686acc334b 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
 @@ -977,7 +977,7 @@ InspectorStartsAttached:
@@ -2110,7 +2110,7 @@ index 704adf1bb71721cebd3e20341e3e625511bfd0dd..9bb4573b65d2c6f80661687f3e446786
    type: bool
    humanReadableName: "Private Click Measurement"
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
-index 2f1830cf87a7d8037663957a2e0fbd97e83d9c06..b991d64670c31b3e681c066d011d3a9a9f2a7ca5 100644
+index a8d409cc3083fc4d9bd91e9e34effc020802c40d..77c0e4de37cf97549c91eee7630f997acd06edb6 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
 @@ -527,7 +527,7 @@ CrossOriginOpenerPolicyEnabled:
@@ -2154,7 +2154,7 @@ index 2f1830cf87a7d8037663957a2e0fbd97e83d9c06..b991d64670c31b3e681c066d011d3a9a
  
  # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
  MediaCapabilitiesExtensionsEnabled:
-@@ -1415,7 +1416,7 @@ SpeechRecognitionEnabled:
+@@ -1402,7 +1403,7 @@ SpeechRecognitionEnabled:
      WebKitLegacy:
        default: false
      WebKit:
@@ -2163,7 +2163,7 @@ index 2f1830cf87a7d8037663957a2e0fbd97e83d9c06..b991d64670c31b3e681c066d011d3a9a
        default: false
      WebCore:
        default: false
-@@ -1530,6 +1531,7 @@ UseGPUProcessForDisplayCapture:
+@@ -1517,6 +1518,7 @@ UseGPUProcessForDisplayCapture:
      WebKit:
        default: true
  
@@ -2171,7 +2171,7 @@ index 2f1830cf87a7d8037663957a2e0fbd97e83d9c06..b991d64670c31b3e681c066d011d3a9a
  UseGPUProcessForWebGLEnabled:
    type: bool
    humanReadableName: "GPU Process: WebGL"
-@@ -1540,7 +1542,7 @@ UseGPUProcessForWebGLEnabled:
+@@ -1527,7 +1529,7 @@ UseGPUProcessForWebGLEnabled:
        default: false
      WebKit:
        "ENABLE(GPU_PROCESS_BY_DEFAULT) && PLATFORM(IOS_FAMILY) && !HAVE(UIKIT_WEBKIT_INTERNALS)": true
@@ -2181,10 +2181,10 @@ index 2f1830cf87a7d8037663957a2e0fbd97e83d9c06..b991d64670c31b3e681c066d011d3a9a
      WebCore:
        "ENABLE(GPU_PROCESS_BY_DEFAULT) && PLATFORM(IOS_FAMILY) && !HAVE(UIKIT_WEBKIT_INTERNALS)": true
 diff --git a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
-index 71a623915926f9b51788947059fe8f317ce58949..2161a101c29dcb8d4a0963ea8f2a46b6fc68db2e 100644
+index 300442b8d77f136580f2f1798675fc5dfec3f10a..8deb58b1de178c6343c42d2632d1ccfabbc68ac4 100644
 --- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
 +++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
-@@ -966,6 +966,7 @@ UseCGDisplayListsForDOMRendering:
+@@ -979,6 +979,7 @@ UseCGDisplayListsForDOMRendering:
      WebKit:
        default: true
  
@@ -2192,7 +2192,7 @@ index 71a623915926f9b51788947059fe8f317ce58949..2161a101c29dcb8d4a0963ea8f2a46b6
  UseGPUProcessForCanvasRenderingEnabled:
    type: bool
    humanReadableName: "GPU Process: Canvas Rendering"
-@@ -976,7 +977,7 @@ UseGPUProcessForCanvasRenderingEnabled:
+@@ -989,7 +990,7 @@ UseGPUProcessForCanvasRenderingEnabled:
    defaultValue:
      WebKit:
        "ENABLE(GPU_PROCESS_BY_DEFAULT)": true
@@ -2224,7 +2224,7 @@ index 1db561ba6e2db93225956abb259db78e0c024351..b86aaa95fca156ef7d58023c396d54e1
  
  #if !defined(ENABLE_TOUCH_ACTION_REGIONS)
 diff --git a/Source/WTF/wtf/PlatformEnableCocoa.h b/Source/WTF/wtf/PlatformEnableCocoa.h
-index 96d97d096e493526bd825bd8707fa39de7f0a759..d9af0c3914845bf5d3052124ce352c5936f7ca96 100644
+index 1ef19df97cc65686046fce039176d1c9d774af9a..797164f3bfa80d0d22d1b263d913b80bb5de9a51 100644
 --- a/Source/WTF/wtf/PlatformEnableCocoa.h
 +++ b/Source/WTF/wtf/PlatformEnableCocoa.h
 @@ -247,7 +247,7 @@
@@ -2237,10 +2237,10 @@ index 96d97d096e493526bd825bd8707fa39de7f0a759..d9af0c3914845bf5d3052124ce352c59
  #endif
  
 diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
-index e5124e271efb51906dc93ad6513aa72c28321292..86f91f6a7e0893f83df2c6ff5900583b9fc4b301 100644
+index d70f3608e994ce06dead2af85f6e354e6cf16ca9..79c810db427a2b277fec97a0580e302c8bedb2ed 100644
 --- a/Source/WTF/wtf/PlatformHave.h
 +++ b/Source/WTF/wtf/PlatformHave.h
-@@ -430,7 +430,7 @@
+@@ -426,7 +426,7 @@
  #define HAVE_FOUNDATION_WITH_SAME_SITE_COOKIE_SUPPORT 1
  #endif
  
@@ -2249,7 +2249,7 @@ index e5124e271efb51906dc93ad6513aa72c28321292..86f91f6a7e0893f83df2c6ff5900583b
  #define HAVE_OS_DARK_MODE_SUPPORT 1
  #endif
  
-@@ -1304,7 +1304,8 @@
+@@ -1301,7 +1301,8 @@
  #endif
  
  #if PLATFORM(MAC)
@@ -2303,7 +2303,7 @@ diff --git a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm b/So
 index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d768ace22 100644
 --- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
 +++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
-@@ -198,6 +198,7 @@ - (void)sendEndIfNeeded
+@@ -198,6 +198,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  - (void)speechRecognizer:(SFSpeechRecognizer *)speechRecognizer availabilityDidChange:(BOOL)available
  {
@@ -2311,7 +2311,7 @@ index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d
      ASSERT(isMainThread());
  
      if (available || !_task)
-@@ -211,6 +212,7 @@ - (void)speechRecognizer:(SFSpeechRecognizer *)speechRecognizer availabilityDidC
+@@ -211,6 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didHypothesizeTranscription:(SFTranscription *)transcription
  {
@@ -2319,7 +2319,7 @@ index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d
      ASSERT(isMainThread());
  
      [self sendSpeechStartIfNeeded];
-@@ -219,6 +221,7 @@ - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didHypothesizeTran
+@@ -219,6 +221,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didFinishRecognition:(SFSpeechRecognitionResult *)recognitionResult
  {
@@ -2327,7 +2327,7 @@ index a941d76a4f748718df1e3cff2a6c5e0827f48891..f62db5a27ac0e4c12430e7d19e60c83d
      ASSERT(isMainThread());
      [self callbackWithTranscriptions:recognitionResult.transcriptions isFinal:YES];
  
-@@ -230,6 +233,7 @@ - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didFinishRecogniti
+@@ -230,6 +233,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  - (void)speechRecognitionTaskWasCancelled:(SFSpeechRecognitionTask *)task
  {
@@ -2422,10 +2422,10 @@ index a5938677622935e2c6ca3ed76c3a12d0eb7e04a7..cea2a0e330cfdf01b172b3f6acc60acb
  __ZN7WebCore14DocumentLoaderD2Ev
  __ZN7WebCore14DocumentLoader17clearMainResourceEv
 diff --git a/Source/WebCore/WebCore.xcodeproj/project.pbxproj b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-index 0aa1ca706841d7ec62aa1aa9b834d68673020c68..781057e521c3be3b070f7fe6c55d6e75b4a9bea2 100644
+index 874e7f94bfeeccfc82875a348cd6bd9779ad7d6b..ee833911db5c5391de1bf827ec46e052f6e7598c 100644
 --- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
 +++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
-@@ -5577,6 +5577,13 @@
+@@ -5578,6 +5578,13 @@
  		EDE3A5000C7A430600956A37 /* ColorMac.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE3A4FF0C7A430600956A37 /* ColorMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		EDEC98030AED7E170059137F /* WebCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEC98020AED7E170059137F /* WebCorePrefix.h */; };
  		EFCC6C8F20FE914400A2321B /* CanvasActivityRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2439,7 +2439,7 @@ index 0aa1ca706841d7ec62aa1aa9b834d68673020c68..781057e521c3be3b070f7fe6c55d6e75
  		F12171F616A8CF0B000053CA /* WebVTTElement.h in Headers */ = {isa = PBXBuildFile; fileRef = F12171F416A8BC63000053CA /* WebVTTElement.h */; };
  		F32BDCD92363AACA0073B6AE /* UserGestureEmulationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F32BDCD72363AACA0073B6AE /* UserGestureEmulationScope.h */; };
  		F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
-@@ -18037,6 +18044,14 @@
+@@ -18041,6 +18048,14 @@
  		EDEC98020AED7E170059137F /* WebCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCorePrefix.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
  		EFB7287B2124C73D005C2558 /* CanvasActivityRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasActivityRecord.cpp; sourceTree = "<group>"; };
  		EFCC6C8D20FE914000A2321B /* CanvasActivityRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasActivityRecord.h; sourceTree = "<group>"; };
@@ -2454,7 +2454,7 @@ index 0aa1ca706841d7ec62aa1aa9b834d68673020c68..781057e521c3be3b070f7fe6c55d6e75
  		F12171F316A8BC63000053CA /* WebVTTElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebVTTElement.cpp; sourceTree = "<group>"; };
  		F12171F416A8BC63000053CA /* WebVTTElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebVTTElement.h; sourceTree = "<group>"; };
  		F32BDCD52363AAC90073B6AE /* UserGestureEmulationScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserGestureEmulationScope.cpp; sourceTree = "<group>"; };
-@@ -24762,6 +24777,11 @@
+@@ -24768,6 +24783,11 @@
  				BC4A5324256055590028C592 /* TextDirectionSubmenuInclusionBehavior.h */,
  				2D4F96F11A1ECC240098BF88 /* TextIndicator.cpp */,
  				2D4F96F21A1ECC240098BF88 /* TextIndicator.h */,
@@ -2466,7 +2466,7 @@ index 0aa1ca706841d7ec62aa1aa9b834d68673020c68..781057e521c3be3b070f7fe6c55d6e75
  				F48570A42644C76D00C05F71 /* TranslationContextMenuInfo.h */,
  				F4E1965F21F26E4E00285078 /* UndoItem.cpp */,
  				2ECDBAD521D8906300F00ECD /* UndoItem.h */,
-@@ -30590,6 +30610,8 @@
+@@ -30597,6 +30617,8 @@
  				29E4D8DF16B0940F00C84704 /* PlatformSpeechSynthesizer.h */,
  				1AD8F81A11CAB9E900E93E54 /* PlatformStrategies.cpp */,
  				1AD8F81911CAB9E900E93E54 /* PlatformStrategies.h */,
@@ -2475,7 +2475,7 @@ index 0aa1ca706841d7ec62aa1aa9b834d68673020c68..781057e521c3be3b070f7fe6c55d6e75
  				0FD7C21D23CE41E30096D102 /* PlatformWheelEvent.cpp */,
  				935C476A09AC4D4F00A6AAB4 /* PlatformWheelEvent.h */,
  				BCBB8AB513F1AFB000734DF0 /* PODInterval.h */,
-@@ -32935,6 +32957,7 @@
+@@ -32942,6 +32964,7 @@
  				AD6E71AB1668899D00320C13 /* DocumentSharedObjectPool.h */,
  				6BDB5DC1227BD3B800919770 /* DocumentStorageAccess.cpp */,
  				6BDB5DC0227BD3B800919770 /* DocumentStorageAccess.h */,
@@ -2483,7 +2483,7 @@ index 0aa1ca706841d7ec62aa1aa9b834d68673020c68..781057e521c3be3b070f7fe6c55d6e75
  				7CE7FA5B1EF882300060C9D6 /* DocumentTouch.cpp */,
  				7CE7FA591EF882300060C9D6 /* DocumentTouch.h */,
  				A8185F3209765765005826D9 /* DocumentType.cpp */,
-@@ -37238,6 +37261,8 @@
+@@ -37246,6 +37269,8 @@
  				1AD8F81B11CAB9E900E93E54 /* PlatformStrategies.h in Headers */,
  				0F7D07331884C56C00B4AF86 /* PlatformTextTrack.h in Headers */,
  				074E82BB18A69F0E007EF54C /* PlatformTimeRanges.h in Headers */,
@@ -2492,7 +2492,7 @@ index 0aa1ca706841d7ec62aa1aa9b834d68673020c68..781057e521c3be3b070f7fe6c55d6e75
  				CDD08ABD277E542600EA3755 /* PlatformTrackConfiguration.h in Headers */,
  				CD1F9B022700323D00617EB6 /* PlatformVideoColorPrimaries.h in Headers */,
  				CD1F9B01270020B700617EB6 /* PlatformVideoColorSpace.h in Headers */,
-@@ -38384,6 +38409,7 @@
+@@ -38392,6 +38417,7 @@
  				0F54DD081881D5F5003EEDBB /* Touch.h in Headers */,
  				71B7EE0D21B5C6870031C1EF /* TouchAction.h in Headers */,
  				0F54DD091881D5F5003EEDBB /* TouchEvent.h in Headers */,
@@ -2500,7 +2500,7 @@ index 0aa1ca706841d7ec62aa1aa9b834d68673020c68..781057e521c3be3b070f7fe6c55d6e75
  				0F54DD0A1881D5F5003EEDBB /* TouchList.h in Headers */,
  				070334D71459FFD5008D8D45 /* TrackBase.h in Headers */,
  				BE88E0C21715CE2600658D98 /* TrackListBase.h in Headers */,
-@@ -39327,6 +39353,7 @@
+@@ -39335,6 +39361,7 @@
  				1ABA76CA11D20E50004C201C /* CSSPropertyNames.cpp in Sources */,
  				2D22830323A8470700364B7E /* CursorMac.mm in Sources */,
  				5CBD59592280E926002B22AA /* CustomHeaderFields.cpp in Sources */,
@@ -2508,7 +2508,7 @@ index 0aa1ca706841d7ec62aa1aa9b834d68673020c68..781057e521c3be3b070f7fe6c55d6e75
  				7CE6CBFD187F394900D46BF5 /* FormatConverter.cpp in Sources */,
  				5130F2F624AEA60A00E1D0A0 /* GameControllerSoftLink.mm in Sources */,
  				51A4BB0A1954D61600FA5C2E /* Gamepad.cpp in Sources */,
-@@ -39404,6 +39431,9 @@
+@@ -39412,6 +39439,9 @@
  				C1692DD223D23ABD006E88F7 /* SystemBattery.mm in Sources */,
  				CE88EE262414467B007F29C2 /* TextAlternativeWithRange.mm in Sources */,
  				51DF6D800B92A18E00C2DC85 /* ThreadCheck.mm in Sources */,
@@ -2848,20 +2848,6 @@ index c43310a5628456dddbdb27d5496c580854d40758..c962f3b962e28ef82baa1bf3da377e26
      if (!UserGestureIndicator::processingUserGesture())
          return;
  
-diff --git a/Source/WebCore/html/LinkRelAttribute.h b/Source/WebCore/html/LinkRelAttribute.h
-index dce5e6890eaa8a123506c0920ac2bc1f4f1bdf0d..929df7f7b77d1a7421e80f76a899658dffa6edb8 100644
---- a/Source/WebCore/html/LinkRelAttribute.h
-+++ b/Source/WebCore/html/LinkRelAttribute.h
-@@ -73,4 +73,9 @@ inline bool operator==(const LinkRelAttribute& left, const LinkRelAttribute& rig
-         ;
- }
- 
-+inline bool operator!=(const LinkRelAttribute& left, const LinkRelAttribute& right)
-+{
-+    return !(left == right);
-+}
-+
- }
 diff --git a/Source/WebCore/inspector/InspectorController.cpp b/Source/WebCore/inspector/InspectorController.cpp
 index 9e4515b7e7f7261f936471b81557ec96697c34e6..3b32377172112fc143b5e719122e8bf648be5b25 100644
 --- a/Source/WebCore/inspector/InspectorController.cpp
@@ -5206,7 +5192,7 @@ index 6f4e9972a701f81facda14feffa905135f473916..c26d72c6e502ba19076fd5355f0af64a
  }
  
 diff --git a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
-index 5e7a1214da060ba3a168cf21b22e6c398c0e07f7..942c4e79e713908e428adc5aec89ce42844e220f 100644
+index 5e7a1214da060ba3a168cf21b22e6c398c0e07f7..d0cabe5df9b3ae42b3e99f02cc4ab9319c78905a 100644
 --- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
 +++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
 @@ -35,6 +35,7 @@
@@ -5265,7 +5251,7 @@ index 5e7a1214da060ba3a168cf21b22e6c398c0e07f7..942c4e79e713908e428adc5aec89ce42
 +{
 +    JSC::JSGlobalObject* globalObject = frame.script().globalObject(mainThreadNormalWorld());
 +    auto& vm = globalObject->vm();
-+    globalObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, name), 1, bindingCallback, JSC::NoIntrinsic, JSC::attributesForStructure(static_cast<unsigned>(JSC::PropertyAttribute::Function)));
++    globalObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, name), 1, bindingCallback, JSC::ImplementationVisibility::Public, JSC::NoIntrinsic, JSC::attributesForStructure(static_cast<unsigned>(JSC::PropertyAttribute::Function)));
 +}
 +
 +Protocol::ErrorStringOr<void> PageRuntimeAgent::addBinding(const String& name)
@@ -5423,7 +5409,7 @@ index 21e33e46bdb1af8434527747e3c308cbe53f60f0..c17c4de17f439c04d27caa532771934c
  protected:
      static SameSiteInfo sameSiteInfo(const Document&, IsForDOMCookieAccess = IsForDOMCookieAccess::No);
 diff --git a/Source/WebCore/loader/DocumentLoader.cpp b/Source/WebCore/loader/DocumentLoader.cpp
-index f6918d1141307a2d06a2387b40a6ccea114de7c7..7eb8f056e6eba1167c44b2c28240d5e87c7fc4bc 100644
+index 836f2fc09e41d60ddcabe328dd98b44f18297870..f121992cafa7e944b2cec6be72ea0404c11d6521 100644
 --- a/Source/WebCore/loader/DocumentLoader.cpp
 +++ b/Source/WebCore/loader/DocumentLoader.cpp
 @@ -1510,8 +1510,6 @@ void DocumentLoader::detachFromFrame()
@@ -5436,7 +5422,7 @@ index f6918d1141307a2d06a2387b40a6ccea114de7c7..7eb8f056e6eba1167c44b2c28240d5e8
  }
  
 diff --git a/Source/WebCore/loader/DocumentLoader.h b/Source/WebCore/loader/DocumentLoader.h
-index 4877a8fd398b0100ca3ed29aee9529281c7d19e7..e2e6c1c3ff04cb07c088ae666573008d58fac127 100644
+index 4287ac055edca73b3ca4c2d58b53a34a59f255e2..6f38d54ef3b333b5935ffd7484e10da91788fed4 100644
 --- a/Source/WebCore/loader/DocumentLoader.h
 +++ b/Source/WebCore/loader/DocumentLoader.h
 @@ -181,9 +181,13 @@ public:
@@ -5454,7 +5440,7 @@ index 4877a8fd398b0100ca3ed29aee9529281c7d19e7..e2e6c1c3ff04cb07c088ae666573008d
      DocumentWriter& writer() const { return m_writer; }
  
 diff --git a/Source/WebCore/loader/FrameLoader.cpp b/Source/WebCore/loader/FrameLoader.cpp
-index d38ad6e902bbdeb11b53778d51bbb77185b41020..7e225f3e466755d030de7c4b7242755f5579f243 100644
+index 82aefcbc0f2a94eaac020656fe422f5d176120ec..341eb0456e8947b847d626f3ba72d5fa45fb970a 100644
 --- a/Source/WebCore/loader/FrameLoader.cpp
 +++ b/Source/WebCore/loader/FrameLoader.cpp
 @@ -1173,6 +1173,7 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
@@ -5465,7 +5451,7 @@ index d38ad6e902bbdeb11b53778d51bbb77185b41020..7e225f3e466755d030de7c4b7242755f
  
      m_frame.document()->statePopped(stateObject ? stateObject.releaseNonNull() : SerializedScriptValue::nullValue());
      m_client->dispatchDidPopStateWithinPage();
-@@ -1610,6 +1611,8 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
+@@ -1609,6 +1610,8 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
      const String& httpMethod = loader->request().httpMethod();
  
      if (shouldPerformFragmentNavigation(isFormSubmission, httpMethod, policyChecker().loadType(), newURL)) {
@@ -5473,8 +5459,8 @@ index d38ad6e902bbdeb11b53778d51bbb77185b41020..7e225f3e466755d030de7c4b7242755f
 +
          RefPtr<DocumentLoader> oldDocumentLoader = m_documentLoader;
          NavigationAction action { *m_frame.document(), loader->request(), InitiatedByMainFrame::Unknown, policyChecker().loadType(), isFormSubmission };
- 
-@@ -1639,7 +1642,9 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
+         action.setIsRequestFromClientOrUserInput(loader->isRequestFromClientOrUserInput());
+@@ -1638,7 +1641,9 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
      }
  
      RELEASE_ASSERT(!isBackForwardLoadType(policyChecker().loadType()) || history().provisionalItem());
@@ -5484,7 +5470,7 @@ index d38ad6e902bbdeb11b53778d51bbb77185b41020..7e225f3e466755d030de7c4b7242755f
          continueLoadAfterNavigationPolicy(request, formState.get(), navigationPolicyDecision, allowNavigationToInvalidURL);
          completionHandler();
      }, PolicyDecisionMode::Asynchronous);
-@@ -2807,12 +2812,17 @@ String FrameLoader::userAgent(const URL& url) const
+@@ -2805,12 +2810,17 @@ String FrameLoader::userAgent(const URL& url) const
  
  String FrameLoader::navigatorPlatform() const
  {
@@ -5504,7 +5490,7 @@ index d38ad6e902bbdeb11b53778d51bbb77185b41020..7e225f3e466755d030de7c4b7242755f
  }
  
  void FrameLoader::dispatchOnloadEvents()
-@@ -3223,6 +3233,8 @@ void FrameLoader::receivedMainResourceError(const ResourceError& error)
+@@ -3221,6 +3231,8 @@ void FrameLoader::receivedMainResourceError(const ResourceError& error)
      checkCompleted();
      if (m_frame.page())
          checkLoadComplete();
@@ -5513,7 +5499,7 @@ index d38ad6e902bbdeb11b53778d51bbb77185b41020..7e225f3e466755d030de7c4b7242755f
  }
  
  void FrameLoader::continueFragmentScrollAfterNavigationPolicy(const ResourceRequest& request, bool shouldContinue)
-@@ -3999,9 +4011,6 @@ String FrameLoader::referrer() const
+@@ -3997,9 +4009,6 @@ String FrameLoader::referrer() const
  
  void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
  {
@@ -5523,7 +5509,7 @@ index d38ad6e902bbdeb11b53778d51bbb77185b41020..7e225f3e466755d030de7c4b7242755f
      Vector<Ref<DOMWrapperWorld>> worlds;
      ScriptController::getAllWorlds(worlds);
      for (auto& world : worlds)
-@@ -4010,13 +4019,13 @@ void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
+@@ -4008,13 +4017,13 @@ void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
  
  void FrameLoader::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld& world)
  {
@@ -5590,10 +5576,10 @@ index a2c6d72b5ba0f04a49ca6dc710ef6fa5e0125c33..759b0d34b7db839027063a1b6ce8fb0f
  
  void ProgressTracker::incrementProgress(ResourceLoaderIdentifier identifier, const ResourceResponse& response)
 diff --git a/Source/WebCore/page/ChromeClient.h b/Source/WebCore/page/ChromeClient.h
-index 331231f5e0e10dbeb74c7827929ac76bf49e2953..f6a9eb480f350a5cd4dbfec5e393f77e3fab1225 100644
+index 45da6b795b2f1b28e79bc549effa2fed862cec4c..dfc6c68665eb1c88fcdc116f08764eaa37f8782a 100644
 --- a/Source/WebCore/page/ChromeClient.h
 +++ b/Source/WebCore/page/ChromeClient.h
-@@ -320,7 +320,7 @@ public:
+@@ -319,7 +319,7 @@ public:
  #endif
  
  #if ENABLE(ORIENTATION_EVENTS)
@@ -8996,7 +8982,7 @@ index 77597632a0e3f5dbac4ed45312c401496cf2387d..c3861e47242b15234101ca02a83f2766
      RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
      LogUserInteraction(WebCore::RegistrableDomain domain)
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.cpp b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
-index f8a78ceb307b19acb2190a014e8d11808fff6c51..2720d680cae63ba5661bf357387720f0ae55ea38 100644
+index 6e7eba1d92be4f7346ff35cc26e7e6bfdc0f2de9..ade95eb859048a14d2b191e8138dbd5a50003201 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
 @@ -529,6 +529,12 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID)
@@ -9013,7 +8999,7 @@ index f8a78ceb307b19acb2190a014e8d11808fff6c51..2720d680cae63ba5661bf357387720f0
  void NetworkProcess::dumpResourceLoadStatistics(PAL::SessionID sessionID, CompletionHandler<void(String)>&& completionHandler)
  {
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.h b/Source/WebKit/NetworkProcess/NetworkProcess.h
-index f0e073fe4c1b9294807318e93a5ab22cc53fe2d3..30da68f684d3878644be1de3fe651c540c9b403b 100644
+index 79529bec31b56db31d9501f763cb7d0ea0255e71..5a7c9b1982560c226526574033d28af4176ae4a8 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.h
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
 @@ -36,6 +36,7 @@
@@ -9042,7 +9028,7 @@ index f0e073fe4c1b9294807318e93a5ab22cc53fe2d3..30da68f684d3878644be1de3fe651c54
      void clearPrevalentResource(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);
      void clearUserInteraction(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);
 diff --git a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
-index dadfd868ac99bc07b9b4cddddda8e1f09dd6eb88..87f24b6b38117619f4a76e9a99d998cad0909539 100644
+index 72b4a17928321402f4234e0fa60f92659d6617a1..fd0a7b05935a13caf102b69ee9ac3548420ff812 100644
 --- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 +++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
 @@ -77,6 +77,8 @@ messages -> NetworkProcess LegacyReceiver {
@@ -9055,7 +9041,7 @@ index dadfd868ac99bc07b9b4cddddda8e1f09dd6eb88..87f24b6b38117619f4a76e9a99d998ca
      ClearPrevalentResource(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> ()
      ClearUserInteraction(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> ()
 diff --git a/Source/WebKit/NetworkProcess/NetworkSession.h b/Source/WebKit/NetworkProcess/NetworkSession.h
-index e58961bfa4dd8133eb991531dc5273ada68c4473..af9edd4418e78ddfe7cfa793e27058361f3c45b7 100644
+index b60aeda86f298c1501a659af54a6416c04d66afc..ec6a7eeefc50d7fb6a3e32d235546eb5994b0b8c 100644
 --- a/Source/WebKit/NetworkProcess/NetworkSession.h
 +++ b/Source/WebKit/NetworkProcess/NetworkSession.h
 @@ -192,6 +192,9 @@ public:
@@ -9068,7 +9054,7 @@ index e58961bfa4dd8133eb991531dc5273ada68c4473..af9edd4418e78ddfe7cfa793e2705836
  #if ENABLE(SERVICE_WORKER)
      void addSoftUpdateLoader(std::unique_ptr<ServiceWorkerSoftUpdateLoader>&& loader) { m_softUpdateLoaders.add(WTFMove(loader)); }
      void removeSoftUpdateLoader(ServiceWorkerSoftUpdateLoader* loader) { m_softUpdateLoaders.remove(loader); }
-@@ -277,6 +280,7 @@ protected:
+@@ -276,6 +279,7 @@ protected:
      bool m_privateClickMeasurementDebugModeEnabled { false };
      std::optional<WebCore::PrivateClickMeasurement> m_ephemeralMeasurement;
      bool m_isRunningEphemeralMeasurementTest { false };
@@ -9080,7 +9066,7 @@ diff --git a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm b/Source/
 index d8eeb6c27a92134728ffada573a1f140e303c727..9ddddb0796cc00d7eea060b11919711446a39586 100644
 --- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
 +++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
-@@ -720,7 +720,7 @@ - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didRece
+@@ -720,7 +720,7 @@ void NetworkSessionCocoa::setClientAuditToken(const WebCore::AuthenticationChall
  
      if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
          sessionCocoa->setClientAuditToken(challenge);
@@ -10097,7 +10083,7 @@ index 90df093a49c09dc670dfea55077c77d889dd1c1b..6ffd51532e29b941b8dc10f545b7f5b8
      return WebTouchEvent();
  }
 diff --git a/Source/WebKit/Sources.txt b/Source/WebKit/Sources.txt
-index f1dbfe82ac54b6a21c578290816d38101df99163..d6673c25b881fd879bc5622bba401b7fdbdde37c 100644
+index 67f054b35749b05c22000ea70e7ab88440aafeae..fc3636bf931c38e29cff11caf5ff3fc6f862c851 100644
 --- a/Source/WebKit/Sources.txt
 +++ b/Source/WebKit/Sources.txt
 @@ -399,11 +399,14 @@ Shared/XR/XRDeviceProxy.cpp
@@ -10132,7 +10118,7 @@ index f1dbfe82ac54b6a21c578290816d38101df99163..d6673c25b881fd879bc5622bba401b7f
  UIProcess/WebPageProxy.cpp
  UIProcess/WebPasteboardProxy.cpp
  UIProcess/WebPreferences.cpp
-@@ -577,7 +583,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
+@@ -579,7 +585,11 @@ UIProcess/Inspector/WebInspectorUtilities.cpp
  UIProcess/Inspector/WebPageDebuggable.cpp
  UIProcess/Inspector/WebPageInspectorController.cpp
  
@@ -10369,7 +10355,7 @@ index 026121d114c5fcad84c1396be8d692625beaa3bd..edd6e5cae033124c589959a42522fde0
  }
  #endif
 diff --git a/Source/WebKit/UIProcess/API/C/WKPage.cpp b/Source/WebKit/UIProcess/API/C/WKPage.cpp
-index 2d2ca701c9092613f96c7ab102fe2a2f224d8e65..2358414be2644a4157723a8b0f69ba47d78a19d0 100644
+index 2ded6f050d4560a5a405d9fbe4a38a5c32a85264..32d395e5edc12041e3234f352a2946b7e1f52835 100644
 --- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
 +++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
 @@ -1762,6 +1762,13 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
@@ -10448,10 +10434,10 @@ index 63323ea918dcddf512dadfff52dd5e60326e6ab8..63acaadcdb0d4a80b543db2728f3657c
      // Version 15.
      WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
-index 4c0d4c3be8fc372ccd7cffc81cdb52ddef2bbc42..667ac9fd6d5117b98af8e801a09abdd957136042 100644
+index a3c0e6e941ce99bf094362e094d83fe6480568a2..d38b26f79f12a89fa8e14dcaecef64505f2431d8 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
-@@ -147,6 +147,12 @@ typedef NS_ENUM(NSInteger, WKDialogResult) {
+@@ -148,6 +148,12 @@ typedef NS_ENUM(NSInteger, WKDialogResult) {
   */
  - (void)webView:(WKWebView *)webView runJavaScriptTextInputPanelWithPrompt:(NSString *)prompt defaultText:(nullable NSString *)defaultText initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSString * _Nullable result))completionHandler;
  
@@ -10486,7 +10472,7 @@ index afa925f36c29db9c23921298dead9cce737500d6..42d396342acdb6d39830f611df0ee40e
  
  NS_ASSUME_NONNULL_END
 diff --git a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
-index 42efb8882044e4a3272d6cdccff47c33ee6fcfb7..ac503cd703c81f89fc04bcb2954b2d17d0f60a96 100644
+index 67c2480832991ff512fd49b0195cc195e85794e2..619c8a85bd1bdb14a593f15fa02ae90bf6e877ba 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 @@ -47,6 +47,7 @@
@@ -10497,7 +10483,7 @@ index 42efb8882044e4a3272d6cdccff47c33ee6fcfb7..ac503cd703c81f89fc04bcb2954b2d17
  #import <WebCore/Credential.h>
  #import <WebCore/RegistrationDatabase.h>
  #import <WebCore/ServiceWorkerClientData.h>
-@@ -234,6 +235,11 @@ - (void)removeDataOfTypes:(NSSet *)dataTypes modifiedSince:(NSDate *)date comple
+@@ -234,6 +235,11 @@ static WallTime toSystemClockTime(NSDate *date)
      });
  }
  
@@ -10676,7 +10662,7 @@ diff --git a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm b/
 index 2e235bb880c638a0e74256b6d66cb0244ea0a3f1..3471eebb47e860f7c2071d0e7f2691c9f0a6355d 100644
 --- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 +++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
-@@ -257,6 +257,16 @@ - (BOOL)processSwapsOnNavigation
+@@ -257,6 +257,16 @@
      return _processPoolConfiguration->processSwapsOnNavigation();
  }
  
@@ -10989,7 +10975,7 @@ index 78d1578f94793e9e59a3d4d2b33e79ea8530fa04..493cdadac3873508b3efa3048638e73a
  #endif
 +int webkitWebContextExistingCount();
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
-index 59496a874f7b4541429bbe1e2ffeed755f5d8fe5..b0f421fa3d590ba890ddc4219aded0403dee759e 100644
+index f331430f4df7cea72a0d7477fa7f36bc8eaf2079..fb218d4df7d269b2d62c4040e60cba6aaa21e2e8 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 @@ -32,6 +32,7 @@
@@ -11204,10 +11190,10 @@ index 0000000000000000000000000000000000000000..9f1a0173a5641d6f158d815b8f7b9ea6
 +
 +#endif
 diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
-index 54293e7e4c923eafb2459c243cc9a3913e970e3f..f7a16a553798b0608371cb9a4aade2c0ccb00114 100644
+index 430e8f8195a361932999f598385b770e75322fa9..c4f6c200a388497ea46b70506f5a12f17910ae7b 100644
 --- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
 +++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
-@@ -2558,6 +2558,11 @@ void webkitWebViewBaseResetClickCounter(WebKitWebViewBase* webkitWebViewBase)
+@@ -2569,6 +2569,11 @@ void webkitWebViewBaseResetClickCounter(WebKitWebViewBase* webkitWebViewBase)
  #endif
  }
  
@@ -16720,7 +16706,7 @@ index 0000000000000000000000000000000000000000..48c9ccc420c1b4ae3259e1d5ba17fd8f
 +
 +} // namespace WebKit
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5ce16c77b 100644
+index c13f8a1a2ed0a6502403af436ed87de31ca8df89..6efcbd91fdf105c826dcfef4f6d29f25c635c37e 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
 @@ -246,6 +246,9 @@
@@ -16832,7 +16818,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
      if (flagsToUpdate & ActivityState::IsFocused && pageClient().isViewFocused())
          m_activityState.add(ActivityState::IsFocused);
      if (flagsToUpdate & ActivityState::WindowIsActive && pageClient().isViewWindowActive())
-@@ -2791,6 +2858,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
+@@ -2796,6 +2863,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
  {
      if (!hasRunningProcess())
          return;
@@ -16841,7 +16827,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  #if PLATFORM(GTK)
      UNUSED_PARAM(dragStorageName);
      UNUSED_PARAM(sandboxExtensionHandle);
-@@ -2801,6 +2870,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
+@@ -2806,6 +2875,8 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
          m_process->assumeReadAccessToBaseURL(*this, url);
  
      ASSERT(dragData.platformData());
@@ -16850,7 +16836,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
      send(Messages::WebPage::PerformDragControllerAction(action, dragData.clientPosition(), dragData.globalPosition(), dragData.draggingSourceOperationMask(), *dragData.platformData(), dragData.flags()));
  #else
      send(Messages::WebPage::PerformDragControllerAction(action, dragData, sandboxExtensionHandle, sandboxExtensionsForUpload));
-@@ -2816,18 +2887,41 @@ void WebPageProxy::didPerformDragControllerAction(std::optional<WebCore::DragOpe
+@@ -2821,18 +2892,41 @@ void WebPageProxy::didPerformDragControllerAction(std::optional<WebCore::DragOpe
      m_currentDragCaretEditableElementRect = editableElementRect;
      setDragCaretRect(insertionRect);
      pageClient().didPerformDragControllerAction();
@@ -16895,7 +16881,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<WebCore::DragOperation> dragOperationMask)
  {
      if (!hasRunningProcess())
-@@ -2836,6 +2930,24 @@ void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& glo
+@@ -2841,6 +2935,24 @@ void WebPageProxy::dragEnded(const IntPoint& clientPosition, const IntPoint& glo
      setDragCaretRect({ });
  }
  
@@ -16920,7 +16906,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  void WebPageProxy::didPerformDragOperation(bool handled)
  {
      pageClient().didPerformDragOperation(handled);
-@@ -2848,8 +2960,18 @@ void WebPageProxy::didStartDrag()
+@@ -2853,8 +2965,18 @@ void WebPageProxy::didStartDrag()
  
      discardQueuedMouseEvents();
      send(Messages::WebPage::DidStartDrag());
@@ -16940,7 +16926,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  void WebPageProxy::dragCancelled()
  {
      if (hasRunningProcess())
-@@ -2954,16 +3076,38 @@ void WebPageProxy::processNextQueuedMouseEvent()
+@@ -2959,16 +3081,38 @@ void WebPageProxy::processNextQueuedMouseEvent()
          m_process->startResponsivenessTimer();
      }
  
@@ -16985,7 +16971,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  }
  
  void WebPageProxy::doAfterProcessingAllPendingMouseEvents(WTF::Function<void ()>&& action)
-@@ -3127,7 +3271,7 @@ static TrackingType mergeTrackingTypes(TrackingType a, TrackingType b)
+@@ -3132,7 +3276,7 @@ static TrackingType mergeTrackingTypes(TrackingType a, TrackingType b)
  
  void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent)
  {
@@ -16994,7 +16980,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
      for (auto& touchPoint : touchStartEvent.touchPoints()) {
          IntPoint location = touchPoint.location();
          auto updateTrackingType = [this, location](TrackingType& trackingType, EventTrackingRegions::EventType eventType) {
-@@ -3159,7 +3303,7 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
+@@ -3164,7 +3308,7 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
      m_touchAndPointerEventTracking.touchStartTracking = TrackingType::Synchronous;
      m_touchAndPointerEventTracking.touchMoveTracking = TrackingType::Synchronous;
      m_touchAndPointerEventTracking.touchEndTracking = TrackingType::Synchronous;
@@ -17003,7 +16989,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  }
  
  TrackingType WebPageProxy::touchEventTrackingType(const WebTouchEvent& touchStartEvent) const
-@@ -3547,6 +3691,8 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
+@@ -3552,6 +3696,8 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
          policyAction = PolicyAction::Download;
  
      if (policyAction != PolicyAction::Use || !frame.isMainFrame() || !navigation) {
@@ -17012,7 +16998,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
          receivedPolicyDecision(policyAction, navigation, navigation->websitePolicies(), WTFMove(navigationAction), WTFMove(sender));
          return;
      }
-@@ -3617,6 +3763,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
+@@ -3622,6 +3768,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
  
  void WebPageProxy::receivedPolicyDecision(PolicyAction action, API::Navigation* navigation, RefPtr<API::WebsitePolicies>&& websitePolicies, std::variant<Ref<API::NavigationResponse>, Ref<API::NavigationAction>>&& navigationActionOrResponse, Ref<PolicyDecisionSender>&& sender, WillContinueLoadInNewProcess willContinueLoadInNewProcess, std::optional<SandboxExtension::Handle> sandboxExtensionHandle)
  {
@@ -17020,7 +17006,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
      if (!hasRunningProcess()) {
          sender->send(PolicyDecision { sender->identifier(), isNavigatingToAppBoundDomain(), PolicyAction::Ignore, 0, std::nullopt, std::nullopt });
          return;
-@@ -4391,6 +4538,11 @@ void WebPageProxy::pageScaleFactorDidChange(double scaleFactor)
+@@ -4396,6 +4543,11 @@ void WebPageProxy::pageScaleFactorDidChange(double scaleFactor)
      m_pageScaleFactor = scaleFactor;
  }
  
@@ -17032,7 +17018,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  void WebPageProxy::pluginScaleFactorDidChange(double pluginScaleFactor)
  {
      m_pluginScaleFactor = pluginScaleFactor;
-@@ -4802,6 +4954,7 @@ void WebPageProxy::didDestroyNavigation(uint64_t navigationID)
+@@ -4807,6 +4959,7 @@ void WebPageProxy::didDestroyNavigation(uint64_t navigationID)
          return;
  
      m_navigationState->didDestroyNavigation(navigationID);
@@ -17040,7 +17026,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  }
  
  void WebPageProxy::didStartProvisionalLoadForFrame(FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, uint64_t navigationID, URL&& url, URL&& unreachableURL, const UserData& userData)
-@@ -5027,6 +5180,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
+@@ -5032,6 +5185,8 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
  
      m_failingProvisionalLoadURL = { };
  
@@ -17049,7 +17035,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
      // If the provisional page's load fails then we destroy the provisional page.
      if (m_provisionalPage && m_provisionalPage->mainFrame() == &frame && willContinueLoading == WillContinueLoading::No)
          m_provisionalPage = nullptr;
-@@ -5550,7 +5705,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
+@@ -5555,7 +5710,14 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(FrameIdentifier frameID,
      NavigationActionData&& navigationActionData, FrameInfoData&& originatingFrameInfo, std::optional<WebPageProxyIdentifier> originatingPageID, const WebCore::ResourceRequest& originalRequest, WebCore::ResourceRequest&& request,
      IPC::FormDataReference&& requestBody, WebCore::ResourceResponse&& redirectResponse, const UserData& userData, uint64_t listenerID)
  {
@@ -17065,7 +17051,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  }
  
  void WebPageProxy::decidePolicyForNavigationActionAsyncShared(Ref<WebProcessProxy>&& process, PageIdentifier webPageID, FrameIdentifier frameID, FrameInfoData&& frameInfo,
-@@ -6140,6 +6302,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -6145,6 +6307,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
      if (originatingPage)
          openerAppInitiatedState = originatingPage->lastNavigationWasAppInitiated();
  
@@ -17073,7 +17059,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
      auto completionHandler = [this, protectedThis = Ref { *this }, mainFrameURL, request, reply = WTFMove(reply), privateClickMeasurement = navigationActionData.privateClickMeasurement, openerAppInitiatedState = WTFMove(openerAppInitiatedState)] (RefPtr<WebPageProxy> newPage) mutable {
          if (!newPage) {
              reply(std::nullopt, std::nullopt);
-@@ -6186,6 +6349,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
+@@ -6191,6 +6354,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
  void WebPageProxy::showPage()
  {
      m_uiClient->showPage(this);
@@ -17081,7 +17067,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  }
  
  void WebPageProxy::exitFullscreenImmediately()
-@@ -6245,6 +6409,10 @@ void WebPageProxy::closePage()
+@@ -6250,6 +6414,10 @@ void WebPageProxy::closePage()
      if (isClosed())
          return;
  
@@ -17092,7 +17078,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
      WEBPAGEPROXY_RELEASE_LOG(Process, "closePage:");
      pageClient().clearAllEditCommands();
      m_uiClient->close(this);
-@@ -6281,6 +6449,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
+@@ -6286,6 +6454,8 @@ void WebPageProxy::runJavaScriptAlert(FrameIdentifier frameID, FrameInfoData&& f
      }
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
@@ -17101,7 +17087,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
          page.m_uiClient->runJavaScriptAlert(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)]() mutable {
              reply();
              completion();
-@@ -6302,6 +6472,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
+@@ -6307,6 +6477,8 @@ void WebPageProxy::runJavaScriptConfirm(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17110,7 +17096,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptConfirm(page, message, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](bool result) mutable {
-@@ -6325,6 +6497,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
+@@ -6330,6 +6502,8 @@ void WebPageProxy::runJavaScriptPrompt(FrameIdentifier frameID, FrameInfoData&&
          if (auto* automationSession = process().processPool().automationSession())
              automationSession->willShowJavaScriptDialog(*this);
      }
@@ -17119,7 +17105,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  
      runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply), defaultValue](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
          page.m_uiClient->runJavaScriptPrompt(page, message, defaultValue, frame, WTFMove(frameInfo), [reply = WTFMove(reply), completion = WTFMove(completion)](auto& result) mutable {
-@@ -6452,6 +6626,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
+@@ -6457,6 +6631,8 @@ void WebPageProxy::runBeforeUnloadConfirmPanel(FrameIdentifier frameID, FrameInf
              return;
          }
      }
@@ -17128,7 +17114,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  
      // Since runBeforeUnloadConfirmPanel() can spin a nested run loop we need to turn off the responsiveness timer and the tryClose timer.
      m_process->stopResponsivenessTimer();
-@@ -7733,6 +7909,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7738,6 +7914,8 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->mouseEventsFlushedForPage(*this);
              didFinishProcessingAllPendingMouseEvents();
@@ -17137,7 +17123,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
          }
          break;
      }
-@@ -7747,10 +7925,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7752,10 +7930,13 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
              pageClient().wheelEventWasNotHandledByWebCore(oldestProcessedEvent);
          }
  
@@ -17154,7 +17140,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
          break;
      }
  
-@@ -7759,7 +7940,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7764,7 +7945,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
      case WebEvent::RawKeyDown:
      case WebEvent::Char: {
          LOG(KeyHandling, "WebPageProxy::didReceiveEvent: %s (queue empty %d)", webKeyboardEventTypeString(type), m_keyEventQueue.isEmpty());
@@ -17162,7 +17148,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
          MESSAGE_CHECK(m_process, !m_keyEventQueue.isEmpty());
          auto event = m_keyEventQueue.takeFirst();
          MESSAGE_CHECK(m_process, type == event.type());
-@@ -7778,7 +7958,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7783,7 +7963,6 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          // The call to doneWithKeyEvent may close this WebPage.
          // Protect against this being destroyed.
          Ref<WebPageProxy> protect(*this);
@@ -17170,7 +17156,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
          pageClient().doneWithKeyEvent(event, handled);
          if (!handled)
              m_uiClient->didNotHandleKeyEvent(this, event);
-@@ -7787,6 +7966,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
+@@ -7792,6 +7971,7 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
          if (!canProcessMoreKeyEvents) {
              if (auto* automationSession = process().processPool().automationSession())
                  automationSession->keyboardEventsFlushedForPage(*this);
@@ -17178,7 +17164,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
          }
          break;
      }
-@@ -8120,7 +8300,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
+@@ -8125,7 +8305,10 @@ void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
  {
      WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "dispatchProcessDidTerminate: reason=%{public}s", processTerminationReasonToString(reason));
  
@@ -17190,7 +17176,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
      if (m_loaderClient)
          handledByClient = reason != ProcessTerminationReason::RequestedByClient && m_loaderClient->processDidCrash(*this);
      else
-@@ -8454,6 +8637,7 @@ static Span<const ASCIILiteral> gpuMachServices()
+@@ -8459,6 +8642,7 @@ static Span<const ASCIILiteral> gpuMachServices()
  
  WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& process, DrawingAreaProxy& drawingArea, RefPtr<API::WebsitePolicies>&& websitePolicies)
  {
@@ -17198,7 +17184,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
      WebPageCreationParameters parameters;
  
      parameters.processDisplayName = configuration().processDisplayName();
-@@ -8647,6 +8831,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
+@@ -8652,6 +8836,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
  
      parameters.httpsUpgradeEnabled = preferences().upgradeKnownHostsToHTTPSEnabled() ? m_configuration->httpsUpgradeEnabled() : false;
  
@@ -17207,7 +17193,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
  #if PLATFORM(IOS)
      // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
      parameters.allowsDeprecatedSynchronousXMLHttpRequestDuringUnload = allowsDeprecatedSynchronousXMLHttpRequestDuringUnload();
-@@ -8719,6 +8905,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
+@@ -8724,6 +8910,14 @@ void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, Even
  
  void WebPageProxy::didReceiveAuthenticationChallengeProxy(Ref<AuthenticationChallengeProxy>&& authenticationChallenge, NegotiatedLegacyTLS negotiatedLegacyTLS)
  {
@@ -17222,7 +17208,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
      if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes) {
          m_navigationClient->shouldAllowLegacyTLS(*this, authenticationChallenge.get(), [this, protectedThis = Ref { *this }, authenticationChallenge] (bool shouldAllowLegacyTLS) {
              if (shouldAllowLegacyTLS)
-@@ -8812,6 +9006,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
+@@ -8817,6 +9011,15 @@ void WebPageProxy::requestGeolocationPermissionForFrame(GeolocationIdentifier ge
              request->deny();
      };
  
@@ -17239,7 +17225,7 @@ index 87ef19599fd80bc81064c00c52b9ddd82c301186..2d70cfbeaee28ef98cf43fbe6da0cea5
      // and make it one UIClient call that calls the completionHandler with false
      // if there is no delegate instead of returning the completionHandler
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.h b/Source/WebKit/UIProcess/WebPageProxy.h
-index 4b5d30cf64ca8817bb82832103475012b4822740..8ef013ccca5aae1d6cb8c2c848d158535fca9c0b 100644
+index b6243ccfe83e2e044ea0a3ec644dc10119c168d0..78a567c9e22d20731cd124da30b6ac3f50077bd2 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.h
 +++ b/Source/WebKit/UIProcess/WebPageProxy.h
 @@ -39,6 +39,7 @@
@@ -17361,7 +17347,7 @@ index 4b5d30cf64ca8817bb82832103475012b4822740..8ef013ccca5aae1d6cb8c2c848d15853
  #endif
  
  #if ENABLE(WEB_CRYPTO)
-@@ -2756,6 +2785,7 @@ private:
+@@ -2760,6 +2789,7 @@ private:
      String m_overrideContentSecurityPolicy;
  
      RefPtr<WebInspectorUIProxy> m_inspector;
@@ -17369,7 +17355,7 @@ index 4b5d30cf64ca8817bb82832103475012b4822740..8ef013ccca5aae1d6cb8c2c848d15853
  
  #if PLATFORM(COCOA)
      WeakObjCPtr<WKWebView> m_cocoaView;
-@@ -3026,6 +3056,20 @@ private:
+@@ -3034,6 +3064,20 @@ private:
      unsigned m_currentDragNumberOfFilesToBeAccepted { 0 };
      WebCore::IntRect m_currentDragCaretRect;
      WebCore::IntRect m_currentDragCaretEditableElementRect;
@@ -17390,7 +17376,7 @@ index 4b5d30cf64ca8817bb82832103475012b4822740..8ef013ccca5aae1d6cb8c2c848d15853
  #endif
  
      PageLoadState m_pageLoadState;
-@@ -3240,6 +3284,9 @@ private:
+@@ -3248,6 +3292,9 @@ private:
          RefPtr<API::Object> messageBody;
      };
      Vector<InjectedBundleMessage> m_pendingInjectedBundleMessages;
@@ -17557,10 +17543,10 @@ index abffeea475cd298870eb3f3c385e9b411c88113a..7b4fa6254fd2a384645c574a3df3f51e
      WebConnection* webConnection() const { return m_webConnection.get(); }
  
 diff --git a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-index eeb1c0f9e6712de6b3ccd191db6ce06c793b8c98..3af592fd17cd45b536431e28c1890a5fca79e7fe 100644
+index 17829d15c9dc0ae5a6fbde29c13854364f175dcb..881bcf0f8b92963e1e10ac81835ca9017ba2fa77 100644
 --- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
 +++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
-@@ -1994,6 +1994,12 @@ void WebsiteDataStore::originDirectoryForTesting(URL&& origin, URL&& topOrigin,
+@@ -1969,6 +1969,12 @@ void WebsiteDataStore::originDirectoryForTesting(URL&& origin, URL&& topOrigin,
      networkProcess().websiteDataOriginDirectoryForTesting(m_sessionID, WTFMove(origin), WTFMove(topOrigin), type, WTFMove(completionHandler));
  }
  
@@ -19612,10 +19598,10 @@ index 0000000000000000000000000000000000000000..c3d7cacea987ba2b094d5022c670705e
 + 
 +} // namespace WebKit
 diff --git a/Source/WebKit/WebKit.xcodeproj/project.pbxproj b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27b7a84d96 100644
+index 266417ad4c010baacb11763f5c5519266fedc028..28eeb16dc17c415247f7385a292d6f5bb68e1445 100644
 --- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
 +++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
-@@ -1247,6 +1247,7 @@
+@@ -1249,6 +1249,7 @@
  		5CABDC8722C40FED001EDE8E /* APIMessageListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CABDC8322C40FA7001EDE8E /* APIMessageListener.h */; };
  		5CADDE05215046BD0067D309 /* WKWebProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C74300E21500492004BFA17 /* WKWebProcess.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		5CAECB6627465AE400AB78D0 /* UnifiedSource115.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */; };
@@ -19623,7 +19609,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  		5CAF7AA726F93AB00003F19E /* adattributiond.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CAF7AA526F93A950003F19E /* adattributiond.cpp */; };
  		5CAFDE452130846300B1F7E1 /* _WKInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE422130843500B1F7E1 /* _WKInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		5CAFDE472130846A00B1F7E1 /* _WKInspectorInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAFDE442130843600B1F7E1 /* _WKInspectorInternal.h */; };
-@@ -2223,6 +2224,18 @@
+@@ -2225,6 +2226,18 @@
  		DF0C5F28252ECB8E00D921DB /* WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F24252ECB8D00D921DB /* WKDownload.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2A252ECB8E00D921DB /* WKDownloadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		DF0C5F2B252ED44000D921DB /* WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */; };
@@ -19642,7 +19628,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  		DF462E0F23F22F5500EFF35F /* WKHTTPCookieStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */; };
-@@ -2285,6 +2298,8 @@
+@@ -2287,6 +2300,8 @@
  		E5BEF6822130C48000F31111 /* WebDataListSuggestionsDropdownIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E5BEF6802130C47F00F31111 /* WebDataListSuggestionsDropdownIOS.h */; };
  		E5CB07DC20E1678F0022C183 /* WKFormColorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */; };
  		E5CBA76427A318E100DF7858 /* UnifiedSource120.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */; };
@@ -19651,7 +19637,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  		E5CBA76527A318E100DF7858 /* UnifiedSource118.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */; };
  		E5CBA76627A318E100DF7858 /* UnifiedSource116.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76327A3187B00DF7858 /* UnifiedSource116.cpp */; };
  		E5CBA76727A318E100DF7858 /* UnifiedSource119.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */; };
-@@ -2301,6 +2316,9 @@
+@@ -2303,6 +2318,9 @@
  		EBA8D3B627A5E33F00CB7900 /* MockPushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B027A5E33F00CB7900 /* MockPushServiceConnection.mm */; };
  		EBA8D3B727A5E33F00CB7900 /* PushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B127A5E33F00CB7900 /* PushServiceConnection.mm */; };
  		ED82A7F2128C6FAF004477B3 /* WKBundlePageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22F0FF1289FCD90085E74F /* WKBundlePageOverlay.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -19661,7 +19647,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
  		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
  		F42D634122A0EFDF00D2FB3A /* WebAutocorrectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */; };
-@@ -5276,6 +5294,7 @@
+@@ -5282,6 +5300,7 @@
  		5CABDC8522C40FCC001EDE8E /* WKMessageListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKMessageListener.h; sourceTree = "<group>"; };
  		5CADDE0D2151AA010067D309 /* AuthenticationChallengeDisposition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthenticationChallengeDisposition.h; sourceTree = "<group>"; };
  		5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource115.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource115.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -19669,7 +19655,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  		5CAF7AA426F93A750003F19E /* adattributiond */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = adattributiond; sourceTree = BUILT_PRODUCTS_DIR; };
  		5CAF7AA526F93A950003F19E /* adattributiond.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = adattributiond.cpp; sourceTree = "<group>"; };
  		5CAF7AA626F93AA50003F19E /* adattributiond.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = adattributiond.xcconfig; sourceTree = "<group>"; };
-@@ -6991,6 +7010,19 @@
+@@ -6997,6 +7016,19 @@
  		DF0C5F24252ECB8D00D921DB /* WKDownload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownload.h; sourceTree = "<group>"; };
  		DF0C5F25252ECB8E00D921DB /* WKDownloadInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadInternal.h; sourceTree = "<group>"; };
  		DF0C5F26252ECB8E00D921DB /* WKDownloadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDownloadDelegate.h; sourceTree = "<group>"; };
@@ -19689,7 +19675,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  		DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHTTPCookieStorePrivate.h; sourceTree = "<group>"; };
  		DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKContentWorldPrivate.h; sourceTree = "<group>"; };
  		DF58C6311371AC5800F9A37C /* NativeWebWheelEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeWebWheelEvent.h; sourceTree = "<group>"; };
-@@ -7120,6 +7152,8 @@
+@@ -7126,6 +7158,8 @@
  		E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKFormColorControl.h; path = ios/forms/WKFormColorControl.h; sourceTree = "<group>"; };
  		E5CB07DB20E1678F0022C183 /* WKFormColorControl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKFormColorControl.mm; path = ios/forms/WKFormColorControl.mm; sourceTree = "<group>"; };
  		E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource120.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource120.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -19698,7 +19684,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  		E5CBA76027A3187900DF7858 /* UnifiedSource119.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource119.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource119.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
  		E5CBA76127A3187900DF7858 /* UnifiedSource118.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource118.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource118.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
  		E5CBA76227A3187900DF7858 /* UnifiedSource117.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource117.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource117.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
-@@ -7141,6 +7175,14 @@
+@@ -7147,6 +7181,14 @@
  		ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtraPrivateSymbolsForTAPI.h; sourceTree = "<group>"; };
  		ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExtraPublicSymbolsForTAPI.h; sourceTree = "<group>"; };
  		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
@@ -19713,7 +19699,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  		F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDragDestinationAction.h; sourceTree = "<group>"; };
  		F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionContext.h; path = ios/WebAutocorrectionContext.h; sourceTree = "<group>"; };
  		F41056612130699A0092281D /* APIAttachmentCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = APIAttachmentCocoa.mm; sourceTree = "<group>"; };
-@@ -7275,6 +7317,7 @@
+@@ -7281,6 +7323,7 @@
  				52A69BEA286CFFAC00893E8F /* CryptoTokenKit.framework in Frameworks */,
  				3766F9EE189A1241003CF19B /* JavaScriptCore.framework in Frameworks */,
  				3766F9F1189A1254003CF19B /* libicucore.dylib in Frameworks */,
@@ -19721,7 +19707,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				3766F9EF189A1244003CF19B /* QuartzCore.framework in Frameworks */,
  				37694525184FC6B600CDE21F /* Security.framework in Frameworks */,
  				37BEC4DD1948FC6A008B4286 /* WebCore.framework in Frameworks */,
-@@ -9421,6 +9464,7 @@
+@@ -9427,6 +9470,7 @@
  				99788ACA1F421DCA00C08000 /* _WKAutomationSessionConfiguration.mm */,
  				990D28A81C6404B000986977 /* _WKAutomationSessionDelegate.h */,
  				990D28AF1C65203900986977 /* _WKAutomationSessionInternal.h */,
@@ -19729,7 +19715,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				5C4609E222430E4C009943C2 /* _WKContentRuleListAction.h */,
  				5C4609E322430E4D009943C2 /* _WKContentRuleListAction.mm */,
  				5C4609E422430E4D009943C2 /* _WKContentRuleListActionInternal.h */,
-@@ -10514,6 +10558,7 @@
+@@ -10520,6 +10564,7 @@
  				E34B110C27C46BC6006D2F2E /* libWebCoreTestShim.dylib */,
  				E34B110F27C46D09006D2F2E /* libWebCoreTestSupport.dylib */,
  				DDE992F4278D06D900F60D26 /* libWebKitAdditions.a */,
@@ -19737,7 +19723,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				57A9FF15252C6AEF006A2040 /* libWTF.a */,
  				5750F32A2032D4E500389347 /* LocalAuthentication.framework */,
  				570DAAB0230273D200E8FC04 /* NearField.framework */,
-@@ -11049,6 +11094,12 @@
+@@ -11055,6 +11100,12 @@
  			children = (
  				9197940423DBC4BB00257892 /* InspectorBrowserAgent.cpp */,
  				9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */,
@@ -19750,7 +19736,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  			);
  			path = Agents;
  			sourceTree = "<group>";
-@@ -11057,6 +11108,7 @@
+@@ -11063,6 +11114,7 @@
  			isa = PBXGroup;
  			children = (
  				A5D3504D1D78F0D2005124A9 /* RemoteWebInspectorUIProxyMac.mm */,
@@ -19758,7 +19744,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */,
  				99A7ACE326012919006D57FD /* WKInspectorResourceURLSchemeHandler.h */,
  				99A7ACE42601291A006D57FD /* WKInspectorResourceURLSchemeHandler.mm */,
-@@ -11600,6 +11652,7 @@
+@@ -11606,6 +11658,7 @@
  				E1513C65166EABB200149FCB /* AuxiliaryProcessProxy.h */,
  				46A2B6061E5675A200C3DEDA /* BackgroundProcessResponsivenessTimer.cpp */,
  				46A2B6071E5675A200C3DEDA /* BackgroundProcessResponsivenessTimer.h */,
@@ -19766,7 +19752,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				4659F25E275FF6B200BBB369 /* CaptivePortalModeObserver.h */,
  				07297F9C1C1711EA003F0735 /* DeviceIdHashSaltStorage.cpp */,
  				07297F9D1C17BBEA223F0735 /* DeviceIdHashSaltStorage.h */,
-@@ -11617,6 +11670,8 @@
+@@ -11623,6 +11676,8 @@
  				2DD5A72A1EBF09A7009BA597 /* HiddenPageThrottlingAutoIncreasesCounter.h */,
  				839A2F2F1E2067390039057E /* HighPerformanceGraphicsUsageSampler.cpp */,
  				839A2F301E2067390039057E /* HighPerformanceGraphicsUsageSampler.h */,
@@ -19775,7 +19761,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				5CEABA2B2333251400797797 /* LegacyGlobalSettings.cpp */,
  				5CEABA2A2333247700797797 /* LegacyGlobalSettings.h */,
  				31607F3819627002009B87DA /* LegacySessionStateCoding.h */,
-@@ -11648,6 +11703,7 @@
+@@ -11654,6 +11709,7 @@
  				1A0C227D2451130A00ED614D /* QuickLookThumbnailingSoftLink.mm */,
  				1AEE57232409F142002005D6 /* QuickLookThumbnailLoader.h */,
  				1AEE57242409F142002005D6 /* QuickLookThumbnailLoader.mm */,
@@ -19783,7 +19769,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				BC111B08112F5E3C00337BAB /* ResponsivenessTimer.cpp */,
  				1A30066C1110F4F70031937C /* ResponsivenessTimer.h */,
  				5CA98549210BEB5A0057EB6B /* SafeBrowsingWarning.h */,
-@@ -11748,6 +11804,8 @@
+@@ -11754,6 +11810,8 @@
  				BC7B6204129A0A6700D174A4 /* WebPageGroup.h */,
  				2D9EA3101A96D9EB002D2807 /* WebPageInjectedBundleClient.cpp */,
  				2D9EA30E1A96CBFF002D2807 /* WebPageInjectedBundleClient.h */,
@@ -19792,7 +19778,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				BC111B0B112F5E4F00337BAB /* WebPageProxy.cpp */,
  				BC032DCB10F4389F0058C15A /* WebPageProxy.h */,
  				BCBD38FA125BAB9A00D2C29F /* WebPageProxy.messages.in */,
-@@ -11900,6 +11958,7 @@
+@@ -11906,6 +11964,7 @@
  				BC646C1911DD399F006455B0 /* WKBackForwardListItemRef.h */,
  				BC646C1611DD399F006455B0 /* WKBackForwardListRef.cpp */,
  				BC646C1711DD399F006455B0 /* WKBackForwardListRef.h */,
@@ -19800,7 +19786,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				BCB9E24A1120E15C00A137E0 /* WKContext.cpp */,
  				BCB9E2491120E15C00A137E0 /* WKContext.h */,
  				1AE52F9319201F6B00A1FA37 /* WKContextConfigurationRef.cpp */,
-@@ -12483,6 +12542,9 @@
+@@ -12493,6 +12552,9 @@
  				C18173602058424700DFDA65 /* DisplayLink.h */,
  				31ABA79C215AF9E000C90E31 /* HighPerformanceGPUManager.h */,
  				31ABA79D215AF9E000C90E31 /* HighPerformanceGPUManager.mm */,
@@ -19810,7 +19796,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				1AFDE65B1954E8D500C48FFA /* LegacySessionStateCoding.cpp */,
  				0FCB4E5818BBE3D9000FCFC9 /* PageClientImplMac.h */,
  				0FCB4E5918BBE3D9000FCFC9 /* PageClientImplMac.mm */,
-@@ -12509,6 +12571,8 @@
+@@ -12519,6 +12581,8 @@
  				E568B92120A3AC6A00E3C856 /* WebDataListSuggestionsDropdownMac.mm */,
  				E55CD20124D09F1F0042DB9C /* WebDateTimePickerMac.h */,
  				E55CD20224D09F1F0042DB9C /* WebDateTimePickerMac.mm */,
@@ -19819,7 +19805,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				BC857E8512B71EBB00EDEB2E /* WebPageProxyMac.mm */,
  				BC5750951268F3C6006F0F12 /* WebPopupMenuProxyMac.h */,
  				BC5750961268F3C6006F0F12 /* WebPopupMenuProxyMac.mm */,
-@@ -13693,6 +13757,7 @@
+@@ -13703,6 +13767,7 @@
  				99788ACB1F421DDA00C08000 /* _WKAutomationSessionConfiguration.h in Headers */,
  				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
  				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
@@ -19827,7 +19813,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
  				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
  				1A5704F81BE01FF400874AF1 /* _WKContextMenuElementInfo.h in Headers */,
-@@ -13941,6 +14006,7 @@
+@@ -13951,6 +14016,7 @@
  				E170876C16D6CA6900F99226 /* BlobRegistryProxy.h in Headers */,
  				4F601432155C5AA2001FBDE0 /* BlockingResponseMap.h in Headers */,
  				1A5705111BE410E600874AF1 /* BlockSPI.h in Headers */,
@@ -19835,7 +19821,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				BC3065FA1259344E00E71278 /* CacheModel.h in Headers */,
  				41897ED81F415D8A0016FA42 /* CacheStorageEngine.h in Headers */,
  				41FABD2A1F4DE001006A6C97 /* CacheStorageEngineCache.h in Headers */,
-@@ -14208,7 +14274,11 @@
+@@ -14218,7 +14284,11 @@
  				2DD45ADE1E5F8972006C355F /* InputViewUpdateDeferrer.h in Headers */,
  				CE550E152283752200D28791 /* InsertTextOptions.h in Headers */,
  				9197940523DBC4BB00257892 /* InspectorBrowserAgent.h in Headers */,
@@ -19847,7 +19833,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				A5E391FD2183C1F800C8FB31 /* InspectorTargetProxy.h in Headers */,
  				51E9049C27BCB9D400929E7E /* InstallCoordinationSPI.h in Headers */,
  				C5BCE5DF1C50766A00CDE3FA /* InteractionInformationAtPosition.h in Headers */,
-@@ -14426,6 +14496,7 @@
+@@ -14436,6 +14506,7 @@
  				CDAC20CA23FC2F750021DEE3 /* RemoteCDMInstanceSession.h in Headers */,
  				CDAC20C923FC2F750021DEE3 /* RemoteCDMInstanceSessionIdentifier.h in Headers */,
  				F451C0FE2703B263002BA03B /* RemoteDisplayListRecorderProxy.h in Headers */,
@@ -19855,7 +19841,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				2D47B56D1810714E003A3AEE /* RemoteLayerBackingStore.h in Headers */,
  				2DDF731518E95060004F5A66 /* RemoteLayerBackingStoreCollection.h in Headers */,
  				1AB16AEA164B3A8800290D62 /* RemoteLayerTreeContext.h in Headers */,
-@@ -14484,6 +14555,7 @@
+@@ -14494,6 +14565,7 @@
  				E1E552C516AE065F004ED653 /* SandboxInitializationParameters.h in Headers */,
  				E36FF00327F36FBD004BE21A /* SandboxStateVariables.h in Headers */,
  				7BAB111025DD02B3008FC479 /* ScopedActiveMessageReceiveQueue.h in Headers */,
@@ -19863,7 +19849,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				E4D54D0421F1D72D007E3C36 /* ScrollingTreeFrameScrollingNodeRemoteIOS.h in Headers */,
  				0F931C1C18C5711900DBA7C3 /* ScrollingTreeOverflowScrollingNodeIOS.h in Headers */,
  				0F931C1C18C5711900DBB8D4 /* ScrollingTreeScrollingNodeDelegateIOS.h in Headers */,
-@@ -14832,6 +14904,8 @@
+@@ -14842,6 +14914,8 @@
  				2D9EA30F1A96CBFF002D2807 /* WebPageInjectedBundleClient.h in Headers */,
  				9197940823DBC4CB00257892 /* WebPageInspectorAgentBase.h in Headers */,
  				A513F5402154A5D700662841 /* WebPageInspectorController.h in Headers */,
@@ -19872,7 +19858,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				A543E30C215C8A8D00279CD9 /* WebPageInspectorTarget.h in Headers */,
  				A543E30D215C8A9000279CD9 /* WebPageInspectorTargetController.h in Headers */,
  				A543E307215AD13700279CD9 /* WebPageInspectorTargetFrontendChannel.h in Headers */,
-@@ -16761,6 +16835,8 @@
+@@ -16773,6 +16847,8 @@
  				51E9049727BCB3D900929E7E /* ICAppBundle.mm in Sources */,
  				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
  				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
@@ -19881,7 +19867,7 @@ index d36b51a12d9da9435201f90ff1a977a0be047c57..bb2e9f64d40449ee06daf5c2052b8e27
  				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
  				C1710CF724AA643200D7C112 /* LaunchServicesDatabaseObserver.mm in Sources */,
  				2984F588164BA095004BC0C6 /* LegacyCustomProtocolManagerMessageReceiver.cpp in Sources */,
-@@ -17095,6 +17171,8 @@
+@@ -17107,6 +17183,8 @@
  				E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */,
  				31BA924D148831260062EDB5 /* WebNotificationManagerMessageReceiver.cpp in Sources */,
  				2DF6FE52212E110900469030 /* WebPage.cpp in Sources */,
@@ -20066,10 +20052,10 @@ index 529ad5482554d07bd7bedbf3d48dc9f76e323c7c..b66401713b40e607f646414b90d6bf87
      }
  
 diff --git a/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp b/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp
-index 54650c8bb0e14d56a40969cd0d602930afb1dd22..9b7e57e07269d2504af30e73ea7e3623a44d0417 100644
+index f6cbdb00920e43b98b43f153797d60a622f113dc..6d1a6fb19056a6c87d8900c8022efc42acff77c2 100644
 --- a/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp
 +++ b/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp
-@@ -88,7 +88,7 @@ void NotificationPermissionRequestManager::startRequest(const SecurityOriginData
+@@ -84,7 +84,7 @@ void NotificationPermissionRequestManager::startRequest(const SecurityOriginData
  
      m_page->sendWithAsyncReply(Messages::WebPageProxy::RequestNotificationPermission(securityOrigin.toString()), [this, protectedThis = Ref { *this }, securityOrigin, permissionHandler = WTFMove(permissionHandler)](bool allowed) mutable {
  
@@ -20499,7 +20485,7 @@ index f127d64d005ab7b93875591b94a5899205e91579..df0de26e4dc449a0fbf93e7037444df4
      uint64_t m_navigationID;
  };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index 624de3b3fa39f0cdac0727b40cc6e59c5150a83f..cff329cfb75466a7bdd651cd5bf48965e3913a18 100644
+index 19ba39144862b90138535cb165519999802faf62..880ec33c555a9b7663e83b115fb92b2a9f4ed575 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 @@ -944,6 +944,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
@@ -20742,7 +20728,7 @@ index 624de3b3fa39f0cdac0727b40cc6e59c5150a83f..cff329cfb75466a7bdd651cd5bf48965
  }
  
  void WebPage::setIsTakingSnapshotsForApplicationSuspension(bool isTakingSnapshotsForApplicationSuspension)
-@@ -4590,7 +4703,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
+@@ -4606,7 +4719,7 @@ NotificationPermissionRequestManager* WebPage::notificationPermissionRequestMana
  
  #if ENABLE(DRAG_SUPPORT)
  
@@ -20751,7 +20737,7 @@ index 624de3b3fa39f0cdac0727b40cc6e59c5150a83f..cff329cfb75466a7bdd651cd5bf48965
  void WebPage::performDragControllerAction(DragControllerAction action, const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation> draggingSourceOperationMask, SelectionData&& selectionData, OptionSet<DragApplicationFlags> flags)
  {
      if (!m_page) {
-@@ -7012,6 +7125,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
+@@ -7028,6 +7141,9 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRe
              WebsitePoliciesData::applyToDocumentLoader(WTFMove(*m_pendingWebsitePolicies), documentLoader);
              m_pendingWebsitePolicies = std::nullopt;
          }
@@ -20762,10 +20748,10 @@ index 624de3b3fa39f0cdac0727b40cc6e59c5150a83f..cff329cfb75466a7bdd651cd5bf48965
  
      return documentLoader;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.h b/Source/WebKit/WebProcess/WebPage/WebPage.h
-index 60a526cbc8ca0fbeb5eb8a1d13a0c30afbad9792..393ec7215dee38605e44fcec51c9b27d49f25766 100644
+index 1a5899890f00a8a3b75ab341e8655255380443a2..f556782065300a1cb009e7c9f17c13184eda8e30 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.h
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
-@@ -117,6 +117,10 @@
+@@ -118,6 +118,10 @@
  #include "WebPrintOperationGtk.h"
  #endif
  
@@ -20776,7 +20762,7 @@ index 60a526cbc8ca0fbeb5eb8a1d13a0c30afbad9792..393ec7215dee38605e44fcec51c9b27d
  #if PLATFORM(GTK) || PLATFORM(WPE)
  #include "InputMethodState.h"
  #endif
-@@ -1015,11 +1019,11 @@ public:
+@@ -1017,11 +1021,11 @@ public:
      void clearSelection();
      void restoreSelectionInFocusedEditableElement();
  
@@ -20790,7 +20776,7 @@ index 60a526cbc8ca0fbeb5eb8a1d13a0c30afbad9792..393ec7215dee38605e44fcec51c9b27d
      void performDragControllerAction(DragControllerAction, const WebCore::DragData&, SandboxExtension::Handle&&, Vector<SandboxExtension::Handle>&&);
  #endif
  
-@@ -1033,6 +1037,9 @@ public:
+@@ -1035,6 +1039,9 @@ public:
      void didStartDrag();
      void dragCancelled();
      OptionSet<WebCore::DragSourceAction> allowedDragSourceActions() const { return m_allowedDragSourceActions; }
@@ -20800,7 +20786,7 @@ index 60a526cbc8ca0fbeb5eb8a1d13a0c30afbad9792..393ec7215dee38605e44fcec51c9b27d
  #endif
  
      void beginPrinting(WebCore::FrameIdentifier, const PrintInfo&);
-@@ -1267,6 +1274,7 @@ public:
+@@ -1269,6 +1276,7 @@ public:
      void connectInspector(const String& targetId, Inspector::FrontendChannel::ConnectionType);
      void disconnectInspector(const String& targetId);
      void sendMessageToTargetBackend(const String& targetId, const String& message);
@@ -20808,7 +20794,7 @@ index 60a526cbc8ca0fbeb5eb8a1d13a0c30afbad9792..393ec7215dee38605e44fcec51c9b27d
  
      void insertNewlineInQuotedContent();
  
-@@ -1657,6 +1665,7 @@ private:
+@@ -1663,6 +1671,7 @@ private:
      // Actions
      void tryClose(CompletionHandler<void(bool)>&&);
      void platformDidReceiveLoadParameters(const LoadParameters&);
@@ -20816,7 +20802,7 @@ index 60a526cbc8ca0fbeb5eb8a1d13a0c30afbad9792..393ec7215dee38605e44fcec51c9b27d
      void loadRequest(LoadParameters&&);
      NO_RETURN void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
      void loadData(LoadParameters&&);
-@@ -1694,6 +1703,7 @@ private:
+@@ -1700,6 +1709,7 @@ private:
      void updatePotentialTapSecurityOrigin(const WebTouchEvent&, bool wasHandled);
  #elif ENABLE(TOUCH_EVENTS)
      void touchEvent(const WebTouchEvent&);
@@ -20824,7 +20810,7 @@ index 60a526cbc8ca0fbeb5eb8a1d13a0c30afbad9792..393ec7215dee38605e44fcec51c9b27d
  #endif
  
      void cancelPointer(WebCore::PointerID, const WebCore::IntPoint&);
-@@ -1839,9 +1849,7 @@ private:
+@@ -1845,9 +1855,7 @@ private:
      void addLayerForFindOverlay(CompletionHandler<void(WebCore::GraphicsLayer::PlatformLayerID)>&&);
      void removeLayerForFindOverlay(CompletionHandler<void()>&&);
  
@@ -20834,7 +20820,7 @@ index 60a526cbc8ca0fbeb5eb8a1d13a0c30afbad9792..393ec7215dee38605e44fcec51c9b27d
  
      void didChangeSelectedIndexForActivePopupMenu(int32_t newIndex);
      void setTextForActivePopupMenu(int32_t index);
-@@ -2380,6 +2388,7 @@ private:
+@@ -2388,6 +2396,7 @@ private:
      UserActivity m_userActivity;
  
      uint64_t m_pendingNavigationID { 0 };
@@ -20843,10 +20829,10 @@ index 60a526cbc8ca0fbeb5eb8a1d13a0c30afbad9792..393ec7215dee38605e44fcec51c9b27d
  
      bool m_mainFrameProgressCompleted { false };
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-index d39310111ef403bbcb47029d622dc6f089d5b38d..c8a0ecc17ea0e82b173012f01583aae26921b315 100644
+index 7957aada242c91f7242629a6a07da55119579df4..267ecbe285854b78a723f66e6d09ee4d51691988 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
-@@ -139,6 +139,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -144,6 +144,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      ConnectInspector(String targetId, Inspector::FrontendChannel::ConnectionType connectionType)
      DisconnectInspector(String targetId)
      SendMessageToTargetBackend(String targetId, String message)
@@ -20854,7 +20840,7 @@ index d39310111ef403bbcb47029d622dc6f089d5b38d..c8a0ecc17ea0e82b173012f01583aae2
  
  #if ENABLE(REMOTE_INSPECTOR)
      SetIndicating(bool indicating);
-@@ -149,6 +150,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -154,6 +155,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
  #endif
  #if !ENABLE(IOS_TOUCH_EVENTS) && ENABLE(TOUCH_EVENTS)
      TouchEvent(WebKit::WebTouchEvent event)
@@ -20862,7 +20848,7 @@ index d39310111ef403bbcb47029d622dc6f089d5b38d..c8a0ecc17ea0e82b173012f01583aae2
  #endif
  
      CancelPointer(WebCore::PointerID pointerId, WebCore::IntPoint documentPoint)
-@@ -178,6 +180,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -183,6 +185,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      LoadURLInFrame(URL url, String referrer, WebCore::FrameIdentifier frameID)
      LoadDataInFrame(IPC::DataReference data, String MIMEType, String encodingName, URL baseURL, WebCore::FrameIdentifier frameID)
      LoadRequest(struct WebKit::LoadParameters loadParameters)
@@ -20870,7 +20856,7 @@ index d39310111ef403bbcb47029d622dc6f089d5b38d..c8a0ecc17ea0e82b173012f01583aae2
      LoadRequestWaitingForProcessLaunch(struct WebKit::LoadParameters loadParameters, URL resourceDirectoryURL, WebKit::WebPageProxyIdentifier pageID, bool checkAssumedReadAccessToResourceURL)
      LoadData(struct WebKit::LoadParameters loadParameters)
      LoadSimulatedRequestAndResponse(struct WebKit::LoadParameters loadParameters, WebCore::ResourceResponse simulatedResponse)
-@@ -344,10 +347,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -349,10 +352,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      AddMIMETypeWithCustomContentProvider(String mimeType)
  
      # Drag and drop.
@@ -20883,7 +20869,7 @@ index d39310111ef403bbcb47029d622dc6f089d5b38d..c8a0ecc17ea0e82b173012f01583aae2
      PerformDragControllerAction(enum:uint8_t WebKit::DragControllerAction action, WebCore::DragData dragData, WebKit::SandboxExtension::Handle sandboxExtensionHandle, Vector<WebKit::SandboxExtension::Handle> sandboxExtensionsForUpload)
  #endif
  #if ENABLE(DRAG_SUPPORT)
-@@ -356,6 +359,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
+@@ -361,6 +364,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
      DragCancelled()
  #endif
  
@@ -21026,7 +21012,7 @@ diff --git a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm b/Source/WebKitLegac
 index 81093dca5a3f4cf8fa7a71551b9d7b11d7513d9e..0e62bc13f72397239c80bfbc3a272286d1fcb39f 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
-@@ -4205,7 +4205,7 @@ - (void)mouseDown:(WebEvent *)event
+@@ -4205,7 +4205,7 @@ static BOOL currentScrollIsBlit(NSView *clipView)
      _private->handlingMouseDownEvent = NO;
  }
  
@@ -21036,10 +21022,10 @@ index 81093dca5a3f4cf8fa7a71551b9d7b11d7513d9e..0e62bc13f72397239c80bfbc3a272286
  - (void)touch:(WebEvent *)event
  {
 diff --git a/Source/WebKitLegacy/mac/WebView/WebView.mm b/Source/WebKitLegacy/mac/WebView/WebView.mm
-index f57ff1862f7bc2d2e88710c7b43d62b78b1765a0..fdcf7866546515473fe579333184d9400d1f6bb6 100644
+index e9f03c5136ad79870b8bdfa63f496e0b334238e1..bc82c7bd0b0778c2a16c4db2570bc3e27245f101 100644
 --- a/Source/WebKitLegacy/mac/WebView/WebView.mm
 +++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
-@@ -4038,7 +4038,7 @@ + (void)_doNotStartObservingNetworkReachability
+@@ -4038,7 +4038,7 @@ IGNORE_WARNINGS_END
  }
  #endif // PLATFORM(IOS_FAMILY)
  
@@ -21048,7 +21034,7 @@ index f57ff1862f7bc2d2e88710c7b43d62b78b1765a0..fdcf7866546515473fe579333184d940
  
  - (NSArray *)_touchEventRegions
  {
-@@ -4080,7 +4080,7 @@ - (NSArray *)_touchEventRegions
+@@ -4080,7 +4080,7 @@ IGNORE_WARNINGS_END
      }).autorelease();
  }
  
@@ -21057,6 +21043,20 @@ index f57ff1862f7bc2d2e88710c7b43d62b78b1765a0..fdcf7866546515473fe579333184d940
  
  // For backwards compatibility with the WebBackForwardList API, we honor both
  // a per-WebView and a per-preferences setting for whether to use the back/forward cache.
+diff --git a/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h b/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
+index 3ed076da2777bda665bb9df0ca9ac4e31166834e..57dafeef1db6164092d737ebd5d48902aefe2cc2 100644
+--- a/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
++++ b/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
+@@ -58,7 +58,8 @@ __PAS_BEGIN_EXTERN_C;
+ #if defined(PAS_LIBMALLOC) && PAS_LIBMALLOC
+ #define __PAS_API __attribute__((visibility("hidden")))
+ #else
+-#define __PAS_API __attribute__((visibility("default")))
++// Playwright: Avoid linking error: 'pas_deallocate.c.o: requires dynamic R_X86_64_PC32 reloc against 'pas_segregated_page_deallocation_did_fail' which may overflow at runtime; recompile with -fPIC'.
++#define __PAS_API
+ #endif
+ 
+ #if defined(PAS_BMALLOC) && PAS_BMALLOC
 diff --git a/Source/cmake/FindLibVPX.cmake b/Source/cmake/FindLibVPX.cmake
 new file mode 100644
 index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d5d9dc387
@@ -21089,7 +21089,7 @@ index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d
 +    LIBVPX_LIBRARIES
 +)
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index b23e53adb4b366a83240951bb8c64894f4a61048..1e3c295c9478f62e57d60041e6abd87b01869f83 100644
+index 9f83a2ce06da0656de69fd18ea6e4bc8065b81bd..870528b5e0f00bacd29578c614cb528bff790752 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
 @@ -11,8 +11,13 @@ if (${CMAKE_VERSION} VERSION_LESS "3.20" AND NOT ${CMAKE_GENERATOR} STREQUAL "Ni
@@ -21171,9 +21171,9 @@ index b23e53adb4b366a83240951bb8c64894f4a61048..1e3c295c9478f62e57d60041e6abd87b
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_PERIODIC_MEMORY_MONITOR PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_POINTER_LOCK PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SERVICE_WORKER PRIVATE ON)
-@@ -179,6 +188,15 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SHAREABLE_RESOURCE PRIVATE ON)
- WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_API_STATISTICS PRIVATE ON)
+@@ -180,6 +189,15 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_API_STATISTICS PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_RTC PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
+ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEBGL2 PRIVATE ON)
  
 +# Playwright
 +WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_APPLICATION_MANIFEST PRIVATE ON)
@@ -21187,7 +21187,7 @@ index b23e53adb4b366a83240951bb8c64894f4a61048..1e3c295c9478f62e57d60041e6abd87b
  include(GStreamerDependencies)
  
  # Finalize the value for all options. Do not attempt to use an option before
-@@ -277,6 +295,7 @@ if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
+@@ -278,6 +296,7 @@ if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
  endif ()
  
  SET_AND_EXPOSE_TO_BUILD(USE_ATSPI ${ENABLE_ACCESSIBILITY})
@@ -21196,7 +21196,7 @@ index b23e53adb4b366a83240951bb8c64894f4a61048..1e3c295c9478f62e57d60041e6abd87b
  SET_AND_EXPOSE_TO_BUILD(HAVE_OS_DARK_MODE_SUPPORT 1)
  
 diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
-index 2cdf38d15dccb56c08b3fa2f9c819a7a0190c6c3..ac427365642f9b2b8438240d7918af0ff6e0cc5c 100644
+index 0078b2ff6b0e267f1fb5c02d6e3b331db3013703..be378fe3aa6b3137f9a1c63ebd346304274b7d67 100644
 --- a/Source/cmake/OptionsWPE.cmake
 +++ b/Source/cmake/OptionsWPE.cmake
 @@ -9,8 +9,13 @@ if (${CMAKE_VERSION} VERSION_LESS "3.20" AND NOT ${CMAKE_GENERATOR} STREQUAL "Ni
@@ -21235,7 +21235,7 @@ index 2cdf38d15dccb56c08b3fa2f9c819a7a0190c6c3..ac427365642f9b2b8438240d7918af0f
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MHTML PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MODERN_MEDIA_CONTROLS PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_NETSCAPE_PLUGIN_API PRIVATE OFF)
-@@ -77,24 +82,42 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_OFFSCREEN_CANVAS_IN_WORKERS PRIVATE ${EN
+@@ -77,25 +82,43 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_OFFSCREEN_CANVAS_IN_WORKERS PRIVATE ${EN
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_PERIODIC_MEMORY_MONITOR PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SERVICE_WORKER PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_SHAREABLE_RESOURCE PRIVATE ON)
@@ -21243,6 +21243,7 @@ index 2cdf38d15dccb56c08b3fa2f9c819a7a0190c6c3..ac427365642f9b2b8438240d7918af0f
 +WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_THUNDER PRIVATE OFF)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_TOUCH_EVENTS PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_RTC PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
+ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEBGL2 PRIVATE ON)
  WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEBXR PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
  
 +# Playwright
@@ -21284,7 +21285,7 @@ index 2cdf38d15dccb56c08b3fa2f9c819a7a0190c6c3..ac427365642f9b2b8438240d7918af0f
  
  # Private options specific to the WPE port.
 diff --git a/Source/cmake/OptionsWin.cmake b/Source/cmake/OptionsWin.cmake
-index 3b6d4a7eaa531c9e26e8ebd907a4b846d04bece9..72d3a1e7fd2a2c5427139869644b95956f936260 100644
+index 00ac7921bf6903d047585063cc374231397f236b..038ddb5f9adeda2f950e4631f4390fc9ef51e93c 100644
 --- a/Source/cmake/OptionsWin.cmake
 +++ b/Source/cmake/OptionsWin.cmake
 @@ -7,8 +7,9 @@ add_definitions(-D_WINDOWS -DWINVER=0x601 -D_WIN32_WINNT=0x601)
@@ -21943,10 +21944,10 @@ index ed6c15ce06c25ef12b165552bd665c5108d209dc..267612eb7239cfa91f0c675ec18d0975
              # WebInspectorUI must come after JavaScriptCore and WebCore but before WebKit and WebKit2
              my $webKitIndex = first { $projects[$_] eq "Source/WebKitLegacy" } 0..$#projects;
 diff --git a/Tools/WebKitTestRunner/TestController.cpp b/Tools/WebKitTestRunner/TestController.cpp
-index e8e387c158ec25408ac34e483b9e7158dfaa7ffd..415a9062054bcd31c1854d66c50f1c9444234100 100644
+index f7fd40ab596fe75ecbf773d94d1e3a09ba313903..19dc94ff4d78afc32766d2ec5d5878aa7bbb8033 100644
 --- a/Tools/WebKitTestRunner/TestController.cpp
 +++ b/Tools/WebKitTestRunner/TestController.cpp
-@@ -874,6 +874,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
+@@ -891,6 +891,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
          0, // requestStorageAccessConfirm
          shouldAllowDeviceOrientationAndMotionAccess,
          runWebAuthenticationPanel,


### PR DESCRIPTION
No conflicts, only build fixes. Changes:

* [chore(webkit): bootstrap build 1696](https://github.com/dpino/webkit/commit/823a4422361c99ecf3820c6fe03f9fc9dae8ee07)
* [[macOS] Build fix after 253022@main](https://github.com/dpino/webkit/commit/b77606ebfbe01da8a28d02ec43be225ac6e92d0a)
* [[GLIB] Ubuntu 18.04, fix build error after 252977@main](https://github.com/dpino/webkit/commit/2cb5a6a457b3b27c9a9cbb12c4f8297972e76328)
  * This build error is happening upstream in the [Ubuntu 18.04 bots]( https://build.webkit.org/#/builders/71/builds/600/steps/10/logs/stdio). It doesn't happen in Ubuntu 20.04 neither in Debian Stable bot which features GCC8.3. Ubuntu 18.04 featuers GCC8.4. I attempted to build libpas and bmalloc with -fPIC as the build error indicates but it didn't fix the build error. Eventually I decided to partially revert 252977@main.
  * Upstream bug: https://bugs.webkit.org/show_bug.cgi?id=243535