### PR TITLE
test: fix transport tests

### DIFF
--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -81,11 +81,8 @@ if (mode === 'service') {
       PWTEST_UNSAFE_GRID_VERSION: '1',
     },
   };
-  config.use.connectOptions = {
-    wsEndpoint: 'ws://localhost:3333/mysecret/claimWorker?os=linux',
-    // @ts-expect-error
-    _exposeNetwork: '*',
-  };
+  process.env.PW_TEST_CONNECT_WS_ENDPOINT = 'ws://localhost:3333/mysecret/claimWorker?os=linux';
+  process.env.PW_TEST_CONNECT_EXPOSE_NETWORK = '*';
   config.projects = [{
     name: 'Chromium page tests',
     testMatch: /page\/.*spec.ts$/,

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -81,9 +81,8 @@ if (mode === 'service') {
       PWTEST_UNSAFE_GRID_VERSION: '1',
     },
   };
-  config.use.connectOptions = {
-    wsEndpoint: 'ws://localhost:3333/mysecret/claimWorker?os=linux',
-  };
+  process.env.PW_TEST_CONNECT_WS_ENDPOINT = 'ws://localhost:3333/mysecret/claimWorker?os=linux';
+  process.env.PW_TEST_CONNECT_EXPOSE_NETWORK = '*';
   config.projects = [{
     name: 'Chromium page tests',
     testMatch: /page\/.*spec.ts$/,

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -81,8 +81,11 @@ if (mode === 'service') {
       PWTEST_UNSAFE_GRID_VERSION: '1',
     },
   };
-  process.env.PW_TEST_CONNECT_WS_ENDPOINT = 'ws://localhost:3333/mysecret/claimWorker?os=linux';
-  process.env.PW_TEST_CONNECT_EXPOSE_NETWORK = '*';
+  config.use.connectOptions = {
+    wsEndpoint: 'ws://localhost:3333/mysecret/claimWorker?os=linux',
+    // @ts-expect-error
+    _exposeNetwork: '*',
+  };
   config.projects = [{
     name: 'Chromium page tests',
     testMatch: /page\/.*spec.ts$/,


### PR DESCRIPTION
Transport tests were failing since https://github.com/microsoft/playwright/commit/256e9fd443c0e67dc6a42d3f1e0c40680dc7a5f1. I found two ways of fixing it:
a) dc6ed838cf9e1cf7642e288d10125f8bff9f1b43 aka. use env vars to set connect options and network filter
b) b3748d44ee31fa6e2f65666b910dafb382fbb443 aka. pass a private connect option for the network filter

~used b) since it has a smaller diff.~ did a) now

Can be repro'd via `WTEST_MODE=service  npm run test -- --project='Chromium page tests' --reporter=list page/elementhandle-click.spec.ts:20`.