### PR TITLE
fix(driver): AttributeError error when CWD contains space

### DIFF
--- a/utils/build/run-driver-win.cmd
+++ b/utils/build/run-driver-win.cmd
@@ -1,6 +1,6 @@
 @echo off
 setlocal
 if not defined PLAYWRIGHT_NODEJS_PATH (
-  set PLAYWRIGHT_NODEJS_PATH=%~dp0\node.exe
+  set PLAYWRIGHT_NODEJS_PATH="%~dp0\node.exe"
 )
-"""%PLAYWRIGHT_NODEJS_PATH%""" "%~dp0\package\lib\cli\cli.js" %*
+""%PLAYWRIGHT_NODEJS_PATH%"" "%~dp0\package\lib\cli\cli.js" %*


### PR DESCRIPTION
Using Playwright (1.29.0, Python 3.10.2 on Windows 11) from a path containing spaces, for example `C:\Program Files (x86)\My App Name With Spaces\`, gives the following error message:

```log
AttributeError: 'PlaywrightContextManager' object has no attribute '_playwright'
```

This PR is based on the fix [suggested](https://github.com/microsoft/playwright-python/issues/1561#issuecomment-1257091619) by @funnydevdotvn.

In the `[...]Lib\site-packages\playwright\driver\playwright.cmd` file, `%~dp0\node.exe` must be in quotes to handle spaces properly.

Because the `playwright.cmd` file is generated from `utils\build\run-driver-win.cmd`, you'll find the change there.

This improves the solution from related PR #17579.