### PR TITLE
fix(playwright-test): add env var to skip running in jest validation

### DIFF
--- a/packages/playwright-test/src/testType.ts
+++ b/packages/playwright-test/src/testType.ts
@@ -242,8 +242,8 @@ function throwIfRunningInsideJest() {
   const skipValidateRunningInJest =
     process.env.PLAYWRIGHT_SKIP_VALIDATE_RUNNING_IN_JEST;
   const shouldSkip =
-    skipValidateRunningInJest !== undefined &&
-    (skipValidateRunningInJest === "1" || skipValidateRunningInJest === "true");
+    skipValidateRunningInJest &&
+    (skipValidateRunningInJest === '1' || skipValidateRunningInJest === 'true');
   if (process.env.JEST_WORKER_ID && !shouldSkip) {
     throw new Error(
         `Playwright Test needs to be invoked via 'npx playwright test' and excluded from Jest test runs.\n` +

--- a/packages/playwright-test/src/testType.ts
+++ b/packages/playwright-test/src/testType.ts
@@ -239,7 +239,12 @@ export class TestTypeImpl {
 }
 
 function throwIfRunningInsideJest() {
-  if (process.env.JEST_WORKER_ID) {
+  const skipValidateRunningInJest =
+    process.env.PLAYWRIGHT_SKIP_VALIDATE_RUNNING_IN_JEST;
+  const shouldSkip =
+    skipValidateRunningInJest !== undefined &&
+    (skipValidateRunningInJest === "1" || skipValidateRunningInJest === "true");
+  if (process.env.JEST_WORKER_ID && !shouldSkip) {
     throw new Error(
         `Playwright Test needs to be invoked via 'npx playwright test' and excluded from Jest test runs.\n` +
         `Creating one directory for Playwright tests and one for Jest is the recommended way of doing it.\n` +


### PR DESCRIPTION
Add the `PLAYWRIGHT_SKIP_VALIDATE_RUNNING_IN_JEST` env var to optionally skip running in jest validation for situations where `@playwright/test` cli process is invoked from a test suite using Jest as test runner.

Environment variable

`PLAYWRIGHT_SKIP_VALIDATE_RUNNING_IN_JEST`

Valid values to skip running in Jest validation:

`1` or `true`

Closes #17438