### PR TITLE
chery-pick(#19783): chore: bump json5 to 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3754,8 +3754,9 @@
       "optional": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "license": "MIT",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -8534,7 +8535,9 @@
       "optional": true
     },
     "json5": {
-      "version": "2.2.1"
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
     },
     "jsonfile": {
       "version": "4.0.0",


### PR DESCRIPTION
This PR cherry-picks the following commits:

- fc56afb99028fc04d8f3b41f1abdc1fd40707575