### PR TITLE
feat(trace-viewer): allow host and port to be specified

### DIFF
--- a/packages/playwright-core/src/cli/cli.ts
+++ b/packages/playwright-core/src/cli/cli.ts
@@ -298,6 +298,8 @@ program
 program
     .command('show-trace [trace...]')
     .option('-b, --browser <browserType>', 'browser to use, one of cr, chromium, ff, firefox, wk, webkit', 'chromium')
+    .option('-h, --host <host>', 'Host to serve trace on', 'localhost')
+    .option('-p, --port <port>', 'Port to serve trace on', '9323')
     .description('show trace viewer')
     .action(function(traces, options) {
       if (options.browser === 'cr')
@@ -306,7 +308,8 @@ program
         options.browser = 'firefox';
       if (options.browser === 'wk')
         options.browser = 'webkit';
-      showTraceViewer(traces, options.browser, false, 9322).catch(logErrorAndExit);
+
+      showTraceViewer(traces, options.browser, false, options.host, +options.port).catch(logErrorAndExit);
     }).addHelpText('afterAll', `
 Examples:
 

--- a/packages/playwright-core/src/cli/cli.ts
+++ b/packages/playwright-core/src/cli/cli.ts
@@ -299,7 +299,7 @@ program
     .command('show-trace [trace...]')
     .option('-b, --browser <browserType>', 'browser to use, one of cr, chromium, ff, firefox, wk, webkit', 'chromium')
     .option('-h, --host <host>', 'Host to serve trace on', 'localhost')
-    .option('-p, --port <port>', 'Port to serve trace on', '9323')
+    .option('-p, --port <port>', 'Port to serve trace on', '9322')
     .description('show trace viewer')
     .action(function(traces, options) {
       if (options.browser === 'cr')
@@ -309,7 +309,7 @@ program
       if (options.browser === 'wk')
         options.browser = 'webkit';
 
-      showTraceViewer(traces, options.browser, false, options.host, +options.port).catch(logErrorAndExit);
+      showTraceViewer(traces, options.browser, { headless: false, host: options.host, port: +options.port }).catch(logErrorAndExit);
     }).addHelpText('afterAll', `
 Examples:
 

--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -26,7 +26,7 @@ import { serverSideCallMetadata } from '../../instrumentation';
 import { createPlaywright } from '../../playwright';
 import { ProgressController } from '../../progress';
 
-export async function showTraceViewer(traceUrls: string[], browserName: string, headless = false, host?: string, preferredPort?: number): Promise<BrowserContext | undefined> {
+export async function showTraceViewer(traceUrls: string[], browserName: string, { headless = false, host, port }: { headless?: boolean, host?: string, port?: number }): Promise<BrowserContext | undefined> {
   for (const traceUrl of traceUrls) {
     if (!traceUrl.startsWith('http://') && !traceUrl.startsWith('https://') && !fs.existsSync(traceUrl)) {
       // eslint-disable-next-line no-console
@@ -49,7 +49,7 @@ export async function showTraceViewer(traceUrls: string[], browserName: string, 
     return server.serveFile(request, response, absolutePath);
   });
 
-  const urlPrefix = await server.start({ preferredPort, host });
+  const urlPrefix = await server.start({ preferredPort: port, host });
 
   const traceViewerPlaywright = createPlaywright('javascript', true);
   const traceViewerBrowser = isUnderTest() ? 'chromium' : browserName;

--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -26,7 +26,7 @@ import { serverSideCallMetadata } from '../../instrumentation';
 import { createPlaywright } from '../../playwright';
 import { ProgressController } from '../../progress';
 
-export async function showTraceViewer(traceUrls: string[], browserName: string, headless = false, preferredPort?: number): Promise<BrowserContext | undefined> {
+export async function showTraceViewer(traceUrls: string[], browserName: string, headless = false, host?: string, preferredPort?: number): Promise<BrowserContext | undefined> {
   for (const traceUrl of traceUrls) {
     if (!traceUrl.startsWith('http://') && !traceUrl.startsWith('https://') && !fs.existsSync(traceUrl)) {
       // eslint-disable-next-line no-console
@@ -49,7 +49,7 @@ export async function showTraceViewer(traceUrls: string[], browserName: string, 
     return server.serveFile(request, response, absolutePath);
   });
 
-  const urlPrefix = await server.start({ preferredPort });
+  const urlPrefix = await server.start({ preferredPort, host });
 
   const traceViewerPlaywright = createPlaywright('javascript', true);
   const traceViewerBrowser = isUnderTest() ? 'chromium' : browserName;

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -29,7 +29,7 @@ type BaseWorkerFixtures = {
 };
 
 export type TraceViewerFixtures = {
-  showTraceViewer: (trace: string[], preferredPort?: number) => Promise<TraceViewerPage>;
+  showTraceViewer: (trace: string[], host?: string, preferredPort?: number) => Promise<TraceViewerPage>;
   runAndTrace: (body: () => Promise<void>) => Promise<TraceViewerPage>;
 };
 
@@ -112,8 +112,8 @@ export const traceViewerFixtures: Fixtures<TraceViewerFixtures, {}, BaseTestFixt
   showTraceViewer: async ({ playwright, browserName, headless }, use) => {
     const browsers: Browser[] = [];
     const contextImpls: any[] = [];
-    await use(async (traces: string[], preferredPort?: number) => {
-      const contextImpl = await showTraceViewer(traces, browserName, headless, preferredPort);
+    await use(async (traces: string[], host?: string, preferredPort?: number) => {
+      const contextImpl = await showTraceViewer(traces, browserName, headless, host, preferredPort);
       const browser = await playwright.chromium.connectOverCDP(contextImpl._browser.options.wsEndpoint);
       browsers.push(browser);
       contextImpls.push(contextImpl);

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -29,7 +29,7 @@ type BaseWorkerFixtures = {
 };
 
 export type TraceViewerFixtures = {
-  showTraceViewer: (trace: string[], host?: string, preferredPort?: number) => Promise<TraceViewerPage>;
+  showTraceViewer: (trace: string[], options?: {host?: string, port?: number}) => Promise<TraceViewerPage>;
   runAndTrace: (body: () => Promise<void>) => Promise<TraceViewerPage>;
 };
 
@@ -112,8 +112,8 @@ export const traceViewerFixtures: Fixtures<TraceViewerFixtures, {}, BaseTestFixt
   showTraceViewer: async ({ playwright, browserName, headless }, use) => {
     const browsers: Browser[] = [];
     const contextImpls: any[] = [];
-    await use(async (traces: string[], host?: string, preferredPort?: number) => {
-      const contextImpl = await showTraceViewer(traces, browserName, headless, host, preferredPort);
+    await use(async (traces: string[], { host, port } = {}) => {
+      const contextImpl = await showTraceViewer(traces, browserName, { headless, host, port });
       const browser = await playwright.chromium.connectOverCDP(contextImpl._browser.options.wsEndpoint);
       browsers.push(browser);
       contextImpls.push(contextImpl);

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -80,10 +80,16 @@ test('should show empty trace viewer', async ({ showTraceViewer }, testInfo) => 
 
 test('should open two trace viewers', async ({ showTraceViewer }, testInfo) => {
   const preferredPort = testInfo.workerIndex + 48321;
-  const traceViewer1 = await showTraceViewer([testInfo.outputPath()], preferredPort);
+  const traceViewer1 = await showTraceViewer([testInfo.outputPath()], 'localhost', preferredPort);
   await expect(traceViewer1.page).toHaveTitle('Playwright Trace Viewer');
-  const traceViewer2 = await showTraceViewer([testInfo.outputPath()], preferredPort);
+  const traceViewer2 = await showTraceViewer([testInfo.outputPath()], 'localhost', preferredPort);
   await expect(traceViewer2.page).toHaveTitle('Playwright Trace Viewer');
+});
+
+test('should open trace viewer on specific host', async ({ showTraceViewer }, testInfo) => {
+  const traceViewer = await showTraceViewer([testInfo.outputPath()], '127.0.0.1');
+  await expect(traceViewer.page).toHaveTitle('Playwright Trace Viewer');
+  await expect(traceViewer.page).toHaveURL(/127.0.0.1/);
 });
 
 test('should open simple trace viewer', async ({ showTraceViewer }) => {

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -79,15 +79,15 @@ test('should show empty trace viewer', async ({ showTraceViewer }, testInfo) => 
 });
 
 test('should open two trace viewers', async ({ showTraceViewer }, testInfo) => {
-  const preferredPort = testInfo.workerIndex + 48321;
-  const traceViewer1 = await showTraceViewer([testInfo.outputPath()], 'localhost', preferredPort);
+  const port = testInfo.workerIndex + 48321;
+  const traceViewer1 = await showTraceViewer([testInfo.outputPath()], { host: 'localhost', port });
   await expect(traceViewer1.page).toHaveTitle('Playwright Trace Viewer');
-  const traceViewer2 = await showTraceViewer([testInfo.outputPath()], 'localhost', preferredPort);
+  const traceViewer2 = await showTraceViewer([testInfo.outputPath()], { host: 'localhost', port });
   await expect(traceViewer2.page).toHaveTitle('Playwright Trace Viewer');
 });
 
 test('should open trace viewer on specific host', async ({ showTraceViewer }, testInfo) => {
-  const traceViewer = await showTraceViewer([testInfo.outputPath()], '127.0.0.1');
+  const traceViewer = await showTraceViewer([testInfo.outputPath()], { host: '127.0.0.1' });
   await expect(traceViewer.page).toHaveTitle('Playwright Trace Viewer');
   await expect(traceViewer.page).toHaveURL(/127.0.0.1/);
 });


### PR DESCRIPTION
Currently the `--host` and `--port` cli options are only available for `show-report`. 
This change would allow the two options to be passed to the `show-trace` command.