### PR TITLE
docs: update page-object-model example

### DIFF
--- a/docs/src/test-pom-js.md
+++ b/docs/src/test-pom-js.md
@@ -19,7 +19,7 @@ exports.PlaywrightDevPage = class PlaywrightDevPage {
   constructor(page) {
     this.page = page;
     this.getStartedLink = page.locator('a', { hasText: 'Get started' });
-    this.gettingStartedHeader = page.locator('h1', { hasText: 'Getting started' });
+    this.gettingStartedHeader = page.locator('h1', { hasText: 'Installation' });
     this.pomLink = page.locator('li', { hasText: 'Playwright Test' }).locator('a', { hasText: 'Page Object Model' });
     this.tocList = page.locator('article div.markdown ul > li > a');
   }
@@ -54,7 +54,7 @@ export class PlaywrightDevPage {
   constructor(page: Page) {
     this.page = page;
     this.getStartedLink = page.locator('a', { hasText: 'Get started' });
-    this.gettingStartedHeader = page.locator('h1', { hasText: 'Getting started' });
+    this.gettingStartedHeader = page.locator('h1', { hasText: 'Installation' });
     this.pomLink = page.locator('li', { hasText: 'Playwright Test' }).locator('a', { hasText: 'Page Object Model' });
     this.tocList = page.locator('article div.markdown ul > li > a');
   }
@@ -87,16 +87,14 @@ test('getting started should contain table of contents', async ({ page }) => {
   await playwrightDev.goto();
   await playwrightDev.getStarted();
   await expect(playwrightDev.tocList).toHaveText([
-    'Installation',
-    'First test',
-    'Configuration file',
-    'Writing assertions',
-    'Using test fixtures',
-    'Using test hooks',
-    'VS Code extension',
-    'Command line',
-    'Configure NPM scripts',
-    'Release notes'
+    `How to install Playwright`,
+    `What's Installed`,
+    `How to run the example test`,
+    `How to open the HTML test report`,
+    `Write tests using web first assertions, page fixtures and locators`,
+    `Run single tests, multiple tests, headed mode`,
+    `Generate tests with Codegen`,
+    `See a trace of your tests`
   ]);
 });
 
@@ -118,16 +116,14 @@ test('getting started should contain table of contents', async ({ page }) => {
   await playwrightDev.goto();
   await playwrightDev.getStarted();
   await expect(playwrightDev.tocList).toHaveText([
-    'Installation',
-    'First test',
-    'Configuration file',
-    'Writing assertions',
-    'Using test fixtures',
-    'Using test hooks',
-    'VS Code extension',
-    'Command line',
-    'Configure NPM scripts',
-    'Release notes'
+    `How to install Playwright`,
+    `What's Installed`,
+    `How to run the example test`,
+    `How to open the HTML test report`,
+    `Write tests using web first assertions, page fixtures and locators`,
+    `Run single tests, multiple tests, headed mode`,
+    `Generate tests with Codegen`,
+    `See a trace of your tests`
   ]);
 });
 


### PR DESCRIPTION
hi all,
there's failed test example in https://playwright.dev/docs/test-pom related to wrong selector and text assertion.

after this PR:
![after](https://user-images.githubusercontent.com/6134774/185541006-994b632d-fc84-4646-94b9-4d5e704b47e7.png)

before this PR:
![before](https://user-images.githubusercontent.com/6134774/185541033-7fe3d300-aba4-478f-9064-d22057cb0c69.png)
