### PR TITLE
fix(codegen): use constants when generating C# and Java roles

### DIFF
--- a/packages/playwright-core/src/server/isomorphic/locatorGenerators.ts
+++ b/packages/playwright-core/src/server/isomorphic/locatorGenerators.ts
@@ -234,7 +234,7 @@ export class JavaLocatorFactory implements LocatorFactory {
         for (const [name, value] of Object.entries(options.attrs!))
           attrs.push(`.set${toTitleCase(name)}(${typeof value === 'string' ? this.quote(value) : value})`);
         const attrString = attrs.length ? `, new ${clazz}.GetByRoleOptions()${attrs.join('')}` : '';
-        return `getByRole(${this.quote(body)}${attrString})`;
+        return `getByRole(AriaRole.${toSnakeCase(body).toUpperCase()}${attrString})`;
       case 'has-text':
         return `locator(${this.quote(body)}, new ${clazz}.LocatorOptions().setHasText(${this.quote(options.hasText!)}))`;
       case 'test-id':
@@ -286,7 +286,7 @@ export class CSharpLocatorFactory implements LocatorFactory {
         for (const [name, value] of Object.entries(options.attrs!))
           attrs.push(`${toTitleCase(name)} = ${typeof value === 'string' ? this.quote(value) : value}`);
         const attrString = attrs.length ? `, new () { ${attrs.join(', ')} }` : '';
-        return `GetByRole(${this.quote(body)}${attrString})`;
+        return `GetByRole(AriaRole.${toTitleCase(body)}${attrString})`;
       case 'has-text':
         return `Locator(${this.quote(body)}, new () { HasTextString: ${this.quote(options.hasText!)} })`;
       case 'test-id':

--- a/tests/library/inspector/cli-codegen-1.spec.ts
+++ b/tests/library/inspector/cli-codegen-1.spec.ts
@@ -34,20 +34,20 @@ test.describe('cli codegen', () => {
       page.dispatchEvent('button', 'click', { detail: 1 })
     ]);
 
-    expect(sources.get('JavaScript').text).toContain(`
+    expect.soft(sources.get('JavaScript').text).toContain(`
   await page.getByRole('button', { name: 'Submit' }).click();`);
 
-    expect(sources.get('Python').text).toContain(`
+    expect.soft(sources.get('Python').text).toContain(`
     page.get_by_role("button", name="Submit").click()`);
 
-    expect(sources.get('Python Async').text).toContain(`
+    expect.soft(sources.get('Python Async').text).toContain(`
     await page.get_by_role("button", name="Submit").click()`);
 
-    expect(sources.get('Java').text).toContain(`
-      page.getByRole("button", new Page.GetByRoleOptions().setName("Submit")).click()`);
+    expect.soft(sources.get('Java').text).toContain(`
+      page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Submit")).click()`);
 
-    expect(sources.get('C#').text).toContain(`
-        await page.GetByRole("button", new () { Name = "Submit" }).ClickAsync();`);
+    expect.soft(sources.get('C#').text).toContain(`
+        await page.GetByRole(AriaRole.Button, new () { Name = "Submit" }).ClickAsync();`);
 
     expect(message.text()).toBe('click');
   });
@@ -157,20 +157,20 @@ test.describe('cli codegen', () => {
       page.dispatchEvent('button', 'click', { detail: 1 })
     ]);
 
-    expect(sources.get('JavaScript').text).toContain(`
+    expect.soft(sources.get('JavaScript').text).toContain(`
   await page.getByRole('button', { name: 'Submit' }).click();`);
 
-    expect(sources.get('Python').text).toContain(`
+    expect.soft(sources.get('Python').text).toContain(`
     page.get_by_role("button", name="Submit").click()`);
 
-    expect(sources.get('Python Async').text).toContain(`
+    expect.soft(sources.get('Python Async').text).toContain(`
     await page.get_by_role("button", name="Submit").click()`);
 
-    expect(sources.get('Java').text).toContain(`
-      page.getByRole("button", new Page.GetByRoleOptions().setName("Submit")).click()`);
+    expect.soft(sources.get('Java').text).toContain(`
+      page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Submit")).click()`);
 
-    expect(sources.get('C#').text).toContain(`
-        await page.GetByRole("button", new () { Name = "Submit" }).ClickAsync();`);
+    expect.soft(sources.get('C#').text).toContain(`
+        await page.GetByRole(AriaRole.Button, new () { Name = "Submit" }).ClickAsync();`);
 
     expect(message.text()).toBe('click');
   });
@@ -548,31 +548,31 @@ test.describe('cli codegen', () => {
       page.dispatchEvent('a', 'click', { detail: 1 })
     ]);
 
-    expect(sources.get('JavaScript').text).toContain(`
+    expect.soft(sources.get('JavaScript').text).toContain(`
   const [page1] = await Promise.all([
     page.waitForEvent('popup'),
     page.getByRole('link', { name: 'link' }).click()
   ]);`);
 
-    expect(sources.get('Java').text).toContain(`
+    expect.soft(sources.get('Java').text).toContain(`
       Page page1 = page.waitForPopup(() -> {
-        page.getByRole("link", new Page.GetByRoleOptions().setName("link")).click();
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("link")).click();
       });`);
 
-    expect(sources.get('Python').text).toContain(`
+    expect.soft(sources.get('Python').text).toContain(`
     with page.expect_popup() as popup_info:
         page.get_by_role("link", name="link").click()
     page1 = popup_info.value`);
 
-    expect(sources.get('Python Async').text).toContain(`
+    expect.soft(sources.get('Python Async').text).toContain(`
     async with page.expect_popup() as popup_info:
         await page.get_by_role("link", name="link").click()
     page1 = await popup_info.value`);
 
-    expect(sources.get('C#').text).toContain(`
+    expect.soft(sources.get('C#').text).toContain(`
         var page1 = await page.RunAndWaitForPopupAsync(async () =>
         {
-            await page.GetByRole("link", new () { Name = "link" }).ClickAsync();
+            await page.GetByRole(AriaRole.Link, new () { Name = "link" }).ClickAsync();
         });`);
 
     expect(popup.url()).toBe('about:blank');

--- a/tests/library/inspector/cli-codegen-2.spec.ts
+++ b/tests/library/inspector/cli-codegen-2.spec.ts
@@ -226,41 +226,41 @@ test.describe('cli codegen', () => {
     ]);
     const sources = await recorder.waitForOutput('JavaScript', 'waitForEvent');
 
-    expect(sources.get('JavaScript').text).toContain(`
+    expect.soft(sources.get('JavaScript').text).toContain(`
   const context = await browser.newContext();`);
-    expect(sources.get('JavaScript').text).toContain(`
+    expect.soft(sources.get('JavaScript').text).toContain(`
   const [download] = await Promise.all([
     page.waitForEvent('download'),
     page.getByRole('link', { name: 'Download' }).click()
   ]);`);
 
-    expect(sources.get('Java').text).toContain(`
+    expect.soft(sources.get('Java').text).toContain(`
       BrowserContext context = browser.newContext();`);
-    expect(sources.get('Java').text).toContain(`
+    expect.soft(sources.get('Java').text).toContain(`
       Download download = page.waitForDownload(() -> {
-        page.getByRole("link", new Page.GetByRoleOptions().setName("Download")).click();
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Download")).click();
       });`);
 
-    expect(sources.get('Python').text).toContain(`
+    expect.soft(sources.get('Python').text).toContain(`
     context = browser.new_context()`);
-    expect(sources.get('Python').text).toContain(`
+    expect.soft(sources.get('Python').text).toContain(`
     with page.expect_download() as download_info:
         page.get_by_role("link", name="Download").click()
     download = download_info.value`);
 
-    expect(sources.get('Python Async').text).toContain(`
+    expect.soft(sources.get('Python Async').text).toContain(`
     context = await browser.new_context()`);
-    expect(sources.get('Python Async').text).toContain(`
+    expect.soft(sources.get('Python Async').text).toContain(`
     async with page.expect_download() as download_info:
         await page.get_by_role("link", name="Download").click()
     download = await download_info.value`);
 
-    expect(sources.get('C#').text).toContain(`
+    expect.soft(sources.get('C#').text).toContain(`
         var context = await browser.NewContextAsync();`);
-    expect(sources.get('C#').text).toContain(`
+    expect.soft(sources.get('C#').text).toContain(`
         var download1 = await page.RunAndWaitForDownloadAsync(async () =>
         {
-            await page.GetByRole("link", new () { Name = "Download" }).ClickAsync();
+            await page.GetByRole(AriaRole.Link, new () { Name = "Download" }).ClickAsync();
         });`);
   });
 
@@ -278,29 +278,29 @@ test.describe('cli codegen', () => {
 
     const sources = await recorder.waitForOutput('JavaScript', 'once');
 
-    expect(sources.get('JavaScript').text).toContain(`
+    expect.soft(sources.get('JavaScript').text).toContain(`
   page.once('dialog', dialog => {
     console.log(\`Dialog message: \${dialog.message()}\`);
     dialog.dismiss().catch(() => {});
   });
   await page.getByRole('button', { name: 'click me' }).click();`);
 
-    expect(sources.get('Java').text).toContain(`
+    expect.soft(sources.get('Java').text).toContain(`
       page.onceDialog(dialog -> {
         System.out.println(String.format("Dialog message: %s", dialog.message()));
         dialog.dismiss();
       });
-      page.getByRole("button", new Page.GetByRoleOptions().setName("click me")).click();`);
+      page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("click me")).click();`);
 
-    expect(sources.get('Python').text).toContain(`
+    expect.soft(sources.get('Python').text).toContain(`
     page.once(\"dialog\", lambda dialog: dialog.dismiss())
     page.get_by_role("button", name="click me").click()`);
 
-    expect(sources.get('Python Async').text).toContain(`
+    expect.soft(sources.get('Python Async').text).toContain(`
     page.once(\"dialog\", lambda dialog: dialog.dismiss())
     await page.get_by_role("button", name="click me").click()`);
 
-    expect(sources.get('C#').text).toContain(`
+    expect.soft(sources.get('C#').text).toContain(`
         void page_Dialog1_EventHandler(object sender, IDialog dialog)
         {
             Console.WriteLine($\"Dialog message: {dialog.Message}\");
@@ -308,7 +308,7 @@ test.describe('cli codegen', () => {
             page.Dialog -= page_Dialog1_EventHandler;
         }
         page.Dialog += page_Dialog1_EventHandler;
-        await page.GetByRole("button", new () { Name = "click me" }).ClickAsync();`);
+        await page.GetByRole(AriaRole.Button, new () { Name = "click me" }).ClickAsync();`);
 
   });
 

--- a/tests/library/inspector/cli-codegen-3.spec.ts
+++ b/tests/library/inspector/cli-codegen-3.spec.ts
@@ -46,10 +46,10 @@ test.describe('cli codegen', () => {
     await page.get_by_role("button", name="Submit").first.click()`);
 
     expect.soft(sources.get('Java').text).toContain(`
-      page.getByRole("button", new Page.GetByRoleOptions().setName("Submit")).first().click();`);
+      page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Submit")).first().click();`);
 
     expect.soft(sources.get('C#').text).toContain(`
-        await page.GetByRole("button", new () { Name = "Submit" }).First.ClickAsync();`);
+        await page.GetByRole(AriaRole.Button, new () { Name = "Submit" }).First.ClickAsync();`);
 
     expect(message.text()).toBe('click1');
   });
@@ -81,10 +81,10 @@ test.describe('cli codegen', () => {
     await page.get_by_role("button", name="Submit").nth(1).click()`);
 
     expect.soft(sources.get('Java').text).toContain(`
-      page.getByRole("button", new Page.GetByRoleOptions().setName("Submit")).nth(1).click();`);
+      page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Submit")).nth(1).click();`);
 
     expect.soft(sources.get('C#').text).toContain(`
-        await page.GetByRole("button", new () { Name = "Submit" }).Nth(1).ClickAsync();`);
+        await page.GetByRole(AriaRole.Button, new () { Name = "Submit" }).Nth(1).ClickAsync();`);
 
     expect(message.text()).toBe('click2');
   });
@@ -217,7 +217,7 @@ test.describe('cli codegen', () => {
   await page.frameLocator('#frame1').getByRole('button', { name: 'Submit' }).click();`);
 
     expect.soft(sources.get('Java').text).toContain(`
-      page.frameLocator("#frame1").getByRole("button", new FrameLocator.GetByRoleOptions().setName("Submit")).click();`);
+      page.frameLocator("#frame1").getByRole(AriaRole.BUTTON, new FrameLocator.GetByRoleOptions().setName("Submit")).click();`);
 
     expect.soft(sources.get('Python').text).toContain(`
     page.frame_locator("#frame1").get_by_role("button", name="Submit").click()`);
@@ -226,7 +226,7 @@ test.describe('cli codegen', () => {
     await page.frame_locator("#frame1").get_by_role("button", name="Submit").click()`);
 
     expect.soft(sources.get('C#').text).toContain(`
-        await page.FrameLocator("#frame1").GetByRole("button", new () { Name = "Submit" }).ClickAsync();`);
+        await page.FrameLocator("#frame1").GetByRole(AriaRole.Button, new () { Name = "Submit" }).ClickAsync();`);
   });
 
   test('should generate getByTestId', async ({ page, openRecorder }) => {


### PR DESCRIPTION
Fixes #[17960](https://github.com/microsoft/playwright/issues/17960)