### PR TITLE
chore: allow `py` code blocks for python

### DIFF
--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -492,6 +492,8 @@ function parseCodeLang(codeLang) {
   if (!language) {
     if (highlighter === 'ts')
       language = 'js';
+    else if (highlighter === 'py')
+      language = 'python';
     else if (['js', 'python', 'csharp', 'java'].includes(highlighter))
       language = highlighter;
   }


### PR DESCRIPTION
Turns out, we have some snippets that use `py` instead of `python`.