### PR TITLE
chore: Fix README link

### DIFF
--- a/packages/playwright-core/bin/README.md
+++ b/packages/playwright-core/bin/README.md
@@ -1,2 +1,2 @@
-See building instructions at [`//browser_patches/winldd/README.md`](../browser_patches/winldd/README.md)
+See building instructions at [`/browser_patches/winldd/README.md`](../../../browser_patches/winldd/README.md)
 


### PR DESCRIPTION
While I was reading through some docs on Playwright's browser patches, I noticed there's a broken link in the `playwright-core/bin` package - pretty simple update here to fix that!