### PR TITLE
feat(core): type addInitScript function arg

### DIFF
--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -34,6 +34,8 @@ export interface Page {
   evaluateHandle<R, Arg>(pageFunction: PageFunction<Arg, R>, arg: Arg): Promise<SmartHandle<R>>;
   evaluateHandle<R>(pageFunction: PageFunction<void, R>, arg?: any): Promise<SmartHandle<R>>;
 
+  addInitScript<Arg>(script: PageFunction<Arg, any> | { path?: string, content?: string }, arg?: Arg): Promise<void>;
+
   $<K extends keyof HTMLElementTagNameMap>(selector: K, options?: { strict: boolean }): Promise<ElementHandleForTag<K> | null>;
   $(selector: string, options?: { strict: boolean }): Promise<ElementHandle<SVGElement | HTMLElement> | null>;
 
@@ -97,6 +99,8 @@ export interface Frame {
 export interface BrowserContext {
   exposeBinding(name: string, playwrightBinding: (source: BindingSource, arg: JSHandle) => any, options: { handle: true }): Promise<void>;
   exposeBinding(name: string, playwrightBinding: (source: BindingSource, ...args: any[]) => any, options?: { handle?: boolean }): Promise<void>;
+
+  addInitScript<Arg>(script: PageFunction<Arg, any> | { path?: string, content?: string }, arg?: Arg): Promise<void>;
 }
 
 export interface Worker {

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -576,6 +576,17 @@ playwright.chromium.launch().then(async browser => {
     });
   }
 
+  {
+    await page.addInitScript((args) => {
+      args.foo === args.hello.world
+    }, {
+      foo: 'bar',
+      hello: {
+        world: 'bar'
+      }
+    });
+  }
+
   await browser.close();
 })();
 


### PR DESCRIPTION
Allows autocomplete on the arg passed to the init script

```ts
await page.addInitScript((arg) => {
    window.localStorage.setItem('init_user_state', JSON.stringify(arg.initUserState)) // arg was previously 'any'
}, {
    initUserState: { foo: 'bar' },
})
```