### PR TITLE
chore: replace deprecated command with environment file

### DIFF
--- a/.github/workflows/cherry_pick_into_release_branch.yml
+++ b/.github/workflows/cherry_pick_into_release_branch.yml
@@ -48,12 +48,12 @@ jobs:
           git commit -m "$COMMIT_MESSAGE"
         done
         LAST_COMMIT_MESSAGE=$(git show -s --format=%B)
-        echo "::set-output name=PR_TITLE::$LAST_COMMIT_MESSAGE"
+        echo "PR_TITLE=$LAST_COMMIT_MESSAGE" >> $GITHUB_OUTPUT
     - name: Prepare branch
       id: prepare-branch
       run: |
         BRANCH_NAME="cherry-pick-${{ github.event.inputs.version }}-$(date +%Y-%m-%d-%H-%M-%S)"
-        echo "::set-output name=BRANCH_NAME::$BRANCH_NAME"
+        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
         git checkout -b "$BRANCH_NAME"
         git push origin $BRANCH_NAME
     - name: Create Pull Request

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -25,7 +25,7 @@ jobs:
       id: prepare-branch
       run: |
         BRANCH_NAME="roll-into-pw-${{ github.event.client_payload.browser }}/${{ github.event.client_payload.revision }}"
-        echo "::set-output name=BRANCH_NAME::$BRANCH_NAME"
+        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
         git config --global user.name github-actions
         git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
         git checkout -b "$BRANCH_NAME"

--- a/.github/workflows/roll_driver_nodejs.yml
+++ b/.github/workflows/roll_driver_nodejs.yml
@@ -22,9 +22,9 @@ jobs:
               echo "there are no changes";
               exit 0;
           fi
-          echo "::set-output name=HAS_CHANGES::1"
+          echo "HAS_CHANGES=1" >> $GITHUB_OUTPUT
           BRANCH_NAME="roll-driver-nodejs/$(date +%Y-%b-%d)"
-          echo "::set-output name=BRANCH_NAME::$BRANCH_NAME"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
           git config --global user.name github-actions
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
           git checkout -b "$BRANCH_NAME"


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

Resolve #20751 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```
