### PR TITLE
docs: update test runners for .NET 

### DIFF
--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -28,7 +28,7 @@ You can choose any testing framework such as JUnit or TestNG based on your proje
 
 ## .NET
 
-Playwright for .NET comes with [NUnit base classes](./test-runners.md#nunit) and [MSTest base classes](./test-runners.md#nunit) for writing end-to-end tests.
+Playwright for .NET comes with [NUnit base classes](https://playwright.dev/dotnet/docs/test-runners#nunit) and [MSTest base classes](https://playwright.dev/dotnet/docs/test-runners#mstest) for writing end-to-end tests.
 
 * [Documentation](https://playwright.dev/dotnet/docs/intro)
 * [GitHub repo](https://github.com/microsoft/playwright-dotnet)


### PR DESCRIPTION
Update test runners for .NET 

- the link goes to a wrong page when you're not on the .NET ecosystem (e.g. the first time in the GIF I'm in the Node.js ecosystem and it redirects me to the test runners of Node.js)
- update link to MSTest base class

![supported languages](https://user-images.githubusercontent.com/28659384/210307702-32c1978b-8644-49a6-bdef-54245c945bfe.gif)


