### PR TITLE
docs(test-parameterize): fix typos

### DIFF
--- a/docs/src/test-parameterize-js.md
+++ b/docs/src/test-parameterize-js.md
@@ -1,9 +1,9 @@
 ---
 id: test-parameterize
-title: "Parametrize tests"
+title: "Parameterize tests"
 ---
 
-You can either parametrize tests on a test level or on a project level.
+You can either parameterize tests on a test level or on a project level.
 
 ## Parameterized Tests
 
@@ -173,7 +173,7 @@ export const test = base.extend<TestOptions>({
 ```
 
 :::note
-Parametrized projects behavior has changed in version 1.18. [Learn more](./release-notes#breaking-change-custom-config-options).
+Parameterized projects behavior has changed in version 1.18. [Learn more](./release-notes#breaking-change-custom-config-options).
 :::
 
 ## Passing Environment Variables


### PR DESCRIPTION
Fixed additional typos of parameterized missed by 80235c47a5fb142c3b21fbbb9350de81b60e6faf

Signed-off-by: Rob Donnelly <rfdonnelly@gmail.com>