### PR TITLE
chore: do not specify custom `LD_LIBRARY_PATH` for Firefox

### DIFF
--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -46,13 +46,6 @@ export class Firefox extends BrowserType {
   _amendEnvironment(env: Env, userDataDir: string, executable: string, browserArguments: string[]): Env {
     if (!path.isAbsolute(os.homedir()))
       throw new Error(`Cannot launch Firefox with relative home directory. Did you set ${os.platform() === 'win32' ? 'USERPROFILE' : 'HOME'} to a relative path?`);
-    if (os.platform() === 'linux') {
-      return {
-        ...env,
-        // On linux Juggler ships the libstdc++ it was linked against.
-        LD_LIBRARY_PATH: `${path.dirname(executable)}:${process.env.LD_LIBRARY_PATH}`,
-      };
-    }
     return env;
   }
 


### PR DESCRIPTION
We used to bundle `libstdc++` for Firefox but we no longer do so,
so this code should not be needed.
