### PR TITLE
docs(advanced): fix typo in docs about global.d.ts

### DIFF
--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -681,7 +681,7 @@ test('numeric ranges', () => {
 });
 ```
 
-For TypeScript, also add the following to your [`global.d.ts`](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-d-ts.html). If it does not exit, you need to create it inside your repository. Make sure that your `global.d.ts` gets included inside your `tsconfig.json` via the `include` or `compilerOptions.typeRoots` option so that your IDE will pick it up.
+For TypeScript, also add the following to your [`global.d.ts`](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-d-ts.html). If it does not exist, you need to create it inside your repository. Make sure that your `global.d.ts` gets included inside your `tsconfig.json` via the `include` or `compilerOptions.typeRoots` option so that your IDE will pick it up.
 
 You don't need it for JavaScript.
 


### PR DESCRIPTION
follow up to #16631