### PR TITLE
Add fallback "default" key to "." exports object

### DIFF
--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -12,7 +12,8 @@
     ".": {
       "types": "./index.d.ts",
       "import": "./index.mjs",
-      "require": "./index.js"
+      "require": "./index.js",
+      "default": "./index.js"
     },
     "./cli": "./cli.js",
     "./package.json": "./package.json",


### PR DESCRIPTION
Adds a [`default`](https://nodejs.org/api/packages.html#conditional-exports) export in the `package.json` file.

See https://github.com/microsoft/playwright/issues/16345