### PR TITLE
fix(test runner): make sure soft expect error does not mask a timeout flag

### DIFF
--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -487,7 +487,7 @@ export const test = _baseTest.extend<TestFixtures, WorkerFixtures>({
       return context;
     });
 
-    const prependToError = testInfo.status === 'timedOut' ?
+    const prependToError = (testInfo as any)._didTimeout ?
       formatPendingCalls((browser as any)._connection.pendingProtocolCalls()) : '';
 
     let counter = 0;

--- a/tests/playwright-test/timeout.spec.ts
+++ b/tests/playwright-test/timeout.spec.ts
@@ -378,3 +378,42 @@ test('should not include fixtures with own timeout and beforeAll in test duratio
   expect(duration).toBeGreaterThanOrEqual(300 * 4);  // Includes test, beforeEach, afterEach and bar.
   expect(duration).toBeLessThan(300 * 4 + 1000);  // Does not include beforeAll and foo.
 });
+
+test('should run fixture teardowns after timeout with soft expect error', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'helper.ts': `
+      export const test = pwt.test.extend({
+        foo: async ({}, run, testInfo) => {
+          await run();
+          await new Promise(f => setTimeout(f, 500));
+          testInfo.attachments.push({ name: 'foo', contentType: 'text/plain', body: Buffer.from('foo') });
+        },
+        bar: async ({ foo }, run, testInfo) => {
+          await run(foo);
+          await new Promise(f => setTimeout(f, 500));
+          testInfo.attachments.push({ name: 'bar', contentType: 'text/plain', body: Buffer.from('bar') });
+        },
+      });
+    `,
+    'c.spec.ts': `
+      import { test } from './helper';
+      test('works', async ({ bar }) => {
+        expect.soft(1).toBe(2);
+        await new Promise(f => setTimeout(f, 5000));
+      });
+    `
+  }, { timeout: 2000 });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  const test = result.report.suites[0].specs[0].tests[0];
+  expect(test.results[0].attachments[0]).toEqual({
+    name: 'bar',
+    body: 'YmFy',
+    contentType: 'text/plain',
+  });
+  expect(test.results[0].attachments[1]).toEqual({
+    name: 'foo',
+    body: 'Zm9v',
+    contentType: 'text/plain',
+  });
+});


### PR DESCRIPTION
We have to reliably know whether test timed out or not, and soft expect error could have marked it with `status=failed` but it would still time out. Now we have a separate `_didTimeout` flag for this.

Fixes #18023.