### PR TITLE
chore: improve browser download failure message

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -748,7 +748,7 @@ export class Registry {
 
     const downloadFileName = `playwright-download-${descriptor.name}-${hostPlatform}-${descriptor.revision}.zip`;
     await downloadBrowserWithProgressBar(title, descriptor.dir, executablePath, downloadURLs, downloadFileName).catch(e => {
-      throw new Error(`Failed to download ${title}, caused by\n${e.stack}`);
+      throw new Error(`Failed to download ${title}, caused by\n${e.stack}\nIf this persists, please check here for a possible outage: https://azure.status.microsoft/en-us/status`);
     });
     await fs.promises.writeFile(markerFilePath(descriptor.dir), '');
   }


### PR DESCRIPTION
I realize that this is an unsolicited PR and maybe you would want to use a different URL but given that this happens [here and there](https://github.com/microsoft/playwright/issues/14790), I thought I would just go for it.
At least I would assume that the outage scenario is the most likely and so I think it would be great to give users this hint instead of making them search the GitHub issues. 😅 

Related to: https://github.com/microsoft/playwright/issues/14790