### PR TITLE
fix(loader): experimentalLoader with node@18

### DIFF
--- a/packages/playwright-test/src/experimentalLoader.ts
+++ b/packages/playwright-test/src/experimentalLoader.ts
@@ -29,8 +29,9 @@ async function resolve(specifier: string, context: { parentURL?: string }, defau
       specifier = url.pathToFileURL(resolved).toString();
   }
   const result = await defaultResolve(specifier, context, defaultResolve);
-  if (result?.url)
+  if (result?.url && result.url.startsWith('file://'))
     currentFileDepsCollector()?.add(url.fileURLToPath(result.url));
+
   return result;
 }
 

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -612,3 +612,29 @@ test('should import export assignment from ts', async ({ runInlineTest }) => {
   expect(result.passed).toBe(1);
   expect(result.exitCode).toBe(0);
 });
+
+test('should support node imports', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'package.json': JSON.stringify({
+      type: 'module'
+    }),
+    'test.json': 'test data',
+    'utils.mjs': `
+      import fs from "node:fs/promises";
+
+      export async function utilityModuleThatImportsNodeModule() {
+        return await fs.readFile('test.json', 'utf8');
+      }
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      import { utilityModuleThatImportsNodeModule } from './utils.mjs';
+
+      test('pass', async () => {
+        expect(await utilityModuleThatImportsNodeModule()).toBe('test data');
+      });
+    `
+  });
+  expect(result.passed).toBe(1);
+  expect(result.exitCode).toBe(0);
+});

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -613,8 +613,11 @@ test('should import export assignment from ts', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
 });
 
-test('should support node imports', async ({ runInlineTest }) => {
+test('should support node imports', async ({ runInlineTest, nodeVersion }) => {
+  // We only support experimental esm mode on Node 16+
+  test.skip(nodeVersion.major < 16);
   const result = await runInlineTest({
+    'playwright.config.ts': 'export default {}',
     'package.json': JSON.stringify({
       type: 'module'
     }),


### PR DESCRIPTION
There is currently a bug when running `node@18.14.2` when running with experimentalLoader

```
TypeError: The URL must be of scheme file
  at new NodeError (node:internal/errors:399:5)
  at Object.fileURLToPath (node:internal/url:1492:11)
  at resolve (./node_modules/@playwright/test/lib/experimentalLoader.js:39:48)
  at nextResolve (node:internal/modules/esm/loader:163:22)
  at ESMLoader.resolve (node:internal/modules/esm/loader:838:24)
  at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:7)
  at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:79:21)
```

This came from my test `vrt.spec.ts` which had a non package import inside of it

```ts
import fs from "node:fs/promises"
```

The test run failed due to node imports not returning fileUrls when resolved.