### PR TITLE
docs(nodejs): extend geolocation context examples

### DIFF
--- a/docs/src/emulation.md
+++ b/docs/src/emulation.md
@@ -553,7 +553,35 @@ await using var context = await browser.NewContextAsync(new()
 
 Change the location later:
 
-```js
+```js tab=js-ts
+import { test, expect } from '@playwright/test';
+
+test.use({ 
+  geolocation: { longitude: 48.858455, latitude: 2.294474 },
+  permissions: ['geolocation'],
+});
+
+test('my test with geolocation', async ({ page, context }) => {
+  // overwrite the location for this test
+  context.setGeolocation({ longitude: 29.979097, latitude: 31.134256 });
+});
+```
+
+```js tab=js-js
+const { test, expect } = require('@playwright/test');
+
+test.use({ 
+  geolocation: { longitude: 48.858455, latitude: 2.294474 },
+  permissions: ['geolocation'],
+});
+
+test('my test with geolocation', async ({ page, context }) => {
+  // overwrite the location for this test
+  context.setGeolocation({ longitude: 29.979097, latitude: 31.134256 });
+});
+```
+
+```js tab=js-library
 await context.setGeolocation({ longitude: 29.979097, latitude: 31.134256 });
 ```
 


### PR DESCRIPTION
The [geolocation](https://playwright.dev/docs/emulation#geolocation) docs mention that the location can be overwritten with `context.setGeolocation`. These examples are easy to follow for library usages, but within a test environment, the example doesn't show how to access the `context`.

This PR, extend the examples to make it aware if it's run in a test environment, or in a library environment.

Before:
![image](https://user-images.githubusercontent.com/28659384/195427282-d9f01def-f211-4fa2-8073-b885a1c50b32.png)


After:
![image](https://user-images.githubusercontent.com/28659384/192318015-06da9004-b4d4-456d-81dc-dd970562940e.png)
