### PR TITLE
fix(junit reporter): remove source location from classname attribute

### DIFF
--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -356,10 +356,14 @@ function stepSuffix(step: TestStep | undefined) {
   return stepTitles.map(t => ' › ' + t).join('');
 }
 
-export function formatTestTitle(config: FullConfig, test: TestCase, step?: TestStep): string {
+export function formatTestTitle(config: FullConfig, test: TestCase, step?: TestStep, omitLocation: boolean = false): string {
   // root, project, file, ...describes, test
   const [, projectName, , ...titles] = test.titlePath();
-  const location = `${relativeTestPath(config, test)}:${test.location.line}:${test.location.column}`;
+  let location;
+  if (omitLocation)
+    location = `${relativeTestPath(config, test)}`;
+  else
+    location = `${relativeTestPath(config, test)}:${test.location.line}:${test.location.column}`;
   const projectTitle = projectName ? `[${projectName}] › ` : '';
   return `${projectTitle}${location} › ${titles.join(' › ')}${stepSuffix(step)}`;
 }

--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -133,7 +133,7 @@ class JUnitReporter implements Reporter {
       attributes: {
         // Skip root, project, file
         name: test.titlePath().slice(3).join(' '),
-        classname: formatTestTitle(this.config, test),
+        classname: formatTestTitle(this.config, test, undefined, true),
         time: (test.results.reduce((acc, value) => acc + value.duration, 0)) / 1000
       },
       children: [] as XMLEntry[]

--- a/tests/playwright-test/reporter-junit.spec.ts
+++ b/tests/playwright-test/reporter-junit.spec.ts
@@ -212,6 +212,31 @@ test('should report skipped due to sharding', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
 });
 
+test('should not render projects if they dont exist', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { };
+    `,
+    'a.test.js': `
+      const { test } = pwt;
+      test('one', async ({}) => {
+        expect(1).toBe(1);
+      });
+    `,
+  }, { reporter: 'junit' });
+  const xml = parseXML(result.output);
+  expect(xml['testsuites']['$']['tests']).toBe('1');
+  expect(xml['testsuites']['$']['failures']).toBe('0');
+  expect(xml['testsuites']['testsuite'].length).toBe(1);
+
+  expect(xml['testsuites']['testsuite'][0]['$']['name']).toBe('a.test.js');
+  expect(xml['testsuites']['testsuite'][0]['$']['tests']).toBe('1');
+  expect(xml['testsuites']['testsuite'][0]['$']['failures']).toBe('0');
+  expect(xml['testsuites']['testsuite'][0]['$']['skipped']).toBe('0');
+  expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['name']).toBe('one');
+  expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['classname']).toContain('a.test.js › one');
+  expect(result.exitCode).toBe(0);
+});
 
 test('should render projects', async ({ runInlineTest }) => {
   const result = await runInlineTest({
@@ -235,14 +260,14 @@ test('should render projects', async ({ runInlineTest }) => {
   expect(xml['testsuites']['testsuite'][0]['$']['failures']).toBe('0');
   expect(xml['testsuites']['testsuite'][0]['$']['skipped']).toBe('0');
   expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['name']).toBe('one');
-  expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['classname']).toContain('[project1] › a.test.js:6:7 › one');
+  expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['classname']).toContain('[project1] › a.test.js › one');
 
   expect(xml['testsuites']['testsuite'][1]['$']['name']).toBe('a.test.js');
   expect(xml['testsuites']['testsuite'][1]['$']['tests']).toBe('1');
   expect(xml['testsuites']['testsuite'][1]['$']['failures']).toBe('0');
   expect(xml['testsuites']['testsuite'][1]['$']['skipped']).toBe('0');
   expect(xml['testsuites']['testsuite'][1]['testcase'][0]['$']['name']).toBe('one');
-  expect(xml['testsuites']['testsuite'][1]['testcase'][0]['$']['classname']).toContain('[project2] › a.test.js:6:7 › one');
+  expect(xml['testsuites']['testsuite'][1]['testcase'][0]['$']['classname']).toContain('[project2] › a.test.js › one');
   expect(result.exitCode).toBe(0);
 });
 


### PR DESCRIPTION
Ensures JUnit XML reports contain robust `testcase` elements that can be uniquely identified based on their `classname` (and `name`) attribute, by removing the source location (line and column numbers) from the `classname`.
This way,  tools that process these reports (e.g. test management tools) can correctly identify the same testcases, even whenever they change in terms of their source code position. This follows the same approach the original JUnit project has, where `classname` and `name` attributes for the `testcase` element are only based on the class name and test method name of the test code.

fixes #16492 
