### PR TITLE
Typo: Github -> GitHub

### DIFF
--- a/docs/src/ci-intro-js.md
+++ b/docs/src/ci-intro-js.md
@@ -1,6 +1,6 @@
 ---
 id: ci-intro
-title: "CI Github Actions"
+title: "CI GitHub Actions"
 ---
 
 When installing Playwright you are given the option to add a [GitHub Actions](https://docs.github.com/en/actions). This creates a `playwright.yml` file inside a `.github/workflows` folder containing everything you need so that your tests run on each push and pull request into the main/master branch.

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -362,7 +362,7 @@ in `playwright.config.ts`.
 
 ### CircleCI
 
-Running Playwright on Circle CI is very similar to running on Github Actions. In order to specify the pre-built Playwright [Docker image](./docker.md) , simply modify the agent definition with `docker:` in your config like so:
+Running Playwright on Circle CI is very similar to running on GitHub Actions. In order to specify the pre-built Playwright [Docker image](./docker.md) , simply modify the agent definition with `docker:` in your config like so:
 
    ```yml
    executors:


### PR DESCRIPTION
Spell GitHub in a consistent and correct way.