### PR TITLE
docs(class-testconfig.md): since version for fullyParalell

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -113,7 +113,7 @@ export default config;
 ```
 
 ## property: TestConfig.fullyParallel
-* since: v1.10
+* since: v1.20
 - type: ?<[boolean]>
 
 Playwright Test runs tests in parallel. In order to achieve that, it runs several worker processes that run at the same time.


### PR DESCRIPTION
fullyParallel was added in 1.20 https://playwright.dev/docs/release-notes#version-120 this updated the docs to match that.