### PR TITLE
test: unflake "should work with newBrowserCDPSession"

### DIFF
--- a/tests/library/chromium/session.spec.ts
+++ b/tests/library/chromium/session.spec.ts
@@ -141,7 +141,9 @@ browserTest('should work with newBrowserCDPSession', async function({ browser })
   let gotEvent = false;
   session.on('Target.targetCreated', () => gotEvent = true);
   await session.send('Target.setDiscoverTargets', { discover: true });
+  const page = await browser.newPage();
   expect(gotEvent).toBe(true);
+  await page.close();
 
   await session.detach();
 });


### PR DESCRIPTION
There could be no targets in a freshly created browser.