### PR TITLE
devops: fix firefox-beta build

### DIFF
--- a/browser_patches/firefox-beta/build.sh
+++ b/browser_patches/firefox-beta/build.sh
@@ -2,7 +2,7 @@
 set -e
 set +x
 
-RUST_VERSION="1.59.0"
+RUST_VERSION="1.61.0"
 CBINDGEN_VERSION="0.24.3"
 
 trap "cd $(pwd -P)" EXIT


### PR DESCRIPTION
The build now requires Rust 1.61.
