### PR TITLE
docs: update POM test example

### DIFF
--- a/docs/src/test-pom-js.md
+++ b/docs/src/test-pom-js.md
@@ -20,7 +20,7 @@ exports.PlaywrightDevPage = class PlaywrightDevPage {
     this.page = page;
     this.getStartedLink = page.locator('a', { hasText: 'Get started' });
     this.gettingStartedHeader = page.locator('h1', { hasText: 'Installation' });
-    this.pomLink = page.locator('li', { hasText: 'Playwright Test' }).locator('a', { hasText: 'Page Object Model' });
+    this.pomLink = page.locator('li', { hasText: 'Guides' }).locator('a', { hasText: 'Page Object Model' });
     this.tocList = page.locator('article div.markdown ul > li > a');
   }
 
@@ -55,7 +55,7 @@ export class PlaywrightDevPage {
     this.page = page;
     this.getStartedLink = page.locator('a', { hasText: 'Get started' });
     this.gettingStartedHeader = page.locator('h1', { hasText: 'Installation' });
-    this.pomLink = page.locator('li', { hasText: 'Playwright Test' }).locator('a', { hasText: 'Page Object Model' });
+    this.pomLink = page.locator('li', { hasText: 'Guides' }).locator('a', { hasText: 'Page Object Model' });
     this.tocList = page.locator('article div.markdown ul > li > a');
   }
 


### PR DESCRIPTION
hi all,
since `Page Object Models` docs is no longer under `Playwright Test`. there's failed test example in https://playwright.dev/docs/test-pom related to wrong selector.

- after this PR:
![playwright - pom - after](https://user-images.githubusercontent.com/6134774/191650271-ead85165-b148-4be2-9d5d-85ff4245c056.png)

- before this PR:
![playwright - pom - before](https://user-images.githubusercontent.com/6134774/191650292-33dffd52-5f44-4afd-a4da-a3f2db872ee4.png)
