### PR TITLE
fix(reuse): make sure all dispose and close sequences are executed

### DIFF
--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -65,6 +65,8 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
   async _newContextForReuse(options: BrowserContextOptions = {}): Promise<BrowserContext> {
     for (const context of this._contexts) {
       await this._browserType._onWillCloseContext?.(context);
+      for (const page of context.pages())
+        page._onClose();
       context._onClose();
     }
     this._contexts.clear();

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -270,8 +270,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
       this._subscriptions.delete(params.event);
   }
 
-  override _dispose() {
-    super._dispose();
+  override _onDispose() {
     // Avoid protocol calls for the closed context.
     if (!this._context.isClosingOrClosed())
       this._context.setRequestInterceptor(undefined).catch(() => {});

--- a/packages/playwright-core/src/server/dispatchers/debugControllerDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/debugControllerDispatcher.ts
@@ -79,8 +79,7 @@ export class DebugControllerDispatcher extends Dispatcher<DebugController, chann
     await this._object.closeAllBrowsers();
   }
 
-  override _dispose() {
-    super._dispose();
+  override _onDispose() {
     this._object.dispose();
   }
 }

--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -102,8 +102,12 @@ export class Dispatcher<Type extends { guid: string }, ChannelType, ParentScopeT
     this._connection.sendDispose(this);
   }
 
+  protected _onDispose() {
+  }
+
   private _disposeRecursively() {
     assert(!this._disposed, `${this._guid} is disposed more than once`);
+    this._onDispose();
     this._disposed = true;
     eventsHelper.removeEventListeners(this._eventListeners);
 

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -299,9 +299,10 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     this._dispatchEvent('frameDetached', { frame: FrameDispatcher.from(this, frame) });
   }
 
-  override _dispose() {
-    super._dispose();
-    this._page.setClientRequestInterceptor(undefined).catch(() => {});
+  override _onDispose() {
+    // Avoid protocol calls for the closed page.
+    if (!this._page.isClosedOrClosingOrCrashed())
+      this._page.setClientRequestInterceptor(undefined).catch(() => {});
   }
 }
 

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -612,6 +612,10 @@ export class Page extends SdkObject {
     return this._closedState === 'closed';
   }
 
+  isClosedOrClosingOrCrashed() {
+    return this._closedState !== 'open' || this._crashedPromise.isDone();
+  }
+
   _addWorker(workerId: string, worker: Worker) {
     this._workers.set(workerId, worker);
     this.emit(Page.Events.Worker, worker);


### PR DESCRIPTION
- When disposing recursively, only the root dispatcher received `_dispose()` call, while some dispatchers need `_onDispose()` to clean things up.
- When reusing the context, pages should be notified with `_onClose()` so that all client-side waiting promises could reject.

Fixes #19216.