### PR TITLE
test: mark new test as failing in ff

### DIFF
--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -703,7 +703,9 @@ it('should work with overridden globalThis.Window/Document/Node', async ({ page,
   }
 });
 
-it('should work with overridden URL/Date/RegExp', async ({ page, server }) => {
+it('should work with overridden URL/Date/RegExp', async ({ page, server, browserName }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/21109' });
+  it.fixme(browserName === 'firefox');
   const testCases = [
     // @ts-ignore
     () => globalThis.URL = 'foo',


### PR DESCRIPTION
The test is failing for overridden Date in Firefox.

#21109