### PR TITLE
test: update "page.goBack should work for file urls" to match status quo

### DIFF
--- a/tests/assets/consolelog.html
+++ b/tests/assets/consolelog.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <script>
-      console.log('yellow')
+      console.log('here:' + location.href)
     </script>
   </body>
 </html>

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -138,7 +138,7 @@ it('should trigger correct Log', async ({ page, server, browserName, isWindows }
 it('should have location for console API calls', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [message] = await Promise.all([
-    page.waitForEvent('console', m => m.text() === 'yellow'),
+    page.waitForEvent('console', m => m.text().startsWith('here:')),
     page.goto(server.PREFIX + '/consolelog.html'),
   ]);
   expect(message.type()).toBe('log');


### PR DESCRIPTION
Chromium works correctly, WebKit mac has a security error, Firefox fails to go back.