### PR TITLE
docs(dotnet): document unsupported Parallelizable attributes on Nunit

### DIFF
--- a/docs/src/test-runners-csharp.md
+++ b/docs/src/test-runners-csharp.md
@@ -24,9 +24,11 @@ Playwright provides base classes to write tests with NUnit via the [`Microsoft.P
 # Create a new project
 dotnet new nunit -n PlaywrightTests
 cd PlaywrightTests
+
 # Add the required reference
 dotnet add package Microsoft.Playwright.NUnit
 dotnet build
+
 # Install the required browsers and operating system dependencies
 pwsh bin\Debug\netX\playwright.ps1 install --with-deps
 ```
@@ -57,6 +59,10 @@ public class MyTest : PageTest
     }
 }
 ```
+
+:::note
+You can only set Parallelizable to ParallelScope.Self. ParallelScope.All and ParallelScope.Fixtures are not supported.
+:::
 
 Run your tests against Chromium
 
@@ -389,7 +395,7 @@ For example, to specify the amount of workers (`MSTest.Parallelize.Workers`), yo
 
 ```xml
 <RunSettings>
-<!-- MSTest adapter -->  
+<!-- MSTest adapter -->
   <MSTest>
     <Parallelize>
       <Workers>4</Workers>

--- a/docs/src/test-runners-csharp.md
+++ b/docs/src/test-runners-csharp.md
@@ -230,9 +230,11 @@ Playwright provides base classes to write tests with MSTest via the [`Microsoft.
 # Create a new project
 dotnet new mstest -n PlaywrightTests
 cd PlaywrightTests
+
 # Add the required reference
 dotnet add package Microsoft.Playwright.MSTest
 dotnet build
+
 # Install the required browsers and operating system dependencies
 pwsh bin\Debug\netX\playwright.ps1 install --with-deps
 ```
@@ -310,7 +312,8 @@ dotnet test --filter "Name~Slogan"
 
 ### Running MSTest tests in Parallel
 
-By default MSTest will run all classes in parallel, while running tests inside each class sequentially. It will create as many processes as there are cores on the host system. You can adjust this behavior by using the following CLI parameter or using a `.runsettings` file, see below.
+By default MSTest will run all classes in parallel, while running tests inside each class sequentially (`ExecutionScope.ClassLevel`). It will create as many processes as there are cores on the host system. You can adjust this behavior by using the following CLI parameter or using a `.runsettings` file, see below.
+Running tests in parallel at the method level (`ExecutionScope.MethodLevel`) is not supported.
 
 ```bash
 dotnet test --settings:.runsettings -- MSTest.Parallelize.Workers=4

--- a/docs/src/test-runners-csharp.md
+++ b/docs/src/test-runners-csharp.md
@@ -60,10 +60,6 @@ public class MyTest : PageTest
 }
 ```
 
-:::note
-You can only set Parallelizable to `ParallelScope.Self`. `ParallelScope.All` and `ParallelScope.Fixtures` are not supported.
-:::
-
 Run your tests against Chromium
 
 ```bash
@@ -110,7 +106,8 @@ dotnet test --filter "Name~Slogan"
 
 ### Running NUnit tests in Parallel
 
-By default NUnit will run all test files in parallel, while running tests inside each file sequentially. It will create as many processes as there are cores on the host system. You can adjust this behavior using the NUnit.NumberOfTestWorkers parameter.
+By default NUnit will run all test files in parallel, while running tests inside each file sequentially (`ParallelScope.Self`). It will create as many processes as there are cores on the host system. You can adjust this behavior using the NUnit.NumberOfTestWorkers parameter.
+Running test in parallel using `ParallelScope.All` or `ParallelScope.Fixtures` is not supported.
 
 For CPU-bound tests, we recommend using as many workers as there are cores on your system, divided by 2. For IO-bound tests you can use as many workers as you have cores.
 

--- a/docs/src/test-runners-csharp.md
+++ b/docs/src/test-runners-csharp.md
@@ -61,7 +61,7 @@ public class MyTest : PageTest
 ```
 
 :::note
-You can only set Parallelizable to ParallelScope.Self. ParallelScope.All and ParallelScope.Fixtures are not supported.
+You can only set Parallelizable to `ParallelScope.Self`. `ParallelScope.All` and `ParallelScope.Fixtures` are not supported.
 :::
 
 Run your tests against Chromium


### PR DESCRIPTION
Related to https://github.com/microsoft/playwright-dotnet/issues/

I'm clarifying what the valid options for `Parallelizable` are.