### PR TITLE
fix(cli): pdf/screenshot did not save artifacts

### DIFF
--- a/packages/playwright-core/src/cli/cli.ts
+++ b/packages/playwright-core/src/cli/cli.ts
@@ -600,13 +600,14 @@ async function waitForPage(page: Page, captureOptions: CaptureOptions) {
 }
 
 async function screenshot(options: Options, captureOptions: CaptureOptions, url: string, path: string) {
-  const { browser, context } = await launchContext(options, true);
+  const { context } = await launchContext(options, true);
   console.log('Navigating to ' + url);
   const page = await openPage(context, url);
   await waitForPage(page, captureOptions);
   console.log('Capturing screenshot into ' + path);
   await page.screenshot({ path, fullPage: !!captureOptions.fullPage });
-  await browser.close();
+  // launchContext takes care of closing the browser.
+  await page.close();
 }
 
 async function pdf(options: Options, captureOptions: CaptureOptions, url: string, path: string) {
@@ -614,13 +615,14 @@ async function pdf(options: Options, captureOptions: CaptureOptions, url: string
     console.error('PDF creation is only working with Chromium');
     process.exit(1);
   }
-  const { browser, context } = await launchContext({ ...options, browser: 'chromium' }, true);
+  const { context } = await launchContext({ ...options, browser: 'chromium' }, true);
   console.log('Navigating to ' + url);
   const page = await openPage(context, url);
   await waitForPage(page, captureOptions);
   console.log('Saving as pdf into ' + path);
   await page.pdf!({ path });
-  await browser.close();
+  // launchContext takes care of closing the browser.
+  await page.close();
 }
 
 function lookupBrowserType(options: Options): BrowserType {


### PR DESCRIPTION
As of today we support CLI argument wise `--save-storage` and `--save-har` in pdf/screenshot CLI command. But they are not working, since we just close the browser rather than the context where we take care of saving the artifacts.

`launchContext` has 4 usages:

- open/codegen there closing the browser / `SIGINT` will close it gracefully
- pdf/screenshot there we will now close the page which will then [here](https://cs.github.com/microsoft/playwright/blob/b00579edb7f80ee239d27025df253cc4f38179a1/packages/playwright-core/src/cli/cli.ts?q=cli.ts#L503) close the browser.

I did not find any tests except the [installation test](https://github.com/microsoft/playwright/blob/3e84ab4701b3d0d1725e595009458dacdab03b62/tests/installation/playwright-cli-screenshot-should-work.spec.ts), I'm happy to add one for both command if requested.

Fixes https://github.com/microsoft/playwright/issues/20718