### PR TITLE
docs: fix broken docslint

### DIFF
--- a/docs/src/events.md
+++ b/docs/src/events.md
@@ -51,7 +51,7 @@ var request = await waitForRequestTask;
 Console.WriteLine(request.Url);
 ```
 
-Wait for popup window using [`method: Page.waitForEvent`]:
+Wait for popup window:
 
 ```js
 // Note that Promise.all prevents a race condition


### PR DESCRIPTION
Reverts back to https://github.com/microsoft/playwright/commit/b13bedba57781217dbefc6012f861096ec55a909#diff-1a2de98f503e0d927be76e1662b707c98acd4d7de42d72da16d2a884090f3e19R54.

Broken docslint since https://github.com/microsoft/playwright/commit/2a5acfac97b0b453369e8c663906da3eee4044f0.

since there is no waitForEvent in Java/Python/.NET we can't use it. and waitForPopup is no thing in Java.