### PR TITLE
chery-pick(#17473): docs(release-notes): add 1.26 port release notes

### DIFF
--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -4,6 +4,37 @@ title: "Release notes"
 toc_max_heading_level: 2
 ---
 
+## Version 1.26
+
+### Assertions
+
+- New option `Enabled` for [`method: LocatorAssertions.toBeEnabled`].
+- [`method: LocatorAssertions.toHaveText`] now pierces open shadow roots.
+- New option `Editable` for [`method: LocatorAssertions.toBeEditable`].
+- New option `Visible` for [`method: LocatorAssertions.toBeVisible`].
+- [`method: APIResponseAssertions.toBeOK`] is now available.
+
+### Other highlights
+
+- New option `MaxRedirects` for [`method: APIRequestContext.get`] and others to limit redirect count.
+- Codegen now supports NUnit and MSTest frameworks.
+- ASP .NET is now supported.
+
+### Behavior Change
+
+A bunch of Playwright APIs already support the `WaitUntil: WaitUntilState.DOMContentLoaded` option.
+For example:
+
+```csharp
+await Page.GotoAsync("https://playwright.dev", new() { WaitUntil = WaitUntilState.DOMContentLoaded });
+```
+
+Prior to 1.26, this would wait for all iframes to fire the `DOMContentLoaded`
+event. 
+
+To align with web specification, the `WaitUntilState.DOMContentLoaded` value only waits for
+the target frame to fire the `'DOMContentLoaded'` event. Use `WaitUntil: WaitUntilState.Load` to wait for all iframes.
+
 ## Version 1.25
 
 ### New .runsettings file support
@@ -263,7 +294,7 @@ namespace PlaywrightTests;
 [TestFixture]
 public class ExampleTests : PageTest
 {
-    [Test]
+    [PlaywrightTest]
     public async Task StatusBecomesSubmitted()
     {
         await Expect(Page.Locator(".status")).ToHaveTextAsync("Submitted");

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -4,6 +4,35 @@ title: "Release notes"
 toc_max_heading_level: 2
 ---
 
+## Version 1.26
+
+### Assertions
+
+- New option `enabled` for [`method: LocatorAssertions.toBeEnabled`].
+- [`method: LocatorAssertions.toHaveText`] now pierces open shadow roots.
+- New option `editable` for [`method: LocatorAssertions.toBeEditable`].
+- New option `visible` for [`method: LocatorAssertions.toBeVisible`].
+
+### Other highlights
+
+- New option `setMaxRedirects` for [`method: APIRequestContext.get`] and others to limit redirect count.
+- Docker images are now using OpenJDK 17.
+
+### Behavior Change
+
+A bunch of Playwright APIs already support the `setWaitUntil(WaitUntilState.DOMCONTENTLOADED)` option.
+For example:
+
+```js
+page.navigate("https://playwright.dev", new Page.NavigateOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
+```
+
+Prior to 1.26, this would wait for all iframes to fire the `DOMContentLoaded`
+event. 
+
+To align with web specification, the `WaitUntilState.DOMCONTENTLOADED` value only waits for
+the target frame to fire the `'DOMContentLoaded'` event. Use `setWaitUntil(WaitUntilState.LOAD)` to wait for all iframes.
+
 ## Version 1.25
 
 ### New APIs & changes

--- a/docs/src/release-notes-python.md
+++ b/docs/src/release-notes-python.md
@@ -4,6 +4,35 @@ title: "Release notes"
 toc_max_heading_level: 2
 ---
 
+## Version 1.26
+
+### Assertions
+
+- New option `enabled` for [`method: LocatorAssertions.toBeEnabled`].
+- [`method: LocatorAssertions.toHaveText`] now pierces open shadow roots.
+- New option `editable` for [`method: LocatorAssertions.toBeEditable`].
+- New option `visible` for [`method: LocatorAssertions.toBeVisible`].
+
+### Other highlights
+
+- New option `max_redirects` for [`method: APIRequestContext.get`] and others to limit redirect count.
+- Python 3.11 is now supported.
+
+### Behavior Change
+
+A bunch of Playwright APIs already support the `wait_until: "domcontentloaded"` option.
+For example:
+
+```python
+page.goto("https://playwright.dev", wait_until="domcontentloaded")
+```
+
+Prior to 1.26, this would wait for all iframes to fire the `DOMContentLoaded`
+event. 
+
+To align with web specification, the `'domcontentloaded'` value only waits for
+the target frame to fire the `'DOMContentLoaded'` event. Use `wait_until="load"` to wait for all iframes.
+
 ## Version 1.25
 
 ### Announcements


### PR DESCRIPTION
This PR cherry-picks the following commits:

- 1d5e90f30bbc4cfb2420420581ec4ce9d1b11672