### PR TITLE
test: fix toIntersectViewport test on WebKit @ Ubuntu 22.04

### DIFF
--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -290,7 +290,7 @@ test.describe('toIntersectViewport', () => {
   test('should work', async ({ page }) => {
     await page.setContent(`
       <div id=big style="height: 10000px;"></div>
-      <span id=small>foo</span>
+      <div id=small>foo</div>
     `);
     await expect(page.locator('#big')).toIntersectViewport();
     await expect(page.locator('#small')).not.toIntersectViewport();


### PR DESCRIPTION
For some reason scrolling inline element into view doesn't
always work.
