### PR TITLE
feat: support sharding in HTML Reporter

### DIFF
--- a/packages/html-reporter/index.html
+++ b/packages/html-reporter/index.html
@@ -25,5 +25,12 @@
   <body>
     <div id='root'></div>
     <script type='module' src='/src/index.tsx'></script>
+    <dialog id="fallback-error">
+      <p>The Playwright Test Report must be loaded over the <code>http://</code> or <code>https://</code> protocols.</p>
+    </dialog>
+    <script>
+      if (!/^https?:/.test(window.location.protocol))
+        document.getElementById("fallback-error").show();
+    </script>
   </body>
 </html>

--- a/packages/html-reporter/src/mergeReports.ts
+++ b/packages/html-reporter/src/mergeReports.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { HTMLReport, Stats } from './types';
+
+export function mergeReports(reports: HTMLReport[]): HTMLReport {
+  const [report, ...rest] = reports;
+
+  for (const currentReport of rest) {
+    currentReport.files.forEach(file => {
+      const existingGroup = report.files.find(({ fileId }) => fileId === file.fileId);
+
+      if (existingGroup) {
+        existingGroup.tests.push(...file.tests);
+        mergeStats(existingGroup.stats, file.stats);
+      } else {
+        report.files.push(file);
+      }
+    });
+
+    mergeStats(report.stats, currentReport.stats);
+  }
+
+  return report;
+}
+
+function mergeStats(stats: Stats, sourceStats: Stats) {
+  stats.total += sourceStats.total;
+  stats.expected += sourceStats.expected;
+  stats.unexpected += sourceStats.unexpected;
+  stats.flaky += sourceStats.flaky;
+  stats.skipped += sourceStats.skipped;
+  stats.duration += sourceStats.duration;
+  stats.ok = stats.ok && sourceStats.ok;
+}

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -476,7 +476,6 @@ test('should warn user when viewing via file:// protocol', async ({ runInlineTes
   await test.step('view via local file://', async () => {
     const reportFolder = testInfo.outputPath('playwright-report');
     await page.goto(url.pathToFileURL(path.join(reportFolder, 'index.html')).toString());
-    await page.locator('[title="View trace"]').click();
     await expect(page.locator('dialog')).toBeVisible();
     await expect(page.locator('dialog')).toContainText('must be loaded over');
   });


### PR DESCRIPTION
Close https://github.com/microsoft/playwright/issues/10437.

This feature aims to bring official support to combine sharded reports in the HTML reporter. This is probably not the best solution, but I think it works with minimal changes.

## How it works

1. We inline the `shard` config into a global variable along with other metadata for future usage called `window.playwrightMetadata`.
2. Instead of inlining the ZIP file into a base64 string, we write the ZIP into a `report.zip` file. If there's sharding, we instead write them into a `report-{shardIndex}.zip` file.
3. After each run, we typically upload the generated report directory somewhere to an artifact. Once every part is finished, we download and extract them to a single place. Everything except for the `report-{shardIndex}.zip` files should be overridden and replaced.
4. In the web app, instead of reading the ZIP from a base64 string, we read them from HTTP. If there's sharding, we read the reports one by one and merge them together.

## Comparing to [`playwright-merge-html-reports`](https://github.com/Rippling/playwright-merge-html-reports)

The `mergeStats` helper is largely inspired by `playwright-merge-html-reports`, but I think this approach has some advantages:

1. Official support.
2. No extra steps are needed, no need to run another script to combine the reports. This can be tedious for CI as they have to initialize an environment, npm install, download reports, run the scripts, then finally upload the report.
3. Works out of the box, no need for another API.

## Example setup

GitHub Actions with artifacts

```yml
steps:
  playwright:
    name: 'Playwright Tests - ${{ matrix.project }} - Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }}'
    runs-on: ubuntu-latest
    container:
      image: mcr.microsoft.com/playwright:v1.29.0-focal
    strategy:
      fail-fast: false
      matrix:
        project: [chromium, webkit]
        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
        shardTotal: [10]
    steps:
      - uses: actions/checkout@v3
      - uses: actions/setup-node@v3
        with:
          node-version: '18'
      - name: Install dependencies
        run: npm ci
      - name: Run your tests
        run: npx playwright test --project=${{ matrix.project }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
      - uses: actions/upload-artifact@v3
        with:
          name: playwright-report
          path: playwright-report
```

WDYT? Once we're happy with the approach we can start writing some docs and tests.