### PR TITLE
Add a flag to build a docker image if needed when starting container

### DIFF
--- a/packages/playwright-core/src/containers/docker.ts
+++ b/packages/playwright-core/src/containers/docker.ts
@@ -340,6 +340,7 @@ export function addDockerCLI(program: Command) {
   dockerCommand.command('start')
       .description('start docker container')
       .option('--port <port>', 'port to start container on. Auto-pick by default')
+      .option('--build-if-needed', 'builds docker image for the container if needed before starting')
       .action(async function(options) {
         try {
           const port = options.port ? +options.port : 0;
@@ -347,6 +348,13 @@ export function addDockerCLI(program: Command) {
             console.error(`ERROR: bad port number "${options.port}"`);
             process.exit(1);
           }
+
+          if (options.buildIfNeeded) {
+            const dockerImage = await findDockerImage(VRT_IMAGE_NAME);
+            if (!dockerImage)
+              await buildPlaywrightImage();
+          }
+
           await startPlaywrightContainer(port);
         } catch (e) {
           console.error(e.stack ? e : e.message);


### PR DESCRIPTION
If I need to connect playwright to a local docker, I need to —
1. Ensure that there is a local image with `wss` server exposed
2. Run that docker image

before I can execute `playwright test`.

While `playwright docker build` and `playwright docker start` are helpful as setup steps, you don't always want to build un-necessarily if there's already an image available on disk (when iterating locally, say).

In this PR I add a `--build-if-needed` flag to `playwright docker start` so image is built only if it doesn't already exists.

An alternative  way to solve this problem would would be to provide a command to check for docker image's existence `playwright docker exists` but I felt that the flag implementation was neater.