### PR TITLE
fix: avoid using builtins in injected script bundles

### DIFF
--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -662,3 +662,21 @@ it('should throw when frame is detached', async ({ page, server }) => {
   expect(error).toBeTruthy();
   expect(error.message).toMatch(/frame.evaluate: (Frame was detached|Execution context was destroyed)/);
 });
+
+it('should work with overridden Object.defineProperty', async ({ page, server }) => {
+  server.setRoute('/test', (req, res) => {
+    res.writeHead(200, {
+      'content-type': 'text/html',
+    });
+    res.end(`<script>
+    Object.create = null;
+    Object.defineProperty = null;
+    Object.getOwnPropertyDescriptor = null;
+    Object.getOwnPropertyNames = null;
+    Object.getPrototypeOf = null;
+    Object.prototype.hasOwnProperty = null;
+    </script>`);
+  });
+  await page.goto(server.PREFIX + '/test');
+  expect(await page.evaluate('1+2')).toBe(3);
+});

--- a/utils/generate_injected.js
+++ b/utils/generate_injected.js
@@ -29,6 +29,40 @@ const injectedScripts = [
   path.join(ROOT, 'packages', 'playwright-core', 'src', 'server', 'injected', 'recorder.ts'),
 ];
 
+const modulePrefix = `"use strict";
+let __export = (target, all) => {
+  for (var name in all)
+    target[name] = all[name];
+};
+let __commonJS = cb => function __require() {
+  let fn;
+  for (const name in cb) {
+    fn = cb[name];
+    break;
+  }
+  const exports = {};
+  fn(exports);
+  return exports;
+};
+let __toESM = mod => ({ ...mod, 'default': mod });
+let __toCommonJS = mod =>  ({ ...mod, __esModule: true });
+`;
+
+async function replaceEsbuildHeader(content, outFileJs) {
+  const sourcesStart = content.indexOf('// packages/playwright-core/src/server');
+  if (sourcesStart === -1)
+    throw new Error(`Did not find start of bundled code in ${outFileJs}`);
+
+  const preambule = content.substring(0, sourcesStart);
+  // Replace standard esbuild definition with our own which do not depend on builtins.
+  // See https://github.com/microsoft/playwright/issues/17029
+  if (preambule.indexOf('__toESM') !== -1 || preambule.indexOf('__toCommonJS') !== -1) {
+    content = modulePrefix + content.substring(sourcesStart);
+    await fs.promises.writeFile(outFileJs, content);
+  }
+  return content;
+}
+
 (async () => {
   const generatedFolder = path.join(ROOT, 'packages', 'playwright-core', 'src', 'generated');
   await fs.promises.mkdir(generatedFolder, { recursive: true });
@@ -43,7 +77,9 @@ const injectedScripts = [
       target: 'ES2019'
     });
     const baseName = path.basename(injected);
-    const content = await fs.promises.readFile(path.join(outdir, baseName.replace('.ts', '.js')), 'utf-8');
+    const outFileJs = path.join(outdir, baseName.replace('.ts', '.js'));
+    let content = await fs.promises.readFile(outFileJs, 'utf-8');
+    content = await replaceEsbuildHeader(content, outFileJs);
     const newContent = `export const source = ${JSON.stringify(content)};`;
     await fs.promises.writeFile(path.join(generatedFolder, baseName.replace('.ts', 'Source.ts')), newContent);
   }


### PR DESCRIPTION
The build script will replace the following standard esbuild header:
```js
"use strict";
var __create = Object.create;
var __defProp = Object.defineProperty;
var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
var __getOwnPropNames = Object.getOwnPropertyNames;
var __getProtoOf = Object.getPrototypeOf;
var __hasOwnProp = Object.prototype.hasOwnProperty;
var __commonJS = (cb, mod) => function __require() {
  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
};
var __export = (target, all) => {
  for (var name in all)
    __defProp(target, name, { get: all[name], enumerable: true });
};
var __copyProps = (to, from, except, desc) => {
  if (from && typeof from === "object" || typeof from === "function") {
    for (let key of __getOwnPropNames(from))
      if (!__hasOwnProp.call(to, key) && key !== except)
        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
  }
  return to;
};
var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target, mod));
var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);

// packages/playwright-core/src/server/isomorphic/cssTokenizer.js
...
```

with our custom one:
```js
"use strict";
let __export = (target, all) => {
  for (var name in all)
    target[name] = all[name];
};
let __commonJS = cb => function __require() {
  let fn;
  for (const name in cb) {
    fn = cb[name];
    break;
  }
  const exports = {};
  fn(exports);
  return exports;
};
let __toESM = mod => ({ ...mod, 'default': mod });
let __toCommonJS = mod =>  ({ ...mod, __esModule: true });
// packages/playwright-core/src/server/isomorphic/cssTokenizer.js
...
```

We'd rather disable generation of such esm/cjs support but it's [not currently possible](https://cs.github.com/evanw/esbuild/blob/41c45af627cd72e86e6389434547d3d9a15b4ab2/internal/bundler/bundler.go#L2351) with esbuild.

Fixes https://github.com/microsoft/playwright/issues/17029