### PR TITLE
chore: support narrow terminal windows for messages

### DIFF
--- a/packages/playwright-core/src/utils/index.ts
+++ b/packages/playwright-core/src/utils/index.ts
@@ -192,6 +192,13 @@ export function constructURLBasedOnBaseURL(baseURL: string | undefined, givenURL
 export function wrapInASCIIBox(text: string, padding = 0): string {
   const lines = text.split('\n');
   const maxLength = Math.max(...lines.map(line => line.length));
+  if (process.stdout.isTTY && process.stdout.columns < maxLength + padding * 2 + 2) {
+    return [
+      '═'.repeat(process.stdout.columns),
+      ...lines,
+      '═'.repeat(process.stdout.columns),
+    ].join('\n');
+  }
   return [
     '╔' + '═'.repeat(maxLength + padding * 2) + '╗',
     ...lines.map(line => '║' + ' '.repeat(padding) + line + ' '.repeat(maxLength - line.length + padding) + '║'),

--- a/packages/playwright-core/src/utils/index.ts
+++ b/packages/playwright-core/src/utils/index.ts
@@ -191,19 +191,10 @@ export function constructURLBasedOnBaseURL(baseURL: string | undefined, givenURL
 
 export function wrapInASCIIBox(text: string, padding = 0): string {
   const lines = text.split('\n');
-  const maxLength = Math.max(...lines.map(line => line.length));
-  if (process.stdout.isTTY && process.stdout.columns < maxLength + padding * 2 + 2) {
-    return [
-      '═'.repeat(process.stdout.columns),
-      ...lines,
-      '═'.repeat(process.stdout.columns),
-    ].join('\n');
-  }
-  return [
-    '╔' + '═'.repeat(maxLength + padding * 2) + '╗',
-    ...lines.map(line => '║' + ' '.repeat(padding) + line + ' '.repeat(maxLength - line.length + padding) + '║'),
-    '╚' + '═'.repeat(maxLength + padding * 2) + '╝',
-  ].join('\n');
+  const maxLineLength = Math.max(...lines.map(line => line.length));
+  const separatorLength = process.stdout.isTTY ? process.stdout.columns : maxLineLength;
+  const separator = '═'.repeat(separatorLength);
+  return [separator, ...lines, separator, ''].join('\n');
 }
 
 export function isFilePayload(value: any): boolean {

--- a/packages/playwright-core/src/utils/index.ts
+++ b/packages/playwright-core/src/utils/index.ts
@@ -192,7 +192,7 @@ export function constructURLBasedOnBaseURL(baseURL: string | undefined, givenURL
 export function wrapInASCIIBox(text: string, padding = 0): string {
   const lines = text.split('\n');
   const maxLineLength = Math.max(...lines.map(line => line.length));
-  const separatorLength = process.stdout.isTTY ? process.stdout.columns : maxLineLength;
+  const separatorLength = process.stdout.columns || maxLineLength;
   const separator = '═'.repeat(separatorLength);
   return [separator, ...lines, separator, ''].join('\n');
 }


### PR DESCRIPTION
This patch starts using a message box that's not really a box and thus
is better behaving on a narrow-width terminals.

Before:
<img width="744" alt="image" src="https://user-images.githubusercontent.com/746130/201216551-abbac0f8-71b4-413f-9f4e-159c7123ef3d.png">

After:
<img width="745" alt="image" src="https://user-images.githubusercontent.com/746130/201216504-25257727-06c8-4ae9-8557-a2d937b7ca0b.png">

