### PR TITLE
feat(containers): implement global network tethering for playwright server

### DIFF
--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -147,6 +147,7 @@ jobs:
     - run: |
         ./utils/docker/build.sh --amd64 focal $PWTEST_DOCKER_BASE_IMAGE
         npx playwright docker build
+        nohup npx playwright docker start &
         xvfb-run npm run test-html-reporter
       env:
         PLAYWRIGHT_DOCKER: 1

--- a/packages/playwright-core/bin/container_install_deps.sh
+++ b/packages/playwright-core/bin/container_install_deps.sh
@@ -67,20 +67,15 @@ git apply clip.patch
 
 # Configure FluxBox menus
 mkdir /root/.fluxbox
-cd /ms-playwright-agent
-cat <<'EOF' | node > /root/.fluxbox/menu
-  const { chromium, firefox, webkit } = require('playwright-core');
-
-  console.log(`
-    [begin] (fluxbox)
-      [submenu] (Browsers) {}
-        [exec] (Chromium) { ${chromium.executablePath()} --no-sandbox --test-type= } <>
-        [exec] (Firefox) { ${firefox.executablePath()} } <>
-        [exec] (WebKit) { ${webkit.executablePath()} } <>
-      [end]
-      [include] (/etc/X11/fluxbox/fluxbox-menu)
+cat <<'EOF' > /root/.fluxbox/menu
+  [begin] (fluxbox)
+    [submenu] (Browsers) {}
+      [exec] (Chromium) { /ms-playwright-agent/node_modules/.bin/playwright docker launch --endpoint http://127.0.0.1:5400 --browser chromium } <>
+      [exec] (Firefox) { /ms-playwright-agent/node_modules/.bin/playwright docker launch --endpoint http://127.0.0.1:5400 --browser firefox  } <>
+      [exec] (WebKit) { /ms-playwright-agent/node_modules/.bin/playwright docker launch --endpoint http://127.0.0.1:5400 --browser webkit  } <>
     [end]
-  `);
+    [include] (/etc/X11/fluxbox/fluxbox-menu)
+  [end]
 EOF
 
 cat <<'EOF' > /root/.fluxbox/lastwallpaper

--- a/packages/playwright-core/bin/container_run_server.sh
+++ b/packages/playwright-core/bin/container_run_server.sh
@@ -28,4 +28,12 @@ NOVNC_UUID=$(cat /proc/sys/kernel/random/uuid)
 echo "novnc is listening on http://127.0.0.1:7900?path=$NOVNC_UUID&resize=scale&autoconnect=1"
 
 PW_UUID=$(cat /proc/sys/kernel/random/uuid)
-npx playwright run-server --port=5400 --path=/$PW_UUID
+
+# Make sure to re-start playwright server if something goes wrong.
+# The approach taken from: https://stackoverflow.com/a/697064/314883
+
+until npx playwright run-server --port=5400 --path=/$PW_UUID --proxy-mode=tether; do
+  echo "Server crashed with exit code $?. Respawning.." >&2
+  sleep 1
+done
+

--- a/packages/playwright-core/src/androidServerImpl.ts
+++ b/packages/playwright-core/src/androidServerImpl.ts
@@ -49,7 +49,7 @@ export class AndroidServerLauncherImpl {
     const path = options.wsPath ? (options.wsPath.startsWith('/') ? options.wsPath : `/${options.wsPath}`) : `/${createGuid()}`;
 
     // 2. Start the server
-    const server = new PlaywrightServer({ path, maxConnections: 1, enableSocksProxy: false, preLaunchedAndroidDevice: device });
+    const server = new PlaywrightServer({ path, maxConnections: 1, preLaunchedAndroidDevice: device, browserProxyMode: 'disabled' });
     const wsEndpoint = await server.listen(options.port);
 
     // 3. Return the BrowserServer interface

--- a/packages/playwright-core/src/browserServerImpl.ts
+++ b/packages/playwright-core/src/browserServerImpl.ts
@@ -52,7 +52,7 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
     const path = options.wsPath ? (options.wsPath.startsWith('/') ? options.wsPath : `/${options.wsPath}`) : `/${createGuid()}`;
 
     // 2. Start the server
-    const server = new PlaywrightServer({ path, maxConnections: Infinity, enableSocksProxy: false, preLaunchedBrowser: browser });
+    const server = new PlaywrightServer({ path, maxConnections: Infinity, browserProxyMode: 'disabled', preLaunchedBrowser: browser });
     const wsEndpoint = await server.listen(options.port);
 
     // 3. Return the BrowserServer interface

--- a/packages/playwright-core/src/cli/cli.ts
+++ b/packages/playwright-core/src/cli/cli.ts
@@ -270,9 +270,15 @@ program
     .option('--port <port>', 'Server port')
     .option('--path <path>', 'Endpoint Path', '/')
     .option('--max-clients <maxClients>', 'Maximum clients')
-    .option('--no-socks-proxy', 'Disable Socks Proxy')
+    .option('--proxy-mode <mode>', 'Either `client`, `tether` or `disabled`. Defaults to `client`.', 'client')
     .action(function(options) {
-      runServer(options.port ? +options.port : undefined,  options.path, options.maxClients ? +options.maxClients : Infinity, options.socksProxy).catch(logErrorAndExit);
+      runServer({
+        port: options.port ? +options.port : undefined,
+        path: options.path,
+        maxConnections: options.maxClients ? +options.maxClients : Infinity,
+        browserProxyMode: options.proxyMode,
+        ownedByTetherClient: !!process.env.PW_OWNED_BY_TETHER_CLIENT,
+      }).catch(logErrorAndExit);
     });
 
 program

--- a/packages/playwright-core/src/cli/driver.ts
+++ b/packages/playwright-core/src/cli/driver.ts
@@ -46,8 +46,23 @@ export function runDriver() {
   };
 }
 
-export async function runServer(port: number | undefined, path = '/', maxConnections = Infinity, enableSocksProxy = true) {
-  const server = new PlaywrightServer({ path, maxConnections, enableSocksProxy });
+export type RunServerOptions = {
+  port?: number,
+  path?: string,
+  maxConnections?: number,
+  browserProxyMode?: 'client' | 'tether' | 'disabled',
+  ownedByTetherClient?: boolean,
+};
+
+export async function runServer(options: RunServerOptions) {
+  const {
+    port,
+    path = '/',
+    maxConnections = Infinity,
+    browserProxyMode = 'client',
+    ownedByTetherClient = false,
+  } = options;
+  const server = new PlaywrightServer({ path, maxConnections, browserProxyMode, ownedByTetherClient });
   const wsEndpoint = await server.listen(port);
   process.on('exit', () => server.close().catch(console.error));
   console.log('Listening on ' + wsEndpoint);  // eslint-disable-line no-console

--- a/packages/playwright-core/src/client/playwright.ts
+++ b/packages/playwright-core/src/client/playwright.ts
@@ -16,7 +16,6 @@
 
 import type * as channels from '@protocol/channels';
 import { TimeoutError } from '../common/errors';
-import type * as socks from '../common/socksProxy';
 import { Android } from './android';
 import { BrowserType } from './browserType';
 import { ChannelOwner } from './channelOwner';
@@ -45,7 +44,6 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel> {
   selectors: Selectors;
   readonly request: APIRequest;
   readonly errors: { TimeoutError: typeof TimeoutError };
-  private _socksProxyHandler: socks.SocksProxyHandler | undefined;
 
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.PlaywrightInitializer) {
     super(parent, type, guid, initializer);
@@ -68,7 +66,6 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel> {
     this.selectors._addChannel(selectorsOwner);
     this._connection.on('close', () => {
       this.selectors._removeChannel(selectorsOwner);
-      this._socksProxyHandler?.cleanup();
     });
     (global as any)._playwrightInstance = this;
   }

--- a/packages/playwright-core/src/common/socksProxy.ts
+++ b/packages/playwright-core/src/common/socksProxy.ts
@@ -296,6 +296,7 @@ export class SocksProxy extends EventEmitter implements SocksConnectionClient {
   private _connections = new Map<string, SocksConnection>();
   private _sockets = new Set<net.Socket>();
   private _closed = false;
+  private _port: number | undefined;
 
   constructor() {
     super();
@@ -314,10 +315,15 @@ export class SocksProxy extends EventEmitter implements SocksConnectionClient {
     });
   }
 
+  port() {
+    return this._port;
+  }
+
   async listen(port: number): Promise<number> {
     return new Promise(f => {
       this._server.listen(port, () => {
         const port = (this._server.address() as AddressInfo).port;
+        this._port = port;
         debugLogger.log('proxy', `Starting socks proxy server on port ${port}`);
         f(port);
       });

--- a/packages/playwright-core/src/containers/DEPS.list
+++ b/packages/playwright-core/src/containers/DEPS.list
@@ -2,3 +2,6 @@
 ../utils/
 ../utilsBundle.ts
 ../common/
+../server/
+../server/dispatchers/
+../..

--- a/packages/playwright-core/src/containers/docker.ts
+++ b/packages/playwright-core/src/containers/docker.ts
@@ -18,9 +18,13 @@
 import path from 'path';
 import { spawnAsync } from '../utils/spawnAsync';
 import * as utils from '../utils';
-import { getPlaywrightVersion } from '../common/userAgent';
+import { getPlaywrightVersion, getUserAgent } from '../common/userAgent';
+import { urlToWSEndpoint } from '../server/dispatchers/localUtilsDispatcher';
+import { WebSocketTransport } from '../server/transport';
+import { SocksInterceptor } from '../server/socksInterceptor';
 import * as dockerApi from './dockerApi';
 import type { Command } from '../utilsBundle';
+import * as playwright from '../..';
 
 const VRT_IMAGE_DISTRO = 'focal';
 const VRT_IMAGE_NAME = `playwright:local-${getPlaywrightVersion()}-${VRT_IMAGE_DISTRO}`;
@@ -28,24 +32,22 @@ const VRT_CONTAINER_NAME = `playwright-${getPlaywrightVersion()}-${VRT_IMAGE_DIS
 const VRT_CONTAINER_LABEL_NAME = 'dev.playwright.vrt-service.version';
 const VRT_CONTAINER_LABEL_VALUE = '1';
 
-async function startPlaywrightContainer() {
+async function startPlaywrightContainer(port: number) {
   await checkDockerEngineIsRunningOrDie();
 
-  let info = await containerInfo();
-  if (!info) {
-    process.stdout.write(`Starting docker container... `);
-    const time = Date.now();
-    info = await ensurePlaywrightContainerOrDie();
-    const deltaMs = (Date.now() - time);
-    console.log('Done in ' + (deltaMs / 1000).toFixed(1) + 's');
-  }
+  await stopAllPlaywrightContainers();
+
+  process.stdout.write(`Starting docker container... `);
+  const time = Date.now();
+  const info = await ensurePlaywrightContainerOrDie(port);
+  const deltaMs = (Date.now() - time);
+  console.log('Done in ' + (deltaMs / 1000).toFixed(1) + 's');
+  await tetherHostNetwork(info.wsEndpoint);
+
   console.log([
+    `- Endpoint: ${info.httpEndpoint}`,
     `- View screen:`,
-    `      ${info.vncSession}`,
-    `- Run tests with browsers inside container:`,
-    `      npx playwright docker test`,
-    `- Stop background container *manually* when you are done working with tests:`,
-    `      npx playwright docker stop`,
+    `    ${info.vncSession}`,
   ].join('\n'));
 }
 
@@ -130,6 +132,7 @@ async function buildPlaywrightImage() {
 }
 
 interface ContainerInfo {
+  httpEndpoint: string;
   wsEndpoint: string;
   vncSession: string;
 }
@@ -174,10 +177,14 @@ export async function containerInfo(): Promise<ContainerInfo|undefined> {
     return undefined;
   const wsEndpoint = containerUrlToHostUrl('ws://' + webSocketLine.substring(WS_LINE_PREFIX.length));
   const vncSession = containerUrlToHostUrl(novncLine.substring(NOVNC_LINE_PREFIX.length));
-  return wsEndpoint && vncSession ? { wsEndpoint, vncSession } : undefined;
+  if (!wsEndpoint || !vncSession)
+    return undefined;
+  const wsUrl = new URL(wsEndpoint);
+  const httpEndpoint = 'http://' + wsUrl.host;
+  return { wsEndpoint, vncSession, httpEndpoint };
 }
 
-export async function ensurePlaywrightContainerOrDie(): Promise<ContainerInfo> {
+export async function ensurePlaywrightContainerOrDie(port: number): Promise<ContainerInfo> {
   const pwImage = await findDockerImage(VRT_IMAGE_NAME);
   if (!pwImage) {
     throw createStacklessError('\n' + utils.wrapInASCIIBox([
@@ -228,14 +235,26 @@ export async function ensurePlaywrightContainerOrDie(): Promise<ContainerInfo> {
     }
   }
 
+  const env: any = {
+    PW_OWNED_BY_TETHER_CLIENT: '1',
+    DEBUG: process.env.DEBUG,
+  };
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith('PLAYWRIGHT_'))
+      env[key] = value;
+  }
   await dockerApi.launchContainer({
     imageId: pwImage.imageId,
     name: VRT_CONTAINER_NAME,
     autoRemove: true,
-    ports: [5400, 7900],
+    ports: [
+      { container: 5400, host: port },
+      { container: 7900, host: 0 },
+    ],
     labels: {
       [VRT_CONTAINER_LABEL_NAME]: VRT_CONTAINER_LABEL_VALUE,
     },
+    env,
   });
 
   // Wait for the service to become available.
@@ -274,6 +293,34 @@ function createStacklessError(message: string) {
   return error;
 }
 
+async function tetherHostNetwork(endpoint: string) {
+  const wsEndpoint = await urlToWSEndpoint(undefined /* progress */, endpoint);
+
+  const headers: any = {
+    'User-Agent': getUserAgent(),
+    'x-playwright-network-tethering': '1',
+  };
+  const transport = await WebSocketTransport.connect(undefined /* progress */, wsEndpoint, headers, true /* followRedirects */);
+  const socksInterceptor = new SocksInterceptor(transport, undefined);
+  transport.onmessage = json => socksInterceptor.interceptMessage(json);
+  transport.onclose = () => {
+    socksInterceptor.cleanup();
+  };
+  await transport.send({
+    id: 1,
+    guid: '',
+    method: 'initialize',
+    params: {
+      'sdkLanguage': 'javascript'
+    },
+    metadata: {
+      stack: [],
+      apiName: '',
+      internal: true
+    },
+  } as any);
+}
+
 export function addDockerCLI(program: Command) {
   const dockerCommand = program.command('docker', { hidden: true })
       .description(`Manage Docker integration (EXPERIMENTAL)`);
@@ -291,9 +338,15 @@ export function addDockerCLI(program: Command) {
 
   dockerCommand.command('start')
       .description('start docker container')
+      .option('--port <port>', 'port to start container on. Auto-pick by default')
       .action(async function(options) {
         try {
-          await startPlaywrightContainer();
+          const port = options.port ? +options.port : 0;
+          if (isNaN(port)) {
+            console.error(`ERROR: bad port number "${options.port}"`);
+            process.exit(1);
+          }
+          await startPlaywrightContainer(port);
         } catch (e) {
           console.error(e.stack ? e : e.message);
           process.exit(1);
@@ -340,5 +393,51 @@ export function addDockerCLI(program: Command) {
       .description('print docker status')
       .action(async function(options) {
         await printDockerStatus();
+      });
+
+  dockerCommand.command('launch', { hidden: true })
+      .description('launch browser in container')
+      .option('--browser <name>', 'browser to launch')
+      .option('--endpoint <url>', 'server endpoint')
+      .action(async function(options: { browser: string, endpoint: string }) {
+        let browserType: any;
+        if (options.browser === 'chromium')
+          browserType = playwright.chromium;
+        else if (options.browser === 'firefox')
+          browserType = playwright.firefox;
+        else if (options.browser === 'webkit')
+          browserType = playwright.webkit;
+        if (!browserType) {
+          console.error('Unknown browser name: ', options.browser);
+          process.exit(1);
+        }
+        const browser = await browserType.connect(options.endpoint, {
+          headers: {
+            'x-playwright-launch-options': JSON.stringify({
+              headless: false,
+              viewport: null,
+            }),
+            'x-playwright-proxy': '*',
+          },
+        });
+        const context = await browser.newContext();
+        context.on('page', (page: playwright.Page) => {
+          page.on('dialog', () => {});  // Prevent dialogs from being automatically dismissed.
+          page.once('close', () => {
+            const hasPage = browser.contexts().some((context: playwright.BrowserContext) => context.pages().length > 0);
+            if (hasPage)
+              return;
+            // Avoid the error when the last page is closed because the browser has been closed.
+            browser.close().catch((e: Error) => null);
+          });
+        });
+        await context.newPage();
+      });
+
+  dockerCommand.command('tether', { hidden: true })
+      .description('tether local network to the playwright server')
+      .option('--endpoint <url>', 'server endpoint')
+      .action(async function(options: { endpoint: string }) {
+        await tetherHostNetwork(options.endpoint);
       });
 }

--- a/packages/playwright-core/src/containers/docker.ts
+++ b/packages/playwright-core/src/containers/docker.ts
@@ -235,7 +235,7 @@ export async function ensurePlaywrightContainerOrDie(port: number): Promise<Cont
     }
   }
 
-  const env: any = {
+  const env: Record<string, string | undefined> = {
     PW_OWNED_BY_TETHER_CLIENT: '1',
     DEBUG: process.env.DEBUG,
   };

--- a/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import EventEmitter from 'events';
+import type EventEmitter from 'events';
 import fs from 'fs';
 import path from 'path';
 import type * as channels from '@protocol/channels';
@@ -27,14 +27,12 @@ import { ZipFile } from '../../utils/zipFile';
 import type * as har from '@trace/har';
 import type { HeadersArray } from '../types';
 import { JsonPipeDispatcher } from '../dispatchers/jsonPipeDispatcher';
-import * as socks from '../../common/socksProxy';
 import { WebSocketTransport } from '../transport';
+import { SocksInterceptor } from '../socksInterceptor';
 import type { CallMetadata } from '../instrumentation';
 import { getUserAgent } from '../../common/userAgent';
 import type { Progress } from '../progress';
 import { ProgressController } from '../progress';
-import { findValidator, ValidationError } from '../../protocol/validator';
-import type { ValidatorContext } from '../../protocol/validator';
 import { fetchData } from '../../common/netUtils';
 import type { HTTPRequestParams } from '../../common/netUtils';
 import type http from 'http';
@@ -162,12 +160,10 @@ export class LocalUtilsDispatcher extends Dispatcher<{ guid: string }, channels.
       const wsEndpoint = await urlToWSEndpoint(progress, params.wsEndpoint);
 
       const transport = await WebSocketTransport.connect(progress, wsEndpoint, paramsHeaders, true);
-      let socksInterceptor: SocksInterceptor | undefined;
+      const socksInterceptor = new SocksInterceptor(transport, params.socksProxyRedirectPortForTest);
       const pipe = new JsonPipeDispatcher(this);
       transport.onmessage = json => {
-        if (json.method === '__create__' && json.params.type === 'SocksSupport')
-          socksInterceptor = new SocksInterceptor(transport, params.socksProxyRedirectPortForTest, json.params.guid);
-        if (socksInterceptor?.interceptMessage(json))
+        if (socksInterceptor.interceptMessage(json))
           return;
         const cb = () => {
           try {
@@ -317,62 +313,6 @@ class HarBackend {
   }
 }
 
-class SocksInterceptor {
-  private _handler: socks.SocksProxyHandler;
-  private _channel: channels.SocksSupportChannel & EventEmitter;
-  private _socksSupportObjectGuid: string;
-  private _ids = new Set<number>();
-
-  constructor(transport: WebSocketTransport, redirectPortForTest: number | undefined, socksSupportObjectGuid: string) {
-    this._handler = new socks.SocksProxyHandler(redirectPortForTest);
-    this._socksSupportObjectGuid = socksSupportObjectGuid;
-
-    let lastId = -1;
-    this._channel = new Proxy(new EventEmitter(), {
-      get: (obj: any, prop) => {
-        if ((prop in obj) || obj[prop] !== undefined || typeof prop !== 'string')
-          return obj[prop];
-        return (params: any) => {
-          try {
-            const id = --lastId;
-            this._ids.add(id);
-            const validator = findValidator('SocksSupport', prop, 'Params');
-            params = validator(params, '', { tChannelImpl: tChannelForSocks, binary: 'toBase64' });
-            transport.send({ id, guid: socksSupportObjectGuid, method: prop, params, metadata: { stack: [], apiName: '', internal: true } } as any);
-          } catch (e) {
-          }
-        };
-      },
-    }) as channels.SocksSupportChannel & EventEmitter;
-    this._handler.on(socks.SocksProxyHandler.Events.SocksConnected, (payload: socks.SocksSocketConnectedPayload) => this._channel.socksConnected(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksData, (payload: socks.SocksSocketDataPayload) => this._channel.socksData(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksError, (payload: socks.SocksSocketErrorPayload) => this._channel.socksError(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksFailed, (payload: socks.SocksSocketFailedPayload) => this._channel.socksFailed(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksEnd, (payload: socks.SocksSocketEndPayload) => this._channel.socksEnd(payload));
-    this._channel.on('socksRequested', payload => this._handler.socketRequested(payload));
-    this._channel.on('socksClosed', payload => this._handler.socketClosed(payload));
-    this._channel.on('socksData', payload => this._handler.sendSocketData(payload));
-  }
-
-  cleanup() {
-    this._handler.cleanup();
-  }
-
-  interceptMessage(message: any): boolean {
-    if (this._ids.has(message.id)) {
-      this._ids.delete(message.id);
-      return true;
-    }
-    if (message.guid === this._socksSupportObjectGuid) {
-      const validator = findValidator('SocksSupport', message.method, 'Event');
-      const params = validator(message.params, '', { tChannelImpl: tChannelForSocks, binary: 'fromBase64' });
-      this._channel.emit(message.method, params);
-      return true;
-    }
-    return false;
-  }
-}
-
 function countMatchingHeaders(harHeaders: har.Header[], headers: HeadersArray): number {
   const set = new Set(headers.map(h => h.name.toLowerCase() + ':' + h.value));
   let matches = 0;
@@ -383,15 +323,11 @@ function countMatchingHeaders(harHeaders: har.Header[], headers: HeadersArray): 
   return matches;
 }
 
-function tChannelForSocks(names: '*' | string[], arg: any, path: string, context: ValidatorContext) {
-  throw new ValidationError(`${path}: channels are not expected in SocksSupport`);
-}
-
-async function urlToWSEndpoint(progress: Progress, endpointURL: string): Promise<string> {
+export async function urlToWSEndpoint(progress: Progress|undefined, endpointURL: string): Promise<string> {
   if (endpointURL.startsWith('ws'))
     return endpointURL;
 
-  progress.log(`<ws preparing> retrieving websocket url from ${endpointURL}`);
+  progress?.log(`<ws preparing> retrieving websocket url from ${endpointURL}`);
   const fetchUrl = new URL(endpointURL);
   if (!fetchUrl.pathname.endsWith('/'))
     fetchUrl.pathname += '/';
@@ -399,13 +335,13 @@ async function urlToWSEndpoint(progress: Progress, endpointURL: string): Promise
   const json = await fetchData({
     url: fetchUrl.toString(),
     method: 'GET',
-    timeout: progress.timeUntilDeadline(),
+    timeout: progress?.timeUntilDeadline() ?? 30_000,
     headers: { 'User-Agent': getUserAgent() },
   }, async (params: HTTPRequestParams, response: http.IncomingMessage) => {
     return new Error(`Unexpected status ${response.statusCode} when connecting to ${fetchUrl.toString()}.\n` +
         `This does not look like a Playwright server, try connecting via ws://.`);
   });
-  progress.throwIfAborted();
+  progress?.throwIfAborted();
 
   const wsUrl = new URL(endpointURL);
   let wsEndpointPath = JSON.parse(json).wsEndpointPath;

--- a/packages/playwright-core/src/server/socksInterceptor.ts
+++ b/packages/playwright-core/src/server/socksInterceptor.ts
@@ -68,7 +68,7 @@ export class SocksInterceptor {
     }
     if (message.method === '__create__' && message.params.type === 'SocksSupport') {
       this._socksSupportObjectGuid = message.params.guid;
-      return true;
+      return false;
     }
     if (this._socksSupportObjectGuid && message.guid === this._socksSupportObjectGuid) {
       const validator = findValidator('SocksSupport', message.method, 'Event');

--- a/packages/playwright-core/src/server/socksInterceptor.ts
+++ b/packages/playwright-core/src/server/socksInterceptor.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as socks from '../common/socksProxy';
+import EventEmitter from 'events';
+import type * as channels from '@protocol/channels';
+import type { WebSocketTransport } from './transport';
+import { findValidator, ValidationError } from '../protocol/validator';
+import type { ValidatorContext } from '../protocol/validator';
+
+export class SocksInterceptor {
+  private _handler: socks.SocksProxyHandler;
+  private _channel: channels.SocksSupportChannel & EventEmitter;
+  private _socksSupportObjectGuid?: string;
+  private _ids = new Set<number>();
+
+  constructor(transport: WebSocketTransport, redirectPortForTest: number | undefined) {
+    this._handler = new socks.SocksProxyHandler(redirectPortForTest);
+
+    let lastId = -1;
+    this._channel = new Proxy(new EventEmitter(), {
+      get: (obj: any, prop) => {
+        if ((prop in obj) || obj[prop] !== undefined || typeof prop !== 'string')
+          return obj[prop];
+        return (params: any) => {
+          try {
+            const id = --lastId;
+            this._ids.add(id);
+            const validator = findValidator('SocksSupport', prop, 'Params');
+            params = validator(params, '', { tChannelImpl: tChannelForSocks, binary: 'toBase64' });
+            transport.send({ id, guid: this._socksSupportObjectGuid, method: prop, params, metadata: { stack: [], apiName: '', internal: true } } as any);
+          } catch (e) {
+          }
+        };
+      },
+    }) as channels.SocksSupportChannel & EventEmitter;
+    this._handler.on(socks.SocksProxyHandler.Events.SocksConnected, (payload: socks.SocksSocketConnectedPayload) => this._channel.socksConnected(payload));
+    this._handler.on(socks.SocksProxyHandler.Events.SocksData, (payload: socks.SocksSocketDataPayload) => this._channel.socksData(payload));
+    this._handler.on(socks.SocksProxyHandler.Events.SocksError, (payload: socks.SocksSocketErrorPayload) => this._channel.socksError(payload));
+    this._handler.on(socks.SocksProxyHandler.Events.SocksFailed, (payload: socks.SocksSocketFailedPayload) => this._channel.socksFailed(payload));
+    this._handler.on(socks.SocksProxyHandler.Events.SocksEnd, (payload: socks.SocksSocketEndPayload) => this._channel.socksEnd(payload));
+    this._channel.on('socksRequested', payload => this._handler.socketRequested(payload));
+    this._channel.on('socksClosed', payload => this._handler.socketClosed(payload));
+    this._channel.on('socksData', payload => this._handler.sendSocketData(payload));
+  }
+
+  cleanup() {
+    this._handler.cleanup();
+  }
+
+  interceptMessage(message: any): boolean {
+    if (this._ids.has(message.id)) {
+      this._ids.delete(message.id);
+      return true;
+    }
+    if (message.method === '__create__' && message.params.type === 'SocksSupport') {
+      this._socksSupportObjectGuid = message.params.guid;
+      return true;
+    }
+    if (this._socksSupportObjectGuid && message.guid === this._socksSupportObjectGuid) {
+      const validator = findValidator('SocksSupport', message.method, 'Event');
+      const params = validator(message.params, '', { tChannelImpl: tChannelForSocks, binary: 'fromBase64' });
+      this._channel.emit(message.method, params);
+      return true;
+    }
+    return false;
+  }
+}
+
+function tChannelForSocks(names: '*' | string[], arg: any, path: string, context: ValidatorContext) {
+  throw new ValidationError(`${path}: channels are not expected in SocksSupport`);
+}
+

--- a/packages/playwright-test/src/plugins/dockerPlugin.ts
+++ b/packages/playwright-test/src/plugins/dockerPlugin.ts
@@ -17,7 +17,7 @@
 import type { TestRunnerPlugin } from '.';
 import type { FullConfig, Reporter, Suite } from '../../types/testReporter';
 import { colors } from 'playwright-core/lib/utilsBundle';
-import { checkDockerEngineIsRunningOrDie, containerInfo, ensurePlaywrightContainerOrDie } from 'playwright-core/lib/containers/docker';
+import { checkDockerEngineIsRunningOrDie, containerInfo } from 'playwright-core/lib/containers/docker';
 
 export const dockerPlugin: TestRunnerPlugin = {
   name: 'playwright:docker',
@@ -26,22 +26,13 @@ export const dockerPlugin: TestRunnerPlugin = {
     if (!process.env.PLAYWRIGHT_DOCKER)
       return;
 
-    const print = (text: string) => reporter.onStdOut?.(text);
     const println = (text: string) => reporter.onStdOut?.(text + '\n');
 
     println(colors.dim('Using docker container to run browsers.'));
     await checkDockerEngineIsRunningOrDie();
-    let info = await containerInfo();
-    if (!info) {
-      print(colors.dim(`Starting docker container... `));
-      const time = Date.now();
-      info = await ensurePlaywrightContainerOrDie();
-      const deltaMs = (Date.now() - time);
-      println(colors.dim('Done in ' + (deltaMs / 1000).toFixed(1) + 's'));
-      println(colors.dim('The Docker container will keep running after tests finished.'));
-      println(colors.dim('Stop manually using:'));
-      println(colors.dim('    npx playwright docker stop'));
-    }
+    const info = await containerInfo();
+    if (!info)
+      throw new Error('ERROR: please launch docker container separately!');
     println(colors.dim(`View screen: ${info.vncSession}`));
     println('');
     process.env.PW_TEST_CONNECT_WS_ENDPOINT = info.wsEndpoint;

--- a/tests/config/baseTest.ts
+++ b/tests/config/baseTest.ts
@@ -16,7 +16,7 @@
 
 import type { TestType, Fixtures } from '@playwright/test';
 import { test } from '@playwright/test';
-import type { CommonFixtures } from './commonFixtures';
+import type { CommonFixtures, CommonWorkerFixtures } from './commonFixtures';
 import { commonFixtures } from './commonFixtures';
 import type { ServerFixtures, ServerWorkerOptions } from './serverFixtures';
 import { serverFixtures } from './serverFixtures';
@@ -36,7 +36,7 @@ export const baseTest = base
     ._extendTest(coverageTest)
     ._extendTest(platformTest)
     ._extendTest(testModeTest)
-    .extend<CommonFixtures>(commonFixtures)
+    .extend<CommonFixtures, CommonWorkerFixtures>(commonFixtures)
     .extend<ServerFixtures, ServerWorkerOptions>(serverFixtures)
     .extend<{}, { _snapshotSuffix: string }>({
       _snapshotSuffix: ['', { scope: 'worker' }],

--- a/tests/config/commonFixtures.ts
+++ b/tests/config/commonFixtures.ts
@@ -115,7 +115,11 @@ export type CommonFixtures = {
   waitForPort: (port: number) => Promise<void>;
 };
 
-export const commonFixtures: Fixtures<CommonFixtures, {}> = {
+export type CommonWorkerFixtures = {
+  demonProcess: (params: TestChildParams) => TestChildProcess;
+};
+
+export const commonFixtures: Fixtures<CommonFixtures, CommonWorkerFixtures> = {
   childProcess: async ({}, use, testInfo) => {
     const processes: TestChildProcess[] = [];
     await use(params => {
@@ -132,6 +136,16 @@ export const commonFixtures: Fixtures<CommonFixtures, {}> = {
       }
     }
   },
+
+  demonProcess: [async ({}, use) => {
+    const processes: TestChildProcess[] = [];
+    await use(params => {
+      const process = new TestChildProcess(params);
+      processes.push(process);
+      return process;
+    });
+    await Promise.all(processes.map(child => child.close()));
+  }, { scope: 'worker' }],
 
   waitForPort: async ({}, use) => {
     const token = { canceled: false };

--- a/tests/config/commonFixtures.ts
+++ b/tests/config/commonFixtures.ts
@@ -116,7 +116,7 @@ export type CommonFixtures = {
 };
 
 export type CommonWorkerFixtures = {
-  demonProcess: (params: TestChildParams) => TestChildProcess;
+  daemonProcess: (params: TestChildParams) => TestChildProcess;
 };
 
 export const commonFixtures: Fixtures<CommonFixtures, CommonWorkerFixtures> = {
@@ -137,7 +137,7 @@ export const commonFixtures: Fixtures<CommonFixtures, CommonWorkerFixtures> = {
     }
   },
 
-  demonProcess: [async ({}, use) => {
+  daemonProcess: [async ({}, use) => {
     const processes: TestChildProcess[] = [];
     await use(params => {
       const process = new TestChildProcess(params);

--- a/tests/installation/docker-integration.spec.ts
+++ b/tests/installation/docker-integration.spec.ts
@@ -38,12 +38,12 @@ test('make sure it tells to run `npx playwright docker build` when image is not 
 });
 
 test.describe('installed image', () => {
-  test.beforeAll(async ({ exec, demonProcess, waitForPort }) => {
+  test.beforeAll(async ({ exec, daemonProcess, waitForPort }) => {
     await exec('npx playwright docker build', {
       env: { PWTEST_DOCKER_BASE_IMAGE: 'playwright:installation-tests-focal' },
       cwd: path.join(__dirname, '..', '..'),
     });
-    const dockerProcess = await demonProcess({
+    const dockerProcess = await daemonProcess({
       command: ['npx', 'playwright', 'docker', 'start', '--port=5667'],
       shell: true,
       cwd: path.join(__dirname, '..', '..'),

--- a/tests/installation/docker-integration.spec.ts
+++ b/tests/installation/docker-integration.spec.ts
@@ -17,6 +17,7 @@ import { test, expect } from './npmTest';
 import * as path from 'path';
 import { TestServer } from '../../utils/testserver';
 
+
 // Skipping docker tests on CI on non-linux since GHA does not have
 // Docker engine installed on macOS and Windows.
 test.skip(() => process.env.CI && process.platform !== 'linux');
@@ -28,126 +29,97 @@ test.beforeAll(async ({ exec }) => {
   });
 });
 
-test('make sure it tells to run `npx playwright docker build` when image is not instaleld', async ({ exec }) => {
+test('make sure it tells to run `npx playwright docker build` when image is not installed', async ({ exec }) => {
   await exec('npm i --foreground-scripts @playwright/test');
-  const result = await exec('npx playwright test docker.spec.js', {
+  const result = await exec('npx playwright docker start', {
     expectToExitWithError: true,
-    env: { PLAYWRIGHT_DOCKER: '1' },
   });
   expect(result).toContain('npx playwright docker build');
 });
 
 test.describe('installed image', () => {
-  test.beforeAll(async ({ exec }) => {
+  test.beforeAll(async ({ exec, demonProcess, waitForPort }) => {
     await exec('npx playwright docker build', {
       env: { PWTEST_DOCKER_BASE_IMAGE: 'playwright:installation-tests-focal' },
       cwd: path.join(__dirname, '..', '..'),
     });
+    const dockerProcess = await demonProcess({
+      command: ['npx', 'playwright', 'docker', 'start', '--port=5667'],
+      shell: true,
+      cwd: path.join(__dirname, '..', '..'),
+    });
+    await dockerProcess.waitForOutput('- Endpoint:');
   });
+
   test.afterAll(async ({ exec }) => {
     await exec('npx playwright docker delete-image', {
       cwd: path.join(__dirname, '..', '..'),
     });
   });
 
-  test('make sure it auto-starts container', async ({ exec }) => {
+  test('all browsers work headless', async ({ exec }) => {
     await exec('npm i --foreground-scripts @playwright/test');
-    await exec('npx playwright docker stop');
-    const result = await exec('npx playwright test docker.spec.js --grep platform', {
+    const result = await exec('npx playwright test docker.spec.js --grep platform --browser all', {
       env: { PLAYWRIGHT_DOCKER: '1' },
     });
     expect(result).toContain('@chromium Linux');
+    expect(result).toContain('@webkit Linux');
+    expect(result).toContain('@firefox Linux');
   });
 
-  test.describe('running container', () => {
-    test.beforeAll(async ({ exec }) => {
-      await exec('npx playwright docker start', {
-        cwd: path.join(__dirname, '..', '..'),
-      });
-    });
-
-    test.afterAll(async ({ exec }) => {
-      await exec('npx playwright docker stop', {
-        cwd: path.join(__dirname, '..', '..'),
-      });
-    });
-
-    test('all browsers work headless', async ({ exec }) => {
-      await exec('npm i --foreground-scripts @playwright/test');
-      const result = await exec('npx playwright test docker.spec.js --grep platform --browser all', {
+  test('all browsers work headed', async ({ exec }) => {
+    await exec('npm i --foreground-scripts @playwright/test');
+    {
+      const result = await exec(`npx playwright test docker.spec.js --headed --grep userAgent --browser chromium`, {
         env: { PLAYWRIGHT_DOCKER: '1' },
       });
-      expect(result).toContain('@chromium Linux');
-      expect(result).toContain('@webkit Linux');
-      expect(result).toContain('@firefox Linux');
-    });
-
-    test('supports PLAYWRIGHT_DOCKER env variable', async ({ exec }) => {
-      await exec('npm i --foreground-scripts @playwright/test');
-      const result = await exec('npx playwright test docker.spec.js --grep platform --browser all', {
-        env: {
-          PLAYWRIGHT_DOCKER: '1',
-        },
-      });
-      expect(result).toContain('@chromium Linux');
-      expect(result).toContain('@webkit Linux');
-      expect(result).toContain('@firefox Linux');
-    });
-
-    test('all browsers work headed', async ({ exec }) => {
-      await exec('npm i --foreground-scripts @playwright/test');
-      {
-        const result = await exec(`npx playwright test docker.spec.js --headed --grep userAgent --browser chromium`, {
-          env: { PLAYWRIGHT_DOCKER: '1' },
-        });
-        expect(result).toContain('@chromium');
-        expect(result).not.toContain('Headless');
-        expect(result).toContain(' Chrome/');
-      }
-      {
-        const result = await exec(`npx playwright test docker.spec.js --headed --grep userAgent --browser webkit`, {
-          env: { PLAYWRIGHT_DOCKER: '1' },
-        });
-        expect(result).toContain('@webkit');
-        expect(result).toContain(' Version/');
-      }
-      {
-        const result = await exec(`npx playwright test docker.spec.js --headed --grep userAgent --browser firefox`, {
-          env: { PLAYWRIGHT_DOCKER: '1' },
-        });
-        expect(result).toContain('@firefox');
-        expect(result).toContain(' Firefox/');
-      }
-    });
-
-    test('screenshots should use __screenshots__ folder', async ({ exec, tmpWorkspace }) => {
-      await exec('npm i --foreground-scripts @playwright/test');
-      await exec('npx playwright test docker.spec.js --grep screenshot --browser all', {
-        expectToExitWithError: true,
+      expect(result).toContain('@chromium');
+      expect(result).not.toContain('Headless');
+      expect(result).toContain(' Chrome/');
+    }
+    {
+      const result = await exec(`npx playwright test docker.spec.js --headed --grep userAgent --browser webkit`, {
         env: { PLAYWRIGHT_DOCKER: '1' },
       });
-      await expect(path.join(tmpWorkspace, '__screenshots__', 'firefox', 'docker.spec.js', 'img.png')).toExistOnFS();
-      await expect(path.join(tmpWorkspace, '__screenshots__', 'chromium', 'docker.spec.js', 'img.png')).toExistOnFS();
-      await expect(path.join(tmpWorkspace, '__screenshots__', 'webkit', 'docker.spec.js', 'img.png')).toExistOnFS();
-    });
+      expect(result).toContain('@webkit');
+      expect(result).toContain(' Version/');
+    }
+    {
+      const result = await exec(`npx playwright test docker.spec.js --headed --grep userAgent --browser firefox`, {
+        env: { PLAYWRIGHT_DOCKER: '1' },
+      });
+      expect(result).toContain('@firefox');
+      expect(result).toContain(' Firefox/');
+    }
+  });
 
-    test('port forwarding works', async ({ exec, tmpWorkspace }) => {
-      await exec('npm i --foreground-scripts @playwright/test');
-      const TEST_PORT = 8425;
-      const server = await TestServer.create(tmpWorkspace, TEST_PORT);
-      server.setRoute('/', (request, response) => {
-        response.end('Hello from host');
-      });
-      const result = await exec('npx playwright test docker.spec.js --grep localhost --browser all', {
-        env: {
-          PLAYWRIGHT_DOCKER: '1',
-          TEST_PORT: TEST_PORT + '',
-        },
-      });
-      expect(result).toContain('@chromium Hello from host');
-      expect(result).toContain('@webkit Hello from host');
-      expect(result).toContain('@firefox Hello from host');
+  test('screenshots should use __screenshots__ folder', async ({ exec, tmpWorkspace }) => {
+    await exec('npm i --foreground-scripts @playwright/test');
+    await exec('npx playwright test docker.spec.js --grep screenshot --browser all', {
+      expectToExitWithError: true,
+      env: { PLAYWRIGHT_DOCKER: '1' },
     });
+    await expect(path.join(tmpWorkspace, '__screenshots__', 'firefox', 'docker.spec.js', 'img.png')).toExistOnFS();
+    await expect(path.join(tmpWorkspace, '__screenshots__', 'chromium', 'docker.spec.js', 'img.png')).toExistOnFS();
+    await expect(path.join(tmpWorkspace, '__screenshots__', 'webkit', 'docker.spec.js', 'img.png')).toExistOnFS();
+  });
+
+  test('port forwarding works', async ({ exec, tmpWorkspace }) => {
+    await exec('npm i --foreground-scripts @playwright/test');
+    const TEST_PORT = 8425;
+    const server = await TestServer.create(tmpWorkspace, TEST_PORT);
+    server.setRoute('/', (request, response) => {
+      response.end('Hello from host');
+    });
+    const result = await exec('npx playwright test docker.spec.js --grep localhost --browser all', {
+      env: {
+        TEST_PORT: TEST_PORT + '',
+        PLAYWRIGHT_DOCKER: '1'
+      },
+    });
+    expect(result).toContain('@chromium Hello from host');
+    expect(result).toContain('@webkit Hello from host');
+    expect(result).toContain('@firefox Hello from host');
   });
 });
 


### PR DESCRIPTION
This patch implements a new mode of network tethering for Playwright server & its clients.
With this patch:
- playwright server could be launched with the `--browser-proxy-mode=tether` flag to engage in the new mode
- a new type of client, "Network Tethering Client" can connect to the server to provide network traffic to the browsers
- all clients that connect to the server with the `x-playwright-proxy: *` header will get traffic from the "Network Tethering Client"

This patch also adds an environment variable `PW_OWNED_BY_TETHER_CLIENT`. With this env, playwright server will auto-close when the network tethering client disconnects. It will also auto-close if the network client does not connect to the server in the first 10 seconds of the server existence. This way we can ensure that `npx playwright docker start` blocks terminal & controls the lifetime of the started container.