### PR TITLE
docs(python): Remove not-needed semicolons from codes

### DIFF
--- a/docs/src/api/class-framelocator.md
+++ b/docs/src/api/class-framelocator.md
@@ -85,11 +85,11 @@ Locator frameLocator = locator.frameLocator(':scope');
 ```
 
 ```python async
-frameLocator = locator.frame_locator(":scope");
+frameLocator = locator.frame_locator(":scope")
 ```
 
 ```python sync
-frameLocator = locator.frame_locator(":scope");
+frameLocator = locator.frame_locator(":scope")
 ```
 
 ```csharp

--- a/docs/src/navigations.md
+++ b/docs/src/navigations.md
@@ -212,13 +212,13 @@ page.waitForLoadState(LoadState.NETWORKIDLE); // This resolves after "networkidl
 ```
 
 ```python async
-await page.locator("button").click(); # Click triggers navigation
-await page.wait_for_load_state("networkidle"); # This waits for the "networkidle"
+await page.locator("button").click()  # Click triggers navigation
+await page.wait_for_load_state("networkidle")  # This waits for the "networkidle"
 ```
 
 ```python sync
-page.locator("button").click(); # Click triggers navigation
-page.wait_for_load_state("networkidle"); # This waits for the "networkidle"
+page.locator("button").click()  # Click triggers navigation
+page.wait_for_load_state("networkidle")  # This waits for the "networkidle"
 ```
 
 ```csharp

--- a/docs/src/writing-tests-python.md
+++ b/docs/src/writing-tests-python.md
@@ -19,7 +19,7 @@ def test_homepage_has_Playwright_in_title_and_get_started_link_linking_to_the_in
     expect(page).to_have_title(re.compile("Playwright"))
 
     # create a locator
-    get_started = page.get_by_role("link", name="Get started");
+    get_started = page.get_by_role("link", name="Get started")
 
     # Expect an attribute "to be strictly equal" to the value.
     expect(get_started).to_have_attribute("href", "/docs/intro")
@@ -51,7 +51,7 @@ expect(page).to_have_title(re.compile("Playwright"))
 ```python
 from playwright.sync_api import expect
 
-get_started = page.get_by_role("link", name="Get started");
+get_started = page.get_by_role("link", name="Get started")
 
 expect(get_started).to_have_attribute("href", "/docs/installation")
 get_started.click()


### PR DESCRIPTION
There are semicolons in some python codes in docs that is not needed to run.

This PR is to remove these.