### PR TITLE
docs: Added Testmo to the community tools list

### DIFF
--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -50,6 +50,7 @@ title: "Community Showcase"
 * [Testim Playground](https://www.testim.io/playground/): Record Playwright UI tests as code
 * [Tesults](https://www.tesults.com/docs/playwright): Test automation reporting application and dashboard with Playwright integration
 * [Try Playwright](https://try.playwright.tech/): Interactive playground for Playwright to run examples directly from your browser
+* [Testmo](https://www.testmo.com/tools/playwright-test-management): Test management tool with Playwright reporting and test result integration
 
 ## Frameworks
 


### PR DESCRIPTION
I've added a community tool link to Testmo's Playwright integration page. I would appreciate merging this.