### PR TITLE
Correct CircleCI brand name

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -362,7 +362,7 @@ in `playwright.config.ts`.
 
 ### CircleCI
 
-Running Playwright on Circle CI is very similar to running on GitHub Actions. In order to specify the pre-built Playwright [Docker image](./docker.md) , simply modify the agent definition with `docker:` in your config like so:
+Running Playwright on CircleCI is very similar to running on GitHub Actions. In order to specify the pre-built Playwright [Docker image](./docker.md) , simply modify the agent definition with `docker:` in your config like so:
 
    ```yml
    executors:
@@ -385,9 +385,9 @@ Similarly, If you’re using Playwright through Jest, then you may encounter an 
 
    This is likely caused by Jest autodetecting the number of processes on the entire machine (`36`) rather than the number allowed to your container (`2`). To fix this, set `jest --maxWorkers=2` in your test command.
 
-#### Sharding in Circle CI
+#### Sharding in CircleCI
 
-Sharding in Circle CI is indexed with 0 which means that you will need to override the default parallelism ENV VARS. The following example demonstrates how to run Playwright with a Circle CI Parallelism of 4 by adding 1 to the `CIRCLE_NODE_INDEX` to pass into the `--shard` cli arg.
+Sharding in CircleCI is indexed with 0 which means that you will need to override the default parallelism ENV VARS. The following example demonstrates how to run Playwright with a CircleCI Parallelism of 4 by adding 1 to the `CIRCLE_NODE_INDEX` to pass into the `--shard` cli arg.
 
   ```yml
     playwright-job-name:


### PR DESCRIPTION
Small correction to fix brand name: Circle CI to CircleCI

Signed-off-by: Devin Beliveau <devinmarieb@gmail.com>