### PR TITLE
test: fix installation tests on win32

### DIFF
--- a/tests/installation/npx-global-install.spec.ts
+++ b/tests/installation/npx-global-install.spec.ts
@@ -15,11 +15,13 @@
  */
 import { test, expect } from './npmTest';
 
+const INSTALLED_CHROMIUM = process.platform === 'win32' ? 'chromium_win64_special' : 'chromium';
+
 test('npx playwright install global', async ({ exec, installedSoftwareOnDisk }) => {
   test.skip(process.platform === 'win32', 'isLikelyNpxGlobal() does not work in this setup on our bots');
   const result = await exec('npx playwright install', { env: { npm_config_prefix: '' } }); // global npx and npm_config_prefix do not work together nicely (https://github.com/npm/cli/issues/5268)
   expect(result).toHaveLoggedSoftwareDownload(['chromium', 'ffmpeg', 'firefox', 'webkit']);
-  expect(await installedSoftwareOnDisk()).toEqual(['chromium', 'ffmpeg', 'firefox', 'webkit']);
+  expect(await installedSoftwareOnDisk()).toEqual([INSTALLED_CHROMIUM, 'ffmpeg', 'firefox', 'webkit']);
   expect(result).not.toContain(`Please run the following command to download new browsers`);
   expect(result).toContain(`To avoid unexpected behavior, please install your dependencies first`);
 });

--- a/tests/installation/playwright-cdn-failover-should-work.spec.ts
+++ b/tests/installation/playwright-cdn-failover-should-work.spec.ts
@@ -32,12 +32,13 @@ const parsedDownloads = (rawLogs: string) => {
   return out;
 };
 
+const INSTALLED_CHROMIUM = process.platform === 'win32' ? 'chromium_win64_special' : 'chromium';
 
 for (const cdn of CDNS) {
   test(`playwright cdn failover should work (${cdn})`, async ({ exec, nodeMajorVersion, installedSoftwareOnDisk }) => {
     const result = await exec('npm i --foreground-scripts playwright', { env: { PW_TEST_CDN_THAT_SHOULD_WORK: cdn, DEBUG: 'pw:install' } });
     expect(result).toHaveLoggedSoftwareDownload(['chromium', 'ffmpeg', 'firefox', 'webkit']);
-    expect(await installedSoftwareOnDisk()).toEqual(['chromium', 'ffmpeg', 'firefox', 'webkit']);
+    expect(await installedSoftwareOnDisk()).toEqual([INSTALLED_CHROMIUM, 'ffmpeg', 'firefox', 'webkit']);
     const dls = parsedDownloads(result);
     for (const software of ['chromium', 'ffmpeg', 'firefox', 'webkit'])
       expect(dls).toContainEqual({ status: 200, name: software, url: expect.stringContaining(cdn) });

--- a/tests/installation/playwright-cli-install-should-work.spec.ts
+++ b/tests/installation/playwright-cli-install-should-work.spec.ts
@@ -15,19 +15,21 @@
  */
 import { test, expect } from './npmTest';
 
+const INSTALLED_CHROMIUM = process.platform === 'win32' ? 'chromium_win64_special' : 'chromium';
+
 test('codegen should work', async ({ exec, installedSoftwareOnDisk }) => {
   await exec('npm i --foreground-scripts playwright', { env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' } });
 
   await test.step('playwright install chromium', async () => {
     const result = await exec('npx playwright install chromium');
     expect(result).toHaveLoggedSoftwareDownload(['chromium', 'ffmpeg']);
-    expect(await installedSoftwareOnDisk()).toEqual(['chromium', 'ffmpeg']);
+    expect(await installedSoftwareOnDisk()).toEqual([INSTALLED_CHROMIUM, 'ffmpeg']);
   });
 
   await test.step('playwright install', async () => {
     const result = await exec('npx playwright install');
     expect(result).toHaveLoggedSoftwareDownload(['firefox', 'webkit']);
-    expect(await installedSoftwareOnDisk()).toEqual(['chromium', 'ffmpeg', 'firefox', 'webkit']);
+    expect(await installedSoftwareOnDisk()).toEqual([INSTALLED_CHROMIUM, 'ffmpeg', 'firefox', 'webkit']);
   });
 
   await exec('node sanity.js playwright none', { env: {  PLAYWRIGHT_BROWSERS_PATH: undefined } });

--- a/tests/installation/playwright-global-installation-cross-package.spec.ts
+++ b/tests/installation/playwright-global-installation-cross-package.spec.ts
@@ -15,13 +15,15 @@
  */
 import { test, expect } from './npmTest';
 
+const INSTALLED_CHROMIUM = process.platform === 'win32' ? 'chromium_win64_special' : 'chromium';
+
 test('global installation cross package', async ({ exec, installedSoftwareOnDisk }) => {
   const packages = ['playwright-chromium', 'playwright-firefox', 'playwright-webkit'];
   for (const pkg of packages)
     await exec('npm i --foreground-scripts', pkg, { env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' } });
   const result = await exec('npm i --foreground-scripts playwright');
   expect(result).toHaveLoggedSoftwareDownload(['chromium', 'ffmpeg', 'firefox', 'webkit']);
-  expect(await installedSoftwareOnDisk()).toEqual(['chromium', 'ffmpeg', 'firefox', 'webkit']);
+  expect(await installedSoftwareOnDisk()).toEqual([INSTALLED_CHROMIUM, 'ffmpeg', 'firefox', 'webkit']);
 
   for (const pkg of packages)
     await test.step(pkg, () => exec('node sanity.js', pkg, 'all'));

--- a/tests/installation/playwright-global-installation.spec.ts
+++ b/tests/installation/playwright-global-installation.spec.ts
@@ -15,10 +15,12 @@
  */
 import { test, expect } from './npmTest';
 
+const INSTALLED_CHROMIUM = process.platform === 'win32' ? 'chromium_win64_special' : 'chromium';
+
 test('global installation', async ({ exec, installedSoftwareOnDisk }) => {
   const result = await exec('npm i --foreground-scripts playwright');
   expect(result).toHaveLoggedSoftwareDownload(['chromium', 'ffmpeg', 'firefox', 'webkit']);
-  expect(await installedSoftwareOnDisk()).toEqual(['chromium', 'ffmpeg', 'firefox', 'webkit']);
+  expect(await installedSoftwareOnDisk()).toEqual([INSTALLED_CHROMIUM, 'ffmpeg', 'firefox', 'webkit']);
   await exec('node sanity.js playwright none', { env: { PLAYWRIGHT_BROWSERS_PATH: undefined } });
   await exec('node sanity.js playwright');
 });

--- a/tests/installation/playwright-should-work.spec.ts
+++ b/tests/installation/playwright-should-work.spec.ts
@@ -15,10 +15,12 @@
  */
 import { test, expect } from './npmTest';
 
+const INSTALLED_CHROMIUM = process.platform === 'win32' ? 'chromium_win64_special' : 'chromium';
+
 test(`playwright should work`, async ({ exec, nodeMajorVersion, installedSoftwareOnDisk }) => {
   const result = await exec('npm i --foreground-scripts playwright');
   expect(result).toHaveLoggedSoftwareDownload(['chromium', 'ffmpeg', 'firefox', 'webkit']);
-  expect(await installedSoftwareOnDisk()).toEqual(['chromium', 'ffmpeg', 'firefox', 'webkit']);
+  expect(await installedSoftwareOnDisk()).toEqual([INSTALLED_CHROMIUM, 'ffmpeg', 'firefox', 'webkit']);
   await exec('node sanity.js playwright');
   if (nodeMajorVersion >= 14)
     await exec('node esm-playwright.mjs');

--- a/tests/installation/playwright-xyz-should-work.spec.ts
+++ b/tests/installation/playwright-xyz-should-work.spec.ts
@@ -16,13 +16,19 @@
  */
 import { test, expect } from './npmTest';
 
+const INSTALLED_CHROMIUM = process.platform === 'win32' ? 'chromium_win64_special' : 'chromium';
+
 for (const pkg of ['playwright-chromium', 'playwright-firefox', 'playwright-webkit']) {
   test(`${pkg} should work`, async ({ exec, nodeMajorVersion, installedSoftwareOnDisk }) => {
     const result = await exec('npm i --foreground-scripts', pkg);
     const browserName = pkg.split('-')[1];
-    const expectedSoftware = [browserName];
-    if (browserName === 'chromium')
+    const expectedSoftware = [];
+    if (browserName === 'chromium') {
+      expectedSoftware.push(INSTALLED_CHROMIUM);
       expectedSoftware.push('ffmpeg');
+    } else {
+      expectedSoftware.push(browserName);
+    }
     expect(result).toHaveLoggedSoftwareDownload(expectedSoftware as any);
     expect(await installedSoftwareOnDisk()).toEqual(expectedSoftware);
     expect(result).not.toContain(`To avoid unexpected behavior, please install your dependencies first`);


### PR DESCRIPTION
Since we now use a special build for win32, the
`installedSoftwareOnDisk` reports a different installed browser.
