### PR TITLE
fix(docker): do not pollute stdout when used with JSON reporter

### DIFF
--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -100,9 +100,8 @@ function addTestCommand(program: Command, isDocker: boolean) {
   command.option('-x', `Stop after the first failure`);
   command.action(async (args, opts) => {
     try {
-      isDocker = isDocker || !!process.env.PLAYWRIGHT_DOCKER;
-      if (isDocker && !process.env.PW_TS_ESM_ON)
-        await docker.configureTestRunnerToUseDocker();
+      if (isDocker)
+        process.env.PLAYWRIGHT_DOCKER = '1';
       await runTests(args, opts);
     } catch (e) {
       console.error(e);

--- a/packages/playwright-test/src/docker/docker.ts
+++ b/packages/playwright-test/src/docker/docker.ts
@@ -22,6 +22,8 @@ import { spawnAsync } from 'playwright-core/lib/utils/spawnAsync';
 import * as utils from 'playwright-core/lib/utils';
 import { getPlaywrightVersion } from 'playwright-core/lib/common/userAgent';
 import * as dockerApi from './dockerApi';
+import { addRunnerPlugin } from '../plugins';
+import type { FullConfig, Reporter, Suite } from '../../types/testReporter';
 
 const VRT_IMAGE_DISTRO = 'focal';
 const VRT_IMAGE_NAME = `playwright:local-${getPlaywrightVersion()}-${VRT_IMAGE_DISTRO}`;
@@ -129,25 +131,32 @@ export async function buildPlaywrightImage() {
 }
 
 export async function configureTestRunnerToUseDocker() {
-  console.log(colors.dim('Using docker container to run browsers.'));
-  await checkDockerEngineIsRunningOrDie();
-  let info = await containerInfo();
-  if (!info) {
-    process.stdout.write(colors.dim(`Starting docker container... `));
-    const time = Date.now();
-    info = await ensurePlaywrightContainerOrDie();
-    const deltaMs = (Date.now() - time);
-    console.log(colors.dim('Done in ' + (deltaMs / 1000).toFixed(1) + 's'));
-    console.log(colors.dim('The Docker container will keep running after tests finished.'));
-    console.log(colors.dim('Stop manually using:'));
-    console.log(colors.dim('    npx playwright docker stop'));
-  }
-  console.log(colors.dim(`View screen: ${info.vncSession}`));
-  process.env.PW_TEST_CONNECT_WS_ENDPOINT = info.wsEndpoint;
-  process.env.PW_TEST_CONNECT_HEADERS = JSON.stringify({
-    'x-playwright-proxy': '*',
-  });
-  process.env.PLAYWRIGHT_DOCKER = '1';
+  addRunnerPlugin(() => ({
+    async setup(config: FullConfig, configDir: string, rootSuite: Suite, reporter: Reporter) {
+      const print = (text: string) => reporter.onStdOut?.(text);
+      const println = (text: string) => reporter.onStdOut?.(text + '\n');
+
+      println(colors.dim('Using docker container to run browsers.'));
+      await checkDockerEngineIsRunningOrDie();
+      let info = await containerInfo();
+      if (!info) {
+        print(colors.dim(`Starting docker container... `));
+        const time = Date.now();
+        info = await ensurePlaywrightContainerOrDie();
+        const deltaMs = (Date.now() - time);
+        println(colors.dim('Done in ' + (deltaMs / 1000).toFixed(1) + 's'));
+        println(colors.dim('The Docker container will keep running after tests finished.'));
+        println(colors.dim('Stop manually using:'));
+        println(colors.dim('    npx playwright docker stop'));
+      }
+      println(colors.dim(`View screen: ${info.vncSession}`));
+      process.env.PW_TEST_CONNECT_WS_ENDPOINT = info.wsEndpoint;
+      process.env.PW_TEST_CONNECT_HEADERS = JSON.stringify({
+        'x-playwright-proxy': '*',
+      });
+      process.env.PLAYWRIGHT_DOCKER = '1';
+    },
+  }));
 }
 
 

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -44,6 +44,7 @@ import { SigIntWatcher } from './sigIntWatcher';
 import type { TestRunnerPlugin } from './plugins';
 import { setRunnerToAddPluginsTo } from './plugins';
 import { webServerPluginsForConfig } from './plugins/webServerPlugin';
+import { dockerPlugin } from './docker/docker';
 import { MultiMap } from 'playwright-core/lib/utils/multimap';
 
 const removeFolderAsync = promisify(rimraf);
@@ -604,6 +605,9 @@ export class Runner {
 
     // Legacy webServer support.
     this._plugins.push(...webServerPluginsForConfig(config));
+
+    // Docker support.
+    this._plugins.push(dockerPlugin);
 
     await this._runAndReportError(async () => {
       // First run the plugins, if plugin is a web server we want it to run before the

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -603,14 +603,14 @@ export class Runner {
     };
 
     // Legacy webServer support.
-    this._plugins.push(...webServerPluginsForConfig(config, this._reporter));
+    this._plugins.push(...webServerPluginsForConfig(config));
 
     await this._runAndReportError(async () => {
       // First run the plugins, if plugin is a web server we want it to run before the
       // config's global setup.
       for (const plugin of this._plugins) {
         await Promise.race([
-          plugin.setup?.(config, config._configDir, rootSuite),
+          plugin.setup?.(config, config._configDir, rootSuite, this._reporter),
           sigintWatcher.promise(),
         ]);
         if (sigintWatcher.hadSignal())


### PR DESCRIPTION
This patch moves parts of docker configuration to a plugin so that
it can rely on repoter for stdout.

Drive-by: provide all plugins with reporter in the `setup` callback.
