### PR TITLE
Ct vite config async

### DIFF
--- a/packages/playwright-ct-react/index.d.ts
+++ b/packages/playwright-ct-react/index.d.ts
@@ -30,7 +30,7 @@ export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig
     ctPort?: number;
     ctTemplateDir?: string;
     ctCacheDir?: string;
-    ctViteConfig?: InlineConfig;
+    ctViteConfig?: InlineConfig | (() => Promise<InlineConfig>);
   };
 };
 

--- a/packages/playwright-ct-solid/index.d.ts
+++ b/packages/playwright-ct-solid/index.d.ts
@@ -30,7 +30,7 @@ export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig
     ctPort?: number;
     ctTemplateDir?: string;
     ctCacheDir?: string;
-    ctViteConfig?: InlineConfig;
+    ctViteConfig?: InlineConfig | (() => Promise<InlineConfig>);
   };
 };
 

--- a/packages/playwright-ct-svelte/index.d.ts
+++ b/packages/playwright-ct-svelte/index.d.ts
@@ -31,7 +31,7 @@ export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig
     ctPort?: number;
     ctTemplateDir?: string;
     ctCacheDir?: string;
-    ctViteConfig?: InlineConfig;
+    ctViteConfig?: InlineConfig | (() => Promise<InlineConfig>);
   };
 };
 

--- a/packages/playwright-ct-vue/index.d.ts
+++ b/packages/playwright-ct-vue/index.d.ts
@@ -30,7 +30,7 @@ export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig
     ctPort?: number;
     ctTemplateDir?: string;
     ctCacheDir?: string;
-    ctViteConfig?: InlineConfig;
+    ctViteConfig?: InlineConfig | (() => Promise<InlineConfig>);
   };
 };
 

--- a/packages/playwright-ct-vue2/index.d.ts
+++ b/packages/playwright-ct-vue2/index.d.ts
@@ -30,7 +30,7 @@ export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig
     ctPort?: number;
     ctTemplateDir?: string;
     ctCacheDir?: string;
-    ctViteConfig?: InlineConfig;
+    ctViteConfig?: InlineConfig | (() => Promise<InlineConfig>);
   };
 };
 

--- a/packages/playwright-test/src/plugins/vitePlugin.ts
+++ b/packages/playwright-test/src/plugins/vitePlugin.ts
@@ -36,7 +36,7 @@ type CtConfig = BasePlaywrightTestConfig['use'] & {
   ctPort?: number;
   ctTemplateDir?: string;
   ctCacheDir?: string;
-  ctViteConfig?: InlineConfig;
+  ctViteConfig?: InlineConfig | (() => Promise<InlineConfig>);
 };
 
 const importReactRE = /(^|\n)import\s+(\*\s+as\s+)?React(,|\s+)/;
@@ -53,7 +53,7 @@ export function createPlugin(
       configDir = configDirectory;
       const use = config.projects[0].use as CtConfig;
       const port = use.ctPort || 3100;
-      const viteConfig: InlineConfig = use.ctViteConfig || {};
+      const viteConfig = typeof use.ctViteConfig === 'function' ? await use.ctViteConfig() : (use.ctViteConfig || {});
       const relativeTemplateDir = use.ctTemplateDir || 'playwright';
 
       const rootDir = viteConfig.root || configDir;


### PR DESCRIPTION
This PR adds the ability to `ctViteConfig` be async 

This allows read the vite config file by importing the `loadConfigFromFile` function from the `vite` package and using it within the `ctViteConfig` function. The config object is then returned, in this way it's possible to fully reuse the existing vite config

```
import { loadConfigFromFile } from "vite"

const config = {
    use: {
        async ctViteConfig() {
            const { config } = await loadConfigFromFile(
                resolve(__dirname, "./vite.config.js")
            );

            return config
        }
    }
}

export default config
```