### PR TITLE
fix: better formatting for sparse arrays

### DIFF
--- a/packages/playwright-core/src/server/chromium/crExecutionContext.ts
+++ b/packages/playwright-core/src/server/chromium/crExecutionContext.ts
@@ -137,16 +137,7 @@ function renderPreview(object: Protocol.Runtime.RemoteObject): string | undefine
       tokens.push(`${name}: ${value}`);
     return `{${tokens.join(', ')}}`;
   }
-  if (object.subtype === 'array' && object.preview) {
-    const arrayEntries = [];
-    for (const { name, value } of object.preview.properties) {
-      const index = +name;
-      if (isNaN(index) || index < 0)
-        continue;
-      arrayEntries.push({ index, value });
-    }
-    arrayEntries.sort((a, b) => a.index - b.index);
-    return js.sparseArrayToString(arrayEntries);
-  }
+  if (object.subtype === 'array' && object.preview)
+    return js.sparseArrayToString(object.preview.properties);
   return object.description;
 }

--- a/packages/playwright-core/src/server/chromium/crExecutionContext.ts
+++ b/packages/playwright-core/src/server/chromium/crExecutionContext.ts
@@ -138,10 +138,15 @@ function renderPreview(object: Protocol.Runtime.RemoteObject): string | undefine
     return `{${tokens.join(', ')}}`;
   }
   if (object.subtype === 'array' && object.preview) {
-    const result = [];
-    for (const { name, value } of object.preview.properties)
-      result[+name] = value;
-    return '[' + String(result) + ']';
+    const arrayEntries = [];
+    for (const { name, value } of object.preview.properties) {
+      const index = +name;
+      if (isNaN(index) || index < 0)
+        continue;
+      arrayEntries.push({ index, value });
+    }
+    arrayEntries.sort((a, b) => a.index - b.index);
+    return js.sparseArrayToString(arrayEntries);
   }
   return object.description;
 }

--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -329,18 +329,26 @@ export function isJavaScriptErrorInEvaluate(error: Error) {
   return error instanceof JavaScriptErrorInEvaluate;
 }
 
-export function sparseArrayToString(entries: { index: number, value: any }[]): string {
-  let lastIndex = 0;
+export function sparseArrayToString(entries: { key: string, value: any }[]): string {
+  const arrayEntries = [];
+  for (const { name, value } of entries) {
+    const index = +name;
+    if (isNaN(index) || index < 0)
+      continue;
+    arrayEntries.push({ index, value });
+  }
+  arrayEntries.sort((a, b) => a.index - b.index);
+  let lastIndex = -1;
   const tokens = [];
-  for (const { index, value } of entries) {
+  for (const { index, value } of arrayEntries) {
     const emptyItems = index - lastIndex - 1;
     if (emptyItems === 1)
-      tokens.push(`<1 empty item>`);
+      tokens.push(`empty`);
     else if (emptyItems > 1)
-      tokens.push(`<${emptyItems} empty items>`);
+      tokens.push(`empty x ${emptyItems}`);
     tokens.push(String(value));
     lastIndex = index;
   }
 
-  return '[' + tokens.join(',') + ']';
+  return '[' + tokens.join(', ') + ']';
 }

--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -328,3 +328,19 @@ export class JavaScriptErrorInEvaluate extends Error {
 export function isJavaScriptErrorInEvaluate(error: Error) {
   return error instanceof JavaScriptErrorInEvaluate;
 }
+
+export function sparseArrayToString(entries: { index: number, value: any }[]): string {
+  let lastIndex = 0;
+  const tokens = [];
+  for (const { index, value } of entries) {
+    const emptyItems = index - lastIndex - 1;
+    if (emptyItems === 1)
+      tokens.push(`<1 empty item>`);
+    else if (emptyItems > 1)
+      tokens.push(`<${emptyItems} empty items>`);
+    tokens.push(String(value));
+    lastIndex = index;
+  }
+
+  return '[' + tokens.join(',') + ']';
+}

--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -329,7 +329,7 @@ export function isJavaScriptErrorInEvaluate(error: Error) {
   return error instanceof JavaScriptErrorInEvaluate;
 }
 
-export function sparseArrayToString(entries: { key: string, value: any }[]): string {
+export function sparseArrayToString(entries: { name: string, value?: any }[]): string {
   const arrayEntries = [];
   for (const { name, value } of entries) {
     const index = +name;

--- a/packages/playwright-core/src/server/webkit/wkExecutionContext.ts
+++ b/packages/playwright-core/src/server/webkit/wkExecutionContext.ts
@@ -142,16 +142,7 @@ function renderPreview(object: Protocol.Runtime.RemoteObject): string | undefine
       tokens.push(`${name}: ${value}`);
     return `{${tokens.join(', ')}}`;
   }
-  if (object.subtype === 'array' && object.preview) {
-    const arrayEntries = [];
-    for (const { name, value } of object.preview.properties!) {
-      const index = +name;
-      if (isNaN(index) || index < 0)
-        continue;
-      arrayEntries.push({ index, value });
-    }
-    arrayEntries.sort((a, b) => a.index - b.index);
-    return js.sparseArrayToString(arrayEntries);
-  }
+  if (object.subtype === 'array' && object.preview)
+    return js.sparseArrayToString(object.preview.properties);
   return object.description;
 }

--- a/packages/playwright-core/src/server/webkit/wkExecutionContext.ts
+++ b/packages/playwright-core/src/server/webkit/wkExecutionContext.ts
@@ -143,10 +143,15 @@ function renderPreview(object: Protocol.Runtime.RemoteObject): string | undefine
     return `{${tokens.join(', ')}}`;
   }
   if (object.subtype === 'array' && object.preview) {
-    const result = [];
-    for (const { name, value } of object.preview.properties!)
-      result[+name] = value;
-    return '[' + String(result) + ']';
+    const arrayEntries = [];
+    for (const { name, value } of object.preview.properties!) {
+      const index = +name;
+      if (isNaN(index) || index < 0)
+        continue;
+      arrayEntries.push({ index, value });
+    }
+    arrayEntries.sort((a, b) => a.index - b.index);
+    return js.sparseArrayToString(arrayEntries);
   }
   return object.description;
 }

--- a/packages/playwright-core/src/server/webkit/wkExecutionContext.ts
+++ b/packages/playwright-core/src/server/webkit/wkExecutionContext.ts
@@ -143,6 +143,6 @@ function renderPreview(object: Protocol.Runtime.RemoteObject): string | undefine
     return `{${tokens.join(', ')}}`;
   }
   if (object.subtype === 'array' && object.preview)
-    return js.sparseArrayToString(object.preview.properties);
+    return js.sparseArrayToString(object.preview.properties!);
   return object.description;
 }

--- a/tests/page/jshandle-to-string.spec.ts
+++ b/tests/page/jshandle-to-string.spec.ts
@@ -32,6 +32,22 @@ it('should work for complicated objects', async ({ page, browserName }) => {
     expect(aHandle.toString()).toBe('JSHandle@object');
 });
 
+it('should beutifully render sparse arrays', async ({ page, browserName }) => {
+  const [msg] = await Promise.all([
+    page.waitForEvent('console'),
+    page.evaluateHandle(() => {
+      const a = [];
+      a[10000] = 1;
+      a[100000] = 2;
+      console.log(a);
+    }),
+  ]);
+  if (browserName === 'firefox')
+    expect(msg.text()).toBe('Array');
+  else
+    expect(msg.text()).toBe('[<9999 empty items>,1,<89999 empty items>,2]');
+});
+
 it('should work for promises', async ({ page }) => {
   // wrap the promise in an object, otherwise we will await.
   const wrapperHandle = await page.evaluateHandle(() => ({ b: Promise.resolve(123) }));

--- a/tests/page/jshandle-to-string.spec.ts
+++ b/tests/page/jshandle-to-string.spec.ts
@@ -32,7 +32,7 @@ it('should work for complicated objects', async ({ page, browserName }) => {
     expect(aHandle.toString()).toBe('JSHandle@object');
 });
 
-it.only('should beutifully render sparse arrays', async ({ page, browserName }) => {
+it('should beautifully render sparse arrays', async ({ page, browserName }) => {
   const [msg] = await Promise.all([
     page.waitForEvent('console'),
     page.evaluateHandle(() => {

--- a/tests/page/jshandle-to-string.spec.ts
+++ b/tests/page/jshandle-to-string.spec.ts
@@ -32,20 +32,21 @@ it('should work for complicated objects', async ({ page, browserName }) => {
     expect(aHandle.toString()).toBe('JSHandle@object');
 });
 
-it('should beutifully render sparse arrays', async ({ page, browserName }) => {
+it.only('should beutifully render sparse arrays', async ({ page, browserName }) => {
   const [msg] = await Promise.all([
     page.waitForEvent('console'),
     page.evaluateHandle(() => {
       const a = [];
-      a[10000] = 1;
-      a[100000] = 2;
+      a[1] = 1;
+      a[10] = 2;
+      a[100] = 3;
       console.log(a);
     }),
   ]);
   if (browserName === 'firefox')
     expect(msg.text()).toBe('Array');
   else
-    expect(msg.text()).toBe('[<9999 empty items>,1,<89999 empty items>,2]');
+    expect(msg.text()).toBe('[empty, 1, empty x 8, 2, empty x 89, 3]');
 });
 
 it('should work for promises', async ({ page }) => {

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -183,7 +183,7 @@ it('should use object previews for arrays and objects', async ({ page, browserNa
   await page.evaluate(() => console.log([1, 2, 3], { a: 1 }, window));
 
   if (browserName !== 'firefox')
-    expect(text).toEqual('[1,2,3] {a: 1} Window');
+    expect(text).toEqual('[1, 2, 3] {a: 1} Window');
   else
     expect(text).toEqual('Array JSHandle@object JSHandle@object');
 });


### PR DESCRIPTION
Right now arrays preview yields all array elements. In case
of a sparse array with a single element on index 10000000,
this results in a large string that OOM Node.js.

This patch changes pretty-printing. For example:

```ts
// Given this array
const a = [];
a[10] = 1;
// Before this patch, pretty printing will yield:
"[,,,,,,,,1]"
// With this patch, pretty printing yields:
"[empty x 9, 1]"
```

The new array pretty-printing is equal to what Chrome DevTools
do to render sparse arrays.

Fixes #20347
