### PR TITLE
fix(driver): PLAYWRIGHT_NODEJS_PATH test in sh

### DIFF
--- a/utils/build/run-driver-posix.sh
+++ b/utils/build/run-driver-posix.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 SCRIPT_PATH="$(cd "$(dirname "$0")" ; pwd -P)"
-if [[ -z "$PLAYWRIGHT_NODEJS_PATH" ]]; then
+if [ -z "$PLAYWRIGHT_NODEJS_PATH" ]; then
   PLAYWRIGHT_NODEJS_PATH="$SCRIPT_PATH/node"
 fi
 "$PLAYWRIGHT_NODEJS_PATH" "$SCRIPT_PATH/package/lib/cli/cli.js" "$@"


### PR DESCRIPTION
Fix for:
```
/tmp/playwright-java-16395920723044173468/playwright.sh: 3: [[: not found
```
On java [GHA bot](https://github.com/microsoft/playwright-java/runs/7843716950?check_suite_focus=true). In `sh` `[[ condition ]]` is not supported (it's an extension added by bash, ksh etc, see [this post](https://unix.stackexchange.com/a/306115/365633)).