### PR TITLE
docs(release-notes): add missing reference to Page.getByTestId in 1.27 release notes

### DIFF
--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -12,6 +12,7 @@ With these new APIs writing locators is a joy:
 - [`method: Page.getByText`] to locate by text content.
 - [`method: Page.getByRole`] to locate by [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles), [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
 - [`method: Page.getByLabel`] to locate a form control by associated label's text.
+- [`method: Page.getByTestId`] to locate an element based on its `data-testid` attribute (other attribute can be configured).
 - [`method: Page.getByPlaceholder`] to locate an input by placeholder.
 - [`method: Page.getByAltText`] to locate an element, usually image, by its text alternative.
 - [`method: Page.getByTitle`] to locate an element by its title.

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -12,6 +12,7 @@ With these new APIs writing locators is a joy:
 - [`method: Page.getByText`] to locate by text content.
 - [`method: Page.getByRole`] to locate by [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles), [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
 - [`method: Page.getByLabel`] to locate a form control by associated label's text.
+- [`method: Page.getByTestId`] to locate an element based on its `data-testid` attribute (other attribute can be configured).
 - [`method: Page.getByPlaceholder`] to locate an input by placeholder.
 - [`method: Page.getByAltText`] to locate an element, usually image, by its text alternative.
 - [`method: Page.getByTitle`] to locate an element by its title.

--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -12,6 +12,7 @@ With these new APIs writing locators is a joy:
 - [`method: Page.getByText`] to locate by text content.
 - [`method: Page.getByRole`] to locate by [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles), [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
 - [`method: Page.getByLabel`] to locate a form control by associated label's text.
+- [`method: Page.getByTestId`] to locate an element based on its `data-testid` attribute (other attribute can be configured).
 - [`method: Page.getByPlaceholder`] to locate an input by placeholder.
 - [`method: Page.getByAltText`] to locate an element, usually image, by its text alternative.
 - [`method: Page.getByTitle`] to locate an element by its title.

--- a/docs/src/release-notes-python.md
+++ b/docs/src/release-notes-python.md
@@ -12,6 +12,7 @@ With these new APIs writing locators is a joy:
 - [`method: Page.getByText`] to locate by text content.
 - [`method: Page.getByRole`] to locate by [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles), [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
 - [`method: Page.getByLabel`] to locate a form control by associated label's text.
+- [`method: Page.getByTestId`] to locate an element based on its `data-testid` attribute (other attribute can be configured).
 - [`method: Page.getByPlaceholder`] to locate an input by placeholder.
 - [`method: Page.getByAltText`] to locate an element, usually image, by its text alternative.
 - [`method: Page.getByTitle`] to locate an element by its title.


### PR DESCRIPTION
1.27 release notes don't mention the new `Page.getByTestId` method alongside the other added methods (`getByRole`, `getByLabelText` etc.)

This PR adds it to the corresponding release notes.

I'm not 100% sure this is the way to do it, I assume there's some automation going on to update the documentation website, let me know if it needs t be done differently.