### PR TITLE
feat(html): add `--host` and `--port` to the `show-report` command

### DIFF
--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -100,7 +100,9 @@ function addListFilesCommand(program: Command) {
 function addShowReportCommand(program: Command) {
   const command = program.command('show-report [report]');
   command.description('show HTML report');
-  command.action(report => showHTMLReport(report));
+  command.action((report, options) => showHTMLReport(report, options.host, +options.port));
+  command.option('--host <host>', 'Host to serve report on', 'localhost');
+  command.option('--port <port>', 'Port to serve report on', '9323');
   command.addHelpText('afterAll', `
 Arguments [report]:
   When specified, opens given report, otherwise opens last generated report.

--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -159,7 +159,7 @@ export async function showHTMLReport(reportFolder: string | undefined, host: str
     return;
   }
   const server = startHtmlReportServer(folder);
-  let url = await server.start({ port, host, preferredPort: port ? undefined : 9223 });
+  let url = await server.start({ port, host, preferredPort: port ? undefined : 9323 });
   console.log('');
   console.log(colors.cyan(`  Serving HTML report at ${url}. Press Ctrl+C to quit.`));
   if (testId)


### PR DESCRIPTION
This enables serving HTML report from inside docker container.

Drive-by: restore default HTML serving port to 9323. This was
accidentally changed in 1.27 and mentioned in
https://github.com/microsoft/playwright/issues/16667#issuecomment-1269861623