### PR TITLE
fix(actions): pass retarget behavior matching the action

### DIFF
--- a/tests/page/elementhandle-convenience.spec.ts
+++ b/tests/page/elementhandle-convenience.spec.ts
@@ -65,6 +65,11 @@ it('inputValue should work on label', async ({ page, server }) => {
   expect(await handle.inputValue()).toBe('foo');
 });
 
+it('inputValue should work inside button', async ({ page, server }) => {
+  await page.setContent(`<button><input type=text value=bar></input></button>`);
+  expect(await page.locator('input').inputValue()).toBe('bar');
+});
+
 it('innerHTML should work', async ({ page, server }) => {
   await page.goto(`${server.PREFIX}/dom.html`);
   const handle = await page.$('#outer');
@@ -154,6 +159,7 @@ it('isEnabled and isDisabled should work', async ({ page }) => {
     <button disabled>button1</button>
     <button>button2</button>
     <div>div</div>
+    <button disabled><span>inside</span></button>
   `);
   const div = await page.$('div');
   expect(await div.isEnabled()).toBe(true);
@@ -170,6 +176,8 @@ it('isEnabled and isDisabled should work', async ({ page }) => {
   expect(await button2.isDisabled()).toBe(false);
   expect(await page.isEnabled(':text("button2")')).toBe(true);
   expect(await page.isDisabled(':text("button2")')).toBe(false);
+  expect(await page.locator('span').isEnabled()).toBe(false);
+  expect(await page.locator('span').isDisabled()).toBe(true);
 });
 
 it('isEnabled and isDisabled should work with <select/> option/optgroup correctly', async ({ page }) => {

--- a/tests/page/locator-convenience.spec.ts
+++ b/tests/page/locator-convenience.spec.ts
@@ -180,6 +180,11 @@ it('isEditable should work', async ({ page }) => {
   expect(await page.isEditable('textarea')).toBe(false);
 });
 
+it('isEditable should work inside button', async ({ page }) => {
+  await page.setContent(`<button>Button<input></button>`);
+  expect(await page.locator('input').isEditable()).toBe(true);
+});
+
 it('isChecked should work', async ({ page }) => {
   await page.setContent(`<input type='checkbox' checked><div>Not a checkbox</div>`);
   const element = page.locator('input');

--- a/tests/page/locator-misc-2.spec.ts
+++ b/tests/page/locator-misc-2.spec.ts
@@ -88,6 +88,23 @@ it('should select textarea', async ({ page, server, browserName }) => {
   }
 });
 
+it('should select inside button', async ({ page, server, browserName }) => {
+  await page.setContent(`
+    <button>
+      I am a <span>styled</span> button
+    </button>
+  `);
+  await page.locator('span').selectText();
+  if (browserName === 'firefox') {
+    expect(await page.$eval('span', span => {
+      const selection = window.getSelection();
+      return selection.anchorNode === span && selection.focusNode === span;
+    })).toBe(true);
+  } else {
+    expect(await page.evaluate(() => window.getSelection().toString())).toBe('styled');
+  }
+});
+
 it('should type', async ({ page }) => {
   await page.setContent(`<input type='text' />`);
   await page.locator('input').type('hello');


### PR DESCRIPTION
We used to determine retarget behavior in various places, and for some APIs it was not determined correctly. Now every API method explicitly passes the desired retarget behavior through helper methods to avoid surprises.

- Fixes retarget behavior from "follow label and enclosing button" to "follow label" for the following methods: `toHaveValue`, `toHaveValues`, `fill`, `selectOptions`, `inputValue`, `setInputFiles`, `toBeEditable`, `isEditable`, `selectText`, `waitForElementState('editable')`.

- Fixes `scrollIntoView` retarget from "enclosing button" to "none".

- Does not fix `check`/`setChecked` retarget behavior, leaving it partially "follow label and enclosing button", and partially "enclosing button or link". Fixing this requires more changes.

References #15934.