### PR TITLE
fix(element text): iterate over flat tree rather than shadowy tree

### DIFF
--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -101,16 +101,16 @@ export class FrameExecutionContext extends js.ExecutionContext {
       const sdkLanguage = this.frame._page.context()._browser.options.sdkLanguage;
       const source = `
         (() => {
-        const module = {};
-        ${injectedScriptSource.source}
-        return new module.exports(
-          ${isUnderTest()},
-          "${sdkLanguage}",
-          ${JSON.stringify(this.frame._page.selectors.testIdAttributeName())},
-          ${this.frame._page._delegate.rafCountForStablePosition()},
-          "${this.frame._page._browserContext._browser.options.name}",
-          [${custom.join(',\n')}]
-        );
+          const module = {};
+          ${injectedScriptSource.source}
+          return new module.exports({
+            isUnderTest: ${isUnderTest()},
+            sdkLanguage: "${sdkLanguage}",
+            testIdAttributeNameForStrictErrorAndConsoleCodegen: ${JSON.stringify(this.frame._page.selectors.testIdAttributeName())},
+            stableRafCount: ${this.frame._page._delegate.rafCountForStablePosition()},
+            browserName: "${this.frame._page._browserContext._browser.options.name}",
+            textShadowDomMode: "${process.env.PLAYWRIGHT_NO_FLAT_TREE_TEXT ? 'shadowy' : 'flat'}",
+          }, [${custom.join(',\n')}]);
         })();
       `;
       this._injectedScriptPromise = this.rawEvaluateHandle(source).then(objectId => new js.JSHandle(this, 'object', undefined, objectId));

--- a/packages/playwright-core/src/server/injected/domUtils.ts
+++ b/packages/playwright-core/src/server/injected/domUtils.ts
@@ -55,6 +55,20 @@ export function closestCrossShadow(element: Element | undefined, css: string): E
   }
 }
 
+export function flatTreeChildNodes(node: Node): Node[] {
+  // Note: slots with zero assigned nodes render their children as fallback content.
+  const assignedNodes = node.nodeName === 'SLOT' ? (node as HTMLSlotElement).assignedNodes() : [];
+  if (assignedNodes.length)
+    return assignedNodes;
+  const direct = node.childNodes;
+  const shadow = (node as Element).shadowRoot?.childNodes || [];
+  return [...direct, ...shadow].filter(child => !(child as Element | Text).assignedSlot);
+}
+
+export function flatTreeChildElements(element: Element): Element[] {
+  return flatTreeChildNodes(element).filter(node => node.nodeType === 1 /* Node.ELEMENT_NODE */) as Element[];
+}
+
 export function isElementVisible(element: Element): boolean {
   // Note: this logic should be similar to waitForDisplayedAtStablePosition() to avoid surprises.
   if (!element.ownerDocument || !element.ownerDocument.defaultView)

--- a/packages/playwright-core/src/server/injected/roleUtils.ts
+++ b/packages/playwright-core/src/server/injected/roleUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { closestCrossShadow, enclosingShadowRootOrDocument, parentElementOrShadowHost } from './domUtils';
+import { closestCrossShadow, enclosingShadowRootOrDocument, flatTreeChildNodes, parentElementOrShadowHost } from './domUtils';
 
 function hasExplicitAccessibleName(e: Element) {
   return e.hasAttribute('aria-label') || e.hasAttribute('aria-labelledby');
@@ -586,9 +586,7 @@ function getElementAccessibleNameInternal(element: Element, options: AccessibleN
   if (allowsNameFromContent || options.embeddedInLabelledBy !== 'none' || options.embeddedInLabel !== 'none' || options.embeddedInTextAlternativeElement || options.embeddedInTargetElement === 'descendant') {
     options.visitedElements.add(element);
     const tokens: string[] = [];
-    const visit = (node: Node, skipSlotted: boolean) => {
-      if (skipSlotted && (node as Element | Text).assignedSlot)
-        return;
+    const visit = (node: Node) => {
       if (node.nodeType === 1 /* Node.ELEMENT_NODE */) {
         const display = getComputedStyle(node as Element)?.getPropertyValue('display') || 'inline';
         let token = getElementAccessibleNameInternal(node as Element, childOptions);
@@ -605,20 +603,10 @@ function getElementAccessibleNameInternal(element: Element, options: AccessibleN
       }
     };
     tokens.push(getPseudoContent(getComputedStyle(element, '::before')));
-    const assignedNodes = element.nodeName === 'SLOT' ? (element as HTMLSlotElement).assignedNodes() : [];
-    if (assignedNodes.length) {
-      for (const child of assignedNodes)
-        visit(child, false);
-    } else {
-      for (let child = element.firstChild; child; child = child.nextSibling)
-        visit(child, true);
-      if (element.shadowRoot) {
-        for (let child = element.shadowRoot.firstChild; child; child = child.nextSibling)
-          visit(child, true);
-      }
-      for (const owned of getIdRefs(element, element.getAttribute('aria-owns')))
-        visit(owned, true);
-    }
+    for (const node of flatTreeChildNodes(element))
+      visit(node);
+    for (const owned of getIdRefs(element, element.getAttribute('aria-owns')))
+      visit(owned);
     tokens.push(getPseudoContent(getComputedStyle(element, '::after')));
     const accessibleName = tokens.join('');
     if (accessibleName.trim())

--- a/packages/playwright-core/src/server/injected/selectorGenerator.ts
+++ b/packages/playwright-core/src/server/injected/selectorGenerator.ts
@@ -174,7 +174,7 @@ function buildCandidates(injectedScript: InjectedScript, element: Element, testI
       candidates.push({ engine: 'internal:attr', selector: `[placeholder=${escapeForAttributeSelector(input.placeholder, false)}]`, score: kPlaceholderScore });
     const label = input.labels?.[0];
     if (label) {
-      const labelText = elementText(injectedScript._evaluator._cacheText, label).full.trim();
+      const labelText = elementText(injectedScript._evaluator._cacheText, label, injectedScript.textShadowDomMode()).full.trim();
       candidates.push({ engine: 'internal:label', selector: escapeForTextSelector(labelText, false), score: kLabelScore });
     }
   }
@@ -216,7 +216,7 @@ function buildCandidates(injectedScript: InjectedScript, element: Element, testI
 function buildTextCandidates(injectedScript: InjectedScript, element: Element, isTargetNode: boolean, accessibleNameCache: Map<Element, boolean>): SelectorToken[][] {
   if (element.nodeName === 'SELECT')
     return [];
-  const text = normalizeWhiteSpace(elementText(injectedScript._evaluator._cacheText, element).full).substring(0, 80);
+  const text = normalizeWhiteSpace(elementText(injectedScript._evaluator._cacheText, element, injectedScript.textShadowDomMode()).full).substring(0, 80);
   if (!text)
     return [];
   const candidates: SelectorToken[][] = [];

--- a/tests/library/selector-generator.spec.ts
+++ b/tests/library/selector-generator.spec.ts
@@ -414,4 +414,23 @@ it.describe('selector generator', () => {
     </div>`);
     expect(await generate(page, 'button')).toBe('internal:attr=[title=\"Send to\"i]');
   });
+
+  it('should find text in flat (composed) shadow tree', async ({ page }) => {
+    await page.setContent(`
+      <div><span>foo</span></div>
+      <section>non-target</section>
+      <script>
+        (() => {
+          const container = document.querySelector('div');
+          const shadow = container.attachShadow({ mode: 'open' });
+          const section = document.createElement('section');
+          section.setAttribute('attr', 'target');
+          shadow.appendChild(section);
+          const slot = document.createElement('slot');
+          section.appendChild(slot);
+        })();
+      </script>
+    `);
+    expect(await generate(page, '[attr=target]')).toBe('section >> internal:has-text="foo"i');
+  });
 });

--- a/tests/page/expect-to-have-text.spec.ts
+++ b/tests/page/expect-to-have-text.spec.ts
@@ -128,6 +128,26 @@ test.describe('toHaveText with text', () => {
     await expect(page.locator('div')).not.toHaveText('some text', { useInnerText: true });
     await expect(page.locator('div')).not.toContainText('text', { useInnerText: true });
   });
+
+  test('in shadow dom with slots', async ({ page }) => {
+    await page.setContent(`
+      <div>foo</div>
+      <script>
+        (() => {
+          const container = document.querySelector('div');
+          const shadow = container.attachShadow({ mode: 'open' });
+          const button = document.createElement('button');
+          shadow.appendChild(button);
+          const slot = document.createElement('slot');
+          button.appendChild(slot);
+          const span = document.createElement('span');
+          span.textContent = 'pre';
+          slot.appendChild(span);
+        })();
+      </script>
+    `);
+    await expect(page.locator('button')).toHaveText('foo');
+  });
 });
 
 test.describe('not.toHaveText', () => {


### PR DESCRIPTION
Flat tree visits nodes assigned to a slot as children of that slot.

This change affects the following APIs and might change some existing tests.
- `getByText`, `getByLabel`
- `filter({ hasText })`
- `toHaveText`, `toContainText`
- `text=`, `:text()`, `:has-text()`, `:text-is()`

Setting `process.env.PLAYWRIGHT_NO_FLAT_TREE_TEXT` reverts to the old behavior. 

Fixes #19473.