### PR TITLE
feat(docker): add pnpm to docker images

### DIFF
--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -13,7 +13,7 @@ RUN apt-get update && \
     apt-get install -y nodejs && \
     # Feature-parity with node.js base images.
     apt-get install -y --no-install-recommends git openssh-client && \
-    npm install -g yarn && \
+    npm install -g yarn pnpm && \
     # clean apt cache
     rm -rf /var/lib/apt/lists/* && \
     # Create the pwuser

--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -13,7 +13,7 @@ RUN apt-get update && \
     apt-get install -y nodejs && \
     # Feature-parity with node.js base images.
     apt-get install -y --no-install-recommends git openssh-client && \
-    npm install -g yarn && \
+    npm install -g yarn pnpm && \
     # clean apt cache
     rm -rf /var/lib/apt/lists/* && \
     # Create the pwuser


### PR DESCRIPTION
Hello,

We use your official Docker image in our CI and it works great! But having [pnpm](https://pnpm.io/) inside the image would save an npm install every time we run our tests :)

Thank you!