### PR TITLE
chore(docker): address docker offline comments

### DIFF
--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -179,12 +179,7 @@ Docker integration usage:
     npx playwright docker start
     ```
 
-1. Run tests inside Docker container using the `PLAYWRIGHT_DOCKER` environment variable:
-
-    ```bash js
-    PLAYWRIGHT_DOCKER=1 npx playwright test
-    ```
-
+1. Run tests inside Docker container using the `PLAYWRIGHT_DOCKER` environment variable.
    You can set this environment variable as a part of your config:
 
     ```ts
@@ -199,7 +194,8 @@ Docker integration usage:
     export default config;
     ```
 
-   NOTE: this command will detect running Docker container, and auto-launch it if needed.
+   NOTE: Running tests with `PLAYWRIGHT_DOCKER` environment variable will detect pre-launched
+   Docker container, and auto-launch it if there's no running one.
 
 1. Finally, stop background Docker container when you're done working with tests:
 

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -194,8 +194,7 @@ Docker integration usage:
     export default config;
     ```
 
-   NOTE: Running tests with `PLAYWRIGHT_DOCKER` environment variable will detect pre-launched
-   Docker container, and auto-launch it if there's no running one.
+   NOTE: Playwright will automatically detect a running Docker container or start it if needed.
 
 1. Finally, stop background Docker container when you're done working with tests:
 

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -179,14 +179,27 @@ Docker integration usage:
     npx playwright docker start
     ```
 
-1. Run tests inside Docker container. Note that this command accepts all the same arguments
-   as a regular `npx playwright test` command.
+1. Run tests inside Docker container using the `PLAYWRIGHT_DOCKER` environment variable:
 
     ```bash js
-    npx playwright docker test
+    PLAYWRIGHT_DOCKER=1 npx playwright test
     ```
 
-   Note that this command will detect running Docker container, and auto-launch it if needed.
+   You can set this environment variable as a part of your config:
+
+    ```ts
+    // playwright.config.ts
+    import type { PlaywrightTestConfig } from '@playwright/test';
+
+    process.env.PLAYWRIGHT_DOCKER = '1';
+
+    const config: PlaywrightTestConfig = {
+      /* ... configuration ... */
+    };
+    export default config;
+    ```
+
+   NOTE: this command will detect running Docker container, and auto-launch it if needed.
 
 1. Finally, stop background Docker container when you're done working with tests:
 
@@ -194,17 +207,3 @@ Docker integration usage:
     npx playwright docker stop
     ```
 
-Playwright Test sets `PLAYWRIGHT_DOCKER` environment variable when it uses Docker integration.
-You can use this variable to customize config or tests behavior, for example:
-
-```ts
-// playwright.config.ts
-import type { PlaywrightTestConfig } from '@playwright/test';
-
-const config: PlaywrightTestConfig = {
-  // Ignore all snapshot expectations when running outside
-  // of docker integration.
-  ignoreSnapshots: !process.env.PLAYWRIGHT_DOCKER,
-};
-export default config;
-```

--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -30,7 +30,7 @@ import { baseFullConfig, defaultTimeout, fileIsModule } from './loader';
 import type { TraceMode } from './types';
 
 export function addTestCommands(program: Command) {
-  addTestCommand(program, false /* isDocker */);
+  addTestCommand(program);
   addShowReportCommand(program);
   addListFilesCommand(program);
   addDockerCommand(program);
@@ -38,41 +38,58 @@ export function addTestCommands(program: Command) {
 
 function addDockerCommand(program: Command) {
   const dockerCommand = program.command('docker')
-      .description(`run tests in Docker (EXPERIMENTAL)`);
+      .description(`Manage Docker integration (EXPERIMENTAL)`);
 
   dockerCommand.command('build')
       .description('build local docker image')
       .action(async function(options) {
-        await docker.buildPlaywrightImage();
+        try {
+          await docker.buildPlaywrightImage();
+        } catch (e) {
+          console.error(e.stack ? e : e.message);
+        }
       });
 
   dockerCommand.command('start')
       .description('start docker container')
       .action(async function(options) {
-        await docker.startPlaywrightContainer();
+        try {
+          await docker.startPlaywrightContainer();
+        } catch (e) {
+          console.error(e.stack ? e : e.message);
+        }
       });
 
   dockerCommand.command('stop')
       .description('stop docker container')
       .action(async function(options) {
-        await docker.stopAllPlaywrightContainers();
+        try {
+          await docker.stopAllPlaywrightContainers();
+        } catch (e) {
+          console.error(e.stack ? e : e.message);
+        }
       });
 
   dockerCommand.command('delete-image', { hidden: true })
       .description('delete docker image, if any')
       .action(async function(options) {
-        await docker.deletePlaywrightImage();
+        try {
+          await docker.deletePlaywrightImage();
+        } catch (e) {
+          console.error(e.stack ? e : e.message);
+        }
       });
 
-  addTestCommand(dockerCommand, true /* isDocker */);
+  dockerCommand.command('status', { hidden: true })
+      .description('print docker status')
+      .action(async function(options) {
+        await docker.printDockerStatus();
+      });
 }
 
-function addTestCommand(program: Command, isDocker: boolean) {
+function addTestCommand(program: Command) {
   const command = program.command('test [test-filter...]');
-  if (isDocker)
-    command.description('run tests with Playwright Test and browsers inside docker container');
-  else
-    command.description('run tests with Playwright Test');
+  command.description('run tests with Playwright Test');
   command.option('--browser <browser>', `Browser to use for tests, one of "all", "chromium", "firefox" or "webkit" (default: "chromium")`);
   command.option('--headed', `Run tests in headed browsers (default: headless)`);
   command.option('--debug', `Run tests with Playwright Inspector. Shortcut for "PWDEBUG=1" environment variable and "--timeout=0 --maxFailures=1 --headed --workers=1" options`);
@@ -100,8 +117,6 @@ function addTestCommand(program: Command, isDocker: boolean) {
   command.option('-x', `Stop after the first failure`);
   command.action(async (args, opts) => {
     try {
-      if (isDocker)
-        process.env.PLAYWRIGHT_DOCKER = '1';
       await runTests(args, opts);
     } catch (e) {
       console.error(e);
@@ -113,10 +128,10 @@ Arguments [test-filter...]:
   Pass arguments to filter test files. Each argument is treated as a regular expression.
 
 Examples:
-  $ npx playwright${isDocker ? ' docker ' : ' '}test my.spec.ts
-  $ npx playwright${isDocker ? ' docker ' : ' '}test some.spec.ts:42
-  $ npx playwright${isDocker ? ' docker ' : ' '}test --headed
-  $ npx playwright${isDocker ? ' docker ' : ' '}test --browser=webkit`);
+  $ npx playwright test my.spec.ts
+  $ npx playwright test some.spec.ts:42
+  $ npx playwright test --headed
+  $ npx playwright test --browser=webkit`);
 }
 
 function addListFilesCommand(program: Command) {

--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -80,7 +80,7 @@ function addDockerCommand(program: Command) {
         }
       });
 
-  dockerCommand.command('status', { hidden: true })
+  dockerCommand.command('print-status-json', { hidden: true })
       .description('print docker status')
       .action(async function(options) {
         await docker.printDockerStatus();

--- a/tests/installation/docker-integration.spec.ts
+++ b/tests/installation/docker-integration.spec.ts
@@ -30,8 +30,9 @@ test.beforeAll(async ({ exec }) => {
 
 test('make sure it tells to run `npx playwright docker build` when image is not instaleld', async ({ exec }) => {
   await exec('npm i --foreground-scripts @playwright/test');
-  const result = await exec('npx playwright docker test docker.spec.js', {
+  const result = await exec('npx playwright test docker.spec.js', {
     expectToExitWithError: true,
+    env: { PLAYWRIGHT_DOCKER: '1' },
   });
   expect(result).toContain('npx playwright docker build');
 });
@@ -52,7 +53,9 @@ test.describe('installed image', () => {
   test('make sure it auto-starts container', async ({ exec }) => {
     await exec('npm i --foreground-scripts @playwright/test');
     await exec('npx playwright docker stop');
-    const result = await exec('npx playwright docker test docker.spec.js --grep platform');
+    const result = await exec('npx playwright test docker.spec.js --grep platform', {
+      env: { PLAYWRIGHT_DOCKER: '1' },
+    });
     expect(result).toContain('@chromium Linux');
   });
 
@@ -71,7 +74,9 @@ test.describe('installed image', () => {
 
     test('all browsers work headless', async ({ exec }) => {
       await exec('npm i --foreground-scripts @playwright/test');
-      const result = await exec('npx playwright docker test docker.spec.js --grep platform --browser all');
+      const result = await exec('npx playwright test docker.spec.js --grep platform --browser all', {
+        env: { PLAYWRIGHT_DOCKER: '1' },
+      });
       expect(result).toContain('@chromium Linux');
       expect(result).toContain('@webkit Linux');
       expect(result).toContain('@firefox Linux');
@@ -92,18 +97,24 @@ test.describe('installed image', () => {
     test('all browsers work headed', async ({ exec }) => {
       await exec('npm i --foreground-scripts @playwright/test');
       {
-        const result = await exec(`npx playwright docker test docker.spec.js --headed --grep userAgent --browser chromium`);
+        const result = await exec(`npx playwright test docker.spec.js --headed --grep userAgent --browser chromium`, {
+          env: { PLAYWRIGHT_DOCKER: '1' },
+        });
         expect(result).toContain('@chromium');
         expect(result).not.toContain('Headless');
         expect(result).toContain(' Chrome/');
       }
       {
-        const result = await exec(`npx playwright docker test docker.spec.js --headed --grep userAgent --browser webkit`);
+        const result = await exec(`npx playwright test docker.spec.js --headed --grep userAgent --browser webkit`, {
+          env: { PLAYWRIGHT_DOCKER: '1' },
+        });
         expect(result).toContain('@webkit');
         expect(result).toContain(' Version/');
       }
       {
-        const result = await exec(`npx playwright docker test docker.spec.js --headed --grep userAgent --browser firefox`);
+        const result = await exec(`npx playwright test docker.spec.js --headed --grep userAgent --browser firefox`, {
+          env: { PLAYWRIGHT_DOCKER: '1' },
+        });
         expect(result).toContain('@firefox');
         expect(result).toContain(' Firefox/');
       }
@@ -111,8 +122,9 @@ test.describe('installed image', () => {
 
     test('screenshots should use __screenshots__ folder', async ({ exec, tmpWorkspace }) => {
       await exec('npm i --foreground-scripts @playwright/test');
-      await exec('npx playwright docker test docker.spec.js --grep screenshot --browser all', {
+      await exec('npx playwright test docker.spec.js --grep screenshot --browser all', {
         expectToExitWithError: true,
+        env: { PLAYWRIGHT_DOCKER: '1' },
       });
       await expect(path.join(tmpWorkspace, '__screenshots__', 'firefox', 'docker.spec.js', 'img.png')).toExistOnFS();
       await expect(path.join(tmpWorkspace, '__screenshots__', 'chromium', 'docker.spec.js', 'img.png')).toExistOnFS();
@@ -126,8 +138,9 @@ test.describe('installed image', () => {
       server.setRoute('/', (request, response) => {
         response.end('Hello from host');
       });
-      const result = await exec('npx playwright docker test docker.spec.js --grep localhost --browser all', {
+      const result = await exec('npx playwright test docker.spec.js --grep localhost --browser all', {
         env: {
+          PLAYWRIGHT_DOCKER: '1',
           TEST_PORT: TEST_PORT + '',
         },
       });


### PR DESCRIPTION
This patch:
- Removes all `process.exit(1)` from `docker.ts` and instead throws
  errors.
- Drops the `npx playwright docker test` command. We agreed to
  engage docker when `PLAYWRIGHT_DOCKER` environment variable
  is set.
- Introduces hidden `npx playwright docker status` command that
  dumps a JSON with docker status:
  ```sh
  aslushnikov:~/prog/playwright$ npx playwright docker status
  {
    "dockerEngineRunning": true,
    "imageName": "playwright:local-1.27.0-next-focal",
    "imageIsPulled": true,
    "containerWSEndpoing": "ws://127.0.0.1:55077/eafeb84c-571b-4d12-ac51-f6a2b43e9155",
    "containerVNCEndpoint": "http://127.0.0.1:55076/?path=fb6d4add-9adf-4c3c-b335-893bdc235cd7&resize=scale&autoconnect=1"
  }
  ```
