### PR TITLE
chore: bump json5 to 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4053,8 +4053,9 @@
       "optional": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "license": "MIT",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -8675,7 +8676,9 @@
       "optional": true
     },
     "json5": {
-      "version": "2.2.1"
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
     },
     "jsonfile": {
       "version": "4.0.0",


### PR DESCRIPTION
We run `npm audit` on our CI and this breaks our builds since ~8 hours, see [here](https://github.com/microsoft/playwright/actions/runs/3799667426/jobs/6462399107#step:11:8).

This patch runs `npm audit fix` to bump it to 2.2.2 so it will be green again.