### PR TITLE
test: page.reload() works with cross-origin redirect

### DIFF
--- a/tests/page/page-history.spec.ts
+++ b/tests/page/page-history.spec.ts
@@ -146,6 +146,23 @@ it('page.reload should not resolve with same-document navigation', async ({ page
   expect(await gotResponse.text()).toBe('hello');
 });
 
+it('page.reload should work with same origin redirect', async ({ page, server, browserName }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16147' });
+  await page.goto(server.EMPTY_PAGE);
+  server.setRedirect('/empty.html', server.PREFIX + '/title.html');
+  await page.reload();
+  await expect(page).toHaveURL(server.PREFIX + '/title.html');
+});
+
+it('page.reload should work with cross-origin redirect', async ({ page, server, browserName }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16147' });
+  it.fixme(browserName === 'webkit');
+  await page.goto(server.EMPTY_PAGE);
+  server.setRedirect('/empty.html', server.CROSS_PROCESS_PREFIX + '/title.html');
+  await page.reload();
+  await expect(page).toHaveURL(server.CROSS_PROCESS_PREFIX + '/title.html');
+});
+
 it('page.goBack during renderer-initiated navigation', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/one-style.html');
   await page.goto(server.EMPTY_PAGE);

--- a/tests/page/page-history.spec.ts
+++ b/tests/page/page-history.spec.ts
@@ -146,7 +146,7 @@ it('page.reload should not resolve with same-document navigation', async ({ page
   expect(await gotResponse.text()).toBe('hello');
 });
 
-it('page.reload should work with same origin redirect', async ({ page, server, browserName }) => {
+it('page.reload should work with same origin redirect', async ({ page, server }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16147' });
   await page.goto(server.EMPTY_PAGE);
   server.setRedirect('/empty.html', server.PREFIX + '/title.html');


### PR DESCRIPTION
Adding a failing test for https://github.com/microsoft/playwright/issues/16147