### PR TITLE
fix(trace): show waitForLoadState when event has already fired

### DIFF
--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -153,7 +153,7 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
       if (this._loadStates.has(state)) {
         waiter.log(`  not waiting, "${state}" event already fired`);
       } else {
-        await waiter.waitForEvent(this._eventEmitter, 'loadstate', s => {
+        await waiter.waitForEvent<LifecycleEvent>(this._eventEmitter, 'loadstate', s => {
           waiter.log(`  "${s}" event fired`);
           return s === state;
         });

--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -148,14 +148,16 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
 
   async waitForLoadState(state: LifecycleEvent = 'load', options: { timeout?: number } = {}): Promise<void> {
     state = verifyLoadState('state', state);
-    if (this._loadStates.has(state))
-      return;
     return this._page!._wrapApiCall(async () => {
       const waiter = this._setupNavigationWaiter(options);
-      await waiter.waitForEvent<LifecycleEvent>(this._eventEmitter, 'loadstate', s => {
-        waiter.log(`  "${s}" event fired`);
-        return s === state;
-      });
+      if (this._loadStates.has(state)) {
+        waiter.log(`  not waiting, "${state}" event already fired`);
+      } else {
+        await waiter.waitForEvent(this._eventEmitter, 'loadstate', s => {
+          waiter.log(`  "${s}" event fired`);
+          return s === state;
+        });
+      }
       waiter.dispose();
     });
   }

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -717,3 +717,15 @@ test('should serve overridden request', async ({ page, runAndTrace, server }) =>
   expect(color).toBe('rgb(255, 0, 0)');
 });
 
+test('should display waitForLoadState even if did not wait for it', async ({ runAndTrace, server, page }) => {
+  const traceViewer = await runAndTrace(async () => {
+    await page.goto(server.EMPTY_PAGE);
+    await page.waitForLoadState('load');
+    await page.waitForLoadState('load');
+  });
+  await expect(traceViewer.actionTitles).toHaveText([
+    /page.goto/,
+    /page.waitForLoadState/,
+    /page.waitForLoadState/,
+  ]);
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/17807