### PR TITLE
docs: remove toc and reduce api ref heading

### DIFF
--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -1,6 +1,6 @@
 ---
 id: input
-title: "Performing actions"
+title: "Performing Actions"
 ---
 
 Playwright can interact with HTML Input elements such as text inputs, checkboxes, radio buttons, select options, mouse clicks, type characters, keys and shortcuts as well as upload files and focus elements.
@@ -228,12 +228,6 @@ await page.Locator("select#colors").SelectOptionAsync(new SelectOptionValue { La
 await page.Locator("select#colors").SelectOptionAsync(new[] { "blue", "green", "red" });
 ```
 
-#### API reference
-
-- [`method: Locator.selectOption`]
-- [`method: Page.selectOption`]
-- [`method: Frame.selectOption`]
-
 ## Mouse click
 
 Performs a simple human click.
@@ -394,21 +388,6 @@ page.locator('button#submit').dispatch_event('click')
 ```csharp
 await page.Locator("button#submit").DispatchEventAsync("click");
 ```
-#### API reference
-
-- [`method: Locator.click`]
-- [`method: Page.click`]
-- [`method: Frame.click`]
-- [`method: Locator.dblclick`]
-- [`method: Page.dblclick`]
-- [`method: Frame.dblclick`]
-- [`method: Locator.hover`]
-- [`method: Page.hover`]
-- [`method: Frame.hover`]
-- [`method: Locator.dispatchEvent`]
-- [`method: Page.dispatchEvent`]
-- [`method: Frame.dispatchEvent`]
-
 
 ## Type characters
 
@@ -444,13 +423,6 @@ This method will emit all the necessary keyboard events, with all the `keydown`,
 :::note
 Most of the time, [`method: Page.fill`] will just work. You only need to type characters if there is special keyboard handling on the page.
 :::
-
-#### API reference
-
-- [`method: Locator.type`]
-- [`method: Page.type`]
-- [`method: Frame.type`]
-- [`method: Keyboard.type`]
 
 ## Keys and shortcuts
 
@@ -567,14 +539,6 @@ await page.Locator("#name").PressAsync("Shift+ArrowLeft");
 Shortcuts such as `"Control+o"` or `"Control+Shift+T"` are supported as well. When specified with the modifier, modifier is pressed and being held while the subsequent key is being pressed.
 
 Note that you still need to specify the capital `A` in `Shift-A` to produce the capital character. `Shift-a` produces a lower-case one as if you had the `CapsLock` toggled.
-
-
-#### API reference
-
-- [`method: Locator.press`]
-- [`method: Page.press`]
-- [`method: Frame.press`]
-- [`method: Keyboard.press`]
 
 ## Upload files
 
@@ -711,13 +675,6 @@ var fileChooser = page.RunAndWaitForFileChooserAsync(async () =>
 await fileChooser.SetFilesAsync("myfile.pdf");
 ```
 
-#### API reference
-
-- [FileChooser]
-- [`method: Locator.setInputFiles`]
-- [`method: Page.setInputFiles`]
-- [`method: Frame.setInputFiles`]
-
 ## Focus element
 
 For the dynamic pages that handle focus events, you can focus the given element with [`method: Locator.focus`].
@@ -741,9 +698,3 @@ page.locator('input#name').focus()
 ```csharp
 await page.Locator("input#name").FocusAsync();
 ```
-
-#### API reference
-
-- [`method: Locator.focus`]
-- [`method: Page.focus`]
-- [`method: Frame.focus`]

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -185,7 +185,7 @@ await page.Locator("text=XL").CheckAsync();
 
 ## Select options
 
-Selects one or multiple options in the `<select>` element.
+Selects one or multiple options in the `<select>` element with [`method: Locator.selectOption`].
 You can specify option `value`, or `label` to select. Multiple options can be selected.
 
 ```js

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -6,7 +6,7 @@ title: "Input"
 Playwright can interact with HTML Input elements such as text inputs, checkboxes, radio buttons, select options, mouse clicks, type characters, keys and shortcuts as well as upload files and focus elements.
 ## Text input
 
-This is the easiest way to fill out the form fields. It focuses the element and triggers an `input` event with the entered text. It works for `<input>`, `<textarea>`, `[contenteditable]` and `<label>` associated with an input or textarea.
+Using [`method: Locator.fill`] is the easiest way to fill out the form fields. It focuses the element and triggers an `input` event with the entered text. It works for `<input>`, `<textarea>`, `[contenteditable]` and `<label>` associated with an input or textarea.
 
 ```js
 // Text input

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -3,8 +3,7 @@ id: input
 title: "Input"
 ---
 
-<!-- TOC -->
-
+Run tests on HTML Input elements such as text inputs, checkboxes, radio buttons, select options, mouse clicks, type characters, keys and shortcuts as well as upload files and focus elements.
 ## Text input
 
 This is the easiest way to fill out the form fields. It focuses the element and triggers an `input` event with the entered text. It works for `<input>`, `<textarea>`, `[contenteditable]` and `<label>` associated with an input or textarea.
@@ -94,13 +93,12 @@ await page.Locator("#local").FillAsync("2020-03-02T05:15");
 await page.Locator("text=First Name").FillAsync("Peter");
 ```
 
-### API reference
+#### API reference
 
 - [`method: Locator.fill`]
 - [`method: Page.fill`]
 - [`method: Frame.fill`]
 
-<br/>
 
 ## Checkboxes and radio buttons
 
@@ -176,7 +174,7 @@ await page.Locator("#subscribe-label").UncheckAsync();
 await page.Locator("text=XL").CheckAsync();
 ```
 
-### API reference
+#### API reference
 
 - [`method: Locator.check`]
 - [`method: Locator.isChecked`]
@@ -184,8 +182,6 @@ await page.Locator("text=XL").CheckAsync();
 - [`method: Page.check`]
 - [`method: Page.isChecked`]
 - [`method: Page.uncheck`]
-
-<br/>
 
 ## Select options
 
@@ -247,13 +243,11 @@ await page.Locator("select#colors").SelectOptionAsync(new SelectOptionValue { La
 await page.Locator("select#colors").SelectOptionAsync(new[] { "blue", "green", "red" });
 ```
 
-### API reference
+#### API reference
 
 - [`method: Locator.selectOption`]
 - [`method: Page.selectOption`]
 - [`method: Frame.selectOption`]
-
-<br/>
 
 ## Mouse click
 
@@ -415,8 +409,7 @@ page.locator('button#submit').dispatch_event('click')
 ```csharp
 await page.Locator("button#submit").DispatchEventAsync("click");
 ```
-
-### API reference
+#### API reference
 
 - [`method: Locator.click`]
 - [`method: Page.click`]
@@ -431,7 +424,6 @@ await page.Locator("button#submit").DispatchEventAsync("click");
 - [`method: Page.dispatchEvent`]
 - [`method: Frame.dispatchEvent`]
 
-<br/>
 
 ## Type characters
 
@@ -468,14 +460,12 @@ This method will emit all the necessary keyboard events, with all the `keydown`,
 Most of the time, [`method: Page.fill`] will just work. You only need to type characters if there is special keyboard handling on the page.
 :::
 
-### API reference
+#### API reference
 
 - [`method: Locator.type`]
 - [`method: Page.type`]
 - [`method: Frame.type`]
 - [`method: Keyboard.type`]
-
-<br/>
 
 ## Keys and shortcuts
 
@@ -594,14 +584,12 @@ Shortcuts such as `"Control+o"` or `"Control+Shift+T"` are supported as well. Wh
 Note that you still need to specify the capital `A` in `Shift-A` to produce the capital character. `Shift-a` produces a lower-case one as if you had the `CapsLock` toggled.
 
 
-### API reference
+#### API reference
 
 - [`method: Locator.press`]
 - [`method: Page.press`]
 - [`method: Frame.press`]
 - [`method: Keyboard.press`]
-
-<br/>
 
 ## Upload files
 
@@ -738,13 +726,12 @@ var fileChooser = page.RunAndWaitForFileChooserAsync(async () =>
 await fileChooser.SetFilesAsync("myfile.pdf");
 ```
 
-### API reference
+#### API reference
+
 - [FileChooser]
 - [`method: Locator.setInputFiles`]
 - [`method: Page.setInputFiles`]
 - [`method: Frame.setInputFiles`]
-
-<br/>
 
 ## Focus element
 
@@ -770,9 +757,8 @@ page.locator('input#name').focus()
 await page.Locator("input#name").FocusAsync();
 ```
 
-### API reference
+#### API reference
 
 - [`method: Locator.focus`]
 - [`method: Page.focus`]
 - [`method: Frame.focus`]
-<br/>

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -720,7 +720,7 @@ await fileChooser.SetFilesAsync("myfile.pdf");
 
 ## Focus element
 
-For the dynamic pages that handle focus events, you can focus the given element.
+For the dynamic pages that handle focus events, you can focus the given element with [`method: Locator.focus`].
 
 ```js
 await page.locator('input#name').focus();

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -3,7 +3,7 @@ id: input
 title: "Input"
 ---
 
-Run tests on HTML Input elements such as text inputs, checkboxes, radio buttons, select options, mouse clicks, type characters, keys and shortcuts as well as upload files and focus elements.
+Playwright can interact with HTML Input elements such as text inputs, checkboxes, radio buttons, select options, mouse clicks, type characters, keys and shortcuts as well as upload files and focus elements.
 ## Text input
 
 This is the easiest way to fill out the form fields. It focuses the element and triggers an `input` event with the entered text. It works for `<input>`, `<textarea>`, `[contenteditable]` and `<label>` associated with an input or textarea.

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -593,7 +593,7 @@ Note that you still need to specify the capital `A` in `Shift-A` to produce the 
 
 ## Upload files
 
-You can select input files for upload using the [`method: Page.setInputFiles`] method. It expects first argument to point to an [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) with the type `"file"`. Multiple files can be passed in the array. If some of the file paths are relative, they are resolved relative to the current working directory. Empty array clears the selected files.
+You can select input files for upload using the [`method: Locator.setInputFiles`] method. It expects first argument to point to an [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) with the type `"file"`. Multiple files can be passed in the array. If some of the file paths are relative, they are resolved relative to the current working directory. Empty array clears the selected files.
 
 ```js
 // Select one file

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -1,6 +1,6 @@
 ---
 id: input
-title: "Input"
+title: "Performing actions"
 ---
 
 Playwright can interact with HTML Input elements such as text inputs, checkboxes, radio buttons, select options, mouse clicks, type characters, keys and shortcuts as well as upload files and focus elements.
@@ -93,16 +93,9 @@ await page.Locator("#local").FillAsync("2020-03-02T05:15");
 await page.Locator("text=First Name").FillAsync("Peter");
 ```
 
-#### API reference
-
-- [`method: Locator.fill`]
-- [`method: Page.fill`]
-- [`method: Frame.fill`]
-
-
 ## Checkboxes and radio buttons
 
-This is the easiest way to check and uncheck a checkbox or a radio button. This method can be used with `input[type=checkbox]`, `input[type=radio]`, `[role=checkbox]` or `label` associated with checkbox or radio button.
+Using [method: Locator.setChecked] is the easiest way to check and uncheck a checkbox or a radio button. This method can be used with `input[type=checkbox]`, `input[type=radio]`, `[role=checkbox]` or `label` associated with checkbox or radio button.
 
 ```js
 // Check the checkbox
@@ -173,15 +166,6 @@ await page.Locator("#subscribe-label").UncheckAsync();
 // Select the radio button
 await page.Locator("text=XL").CheckAsync();
 ```
-
-#### API reference
-
-- [`method: Locator.check`]
-- [`method: Locator.isChecked`]
-- [`method: Locator.uncheck`]
-- [`method: Page.check`]
-- [`method: Page.isChecked`]
-- [`method: Page.uncheck`]
 
 ## Select options
 
@@ -388,7 +372,7 @@ await page.Locator("button#submit").ClickAsync(new() { Force = true });
 
 #### Programmatic click
 
-If you are not interested in testing your app under the real conditions and want to simulate the click by any means possible, you can trigger the [`HTMLElement.click()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click) behavior via simply dispatching a click event on the element:
+If you are not interested in testing your app under the real conditions and want to simulate the click by any means possible, you can trigger the [`HTMLElement.click()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click) behavior via simply dispatching a click event on the element with [method: Locator.dispatchEvent]:
 
 ```js
 await page.locator('button#submit').dispatchEvent('click');
@@ -427,7 +411,7 @@ await page.Locator("button#submit").DispatchEventAsync("click");
 
 ## Type characters
 
-Type into the field character by character, as if it was a user with a real keyboard.
+Type into the field character by character, as if it was a user with a real keyboard with [method: Locator.type].
 
 ```js
 // Type character by character
@@ -524,7 +508,7 @@ await page.Locator("#name").PressAsync("Control+ArrowRight");
 await page.Locator("#value").PressAsync("$");
 ```
 
-This method focuses the selected element and produces a single keystroke. It accepts the logical key names that are emitted in the [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) property of the keyboard events:
+The [method: Locator.press] method focuses the selected element and produces a single keystroke. It accepts the logical key names that are emitted in the [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) property of the keyboard events:
 
 ```
 Backquote, Minus, Equal, Backslash, Backspace, Tab, Delete, Escape,


### PR DESCRIPTION
api list is too long here. we need to decide if we can remove it all together or have one link under each section rather than a list of 12 links under a section. thoughts?

<img width="1100" alt="Screenshot 2022-09-05 at 19 43 38" src="https://user-images.githubusercontent.com/13063165/188496730-6d6b41c4-042a-4b8d-96e7-5afd24c1fa20.png">
