### PR TITLE
feat(plugins): send accept header in webServer url checking

### DIFF
--- a/packages/playwright-test/src/plugins/webServerPlugin.ts
+++ b/packages/playwright-test/src/plugins/webServerPlugin.ts
@@ -158,10 +158,12 @@ async function isURLAvailable(url: URL, ignoreHTTPSErrors: boolean, onStdErr: Re
 }
 
 async function httpStatusCode(url: URL, ignoreHTTPSErrors: boolean, onStdErr: Reporter['onStdErr']): Promise<number> {
+  const commonRequestOptions = { headers: { Accept: '*/*' } };
   const isHttps = url.protocol === 'https:';
   const requestOptions = isHttps ? {
+    ...commonRequestOptions,
     rejectUnauthorized: !ignoreHTTPSErrors,
-  } : {};
+  } : commonRequestOptions;
   return new Promise(resolve => {
     debugWebServer(`HTTP GET: ${url}`);
     (isHttps ? https : http).get(url, requestOptions, res => {


### PR DESCRIPTION
This PR sets the Accept HTTP header to `*/*` for HTTP requests made by the webServer plugin when using a URL to check if the server has already started. So far, the Accept header was not being sent at all, which should be semantically equivalent to sending `*/*`, according to [RFC 7231](https://www.rfc-editor.org/rfc/rfc7231#section-5.3.2). However, there are some web servers that handle this differently. Most notably, [Vite](https://vitejs.dev/)'s server just returns a 404 if the `Accept` header is missing from the request. I created https://github.com/vitejs/vite/issues/9520 in order to address the issue on their side, but I think it's also fine to just add the header here, which is why I created this PR.