### PR TITLE
chore: restore userAgent export from playwright-core

### DIFF
--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -24,6 +24,7 @@
     "./lib/outofprocess": "./lib/outofprocess.js",
     "./lib/utils": "./lib/utils/index.js",
     "./lib/utils/comparators": "./lib/utils/comparators.js",
+    "./lib/common/userAgent": "./lib/common/userAgent.js",
     "./lib/utils/eventsHelper": "./lib/utils/eventsHelper.js",
     "./lib/utils/fileUtils": "./lib/utils/fileUtils.js",
     "./lib/utils/httpServer": "./lib/utils/httpServer.js",


### PR DESCRIPTION
This import is used in 8a8c89bea8932624dc28a525999e867fea8b1c74:

- cherry-pick(#17367): chore: rebuild components on new vite
