### PR TITLE
test: disable page/page-set-content.spec.ts:126 in webkit

### DIFF
--- a/tests/page/page-set-content.spec.ts
+++ b/tests/page/page-set-content.spec.ts
@@ -123,8 +123,8 @@ it('content() should throw nice error during navigation', async ({ page, server 
   }
 });
 
-it('should return empty content there is no iframe src', async ({ page, browserName }) => {
-  it.fixme(browserName === 'firefox' || browserName === 'chromium', 'Hangs in FF && CR because there is no utility context');
+it('should return empty content there is no iframe src', async ({ page }) => {
+  it.fixme(true, 'Hangs in all browsers because there is no utility context');
   await page.setContent(`<iframe src="javascript:console.log(1)"></iframe>`);
   expect(page.frames().length).toBe(2);
   expect(await page.frames()[1].content()).toBe('<html><head></head><body></body></html>');


### PR DESCRIPTION
The test started failing on WebKit after https://github.com/WebKit/WebKit/commit/7de67f9a0ccc4fc8ce195e32f61e7873ad81345e The cause is the same as in other browsers - missing utility context. Disabling the test in WebKit similar to the other browsers in order to prepare for the next webkit roll.

Related: https://github.com/microsoft/playwright/pull/16536