### PR TITLE
devops: fix firefox builds

### DIFF
--- a/browser_patches/docker/firefox-beta/debian-11.dockerfile
+++ b/browser_patches/docker/firefox-beta/debian-11.dockerfile
@@ -46,6 +46,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright

--- a/browser_patches/docker/firefox-beta/ubuntu-18.04.dockerfile
+++ b/browser_patches/docker/firefox-beta/ubuntu-18.04.dockerfile
@@ -52,6 +52,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright

--- a/browser_patches/docker/firefox-beta/ubuntu-20.04-arm64.dockerfile
+++ b/browser_patches/docker/firefox-beta/ubuntu-20.04-arm64.dockerfile
@@ -54,6 +54,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright

--- a/browser_patches/docker/firefox-beta/ubuntu-20.04.dockerfile
+++ b/browser_patches/docker/firefox-beta/ubuntu-20.04.dockerfile
@@ -46,6 +46,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright

--- a/browser_patches/docker/firefox-beta/ubuntu-22.04-arm64.dockerfile
+++ b/browser_patches/docker/firefox-beta/ubuntu-22.04-arm64.dockerfile
@@ -54,6 +54,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright

--- a/browser_patches/docker/firefox-beta/ubuntu-22.04.dockerfile
+++ b/browser_patches/docker/firefox-beta/ubuntu-22.04.dockerfile
@@ -46,6 +46,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright

--- a/browser_patches/docker/firefox/debian-11.dockerfile
+++ b/browser_patches/docker/firefox/debian-11.dockerfile
@@ -46,6 +46,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright

--- a/browser_patches/docker/firefox/ubuntu-18.04.dockerfile
+++ b/browser_patches/docker/firefox/ubuntu-18.04.dockerfile
@@ -52,6 +52,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright

--- a/browser_patches/docker/firefox/ubuntu-20.04-arm64.dockerfile
+++ b/browser_patches/docker/firefox/ubuntu-20.04-arm64.dockerfile
@@ -54,6 +54,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright

--- a/browser_patches/docker/firefox/ubuntu-20.04.dockerfile
+++ b/browser_patches/docker/firefox/ubuntu-20.04.dockerfile
@@ -46,6 +46,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright

--- a/browser_patches/docker/firefox/ubuntu-22.04-arm64.dockerfile
+++ b/browser_patches/docker/firefox/ubuntu-22.04-arm64.dockerfile
@@ -54,6 +54,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright

--- a/browser_patches/docker/firefox/ubuntu-22.04.dockerfile
+++ b/browser_patches/docker/firefox/ubuntu-22.04.dockerfile
@@ -46,6 +46,7 @@ USER pwuser
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="${PATH}:/home/pwuser/.cargo/bin"
 
+RUN mkdir -p /home/pwuser/.mozbuild
 RUN cd /home/pwuser && git clone --depth=1 https://github.com/microsoft/playwright
 
 WORKDIR /home/pwuser/playwright


### PR DESCRIPTION
Turns out Firefox mach does not respect `DEBIAN_FRONTEND=noninteractive`
command and insists on interactive input for the mozbuild folder
creation.

Pre-creation of the folder avoid this codepath.
