### PR TITLE
fix: expose window.safari in webkit

### DIFF
--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -785,6 +785,8 @@ export class WKPage implements PageDelegate {
       scripts.push('delete window.ondevicemotion');
       scripts.push('delete window.ondeviceorientation');
     }
+    scripts.push('if (!window.safari) window.safari = {};');
+
     for (const binding of this._page.allBindings())
       scripts.push(binding.source);
     scripts.push(...this._browserContext.initScripts);

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -200,3 +200,11 @@ it('serviceWorker should intercept document request', async ({ page, server, bro
   await page.reload();
   expect(await page.textContent('body')).toBe('intercepted');
 });
+
+it('webkit should define window.safari', async ({ page, server, browserName }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/21037' });
+  it.skip(browserName !== 'webkit');
+  await page.goto(server.EMPTY_PAGE);
+  const defined = await page.evaluate(() => !!(window as any).safari);
+  expect(defined).toBeTruthy();
+});


### PR DESCRIPTION
The actual API of the object is not implemented because those who want to test it will likely need their own mock and for the browser detection logic (as described in the bug) just having the property on window should be sufficient.

Fixes #21037