### PR TITLE
test: update tests for waituntil:commit

### DIFF
--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -663,17 +663,14 @@ it('should return from goto if new navigation is started', async ({ page, server
 });
 
 it('should return when navigation is committed if commit is specified', async ({ page, server }) => {
+  server.setRoute('/script.js', (req, res) => {});
   server.setRoute('/empty.html', (req, res) => {
-    res.writeHead(200, {
-      'content-type': 'text/html',
-      'content-length': '8192'
-    });
-    // Write enought bytes of the body to trigge response received event.
-    res.write('<title>' + 'A'.repeat(4100));
-    res.uncork();
+    res.setHeader('content-type', 'text/html');
+    res.end('<title>Hello</title><script src="script.js"></script>');
   });
   const response = await page.goto(server.EMPTY_PAGE, { waitUntil: 'commit' });
   expect(response.status()).toBe(200);
+  expect(await page.title()).toBe('Hello');
 });
 
 it('should wait for load when iframe attaches and detaches', async ({ page, server }) => {

--- a/tests/page/page-wait-for-navigation.spec.ts
+++ b/tests/page/page-wait-for-navigation.spec.ts
@@ -61,18 +61,14 @@ it('should work with both domcontentloaded and load', async ({ page, server }) =
 });
 
 it('should work with commit', async ({ page, server }) => {
+  server.setRoute('/script.js', (req, res) => {});
   server.setRoute('/empty.html', (req, res) => {
-    res.writeHead(200, {
-      'content-type': 'text/html',
-      'content-length': '8192'
-    });
-    // Write enought bytes of the body to trigge response received event.
-    res.write('<title>' + 'A'.repeat(4100));
-    res.uncork();
+    res.setHeader('content-type', 'text/html');
+    res.end('<title>Hello</title><script src="script.js"></script>');
   });
-
   page.goto(server.EMPTY_PAGE).catch(e => {});
   await page.waitForNavigation({ waitUntil: 'commit' });
+  expect(await page.title()).toBe('Hello');
 });
 
 it('should work with clicking on anchor links', async ({ page, server }) => {

--- a/tests/page/page-wait-for-url.spec.ts
+++ b/tests/page/page-wait-for-url.spec.ts
@@ -50,18 +50,14 @@ it('should work with both domcontentloaded and load', async ({ page, server }) =
 });
 
 it('should work with commit', async ({ page, server }) => {
+  server.setRoute('/script.js', (req, res) => {});
   server.setRoute('/empty.html', (req, res) => {
-    res.writeHead(200, {
-      'content-type': 'text/html',
-      'content-length': '8192'
-    });
-    // Write enought bytes of the body to trigge response received event.
-    res.write('<title>' + 'A'.repeat(4100));
-    res.uncork();
+    res.setHeader('content-type', 'text/html');
+    res.end('<title>Hello</title><script src="script.js"></script>');
   });
-
   page.goto(server.EMPTY_PAGE).catch(e => {});
   await page.waitForURL('**/empty.html', { waitUntil: 'commit' });
+  expect(await page.title()).toBe('Hello');
 });
 
 it('should work with commit and about:blank', async ({ page, server }) => {


### PR DESCRIPTION
Instead of never finishing the response which works differently across browsers, stall the required script.
This makes "DOMContentLoaded" to never fire and properly tests the "commit" signal.