### PR TITLE
test: update 'should handle custom dataTransfer' expectation

### DIFF
--- a/tests/page/page-drag.spec.ts
+++ b/tests/page/page-drag.spec.ts
@@ -391,9 +391,9 @@ async function trackEvents(target: ElementHandle) {
   return eventsHandle;
 }
 
-it('should handle custom dataTransfer', async ({ page, browserName, isLinux, headless }) => {
+it('should handle custom dataTransfer', async ({ page, browserName, isWindows }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/18013' });
-  it.skip(browserName === 'webkit' && isLinux && headless);
+  it.fixme(browserName === 'webkit' && isWindows);
   await page.setContent(`<button draggable="true">Draggable</button>`);
 
   const resultPromise = page.evaluate(() =>


### PR DESCRIPTION
Headless linux was fixed by recent webkit roll, but it turns out the test has been failing on webkit windows too.

#18013