### PR TITLE
fix: throw clear message when requested screenshot is too large

### DIFF
--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -834,9 +834,8 @@ export class WKPage implements PageDelegate {
     // (see https://github.com/microsoft/playwright/issues/16727).
     if (process.platform === 'darwin')
       return;
-    if (!omitDeviceScaleFactor && this._page._browserContext._options.deviceScaleFactor) {
+    if (!omitDeviceScaleFactor && this._page._browserContext._options.deviceScaleFactor)
       side = Math.ceil(side * this._page._browserContext._options.deviceScaleFactor);
-    }
     if (side > 32767)
       throw new Error('Cannot take screenshot larger than 32767 pixels on any dimension');
   }

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -829,9 +829,24 @@ export class WKPage implements PageDelegate {
     this._recordingVideoFile = null;
   }
 
+  private validateScreenshotDimension(side: number, omitDeviceScaleFactor: boolean) {
+    // Cairo based implementations (Linux and Windows) have hard limit of 32767
+    // (see https://github.com/microsoft/playwright/issues/16727).
+    if (process.platform === 'darwin')
+      return;
+    if (!omitDeviceScaleFactor && this._page._browserContext._options.deviceScaleFactor) {
+      side = Math.ceil(side * this._page._browserContext._options.deviceScaleFactor);
+    }
+    if (side > 32767)
+      throw new Error('Cannot take screenshot larger than 32767 pixels on any dimension');
+  }
+
   async takeScreenshot(progress: Progress, format: string, documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined, fitsViewport: boolean, scale: 'css' | 'device'): Promise<Buffer> {
     const rect = (documentRect || viewportRect)!;
-    const result = await this._session.send('Page.snapshotRect', { ...rect, coordinateSystem: documentRect ? 'Page' : 'Viewport', omitDeviceScaleFactor: scale === 'css' });
+    const omitDeviceScaleFactor = scale === 'css';
+    this.validateScreenshotDimension(rect.width, omitDeviceScaleFactor);
+    this.validateScreenshotDimension(rect.height, omitDeviceScaleFactor);
+    const result = await this._session.send('Page.snapshotRect', { ...rect, coordinateSystem: documentRect ? 'Page' : 'Viewport', omitDeviceScaleFactor });
     const prefix = 'data:image/png;base64,';
     let buffer = Buffer.from(result.dataURL.substr(prefix.length), 'base64');
     if (format === 'jpeg')

--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -108,6 +108,27 @@ browserTest.describe('page screenshot', () => {
     await context.close();
   });
 
+  browserTest('should throw if screenshot size is too large with device scale factor', async ({ browser, browserName, isMac }) => {
+    browserTest.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16727' });
+    const context = await browser.newContext({ viewport: { width: 500, height: 500 }, deviceScaleFactor: 2 });
+    const page = await context.newPage();
+    {
+      await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: 16383px; background: red;'></div>`);
+      const result = await page.screenshot({ fullPage: true });
+      expect(result).toBeTruthy();
+    }
+    {
+      await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: 16384px; background: red;'></div>`);
+      const exception = await page.screenshot({ fullPage: true }).catch(e => e);
+      if (browserName === 'firefox' || (browserName === 'webkit' && !isMac))
+        expect(exception.message).toContain('Cannot take screenshot larger than 32767');
+
+      const image = await page.screenshot({ fullPage: true, scale: 'css' });
+      expect(image).toBeTruthy();
+    }
+    await context.close();
+  });
+
   browserTest('should work with large size', async ({ browserName, headless, platform, contextFactory }) => {
     browserTest.fixme(browserName === 'chromium' && !headless && platform === 'linux', 'Chromium has gpu problems on linux with large screnshots');
     browserTest.slow(true, 'Large screenshot is slow');

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -814,3 +814,17 @@ it.describe('page screenshot animations', () => {
   });
 });
 
+it('should throw if screenshot size is too large', async ({ page, browserName, isMac }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16727' });
+  {
+    await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: 32767px; background: red;'></div>`);
+    const result = await page.screenshot({ fullPage: true });
+    expect(result).toBeTruthy();
+  }
+  {
+    await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: 32768px; background: red;'></div>`);
+    const exception = await page.screenshot({ fullPage: true }).catch(e => e);
+    if (browserName === 'firefox' || (browserName === 'webkit' && !isMac))
+      expect(exception.message).toContain('Cannot take screenshot larger than 32767');
+  }
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/16727