### PR TITLE
cherry-pick(#16898): fix: include headlessness as a launch argument to browser

### DIFF
--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -106,7 +106,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
       (browserType as any)._defaultLaunchOptions = undefined;
   }, { scope: 'worker', auto: true }],
 
-  _connectedBrowser: [async ({ playwright, browserName, channel, headless, connectOptions, launchOptions }, use) => {
+  _connectedBrowser: [async ({ playwright, browserName, connectOptions, _browserOptions }, use) => {
     if (!connectOptions) {
       await use(undefined);
       return;
@@ -116,7 +116,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
     const browser = await playwright[browserName].connect(connectOptions.wsEndpoint, {
       headers: {
         'x-playwright-browser': browserName,
-        'x-playwright-launch-options': JSON.stringify(launchOptions),
+        'x-playwright-launch-options': JSON.stringify(_browserOptions),
         ...connectOptions.headers,
       },
       timeout: connectOptions.timeout ?? 3 * 60 * 1000, // 3 minutes


### PR DESCRIPTION
Fixes #16955.