### PR TITLE
chore: set --allow-pre-commit-input flag on Android/Electron

### DIFF
--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -35,6 +35,7 @@ import { gracefullyCloseSet } from '../../utils/processLauncher';
 import { TimeoutSettings } from '../../common/timeoutSettings';
 import type * as channels from '../../protocol/channels';
 import { SdkObject, serverSideCallMetadata } from '../instrumentation';
+import { DEFAULT_ARGS } from '../chromium/chromium';
 
 const ARTIFACTS_FOLDER = path.join(os.tmpdir(), 'playwright-artifacts-');
 
@@ -247,7 +248,13 @@ export class AndroidDevice extends SdkObject {
     debug('pw:android')('Force-stopping', pkg);
     await this._backend.runCommand(`shell:am force-stop ${pkg}`);
     const socketName = isUnderTest() ? 'webview_devtools_remote_playwright_test' : ('playwright-' + createGuid());
-    const commandLine = `_ --disable-fre --no-default-browser-check --no-first-run --remote-debugging-socket-name=${socketName}`;
+    const commandLine = [
+      '_',
+      '--disable-fre',
+      '--no-default-browser-check',
+      `--remote-debugging-socket-name=${socketName}`,
+      ...DEFAULT_ARGS,
+    ].join(' ');
     debug('pw:android')('Starting', pkg, commandLine);
     await this._backend.runCommand(`shell:echo "${commandLine}" > /data/local/tmp/chrome-command-line`);
     await this._backend.runCommand(`shell:am start -a android.intent.action.VIEW -d about:blank ${pkg}`);

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -324,7 +324,7 @@ export class Chromium extends BrowserType {
   }
 }
 
-const DEFAULT_ARGS = [
+export const DEFAULT_ARGS = [
   '--disable-field-trial-config', // https://source.chromium.org/chromium/chromium/src/+/main:testing/variations/README.md
   '--disable-background-networking',
   '--enable-features=NetworkService,NetworkServiceInProcess',
@@ -339,7 +339,8 @@ const DEFAULT_ARGS = [
   '--disable-extensions',
   // AvoidUnnecessaryBeforeUnloadCheckSync - https://github.com/microsoft/playwright/issues/14047
   // Translate - https://github.com/microsoft/playwright/issues/16126
-  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate',
+  // PaintHolding - https://crbug.com/1322971
+  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,PaintHolding',
   '--allow-pre-commit-input',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -339,8 +339,7 @@ export const DEFAULT_ARGS = [
   '--disable-extensions',
   // AvoidUnnecessaryBeforeUnloadCheckSync - https://github.com/microsoft/playwright/issues/14047
   // Translate - https://github.com/microsoft/playwright/issues/16126
-  // PaintHolding - https://crbug.com/1322971
-  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,PaintHolding',
+  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate',
   '--allow-pre-commit-input',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',

--- a/tests/electron/electron-app.js
+++ b/tests/electron/electron-app.js
@@ -1,8 +1,8 @@
 const { app, protocol } = require('electron');
 const path = require('path');
 
-// PaintHolding - https://crbug.com/1322971
-app.commandLine.appendSwitch('disable-features', 'PaintHolding,AutoExpandDetailsElement');
+app.commandLine.appendSwitch('disable-features', 'AutoExpandDetailsElement');
+app.commandLine.appendSwitch('allow-pre-commit-input')
 
 app.on('window-all-closed', e => e.preventDefault());
 

--- a/tests/electron/electron-app.js
+++ b/tests/electron/electron-app.js
@@ -1,6 +1,9 @@
 const { app, protocol } = require('electron');
 const path = require('path');
 
+// PaintHolding - https://crbug.com/1322971
+app.commandLine.appendSwitch('disable-features', 'PaintHolding,AutoExpandDetailsElement');
+
 app.on('window-all-closed', e => e.preventDefault());
 
 app.whenReady().then(() => {

--- a/tests/page/locator-convenience.spec.ts
+++ b/tests/page/locator-convenience.spec.ts
@@ -202,10 +202,8 @@ it('allInnerTexts should work', async ({ page }) => {
   expect(await page.locator('div').allInnerTexts()).toEqual(['A', 'B', 'C']);
 });
 
-it('isVisible and isHidden should work with details', async ({ page, isAndroid, isElectron }) => {
+it('isVisible and isHidden should work with details', async ({ page }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/10674' });
-  it.skip(isElectron, 'We don\'t disable the AutoExpandDetailsElement feature on Electron');
-  it.skip(isAndroid, 'We can\'t disable the AutoExpandDetailsElement feature on Android');
   await page.setContent(`<details>
     <summary>click to open</summary>
       <ul>

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -379,6 +379,13 @@ it('should press the meta key', async ({ page, browserName, isMac }) => {
 
 });
 
+it('should work with keyboard events with empty.html', async ({ page, server }) => {
+  await page.goto(server.PREFIX + '/empty.html');
+  const lastEvent = await captureLastKeydown(page);
+  await page.keyboard.press('a');
+  expect(await lastEvent.evaluate(l => l.key)).toBe('a');
+});
+
 it('should work after a cross origin navigation', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/empty.html');
   await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');


### PR DESCRIPTION
This change makes the following 3 tests green:

<img width="948" alt="image" src="https://user-images.githubusercontent.com/17984549/183698515-bd16ebe1-7c67-4ed8-af4c-cb8d95c5b2de.png">

Relates https://github.com/microsoft/playwright/issues/16025
https://chromium.googlesource.com/chromium/src/+/a66dd70f18818e62586d78421daae10fa9f246ad
https://crbug.com/1322971