### PR TITLE
feat: allow running driver with preinstalled node.js

### DIFF
--- a/utils/build/run-driver-posix.sh
+++ b/utils/build/run-driver-posix.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 SCRIPT_PATH="$(cd "$(dirname "$0")" ; pwd -P)"
-"$SCRIPT_PATH/node" "$SCRIPT_PATH/package/lib/cli/cli.js" "$@"
+if [[ -z "$PLAYWRIGHT_NODEJS_PATH" ]]; then
+  PLAYWRIGHT_NODEJS_PATH="$SCRIPT_PATH/node"
+fi
+"$PLAYWRIGHT_NODEJS_PATH" "$SCRIPT_PATH/package/lib/cli/cli.js" "$@"

--- a/utils/build/run-driver-win.cmd
+++ b/utils/build/run-driver-win.cmd
@@ -1,3 +1,4 @@
 @ECHO OFF
 SETLOCAL
-"%~dp0\node.exe" "%~dp0\package\lib\cli\cli.js" %*
+IF %PLAYWRIGHT_NODEJS_PATH%x == x SET PLAYWRIGHT_NODEJS_PATH="%~dp0\node.exe"
+"%PLAYWRIGHT_NODEJS_PATH%" "%~dp0\package\lib\cli\cli.js" %*


### PR DESCRIPTION
Path to the Node.js can be changed via `PLAYWRIGHT_NODEJS_PATH` environment variable.

https://github.com/microsoft/playwright-java/issues/1016