### PR TITLE
test: fix flaky cookie roundtrip test

### DIFF
--- a/tests/library/browsercontext-add-cookies.spec.ts
+++ b/tests/library/browsercontext-add-cookies.spec.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import type { Cookie } from '@playwright/test';
 import { contextTest as it, playwrightTest, expect } from '../config/browserTest';
 
 it('should work @smoke', async ({ context, page, server }) => {
@@ -77,7 +78,8 @@ it('should roundtrip cookie', async ({ context, page, server }) => {
   await context.clearCookies();
   expect(await context.cookies()).toEqual([]);
   await context.addCookies(cookies);
-  expect(await context.cookies()).toEqual(cookies);
+  const normalizedExpires = (cookies: Cookie[]) => cookies.map(c => ({ ...c, expires: Math.floor(c.expires) }));
+  expect(normalizedExpires(await context.cookies())).toEqual(normalizedExpires(cookies));
 });
 
 it('should send cookie header', async ({ server, context }) => {

--- a/tests/library/browsercontext-add-cookies.spec.ts
+++ b/tests/library/browsercontext-add-cookies.spec.ts
@@ -78,6 +78,7 @@ it('should roundtrip cookie', async ({ context, page, server }) => {
   await context.clearCookies();
   expect(await context.cookies()).toEqual([]);
   await context.addCookies(cookies);
+  // Slightly different rounding on chromium win.
   const normalizedExpires = (cookies: Cookie[]) => cookies.map(c => ({ ...c, expires: Math.floor(c.expires) }));
   expect(normalizedExpires(await context.cookies())).toEqual(normalizedExpires(cookies));
 });


### PR DESCRIPTION
<img width="1676" alt="Screenshot 2022-12-14 at 2 05 29 PM" src="https://user-images.githubusercontent.com/11915034/207726274-167d9ee7-c01b-4379-aff1-37dad979d23b.png">

Flakiness dashboard reveals on Window's variants of Chromium, the decimal for actual vs. expected was slightly off (e.g. 1705568002.677066 vs. 1705568002.674173).

This test fix assumes it's acceptable to suppress the roundrip floating point difference (which appears to be constrained to Windows).