### PR TITLE
docs: note assertion methods that only work with playwright test runner

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -1336,6 +1336,8 @@ const locator = page.getByRole('button');
 await expect(locator).toHaveScreenshot('image.png');
 ```
 
+Note that screenshot assertions only work with Playwright test runner.
+
 ### param: LocatorAssertions.toHaveScreenshot#1.name
 * since: v1.23
 - `name` <[string]|[Array]<[string]>>
@@ -1382,6 +1384,8 @@ yield the same result, and then compare the last screenshot with the expectation
 const locator = page.getByRole('button');
 await expect(locator).toHaveScreenshot();
 ```
+
+Note that screenshot assertions only work with Playwright test runner.
 
 ### option: LocatorAssertions.toHaveScreenshot#2.timeout = %%-js-assertions-timeout-%%
 * since: v1.23

--- a/docs/src/api/class-pageassertions.md
+++ b/docs/src/api/class-pageassertions.md
@@ -138,6 +138,8 @@ yield the same result, and then compare the last screenshot with the expectation
 await expect(page).toHaveScreenshot('image.png');
 ```
 
+Note that screenshot assertions only work with Playwright test runner.
+
 ### param: PageAssertions.toHaveScreenshot#1.name
 * since: v1.23
 - `name` <[string]|[Array]<[string]>>
@@ -189,6 +191,8 @@ yield the same result, and then compare the last screenshot with the expectation
 ```js
 await expect(page).toHaveScreenshot();
 ```
+
+Note that screenshot assertions only work with Playwright test runner.
 
 ### option: PageAssertions.toHaveScreenshot#2.timeout = %%-js-assertions-timeout-%%
 * since: v1.23

--- a/docs/src/api/class-screenshotassertions.md
+++ b/docs/src/api/class-screenshotassertions.md
@@ -35,6 +35,8 @@ expect(await page.screenshot()).toMatchSnapshot(['landing', 'step3.png']);
 
 Learn more about [visual comparisons](../test-snapshots.md).
 
+Note that matching snapshots only work with Playwright test runner.
+
 ### param: ScreenshotAssertions.toMatchSnapshot#1.name
 * since: v1.22
 - `name` <[string]|[Array]<[string]>>
@@ -74,6 +76,8 @@ expect(await page.screenshot()).toMatchSnapshot({
 ```
 
 Learn more about [visual comparisons](../test-snapshots.md).
+
+Note that matching snapshots only work with Playwright test runner.
 
 ### option: ScreenshotAssertions.toMatchSnapshot#2.maxDiffPixels = %%-assertions-max-diff-pixels-%%
 * since: v1.22

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -86,6 +86,8 @@ await expect.soft(page.locator('#eta')).toHaveText('1 day');
 expect(test.info().errors).toHaveLength(0);
 ```
 
+Note that soft assertions only work with Playwright test runner.
+
 ## Custom Expect Message
 
 You can specify a custom error message as a second argument to the `expect` function, for example:

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -3820,6 +3820,7 @@ interface LocatorAssertions {
    * await expect(locator).toHaveScreenshot('image.png');
    * ```
    *
+   * Note that screenshot assertions only work with Playwright test runner.
    * @param name Snapshot name.
    * @param options
    */
@@ -3897,6 +3898,7 @@ interface LocatorAssertions {
    * await expect(locator).toHaveScreenshot();
    * ```
    *
+   * Note that screenshot assertions only work with Playwright test runner.
    * @param options
    */
   toHaveScreenshot(options?: {
@@ -4118,6 +4120,7 @@ interface PageAssertions {
    * await expect(page).toHaveScreenshot('image.png');
    * ```
    *
+   * Note that screenshot assertions only work with Playwright test runner.
    * @param name Snapshot name.
    * @param options
    */
@@ -4225,6 +4228,7 @@ interface PageAssertions {
    * await expect(page).toHaveScreenshot();
    * ```
    *
+   * Note that screenshot assertions only work with Playwright test runner.
    * @param options
    */
   toHaveScreenshot(options?: {
@@ -4393,6 +4397,8 @@ interface ScreenshotAssertions {
    * ```
    *
    * Learn more about [visual comparisons](https://playwright.dev/docs/test-snapshots).
+   *
+   * Note that matching snapshots only work with Playwright test runner.
    * @param name Snapshot name.
    * @param options
    */
@@ -4440,6 +4446,8 @@ interface ScreenshotAssertions {
    * ```
    *
    * Learn more about [visual comparisons](https://playwright.dev/docs/test-snapshots).
+   *
+   * Note that matching snapshots only work with Playwright test runner.
    * @param options
    */
   toMatchSnapshot(options?: {


### PR DESCRIPTION
Fixes #18963.