### PR TITLE
docs(debug.md): clarify what slowMo number means

### DIFF
--- a/docs/src/debug.md
+++ b/docs/src/debug.md
@@ -251,7 +251,7 @@ prevent the Playwright script from executing any further.
 
 Playwright runs browsers in headless mode by default. To change this behavior,
 use `headless: false` as a launch option. You can also use the [`option: slowMo`] option
-to slow down execution and follow along while debugging.
+to slow down execution (by N milliseconds per operation) and follow along while debugging.
 
 ```js
 await chromium.launch({ headless: false, slowMo: 100 }); // or firefox, webkit


### PR DESCRIPTION
I found the slowMo option referenced here without explanation: https://playwright.dev/docs/library#first-script
which then linked to this page, which also didn't explain what the number means: https://playwright.dev/docs/debug#headed-mode
I eventually found that it was milliseconds per operation here: https://playwright.dev/docs/api/class-browsertype#browser-type-connect but it would be nice to make it more obvious.

Signed-off-by: Tom Sparrow <793763+sparrowt@users.noreply.github.com>