### PR TITLE
Fix timeout documentation

### DIFF
--- a/docs/src/test-timeouts-js.md
+++ b/docs/src/test-timeouts-js.md
@@ -87,7 +87,7 @@ test('very slow test', async ({ page }) => {
 
 API reference: [`method: Test.setTimeout`] and [`method: Test.slow#1`].
 
-### Change timeout from a slow hook
+### Change timeout from a `beforeEach` hook
 
 ```js tab=js-js
 const { test, expect } = require('@playwright/test');


### PR DESCRIPTION
Signed-off-by: ffluk3 <99682335+ffluk3@users.noreply.github.com>

This change just acknowledges that this use case is from a `beforeEach` hook, not what is written as a `slow` hook