### PR TITLE
fix: Fixes #19169 Issue with moving up a directory in snapshotPathTemplate

### DIFF
--- a/packages/playwright-test/src/testInfo.ts
+++ b/packages/playwright-test/src/testInfo.ts
@@ -246,13 +246,11 @@ export class TestInfoImpl implements TestInfo {
     const parsedRelativeTestFilePath = path.parse(relativeTestFilePath);
     const projectNamePathSegment = sanitizeForFilePath(this.project.name);
 
-    const snapshotPath = path.resolve(
-        this.config._configDir, this.project.snapshotPathTemplate
-            .replace(/\{(.)?testDir\}/g, '$1' + this.project.testDir)
-            .replace(/\{(.)?snapshotDir\}/g, '$1' + this.project.snapshotDir)
-            .replace(/\{(.)?snapshotSuffix\}/g, this.snapshotSuffix ? '$1' + this.snapshotSuffix : '')
-            .replace(/\{(.)?testFileDir\}/g, '$1' + parsedRelativeTestFilePath.dir)
-    )
+    const snapshotPath = this.project.snapshotPathTemplate
+        .replace(/\{(.)?testDir\}/g, '$1' + this.project.testDir)
+        .replace(/\{(.)?snapshotDir\}/g, '$1' + this.project.snapshotDir)
+        .replace(/\{(.)?snapshotSuffix\}/g, this.snapshotSuffix ? '$1' + this.snapshotSuffix : '')
+        .replace(/\{(.)?testFileDir\}/g, '$1' + parsedRelativeTestFilePath.dir)
         .replace(/\{(.)?platform\}/g, '$1' + process.platform)
         .replace(/\{(.)?projectName\}/g, projectNamePathSegment ? '$1' + projectNamePathSegment : '')
         .replace(/\{(.)?testName\}/g, '$1' + this._fsSanitizedTestName())
@@ -260,7 +258,8 @@ export class TestInfoImpl implements TestInfo {
         .replace(/\{(.)?testFilePath\}/g, '$1' + relativeTestFilePath)
         .replace(/\{(.)?arg\}/g, '$1' + path.join(parsedSubPath.dir, parsedSubPath.name))
         .replace(/\{(.)?ext\}/g, parsedSubPath.ext ? '$1' + parsedSubPath.ext : '');
-    return path.normalize(snapshotPath);
+
+    return path.normalize(path.resolve(this.config._configDir, snapshotPath));
   }
 
   skip(...args: [arg?: any, description?: string]) {

--- a/packages/playwright-test/src/testInfo.ts
+++ b/packages/playwright-test/src/testInfo.ts
@@ -246,14 +246,16 @@ export class TestInfoImpl implements TestInfo {
     const parsedRelativeTestFilePath = path.parse(relativeTestFilePath);
     const projectNamePathSegment = sanitizeForFilePath(this.project.name);
 
-    const snapshotPath = path.resolve(this.config._configDir, this.project.snapshotPathTemplate
-        .replace(/\{(.)?testDir\}/g, '$1' + this.project.testDir)
-        .replace(/\{(.)?snapshotDir\}/g, '$1' + this.project.snapshotDir)
-        .replace(/\{(.)?snapshotSuffix\}/g, this.snapshotSuffix ? '$1' + this.snapshotSuffix : ''))
+    const snapshotPath = path.resolve(
+        this.config._configDir, this.project.snapshotPathTemplate
+            .replace(/\{(.)?testDir\}/g, '$1' + this.project.testDir)
+            .replace(/\{(.)?snapshotDir\}/g, '$1' + this.project.snapshotDir)
+            .replace(/\{(.)?snapshotSuffix\}/g, this.snapshotSuffix ? '$1' + this.snapshotSuffix : '')
+            .replace(/\{(.)?testFileDir\}/g, '$1' + parsedRelativeTestFilePath.dir)
+    )
         .replace(/\{(.)?platform\}/g, '$1' + process.platform)
         .replace(/\{(.)?projectName\}/g, projectNamePathSegment ? '$1' + projectNamePathSegment : '')
         .replace(/\{(.)?testName\}/g, '$1' + this._fsSanitizedTestName())
-        .replace(/\{(.)?testFileDir\}/g, '$1' + parsedRelativeTestFilePath.dir)
         .replace(/\{(.)?testFileName\}/g, '$1' + parsedRelativeTestFilePath.base)
         .replace(/\{(.)?testFilePath\}/g, '$1' + relativeTestFilePath)
         .replace(/\{(.)?arg\}/g, '$1' + path.join(parsedSubPath.dir, parsedSubPath.name))

--- a/tests/playwright-test/snapshot-path-template.spec.ts
+++ b/tests/playwright-test/snapshot-path-template.spec.ts
@@ -115,16 +115,6 @@ test('args array should work', async ({ runInlineTest }, testInfo) => {
   expect.soft(snapshotPath['proj']).toBe(path.join('.jpegfoo', 'bar', 'baz'));
 });
 
-test('moving up directory should work fine with test file dir', async ({ runInlineTest }, testInfo) => {
-  const snapshotPath = await getSnapshotPaths(runInlineTest, testInfo, {
-    projects: [{
-      name: 'proj',
-      snapshotPathTemplate: '{testFileDir}/../image{ext}',
-    }],
-  }, ['foo', 'bar', 'baz.jpeg']);
-  expect.soft(snapshotPath['proj']).toBe(path.join('a', 'b', 'image.jpeg'));
-});
-
 test('arg should receive default arg', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'playwright.config.js': `

--- a/tests/playwright-test/snapshot-path-template.spec.ts
+++ b/tests/playwright-test/snapshot-path-template.spec.ts
@@ -115,6 +115,16 @@ test('args array should work', async ({ runInlineTest }, testInfo) => {
   expect.soft(snapshotPath['proj']).toBe(path.join('.jpegfoo', 'bar', 'baz'));
 });
 
+test('moving up directory should work fine with test file dir', async ({ runInlineTest }, testInfo) => {
+  const snapshotPath = await getSnapshotPaths(runInlineTest, testInfo, {
+    projects: [{
+      name: 'proj',
+      snapshotPathTemplate: '{testFileDir}/../image{ext}',
+    }],
+  }, ['foo', 'bar', 'baz.jpeg']);
+  expect.soft(snapshotPath['proj']).toBe(path.join('a', 'b', 'image.jpeg'));
+});
+
 test('arg should receive default arg', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'playwright.config.js': `


### PR DESCRIPTION
Fixes #19169

Note, I'm not sure why it was done this way before — e.g. Why `testDir` were considered for resolution, but `testFileDir` wasn't.

Looking for guidance on the approach here, because there are still some template tokens outside `path.resolve`