### PR TITLE
fix(snapshot): render srcdoc iframe snapshots

### DIFF
--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -464,7 +464,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string) {
             const name = element.attributes[i].name;
             if (nodeName === 'LINK' && name === 'integrity')
               continue;
-            if (nodeName === 'IFRAME' && (name === 'src' || name === 'sandbox'))
+            if (nodeName === 'IFRAME' && (name === 'src' || name === 'srcdoc' || name === 'sandbox'))
               continue;
             if (nodeName === 'FRAME' && name === 'src')
               continue;


### PR DESCRIPTION
This PR fixes DOM snapshots for iframes that have an `srcdoc` attribute.

Currently `srcdoc` attributes are left as is. They should be stripped just like `src` attributes currently are.

Leaving it as is results in the `srcdoc` being used for the iframe when viewing traces. That prevents the proper iframe DOM snapshot from being present and visible.