### PR TITLE
fix(firefox): disable cookie partitioning

### DIFF
--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -61,7 +61,7 @@ export class Firefox extends BrowserType {
       throw new Error('Pass userDataDir parameter to `browserType.launchPersistentContext(userDataDir, ...)` instead of specifying --profile argument');
     if (args.find(arg => arg.startsWith('-juggler')))
       throw new Error('Use the port parameter instead of -juggler argument');
-    const firefoxUserPrefs = isPersistent ? undefined : options.firefoxUserPrefs;
+    const firefoxUserPrefs = isPersistent ? undefined : { ...kBandaidFirefoxUserPrefs, ...options.firefoxUserPrefs };
     if (firefoxUserPrefs) {
       const lines: string[] = [];
       for (const [name, value] of Object.entries(firefoxUserPrefs))
@@ -85,3 +85,9 @@ export class Firefox extends BrowserType {
     return firefoxArguments;
   }
 }
+
+// Prefs for quick fixes that didn't make it to the build.
+// Should all be moved to `playwright.cfg`.
+const kBandaidFirefoxUserPrefs = {
+  'network.cookie.cookieBehavior': 4,
+};

--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -322,7 +322,7 @@ it('should add cookies with an expiration', async ({ context }) => {
 });
 
 it('should be able to send third party cookies via an iframe', async ({ browser, httpsServer, browserName, isMac }) => {
-  it.fixme(browserName === 'firefox' || (browserName === 'webkit' && isMac));
+  it.fixme(browserName === 'webkit' && isMac);
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16937' });
 
   const context = await browser.newContext({


### PR DESCRIPTION
This should be mergeable to v1.25.

References #16937.