### PR TITLE
fix: reset SNAP* env variables when launching Firefox

### DIFF
--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -46,6 +46,12 @@ export class Firefox extends BrowserType {
   _amendEnvironment(env: Env, userDataDir: string, executable: string, browserArguments: string[]): Env {
     if (!path.isAbsolute(os.homedir()))
       throw new Error(`Cannot launch Firefox with relative home directory. Did you set ${os.platform() === 'win32' ? 'USERPROFILE' : 'HOME'} to a relative path?`);
+    if (os.platform() === 'linux') {
+      // Always remove SNAP_NAMe and SNAP_INSTANCE_NAME env variables since they
+      // confuse Firefox: in our case, builds never come from SNAP.
+      // See https://github.com/microsoft/playwright/issues/20555
+      return {...env, SNAP_NAME: undefined, SNAP_INSTANCE_NAME: undefined };
+    }
     return env;
   }
 

--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -50,7 +50,7 @@ export class Firefox extends BrowserType {
       // Always remove SNAP_NAME and SNAP_INSTANCE_NAME env variables since they
       // confuse Firefox: in our case, builds never come from SNAP.
       // See https://github.com/microsoft/playwright/issues/20555
-      return {...env, SNAP_NAME: undefined, SNAP_INSTANCE_NAME: undefined };
+      return { ...env, SNAP_NAME: undefined, SNAP_INSTANCE_NAME: undefined };
     }
     return env;
   }

--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -47,7 +47,7 @@ export class Firefox extends BrowserType {
     if (!path.isAbsolute(os.homedir()))
       throw new Error(`Cannot launch Firefox with relative home directory. Did you set ${os.platform() === 'win32' ? 'USERPROFILE' : 'HOME'} to a relative path?`);
     if (os.platform() === 'linux') {
-      // Always remove SNAP_NAMe and SNAP_INSTANCE_NAME env variables since they
+      // Always remove SNAP_NAME and SNAP_INSTANCE_NAME env variables since they
       // confuse Firefox: in our case, builds never come from SNAP.
       // See https://github.com/microsoft/playwright/issues/20555
       return {...env, SNAP_NAME: undefined, SNAP_INSTANCE_NAME: undefined };


### PR DESCRIPTION
Our builds never come from Snap, so Playwright's Firefox should
never consider that it's been installed via SNAP.

Fixes #20555
