### PR TITLE
[Feature] Add a way to add user browser args while launching browser in android

### DIFF
--- a/docs/src/api/class-androiddevice.md
+++ b/docs/src/api/class-androiddevice.md
@@ -144,10 +144,10 @@ Optional package name to launch instead of default Chrome for Android.
 * since: v1.9
 
 ### option: AndroidDevice.launchBrowser.proxy = %%-browser-option-proxy-%%
-* since: v1.9
+* since: v1.29
 
 ### option: AndroidDevice.launchBrowser.args = %%-browser-option-args-%%
-* since: v1.9
+* since: v1.29
 
 ## async method: AndroidDevice.longTap
 * since: v1.9

--- a/docs/src/api/class-androiddevice.md
+++ b/docs/src/api/class-androiddevice.md
@@ -143,6 +143,12 @@ Optional package name to launch instead of default Chrome for Android.
 ### option: AndroidDevice.launchBrowser.-inline- = %%-shared-context-params-list-v1.8-%%
 * since: v1.9
 
+### option: AndroidDevice.launchBrowser.proxy = %%-browser-option-proxy-%%
+* since: v1.9
+
+### option: AndroidDevice.launchBrowser.args = %%-browser-option-args-%%
+* since: v1.9
+
 ## async method: AndroidDevice.longTap
 * since: v1.9
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -534,6 +534,7 @@ scheme.BrowserTypeLaunchPersistentContextParams = tObject({
   recordHar: tOptional(tType('RecordHarOptions')),
   strictSelectors: tOptional(tBoolean),
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
+  browserArgs: tOptional(tArray(tString)),
   userDataDir: tString,
   slowMo: tOptional(tNumber),
 });
@@ -605,6 +606,7 @@ scheme.BrowserNewContextParams = tObject({
   recordHar: tOptional(tType('RecordHarOptions')),
   strictSelectors: tOptional(tBoolean),
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
+  browserArgs: tOptional(tArray(tString)),
   proxy: tOptional(tObject({
     server: tString,
     bypass: tOptional(tString),
@@ -665,6 +667,7 @@ scheme.BrowserNewContextForReuseParams = tObject({
   recordHar: tOptional(tType('RecordHarOptions')),
   strictSelectors: tOptional(tBoolean),
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
+  browserArgs: tOptional(tArray(tString)),
   proxy: tOptional(tObject({
     server: tString,
     bypass: tOptional(tString),
@@ -2383,6 +2386,7 @@ scheme.AndroidDeviceLaunchBrowserParams = tObject({
   recordHar: tOptional(tType('RecordHarOptions')),
   strictSelectors: tOptional(tBoolean),
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
+  browserArgs: tOptional(tArray(tString)),
   pkg: tOptional(tString),
   proxy: tOptional(tObject({
     server: tString,

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -611,7 +611,6 @@ scheme.BrowserNewContextParams = tObject({
     username: tOptional(tString),
     password: tOptional(tString),
   })),
-  args: tOptional(tArray(tString)),
   storageState: tOptional(tObject({
     cookies: tOptional(tArray(tType('SetNetworkCookie'))),
     origins: tOptional(tArray(tType('OriginStorage'))),
@@ -2385,6 +2384,7 @@ scheme.AndroidDeviceLaunchBrowserParams = tObject({
   strictSelectors: tOptional(tBoolean),
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
   pkg: tOptional(tString),
+  args: tOptional(tArray(tString)),
   proxy: tOptional(tObject({
     server: tString,
     bypass: tOptional(tString),

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -534,7 +534,6 @@ scheme.BrowserTypeLaunchPersistentContextParams = tObject({
   recordHar: tOptional(tType('RecordHarOptions')),
   strictSelectors: tOptional(tBoolean),
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
-  browserArgs: tOptional(tArray(tString)),
   userDataDir: tString,
   slowMo: tOptional(tNumber),
 });
@@ -606,13 +605,13 @@ scheme.BrowserNewContextParams = tObject({
   recordHar: tOptional(tType('RecordHarOptions')),
   strictSelectors: tOptional(tBoolean),
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
-  browserArgs: tOptional(tArray(tString)),
   proxy: tOptional(tObject({
     server: tString,
     bypass: tOptional(tString),
     username: tOptional(tString),
     password: tOptional(tString),
   })),
+  args: tOptional(tArray(tString)),
   storageState: tOptional(tObject({
     cookies: tOptional(tArray(tType('SetNetworkCookie'))),
     origins: tOptional(tArray(tType('OriginStorage'))),
@@ -667,7 +666,6 @@ scheme.BrowserNewContextForReuseParams = tObject({
   recordHar: tOptional(tType('RecordHarOptions')),
   strictSelectors: tOptional(tBoolean),
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
-  browserArgs: tOptional(tArray(tString)),
   proxy: tOptional(tObject({
     server: tString,
     bypass: tOptional(tString),
@@ -2386,7 +2384,6 @@ scheme.AndroidDeviceLaunchBrowserParams = tObject({
   recordHar: tOptional(tType('RecordHarOptions')),
   strictSelectors: tOptional(tBoolean),
   serviceWorkers: tOptional(tEnum(['allow', 'block'])),
-  browserArgs: tOptional(tArray(tString)),
   pkg: tOptional(tString),
   proxy: tOptional(tObject({
     server: tString,

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -271,7 +271,7 @@ export class AndroidDevice extends SdkObject {
     return await this._connectToBrowser(socketName, options);
   }
 
-  _defaultArgs(options: channels.BrowserNewContextParams, socketName: string): string[] {
+  private _defaultArgs(options: channels.BrowserNewContextParams, socketName: string): string[] {
     const chromeArguments = [
       '_',
       '--disable-fre',

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -260,7 +260,7 @@ export class AndroidDevice extends SdkObject {
     this.emit(AndroidDevice.Events.Close);
   }
 
-  async launchBrowser(pkg: string = 'com.android.chrome', options: channels.BrowserNewContextParams): Promise<BrowserContext> {
+  async launchBrowser(pkg: string = 'com.android.chrome', options: channels.AndroidDeviceLaunchBrowserParams): Promise<BrowserContext> {
     debug('pw:android')('Force-stopping', pkg);
     await this._backend.runCommand(`shell:am force-stop ${pkg}`);
     const socketName = isUnderTest() ? 'webview_devtools_remote_playwright_test' : ('playwright-' + createGuid());
@@ -271,7 +271,7 @@ export class AndroidDevice extends SdkObject {
     return await this._connectToBrowser(socketName, options);
   }
 
-  private _defaultArgs(options: channels.BrowserNewContextParams, socketName: string): string[] {
+  private _defaultArgs(options: channels.AndroidDeviceLaunchBrowserParams, socketName: string): string[] {
     const chromeArguments = [
       '_',
       '--disable-fre',
@@ -283,7 +283,7 @@ export class AndroidDevice extends SdkObject {
     return chromeArguments;
   }
 
-  private _innerDefaultArgs(options: channels.BrowserNewContextParams): string[] {
+  private _innerDefaultArgs(options: channels.AndroidDeviceLaunchBrowserParams): string[] {
     const { args = [], proxy } = options;
     const chromeArguments = [];
     if (proxy) {

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -279,14 +279,13 @@ export class AndroidDevice extends SdkObject {
       `--remote-debugging-socket-name=${socketName}`,
       ...chromiumSwitches,
       ...this._innerDefaultArgs(options)
-    ]
+    ];
     return chromeArguments;
   }
 
   private _innerDefaultArgs(options: channels.BrowserNewContextParams): string[] {
     const { args = [], proxy } = options;
     const chromeArguments = [];
-
     if (proxy) {
       chromeArguments.push(`--proxy-server=${proxy.server}`);
       const proxyBypassRules = [];
@@ -297,7 +296,6 @@ export class AndroidDevice extends SdkObject {
       if (proxyBypassRules.length > 0)
         chromeArguments.push(`--proxy-bypass-list=${proxyBypassRules.join(';')}`);
     }
-    
     chromeArguments.push(...args);
     return chromeArguments;
   }

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -264,12 +264,14 @@ export class AndroidDevice extends SdkObject {
     debug('pw:android')('Force-stopping', pkg);
     await this._backend.runCommand(`shell:am force-stop ${pkg}`);
     const socketName = isUnderTest() ? 'webview_devtools_remote_playwright_test' : ('playwright-' + createGuid());
+    const additionalBrowserArgs = (options && options.browserArgs) ? options.browserArgs : [];
     const commandLine = [
       '_',
       '--disable-fre',
       '--no-default-browser-check',
       `--remote-debugging-socket-name=${socketName}`,
       ...chromiumSwitches,
+      ...additionalBrowserArgs
     ].join(' ');
     debug('pw:android')('Starting', pkg, commandLine);
     await this._backend.runCommand(`shell:echo "${commandLine}" > /data/local/tmp/chrome-command-line`);

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -264,19 +264,42 @@ export class AndroidDevice extends SdkObject {
     debug('pw:android')('Force-stopping', pkg);
     await this._backend.runCommand(`shell:am force-stop ${pkg}`);
     const socketName = isUnderTest() ? 'webview_devtools_remote_playwright_test' : ('playwright-' + createGuid());
-    const additionalBrowserArgs = (options && options.browserArgs) ? options.browserArgs : [];
-    const commandLine = [
+    const commandLine = this._defaultArgs(options, socketName).join(' ');
+    debug('pw:android')('Starting', pkg, commandLine);
+    await this._backend.runCommand(`shell:echo "${commandLine}" > /data/local/tmp/chrome-command-line`);
+    await this._backend.runCommand(`shell:am start -a android.intent.action.VIEW -d about:blank ${pkg}`);
+    return await this._connectToBrowser(socketName, options);
+  }
+
+  _defaultArgs(options: channels.BrowserNewContextParams, socketName: string): string[] {
+    const chromeArguments = [
       '_',
       '--disable-fre',
       '--no-default-browser-check',
       `--remote-debugging-socket-name=${socketName}`,
       ...chromiumSwitches,
-      ...additionalBrowserArgs
-    ].join(' ');
-    debug('pw:android')('Starting', pkg, commandLine);
-    await this._backend.runCommand(`shell:echo "${commandLine}" > /data/local/tmp/chrome-command-line`);
-    await this._backend.runCommand(`shell:am start -a android.intent.action.VIEW -d about:blank ${pkg}`);
-    return await this._connectToBrowser(socketName, options);
+      ...this._innerDefaultArgs(options)
+    ]
+    return chromeArguments;
+  }
+
+  private _innerDefaultArgs(options: channels.BrowserNewContextParams): string[] {
+    const { args = [], proxy } = options;
+    const chromeArguments = [];
+
+    if (proxy) {
+      chromeArguments.push(`--proxy-server=${proxy.server}`);
+      const proxyBypassRules = [];
+      if (proxy.bypass)
+        proxyBypassRules.push(...proxy.bypass.split(',').map(t => t.trim()).map(t => t.startsWith('.') ? '*' + t : t));
+      if (!process.env.PLAYWRIGHT_DISABLE_FORCED_CHROMIUM_PROXIED_LOOPBACK && !proxyBypassRules.includes('<-loopback>'))
+        proxyBypassRules.push('<-loopback>');
+      if (proxyBypassRules.length > 0)
+        chromeArguments.push(`--proxy-bypass-list=${proxyBypassRules.join(';')}`);
+    }
+    
+    chromeArguments.push(...args);
+    return chromeArguments;
   }
 
   async connectToWebView(socketName: string): Promise<BrowserContext> {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -12942,6 +12942,12 @@ export interface AndroidDevice {
     acceptDownloads?: boolean;
 
     /**
+     * Additional arguments to pass to the browser instance. The list of Chromium flags can be found
+     * [here](http://peter.sh/experiments/chromium-command-line-switches/).
+     */
+    args?: Array<string>;
+
+    /**
      * When using [page.goto(url[, options])](https://playwright.dev/docs/api/class-page#page-goto),
      * [page.route(url, handler[, options])](https://playwright.dev/docs/api/class-page#page-route),
      * [page.waitForURL(url[, options])](https://playwright.dev/docs/api/class-page#page-wait-for-url),
@@ -13062,6 +13068,32 @@ export interface AndroidDevice {
      * for more details.
      */
     permissions?: Array<string>;
+
+    /**
+     * Network proxy settings.
+     */
+    proxy?: {
+      /**
+       * Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or
+       * `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
+       */
+      server: string;
+
+      /**
+       * Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
+       */
+      bypass?: string;
+
+      /**
+       * Optional username to use if HTTP proxy requires authentication.
+       */
+      username?: string;
+
+      /**
+       * Optional password to use if HTTP proxy requires authentication.
+       */
+      password?: string;
+    };
 
     /**
      * Enables [HAR](http://www.softwareishard.com/blog/har-12-spec) recording for all pages into `recordHar.path` file.

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1099,7 +1099,6 @@ export type BrowserNewContextParams = {
     username?: string,
     password?: string,
   },
-  args?: string[],
   storageState?: {
     cookies?: SetNetworkCookie[],
     origins?: OriginStorage[],
@@ -1157,7 +1156,6 @@ export type BrowserNewContextOptions = {
     username?: string,
     password?: string,
   },
-  args?: string[],
   storageState?: {
     cookies?: SetNetworkCookie[],
     origins?: OriginStorage[],
@@ -4324,6 +4322,7 @@ export type AndroidDeviceLaunchBrowserParams = {
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
   pkg?: string,
+  args?: string[],
   proxy?: {
     server: string,
     bypass?: string,
@@ -4378,6 +4377,7 @@ export type AndroidDeviceLaunchBrowserOptions = {
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
   pkg?: string,
+  args?: string[],
   proxy?: {
     server: string,
     bypass?: string,

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -928,6 +928,7 @@ export type BrowserTypeLaunchPersistentContextParams = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
+  browserArgs?: string[],
   userDataDir: string,
   slowMo?: number,
 };
@@ -998,6 +999,7 @@ export type BrowserTypeLaunchPersistentContextOptions = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
+  browserArgs?: string[],
   slowMo?: number,
 };
 export type BrowserTypeLaunchPersistentContextResult = {
@@ -1093,6 +1095,7 @@ export type BrowserNewContextParams = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
+  browserArgs?: string[],
   proxy?: {
     server: string,
     bypass?: string,
@@ -1150,6 +1153,7 @@ export type BrowserNewContextOptions = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
+  browserArgs?: string[],
   proxy?: {
     server: string,
     bypass?: string,
@@ -1210,6 +1214,7 @@ export type BrowserNewContextForReuseParams = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
+  browserArgs?: string[],
   proxy?: {
     server: string,
     bypass?: string,
@@ -1267,6 +1272,7 @@ export type BrowserNewContextForReuseOptions = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
+  browserArgs?: string[],
   proxy?: {
     server: string,
     bypass?: string,
@@ -4321,6 +4327,7 @@ export type AndroidDeviceLaunchBrowserParams = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
+  browserArgs?: string[],
   pkg?: string,
   proxy?: {
     server: string,
@@ -4375,6 +4382,7 @@ export type AndroidDeviceLaunchBrowserOptions = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
+  browserArgs?: string[],
   pkg?: string,
   proxy?: {
     server: string,

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -928,7 +928,6 @@ export type BrowserTypeLaunchPersistentContextParams = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
-  browserArgs?: string[],
   userDataDir: string,
   slowMo?: number,
 };
@@ -999,7 +998,6 @@ export type BrowserTypeLaunchPersistentContextOptions = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
-  browserArgs?: string[],
   slowMo?: number,
 };
 export type BrowserTypeLaunchPersistentContextResult = {
@@ -1095,13 +1093,13 @@ export type BrowserNewContextParams = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
-  browserArgs?: string[],
   proxy?: {
     server: string,
     bypass?: string,
     username?: string,
     password?: string,
   },
+  args?: string[],
   storageState?: {
     cookies?: SetNetworkCookie[],
     origins?: OriginStorage[],
@@ -1153,13 +1151,13 @@ export type BrowserNewContextOptions = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
-  browserArgs?: string[],
   proxy?: {
     server: string,
     bypass?: string,
     username?: string,
     password?: string,
   },
+  args?: string[],
   storageState?: {
     cookies?: SetNetworkCookie[],
     origins?: OriginStorage[],
@@ -1214,7 +1212,6 @@ export type BrowserNewContextForReuseParams = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
-  browserArgs?: string[],
   proxy?: {
     server: string,
     bypass?: string,
@@ -1272,7 +1269,6 @@ export type BrowserNewContextForReuseOptions = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
-  browserArgs?: string[],
   proxy?: {
     server: string,
     bypass?: string,
@@ -4327,7 +4323,6 @@ export type AndroidDeviceLaunchBrowserParams = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
-  browserArgs?: string[],
   pkg?: string,
   proxy?: {
     server: string,
@@ -4382,7 +4377,6 @@ export type AndroidDeviceLaunchBrowserOptions = {
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
   serviceWorkers?: 'allow' | 'block',
-  browserArgs?: string[],
   pkg?: string,
   proxy?: {
     server: string,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -867,9 +867,6 @@ Browser:
             bypass: string?
             username: string?
             password: string?
-        args:
-          type: array?
-          items: string
         storageState:
           type: object?
           properties:
@@ -3261,6 +3258,9 @@ AndroidDevice:
       parameters:
         $mixin: ContextOptions
         pkg: string?
+        args:
+          type: array?
+          items: string
         proxy:
           type: object?
           properties:

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -476,6 +476,9 @@ ContextOptions:
       literals:
       - allow
       - block
+    browserArgs:
+      type: array?
+      items: string
 
 LocalUtils:
   type: interface

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -476,9 +476,6 @@ ContextOptions:
       literals:
       - allow
       - block
-    browserArgs:
-      type: array?
-      items: string
 
 LocalUtils:
   type: interface
@@ -870,6 +867,9 @@ Browser:
             bypass: string?
             username: string?
             password: string?
+        args:
+          type: array?
+          items: string
         storageState:
           type: object?
           properties:

--- a/tests/android/browser.spec.ts
+++ b/tests/android/browser.spec.ts
@@ -53,7 +53,7 @@ test('androidDevice.launchBrowser should pass proxy config', async ({ androidDev
   server.setRoute('/target.html', async (req, res) => {
     res.end('<html><title>Served by the proxy</title></html>');
   });
-  const context = await androidDevice.launchBrowser({proxy: { server: `localhost:${server.PORT}` }});
+  const context = await androidDevice.launchBrowser({ proxy: { server: `localhost:${server.PORT}` } });
   const page = await context.newPage();
   await page.goto('http://non-existent.com/target.html');
   expect(await page.title()).toBe('Served by the proxy');

--- a/tests/android/browser.spec.ts
+++ b/tests/android/browser.spec.ts
@@ -33,7 +33,6 @@ test('androidDevice.launchBrowser', async function({ androidDevice }) {
 });
 
 test('androidDevice.launchBrowser should pass args with spaces', async ({ androidDevice }) => {
-  console.log(androidDevice.model());
   const context = await androidDevice.launchBrowser({ args: ['--user-agent=I am Foo'] });
   const page = await context.newPage();
   const userAgent = await page.evaluate(() => navigator.userAgent);
@@ -42,7 +41,6 @@ test('androidDevice.launchBrowser should pass args with spaces', async ({ androi
 });
 
 test('androidDevice.launchBrowser should throw for bad proxy server value', async ({ androidDevice }) => {
-  console.log(androidDevice.model());
   const error = await androidDevice.launchBrowser({
     // @ts-expect-error server must be a string
     proxy: { server: 123 }
@@ -55,7 +53,6 @@ test('androidDevice.launchBrowser should pass proxy config', async ({ androidDev
   server.setRoute('/target.html', async (req, res) => {
     res.end('<html><title>Served by the proxy</title></html>');
   });
-  console.log(androidDevice.model());
   const context = await androidDevice.launchBrowser({proxy: { server: `localhost:${server.PORT}` }});
   const page = await context.newPage();
   await page.goto('http://non-existent.com/target.html');

--- a/tests/android/browser.spec.ts
+++ b/tests/android/browser.spec.ts
@@ -32,6 +32,37 @@ test('androidDevice.launchBrowser', async function({ androidDevice }) {
   await context.close();
 });
 
+test('androidDevice.launchBrowser should pass args with spaces', async ({ androidDevice }) => {
+  console.log(androidDevice.model());
+  const context = await androidDevice.launchBrowser({ args: ['--user-agent=I am Foo'] });
+  const page = await context.newPage();
+  const userAgent = await page.evaluate(() => navigator.userAgent);
+  await context.close();
+  expect(userAgent).toBe('I am Foo');
+});
+
+test('androidDevice.launchBrowser should throw for bad proxy server value', async ({ androidDevice }) => {
+  console.log(androidDevice.model());
+  const error = await androidDevice.launchBrowser({
+    // @ts-expect-error server must be a string
+    proxy: { server: 123 }
+  }).catch(e => e);
+  expect(error.message).toContain('proxy.server: expected string, got number');
+});
+
+test('androidDevice.launchBrowser should pass proxy config', async ({ androidDevice, server, mode }) => {
+  test.skip(mode === 'docker', 'proxy is not supported for remote connection');
+  server.setRoute('/target.html', async (req, res) => {
+    res.end('<html><title>Served by the proxy</title></html>');
+  });
+  console.log(androidDevice.model());
+  const context = await androidDevice.launchBrowser({proxy: { server: `localhost:${server.PORT}` }});
+  const page = await context.newPage();
+  await page.goto('http://non-existent.com/target.html');
+  expect(await page.title()).toBe('Served by the proxy');
+  await context.close();
+});
+
 test('should create new page', async function({ androidDevice }) {
   const context = await androidDevice.launchBrowser();
   const page = await context.newPage();


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/19211

The code goes through the new param (`browserArgs: string[]`) and adds it to the existing list of arguments before launching the browser in android.