### PR TITLE
chery-pick(#16547): docs(release-notes): deprecate Node.js 12

### DIFF
--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -36,6 +36,7 @@ toc_max_heading_level: 2
 
 * 🎁 We now ship Ubuntu 22.04 Jammy Jellyfish docker image: `mcr.microsoft.com/playwright:v1.25.0-jammy`.
 * 🪦 This is the last release with macOS 10.15 support (deprecated as of 1.21).
+* 🪦 This is the last release with Node.js 12 support, we recommend upgrading to Node.js LTS (16).
 * ⚠️ Ubuntu 18 is now deprecated and will not be supported as of Dec 2022.
 
 ### Browser Versions


### PR DESCRIPTION
This PR cherry-picks the following commits:

- 57326f9401c1abb40cfaded76d861a8874b03fa7