### PR TITLE
cherry-pick(#20336): Revert "chore: respect headless option when reusing browser (#19980)"

### DIFF
--- a/packages/playwright-core/src/remote/playwrightConnection.ts
+++ b/packages/playwright-core/src/remote/playwrightConnection.ts
@@ -220,7 +220,10 @@ export class PlaywrightConnection {
     }
 
     if (!browser) {
-      browser = await playwright[(this._options.browserName || 'chromium') as 'chromium'].launch(serverSideCallMetadata(), this._options.launchOptions);
+      browser = await playwright[(this._options.browserName || 'chromium') as 'chromium'].launch(serverSideCallMetadata(), {
+        ...this._options.launchOptions,
+        headless: !!process.env.PW_DEBUG_CONTROLLER_HEADLESS,
+      });
       browser.on(Browser.Events.Disconnected, () => {
         // Underlying browser did close for some reason - force disconnect the client.
         this.close({ code: 1001, reason: 'Browser closed' });
@@ -284,6 +287,8 @@ function launchOptionsHash(options: LaunchOptions) {
     if (copy[key] === defaultLaunchOptions[key])
       delete copy[key];
   }
+  for (const key of optionsThatAllowBrowserReuse)
+    delete copy[key];
   return JSON.stringify(copy);
 }
 
@@ -295,3 +300,7 @@ const defaultLaunchOptions: LaunchOptions = {
   headless: true,
   devtools: false,
 };
+
+const optionsThatAllowBrowserReuse: (keyof LaunchOptions)[] = [
+  'headless',
+];

--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -30,6 +30,7 @@ type Fixtures = {
 
 const test = baseTest.extend<Fixtures>({
   wsEndpoint: async ({ }, use) => {
+    process.env.PW_DEBUG_CONTROLLER_HEADLESS = '1';
     const server = new PlaywrightServer({ path: '/' + createGuid(), maxConnections: Number.MAX_VALUE, enableSocksProxy: false });
     const wsEndpoint = await server.listen();
     await use(wsEndpoint);


### PR DESCRIPTION
This reverts commit e674ea217f5facffc668bf7aaea890dab20d68ca.