### PR TITLE
chore: drop adm-zip from dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "@typescript-eslint/parser": "^5.10.2",
         "@vitejs/plugin-react": "^1.3.2",
         "@zip.js/zip.js": "^2.4.2",
-        "adm-zip": "^0.5.9",
         "ansi-to-html": "^0.7.2",
         "chokidar": "^3.5.3",
         "colors": "^1.4.0",
@@ -1922,14 +1921,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/adm-zip": {
-      "version": "0.5.9",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/ajv": {
@@ -9627,10 +9618,6 @@
       "version": "5.3.2",
       "dev": true,
       "requires": {}
-    },
-    "adm-zip": {
-      "version": "0.5.9",
-      "dev": true
     },
     "ajv": {
       "version": "6.12.6",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@typescript-eslint/parser": "^5.10.2",
     "@vitejs/plugin-react": "^1.3.2",
     "@zip.js/zip.js": "^2.4.2",
-    "adm-zip": "^0.5.9",
     "ansi-to-html": "^0.7.2",
     "chokidar": "^3.5.3",
     "colors": "^1.4.0",


### PR DESCRIPTION
This was used in the `repack-juggler`.
