### PR TITLE
chore: avoid protocol calls on disposed context

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -227,6 +227,8 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
 
   override _dispose() {
     super._dispose();
-    this._context.setRequestInterceptor(undefined).catch(() => {});
+    // Avoid protocol calls for the closed context.
+    if (!this._context.isClosingOrClosed())
+      this._context.setRequestInterceptor(undefined).catch(() => {});
   }
 }


### PR DESCRIPTION
Otherwise, we always get a failing protocol message when closing a context.