### PR TITLE
fix(serviceworker): network inspection works without options.serviceWorkers set

### DIFF
--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -421,7 +421,7 @@ export async function prepareBrowserContextParams(options: BrowserContextOptions
     noDefaultViewport: options.viewport === null,
     extraHTTPHeaders: options.extraHTTPHeaders ? headersObjectToArray(options.extraHTTPHeaders) : undefined,
     storageState: await prepareStorageState(options),
-    serviceWorkers: options.serviceWorkers === null ? 'allow' : options.serviceWorkers,
+    serviceWorkers: options.serviceWorkers,
     recordHar: prepareRecordHarOptions(options.recordHar),
     colorScheme: options.colorScheme === null ? 'no-override' : options.colorScheme,
     reducedMotion: options.reducedMotion === null ? 'no-override' : options.reducedMotion,

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -421,7 +421,7 @@ export async function prepareBrowserContextParams(options: BrowserContextOptions
     noDefaultViewport: options.viewport === null,
     extraHTTPHeaders: options.extraHTTPHeaders ? headersObjectToArray(options.extraHTTPHeaders) : undefined,
     storageState: await prepareStorageState(options),
-    serviceWorkers: options.serviceWorkers,
+    serviceWorkers: options.serviceWorkers === null ? 'allow' : options.serviceWorkers,
     recordHar: prepareRecordHarOptions(options.recordHar),
     colorScheme: options.colorScheme === null ? 'no-override' : options.colorScheme,
     reducedMotion: options.reducedMotion === null ? 'no-override' : options.reducedMotion,

--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -121,6 +121,6 @@ export class CRServiceWorker extends Worker {
   }
 
   private _isNetworkInspectionEnabled(): boolean {
-    return this._browserContext._options.serviceWorkers === 'allow';
+    return this._browserContext._options.serviceWorkers !== 'block';
   }
 }


### PR DESCRIPTION
In the implementation of adding the serviceWorkers option (#14714), the default value was not properly set.

This PR fixes the workaround needed here:
https://github.com/microsoft/playwright/issues/15684#issuecomment-1371127580

As you can see, it is documented to default to `"allow"`: https://github.com/rwoll/playwright/blob/main/docs/src/api/params.md#context-option-service-worker-policy

An alternative fix suggested is to edit the documentation:
https://github.com/microsoft/playwright/pull/19871

Signed-off-by: Oren <orenyomtov@users.noreply.github.com>