### PR TITLE
fix(test runner): do not print timeout message upon interrupt

### DIFF
--- a/packages/playwright-test/src/common/testInfo.ts
+++ b/packages/playwright-test/src/common/testInfo.ts
@@ -161,10 +161,12 @@ export class TestInfoImpl implements TestInfo {
 
   async _runWithTimeout(cb: () => Promise<any>): Promise<void> {
     const timeoutError = await this._timeoutManager.runWithTimeout(cb);
-    // Do not overwrite existing failure upon hook/teardown timeout.
-    if (timeoutError && !this._didTimeout) {
+    // When interrupting, we arrive here with a timeoutError, but we should not
+    // consider it a timeout.
+    if (this.status !== 'interrupted' && timeoutError && !this._didTimeout) {
       this._didTimeout = true;
       this.errors.push(timeoutError);
+      // Do not overwrite existing failure upon hook/teardown timeout.
       if (this.status === 'passed' || this.status === 'skipped')
         this.status = 'timedOut';
     }

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -112,7 +112,7 @@ test('sigint should stop workers', async ({ runInlineTest }) => {
         console.log('\\n%%skipped2');
       });
     `,
-  }, { 'workers': 2 }, {}, { sendSIGINTAfter: 2 });
+  }, { 'workers': 2, 'reporter': 'line,json' }, {}, { sendSIGINTAfter: 2 });
   expect(result.exitCode).toBe(130);
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(0);
@@ -122,6 +122,8 @@ test('sigint should stop workers', async ({ runInlineTest }) => {
   expect(result.output).toContain('%%SEND-SIGINT%%2');
   expect(result.output).not.toContain('%%skipped1');
   expect(result.output).not.toContain('%%skipped2');
+  expect(result.output).toContain('Test was interrupted.');
+  expect(result.output).not.toContain('Test timeout of');
 
   const interrupted2 = result.report.suites[1].specs[0];
   expect(interrupted2.title).toBe('interrupted2');


### PR DESCRIPTION
We should only print "Test was interrupted."

Regressed in #18321.