### PR TITLE
fix: make viewer reference all trace urls

### DIFF
--- a/packages/playwright-core/src/utils/multimap.ts
+++ b/packages/playwright-core/src/utils/multimap.ts
@@ -46,6 +46,9 @@ export class MultiMap<K, V> {
       this._map.set(key, values.filter(v => value !== v));
   }
 
+  deleteAll(key: K) {
+    this._map.delete(key);
+  }
 
   hasValue(key: K, value: V): boolean {
     const values = this._map.get(key);
@@ -56,6 +59,10 @@ export class MultiMap<K, V> {
 
   get size(): number {
     return this._map.size;
+  }
+
+  [Symbol.iterator](): Iterator<[K, V[]]> {
+    return this._map[Symbol.iterator]();
   }
 
   keys(): IterableIterator<K> {

--- a/packages/trace-viewer/src/DEPS.list
+++ b/packages/trace-viewer/src/DEPS.list
@@ -1,4 +1,4 @@
 [*]
-@playwright-core/src/utils/multimap.ts
+@playwright-core/utils/multimap.ts
 @web/**
 ui/

--- a/packages/trace-viewer/src/DEPS.list
+++ b/packages/trace-viewer/src/DEPS.list
@@ -1,3 +1,4 @@
 [*]
+@playwright-core/src/utils/multimap.ts
 @web/**
 ui/

--- a/packages/trace-viewer/src/sw.ts
+++ b/packages/trace-viewer/src/sw.ts
@@ -32,11 +32,15 @@ const scopePath = new URL(self.registration.scope).pathname;
 
 const loadedTraces = new Map<string, { traceModel: TraceModel, snapshotServer: SnapshotServer }>();
 
-const clientIdToTraceUrl = new Map<string, string>();
+const clientIdToTraceUrls = new Map<string, string[]>();
 
 async function loadTrace(trace: string, clientId: string, progress: (done: number, total: number) => void): Promise<TraceModel> {
   const entry = loadedTraces.get(trace);
-  clientIdToTraceUrl.set(clientId, trace);
+  const traceUrls = clientIdToTraceUrls.get(clientId);
+  if (traceUrls)
+    traceUrls.push(trace);
+  else
+    clientIdToTraceUrls.set(clientId, [trace]);
   if (entry)
     return entry.traceModel;
   const traceModel = new TraceModel();
@@ -123,12 +127,12 @@ async function gc() {
   const clients = await self.clients.matchAll();
   const usedTraces = new Set<string>();
 
-  for (const [clientId, traceUrl] of clientIdToTraceUrl) {
+  for (const [clientId, traceUrls] of clientIdToTraceUrls) {
     // @ts-ignore
     if (!clients.find(c => c.id === clientId))
-      clientIdToTraceUrl.delete(clientId);
+      clientIdToTraceUrls.delete(clientId);
     else
-      usedTraces.add(traceUrl);
+      traceUrls.forEach(url => usedTraces.add(url));
   }
 
   for (const traceUrl of loadedTraces.keys()) {


### PR DESCRIPTION
Single trace viewer page may render several traces, count it as a client for each of the trace files.

Fixes #16429