### PR TITLE
chery-pick(#17288): fix: make evaluate work with overridden Window/Document/Node

### DIFF
--- a/packages/playwright-core/src/server/isomorphic/utilityScriptSerializers.ts
+++ b/packages/playwright-core/src/server/isomorphic/utilityScriptSerializers.ts
@@ -107,11 +107,11 @@ export function source() {
 
   function serialize(value: any, handleSerializer: (value: any) => HandleOrValue, visitorInfo: VisitorInfo): SerializedValue {
     if (value && typeof value === 'object') {
-      if (globalThis.Window && value instanceof globalThis.Window)
+      if (typeof globalThis.Window === 'function' && value instanceof globalThis.Window)
         return 'ref: <Window>';
-      if (globalThis.Document && value instanceof globalThis.Document)
+      if (typeof globalThis.Document === 'function' && value instanceof globalThis.Document)
         return 'ref: <Document>';
-      if (globalThis.Node && value instanceof globalThis.Node)
+      if (typeof globalThis.Node === 'function' && value instanceof globalThis.Node)
         return 'ref: <Node>';
     }
     return innerSerialize(value, handleSerializer, visitorInfo);

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -680,3 +680,25 @@ it('should work with overridden Object.defineProperty', async ({ page, server })
   await page.goto(server.PREFIX + '/test');
   expect(await page.evaluate('1+2')).toBe(3);
 });
+
+it('should work with overridden globalThis.Window/Document/Node', async ({ page, server }) => {
+  const testCases = [
+    // @ts-ignore
+    () => globalThis.Window = {},
+    // @ts-ignore
+    () => globalThis.Document = {},
+    // @ts-ignore
+    () => globalThis.Node = {},
+    () => globalThis.Window = null,
+    () => globalThis.Document = null,
+    () => globalThis.Node = null,
+  ];
+  for (const testCase of testCases) {
+    await it.step(testCase.toString(), async () => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(testCase);
+      expect(await page.evaluate('1+2')).toBe(3);
+      expect(await page.evaluate(() => ['foo'])).toEqual(['foo']);
+    });
+  }
+});


### PR DESCRIPTION
This PR cherry-picks the following commits:

- 00a3b1b0a22a1ca29b4bb0ea218b5871748bde43