### PR TITLE
fix(docker): take language binding version in consideration

### DIFF
--- a/packages/playwright-core/src/server/registry/dependencies.ts
+++ b/packages/playwright-core/src/server/registry/dependencies.ts
@@ -26,7 +26,7 @@ import { deps } from './nativeDeps';
 import { getPlaywrightVersion } from '../../common/userAgent';
 
 const BIN_DIRECTORY = path.join(__dirname, '..', '..', '..', 'bin');
-const packageJSON = require('../../../package.json');
+const languageBindingVersion = process.env.PW_CLI_DISPLAY_VERSION || require('../../../package.json').version;
 
 const dockerVersionFilePath = '/ms-playwright/.docker-info';
 export async function writeDockerVersion(dockerImageNameTemplate: string) {
@@ -38,8 +38,8 @@ export async function writeDockerVersion(dockerImageNameTemplate: string) {
 
 export function dockerVersion(dockerImageNameTemplate: string): { driverVersion: string, dockerImageName: string } {
   return {
-    driverVersion: packageJSON.version,
-    dockerImageName: dockerImageNameTemplate.replace('%version%', packageJSON.version),
+    driverVersion: languageBindingVersion,
+    dockerImageName: dockerImageNameTemplate.replace('%version%', languageBindingVersion),
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/19658

Issue was that Playwright Docker 1.28 was used and inside was Playwright for Python 1.29.0 with a Playwright 1.29.1 driver.

We should priories the language binding version before the driver version, since Docker images are published per language.