### PR TITLE
chore: use Node.js 18 for Docker images

### DIFF
--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -7,9 +7,9 @@ ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright:v%version%-focal"
 # === INSTALL Node.js ===
 
 RUN apt-get update && \
-    # Install node16
+    # Install node18
     apt-get install -y curl wget gpg && \
-    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get install -y nodejs && \
     # Feature-parity with node.js base images.
     apt-get install -y --no-install-recommends git openssh-client && \

--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -7,9 +7,9 @@ ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright:v%version%-jammy"
 # === INSTALL Node.js ===
 
 RUN apt-get update && \
-    # Install node16
+    # Install node18
     apt-get install -y curl wget gpg && \
-    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get install -y nodejs && \
     # Feature-parity with node.js base images.
     apt-get install -y --no-install-recommends git openssh-client && \

--- a/utils/linux-browser-dependencies/inside_docker/process.sh
+++ b/utils/linux-browser-dependencies/inside_docker/process.sh
@@ -5,7 +5,7 @@ set +x
 # Install Node.js
 
 apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get install -y nodejs
 
 # Install apt-file


### PR DESCRIPTION
Node.js 18 is now LTS and we follow LTS schedule.