### PR TITLE
feat(connect): support special headers for debug/attachments

### DIFF
--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -19,7 +19,7 @@ import { BrowserContext, prepareBrowserContextParams } from './browserContext';
 import type { Page } from './page';
 import { ChannelOwner } from './channelOwner';
 import { Events } from './events';
-import type { BrowserContextOptions } from './types';
+import type { BrowserContextOptions, HeadersArray } from './types';
 import { isSafeCloseError, kBrowserClosedError } from '../common/errors';
 import type * as api from '../../types/types';
 import { CDPSession } from './cdpSession';
@@ -32,6 +32,9 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
   _shouldCloseConnectionOnClose = false;
   private _browserType!: BrowserType;
   readonly _name: string;
+
+  // Used from @playwright/test fixtures.
+  _connectHeaders?: HeadersArray;
 
   static from(browser: channels.BrowserChannel): Browser {
     return (browser as any)._object;

--- a/packages/playwright-core/src/client/fetch.ts
+++ b/packages/playwright-core/src/client/fetch.ts
@@ -56,7 +56,7 @@ export class APIRequest implements api.APIRequest {
   private _playwright: Playwright;
   readonly _contexts = new Set<APIRequestContext>();
 
-  // Instrumentation.
+  // Instrumentation, used from @playwright/test fixtures.
   _onDidCreateContext?: (context: APIRequestContext) => Promise<void>;
   _onWillCloseContext?: (context: APIRequestContext) => Promise<void>;
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -254,6 +254,7 @@ scheme.LocalUtilsConnectParams = tObject({
 });
 scheme.LocalUtilsConnectResult = tObject({
   pipe: tChannel(['JsonPipe']),
+  headers: tArray(tType('NameValue')),
 });
 scheme.RootInitializer = tOptional(tObject({}));
 scheme.RootInitializeParams = tObject({

--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -109,6 +109,11 @@ export class PlaywrightServer {
     const controllerSemaphore = new Semaphore(1);
     const reuseBrowserSemaphore = new Semaphore(1);
     const networkTetheringSemaphore = new Semaphore(1);
+    if (process.env.PWTEST_SERVER_WS_HEADERS) {
+      this._wsServer.on('headers', (headers, request) => {
+        headers.push(process.env.PWTEST_SERVER_WS_HEADERS!);
+      });
+    }
     this._wsServer.on('connection', (ws, request) => {
       const url = new URL('http://localhost' + (request.url || ''));
       const browserHeader = request.headers['x-playwright-browser'];

--- a/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
@@ -185,7 +185,7 @@ export class LocalUtilsDispatcher extends Dispatcher<{ guid: string }, channels.
         pipe.wasClosed();
       };
       pipe.on('close', () => transport.close());
-      return { pipe };
+      return { pipe, headers: transport.headers };
     }, params.timeout || 0);
   }
 

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -458,6 +458,7 @@ export type LocalUtilsConnectOptions = {
 };
 export type LocalUtilsConnectResult = {
   pipe: JsonPipeChannel,
+  headers: NameValue[],
 };
 
 export interface LocalUtilsEvents {

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -540,6 +540,9 @@ LocalUtils:
         socksProxyRedirectPortForTest: number?
       returns:
         pipe: JsonPipe
+        headers:
+          type: array
+          items: NameValue
 
 Root:
   type: interface

--- a/tests/playwright-test/playwright.connect.spec.ts
+++ b/tests/playwright-test/playwright.connect.spec.ts
@@ -30,6 +30,12 @@ test('should work with connectOptions', async ({ runInlineTest }) => {
     `,
     'global-setup.ts': `
       module.exports = async () => {
+        process.env.DEBUG = 'pw:browser';
+        process.env.PWTEST_SERVER_WS_HEADERS =
+          'x-playwright-debug-log: a-debug-log-string\\r\\n' +
+          'x-playwright-attach-string: attachment-a=value-a\\r\\n' +
+          'x-playwright-debug-log: b-debug-log-string\\r\\n' +
+          'x-playwright-attach-string: attachment-b=value-b';
         const server = await pwt.chromium.launchServer();
         process.env.CONNECT_WS_ENDPOINT = server.wsEndpoint();
         return () => server.close();
@@ -47,6 +53,20 @@ test('should work with connectOptions', async ({ runInlineTest }) => {
   });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
+  expect(result.output).toContain('a-debug-log-string');
+  expect(result.output).toContain('b-debug-log-string');
+  expect(result.results[0].attachments).toEqual([
+    {
+      name: 'attachment-a',
+      contentType: 'text/plain',
+      body: 'dmFsdWUtYQ=='
+    },
+    {
+      name: 'attachment-b',
+      contentType: 'text/plain',
+      body: 'dmFsdWUtYg=='
+    }
+  ]);
 });
 
 test('should throw with bad connectOptions', async ({ runInlineTest }) => {


### PR DESCRIPTION
`x-playwright-debug-log: value` headers are printed to `pw:browser` debug log.
`x-playwright-attach-string: name=value` headers are attached to each test.