### PR TITLE
fix(firefox): remove pref override

### DIFF
--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -89,5 +89,4 @@ export class Firefox extends BrowserType {
 // Prefs for quick fixes that didn't make it to the build.
 // Should all be moved to `playwright.cfg`.
 const kBandaidFirefoxUserPrefs = {
-  'network.cookie.cookieBehavior': 4,
 };


### PR DESCRIPTION
There is no need for the workaround anymore.

Fixes #17528.