### PR TITLE
chore: truncate long protocol logs

### DIFF
--- a/packages/playwright-core/src/server/helper.ts
+++ b/packages/playwright-core/src/server/helper.ts
@@ -22,7 +22,7 @@ import { debugLogger } from '../common/debugLogger';
 import type { RegisteredListener } from '../utils/eventsHelper';
 import { eventsHelper } from '../utils/eventsHelper';
 
-const MAX_LOG_LENGTH = process.env.MAX_LOG_LENGTH ? parseInt(process.env.MAX_LOG_LENGTH) : Infinity;
+const MAX_LOG_LENGTH = process.env.MAX_LOG_LENGTH ? +process.env.MAX_LOG_LENGTH : Infinity;
 
 class Helper {
   static completeUserURL(urlString: string): string {

--- a/packages/playwright-core/src/server/helper.ts
+++ b/packages/playwright-core/src/server/helper.ts
@@ -22,6 +22,8 @@ import { debugLogger } from '../common/debugLogger';
 import type { RegisteredListener } from '../utils/eventsHelper';
 import { eventsHelper } from '../utils/eventsHelper';
 
+const MAX_LOG_LENGTH = process.env.MAX_LOG_LENGTH ? parseInt(process.env.MAX_LOG_LENGTH) : Infinity;
+
 class Helper {
   static completeUserURL(urlString: string): string {
     if (urlString.startsWith('localhost') || urlString.startsWith('127.0.0.1'))
@@ -86,9 +88,8 @@ class Helper {
         protocolLogger(direction, message);
       if (debugLogger.isEnabled('protocol')) {
         let text = JSON.stringify(message);
-        const MAX_LENGTH = 80 * 10;
-        if (text.length > MAX_LENGTH)
-          text = text.substring(0, MAX_LENGTH / 2) + ' <<<<<( LOG TRUNCATED )>>>>> ' + text.substring(text.length - MAX_LENGTH / 2);
+        if (text.length > MAX_LOG_LENGTH)
+          text = text.substring(0, MAX_LOG_LENGTH / 2) + ' <<<<<( LOG TRUNCATED )>>>>> ' + text.substring(text.length - MAX_LOG_LENGTH / 2);
         debugLogger.log('protocol', (direction === 'send' ? 'SEND ► ' : '◀ RECV ') + text);
       }
     };

--- a/packages/playwright-core/src/server/helper.ts
+++ b/packages/playwright-core/src/server/helper.ts
@@ -84,8 +84,13 @@ class Helper {
     return (direction: 'send' | 'receive', message: object) => {
       if (protocolLogger)
         protocolLogger(direction, message);
-      if (debugLogger.isEnabled('protocol'))
-        debugLogger.log('protocol', (direction === 'send' ? 'SEND ► ' : '◀ RECV ') + JSON.stringify(message));
+      if (debugLogger.isEnabled('protocol')) {
+        let text = JSON.stringify(message);
+        const MAX_LENGTH = 80 * 10;
+        if (text.length > MAX_LENGTH)
+          text = text.substring(0, MAX_LENGTH / 2) + ' <<<<<( LOG TRUNCATED )>>>>> ' + text.substring(text.length - MAX_LENGTH / 2);
+        debugLogger.log('protocol', (direction === 'send' ? 'SEND ► ' : '◀ RECV ') + text);
+      }
     };
   }
 


### PR DESCRIPTION
This affects the logs in the `DEBUG=pw:protocol` mode so that they
never span more then 10 lines of 80-character-width terminal.
