### PR TITLE
fix: hide highlight in recorder before toHaveScreenshot command

### DIFF
--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -695,5 +695,5 @@ class ThrottledFile {
 }
 
 function isScreenshotCommand(metadata: CallMetadata) {
-  return metadata.method.includes('screenshot');
+  return metadata.method.toLowerCase().includes('screenshot');
 }


### PR DESCRIPTION
Fixes #20866
