### PR TITLE
feat(html-report): support objects as description

### DIFF
--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -49,7 +49,9 @@ export const TestCaseView: React.FC<{
   </div>;
 };
 
-function renderAnnotationDescription(description: string) {
+function renderAnnotationDescription(description: string | object) {
+  if (typeof description === 'object')
+    return JSON.stringify(description);
   try {
     if (['http:', 'https:'].includes(new URL(description).protocol))
       return <a href={description} target='_blank' rel='noopener noreferrer'>{description}</a>;

--- a/packages/html-reporter/src/types.ts
+++ b/packages/html-reporter/src/types.ts
@@ -52,7 +52,7 @@ export type TestFileSummary = {
   stats: Stats;
 };
 
-export type TestCaseAnnotation = { type: string, description?: string };
+export type TestCaseAnnotation = { type: string, description?: string | object };
 
 export type TestCaseSummary = {
   testId: string,

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -575,7 +575,7 @@ test('should render annotations', async ({ runInlineTest, page, showReport }) =>
 
   await showReport();
   await page.click('text=skipped test');
-  await expect(page.locator('.test-case-annotation').first()).toHaveText('issues: foobar');
+  await expect(page.locator('.test-case-annotation').first()).toHaveText('issues: ["foo","bar"]');
   await expect(page.locator('.test-case-annotation').nth(1)).toHaveText('skip: I am not interested in this test');
 });
 

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -565,6 +565,7 @@ test('should render annotations', async ({ runInlineTest, page, showReport }) =>
     'a.test.js': `
       import { test, expect } from '@playwright/test';
       test('skipped test', async ({ page }) => {
+        test.info().annotations.push({ type: 'issues', description: ['foo', 'bar'] });
         test.skip(true, 'I am not interested in this test');
       });
     `,
@@ -574,7 +575,8 @@ test('should render annotations', async ({ runInlineTest, page, showReport }) =>
 
   await showReport();
   await page.click('text=skipped test');
-  await expect(page.locator('.test-case-annotation')).toHaveText('skip: I am not interested in this test');
+  await expect(page.locator('.test-case-annotation').first()).toHaveText('issues: foobar');
+  await expect(page.locator('.test-case-annotation').nth(1)).toHaveText('skip: I am not interested in this test');
 });
 
 test('should render annotations as link if needed', async ({ runInlineTest, page, showReport, server }) => {


### PR DESCRIPTION
Currently with an object is set as annotation's description, the report won't even render that test.

With this change, if the annotation's description is an object, it will be stringified and rendered correctly.