### PR TITLE
feat(runner): run all setup files if none matched the filter

### DIFF
--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -272,12 +272,12 @@ export class Runner {
       filesByProject.set(project, testFiles);
     }
 
-    // If the filter didn't match any tests, apply it to the setup files.
-    const applyFilterToSetup = setupFiles.size === fileToProjectName.size;
+    // If none of the setup files matched the filter, we inlude all of them, otherwise
+    // only those that match the filter.
+    const applyFilterToSetup = !!commandLineFileFilters.length && [...setupFiles].some(commandLineFileMatcher);
     if (applyFilterToSetup) {
-      // We now have only setup files in filesByProject, because all test files were filtered out.
-      for (const [project, setupFiles] of filesByProject) {
-        const filteredFiles = setupFiles.filter(commandLineFileMatcher);
+      for (const [project, files] of filesByProject) {
+        const filteredFiles = files.filter(commandLineFileMatcher);
         if (filteredFiles.length)
           filesByProject.set(project, filteredFiles);
         else
@@ -286,15 +286,6 @@ export class Runner {
       for (const file of setupFiles) {
         if (!commandLineFileMatcher(file))
           setupFiles.delete(file);
-      }
-    } else if (commandLineFileFilters.length) {
-      const setupFile = [...setupFiles].find(commandLineFileMatcher);
-      // If the filter is not empty and it matches both setup and tests then it's an error: we allow
-      // to run either subset of tests with full setup or partial setup without any tests.
-      if (setupFile) {
-        const testFile = Array.from(fileToProjectName.keys()).find(f => !setupFiles.has(f));
-        const config = this._loader.fullConfig();
-        throw new Error(`Both setup and test files match command line filter.\n  Setup file: ${relativeFilePath(config, setupFile)}\n  Test file: ${relativeFilePath(config, testFile!)}`);
       }
     }
 
@@ -329,7 +320,6 @@ export class Runner {
       filterByFocusedLine(preprocessRoot, options.testFileFilters, applyFilterToSetup ? new Set() : setupFiles);
 
     // Complain about only.
-    // TODO: check in project setup.
     if (config.forbidOnly) {
       const onlyTestsAndSuites = preprocessRoot._getOnlyItems();
       if (onlyTestsAndSuites.length > 0)
@@ -337,15 +327,8 @@ export class Runner {
     }
 
     // Filter only.
-    if (!options.listOnly) {
-      const hasOnly = filterOnly(preprocessRoot);
-      if (hasOnly) {
-        const setup = preprocessRoot.allTests().filter(testCase => setupFiles.has(testCase._requireFile));
-        const test = preprocessRoot.allTests().filter(testCase => !setupFiles.has(testCase._requireFile));
-        if (setup.length && test.length)
-          fatalErrors.push(createSetupAndTestOnlyError(config, setup, test));
-      }
-    }
+    if (!options.listOnly)
+      filterOnly(preprocessRoot);
 
     // Generate projects.
     const fileSuites = new Map<string, Suite>();
@@ -356,6 +339,13 @@ export class Runner {
     for (const [project, files] of filesByProject) {
       const grepMatcher = createTitleMatcher(project.grep);
       const grepInvertMatcher = project.grepInvert ? createTitleMatcher(project.grepInvert) : null;
+
+      const titleMatcher = (test: TestCase) => {
+        const grepTitle = test.titlePath().join(' ');
+        if (grepInvertMatcher?.(grepTitle))
+          return false;
+        return grepMatcher(grepTitle) && options.testTitleMatcher(grepTitle);
+      };
 
       const projectSuite = new Suite(project.name, 'project');
       projectSuite._projectConfig = project;
@@ -368,13 +358,33 @@ export class Runner {
           continue;
         for (let repeatEachIndex = 0; repeatEachIndex < project.repeatEach; repeatEachIndex++) {
           const builtSuite = this._loader.buildFileSuiteForProject(project, fileSuite, repeatEachIndex, test => {
-            const grepTitle = test.titlePath().join(' ');
-            if (grepInvertMatcher?.(grepTitle))
-              return false;
-            return grepMatcher(grepTitle) && options.testTitleMatcher(grepTitle);
+            if (setupFiles.has(test._requireFile))
+              return true;
+            return titleMatcher(test);
           });
           if (builtSuite)
             projectSuite._addSuite(builtSuite);
+        }
+      }
+
+      // At this point projectSuite contains all setup tests (unfiltered) and all regular
+      // tests matching the filter.
+      if (projectSuite.allTests().some(test => !setupFiles.has(test._requireFile))) {
+        // If >0 tests match and
+        // - none of the setup files match the filter then we run all setup files,
+        // - if the filter also matches some of the setup tests, we'll run only
+        //   that maching subset of setup tests.
+        const filterMatchesSetup = projectSuite.allTests().some(test => {
+          if (!setupFiles.has(test._requireFile))
+            return false;
+          return titleMatcher(test);
+        });
+        if (filterMatchesSetup) {
+          filterSuiteWithOnlySemantics(projectSuite, () => false, test => {
+            if (!setupFiles.has(test._requireFile))
+              return true;
+            return titleMatcher(test);
+          });
         }
       }
     }

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -29,7 +29,7 @@ import type { TestRunnerPlugin } from './plugins';
 import { setRunnerToAddPluginsTo } from './plugins';
 import { dockerPlugin } from './plugins/dockerPlugin';
 import { webServerPluginsForConfig } from './plugins/webServerPlugin';
-import { formatError, relativeFilePath } from './reporters/base';
+import { formatError } from './reporters/base';
 import DotReporter from './reporters/dot';
 import EmptyReporter from './reporters/empty';
 import GitHubReporter from './reporters/github';
@@ -957,30 +957,6 @@ function createForbidOnlyError(config: FullConfigInternal, onlyTestsAndSuites: (
     const title = testOrSuite.titlePath().slice(2).join(' ');
     errorMessage.push(` - ${buildItemLocation(config.rootDir, testOrSuite)} > ${title}`);
   }
-  errorMessage.push('=====================================');
-  return createStacklessError(errorMessage.join('\n'));
-}
-
-function createSetupAndTestOnlyError(config: FullConfigInternal, onlySetups: (TestCase | Suite)[], onlyTests: (TestCase | Suite)[]): TestError {
-  const errorMessage = [
-    '=====================================',
-    'Found both setup and test with .only()'
-  ];
-  const addLocations = (onlyTestsAndSuites: (TestCase | Suite)[]) => {
-    const maxLen = 5;
-    for (let i = 0; i < Math.min(maxLen, onlyTestsAndSuites.length); i++) {
-      const testOrSuite = onlyTestsAndSuites[i];
-      // Skip root and file.
-      const title = testOrSuite.titlePath().slice(2).join(' ');
-      errorMessage.push(` - ${buildItemLocation(config.rootDir, testOrSuite)} > ${title}`);
-    }
-    if (onlyTestsAndSuites.length > maxLen)
-      errorMessage.push(` and ${onlyTestsAndSuites.length - maxLen} more...`);
-  };
-  errorMessage.push('Setups:');
-  addLocations(onlySetups);
-  errorMessage.push('Tests:');
-  addLocations(onlyTests);
   errorMessage.push('=====================================');
   return createStacklessError(errorMessage.join('\n'));
 }

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -966,7 +966,7 @@ function createSetupAndTestOnlyError(config: FullConfigInternal, onlySetups: (Te
     }
     if (onlyTestsAndSuites.length > maxLen)
       errorMessage.push(` and ${onlyTestsAndSuites.length - maxLen} more...`);
-  }
+  };
   errorMessage.push('Setups:');
   addLocations(onlySetups);
   errorMessage.push('Tests:');

--- a/tests/playwright-test/project-setup.spec.ts
+++ b/tests/playwright-test/project-setup.spec.ts
@@ -461,7 +461,7 @@ test('should allow .only in setup files', async ({ runGroups }, testInfo) => {
   expect(passed).toBe(2);
 });
 
-test('should not allow .only in both setup and test files', async ({ runGroups }, testInfo) => {
+test('should allow .only in both setup and test files', async ({ runGroups }, testInfo) => {
   const files = {
     'playwright.config.ts': `
       module.exports = {
@@ -488,14 +488,9 @@ test('should not allow .only in both setup and test files', async ({ runGroups }
   };
 
   const { exitCode, output } =  await runGroups(files);
-  expect(exitCode).toBe(1);
-  expect(output).toContain(`=====================================
-Found both setup and test with .only()
-Setups:
- - a.setup.ts:5 > setup1
-Tests:
- - a.test.ts:7 > test2
-=====================================`);
+  // expect(exitCode).toBe(1);
+  expect(output).toContain('[p1] › a.setup.ts:5:12 › setup1');
+  expect(output).toContain('[p1] › a.test.ts:7:12 › test2');
 });
 
 test('should allow filtering setup by file:line', async ({ runGroups }, testInfo) => {
@@ -554,7 +549,7 @@ test('should allow filtering setup by file:line', async ({ runGroups }, testInfo
   }
 });
 
-test('should prohibit filters matching both setup and test', async ({ runGroups }, testInfo) => {
+test('should support filters matching both setup and test', async ({ runGroups }, testInfo) => {
   const files = {
     'playwright.config.ts': `
       module.exports = {
@@ -576,11 +571,24 @@ test('should prohibit filters matching both setup and test', async ({ runGroups 
       test('setup1', async () => { });
       test('setup2', async () => { });
     `,
+    'b.setup.ts': `
+      const { test } = pwt;
+      test('setup1', async () => { });
+    `,
+    'b.test.ts': `
+      const { test } = pwt;
+      test('test1', async () => { });
+    `,
   };
 
-  const { exitCode, output } =  await runGroups(files, undefined, undefined, { additionalArgs: ['.*ts$'] });
-  expect(output).toContain('Error: Both setup and test files match command line filter.');
-  expect(exitCode).toBe(1);
+  const { exitCode, output } =  await runGroups(files, undefined, undefined, { additionalArgs: ['.*a.(setup|test).ts$'] });
+  expect(exitCode).toBe(0);
+  expect(output).toContain('Running 5 tests using 1 worker');
+  expect(output).toContain('[p1] › a.setup.ts:5:7 › setup1');
+  expect(output).toContain('[p1] › a.setup.ts:6:7 › setup2');
+  expect(output).toContain('[p1] › a.test.ts:6:7 › test1');
+  expect(output).toContain('[p1] › a.test.ts:7:7 › test2');
+  expect(output).toContain('[p1] › a.test.ts:8:7 › test3');
 });
 
 test('should run all setup files if only tests match filter', async ({ runGroups }, testInfo) => {
@@ -619,3 +627,43 @@ test('should run all setup files if only tests match filter', async ({ runGroups
   expect(output).toContain('[p1] › b.setup.ts:5:7 › setup1');
   expect(output).toContain('[p1] › a.test.ts:7:7 › test2');
 });
+
+test('should run all setup files if only tests match grep filter', async ({ runGroups }, testInfo) => {
+  const files = {
+    'playwright.config.ts': `
+      module.exports = {
+        projects: [
+          {
+            name: 'p1',
+            setup: /.*.setup.ts/,
+          },
+        ]
+      };`,
+    'a.test.ts': `
+      const { test } = pwt;
+      test('test1', async () => { });
+      test('test2', async () => { });
+      test('test3', async () => { });
+    `,
+    'a.setup.ts': `
+      const { test } = pwt;
+      test('setup1', async () => { });
+      test('setup2', async () => { });
+    `,
+    'b.setup.ts': `
+      const { test } = pwt;
+      test('setup1', async () => { });
+    `,
+  };
+
+  const { exitCode, output } =  await runGroups(files, undefined, undefined, { additionalArgs: ['--grep', '.*test2$'] });
+  expect(exitCode).toBe(0);
+  expect(output).toContain('Running 4 tests using 2 workers');
+  expect(output).toContain('[p1] › a.setup.ts:5:7 › setup1');
+  expect(output).toContain('[p1] › a.setup.ts:6:7 › setup2');
+  expect(output).toContain('[p1] › b.setup.ts:5:7 › setup1');
+  expect(output).toContain('[p1] › a.test.ts:7:7 › test2');
+});
+
+
+// TODO: test that grep applies to both setup and tests

--- a/tests/playwright-test/project-setup.spec.ts
+++ b/tests/playwright-test/project-setup.spec.ts
@@ -488,7 +488,7 @@ test('should allow .only in both setup and test files', async ({ runGroups }, te
   };
 
   const { exitCode, output } =  await runGroups(files);
-  // expect(exitCode).toBe(1);
+  expect(exitCode).toBe(0);
   expect(output).toContain('[p1] › a.setup.ts:5:12 › setup1');
   expect(output).toContain('[p1] › a.test.ts:7:12 › test2');
 });


### PR DESCRIPTION
The behavior regarding filters (both in config, command line and .only) is the following:
- if some of tests match and none of setup match then we'll run all setup files and all matching tests
- otherwise the filters apply to setup files the same way as to regular tests