### PR TITLE
fix: remove export for file that doesn't exist

### DIFF
--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -17,7 +17,6 @@
     },
     "./cli": "./cli.js",
     "./package.json": "./package.json",
-    "./lib/ci": "./lib/ci.js",
     "./lib/cli": "./lib/cli.js",
     "./lib/experimentalLoader": "./lib/experimentalLoader.js",
     "./lib/mount": "./lib/mount.js",


### PR DESCRIPTION
Signed-off-by: Ben McCann <322311+benmccann@users.noreply.github.com>

https://publint.dev/@playwright/test@1.29.2