### PR TITLE
browser(webkit): Revert downstream change introduced in last roll

### DIFF
--- a/browser_patches/webkit/BUILD_NUMBER
+++ b/browser_patches/webkit/BUILD_NUMBER
@@ -1,2 +1,2 @@
-1697
-Changed: dpino@igalia.com Thu Aug  4 19:20:29 HKT 2022
+1698
+Changed: dpino@igalia.com Fri Aug  5 11:36:09 HKT 2022

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -21043,20 +21043,6 @@ index e9f03c5136ad79870b8bdfa63f496e0b334238e1..bc82c7bd0b0778c2a16c4db2570bc3e2
  
  // For backwards compatibility with the WebBackForwardList API, we honor both
  // a per-WebView and a per-preferences setting for whether to use the back/forward cache.
-diff --git a/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h b/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
-index 3ed076da2777bda665bb9df0ca9ac4e31166834e..57dafeef1db6164092d737ebd5d48902aefe2cc2 100644
---- a/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
-+++ b/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
-@@ -58,7 +58,8 @@ __PAS_BEGIN_EXTERN_C;
- #if defined(PAS_LIBMALLOC) && PAS_LIBMALLOC
- #define __PAS_API __attribute__((visibility("hidden")))
- #else
--#define __PAS_API __attribute__((visibility("default")))
-+// Playwright: Avoid linking error: 'pas_deallocate.c.o: requires dynamic R_X86_64_PC32 reloc against 'pas_segregated_page_deallocation_did_fail' which may overflow at runtime; recompile with -fPIC'.
-+#define __PAS_API
- #endif
- 
- #if defined(PAS_BMALLOC) && PAS_BMALLOC
 diff --git a/Source/cmake/FindLibVPX.cmake b/Source/cmake/FindLibVPX.cmake
 new file mode 100644
 index 0000000000000000000000000000000000000000..dd6a53e2d57318489b7e49dd7373706d5d9dc387


### PR DESCRIPTION
Compilation was failing in all CI Linux bots after [#1697](https://github.com/microsoft/playwright/pull/16249).

Both in Ubuntu 18.04 and Ubuntu 20.04 the stracktrace are the same:

```
FAILED: lib/libTestRunnerInjectedBundle.so
: && <CXX> -fPIC -fdiagnostics-color=always -Wextra -Wall -pipe -Wno-odr -Wno-stringop-overflow -Wno-nonnull -Wno-array-bounds -Wno-expansion-to-defined -Wno-noexcept-type -Wno-psabi -Wno-misleading-indentation -Wno-maybe-uninitialized -Wwrite-strings -Wundef -Wpointer-arit
Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/./__/__/JavaScriptCore/DerivedSources/unified-sources/UnifiedSource-3a3c4ec0-2.cpp.o: In function `JSC::initializeJITPageReservation()':
UnifiedSource-3a3c4ec0-2.cpp:(.text+0xcb): undefined reference to `jit_heap_runtime_config'
Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/./__/__/JavaScriptCore/DerivedSources/unified-sources/UnifiedSource-3a3c4ec0-2.cpp.o: In function `JSC::ExecutableMemoryHandle::createImpl(unsigned long)':
UnifiedSource-3a3c4ec0-2.cpp:(.text+0x475b): undefined reference to `jit_heap_try_allocate'
UnifiedSource-3a3c4ec0-2.cpp:(.text+0x476b): undefined reference to `jit_heap_get_size'
Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/./__/__/JavaScriptCore/DerivedSources/unified-sources/UnifiedSource-3a3c4ec0-2.cpp.o: In function `JSC::ExecutableMemoryHandle::shrink(unsigned long)':
UnifiedSource-3a3c4ec0-2.cpp:(.text+0x4961): undefined reference to `jit_heap_shrink'
UnifiedSource-3a3c4ec0-2.cpp:(.text+0x496a): undefined reference to `jit_heap_get_size'
Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/./__/__/JavaScriptCore/DerivedSources/unified-sources/UnifiedSource-3a3c4ec0-2.cpp.o: In function `JSC::ExecutableAllocator::initializeUnderlyingAllocator()':
UnifiedSource-3a3c4ec0-2.cpp:(.text+0x70c1): undefined reference to `jit_heap_runtime_config'
UnifiedSource-3a3c4ec0-2.cpp:(.text+0x71a1): undefined reference to `jit_heap_add_fresh_memory'
Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/./__/__/JavaScriptCore/DerivedSources/unified-sources/UnifiedSource-3a3c4ec0-2.cpp.o: In function `JSC::ExecutableMemoryHandle::~ExecutableMemoryHandle()':
UnifiedSource-3a3c4ec0-2.cpp:(.text+0x47f9): undefined reference to `jit_heap_deallocate'
Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/./__/__/JavaScriptCore/DerivedSources/unified-sources/UnifiedSource-f2e18ffc-13.cpp.o: In function `std::call_once<JSC::initialize()::{lambda()#1}>(std::once_flag&, JSC::initialize()::{lambda()#1}&&)::{lambda()#2}::_FUN()'
UnifiedSource-f2e18ffc-13.cpp:(.text+0x261): undefined reference to `pas_scavenger_disable_shut_down'
Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/./__/__/JavaScriptCore/DerivedSources/unified-sources/UnifiedSource-0284c6ac-1.cpp.o: In function `JSC::functionDumpAndResetPasDebugSpectrum(JSC::JSGlobalObject*, JSC::CallFrame*)':
UnifiedSource-0284c6ac-1.cpp:(.text+0x18d9): undefined reference to `pas_heap_lock'
UnifiedSource-0284c6ac-1.cpp:(.text+0x18ed): undefined reference to `pas_log_stream'
UnifiedSource-0284c6ac-1.cpp:(.text+0x18f2): undefined reference to `pas_debug_spectrum_dump'
UnifiedSource-0284c6ac-1.cpp:(.text+0x18f7): undefined reference to `pas_debug_spectrum_reset'
UnifiedSource-0284c6ac-1.cpp:(.text+0x1929): undefined reference to `pas_lock_lock_slow'
```

This stactrace is different from what I got when building in Ubuntu 18.04. Since the downstream change is ineffective and it seems to break other Linux platforms let's remove this it and see how the Linux CI bots behave.