### PR TITLE
docs(test-advanced-js.md): fix import config example

### DIFF
--- a/docs/src/test-advanced-js.md
+++ b/docs/src/test-advanced-js.md
@@ -453,7 +453,8 @@ module.exports = defineConfig({
 
 ```js tab=js-ts
 // playwright.config.ts
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
+
 export default defineConfig({
   projects: [
     {


### PR DESCRIPTION
https://playwright.dev/docs/test-advanced#same-tests-different-configuration

Missing include in config.ts file. add import `devices`.