### PR TITLE
test: do not create ipv6 server inside Docker

### DIFF
--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -57,6 +57,10 @@ const test = playwrightTest.extend<ExtraFixtures>({
   },
 
   ipV6ServerUrl: async ({}, use) => {
+    if (process.env.INSIDE_DOCKER) {
+      await use('<not-supported>');
+      return;
+    }
     const server = http.createServer((req: http.IncomingMessage, res: http.ServerResponse) => {
       res.end('<html><body>from-ipv6-server</body></html>');
     });

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -57,10 +57,7 @@ const test = playwrightTest.extend<ExtraFixtures>({
   },
 
   ipV6ServerUrl: async ({}, use) => {
-    if (process.env.INSIDE_DOCKER) {
-      await use('<not-supported>');
-      return;
-    }
+    test.skip(!!process.env.INSIDE_DOCKER, 'docker does not support IPv6 by default');
     const server = http.createServer((req: http.IncomingMessage, res: http.ServerResponse) => {
       res.end('<html><body>from-ipv6-server</body></html>');
     });


### PR DESCRIPTION
Fixes [should be able to visit ipv6](https://github.com/microsoft/playwright/blob/cf0ca2e662ba90071ca3c8d4328fd132fd8b8d41/tests/library/browsertype-connect.spec.ts#L147) on the flakiness dashboard.