### PR TITLE
feat(chromium-tip-of-tree): roll to r1074

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -15,9 +15,9 @@
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1069",
+      "revision": "1074",
       "installByDefault": false,
-      "browserVersion": "110.0.5479.0"
+      "browserVersion": "111.0.5515.0"
     },
     {
       "name": "firefox",

--- a/tests/library/browsercontext-proxy.spec.ts
+++ b/tests/library/browsercontext-proxy.spec.ts
@@ -354,6 +354,10 @@ it('should exclude patterns', async ({ contextFactory, server, browserName, head
     expect(error.message).toBeTruthy();
   }
 
+  // Make sure error page commits.
+  if (browserName === 'chromium')
+    await page.waitForURL('chrome-error://chromewebdata/');
+
   {
     await page.goto('http://3.non.existent.domain.for.the.test/target.html');
     expect(proxyServer.requestUrls).toContain('http://3.non.existent.domain.for.the.test/target.html');

--- a/tests/library/proxy.spec.ts
+++ b/tests/library/proxy.spec.ts
@@ -210,6 +210,10 @@ it('should exclude patterns', async ({ browserType, server, browserName, headles
     expect(error.message).toBeTruthy();
   }
 
+  // Make sure error page commits.
+  if (browserName === 'chromium')
+    await page.waitForURL('chrome-error://chromewebdata/');
+
   {
     await page.goto('http://3.non.existent.domain.for.the.test/target.html');
     expect(await page.title()).toBe('Served by the proxy');

--- a/tests/page/jshandle-to-string.spec.ts
+++ b/tests/page/jshandle-to-string.spec.ts
@@ -39,7 +39,7 @@ it('should work for promises', async ({ page }) => {
   expect(bHandle.toString()).toBe('Promise');
 });
 
-it('should work with different subtypes @smoke', async ({ page, browserName }) => {
+it('should work with different subtypes @smoke', async ({ page, browserName, browserMajorVersion }) => {
   expect((await page.evaluateHandle('(function(){})')).toString()).toContain('function');
   expect((await page.evaluateHandle('12')).toString()).toBe('12');
   expect((await page.evaluateHandle('true')).toString()).toBe('true');
@@ -54,7 +54,7 @@ it('should work with different subtypes @smoke', async ({ page, browserName }) =
   expect((await page.evaluateHandle('new WeakMap()')).toString()).toBe('WeakMap');
   expect((await page.evaluateHandle('new WeakSet()')).toString()).toBe('WeakSet');
   expect((await page.evaluateHandle('new Error()')).toString()).toContain('Error');
-  expect((await page.evaluateHandle('new Proxy({}, {})')).toString()).toBe('Proxy');
+  expect((await page.evaluateHandle('new Proxy({}, {})')).toString()).toBe((browserName === 'chromium' && browserMajorVersion >= 111) ? 'Proxy(Object)' : 'Proxy');
 });
 
 it('should work with previewable subtypes', async ({ page, browserName }) => {


### PR DESCRIPTION
### Regressions

#### ` page/jshandle-to-string.spec.ts:42:3 › should work with different subtypes @smoke`

- a `Proxy` instance toString is now `Proxy(Object)` instead of `Proxy`
- bisect range: https://chromium.googlesource.com/chromium/src/+log/bca6d94b1730f8bef2996ca35ab7f28fcf087aff..adbb84441bb8bbe26ecf52a301e5b72de744fd50
- specific CL https://chromium.googlesource.com/v8/v8/+/57b1dc9acffc464205ea728706f355a32fa086dd

#### `library/proxy.spec.ts:180:3 › should exclude patterns` headless / win + mac

- `Error: Execution context was destroyed, most likely because of a navigation` gets thrown
- bisect range: https://chromium.googlesource.com/chromium/src/+log/50c936ec97b4ecc5fcb8025adb184943a25e9521..9a081ada6bfc9625f04d13bf62042f330f7dfe84
- Filed upstream: https://bugs.chromium.org/p/chromium/issues/detail?id=1405237