### PR TITLE
chore: drive-by fixes for the `snapshotPathTemplate`

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -820,7 +820,7 @@ jobs:
         ./utils/docker/build.sh --amd64 focal $PWTEST_DOCKER_BASE_IMAGE
         npx playwright docker build
         nohup npx playwright docker start &
-        xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --grep '@smoke',
+        xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --grep '@smoke'
       env:
         PLAYWRIGHT_DOCKER: 1
         PWTEST_DOCKER_BASE_IMAGE: playwright:localbuild

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -816,9 +816,14 @@ jobs:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     - run: npm run build
     - run: npx playwright install --with-deps
-    - run: ./utils/docker/build.sh --amd64 focal playwright:localbuild
-    - run: PWTEST_DOCKER_BASE_IMAGE=playwright:localbuild npx playwright docker build
-    - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run dtest
+    - run: |
+        ./utils/docker/build.sh --amd64 focal $PWTEST_DOCKER_BASE_IMAGE
+        npx playwright docker build
+        nohup npx playwright docker start &
+        xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test -- --grep '@smoke',
+      env:
+        PLAYWRIGHT_DOCKER: 1
+        PWTEST_DOCKER_BASE_IMAGE: playwright:localbuild
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()
       shell: bash

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "dtest": "cross-env PLAYWRIGHT_DOCKER=1 playwright test --config=tests/library/playwright.config.ts --grep '@smoke'",
     "ctest": "playwright test --config=tests/library/playwright.config.ts --project=chromium",
     "ftest": "playwright test --config=tests/library/playwright.config.ts --project=firefox",
     "wtest": "playwright test --config=tests/library/playwright.config.ts --project=webkit",

--- a/packages/html-reporter/playwright.config.ts
+++ b/packages/html-reporter/playwright.config.ts
@@ -22,6 +22,7 @@ const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   ignoreSnapshots: !process.env.PLAYWRIGHT_DOCKER,
+  snapshotPathTemplate: '{testDir}/__screenshots__/{projectName}/{testFilePath}/{arg}{ext}',
   reporter: 'html',
   use: {
     ctPort: 3101,

--- a/tests/playwright-test/snapshot-path-template.spec.ts
+++ b/tests/playwright-test/snapshot-path-template.spec.ts
@@ -45,6 +45,7 @@ async function getSnapshotPaths(runInlineTest, testInfo, playwrightConfig, pathA
 }
 
 test('tokens should expand property', async ({ runInlineTest }, testInfo) => {
+  test.slow();
   const snapshotPath = await getSnapshotPaths(runInlineTest, testInfo, {
     projects: [{
       name: 'proj1',


### PR DESCRIPTION
- Use `snapshotPathTemplate` for docker screenshots in html-reporter
- Mark the snapshot path template test as slow since it re-spawns
  worker for each project.
- Fix docker smoke tests
