### PR TITLE
test: send cookies via an embedded iframe

### DIFF
--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -320,3 +320,32 @@ it('should add cookies with an expiration', async ({ context }) => {
     expires: -42,
   }])).rejects.toThrow(/Cookie should have a valid expires/);
 });
+
+it('should be able to send third party cookies via an iframe', async ({ browser, httpsServer, browserName }) => {
+  it.fixme(browserName === 'firefox' || browserName === 'webkit');
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16937' });
+
+  const context = await browser.newContext({
+    ignoreHTTPSErrors: true,
+  });
+  try {
+    const page = await context.newPage();
+    await page.goto(httpsServer.EMPTY_PAGE);
+    await context.addCookies([{
+      domain: new URL(httpsServer.CROSS_PROCESS_PREFIX).hostname,
+      path: '/',
+      name: 'cookie1',
+      value: 'yes',
+      httpOnly: true,
+      secure: true,
+      sameSite: 'None'
+    }]);
+    const [response] = await Promise.all([
+      httpsServer.waitForRequest('/grid.html'),
+      page.setContent(`<iframe src="${httpsServer.CROSS_PROCESS_PREFIX}/grid.html"></iframe>`)
+    ]);
+    expect(response.headers['cookie']).toBe('cookie1=yes');
+  } finally {
+    await context.close();
+  }
+});


### PR DESCRIPTION
Test for https://github.com/microsoft/playwright/issues/16937

This broke in FF 104 since they enabled the Total cookie protection. If I disable it, it works as expected.

```
use: {
  launchOptions: {
      firefoxUserPrefs: {
        'network.cookie.cookieBehavior': 4
      }
  }
}
```

This should fix a bunch of auth0 login storageState scenarios.