### PR TITLE
feat: config.globalScripts

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -149,6 +149,18 @@ const config: PlaywrightTestConfig = {
 export default config;
 ```
 
+## property: TestConfig.globalScripts
+* since: v1.30
+- type: ?<[string]|[RegExp]|[Array]<[string]|[RegExp]>>
+
+Files that contain global setup/teardown hooks.
+
+**Details**
+
+[`method: Test.beforeAll`] hooks in the matching files will run before all tests. [`method: Test.afterAll`] hooks in the matching files will run after all tests.
+
+If global setup fails, test execution will be skipped. [`method: Test.afterAll`] hooks will run in the same process as [`method: Test.beforeAll`].
+
 ## property: TestConfig.globalSetup
 * since: v1.10
 - type: ?<[string]>

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -159,7 +159,7 @@ Files that contain global setup/teardown hooks.
 
 [`method: Test.beforeAll`] hooks in the matching files will run before all tests. [`method: Test.afterAll`] hooks in the matching files will run after all tests.
 
-If global setup fails, test execution will be skipped. [`method: Test.afterAll`] hooks will run in the same process as [`method: Test.beforeAll`].
+If global setup fails, test execution will be skipped. [`method: Test.afterAll`] hooks will run in the same worker process as [`method: Test.beforeAll`].
 
 ## property: TestConfig.globalSetup
 * since: v1.10

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -157,7 +157,7 @@ Files that contain global setup/teardown hooks.
 
 **Details**
 
-[`method: Test.beforeAll`] hooks in the matching files will run before all tests. [`method: Test.afterAll`] hooks in the matching files will run after all tests.
+[`method: Test.beforeAll`] hooks in the matching files will run before testing starts. [`method: Test.afterAll`] hooks in the matching files will run after testing finishes.
 
 If global setup fails, test execution will be skipped. [`method: Test.afterAll`] hooks will run in the same worker process as [`method: Test.beforeAll`].
 

--- a/packages/playwright-test/src/dispatcher.ts
+++ b/packages/playwright-test/src/dispatcher.ts
@@ -32,7 +32,7 @@ export type TestGroup = {
   projectId: string;
   tests: TestCase[];
   watchMode: boolean;
-  isProjectSetup: boolean;
+  phase: 'test' | 'projectSetup' | 'globalSetup';
 };
 
 type TestResultData = {
@@ -573,7 +573,7 @@ class Worker extends EventEmitter {
         return { testId: test.id, retry: test.results.length };
       }),
       watchMode: testGroup.watchMode,
-      projectSetup: testGroup.isProjectSetup,
+      phase: testGroup.phase,
     };
     this.send({ method: 'run', params: runPayload });
   }

--- a/packages/playwright-test/src/ipc.ts
+++ b/packages/playwright-test/src/ipc.ts
@@ -95,7 +95,7 @@ export type RunPayload = {
   file: string;
   entries: TestEntry[];
   watchMode: boolean;
-  projectSetup: boolean;
+  phase: 'test' | 'projectSetup' | 'globalSetup';
 };
 
 export type DonePayload = {

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -463,6 +463,9 @@ export class Runner {
       rootSuite.suites = [];
       rootSuite.tests = [];
     } else {
+      // Unlike project setup files global setup always run regardless of the selected tests.
+      // Because of that we don't add global setup entries to shardTests to avoid running empty
+      // shards which have only global setup.
       filterSuiteWithOnlySemantics(rootSuite, () => false, test => shardTests.has(test) || test._phase === 'globalSetup');
     }
   }

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -516,7 +516,7 @@ export class Runner {
 
     // Run tests.
     try {
-      // TODO: run only setups, keep workers alive
+      // TODO: run only setups, keep workers alive, inherit process.env from global setup workers
       let dispatchResult = await this._dispatchToWorkers(globalSetupGroups);
       if (dispatchResult === 'success') {
         if (globalSetupGroups.some(group => group.tests.some(test => !test.ok()))) {

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -520,7 +520,7 @@ export class Runner {
       let dispatchResult = await this._dispatchToWorkers(globalSetupGroups);
       if (dispatchResult === 'success') {
         if (globalSetupGroups.some(group => group.tests.some(test => !test.ok()))) {
-          this._skipTestsFromMatchingGroups(testGroups, () => true);
+          this._skipTestsFromMatchingGroups([...testGroups, ...projectSetupGroups], () => true);
         } else {
           dispatchResult = await this._dispatchToWorkers(projectSetupGroups);
           if (dispatchResult === 'success') {

--- a/packages/playwright-test/src/test.ts
+++ b/packages/playwright-test/src/test.ts
@@ -23,7 +23,7 @@ class Base {
   title: string;
   _only = false;
   _requireFile: string = '';
-  _isProjectSetup: boolean = false;
+  _phase: 'test' | 'projectSetup' | 'globalSetup' = 'test';
 
   constructor(title: string) {
     this.title = title;
@@ -121,7 +121,7 @@ export class Suite extends Base implements reporterTypes.Suite {
     suite._only = this._only;
     suite.location = this.location;
     suite._requireFile = this._requireFile;
-    suite._isProjectSetup = this._isProjectSetup;
+    suite._phase = this._phase;
     suite._use = this._use.slice();
     suite._hooks = this._hooks.slice();
     suite._timeout = this._timeout;
@@ -193,7 +193,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
     const test = new TestCase(this.title, this.fn, this._testType, this.location);
     test._only = this._only;
     test._requireFile = this._requireFile;
-    test._isProjectSetup = this._isProjectSetup;
+    test._phase = this._phase;
     test.expectedStatus = this.expectedStatus;
     test.annotations = this.annotations.slice();
     test._annotateWithInheritence = this._annotateWithInheritence;

--- a/packages/playwright-test/src/testType.ts
+++ b/packages/playwright-test/src/testType.ts
@@ -80,10 +80,10 @@ export class TestTypeImpl {
       ].join('\n'), location);
       return;
     }
-    if (allowedContext === 'projectSetup' && !suite._isProjectSetup)
+    if (allowedContext === 'projectSetup' && suite._phase !== 'projectSetup')
       addFatalError(`${title} is only allowed in a project setup file.`, location);
-    else if (allowedContext === 'test' && suite._isProjectSetup)
-      addFatalError(`${title} is not allowed in a project setup file.`, location);
+    else if (allowedContext === 'test' && suite._phase !== 'test' && suite._phase !== 'globalSetup')
+      addFatalError(`${title} is not allowed in a setup file.`, location);
     return suite;
   }
 
@@ -106,7 +106,7 @@ export class TestTypeImpl {
       return;
     const test = new TestCase(title, fn, this, location);
     test._requireFile = suite._requireFile;
-    test._isProjectSetup = suite._isProjectSetup;
+    test._phase = suite._phase;
     suite._addTest(test);
 
     if (type === 'only' || type === 'projectSetupOnly')
@@ -134,7 +134,7 @@ export class TestTypeImpl {
 
     const child = new Suite(title, 'describe');
     child._requireFile = suite._requireFile;
-    child._isProjectSetup = suite._isProjectSetup;
+    child._phase = suite._phase;
     child.location = location;
     suite._addSuite(child);
 

--- a/packages/playwright-test/src/types.ts
+++ b/packages/playwright-test/src/types.ts
@@ -54,6 +54,10 @@ export interface FullConfigInternal extends FullConfigPublic {
    */
   webServer: FullConfigPublic['webServer'];
   _webServers: Exclude<FullConfigPublic['webServer'], null>[];
+  _globalScripts: string | RegExp | (string | RegExp)[] | null;
+
+  // This is an ephemeral project that is not added to `projects` list below.
+  _globalProject:  FullProjectInternal;
 
   // Overrides the public field.
   projects: FullProjectInternal[];

--- a/packages/playwright-test/src/workerRunner.ts
+++ b/packages/playwright-test/src/workerRunner.ts
@@ -160,7 +160,11 @@ export class WorkerRunner extends EventEmitter {
       return;
 
     this._loader = await Loader.deserialize(this._params.loader);
-    this._project = this._loader.fullConfig().projects.find(p => p._id === this._params.projectId)!;
+    const globalProject = this._loader.fullConfig()._globalProject;
+    if (this._params.projectId === globalProject._id)
+      this._project = globalProject;
+    else
+      this._project = this._loader.fullConfig().projects.find(p => p._id === this._params.projectId)!;
   }
 
   async runTestGroup(runPayload: RunPayload) {
@@ -169,7 +173,7 @@ export class WorkerRunner extends EventEmitter {
     let fatalUnknownTestIds;
     try {
       await this._loadIfNeeded();
-      const fileSuite = await this._loader.loadTestFile(runPayload.file, 'worker', runPayload.projectSetup);
+      const fileSuite = await this._loader.loadTestFile(runPayload.file, 'worker', runPayload.phase);
       const suite = this._loader.buildFileSuiteForProject(this._project, fileSuite, this._params.repeatEachIndex, test => {
         if (runPayload.watchMode) {
           const testResolvedPayload: WatchTestResolvedPayload = {

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -652,13 +652,13 @@ interface TestConfig {
    * **Details**
    *
    * [test.beforeAll(hookFunction)](https://playwright.dev/docs/api/class-test#test-before-all) hooks in the matching
-   * files will run before all tests.
+   * files will run before testing starts.
    * [test.afterAll(hookFunction)](https://playwright.dev/docs/api/class-test#test-after-all) hooks in the matching
-   * files will run after all tests.
+   * files will run after testing finishes.
    *
    * If global setup fails, test execution will be skipped.
    * [test.afterAll(hookFunction)](https://playwright.dev/docs/api/class-test#test-after-all) hooks will run in the same
-   * process as [test.beforeAll(hookFunction)](https://playwright.dev/docs/api/class-test#test-before-all).
+   * worker process as [test.beforeAll(hookFunction)](https://playwright.dev/docs/api/class-test#test-before-all).
    */
   globalScripts?: string|RegExp|Array<string|RegExp>;
 

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -647,6 +647,22 @@ interface TestConfig {
   fullyParallel?: boolean;
 
   /**
+   * Files that contain global setup/teardown hooks.
+   *
+   * **Details**
+   *
+   * [test.beforeAll(hookFunction)](https://playwright.dev/docs/api/class-test#test-before-all) hooks in the matching
+   * files will run before all tests.
+   * [test.afterAll(hookFunction)](https://playwright.dev/docs/api/class-test#test-after-all) hooks in the matching
+   * files will run after all tests.
+   *
+   * If global setup fails, test execution will be skipped.
+   * [test.afterAll(hookFunction)](https://playwright.dev/docs/api/class-test#test-after-all) hooks will run in the same
+   * process as [test.beforeAll(hookFunction)](https://playwright.dev/docs/api/class-test#test-before-all).
+   */
+  globalScripts?: string|RegExp|Array<string|RegExp>;
+
+  /**
    * Path to the global setup file. This file will be required and run before all the tests. It must export a single
    * function that takes a [`TestConfig`] argument.
    *

--- a/tests/playwright-test/global-scripts.spec.ts
+++ b/tests/playwright-test/global-scripts.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import path from 'path';
+import { test, expect } from './playwright-test-fixtures';
+
+type Timeline = { titlePath: string[], event: 'begin' | 'end' }[];
+
+function formatTimeline(timeline: Timeline) {
+  return timeline.map(e => `${e.titlePath.slice(1).join(' > ')} [${e.event}]`).join('\n');
+}
+
+function formatFileNames(timeline: Timeline) {
+  return timeline.map(e => e.titlePath[2]).join('\n');
+}
+
+function fileNames(timeline: Timeline) {
+  const fileNames = Array.from(new Set(timeline.map(({ titlePath }) => {
+    const name = titlePath[2];
+    const index = name.lastIndexOf(path.sep);
+    if (index === -1)
+      return name;
+    return name.slice(index + 1);
+  })).keys());
+  fileNames.sort();
+  return fileNames;
+}
+
+function expectFilesRunBefore(timeline: Timeline, before: string[], after: string[]) {
+  const fileBegin = name => {
+    const index = timeline.findIndex(({ titlePath }) => titlePath[2] === name);
+    expect(index, `cannot find ${name} in\n${formatFileNames(timeline)}`).not.toBe(-1);
+    return index;
+  };
+  const fileEnd = name => {
+    // There is no Array.findLastIndex in Node < 18.
+    let index = -1;
+    for (index = timeline.length - 1; index >= 0; index--) {
+      if (timeline[index].titlePath[2] === name)
+        break;
+    }
+    expect(index, `cannot find ${name} in\n${formatFileNames(timeline)}`).not.toBe(-1);
+    return index;
+  };
+
+  for (const b of before) {
+    const bEnd = fileEnd(b);
+    for (const a of after) {
+      const aBegin = fileBegin(a);
+      expect(bEnd < aBegin, `'${b}' expected to finish before ${a}, actual order:\n${formatTimeline(timeline)}`).toBeTruthy();
+    }
+  }
+}
+
+test('should work for one project', async ({ runGroups }, testInfo) => {
+  const files = {
+    'playwright.config.ts': `
+      module.exports = {
+        globalScripts: /.*global.ts/,
+        projects: [
+          {
+            name: 'p1',
+            testMatch: /.*.test.ts/,
+          },
+        ]
+      };`,
+    'a.test.ts': `
+      const { test } = pwt;
+      test('test1', async () => { });
+      test('test2', async () => { });
+    `,
+    'global.ts': `
+      const { test } = pwt;
+      test('setup1', async () => { });
+      test('setup2', async () => { });
+    `,
+  };
+  const { exitCode, passed, timeline } = await runGroups(files);
+  expect(exitCode).toBe(0);
+  expect(passed).toBe(4);
+  expect(formatTimeline(timeline)).toEqual(`Global Scripts > global.ts > setup1 [begin]
+Global Scripts > global.ts > setup1 [end]
+Global Scripts > global.ts > setup2 [begin]
+Global Scripts > global.ts > setup2 [end]
+p1 > a.test.ts > test1 [begin]
+p1 > a.test.ts > test1 [end]
+p1 > a.test.ts > test2 [begin]
+p1 > a.test.ts > test2 [end]`);
+});
+
+test('should work for several projects', async ({ runGroups }, testInfo) => {
+  const files = {
+    'playwright.config.ts': `
+      module.exports = {
+        globalScripts: /.*global.ts/,
+        projects: [
+          {
+            name: 'p1',
+            testMatch: /.*a.test.ts/,
+          },
+          {
+            name: 'p2',
+            testMatch: /.*b.test.ts/,
+          },
+        ]
+      };`,
+    'a.test.ts': `
+      const { test } = pwt;
+      test('test1', async () => { });
+      test('test2', async () => { });
+    `,
+    'b.test.ts': `
+      const { test } = pwt;
+      test('test1', async () => { });
+      test('test2', async () => { });
+    `,
+    'global.ts': `
+      const { test } = pwt;
+      test('setup1', async () => { });
+      test('setup2', async () => { });
+    `,
+  };
+  const { exitCode, passed, timeline } = await runGroups(files);
+  expect(exitCode).toBe(0);
+  expect(passed).toBe(6);
+  expectFilesRunBefore(timeline, [`global.ts`], [`a.test.ts`, `b.test.ts`]);
+});
+
+test('should skip tests if global setup fails', async ({ runGroups }, testInfo) => {
+  const files = {
+    'playwright.config.ts': `
+      module.exports = {
+        globalScripts: /.*global.ts/,
+        projects: [
+          {
+            name: 'p1',
+            testMatch: /.*a.test.ts/,
+          },
+          {
+            name: 'p2',
+            testMatch: /.*b.test.ts/,
+          },
+        ]
+      };`,
+    'a.test.ts': `
+      const { test } = pwt;
+      test('test1', async () => { });
+      test('test2', async () => { });
+    `,
+    'b.test.ts': `
+      const { test } = pwt;
+      test('test1', async () => { });
+    `,
+    'global.ts': `
+      const { test, expect } = pwt;
+      test('setup1', async () => { });
+      test('setup2', async () => { expect(1).toBe(2) });
+    `,
+  };
+  const { exitCode, passed, skipped } = await runGroups(files);
+  expect(exitCode).toBe(1);
+  expect(passed).toBe(1);
+  expect(skipped).toBe(3);
+});
+
+test('should run setup in each project shard', async ({ runGroups }, testInfo) => {
+  const files = {
+    'playwright.config.ts': `
+      module.exports = {
+        globalScripts: /.*global.ts/,
+        projects: [
+          {
+            name: 'p1',
+          },
+        ]
+      };`,
+    'a.test.ts': `
+      const { test } = pwt;
+      test('test1', async () => { });
+      test('test2', async () => { });
+      test('test3', async () => { });
+      test('test4', async () => { });
+    `,
+    'b.test.ts': `
+      const { test } = pwt;
+      test('test1', async () => { });
+      test('test2', async () => { });
+    `,
+    'global.ts': `
+      const { test, expect } = pwt;
+      test('setup1', async () => { });
+      test('setup2', async () => { });
+    `,
+  };
+
+  { // Shard 1/2
+    const { exitCode, passed, timeline, output } =  await runGroups(files, { shard: '1/2' });
+    expect(output).toContain('Running 6 tests using 1 worker, shard 1 of 2');
+    expect(fileNames(timeline)).toEqual(['a.test.ts', 'global.ts']);
+    expectFilesRunBefore(timeline, [`global.ts`], [`a.test.ts`]);
+    expect(exitCode).toBe(0);
+    expect(passed).toBe(6);
+  }
+  { // Shard 2/2
+    const { exitCode, passed, timeline, output } =  await runGroups(files, { shard: '2/2' });
+    expect(output).toContain('Running 4 tests using 1 worker, shard 2 of 2');
+    expect(fileNames(timeline)).toEqual(['b.test.ts', 'global.ts']);
+    expectFilesRunBefore(timeline, [`global.ts`], [`b.test.ts`]);
+    expect(exitCode).toBe(0);
+    expect(passed).toBe(4);
+  }
+});
+

--- a/tests/playwright-test/project-setup.spec.ts
+++ b/tests/playwright-test/project-setup.spec.ts
@@ -892,7 +892,7 @@ test('should prohibit beforeAll hooks in setup files', async ({ runGroups }, tes
 
   const { exitCode, output } =  await runGroups(files);
   expect(exitCode).toBe(1);
-  expect(output).toContain('test.beforeAll() is not allowed in a project setup file');
+  expect(output).toContain('test.beforeAll() is not allowed in a setup file');
 });
 
 test('should prohibit test in setup files', async ({ runGroups }, testInfo) => {
@@ -914,7 +914,7 @@ test('should prohibit test in setup files', async ({ runGroups }, testInfo) => {
 
   const { exitCode, output } =  await runGroups(files);
   expect(exitCode).toBe(1);
-  expect(output).toContain('test() is not allowed in a project setup file');
+  expect(output).toContain('test() is not allowed in a setup file');
 });
 
 test('should prohibit test hooks in setup files', async ({ runGroups }, testInfo) => {
@@ -936,5 +936,5 @@ test('should prohibit test hooks in setup files', async ({ runGroups }, testInfo
 
   const { exitCode, output } =  await runGroups(files);
   expect(exitCode).toBe(1);
-  expect(output).toContain('test.beforeEach() is not allowed in a project setup file');
+  expect(output).toContain('test.beforeEach() is not allowed in a setup file');
 });


### PR DESCRIPTION
Introduce config.globalScripts. Tests from the matching files will run before all projects. We'll only allow beforeAll/afterAll instead of tests in such files (next PR).

Global scripts are executed as part of 'Global Scripts' project which is not present in FullConfig.projects but may be referenced by corresponding global setup Suites.