### PR TITLE
docs: update ci example to avoid warnings

### DIFF
--- a/docs/src/ci-intro-js.md
+++ b/docs/src/ci-intro-js.md
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: 18
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers

--- a/docs/src/ci-intro-js.md
+++ b/docs/src/ci-intro-js.md
@@ -31,17 +31,17 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "18.x"
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests
         run: npx playwright test
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
Default CI script presented in docs: https://playwright.dev/docs/ci-intro#github-actions cause generation of warning
![obraz](https://user-images.githubusercontent.com/72373858/198618300-f2962f86-74a0-4115-91cf-429fae7c3f15.png)
According to official statement https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ actions need to be updated

Additionally Node 16 is now in maintenance and Node 18 is new active LTS version. Should that be changed to?

