### PR TITLE
chore: update "X fatal errors" message

### DIFF
--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -98,7 +98,8 @@ export class BaseReporter implements ReporterInternal  {
   }
 
   onError(error: TestError) {
-    this._fatalErrors.push(error);
+    if (!(error as any).__isNotAFatalError)
+      this._fatalErrors.push(error);
   }
 
   async onEnd(result: FullResult) {
@@ -136,8 +137,6 @@ export class BaseReporter implements ReporterInternal  {
 
   protected generateSummaryMessage({ skipped, expected, interrupted, unexpected, flaky, fatalErrors }: TestSummary) {
     const tokens: string[] = [];
-    if (fatalErrors.length)
-      tokens.push(colors.red(`  ${fatalErrors.length} fatal ${fatalErrors.length === 1 ? 'error' : 'errors'}`));
     if (unexpected.length) {
       tokens.push(colors.red(`  ${unexpected.length} failed`));
       for (const test of unexpected)
@@ -159,6 +158,8 @@ export class BaseReporter implements ReporterInternal  {
       tokens.push(colors.green(`  ${expected} passed`) + colors.dim(` (${milliseconds(this.duration)})`));
     if (this.result.status === 'timedout')
       tokens.push(colors.red(`  Timed out waiting ${this.config.globalTimeout / 1000}s for the entire test run`));
+    if (fatalErrors.length)
+      tokens.push(colors.red(`  ${fatalErrors.length === 1 ? '1 error was not a part of any test' : fatalErrors.length + ' errors were not a part of any test'}, see above for details`));
 
     return tokens.join('\n');
   }

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -994,7 +994,7 @@ function createNoTestsError(): TestError {
 }
 
 function createStacklessError(message: string): TestError {
-  return { message };
+  return { message, __isNotAFatalError: true } as any;
 }
 
 export const builtInReporters = ['list', 'line', 'dot', 'json', 'junit', 'null', 'github', 'html'] as const;

--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -316,5 +316,5 @@ test('should report fatal errors at the end', async ({ runInlineTest }) => {
   }, { reporter: 'list' });
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(2);
-  expect(stripAnsi(result.output)).toContain('2 fatal errors');
+  expect(stripAnsi(result.output)).toContain('2 errors were not a part of any test, see above for details');
 });


### PR DESCRIPTION
Also, exclude certain errors from triggering this message:
- `no tests found`
- `duplicate test titles are not allowed`
- `--forbid-only found a focused test`
- `Timed out waiting 3600s for the entire test run`