### PR TITLE
Match documentation to types for waitForLoadState

### DIFF
--- a/docs/src/puppeteer-js.md
+++ b/docs/src/puppeteer-js.md
@@ -24,7 +24,7 @@ This guide describes migration to [Playwright Library](./library) and [Playwrigh
 | `await browser.createIncognitoBrowserContext(...)` | `await browser.newContext(...)`             |
 | `await page.setViewport(...)`                      | `await page.setViewportSize(...)`           |
 | `await page.waitForXPath(XPathSelector)`           | `await page.waitForSelector(XPathSelector)` |
-| `await page.waitForNetworkIdle(...)`               | `await page.waitForLoadState({ state: 'networkidle' })` |
+| `await page.waitForNetworkIdle(...)`               | `await page.waitForLoadState('networkidle')` |
 | `await page.$eval(...)`                            | [Assertions](./test-assertions) can often be used instead to verify text, attribute, class... |
 | `await page.$(...)`                                | Discouraged, use [Locators](./api/class-locator) instead |
 | `await page.$x(xpath_selector)`                    | Discouraged, use [Locators](./api/class-locator) instead |


### PR DESCRIPTION
When working on a conversion from puppeteer to playwright, noticed the example didn't match the current types for `page.waitForLoadState`. (Was expecting a string of `"load" | "domcontentloaded" | "networkidle"` instead of `{ state: "load" | "domcontentloaded" | "networkidle" }`

This PR adjusts the documentation to match the types.

Signed-off-by: smacpherson64 <smacpherson64@gmail.com>