### PR TITLE
fix: support imports without file extensions

### DIFF
--- a/packages/playwright-test/src/transform.ts
+++ b/packages/playwright-test/src/transform.ts
@@ -154,6 +154,13 @@ export function resolveHook(filename: string, specifier: string): string | undef
         return tsResolved;
     }
   }
+
+  if (isRelativeSpecifier(specifier)) {
+    const resolved = path.resolve(path.dirname(filename), specifier);
+
+    for (const ext of ['', '.js', '.ts', '.mjs', '.cjs', '.jsx', '.tsx', '.cjs', '.mts', '.cts'])
+      if (fs.existsSync(resolved + ext)) return resolved + ext;
+  }
 }
 
 export function transformHook(code: string, filename: string, moduleUrl?: string): string {


### PR DESCRIPTION
POC fix for supporting imports without file extenions

related issue: https://github.com/microsoft/playwright/issues/17804