### PR TITLE
feat: add support for "arch" and Arch-like distro to `install-deps`

### DIFF
--- a/packages/playwright-core/src/server/registry/dependencies.ts
+++ b/packages/playwright-core/src/server/registry/dependencies.ts
@@ -105,15 +105,15 @@ export async function installDependenciesLinux(targets: Set<DependencyGroup>, dr
   if (platform.includes('arch')) {
     const { code } = await spawnAsync('command', ['-v', 'yay']);
     if (code !== 0) {
-      console.log('Installing playwright deps in Arch distros requires the pacman helper "yay"')
-      return
+      console.log('Installing playwright deps in Arch distros requires the pacman helper "yay"'); // eslint-disable-line no-console
+      return;
     }
 
     commands.push('pacman -Syy');
     commands.push(['yay', '-S', '--noconfirm', '--removemake', '--noprovides', '--answerdiff', 'None', '--answerclean', 'None', '--mflags', '"--noconfirm"',
       ...uniqueLibraries,
     ].join(' '));
-    commands.push('sudo ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3')
+    commands.push('sudo ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3');
   } else {
     commands.push('apt-get update');
     commands.push(['apt-get', 'install', '-y', '--no-install-recommends',

--- a/packages/playwright-core/src/server/registry/dependencies.ts
+++ b/packages/playwright-core/src/server/registry/dependencies.ts
@@ -103,6 +103,12 @@ export async function installDependenciesLinux(targets: Set<DependencyGroup>, dr
     console.log(`Installing dependencies...`);  // eslint-disable-line no-console
   const commands: string[] = [];
   if (platform.includes('arch')) {
+    const { code } = await spawnAsync('command', ['-v', 'yay']);
+    if (code !== 0) {
+      console.log('Installing playwright deps in Arch distros requires the pacman helper "yay"')
+      return
+    }
+
     commands.push('pacman -Syy');
     commands.push(['yay', '-S', '--noconfirm', '--removemake', '--noprovides', '--answerdiff', 'None', '--answerclean', 'None', '--mflags', '"--noconfirm"',
       ...uniqueLibraries,

--- a/packages/playwright-core/src/server/registry/dependencies.ts
+++ b/packages/playwright-core/src/server/registry/dependencies.ts
@@ -102,11 +102,19 @@ export async function installDependenciesLinux(targets: Set<DependencyGroup>, dr
   if (!dryRun)
     console.log(`Installing dependencies...`);  // eslint-disable-line no-console
   const commands: string[] = [];
-  commands.push('apt-get update');
-  commands.push(['apt-get', 'install', '-y', '--no-install-recommends',
-    ...uniqueLibraries,
-  ].join(' '));
-  const { command, args, elevatedPermissions } = await transformCommandsForRoot(commands);
+  if (platform.includes('arch')) {
+    commands.push('pacman -Syy');
+    commands.push(['yay', '-S', '--noconfirm', '--removemake', '--noprovides', '--answerdiff', 'None', '--answerclean', 'None', '--mflags', '"--noconfirm"',
+      ...uniqueLibraries,
+    ].join(' '));
+    commands.push('sudo ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3')
+  } else {
+    commands.push('apt-get update');
+    commands.push(['apt-get', 'install', '-y', '--no-install-recommends',
+      ...uniqueLibraries,
+    ].join(' '));
+  }
+  const { command, args, elevatedPermissions } = await transformCommandsForRoot(commands);
   if (dryRun) {
     console.log(`${command} ${quoteProcessArgs(args).join(' ')}`); // eslint-disable-line no-console
     return;

--- a/packages/playwright-core/src/server/registry/nativeDeps.ts
+++ b/packages/playwright-core/src/server/registry/nativeDeps.ts
@@ -824,6 +824,28 @@ export const deps: any = {
   }
 };
 
+deps['arch'] = {
+  tools: [...deps['ubuntu20.04'].tools],
+  chromium: [...deps['ubuntu20.04'].chromium],
+  firefox: [
+    ...deps['ubuntu20.04'].firefox,
+  ],
+  webkit: [
+    ...deps['ubuntu20.04'].webkit,
+  ],
+  lib2package: {
+    'libenchant.so.1': 'enchant',
+    'libicui18n.so.66': 'icu66',
+    'libicuuc.so.66': 'icu66',
+    'libpcre.so.3': 'libffi7',
+    'libwebp.so.1': 'libwebp052',
+    'libflite.so.1': 'flite1',
+    'libflite_cmu_us_awb.so.1': 'flite1',
+    'libflite_cmu_us_kal.so.1': 'flite1',
+    'libflite_cmu_us_rms.so.1': 'flite1',
+  },
+}
+
 deps['ubuntu20.04-arm64'] = {
   tools: [...deps['ubuntu20.04'].tools],
   chromium: [...deps['ubuntu20.04'].chromium],

--- a/packages/playwright-core/src/server/registry/nativeDeps.ts
+++ b/packages/playwright-core/src/server/registry/nativeDeps.ts
@@ -844,7 +844,7 @@ deps['arch'] = {
     'libflite_cmu_us_kal.so.1': 'flite1',
     'libflite_cmu_us_rms.so.1': 'flite1',
   },
-}
+};
 
 deps['ubuntu20.04-arm64'] = {
   tools: [...deps['ubuntu20.04'].tools],

--- a/packages/playwright-core/src/utils/hostPlatform.ts
+++ b/packages/playwright-core/src/utils/hostPlatform.ts
@@ -69,7 +69,7 @@ export const hostPlatform = ((): HostPlatform => {
     }
     if (distroInfo?.id === 'debian' && distroInfo?.version === '11')
       return ('debian11' + archSuffix) as HostPlatform;
-    if (distroInfo?.id === 'arch' || distroInfo?.id_like ==='arch')
+    if (distroInfo?.id === 'arch' || distroInfo?.id_like === 'arch')
       return ('arch' + archSuffix) as HostPlatform;
     return ('generic-linux' + archSuffix) as HostPlatform;
   }

--- a/packages/playwright-core/src/utils/hostPlatform.ts
+++ b/packages/playwright-core/src/utils/hostPlatform.ts
@@ -27,6 +27,7 @@ export type HostPlatform = 'win64' |
                            'ubuntu20.04' | 'ubuntu20.04-arm64' |
                            'ubuntu22.04' | 'ubuntu22.04-arm64' |
                            'debian11' | 'debian11-arm64' |
+                           'arch' | 'arch-arm64' |
                            'generic-linux' | 'generic-linux-arm64' |
                            '<unknown>';
 
@@ -68,6 +69,8 @@ export const hostPlatform = ((): HostPlatform => {
     }
     if (distroInfo?.id === 'debian' && distroInfo?.version === '11')
       return ('debian11' + archSuffix) as HostPlatform;
+    if (distroInfo?.id === 'arch' || distroInfo?.id_like ==='arch')
+      return ('arch' + archSuffix) as HostPlatform;
     return ('generic-linux' + archSuffix) as HostPlatform;
   }
   if (platform === 'win32')

--- a/packages/playwright-core/src/utils/linuxUtils.ts
+++ b/packages/playwright-core/src/utils/linuxUtils.ts
@@ -20,10 +20,11 @@ import fs from 'fs';
 let didFailToReadOSRelease = false;
 let osRelease: {
   id: string,
+  id_like: string,
   version: string,
 } | undefined;
 
-export async function getLinuxDistributionInfo(): Promise<{ id: string, version: string } | undefined> {
+export async function getLinuxDistributionInfo(): Promise<typeof osRelease> {
   if (process.platform !== 'linux')
     return undefined;
   if (!osRelease && !didFailToReadOSRelease) {
@@ -34,6 +35,7 @@ export async function getLinuxDistributionInfo(): Promise<{ id: string, version:
       const fields = parseOSReleaseText(osReleaseText);
       osRelease = {
         id: fields.get('id') ?? '',
+        id_like: fields.get('id_like') ?? '',
         version: fields.get('version_id') ?? '',
       };
     } catch (e) {
@@ -43,7 +45,7 @@ export async function getLinuxDistributionInfo(): Promise<{ id: string, version:
   return osRelease;
 }
 
-export function getLinuxDistributionInfoSync(): { id: string, version: string } | undefined {
+export function getLinuxDistributionInfoSync(): typeof osRelease {
   if (process.platform !== 'linux')
     return undefined;
   if (!osRelease && !didFailToReadOSRelease) {
@@ -54,6 +56,7 @@ export function getLinuxDistributionInfoSync(): { id: string, version: string } 
       const fields = parseOSReleaseText(osReleaseText);
       osRelease = {
         id: fields.get('id') ?? '',
+        id_like: fields.get('id_like') ?? '',
         version: fields.get('version_id') ?? '',
       };
     } catch (e) {


### PR DESCRIPTION
Added support for `arch` and `arch-arm64` to the `install-deps` command, including the helper functions for grabbing `distroInfo`, etc.

The `id_like` `/etc/os-release` field is used (in the arch ecosystem at least) for Arch forks like Endeavour and Manjaro. These should still define `ID_LIKE=arch` in their `os-release` :+1: 

I saw the discussion in https://github.com/microsoft/playwright/issues/11122 and based the required packages and required symlinks off of that.

I can understand that Arch isn't something you do testing on normally, but having them in here at least will make it easier for arch users to get up and running now, and community members can much more easily just update the package name(s) in `nativeDeps.ts` in the future should the `pacman`/`yay` package names change or anythign like that! 

Sidenote for those not familiar, arch uses `pacman` as the primary package manager, but `yay` is the defacto standard pkg manager wrapper / helper that also gives access to the AUR (Arch User Repository) which all Arch users will most likely have installed.