### PR TITLE
fix: swallow expect.soft errors inside successful toPass matcher

### DIFF
--- a/packages/playwright-test/src/common/testInfo.ts
+++ b/packages/playwright-test/src/common/testInfo.ts
@@ -24,6 +24,12 @@ import { TimeoutManager } from './timeoutManager';
 import type { Annotation, FullConfigInternal, FullProjectInternal, TestStepInternal } from './types';
 import { getContainedPath, normalizeAndSaveAttachment, sanitizeForFilePath, serializeError, trimLongString } from '../util';
 
+export type TestInfoState = {
+  status: TestStatus,
+  errors: TestInfoError[],
+  hasHardError: boolean,
+};
+
 export class TestInfoImpl implements TestInfo {
   private _onStepBegin: (payload: StepBeginPayload) => void;
   private _onStepEnd: (payload: StepEndPayload) => void;
@@ -246,16 +252,18 @@ export class TestInfoImpl implements TestInfo {
     this.errors.push(error);
   }
 
-  _saveTestInfo() {
+  _saveTestState(): TestInfoState {
     return {
+      hasHardError: this._hasHardError,
       status: this.status,
       errors: this.errors.slice(),
-    }
+    };
   }
 
-  _restoreTestInfo(state: { status: TestStatus, errors: TestInfoError[] }) {
+  _restoreTestState(state: TestInfoState) {
     this.status = state.status;
     this.errors = state.errors.slice();
+    this._hasHardError = state.hasHardError;
   }
 
   async _runAsStep<T>(cb: () => Promise<T>, stepInfo: Omit<TestStepInternal, 'complete'>): Promise<T> {

--- a/packages/playwright-test/src/common/testInfo.ts
+++ b/packages/playwright-test/src/common/testInfo.ts
@@ -24,7 +24,7 @@ import { TimeoutManager } from './timeoutManager';
 import type { Annotation, FullConfigInternal, FullProjectInternal, TestStepInternal } from './types';
 import { getContainedPath, normalizeAndSaveAttachment, sanitizeForFilePath, serializeError, trimLongString } from '../util';
 
-export type TestInfoState = {
+export type TestInfoErrorState = {
   status: TestStatus,
   errors: TestInfoError[],
   hasHardError: boolean,
@@ -252,7 +252,7 @@ export class TestInfoImpl implements TestInfo {
     this.errors.push(error);
   }
 
-  _saveTestState(): TestInfoState {
+  _saveErrorState(): TestInfoErrorState {
     return {
       hasHardError: this._hasHardError,
       status: this.status,
@@ -260,7 +260,7 @@ export class TestInfoImpl implements TestInfo {
     };
   }
 
-  _restoreTestState(state: TestInfoState) {
+  _restoreErrorState(state: TestInfoErrorState) {
     this.status = state.status;
     this.errors = state.errors.slice();
     this._hasHardError = state.hasHardError;

--- a/packages/playwright-test/src/common/testInfo.ts
+++ b/packages/playwright-test/src/common/testInfo.ts
@@ -246,6 +246,18 @@ export class TestInfoImpl implements TestInfo {
     this.errors.push(error);
   }
 
+  _saveTestInfo() {
+    return {
+      status: this.status,
+      errors: this.errors.slice(),
+    }
+  }
+
+  _restoreTestInfo(state: { status: TestStatus, errors: TestInfoError[] }) {
+    this.status = state.status;
+    this.errors = state.errors.slice();
+  }
+
   async _runAsStep<T>(cb: () => Promise<T>, stepInfo: Omit<TestStepInternal, 'complete'>): Promise<T> {
     const step = this._addStep(stepInfo);
     try {

--- a/tests/playwright-test/expect-to-pass.spec.ts
+++ b/tests/playwright-test/expect-to-pass.spec.ts
@@ -181,6 +181,26 @@ test('should swallow all soft errors inside toPass matcher, if successful', asyn
   expect(result.failed).toBe(1);
 });
 
+test('should show only soft errors on last toPass pass', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('should respect soft', async () => {
+        let i = 0;
+        await test.expect(() => {
+          ++i;
+          expect.soft('inside-toPass-' + i).toBe('0');
+        }).toPass({ timeout: 1000, intervals: [100, 100, 100000] });
+      });
+    `
+  });
+  expect(stripAnsi(result.output)).not.toContain('Received: "inside-toPass-1"');
+  expect(stripAnsi(result.output)).not.toContain('Received: "inside-toPass-2"');
+  expect(stripAnsi(result.output)).toContain('Received: "inside-toPass-3"');
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+});
+
 test('should work with soft', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.ts': `

--- a/tests/playwright-test/expect-to-pass.spec.ts
+++ b/tests/playwright-test/expect-to-pass.spec.ts
@@ -160,6 +160,8 @@ test('should use custom message', async ({ runInlineTest }) => {
 });
 
 test('should swallow all soft errors inside toPass matcher, if successful', async ({ runInlineTest }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/20437' });
+
   const result = await runInlineTest({
     'a.spec.ts': `
       const { test } = pwt;

--- a/tests/playwright-test/expect-to-pass.spec.ts
+++ b/tests/playwright-test/expect-to-pass.spec.ts
@@ -176,7 +176,7 @@ test('should swallow all soft errors inside toPass matcher, if successful', asyn
   });
   expect(stripAnsi(result.output)).toContain('Received: "before-toPass"');
   expect(stripAnsi(result.output)).toContain('Received: "after-toPass"');
-  expect(stripAnsi(result.output)).not.toContain('Received: "inside-toPass"');
+  expect(stripAnsi(result.output)).not.toContain('Received: "inside-toPass-1"');
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
 });

--- a/tests/playwright-test/expect-to-pass.spec.ts
+++ b/tests/playwright-test/expect-to-pass.spec.ts
@@ -35,10 +35,17 @@ test('should retry predicate', async ({ runInlineTest }) => {
         }).toPass();
         expect(i).toBe(3);
       });
+      test('should retry expect.soft assertions', async () => {
+        let i = 0;
+        await test.expect(() => {
+          expect.soft(++i).toBe(3);
+        }).toPass();
+        expect(i).toBe(3);
+      });
     `
   });
   expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(2);
+  expect(result.passed).toBe(3);
 });
 
 test('should respect timeout', async ({ runInlineTest }) => {
@@ -148,6 +155,28 @@ test('should use custom message', async ({ runInlineTest }) => {
     `
   });
   expect(stripAnsi(result.output)).toContain('Error: Custom message');
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+});
+
+test('should swallow all soft errors inside toPass matcher, if successful', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const { test } = pwt;
+      test('should respect soft', async () => {
+        expect.soft('before-toPass').toBe('zzzz');
+        let i = 0;
+        await test.expect(() => {
+          ++i;
+          expect.soft('inside-toPass-' + i).toBe('inside-toPass-2');
+        }).toPass({ timeout: 1000 });
+        expect.soft('after-toPass').toBe('zzzz');
+      });
+    `
+  });
+  expect(stripAnsi(result.output)).toContain('Received: "before-toPass"');
+  expect(stripAnsi(result.output)).toContain('Received: "after-toPass"');
+  expect(stripAnsi(result.output)).not.toContain('Received: "inside-toPass"');
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
 });


### PR DESCRIPTION
Fixes #20437
