### PR TITLE
fix: filter out pwt stacks correctly

### DIFF
--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -30,11 +30,9 @@ export function rewriteErrorMessage<E extends Error>(e: E, newMessage: string): 
 const CORE_DIR = path.resolve(__dirname, '..', '..');
 const CORE_LIB = path.join(CORE_DIR, 'lib');
 const CORE_SRC = path.join(CORE_DIR, 'src');
-const TEST_DIR_SRC = path.resolve(CORE_DIR, '..', 'playwright-test');
 const COVERAGE_PATH = path.join(CORE_DIR, '..', '..', 'tests', 'config', 'coverage.js');
 
 const stackFilters = [
-  (frame: StackFrame) => frame.file.startsWith(TEST_DIR_SRC),
   (frame: StackFrame) => frame.file.startsWith(CORE_DIR),
 ];
 export const addStackFilter = (filter: (frame: StackFrame) => boolean) => stackFilters.push(filter);

--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -128,7 +128,7 @@ export function captureStackTrace(rawStack?: string): ParsedStackTrace {
   parsedFrames = parsedFrames.filter((f, i) => {
     if (process.env.PWDEBUGIMPL)
       return true;
-    if (stackFilters.some(filter => filter(f.frame)))
+    if (stackIgnoreFilters.some(filter => filter(f.frame)))
       return false;
     return true;
   });

--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -31,8 +31,13 @@ const CORE_DIR = path.resolve(__dirname, '..', '..');
 const CORE_LIB = path.join(CORE_DIR, 'lib');
 const CORE_SRC = path.join(CORE_DIR, 'src');
 const TEST_DIR_SRC = path.resolve(CORE_DIR, '..', 'playwright-test');
-const TEST_DIR_LIB = path.resolve(CORE_DIR, '..', '@playwright', 'test');
 const COVERAGE_PATH = path.join(CORE_DIR, '..', '..', 'tests', 'config', 'coverage.js');
+
+const stackFilters = [
+  (frame: StackFrame) => frame.file.startsWith(TEST_DIR_SRC),
+  (frame: StackFrame) => frame.file.startsWith(CORE_DIR),
+];
+export const addStackFilter = (filter: (frame: StackFrame) => boolean) => stackFilters.push(filter);
 
 export type StackFrame = {
   file: string,
@@ -125,9 +130,7 @@ export function captureStackTrace(rawStack?: string): ParsedStackTrace {
   parsedFrames = parsedFrames.filter((f, i) => {
     if (process.env.PWDEBUGIMPL)
       return true;
-    if (f.frame.file.startsWith(TEST_DIR_SRC) || f.frame.file.startsWith(TEST_DIR_LIB))
-      return false;
-    if (f.frame.file.startsWith(CORE_DIR))
+    if (stackFilters.some(filter => filter(f.frame)))
       return false;
     return true;
   });

--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -32,10 +32,10 @@ const CORE_LIB = path.join(CORE_DIR, 'lib');
 const CORE_SRC = path.join(CORE_DIR, 'src');
 const COVERAGE_PATH = path.join(CORE_DIR, '..', '..', 'tests', 'config', 'coverage.js');
 
-const stackFilters = [
+const stackIgnoreFilters = [
   (frame: StackFrame) => frame.file.startsWith(CORE_DIR),
 ];
-export const addStackFilter = (filter: (frame: StackFrame) => boolean) => stackFilters.push(filter);
+export const addStackIgnoreFilter = (filter: (frame: StackFrame) => boolean) => stackIgnoreFilters.push(filter);
 
 export type StackFrame = {
   file: string,

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { APIRequestContext, BrowserContext, BrowserContextOptions, LaunchOptions, Page, Tracing, Video } from 'playwright-core';
 import * as playwrightLibrary from 'playwright-core';
-import { createGuid, debugMode, removeFolders, addStackFilter } from 'playwright-core/lib/utils';
+import { createGuid, debugMode, removeFolders, addStackIgnoreFilter } from 'playwright-core/lib/utils';
 import type { Fixtures, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, ScreenshotMode, TestInfo, TestType, TraceMode, VideoMode } from '../types/test';
 import { store as _baseStore } from './store';
 import type { TestInfoImpl } from './testInfo';
@@ -29,7 +29,7 @@ export { addRunnerPlugin as _addRunnerPlugin } from './plugins';
 export const _baseTest: TestType<{}, {}> = rootTestType.test;
 export const store = _baseStore;
 
-addStackFilter((frame: StackFrame) => frame.file.startsWith(path.join(__dirname, '..')));
+addStackIgnoreFilter((frame: StackFrame) => frame.file.startsWith(path.join(__dirname, '..')));
 
 if ((process as any)['__pw_initiator__']) {
   const originalStackTraceLimit = Error.stackTraceLimit;

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -29,7 +29,7 @@ export { addRunnerPlugin as _addRunnerPlugin } from './plugins';
 export const _baseTest: TestType<{}, {}> = rootTestType.test;
 export const store = _baseStore;
 
-addStackIgnoreFilter((frame: StackFrame) => frame.file.startsWith(path.join(__dirname, '..')));
+addStackIgnoreFilter((frame: StackFrame) => frame.file.startsWith(path.dirname(require.resolve('../package.json'))));
 
 if ((process as any)['__pw_initiator__']) {
   const originalStackTraceLimit = Error.stackTraceLimit;

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { APIRequestContext, BrowserContext, BrowserContextOptions, LaunchOptions, Page, Tracing, Video } from 'playwright-core';
 import * as playwrightLibrary from 'playwright-core';
-import { createGuid, debugMode, removeFolders } from 'playwright-core/lib/utils';
+import { createGuid, debugMode, removeFolders, addStackFilter } from 'playwright-core/lib/utils';
 import type { Fixtures, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, ScreenshotMode, TestInfo, TestType, TraceMode, VideoMode } from '../types/test';
 import { store as _baseStore } from './store';
 import type { TestInfoImpl } from './testInfo';
@@ -28,6 +28,8 @@ export { expect } from './expect';
 export { addRunnerPlugin as _addRunnerPlugin } from './plugins';
 export const _baseTest: TestType<{}, {}> = rootTestType.test;
 export const store = _baseStore;
+
+addStackFilter((frame: StackFrame) => frame.file.startsWith(path.join(__dirname, '..')));
 
 if ((process as any)['__pw_initiator__']) {
   const originalStackTraceLimit = Error.stackTraceLimit;


### PR DESCRIPTION
Not sure where to write a test for that.

The issue was that `TEST_DIR_LIB` resolved to:

```
C:\Users\maxschmitt\development\tmp\pw-codegen-repro\node_modules\@playwright\test\node_modules\@playwright\test
```

instead of:

```
C:\Users\maxschmitt\development\tmp\pw-codegen-repro\node_modules\@playwright\test\lib
```

So `C:\Users\maxschmitt\development\tmp\pw-codegen-repro\node_modules\@playwright\test\lib\util.js` did not get filtered out.

Fixes https://github.com/microsoft/playwright/issues/20155