### PR TITLE
Revert "fix(codegen): make sure input recording with japanese IME Wor…

### DIFF
--- a/packages/playwright-core/src/server/injected/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder.ts
@@ -326,7 +326,7 @@ class Recorder {
       if (event.key === 'Insert' && event.shiftKey)
         return false;
     }
-    if (['Shift', 'Control', 'Meta', 'Alt', 'Process'].includes(event.key))
+    if (['Shift', 'Control', 'Meta', 'Alt'].includes(event.key))
       return false;
     const hasModifier = event.ctrlKey || event.altKey || event.metaKey;
     if (event.key.length === 1 && !hasModifier)

--- a/tests/library/inspector/cli-codegen-1.spec.ts
+++ b/tests/library/inspector/cli-codegen-1.spec.ts
@@ -260,50 +260,6 @@ test.describe('cli codegen', () => {
     expect(message.text()).toBe('John');
   });
 
-  test('should fill japanese text', async ({ page, openRecorder }) => {
-    const recorder = await openRecorder();
-
-    // In Japanese, "てすと" or "テスト" means "test".
-    await recorder.setContentAndWait(`<input id="input" name="name" oninput="input.value === 'てすと' && console.log(input.value)"></input>`);
-    const selector = await recorder.focusElement('input');
-    expect(selector).toBe('input[name="name"]');
-
-    async function inputText(text: string) {
-      await recorder.page.dispatchEvent(selector, 'keydown', { key: 'Process' });
-      await recorder.page.keyboard.insertText(text);
-      await recorder.page.dispatchEvent(selector, 'keyup', { key: 'Process' });
-    }
-    const [message, sources] = await Promise.all([
-      page.waitForEvent('console', msg => msg.type() !== 'error'),
-      recorder.waitForOutput('JavaScript', 'fill'),
-      (async () => {
-        await inputText('て');
-        await inputText('す');
-        await inputText('と');
-      })()
-    ]);
-    expect(sources.get('JavaScript').text).toContain(`
-   // Fill input[name="name"]
-   await page.locator('input[name="name"]').fill('てすと');`);
-    expect(sources.get('Java').text).toContain(`
-       // Fill input[name="name"]
-       page.locator("input[name=\\\"name\\\"]").fill("てすと");`);
-
-    expect(sources.get('Python').text).toContain(`
-     # Fill input[name="name"]
-     page.locator(\"input[name=\\\"name\\\"]\").fill(\"てすと\")`);
-
-    expect(sources.get('Python Async').text).toContain(`
-     # Fill input[name="name"]
-     await page.locator(\"input[name=\\\"name\\\"]\").fill(\"てすと\")`);
-
-    expect(sources.get('C#').text).toContain(`
-         // Fill input[name="name"]
-         await page.Locator(\"input[name=\\\"name\\\"]\").FillAsync(\"てすと\");`);
-
-    expect(message.text()).toBe('てすと');
-  });
-
   test('should fill textarea', async ({ page, openRecorder }) => {
     const recorder = await openRecorder();
 


### PR DESCRIPTION
…k (#16210)"

This reverts commit 925de8da2b599f061889d808ba73ff535b39a9f4.

The new test is failing on [all bots](https://github.com/microsoft/playwright/runs/7756641987?check_suite_focus=true):

```
  1) [chromium] › library/inspector/cli-codegen-1.spec.ts:263:3 › cli codegen › should fill japanese text 

    Error: expect(received).toContain(expected) // indexOf

    Expected substring: "
       // Fill input[name=\"name\"]
       await page.locator('input[name=\"name\"]').fill('てすと');"
    Received string:    "const { chromium } = require('playwright');·
    (async () => {
      const browser = await chromium.launch({
        headless: false
      });
      const context = await browser.newContext();·
      // Open new page
      const page = await context.newPage();·
      // Go to about:blank
      await page.goto('about:blank');·
      // Fill input[name=\"name\"]
      await page.locator('input[name=\"name\"]').fill('てすと');·
      // ---------------------
      await context.close();
      await browser.close();
    })();"

      283 |       })()
      284 |     ]);
    > 285 |     expect(sources.get('JavaScript').text).toContain(`
          |                                            ^
      286 |    // Fill input[name="name"]
      287 |    await page.locator('input[name="name"]').fill('てすと');`);
      288 |     expect(sources.get('Java').text).toContain(`

        at /home/runner/work/playwright/playwright/tests/library/inspector/cli-codegen-1.spec.ts:285:44

```
