### PR TITLE
docs: merge cli and vscode getting started

### DIFF
--- a/docs/src/ci-intro-js.md
+++ b/docs/src/ci-intro-js.md
@@ -7,13 +7,10 @@ When installing Playwright you are given the option to add a [GitHub Actions](ht
 
 **What you will learn:**
 
-- [How to use GitHub Actions to run your tests](#github-actions)
-- [How to create a repo and push to GitHub](#create-a-repo-and-push-to-github)
-- [How to open the workflows](#opening-the-workflows)
-- [How to view the test logs](#viewing-test-logs)
-- [How to download the report from GitHub](#downloading-the-html-report)
-- [How to view the report](#viewing-the-html-report)
-- [How to view the trace](#viewing-the-trace)
+- How to use GitHub Actions to run your tests
+- How to open the workflows and view the test logs
+- How to download the report from GitHub
+- How to view the report and trace of your test
 
 ## GitHub Actions
 
@@ -71,8 +68,6 @@ Clicking on the workflow run will show you the all the actions that GitHub perfo
 
 <img width="839" alt="Viewing Test Logs" src="https://user-images.githubusercontent.com/13063165/183423783-58bf2008-514e-4f96-9c12-c9a55703960c.png"/>
 
-
-
 ## HTML Report
 
 The HTML Report shows you a full report of your tests. You can filter the report by browsers, passed tests, failed tests, skipped tests and flaky tests.
@@ -106,7 +101,6 @@ Once you have served the report using `npx playwright show-report`, click on the
 To learn more about traces check out our detailed guide on [Trace Viewer](/trace-viewer.md).
 
 To learn more about running tests on CI check out our detailed guide on [Continuous Integration](/ci.md).
-
 
 ## What's Next
 

--- a/docs/src/codegen-intro.md
+++ b/docs/src/codegen-intro.md
@@ -7,43 +7,48 @@ Playwright comes with the ability to generate tests out of the box and is a grea
 
 **You will learn**
 
-- [How to generate tests with Codegen](/codegen.md#running-codegen)
+- How to record your user actions and generate tests with Codegen
 
+## Generating Tests from VS Code
+* langs: js
 
-## Running Codegen
+Record new tests by clicking on the "record tests" button in the testing sidebar. This will open a browser window where you can navigate to a URL and perform actions on the page which will be recorded to a new test file in VS Code.
+
+<video width="100%" height="100%" controls muted>
+  <source src="https://user-images.githubusercontent.com/13063165/197721416-e525dd60-51a6-4740-ad8b-0f56f4d20045.mp4" type="video/mp4" />
+  Your browser does not support the video tag.
+</video>
+
+Check out the [VS Code Extension](./getting-started-vscode.md) doc to learn more.
+
+## Generating Tests from the CLI
 
 ```bash js
-npx playwright codegen playwright.dev
+npx playwright codegen demo.playwright.dev/todomvc
 ```
 
 ```bash java
-mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen playwright.dev"
+mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen demo.playwright.dev/todomvc"
 ```
 
 ```bash python
-playwright codegen playwright.dev
+playwright codegen demo.playwright.dev/todomvc
 ```
 
 ```bash csharp
-pwsh bin/Debug/netX/playwright.ps1 codegen playwright.dev
+pwsh bin/Debug/netX/playwright.ps1 codegen demo.playwright.dev/todomvc
 ```
 
 Run `codegen` and perform actions in the browser. Playwright will generate the code for the user interactions. `Codegen` will attempt to generate resilient text-based selectors.
 
-<img width="1183" alt="Codegen generating code for tests for playwright.dev website" src="https://user-images.githubusercontent.com/13063165/181852815-971c10da-0b55-4e54-8a73-77e1e825193c.png" />
+<img width="1350" alt="Codegen generating code for tests for playwright.dev website" src="https://user-images.githubusercontent.com/13063165/197802581-70d04c3a-7e90-4bd2-a419-b3e294f946f3.png" />
+
 
 When you have finished interacting with the page, press the **record** button to stop the recording and use the **copy** button to copy the generated code to your editor. 
 
-<img width="1266" alt="Codegen generating code for tests for playwright.dev" src="https://user-images.githubusercontent.com/13063165/183905981-003c4173-0d5e-4960-8190-50e6ca71b2c3.png" />
-
-
 Use the **clear** button to clear the code to start recording again. Once finished close the Playwright inspector window or stop the terminal command.
 
-
-
 To learn more about generating tests check out or detailed guide on [Codegen](./codegen.md).
-
-
 ## What's Next
 
 - [See a trace of your tests](./trace-viewer-intro.md)

--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -7,15 +7,21 @@ Playwright Test was created specifically to accommodate the needs of end-to-end 
 
 **You will learn**
 
-- [How to install Playwright](/intro.md#installing-playwright)
-- [What's Installed](/intro.md#whats-installed)
-- [How to run the example test](/intro.md#running-the-example-test)
-- [How to open the HTML test report](/intro.md#html-test-reports)
+- How to install Playwright using the VS Code Extension or CLI
+- What's Installed
+- How to run the example test
 
+## Installing Playwright VS Code
 
-## Installing Playwright
+Get started by installing Playwright using the [VS Code Extension](./getting-started-vscode.md)
 
-Get started by installing Playwright using npm or yarn. Alternatively you can also get started and run your tests using the [VS Code Extension](./getting-started-vscode.md).
+<img width="1100" alt="VS Code extension for Playwright" src="https://user-images.githubusercontent.com/13063165/197744119-5ed72385-2037-450b-b988-83b2f7554cf1.png" />
+
+Check out the [VS Code Extension](./getting-started-vscode.md) doc to learn more.
+
+## Installing Playwright CLI
+
+Alternatively you can also get started and run your tests using the CLI.
 
 <Tabs
   defaultValue="npm"
@@ -75,7 +81,15 @@ The [playwright.config](./test-configuration.md) is where you can add configurat
  
 The `tests` folder contains a basic example test to help you get started with testing. For a more detailed example check out the `tests-examples` folder which contains tests written to test a todo app.
 
-## Running the Example Test
+## Running Tests in VS Code
+
+The VS Code extension will automatically detect the `playwright.config.ts` file and allow you to run tests directly from the editor. By default tests are run on the first profile only.
+
+<img width="1114" alt="Run a single test" src="https://user-images.githubusercontent.com/13063165/197712138-f4593c0d-ec7e-4a61-b2cd-59fc2af39c6a.png" />
+
+Check out the [VS Code Extension](./getting-started-vscode.md) doc to learn more.
+
+## Running Tests on the CLI
 
 By default tests will be run on all 3 browsers, chromium, firefox and webkit using 3 workers. This can be configured in the [playwright.config file](./test-configuration.md). Tests are run in headless mode meaning no browser will open up when running the tests. Results of the tests and test logs will be shown in the terminal.
 
@@ -85,16 +99,6 @@ npx playwright test
 
 See our doc on [Running Tests](./running-tests.md) to learn more about running tests in headed mode, running multiple tests, running specific tests etc.
 
-## HTML Test Reports
-
-Once your test has finished running a [HTML Reporter](./test-reporters.md#html-reporter) will have been created which shows you a full report of your tests allowing you to filter the report by browsers, passed tests, failed tests, skipped tests and flaky tests. You can click on each test and explore the test's errors as well as each step of the test. By default, the HTML report is opened automatically if some of the tests failed.
-
-```bash
-npx playwright show-report
-```
-
-<img width="739" alt="HTML Reporter" src="https://user-images.githubusercontent.com/13063165/181803518-1f554349-f72a-4ad3-a7aa-4d3d1b4cad13.png" />
-
 
 ## What's next
 
@@ -102,3 +106,4 @@ npx playwright show-report
 - [Run single test, multiple tests, headed mode](./running-tests.md)
 - [Generate tests with Codegen](./codegen-intro.md)
 - [See a trace of your tests](./trace-viewer-intro.md)
+- [Set up tests to run on CI with GitHub Actions](./ci-intro.md)

--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -7,15 +7,19 @@ You can run a single test, a set of tests or all tests. Tests can be run on one 
 
 **You will learn**
 
-- [How to run tests from the command line](/running-tests.md#command-line)
-- [How to debug tests](/running-tests.md#debugging-tests)
-- [How to open the HTML test reporter](/running-tests.md#test-reports)
+- How to run tests using the VS Code Extension and from the CLI
+- How to debug tests in VS Code and from the CLI
+- How to open the HTML test reporter
 
-:::note
-For a better debugging experience check out the [VS Code Extension](./getting-started-vscode.md) for Playwright where you can run tests, add breakpoints and debug your tests right from the VS Code editor.
-:::
+## Running Tests VS Code
 
-## Command Line
+From the testing panel in VS Code you can run a single test or all tests in your file or tests folder. To see tests run in a browser window select the "Show browser" option from the testing panel.
+
+<img width="1279" alt="Running tests using vs code" src="https://user-images.githubusercontent.com/13063165/197797647-8ecbecac-759c-4545-a549-01f58f506448.png" />
+
+Check out the [VS Code Extension](./getting-started-vscode.md) doc to learn more.
+
+## Running Tests CLI
 
 - Running all tests
 
@@ -59,9 +63,17 @@ For a better debugging experience check out the [VS Code Extension](./getting-st
   npx playwright test landing-page.ts --project=chromium
   ```
 
-## Debugging Tests
+## Debugging Tests VS Code
 
-Since Playwright runs in Node.js, you can debug it with your debugger of choice e.g. using `console.log` or inside your IDE or directly in VS Code with the [VS Code Extension](./getting-started-vscode.md). Playwright comes with the [Playwright Inspector](./debug.md#playwright-inspector) which allows you to step through Playwright API calls, see their debug logs and explore [selectors](./selectors.md).
+Since Playwright runs in Node.js, you can debug it with your debugger of choice e.g. using `console.log` or inside your IDE or directly in VS Code with the [VS Code Extension](./getting-started-vscode.md). Right click and start breakpoint debugging. Set a breakpoint and hover over a value. When your cursor is on a Playwright action or a locator, the corresponding element (or elements) are highlighted in the browser.
+
+<img width="1149" alt="setting debug test mode" src="https://user-images.githubusercontent.com/13063165/197715919-98f32957-2ae1-478b-9588-d93cc4548c67.png" />
+
+Check out the [VS Code Extension](./getting-started-vscode.md) doc to learn more.
+
+## Debugging Tests CLI
+
+When debugging tests using the CLI Playwright comes with the [Playwright Inspector](./debug.md#playwright-inspector) which allows you to step through Playwright API calls, see their debug logs and explore [selectors](./selectors.md).
 
 
 - Debugging all tests:
@@ -82,7 +94,7 @@ Since Playwright runs in Node.js, you can debug it with your debugger of choice 
   npx playwright test example.spec.ts:42 --debug
   ```
 
-<img width="1188" alt="Debugging Tests" src="https://user-images.githubusercontent.com/13063165/181847661-7ec5fb6c-7c21-4db0-9931-a593b21bafc2.png" />
+<img width="1350" alt="Debugging Tests with the Playwright inspector" src="https://user-images.githubusercontent.com/13063165/197800771-50cb2f39-2345-4153-b4ed-de9fe63ba29b.png" />
 
 
 Check out our [debugging guide](./debug.md) to learn more about the [Playwright Inspector](./debug.md#playwright-inspector) as well as debugging with [Browser Developer tools](./debug.md#browser-developer-tools).
@@ -93,6 +105,7 @@ Check out our [debugging guide](./debug.md) to learn more about the [Playwright 
 The [HTML Reporter](././test-reporters.md#html-reporter) shows you a full report of your tests allowing you to filter the report by browsers, passed tests, failed tests, skipped tests and flaky tests. By default, the HTML report is opened automatically if some of the tests failed.
 
 ```bash
+npx playwright test
 npx playwright show-report
 ```
 

--- a/docs/src/trace-viewer-intro-js.md
+++ b/docs/src/trace-viewer-intro-js.md
@@ -7,11 +7,9 @@ Playwright Trace Viewer is a GUI tool that lets you explore recorded Playwright 
 
 **You will learn**
 
-- [How to record a trace](/trace-viewer-intro.md#recording-a-trace)
-- [How to open the HTML report](/trace-viewer-intro.md#opening-the-html-report)
-- [How to open and view the trace](/trace-viewer-intro.md#viewing-the-trace)
-
-
+- How to record a trace of your test
+- How to open the HTML report
+- How to open and view the trace
 ## Recording a Trace
 
 By default the [playwright.config](/test-configuration.md#record-test-trace) file will contain the configuration needed to create a `trace.zip` file for each test. Traces are setup to run `on-first-retry` meaning they will be run on the first retry of a failed test. Also `retries` are set to 2 when running on CI and 0 locally. This means the traces will be recorded on the first retry of a failed test but not on the first run and not on the second retry.
@@ -81,3 +79,7 @@ View traces of your test by clicking through each action or hovering using the t
 <img width="1386" alt="Playwright Trace Viewer" src="https://user-images.githubusercontent.com/13063165/189136442-4fc6d7a3-6f0c-4a5f-9d36-2650018b018a.png" />
 
 To learn more about traces check out our detailed guide on [Trace Viewer](/trace-viewer.md).
+
+## What's Next
+
+- [Set up tests to run on CI with GitHub Actions](./ci-intro.md)

--- a/docs/src/writing-tests-js.md
+++ b/docs/src/writing-tests-js.md
@@ -7,11 +7,10 @@ Playwright assertions are created specifically for the dynamic web. Checks are a
 
 **You will learn**
 
-- [How the example test works](/writing-tests.md#the-example-test)
-- [How to use assertions](/writing-tests.md#assertions)
-- [How to use locators](/writing-tests.md#locators)
-- [How tests run in isolation](/writing-tests.md#test-isolation)
-- [How to use test hooks](/writing-tests.md#using-test-hooks)
+- How to use assertions
+- How to use locators
+- How tests run in isolation
+- How to use test hooks
 
 ## The Example Test
 


### PR DESCRIPTION
add simple started vs code into getting started guide so as vs code extensions page can be one page that can be linked to for more non getting started.
remove links from what you will learn 