### PR TITLE
docs: override headers typo

### DIFF
--- a/docs/src/api/class-route.md
+++ b/docs/src/api/class-route.md
@@ -49,7 +49,7 @@ await page.route('**/*', (route, request) => {
     foo: 'foo-value', // set "foo" header
     bar: undefined, // remove "bar" header
   };
-  route.continue({headers});
+  route.continue({headers:{...headers});
 });
 ```
 


### PR DESCRIPTION
headers' object must be nested as a value for the key `headers`