### PR TITLE
chore: update flakiness-dashboard extension bundle

### DIFF
--- a/utils/flakiness-dashboard/host.json
+++ b/utils/flakiness-dashboard/host.json
@@ -16,6 +16,6 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[1.*, 2.0.0)"
+    "version": "[2.*, 3.0.0)"
   }
 }


### PR DESCRIPTION
This way it can work with newer runtimes.
