### PR TITLE
fix(ct): react17 primitive as slot

### DIFF
--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -25,7 +25,7 @@ import { createRoot } from 'react-dom/client';
 
 /** @type {Map<string, FrameworkComponent>} */
 const registry = new Map();
-/** @type {Map<Element, import('react-dom/client').Root>>} */
+/** @type {Map<Element, import('react-dom/client').Root>} */
 const rootRegistry = new Map();
 
 /**

--- a/packages/playwright-ct-react17/registerSource.mjs
+++ b/packages/playwright-ct-react17/registerSource.mjs
@@ -36,9 +36,11 @@ export function register(components) {
 
 /**
  * @param {Component} component
- * @returns {JSX.Element}
  */
 function render(component) {
+  if (typeof component !== 'object' || Array.isArray(component))
+    return component;
+
   let componentFunc = registry.get(component.type);
   if (!componentFunc) {
     // Lookup by shorthand.


### PR DESCRIPTION
The JS primitive check which was added recently was not added to react17. Related to https://github.com/microsoft/playwright/pull/19814 & https://github.com/microsoft/playwright/pull/20125.

@pavelfeldman Are there any tests need for react17? There are currently no tests for it, only for react18-vite and react18-webpack.