### PR TITLE
docs: Tiny grammar fix on Page class API page

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -4162,7 +4162,7 @@ Returns when element specified by selector satisfies [`option: state`] option. R
 
 :::note
 Playwright automatically waits for element to be ready before performing an action. Using
-[Locator] objects and web-first assertions make the code wait-for-selector-free.
+[Locator] objects and web-first assertions makes the code wait-for-selector-free.
 :::
 
 Wait for the [`param: selector`] to satisfy [`option: state`] option (either appear/disappear from dom, or become

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -593,7 +593,7 @@ export interface Page {
    * `detached`.
    *
    * > NOTE: Playwright automatically waits for element to be ready before performing an action. Using [Locator] objects and
-   * web-first assertions make the code wait-for-selector-free.
+   * web-first assertions makes the code wait-for-selector-free.
    *
    * Wait for the `selector` to satisfy `state` option (either appear/disappear from dom, or become visible/hidden). If at
    * the moment of calling the method `selector` already satisfies the condition, the method will return immediately. If the
@@ -625,7 +625,7 @@ export interface Page {
    * `detached`.
    *
    * > NOTE: Playwright automatically waits for element to be ready before performing an action. Using [Locator] objects and
-   * web-first assertions make the code wait-for-selector-free.
+   * web-first assertions makes the code wait-for-selector-free.
    *
    * Wait for the `selector` to satisfy `state` option (either appear/disappear from dom, or become visible/hidden). If at
    * the moment of calling the method `selector` already satisfies the condition, the method will return immediately. If the
@@ -657,7 +657,7 @@ export interface Page {
    * `detached`.
    *
    * > NOTE: Playwright automatically waits for element to be ready before performing an action. Using [Locator] objects and
-   * web-first assertions make the code wait-for-selector-free.
+   * web-first assertions makes the code wait-for-selector-free.
    *
    * Wait for the `selector` to satisfy `state` option (either appear/disappear from dom, or become visible/hidden). If at
    * the moment of calling the method `selector` already satisfies the condition, the method will return immediately. If the
@@ -689,7 +689,7 @@ export interface Page {
    * `detached`.
    *
    * > NOTE: Playwright automatically waits for element to be ready before performing an action. Using [Locator] objects and
-   * web-first assertions make the code wait-for-selector-free.
+   * web-first assertions makes the code wait-for-selector-free.
    *
    * Wait for the `selector` to satisfy `state` option (either appear/disappear from dom, or become visible/hidden). If at
    * the moment of calling the method `selector` already satisfies the condition, the method will return immediately. If the


### PR DESCRIPTION
There's a tiny grammar typo on the API docs page for the `Page` class.
https://playwright.dev/docs/api/class-page#page-wait-for-selector

The sentence `Using Locator objects and web-first assertions make the code wait-for-selector-free` should have used the verb `makes` instead of `make`. The subject of the sentence is the gerund phrase `Using Locator objects and web-first assertions` and gerund phrases act as singular nouns for the purposes of conjugation.