### PR TITLE
[WIP] feat(click): requery locators during actionability checks

### DIFF
--- a/tests/page/page-click-timeout-1.spec.ts
+++ b/tests/page/page-click-timeout-1.spec.ts
@@ -32,5 +32,5 @@ it('should timeout waiting for button to be enabled', async ({ page }) => {
   const error = await page.click('text=Click target', { timeout: 3000 }).catch(e => e);
   expect(await page.evaluate('window.__CLICKED')).toBe(undefined);
   expect(error.message).toContain('page.click: Timeout 3000ms exceeded.');
-  expect(error.message).toContain('element is not enabled - waiting');
+  expect(error.message).toContain('element is not enabled');
 });

--- a/tests/page/page-click-timeout-2.spec.ts
+++ b/tests/page/page-click-timeout-2.spec.ts
@@ -22,8 +22,8 @@ it('should timeout waiting for display:none to be gone', async ({ page, server }
   await page.$eval('button', b => b.style.display = 'none');
   const error = await page.click('button', { timeout: 5000 }).catch(e => e);
   expect(error.message).toContain('page.click: Timeout 5000ms exceeded.');
-  expect(error.message).toContain('waiting for element to be visible, enabled and stable');
-  expect(error.message).toContain('element is not visible - waiting');
+  expect(error.message).toContain('checking element to be visible, enabled and stable');
+  expect(error.message).toContain('element is not visible');
 });
 
 it('should timeout waiting for visibility:hidden to be gone', async ({ page, server }) => {
@@ -31,6 +31,6 @@ it('should timeout waiting for visibility:hidden to be gone', async ({ page, ser
   await page.$eval('button', b => b.style.visibility = 'hidden');
   const error = await page.click('button', { timeout: 5000 }).catch(e => e);
   expect(error.message).toContain('page.click: Timeout 5000ms exceeded.');
-  expect(error.message).toContain('waiting for element to be visible, enabled and stable');
-  expect(error.message).toContain('element is not visible - waiting');
+  expect(error.message).toContain('checking element to be visible, enabled and stable');
+  expect(error.message).toContain('element is not visible');
 });


### PR DESCRIPTION
This way we detect the scenario where locator resolves to something different while waiting for actionability checks, and either throw strict mode violation, or continue with the right element.