### PR TITLE
fix(tsconfig-loader): Fixed issue with wrong path being used to resolve TS-config when TS_NODE_PROJECT is provided

### DIFF
--- a/packages/playwright-test/src/third_party/tsconfig-loader.ts
+++ b/packages/playwright-test/src/third_party/tsconfig-loader.ts
@@ -25,6 +25,7 @@
 /* eslint-disable */
 
 import * as path from 'path';
+import * as process from 'process';
 import * as fs from 'fs';
 import { json5 } from '../utilsBundle';
 
@@ -67,7 +68,7 @@ export function tsConfigLoader({
 
   // tsconfig.loadSync handles if TS_NODE_PROJECT is a file or directory
   // and also overrides baseURL if TS_NODE_BASEURL is available.
-  const loadResult = loadSync(cwd, TS_NODE_PROJECT, TS_NODE_BASEURL);
+  const loadResult = loadSync(TS_NODE_PROJECT ? process.cwd() : cwd, TS_NODE_PROJECT, TS_NODE_BASEURL);
   loadResult.serialized = JSON.stringify(loadResult);
   return loadResult;
 }


### PR DESCRIPTION
Fix for: https://github.com/microsoft/playwright/issues/17469

According to `ts-node` `TS_NODE_PROJECT` is a path to the `tsconfig file`.
I guess `path` could be either a `directory` or a `file`. 
I can't really assume the intention of the implementer. There are three different scenarios: provide `relative` or `absolute` path including a `filename`, a `relative` or `absolute` path without `filename`, or just a `filename`.

1. If `TS_NODE_PROJECT` is set to a `relative` or `absolute` path including `filename`
Example: `./path/tsconfig.custom.json` or `/absolute/path/tsconfig.custom.json`
My assumption here would be to always use `process.cwd()` for the `relative` path instead of `cwd` and NOT walk the tree. If I have provided a specific config file maybe it's best to throw an error? If it just silently fails or fallback to another one, we might think it's working even though it doesn't. An alternative would be a `warning` and `fallback`. However, what would you look for? Any `config file` in the file structure? A `file` with the same name? Other `files` in the same `directory`.

Something like this:
```typescript
export function tsConfigLoader({getEnv, cwd, loadSync = loadSyncDefault}: TsConfigLoaderParams): TsConfigLoaderResult {
  const TS_NODE_PROJECT = getEnv("TS_NODE_PROJECT");
  const TS_NODE_BASEURL = getEnv("TS_NODE_BASEURL");

  // tsconfig.loadSync handles if TS_NODE_PROJECT is a file or directory
  // and also overrides baseURL if TS_NODE_BASEURL is available.
  const loadResult = loadSync(TS_NODE_PROJECT ? process.cwd() : cwd, TS_NODE_PROJECT, TS_NODE_BASEURL);

...

function resolveConfigPath(cwd: string, filename?: string): string | undefined {
  // We assume that just because a filename is provided the file exists. I'm not sure that's good.
  if (filename) {
    const absolutePath = fs.lstatSync(filename).isDirectory()
      ? path.resolve(filename, "./tsconfig.json")
      : path.resolve(cwd, filename);

    if(absolutePath && fs.existsSync(absolutePath)) {
      return absolutePath;
    }
    // If we throw we won't continue looking
    throw new Error('tsconfig could not be found for the provided path.');
    //or if we just show a warning we will continue walking the tree to find a config file at another path.
    console.warn('tsconfig could not be found for the provided path.');
  }

   if (fs.statSync(cwd).isFile()) {
    return path.resolve(cwd);
  }

  const configAbsolutePath = walkForTsConfig(cwd);
  return configAbsolutePath ? path.resolve(configAbsolutePath) : undefined;
```
For `absolute` paths, I don't know. Maybe it should just be treated as a `relative` path and use `process.cwd()`? 
Seems like a longshot that you would want something that is not `relative` to the `working directory`?


2. If `TS_NODE_PROJECT` is set to a `relative` or `absolute` path excluding `filename` (not sure how common this really is)
Example: `./path/` or `/absolute/path`
It this scenario we should also use `process.cwd()` to resolve the path and NOT walk the tree, but look for a config file named `tsconfig.json` in the provided `directory`. As with scenario one, if a config file is not found I would really like to know it. And either fail by throwing or give a warning and fallback. Fallback seems more intuitive here since we would just look walk the tree and look for a file named `tsconfig.json`

3. If `TS_NODE_PROJECT` is set to only a `filename` (not sure how common this is either)
Example: `tsconfig.custom.js`
In this scenario I would say we don't have to use the `process.cwd()`. I'm fine with using `cwd` and walk the tree until a file is found with that name. The only fallback I see here that makes sence if you don't want to throw an error is `tsconfig.json` in `process.cwd()` and then show a warning that the file `tsconfig.custom.js` could not be found.

I don't see any harm in looking for a config file in the `cwd` compared to the `process.cwd()` when `TS_NODE_PROJECT` is NOT provided, or if you only provide a `filename`.

All these scenarios depend on how nice you guys want to be and how much responsibility would fall on the devs.
This is enough to fix my issue:
```
const loadResult = loadSync(TS_NODE_PROJECT ? process.cwd() : cwd, TS_NODE_PROJECT, TS_NODE_BASEURL);
```



@dgozman: Thoughts?