### PR TITLE
feat(ct): https

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/xml2js": "^0.4.9",
         "@typescript-eslint/eslint-plugin": "^5.10.2",
         "@typescript-eslint/parser": "^5.10.2",
+        "@vitejs/plugin-basic-ssl": "^1.0.1",
         "@vitejs/plugin-react": "^3.0.0",
         "@zip.js/zip.js": "^2.4.2",
         "ansi-to-html": "^0.7.2",
@@ -1675,6 +1676,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.0.1.tgz",
+      "integrity": "sha512-pcub+YbFtFhaGRTo1832FQHQSHvMrlb43974e2eS8EKleR3p1cDdkJFPci1UhwkEf1J9Bz+wKBSzqpKp7nNj2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.6.0"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -7141,6 +7154,13 @@
         "@typescript-eslint/types": "5.10.2",
         "eslint-visitor-keys": "^3.0.0"
       }
+    },
+    "@vitejs/plugin-basic-ssl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.0.1.tgz",
+      "integrity": "sha512-pcub+YbFtFhaGRTo1832FQHQSHvMrlb43974e2eS8EKleR3p1cDdkJFPci1UhwkEf1J9Bz+wKBSzqpKp7nNj2A==",
+      "dev": true,
+      "requires": {}
     },
     "@vitejs/plugin-react": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/xml2js": "^0.4.9",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
+    "@vitejs/plugin-basic-ssl": "^1.0.1",
     "@vitejs/plugin-react": "^3.0.0",
     "@zip.js/zip.js": "^2.4.2",
     "ansi-to-html": "^0.7.2",

--- a/packages/playwright-test/src/plugins/vitePlugin.ts
+++ b/packages/playwright-test/src/plugins/vitePlugin.ts
@@ -94,7 +94,7 @@ export function createPlugin(
       const sourcesDirty = !buildExists || hasNewComponents || await checkSources(buildInfo);
 
       viteConfig.root = rootDir;
-      viteConfig.preview = { port };
+      viteConfig.preview = { port, ...viteConfig.preview };
       viteConfig.build = {
         outDir
       };
@@ -152,9 +152,10 @@ export function createPlugin(
       stoppableServer = stoppable(previewServer.httpServer, 0);
       const isAddressInfo = (x: any): x is AddressInfo => x?.address;
       const address = previewServer.httpServer.address();
-      if (isAddressInfo(address))
-        process.env.PLAYWRIGHT_TEST_BASE_URL = `http://localhost:${address.port}`;
-
+      if (isAddressInfo(address)) {
+        const protocol = viteConfig.preview.https ? 'https:' : 'http:';
+        process.env.PLAYWRIGHT_TEST_BASE_URL = `${protocol}//localhost:${address.port}`;
+      }
     },
 
     teardown: async () => {

--- a/tests/playwright-test/playwright.ct-build.spec.ts
+++ b/tests/playwright-test/playwright.ct-build.spec.ts
@@ -297,3 +297,35 @@ test('should not use global config for preview', async ({ runInlineTest }) => {
   expect(result2.exitCode).toBe(0);
   expect(result2.passed).toBe(1);
 });
+
+test('should work with https enabled', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright/index.html': `<script type="module" src="./index.js"></script>`,
+    'playwright/index.js': `//@no-header`,
+    'playwright.config.js': `
+      //@no-header
+      import basicSsl from '@vitejs/plugin-basic-ssl';
+      export default {
+        use: {
+          ignoreHTTPSErrors: true,
+          ctViteConfig: {
+            plugins: [basicSsl()],
+            preview: {
+              https: true
+            }
+          }
+        },
+      };
+    `,
+    'http.test.tsx': `
+      //@no-header
+      import { test, expect } from '@playwright/experimental-ct-react';
+
+      test('pass', async ({ page }) => {
+        await expect(page).toHaveURL(/https:.*/);
+      });
+    `,
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});


### PR DESCRIPTION
fixes: https://github.com/microsoft/playwright/issues/15651, https://github.com/microsoft/playwright/issues/16460

Not sure how to test it. Tried it with the test below but i can't get it to work :( 

```typescript
test('works', async ({ runInlineTest }) => {
  const result1 = await runInlineTest({
    'playwright/index.html': `<script type="module" src="./index.js"></script>`,
    'playwright/index.js': ``,
    'playwright.config.js': `
      export default {
        use: {
          ignoreHTTPSErrors: true,
          ctViteConfig: {
            preview: {
              https: true
            }
          }
        },
      };
    `,
    'http.test.ts': `
      //@no-header
      import { test, expect } from '@playwright/experimental-ct-react';
      test('pass', async ({ page }) => {
        await expect(page).toHaveURL('https://localhost:3100');
      });
    `,
  }, { workers: 1 });
  expect(result1.exitCode).toBe(0);
  expect(result1.passed).toBe(1);
});
```

it throws _(even with `ignoreHTTPSErrors: true`)_:

```bash
net::ERR_SSL_VERSION_OR_CIPHER_MISMATCH at https://localhost:3100/
=========================== logs ===========================
navigating to "https://localhost:3100/", waiting until "load"
============================================================
```


any tips?