### PR TITLE
Add explainer for CLI output of `DotReporter`

### DIFF
--- a/packages/playwright-test/src/reporters/dot.ts
+++ b/packages/playwright-test/src/reporters/dot.ts
@@ -28,6 +28,12 @@ class DotReporter extends BaseReporter {
   override onBegin(config: FullConfig, suite: Suite) {
     super.onBegin(config, suite);
     console.log(this.generateStartingMessage());
+    console.log('\n' + colors.green('·') + ' - passed\n');
+    console.log('\n' + colors.yellow('°') + ' - skipped\n');
+    console.log('\n' + colors.gray('×') + ' - will retry\n');
+    console.log('\n' + colors.yellow('±') + ' - flaky\n');
+    console.log('\n' + colors.red('T') + ' - timed out\n');
+    console.log('\n' + colors.red('F') + ' - failed\n');
   }
 
   override onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {


### PR DESCRIPTION
After running tests, playwright outputs something like:
```sh
········································································×····±··
·×··×··××····F·±·······················
```

And it was never clear to me what each of these symbols meant, and I couldn't find the explanation anywhere until I looked at the source code itself. I propose having the labels directly in the terminal. For reference, Next.js and Gatsby both do this for their build output and it's very pleasing.