### PR TITLE
docs: fix csharp type examples

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -921,7 +921,7 @@ element_handle.type("world", delay=100) # types slower, like a user
 
 ```csharp
 await elementHandle.TypeAsync("Hello"); // Types instantly
-await elementHandle.TypeAsync("World", delay: 100); // Types slower, like a user
+await elementHandle.TypeAsync("World", new ElementHandleTypeOptions { Delay = 100 }); // Types slower, like a user
 ```
 
 An example of typing into a text field and then submitting the form:

--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -921,7 +921,7 @@ element_handle.type("world", delay=100) # types slower, like a user
 
 ```csharp
 await elementHandle.TypeAsync("Hello"); // Types instantly
-await elementHandle.TypeAsync("World", new ElementHandleTypeOptions { Delay = 100 }); // Types slower, like a user
+await elementHandle.TypeAsync("World", new() { Delay = 100 }); // Types slower, like a user
 ```
 
 An example of typing into a text field and then submitting the form:

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -1484,7 +1484,7 @@ frame.type("#mytextarea", "world", delay=100) # types slower, like a user
 
 ```csharp
 await frame.TypeAsync("#mytextarea", "hello"); // types instantly
-await frame.TypeAsync("#mytextarea", "world", new FrameTypeOptions { Delay = 100 }); // types slower, like a user
+await frame.TypeAsync("#mytextarea", "world", new() { Delay = 100 }); // types slower, like a user
 ```
 
 ### param: Frame.type.selector = %%-input-selector-%%

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -1484,7 +1484,7 @@ frame.type("#mytextarea", "world", delay=100) # types slower, like a user
 
 ```csharp
 await frame.TypeAsync("#mytextarea", "hello"); // types instantly
-await frame.TypeAsync("#mytextarea", "world", delay: 100); // types slower, like a user
+await frame.TypeAsync("#mytextarea", "world", new FrameTypeOptions { Delay = 100 }); // types slower, like a user
 ```
 
 ### param: Frame.type.selector = %%-input-selector-%%

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -984,7 +984,7 @@ element.type("world", delay=100) # types slower, like a user
 
 ```csharp
 await element.TypeAsync("Hello"); // Types instantly
-await element.TypeAsync("World", new LocatorTypeOptions { Delay = 100 }); // Types slower, like a user
+await element.TypeAsync("World", new() { Delay = 100 }); // Types slower, like a user
 ```
 
 An example of typing into a text field and then submitting the form:

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -984,7 +984,7 @@ element.type("world", delay=100) # types slower, like a user
 
 ```csharp
 await element.TypeAsync("Hello"); // Types instantly
-await element.TypeAsync("World", delay: 100); // Types slower, like a user
+await element.TypeAsync("World", new LocatorTypeOptions { Delay = 100 }); // Types slower, like a user
 ```
 
 An example of typing into a text field and then submitting the form:

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3380,7 +3380,7 @@ page.type("#mytextarea", "world", delay=100) # types slower, like a user
 
 ```csharp
 await page.TypeAsync("#mytextarea", "hello"); // types instantly
-await page.TypeAsync("#mytextarea", "world", new PageTypeOptions { Delay = 100 }); // types slower, like a user
+await page.TypeAsync("#mytextarea", "world", new() { Delay = 100 }); // types slower, like a user
 ```
 
 Shortcut for main frame's [`method: Frame.type`].

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3380,7 +3380,7 @@ page.type("#mytextarea", "world", delay=100) # types slower, like a user
 
 ```csharp
 await page.TypeAsync("#mytextarea", "hello"); // types instantly
-await page.TypeAsync("#mytextarea", "world"); // types slower, like a user
+await page.TypeAsync("#mytextarea", "world", new PageTypeOptions { Delay = 100 }); // types slower, like a user
 ```
 
 Shortcut for main frame's [`method: Frame.type`].


### PR DESCRIPTION
The *TypeOptions where missing / wrong in the type slower examples.