### PR TITLE
feat(expect): ensure at least one expectation check, no matter the timeout

### DIFF
--- a/tests/page/expect-boolean.spec.ts
+++ b/tests/page/expect-boolean.spec.ts
@@ -96,6 +96,16 @@ test.describe('toBeChecked', () => {
     const message2 = await expect(page.locator('input')).toBeChecked({ checked: false, timeout: 1000 }).catch(e => e.message);
     expect(message2).toContain('unexpected value "checked"');
   });
+
+  test('with impossible timeout', async ({ page }) => {
+    await page.setContent('<input type=checkbox checked></input>');
+    await expect(page.locator('input')).toBeChecked({ timeout: 1 });
+  });
+
+  test('with impossible timeout .not', async ({ page }) => {
+    await page.setContent('<input type=checkbox></input>');
+    await expect(page.locator('input')).not.toBeChecked({ timeout: 1 });
+  });
 });
 
 test.describe('toBeEditable', () => {
@@ -291,6 +301,16 @@ test.describe('toBeVisible', () => {
     const error = await expect(locator).not.toBeVisible({ timeout: 1000 }).catch(e => e);
     expect(error.message).toContain(`locator resolved to <input/>`);
   });
+
+  test('with impossible timeout', async ({ page }) => {
+    await page.setContent('<div id=node>Text content</div>');
+    await expect(page.locator('#node')).toBeVisible({ timeout: 1 });
+  });
+
+  test('with impossible timeout .not', async ({ page }) => {
+    await page.setContent('<div id=node>Text content</div>');
+    await expect(page.locator('no-such-thing')).not.toBeVisible({ timeout: 1 });
+  });
 });
 
 test.describe('toBeHidden', () => {
@@ -349,6 +369,16 @@ test.describe('toBeHidden', () => {
     const locator = page.locator('button');
     const error = await expect(locator).not.toBeHidden({ timeout: 1000 }).catch(e => e);
     expect(error.message).toContain(`expect.toBeHidden with timeout 1000ms`);
+  });
+
+  test('with impossible timeout .not', async ({ page }) => {
+    await page.setContent('<div id=node>Text content</div>');
+    await expect(page.locator('#node')).not.toBeHidden({ timeout: 1 });
+  });
+
+  test('with impossible timeout', async ({ page }) => {
+    await page.setContent('<div id=node>Text content</div>');
+    await expect(page.locator('no-such-thing')).toBeHidden({ timeout: 1 });
   });
 });
 

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -540,12 +540,12 @@ test('should print timed out error message', async ({ runInlineTest }) => {
 
       test('fail', async ({ page }) => {
         await page.setContent('<div id=node>Text content</div>');
-        await expect(page.locator('no-such-thing')).not.toBeVisible({ timeout: 1 });
+        await expect(page.locator('no-such-thing')).toBeChecked({ timeout: 1 });
       });
       `,
   }, { workers: 1 });
   expect(result.failed).toBe(1);
   expect(result.exitCode).toBe(1);
   const output = stripAnsi(result.output);
-  expect(output).toContain('Timed out 1ms waiting for expect(received).not.toBeVisible()');
+  expect(output).toContain('Timed out 1ms waiting for expect(received).toBeChecked()');
 });


### PR DESCRIPTION
References #18859.