### PR TITLE
docs(test-components-js.md): Fix mount parameter for Vue example

### DIFF
--- a/docs/src/test-components-js.md
+++ b/docs/src/test-components-js.md
@@ -135,7 +135,7 @@ import App from './App.vue';
 test.use({ viewport: { width: 500, height: 500 } });
 
 test('should work', async ({ mount }) => {
-  const component = await mount(<App />);
+  const component = await mount(App);
   await expect(component).toContainText('Vite + Vue');
 });
 ```


### PR DESCRIPTION
The example for mounting a Vue js component seems to be a duplicate of the React example.
For a Vue component we don't need the brackets syntax. (See also the difference between the two in [another part of the documentation](https://playwright.dev/docs/test-components#q-whats-the-difference-between-playwrighttest-and-playwrightexperimental-ct-reactsveltevuesolid))