### PR TITLE
docs(test-cli): typo for tests at a specific line

### DIFF
--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -25,7 +25,7 @@ Here are the most common options available in the command line.
   npx playwright test my-spec my-spec-2
   ```
 
-- Run files that are in line 42 in my-spec.ts
+- Run tests that are in line 42 in my-spec.ts
   ```bash
   npx playwright test my-spec.ts:42
   ```


### PR DESCRIPTION
HI there 👋

I just noticed a typo in the documentation, while looking for details on "test" command.

Thanks for your work.