### PR TITLE
feat: expose transferSize for all responses

### DIFF
--- a/docs/src/api/class-request.md
+++ b/docs/src/api/class-request.md
@@ -244,6 +244,7 @@ The Service [Worker] that is performing the request.
   - `requestHeadersSize` <[int]> Total number of bytes from the start of the HTTP request message until (and including) the double CRLF before the body.
   - `responseBodySize` <[int]> Size of the received response body (encoded) in bytes.
   - `responseHeadersSize` <[int]> Total number of bytes from the start of the HTTP response message until (and including) the double CRLF before the body.
+  - `transferSize` <[int]> Total number of bytes received from the start of the HTTP response including the header and body sizes.
 
 Returns resource size information for given request.
 

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -416,6 +416,7 @@ export type RequestSizes = {
   requestHeadersSize: number;
   responseBodySize: number;
   responseHeadersSize: number;
+  transferSize: number;
 };
 
 export class Response extends ChannelOwner<channels.ResponseChannel> implements api.Response {

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1972,6 +1972,7 @@ scheme.RequestSizes = tObject({
   requestHeadersSize: tNumber,
   responseBodySize: tNumber,
   responseHeadersSize: tNumber,
+  transferSize: tNumber,
 });
 scheme.RemoteAddr = tObject({
   ipAddress: tString,

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -15299,6 +15299,11 @@ export interface Request {
      * Total number of bytes from the start of the HTTP response message until (and including) the double CRLF before the body.
      */
     responseHeadersSize: number;
+
+    /**
+     * Total number of bytes received from the start of the HTTP response including the header and body sizes.
+     */
+    transferSize: number;
   }>;
 
   /**

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -3521,6 +3521,7 @@ export type RequestSizes = {
   requestHeadersSize: number,
   responseBodySize: number,
   responseHeadersSize: number,
+  transferSize: number,
 };
 
 export type RemoteAddr = {

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -2713,6 +2713,7 @@ RequestSizes:
     requestHeadersSize: number
     responseBodySize: number
     responseHeadersSize: number
+    transferSize: number
 
 
 RemoteAddr:

--- a/tests/page/page-network-sizes.spec.ts
+++ b/tests/page/page-network-sizes.spec.ts
@@ -60,6 +60,7 @@ it('should set bodySize, headersSize, and transferSize', async ({ page, server }
   const sizes = await response.request().sizes();
   expect(sizes.responseBodySize).toBe(6);
   expect(sizes.responseHeadersSize).toBeGreaterThanOrEqual(100);
+  expect(sizes.transferSize).toBeGreaterThanOrEqual(sizes.responseHeadersSize + sizes.responseBodySize);
 });
 
 it('should set bodySize to 0 when there was no response body', async ({ page, server }) => {
@@ -67,6 +68,7 @@ it('should set bodySize to 0 when there was no response body', async ({ page, se
   const sizes = await response.request().sizes();
   expect(sizes.responseBodySize).toBe(0);
   expect(sizes.responseHeadersSize).toBeGreaterThanOrEqual(150);
+  expect(sizes.transferSize).toBeGreaterThanOrEqual(sizes.responseHeadersSize + sizes.responseBodySize);
 });
 
 it('should have the correct responseBodySize', async ({ page, server, asset, browserName }) => {


### PR DESCRIPTION
+ expose the missing `transferSize` information on all network data when `request.sizes()` is invoked. 