### PR TITLE
feat(connect): allow exposing local network to the remote browser (experimental)

### DIFF
--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -87,6 +87,7 @@ export type LaunchPersistentContextOptions = Omit<LaunchOptionsBase & BrowserCon
 export type ConnectOptions = {
   wsEndpoint: string,
   headers?: { [key: string]: string; };
+  _exposeNetwork?: string,
   slowMo?: number,
   timeout?: number,
   logger?: Logger,

--- a/packages/playwright-core/src/containers/docker.ts
+++ b/packages/playwright-core/src/containers/docker.ts
@@ -288,7 +288,7 @@ async function tetherHostNetwork(endpoint: string) {
     'x-playwright-proxy': '*',
   };
   const transport = await WebSocketTransport.connect(undefined /* progress */, wsEndpoint, headers, true /* followRedirects */);
-  const socksInterceptor = new SocksInterceptor(transport, undefined);
+  const socksInterceptor = new SocksInterceptor(transport, '*', undefined);
   transport.onmessage = json => socksInterceptor.interceptMessage(json);
   transport.onclose = () => {
     socksInterceptor.cleanup();
@@ -387,7 +387,7 @@ export function addDockerCLI(program: Command) {
       .option('--browser <name>', 'browser to launch')
       .option('--endpoint <url>', 'server endpoint')
       .action(async function(options: { browser: string, endpoint: string }) {
-        let browserType: any;
+        let browserType: playwright.BrowserType | undefined;
         if (options.browser === 'chromium')
           browserType = playwright.chromium;
         else if (options.browser === 'firefox')
@@ -404,9 +404,9 @@ export function addDockerCLI(program: Command) {
               headless: false,
               viewport: null,
             }),
-            'x-playwright-proxy': '*',
           },
-        });
+          _exposeNetwork: '*',
+        } as any);
         const context = await browser.newContext();
         context.on('page', (page: playwright.Page) => {
           page.on('dialog', () => {});  // Prevent dialogs from being automatically dismissed.

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -248,6 +248,7 @@ scheme.LocalUtilsHarUnzipResult = tOptional(tObject({}));
 scheme.LocalUtilsConnectParams = tObject({
   wsEndpoint: tString,
   headers: tOptional(tAny),
+  exposeNetwork: tOptional(tString),
   slowMo: tOptional(tNumber),
   timeout: tOptional(tNumber),
   socksProxyRedirectPortForTest: tOptional(tNumber),

--- a/packages/playwright-core/src/server/socksInterceptor.ts
+++ b/packages/playwright-core/src/server/socksInterceptor.ts
@@ -27,8 +27,8 @@ export class SocksInterceptor {
   private _socksSupportObjectGuid?: string;
   private _ids = new Set<number>();
 
-  constructor(transport: WebSocketTransport, redirectPortForTest: number | undefined) {
-    this._handler = new socks.SocksProxyHandler(redirectPortForTest);
+  constructor(transport: WebSocketTransport, pattern: string | undefined, redirectPortForTest: number | undefined) {
+    this._handler = new socks.SocksProxyHandler(pattern,  redirectPortForTest);
 
     let lastId = -1;
     this._channel = new Proxy(new EventEmitter(), {

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -87,8 +87,9 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
     }
     return use({
       wsEndpoint,
-      headers
-    });
+      headers,
+      _exposeNetwork: process.env.PW_TEST_CONNECT_EXPOSE_NETWORK,
+    } as any);
   }, { scope: 'worker', option: true }],
   screenshot: ['off', { scope: 'worker', option: true }],
   video: ['off', { scope: 'worker', option: true }],

--- a/packages/playwright-test/src/plugins/dockerPlugin.ts
+++ b/packages/playwright-test/src/plugins/dockerPlugin.ts
@@ -35,9 +35,7 @@ export const dockerPlugin: TestRunnerPlugin = {
       throw new Error('ERROR: please launch docker container separately!');
     println('');
     process.env.PW_TEST_CONNECT_WS_ENDPOINT = info.httpEndpoint;
-    process.env.PW_TEST_CONNECT_HEADERS = JSON.stringify({
-      'x-playwright-proxy': '*',
-    });
+    process.env.PW_TEST_CONNECT_EXPOSE_NETWORK = '*';
   },
 };
 

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -446,12 +446,14 @@ export type LocalUtilsHarUnzipResult = void;
 export type LocalUtilsConnectParams = {
   wsEndpoint: string,
   headers?: any,
+  exposeNetwork?: string,
   slowMo?: number,
   timeout?: number,
   socksProxyRedirectPortForTest?: number,
 };
 export type LocalUtilsConnectOptions = {
   headers?: any,
+  exposeNetwork?: string,
   slowMo?: number,
   timeout?: number,
   socksProxyRedirectPortForTest?: number,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -535,6 +535,7 @@ LocalUtils:
       parameters:
         wsEndpoint: string
         headers: json?
+        exposeNetwork: string?
         slowMo: number?
         timeout: number?
         socksProxyRedirectPortForTest: number?

--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -15,7 +15,7 @@
  */
 
 import path from 'path';
-import type { BrowserType, Browser, LaunchOptions } from 'playwright-core';
+import type { BrowserType, Browser } from 'playwright-core';
 import type { CommonFixtures, TestChildProcess } from './commonFixtures';
 
 export interface PlaywrightServer {
@@ -79,7 +79,7 @@ export class RemoteServer implements PlaywrightServer {
     const browserOptions = (browserType as any)._defaultLaunchOptions;
     // Copy options to prevent a large JSON string when launching subprocess.
     // Otherwise, we get `Error: spawn ENAMETOOLONG` on Windows.
-    const launchOptions: LaunchOptions = {
+    const launchOptions: Parameters<BrowserType['launchServer']>[0] = {
       args: browserOptions.args,
       headless: browserOptions.headless,
       channel: browserOptions.channel,


### PR DESCRIPTION
`connectOptions: { _exposeNetwork: '*' | 'localhost' }`

References #19287.