### PR TITLE
feat: key value store backed by filesystem

### DIFF
--- a/docs/src/test-api/class-teststore.md
+++ b/docs/src/test-api/class-teststore.md
@@ -1,0 +1,58 @@
+# class: TestStore
+* since: v1.31
+* langs: js
+
+Playwright Test provides a global `store` object for passing values between project test and tests. It is
+an error to call store methods outside of test and tests.
+
+```js tab=js-js
+const { test, store } = require('@playwright/test');
+
+test('sign in', async ({ page, context }) => {
+  // Perform sign in steps.
+  // Save signed-in state to an entry named 'test-user'.
+  const contextState = await context.storageState();
+  await store.set('test-user', contextState)
+});
+```
+
+```js tab=js-ts
+import { test, store } from '@playwright/test';
+
+test('sign in', async ({ page, context }) => {
+  // Perform sign in steps.
+  // Save signed-in state to an entry named 'test-user'.
+  const contextState = await context.storageState();
+  await store.set('test-user', contextState)
+});
+```
+
+## async method: TestStore.get
+* since: v1.31
+- returns: <[any]>
+
+Get named item from the store. Returns undefined if there is no value with given name.
+
+### param: TestStore.get.name
+* since: v1.31
+- `name` <[string]>
+
+Item name.
+
+## async method: TestStore.set
+* since: v1.31
+
+Set value to the store.
+
+### param: TestStore.set.name
+* since: v1.31
+- `name` <[string]>
+
+Item name.
+
+### param: TestStore.set.value
+* since: v1.31
+- `value` <[any]>
+
+Item value. The value must be serializable to JSON. Passing `undefined` deletes the entry with given name.
+

--- a/docs/src/test-api/class-teststore.md
+++ b/docs/src/test-api/class-teststore.md
@@ -2,7 +2,7 @@
 * since: v1.31
 * langs: js
 
-Playwright Test provides a global `store` object for passing values between project test and tests. It is
+Playwright Test provides a global `store` object that can be used in global setup and tests.
 an error to call store methods outside of test and tests.
 
 ```js tab=js-js

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -22,9 +22,11 @@ import { createGuid, debugMode, removeFolders, addStackIgnoreFilter } from 'play
 import type { Fixtures, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, ScreenshotMode, TestInfo, TestType, TraceMode, VideoMode } from '../types/test';
 import type { TestInfoImpl } from './common/testInfo';
 import { rootTestType } from './common/testType';
+import { store as _baseStore } from './store';
 import { type ContextReuseMode } from './common/types';
 export { expect } from './matchers/expect';
 export const _baseTest: TestType<{}, {}> = rootTestType.test;
+export const store = _baseStore;
 
 addStackIgnoreFilter((frame: StackFrame) => frame.file.startsWith(path.dirname(require.resolve('../package.json'))));
 

--- a/packages/playwright-test/src/store.ts
+++ b/packages/playwright-test/src/store.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type { TestStore } from '../types/test';
+import { currentTestInfo } from './common/globals';
+
+class JsonStore implements TestStore {
+  private _toFilePath(name: string) {
+    const testInfo = currentTestInfo();
+    if (!testInfo)
+      throw new Error('store can only be called while test is running');
+    const fileName = name + '.json';
+    return path.join(testInfo.config._internal.storeDir, fileName);
+  }
+
+  async get<T>(name: string) {
+    const file = this._toFilePath(name);
+    try {
+      const data = (await fs.promises.readFile(file)).toString('utf-8');
+      return JSON.parse(data) as T;
+    } catch (e) {
+      return undefined;
+    }
+  }
+
+  async set<T>(name: string, value: T | undefined) {
+    const file = this._toFilePath(name);
+    if (value === undefined) {
+      await fs.promises.rm(file, { force: true });
+      return;
+    }
+    const data = JSON.stringify(value, undefined, 2);
+    await fs.promises.mkdir(path.dirname(file), { recursive: true });
+    await fs.promises.writeFile(file, data);
+  }
+}
+
+export const store = new JsonStore();

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -3303,6 +3303,36 @@ type ConnectOptions = {
 };
 
 /**
+ * Playwright Test provides a global `store` object for passing values between project test and tests. It is an error
+ * to call store methods outside of test and tests.
+ *
+ * ```js
+ * import { test, store } from '@playwright/test';
+ *
+ * test('sign in', async ({ page, context }) => {
+ *   // Perform sign in steps.
+ *   // Save signed-in state to an entry named 'test-user'.
+ *   const contextState = await context.storageState();
+ *   await store.set('test-user', contextState)
+ * });
+ * ```
+ *
+ */
+export interface TestStore {
+  /**
+   * Get named item from the store. Returns undefined if there is no value with given name.
+   * @param name Item name.
+   */
+  get<T>(name: string): Promise<T | undefined>;
+  /**
+   * Set value to the store.
+   * @param name Item name.
+   * @param value Item value. The value must be serializable to JSON. Passing `undefined` deletes the entry with given name.
+   */
+  set<T>(name: string, value: T | undefined): Promise<void>;
+}
+
+/**
  * Playwright Test provides many options to configure test environment, [Browser], [BrowserContext] and more.
  *
  * These options are usually provided in the [configuration file](https://playwright.dev/docs/test-configuration) through
@@ -4265,6 +4295,7 @@ export default test;
 
 export const _baseTest: TestType<{}, {}>;
 export const expect: Expect;
+export const store: TestStore;
 
 /**
  * Defines Playwright config

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -197,6 +197,11 @@ type ConnectOptions = {
   timeout?: number;
 };
 
+export interface TestStore {
+  get<T>(name: string): Promise<T | undefined>;
+  set<T>(name: string, value: T | undefined): Promise<void>;
+}
+
 export interface PlaywrightWorkerOptions {
   browserName: BrowserName;
   defaultBrowserType: BrowserName;
@@ -385,6 +390,7 @@ export default test;
 
 export const _baseTest: TestType<{}, {}>;
 export const expect: Expect;
+export const store: TestStore;
 
 /**
  * Defines Playwright config


### PR DESCRIPTION
Keys are used as a relative file path without any sanitization assuming that the underlying fs will throw on error.