### PR TITLE
fix: do not rely upon the package paths on file system

### DIFF
--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -31,7 +31,7 @@ const CORE_DIR = path.resolve(__dirname, '..', '..');
 const CORE_LIB = path.join(CORE_DIR, 'lib');
 const CORE_SRC = path.join(CORE_DIR, 'src');
 const TEST_DIR_SRC = path.resolve(CORE_DIR, '..', 'playwright-test');
-const TEST_DIR_LIB = path.resolve(CORE_DIR, '..', '@playwright', 'test');
+
 const COVERAGE_PATH = path.join(CORE_DIR, '..', '..', 'tests', 'config', 'coverage.js');
 
 export type StackFrame = {
@@ -125,7 +125,7 @@ export function captureStackTrace(rawStack?: string): ParsedStackTrace {
   parsedFrames = parsedFrames.filter((f, i) => {
     if (process.env.PWDEBUGIMPL)
       return true;
-    if (f.frame.file.startsWith(TEST_DIR_SRC) || f.frame.file.startsWith(TEST_DIR_LIB))
+    if (f.frame.file.startsWith(TEST_DIR_SRC))
       return false;
     if (f.frame.file.startsWith(CORE_DIR))
       return false;

--- a/packages/playwright-test/src/matchers/toEqual.ts
+++ b/packages/playwright-test/src/matchers/toEqual.ts
@@ -15,10 +15,9 @@
  */
 
 import type { Expect } from '../types';
-import { expectTypes } from '../util';
+import { expectTypes, captureStackTrace } from '../util';
 import { callLogText, currentExpectTimeout } from '../util';
 import type { ParsedStackTrace } from 'playwright-core/lib/utils/stackTrace';
-import { captureStackTrace } from 'playwright-core/lib/utils/stackTrace';
 import { matcherHint } from './matcherHint';
 
 // Omit colon and one or more spaces, so can call getLabelPrinter.

--- a/packages/playwright-test/src/util.ts
+++ b/packages/playwright-test/src/util.ts
@@ -30,8 +30,6 @@ import { captureStackTrace as coreCaptureStackTrace } from 'playwright-core/lib/
 export type { ParsedStackTrace };
 
 const PLAYWRIGHT_CORE_PATH = path.dirname(require.resolve('playwright-core'));
-const EXPECT_PATH = require.resolve('./expectBundle');
-const EXPECT_PATH_IMPL = require.resolve('./expectBundleImpl');
 const PLAYWRIGHT_TEST_PATH = path.join(__dirname, '..');
 
 function filterStackTrace(e: Error) {
@@ -73,7 +71,7 @@ export function captureStackTrace(customApiName?: string): ParsedStackTrace {
   const frameTexts = [];
   for (let i = 0; i < stackTrace.frames.length; ++i) {
     const frame = stackTrace.frames[i];
-    if (frame.file === EXPECT_PATH || frame.file === EXPECT_PATH_IMPL)
+    if (frame.file.startsWith(PLAYWRIGHT_TEST_PATH))
       continue;
     frames.push(frame);
     frameTexts.push(stackTrace.frameTexts[i]);


### PR DESCRIPTION
Package managers can save packages at whatever names
while installing. For example, PNPM package manager can put packages `@playwright/test` and `playwright-core`
at a far-away locations:

```
> require.resolve('playwright-core')
'/Users/andreylushnikov/tmp/node_modules/.pnpm/playwright-core@1.28.1/node_modules/playwright-core/index.js'
> require.resolve('@playwright/test')
'/Users/andreylushnikov/tmp/node_modules/.pnpm/@playwright+test@1.28.1/node_modules/@playwright/test/index.js'
>
```

This patch fixes filtering of the `@playwright/test` captured stacks.

Fixes #19087
