### PR TITLE
Make annotations searchable in HTML reporter

### DIFF
--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -211,7 +211,11 @@ test('user profile', async ({ page }) => {
 
 ## Custom annotations
 
-It's also possible to add custom metadata in the form of annotations to your tests. Annotations are key/value pairs accessible via [`test.info().annotations`](./api/class-testinfo#test-info-annotations). Many reporters show annotations, for example `'html'`.
+It's also possible to add custom metadata in the form of annotations to your tests. Annotations are key/value pairs accessible via [`test.info().annotations`](./api/class-testinfo#test-info-annotations). 
+Many reporters show annotations, for example `'html'`. 
+
+Annotations can also be used to search for tests in the `html reporter` as `type:description`.
+
 
 ```js tab=js-js
 // example.spec.js


### PR DESCRIPTION
Currently, annotations are only visible in the test details view.

This PR allows tests to be searched by annotations in the test listing view of the HTML reporter. 
Entering `type: description` allows for searching by annotation.

This is helpful because teams can tag tests (either manually or through common fixtures) with certain metadata, and get a shareable URL to a subset of test cases shown in the HTML report filtered by annotation.

The assumption here is that `type: description` is the key value pair for an annotation — which may need to expand to properties other than `description` in the future.

Ideally, we'd use tagging for this, but currently, tags appear in the test description which makes it noisy when using multiple tags at once.