### PR TITLE
fix(esm): silence warning when running with experimental loader

### DIFF
--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -315,7 +315,7 @@ function restartWithExperimentalTsEsm(configFile: string | null): boolean {
 }
 
 export function experimentalLoaderOption() {
-  return ` --experimental-loader=${url.pathToFileURL(require.resolve('@playwright/test/lib/experimentalLoader')).toString()}`;
+  return ` --no-warnings --experimental-loader=${url.pathToFileURL(require.resolve('@playwright/test/lib/experimentalLoader')).toString()}`;
 }
 
 export function envWithoutExperimentalLoaderOptions(): NodeJS.ProcessEnv {

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -245,6 +245,7 @@ test('should load ts from esm when package.json has type module', async ({ runIn
 
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
+  expect(result.output).not.toContain(`is an experimental feature`);
 });
 
 test('should filter stack trace for simple expect', async ({ runInlineTest }) => {


### PR DESCRIPTION
Unfortunately, this silences all warnings, not just the experimental loader warning.