### PR TITLE
Fix prop path

### DIFF
--- a/docs/src/test-parameterize-js.md
+++ b/docs/src/test-parameterize-js.md
@@ -159,7 +159,7 @@ export type TestOptions = {
   person: string;
 };
 
-export const test = base.test.extend<TestOptions>({
+export const test = base.extend<TestOptions>({
   // Define an option and provide a default value.
   // We can later override it in the config.
   person: ['John', { option: true }],


### PR DESCRIPTION
Fixes the TS version of the example code for accessing the `extend` prop.