### PR TITLE
feat(chromium-tip-of-tree): roll to 1033

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -15,9 +15,9 @@
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1032",
+      "revision": "1033",
       "installByDefault": false,
-      "browserVersion": "106.0.5228.0"
+      "browserVersion": "106.0.5232.0"
     },
     {
       "name": "firefox",


### PR DESCRIPTION
We missed this one because the API token was broken.