### PR TITLE
devops: re-add Chromium symbols build

### DIFF
--- a/.github/workflows/trigger_build_chromium_with_symbols.yml
+++ b/.github/workflows/trigger_build_chromium_with_symbols.yml
@@ -10,11 +10,21 @@ jobs:
     name: "trigger"
     runs-on: ubuntu-22.04
     steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+    - name: Get Chromium revision
+      id: chromium-version
+      run: |
+        REVISION=$(node -e "console.log(require('./packages/playwright-core/browsers.json').browsers.find(b => b.name === 'chromium').revision)")
+        echo "REVISION=$REVISION" >> $GITHUB_OUTPUT
     - run: |
         curl -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${GH_TOKEN}" \
-          --data "{\"event_type\": \"build_chromium_with_symbols\"}" \
+          --data "{\"event_type\": \"build_chromium_with_symbols\", \"client_payload\": {\"revision\": \"${CHROMIUM_REVISON}\"}}" \
           https://api.github.com/repos/microsoft/playwright-browsers/dispatches
       env:
         GH_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_PERSONAL_ACCESS_TOKEN }}
+        CHROMIUM_REVISON: ${{ steps.chromium-version.outputs.REVISON }}

--- a/.github/workflows/trigger_build_chromium_with_symbols.yml
+++ b/.github/workflows/trigger_build_chromium_with_symbols.yml
@@ -1,0 +1,20 @@
+name: "Trigger: Chromium with Symbols Builds"
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  trigger:
+    name: "trigger"
+    runs-on: ubuntu-22.04
+    steps:
+    - run: |
+        curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${GH_TOKEN}" \
+          --data "{\"event_type\": \"build_chromium_with_symbols\"}" \
+          https://api.github.com/repos/microsoft/playwright-browsers/dispatches
+      env:
+        GH_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/trigger_build_chromium_with_symbols.yml
+++ b/.github/workflows/trigger_build_chromium_with_symbols.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Get Chromium revision
       id: chromium-version
       run: |
-        REVISION=$(node -e "console.log(require('./packages/playwright-core/browsers.json').browsers.find(b => b.name === 'chromium').revision)")
+        REVISION=$(node -e "console.log(require('./packages/playwright-core/browsers.json').browsers.find(b => b.name === 'chromium-with-symbols').revision)")
         echo "REVISION=$REVISION" >> $GITHUB_OUTPUT
     - run: |
         curl -X POST \


### PR DESCRIPTION
Note: This the workflow how it previously was, just instead of sending the ref, its sending the CR revision.