### PR TITLE
docs(library) fix js example

### DIFF
--- a/docs/src/library-js.md
+++ b/docs/src/library-js.md
@@ -24,6 +24,7 @@ The following is an example of using the Playwright Library directly to launch C
 
 ```js tab=js-ts
 import playwright, { devices } from 'playwright';
+import assert from 'node:assert';
 
 (async () => {
   // Setup
@@ -35,7 +36,7 @@ import playwright, { devices } from 'playwright';
   await context.route('**.jpg', route => route.abort());
   await page.goto('https://example.com/');
 
-  assert(await page.title() === 'Example'); // 👎 not a Web First assertion
+  assert(await page.title() === 'Example Domain'); // 👎 not a Web First assertion
 
   // Teardown
   await context.close();

--- a/docs/src/library-js.md
+++ b/docs/src/library-js.md
@@ -44,19 +44,20 @@ import playwright, { devices } from 'playwright';
 ```
 
 ```js tab=js-js
+const assert = require('node:assert');
 const playwright = require('playwright');
 
 (async () => {
   // Setup
   const browser = await playwright.chromium.launch();
-  const context = await browser.newContext(devices['iPhone 11']);
+  const context = await browser.newContext(playwright.devices['iPhone 11']);
   const page = await context.newPage();
 
   // The actual interesting bit
   await context.route('**.jpg', route => route.abort());
   await page.goto('https://example.com/');
 
-  assert(await page.title() === 'Example'); // 👎 not a Web First assertion
+  assert(await page.title() === 'Example Domain'); // 👎 not a Web First assertion
 
   // Teardown
   await context.close();


### PR DESCRIPTION
Correct three failures:
1. assert() is not defined by default and must be require()'d
2. the devices object is not imported properly
3. the page.title() of https://example.com is "Example Domain" not "Example."


Should I be concerned that the examples in the docs don't work reliably? It seems like there are some problems with the adjacent typescript example, but I don't use typescript and ran into trouble making it run, so I'm reluctant to touch it.