### PR TITLE
fix: Minor typo in Locators link

### DIFF
--- a/docs/src/selectors.md
+++ b/docs/src/selectors.md
@@ -3,7 +3,7 @@ id: selectors
 title: "Selectors"
 ---
 
-Selectors are strings that are used to create [Locator]s. Locators are used to perform actions on the elements by means of methods such as [`method: Locator.click`], [`method: Locator.fill`] and alike. For debugging selectors, see [here](./debug-selectors).
+Selectors are strings that are used to create [Locators]. Locators are used to perform actions on the elements by means of methods such as [`method: Locator.click`], [`method: Locator.fill`] and alike. For debugging selectors, see [here](./debug-selectors).
 
 Writing good selectors is part art, part science so be sure to checkout the [Best Practices](#best-practices) section.
 


### PR DESCRIPTION
Fix link from [Locator](https://playwright.dev/docs/selectors)s to [Locators](https://playwright.dev/docs/selectors)

Signed-off-by: Guillaume Delacour <guillaume.delacour@gmail.com>