### PR TITLE
chore(ct): vue prop type of JsonObject

### DIFF
--- a/packages/playwright-ct-vue/index.d.ts
+++ b/packages/playwright-ct-vue/index.d.ts
@@ -41,19 +41,14 @@ type JsonObject = { [Key in string]?: JsonValue };
 
 type Slot = string | string[];
 
-export interface MountOptions<
-HooksConfig extends JsonObject,
-Props extends Record<string, unknown>
-> {
+export interface MountOptions<HooksConfig extends JsonObject, Props extends JsonObject> {
   props?: Props;
   slots?: Record<string, Slot> & { default?: Slot };
   on?: Record<string, Function>;
   hooksConfig?: HooksConfig;
 }
 
-interface MountResult<
-  Props extends Record<string, unknown>
-> extends Locator {
+interface MountResult<Props extends JsonObject> extends Locator {
   unmount(): Promise<void>;
   update(options: Omit<MountOptions<never, Props>, 'hooksConfig'>): Promise<void>;
 }
@@ -67,12 +62,9 @@ export interface ComponentFixtures {
   mount(component: JSX.Element): Promise<MountResultJsx>;
   mount<HooksConfig extends JsonObject>(
     component: any,
-    options?: MountOptions<HooksConfig, Record<string, unknown>>
-  ): Promise<MountResult<Record<string, unknown>>>;
-  mount<
-    HooksConfig extends JsonObject,
-    Props extends Record<string, unknown> = Record<string, unknown>
-  >(
+    options?: MountOptions<HooksConfig, JsonObject>
+  ): Promise<MountResult<JsonObject>>;
+  mount<HooksConfig extends JsonObject, Props extends JsonObject = JsonObject>(
     component: any,
     options: MountOptions<HooksConfig, never> & { props: Props }
   ): Promise<MountResult<Props>>;

--- a/packages/playwright-ct-vue2/index.d.ts
+++ b/packages/playwright-ct-vue2/index.d.ts
@@ -41,19 +41,14 @@ type JsonObject = { [Key in string]?: JsonValue };
 
 type Slot = string | string[];
 
-export interface MountOptions<
-  HooksConfig extends JsonObject,
-  Props extends Record<string, unknown>
-> {
+export interface MountOptions<HooksConfig extends JsonObject, Props extends JsonObject> {
   props?: Props;
   slots?: Record<string, Slot> & { default?: Slot };
   on?: Record<string, Function>;
   hooksConfig?: HooksConfig;
 }
 
-interface MountResult<
-  Props extends Record<string, unknown>
-> extends Locator {
+interface MountResult<Props extends JsonObject> extends Locator {
   unmount(): Promise<void>;
   update(options: Omit<MountOptions<never, Props>, 'hooksConfig'>): Promise<void>;
 }
@@ -67,12 +62,9 @@ export interface ComponentFixtures {
   mount(component: JSX.Element): Promise<MountResultJsx>;
   mount<HooksConfig extends JsonObject>(
     component: any,
-    options?: MountOptions<HooksConfig, Record<string, unknown>>
-  ): Promise<MountResult<Record<string, unknown>>>;
-  mount<
-    HooksConfig extends JsonObject,
-    Props extends Record<string, unknown> = Record<string, unknown>
-  >(
+    options?: MountOptions<HooksConfig, JsonObject>
+  ): Promise<MountResult<JsonObject>>;
+  mount<HooksConfig extends JsonObject, Props extends JsonObject = JsonObject>(
     component: any,
     options: MountOptions<HooksConfig, never> & { props: Props }
   ): Promise<MountResult<Props>>;


### PR DESCRIPTION
The `props` type has been changed so that code below throws a type error:

```typescript
test('type error', async ({ mount }) => {
  const component = await mount(Button, {
    props: {
      submit: () => {} // Type '() => void' is not assignable to type 'JsonValue | undefined'
    },
  });
});
```