### PR TITLE
feat(playwright-test): support `connectOverCDP` option in `connectOptions`

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -89,7 +89,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
 
   private async _connectInsteadOfLaunching(): Promise<Browser> {
     const connectOptions = this._defaultConnectOptions!;
-    return this._connect(connectOptions.wsEndpoint, {
+    return this[connectOptions.connectOverCDP ? '_connectOverCDP' : '_connect'](connectOptions.wsEndpoint, {
       headers: {
         'x-playwright-browser': this.name(),
         'x-playwright-launch-options': JSON.stringify(this._defaultLaunchOptions || {}),

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -82,6 +82,7 @@ export type LaunchPersistentContextOptions = Omit<LaunchOptionsBase & BrowserCon
 
 export type ConnectOptions = {
   wsEndpoint: string,
+  connectOverCDP?: boolean,
   headers?: { [key: string]: string; };
   slowMo?: number,
   timeout?: number,

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -2660,6 +2660,11 @@ type ConnectOptions = {
   wsEndpoint: string;
 
   /**
+   * Connect using the Chrome DevTools Protocol.
+   */
+   connectOverCDP?: boolean;
+
+  /**
    * Additional HTTP headers to be sent with web socket connect request.
    */
   headers?: { [key: string]: string; };

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -189,6 +189,11 @@ type ConnectOptions = {
   wsEndpoint: string;
 
   /**
+   * Connect using the Chrome DevTools Protocol. 
+   */
+   connectOverCDP?: boolean;
+
+  /**
    * Additional HTTP headers to be sent with web socket connect request.
    */
   headers?: { [key: string]: string; };


### PR DESCRIPTION
Open to suggestions for a better way to do this. We just need to be able to use the CDP protocol to connect to chrome using the test library.

Don't suppose there's a way of achieving this on the current version? I couldn't find any