### PR TITLE
New TestFilter extension

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -814,3 +814,10 @@ const config: PlaywrightTestConfig = {
 };
 export default config;
 ```
+
+## optional property: TestConfig.filters
+* since: v1.10
+- type: ?<[string]|[Array]<[Object]>>
+  - `0` <[string]> TestFilter name or module or file path
+  - `1` <[Object]> An object with test filter options if any
+

--- a/docs/src/test-reporter-api/class-testfilter.md
+++ b/docs/src/test-reporter-api/class-testfilter.md
@@ -1,0 +1,21 @@
+# class: TestFilter
+* since: v1.26
+* langs: js
+
+`TestFilter` is used to filter [TestCase] before test run.
+
+## optional method: TestFilter.include
+* since: v1.26
+- returns: <[boolean]>
+
+### param: TestFilter.include.test
+* since: v1.26
+- `test` <[TestCase]>
+
+## optional method: TestFilter.exclude
+* since: v1.26
+- returns: <[boolean]>
+
+### param: TestFilter.exclude.test
+* since: v1.26
+- `test` <[TestCase]>

--- a/packages/playwright-test/src/loader.ts
+++ b/packages/playwright-test/src/loader.ts
@@ -25,7 +25,7 @@ import * as url from 'url';
 import * as fs from 'fs';
 import * as os from 'os';
 import type { BuiltInReporter, ConfigCLIOverrides } from './runner';
-import type { Reporter } from '../types/testReporter';
+import type { Reporter, TestFilter } from '../types/testReporter';
 import { builtInReporters } from './runner';
 import { isRegExp, calculateSha1 } from 'playwright-core/lib/utils';
 import { serializeError } from './util';
@@ -143,6 +143,7 @@ export class Loader {
     this._fullConfig._ignoreSnapshots = takeFirst(config.ignoreSnapshots, baseFullConfig._ignoreSnapshots);
     this._fullConfig.updateSnapshots = takeFirst(config.updateSnapshots, baseFullConfig.updateSnapshots);
     this._fullConfig.workers = takeFirst(config.workers, baseFullConfig.workers);
+    this._fullConfig.filters = takeFirst(config.filters, baseFullConfig.filters);
     const webServers = takeFirst(config.webServer, baseFullConfig.webServer);
     if (Array.isArray(webServers)) { // multiple web server mode
       // Due to previous choices, this value shows up to the user in globalSetup as part of FullConfig. Arrays are not supported by the old type.
@@ -219,6 +220,10 @@ export class Loader {
   }
 
   async loadReporter(file: string): Promise<new (arg?: any) => Reporter> {
+    return this._requireOrImportDefaultFunction(path.resolve(this._fullConfig.rootDir, file), true);
+  }
+
+  async loadTestFilter(file: string): Promise<new (arg?: any) => TestFilter> {
     return this._requireOrImportDefaultFunction(path.resolve(this._fullConfig.rootDir, file), true);
   }
 

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -29,6 +29,8 @@ export type ReporterDescription =
   ['null'] |
   [string] | [string, any];
 
+export type TestFilterDescription = [string] | [string, any];
+
 type UseOptions<TestArgs, WorkerArgs> = { [K in keyof WorkerArgs]?: WorkerArgs[K] } & { [K in keyof TestArgs]?: TestArgs[K] };
 
 /**
@@ -488,6 +490,7 @@ interface TestConfig {
    *
    */
   webServer?: TestConfigWebServer | TestConfigWebServer[];
+  filters?: TestFilterDescription[];
   /**
    * Configuration for the `expect` assertion library. Learn more about [various timeouts](https://playwright.dev/docs/test-timeouts).
    *
@@ -1298,6 +1301,7 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
    *
    */
   webServer: TestConfigWebServer | null;
+  filters: TestFilterDescription[];
 }
 
 export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped' | 'interrupted';

--- a/packages/playwright-test/types/testReporter.d.ts
+++ b/packages/playwright-test/types/testReporter.d.ts
@@ -537,6 +537,21 @@ export interface Location {
 }
 
 /**
+ * `TestFilter` is used to filter [TestCase] before test run.
+ */
+export interface TestFilter {
+  /**
+   * @param config
+   */
+  include?(config: TestCase): boolean;
+
+  /**
+   * @param config
+   */
+  exclude?(config: TestCase): boolean;
+}
+
+/**
  * Represents a step in the [TestRun].
  */
 export interface TestStep {

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -28,6 +28,8 @@ export type ReporterDescription =
   ['null'] |
   [string] | [string, any];
 
+export type TestFilterDescription = [string] | [string, any];
+
 type UseOptions<TestArgs, WorkerArgs> = { [K in keyof WorkerArgs]?: WorkerArgs[K] } & { [K in keyof TestArgs]?: TestArgs[K] };
 
 export interface Project<TestArgs = {}, WorkerArgs = {}> extends TestProject {
@@ -59,6 +61,7 @@ type LiteralUnion<T extends U, U = string> = T | (U & { zz_IGNORE_ME?: never });
 interface TestConfig {
   reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html', string> | ReporterDescription[];
   webServer?: TestConfigWebServer | TestConfigWebServer[];
+  filters?: TestFilterDescription[];
 }
 
 export interface Config<TestArgs = {}, WorkerArgs = {}> extends TestConfig {
@@ -92,6 +95,7 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
   updateSnapshots: 'all' | 'none' | 'missing';
   workers: number;
   webServer: TestConfigWebServer | null;
+  filters: TestFilterDescription[];
   // [internal] !!! DO NOT ADD TO THIS !!! See prior note.
 }
 


### PR DESCRIPTION
The draft implementation of test filter requested in #17037

The provided solution introduces new configuration option that allows users to specify a module with TestFilter implementation.

This change doesn't include tests, documentation changes and stuff like that. Also I'm not sure about naming (you already have a TestFileFilter). And some types could be done better. 

Also we can introduce build-in filters like `by test name`, `by test tag`, `by annotation` etc.

If you OK in general, I'll be happy to continue my work on this

### TestFilter:

```ts
export interface TestFilter {
  /**
   * @param test
   */
  include?(test: TestCase): boolean;

  /**
   * @param test
   */
  exclude?(test: TestCase): boolean;
}
```

### Usage:

1. Create a demo project using `npx playwright init`, select TypeScript
2. Create a filter implementation `tests/TestIdFilter.ts`:
    ```ts
    import { TestCase, TestFilter } from '@playwright/test/reporter';
    
    export default class TestIdFilter implements TestFilter {
    
      include(test: TestCase): boolean {
        return test.id === "a30a6eba6312f6b87ea5-5f7f5d07b39c1f61c732";
      }
    }
    ```
3. Add a `filters: [['TestIdFilter.ts']]` configuration option to `playwright.config.ts`

