### PR TITLE
docs: fix example code of Route.fetch for Python

### DIFF
--- a/docs/src/api/class-route.md
+++ b/docs/src/api/class-route.md
@@ -454,7 +454,7 @@ page.route("https://dog.ceo/api/breeds/list/all", route -> {
 
 ```python async
 async def handle(route):
-    response = await route.fulfill()
+    response = await route.fetch()
     json = await response.json()
     json["message"]["big_red_dog"] = []
     await route.fulfill(response=response, json=json)
@@ -464,7 +464,7 @@ await page.route("https://dog.ceo/api/breeds/list/all", handle)
 
 ```python sync
 def handle(route):
-    response = route.fulfill()
+    response = route.fetch()
     json = response.json()
     json["message"]["big_red_dog"] = []
     route.fulfill(response=response, json=json)


### PR DESCRIPTION
Fix typo in Route.fetch for Python. `route.fetch()` would be correct.

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/11763113/210385876-2101295f-451a-4b02-867e-bc418345131e.png">

