### PR TITLE
test: check channel is not null

### DIFF
--- a/tests/page/page-click-scroll.spec.ts
+++ b/tests/page/page-click-scroll.spec.ts
@@ -81,7 +81,7 @@ it('should scroll into view display:contents with position', async ({ page, brow
 
 it('should not crash when force-clicking hidden input', async ({ page, browserName, channel, browserMajorVersion }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/18183' });
-  it.skip(browserName === 'chromium' && browserMajorVersion < 109 || channel.startsWith('msedge') && browserMajorVersion < 110);
+  it.skip(browserName === 'chromium' && browserMajorVersion < 109 || channel && channel.startsWith('msedge') && browserMajorVersion < 110);
 
   await page.setContent(`<input type=hidden>`);
   const error = await page.locator('input').click({ force: true, timeout: 2000 }).catch(e => e);


### PR DESCRIPTION
Follow-up #18823 

It seems test 'page/page-click-scroll.spec.ts:should not crash when force-clicking hidden input' is failing in WebKit and Firefox because variable 'channel' is undefined.

* https://github.com/microsoft/playwright/actions/runs/3494971891/jobs/5851247764#step:8:98
* https://github.com/microsoft/playwright/actions/runs/3494971891/jobs/5851247658#step:8:54