### PR TITLE
docs: remove Serializable from Route.*.postData in java

### DIFF
--- a/docs/src/api/class-route.md
+++ b/docs/src/api/class-route.md
@@ -114,8 +114,15 @@ If set changes the request method (e.g. GET or POST).
 
 ### option: Route.continue.postData
 * since: v1.8
-* langs: js, python, java
+* langs: js, python
 - `postData` <[string]|[Buffer]|[Serializable]>
+
+If set changes the post data of request.
+
+### option: Route.continue.postData
+* since: v1.8
+* langs: java
+- `postData` <[string]|[Buffer]>
 
 If set changes the post data of request.
 
@@ -390,8 +397,15 @@ If set changes the request method (e.g. GET or POST).
 
 ### option: Route.fallback.postData
 * since: v1.23
-* langs: js, python, java
+* langs: js, python
 - `postData` <[string]|[Buffer]|[Serializable]>
+
+If set changes the post data of request.
+
+### option: Route.fallback.postData
+* since: v1.23
+* langs: java
+- `postData` <[string]|[Buffer]>
 
 If set changes the post data of request.
 
@@ -481,13 +495,20 @@ If set changes the request URL. New URL must have same protocol as original one.
 If set changes the request method (e.g. GET or POST).
 
 ### option: Route.fetch.postData
-* langs: js, python, java
+* langs: js, python
 * since: v1.29
 - `postData` <[string]|[Buffer]|[Serializable]>
 
 Allows to set post data of the request. If the data parameter is an object, it will be serialized to json string
 and `content-type` header will be set to `application/json` if not explicitly set. Otherwise the `content-type` header will be
 set to `application/octet-stream` if not explicitly set.
+
+### option: Route.fetch.postData
+* langs: java
+* since: v1.29
+- `postData` <[string]|[Buffer]>
+
+If set changes the post data of request.
 
 ### option: Route.fetch.postData
 * since: v1.29


### PR DESCRIPTION
We only support String and  byte[] and throw otherwise, align the types with it.