### PR TITLE
docs(locators.md):  small typo - lsocator

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -341,7 +341,7 @@ rowLocator
     .screenshot();
 ```
 ```python async
-row_locator = page.lsocator("tr")
+row_locator = page.locator("tr")
 # ...
 await row_locator
     .filter(has_text="text in column 1")
@@ -349,7 +349,7 @@ await row_locator
     .screenshot()
 ```
 ```python sync
-row_locator = page.lsocator("tr")
+row_locator = page.locator("tr")
 # ...
 row_locator
     .filter(has_text="text in column 1")


### PR DESCRIPTION
locator typed as lsocator in 2 places