### PR TITLE
fix: expect unquoted npde.exe path

### DIFF
--- a/utils/build/run-driver-win.cmd
+++ b/utils/build/run-driver-win.cmd
@@ -1,6 +1,4 @@
 @echo off
 setlocal
-if not defined PLAYWRIGHT_NODEJS_PATH (
-  set PLAYWRIGHT_NODEJS_PATH="%~dp0\node.exe"
-)
-""%PLAYWRIGHT_NODEJS_PATH%"" "%~dp0\package\lib\cli\cli.js" %*
+if not defined PLAYWRIGHT_NODEJS_PATH set PLAYWRIGHT_NODEJS_PATH=%~dp0node.exe
+"%PLAYWRIGHT_NODEJS_PATH%" "%~dp0package\lib\cli\cli.js" %*


### PR DESCRIPTION
* It is more common to set env variable value without quotes on Windows (see the bug)
* Use defined to check for string presence, it will work nicely with strings that contain whitespaces

https://github.com/microsoft/playwright-java/issues/1213