### PR TITLE
cherry-pick(#16396): fix(test runner): show interrupted as yellow

### DIFF
--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -143,9 +143,9 @@ export class BaseReporter implements ReporterInternal  {
         tokens.push(colors.red(formatTestHeader(this.config, test, '    ')));
     }
     if (interrupted.length) {
-      tokens.push(colors.red(`  ${interrupted.length} interrupted`));
+      tokens.push(colors.yellow(`  ${interrupted.length} interrupted`));
       for (const test of interrupted)
-        tokens.push(colors.red(formatTestHeader(this.config, test, '    ')));
+        tokens.push(colors.yellow(formatTestHeader(this.config, test, '    ')));
     }
     if (flaky.length) {
       tokens.push(colors.yellow(`  ${flaky.length} flaky`));

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -950,7 +950,7 @@ function createDuplicateTitlesError(config: FullConfigInternal, rootSuite: Suite
     for (const fullTitle of testsByFullTitle.keys()) {
       const tests = testsByFullTitle.get(fullTitle);
       if (tests.length > 1) {
-        lines.push(` - title: ${fullTitle}`);
+        lines.push(` - title: ${fullTitle.replace(/\u001e/g, ' › ')}`);
         for (const test of tests)
           lines.push(`   - ${buildItemLocation(config.rootDir, test)}`);
       }

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -20,15 +20,19 @@ test('it should not allow multiple tests with the same name per suite', async ({
   const result = await runInlineTest({
     'tests/example.spec.js': `
       const { test } = pwt;
-      test('i-am-a-duplicate', async () => {});
-      test('i-am-a-duplicate', async () => {});
+      test.describe('suite', () => {
+        test('i-am-a-duplicate', async () => {});
+      });
+      test.describe('suite', () => {
+        test('i-am-a-duplicate', async () => {});
+      });
     `
   });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('duplicate test titles are not allowed');
-  expect(result.output).toContain(`- title: i-am-a-duplicate`);
-  expect(result.output).toContain(`  - tests${path.sep}example.spec.js:6`);
+  expect(result.output).toContain(`- title: suite › i-am-a-duplicate`);
   expect(result.output).toContain(`  - tests${path.sep}example.spec.js:7`);
+  expect(result.output).toContain(`  - tests${path.sep}example.spec.js:10`);
 });
 
 test('it should not allow multiple tests with the same name in multiple files', async ({ runInlineTest }) => {


### PR DESCRIPTION
SHA: baa2ef2700536d94797f38aeda42f26aa61cab3b