### PR TITLE
explain that the `Selectors.register` script is executed in the page context

### DIFF
--- a/docs/src/api/class-selectors.md
+++ b/docs/src/api/class-selectors.md
@@ -45,7 +45,7 @@ const { selectors, firefox } = require('playwright');  // Or 'chromium' or 'webk
 ```
 
 ```java
-// Script that evaluates to a selector engine instance.
+// Script that evaluates to a selector engine instance. The script is evaluated in the page context.
 String createTagNameEngine = "{\n" +
   "  // Returns the first element matching given selector in the root's subtree.\n" +
   "  query(root, selector) {\n" +
@@ -146,7 +146,7 @@ with sync_playwright() as playwright:
 
 ```csharp
 using var playwright = await Playwright.CreateAsync();
-// Script that evaluates to a selector engine instance.
+// Script that evaluates to a selector engine instance. The script is evaluated in the page context.
 await playwright.Selectors.RegisterAsync("tag", @"{
 // Returns the first element matching given selector in the root's subtree.
 query(root, selector) {
@@ -184,28 +184,28 @@ contain `[a-zA-Z0-9_]` characters.
     current working directory. Optional.
   - `content` ?<[string]> Raw script content. Optional.
 
-Script that evaluates to a selector engine instance.
+Script that evaluates to a selector engine instance. The script is evaluated in the page context.
 
 ### param: Selectors.register.script
 * since: v1.8
 * langs: java
 - `script` <[string]|[path]>
 
-Script that evaluates to a selector engine instance.
+Script that evaluates to a selector engine instance. The script is evaluated in the page context.
 
 ### option: Selectors.register.script
 * since: v1.8
 * langs: csharp
 - `script` <[string]>
 
-Script that evaluates to a selector engine instance.
+Script that evaluates to a selector engine instance. The script is evaluated in the page context.
 
 ### option: Selectors.register.path
 * since: v1.8
 * langs: csharp
 - `path` <[path]>
 
-Script that evaluates to a selector engine instance.
+Script that evaluates to a selector engine instance. The script is evaluated in the page context.
 
 ### option: Selectors.register.contentScript
 * since: v1.8

--- a/docs/src/extensibility.md
+++ b/docs/src/extensibility.md
@@ -53,7 +53,7 @@ const buttonCount = await page.locator('tag=button').count();
 ```
 
 ```java
-// Must be a script that evaluates to a selector engine instance.
+// Must be a script that evaluates to a selector engine instance.  The script is evaluated in the page context.
 String createTagNameEngine = "{\n" +
   "  // Returns the first element matching given selector in the root's subtree.\n" +
   "  query(root, selector) {\n" +

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -15532,7 +15532,7 @@ export interface Selectors {
    * ```
    *
    * @param name Name that is used in selectors as a prefix, e.g. `{name: 'foo'}` enables `foo=myselectorbody` selectors. May only contain `[a-zA-Z0-9_]` characters.
-   * @param script Script that evaluates to a selector engine instance.
+   * @param script Script that evaluates to a selector engine instance. The script is evaluated in the page context.
    * @param options
    */
   register(name: string, script: Function|string|{


### PR DESCRIPTION
fixes #16915