### PR TITLE
test: serviceWorker should intercept document request

### DIFF
--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -186,3 +186,20 @@ it('should set CloseEvent.wasClean to false when the server terminates a WebSock
   }), server.PORT);
   expect(wasClean).toBe(false);
 });
+
+it('serviceWorker should intercept document request', async ({ page, server, browserName }) => {
+  it.fixme(browserName === 'firefox');
+
+  server.setRoute('/sw.js', (req, res) => {
+    res.setHeader('Content-Type', 'application/javascript');
+    res.end(`
+      self.addEventListener('fetch', event => {
+        event.respondWith(new Response('intercepted'));
+      });
+    `);
+  });
+  await page.goto(server.EMPTY_PAGE);
+  await page.evaluate(() => navigator.serviceWorker.register('/sw.js'));
+  await page.reload();
+  expect(await page.textContent('body')).toBe('intercepted');
+});


### PR DESCRIPTION
Not sure whats actually going on here, turns out this breaks the trace viewer on firefox. -> all the iframes won't work.

Can't repro on stock firefox, so seems like something fishy on our end.

References #20259