### PR TITLE
fix(html-reporter): duplicate attachment name

### DIFF
--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -503,7 +503,6 @@ class HtmlBuilder {
           name: a.name,
           contentType: a.contentType,
           path: 'data/' + sha1,
-          body: a.body,
         };
       }
 


### PR DESCRIPTION
Fixes #16456.

The extra span/name was coming from
https://github.com/microsoft/playwright/blob/077b8a928960493a4cf275bc4fc4d4176b2a6098/packages/html-reporter/src/links.tsx#L72
(in conjunction with the line above it).

These two lines assume `path` and `body` are mutally exclusive.

Regression likely introduced by the PR that added the now removed line #10778.