### PR TITLE
devops: upload reports to a new container

### DIFF
--- a/utils/upload_flakiness_dashboard.sh
+++ b/utils/upload_flakiness_dashboard.sh
@@ -91,5 +91,6 @@ node -e "${EMBED_METADATA_SCRIPT}" "$1" > "${REPORT_NAME}"
 gzip "${REPORT_NAME}"
 
 az storage blob upload --connection-string "${FLAKINESS_CONNECTION_STRING}" -c uploads -f "${REPORT_NAME}.gz" -n "${REPORT_NAME}.gz"
+az storage blob upload --connection-string "${FLAKINESS_CONNECTION_STRING}" -c uploads-permanent -f "${REPORT_NAME}.gz" -n "${REPORT_NAME}.gz"
 rm -rf "${REPORT_NAME}.gz"
 

--- a/utils/upload_flakiness_dashboard.sh
+++ b/utils/upload_flakiness_dashboard.sh
@@ -80,6 +80,7 @@ EMBED_METADATA_SCRIPT=$(cat <<EOF
     commitTitle: process.env.COMMIT_TITLE,
     commitAuthorName: process.env.COMMIT_AUTHOR_NAME,
     commitAuthorEmail: process.env.COMMIT_AUTHOR_EMAIL,
+    gitBranchName: process.env.GITHUB_REF_NAME,
   };
   console.log(JSON.stringify(json));
 EOF
@@ -91,6 +92,13 @@ node -e "${EMBED_METADATA_SCRIPT}" "$1" > "${REPORT_NAME}"
 gzip "${REPORT_NAME}"
 
 az storage blob upload --connection-string "${FLAKINESS_CONNECTION_STRING}" -c uploads -f "${REPORT_NAME}.gz" -n "${REPORT_NAME}.gz"
-az storage blob upload --connection-string "${FLAKINESS_CONNECTION_STRING}" -c uploads-permanent -f "${REPORT_NAME}.gz" -n "${REPORT_NAME}.gz"
+
+UTC_DATE=$(cat <<EOF | node
+  const date = new Date();
+  console.log([date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()].join('-'));
+EOF
+)
+
+az storage blob upload --connection-string "${FLAKINESS_CONNECTION_STRING}" -c uploads-permanent -f "${REPORT_NAME}.gz" -n "${UTC_DATE}-${REPORT_NAME}.gz"
 rm -rf "${REPORT_NAME}.gz"
 


### PR DESCRIPTION
This patch:
- adds `gitBranchName` to the infra metadata to the report
- starts uploading persistent reports to a different container, prefixed with utc year-month-date.