### PR TITLE
fix(driver): with CWD which contained spaces

### DIFF
--- a/utils/build/run-driver-win.cmd
+++ b/utils/build/run-driver-win.cmd
@@ -1,5 +1,5 @@
-@ECHO OFF
-SETLOCAL
+@echo off
+setlocal
 if not defined PLAYWRIGHT_NODEJS_PATH (
   set PLAYWRIGHT_NODEJS_PATH=%~dp0\node.exe
 )

--- a/utils/build/run-driver-win.cmd
+++ b/utils/build/run-driver-win.cmd
@@ -1,4 +1,6 @@
 @ECHO OFF
 SETLOCAL
-IF %PLAYWRIGHT_NODEJS_PATH%x == x SET PLAYWRIGHT_NODEJS_PATH="%~dp0\node.exe"
-"%PLAYWRIGHT_NODEJS_PATH%" "%~dp0\package\lib\cli\cli.js" %*
+if not defined PLAYWRIGHT_NODEJS_PATH (
+  set PLAYWRIGHT_NODEJS_PATH=%~dp0\node.exe
+)
+"""%PLAYWRIGHT_NODEJS_PATH%""" "%~dp0\package\lib\cli\cli.js" %*


### PR DESCRIPTION
Did manual testing on my Windows machine to verify that it works in a folder with spaces. Also passing a custom Node.js path seemed to not have worked before.

Fixes https://github.com/microsoft/playwright-python/issues/1561
Fixes https://github.com/microsoft/playwright-python/issues/1565