### PR TITLE
support array headers (eg: set-cookie)

### DIFF
--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -342,7 +342,7 @@ export class Route extends ChannelOwner<channels.RouteChannel> implements api.Ro
 
     const headers: Headers = {};
     for (const header of Object.keys(headersOption || {}))
-      headers[header.toLowerCase()] = String(headersOption![header]);
+      headers[header.toLowerCase()] = Array.isArray(headersOption![header]) ? headersOption![header] : String(headersOption![header]);
     if (options.contentType)
       headers['content-type'] = String(options.contentType);
     else if (options.path)

--- a/packages/playwright-core/src/utils/index.ts
+++ b/packages/playwright-core/src/utils/index.ts
@@ -134,7 +134,7 @@ export function headersObjectToArray(headers: HeadersObject, separator?: string,
     if (Array.isArray(values)) {
       values.forEach(value => {
         result.push({ name, value });
-      })
+      });
     } else if (separator) {
       const sep = name.toLowerCase() === 'set-cookie' ? setCookieSeparator : separator;
       for (const value of values.split(sep!))

--- a/packages/playwright-core/src/utils/index.ts
+++ b/packages/playwright-core/src/utils/index.ts
@@ -131,11 +131,11 @@ export function headersObjectToArray(headers: HeadersObject, separator?: string,
     if (values === undefined)
       continue;
 
-    if(Array.isArray(values)){
+    if (Array.isArray(values)) {
       values.forEach(value => {
         result.push({ name, value });
       })
-    }else if (separator) {
+    } else if (separator) {
       const sep = name.toLowerCase() === 'set-cookie' ? setCookieSeparator : separator;
       for (const value of values.split(sep!))
         result.push({ name, value: value.trim() });

--- a/packages/playwright-core/src/utils/index.ts
+++ b/packages/playwright-core/src/utils/index.ts
@@ -130,7 +130,12 @@ export function headersObjectToArray(headers: HeadersObject, separator?: string,
     const values = headers[name];
     if (values === undefined)
       continue;
-    if (separator) {
+
+    if(Array.isArray(values)){
+      values.forEach(value => {
+        result.push({ name, value });
+      })
+    }else if (separator) {
       const sep = name.toLowerCase() === 'set-cookie' ? setCookieSeparator : separator;
       for (const value of values.split(sep!))
         result.push({ name, value: value.trim() });


### PR DESCRIPTION
If the headers option is entered as an array in the route.fulfill function, it will parse all the headers entered.

Example:
```
route.fulfill({
  body: JSON.stringify({message: 'ok'}),
  contentType: 'application/json',
  status: 200,
  headers: {
    'Content-Type': 'application/json',
    'Content-Length': 16,
    'Set-Cookie': [
      'session=xxxxxxx; expires=Fri, 12 Aug 2055 00:00:00 GMT; Max-Age=7200; path=/; httponly; samesite=lax',
      'xsrf-token=xxxxxxx; expires=Fri, 12 Aug 2055 00:00:00 GMT; Max-Age=7200; path=/; httponly; samesite=lax',
    ]
  }
})
```