### PR TITLE
tests: do not test on MacOS 10.15 any more

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, macos-12]
+        os: [macos-11, macos-12]
         browser: [chromium, firefox, webkit]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Playwright v1.25 was the last release to support macOS 10.15, so we
no longer need to test on macOS 10.15.
