### PR TITLE
feat(core): improve type for `addInitScript()`

### DIFF
--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -24,7 +24,7 @@ import { Serializable, EvaluationArgument, PageFunction0, PageFunction, PageFunc
 type AddInitScriptOptions = {
   path?: string;
   content?: string;
-}
+};
 
 type PageWaitForSelectorOptionsNotHidden = PageWaitForSelectorOptions & {
   state?: 'visible'|'attached';
@@ -281,7 +281,7 @@ export interface Page {
    * @param script Script to be evaluated in the page.
    * @param arg Optional argument to pass to `script` (only supported when passing a function).
    */
-  addInitScript<Arg>(script: PageFunction<Arg, any> | AddInitScriptOptions, arg: Arg): Promise<void>
+  addInitScript<Arg>(script: PageFunction<Arg, any> | AddInitScriptOptions, arg: Arg): Promise<void>;
   /**
    * Adds a script which would be evaluated in one of the following scenarios:
    * - Whenever the page is navigated.
@@ -309,7 +309,7 @@ export interface Page {
    * @param script Script to be evaluated in the page.
    * @param arg Optional argument to pass to `script` (only supported when passing a function).
    */
-  addInitScript(script: PageFunction0<any> | AddInitScriptOptions): Promise<void>
+  addInitScript(script: PageFunction0<any> | AddInitScriptOptions): Promise<void>;
 
   /**
    * > NOTE: The use of [ElementHandle] is discouraged, use [Locator] objects and web-first assertions instead.
@@ -6854,7 +6854,7 @@ export interface BrowserContext {
    * @param script Script to be evaluated in all pages in the browser context.
    * @param arg Optional argument to pass to `script` (only supported when passing a function).
    */
-  addInitScript<Arg>(script: PageFunction<Arg, any> | AddInitScriptOptions, arg: Arg): Promise<void>
+  addInitScript<Arg>(script: PageFunction<Arg, any> | AddInitScriptOptions, arg: Arg): Promise<void>;
   /**
    * Adds a script which would be evaluated in one of the following scenarios:
    * - Whenever a page is created in the browser context or is navigated.
@@ -6884,7 +6884,7 @@ export interface BrowserContext {
    * @param script Script to be evaluated in all pages in the browser context.
    * @param arg Optional argument to pass to `script` (only supported when passing a function).
    */
-  addInitScript(script: PageFunction0<any> | AddInitScriptOptions): Promise<void>
+  addInitScript(script: PageFunction0<any> | AddInitScriptOptions): Promise<void>;
   /**
    * > NOTE: Only works with Chromium browser's persistent context.
    *

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -18,7 +18,12 @@ import { EventEmitter } from 'events';
 import { Readable } from 'stream';
 import { ReadStream } from 'fs';
 import { Protocol } from './protocol';
-import { Serializable, EvaluationArgument, PageFunction, PageFunctionOn, SmartHandle, ElementHandleForTag, BindingSource } from './structs';
+import { Serializable, EvaluationArgument, PageFunction0, PageFunction, PageFunctionOn, SmartHandle, ElementHandleForTag, BindingSource } from './structs';
+
+type AddInitScriptOptions = {
+  path?: string;
+  content?: string;
+}
 
 type PageWaitForSelectorOptionsNotHidden = PageWaitForSelectorOptions & {
   state?: 'visible'|'attached';
@@ -34,7 +39,8 @@ export interface Page {
   evaluateHandle<R, Arg>(pageFunction: PageFunction<Arg, R>, arg: Arg): Promise<SmartHandle<R>>;
   evaluateHandle<R>(pageFunction: PageFunction<void, R>, arg?: any): Promise<SmartHandle<R>>;
 
-  addInitScript<Arg>(script: PageFunction<Arg, any> | { path?: string, content?: string }, arg?: Arg): Promise<void>;
+  addInitScript<Arg>(script: PageFunction<Arg, any> | AddInitScriptOptions, arg: Arg): Promise<void>
+  addInitScript(script: PageFunction0<any> | AddInitScriptOptions): Promise<void>
 
   $<K extends keyof HTMLElementTagNameMap>(selector: K, options?: { strict: boolean }): Promise<ElementHandleForTag<K> | null>;
   $(selector: string, options?: { strict: boolean }): Promise<ElementHandle<SVGElement | HTMLElement> | null>;
@@ -100,7 +106,8 @@ export interface BrowserContext {
   exposeBinding(name: string, playwrightBinding: (source: BindingSource, arg: JSHandle) => any, options: { handle: true }): Promise<void>;
   exposeBinding(name: string, playwrightBinding: (source: BindingSource, ...args: any[]) => any, options?: { handle?: boolean }): Promise<void>;
 
-  addInitScript<Arg>(script: PageFunction<Arg, any> | { path?: string, content?: string }, arg?: Arg): Promise<void>;
+  addInitScript<Arg>(script: PageFunction<Arg, any> | AddInitScriptOptions, arg: Arg): Promise<void>
+  addInitScript(script: PageFunction0<any> | AddInitScriptOptions): Promise<void>
 }
 
 export interface Worker {

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -23,7 +23,7 @@ import { Serializable, EvaluationArgument, PageFunction0, PageFunction, PageFunc
 type AddInitScriptOptions = {
   path?: string;
   content?: string;
-}
+};
 
 type PageWaitForSelectorOptionsNotHidden = PageWaitForSelectorOptions & {
   state?: 'visible'|'attached';
@@ -39,8 +39,8 @@ export interface Page {
   evaluateHandle<R, Arg>(pageFunction: PageFunction<Arg, R>, arg: Arg): Promise<SmartHandle<R>>;
   evaluateHandle<R>(pageFunction: PageFunction<void, R>, arg?: any): Promise<SmartHandle<R>>;
 
-  addInitScript<Arg>(script: PageFunction<Arg, any> | AddInitScriptOptions, arg: Arg): Promise<void>
-  addInitScript(script: PageFunction0<any> | AddInitScriptOptions): Promise<void>
+  addInitScript<Arg>(script: PageFunction<Arg, any> | AddInitScriptOptions, arg: Arg): Promise<void>;
+  addInitScript(script: PageFunction0<any> | AddInitScriptOptions): Promise<void>;
 
   $<K extends keyof HTMLElementTagNameMap>(selector: K, options?: { strict: boolean }): Promise<ElementHandleForTag<K> | null>;
   $(selector: string, options?: { strict: boolean }): Promise<ElementHandle<SVGElement | HTMLElement> | null>;
@@ -106,8 +106,8 @@ export interface BrowserContext {
   exposeBinding(name: string, playwrightBinding: (source: BindingSource, arg: JSHandle) => any, options: { handle: true }): Promise<void>;
   exposeBinding(name: string, playwrightBinding: (source: BindingSource, ...args: any[]) => any, options?: { handle?: boolean }): Promise<void>;
 
-  addInitScript<Arg>(script: PageFunction<Arg, any> | AddInitScriptOptions, arg: Arg): Promise<void>
-  addInitScript(script: PageFunction0<any> | AddInitScriptOptions): Promise<void>
+  addInitScript<Arg>(script: PageFunction<Arg, any> | AddInitScriptOptions, arg: Arg): Promise<void>;
+  addInitScript(script: PageFunction0<any> | AddInitScriptOptions): Promise<void>;
 }
 
 export interface Worker {

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -588,7 +588,7 @@ playwright.chromium.launch().then(async browser => {
   }
   {
     // @ts-expect-error
-      await page.addInitScript((_expectNoArg: any) => {});
+    await page.addInitScript((_expectNoArg: any) => {});
   }
 
   await browser.close();

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -586,6 +586,10 @@ playwright.chromium.launch().then(async browser => {
       }
     });
   }
+  {
+    // @ts-expect-error
+      await page.addInitScript((_expectNoArg: any) => {});
+  }
 
   await browser.close();
 })();


### PR DESCRIPTION
No callback parameter when no Arg.