### PR TITLE
chore: make local docker build work on branch

### DIFF
--- a/packages/playwright-core/src/containers/docker.ts
+++ b/packages/playwright-core/src/containers/docker.ts
@@ -76,7 +76,7 @@ async function buildPlaywrightImage() {
   await checkDockerEngineIsRunningOrDie();
 
   const isDevelopmentMode = getPlaywrightVersion().includes('next');
-  let baseImageName = `mcr.microsoft.com/playwright:v${getPlaywrightVersion()}-${VRT_IMAGE_DISTRO}`;
+  let baseImageName = process.env.PWTEST_DOCKER_BASE_IMAGE || `mcr.microsoft.com/playwright:v${getPlaywrightVersion()}-${VRT_IMAGE_DISTRO}`;
   // 1. Build or pull base image.
   if (isDevelopmentMode) {
     // Use our docker build scripts in development mode!


### PR DESCRIPTION
Branch does not pass `isDevelopmentMode` check because it does not have a version ending with `-next`. Therefore, `env.PWTEST_DOCKER_BASE_IMAGE` is ignored which leads to the pull of non-existent image.