### PR TITLE
fix(fetch): handle invalid redirect URL

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -306,7 +306,14 @@ export abstract class APIRequestContext extends SdkObject {
 
           // HTTP-redirect fetch step 4: If locationURL is null, then return response.
           if (response.headers.location) {
-            const locationURL = new URL(response.headers.location, url);
+            let locationURL;
+            try {
+              locationURL = new URL(response.headers.location, url);
+            } catch (error) {
+              reject(new Error(`uri requested responds with an invalid redirect URL: ${response.headers.location}`));
+              request.destroy();
+              return;
+            }
             notifyRequestFinished();
             fulfill(this._sendRequest(progress, locationURL, redirectOptions, postData));
             request.destroy();


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/19879.

This part is then similar to how node-fetch is doing it: https://cs.github.com/node-fetch/node-fetch/blob/55a4870ae5f805d8ff9a890ea2c652c9977e048e/src/index.js?q=location#L152-L159

node-fetch also throws as of today with this URL. Before in Python it was stalling, because the error was written to stdout and on Windows the stdout wasn't working. On Node.js it ended up in an unhandled exception.