### PR TITLE
test: fix large string expectations

### DIFF
--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -141,7 +141,7 @@ it('should work with large strings', async ({ page }) => {
 });
 
 it('should work with large unicode strings', async ({ page, browserName, platform }) => {
-  it.fail(browserName === 'firefox' && platform !== 'linux');
+  it.fixme(browserName === 'firefox' && platform === 'darwin');
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16367' });
 
   const expected = '🎭'.repeat(10000);


### PR DESCRIPTION
The tests actually pass on Windows, and it looks like it's just macOS FF that's failing (and it's flaky at that). 