### PR TITLE
fixed regexp not properly escape windows backslash in path

### DIFF
--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -200,7 +200,7 @@ function forceRegExp(pattern: string): RegExp {
   const match = pattern.match(/^\/(.*)\/([gi]*)$/);
   if (match)
     return new RegExp(match[1], match[2]);
-  return new RegExp(pattern, 'gi');
+  return new RegExp(pattern.replace(/([^\\]|^)\\([^\\]|$)/g, '$1\\\\$2'), 'gi');
 }
 
 function overridesFromOptions(options: { [key: string]: any }): ConfigCLIOverrides {

--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -199,7 +199,7 @@ async function listTestFiles(opts: { [key: string]: any }) {
 function forceRegExp(pattern: string): RegExp {
   const match = pattern.match(/^\/(.*)\/([gi]*)$/);
   if (match)
-    return new RegExp(match[1], match[2]);
+    return new RegExp(match[1].replace(/([^\\]|^)\\([^\\]|$)/g, '$1\\\\$2'), match[2]);
   return new RegExp(pattern.replace(/([^\\]|^)\\([^\\]|$)/g, '$1\\\\$2'), 'gi');
 }
 


### PR DESCRIPTION
Suddenly, my CLI stopped working when provided a file path on windows in `npx playwright test c:\foo\bar\123`. I tracked it down, that the cli runner forces a path to become a regex, if a string is given. But, for whatever reason (I don't see any relevant change here since a long time), this stopped working. If a path contains a backslash (so on windows), the regex never match, because a backslash need to be double escaped. Especially when you have number as filename in your path, it get's weird. Example: `c:\foo\bar\3rdparty` will become `c:\foo\bar\x03rdparty` in the regex, without escaping.

This change fix this behaviour.
Also this works when providing already escaped backslashes in path.

Here is the regex test for it: https://regex101.com/r/W5QO7Q/2

I don't see why this has ever worked before, but maybe a TS compiler change or a NodeJs change in a recent version (i am on 16.17.0 now) caused this regex to no longer work.