### PR TITLE
docs(puppeteer-js.md): fix unbalanced parentheses

### DIFF
--- a/docs/src/puppeteer-js.md
+++ b/docs/src/puppeteer-js.md
@@ -24,7 +24,7 @@ This guide describes migration to [Playwright Library](./library) and [Playwrigh
 | `await browser.createIncognitoBrowserContext(...)` | `await browser.newContext(...)`             |
 | `await page.setViewport(...)`                      | `await page.setViewportSize(...)`           |
 | `await page.waitForXPath(XPathSelector)`           | `await page.waitForSelector(XPathSelector)` |
-| `await page.waitForNetworkIdle(...)`               | `await page.waitForLoadState({ state: 'networkidle' }})` |
+| `await page.waitForNetworkIdle(...)`               | `await page.waitForLoadState({ state: 'networkidle' })` |
 | `await page.$eval(...)`                            | [Assertions](./test-assertions) can often be used instead to verify text, attribute, class... |
 | `await page.$(...)`                                | Discouraged, use [Locators](./api/class-locator) instead |
 | `await page.$x(xpath_selector)`                    | Discouraged, use [Locators](./api/class-locator) instead |


### PR DESCRIPTION
There is an unbalanced parentheses in `await page.waitForLoadState({ state: 'networkidle' }})`