### PR TITLE
feat(reactSelectorEngine): extract names of React.memo/lazy/forwardRe…

### DIFF
--- a/tests/assets/reading-list/react-lazy.js
+++ b/tests/assets/reading-list/react-lazy.js
@@ -1,0 +1,3 @@
+export default function ReactLazy() {
+  return e('div', null, 'ReactLazy');
+};

--- a/tests/assets/reading-list/react16.html
+++ b/tests/assets/reading-list/react16.html
@@ -91,6 +91,9 @@ class App extends React.Component {
       e(BookList, {books: this.state.books}, null),
       e(ButtonGrid, null, null),
       e('div', {ref: this.mountPoint}, null),
+      e(Memoized, null, null),
+      e(MemoizedForwardRef, null, null),
+      e(React.Suspense, { fallback: null }, e(Lazy, null, null)),
     );
   }
 
@@ -100,6 +103,20 @@ class App extends React.Component {
     });
   }
 }
+
+const MemoizedForwardRef = React.memo(React.forwardRef(() => {
+  return e('div', null, 'MemoizedForwardRef');
+}));
+
+MemoizedForwardRef.displayName = 'MemoizedForwardRef';
+
+const Memoized = React.memo(() => {
+  return e('div', null, 'Memoized');
+});
+
+Memoized.displayName = 'Memoized';
+
+const Lazy = React.lazy(() => import('./react-lazy.js'));
 
 window.mountApp = element => ReactDOM.render(e(App, null, null), element);
 window.app = window.mountApp(document.getElementById('root'));

--- a/tests/assets/reading-list/react17.html
+++ b/tests/assets/reading-list/react17.html
@@ -85,6 +85,9 @@ class App extends React.Component {
       e(BookList, {books: this.state.books}, null),
       e(ButtonGrid, null, null),
       e('div', {ref: this.mountPoint}, null),
+      e(Memoized, null, null),
+      e(MemoizedForwardRef, null, null),
+      e(React.Suspense, { fallback: null }, e(Lazy, null, null)),
     );
   }
 
@@ -94,6 +97,20 @@ class App extends React.Component {
     });
   }
 }
+
+const MemoizedForwardRef = React.memo(React.forwardRef(() => {
+  return e('div', null, 'MemoizedForwardRef');
+}));
+
+MemoizedForwardRef.displayName = 'MemoizedForwardRef';
+
+const Memoized = React.memo(() => {
+  return e('div', null, 'Memoized');
+});
+
+Memoized.displayName = 'Memoized';
+
+const Lazy = React.lazy(() => import('./react-lazy.js'));
 
 window.mountApp = element => ReactDOM.render(e(App, null, null), element);
 window.app = window.mountApp(document.getElementById('root'));

--- a/tests/assets/reading-list/react18.html
+++ b/tests/assets/reading-list/react18.html
@@ -88,6 +88,9 @@ class App extends React.Component {
       e(BookList, {books: this.state.books}, null),
       e(ButtonGrid, null, null),
       e('div', {ref: this.mountPoint}, null),
+      e(Memoized, null, null),
+      e(MemoizedForwardRef, null, null),
+      e(React.Suspense, { fallback: null }, e(Lazy, null, null)),
     );
   }
 
@@ -97,6 +100,20 @@ class App extends React.Component {
     });
   }
 }
+
+const MemoizedForwardRef = React.memo(React.forwardRef(() => {
+  return e('div', null, 'MemoizedForwardRef');
+}));
+
+MemoizedForwardRef.displayName = 'MemoizedForwardRef';
+
+const Memoized = React.memo(() => {
+  return e('div', null, 'Memoized');
+});
+
+Memoized.displayName = 'Memoized';
+
+const Lazy = React.lazy(() => import('./react-lazy.js'));
 
 {
   window.mountApp = element => {

--- a/tests/page/selectors-react.spec.ts
+++ b/tests/page/selectors-react.spec.ts
@@ -39,7 +39,6 @@ for (const [name, url] of Object.entries(reacts)) {
 
     it('should work with multi-root elements (fragments)', async ({ page }) => {
       it.skip(name === 'react15', 'React 15 does not support fragments');
-      await expect(page.locator(`_react=App`)).toHaveCount(15);
       await expect(page.locator(`_react=AppHeader`)).toHaveCount(2);
       await expect(page.locator(`_react=NewBook`)).toHaveCount(2);
     });
@@ -156,6 +155,16 @@ for (const [name, url] of Object.entries(reacts)) {
       });
       await expect(page.locator(`_react=BookItem`)).toHaveCount(6);
     });
+
+
+    it('should support React.memo & React.forwardRef with correct displayName', async ({ page }) => {
+      it.skip(name === 'react15', 'React 15 does not support functional components, let alone this');
+      await page.locator(`_react=BookItem`).first().waitFor();
+      await expect(page.locator(`_react=MemoizedForwardRef`)).toHaveCount(1);
+      await expect(page.locator(`_react=Memoized`)).toHaveCount(1);
+      await expect(page.locator(`_react=ReactLazy`)).toHaveCount(1);
+    });
+
   });
 }
 


### PR DESCRIPTION
…f for getComponentName

Previously, playwright's `_react` selector fails to match the following components:

```js
// in browser
const MemoizedForwardRef = React.memo(React.forwardRef(() => {
  return e('div', null, 'MemoizedForwardRef');
}));

MemoizedForwardRef.displayName = 'MemoizedForwardRef';

const Lazy = React.lazy(() => import('./react-lazy.js'));
```

```js
// ./react-lazy
export default function ReactLazy() {
  return e('div', null, 'ReactLazy');
};
```

```
"_react=MemoizedForwardRef"
"_react=Memoized"
"_react=ReactLazy"
```

That said, even if the user has the correct `displayName` displayed in the devtool, the user still cannot match the React element with `_react` selector.

This PR looks into the element's VDOM's `type` field and handles when it is not `class` or `function`. It does that according to the [source code of react](https://github.com/facebook/react/blob/main/packages/shared/getComponentNameFromType.js).

The selector is tested on react 16/17/18.


 