### PR TITLE
test: add test with wheel events and opened popup

### DIFF
--- a/tests/page/wheel.spec.ts
+++ b/tests/page/wheel.spec.ts
@@ -75,7 +75,7 @@ it('should dispatch wheel events after popup was opened @smoke', async ({ page, 
   await listenForWheelEvents(page, 'div');
   await Promise.all([
     page.waitForEvent('popup'),
-    page.evaluate(() => window.open("")),
+    page.evaluate(() => window.open('')),
   ]);
   await page.mouse.wheel(0, 100);
   await page.waitForFunction('window.scrollY === 100');

--- a/tests/page/wheel.spec.ts
+++ b/tests/page/wheel.spec.ts
@@ -67,6 +67,31 @@ it('should dispatch wheel events @smoke', async ({ page, server }) => {
   });
 });
 
+it('should dispatch wheel events after popup was opened @smoke', async ({ page, server }) => {
+  await page.setContent(`
+    <div style="width: 5000px; height: 5000px;"></div>
+  `);
+  await page.mouse.move(50, 60);
+  await listenForWheelEvents(page, 'div');
+  await Promise.all([
+    page.waitForEvent('popup'),
+    page.evaluate(() => window.open("")),
+  ]);
+  await page.mouse.wheel(0, 100);
+  await page.waitForFunction('window.scrollY === 100');
+  await expectEvent(page, {
+    deltaX: 0,
+    deltaY: 100,
+    clientX: 50,
+    clientY: 60,
+    deltaMode: 0,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+  });
+});
+
 it('should dispatch wheel event on svg element', async ({ page, browserName, headless, isLinux }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/15566' });
   await page.setContent(`


### PR DESCRIPTION
This should be merged once Firefox Stable 1376 is rolled in.

References #19685
