### PR TITLE
docs(dotnet): PowerShell install enhancements

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -134,27 +134,27 @@ you can still opt into stable channels on the bots that are typically free of su
 To invoke Playwright CLI commands, you need to invoke a PowerShell script:
 
 ```bash
-pwsh bin\Debug\netX\playwright.ps1 --help
+pwsh bin/Debug/netX/playwright.ps1 --help
 ```
 
 Playwright can install supported browsers by means of the CLI tool.
 
 ```bash csharp
 # Running without arguments will install all browsers
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 You can also install specific browsers by providing an argument:
 
 ```bash csharp
 # Install WebKit
-pwsh bin\Debug\netX\playwright.ps1 install webkit
+pwsh bin/Debug/netX/playwright.ps1 install webkit
 ```
 
 See all supported browsers:
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 install --help
+pwsh bin/Debug/netX/playwright.ps1 install --help
 ```
 
 ## Install browsers via API
@@ -236,17 +236,17 @@ mvn test
 
 ```bash tab=bash-bash lang=csharp
 PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ```batch tab=bash-batch lang=csharp
 set PLAYWRIGHT_BROWSERS_PATH=%USERPROFILE%\pw-browsers
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ```powershell tab=bash-powershell lang=csharp
 $env:PLAYWRIGHT_BROWSERS_PATH="$env:USERPROFILE\pw-browsers"
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 When running Playwright scripts, ask it to search for browsers in a shared location.
@@ -405,17 +405,17 @@ mvn test
 ```
 
 ```bash tab=bash-bash lang=csharp
-HTTPS_PROXY=https://192.0.2.1 pwsh bin\Debug\netX\playwright.ps1 install
+HTTPS_PROXY=https://192.0.2.1 pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ```batch tab=bash-batch lang=csharp
 set HTTPS_PROXY=https://192.0.2.1
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ```powershell tab=bash-powershell lang=csharp
 $env:HTTPS_PROXY="https://192.0.2.1"
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 If the requests of the proxy get intercepted with a custom untrusted certificate authority (CA) and it yields to `Error: self signed certificate in certificate chain` while downloading the browsers, you must set your custom root certificates via the [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) environment variable before installing the browsers:
@@ -500,17 +500,17 @@ mvn test
 ```
 
 ```bash tab=bash-bash lang=csharp
-PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 pwsh bin\Debug\netX\playwright.ps1 install
+PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ```batch tab=bash-batch lang=csharp
 set PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ```powershell tab=bash-powershell lang=csharp
 $env:PLAYWRIGHT_DOWNLOAD_HOST="192.0.2.1"
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 It is also possible to use a per-browser download hosts using `PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST`, `PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST` and `PLAYWRIGHT_WEBKIT_DOWNLOAD_HOST` env variables that
@@ -584,19 +584,19 @@ mvn test
 ```
 
 ```bash tab=bash-bash lang=csharp
-PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=203.0.113.3 PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 pwsh bin\Debug\netX\playwright.ps1 install
+PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=203.0.113.3 PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1 pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ```batch tab=bash-batch lang=csharp
 set PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=203.0.113.3
 set PLAYWRIGHT_DOWNLOAD_HOST=192.0.2.1
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ```powershell tab=bash-powershell lang=csharp
 $env:PLAYWRIGHT_DOWNLOAD_HOST="192.0.2.1"
 $env:PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST="203.0.113.3"
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ## Skip browser downloads
@@ -638,17 +638,17 @@ mvn test
 ```
 
 ```bash tab=bash-bash lang=csharp
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pwsh bin\Debug\netX\playwright.ps1 install
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ```batch tab=bash-batch lang=csharp
 set PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ```powershell tab=bash-powershell lang=csharp
 $env:PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 ## Download single browser binary

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -32,7 +32,7 @@ configurations for common CI providers.
    mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps"
    ```
    ```bash csharp
-   pwsh bin\Debug\netX\playwright.ps1 install --with-deps
+   pwsh bin/Debug/netX/playwright.ps1 install --with-deps
    ```
 
 1. **Run your tests**:

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -23,7 +23,7 @@ playwright
 
 ```bash csharp
 # Use the tools.
-pwsh bin\Debug\netX\playwright.ps1 --help
+pwsh bin/Debug/netX/playwright.ps1 --help
 ```
 
 ```json js
@@ -56,7 +56,7 @@ playwright install
 
 ```bash csharp
 # Running without arguments will install default browsers
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
 You can also install specific browsers by providing an argument:
@@ -78,7 +78,7 @@ playwright install webkit
 
 ```bash csharp
 # Install WebKit
-pwsh bin\Debug\netX\playwright.ps1 install webkit
+pwsh bin/Debug/netX/playwright.ps1 install webkit
 ```
 
 See all supported browsers:
@@ -96,7 +96,7 @@ playwright install --help
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 install --help
+pwsh bin/Debug/netX/playwright.ps1 install --help
 ```
 
 ## Install system dependencies
@@ -120,7 +120,7 @@ playwright install-deps
 
 ```bash csharp
 # See command help
-pwsh bin\Debug\netX\playwright.ps1 install-deps
+pwsh bin/Debug/netX/playwright.ps1 install-deps
 ```
 
 You can also install the dependencies for a single browser only by passing it as an argument:
@@ -138,7 +138,7 @@ playwright install-deps chromium
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 install-deps chromium
+pwsh bin/Debug/netX/playwright.ps1 install-deps chromium
 ```
 
 It's also possible to combine `install-deps` with `install` and install by that the browsers and OS dependencies with a single command. This would do both for Chromium, but you can also leave it out.
@@ -156,7 +156,7 @@ playwright install --with-deps chromium
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 install --with-deps chromium
+pwsh bin/Debug/netX/playwright.ps1 install --with-deps chromium
 ```
 
 ## Generate code
@@ -174,7 +174,7 @@ playwright codegen wikipedia.org
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 codegen wikipedia.org
+pwsh bin/Debug/netX/playwright.ps1 codegen wikipedia.org
 ```
 
 Run `codegen` and perform actions in the browser. Playwright CLI will generate JavaScript code for the user interactions. `codegen` will attempt to generate resilient text-based selectors.
@@ -204,7 +204,7 @@ playwright codegen --save-storage=auth.json
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 codegen --save-storage=auth.json
+pwsh bin/Debug/netX/playwright.ps1 codegen --save-storage=auth.json
 # Perform authentication and exit.
 # auth.json will contain the storage state.
 ```
@@ -231,8 +231,8 @@ playwright codegen --load-storage=auth.json my.web.app
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 open --load-storage=auth.json my.web.app
-pwsh bin\Debug\netX\playwright.ps1 codegen --load-storage=auth.json my.web.app
+pwsh bin/Debug/netX/playwright.ps1 open --load-storage=auth.json my.web.app
+pwsh bin/Debug/netX/playwright.ps1 codegen --load-storage=auth.json my.web.app
 # Perform actions in authenticated state.
 ```
 
@@ -351,7 +351,7 @@ playwright open example.com
 
 ```bash csharp
 # Open page in Chromium
-pwsh bin\Debug\netX\playwright.ps1 open example.com
+pwsh bin/Debug/netX/playwright.ps1 open example.com
 ```
 
 ```bash js
@@ -371,7 +371,7 @@ playwright wk example.com
 
 ```bash csharp
 # Open page in WebKit
-pwsh bin\Debug\netX\playwright.ps1 wk example.com
+pwsh bin/Debug/netX/playwright.ps1 wk example.com
 ```
 
 ### Emulate devices
@@ -394,7 +394,7 @@ playwright open --device="iPhone 11" wikipedia.org
 
 ```bash csharp
 # Emulate iPhone 11.
-pwsh bin\Debug\netX\playwright.ps1 open --device="iPhone 11" wikipedia.org
+pwsh bin/Debug/netX/playwright.ps1 open --device="iPhone 11" wikipedia.org
 ```
 
 ### Emulate color scheme and viewport size
@@ -416,7 +416,7 @@ playwright open --viewport-size=800,600 --color-scheme=dark twitter.com
 
 ```bash csharp
 # Emulate screen size and color scheme.
-pwsh bin\Debug\netX\playwright.ps1 open --viewport-size=800,600 --color-scheme=dark twitter.com
+pwsh bin/Debug/netX/playwright.ps1 open --viewport-size=800,600 --color-scheme=dark twitter.com
 ```
 
 ### Emulate geolocation, language and timezone
@@ -442,7 +442,7 @@ playwright open --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --l
 ```bash csharp
 # Emulate timezone, language & location
 # Once page opens, click the "my location" button to see geolocation in action
-pwsh bin\Debug\netX\playwright.ps1 open --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" maps.google.com
+pwsh bin/Debug/netX/playwright.ps1 open --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" maps.google.com
 ```
 
 ## Inspect selectors
@@ -542,7 +542,7 @@ playwright screenshot \
 
 ```bash csharp
 # Wait 3 seconds before capturing a screenshot after page loads ('load' event fires)
-pwsh bin\Debug\netX\playwright.ps1 screenshot \
+pwsh bin/Debug/netX/playwright.ps1 screenshot \
     --device="iPhone 11" \
     --color-scheme=dark \
     --wait-for-timeout=3000 \
@@ -566,7 +566,7 @@ playwright screenshot --full-page en.wikipedia.org wiki-full.png
 
 ```bash csharp
 # Capture a full page screenshot
-pwsh bin\Debug\netX\playwright.ps1 screenshot --full-page en.wikipedia.org wiki-full.png
+pwsh bin/Debug/netX/playwright.ps1 screenshot --full-page en.wikipedia.org wiki-full.png
 ```
 
 ## Generate PDF
@@ -590,5 +590,5 @@ playwright pdf https://en.wikipedia.org/wiki/PDF wiki.pdf
 
 ```bash csharp
 # See command help
-pwsh bin\Debug\netX\playwright.ps1 pdf https://en.wikipedia.org/wiki/PDF wiki.pdf
+pwsh bin/Debug/netX/playwright.ps1 pdf https://en.wikipedia.org/wiki/PDF wiki.pdf
 ```

--- a/docs/src/codegen-intro.md
+++ b/docs/src/codegen-intro.md
@@ -25,7 +25,7 @@ playwright codegen playwright.dev
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 codegen playwright.dev
+pwsh bin/Debug/netX/playwright.ps1 codegen playwright.dev
 ```
 
 Run `codegen` and perform actions in the browser. Playwright will generate the code for the user interactions. `Codegen` will attempt to generate resilient text-based selectors.

--- a/docs/src/codegen.md
+++ b/docs/src/codegen.md
@@ -20,7 +20,7 @@ playwright codegen playwright.dev
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 codegen playwright.dev
+pwsh bin/Debug/netX/playwright.ps1 codegen playwright.dev
 ```
 
 Run `codegen` and perform actions in the browser. Playwright will generate the code for the user interactions. `Codegen` will attempt to generate resilient text-based selectors.
@@ -45,7 +45,7 @@ playwright codegen --viewport-size=800,600 playwright.dev
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 codegen --viewport-size=800,600 playwright.dev
+pwsh bin/Debug/netX/playwright.ps1 codegen --viewport-size=800,600 playwright.dev
 ```
 
 
@@ -69,7 +69,7 @@ playwright codegen --device="iPhone 11" playwright.dev
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 codegen --device="iPhone 11" playwright.dev
+pwsh bin/Debug/netX/playwright.ps1 codegen --device="iPhone 11" playwright.dev
 ```
 
 <img width="1239" alt="Codegen generating code for tests for playwright.dev website emulated for iPhone 11" src="https://user-images.githubusercontent.com/13063165/182360089-9dc6d33d-480e-4bb2-86a3-fec51c1c228e.png" />
@@ -92,7 +92,7 @@ playwright codegen --color-scheme=dark playwright.dev
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 codegen --color-scheme=dark playwright.dev
+pwsh bin/Debug/netX/playwright.ps1 codegen --color-scheme=dark playwright.dev
 ```
 
 <img width="1258" alt="Codegen generating code for tests for playwright.dev website in dark mode" src="https://user-images.githubusercontent.com/13063165/182359371-0bb4a7a2-abbb-4f73-8550-d67e0101f0ad.png" />
@@ -114,7 +114,7 @@ playwright codegen --timezone="Europe/Rome" --geolocation="41.890221,12.492348" 
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 codegen --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" maps.google.com
+pwsh bin/Debug/netX/playwright.ps1 codegen --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" maps.google.com
 ```
 
 <img width="1276" alt="Codegen generating code for tests for google maps showing timezone, geoloation as Rome, Italy and in Italian language" src="https://user-images.githubusercontent.com/13063165/182394434-73e1c2a8-767e-411a-94e4-0912c1c50ecc.png" />
@@ -138,7 +138,7 @@ playwright codegen --save-storage=auth.json
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 codegen --save-storage=auth.json
+pwsh bin/Debug/netX/playwright.ps1 codegen --save-storage=auth.json
 ```
 
 <img width="1264" alt="Screenshot 2022-08-03 at 13 28 02" src="https://user-images.githubusercontent.com/13063165/182599605-df2fbd05-622b-4cd7-8a32-0abdfea7d38d.png" />
@@ -158,7 +158,7 @@ playwright codegen --load-storage=auth.json github.com/microsoft/playwright
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 codegen --load-storage=auth.json github.com/microsoft/playwright
+pwsh bin/Debug/netX/playwright.ps1 codegen --load-storage=auth.json github.com/microsoft/playwright
 ```
 
 <img width="1261" alt="Screenshot 2022-08-03 at 13 33 40" src="https://user-images.githubusercontent.com/13063165/182599680-05297b4e-c258-4416-8daa-b8637c1db120.png" />
@@ -178,7 +178,7 @@ playwright open --load-storage=auth.json github.com/microsoft/playwright
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 open --load-storage=auth.json github.com/microsoft/playwright
+pwsh bin/Debug/netX/playwright.ps1 open --load-storage=auth.json github.com/microsoft/playwright
 ```
 
 

--- a/docs/src/debug.md
+++ b/docs/src/debug.md
@@ -193,7 +193,7 @@ playwright codegen wikipedia.org
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 codegen wikipedia.org
+pwsh bin/Debug/netX/playwright.ps1 codegen wikipedia.org
 ```
 
 ### Stepping through the Playwright script

--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -70,8 +70,10 @@ dotnet build
 4. Install required browsers by replacing `netX` with the actual output folder name, e.g. `net6.0`:
 
 ```bash
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 ```
+
+If `pwsh` is not available, you have to [install PowerShell](https://docs.microsoft.com/powershell/scripting/install/installing-powershell). 
 
 ## Add Example Tests
 

--- a/docs/src/library-csharp.md
+++ b/docs/src/library-csharp.md
@@ -19,7 +19,7 @@ dotnet add package Microsoft.Playwright
 # Build the project
 dotnet build
 # Install required browsers - replace netX with actual output folder name, e.g. net6.0.
-pwsh bin\Debug\netX\playwright.ps1 install
+pwsh bin/Debug/netX/playwright.ps1 install
 
 # If the pwsh command does not work (throws TypeNotFound), make sure to use an up-to-date version of PowerShell.
 dotnet tool update --global PowerShell

--- a/docs/src/network.md
+++ b/docs/src/network.md
@@ -719,7 +719,7 @@ playwright open --save-har=example.har --save-har-glob="**/api/**" https://examp
 
 ```bash csharp
 # Save API requests from example.com as "example.har" archive.
-pwsh bin\Debug\netX\playwright.ps1 open --save-har=example.har --save-har-glob="**/api/**" https://example.com
+pwsh bin/Debug/netX/playwright.ps1 open --save-har=example.har --save-har-glob="**/api/**" https://example.com
 ```
 
 ### Recording HAR with a script

--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -60,7 +60,7 @@ Now you can record network traffic into a HAR file and re-use this traffic in yo
 To record network into HAR file:
 
 ```bash
-pwsh bin\Debug\netX\playwright.ps1 open --save-har=example.har --save-har-glob="**/api/**" https://example.com
+pwsh bin/Debug/netX/playwright.ps1 open --save-har=example.har --save-har-glob="**/api/**" https://example.com
 ```
 
 Alternatively, you can record HAR programmatically:
@@ -354,7 +354,7 @@ Playwright Trace Viewer is now **available online** at https://trace.playwright.
 - Playwright now supports **Ubuntu 20.04 ARM64**. You can now run Playwright tests inside Docker on Apple M1 and on Raspberry Pi.
 - You can now use Playwright to install stable version of Edge on Linux:
     ```bash
-    pwsh bin\Debug\netX\playwright.ps1 install msedge
+    pwsh bin/Debug/netX/playwright.ps1 install msedge
     ```
 
 
@@ -381,7 +381,7 @@ Read more about [`method: Locator.waitFor`].
 
 ### 🎭 Playwright Trace Viewer
 
-- run trace viewer with `pwsh bin\Debug\netX\playwright.ps1 show-trace` and drop trace files to the trace viewer PWA
+- run trace viewer with `pwsh bin/Debug/netX/playwright.ps1 show-trace` and drop trace files to the trace viewer PWA
 - better visual attribution of action targets
 
 Read more about [Trace Viewer](./trace-viewer).

--- a/docs/src/test-runners-csharp.md
+++ b/docs/src/test-runners-csharp.md
@@ -30,7 +30,7 @@ dotnet add package Microsoft.Playwright.NUnit
 dotnet build
 
 # Install the required browsers and operating system dependencies
-pwsh bin\Debug\netX\playwright.ps1 install --with-deps
+pwsh bin/Debug/netX/playwright.ps1 install --with-deps
 ```
 
 Modify the UnitTest1.cs:
@@ -197,7 +197,7 @@ For example, to specify the amount of workers you can use `NUnit.NumberOfTestWor
     <BrowserName>chromium</BrowserName>
     <ExpectTimeout>5000</ExpectTimeout>
     <LaunchOptions>
-      <Headless>true</Headless>
+      <Headless>false</Headless>
       <Channel>msedge</Channel>
     </LaunchOptions>
   </Playwright>
@@ -231,7 +231,7 @@ dotnet add package Microsoft.Playwright.MSTest
 dotnet build
 
 # Install the required browsers and operating system dependencies
-pwsh bin\Debug\netX\playwright.ps1 install --with-deps
+pwsh bin/Debug/netX/playwright.ps1 install --with-deps
 ```
 
 Modify the UnitTest1.cs:

--- a/docs/src/trace-viewer-intro-csharp-java-python.md
+++ b/docs/src/trace-viewer-intro-csharp-java-python.md
@@ -101,7 +101,7 @@ playwright show-trace trace.zip
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 show-trace trace.zip
+pwsh bin/Debug/netX/playwright.ps1 show-trace trace.zip
 ```
 
 

--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -153,7 +153,7 @@ playwright show-trace trace.zip
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 show-trace trace.zip
+pwsh bin/Debug/netX/playwright.ps1 show-trace trace.zip
 ```
 
 ## Actions
@@ -220,7 +220,7 @@ playwright show-trace https://example.com/trace.zip
 ```
 
 ```bash csharp
-pwsh bin\Debug\netX\playwright.ps1 show-trace https://example.com/trace.zip
+pwsh bin/Debug/netX/playwright.ps1 show-trace https://example.com/trace.zip
 ```
 
 ## Using [trace.playwright.dev](https://trace.playwright.dev)

--- a/packages/playwright-core/src/cli/cli.ts
+++ b/packages/playwright-core/src/cli/cli.ts
@@ -715,7 +715,7 @@ function buildBasePlaywrightCLICommand(cliTargetLang: string | undefined): strin
     case 'java':
       return `mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="...options.."`;
     case 'csharp':
-      return `pwsh bin\\Debug\\netX\\playwright.ps1`;
+      return `pwsh bin/Debug/netX/playwright.ps1`;
     default:
       return `npx playwright`;
   }

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -853,7 +853,7 @@ export function buildPlaywrightCLICommand(sdkLanguage: string, parameters: strin
     case 'java':
       return `mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="${parameters}"`;
     case 'csharp':
-      return `pwsh bin\\Debug\\netX\\playwright.ps1 ${parameters}`;
+      return `pwsh bin/Debug/netX/playwright.ps1 ${parameters}`;
     default:
       return `npx playwright ${parameters}`;
   }


### PR DESCRIPTION
I made a dry-run by publishing playwright-dotnet `1.25.0-next-1` on Linux and Windows. The findings were that the backslashes were not working on Linux/macOS, the normal slashes work on all operating systems.