### PR TITLE
feat(runner): allow filtering setup and tests

### DIFF
--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -344,7 +344,7 @@ export function formatResultFailure(config: FullConfig, test: TestCase, result: 
   return errorDetails;
 }
 
-function relativeFilePath(config: FullConfig, file: string): string {
+export function relativeFilePath(config: FullConfig, file: string): string {
   return path.relative(config.rootDir, file) || path.basename(file);
 }
 

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -29,7 +29,7 @@ import type { TestRunnerPlugin } from './plugins';
 import { setRunnerToAddPluginsTo } from './plugins';
 import { dockerPlugin } from './plugins/dockerPlugin';
 import { webServerPluginsForConfig } from './plugins/webServerPlugin';
-import { formatError } from './reporters/base';
+import { formatError, relativeFilePath } from './reporters/base';
 import DotReporter from './reporters/dot';
 import EmptyReporter from './reporters/empty';
 import GitHubReporter from './reporters/github';
@@ -235,13 +235,13 @@ export class Runner {
     return projects;
   }
 
-  private async _collectFiles(projects: FullProjectInternal[], testFileFilters: TestFileFilter[]): Promise<{filesByProject: Map<FullProjectInternal, string[]>; setupFiles: Set<string>, applyFilterToSetup: boolean}> {
+  private async _collectFiles(projects: FullProjectInternal[], commandLineFileFilters: TestFileFilter[]): Promise<{filesByProject: Map<FullProjectInternal, string[]>; setupFiles: Set<string>, applyFilterToSetup: boolean}> {
     const extensions = ['.js', '.ts', '.mjs', '.tsx', '.jsx'];
     const testFileExtension = (file: string) => extensions.includes(path.extname(file));
     const filesByProject = new Map<FullProjectInternal, string[]>();
     const setupFiles = new Set<string>();
     const fileToProjectName = new Map<string, string>();
-    const testFileFilter = fileMatcherFrom(testFileFilters);
+    const commandLineFileMatcher = fileMatcherFrom(commandLineFileFilters);
     for (const project of projects) {
       const allFiles = await collectFiles(project.testDir, project._respectGitIgnore);
       const setupMatch = createFileMatcher(project._setup);
@@ -251,7 +251,7 @@ export class Runner {
         if (!testFileExtension(file))
           return false;
         const isSetup = setupMatch(file);
-        const isTest = !testIgnore(file) && testMatch(file) && testFileFilter(file);
+        const isTest = !testIgnore(file) && testMatch(file) && commandLineFileMatcher(file);
         if (!isTest && !isSetup)
           return false;
         if (isSetup && isTest)
@@ -272,30 +272,29 @@ export class Runner {
       filesByProject.set(project, testFiles);
     }
 
-    let applyFilterToSetup = false;
-    if (testFileFilters.length && setupFiles.size) {
-      // If the filter didn't match any tests apply it to the setup files.
-      if (setupFiles.size === fileToProjectName.size) {
-        applyFilterToSetup = true;
-        for (const [project, files] of filesByProject) {
-          const filteredFiles = files.filter(testFileFilter);
-          if (filteredFiles.length)
-            filesByProject.set(project, filteredFiles);
-          else
-            filesByProject.delete(project);
-        }
-        for (const file of setupFiles) {
-          if (!testFileFilter(file))
-            setupFiles.delete(file);
-        }
-      } else {
-        const setupFile = [...setupFiles].find(testFileFilter);
-        // If the filter is not empty and it matches both setup and tests then it's an error: we allow
-        // to run either subset of tests with full setup or partial setup without any tests.
-        if (setupFile) {
-          const testFile = Array.from(fileToProjectName.keys()).find(f => !setupFiles.has(f));
-          throw new Error(`Both setup and test files match command line filter.\n  Setup file: ${setupFile}\n  Test file: ${testFile}`);
-        }
+    // If the filter didn't match any tests, apply it to the setup files.
+    const applyFilterToSetup = setupFiles.size === fileToProjectName.size;
+    if (applyFilterToSetup) {
+      // We now have only setup files in filesByProject, because all test files were filtered out.
+      for (const [project, setupFiles] of filesByProject) {
+        const filteredFiles = setupFiles.filter(commandLineFileMatcher);
+        if (filteredFiles.length)
+          filesByProject.set(project, filteredFiles);
+        else
+          filesByProject.delete(project);
+      }
+      for (const file of setupFiles) {
+        if (!commandLineFileMatcher(file))
+          setupFiles.delete(file);
+      }
+    } else if (commandLineFileFilters.length) {
+      const setupFile = [...setupFiles].find(commandLineFileMatcher);
+      // If the filter is not empty and it matches both setup and tests then it's an error: we allow
+      // to run either subset of tests with full setup or partial setup without any tests.
+      if (setupFile) {
+        const testFile = Array.from(fileToProjectName.keys()).find(f => !setupFiles.has(f));
+        const config = this._loader.fullConfig();
+        throw new Error(`Both setup and test files match command line filter.\n  Setup file: ${relativeFilePath(config, setupFile)}\n  Test file: ${relativeFilePath(config, testFile!)}`);
       }
     }
 

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -316,7 +316,7 @@ export const test = base
 
           let timeline;
           try {
-            timeline = JSON.parse((await fs.promises.readFile(timelinePath, 'utf8')).toString('utf8'));
+            timeline = JSON.parse((await fs.promises.readFile(timelinePath, 'utf8')).toString());
           } catch (e) {
           }
           return {


### PR DESCRIPTION
Running `npx playwright test file:123` will have the following behavior
- if only test files match then only matching subset of tests will run but all setup files will run as well
- if only setup files match the filter then only those setup tests will run
- if both setup and test files match an error will be thrown