### PR TITLE
chore: roll stable-test-runner to 1.28.1

### DIFF
--- a/packages/playwright-core/src/server/recorder/csharp.ts
+++ b/packages/playwright-core/src/server/recorder/csharp.ts
@@ -22,7 +22,7 @@ import type { Action } from './recorderActions';
 import type { MouseClickOptions } from './utils';
 import { toModifiers } from './utils';
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
-import deviceDescriptors from '../deviceDescriptors';
+const deviceDescriptors = require('../deviceDescriptorsSource.json');
 import { asLocator } from '../isomorphic/locatorGenerators';
 
 type CSharpLanguageMode = 'library' | 'mstest' | 'nunit';

--- a/packages/playwright-core/src/server/recorder/java.ts
+++ b/packages/playwright-core/src/server/recorder/java.ts
@@ -21,7 +21,7 @@ import type { ActionInContext } from './codeGenerator';
 import type { Action } from './recorderActions';
 import type { MouseClickOptions } from './utils';
 import { toModifiers } from './utils';
-import deviceDescriptors from '../deviceDescriptors';
+const deviceDescriptors = require('../deviceDescriptorsSource.json');
 import { JavaScriptFormatter } from './javascript';
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
 import { asLocator } from '../isomorphic/locatorGenerators';

--- a/packages/playwright-core/src/server/recorder/javascript.ts
+++ b/packages/playwright-core/src/server/recorder/javascript.ts
@@ -21,7 +21,7 @@ import type { ActionInContext } from './codeGenerator';
 import type { Action } from './recorderActions';
 import type { MouseClickOptions } from './utils';
 import { toModifiers } from './utils';
-import deviceDescriptors from '../deviceDescriptors';
+const deviceDescriptors = require('../deviceDescriptorsSource.json');
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
 import { asLocator } from '../isomorphic/locatorGenerators';
 

--- a/packages/playwright-core/src/server/recorder/python.ts
+++ b/packages/playwright-core/src/server/recorder/python.ts
@@ -22,7 +22,7 @@ import type { Action } from './recorderActions';
 import type { MouseClickOptions } from './utils';
 import { toModifiers } from './utils';
 import { escapeWithQuotes, toSnakeCase } from '../../utils/isomorphic/stringUtils';
-import deviceDescriptors from '../deviceDescriptors';
+const deviceDescriptors = require('../deviceDescriptorsSource.json');
 import { asLocator } from '../isomorphic/locatorGenerators';
 
 export class PythonLanguageGenerator implements LanguageGenerator {

--- a/packages/playwright-core/src/utils/comparators.ts
+++ b/packages/playwright-core/src/utils/comparators.ts
@@ -16,9 +16,9 @@
  */
 
 import { colors, jpegjs } from '../utilsBundle';
-import pixelmatch from '../third_party/pixelmatch';
+const pixelmatch = require('../third_party/pixelmatch');
 import { compare } from '../image_tools/compare';
-import { diff_match_patch, DIFF_INSERT, DIFF_DELETE, DIFF_EQUAL } from '../third_party/diff_match_patch';
+const { diff_match_patch, DIFF_INSERT, DIFF_DELETE, DIFF_EQUAL } = require('../third_party/diff_match_patch');
 import { PNG } from '../utilsBundle';
 
 export type ImageComparatorOptions = { threshold?: number, maxDiffPixels?: number, maxDiffPixelRatio?: number, comparator?: string };
@@ -100,7 +100,7 @@ function compareText(actual: Buffer | string, expectedBuffer: Buffer): Comparato
   };
 }
 
-function diff_prettyTerminal(diffs: diff_match_patch.Diff[]) {
+function diff_prettyTerminal(diffs: [number, string][]) {
   const html = [];
   for (let x = 0; x < diffs.length; x++) {
     const op = diffs[x][0];    // Operation (insert, delete, equal)

--- a/tests/playwright-test/playwright.config.ts
+++ b/tests/playwright-test/playwright.config.ts
@@ -26,6 +26,7 @@ const config: Config = {
   forbidOnly: !!process.env.CI,
   workers: process.env.CI ? 2 : undefined,
   preserveOutput: process.env.CI ? 'failures-only' : 'always',
+  snapshotPathTemplate: '__screenshots__/{testFilePath}/{arg}{ext}',
   projects: [
     {
       name: 'playwright-test',

--- a/tests/playwright-test/stable-test-runner/package-lock.json
+++ b/tests/playwright-test/stable-test-runner/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@playwright/test": "1.27.0-alpha-sep-15-2022"
+        "@playwright/test": "1.28.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.27.0-alpha-sep-15-2022",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.0-alpha-sep-15-2022.tgz",
-      "integrity": "sha512-8v6zhbFDpjDgSC74vOZKEUPlsFtU+JhZP1l+FjhY7Tz31/ohwBkXWYtbXl/3a4qD8AqdJ+NJ4RHQx4AkwqNFTA==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz",
+      "integrity": "sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==",
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.27.0-alpha-sep-15-2022"
+        "playwright-core": "1.28.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -29,9 +29,9 @@
       "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
     },
     "node_modules/playwright-core": {
-      "version": "1.27.0-alpha-sep-15-2022",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.0-alpha-sep-15-2022.tgz",
-      "integrity": "sha512-QWwYeWoXZaj5cBiR+IE35dXT8QbR6JNftr0yIN9wt0JI7Ju5rnoKJxCCYtIY9drPb+aAXbAC83xV/bt5t6N9fA==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz",
+      "integrity": "sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==",
       "bin": {
         "playwright": "cli.js"
       },
@@ -42,12 +42,12 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.27.0-alpha-sep-15-2022",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.0-alpha-sep-15-2022.tgz",
-      "integrity": "sha512-8v6zhbFDpjDgSC74vOZKEUPlsFtU+JhZP1l+FjhY7Tz31/ohwBkXWYtbXl/3a4qD8AqdJ+NJ4RHQx4AkwqNFTA==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz",
+      "integrity": "sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==",
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.27.0-alpha-sep-15-2022"
+        "playwright-core": "1.28.1"
       }
     },
     "@types/node": {
@@ -56,9 +56,9 @@
       "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
     },
     "playwright-core": {
-      "version": "1.27.0-alpha-sep-15-2022",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.0-alpha-sep-15-2022.tgz",
-      "integrity": "sha512-QWwYeWoXZaj5cBiR+IE35dXT8QbR6JNftr0yIN9wt0JI7Ju5rnoKJxCCYtIY9drPb+aAXbAC83xV/bt5t6N9fA=="
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz",
+      "integrity": "sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag=="
     }
   }
 }

--- a/tests/playwright-test/stable-test-runner/package.json
+++ b/tests/playwright-test/stable-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "@playwright/test": "1.27.0-alpha-sep-15-2022"
+    "@playwright/test": "1.28.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     },
     "esModuleInterop": true,
     "strict": true,
-    "allowJs": true,
+    "allowJs": false,
     "jsx": "react",
     "resolveJsonModule": true,
     "noEmit": true,


### PR DESCRIPTION
This required `allowJs: false` in our `tsconfig.json` due to the following error:

```

Error: Cannot find module './utilsBundleImpl'
Require stack:
- <playwright>/packages/playwright-core/src/utilsBundle.ts
- <playwright>/packages/playwright-test/lib/reporters/html.js
- <playwright>/tests/playwright-test/reporter-html.spec.ts
- <playwright>/tests/playwright-test/stable-test-runner/node_modules/@playwright/test/lib/loader.js
- <playwright>/tests/playwright-test/stable-test-runner/node_modules/@playwright/test/lib/runner.js
- <playwright>/tests/playwright-test/stable-test-runner/node_modules/@playwright/test/lib/cli.js
- <playwright>/tests/playwright-test/stable-test-runner/node_modules/playwright-core/lib/cli/cli.js
- <playwright>/tests/playwright-test/stable-test-runner/node_modules/playwright-core/cli.js
- <playwright>/tests/playwright-test/stable-test-runner/node_modules/@playwright/test/cli.js

   at ../../packages/playwright-core/src/utilsBundle.ts:20

  18 | import path from 'path';
  19 |
> 20 | export const colors: typeof import('../bundles/utils/node_modules/colors/safe') = require('./utilsBundleImpl').colors;
     |                                                                                   ^
  21 | export const debug: typeof import('../bundles/utils/node_modules/@types/debug') = require('./utilsBundleImpl').debug;
  22 | export const getProxyForUrl: typeof import('../bundles/utils/node_modules/@types/proxy-from-env').getProxyForUrl = require('./utilsBundleImpl').getProxyForUrl;
  23 | export const HttpsProxyAgent: typeof import('../bundles/utils/node_modules/https-proxy-agent').HttpsProxyAgent = require('./utilsBundleImpl').HttpsProxyAgent;

    at Object.<anonymous> (<playwright>/packages/playwright-core/src/utilsBundle.ts:20:83)
    at Object.<anonymous> (<playwright>/packages/playwright-test/src/reporters/html.ts:17:1)

```