### PR TITLE
fix(reload): make sure reload() does not pick same-document navigaiton

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -715,7 +715,7 @@ export class Frame extends SdkObject {
     return response;
   }
 
-  async _waitForNavigation(progress: Progress, options: types.NavigateOptions): Promise<network.Response | null> {
+  async _waitForNavigation(progress: Progress, requiresNewDocument: boolean, options: types.NavigateOptions): Promise<network.Response | null> {
     const waitUntil = verifyLifecycle('waitUntil', options.waitUntil === undefined ? 'load' : options.waitUntil);
     progress.log(`waiting for navigation until "${waitUntil}"`);
 
@@ -723,6 +723,8 @@ export class Frame extends SdkObject {
       // Any failed navigation results in a rejection.
       if (event.error)
         return true;
+      if (requiresNewDocument && !event.newDocument)
+        return false;
       progress.log(`  navigated to "${this._url}"`);
       return true;
     }).promise;

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -372,7 +372,8 @@ export class Page extends SdkObject {
       // Note: waitForNavigation may fail before we get response to reload(),
       // so we should await it immediately.
       const [response] = await Promise.all([
-        this.mainFrame()._waitForNavigation(progress, options),
+        // Reload must be a new document, and should not be confused with a stray pushState.
+        this.mainFrame()._waitForNavigation(progress, true /* requiresNewDocument */, options),
         this._delegate.reload(),
       ]);
       await this._doSlowMo();
@@ -386,7 +387,7 @@ export class Page extends SdkObject {
       // Note: waitForNavigation may fail before we get response to goBack,
       // so we should catch it immediately.
       let error: Error | undefined;
-      const waitPromise = this.mainFrame()._waitForNavigation(progress, options).catch(e => {
+      const waitPromise = this.mainFrame()._waitForNavigation(progress, false /* requiresNewDocument */, options).catch(e => {
         error = e;
         return null;
       });
@@ -407,7 +408,7 @@ export class Page extends SdkObject {
       // Note: waitForNavigation may fail before we get response to goForward,
       // so we should catch it immediately.
       let error: Error | undefined;
-      const waitPromise = this.mainFrame()._waitForNavigation(progress, options).catch(e => {
+      const waitPromise = this.mainFrame()._waitForNavigation(progress, false /* requiresNewDocument */, options).catch(e => {
         error = e;
         return null;
       });


### PR DESCRIPTION
We lack `documentId` when doing a reload over browser protocols, so `reload()` waits for the next navigation to finish. Sometimes, the page might issue a same-document navigation while reload is in progress, which confuses the reload command.

To fix the issue, just ignore same-document navigations for reload, because it is always a new document.

Fixes #16108.