### PR TITLE
feat(expect): introduce expect(locator).toIntersectViewport()

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -1719,3 +1719,19 @@ Expected options currently selected.
 
 ### option: LocatorAssertions.toHaveValues.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.23
+
+## async method: LocatorAssertions.toIntersectViewport
+* since: v1.30
+* langs: js
+
+Ensures the [Locator] points to an element that intersects viewport, according to the [intersection observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+
+**Usage**
+
+```js
+const locator = page.locator('button.submit');
+await expect(locator).toIntersectViewport();
+```
+
+### option: LocatorAssertions.toIntersectViewport.timeout = %%-js-assertions-timeout-%%
+* since: v1.30

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -43,6 +43,7 @@ By default, the timeout for assertions is set to 5 seconds. Learn more about [va
 | [`method: LocatorAssertions.toHaveText`] | Element matches text |
 | [`method: LocatorAssertions.toHaveValue`] | Input has a value |
 | [`method: LocatorAssertions.toHaveValues`] | Select has options selected |
+| [`method: LocatorAssertions.toIntersectViewport`] | Element intersects viewport |
 | [`method: PageAssertions.toHaveScreenshot#1`] | Page has a screenshot |
 | [`method: PageAssertions.toHaveTitle`] | Page has a title |
 | [`method: PageAssertions.toHaveURL`] | Page has a URL |

--- a/packages/playwright-test/src/expect.ts
+++ b/packages/playwright-test/src/expect.ts
@@ -38,6 +38,7 @@ import {
   toHaveURL,
   toHaveValue,
   toHaveValues,
+  toIntersectViewport,
   toPass
 } from './matchers/matchers';
 import { toMatchSnapshot, toHaveScreenshot } from './matchers/toMatchSnapshot';
@@ -143,6 +144,7 @@ const customMatchers = {
   toHaveURL,
   toHaveValue,
   toHaveValues,
+  toIntersectViewport,
   toMatchSnapshot,
   toHaveScreenshot,
   toPass,

--- a/packages/playwright-test/src/matchers/matchers.ts
+++ b/packages/playwright-test/src/matchers/matchers.ts
@@ -119,6 +119,16 @@ export function toBeVisible(
   }, options);
 }
 
+export function toIntersectViewport(
+  this: ReturnType<Expect['getState']>,
+  locator: LocatorEx,
+  options?: { timeout?: number },
+) {
+  return toBeTruthy.call(this, 'toIntersectViewport', locator, 'Locator', async (isNot, timeout, customStackTrace) => {
+    return await locator._expect(customStackTrace, 'to.intersect.viewport', { isNot, timeout });
+  }, options);
+}
+
 export function toContainText(
   this: ReturnType<Expect['getState']>,
   locator: LocatorEx,

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -4641,6 +4641,26 @@ interface LocatorAssertions {
      */
     timeout?: number;
   }): Promise<void>;
+
+  /**
+   * Ensures the [Locator] points to an element that intersects viewport, according to the
+   * [intersection observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+   *
+   * **Usage**
+   *
+   * ```js
+   * const locator = page.locator('button.submit');
+   * await expect(locator).toIntersectViewport();
+   * ```
+   *
+   * @param options
+   */
+  toIntersectViewport(options?: {
+    /**
+     * Time to retry the assertion for. Defaults to `timeout` in `TestConfig.expect`.
+     */
+    timeout?: number;
+  }): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
This is a new web-first assertion that should be used like this:

```ts
test('should work', async ({ page }) => {
  const locator = page.locator('body');
  // New web-first assertion.
  await expect(locator).toIntersectViewport();
  // The same functionality.
  await expect.poll(() => locator.viewportRatio()).toBeGreaterThan(0);
});
```

Fixes #8740
