### PR TITLE
feat: show warning when some report shards are missing

### DIFF
--- a/packages/html-reporter/src/headerView.css
+++ b/packages/html-reporter/src/headerView.css
@@ -30,3 +30,7 @@
     border-right: none;
   }
 }
+
+.header-view-status-line {
+  padding-right: '10px'
+}

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -29,7 +29,8 @@ export const HeaderView: React.FC<React.PropsWithChildren<{
   filterText: string,
   setFilterText: (filterText: string) => void,
   projectNames: string[],
-}>> = ({ stats, filterText, setFilterText, projectNames }) => {
+  reportLoaderError?: string,
+}>> = ({ stats, filterText, setFilterText, projectNames, reportLoaderError }) => {
   React.useEffect(() => {
     (async () => {
       window.addEventListener('popstate', () => {
@@ -57,9 +58,10 @@ export const HeaderView: React.FC<React.PropsWithChildren<{
         }}></input>
       </form>
     </div>
-    <div className='pt-2'>
+    {reportLoaderError && <div className='header-view-status-line pt-2' data-testid='loader-error' style={{ color: 'var(--color-danger-emphasis)', textAlign: 'right' }}>{reportLoaderError}</div>}
+    <div className='header-view-status-line pt-2'>
       {projectNames.length === 1 && <span data-testid="project-name" style={{ color: 'var(--color-fg-subtle)', float: 'left' }}>Project: {projectNames[0]}</span>}
-      <span data-testid="overall-duration" style={{ color: 'var(--color-fg-subtle)', paddingRight: '10px', float: 'right' }}>Total time: {msToString(stats.duration)}</span>
+      <span data-testid="overall-duration" style={{ color: 'var(--color-fg-subtle)', float: 'right' }}>Total time: {msToString(stats.duration)}</span>
     </div>
   </>);
 };

--- a/packages/html-reporter/src/loadedReport.ts
+++ b/packages/html-reporter/src/loadedReport.ts
@@ -19,4 +19,5 @@ import type { HTMLReport } from './types';
 export interface LoadedReport {
   json(): HTMLReport;
   entry(name: string): Promise<Object | undefined>;
+  loaderError(): string | undefined;
 }

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -51,7 +51,7 @@ export const ReportView: React.FC<{
 
   return <div className='htmlreport vbox px-4 pb-4'>
     <main>
-      {report?.json() && <HeaderView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText} projectNames={report.json().projectNames}></HeaderView>}
+      {report?.json() && <HeaderView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText} projectNames={report.json().projectNames} reportLoaderError={report.loaderError()}></HeaderView>}
       {report?.json().metadata && <MetadataView {...report?.json().metadata as Metainfo} />}
       <Route predicate={testFilesRoutePredicate}>
         <TestFilesView report={report?.json()} filter={filter} expandedFiles={expandedFiles} setExpandedFiles={setExpandedFiles}></TestFilesView>


### PR DESCRIPTION
When some of the report shards are missing still show the report but display an error in the status line:
![image](https://user-images.githubusercontent.com/9798949/217371112-2317a307-204e-4c11-8d01-42e91fe6ca7a.png)

#10437