### PR TITLE
fix(generator): .NET getByRole w/ name

### DIFF
--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -22,7 +22,7 @@ await page.GetByLabel("User Name").FillAsync("John");
 
 await page.GetByLabel("Password").FillAsync("secret-password");
 
-await page.GetByRole("button", new() { Name = "Sign in" }).ClickAsync();
+await page.GetByRole("button", new() { NameString = "Sign in" }).ClickAsync();
 
 await Expect(page.GetByText("Welcome, John!")).ToBeVisibleAsync();
 ```

--- a/packages/playwright-core/src/server/isomorphic/locatorGenerators.ts
+++ b/packages/playwright-core/src/server/isomorphic/locatorGenerators.ts
@@ -285,12 +285,14 @@ export class CSharpLocatorFactory implements LocatorFactory {
         return `Last`;
       case 'role':
         const attrs: string[] = [];
-        for (const [name, value] of Object.entries(options.attrs!))
-          attrs.push(`${toTitleCase(name)} = ${typeof value === 'string' ? this.quote(value) : value}`);
-        const attrString = attrs.length ? `, new () { ${attrs.join(', ')} }` : '';
+        for (const [name, value] of Object.entries(options.attrs!)) {
+          const optionKey = name === 'name' ? 'NameString' : toTitleCase(name);
+          attrs.push(`${optionKey} = ${typeof value === 'string' ? this.quote(value) : value}`);
+        }
+        const attrString = attrs.length ? `, new() { ${attrs.join(', ')} }` : '';
         return `GetByRole(AriaRole.${toTitleCase(body as string)}${attrString})`;
       case 'has-text':
-        return `Locator(${this.quote(body as string)}, new () { HasTextString: ${this.quote(options.hasText!)} })`;
+        return `Locator(${this.quote(body as string)}, new() { HasTextString: ${this.quote(options.hasText!)} })`;
       case 'test-id':
         return `GetByTestId(${this.quote(body as string)})`;
       case 'text':
@@ -314,7 +316,7 @@ export class CSharpLocatorFactory implements LocatorFactory {
       return `${method}(new Regex(${this.quote(body.source)}${suffix}))`;
     }
     if (exact)
-      return `${method}(${this.quote(body)}, new () { Exact: true })`;
+      return `${method}(${this.quote(body)}, new() { Exact: true })`;
     return `${method}(${this.quote(body)})`;
   }
 

--- a/tests/library/inspector/cli-codegen-1.spec.ts
+++ b/tests/library/inspector/cli-codegen-1.spec.ts
@@ -47,7 +47,7 @@ test.describe('cli codegen', () => {
       page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Submit")).click()`);
 
     expect.soft(sources.get('C#').text).toContain(`
-        await page.GetByRole(AriaRole.Button, new () { Name = "Submit" }).ClickAsync();`);
+        await page.GetByRole(AriaRole.Button, new() { NameString = "Submit" }).ClickAsync();`);
 
     expect(message.text()).toBe('click');
   });
@@ -170,7 +170,7 @@ test.describe('cli codegen', () => {
       page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Submit")).click()`);
 
     expect.soft(sources.get('C#').text).toContain(`
-        await page.GetByRole(AriaRole.Button, new () { Name = "Submit" }).ClickAsync();`);
+        await page.GetByRole(AriaRole.Button, new() { NameString = "Submit" }).ClickAsync();`);
 
     expect(message.text()).toBe('click');
   });
@@ -572,7 +572,7 @@ test.describe('cli codegen', () => {
     expect.soft(sources.get('C#').text).toContain(`
         var page1 = await page.RunAndWaitForPopupAsync(async () =>
         {
-            await page.GetByRole(AriaRole.Link, new () { Name = "link" }).ClickAsync();
+            await page.GetByRole(AriaRole.Link, new() { NameString = "link" }).ClickAsync();
         });`);
 
     expect(popup.url()).toBe('about:blank');

--- a/tests/library/inspector/cli-codegen-2.spec.ts
+++ b/tests/library/inspector/cli-codegen-2.spec.ts
@@ -260,7 +260,7 @@ test.describe('cli codegen', () => {
     expect.soft(sources.get('C#').text).toContain(`
         var download1 = await page.RunAndWaitForDownloadAsync(async () =>
         {
-            await page.GetByRole(AriaRole.Link, new () { Name = "Download" }).ClickAsync();
+            await page.GetByRole(AriaRole.Link, new() { NameString = "Download" }).ClickAsync();
         });`);
   });
 
@@ -308,7 +308,7 @@ test.describe('cli codegen', () => {
             page.Dialog -= page_Dialog1_EventHandler;
         }
         page.Dialog += page_Dialog1_EventHandler;
-        await page.GetByRole(AriaRole.Button, new () { Name = "click me" }).ClickAsync();`);
+        await page.GetByRole(AriaRole.Button, new() { NameString = "click me" }).ClickAsync();`);
 
   });
 

--- a/tests/library/inspector/cli-codegen-3.spec.ts
+++ b/tests/library/inspector/cli-codegen-3.spec.ts
@@ -49,7 +49,7 @@ test.describe('cli codegen', () => {
       page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Submit")).first().click();`);
 
     expect.soft(sources.get('C#').text).toContain(`
-        await page.GetByRole(AriaRole.Button, new () { Name = "Submit" }).First.ClickAsync();`);
+        await page.GetByRole(AriaRole.Button, new() { NameString = "Submit" }).First.ClickAsync();`);
 
     expect(message.text()).toBe('click1');
   });
@@ -84,7 +84,7 @@ test.describe('cli codegen', () => {
       page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Submit")).nth(1).click();`);
 
     expect.soft(sources.get('C#').text).toContain(`
-        await page.GetByRole(AriaRole.Button, new () { Name = "Submit" }).Nth(1).ClickAsync();`);
+        await page.GetByRole(AriaRole.Button, new() { NameString = "Submit" }).Nth(1).ClickAsync();`);
 
     expect(message.text()).toBe('click2');
   });
@@ -226,7 +226,7 @@ test.describe('cli codegen', () => {
     await page.frame_locator("#frame1").get_by_role("button", name="Submit").click()`);
 
     expect.soft(sources.get('C#').text).toContain(`
-        await page.FrameLocator("#frame1").GetByRole(AriaRole.Button, new () { Name = "Submit" }).ClickAsync();`);
+        await page.FrameLocator("#frame1").GetByRole(AriaRole.Button, new() { NameString = "Submit" }).ClickAsync();`);
   });
 
   test('should generate getByTestId', async ({ page, openRecorder }) => {

--- a/tests/library/locator-generator.spec.ts
+++ b/tests/library/locator-generator.spec.ts
@@ -41,7 +41,7 @@ it('reverse engineer locators', async ({ page }) => {
   });
 
   expect.soft(generate(page.getByText('Hello', { exact: true }))).toEqual({
-    csharp: 'GetByText("Hello", new () { Exact: true })',
+    csharp: 'GetByText("Hello", new() { Exact: true })',
     java: 'getByText("Hello", new Page.GetByTextOptions().setExact(exact))',
     javascript: 'getByText(\'Hello\', { exact: true })',
     python: 'get_by_text("Hello", exact=true)',
@@ -66,7 +66,7 @@ it('reverse engineer locators', async ({ page }) => {
     python: 'get_by_label("Name")',
   });
   expect.soft(generate(page.getByLabel('Last Name', { exact: true }))).toEqual({
-    csharp: 'GetByLabel("Last Name", new () { Exact: true })',
+    csharp: 'GetByLabel("Last Name", new() { Exact: true })',
     java: 'getByLabel("Last Name", new Page.GetByLabelOptions().setExact(exact))',
     javascript: 'getByLabel(\'Last Name\', { exact: true })',
     python: 'get_by_label("Last Name", exact=true)',
@@ -85,7 +85,7 @@ it('reverse engineer locators', async ({ page }) => {
     python: 'get_by_placeholder("hello")',
   });
   expect.soft(generate(page.getByPlaceholder('Hello', { exact: true }))).toEqual({
-    csharp: 'GetByPlaceholder("Hello", new () { Exact: true })',
+    csharp: 'GetByPlaceholder("Hello", new() { Exact: true })',
     java: 'getByPlaceholder("Hello", new Page.GetByPlaceholderOptions().setExact(exact))',
     javascript: 'getByPlaceholder(\'Hello\', { exact: true })',
     python: 'get_by_placeholder("Hello", exact=true)',
@@ -104,7 +104,7 @@ it('reverse engineer locators', async ({ page }) => {
     python: 'get_by_alt_text("hello")',
   });
   expect.soft(generate(page.getByAltText('Hello', { exact: true }))).toEqual({
-    csharp: 'GetByAltText("Hello", new () { Exact: true })',
+    csharp: 'GetByAltText("Hello", new() { Exact: true })',
     java: 'getByAltText("Hello", new Page.GetByAltTextOptions().setExact(exact))',
     javascript: 'getByAltText(\'Hello\', { exact: true })',
     python: 'get_by_alt_text("Hello", exact=true)',
@@ -123,7 +123,7 @@ it('reverse engineer locators', async ({ page }) => {
     python: 'get_by_title("hello")',
   });
   expect.soft(generate(page.getByTitle('Hello', { exact: true }))).toEqual({
-    csharp: 'GetByTitle("Hello", new () { Exact: true })',
+    csharp: 'GetByTitle("Hello", new() { Exact: true })',
     java: 'getByTitle("Hello", new Page.GetByTitleOptions().setExact(exact))',
     javascript: 'getByTitle(\'Hello\', { exact: true })',
     python: 'get_by_title("Hello", exact=true)',


### PR DESCRIPTION
See: https://github.com/microsoft/playwright-dotnet/blob/607cc1f260310006ddf74e8f923a70f3b88b4b26/src/Playwright/API/Generated/Options/LocatorGetByRoleOptions.cs#L36-L52

Fixes https://github.com/microsoft/playwright/issues/17960
Fixes https://github.com/microsoft/playwright-dotnet/issues/2345

drive-by: new () -> new() since its the style-guide.