### PR TITLE
fix(selectors): `:scope` combined with other css should work

### DIFF
--- a/packages/playwright-core/src/server/injected/selectorEvaluator.ts
+++ b/packages/playwright-core/src/server/injected/selectorEvaluator.ts
@@ -206,7 +206,7 @@ export class SelectorEvaluatorImpl implements SelectorEvaluator {
       if (css !== undefined) {
         elements = this._queryCSS(context, css);
         const hasScopeClause = funcs.some(f => f.name === 'scope');
-        if (hasScopeClause && context.scope.nodeType === 1 /* Node.ELEMENT_NODE */)
+        if (hasScopeClause && context.scope.nodeType === 1 /* Node.ELEMENT_NODE */ && this._matchesCSS(context.scope as Element, css))
           elements.unshift(context.scope as Element);
       } else {
         firstIndex = funcs.findIndex(func => this._getEngine(func.name).query !== undefined);

--- a/tests/page/selectors-css.spec.ts
+++ b/tests/page/selectors-css.spec.ts
@@ -394,7 +394,6 @@ it('should work with :scope', async ({ page, server }) => {
 
 it('should work with :scope and class', async ({ page }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/17824' });
-  it.fixme();
   await page.setContent(`<div class="apple"></div>
                          <div class="apple selected"></div>`);
   const apples = page.locator('.apple');


### PR DESCRIPTION
Previously, we considered root when selector has `:scope` modifier, but did not actually match it with other css specifiers, like in `:scope.selected`.

Fixes #17824.