### PR TITLE
chore: remove toIntersectViewport for the next release

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -1719,19 +1719,3 @@ Expected options currently selected.
 
 ### option: LocatorAssertions.toHaveValues.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.23
-
-## async method: LocatorAssertions.toIntersectViewport
-* since: v1.30
-* langs: js
-
-Ensures the [Locator] points to an element that intersects viewport, according to the [intersection observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
-
-**Usage**
-
-```js
-const locator = page.locator('button.submit');
-await expect(locator).toIntersectViewport();
-```
-
-### option: LocatorAssertions.toIntersectViewport.timeout = %%-js-assertions-timeout-%%
-* since: v1.30

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -43,7 +43,6 @@ By default, the timeout for assertions is set to 5 seconds. Learn more about [va
 | [`method: LocatorAssertions.toHaveText`] | Element matches text |
 | [`method: LocatorAssertions.toHaveValue`] | Input has a value |
 | [`method: LocatorAssertions.toHaveValues`] | Select has options selected |
-| [`method: LocatorAssertions.toIntersectViewport`] | Element intersects viewport |
 | [`method: PageAssertions.toHaveScreenshot#1`] | Page has a screenshot |
 | [`method: PageAssertions.toHaveTitle`] | Page has a title |
 | [`method: PageAssertions.toHaveURL`] | Page has a URL |

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1426,7 +1426,7 @@ export class Frame extends SdkObject {
         const injected = await context.injectedScript();
         progress.throwIfAborted();
 
-        const { log, matches, received } = await injected.evaluate(async (injected, { info, options, snapshotName }) => {
+        const { log, matches, received } = await injected.evaluate((injected, { info, options, snapshotName }) => {
           const elements = info ? injected.querySelectorAll(info.parsed, document) : [];
           const isArray = options.expression === 'to.have.count' || options.expression.endsWith('.array');
           let log = '';
@@ -1438,7 +1438,7 @@ export class Frame extends SdkObject {
             log = `  locator resolved to ${injected.previewNode(elements[0])}`;
           if (snapshotName)
             injected.markTargetElements(new Set(elements), snapshotName);
-          return { log, ...(await injected.expect(elements[0], options, elements)) };
+          return { log, ...injected.expect(elements[0], options, elements) };
         }, { info, options, snapshotName: progress.metadata.afterSnapshot });
 
         if (log)

--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -1119,7 +1119,7 @@ export class InjectedScript {
     this.onGlobalListenersRemoved.add(addHitTargetInterceptorListeners);
   }
 
-  async expect(element: Element | undefined, options: FrameExpectParams, elements: Element[]) {
+  expect(element: Element | undefined, options: FrameExpectParams, elements: Element[]) {
     const isArray = options.expression === 'to.have.count' || options.expression.endsWith('.array');
     if (isArray)
       return this.expectArray(elements, options);
@@ -1130,16 +1130,13 @@ export class InjectedScript {
       // expect(locator).not.toBeVisible() passes when there is no element.
       if (options.isNot && options.expression === 'to.be.visible')
         return { matches: false };
-      // expect(locator).not.toIntersectViewport() passes when there is no element.
-      if (options.isNot && options.expression === 'to.intersect.viewport')
-        return { matches: false };
       // When none of the above applies, expect does not match.
       return { matches: options.isNot };
     }
-    return await this.expectSingleElement(element, options);
+    return this.expectSingleElement(element, options);
   }
 
-  private async expectSingleElement(element: Element, options: FrameExpectParams): Promise<{ matches: boolean, received?: any }> {
+  private expectSingleElement(element: Element, options: FrameExpectParams): { matches: boolean, received?: any } {
     const expression = options.expression;
 
     {
@@ -1185,13 +1182,6 @@ export class InjectedScript {
         const received = (element as any)[options.expressionArg];
         const matches = deepEquals(received, options.expectedValue);
         return { received, matches };
-      }
-    }
-    {
-      // Viewport intersection
-      if (expression === 'to.intersect.viewport') {
-        const ratio = await this.viewportRatio(element);
-        return { received: `viewport ratio ${ratio}`, matches: ratio > 0 };
       }
     }
 

--- a/packages/playwright-test/src/expect.ts
+++ b/packages/playwright-test/src/expect.ts
@@ -38,7 +38,6 @@ import {
   toHaveURL,
   toHaveValue,
   toHaveValues,
-  toIntersectViewport,
   toPass
 } from './matchers/matchers';
 import { toMatchSnapshot, toHaveScreenshot } from './matchers/toMatchSnapshot';
@@ -144,7 +143,6 @@ const customMatchers = {
   toHaveURL,
   toHaveValue,
   toHaveValues,
-  toIntersectViewport,
   toMatchSnapshot,
   toHaveScreenshot,
   toPass,

--- a/packages/playwright-test/src/matchers/matchers.ts
+++ b/packages/playwright-test/src/matchers/matchers.ts
@@ -117,16 +117,6 @@ export function toBeVisible(
   }, options);
 }
 
-export function toIntersectViewport(
-  this: ReturnType<Expect['getState']>,
-  locator: LocatorEx,
-  options?: { timeout?: number },
-) {
-  return toBeTruthy.call(this, 'toIntersectViewport', locator, 'Locator', async (isNot, timeout, customStackTrace) => {
-    return await locator._expect(customStackTrace, 'to.intersect.viewport', { isNot, timeout });
-  }, options);
-}
-
 export function toContainText(
   this: ReturnType<Expect['getState']>,
   locator: LocatorEx,

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -4539,26 +4539,6 @@ interface LocatorAssertions {
      */
     timeout?: number;
   }): Promise<void>;
-
-  /**
-   * Ensures the [Locator] points to an element that intersects viewport, according to the
-   * [intersection observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
-   *
-   * **Usage**
-   *
-   * ```js
-   * const locator = page.locator('button.submit');
-   * await expect(locator).toIntersectViewport();
-   * ```
-   *
-   * @param options
-   */
-  toIntersectViewport(options?: {
-    /**
-     * Time to retry the assertion for. Defaults to `timeout` in `TestConfig.expect`.
-     */
-    timeout?: number;
-  }): Promise<void>;
 }
 
 /**

--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -285,38 +285,3 @@ test.describe('toHaveId', () => {
     await expect(locator).toHaveId('node');
   });
 });
-
-test.describe('toIntersectViewport', () => {
-  test('should work', async ({ page }) => {
-    await page.setContent(`
-      <div id=big style="height: 10000px;"></div>
-      <div id=small>foo</div>
-    `);
-    await expect(page.locator('#big')).toIntersectViewport();
-    await expect(page.locator('#small')).not.toIntersectViewport();
-    await page.locator('#small').scrollIntoViewIfNeeded();
-    await expect(page.locator('#small')).toIntersectViewport();
-  });
-
-  test('should have good stack', async ({ page }) => {
-    let error;
-    try {
-      await expect(page.locator('body')).not.toIntersectViewport({ timeout: 100 });
-    } catch (e) {
-      error = e;
-    }
-    expect(error).toBeTruthy();
-    expect(/unexpected value "viewport ratio \d+/.test(error.stack)).toBe(true);
-    const stackFrames = error.stack.split('\n').filter(line => line.trim().startsWith('at '));
-    expect(stackFrames.length).toBe(1);
-    expect(stackFrames[0]).toContain(__filename);
-  });
-
-  test('should report intersection even if fully covered by other element', async ({ page }) => {
-    await page.setContent(`
-      <h1>hello</h1>
-      <div style="position: relative; height: 10000px; top: -5000px;></div>
-    `);
-    await expect(page.locator('h1')).toIntersectViewport();
-  });
-});


### PR DESCRIPTION
Mostly reverts #19901.