### PR TITLE
docs: mention test-runner docs in library docs

### DIFF
--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -16,6 +16,13 @@ app UI). For [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/
 
 <!-- TOC -->
 
+## Playwright Test vs. Library
+* langs: js
+
+:::caution
+This guide is for [Playwright Library](./library.md), if you are using Playwright Test (`@playwright/test`) see [here](./test-auth.md).
+:::
+
 ## Automate logging in
 
 The Playwright API can automate interaction with a login form. See

--- a/docs/src/emulation.md
+++ b/docs/src/emulation.md
@@ -14,7 +14,12 @@ can be changed for individual pages.
 
 <!-- TOC -->
 
-<br/>
+## Playwright Test vs. Library
+* langs: js
+
+:::caution
+This guide is for [Playwright Library](./library.md), if you are using Playwright Test (`@playwright/test`) see [here](./test-configuration.md).
+:::
 
 ## Devices
 * langs: js, python, csharp

--- a/docs/src/pom.md
+++ b/docs/src/pom.md
@@ -8,6 +8,13 @@ approach to structure your test suite.
 
 <!-- TOC -->
 
+## Playwright Test vs. Library
+* langs: js
+
+:::caution
+This guide is for [Playwright Library](./library.md), if you are using Playwright Test (`@playwright/test`) see [here](./test-pom.md).
+:::
+
 ## Introduction
 
 A page object represents a part of your web application. An e-commerce web application might have a home page, a


### PR DESCRIPTION
We can have this in the meantime until we figured out a full story for library vs test-runner.

fixes https://github.com/microsoft/playwright.dev/issues/685