### PR TITLE
feat(screenshots): when actual and expected have different sizes, pad and produce the diff image

### DIFF
--- a/packages/html-reporter/src/imageDiffView.css
+++ b/packages/html-reporter/src/imageDiffView.css
@@ -21,10 +21,27 @@
   position: relative;
 }
 
-.image-diff-view img {
-  flex: none;
+.image-diff-view .image-wrapper img {
+  flex: auto;
   box-shadow: var(--box-shadow-thick);
   margin: 24px auto;
   min-width: 200px;
   max-width: 80%;
+}
+
+.image-diff-view .image-wrapper {
+  flex: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.image-diff-view .image-wrapper div {
+  flex: none;
+  align-self: stretch;
+  height: 2em;
+  font-weight: 500;
+  padding-top: 1em;
+  display: flex;
+  flex-direction: row;
 }

--- a/packages/html-reporter/src/imageDiffView.spec.tsx
+++ b/packages/html-reporter/src/imageDiffView.spec.tsx
@@ -54,7 +54,7 @@ test('should show actual by default', async ({ mount }) => {
   for (let i = 0; i < imageCount; ++i) {
     const image = images.nth(i);
     const box = await image.boundingBox();
-    expect(box).toEqual({ x: 400, y: 80, width: 200, height: 200 });
+    expect(box).toEqual({ x: 400, y: 108, width: 200, height: 200 });
   }
 });
 
@@ -69,7 +69,7 @@ test('should switch to expected', async ({ mount }) => {
   for (let i = 0; i < imageCount; ++i) {
     const image = images.nth(i);
     const box = await image.boundingBox();
-    expect(box).toEqual({ x: 400, y: 80, width: 200, height: 200 });
+    expect(box).toEqual({ x: 400, y: 108, width: 200, height: 200 });
   }
 });
 
@@ -79,5 +79,5 @@ test('should switch to diff', async ({ mount }) => {
 
   const image = component.locator('img');
   const box = await image.boundingBox();
-  expect(box).toEqual({ x: 400, y: 80, width: 200, height: 200 });
+  expect(box).toEqual({ x: 400, y: 108, width: 200, height: 200 });
 });

--- a/packages/html-reporter/src/imageDiffView.tsx
+++ b/packages/html-reporter/src/imageDiffView.tsx
@@ -54,35 +54,35 @@ export const ImageDiffView: React.FunctionComponent<{
       id: 'actual',
       title: 'Actual',
       render: () => <ImageDiffSlider sliderPosition={sliderPosition} setSliderPosition={setSliderPosition}>
-        <img src={diff.expected!.attachment.path!} onLoad={() => onImageLoaded('right')} ref={imageElement} />
-        <img src={diff.actual!.attachment.path!} />
+        <ImageWithSize src={diff.expected!.attachment.path!} onLoad={() => onImageLoaded('right')} imageRef={imageElement} style={{ boxShadow: 'none' }} />
+        <ImageWithSize src={diff.actual!.attachment.path!} />
       </ImageDiffSlider>,
     });
     tabs.push({
       id: 'expected',
       title: diff.expected!.title,
       render: () => <ImageDiffSlider sliderPosition={sliderPosition} setSliderPosition={setSliderPosition}>
-        <img src={diff.expected!.attachment.path!} onLoad={() => onImageLoaded('left')} ref={imageElement} />
-        <img src={diff.actual!.attachment.path!} style={{ boxShadow: 'none' }} />
+        <ImageWithSize src={diff.expected!.attachment.path!} onLoad={() => onImageLoaded('left')} imageRef={imageElement} />
+        <ImageWithSize src={diff.actual!.attachment.path!} style={{ boxShadow: 'none' }} />
       </ImageDiffSlider>,
     });
   } else {
     tabs.push({
       id: 'actual',
       title: 'Actual',
-      render: () => <img src={diff.actual!.attachment.path!} onLoad={() => onImageLoaded()} />
+      render: () => <ImageWithSize src={diff.actual!.attachment.path!} onLoad={() => onImageLoaded()} />
     });
     tabs.push({
       id: 'expected',
       title: diff.expected!.title,
-      render: () => <img src={diff.expected!.attachment.path!} onLoad={() => onImageLoaded()} />
+      render: () => <ImageWithSize src={diff.expected!.attachment.path!} onLoad={() => onImageLoaded()} />
     });
   }
   if (diff.diff) {
     tabs.push({
       id: 'diff',
       title: 'Diff',
-      render: () => <img src={diff.diff!.attachment.path} onLoad={() => onImageLoaded()} />
+      render: () => <ImageWithSize src={diff.diff!.attachment.path!} onLoad={() => onImageLoaded()} />
     });
   }
   return <div className='vbox image-diff-view' data-testid='test-result-image-mismatch' ref={diffElement}>
@@ -165,6 +165,29 @@ export const ImageDiffSlider: React.FC<React.PropsWithChildren<{
       </div>
     </div>
   </>;
+};
+
+const ImageWithSize: React.FunctionComponent<{
+  src: string,
+  onLoad?: () => void,
+  imageRef?: React.RefObject<HTMLImageElement>,
+  style?: React.CSSProperties,
+}> = ({ src, onLoad, imageRef, style }) => {
+  const newRef = React.useRef<HTMLImageElement>(null);
+  const ref = imageRef ?? newRef;
+  const [size, setSize] = React.useState<{ width: number, height: number } | null>(null);
+  return <div className='image-wrapper'>
+    <div>
+      <span style={{ flex: '1 1 0', textAlign: 'end' }}>{ size ? size.width : ''}</span>
+      <span style={{ flex: 'none', margin: '0 5px' }}>x</span>
+      <span style={{ flex: '1 1 0', textAlign: 'start' }}>{ size ? size.height : ''}</span>
+    </div>
+    <img src={src} onLoad={() => {
+      onLoad?.();
+      if (ref.current)
+        setSize({ width: ref.current.naturalWidth, height: ref.current.naturalHeight });
+    }} ref={ref} style={style} />
+  </div>;
 };
 
 const absolute: React.CSSProperties = {

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -927,7 +927,7 @@ test('should attach expected/actual/diff', async ({ runInlineTest }, testInfo) =
   ]);
 });
 
-test('should attach expected/actual and no diff', async ({ runInlineTest }, testInfo) => {
+test('should attach expected/actual/diff for different sizes', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...files,
     'a.spec.js-snapshots/snapshot.png':
@@ -945,6 +945,7 @@ test('should attach expected/actual and no diff', async ({ runInlineTest }, test
 
   const outputText = stripAnsi(result.output);
   expect(outputText).toContain('Expected an image 2px by 2px, received 1px by 1px.');
+  expect(outputText).toContain('4 pixels (ratio 1.00 of all image pixels) are different.');
   const attachments = outputText.split('\n').filter(l => l.startsWith('## ')).map(l => l.substring(3)).map(l => JSON.parse(l))[0];
   for (const attachment of attachments)
     attachment.path = attachment.path.replace(/\\/g, '/').replace(/.*test-results\//, '');
@@ -958,6 +959,11 @@ test('should attach expected/actual and no diff', async ({ runInlineTest }, test
       name: 'snapshot-actual.png',
       contentType: 'image/png',
       path: 'a-is-a-test/snapshot-actual.png'
+    },
+    {
+      name: 'snapshot-diff.png',
+      contentType: 'image/png',
+      path: 'a-is-a-test/snapshot-diff.png'
     },
   ]);
 });

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -137,6 +137,7 @@ test('should include image diff', async ({ runInlineTest, page, showReport }) =>
   set.add(await expectedImage.getAttribute('src'));
   set.add(await actualImage.getAttribute('src'));
   expect(set.size, 'Should be two images overlaid').toBe(2);
+  await expect(imageDiff).toContainText('200x200');
 
   const sliderElement = imageDiff.locator('data-testid=test-result-image-mismatch-grip');
   await expect.poll(() => sliderElement.evaluate(e => e.style.left), 'Actual slider is on the right').toBe('590px');

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -943,7 +943,7 @@ test('should throw for invalid maxDiffPixelRatio values', async ({ runInlineTest
 });
 
 
-test('should attach expected/actual and no diff when sizes are different', async ({ runInlineTest }, testInfo) => {
+test('should attach expected/actual/diff when sizes are different', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...playwrightConfig({
       snapshotPathTemplate: '__screenshots__/{testFilePath}/{arg}{ext}',
@@ -962,6 +962,7 @@ test('should attach expected/actual and no diff when sizes are different', async
   expect(result.exitCode).toBe(1);
   const outputText = stripAnsi(result.output);
   expect(outputText).toContain('Expected an image 2px by 2px, received 1280px by 720px.');
+  expect(outputText).toContain('4 pixels (ratio 0.01 of all image pixels) are different.');
   const attachments = outputText.split('\n').filter(l => l.startsWith('## ')).map(l => l.substring(3)).map(l => JSON.parse(l))[0];
   for (const attachment of attachments)
     attachment.path = attachment.path.replace(/\\/g, '/').replace(/.*test-results\//, '');
@@ -975,6 +976,11 @@ test('should attach expected/actual and no diff when sizes are different', async
       name: 'snapshot-actual.png',
       contentType: 'image/png',
       path: 'a-is-a-test/snapshot-actual.png'
+    },
+    {
+      name: 'snapshot-diff.png',
+      contentType: 'image/png',
+      path: 'a-is-a-test/snapshot-diff.png'
     },
   ]);
 });


### PR DESCRIPTION
Also show sizes in the html report to easier spot the size mismatch issue.

<img width="1030" alt="diff" src="https://user-images.githubusercontent.com/9881434/213327632-b8fcd69c-8d08-460c-9de1-b5f4f8c56359.png">

Fixes #15802.