### PR TITLE
Change title of command to run tests in a project

### DIFF
--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -53,7 +53,7 @@ For a better debugging experience check out the [VS Code Extension](./getting-st
   npx playwright test landing-page.spec.ts --headed
   ```
 
-- Running Tests on specific browsers
+- Running tests on a specific project
 
   ```bash
   npx playwright test landing-page.ts --project=chromium


### PR DESCRIPTION
The command runs tests on a particular project. However, the caption says browsers. This PR fixes that.