### PR TITLE
fix: stricter condition for Firefox codegen tests workaround

### DIFF
--- a/packages/playwright-core/src/server/injected/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder.ts
@@ -239,7 +239,7 @@ export class Recorder {
     const activeElement = this._deepActiveElement(this.document);
     // Firefox dispatches "focus" event to body when clicking on a backgrounded headed browser window.
     // We'd like to ignore this stray event.
-    if (activeElement === this.document.body)
+    if (userGesture && activeElement === this.document.body)
       return;
     const result = activeElement ? generateSelector(this._injectedScript, activeElement, this._testIdAttributeName) : null;
     this._activeModel = result && result.selector ? result : null;


### PR DESCRIPTION
This patch fixes the following tests on WebKit @ Darwin:
- library/inspector/cli-codegen-2.spec.ts:197:7 › cli codegen › should download files
- library/inspector/cli-codegen-2.spec.ts:428:7 › cli codegen › should update hover model on action
