### PR TITLE
fix(test-runner): correct currentStep

### DIFF
--- a/packages/playwright-test/src/expect.ts
+++ b/packages/playwright-test/src/expect.ts
@@ -204,7 +204,6 @@ class ExpectMetaInfoProxyHandler {
         canHaveChildren: true,
         forceNoParent: false
       });
-      testInfo.currentStep = step;
 
       const reportStepError = (jestError: Error) => {
         const message = jestError.message;

--- a/packages/playwright-test/src/testInfo.ts
+++ b/packages/playwright-test/src/testInfo.ts
@@ -27,7 +27,7 @@ import { addSuffixToFilePath, getContainedPath, normalizeAndSaveAttachment, sani
 import { monotonicTime } from 'playwright-core/lib/utils';
 
 export class TestInfoImpl implements TestInfo {
-  private _addStepImpl: (data: Omit<TestStepInternal, 'complete'>, setCurrentStep: (step: TestStepInternal | undefined) => void) => TestStepInternal;
+  private _addStepImpl: (data: Omit<TestStepInternal, 'complete'>) => TestStepInternal;
   readonly _test: TestCase;
   readonly _timeoutManager: TimeoutManager;
   readonly _startTime: number;
@@ -89,7 +89,7 @@ export class TestInfoImpl implements TestInfo {
     workerParams: WorkerInitParams,
     test: TestCase,
     retry: number,
-    addStepImpl: (data: Omit<TestStepInternal, 'complete'>, setCurrentStep: (step: TestStepInternal | undefined) => void) => TestStepInternal,
+    addStepImpl: (data: Omit<TestStepInternal, 'complete'>) => TestStepInternal,
   ) {
     this._test = test;
     this._addStepImpl = addStepImpl;
@@ -189,12 +189,8 @@ export class TestInfoImpl implements TestInfo {
     }
   }
 
-  setCurrentStep(val: TestStepInternal | undefined){
-    this.currentStep = val;
-  }
-
   _addStep(data: Omit<TestStepInternal, 'complete'>) {
-    return this._addStepImpl(data, this.setCurrentStep);
+    return this._addStepImpl(data);
   }
 
   _failWithError(error: TestError, isHardError: boolean) {

--- a/packages/playwright-test/src/testInfo.ts
+++ b/packages/playwright-test/src/testInfo.ts
@@ -27,7 +27,7 @@ import { addSuffixToFilePath, getContainedPath, normalizeAndSaveAttachment, sani
 import { monotonicTime } from 'playwright-core/lib/utils';
 
 export class TestInfoImpl implements TestInfo {
-  private _addStepImpl: (data: Omit<TestStepInternal, 'complete'>) => TestStepInternal;
+  private _addStepImpl: (data: Omit<TestStepInternal, 'complete'>, setCurrentStep: (step: TestStepInternal | undefined) => void) => TestStepInternal;
   readonly _test: TestCase;
   readonly _timeoutManager: TimeoutManager;
   readonly _startTime: number;
@@ -89,7 +89,7 @@ export class TestInfoImpl implements TestInfo {
     workerParams: WorkerInitParams,
     test: TestCase,
     retry: number,
-    addStepImpl: (data: Omit<TestStepInternal, 'complete'>) => TestStepInternal,
+    addStepImpl: (data: Omit<TestStepInternal, 'complete'>, setCurrentStep: (step: TestStepInternal | undefined) => void) => TestStepInternal,
   ) {
     this._test = test;
     this._addStepImpl = addStepImpl;
@@ -189,8 +189,12 @@ export class TestInfoImpl implements TestInfo {
     }
   }
 
+  setCurrentStep(val: TestStepInternal | undefined){
+    this.currentStep = val;
+  }
+
   _addStep(data: Omit<TestStepInternal, 'complete'>) {
-    return this._addStepImpl(data);
+    return this._addStepImpl(data, this.setCurrentStep);
   }
 
   _failWithError(error: TestError, isHardError: boolean) {

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -227,7 +227,7 @@ export class WorkerRunner extends EventEmitter {
 
   private async _runTest(test: TestCase, retry: number, nextTest: TestCase | undefined) {
     let lastStepId = 0;
-    const testInfo = new TestInfoImpl(this._loader, this._project, this._params, test, retry, data => {
+    const testInfo = new TestInfoImpl(this._loader, this._project, this._params, test, retry, (data, setCurrentStep) => {
       const stepId = `${data.category}@${data.title}@${++lastStepId}`;
       let callbackHandled = false;
       const step: TestStepInternal = {
@@ -244,6 +244,7 @@ export class WorkerRunner extends EventEmitter {
             wallTime: Date.now(),
             error,
           };
+          setCurrentStep(undefined);
           this.emit('stepEnd', payload);
         }
       };
@@ -257,6 +258,7 @@ export class WorkerRunner extends EventEmitter {
         location,
         wallTime: Date.now(),
       };
+      setCurrentStep(step);
       this.emit('stepBegin', payload);
       return step;
     });

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -227,7 +227,7 @@ export class WorkerRunner extends EventEmitter {
 
   private async _runTest(test: TestCase, retry: number, nextTest: TestCase | undefined) {
     let lastStepId = 0;
-    const testInfo = new TestInfoImpl(this._loader, this._project, this._params, test, retry, (data, setCurrentStep) => {
+    const testInfo = new TestInfoImpl(this._loader, this._project, this._params, test, retry, data => {
       const stepId = `${data.category}@${data.title}@${++lastStepId}`;
       let callbackHandled = false;
       const step: TestStepInternal = {
@@ -244,7 +244,7 @@ export class WorkerRunner extends EventEmitter {
             wallTime: Date.now(),
             error,
           };
-          setCurrentStep(undefined);
+          testInfo.currentStep = undefined;
           this.emit('stepEnd', payload);
         }
       };
@@ -258,7 +258,7 @@ export class WorkerRunner extends EventEmitter {
         location,
         wallTime: Date.now(),
       };
-      setCurrentStep(step);
+      testInfo.currentStep = step;
       this.emit('stepBegin', payload);
       return step;
     });

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -403,7 +403,7 @@ test('should return value from step', async ({ runInlineTest }) => {
 });
 
 
-test.only('should set correct currentStep', async ({ runInlineTest }) => {
+test('should set correct currentStep', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `
       const { test } = pwt;

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -401,3 +401,35 @@ test('should return value from step', async ({ runInlineTest }) => {
   expect(result.output).toContain('v1 = 10');
   expect(result.output).toContain('v2 = 20');
 });
+
+
+test('should return value from step', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      test('pass', async ({ page }) => {
+        await test.step('outer step 1', async () => {
+          expect(test.info().currentStep.title).toBe('outer step 1')
+          await test.step('inner step 1.1', async () => {
+            expect(test.info().currentStep.title).toBe('inner step 1.1')
+          });
+          await test.step('inner step 1.2', async () => {
+            expect(test.info().currentStep.title).toBe('inner step 1.2')
+          });
+        });
+        expect(test.info().currentStep).toBeUndefined()
+        await test.step('outer step 2', async () => {
+          expect(test.info().currentStep.title).toBe('outer step 2')
+          await test.step('inner step 2.1', async () => {
+          expect(test.info().currentStep.title).toBe('inner step 2.1')
+          });
+          await test.step('inner step 2.2', async () => {
+          expect(test.info().currentStep.title).toBe('inner step 2.2')
+          });
+        });
+      });
+    
+    `
+  }, { reporter: '', workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -403,9 +403,10 @@ test('should return value from step', async ({ runInlineTest }) => {
 });
 
 
-test('should set correct currentStep', async ({ runInlineTest }) => {
+test.only('should set correct currentStep', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `
+      const { test } = pwt;
       test('pass', async ({ page }) => {
         await test.step('outer step 1', async () => {
           expect(test.info().currentStep.title).toBe('outer step 1')

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -403,7 +403,7 @@ test('should return value from step', async ({ runInlineTest }) => {
 });
 
 
-test('should return value from step', async ({ runInlineTest }) => {
+test('should set correct currentStep', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `
       test('pass', async ({ page }) => {

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -415,6 +415,7 @@ test('should set correct currentStep', async ({ runInlineTest }) => {
           await test.step('inner step 1.2', async () => {
             expect(test.info().currentStep.title).toBe('inner step 1.2')
           });
+          expect(test.info().currentStep.title).toBe('outer step 1');
         });
         expect(test.info().currentStep).toBeUndefined()
         await test.step('outer step 2', async () => {
@@ -425,6 +426,7 @@ test('should set correct currentStep', async ({ runInlineTest }) => {
           await test.step('inner step 2.2', async () => {
           expect(test.info().currentStep.title).toBe('inner step 2.2')
           });
+          expect(test.info().currentStep.title).toBe('outer step 2');
         });
       });
     


### PR DESCRIPTION
We have `currentStep` field inside `TestInfo` but we set this filed only for `ExpectMetaInfoProxy`.

This PR fix this behavior and set correct currentTest for all addStep calls.