### PR TITLE
test: fix locator.viewportRatio() tests

### DIFF
--- a/tests/page/locator-misc-2.spec.ts
+++ b/tests/page/locator-misc-2.spec.ts
@@ -157,7 +157,7 @@ it('locator.count should work with deleted Map in main world', async ({ page }) 
 
 it('locator.viewportRatio', async ({ page }) => {
   await page.setContent(`
-    <style>body { padding: 0; margin: 0; } div { position: absolute; left: 0; top: 0 }</style>
+    <style>body { overflow: hidden; padding: 0; margin: 0; } div { position: absolute; left: 0; top: 0 }</style>
     <div id=fills-viewport style='width: 100vw; height: 100vh;'></div>
     <div id=half-viewport style='width: 50vw; height: 100vh;'></div>
     <div id=twice-viewport style='width: 200vw; height: 100vh;'></div>
@@ -167,4 +167,5 @@ it('locator.viewportRatio', async ({ page }) => {
   expect.soft(await page.locator('#half-viewport').viewportRatio()).toBe(1);
   expect.soft(await page.locator('#twice-viewport').viewportRatio()).toBe(0.5);
   expect.soft(await page.locator('#off-viewport').viewportRatio()).toBe(0);
+  expect.soft(await page.locator('#does-not-exist').viewportRatio()).toBe(0);
 });


### PR DESCRIPTION
Drive-by: make sure `locator.viewportRatio()` returns `0`
for non-existing element.
