### PR TITLE
chore: make connectOverCDP work with localhost

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -51,6 +51,7 @@ import { registry } from '../registry';
 import { ManualPromise } from '../../utils/manualPromise';
 import { validateBrowserContextOptions } from '../browserContext';
 import { chromiumSwitches } from './chromiumSwitches';
+import { httpHappyEyeballsAgent, httpsHappyEyeballsAgent } from '../happy-eyeballs';
 
 const ARTIFACTS_FOLDER = path.join(os.tmpdir(), 'playwright-artifacts-');
 
@@ -333,10 +334,11 @@ async function urlToWSEndpoint(progress: Progress, endpointURL: string) {
     return endpointURL;
   progress.log(`<ws preparing> retrieving websocket url from ${endpointURL}`);
   const httpURL = endpointURL.endsWith('/') ? `${endpointURL}json/version/` : `${endpointURL}/json/version/`;
-  const request = endpointURL.startsWith('https') ? https : http;
+  const isHTTPS = endpointURL.startsWith('https://');
   const json = await new Promise<string>((resolve, reject) => {
-    request.get(httpURL, {
+    (isHTTPS ? https : http).get(httpURL, {
       timeout: NET_DEFAULT_TIMEOUT,
+      agent: isHTTPS ? httpsHappyEyeballsAgent : httpHappyEyeballsAgent,
     }, resp => {
       if (resp.statusCode! < 200 || resp.statusCode! >= 400) {
         reject(new Error(`Unexpected status ${resp.statusCode} when connecting to ${httpURL}.\n` +

--- a/packages/playwright-core/src/server/transport.ts
+++ b/packages/playwright-core/src/server/transport.ts
@@ -20,6 +20,7 @@ import type { WebSocket } from '../utilsBundle';
 import type { ClientRequest, IncomingMessage } from 'http';
 import type { Progress } from './progress';
 import { makeWaitForNextTask } from '../utils';
+import { httpHappyEyeballsAgent, httpsHappyEyeballsAgent } from './happy-eyeballs';
 
 export type ProtocolRequest = {
   id: number;
@@ -100,6 +101,7 @@ export class WebSocketTransport implements ConnectionTransport {
       handshakeTimeout: Math.max(progress?.timeUntilDeadline() ?? 30_000, 1),
       headers,
       followRedirects,
+      agent: (/^(https|wss):\/\//.test(url)) ? httpsHappyEyeballsAgent : httpHappyEyeballsAgent
     });
     this._progress = progress;
     // The 'ws' module in node sometimes sends us multiple messages in a single task.

--- a/tests/library/chromium/chromium.spec.ts
+++ b/tests/library/chromium/chromium.spec.ts
@@ -548,6 +548,21 @@ playwrightTest('should use proxy with connectOverCDP', async ({ browserType, ser
   }
 });
 
+playwrightTest('should be able to connect via localhost', async ({ browserType }, testInfo) => {
+  const port = 9339 + testInfo.workerIndex;
+  const browserServer = await browserType.launch({
+    args: ['--remote-debugging-port=' + port]
+  });
+  try {
+    const cdpBrowser = await browserType.connectOverCDP(`http://localhost:${port}`);
+    const contexts = cdpBrowser.contexts();
+    expect(contexts.length).toBe(1);
+    await cdpBrowser.close();
+  } finally {
+    await browserServer.close();
+  }
+});
+
 playwrightTest('should pass args with spaces', async ({ browserType, createUserDataDir }, testInfo) => {
   const browser = await browserType.launchPersistentContext(await createUserDataDir(), {
     args: ['--user-agent=I am Foo']


### PR DESCRIPTION
This wraps happy eyeballs in two places, the place where we make the JSON request to Chromium and the actual CDP WebSocket request.

It required changes inside our happy eyeballs implementation since the [websocket library does not set](https://github.com/websockets/ws/blob/master/lib/websocket.js#L714) the `clientRequestOptions.hostname` field, it just sets the `host` field where we then fall back to when its not set.

This test would pass before Node.js 18 and fail after Node.js 18 without my changes.

Fixes https://github.com/microsoft/playwright/issues/20364
