### PR TITLE
Rewrite error message for missing snapshot

### DIFF
--- a/docs/src/test-snapshots-js.md
+++ b/docs/src/test-snapshots-js.md
@@ -27,7 +27,7 @@ test('example test', async ({ page }) => {
 
 When you run above for the first time, test runner will say:
 ```
-Error: example.spec.ts-snapshots/example-test-1-chromium-darwin.png is missing in snapshots, writing actual.
+Error: A snapshot doesn't exist at example.spec.ts-snapshots/example-test-1-chromium-darwin.png, writing actual.
 ```
 
 That's because there was no golden file yet. This method took a bunch of screenshots until two consecutive

--- a/packages/playwright-test/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright-test/src/matchers/toMatchSnapshot.ts
@@ -151,7 +151,7 @@ class SnapshotHelper<T extends ImageComparatorOptions> {
 
   handleMissingNegated() {
     const isWriteMissingMode = this.updateSnapshots === 'all' || this.updateSnapshots === 'missing';
-    const message = `${this.snapshotPath} is missing in snapshots${isWriteMissingMode ? ', matchers using ".not" won\'t write them automatically.' : '.'}`;
+    const message = `A snapshot doesn't exist at ${this.snapshotPath}${isWriteMissingMode ? ', matchers using ".not" won\'t write them automatically.' : '.'}`;
     return {
       // NOTE: 'isNot' matcher implies inversed value.
       pass: true,
@@ -180,7 +180,7 @@ class SnapshotHelper<T extends ImageComparatorOptions> {
       writeFileSync(this.snapshotPath, actual);
       writeFileSync(this.actualPath, actual);
     }
-    const message = `${this.snapshotPath} is missing in snapshots${isWriteMissingMode ? ', writing actual.' : '.'}`;
+    const message = `A snapshot doesn't exist at ${this.snapshotPath}${isWriteMissingMode ? ', writing actual.' : '.'}`;
     if (this.updateSnapshots === 'all') {
       /* eslint-disable no-console */
       console.log(message);
@@ -349,7 +349,7 @@ export async function toHaveScreenshot(
 
   // Fast path: there's no screenshot and we don't intend to update it.
   if (helper.updateSnapshots === 'none' && !hasSnapshot)
-    return { pass: false, message: () => `${helper.snapshotPath} is missing in snapshots.` };
+    return { pass: false, message: () => `A snapshot doesn't exist at ${helper.snapshotPath}.` };
 
   if (!hasSnapshot) {
     // Regenerate a new screenshot by waiting until two screenshots are the same.

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -216,11 +216,11 @@ test('should write missing expectations locally twice and continue', async ({ ru
   expect(result.failed).toBe(1);
 
   const snapshot1OutputPath = testInfo.outputPath('a.spec.js-snapshots/snapshot.txt');
-  expect(result.output).toContain(`Error: ${snapshot1OutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`Error: A snapshot doesn't exist at ${snapshot1OutputPath}, writing actual`);
   expect(fs.readFileSync(snapshot1OutputPath, 'utf-8')).toBe('Hello world');
 
   const snapshot2OutputPath = testInfo.outputPath('a.spec.js-snapshots/snapshot2.txt');
-  expect(result.output).toContain(`Error: ${snapshot2OutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`Error: A snapshot doesn't exist at ${snapshot2OutputPath}, writing actual`);
   expect(fs.readFileSync(snapshot2OutputPath, 'utf-8')).toBe('Hello world2');
 
   expect(result.output).toContain('Here we are!');
@@ -243,7 +243,7 @@ test('should not write missing expectations for negated matcher', async ({ runIn
 
   expect(result.exitCode).toBe(1);
   const snapshotOutputPath = testInfo.outputPath('a.spec.js-snapshots/snapshot.txt');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, matchers using ".not" won\'t write them automatically.`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, matchers using ".not" won\'t write them automatically.`);
   expect(fs.existsSync(snapshotOutputPath)).toBe(false);
 });
 
@@ -323,7 +323,7 @@ test('should silently write missing expectations locally with the update-snapsho
 
   expect(result.exitCode).toBe(0);
   const snapshotOutputPath = testInfo.outputPath('a.spec.js-snapshots/snapshot.txt');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, writing actual`);
   const data = fs.readFileSync(snapshotOutputPath);
   expect(data.toString()).toBe(ACTUAL_SNAPSHOT);
 });
@@ -341,7 +341,7 @@ test('should silently write missing expectations locally with the update-snapsho
 
   expect(result.exitCode).toBe(1);
   const snapshotOutputPath = testInfo.outputPath('a.spec.js-snapshots/snapshot.txt');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, matchers using ".not" won\'t write them automatically.`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, matchers using ".not" won\'t write them automatically.`);
   expect(fs.existsSync(snapshotOutputPath)).toBe(false);
 });
 
@@ -647,7 +647,7 @@ test('should write missing expectations with sanitized snapshot name', async ({ 
 
   expect(result.exitCode).toBe(1);
   const snapshotOutputPath = testInfo.outputPath('a.spec.js-snapshots/-snapshot-.txt');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, writing actual`);
   const data = fs.readFileSync(snapshotOutputPath);
   expect(data.toString()).toBe('Hello world');
 });
@@ -768,7 +768,7 @@ test('should update snapshot with array of path segments', async ({ runInlineTes
 
   expect(result.exitCode).toBe(0);
   const snapshotOutputPath = testInfo.outputPath('a.spec.js-snapshots/test/path/snapshot.txt');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, writing actual`);
   const data = fs.readFileSync(snapshotOutputPath);
   expect(data.toString()).toBe('Hello world');
 });
@@ -905,7 +905,7 @@ test('should fail with missing expectations and retries', async ({ runInlineTest
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
   const snapshotOutputPath = testInfo.outputPath('a.spec.js-snapshots/snapshot.txt');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, writing actual`);
   const data = fs.readFileSync(snapshotOutputPath);
   expect(data.toString()).toBe('Hello world');
 });
@@ -927,7 +927,7 @@ test('should update expectations with retries', async ({ runInlineTest }, testIn
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
   const snapshotOutputPath = testInfo.outputPath('a.spec.js-snapshots/snapshot.txt');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, writing actual`);
   const data = fs.readFileSync(snapshotOutputPath);
   expect(data.toString()).toBe('Hello world');
 });

--- a/tests/playwright-test/snapshot-path-template.spec.ts
+++ b/tests/playwright-test/snapshot-path-template.spec.ts
@@ -132,7 +132,7 @@ test('arg should receive default arg', async ({ runInlineTest }, testInfo) => {
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
   const snapshotOutputPath = testInfo.outputPath('__screenshots__/is-a-test-1.png');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, writing actual`);
   expect(fs.existsSync(snapshotOutputPath)).toBe(true);
 });
 

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -557,11 +557,11 @@ test('should write missing expectations locally twice and continue', async ({ ru
   expect(result.failed).toBe(1);
 
   const snapshot1OutputPath = testInfo.outputPath('__screenshots__', 'a.spec.js', 'snapshot.png');
-  expect(result.output).toContain(`Error: ${snapshot1OutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`Error: A snapshot doesn't exist at ${snapshot1OutputPath}, writing actual`);
   expect(comparePNGs(fs.readFileSync(snapshot1OutputPath), whiteImage)).toBe(null);
 
   const snapshot2OutputPath = testInfo.outputPath('__screenshots__', 'a.spec.js', 'snapshot2.png');
-  expect(result.output).toContain(`Error: ${snapshot2OutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`Error: A snapshot doesn't exist at ${snapshot2OutputPath}, writing actual`);
   expect(comparePNGs(fs.readFileSync(snapshot2OutputPath), whiteImage)).toBe(null);
 
   expect(result.output).toContain('Here we are!');
@@ -585,7 +585,7 @@ test('shouldn\'t write missing expectations locally for negated matcher', async 
 
   expect(result.exitCode).toBe(1);
   const snapshotOutputPath = testInfo.outputPath('__screenshots__/a.spec.js/snapshot.png');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, matchers using ".not" won\'t write them automatically.`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, matchers using ".not" won\'t write them automatically.`);
   expect(fs.existsSync(snapshotOutputPath)).toBe(false);
 });
 
@@ -641,7 +641,7 @@ test('should silently write missing expectations locally with the update-snapsho
 
   expect(result.exitCode).toBe(0);
   const snapshotOutputPath = testInfo.outputPath('__screenshots__/a.spec.js/snapshot.png');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, writing actual`);
   const data = fs.readFileSync(snapshotOutputPath);
   expect(comparePNGs(data, whiteImage)).toBe(null);
 });
@@ -660,7 +660,7 @@ test('should not write missing expectations locally with the update-snapshots fl
 
   expect(result.exitCode).toBe(1);
   const snapshotOutputPath = testInfo.outputPath('__screenshots__/a.spec.js/snapshot.png');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, matchers using ".not" won\'t write them automatically.`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, matchers using ".not" won\'t write them automatically.`);
   expect(fs.existsSync(snapshotOutputPath)).toBe(false);
 });
 
@@ -996,7 +996,7 @@ test('should fail with missing expectations and retries', async ({ runInlineTest
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
   const snapshotOutputPath = testInfo.outputPath('__screenshots__/a.spec.js/snapshot.png');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, writing actual`);
   const data = fs.readFileSync(snapshotOutputPath);
   expect(comparePNGs(data, whiteImage)).toBe(null);
 });
@@ -1017,7 +1017,7 @@ test('should update expectations with retries', async ({ runInlineTest }, testIn
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
   const snapshotOutputPath = testInfo.outputPath('__screenshots__/a.spec.js/snapshot.png');
-  expect(result.output).toContain(`${snapshotOutputPath} is missing in snapshots, writing actual`);
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}, writing actual`);
   const data = fs.readFileSync(snapshotOutputPath);
   expect(comparePNGs(data, whiteImage)).toBe(null);
 });


### PR DESCRIPTION
When snapshots are missing (new tests are written), the error message can be hard to read as the path to the image is printed before the error message itself. One needs to scroll sideways to reach the actual error message.

##### Before
<img width="1057" alt="Screenshot 2022-11-28 at 2 31 06 PM" src="https://user-images.githubusercontent.com/8946207/204236817-ad4c8153-3e4f-4bf2-8b03-97b1330d087d.png">


##### After
<img width="1052" alt="Screenshot 2022-11-28 at 2 31 40 PM" src="https://user-images.githubusercontent.com/8946207/204236920-336abbf3-47b4-4e19-9b6c-b96067488eb8.png">

