### PR TITLE
fix: accept post data params for request.get and request.head

### DIFF
--- a/docs/src/api/class-apirequestcontext.md
+++ b/docs/src/api/class-apirequestcontext.md
@@ -371,6 +371,16 @@ await request.GetAsync("https://example.com/api/getText", new() { Params = param
 * since: v1.16
 ### option: APIRequestContext.get.headers = %%-js-python-csharp-fetch-option-headers-%%
 * since: v1.16
+### option: APIRequestContext.get.data = %%-js-python-csharp-fetch-option-data-%%
+* since: v1.26
+### option: APIRequestContext.get.form = %%-js-python-fetch-option-form-%%
+* since: v1.26
+### option: APIRequestContext.get.form = %%-csharp-fetch-option-form-%%
+* since: v1.26
+### option: APIRequestContext.get.multipart = %%-js-python-fetch-option-multipart-%%
+* since: v1.26
+### option: APIRequestContext.get.multipart = %%-csharp-fetch-option-multipart-%%
+* since: v1.26
 ### option: APIRequestContext.get.timeout = %%-js-python-csharp-fetch-option-timeout-%%
 * since: v1.16
 ### option: APIRequestContext.get.failOnStatusCode = %%-js-python-csharp-fetch-option-failonstatuscode-%%
@@ -398,6 +408,16 @@ context cookies from the response. The method will automatically follow redirect
 * since: v1.16
 ### option: APIRequestContext.head.headers = %%-js-python-csharp-fetch-option-headers-%%
 * since: v1.16
+### option: APIRequestContext.head.data = %%-js-python-csharp-fetch-option-data-%%
+* since: v1.26
+### option: APIRequestContext.head.form = %%-js-python-fetch-option-form-%%
+* since: v1.26
+### option: APIRequestContext.head.form = %%-csharp-fetch-option-form-%%
+* since: v1.26
+### option: APIRequestContext.head.multipart = %%-js-python-fetch-option-multipart-%%
+* since: v1.26
+### option: APIRequestContext.head.multipart = %%-csharp-fetch-option-multipart-%%
+* since: v1.26
 ### option: APIRequestContext.head.timeout = %%-js-python-csharp-fetch-option-timeout-%%
 * since: v1.16
 ### option: APIRequestContext.head.failOnStatusCode = %%-js-python-csharp-fetch-option-failonstatuscode-%%

--- a/packages/playwright-core/src/client/fetch.ts
+++ b/packages/playwright-core/src/client/fetch.ts
@@ -51,7 +51,6 @@ type NewContextOptions = Omit<channels.PlaywrightNewRequestOptions, 'extraHTTPHe
 };
 
 type RequestWithBodyOptions = Omit<FetchOptions, 'method'>;
-type RequestWithoutBodyOptions = Omit<RequestWithBodyOptions, 'data'|'form'|'multipart'>;
 
 export class APIRequest implements api.APIRequest {
   private _playwright: Playwright;
@@ -107,14 +106,14 @@ export class APIRequestContext extends ChannelOwner<channels.APIRequestContextCh
     });
   }
 
-  async head(url: string, options?: RequestWithoutBodyOptions): Promise<APIResponse> {
+  async head(url: string, options?: RequestWithBodyOptions): Promise<APIResponse> {
     return this.fetch(url, {
       ...options,
       method: 'HEAD',
     });
   }
 
-  async get(url: string, options?: RequestWithoutBodyOptions): Promise<APIResponse> {
+  async get(url: string, options?: RequestWithBodyOptions): Promise<APIResponse> {
     return this.fetch(url, {
       ...options,
       method: 'GET',

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -12886,9 +12886,23 @@ export interface APIRequestContext {
    */
   get(url: string, options?: {
     /**
+     * Allows to set post data of the request. If the data parameter is an object, it will be serialized to json string and
+     * `content-type` header will be set to `application/json` if not explicitly set. Otherwise the `content-type` header will
+     * be set to `application/octet-stream` if not explicitly set.
+     */
+    data?: string|Buffer|Serializable;
+
+    /**
      * Whether to throw on response codes other than 2xx and 3xx. By default response object is returned for all status codes.
      */
     failOnStatusCode?: boolean;
+
+    /**
+     * Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent as
+     * this request body. If this parameter is specified `content-type` header will be set to
+     * `application/x-www-form-urlencoded` unless explicitly provided.
+     */
+    form?: { [key: string]: string|number|boolean; };
 
     /**
      * Allows to set HTTP headers.
@@ -12905,6 +12919,29 @@ export interface APIRequestContext {
      * exceeded. Defaults to `20`. Pass `0` to not follow redirects.
      */
     maxRedirects?: number;
+
+    /**
+     * Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this request
+     * body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless explicitly
+     * provided. File values can be passed either as [`fs.ReadStream`](https://nodejs.org/api/fs.html#fs_class_fs_readstream)
+     * or as file-like object containing file name, mime-type and its content.
+     */
+    multipart?: { [key: string]: string|number|boolean|ReadStream|{
+      /**
+       * File name
+       */
+      name: string;
+
+      /**
+       * File type
+       */
+      mimeType: string;
+
+      /**
+       * File content
+       */
+      buffer: Buffer;
+    }; };
 
     /**
      * Query parameters to be sent with the URL.
@@ -12926,9 +12963,23 @@ export interface APIRequestContext {
    */
   head(url: string, options?: {
     /**
+     * Allows to set post data of the request. If the data parameter is an object, it will be serialized to json string and
+     * `content-type` header will be set to `application/json` if not explicitly set. Otherwise the `content-type` header will
+     * be set to `application/octet-stream` if not explicitly set.
+     */
+    data?: string|Buffer|Serializable;
+
+    /**
      * Whether to throw on response codes other than 2xx and 3xx. By default response object is returned for all status codes.
      */
     failOnStatusCode?: boolean;
+
+    /**
+     * Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent as
+     * this request body. If this parameter is specified `content-type` header will be set to
+     * `application/x-www-form-urlencoded` unless explicitly provided.
+     */
+    form?: { [key: string]: string|number|boolean; };
 
     /**
      * Allows to set HTTP headers.
@@ -12945,6 +12996,29 @@ export interface APIRequestContext {
      * exceeded. Defaults to `20`. Pass `0` to not follow redirects.
      */
     maxRedirects?: number;
+
+    /**
+     * Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this request
+     * body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless explicitly
+     * provided. File values can be passed either as [`fs.ReadStream`](https://nodejs.org/api/fs.html#fs_class_fs_readstream)
+     * or as file-like object containing file name, mime-type and its content.
+     */
+    multipart?: { [key: string]: string|number|boolean|ReadStream|{
+      /**
+       * File name
+       */
+      name: string;
+
+      /**
+       * File type
+       */
+      mimeType: string;
+
+      /**
+       * File content
+       */
+      buffer: Buffer;
+    }; };
 
     /**
      * Query parameters to be sent with the URL.

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -409,20 +409,83 @@ it('should return error with wrong credentials', async ({ context, server }) => 
   expect(response2.status()).toBe(401);
 });
 
-for (const method of ['delete', 'get', 'head', 'patch', 'post', 'put']) {
-  it(`${method} should support post data`, async ({ context, server }) => {
-    const [request, response] = await Promise.all([
-      server.waitForRequest('/simple.json'),
-      context.request[method](`${server.PREFIX}/simple.json`, {
-        data: 'My request'
-      })
-    ]);
-    expect(request.method).toBe(method.toUpperCase());
-    expect((await request.postBody).toString()).toBe('My request');
-    expect(response.status()).toBe(200);
-    expect(request.url).toBe('/simple.json');
-  });
-}
+it('delete should support post data', async ({ context, server }) => {
+  const [request, response] = await Promise.all([
+    server.waitForRequest('/simple.json'),
+    context.request.delete(`${server.PREFIX}/simple.json`, {
+      data: 'My request'
+    })
+  ]);
+  expect(request.method).toBe('DELETE');
+  expect((await request.postBody).toString()).toBe('My request');
+  expect(response.status()).toBe(200);
+  expect(request.url).toBe('/simple.json');
+});
+
+it('get should support post data', async ({ context, server }) => {
+  const [request, response] = await Promise.all([
+    server.waitForRequest('/simple.json'),
+    context.request.get(`${server.PREFIX}/simple.json`, {
+      data: 'My request'
+    })
+  ]);
+  expect(request.method).toBe('GET');
+  expect((await request.postBody).toString()).toBe('My request');
+  expect(response.status()).toBe(200);
+  expect(request.url).toBe('/simple.json');
+});
+
+it('head should support post data', async ({ context, server }) => {
+  const [request, response] = await Promise.all([
+    server.waitForRequest('/simple.json'),
+    context.request.head(`${server.PREFIX}/simple.json`, {
+      data: 'My request'
+    })
+  ]);
+  expect(request.method).toBe('HEAD');
+  expect((await request.postBody).toString()).toBe('My request');
+  expect(response.status()).toBe(200);
+  expect(request.url).toBe('/simple.json');
+});
+
+it('patch should support post data', async ({ context, server }) => {
+  const [request, response] = await Promise.all([
+    server.waitForRequest('/simple.json'),
+    context.request.patch(`${server.PREFIX}/simple.json`, {
+      data: 'My request'
+    })
+  ]);
+  expect(request.method).toBe('PATCH');
+  expect((await request.postBody).toString()).toBe('My request');
+  expect(response.status()).toBe(200);
+  expect(request.url).toBe('/simple.json');
+});
+
+it('post should support post data', async ({ context, server }) => {
+  const [request, response] = await Promise.all([
+    server.waitForRequest('/simple.json'),
+    context.request.post(`${server.PREFIX}/simple.json`, {
+      data: 'My request'
+    })
+  ]);
+  expect(request.method).toBe('POST');
+  expect((await request.postBody).toString()).toBe('My request');
+  expect(response.status()).toBe(200);
+  expect(request.url).toBe('/simple.json');
+});
+
+it('put should support post data', async ({ context, server }) => {
+  const [request, response] = await Promise.all([
+    server.waitForRequest('/simple.json'),
+    context.request.put(`${server.PREFIX}/simple.json`, {
+      data: 'My request'
+    })
+  ]);
+  expect(request.method).toBe('PUT');
+  expect((await request.postBody).toString()).toBe('My request');
+  expect(response.status()).toBe(200);
+  expect(request.url).toBe('/simple.json');
+});
 
 it('should add default headers', async ({ context, server, page }) => {
   const [request] = await Promise.all([


### PR DESCRIPTION
#17008 allowed us to send post data via GET, however context.request.get still didn't have the `data` param definition.
This PR add the param for GET and HEAD.

Fixes #16930, refs #17008

| before | after |
|:--|:---|
|<img width="649" alt="image" src="https://user-images.githubusercontent.com/11763113/192111297-8dc408e0-d29f-4e0c-96ba-451ddee1a170.png">|<img width="638" alt="image" src="https://user-images.githubusercontent.com/11763113/192111431-470b7fc5-87af-4a7a-ae20-0fe97faf4656.png">|




I also checked this works with Ruby client (using Playwright driver).

#### before

```
  2) fetch get should support post data
     Failure/Error:
       def get(
             url,
             failOnStatusCode: nil,
             headers: nil,
             ignoreHTTPSErrors: nil,
             maxRedirects: nil,
             params: nil,
             timeout: nil)
         wrap_impl(@impl.get(unwrap_impl(url), failOnStatusCode: unwrap_impl(failOnStatusCode), headers: unwrap_impl(headers), ignoreHTTPSErrors: unwrap_impl(ignoreHTTPSErrors), maxRedirects: unwrap_impl(maxRedirects), params: unwrap_impl(params), timeout: unwrap_impl(timeout)))
       end
     
     ArgumentError:
       unknown keyword: :data
     # ./lib/playwright_api/api_request_context.rb:112:in `get'
     # ./spec/integration/browser_context/fetch_spec.rb:167:in `block (4 levels) in <top (required)>'
     # ./lib/playwright/playwright_api.rb:121:in `block in wrap_block_call'
     # ./lib/playwright/channel_owners/browser.rb:42:in `new_context'
     # ./lib/playwright_api/browser.rb:119:in `new_context'
     # ./spec/spec_helper.rb:80:in `with_context'
     # ./spec/integration/browser_context/fetch_spec.rb:166:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:267:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:51:in `block (4 levels) in <top (required)>'
     # ./lib/playwright/playwright_api.rb:121:in `block in wrap_block_call'
     # ./lib/playwright/channel_owners/browser_type.rb:20:in `launch'
     # ./lib/playwright_api/browser_type.rb:96:in `launch'
     # ./spec/spec_helper.rb:44:in `block (3 levels) in <top (required)>'
     # ./lib/playwright.rb:80:in `create'
     # ./spec/spec_helper.rb:59:in `block (2 levels) in <top (required)>'

  3) fetch head should support post data
     Failure/Error:
       def head(
             url,
             failOnStatusCode: nil,
             headers: nil,
             ignoreHTTPSErrors: nil,
             maxRedirects: nil,
             params: nil,
             timeout: nil)
         wrap_impl(@impl.head(unwrap_impl(url), failOnStatusCode: unwrap_impl(failOnStatusCode), headers: unwrap_impl(headers), ignoreHTTPSErrors: unwrap_impl(ignoreHTTPSErrors), maxRedirects: unwrap_impl(maxRedirects), params: unwrap_impl(params), timeout: unwrap_impl(timeout)))
       end
     
     ArgumentError:
       unknown keyword: :data
     # ./lib/playwright_api/api_request_context.rb:126:in `head'
     # ./spec/integration/browser_context/fetch_spec.rb:167:in `block (4 levels) in <top (required)>'
     # ./lib/playwright/playwright_api.rb:121:in `block in wrap_block_call'
     # ./lib/playwright/channel_owners/browser.rb:42:in `new_context'
     # ./lib/playwright_api/browser.rb:119:in `new_context'
     # ./spec/spec_helper.rb:80:in `with_context'
     # ./spec/integration/browser_context/fetch_spec.rb:166:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:267:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:51:in `block (4 levels) in <top (required)>'
     # ./lib/playwright/playwright_api.rb:121:in `block in wrap_block_call'
     # ./lib/playwright/channel_owners/browser_type.rb:20:in `launch'
     # ./lib/playwright_api/browser_type.rb:96:in `launch'
     # ./spec/spec_helper.rb:44:in `block (3 levels) in <top (required)>'
     # ./lib/playwright.rb:80:in `create'
     # ./spec/spec_helper.rb:59:in `block (2 levels) in <top (required)>'
```

#### after

Test passes.