### PR TITLE
cherry-pick(#21454): fix(types): accept string in expect().toMatch()

### DIFF
--- a/docs/src/api/class-genericassertions.md
+++ b/docs/src/api/class-genericassertions.md
@@ -418,7 +418,7 @@ expect(value).toMatches(/Is \d+ enough/);
 
 ### param: GenericAssertions.toMatch.expected
 * since: v1.9
-- `expected` <[RegExp]>
+- `expected` <[RegExp]|[string]>
 
 Regular expression to match against.
 

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -4095,7 +4095,7 @@ interface GenericAssertions<R> {
    *
    * @param expected Regular expression to match against.
    */
-  toMatch(expected: RegExp): R;
+  toMatch(expected: RegExp | string): R;
   /**
    * Compares contents of the value with contents of `expected`, performing "deep equality" check. Allows extra
    * properties to be present in the value, unlike

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -157,6 +157,7 @@ test('should work with generic matchers', async ({ runTSC }) => {
       expect({}).toEqual({});
       expect([1, 2]).toHaveLength(2);
       expect('abc').toMatch(/a.?c/);
+      expect('abc').toMatch('abc');
       expect({ a: 1, b: 2 }).toMatchObject({ a: 1 });
       expect({}).toStrictEqual({});
       expect(() => { throw new Error('Something bad'); }).toThrow('something');

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -297,7 +297,7 @@ interface GenericAssertions<R> {
   toEqual(expected: unknown): R;
   toHaveLength(expected: number): R;
   toHaveProperty(keyPath: string | Array<string>, value?: unknown): R;
-  toMatch(expected: RegExp): R;
+  toMatch(expected: RegExp | string): R;
   toMatchObject(expected: Record<string, unknown> | Array<unknown>): R;
   toStrictEqual(expected: unknown): R;
   toThrow(error?: unknown): R;


### PR DESCRIPTION
This PR cherry-picks the following commits:

- c9eac69f2bfb1dfbbb57d4882ad068374e3a292d