### PR TITLE
feat: dedupe output logs

### DIFF
--- a/packages/playwright-core/src/client/waiter.ts
+++ b/packages/playwright-core/src/client/waiter.ts
@@ -17,7 +17,7 @@
 import type { EventEmitter } from 'events';
 import { rewriteErrorMessage } from '../utils/stackTrace';
 import { TimeoutError } from '../common/errors';
-import { createGuid } from '../utils';
+import { createGuid, formatLogRecording } from '../utils';
 import type * as channels from '@protocol/channels';
 import type { ChannelOwner } from './channelOwner';
 
@@ -128,14 +128,4 @@ function waitForTimeout(timeout: number): { promise: Promise<void>, dispose: () 
   const promise = new Promise<void>(resolve => timeoutId = setTimeout(resolve, timeout));
   const dispose = () => clearTimeout(timeoutId);
   return { promise, dispose };
-}
-
-function formatLogRecording(log: string[]): string {
-  if (!log.length)
-    return '';
-  const header = ` logs `;
-  const headerLength = 60;
-  const leftLength = (headerLength - header.length) / 2;
-  const rightLength = headerLength - header.length - leftLength;
-  return `\n${'='.repeat(leftLength)}${header}${'='.repeat(rightLength)}\n${log.join('\n')}\n${'='.repeat(headerLength)}`;
 }

--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -18,7 +18,7 @@ import { EventEmitter } from 'events';
 import type * as channels from '@protocol/channels';
 import { serializeError } from '../../protocol/serializers';
 import { findValidator, ValidationError, createMetadataValidator, type ValidatorContext } from '../../protocol/validator';
-import { assert, isUnderTest, monotonicTime } from '../../utils';
+import { assert, isUnderTest, monotonicTime, formatLogRecording } from '../../utils';
 import { kBrowserOrContextClosedError } from '../../common/errors';
 import type { CallMetadata } from '../instrumentation';
 import { SdkObject } from '../instrumentation';
@@ -316,16 +316,6 @@ export class DispatcherConnection {
       response.error = error;
     this.onmessage(response);
   }
-}
-
-function formatLogRecording(log: string[]): string {
-  if (!log.length)
-    return '';
-  const header = ` logs `;
-  const headerLength = 60;
-  const leftLength = (headerLength - header.length) / 2;
-  const rightLength = headerLength - header.length - leftLength;
-  return `\n${'='.repeat(leftLength)}${header}${'='.repeat(rightLength)}\n${log.join('\n')}\n${'='.repeat(headerLength)}`;
 }
 
 let lastEventId = 0;


### PR DESCRIPTION
This will result in the following log output:

```bash
aslushnikov:~/prog/playwright(dedupe-output-logs)$ node a.mjs
node:internal/process/esm_loader:94
    internalBinding('errors').triggerUncaughtException(
                              ^

page.tap: Timeout 1000ms exceeded.
=========================== logs ===========================
┌──── (repeated 29x) ────
│ waiting for locator('body')
│   locator resolved to visible <body></body>
│ attempting tap action
│   waiting for element to be visible, enabled and stable
│   element is visible, enabled and stable
│   scrolling into view if needed
│   done scrolling
│   performing tap action
└────
waiting for locator('body')
  locator resolved to visible <body></body>
attempting tap action
  waiting for element to be visible, enabled and stable
============================================================
    at file:///Users/andreylushnikov/prog/playwright/a.mjs:6:12 {
  name: 'TimeoutError'
}
```
