### PR TITLE
docs(js): add step to the cli install command overview

### DIFF
--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -55,6 +55,7 @@ Run the install command and select the following to get started:
  - Choose between TypeScript or JavaScript (default is TypeScript)
  - Name of your Tests folder (default is tests or e2e if you already have a tests folder in your project)
  - Add a GitHub Actions workflow to easily run tests on CI
+ - Install Playwright browsers (default is true)
 
 
 ## What's Installed


### PR DESCRIPTION
I noticed the Node.js cli install command (`npm init playwright@latest`) provides a fourth choice that isn't listed on the docs page ('Install Playwright browsers'), so added it in this PR.

Here's a screenshot showing the cli's fourth choice for installing browsers:

<img width="1512" alt="docs-js-add-step-to-install-command-overview" src="https://user-images.githubusercontent.com/3411019/204099042-b0f2b056-3a4f-4089-a796-50d1d83e44d0.png">

ps - I listened to the recent [JS Party podcast episode about Playwright](https://changelog.com/jsparty/253) via @thechangelog which prompted trying it out and this PR!