### PR TITLE
fix(chromium): detach from shared workers

### DIFF
--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -49,6 +49,10 @@ export class CRServiceWorker extends Worker {
 
     session.send('Runtime.enable', {}).catch(e => { });
     session.send('Runtime.runIfWaitingForDebugger').catch(e => { });
+    session.on('Inspector.targetReloadedAfterCrash', () => {
+      // Resume service worker after restart.
+      session._sendMayFail('Runtime.runIfWaitingForDebugger', {});
+    });
   }
 
   async updateOffline(initial: boolean): Promise<void> {

--- a/tests/assets/shared-worker/shared-worker.html
+++ b/tests/assets/shared-worker/shared-worker.html
@@ -1,0 +1,7 @@
+<script>
+  window.sharedWorkerResponsePromise = new Promise(f => {
+    window.myWorker = new SharedWorker("shared-worker.js");
+    window.myWorker.port.postMessage('hello');
+    window.myWorker.port.onmessage = e => f(e.data);
+  });
+</script>

--- a/tests/assets/shared-worker/shared-worker.js
+++ b/tests/assets/shared-worker/shared-worker.js
@@ -1,0 +1,4 @@
+onconnect = event => {
+  const port = event.ports[0];
+  port.onmessage = e => port.postMessage('echo:' + e.data);
+};

--- a/tests/library/shared-worker.spec.ts
+++ b/tests/library/shared-worker.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { contextTest as test, expect } from '../config/browserTest';
+
+test('should survive shared worker restart', async ({ context, server }) => {
+  const page1 = await context.newPage();
+  await page1.goto(server.PREFIX + '/shared-worker/shared-worker.html');
+  expect(await page1.evaluate('window.sharedWorkerResponsePromise')).toBe('echo:hello');
+  await page1.close();
+
+  const page2 = await context.newPage();
+  await page2.goto(server.PREFIX + '/shared-worker/shared-worker.html');
+  expect(await page2.evaluate('window.sharedWorkerResponsePromise')).toBe('echo:hello');
+  await page2.close();
+});


### PR DESCRIPTION
This prevents shared workers from stalling upon restart.

We receive `Inspector.targetCrashed` and `Inspector.targetReloadedAfterCrash` events that assume `Runtime.runIfWaitingForDebugger` from any attached client. It is easier and more stable to just detach from shared workers, because we do not inspect them.

For service workers, we should actually issue `Runtime.runIfWaitingForDebugger` in such cases, because we attach to them.

Fixes #18932.