### PR TITLE
chore: drop `locator.viewportRatio()` method

### DIFF
--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -2031,12 +2031,6 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Locator.uncheck.trial = %%-input-trial-%%
 * since: v1.14
 
-## async method: Locator.viewportRatio
-* since: v1.30
-- returns: <[float]>
-
-Returns the ratio of intersection between viewport and the element, according to the [intersection observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
-
 ## async method: Locator.waitFor
 * since: v1.16
 

--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -257,10 +257,6 @@ export class Locator implements api.Locator {
     return this._withElement((h, timeout) => h.scrollIntoViewIfNeeded({ ...options, timeout }), options.timeout);
   }
 
-  async viewportRatio(): Promise<number> {
-    return (await this._frame._channel.viewportRatio({ selector: this._selector, strict: true })).value;
-  }
-
   async selectOption(values: string | api.ElementHandle | SelectOption | string[] | api.ElementHandle[] | SelectOption[] | null, options: SelectOptionOptions = {}): Promise<string[]> {
     return this._frame.selectOption(this._selector, values, { strict: true, ...options });
   }

--- a/packages/playwright-core/src/protocol/debug.ts
+++ b/packages/playwright-core/src/protocol/debug.ts
@@ -66,7 +66,6 @@ export const commandsWithTracingSnapshots = new Set([
   'Frame.isEnabled',
   'Frame.isHidden',
   'Frame.isVisible',
-  'Frame.viewportRatio',
   'Frame.isEditable',
   'Frame.press',
   'Frame.selectOption',

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1425,13 +1425,6 @@ scheme.FrameIsVisibleParams = tObject({
 scheme.FrameIsVisibleResult = tObject({
   value: tBoolean,
 });
-scheme.FrameViewportRatioParams = tObject({
-  selector: tString,
-  strict: tOptional(tBoolean),
-});
-scheme.FrameViewportRatioResult = tObject({
-  value: tNumber,
-});
 scheme.FrameIsEditableParams = tObject({
   selector: tString,
   strict: tOptional(tBoolean),

--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -203,10 +203,6 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Pa
     return { value: await this._frame.isVisible(metadata, params.selector, params) };
   }
 
-  async viewportRatio(params: channels.FrameViewportRatioParams, metadata: CallMetadata): Promise<channels.FrameViewportRatioResult> {
-    return { value: await this._frame.viewportRatio(metadata, params.selector, params) };
-  }
-
   async hover(params: channels.FrameHoverParams, metadata: CallMetadata): Promise<void> {
     return await this._frame.hover(metadata, params.selector, params);
   }

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1318,22 +1318,6 @@ export class Frame extends SdkObject {
     }, this._page._timeoutSettings.timeout({}));
   }
 
-  async viewportRatio(metadata: CallMetadata, selector: string, options: types.StrictOptions = {}): Promise<number> {
-    const controller = new ProgressController(metadata, this);
-    return controller.run(async progress => {
-      progress.log(`  calculating viewport ratio of ${this._asLocator(selector)}`);
-      const resolved = await this._resolveInjectedForSelector(progress, selector, options);
-      if (!resolved)
-        return 0;
-      return await resolved.injected.evaluate(async (injected, { info }) => {
-        const element = injected.querySelector(info.parsed, document, info.strict);
-        if (!element)
-          return 0;
-        return await injected.viewportRatio(element);
-      }, { info: resolved.info });
-    }, this._page._timeoutSettings.timeout({}));
-  }
-
   async isHidden(metadata: CallMetadata, selector: string, options: types.StrictOptions = {}): Promise<boolean> {
     return !(await this.isVisible(metadata, selector, options));
   }

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -11964,12 +11964,6 @@ export interface Locator {
   }): Promise<void>;
 
   /**
-   * Returns the ratio of intersection between viewport and the element, according to the
-   * [intersection observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
-   */
-  viewportRatio(): Promise<number>;
-
-  /**
    * Returns when element specified by locator satisfies the `state` option.
    *
    * If target element already satisfies the condition, the method returns immediately. Otherwise, waits for up to

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -2196,7 +2196,6 @@ export interface FrameChannel extends FrameEventTarget, Channel {
   isEnabled(params: FrameIsEnabledParams, metadata?: Metadata): Promise<FrameIsEnabledResult>;
   isHidden(params: FrameIsHiddenParams, metadata?: Metadata): Promise<FrameIsHiddenResult>;
   isVisible(params: FrameIsVisibleParams, metadata?: Metadata): Promise<FrameIsVisibleResult>;
-  viewportRatio(params: FrameViewportRatioParams, metadata?: Metadata): Promise<FrameViewportRatioResult>;
   isEditable(params: FrameIsEditableParams, metadata?: Metadata): Promise<FrameIsEditableResult>;
   press(params: FramePressParams, metadata?: Metadata): Promise<FramePressResult>;
   querySelector(params: FrameQuerySelectorParams, metadata?: Metadata): Promise<FrameQuerySelectorResult>;
@@ -2593,16 +2592,6 @@ export type FrameIsVisibleOptions = {
 };
 export type FrameIsVisibleResult = {
   value: boolean,
-};
-export type FrameViewportRatioParams = {
-  selector: string,
-  strict?: boolean,
-};
-export type FrameViewportRatioOptions = {
-  strict?: boolean,
-};
-export type FrameViewportRatioResult = {
-  value: number,
 };
 export type FrameIsEditableParams = {
   selector: string,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1908,15 +1908,6 @@ Frame:
       tracing:
         snapshot: true
 
-    viewportRatio:
-      parameters:
-        selector: string
-        strict: boolean?
-      returns:
-        value: number
-      tracing:
-        snapshot: true
-
     isEditable:
       parameters:
         selector: string

--- a/tests/page/locator-misc-2.spec.ts
+++ b/tests/page/locator-misc-2.spec.ts
@@ -155,17 +155,3 @@ it('locator.count should work with deleted Map in main world', async ({ page }) 
   await expect(page.locator('#searchResultTableDiv .x-grid3-row')).toHaveCount(0);
 });
 
-it('locator.viewportRatio', async ({ page }) => {
-  await page.setContent(`
-    <style>body { overflow: hidden; padding: 0; margin: 0; } div { position: absolute; left: 0; top: 0 }</style>
-    <div id=fills-viewport style='width: 100vw; height: 100vh;'></div>
-    <div id=half-viewport style='width: 50vw; height: 100vh;'></div>
-    <div id=twice-viewport style='width: 200vw; height: 100vh;'></div>
-    <div id=off-viewport style='left:100vw; width: 100vw; height: 100vh;'></div>
-  `);
-  expect.soft(await page.locator('#fills-viewport').viewportRatio()).toBe(1);
-  expect.soft(await page.locator('#half-viewport').viewportRatio()).toBe(1);
-  expect.soft(await page.locator('#twice-viewport').viewportRatio()).toBe(0.5);
-  expect.soft(await page.locator('#off-viewport').viewportRatio()).toBe(0);
-  expect.soft(await page.locator('#does-not-exist').viewportRatio()).toBe(0);
-});


### PR DESCRIPTION
As per API review discussion, we'd like to refrain from
exposing this method.
