### PR TITLE
Revert "chore(generator): use new .NET test attributes (#17172)"

### DIFF
--- a/docs/src/api-testing-csharp.md
+++ b/docs/src/api-testing-csharp.md
@@ -100,7 +100,7 @@ public class TestGitHubAPI : PlaywrightTest
 
     private IAPIRequestContext Request = null;
 
-    [PlaywrightTest]
+    [Test]
     public async Task ShouldCreateBugReport()
     {
         var data = new Dictionary<string, string>();
@@ -127,7 +127,7 @@ public class TestGitHubAPI : PlaywrightTest
         Assert.AreEqual("Bug description", issue?.GetProperty("body").GetString());
     }
 
-    [PlaywrightTest]
+    [Test]
     public async Task ShouldCreateFeatureRequests()
     {
         var data = new Dictionary<string, string>();
@@ -224,7 +224,7 @@ public class TestGitHubAPI : PlaywrightTest
 
     private IAPIRequestContext Request = null;
 
-    [PlaywrightTest]
+    [Test]
     public async Task ShouldCreateBugReport()
     {
         var data = new Dictionary<string, string>();
@@ -251,7 +251,7 @@ public class TestGitHubAPI : PlaywrightTest
         Assert.AreEqual("Bug description", issue?.GetProperty("body").GetString());
     }
 
-    [PlaywrightTest]
+    [Test]
     public async Task ShouldCreateFeatureRequests()
     {
         var data = new Dictionary<string, string>();
@@ -337,7 +337,7 @@ The following test creates a new issue via API and then navigates to the list of
 project to check that it appears at the top of the list. The check is performed using [LocatorAssertions].
 
 ```csharp
-  [PlaywrightTest]
+  [Test]
   public async Task LastCreatedIssueShouldBeFirstInTheList()
   {
       var data = new Dictionary<string, string>();
@@ -360,7 +360,7 @@ The following test creates a new issue via user interface in the browser and the
 it was created:
 
 ```csharp
-  [PlaywrightTest]
+  [Test]
   public async Task LastCreatedIssueShouldBeOnTheServer()
   {
       await Page.GotoAsync("https://github.com/" + USER + "/" + REPO + "/issues");

--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -57,7 +57,7 @@ namespace PlaywrightTests;
 [TestFixture]
 public class ExampleTests : PageTest
 {
-    [PlaywrightTest]
+    [Test]
     public async Task StatusBecomesSubmitted()
     {
         // ..

--- a/docs/src/api/class-pageassertions.md
+++ b/docs/src/api/class-pageassertions.md
@@ -59,7 +59,7 @@ namespace PlaywrightTests;
 [TestFixture]
 public class ExampleTests : PageTest
 {
-    [PlaywrightTest]
+    [Test]
     public async Task NavigatetoLoginPage()
     {
         // ..

--- a/docs/src/api/class-playwrightassertions.md
+++ b/docs/src/api/class-playwrightassertions.md
@@ -58,7 +58,7 @@ namespace PlaywrightTests;
 [TestFixture]
 public class ExampleTests : PageTest
 {
-    [PlaywrightTest]
+    [Test]
     public async Task StatusBecomesSubmitted()
     {
         await Page.Locator("#submit-button").ClickAsync();

--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -101,7 +101,7 @@ namespace PlaywrightTests;
 [TestFixture]
 public class Tests : PageTest
 {
-    [PlaywrightTest]
+    [Test]
     public async Task HomepageHasPlaywrightInTitleAndGetStartedLinkLinkingtoTheIntroPage()
     {
         await Page.GotoAsync("https://playwright.dev");
@@ -136,7 +136,7 @@ namespace PlaywrightTests;
 [TestClass]
 public class UnitTest1 : PageTest
 {
-    [PlaywrightTestMethod]
+    [TestMethod]
     public async Task HomepageHasPlaywrightInTitleAndGetStartedLinkLinkingtoTheIntroPage()
     {
         await Page.GotoAsync("https://playwright.dev");

--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -263,7 +263,7 @@ namespace PlaywrightTests;
 [TestFixture]
 public class ExampleTests : PageTest
 {
-    [PlaywrightTest]
+    [Test]
     public async Task StatusBecomesSubmitted()
     {
         await Expect(Page.Locator(".status")).ToHaveTextAsync("Submitted");

--- a/docs/src/test-runners-csharp.md
+++ b/docs/src/test-runners-csharp.md
@@ -44,14 +44,14 @@ namespace PlaywrightTests;
 [TestFixture]
 public class MyTest : PageTest
 {
-    [PlaywrightTest]
+    [Test]
     public async Task ShouldHaveTheCorrectSlogan()
     {
         await Page.GotoAsync("https://playwright.dev");
         await Expect(Page.Locator("text=enables reliable end-to-end testing for modern web apps")).ToBeVisibleAsync();
     }
 
-    [PlaywrightTest]
+    [Test]
     public async Task ShouldHaveTheCorrectTitle()
     {
         await Page.GotoAsync("https://playwright.dev");
@@ -125,7 +125,7 @@ namespace PlaywrightTests;
 [TestFixture]
 public class MyTest : PageTest
 {
-    [PlaywrightTest]
+    [Test]
     public async Task TestWithCustomContextOptions()
     {
         // The following Page (and BrowserContext) instance has the custom colorScheme, viewport and baseURL set:
@@ -217,10 +217,6 @@ There are a few base classes available to you in `Microsoft.Playwright.NUnit` na
 |BrowserTest   |Each test will get a browser and can create as many contexts as it likes. Each test is responsible for cleaning up all the contexts it created.|
 |PlaywrightTest|This gives each test a Playwright object so that the test could start and stop as many browsers as it likes.|
 
-### 'No test is available'
-
-You need to add `[TestFixture]` to your test class. NUnit does not discover tests without it, if the `TestAttribute` comes from a different assembly.
-
 ## MSTest
 
 Playwright provides base classes to write tests with MSTest via the [`Microsoft.Playwright.MSTest`](https://www.nuget.org/packages/Microsoft.Playwright.MSTest) package.
@@ -250,14 +246,14 @@ namespace PlaywrightTests;
 [TestClass]
 public class UnitTest1: PageTest
 {
-    [PlaywrightTestMethod]
+    [TestMethod]
     public async Task ShouldHaveTheCorrectSlogan()
     {
         await Page.GotoAsync("https://playwright.dev");
         await Expect(Page.Locator("text=enables reliable end-to-end testing for modern web apps")).ToBeVisibleAsync();
     }
 
-    [PlaywrightTestMethod]
+    [TestMethod]
     public async Task ShouldHaveTheCorrectTitle()
     {
         await Page.GotoAsync("https://playwright.dev");
@@ -335,7 +331,7 @@ namespace PlaywrightTests;
 [TestClass]
 public class UnitTest1 : PageTest
 {
-    [PlaywrightTestMethod]
+    [TestMethod]
     public async Task TestWithCustomContextOptions()
     {
         // The following Page (and BrowserContext) instance has the custom colorScheme, viewport and baseURL set:

--- a/docs/src/writing-tests-csharp.md
+++ b/docs/src/writing-tests-csharp.md
@@ -27,7 +27,7 @@ namespace PlaywrightTests;
 [TestFixture]
 public class Tests : PageTest
 {
-    [PlaywrightTest]
+    [Test]
     public async Task HomepageHasPlaywrightInTitleAndGetStartedLinkLinkingtoTheIntroPage()
     {
         await Page.GotoAsync("https://playwright.dev");
@@ -62,7 +62,7 @@ namespace PlaywrightTests;
 [TestClass]
 public class UnitTest1 : PageTest
 {
-    [PlaywrightTestMethod]
+    [TestMethod]
     public async Task HomepageHasPlaywrightInTitleAndGetStartedLinkLinkingtoTheIntroPage()
     {
         await Page.GotoAsync("https://playwright.dev");
@@ -140,7 +140,7 @@ namespace PlaywrightTests;
 [TestFixture]
 public class Tests : PageTest
 {
-    [PlaywrightTest]
+    [Test]
     public async Task BasicTest()
     {
         await Page.GotoAsync("https://playwright.dev");
@@ -159,7 +159,7 @@ namespace PlaywrightTests;
 [TestClass]
 public class UnitTest1 : PageTest
 {
-    [PlaywrightTestMethod]
+    [TestMethod]
     public async Task BasicTest()
     {
         await Page.GotoAsync("https://playwright.dev");
@@ -195,7 +195,7 @@ namespace PlaywrightTests;
 [TestFixture]
 public class Tests : PageTest
 {
-    [PlaywrightTest]
+    [Test]
     public async Task MainNavigation()
     {
         // Assertions use the expect API.
@@ -221,7 +221,7 @@ namespace PlaywrightTests;
 [TestClass]
 public class UnitTest1 : PageTest
 {
-    [PlaywrightTestMethod]
+    [TestMethod]
     public async Task MainNavigation()
     {
         // Assertions use the expect API.

--- a/packages/playwright-core/src/server/recorder/csharp.ts
+++ b/packages/playwright-core/src/server/recorder/csharp.ts
@@ -207,7 +207,7 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
       }`);
       formatter.newLine();
     }
-    formatter.add(`    [${this._mode === 'nunit' ? 'PlaywrightTest' : 'PlaywrightTestMethod'}]
+    formatter.add(`    [${this._mode === 'nunit' ? 'Test' : 'TestMethod'}]
     public async Task MyTest()
     {`);
     return formatter.format();

--- a/tests/library/inspector/cli-codegen-csharp.spec.ts
+++ b/tests/library/inspector/cli-codegen-csharp.spec.ts
@@ -232,7 +232,7 @@ public class Tests : PageTest
         };
     }
 
-    [PlaywrightTestMethod]
+    [TestMethod]
     public async Task MyTest()
     {
         // Go to ${emptyHTML}
@@ -261,7 +261,7 @@ public class Tests : PageTest
         };
     }
 
-    [PlaywrightTest]
+    [Test]
     public async Task MyTest()
     {
         // Go to ${emptyHTML}


### PR DESCRIPTION
This reverts commit 15add13a6a97aad87569fa02818b525d2c195987.

We are not ready yet in shipping this feature.