### PR TITLE
feat: sharded html report

### DIFF
--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -57,8 +57,10 @@ class ZipReport implements LoadedReport {
 
   async loadFromShards(shardTotal: number) {
     const readers = [];
+    const paddedLen = String(shardTotal).length;
     for (let i = 0; i < shardTotal; i++) {
-      const fileName = `report-${i + 1}-of-${shardTotal}.zip`;
+      const paddedNumber = String(i + 1).padStart(paddedLen, '0');
+      const fileName = `report-${paddedNumber}-of-${shardTotal}.zip`;
       const zipReader = new zipjs.ZipReader(new zipjs.HttpReader(fileName), { useWebWorkers: false }) as zip.ZipReader;
       readers.push(this._readReportAndTestEntries(zipReader));
     }

--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { HTMLReport, Stats } from './types';
+import type { HTMLReport } from './types';
 import type zip from '@zip.js/zip.js';
 // @ts-ignore
 import * as zipImport from '@zip.js/zip.js/lib/zip-no-worker-inflate.js';
@@ -23,6 +23,7 @@ import * as ReactDOM from 'react-dom';
 import './colors.css';
 import type { LoadedReport } from './loadedReport';
 import { ReportView } from './reportView';
+import { mergeReports } from './mergeReports';
 // @ts-ignore
 const zipjs = zipImport as typeof zip;
 
@@ -33,10 +34,10 @@ const ReportLoader: React.FC = () => {
       return;
     const shardTotal = window.playwrightShardTotal;
     const zipReport = new ZipReport();
-    const loadPromis = shardTotal ?
+    const loadPromise = shardTotal ?
       zipReport.loadFromShards(shardTotal) :
       zipReport.loadFromBase64(window.playwrightReportBase64!);
-    loadPromis.then(() => setReport(zipReport));
+    loadPromise.then(() => setReport(zipReport));
   }, [report]);
   return <ReportView report={report}></ReportView>;
 };
@@ -57,7 +58,7 @@ class ZipReport implements LoadedReport {
   async loadFromShards(shardTotal: number) {
     const readers = [];
     for (let i = 0; i < shardTotal; i++) {
-      const fileName = `/report-${i + 1}-of-${shardTotal}.zip`;
+      const fileName = `report-${i + 1}-of-${shardTotal}.zip`;
       const zipReader = new zipjs.ZipReader(new zipjs.HttpReader(fileName), { useWebWorkers: false }) as zip.ZipReader;
       readers.push(this._readReportAndTestEntries(zipReader));
     }
@@ -82,34 +83,3 @@ class ZipReport implements LoadedReport {
   }
 }
 
-function mergeReports(reports: HTMLReport[]): HTMLReport {
-  const [report, ...rest] = reports;
-
-  for (const currentReport of rest) {
-    currentReport.files.forEach(file => {
-      const existingGroup = report.files.find(({ fileId }) => fileId === file.fileId);
-
-      if (existingGroup) {
-        existingGroup.tests.push(...file.tests);
-        mergeStats(existingGroup.stats, file.stats);
-      } else {
-        report.files.push(file);
-      }
-    });
-
-    mergeStats(report.stats, currentReport.stats);
-    report.metadata.duration += currentReport.metadata.duration;
-  }
-
-  return report;
-}
-
-function mergeStats(toStats: Stats, fromStats: Stats) {
-  toStats.total += fromStats.total;
-  toStats.expected += fromStats.expected;
-  toStats.unexpected += fromStats.unexpected;
-  toStats.flaky += fromStats.flaky;
-  toStats.skipped += fromStats.skipped;
-  toStats.duration += fromStats.duration;
-  toStats.ok = toStats.ok && fromStats.ok;
-}

--- a/packages/html-reporter/src/mergeReports.ts
+++ b/packages/html-reporter/src/mergeReports.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { HTMLReport, Stats } from './types';
+
+export function mergeReports(reports: HTMLReport[]): HTMLReport {
+  const [report, ...rest] = reports;
+
+  for (const currentReport of rest) {
+    currentReport.files.forEach(file => {
+      const existingGroup = report.files.find(({ fileId }) => fileId === file.fileId);
+
+      if (existingGroup) {
+        existingGroup.tests.push(...file.tests);
+        mergeStats(existingGroup.stats, file.stats);
+      } else {
+        report.files.push(file);
+      }
+    });
+
+    mergeStats(report.stats, currentReport.stats);
+    report.metadata.duration += currentReport.metadata.duration;
+  }
+
+  return report;
+}
+
+function mergeStats(toStats: Stats, fromStats: Stats) {
+  toStats.total += fromStats.total;
+  toStats.expected += fromStats.expected;
+  toStats.unexpected += fromStats.unexpected;
+  toStats.flaky += fromStats.flaky;
+  toStats.skipped += fromStats.skipped;
+  toStats.duration += fromStats.duration;
+  toStats.ok = toStats.ok && fromStats.ok;
+}

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -31,6 +31,7 @@ import './theme.css';
 
 declare global {
   interface Window {
+    playwrightShardTotal?: number;
     playwrightReportBase64?: string;
   }
 }

--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -295,7 +295,8 @@ class HtmlBuilder {
       // For each shard write same index.html and store report data in a separate report-num-of-total.zip
       // so that they can all be copied in one folder.
       fs.appendFileSync(indexFile, `<script>\nwindow.playwrightShardTotal=${shard.total};</script>`);
-      const reportZip = path.join(this._reportFolder, `report-${shard.current}-of-${shard.total}.zip`);
+      const paddedNumber = String(shard.current).padStart(String(shard.total).length, '0');
+      const reportZip = path.join(this._reportFolder, `report-${paddedNumber}-of-${shard.total}.zip`);
       await new Promise(f => {
         this._dataZipFile!.end(undefined, () => {
           this._dataZipFile!.outputStream.pipe(fs.createWriteStream(reportZip)).on('close', f);

--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -202,7 +202,6 @@ class HtmlBuilder {
   constructor(outputDir: string) {
     this._reportFolder = outputDir;
     fs.mkdirSync(this._reportFolder, { recursive: true });
-    console.log('rep = ' + this._reportFolder);
     this._dataZipFile = new yazl.ZipFile();
   }
 

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1023,3 +1023,19 @@ test('should shard report', async ({ runInlineTest, showReport, page }, testInfo
   await expect(page.locator('.test-file-test-outcome-expected >> text=passes')).toHaveCount(totalShards);
   await expect(page.locator('.test-file-test-outcome-skipped >> text=skipped')).toHaveCount(totalShards);
 });
+
+test('should pad report numbers with zeros', async ({ runInlineTest, showReport, page }, testInfo) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      const { test } = pwt;
+      test('passes', async ({}) => {});
+    `,
+  }, { reporter: 'dot,html', shard: '3/100' }, { PW_TEST_HTML_REPORT_OPEN: 'never' });
+
+  expect(result.exitCode).toBe(0);
+  const files = await fs.promises.readdir(testInfo.outputPath(`playwright-report`));
+  expect(new Set(files)).toEqual(new Set([
+    'index.html',
+    `report-003-of-100.zip`
+  ]));
+});


### PR DESCRIPTION
This implementation is based on the [original PR](https://github.com/microsoft/playwright/pull/19691)  by @kevin940726. It makes the reporter produce single file when there is no sharding and multiple out-of-line report-x-of-y.zip reports which are automatically merged together when put in one folder.

References https://github.com/microsoft/playwright/issues/10437

Co-authored-by: Kai Hao <kevin830726@gmail.com>