### PR TITLE
fix(types): update PlaywrightTestConfig types

### DIFF
--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -3724,8 +3724,13 @@ export interface PlaywrightTestArgs {
   request: APIRequestContext;
 }
 
-export type PlaywrightTestProject<TestArgs = {}, WorkerArgs = {}> = Project<PlaywrightTestOptions & TestArgs, PlaywrightWorkerOptions & WorkerArgs>;
-export type PlaywrightTestConfig<TestArgs = {}, WorkerArgs = {}> = Config<PlaywrightTestOptions & TestArgs, PlaywrightWorkerOptions & WorkerArgs>;
+type ExcludeProps<A, B> = {
+  [K in Exclude<keyof A, keyof B>]: A[K];
+};
+type CustomProperties<T> = ExcludeProps<T, PlaywrightTestOptions & PlaywrightWorkerOptions & PlaywrightTestArgs & PlaywrightWorkerArgs>;
+
+export type PlaywrightTestProject<TestArgs = {}, WorkerArgs = {}> = Project<PlaywrightTestOptions & CustomProperties<TestArgs>, PlaywrightWorkerOptions & CustomProperties<WorkerArgs>>;
+export type PlaywrightTestConfig<TestArgs = {}, WorkerArgs = {}> = Config<PlaywrightTestOptions & CustomProperties<TestArgs>, PlaywrightWorkerOptions & CustomProperties<WorkerArgs>>;
 
 import type * as expectType from './expect-types';
 import type { Suite } from './testReporter';

--- a/tests/playwright-test/types.spec.ts
+++ b/tests/playwright-test/types.spec.ts
@@ -166,7 +166,106 @@ test('should check types of fixtures', async ({ runTSC }) => {
       test.afterAll(async ({ a }) => {});
       test.afterAll(async ({ foo, bar }) => {});
       test.afterAll(() => {});
-    `
+    `,
+    'playwright-props.config.ts': `
+      const config0: pwt.PlaywrightTestConfig = {
+        use: {
+          ignoreHTTPSErrors: undefined,
+          isMobile: true,
+          javaScriptEnabled: false,
+        },
+      };
+
+      const config1: pwt.PlaywrightTestConfig = {
+        use: {
+          ignoreHTTPSErrors: undefined,
+          isMobile: true,
+          javaScriptEnabled: false,
+          // @ts-expect-error
+          hasTouch: 'foo',
+        },
+      };
+
+      const config2: pwt.PlaywrightTestConfig = {
+        use: {
+          ignoreHTTPSErrors: undefined,
+          isMobile: true,
+          javaScriptEnabled: false,
+          // @ts-expect-error
+          foo: true,
+        },
+      };
+
+      const config3: pwt.PlaywrightTestConfig<{ foo: boolean }> = {
+        use: {
+          ignoreHTTPSErrors: undefined,
+          isMobile: true,
+          javaScriptEnabled: false,
+          foo: true,
+        },
+      };
+
+      const config4: pwt.PlaywrightTestConfig<{ foo: boolean }> = {
+        use: {
+          ignoreHTTPSErrors: undefined,
+          isMobile: true,
+          javaScriptEnabled: false,
+          foo: true,
+          // @ts-expect-error
+          hasTouch: 'foo',
+        },
+      };
+    `,
+
+    'playwright-define.config.ts': `
+      const config0 = pwt.defineConfig({
+        use: {
+          ignoreHTTPSErrors: undefined,
+          isMobile: true,
+          javaScriptEnabled: false,
+        },
+      });
+
+      const config1 = pwt.defineConfig({
+        use: {
+          ignoreHTTPSErrors: undefined,
+          isMobile: true,
+          javaScriptEnabled: false,
+          // @ts-expect-error
+          hasTouch: 'foo',
+        },
+      });
+
+      const config2 = pwt.defineConfig({
+        use: {
+          ignoreHTTPSErrors: undefined,
+          isMobile: true,
+          javaScriptEnabled: false,
+          // @ts-expect-error
+          foo: true,
+        },
+      });
+
+      const config3 = pwt.defineConfig<{ foo: boolean }>({
+        use: {
+          ignoreHTTPSErrors: undefined,
+          isMobile: true,
+          javaScriptEnabled: false,
+          foo: true,
+        },
+      });
+
+      const config4 = pwt.defineConfig<{ foo: boolean }>({
+        use: {
+          ignoreHTTPSErrors: undefined,
+          isMobile: true,
+          javaScriptEnabled: false,
+          foo: true,
+          // @ts-expect-error
+          hasTouch: 'foo',
+        },
+      });
+    `,
   });
   expect(result.exitCode).toBe(0);
 });

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -252,8 +252,13 @@ export interface PlaywrightTestArgs {
   request: APIRequestContext;
 }
 
-export type PlaywrightTestProject<TestArgs = {}, WorkerArgs = {}> = Project<PlaywrightTestOptions & TestArgs, PlaywrightWorkerOptions & WorkerArgs>;
-export type PlaywrightTestConfig<TestArgs = {}, WorkerArgs = {}> = Config<PlaywrightTestOptions & TestArgs, PlaywrightWorkerOptions & WorkerArgs>;
+type ExcludeProps<A, B> = {
+  [K in Exclude<keyof A, keyof B>]: A[K];
+};
+type CustomProperties<T> = ExcludeProps<T, PlaywrightTestOptions & PlaywrightWorkerOptions & PlaywrightTestArgs & PlaywrightWorkerArgs>;
+
+export type PlaywrightTestProject<TestArgs = {}, WorkerArgs = {}> = Project<PlaywrightTestOptions & CustomProperties<TestArgs>, PlaywrightWorkerOptions & CustomProperties<WorkerArgs>>;
+export type PlaywrightTestConfig<TestArgs = {}, WorkerArgs = {}> = Config<PlaywrightTestOptions & CustomProperties<TestArgs>, PlaywrightWorkerOptions & CustomProperties<WorkerArgs>>;
 
 import type * as expectType from './expect-types';
 import type { Suite } from './testReporter';


### PR DESCRIPTION
This makes errors more focused on the custom properties.

References #20416.