### PR TITLE
test: update context menu tests

### DIFF
--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -665,6 +665,7 @@ async function captureLastKeydown(page) {
 }
 
 it('should dispatch insertText after context menu was opened', async ({ server, page, browserName }) => {
+  it.skip(isWindows, 'context menu support is best-effort for Linux and MacOS');
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.evaluate(() => {
     window['contextMenuPromise'] = new Promise(x => {
@@ -682,7 +683,9 @@ it('should dispatch insertText after context menu was opened', async ({ server, 
   await expect.poll(() => page.locator('textarea').inputValue()).toBe('嗨');
 });
 
-it('should type after context menu was opened', async ({ server, page, browserName }) => {
+it('should type after context menu was opened', async ({ server, page, browserName, isWindows }) => {
+  it.fixme(isWindows && browserName === 'chromium');
+  it.skip(isWindows, 'context menu support is best-effort for Linux and MacOS');
   await page.evaluate(() => {
     window['keys'] = [];
     window.addEventListener('keydown', event => window['keys'].push(event.key));

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -665,7 +665,7 @@ async function captureLastKeydown(page) {
 }
 
 it('should dispatch insertText after context menu was opened', async ({ server, page, browserName }) => {
-  it.skip(isWindows, 'context menu support is best-effort for Linux and MacOS');
+  it.skip(browserName === 'chromium' && isWindows, 'context menu support is best-effort for Linux and MacOS');
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.evaluate(() => {
     window['contextMenuPromise'] = new Promise(x => {
@@ -684,8 +684,7 @@ it('should dispatch insertText after context menu was opened', async ({ server, 
 });
 
 it('should type after context menu was opened', async ({ server, page, browserName, isWindows }) => {
-  it.fixme(isWindows && browserName === 'chromium');
-  it.skip(isWindows, 'context menu support is best-effort for Linux and MacOS');
+  it.skip(browserName === 'chromium' && isWindows, 'context menu support is best-effort for Linux and MacOS');
   await page.evaluate(() => {
     window['keys'] = [];
     window.addEventListener('keydown', event => window['keys'].push(event.key));

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -664,7 +664,7 @@ async function captureLastKeydown(page) {
   return lastEvent;
 }
 
-it('should dispatch insertText after context menu was opened', async ({ server, page, browserName }) => {
+it('should dispatch insertText after context menu was opened', async ({ server, page, browserName, isWindows }) => {
   it.skip(browserName === 'chromium' && isWindows, 'context menu support is best-effort for Linux and MacOS');
   await page.goto(server.PREFIX + '/input/textarea.html');
   await page.evaluate(() => {

--- a/tests/page/page-mouse.spec.ts
+++ b/tests/page/page-mouse.spec.ts
@@ -267,7 +267,7 @@ it('should not crash on mouse drag with any button', async ({ page }) => {
 it('should dispatch mouse move after context menu was opened', async ({ page, browserName, isWindows }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/20823' });
   it.fixme(browserName === 'firefox');
-  it.skip(isWindows, 'context menu support is best-effort for Linux and MacOS');
+  it.skip(browserName === 'chromium' && isWindows, 'context menu support is best-effort for Linux and MacOS');
   await page.evaluate(() => {
     window['contextMenuPromise'] = new Promise(x => {
       window.addEventListener('contextmenu', x, false);

--- a/tests/page/page-mouse.spec.ts
+++ b/tests/page/page-mouse.spec.ts
@@ -253,6 +253,10 @@ it('should always round down', async ({ page }) => {
 
 it('should not crash on mouse drag with any button', async ({ page }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16609' });
+  await page.evaluate(() => {
+    // Do not show contextmenu on right click since it is poorly supported.
+    window.addEventListener('contextmenu', e => e.preventDefault(), false);
+  });
   for (const button of ['left', 'middle', 'right'] as const) {
     await page.mouse.move(50, 50);
     await page.mouse.down({ button });
@@ -260,9 +264,10 @@ it('should not crash on mouse drag with any button', async ({ page }) => {
   }
 });
 
-it('should dispatch mouse move after context menu was opened', async ({ page, browserName }) => {
+it('should dispatch mouse move after context menu was opened', async ({ page, browserName, isWindows }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/20823' });
   it.fixme(browserName === 'firefox');
+  it.skip(isWindows, 'context menu support is best-effort for Linux and MacOS');
   await page.evaluate(() => {
     window['contextMenuPromise'] = new Promise(x => {
       window.addEventListener('contextmenu', x, false);

--- a/tests/page/wheel.spec.ts
+++ b/tests/page/wheel.spec.ts
@@ -70,7 +70,7 @@ it('should dispatch wheel events @smoke', async ({ page, server }) => {
 it('should dispatch wheel events after context menu was opened', async ({ page, browserName, isWindows }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/20823' });
   it.fixme(browserName === 'firefox');
-  it.skip(isWindows, 'context menu support is best-effort for Linux and MacOS');
+  it.skip(browserName === 'chromium' && isWindows, 'context menu support is best-effort for Linux and MacOS');
 
   await page.setContent(`<div style="width: 5000px; height: 5000px;"></div>`);
   await page.mouse.move(50, 60);

--- a/tests/page/wheel.spec.ts
+++ b/tests/page/wheel.spec.ts
@@ -67,9 +67,10 @@ it('should dispatch wheel events @smoke', async ({ page, server }) => {
   });
 });
 
-it('should dispatch wheel events after context menu was opened', async ({ page, browserName }) => {
+it('should dispatch wheel events after context menu was opened', async ({ page, browserName, isWindows }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/20823' });
   it.fixme(browserName === 'firefox');
+  it.skip(isWindows, 'context menu support is best-effort for Linux and MacOS');
 
   await page.setContent(`<div style="width: 5000px; height: 5000px;"></div>`);
   await page.mouse.move(50, 60);


### PR DESCRIPTION
It turns out these new contextmenu-based tests do not work on
Chromium-based browsers on Windows.

We consider context menu support a best-effort, so we skip them
for now.
