### PR TITLE
feat(trace-viewer): add parameters copy to clip

### DIFF
--- a/packages/trace-viewer/src/ui/callTab.css
+++ b/packages/trace-viewer/src/ui/callTab.css
@@ -49,12 +49,31 @@
 
 .call-line {
   padding: 4px 0 4px 6px;
-  flex: none;
+  display: flex;
   align-items: center;
   text-overflow: ellipsis;
   overflow: hidden;
   line-height: 18px;
   white-space: nowrap;
+}
+
+.call-line__copy-icon {
+  visibility: hidden;
+  margin-right: 4px;
+}
+
+.call-line:hover .call-line__copy-icon {
+  visibility: visible;
+}
+
+.call-value {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  flex: 1;
+}
+
+.call-value::before {
+  content: '\00a0';
 }
 
 .call-line .datetime,

--- a/packages/trace-viewer/src/ui/callTab.tsx
+++ b/packages/trace-viewer/src/ui/callTab.tsx
@@ -20,6 +20,7 @@ import type { ActionTraceEvent } from '@trace/trace';
 import { msToString } from '@web/uiUtils';
 import * as React from 'react';
 import './callTab.css';
+import { CopyToClipboard } from './copyToClipboard';
 
 export const CallTab: React.FunctionComponent<{
   action: ActionTraceEvent | undefined,
@@ -42,8 +43,8 @@ export const CallTab: React.FunctionComponent<{
     <div className='call-line'>{action.metadata.apiName}</div>
     {<>
       <div className='call-section'>Time</div>
-      {action.metadata.wallTime && <div className='call-line'>wall time: <span className='datetime' title={wallTime}>{wallTime}</span></div>}
-      <div className='call-line'>duration: <span className='datetime' title={duration}>{duration}</span></div>
+      {action.metadata.wallTime && <div className='call-line'>wall time: <span className='call-value datetime' title={wallTime}>{wallTime}</span></div>}
+      <div className='call-line'>duration: <span className='call-value datetime' title={duration}>{duration}</span></div>
     </>}
     { !!paramKeys.length && <div className='call-section'>Parameters</div> }
     {
@@ -66,12 +67,29 @@ export const CallTab: React.FunctionComponent<{
   </div>;
 };
 
+function shouldCopy(type: string): boolean {
+  return !!({
+    'string': true,
+    'number': true,
+    'object': true,
+  }[type]);
+}
+
 function renderLine(metadata: CallMetadata, name: string, value: any, key: string) {
   const { title, type } = toString(metadata, name, value);
   let text = title.replace(/\n/g, '↵');
   if (type === 'string')
     text = `"${text}"`;
-  return <div key={key} className='call-line'>{name}: <span className={type} title={title}>{text}</span></div>;
+  return (
+    <div key={key} className='call-line'>
+      {name}: <span className={`call-value ${type}`} title={title}>{text}</span>
+      { shouldCopy(type) && (
+        <span className='call-line__copy-icon'>
+          <CopyToClipboard value={title} />
+        </span>
+      )}
+    </div>
+  );
 }
 
 function toString(metadata: CallMetadata, name: string, value: any): { title: string, type: string } {

--- a/packages/trace-viewer/src/ui/copyToClipboard.css
+++ b/packages/trace-viewer/src/ui/copyToClipboard.css
@@ -1,0 +1,7 @@
+.codicon-check {
+  color: var(--green);
+}
+
+.codicon-close {
+  color: var(--red);
+}

--- a/packages/trace-viewer/src/ui/copyToClipboard.tsx
+++ b/packages/trace-viewer/src/ui/copyToClipboard.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import './copyToClipboard.css';
+
+const TIMEOUT = 3000;
+const DEFAULT_ICON = 'codicon-clippy';
+const COPIED_ICON = 'codicon-check';
+const FAILED_ICON = 'codicon-close';
+
+export const CopyToClipboard: React.FunctionComponent<{
+  value: string,
+}> = ({ value }) => {
+  const [iconClassName, setIconClassName] = React.useState(DEFAULT_ICON);
+
+  const handleCopy = React.useCallback(() => {
+    navigator.clipboard.writeText(value).then(() => {
+      setIconClassName(COPIED_ICON);
+      setTimeout(() => {
+        setIconClassName(DEFAULT_ICON);
+      }, TIMEOUT);
+    }, () => {
+      setIconClassName(FAILED_ICON);
+    });
+
+  }, [value]);
+
+  return <span className={`codicon ${iconClassName}`} onClick={handleCopy}/>;
+};


### PR DESCRIPTION
### Add copy to clipboard icon near parameters value

<img width="305" alt="Screenshot 2022-12-28 at 14 37 46" src="https://user-images.githubusercontent.com/6429161/209806349-1a3876d7-c2d6-44d5-8612-ac375aa1b602.png">

This patch adds copy icon at the right of string, number and object values.

On line hover:

<img width="303" alt="Screenshot 2022-12-28 at 14 34 34" src="https://user-images.githubusercontent.com/6429161/209806293-b66a373d-e047-40be-a725-33ad586454d4.png">

Click copies value to clipboard and changes current icon to check:

<img width="307" alt="Screenshot 2022-12-28 at 14 36 13" src="https://user-images.githubusercontent.com/6429161/209806318-3c59e1fa-3d7b-4052-9fc8-13da933900d4.png">

Fixes #19582