### PR TITLE
chore: add id for each test to JSONReporter

### DIFF
--- a/packages/playwright-test/src/reporters/json.ts
+++ b/packages/playwright-test/src/reporters/json.ts
@@ -150,6 +150,7 @@ class JSONReporter implements Reporter {
       ok: test.ok(),
       tags: (test.title.match(/@[\S]+/g) || []).map(t => t.substring(1)),
       tests: [ this._serializeTest(test) ],
+      id: test.id,
       ...this._relativeLocation(test.location),
     };
   }

--- a/packages/playwright-test/types/testReporter.d.ts
+++ b/packages/playwright-test/types/testReporter.d.ts
@@ -469,6 +469,7 @@ export interface JSONReportSpec {
   title: string;
   ok: boolean;
   tests: JSONReportTest[];
+  id: string;
   file: string;
   line: number;
   column: number;

--- a/utils/generate_types/overrides-testReporter.d.ts
+++ b/utils/generate_types/overrides-testReporter.d.ts
@@ -80,6 +80,7 @@ export interface JSONReportSpec {
   title: string;
   ok: boolean;
   tests: JSONReportTest[];
+  id: string;
   file: string;
   line: number;
   column: number;


### PR DESCRIPTION
Since there is a [problem](https://github.com/microsoft/playwright/issues/14310) in the release 1.25 was partially solved, then I decided to try adding the test id to the json reporter on my own

I couldn't run the tests locally, because during the build, my edits in the JSONReportSpec interface were [overwritten](https://github.com/microsoft/playwright/runs/7805545343?check_suite_focus=true#step:6:145)