### PR TITLE
feat(test-runner): minimal proof-of-concept scheduler API

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -349,6 +349,12 @@ Whether to preserve test output in the [`property: TestConfig.outputDir`]. Defau
 Playwright Test supports running multiple test projects at the same time. See [TestProject] for more information.
 
 
+## property: TestConfig.projectSchedule
+* since: v1.26
+- type: ?<[Array]<[[Array]<[string]>]>>
+
+TODO
+
 ## property: TestConfig.quiet
 * since: v1.10
 - type: ?<[boolean]>

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -141,6 +141,7 @@ export class Loader {
     this._fullConfig.shard = takeFirst(config.shard, baseFullConfig.shard);
     this._fullConfig.updateSnapshots = takeFirst(config.updateSnapshots, baseFullConfig.updateSnapshots);
     this._fullConfig.workers = takeFirst(config.workers, baseFullConfig.workers);
+    this._fullConfig._projectSchedule = config.projectSchedule;
     const webServers = takeFirst(config.webServer, baseFullConfig.webServer);
     if (Array.isArray(webServers)) { // multiple web server mode
       // Due to previous choices, this value shows up to the user in globalSetup as part of FullConfig. Arrays are not supported by the old type.
@@ -516,6 +517,13 @@ function validateConfig(file: string, config: Config) {
       validateProject(file, project, `config.projects[${index}]`);
     });
   }
+
+  // Validate projectSchedule if present
+  // 1. no cycles
+  // 2. only refers to valid projects
+  // 3. is not combined with shard option
+  // 3. ???
+  // If present, also validate no dupe project names
 
   if ('quiet' in config && config.quiet !== undefined) {
     if (typeof config.quiet !== 'boolean')

--- a/packages/playwright-test/src/types.ts
+++ b/packages/playwright-test/src/types.ts
@@ -55,6 +55,7 @@ export interface FullConfigInternal extends FullConfigPublic {
 
   // Overrides the public field.
   projects: FullProjectInternal[];
+  _projectSchedule?: string[][];
 }
 
 /**

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -773,6 +773,11 @@ interface TestConfig {
   projects?: Array<TestProject>;
 
   /**
+   * TODO
+   */
+  projectSchedule?: Array<Array<string>>;
+
+  /**
    * Whether to suppress stdio and stderr output from the tests.
    */
   quiet?: boolean;

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { PlaywrightTestConfig } from '@playwright/test';
 import type { JSONReport, JSONReportSuite, JSONReportTest, JSONReportTestResult } from '@playwright/test/reporter';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -224,7 +225,8 @@ type Fixtures = {
   writeFiles: (files: Files) => Promise<string>;
   runInlineTest: (files: Files, params?: Params, env?: Env, options?: RunOptions, beforeRunPlaywrightTest?: ({ baseDir }: { baseDir: string }) => Promise<void>) => Promise<RunResult>;
   runTSC: (files: Files) => Promise<TSCResult>;
-  nodeVersion: { major: number, minor: number, patch: number },
+  nodeVersion: { major: number, minor: number, patch: number };
+  runProjects: (options: { files?: Record<string, string>, config?: PlaywrightTestConfig  }) => Promise<{getTimeline: () => Promise<string[]>; } & RunResult>;
 };
 
 export const test = base
@@ -260,6 +262,39 @@ export const test = base
       nodeVersion: async ({}, use) => {
         const [major, minor, patch] = process.versions.node.split('.');
         await use({ major: +major, minor: +minor, patch: +patch });
+      },
+
+      runProjects: async ({ runInlineTest }, use, testInfo) => {
+        const timelinePath = testInfo.outputPath('timeline.json');
+        await use(async options => {
+          const result = await runInlineTest({
+            'reporter.ts': `
+              import { Reporter, TestCase } from '@playwright/test/reporter';
+              import fs from 'fs';
+              import path from 'path';
+              class TimelineReporter implements Reporter {
+                private _timeline: {project:string, title: string, event: 'begin' | 'end'}[] = [];
+                onTestBegin(test: TestCase) {
+                  this._timeline.push({ project: test.titlePath()[1] || '', title: test.title, event: 'begin' });
+                }
+                onTestEnd(test: TestCase) {
+                  this._timeline.push({ project: test.titlePath()[1] || '', title: test.title, event: 'end' });
+                }
+                onEnd() {
+                  fs.writeFileSync(path.join(${JSON.stringify(timelinePath)}), JSON.stringify(this._timeline, null, 2));
+                }
+              }
+              export default TimelineReporter;
+            `,
+            'playwright.config.ts': `
+            import * as path from 'path';
+            module.exports = ${JSON.stringify(options.config)};
+          `,
+            ...options.files,
+          }, { reporter: 'list,json,./reporter.ts', workers: 2 });
+
+          return { ...result, getTimeline: async () => (JSON.parse(await fs.promises.readFile(timelinePath, 'utf8')) as {project: string, title: string, event: 'begin' | 'end'}[]).map(e => [e.event, e.project, e.title].join('::')) };
+        });
       },
     });
 

--- a/tests/playwright-test/project-schedule.spec.ts
+++ b/tests/playwright-test/project-schedule.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { test, expect } from './playwright-test-fixtures';
+
+test('should work', async ({ runProjects }) => {
+  const { exitCode, passed, getTimeline } =  await runProjects({
+    config: {
+      projects: [
+        { name: 'a' },
+      ],
+      projectSchedule: [['a']],
+    },
+    files: {
+      'a.spec.ts': `
+          const { test } = pwt;
+          test('a test', () => {});
+        `,
+    }
+  });
+  expect(exitCode).toBe(0);
+  expect(passed).toBe(1);
+  expect(await getTimeline()).toEqual([
+    'begin::a::a test',
+    'end::a::a test',
+  ]);
+});
+
+test('should order two projects', async ({ runProjects }, testInfo) => {
+  for (const order of [['a', 'b'], ['b', 'a']]) {
+    await test.step(`order ${order[0]} then ${order[1]}`, async () => {
+      const { exitCode, passed, getTimeline } =  await runProjects({
+        config: {
+          projects: [
+            { name: 'a', testDir: testInfo.outputPath('a') },
+            { name: 'b', testDir: testInfo.outputPath('b') },
+          ],
+          projectSchedule: [[order[0]], [order[1]]],
+        },
+        files: {
+          'a/a.spec.ts': `
+              const { test } = pwt;
+              test('a test', async () => {
+                await new Promise(f => setTimeout(f, 750));
+              });
+            `,
+          'b/b.spec.ts': `
+            const { test } = pwt;
+            test('b test', async () => {
+              await new Promise(f => setTimeout(f, 750));
+            });
+          `,
+        }
+      });
+      expect(exitCode).toBe(0);
+      expect(passed).toBe(2);
+      expect(await getTimeline()).toEqual(order.map(name => [`begin::${name}::${name} test`, `end::${name}::${name} test`]).flat());
+    });
+  }
+});
+
+test('should do setup, run two projects, then do teardown', async ({ runProjects }, testInfo) => {
+  const { exitCode, passed, getTimeline } =  await runProjects({
+    config: {
+      projects: [
+        { name: 'setup', testDir: testInfo.outputPath('setup') },
+        { name: 'a', testDir: testInfo.outputPath('a') },
+        { name: 'b', testDir: testInfo.outputPath('b') },
+        { name: 'teardown', testDir: testInfo.outputPath('teardown') },
+      ],
+      projectSchedule: [
+        ['setup'],
+        ['b', 'a'],
+        ['teardown']
+      ],
+    },
+    files: {
+      'a/a.spec.ts': `
+              const { test } = pwt;
+              test('a test', async () => {
+                await new Promise(f => setTimeout(f, 750));
+              });
+            `,
+      'b/b.spec.ts': `
+            const { test } = pwt;
+            test('b test', async () => {
+              await new Promise(f => setTimeout(f, 750));
+            });
+          `,
+      'setup/setup.spec.ts': `
+              const { test } = pwt;
+              test('setup test', async () => {
+                await new Promise(f => setTimeout(f, 750));
+              });
+            `,
+      'teardown/teardown.spec.ts': `
+            const { test } = pwt;
+            test('teardown test', async () => {
+              await new Promise(f => setTimeout(f, 750));
+            });
+          `,
+    }
+  });
+  expect(exitCode).toBe(0);
+  expect(passed).toBe(4);
+  const timeline = await getTimeline();
+  expect(timeline).toHaveLength(8);
+  expect(await getTimeline()).toEqual(expect.arrayContaining([
+    'begin::setup::setup test',
+    'end::setup::setup test',
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+    'begin::teardown::teardown test',
+    'end::teardown::teardown test',
+  ]));
+  const aStart = timeline.indexOf('begin::a::a test');
+  const aEnd = timeline.indexOf('end::a::a test');
+  const bStart = timeline.indexOf('begin::b::b test');
+  const bEnd = timeline.indexOf('end::b::b test');
+  const interleaved = aStart < bEnd && bStart < aEnd;
+  expect(interleaved).toBe(true);
+});
+
+// TODO(rwoll): Additional tests to add
+// - retries
+// - repeat-each
+// - behavior with fullyParallel flag
+// - what happens when tests fail?
+// - config validation (if projectSchedule present):
+//   - no cycles
+//   - all projects present in schedule
+//   - project name appears exactly once in schedule
+//   - all projects in schedule refer to actual projects
+//   - no duplicate project names in project array
+//   - throws error if projectSchedule is combined with shard option
+


### PR DESCRIPTION
Proof-of-concept for https://github.com/microsoft/playwright/issues/14895#issuecomment-1219986634.

## About

This PR introduces a proof-of-concept, minimal user-facing scheduling API that attempts to address a variety of longstanding issues and feature requests.

At this point, the implementation details should be ignored (although look if you want a puzzle 😄 ). However, the PR serves to allow us to concretely discuss a proposed solution, the general test strategy (which will apply regardless of the solution/API), articulate pros/cons/problems, etc. (The implementation is currently enough so that we can play around with the proposed public API to get a feel for it in the context of the use cases it attempts to solve.)

## API Overview

This introduces a `projectSchedule?: string[][]` configuration option at the top-level, which can be used in combination with the already existing [`projects`](https://playwright.dev/docs/api/class-testproject) configuration option to guarantee which projects run in relation to others.

Using it looks something like:

```ts
      projects: [
        { name: 'My Setup', testDir: './setup',  },
        { name: 'Desktop', testDir: './desktop', use: devices['Desktop Chrome'] },
        { name: 'Mobile', testDir: './mobile', use: devices['iPhone 11'] },
        { name: 'My Teardown', testDir: './teardown', },
      ],
      projectSchedule: [
        ['My Setup'],
        ['Desktop', 'Mobile'],
        ['My Teardown']
      ],
    },
```

In this case, this simply means: run all tests in the _My Setup_ project, when that's done run all the tests in _Desktop_ and _Mobile_ project in parallel, then run _My Teardown_ project.

## Issues Addressed

1. User wants to run global setup/teardown code and have a trace in the HTML Report
    - https://github.com/microsoft/playwright/issues/14895
    - https://github.com/microsoft/playwright/issues/16043
1. Trace, Retry, Device, etc. Settings from Config Should Apply to Global Setup/Teardown
    - https://github.com/microsoft/playwright/issues/14895
1. Different Global Setup Per-Project
    - https://github.com/microsoft/playwright/issues/16008
1. Allow Fixtures to Be Used in Global Setup
    - https://github.com/microsoft/playwright/issues/16215
1. How to Use Create and Use Storage State for Tests in Global Setup
    - https://github.com/microsoft/playwright/issues/14759
    - https://github.com/microsoft/playwright/issues/12063
1. Run Files/Projects in Certain Order AND Include in One HTML Report
    - https://github.com/microsoft/playwright/issues/14084
   - https://github.com/microsoft/playwright/issues/15788
   - https://github.com/microsoft/playwright/issues/14535
   - https://github.com/microsoft/playwright/issues/10290
   - https://github.com/microsoft/playwright/issues/8295
   - https://github.com/microsoft/playwright/issues/16232
   - https://github.com/microsoft/playwright/issues/16467

From memory, there are other issues (and Slack conversations) that fall into some of the buckets above, too.

## Pros

1. minimal, but effective(?) API: less is more. It's much easier to explain and program than some [fancy DAG-based API](https://github.com/microsoft/playwright/issues/14895#issuecomment-1207665459)
2. everything's just a test! we get config, tracing, retries, fixtures, etc. for free — no more trying to figure out how to use globalSetup/globalTeardown

## Cons/Limitations/Questions

When using `projectSchedule`:

- cannot use `shard` option: if you're using the schedule, you can quasi-shard with the schedule itself
- project names must be unique

In the above example, if I want to run _Desktop_ project, but not _Mobile_, how do we express this? Presumably we need to run _My Setup_ and _My Teardown_, too.

We're not exposing a full-featured DAG, so dependency expression is limited (I think for the better, for now — although we can do some really neat scheduling optimizations in the future with 1 timing run + the DAG).

We don't guarantee projects run on the same worker/process, so you can't, for instance, start a webserver in memory in _My Setup_ and kill it in _My Teardown_. Although, in this case you can just use the `webServer` config option, or write a PID in your setup, then read and kill that PID in your teardown.