### PR TITLE
chore: mark `comparator` option back as experimental

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -1385,9 +1385,6 @@ Snapshot name.
 ### option: LocatorAssertions.toHaveScreenshot#1.scale = %%-screenshot-option-scale-default-css-%%
 * since: v1.23
 
-### option: LocatorAssertions.toHaveScreenshot#1.comparator = %%-assertions-comparator-%%
-* since: v1.31
-
 ### option: LocatorAssertions.toHaveScreenshot#1.maxDiffPixels = %%-assertions-max-diff-pixels-%%
 * since: v1.23
 
@@ -1430,9 +1427,6 @@ Note that screenshot assertions only work with Playwright test runner.
 
 ### option: LocatorAssertions.toHaveScreenshot#2.scale = %%-screenshot-option-scale-default-css-%%
 * since: v1.23
-
-### option: LocatorAssertions.toHaveScreenshot#2.comparator = %%-assertions-comparator-%%
-* since: v1.31
 
 ### option: LocatorAssertions.toHaveScreenshot#2.maxDiffPixels = %%-assertions-max-diff-pixels-%%
 * since: v1.23

--- a/docs/src/api/class-pageassertions.md
+++ b/docs/src/api/class-pageassertions.md
@@ -164,9 +164,6 @@ Snapshot name.
 ### option: PageAssertions.toHaveScreenshot#1.scale = %%-screenshot-option-scale-default-css-%%
 * since: v1.23
 
-### option: PageAssertions.toHaveScreenshot#1.comparator = %%-assertions-comparator-%%
-* since: v1.29
-
 ### option: PageAssertions.toHaveScreenshot#1.maxDiffPixels = %%-assertions-max-diff-pixels-%%
 * since: v1.23
 
@@ -214,9 +211,6 @@ Note that screenshot assertions only work with Playwright test runner.
 
 ### option: PageAssertions.toHaveScreenshot#2.scale = %%-screenshot-option-scale-default-css-%%
 * since: v1.23
-
-### option: PageAssertions.toHaveScreenshot#2.comparator = %%-assertions-comparator-%%
-* since: v1.29
 
 ### option: PageAssertions.toHaveScreenshot#2.maxDiffPixels = %%-assertions-max-diff-pixels-%%
 * since: v1.23

--- a/docs/src/api/class-snapshotassertions.md
+++ b/docs/src/api/class-snapshotassertions.md
@@ -43,9 +43,6 @@ Note that matching snapshots only work with Playwright test runner.
 
 Snapshot name.
 
-### option: SnapshotAssertions.toMatchSnapshot#1.comparator = %%-assertions-comparator-%%
-* since: v1.29
-
 ### option: SnapshotAssertions.toMatchSnapshot#1.maxDiffPixels = %%-assertions-max-diff-pixels-%%
 * since: v1.22
 
@@ -81,9 +78,6 @@ expect(await page.screenshot()).toMatchSnapshot({
 Learn more about [visual comparisons](../test-snapshots.md).
 
 Note that matching snapshots only work with Playwright test runner.
-
-### option: SnapshotAssertions.toMatchSnapshot#2.comparator = %%-assertions-comparator-%%
-* since: v1.29
 
 ### option: SnapshotAssertions.toMatchSnapshot#2.maxDiffPixels = %%-assertions-max-diff-pixels-%%
 * since: v1.22

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -812,12 +812,6 @@ Time to retry the assertion for.
 
 An acceptable amount of pixels that could be different. Default is configurable with `TestConfig.expect`. Unset by default.
 
-## assertions-comparator
-* langs: js
-- `comparator` <[string]> Either `"pixelmatch"` or `"ssim-cie94"`.
-
-A comparator function to use when comparing images. Defaults to `"pixelmatch"`.
-
 ## assertions-max-diff-pixel-ratio
 * langs: js
 - `maxDiffPixelRatio` <[float]>
@@ -830,7 +824,7 @@ An acceptable ratio of pixels that are different to the total amount of pixels, 
 
 An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ)
 between the same pixel in compared images, between zero (strict) and one (lax), default is configurable with
-`TestConfig.expect`. Defaults to `0.2`. This option is used by "pixelmatch" image comparator.
+`TestConfig.expect`. Defaults to `0.2`.
 
 ## shared-context-params-list-v1.8
 - %%-context-option-acceptdownloads-%%

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -37,16 +37,14 @@ export default defineConfig({
 - type: ?<[Object]>
   - `timeout` ?<[int]> Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
   - `toHaveScreenshot` ?<[Object]> Configuration for the [`method: PageAssertions.toHaveScreenshot#1`] method.
-    - `comparator` ?<[string]> a comparator function to use, either `"pixelmatch"` or `"ssim-cie94"`. Defaults to `"pixelmatch"`.
-    - `threshold` ?<[float]> an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and `1` (lax). `"pixelmatch"` comparator computes color difference in [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`. This option is used by `pixelmatch` image comparator.
+    - `threshold` ?<[float]> an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and `1` (lax). `"pixelmatch"` comparator computes color difference in [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`.
     - `maxDiffPixels` ?<[int]> an acceptable amount of pixels that could be different, unset by default.
     - `maxDiffPixelRatio` ?<[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
     - `animations` ?<[ScreenshotAnimations]<"allow"|"disabled">> See [`option: animations`] in [`method: Page.screenshot`]. Defaults to `"disabled"`.
     - `caret` ?<[ScreenshotCaret]<"hide"|"initial">> See [`option: caret`] in [`method: Page.screenshot`]. Defaults to `"hide"`.
     - `scale` ?<[ScreenshotScale]<"css"|"device">> See [`option: scale`] in [`method: Page.screenshot`]. Defaults to `"css"`.
   - `toMatchSnapshot` ?<[Object]> Configuration for the [`method: SnapshotAssertions.toMatchSnapshot#1`] method.
-    - `comparator` ?<[string]> a comparator function to use, either `"pixelmatch"` or `"ssim-cie94"`. Defaults to `"pixelmatch"`.
-    - `threshold` ?<[float]> an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and `1` (lax). `"pixelmatch"` comparator computes color difference in [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`. This option is used by `pixelmatch` image comparator.
+    - `threshold` ?<[float]> an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and `1` (lax). `"pixelmatch"` comparator computes color difference in [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`.
     - `maxDiffPixels` ?<[int]> an acceptable amount of pixels that could be different, unset by default.
     - `maxDiffPixelRatio` ?<[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
 

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -133,16 +133,14 @@ export default defineConfig({
 - type: ?<[Object]>
   - `timeout` ?<[int]> Default timeout for async expect matchers in milliseconds, defaults to 5000ms.
   - `toHaveScreenshot` ?<[Object]> Configuration for the [`method: PageAssertions.toHaveScreenshot#1`] method.
-    - `comparator` ?<[string]> a comparator function to use, either `"pixelmatch"` or `"ssim-cie94"`. Defaults to `"pixelmatch"`.
-    - `threshold` ?<[float]> an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and `1` (lax). `"pixelmatch"` comparator computes color difference in [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`. This option is used by `pixelmatch` image comparator.
+    - `threshold` ?<[float]> an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and `1` (lax). `"pixelmatch"` comparator computes color difference in [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`.
     - `maxDiffPixels` ?<[int]> an acceptable amount of pixels that could be different, unset by default.
     - `maxDiffPixelRatio` ?<[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
     - `animations` ?<[ScreenshotAnimations]<"allow"|"disabled">> See [`option: animations`] in [`method: Page.screenshot`]. Defaults to `"disabled"`.
     - `caret` ?<[ScreenshotCaret]<"hide"|"initial">> See [`option: caret`] in [`method: Page.screenshot`]. Defaults to `"hide"`.
     - `scale` ?<[ScreenshotScale]<"css"|"device">> See [`option: scale`] in [`method: Page.screenshot`]. Defaults to `"css"`.
   - `toMatchSnapshot` ?<[Object]> Configuration for the [`method: SnapshotAssertions.toMatchSnapshot#1`] method.
-    - `comparator` ?<[string]> a comparator function to use, either `"pixelmatch"` or `"ssim-cie94"`. Defaults to `"pixelmatch"`.
-    - `threshold` ?<[float]> an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and `1` (lax). `"pixelmatch"` comparator computes color difference in [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`. This option is used by `pixelmatch` image comparator.
+    - `threshold` ?<[float]> an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and `1` (lax). `"pixelmatch"` comparator computes color difference in [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`.
     - `maxDiffPixels` ?<[int]> an acceptable amount of pixels that could be different, unset by default.
     - `maxDiffPixelRatio` ?<[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
 

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -181,6 +181,10 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     return await this._page.expectScreenshot(metadata, {
       ...params,
       locator,
+      comparatorOptions: {
+        ...params.comparatorOptions,
+        _comparator: params.comparatorOptions?.comparator,
+      },
       screenshotOptions: {
         ...params.screenshotOptions,
         mask,

--- a/packages/playwright-core/src/utils/comparators.ts
+++ b/packages/playwright-core/src/utils/comparators.ts
@@ -21,7 +21,7 @@ import { compare } from '../image_tools/compare';
 const { diff_match_patch, DIFF_INSERT, DIFF_DELETE, DIFF_EQUAL } = require('../third_party/diff_match_patch');
 import { PNG } from '../utilsBundle';
 
-export type ImageComparatorOptions = { threshold?: number, maxDiffPixels?: number, maxDiffPixelRatio?: number, comparator?: string };
+export type ImageComparatorOptions = { threshold?: number, maxDiffPixels?: number, maxDiffPixelRatio?: number, _comparator?: string };
 export type ComparatorResult = { diff?: Buffer; errorMessage: string; } | null;
 export type Comparator = (actualBuffer: Buffer | string, expectedBuffer: Buffer, options?: any) => ComparatorResult;
 
@@ -64,18 +64,18 @@ function compareImages(mimeType: string, actualBuffer: Buffer | string, expected
   }
   const diff = new PNG({ width: size.width, height: size.height });
   let count;
-  if (options.comparator === 'ssim-cie94') {
+  if (options._comparator === 'ssim-cie94') {
     count = compare(expected.data, actual.data, diff.data, size.width, size.height, {
       // All ΔE* formulae are originally designed to have the difference of 1.0 stand for a "just noticeable difference" (JND).
       // See https://en.wikipedia.org/wiki/Color_difference#CIELAB_%CE%94E*
       maxColorDeltaE94: 1.0,
     });
-  } else if ((options.comparator ?? 'pixelmatch') === 'pixelmatch') {
+  } else if ((options._comparator ?? 'pixelmatch') === 'pixelmatch') {
     count = pixelmatch(expected.data, actual.data, diff.data, size.width, size.height, {
       threshold: options.threshold ?? 0.2,
     });
   } else {
-    throw new Error(`Configuration specifies unknown comparator "${options.comparator}"`);
+    throw new Error(`Configuration specifies unknown comparator "${options._comparator}"`);
   }
 
   const maxDiffPixels1 = options.maxDiffPixels;

--- a/packages/playwright-test/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright-test/src/matchers/toMatchSnapshot.ts
@@ -145,7 +145,7 @@ class SnapshotHelper<T extends ImageComparatorOptions> {
       maxDiffPixels: options.maxDiffPixels,
       maxDiffPixelRatio: options.maxDiffPixelRatio,
       threshold: options.threshold,
-      comparator: options.comparator,
+      _comparator: options._comparator,
     };
     this.kind = this.mimeType.startsWith('image/') ? 'Screenshot' : 'Snapshot';
   }
@@ -306,7 +306,7 @@ export async function toHaveScreenshot(
   const helper = new SnapshotHelper(
       testInfo, snapshotPathResolver, 'png',
       {
-        comparator: config?.comparator,
+        _comparator: config?._comparator,
         maxDiffPixels: config?.maxDiffPixels,
         maxDiffPixelRatio: config?.maxDiffPixelRatio,
         threshold: config?.threshold,
@@ -342,7 +342,10 @@ export async function toHaveScreenshot(
       expected: await fs.promises.readFile(helper.snapshotPath),
       isNot: true,
       locator,
-      comparatorOptions: helper.comparatorOptions,
+      comparatorOptions: {
+        ...helper.comparatorOptions,
+        comparator: helper.comparatorOptions._comparator,
+      },
       screenshotOptions,
       timeout: currentExpectTimeout(helper.allOptions),
     })).errorMessage;
@@ -360,7 +363,7 @@ export async function toHaveScreenshot(
       expected: undefined,
       isNot: false,
       locator,
-      comparatorOptions: helper.comparatorOptions,
+      comparatorOptions: { ...helper.comparatorOptions, comparator: helper.comparatorOptions._comparator },
       screenshotOptions,
       timeout,
     });
@@ -382,7 +385,7 @@ export async function toHaveScreenshot(
     expected,
     isNot: false,
     locator,
-    comparatorOptions: helper.comparatorOptions,
+    comparatorOptions: { ...helper.comparatorOptions, comparator: helper.comparatorOptions._comparator },
     screenshotOptions,
     timeout: currentExpectTimeout(helper.allOptions),
   });

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -552,15 +552,9 @@ interface TestConfig {
      */
     toHaveScreenshot?: {
       /**
-       * a comparator function to use, either `"pixelmatch"` or `"ssim-cie94"`. Defaults to `"pixelmatch"`.
-       */
-      comparator?: string;
-
-      /**
        * an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and
        * `1` (lax). `"pixelmatch"` comparator computes color difference in
-       * [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`. This option is used
-       * by `pixelmatch` image comparator.
+       * [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`.
        */
       threshold?: number;
 
@@ -601,15 +595,9 @@ interface TestConfig {
      */
     toMatchSnapshot?: {
       /**
-       * a comparator function to use, either `"pixelmatch"` or `"ssim-cie94"`. Defaults to `"pixelmatch"`.
-       */
-      comparator?: string;
-
-      /**
        * an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and
        * `1` (lax). `"pixelmatch"` comparator computes color difference in
-       * [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`. This option is used
-       * by `pixelmatch` image comparator.
+       * [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`.
        */
       threshold?: number;
 
@@ -4768,11 +4756,6 @@ interface LocatorAssertions {
     caret?: "hide"|"initial";
 
     /**
-     * A comparator function to use when comparing images. Defaults to `"pixelmatch"`.
-     */
-    comparator?: string;
-
-    /**
      * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink
      * box `#FF00FF` that completely covers its bounding box.
      */
@@ -4808,7 +4791,7 @@ interface LocatorAssertions {
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
      * same pixel in compared images, between zero (strict) and one (lax), default is configurable with
-     * `TestConfig.expect`. Defaults to `0.2`. This option is used by "pixelmatch" image comparator.
+     * `TestConfig.expect`. Defaults to `0.2`.
      */
     threshold?: number;
 
@@ -4850,11 +4833,6 @@ interface LocatorAssertions {
     caret?: "hide"|"initial";
 
     /**
-     * A comparator function to use when comparing images. Defaults to `"pixelmatch"`.
-     */
-    comparator?: string;
-
-    /**
      * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink
      * box `#FF00FF` that completely covers its bounding box.
      */
@@ -4890,7 +4868,7 @@ interface LocatorAssertions {
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
      * same pixel in compared images, between zero (strict) and one (lax), default is configurable with
-     * `TestConfig.expect`. Defaults to `0.2`. This option is used by "pixelmatch" image comparator.
+     * `TestConfig.expect`. Defaults to `0.2`.
      */
     threshold?: number;
 
@@ -5103,11 +5081,6 @@ interface PageAssertions {
     };
 
     /**
-     * A comparator function to use when comparing images. Defaults to `"pixelmatch"`.
-     */
-    comparator?: string;
-
-    /**
      * When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to
      * `false`.
      */
@@ -5149,7 +5122,7 @@ interface PageAssertions {
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
      * same pixel in compared images, between zero (strict) and one (lax), default is configurable with
-     * `TestConfig.expect`. Defaults to `0.2`. This option is used by "pixelmatch" image comparator.
+     * `TestConfig.expect`. Defaults to `0.2`.
      */
     threshold?: number;
 
@@ -5215,11 +5188,6 @@ interface PageAssertions {
     };
 
     /**
-     * A comparator function to use when comparing images. Defaults to `"pixelmatch"`.
-     */
-    comparator?: string;
-
-    /**
      * When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to
      * `false`.
      */
@@ -5261,7 +5229,7 @@ interface PageAssertions {
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
      * same pixel in compared images, between zero (strict) and one (lax), default is configurable with
-     * `TestConfig.expect`. Defaults to `0.2`. This option is used by "pixelmatch" image comparator.
+     * `TestConfig.expect`. Defaults to `0.2`.
      */
     threshold?: number;
 
@@ -5361,11 +5329,6 @@ interface SnapshotAssertions {
    */
   toMatchSnapshot(name: string|Array<string>, options?: {
     /**
-     * A comparator function to use when comparing images. Defaults to `"pixelmatch"`.
-     */
-    comparator?: string;
-
-    /**
      * An acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1`. Default is
      * configurable with `TestConfig.expect`. Unset by default.
      */
@@ -5380,7 +5343,7 @@ interface SnapshotAssertions {
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
      * same pixel in compared images, between zero (strict) and one (lax), default is configurable with
-     * `TestConfig.expect`. Defaults to `0.2`. This option is used by "pixelmatch" image comparator.
+     * `TestConfig.expect`. Defaults to `0.2`.
      */
     threshold?: number;
   }): void;
@@ -5414,11 +5377,6 @@ interface SnapshotAssertions {
    */
   toMatchSnapshot(options?: {
     /**
-     * A comparator function to use when comparing images. Defaults to `"pixelmatch"`.
-     */
-    comparator?: string;
-
-    /**
      * An acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1`. Default is
      * configurable with `TestConfig.expect`. Unset by default.
      */
@@ -5438,7 +5396,7 @@ interface SnapshotAssertions {
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
      * same pixel in compared images, between zero (strict) and one (lax), default is configurable with
-     * `TestConfig.expect`. Defaults to `0.2`. This option is used by "pixelmatch" image comparator.
+     * `TestConfig.expect`. Defaults to `0.2`.
      */
     threshold?: number;
   }): void;
@@ -5576,15 +5534,9 @@ interface TestProject {
      */
     toHaveScreenshot?: {
       /**
-       * a comparator function to use, either `"pixelmatch"` or `"ssim-cie94"`. Defaults to `"pixelmatch"`.
-       */
-      comparator?: string;
-
-      /**
        * an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and
        * `1` (lax). `"pixelmatch"` comparator computes color difference in
-       * [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`. This option is used
-       * by `pixelmatch` image comparator.
+       * [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`.
        */
       threshold?: number;
 
@@ -5625,15 +5577,9 @@ interface TestProject {
      */
     toMatchSnapshot?: {
       /**
-       * a comparator function to use, either `"pixelmatch"` or `"ssim-cie94"`. Defaults to `"pixelmatch"`.
-       */
-      comparator?: string;
-
-      /**
        * an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and
        * `1` (lax). `"pixelmatch"` comparator computes color difference in
-       * [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`. This option is used
-       * by `pixelmatch` image comparator.
+       * [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`.
        */
       threshold?: number;
 

--- a/tests/config/comparator.ts
+++ b/tests/config/comparator.ts
@@ -22,5 +22,5 @@ type ImageComparatorOptions = { threshold?: number, maxDiffPixels?: number, maxD
 
 export function comparePNGs(actual: Buffer, expected: Buffer, options: ImageComparatorOptions = {}): ComparatorResult {
   // Strict threshold by default in our tests.
-  return pngComparator(actual, expected, { comparator: 'ssim-cie94', threshold: 0, ...options });
+  return pngComparator(actual, expected, { _comparator: 'ssim-cie94', threshold: 0, ...options });
 }

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -47,8 +47,8 @@ const config: Config<CoverageWorkerOptions & PlaywrightWorkerOptions & Playwrigh
   outputDir,
   expect: {
     timeout: 10000,
-    toHaveScreenshot: { comparator: 'ssim-cie94' } as any,
-    toMatchSnapshot: { comparator: 'ssim-cie94' } as any,
+    toHaveScreenshot: { _comparator: 'ssim-cie94' } as any,
+    toMatchSnapshot: { _comparator: 'ssim-cie94' } as any,
   },
   maxFailures: 100,
   timeout: video ? 60000 : 30000,

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -631,13 +631,13 @@ test('should respect comparator name', async ({ runInlineTest }) => {
       test('should pass', ({}) => {
         expect(Buffer.from('${actual.toString('base64')}', 'base64')).toMatchSnapshot('snapshot.png', {
           threshold: 0,
-          comparator: 'ssim-cie94',
+          _comparator: 'ssim-cie94',
         });
       });
       test('should fail', ({}) => {
         expect(Buffer.from('${actual.toString('base64')}', 'base64')).toMatchSnapshot('snapshot.png', {
           threshold: 0,
-          comparator: 'pixelmatch',
+          _comparator: 'pixelmatch',
         });
       });
     `
@@ -662,7 +662,7 @@ test('should respect comparator in config', async ({ runInlineTest }) => {
             name: 'should-pass',
             expect: {
               toMatchSnapshot: {
-                comparator: 'ssim-cie94',
+                _comparator: 'ssim-cie94',
               }
             },
           },
@@ -670,7 +670,7 @@ test('should respect comparator in config', async ({ runInlineTest }) => {
             name: 'should-fail',
             expect: {
               toMatchSnapshot: {
-                comparator: 'pixelmatch',
+                _comparator: 'pixelmatch',
               }
             },
           },

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -1040,14 +1040,14 @@ test('should respect comparator name', async ({ runInlineTest }) => {
         await page.goto('${actualURL}');
         await expect(page.locator('img')).toHaveScreenshot('snapshot.png', {
           threshold: 0,
-          comparator: 'ssim-cie94',
+          _comparator: 'ssim-cie94',
         });
       });
       pwt.test('should fail', async ({ page }) => {
         await page.goto('${actualURL}');
         await expect(page.locator('img')).toHaveScreenshot('snapshot.png', {
           threshold: 0,
-          comparator: 'pixelmatch',
+          _comparator: 'pixelmatch',
         });
       });
     `
@@ -1070,7 +1070,7 @@ test('should respect comparator in config', async ({ runInlineTest }) => {
           name: 'should-pass',
           expect: {
             toHaveScreenshot: {
-              comparator: 'ssim-cie94',
+              _comparator: 'ssim-cie94',
             }
           },
         },
@@ -1078,7 +1078,7 @@ test('should respect comparator in config', async ({ runInlineTest }) => {
           name: 'should-fail',
           expect: {
             toHaveScreenshot: {
-              comparator: 'pixelmatch',
+              _comparator: 'pixelmatch',
             }
           },
         },


### PR DESCRIPTION
This reverts commit 303c5998f8b747e94ac80e2e02c53b47ded11322.

Reason for revert: I tried enabling `ssim-cie94` by default on
ionic-framework test suite, and it proves to be overly strict for their
usecase.
