### PR TITLE
docs: fix the nunit and mstest testing examples

### DIFF
--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -92,6 +92,7 @@ Edit the `UnitTest1.cs` file with the code below to create an example end-to-end
 ```csharp
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.Playwright;
 using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
 
@@ -129,7 +130,10 @@ public class Tests : PageTest
 
 ```csharp
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
 using Microsoft.Playwright.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace PlaywrightTests;
 

--- a/docs/src/writing-tests-csharp.md
+++ b/docs/src/writing-tests-csharp.md
@@ -19,7 +19,10 @@ Take a look at the example test below to see how to write a test using using [lo
 
 ```csharp
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
 using Microsoft.Playwright.NUnit;
+using NUnit.Framework;
 
 namespace PlaywrightTests;
 
@@ -55,7 +58,10 @@ public class Tests : PageTest
 
 ```csharp
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
 using Microsoft.Playwright.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace PlaywrightTests;
 
@@ -145,7 +151,9 @@ public class Tests : PageTest
 <TabItem value="mstest">
 
 ```csharp
+using System.Threading.Tasks;
 using Microsoft.Playwright.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace PlaywrightTests;
 
@@ -207,7 +215,9 @@ public class Tests : PageTest
 <TabItem value="mstest">
 
 ```csharp
+using System.Threading.Tasks;
 using Microsoft.Playwright.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace PlaywrightTests;
 


### PR DESCRIPTION
I got build errors when I tried the .NET NUnit and MSTest examples, so trying to fix with adding `using` statements.