### PR TITLE
fix(pipe): do not store accumulated message as string

### DIFF
--- a/packages/playwright-core/src/server/pipeTransport.ts
+++ b/packages/playwright-core/src/server/pipeTransport.ts
@@ -88,6 +88,6 @@ export class PipeTransport implements ConnectionTransport {
       start = end + 1;
       end = buffer.indexOf('\0', start);
     }
-    this._pendingBuffers = [ buffer.slice(start) ];
+    this._pendingBuffers = [buffer.slice(start)];
   }
 }

--- a/packages/playwright-core/src/server/pipeTransport.ts
+++ b/packages/playwright-core/src/server/pipeTransport.ts
@@ -22,7 +22,7 @@ import { debugLogger } from '../common/debugLogger';
 export class PipeTransport implements ConnectionTransport {
   private _pipeRead: NodeJS.ReadableStream;
   private _pipeWrite: NodeJS.WritableStream;
-  private _pendingMessage = '';
+  private _pendingBuffers: Buffer[] = [];
   private _waitForNextTask = makeWaitForNextTask();
   private _closed = false;
   private _onclose?: () => void;
@@ -67,10 +67,11 @@ export class PipeTransport implements ConnectionTransport {
   _dispatch(buffer: Buffer) {
     let end = buffer.indexOf('\0');
     if (end === -1) {
-      this._pendingMessage += buffer.toString();
+      this._pendingBuffers.push(buffer);
       return;
     }
-    const message = this._pendingMessage + buffer.toString(undefined, 0, end);
+    this._pendingBuffers.push(buffer.slice(0, end));
+    const message = Buffer.concat(this._pendingBuffers).toString();
     this._waitForNextTask(() => {
       if (this.onmessage)
         this.onmessage.call(null, JSON.parse(message));
@@ -87,6 +88,6 @@ export class PipeTransport implements ConnectionTransport {
       start = end + 1;
       end = buffer.indexOf('\0', start);
     }
-    this._pendingMessage = buffer.toString(undefined, start);
+    this._pendingBuffers = [ buffer.slice(start) ];
   }
 }

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -141,7 +141,6 @@ it('should work with large strings', async ({ page }) => {
 });
 
 it('should work with large unicode strings', async ({ page, browserName, platform }) => {
-  it.fixme(browserName === 'firefox' && platform === 'darwin');
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16367' });
 
   const expected = '🎭'.repeat(10000);


### PR DESCRIPTION
Accumulated message must be stored raw; otherwise, unicode encoding
will break while trying to decode them.

Fixes #16367
