### PR TITLE
fix(reuse): disable trace/video when reusing the context

### DIFF
--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -24,6 +24,7 @@ import type { Fixtures, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWor
 import { store as _baseStore } from './store';
 import type { TestInfoImpl } from './testInfo';
 import { rootTestType, _setProjectSetup } from './testType';
+import { type ContextReuseMode } from './types';
 export { expect } from './expect';
 export { addRunnerPlugin as _addRunnerPlugin } from './plugins';
 export const _baseTest: TestType<{}, {}> = rootTestType.test;
@@ -43,7 +44,7 @@ if ((process as any)['__pw_initiator__']) {
 
 type TestFixtures = PlaywrightTestArgs & PlaywrightTestOptions & {
   _combinedContextOptions: BrowserContextOptions,
-  _contextReuseEnabled: boolean,
+  _contextReuseMode: ContextReuseMode,
   _reuseContext: boolean,
   _setupContextOptionsAndArtifacts: void;
   _contextFactory: (options?: BrowserContextOptions) => Promise<BrowserContext>;
@@ -239,7 +240,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
 
   _snapshotSuffix: [process.platform, { scope: 'worker' }],
 
-  _setupContextOptionsAndArtifacts: [async ({ playwright, _snapshotSuffix, _combinedContextOptions, _browserOptions, _artifactsDir, trace, screenshot, actionTimeout, navigationTimeout, testIdAttribute }, use, testInfo) => {
+  _setupContextOptionsAndArtifacts: [async ({ playwright, _snapshotSuffix, _combinedContextOptions, _reuseContext, _artifactsDir, trace, screenshot, actionTimeout, navigationTimeout, testIdAttribute }, use, testInfo) => {
     if (testIdAttribute)
       playwrightLibrary.selectors.setTestIdAttribute(testIdAttribute);
     testInfo.snapshotSuffix = _snapshotSuffix;
@@ -251,7 +252,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
     const traceMode = normalizeTraceMode(trace);
     const defaultTraceOptions = { screenshots: true, snapshots: true, sources: true };
     const traceOptions = typeof trace === 'string' ? defaultTraceOptions : { ...defaultTraceOptions, ...trace, mode: undefined };
-    const captureTrace = shouldCaptureTrace(traceMode, testInfo);
+    const captureTrace = shouldCaptureTrace(traceMode, testInfo) && !_reuseContext;
     const temporaryTraceFiles: string[] = [];
     const temporaryScreenshots: string[] = [];
     const testInfoImpl = testInfo as TestInfoImpl;
@@ -463,9 +464,9 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
     }));
   }, { auto: 'all-hooks-included',  _title: 'playwright configuration' } as any],
 
-  _contextFactory: [async ({ browser, video, _artifactsDir }, use, testInfo) => {
+  _contextFactory: [async ({ browser, video, _artifactsDir, _reuseContext }, use, testInfo) => {
     const videoMode = normalizeVideoMode(video);
-    const captureVideo = shouldCaptureVideo(videoMode, testInfo);
+    const captureVideo = shouldCaptureVideo(videoMode, testInfo) && !_reuseContext;
     const contexts = new Map<BrowserContext, { pages: Page[] }>();
 
     await use(async options => {
@@ -519,10 +520,11 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
       testInfo.errors.push({ message: prependToError });
   }, { scope: 'test',  _title: 'context' } as any],
 
-  _contextReuseEnabled: !!process.env.PW_TEST_REUSE_CONTEXT,
+  _contextReuseMode: process.env.PW_TEST_REUSE_CONTEXT === 'when-possible' ? 'when-possible' : (process.env.PW_TEST_REUSE_CONTEXT ? 'force' : 'none'),
 
-  _reuseContext: async ({ video, trace, _contextReuseEnabled }, use, testInfo) => {
-    const reuse = _contextReuseEnabled && !shouldCaptureVideo(normalizeVideoMode(video), testInfo) && !shouldCaptureTrace(normalizeTraceMode(trace), testInfo);
+  _reuseContext: async ({ video, trace, _contextReuseMode }, use, testInfo) => {
+    const reuse = _contextReuseMode === 'force' ||
+      (_contextReuseMode === 'when-possible' && !shouldCaptureVideo(normalizeVideoMode(video), testInfo) && !shouldCaptureTrace(normalizeTraceMode(trace), testInfo));
     await use(reuse);
   },
 
@@ -603,7 +605,7 @@ export function normalizeVideoMode(video: VideoMode | 'retry-with-video' | { mod
   return videoMode;
 }
 
-export function shouldCaptureVideo(videoMode: VideoMode, testInfo: TestInfo) {
+function shouldCaptureVideo(videoMode: VideoMode, testInfo: TestInfo) {
   return (videoMode === 'on' || videoMode === 'retain-on-failure' || (videoMode === 'on-first-retry' && testInfo.retry === 1));
 }
 
@@ -616,7 +618,7 @@ export function normalizeTraceMode(trace: TraceMode | 'retry-with-trace' | { mod
   return traceMode;
 }
 
-export function shouldCaptureTrace(traceMode: TraceMode, testInfo: TestInfo) {
+function shouldCaptureTrace(traceMode: TraceMode, testInfo: TestInfo) {
   return traceMode === 'on' || traceMode === 'retain-on-failure' || (traceMode === 'on-first-retry' && testInfo.retry === 1);
 }
 

--- a/packages/playwright-test/src/mount.ts
+++ b/packages/playwright-test/src/mount.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Fixtures, Locator, Page, BrowserContextOptions, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, BrowserContext } from './types';
+import type { Fixtures, Locator, Page, BrowserContextOptions, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, BrowserContext, ContextReuseMode } from './types';
 import type { Component, JsxComponent, MountOptions } from '../types/component';
 
 let boundCallbacksForMount: Function[] = [];
@@ -29,9 +29,9 @@ export const fixtures: Fixtures<
     mount: (component: any, options: any) => Promise<MountResult>;
   },
   PlaywrightWorkerArgs & PlaywrightWorkerOptions & { _ctWorker: { context: BrowserContext | undefined, hash: string } },
-  { _contextFactory: (options?: BrowserContextOptions) => Promise<BrowserContext>, _contextReuseEnabled: boolean }> = {
+  { _contextFactory: (options?: BrowserContextOptions) => Promise<BrowserContext>, _contextReuseMode: ContextReuseMode }> = {
 
-    _contextReuseEnabled: true,
+    _contextReuseMode: 'when-possible',
 
     serviceWorkers: 'block',
 

--- a/packages/playwright-test/src/types.ts
+++ b/packages/playwright-test/src/types.ts
@@ -76,3 +76,5 @@ export interface FullProjectInternal extends FullProjectPublic {
 export interface ReporterInternal extends Reporter {
   _onExit?(): void | Promise<void>;
 }
+
+export type ContextReuseMode = 'none' | 'force' | 'when-possible';


### PR DESCRIPTION
Previously, we disabled reuse when trace/video was on. Component testing keeps this behavior.

References #19059.