### PR TITLE
chore: relax npm version constraint in installation tests

### DIFF
--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -176,7 +176,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node_version }}
-    - run: npm i -g npm@8.15.1 # This should NOT be pinned beyond major version once https://github.com/microsoft/playwright/issues/16281 is resolved.
+    - run: npm i -g npm@^8.17.0 # v8.16.0 does not work due to a regression in npm itself (https://github.com/microsoft/playwright/issues/16281)
     - run: npm ci
       env:
         DEBUG: pw:install

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -176,7 +176,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node_version }}
-    - run: npm i -g npm@^8.17.0 # v8.16.0 does not work due to a regression in npm itself (https://github.com/microsoft/playwright/issues/16281)
+    - run: npm i -g npm@8
     - run: npm ci
       env:
         DEBUG: pw:install

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -128,7 +128,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node_version }}
-    - run: npm i -g npm@^8.17.0 # v8.16.0 does not work due to a regression in npm itself (https://github.com/microsoft/playwright/issues/16281)
+    - run: npm i -g npm@8
     - run: npm ci
       env:
         DEBUG: pw:install

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -128,7 +128,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node_version }}
-    - run: npm i -g npm@8.15.1 # This should NOT be pinned beyond major version once https://github.com/microsoft/playwright/issues/16281 is resolved.
+    - run: npm i -g npm@^8.17.0 # v8.16.0 does not work due to a regression in npm itself (https://github.com/microsoft/playwright/issues/16281)
     - run: npm ci
       env:
         DEBUG: pw:install

--- a/tests/installation/npmTest.ts
+++ b/tests/installation/npmTest.ts
@@ -73,6 +73,7 @@ export const test = _test.extend<{
     writeFiles: (nameToContents: Record<string, string>) => Promise<void>,
     exec: (cmd: string, ...argsAndOrOptions: ArgsOrOptions) => Promise<string>
     tsc: (...argsAndOrOptions: ArgsOrOptions) => Promise<string>,
+    npmConfigPrefix: string,
     registry: Registry,
         }>({
           _auto: [async ({ tmpWorkspace, exec }, use) => {
@@ -111,7 +112,10 @@ export const test = _test.extend<{
           installedSoftwareOnDisk: async ({ tmpWorkspace }, use) => {
             await use(async (registryPath?: string) => fs.promises.readdir(registryPath || path.join(tmpWorkspace, 'browsers')).catch(() => []).then(files => files.map(f => f.split('-')[0]).filter(f => !f.startsWith('.'))));
           },
-          exec: async ({ registry, tmpWorkspace }, use, testInfo) => {
+          npmConfigPrefix: async ({}, use, testInfo) => {
+            await use(testInfo.outputPath('npm_global'));
+          },
+          exec: async ({ registry, tmpWorkspace, npmConfigPrefix }, use, testInfo) => {
             await use(async (cmd: string, ...argsAndOrOptions: [] | [...string[]] | [...string[], ExecOptions] | [ExecOptions]) => {
               let args: string[] = [];
               let options: ExecOptions = {};
@@ -133,7 +137,7 @@ export const test = _test.extend<{
                     'PLAYWRIGHT_BROWSERS_PATH': path.join(tmpWorkspace, 'browsers'),
                     'npm_config_cache': testInfo.outputPath('npm_cache'),
                     'npm_config_registry': registry.url(),
-                    'npm_config_prefix': testInfo.outputPath('npm_global'),
+                    'npm_config_prefix': npmConfigPrefix,
                     ...options.env,
                   }
                 });

--- a/tests/installation/npmTest.ts
+++ b/tests/installation/npmTest.ts
@@ -73,7 +73,6 @@ export const test = _test.extend<{
     writeFiles: (nameToContents: Record<string, string>) => Promise<void>,
     exec: (cmd: string, ...argsAndOrOptions: ArgsOrOptions) => Promise<string>
     tsc: (...argsAndOrOptions: ArgsOrOptions) => Promise<string>,
-    npmConfigPrefix: string,
     registry: Registry,
         }>({
           _auto: [async ({ tmpWorkspace, exec }, use) => {
@@ -112,10 +111,7 @@ export const test = _test.extend<{
           installedSoftwareOnDisk: async ({ tmpWorkspace }, use) => {
             await use(async (registryPath?: string) => fs.promises.readdir(registryPath || path.join(tmpWorkspace, 'browsers')).catch(() => []).then(files => files.map(f => f.split('-')[0]).filter(f => !f.startsWith('.'))));
           },
-          npmConfigPrefix: async ({}, use, testInfo) => {
-            await use(testInfo.outputPath('npm_global'));
-          },
-          exec: async ({ registry, tmpWorkspace, npmConfigPrefix }, use, testInfo) => {
+          exec: async ({ registry, tmpWorkspace }, use, testInfo) => {
             await use(async (cmd: string, ...argsAndOrOptions: [] | [...string[]] | [...string[], ExecOptions] | [ExecOptions]) => {
               let args: string[] = [];
               let options: ExecOptions = {};
@@ -137,7 +133,7 @@ export const test = _test.extend<{
                     'PLAYWRIGHT_BROWSERS_PATH': path.join(tmpWorkspace, 'browsers'),
                     'npm_config_cache': testInfo.outputPath('npm_cache'),
                     'npm_config_registry': registry.url(),
-                    'npm_config_prefix': npmConfigPrefix,
+                    'npm_config_prefix': testInfo.outputPath('npm_global'),
                     ...options.env,
                   }
                 });

--- a/tests/installation/npx-global-help.spec.ts
+++ b/tests/installation/npx-global-help.spec.ts
@@ -15,8 +15,8 @@
  */
 import { test, expect } from './npmTest';
 
-test('npx playwright --help should not download browsers', async ({ exec, installedSoftwareOnDisk }) => {
-  const result = await exec('npx playwright --help');
+test.only('npx playwright --help should not download browsers', async ({ exec, installedSoftwareOnDisk, npmConfigPrefix }) => {
+  const result = await exec(`npx --prefix=${npmConfigPrefix} playwright --help`);
   expect(result).toHaveLoggedSoftwareDownload([]);
   expect(await installedSoftwareOnDisk()).toEqual([]);
   expect(result).not.toContain(`To avoid unexpected behavior, please install your dependencies first`);

--- a/tests/installation/npx-global-help.spec.ts
+++ b/tests/installation/npx-global-help.spec.ts
@@ -15,7 +15,7 @@
  */
 import { test, expect } from './npmTest';
 
-test('npx playwright --help should not download browsers', async ({ exec, installedSoftwareOnDisk, npmConfigPrefix }) => {
+test('npx playwright --help should not download browsers', async ({ exec, installedSoftwareOnDisk }) => {
   const result = await exec('npx playwright --help', { env: { npm_config_prefix: '' } }); // global npx and npm_config_prefix do not work together nicely (https://github.com/npm/cli/issues/5268)
   expect(result).toHaveLoggedSoftwareDownload([]);
   expect(await installedSoftwareOnDisk()).toEqual([]);

--- a/tests/installation/npx-global-help.spec.ts
+++ b/tests/installation/npx-global-help.spec.ts
@@ -15,8 +15,8 @@
  */
 import { test, expect } from './npmTest';
 
-test.only('npx playwright --help should not download browsers', async ({ exec, installedSoftwareOnDisk, npmConfigPrefix }) => {
-  const result = await exec(`npx --prefix=${npmConfigPrefix} playwright --help`);
+test('npx playwright --help should not download browsers', async ({ exec, installedSoftwareOnDisk, npmConfigPrefix }) => {
+  const result = await exec('npx playwright --help', { env: { npm_config_prefix: '' } }); // global npx and npm_config_prefix do not work together nicely (https://github.com/npm/cli/issues/5268)
   expect(result).toHaveLoggedSoftwareDownload([]);
   expect(await installedSoftwareOnDisk()).toEqual([]);
   expect(result).not.toContain(`To avoid unexpected behavior, please install your dependencies first`);

--- a/tests/installation/npx-global-install.spec.ts
+++ b/tests/installation/npx-global-install.spec.ts
@@ -15,9 +15,9 @@
  */
 import { test, expect } from './npmTest';
 
-test('npx playwright install global', async ({ exec, installedSoftwareOnDisk }) => {
+test.only('npx playwright install global', async ({ exec, installedSoftwareOnDisk }) => {
   test.skip(process.platform === 'win32', 'isLikelyNpxGlobal() does not work in this setup on our bots');
-  const result = await exec('npx playwright install');
+  const result = await exec('npx playwright install', { env: { npm_config_prefix: '' } });
   expect(result).toHaveLoggedSoftwareDownload(['chromium', 'ffmpeg', 'firefox', 'webkit']);
   expect(await installedSoftwareOnDisk()).toEqual(['chromium', 'ffmpeg', 'firefox', 'webkit']);
   expect(result).not.toContain(`Please run the following command to download new browsers`);

--- a/tests/installation/npx-global-install.spec.ts
+++ b/tests/installation/npx-global-install.spec.ts
@@ -15,9 +15,9 @@
  */
 import { test, expect } from './npmTest';
 
-test.only('npx playwright install global', async ({ exec, installedSoftwareOnDisk }) => {
+test('npx playwright install global', async ({ exec, installedSoftwareOnDisk }) => {
   test.skip(process.platform === 'win32', 'isLikelyNpxGlobal() does not work in this setup on our bots');
-  const result = await exec('npx playwright install', { env: { npm_config_prefix: '' } });
+  const result = await exec('npx playwright install', { env: { npm_config_prefix: '' } }); // global npx and npm_config_prefix do not work together nicely (https://github.com/npm/cli/issues/5268)
   expect(result).toHaveLoggedSoftwareDownload(['chromium', 'ffmpeg', 'firefox', 'webkit']);
   expect(await installedSoftwareOnDisk()).toEqual(['chromium', 'ffmpeg', 'firefox', 'webkit']);
   expect(result).not.toContain(`Please run the following command to download new browsers`);

--- a/tests/installation/npx-global-spec-codegen.spec.ts
+++ b/tests/installation/npx-global-spec-codegen.spec.ts
@@ -15,9 +15,8 @@
  */
 import { test, expect } from './npmTest';
 
-test.only('npx playwright codegen', async ({ exec, installedSoftwareOnDisk, npmConfigPrefix }) => {
-  // --prefix is a workaround related to https://github.com/npm/cli/issues/5268
-  const stdio = await exec(`npx --prefix=${npmConfigPrefix} playwright codegen`, { expectToExitWithError: true });
+test('npx playwright codegen', async ({ exec, installedSoftwareOnDisk }) => {
+  const stdio = await exec('npx playwright codegen', { expectToExitWithError: true, env: { npm_config_prefix: '' } }); // global npx and npm_config_prefix do not work together nicely (https://github.com/npm/cli/issues/5268)
   expect(stdio).toHaveLoggedSoftwareDownload([]);
   expect(await installedSoftwareOnDisk()).toEqual([]);
   expect(stdio).toContain(`Please run the following command to download new browsers`);

--- a/tests/installation/npx-global-spec-codegen.spec.ts
+++ b/tests/installation/npx-global-spec-codegen.spec.ts
@@ -15,8 +15,9 @@
  */
 import { test, expect } from './npmTest';
 
-test('npx playwright codegen', async ({ exec, installedSoftwareOnDisk }) => {
-  const stdio = await exec('npx playwright codegen', { expectToExitWithError: true });
+test.only('npx playwright codegen', async ({ exec, installedSoftwareOnDisk, npmConfigPrefix }) => {
+  // --prefix is a workaround related to https://github.com/npm/cli/issues/5268
+  const stdio = await exec(`npx --prefix=${npmConfigPrefix} playwright codegen`, { expectToExitWithError: true });
   expect(stdio).toHaveLoggedSoftwareDownload([]);
   expect(await installedSoftwareOnDisk()).toEqual([]);
   expect(stdio).toContain(`Please run the following command to download new browsers`);


### PR DESCRIPTION
npm@8.17.0 contains the fix: https://github.com/npm/cli/pull/5291

Resolves #16281.
