### PR TITLE
feat(tether): support hostname pattern in socks proxy

### DIFF
--- a/packages/playwright-core/src/containers/docker.ts
+++ b/packages/playwright-core/src/containers/docker.ts
@@ -299,6 +299,7 @@ async function tetherHostNetwork(endpoint: string) {
   const headers: any = {
     'User-Agent': getUserAgent(),
     'x-playwright-network-tethering': '1',
+    'x-playwright-proxy': '*',
   };
   const transport = await WebSocketTransport.connect(undefined /* progress */, wsEndpoint, headers, true /* followRedirects */);
   const socksInterceptor = new SocksInterceptor(transport, undefined);

--- a/packages/playwright-core/src/grid/gridBrowserWorker.ts
+++ b/packages/playwright-core/src/grid/gridBrowserWorker.ts
@@ -23,7 +23,7 @@ function launchGridBrowserWorker(gridURL: string, agentId: string, workerId: str
   const log = debug(`pw:grid:worker:${workerId}`);
   log('created');
   const ws = new WebSocket(gridURL.replace('http://', 'ws://') + `/registerWorker?agentId=${agentId}&workerId=${workerId}`);
-  new PlaywrightConnection(Promise.resolve(), 'launch-browser', ws, { enableSocksProxy: true, browserName, launchOptions: {} }, { }, log, async () => {
+  new PlaywrightConnection(Promise.resolve(), 'launch-browser', ws, { socksProxy: '*', browserName, launchOptions: {} }, { }, log, async () => {
     log('exiting process');
     setTimeout(() => process.exit(0), 30000);
     // Meanwhile, try to gracefully close all browsers.

--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -115,7 +115,7 @@ export class PlaywrightServer {
       const browserName = url.searchParams.get('browser') || (Array.isArray(browserHeader) ? browserHeader[0] : browserHeader) || null;
       const proxyHeader = request.headers['x-playwright-proxy'];
       const proxyValue = url.searchParams.get('proxy') || (Array.isArray(proxyHeader) ? proxyHeader[0] : proxyHeader);
-      const enableSocksProxy = this._options.browserProxyMode !== 'disabled' && proxyValue === '*';
+      const socksProxy = this._options.browserProxyMode !== 'disabled' ? proxyValue : undefined;
 
       const launchOptionsHeader = request.headers['x-playwright-launch-options'] || '';
       let launchOptions: LaunchOptions = {};
@@ -160,7 +160,7 @@ export class PlaywrightServer {
       const connection = new PlaywrightConnection(
           semaphore.aquire(),
           clientType, ws,
-          { enableSocksProxy, browserName, launchOptions },
+          { socksProxy, browserName, launchOptions },
           {
             playwright: this._preLaunchedPlaywright,
             browser: this._options.preLaunchedBrowser,


### PR DESCRIPTION
For now, only '*' and 'localhost' are supported.

References #19287.