### PR TITLE
fix(expect): support custom AsymmetricMatchers

### DIFF
--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -3821,7 +3821,7 @@ type AsymmetricMatchers = {
   objectContaining(sample: Record<string, unknown>): AsymmetricMatcher;
   stringContaining(sample: string): AsymmetricMatcher;
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
-}
+} & PlaywrightTest.AsymmetricMatchers;
 
 type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 type ExtraMatchers<T, Type, Matchers> = T extends Type ? Matchers : IfAny<T, Matchers, {}>;
@@ -4294,6 +4294,8 @@ type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
 declare global {
   export namespace PlaywrightTest {
     export interface Matchers<R, T = unknown> {
+    }
+    export interface AsymmetricMatchers {
     }
   }
 }

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -45,6 +45,10 @@ test('should be able to call expect.extend in config', async ({ runInlineTest })
       test('numeric ranges', () => {
         test.expect(100).toBeWithinRange(90, 110);
         test.expect(101).not.toBeWithinRange(0, 100);
+        test.expect({ apples: 6, bananas: 3 }).toEqual({
+          apples: test.expect.toBeWithinRange(1, 10),
+          bananas: test.expect.not.toBeWithinRange(11, 20),
+        });
       });
     `
   });
@@ -295,6 +299,9 @@ test('should work with custom PlaywrightTest namespace', async ({ runTSC }) => {
         interface Matchers<R, T> {
           toBeNonEmpty(): R;
         }
+        interface AsymmetricMatchers {
+          toBeWithinRange(floor: number, ceiling: number): void;
+        }
       }
     `,
     'a.spec.ts': `
@@ -310,6 +317,10 @@ test('should work with custom PlaywrightTest namespace', async ({ runTSC }) => {
       test.expect({}).toBeEmpty();
       test.expect({ hello: 'world' }).not.toBeEmpty();
       test.expect('').toBeNonEmpty();
+      expect({apples: 6, bananas: 3}).toEqual({
+        apples: expect.toBeWithinRange(1, 10),
+        bananas: expect.not.toBeWithinRange(11, 20),
+      });
     `
   });
   expect(result.exitCode).toBe(0);

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -590,6 +590,7 @@ class TypesGenerator {
         'PlaywrightWorkerOptions.defaultBrowserType',
         'PlaywrightWorkerArgs.playwright',
         'Matchers',
+        'AsymmetricMatchers',
       ]),
       doNotExportClassNames: new Set([...assertionClasses, 'TestProject']),
       includeExperimental,

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -276,7 +276,7 @@ type AsymmetricMatchers = {
   objectContaining(sample: Record<string, unknown>): AsymmetricMatcher;
   stringContaining(sample: string): AsymmetricMatcher;
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
-}
+} & PlaywrightTest.AsymmetricMatchers;
 
 type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 type ExtraMatchers<T, Type, Matchers> = T extends Type ? Matchers : IfAny<T, Matchers, {}>;
@@ -362,6 +362,8 @@ type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
 declare global {
   export namespace PlaywrightTest {
     export interface Matchers<R, T = unknown> {
+    }
+    export interface AsymmetricMatchers {
     }
   }
 }


### PR DESCRIPTION
This is what they [support upstream](https://jestjs.io/docs/expect#expectextendmatchers).

Fixes https://github.com/microsoft/playwright/issues/20761