### PR TITLE
feat: roll Firefox and Firefox-Beta to latest builds

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -21,13 +21,13 @@
     },
     {
       "name": "firefox",
-      "revision": "1373",
+      "revision": "1374",
       "installByDefault": true,
       "browserVersion": "108.0.2"
     },
     {
       "name": "firefox-beta",
-      "revision": "1375",
+      "revision": "1376",
       "installByDefault": false,
       "browserVersion": "108.0b5"
     },

--- a/packages/playwright-core/src/server/firefox/protocol.d.ts
+++ b/packages/playwright-core/src/server/firefox/protocol.d.ts
@@ -385,7 +385,6 @@ export module Protocol {
     export type navigationStartedPayload = {
       frameId: string;
       navigationId: string;
-      url: string;
     }
     export type navigationCommittedPayload = {
       frameId: string;
@@ -550,7 +549,6 @@ export module Protocol {
     };
     export type navigateReturnValue = {
       navigationId: string|null;
-      navigationURL: string|null;
     };
     export type goBackParameters = {
       frameId: string;

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -28,6 +28,15 @@ it('should work @smoke', async ({ page, server }) => {
 it('should work with file URL', async ({ page, asset, isAndroid }) => {
   it.skip(isAndroid, 'No files on Android');
 
+  const fileurl = url.pathToFileURL(asset('empty.html')).href;
+  await page.goto(fileurl);
+  expect(page.url().toLowerCase()).toBe(fileurl.toLowerCase());
+  expect(page.frames().length).toBe(1);
+});
+
+it('should work with file URL with subframes', async ({ page, asset, isAndroid }) => {
+  it.skip(isAndroid, 'No files on Android');
+
   const fileurl = url.pathToFileURL(asset('frames/two-frames.html')).href;
   await page.goto(fileurl);
   expect(page.url().toLowerCase()).toBe(fileurl.toLowerCase());
@@ -404,10 +413,8 @@ it('should fail when replaced by another navigation', async ({ page, server, bro
   await anotherPromise;
   if (browserName === 'chromium')
     expect(error.message).toContain('net::ERR_ABORTED');
-  else if (browserName === 'webkit')
+  else if (browserName === 'webkit' || browserName === 'firefox')
     expect(error.message).toContain('Navigation interrupted by another one');
-  else
-    expect(error.message).toContain('NS_BINDING_ABORTED');
 });
 
 it('should work when navigating to valid url', async ({ page, server }) => {


### PR DESCRIPTION
These builds initiate browser-side navigation for `page.goto` command.

Drive-by: add a minimal file URL test.
