### PR TITLE
feat(test-runner) correct testResult onStepEnd and onStepBegin

### DIFF
--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { TestError } from '../types/testReporter';
+import type { JSONReportSTDIOEntry, TestError, TestResult } from '../types/testReporter';
 import type { ConfigCLIOverrides } from './runner';
 import type { TestStatus } from './types';
 
@@ -79,12 +79,25 @@ export type StepBeginPayload = {
   location?: { file: string, line: number, column: number };
 };
 
+type SerializedTestResult  = Omit<TestResult, 'attachments' | 'startTime' | 'stderr' | 'stdout' | 'steps' > & {
+  attachments: Array<{
+    name: string;
+    contentType: string;
+    path?: string;
+    body?: string;
+  }>;
+  startTime: number;
+  stderr: Array<JSONReportSTDIOEntry>;
+  stdout: Array<JSONReportSTDIOEntry>;
+};
+
 export type StepEndPayload = {
   testId: string;
   stepId: string;
   refinedTitle?: string;
   wallTime: number;  // milliseconds since unix epoch
   error?: TestError;
+  serializedTestResult: SerializedTestResult;
 };
 
 export type TestEntry = {

--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -77,9 +77,10 @@ export type StepBeginPayload = {
   forceNoParent: boolean;
   wallTime: number;  // milliseconds since unix epoch
   location?: { file: string, line: number, column: number };
+  serializedTestResult: SerializedTestResult;
 };
 
-type SerializedTestResult  = Omit<TestResult, 'attachments' | 'startTime' | 'stderr' | 'stdout' | 'steps' > & {
+export type SerializedTestResult  = Omit<TestResult, 'attachments' | 'startTime' | 'stderr' | 'stdout' | 'steps' > & {
   attachments: Array<{
     name: string;
     contentType: string;

--- a/packages/playwright-test/src/reporters/json.ts
+++ b/packages/playwright-test/src/reporters/json.ts
@@ -16,7 +16,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import type { FullConfig, TestCase, Suite, TestResult, TestError, TestStep, FullResult, Location, Reporter, JSONReport, JSONReportSuite, JSONReportSpec, JSONReportTest, JSONReportTestResult, JSONReportTestStep } from '../../types/testReporter';
+import type { FullConfig, TestCase, Suite, TestResult, TestError, TestStep, FullResult, Location, Reporter, JSONReport, JSONReportSuite, JSONReportSpec, JSONReportTest, JSONReportTestResult, JSONReportTestStep, JSONReportSTDIOEntry } from '../../types/testReporter';
 import { prepareErrorStack } from './base';
 
 export function toPosixPath(aPath: string): string {
@@ -211,10 +211,16 @@ function outputReport(report: JSONReport, outputFile: string | undefined) {
   }
 }
 
-function stdioEntry(s: string | Buffer): any {
+export function stdioEntry(s: string | Buffer): JSONReportSTDIOEntry {
   if (typeof s === 'string')
     return { text: s };
   return { buffer: s.toString('base64') };
+}
+
+export function stdioEntryDecode(e: JSONReportSTDIOEntry): string | Buffer {
+  if ('text' in e) return e.text;
+  if ('buffer' in e) return Buffer.from(e.buffer, 'base64');
+  return '';
 }
 
 export function serializePatterns(patterns: string | RegExp | (string | RegExp)[]): string[] {

--- a/packages/playwright-test/src/testInfo.ts
+++ b/packages/playwright-test/src/testInfo.ts
@@ -27,7 +27,7 @@ import { addSuffixToFilePath, getContainedPath, normalizeAndSaveAttachment, sani
 import { monotonicTime } from 'playwright-core/lib/utils';
 
 export class TestInfoImpl implements TestInfo {
-  private _addStepImpl: (data: Omit<TestStepInternal, 'complete'>) => TestStepInternal;
+  private _addStepImpl: (data: Omit<TestStepInternal, 'complete'>, testInfo: TestInfoImpl) => TestStepInternal;
   readonly _test: TestCase;
   readonly _timeoutManager: TimeoutManager;
   readonly _startTime: number;
@@ -89,7 +89,7 @@ export class TestInfoImpl implements TestInfo {
     workerParams: WorkerInitParams,
     test: TestCase,
     retry: number,
-    addStepImpl: (data: Omit<TestStepInternal, 'complete'>) => TestStepInternal,
+    addStepImpl: (data: Omit<TestStepInternal, 'complete'>, testInfo: TestInfoImpl) => TestStepInternal,
   ) {
     this._test = test;
     this._addStepImpl = addStepImpl;
@@ -190,7 +190,7 @@ export class TestInfoImpl implements TestInfo {
   }
 
   _addStep(data: Omit<TestStepInternal, 'complete'>) {
-    return this._addStepImpl(data);
+    return this._addStepImpl(data, this);
   }
 
   _failWithError(error: TestError, isHardError: boolean) {


### PR DESCRIPTION
## How it works:
If you use `testInfo.attach()` inside step attachment will be flagged as `isStepAttachment` and appended to `stepAttachments` field inside `step`.

Reporters can access current step attachments
```ts
onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
  console.log(step.stepAttachments)
}
```


depends on #17082

fixes #17038 
fixes #14364
fixes #11592