### PR TITLE
fix(mount): ensure unwrapped functions return their value when called

### DIFF
--- a/packages/playwright-test/src/mount.ts
+++ b/packages/playwright-test/src/mount.ts
@@ -84,7 +84,7 @@ async function innerUpdate(page: Page, jsxOrType: JsxComponent | string, options
         if (typeof value === 'string' && (value as string).startsWith('__pw_func_')) {
           const ordinal = +value.substring('__pw_func_'.length);
           object[key] = (...args: any[]) => {
-            (window as any)['__ct_dispatch'](ordinal, args);
+            return (window as any)['__ct_dispatch'](ordinal, args);
           };
         } else if (typeof value === 'object' && value) {
           unwrapFunctions(value);
@@ -111,7 +111,7 @@ async function innerMount(page: Page, jsxOrType: JsxComponent | string, options:
         if (typeof value === 'string' && (value as string).startsWith('__pw_func_')) {
           const ordinal = +value.substring('__pw_func_'.length);
           object[key] = (...args: any[]) => {
-            (window as any)['__ct_dispatch'](ordinal, args);
+            return (window as any)['__ct_dispatch'](ordinal, args);
           };
         } else if (typeof value === 'object' && value) {
           unwrapFunctions(value);


### PR DESCRIPTION
If a callback prop returned a value you should be able to access it. We have components that fail because they expect to receive a promise when invoking one of the callback props (probably not best practice).