### PR TITLE
devops: proper error for the Webkit @ MacOS 10.15

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -187,7 +187,7 @@ const DOWNLOAD_PATHS = {
     'debian11': 'builds/webkit/%s/webkit-debian-11.zip',
     'mac10.13': undefined,
     'mac10.14': 'builds/deprecated-webkit-mac-10.14/%s/deprecated-webkit-mac-10.14.zip',
-    'mac10.15': 'builds/webkit/%s/webkit-mac-10.15.zip',
+    'mac10.15': 'builds/deprecated-webkit-mac-10.15/%s/deprecated-webkit-mac-10.15.zip',
     'mac11': 'builds/webkit/%s/webkit-mac-11.zip',
     'mac11-arm64': 'builds/webkit/%s/webkit-mac-11-arm64.zip',
     'mac12': 'builds/webkit/%s/webkit-mac-12.zip',


### PR DESCRIPTION
The error looks like this:

```
aslushnikov:~/prog/playwright(main)$ npx playwright wk
[object.<anonymous>: Browser closed.
==================== Browser output: ====================
<launching> /Users/andreylushnikov/Library/Caches/ms-playwright/webkit-1616/pw_run.sh --inspector-pipe --no-startup-window
<launched> pid=15076
[pid=15076][out] ****************************************************************
[pid=15076][out] ****************************************************************
[pid=15076][out]
[pid=15076][out] ERROR: MacOS version is too old!
[pid=15076][out]
[pid=15076][out] This version of Playwright does not support running
[pid=15076][out] WebKit on MacOS 10.15. Please either:
[pid=15076][out] - update your operating system to version 11 or higher
[pid=15076][out] - use Playwright v1.25 or older
[pid=15076][out]
[pid=15076][out] ****************************************************************
[pid=15076][out] ****************************************************************
[pid=15076] <process did exit: exitCode=1, signal=null>
[pid=15076] starting temporary directories cleanup
=========================== logs ===========================
```

Fixes #17699
