### PR TITLE
fix(playwright-test): _removeOutputDirs called without await always returns truthy

### DIFF
--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -472,7 +472,7 @@ export class Runner {
       return { status: 'passed' };
 
     // Remove output directores.
-    if (!this._removeOutputDirs(options))
+    if (!await this._removeOutputDirs(options))
       return { status: 'failed' };
 
     // Run Global setup.


### PR DESCRIPTION
without this small change, I believe the conditional will never be true (it'll always be a promise instead of a boolean).