### PR TITLE
feat(html): added tags to the html reporter

### DIFF
--- a/packages/html-reporter/src/headerView.spec.tsx
+++ b/packages/html-reporter/src/headerView.spec.tsx
@@ -30,10 +30,10 @@ test('should render counters', async ({ mount }) => {
     duration: 100000
   }} filterText='' setFilterText={() => {}} projectNames={[]}></HeaderView>);
   await expect(component.locator('a', { hasText: 'All' }).locator('.counter')).toHaveText('100');
-  await expect(component.locator('a', { hasText: 'Passed' }).locator('.counter')).toHaveText('42');
-  await expect(component.locator('a', { hasText: 'Failed' }).locator('.counter')).toHaveText('31');
-  await expect(component.locator('a', { hasText: 'Flaky' }).locator('.counter')).toHaveText('17');
-  await expect(component.locator('a', { hasText: 'Skipped' }).locator('.counter')).toHaveText('10');
+  await expect(component.locator('a', { hasText: 'Passed' }).locator('.counter')).toHaveText('42 (42%)');
+  await expect(component.locator('a', { hasText: 'Failed' }).locator('.counter')).toHaveText('31 (31%)');
+  await expect(component.locator('a', { hasText: 'Flaky' }).locator('.counter')).toHaveText('17 (17%)');
+  await expect(component.locator('a', { hasText: 'Skipped' }).locator('.counter')).toHaveText('10 (10%)');
 });
 
 test('should toggle filters', async ({ page, mount }) => {

--- a/packages/html-reporter/src/icons.tsx
+++ b/packages/html-reporter/src/icons.tsx
@@ -106,3 +106,17 @@ export const trace = () => {
 export const empty = () => {
   return <svg className='octicon' viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'></svg>;
 };
+
+export const plus = () => {
+  return <svg  viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'>
+    <path xmlns="http://www.w3.org/2000/svg" d="M8 1a1 1 0 00-1 1v6H1a1 1 0 000 2h6v6a1 1 0 002 0v-6h6a1 1 0 000-2h-6V2a1 1 0 00-1-1Z"/>
+  </svg>;
+};
+
+export const skipped = () => {
+  return <svg xmlns="http://www.w3.org/2000/svg" viewBox='2 2 18 18' version='1.1' width='16' height='16' className='octicon' aria-hidden='true'>
+    <path fill="#007bff" d="m6.35,7.84c-.06,0-.13,0-.19-.02-.54-.11-.9-.63-.79-1.17l.66-3.34c.11-.54.63-.9,1.17-.79.54.11.9.63.79,1.17l-.66,3.34c-.09.48-.51.81-.98.81Z" />
+    <path fill="#007bff" d="m12,21.5c-4.96,0-9-4.04-9-9,0-.55.45-1,1-1s1,.45,1,1c0,3.86,3.14,7,7,7s7-3.14,7-7-3.14-7-7-7c-1.87,0-3.63.73-4.95,2.05-.39.39-1.02.39-1.41,0s-.39-1.02,0-1.41c1.7-1.7,3.96-2.64,6.36-2.64,4.96,0,9,4.04,9,9s-4.04,9-9,9Z" />
+    <path fill="#007bff" d="m12,15.5c-1.65,0-3-1.35-3-3s1.35-3,3-3,3,1.35,3,3-1.35,3-3,3Zm0-4c-.55,0-1,.45-1,1s.45,1,1,1,1-.45,1-1-.45-1-1-1Z" />
+  </svg>;
+};

--- a/packages/html-reporter/src/imageDiffView.spec.tsx
+++ b/packages/html-reporter/src/imageDiffView.spec.tsx
@@ -48,14 +48,14 @@ test('should switch to actual', async ({ mount }) => {
   const component = await mount(<ImageDiffView key='image-diff' imageDiff={imageDiff}></ImageDiffView>);
   await component.getByText('Actual', { exact: true }).click();
   const sliderElement = component.locator('data-testid=test-result-image-mismatch-grip');
-  await expect.poll(() => sliderElement.evaluate(e => e.style.left), 'Actual slider is on the right').toBe('611px');
+  await expect.poll(() => sliderElement.evaluate(e => e.style.left), 'Actual slider is on the right').toBe('619px');
 
   const images = component.locator('img');
   const imageCount = await component.locator('img').count();
   for (let i = 0; i < imageCount; ++i) {
     const image = images.nth(i);
     const box = await image.boundingBox();
-    expect(box).toEqual({ x: 400, y: 108, width: 200, height: 200 });
+    expect(box).toEqual({ x: 400, y: 100, width: 200, height: 200 });
   }
 });
 
@@ -63,14 +63,14 @@ test('should switch to expected', async ({ mount }) => {
   const component = await mount(<ImageDiffView key='image-diff' imageDiff={imageDiff}></ImageDiffView>);
   await component.getByText('Expected', { exact: true }).click();
   const sliderElement = component.locator('data-testid=test-result-image-mismatch-grip');
-  await expect.poll(() => sliderElement.evaluate(e => e.style.left), 'Expected slider is on the left').toBe('371px');
+  await expect.poll(() => sliderElement.evaluate(e => e.style.left), 'Expected slider is on the left').toBe('379px');
 
   const images = component.locator('img');
   const imageCount = await component.locator('img').count();
   for (let i = 0; i < imageCount; ++i) {
     const image = images.nth(i);
     const box = await image.boundingBox();
-    expect(box).toEqual({ x: 400, y: 108, width: 200, height: 200 });
+    expect(box).toEqual({ x: 400, y: 100, width: 200, height: 200 });
   }
 });
 
@@ -79,5 +79,5 @@ test('should show diff by default', async ({ mount }) => {
 
   const image = component.locator('img');
   const box = await image.boundingBox();
-  expect(box).toEqual({ x: 400, y: 108, width: 200, height: 200 });
+  expect(box).toEqual({ x: 400, y: 100, width: 200, height: 200 });
 });

--- a/packages/html-reporter/src/statusIcon.tsx
+++ b/packages/html-reporter/src/statusIcon.tsx
@@ -31,6 +31,7 @@ export function statusIcon(status: 'failed' | 'timedOut' | 'skipped' | 'passed' 
     case 'flaky':
       return icons.warning();
     case 'skipped':
+      return icons.skipped();
     case 'interrupted':
       return icons.blank();
   }

--- a/packages/html-reporter/src/tags.css
+++ b/packages/html-reporter/src/tags.css
@@ -1,0 +1,59 @@
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.tags span:first-child {
+  margin-right: 8px;
+}
+
+.tag {
+  margin: 4px 0;
+  padding-top: 2px;
+}
+
+.tag:hover {
+  opacity: 1;
+  transition: 0.2s opacity
+}
+
+.tag-not-current {
+  opacity: 0.8;
+  transition: 0.2s opacity;
+}
+
+.tag-current {
+  opacity: 1;
+  transition: 0.2s opacity;
+}
+
+.plus-sign {
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.plus-sign svg {
+  margin: 3px 0 0 4px;
+  height: 10px;
+  transition: 0.2s;
+}
+
+.plus-sign__remove svg {
+  rotate: 45deg;
+  transition: 0.2s rotate;
+}
+
+.tag-disabled {
+  opacity: 0.2;
+  transition: 0.2s opacity;
+}
+
+.tag-disabled:hover,
+.tag-disabled .plus-sign {
+  opacity: 0.2;
+  cursor: not-allowed;
+}

--- a/packages/html-reporter/src/tags.spec.tsx
+++ b/packages/html-reporter/src/tags.spec.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/experimental-ct-react';
+import { Tags } from './tags';
+
+test.use({ viewport: { width: 720, height: 200 } });
+
+test('should render testCase tags', async ({ mount }) => {
+  const component = await mount(<Tags testCase={{
+    testId: 'testId',
+    title: '@foo @bar should render test tags',
+    path: ['packages/html-reporter/src/tags.spec.ts'],
+    projectName: 'html-reporter',
+    location: {
+      file: 'packages/html-reporter/src/tags.spec.ts',
+      line: 43,
+      column: 2 },
+    outcome: 'expected',
+    duration: 2323,
+    ok: true,
+    annotations: [],
+    results: [{ attachments: [{ name: 'image', contentType: 'png' }] }]
+  }}
+  />);
+
+  await expect(component).toBeVisible();
+  await expect(component).toHaveCount(1);
+  await expect(component).toContainText('Tags:');
+  await expect(component.locator('.tag')).toHaveCount(2);
+  await expect(component.locator('.tag')).toHaveText(['bar', 'foo']);
+});

--- a/packages/html-reporter/src/tags.tsx
+++ b/packages/html-reporter/src/tags.tsx
@@ -1,0 +1,245 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from 'react';
+import type { Filter } from './filter';
+import * as icons from './icons';
+import { Route } from './links';
+import { testCaseRoutePredicate, testFilesRoutePredicate } from './reportView';
+import './tags.css';
+import type { HTMLReport, TestCaseSummary } from './types';
+
+export const Tags: React.FC<React.PropsWithChildren<{
+  testCase?: TestCaseSummary,
+  report?: HTMLReport,
+  filterText?: string,
+  filter?: Filter,
+  style?: React.CSSProperties,
+  appliedTagsArray?: string[],
+  setAppliedTagsArray?: React.Dispatch<React.SetStateAction<string[]>>,
+}>> = ({ testCase, report, filterText, filter, style, appliedTagsArray, setAppliedTagsArray }) => {
+  const isTestCaseRow = testCase ? true : false;
+
+  // filter tests by filter and collect all tags for tabs 'All', 'Passed', 'Failed', 'Flaky', 'Skipped'
+  const filteredTests = React.useMemo(() => {
+    const result: TestCaseSummary[] = [];
+    for (const file of report?.files || []) {
+      const tests = file.tests.filter(t => {
+        return filter?.matches(t);
+      });
+      if (tests.length)
+        result.push(...tests);
+    }
+    return result;
+  }, [report, filter]);
+
+  const filteredTags = React.useMemo(() => {
+    const tagsSet = new Set<string>();
+    for (const test of filteredTests){
+      const t = matchTags(test.title, report?.excludeTagsFilterPattern);
+      if (t.length)
+        t.forEach(tag => tagsSet.add(tag));
+    }
+    return [...tagsSet];
+  }, [filteredTests, report?.excludeTagsFilterPattern]);
+
+  const tags = React.useMemo(() => {
+    if (testCase) {
+    // collect all tags from current test only for test page and testFileView
+      return matchTags(testCase.title, report?.excludeTagsFilterPattern).sort((a, b) => a.localeCompare(b));
+    } else {
+    // collect all tags from all tests in report for reportView
+      const tagsSet = new Set<string>();
+      for (const file of report?.files || []) {
+        for (const test of file.tests){
+          const t = matchTags(test.title, report?.excludeTagsFilterPattern);
+          if (t.length)
+            t.forEach(tag => tagsSet.add(tag));
+        }
+      }
+      return [...tagsSet].sort((a, b) => a.localeCompare(b));
+    }
+  }, [report, testCase]);
+
+  // if no tags or no filtered tests and no test, return null
+  // for example, if we are on 'Flaky' tab, there is no filtered tests
+  if (!tags?.length || (!filteredTests?.length && !testCase))
+    return null;
+
+  return <div className='tags' style={{ ...style }}>
+    <span>Tags: </span>
+    {tags && tags.map(tag => {
+      return <Tag
+        key={tag}
+        tag={tag}
+        filterText={filterText || ''}
+        filteredTags={filteredTags}
+        isTestCaseRow={isTestCaseRow}
+        appliedTagsArray={appliedTagsArray}
+        setAppliedTagsArray={setAppliedTagsArray}
+      />;
+    })}
+  </div>;
+};
+
+export const Tag: React.FC<React.PropsWithChildren<{
+  tag: string,
+  filterText: string,
+  filteredTags?: string[],
+  isTestCaseRow?: boolean,
+  appliedTagsArray?: string[],
+  setAppliedTagsArray?: React.Dispatch<React.SetStateAction<string[]>>,
+}>> = ({ tag, filterText, filteredTags, isTestCaseRow, appliedTagsArray, setAppliedTagsArray }) => {
+  const [isCurrentTag, setIsCurrentTag] = React.useState(false);
+  const [tagStyle, setTagStyle] = React.useState('tag');
+
+  const encoded = encodeURIComponent(tag);
+  const value = tag === encoded ? tag : `"${encoded.replace(/%22/g, '%5C%22')}"`;
+
+  React.useEffect(() => {
+    const tagStyleFn = (tag: string) => {
+      const isCurrent = appliedTagsArray?.includes(tag);
+      const isDisabled = !filteredTags?.includes(tag) && !isCurrent;
+      const isNotCurrent = filteredTags?.includes(tag) && !isCurrent;
+      if (testCaseRoutePredicate(new URLSearchParams(window.location.hash.slice(1))))
+        return 'tag';
+      if (isTestCaseRow)
+        return `tag ${isCurrent ? 'tag-current' : 'tag-not-current'}`;
+      else
+        return `tag ${isDisabled ? 'tag-disabled' : isNotCurrent ? 'tag-not-current' : isCurrent ? 'tag-current' : ''}`;
+
+    };
+
+    setTagStyle(tagStyleFn(tag));
+
+  }, [appliedTagsArray, filterText, filteredTags, isTestCaseRow, tag]);
+
+  React.useEffect(() => {
+    setIsCurrentTag(isCurrentTagFunction(new URLSearchParams(window.location.hash.slice(1)), tag));
+  }, [tag, filterText, appliedTagsArray]);
+
+  // handle click on tag and add or remove tag from searchParams and search input
+  const onClickHandle = (tag: string) => {
+    let searchParams = new URLSearchParams(window.location.hash.slice(1));
+    searchParams = (isCurrentTag) ? removeValue(searchParams, tag) : appendValue(searchParams, tag);
+    window.location.hash = decodeURIComponent(searchParams.toString());
+
+    // need to update appliedTagsArray for rerendering tags
+    // if tag is not in appliedTagsArray, it will be added
+    // if tag is in appliedTagsArray, it will be removed
+    if (setAppliedTagsArray){
+      setAppliedTagsArray(prev => {
+        if (prev.includes(tag))
+          return prev.filter(t => t !== tag);
+        else
+          return [...prev, tag];
+      });
+    }
+  };
+
+  return <span className={tagStyle}>
+    <span style={{ margin: '0 4px' }} className={'label label-color-' + (hashStringToInt(tag))}>
+      {value}
+      <Route predicate={testFilesRoutePredicate}>
+        <button
+          className={appliedTagsArray?.includes(value) ? 'plus-sign plus-sign__remove' : 'plus-sign'}
+          onClick={() => onClickHandle(value)}
+          disabled={tagStyle.includes('disabled')}>
+          {icons.plus()}
+        </button>
+      </Route>
+    </span>
+  </span>;
+};
+
+export function escapeRegExp(string: string) {
+  const reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
+  const reHasRegExpChar = RegExp(reRegExpChar.source);
+
+  return (string && reHasRegExpChar.test(string))
+    ? string.replace(reRegExpChar, '\\$&')
+    : (string || '');
+}
+
+// match all tags in test title
+export function matchTags(title: string, excludeTagMatch?: string): string[] {
+  const allTags = title.match(/@(\w+)/g)?.map(tag => tag.slice(1)) || [];
+  return allTags.filter(tag => !excludeTagMatch || !tag.match(excludeTagMatch));
+}
+
+// hash string to integer in range [0, 6] for color index, to get same color for same tag
+function hashStringToInt(str: string) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++)
+    hash = str.charCodeAt(i) + ((hash << 8) - hash);
+  return Math.abs(hash % 6);
+}
+
+// create regex for tag
+export function tagRegex(tag: string): RegExp {
+  const encoded = escapeRegExp(escapeRegExp(tag));
+  return new RegExp(`(\\s|^)t:${encoded}(\\s|$)`);
+}
+
+// check if current tag is applied in filter
+function isCurrentTagFunction(params: URLSearchParams, tag: string): boolean {
+  return params.has('q') && Boolean(params.get('q')?.match(tagRegex(tag))?.length);
+}
+
+// remove tag from filter
+function removeValue(params: URLSearchParams, tagToRemove: string): URLSearchParams {
+  const q = params.get('q');
+  if (q) {
+    // start value is 't:foo t:bar t:baz'
+    const match = q.match(tagRegex(tagToRemove))?.[0];
+    if (match) {
+      // match is 't:foo t:bar t:baz'
+      const values = q.split(' ');
+      if (values.length === 1) {
+        params.delete('q');
+        return params;
+      }
+      // values is ['t:foo', 't:bar', 't:baz']
+      const valueIndex = values.indexOf(`t:${tagToRemove}`);
+      if (valueIndex === -1)
+        return params;
+      values.splice(valueIndex, 1);
+      // values is ['t:foo', 'baz']
+      params.set('q', values.join(' '));
+      return params;
+    }
+  }
+  return params;
+}
+
+// append tag to filter
+function appendValue(params: URLSearchParams, tagToAppend: string): URLSearchParams {
+  const q = params.get('q');
+  if (q) {
+    // match all values like t:foo t:bar t:baz
+    const match = q.match(tagRegex(tagToAppend));
+    if (match) {
+      // if the key exists, do nothing
+      return params;
+    } else {
+      // if the key exists, append the value
+      params.set('q', `${q} t:${tagToAppend}`);
+      return params;
+    }
+  }
+  // if the key doesn't exist, add it
+  params.set('q', `t:${tagToAppend}`);
+  return params;
+}

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -23,20 +23,30 @@ import { ProjectLink } from './links';
 import { statusIcon } from './statusIcon';
 import './testCaseView.css';
 import { TestResultView } from './testResultView';
+import { Tags } from './tags';
+import { msToString } from './uiUtils';
 
 export const TestCaseView: React.FC<{
   projectNames: string[],
   test: TestCase | undefined,
   anchor: 'video' | 'diff' | '',
   run: number,
-}> = ({ projectNames, test, run, anchor }) => {
+  appliedTagsArray: string[],
+  setAppliedTagsArray: React.Dispatch<React.SetStateAction<string[]>>,
+}> = ({ projectNames, test, run, anchor, appliedTagsArray, setAppliedTagsArray }) => {
   const [selectedResultIndex, setSelectedResultIndex] = React.useState(run);
 
   return <div className='test-case-column vbox'>
     {test && <div className='test-case-path'>{test.path.join(' › ')}</div>}
     {test && <div className='test-case-title'>{test?.title}</div>}
+    {test && <span data-testid="overall-duration" style={{ padding: '6px 0 6px 6px' }}>Test case time: {msToString(test.duration)}</span>}
     {test && <div className='test-case-location'>{test.location.file}:{test.location.line}</div>}
-    {test && !!test.projectName && <ProjectLink projectNames={projectNames} projectName={test.projectName}></ProjectLink>}
+    {test && !!test.projectName && <><span style={{ margin: '2px 8px' }}>Project: <ProjectLink projectNames={projectNames} projectName={test.projectName}></ProjectLink></span></>}
+    {<Tags
+      style={{ margin: '2px 8px' }}
+      testCase={test}
+      appliedTagsArray={appliedTagsArray}
+      setAppliedTagsArray={setAppliedTagsArray} />}
     {test && !!test.annotations.length && <AutoChip header='Annotations'>
       {test.annotations.map(a => <div className='test-case-annotation'>
         <span style={{ fontWeight: 'bold' }}>{a.type}</span>

--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -23,6 +23,7 @@ import { generateTraceUrl, Link, ProjectLink } from './links';
 import { statusIcon } from './statusIcon';
 import './testFileView.css';
 import { video, image, trace } from './icons';
+import { Tags } from './tags';
 
 export const TestFileView: React.FC<React.PropsWithChildren<{
   report: HTMLReport;
@@ -30,7 +31,9 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
   isFileExpanded: (fileId: string) => boolean;
   setFileExpanded: (fileId: string, expanded: boolean) => void;
   filter: Filter;
-}>> = ({ file, report, isFileExpanded, setFileExpanded, filter }) => {
+  appliedTagsArray: string[],
+  setAppliedTagsArray: React.Dispatch<React.SetStateAction<string[]>>,
+}>> = ({ file, report, isFileExpanded, setFileExpanded, filter, appliedTagsArray, setAppliedTagsArray }) => {
   return <Chip
     expanded={isFileExpanded(file.fileId)}
     noInsets={true}
@@ -56,6 +59,9 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
           {imageDiffBadge(test)}
           {videoBadge(test)}
           {traceBadge(test)}
+        </div>
+        <div className='test-file-details-row'>
+          <Tags report={report} testCase={test} appliedTagsArray={appliedTagsArray} setAppliedTagsArray={setAppliedTagsArray} />
         </div>
       </div>
     )}

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -25,7 +25,9 @@ export const TestFilesView: React.FC<{
   expandedFiles: Map<string, boolean>,
   setExpandedFiles: (value: Map<string, boolean>) => void,
   filter: Filter,
-}> = ({ report, filter, expandedFiles, setExpandedFiles }) => {
+  appliedTagsArray: string[],
+  setAppliedTagsArray: React.Dispatch<React.SetStateAction<string[]>>,
+}> = ({ report, filter, expandedFiles, setExpandedFiles, appliedTagsArray, setAppliedTagsArray }) => {
   const filteredFiles = React.useMemo(() => {
     const result: { file: TestFileSummary, defaultExpanded: boolean }[] = [];
     let visibleTests = 0;
@@ -54,7 +56,10 @@ export const TestFilesView: React.FC<{
           newExpanded.set(fileId, expanded);
           setExpandedFiles(newExpanded);
         }}
-        filter={filter}>
+        filter={filter}
+        appliedTagsArray={appliedTagsArray}
+        setAppliedTagsArray={setAppliedTagsArray}
+      >
       </TestFileView>;
     })}
   </>;

--- a/packages/html-reporter/src/types.ts
+++ b/packages/html-reporter/src/types.ts
@@ -37,6 +37,7 @@ export type HTMLReport = {
   files: TestFileSummary[];
   stats: Stats;
   projectNames: string[];
+  excludeTagsFilterPattern?: string,
 };
 
 export type TestFile = {


### PR DESCRIPTION
Related to: #14487 #14703

- added tags to the html reporter, which are displayed in the header, test row and in the test case view
- test files can be filtered by tags
- added a new config option `excludeTagsFilterPattern` to exclude tags from the filter. This is useful for tags that are used for TMS purposes like TestRail, e.g. `@C67125` or `@TMS-1234`. Format is a `string|RegExp|Array<string|RegExp>`
- added a stats percentage for each tests type (passed, failed, skipped, etc.)
- added `Test case time` to the test case view
- added `Project` title for project label to the test case view
- added skipped tests status icon

<img width="1027" alt="Screenshot 2023-03-05 at 13 18 23" src="https://user-images.githubusercontent.com/11705902/222958086-42f1e05a-185c-4208-ba21-52a3549b6521.png">

<img width="1032" alt="Screenshot 2023-03-05 at 13 18 47" src="https://user-images.githubusercontent.com/11705902/222958097-d68a9917-92b7-4cb9-bd96-0ca3ed134fa2.png">

https://user-images.githubusercontent.com/11705902/222958103-53022711-665d-46fd-b036-3e335feac0b8.mp4


