### PR TITLE
feat(keyboard): support simple cut-pasting using meta+x/v

### DIFF
--- a/packages/playwright-core/src/server/macEditingCommands.ts
+++ b/packages/playwright-core/src/server/macEditingCommands.ts
@@ -127,6 +127,7 @@ export const macEditingCommands: {[key: string]: string|string[]} = {
 
   'Meta+KeyA': 'selectAll:',
   'Meta+KeyC': 'copy:',
+  'Meta+KeyX': 'cut:',
   'Meta+KeyV': 'paste:',
   'Meta+KeyZ': 'undo:',
   'Shift+Meta+KeyZ': 'redo:',

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -482,7 +482,7 @@ it('should support simple copy-pasting', async ({ page, isMac, browserName }) =>
   expect(await page.evaluate(() => document.querySelector('div').textContent)).toBe('123123');
 });
 
-it('should support simple cut-pasting', async ({ page, isMac, browserName }) => {
+it('should support simple cut-pasting', async ({ page, isMac }) => {
   const modifier = isMac ? 'Meta' : 'Control';
   await page.setContent(`<div contenteditable>123</div>`);
   await page.focus('div');

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -482,6 +482,17 @@ it('should support simple copy-pasting', async ({ page, isMac, browserName }) =>
   expect(await page.evaluate(() => document.querySelector('div').textContent)).toBe('123123');
 });
 
+it('should support simple cut-pasting', async ({ page, isMac, browserName }) => {
+  const modifier = isMac ? 'Meta' : 'Control';
+  await page.setContent(`<div contenteditable>123</div>`);
+  await page.focus('div');
+  await page.keyboard.press(`${modifier}+KeyA`);
+  await page.keyboard.press(`${modifier}+KeyX`);
+  await page.keyboard.press(`${modifier}+KeyV`);
+  await page.keyboard.press(`${modifier}+KeyV`);
+  expect(await page.evaluate(() => document.querySelector('div').textContent)).toBe('123123');
+});
+
 it('should support undo-redo', async ({ page, isMac, browserName, isLinux }) => {
   it.fixme(browserName === 'webkit' && isLinux, 'https://github.com/microsoft/playwright/issues/12000');
   const modifier = isMac ? 'Meta' : 'Control';


### PR DESCRIPTION
Similar to how we handle Meta+c, in this PR we support Meta+x so users can cut text on the page.

References #18755