### PR TITLE
fix: Allow setting process.env.PWDEBUG programatically

### DIFF
--- a/packages/playwright-core/src/utils/index.ts
+++ b/packages/playwright-core/src/utils/index.ts
@@ -90,8 +90,8 @@ export function isError(obj: any): obj is Error {
   return obj instanceof Error || (obj && Object.getPrototypeOf(obj)?.name === 'Error');
 }
 
-const debugEnv = getFromENV('PWDEBUG') || '';
 export function debugMode() {
+  const debugEnv = getFromENV('PWDEBUG') || '';
   if (debugEnv === 'console')
     return 'console';
   if (debugEnv === '0' || debugEnv === 'false')


### PR DESCRIPTION
Currently setting process.env.PWDEBUG programatically is not possible, because it is read once code loaded. After this change use can set it i.e. before launching browser.