### PR TITLE
fix: use the JUnit schema's specified ISO format for timestamp

### DIFF
--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -116,7 +116,7 @@ class JUnitReporter implements Reporter {
       name: 'testsuite',
       attributes: {
         name: suite.title,
-        timestamp: this.timestamp?.toISOString(),
+        timestamp: this.timestamp.toISOString(),
         hostname: projectName,
         tests,
         failures,

--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -24,7 +24,7 @@ import { assert } from 'playwright-core/lib/utils';
 class JUnitReporter implements Reporter {
   private config!: FullConfig;
   private suite!: Suite;
-  private timestamp!: number;
+  private timestamp!: Date;
   private startTime!: number;
   private totalTests = 0;
   private totalFailures = 0;
@@ -51,7 +51,7 @@ class JUnitReporter implements Reporter {
   onBegin(config: FullConfig, suite: Suite) {
     this.config = config;
     this.suite = suite;
-    this.timestamp = Date.now();
+    this.timestamp = new Date();
     this.startTime = monotonicTime();
   }
 
@@ -116,7 +116,7 @@ class JUnitReporter implements Reporter {
       name: 'testsuite',
       attributes: {
         name: suite.title,
-        timestamp: this.timestamp,
+        timestamp: this.timestamp?.toISOString(),
         hostname: projectName,
         tests,
         failures,


### PR DESCRIPTION
JUnit uses an ISO 8601 format for the timestamp attribute of the testsuite element. This updates the code to use that format, rather than milliseconds from epoch.

https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd#L181