### PR TITLE
fix(html-reporter): resolve output dir from given path

### DIFF
--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -173,8 +173,6 @@ class HtmlReporter implements ReporterInternal {
 
   _resolveOptions(): { outputFolder: string, open: HtmlReportOpenOption } {
     let { outputFolder } = this._options;
-    if (outputFolder)
-      outputFolder = path.resolve(this.config._configDir, outputFolder);
     return {
       outputFolder: reportFolderFromEnv() ?? outputFolder ?? defaultReportFolder(this.config._configDir),
       open: process.env.PW_TEST_HTML_REPORT_OPEN as any || this._options.open || 'on-failure',

--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -173,6 +173,8 @@ class HtmlReporter implements ReporterInternal {
 
   _resolveOptions(): { outputFolder: string, open: HtmlReportOpenOption } {
     let { outputFolder } = this._options;
+    if (outputFolder)
+      outputFolder = path.resolve(outputFolder);
     return {
       outputFolder: reportFolderFromEnv() ?? outputFolder ?? defaultReportFolder(this.config._configDir),
       open: process.env.PW_TEST_HTML_REPORT_OPEN as any || this._options.open || 'on-failure',


### PR DESCRIPTION
Resolve the HTML reporter outputFolder location according to the received outputFolder path.

Closes #17412