### PR TITLE
chore: multiply overloaded options in csharp

### DIFF
--- a/docs/src/api/class-route.md
+++ b/docs/src/api/class-route.md
@@ -112,7 +112,15 @@ If set changes the request method (e.g. GET or POST)
 
 ### option: Route.continue.postData
 * since: v1.8
+* langs: js, python, java
 - `postData` <[string]|[Buffer]>
+
+If set changes the post data of request
+
+### option: Route.continue.postData
+* since: v1.8
+* langs: csharp
+- `postData` <[Buffer]>
 
 If set changes the post data of request
 
@@ -378,7 +386,15 @@ If set changes the request method (e.g. GET or POST)
 
 ### option: Route.fallback.postData
 * since: v1.23
+* langs: js, python, java
 - `postData` <[string]|[Buffer]>
+
+If set changes the post data of request
+
+### option: Route.fallback.postData
+* since: v1.23
+* langs: csharp
+- `postData` <[Buffer]>
 
 If set changes the post data of request
 

--- a/docs/src/chrome-extensions-js-python.md
+++ b/docs/src/chrome-extensions-js-python.md
@@ -103,8 +103,8 @@ First, add fixtures that will load the extension:
 
 ```ts
 // fixtures.ts
-import { test as base, expect, chromium, type BrowserContext } from "@playwright/test";
-import path from "path";
+import { test as base, expect, chromium, type BrowserContext } from '@playwright/test';
+import path from 'path';
 
 export const test = base.extend<{
   context: BrowserContext;
@@ -185,16 +185,16 @@ def extension_id(context) -> Generator[str, None, None]:
 Then use these fixtures in a test:
 
 ```ts
-import { test, expect } from "./fixtures";
+import { test, expect } from './fixtures';
 
-test("example test", async ({ page }) => {
-  await page.goto("https://example.com");
-  await expect(page.locator("body")).toHaveText("Changed by my-extension");
+test('example test', async ({ page }) => {
+  await page.goto('https://example.com');
+  await expect(page.locator('body')).toHaveText('Changed by my-extension');
 });
 
-test("popup page", async ({ page, extensionId }) => {
+test('popup page', async ({ page, extensionId }) => {
   await page.goto(`chrome-extension://${extensionId}/popup.html`);
-  await expect(page.locator("body")).toHaveText("my-extension popup");
+  await expect(page.locator('body')).toHaveText('my-extension popup');
 });
 ```
 


### PR DESCRIPTION
This way we'll get the same treatment in docs generator as well as dotnet api generator.

This also adds non-suffixed aliases for string options, e.g. `Name` in addition to `NameString` and `NameRegex`.

Fixes #18407.