### PR TITLE
browser(firefox): Restrain sending http credentials on a specific origin

### DIFF
--- a/browser_patches/firefox/juggler/NetworkObserver.js
+++ b/browser_patches/firefox/juggler/NetworkObserver.js
@@ -300,6 +300,9 @@ class NetworkRequest {
     }
     if (!credentials)
       return false;
+    const hostname = pageNetwork._target.browserContext().httpCredentials.hostname;
+    if (hostname && aChannel.URI.host.toLowerCase() !== hostname.toLowerCase())
+      return false;
     authInfo.username = credentials.username;
     authInfo.password = credentials.password;
     // This will produce a new request with respective auth header set.

--- a/browser_patches/firefox/juggler/protocol/Protocol.js
+++ b/browser_patches/firefox/juggler/protocol/Protocol.js
@@ -188,6 +188,7 @@ networkTypes.HTTPHeader = {
 networkTypes.HTTPCredentials = {
   username: t.String,
   password: t.String,
+  hostname: t.Optional(t.String),
 };
 
 networkTypes.SecurityDetails = {


### PR DESCRIPTION
Fixes #20464

For security purpose, we would like to restrain sending HTTP credentials to only the specified server. The idea is to give the ability to specify a hostname additionally to current pair username/password. When an authorization response is received from servers, the credentials are sent only if the server hostname in the request matches case insensitive the specified hostname.

This is a separate PR following #20374 in order to update juggler files separatly.