### PR TITLE
feat(test runner): error out when one test file imports another

### DIFF
--- a/packages/playwright-test/src/common/compilationCache.ts
+++ b/packages/playwright-test/src/common/compilationCache.ts
@@ -173,6 +173,10 @@ export function collectAffectedTestFiles(dependency: string, testFileCollector: 
   }
 }
 
+export function dependenciesForTestFile(filename: string): Set<string> {
+  return fileDependencies.get(filename) || new Set();
+}
+
 // These two are only used in the dev mode, they are specifically excluding
 // files from packages/playwright*. In production mode, node_modules covers
 // that.

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -641,3 +641,25 @@ test('should support node imports', async ({ runInlineTest, nodeVersion }) => {
   expect(result.passed).toBe(1);
   expect(result.exitCode).toBe(0);
 });
+
+test('should complain when one test file imports another', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      import { foo } from './b.test';
+
+      test('pass1', async () => {
+        expect(foo).toBe('foo');
+      });
+    `,
+    'b.test.ts': `
+      import { test, expect } from '@playwright/test';
+      export const foo = 'foo';
+
+      test('pass2', async () => {
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`test file "a.test.ts" should not import test file "b.test.ts"`);
+});


### PR DESCRIPTION
This situation is not supported, and we can now detect it by looking at collected file dependencies.

Fixes #21270.