### PR TITLE
chore: replace __proto__ by getPrototypeOf

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,6 +71,7 @@ module.exports = {
         "valid-typeof": 2,
         "no-implicit-globals": [2],
         "no-unused-expressions": [2, { "allowShortCircuit": true, "allowTernary": true, "allowTaggedTemplates": true}],
+        "no-proto": 2,
 
         // es2015 features
         "require-yield": 2,

--- a/packages/playwright-core/src/protocol/serializers.ts
+++ b/packages/playwright-core/src/protocol/serializers.ts
@@ -184,5 +184,6 @@ function isURL(obj: any): obj is URL {
 }
 
 function isError(obj: any): obj is Error {
-  return obj instanceof Error || obj?.__proto__?.name === 'Error' || (obj?.__proto__ && isError(obj.__proto__));
+  const proto = obj ? Object.getPrototypeOf(obj) : null;
+  return obj instanceof Error || proto?.name === 'Error' || (proto && isError(proto));
 }

--- a/packages/playwright-core/src/server/isomorphic/utilityScriptSerializers.ts
+++ b/packages/playwright-core/src/server/isomorphic/utilityScriptSerializers.ts
@@ -48,7 +48,7 @@ export function source() {
 
   function isError(obj: any): obj is Error {
     try {
-      return obj instanceof Error || (obj && obj.__proto__ && obj.__proto__.name === 'Error');
+      return obj instanceof Error || (obj && Object.getPrototypeOf(obj)?.name === 'Error');
     } catch (error) {
       return false;
     }

--- a/packages/playwright-core/src/utils/index.ts
+++ b/packages/playwright-core/src/utils/index.ts
@@ -87,7 +87,7 @@ export function isObject(obj: any): obj is NonNullable<object> {
 }
 
 export function isError(obj: any): obj is Error {
-  return obj instanceof Error || (obj && obj.__proto__ && obj.__proto__.name === 'Error');
+  return obj instanceof Error || (obj && Object.getPrototypeOf(obj)?.name === 'Error');
 }
 
 const debugEnv = getFromENV('PWDEBUG') || '';


### PR DESCRIPTION
Some users might want to run `--disable-proto=throw|delete` option for a hardened Node.
It's easy to fix and doesn't prevent `{ __proto__: null }` pattern.


