### PR TITLE
fix: best-effort support for KDE Neon

### DIFF
--- a/packages/playwright-core/src/utils/hostPlatform.ts
+++ b/packages/playwright-core/src/utils/hostPlatform.ts
@@ -58,7 +58,8 @@ export const hostPlatform = ((): HostPlatform => {
     const distroInfo = getLinuxDistributionInfoSync();
 
     // Pop!_OS is ubuntu-based and has the same versions.
-    if (distroInfo?.id === 'ubuntu' || distroInfo?.id === 'pop') {
+    // KDE Neon is ubuntu-based and has the same versions.
+    if (distroInfo?.id === 'ubuntu' || distroInfo?.id === 'pop' || distroInfo?.id === 'neon') {
       if (parseInt(distroInfo.version, 10) <= 19)
         return ('ubuntu18.04' + archSuffix) as HostPlatform;
       if (parseInt(distroInfo.version, 10) <= 21)


### PR DESCRIPTION
This is a yet-another linux distribution based on Ubuntu.

Fixes #20838
