### PR TITLE
fix(test runner): do not send entirely skipped test groups to a worker

### DIFF
--- a/packages/playwright-test/src/test.ts
+++ b/packages/playwright-test/src/test.ts
@@ -41,7 +41,6 @@ export class Suite extends Base implements reporterTypes.Suite {
   location?: Location;
   parent?: Suite;
   _use: FixturesWithLocation[] = [];
-  _skipped = false;
   _entries: (Suite | TestCase)[] = [];
   _hooks: { type: 'beforeEach' | 'afterEach' | 'beforeAll' | 'afterAll', fn: Function, location: Location }[] = [];
   _timeout: number | undefined;
@@ -164,7 +163,6 @@ export class Suite extends Base implements reporterTypes.Suite {
       staticAnnotations: this._staticAnnotations.slice(),
       modifiers: this._modifiers.slice(),
       parallelMode: this._parallelMode,
-      skipped: this._skipped,
       hooks: this._hooks.map(h => ({ type: h.type, location: h.location })),
     };
   }
@@ -179,7 +177,6 @@ export class Suite extends Base implements reporterTypes.Suite {
     suite._staticAnnotations = data.staticAnnotations;
     suite._modifiers = data.modifiers;
     suite._parallelMode = data.parallelMode;
-    suite._skipped = data.skipped;
     suite._hooks = data.hooks.map((h: any) => ({ type: h.type, location: h.location, fn: () => { } }));
     return suite;
   }

--- a/packages/playwright-test/src/testType.ts
+++ b/packages/playwright-test/src/testType.ts
@@ -92,14 +92,8 @@ export class TestTypeImpl {
 
     if (type === 'only')
       test._only = true;
-    if (type === 'skip' || type === 'fixme') {
+    if (type === 'skip' || type === 'fixme')
       test._staticAnnotations.push({ type });
-      test.expectedStatus = 'skipped';
-    }
-    for (let parent: Suite | undefined = suite; parent; parent = parent.parent) {
-      if (parent._skipped)
-        test.expectedStatus = 'skipped';
-    }
   }
 
   private _describe(type: 'default' | 'only' | 'serial' | 'serial.only' | 'parallel' | 'parallel.only' | 'skip' | 'fixme', location: Location, title: string | Function, fn?: Function) {
@@ -124,10 +118,8 @@ export class TestTypeImpl {
       child._parallelMode = 'serial';
     if (type === 'parallel' || type === 'parallel.only')
       child._parallelMode = 'parallel';
-    if (type === 'skip' || type === 'fixme') {
-      child._skipped = true;
+    if (type === 'skip' || type === 'fixme')
       child._staticAnnotations.push({ type });
-    }
 
     for (let parent: Suite | undefined = suite; parent; parent = parent.parent) {
       if (parent._parallelMode === 'serial' && child._parallelMode === 'parallel')

--- a/packages/playwright-test/src/workerMain.ts
+++ b/packages/playwright-test/src/workerMain.ts
@@ -279,16 +279,10 @@ export class WorkerMain extends ProcessRunner {
     const reversedSuites = suites.slice().reverse();
     const nextSuites = new Set(getSuites(nextTest));
 
-    // Inherit test.setTimeout() from parent suites, deepest has the priority.
-    for (const suite of reversedSuites) {
-      if (suite._timeout !== undefined) {
-        testInfo._timeoutManager.setTimeout(suite._timeout);
-        break;
-      }
-    }
-
+    testInfo._timeoutManager.setTimeout(test.timeout);
     for (const annotation of test._staticAnnotations)
       processAnnotation(annotation);
+
     // Process existing annotations dynamically set for parent suites.
     for (const suite of suites) {
       const extraAnnotations = this._extraSuiteAnnotations.get(suite) || [];

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -211,6 +211,8 @@ async function runPlaywrightCommand(childProcess: CommonFixtures['childProcess']
       PW_TEST_REPORTER_WS_ENDPOINT: undefined,
       PW_TEST_SOURCE_TRANSFORM: undefined,
       PW_TEST_SOURCE_TRANSFORM_SCOPE: undefined,
+      TEST_WORKER_INDEX: undefined,
+      TEST_PARLLEL_INDEX: undefined,
       NODE_OPTIONS: undefined,
       ...env,
     },


### PR DESCRIPTION
Move TestCase properties calculation from WorkerMain to suite building phase.

Fixes #20156.