### PR TITLE
feat: support PWTEST_PROFILE_DIR in run-server

### DIFF
--- a/packages/playwright-core/src/remote/playwrightConnection.ts
+++ b/packages/playwright-core/src/remote/playwrightConnection.ts
@@ -24,6 +24,7 @@ import { assert } from '../utils';
 import type { LaunchOptions } from '../server/types';
 import { AndroidDevice } from '../server/android/android';
 import { DebugControllerDispatcher } from '../server/dispatchers/debugControllerDispatcher';
+import { startProfiling, stopProfiling } from '../utils';
 
 export type ClientType = 'controller' | 'playwright' | 'launch-browser' | 'reuse-browser' | 'pre-launched-browser-or-android';
 
@@ -50,6 +51,7 @@ export class PlaywrightConnection {
   private _preLaunched: PreLaunched;
   private _options: Options;
   private _root: DispatcherScope;
+  private _profileName: string;
 
   constructor(lock: Promise<void>, clientType: ClientType, ws: WebSocket, options: Options, preLaunched: PreLaunched, log: (m: string) => void, onClose: () => void) {
     this._ws = ws;
@@ -61,6 +63,7 @@ export class PlaywrightConnection {
       assert(preLaunched.browser || preLaunched.androidDevice);
     this._onClose = onClose;
     this._debugLog = log;
+    this._profileName = `${new Date().toISOString()}-${clientType}`;
 
     this._dispatcherConnection = new DispatcherConnection();
     this._dispatcherConnection.onmessage = async message => {
@@ -82,6 +85,7 @@ export class PlaywrightConnection {
     }
 
     this._root = new RootDispatcher(this._dispatcherConnection, async scope => {
+      await startProfiling();
       if (clientType === 'reuse-browser')
         return await this._initReuseBrowsersMode(scope);
       if (clientType === 'pre-launched-browser-or-android')
@@ -237,6 +241,7 @@ export class PlaywrightConnection {
     this._debugLog(`starting cleanup`);
     for (const cleanup of this._cleanups)
       await cleanup().catch(() => {});
+    await stopProfiling(this._profileName);
     this._onClose();
     this._debugLog(`finished cleanup`);
   }

--- a/packages/playwright-core/src/utils/index.ts
+++ b/packages/playwright-core/src/utils/index.ts
@@ -29,6 +29,7 @@ export * from './mimeType';
 export * from './multimap';
 export * from './network';
 export * from './processLauncher';
+export * from './profiler';
 export * from './rtti';
 export * from './spawnAsync';
 export * from './stackTrace';

--- a/packages/playwright-core/src/utils/profiler.ts
+++ b/packages/playwright-core/src/utils/profiler.ts
@@ -34,14 +34,14 @@ export async function startProfiling() {
   });
 }
 
-export async function stopProfiling(processName: string | undefined) {
+export async function stopProfiling(profileName: string) {
   if (!profileDir)
     return;
 
   await new Promise<void>(f => session.post('Profiler.stop', (err, { profile }) => {
     if (!err) {
       fs.mkdirSync(profileDir, { recursive: true });
-      fs.writeFileSync(path.join(profileDir, (processName || 'runner') + '.json'), JSON.stringify(profile));
+      fs.writeFileSync(path.join(profileDir, profileName + '.json'), JSON.stringify(profile));
     }
     f();
   }));

--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -20,7 +20,7 @@ import type { Command } from 'playwright-core/lib/utilsBundle';
 import fs from 'fs';
 import path from 'path';
 import { Runner } from './runner/runner';
-import { stopProfiling, startProfiling } from './common/profiler';
+import { stopProfiling, startProfiling } from 'playwright-core/lib/utils';
 import { experimentalLoaderOption, fileIsModule } from './util';
 import { showHTMLReport } from './reporters/html';
 import { baseFullConfig, builtInReporters, ConfigLoader, defaultTimeout, kDefaultConfigFiles, resolveConfigFile } from './common/configLoader';
@@ -175,7 +175,7 @@ async function runTests(args: string[], opts: { [key: string]: any }) {
     status = await runner.watchAllTests();
   else
     status = await runner.runAllTests();
-  await stopProfiling(undefined);
+  await stopProfiling('runner');
   if (status === 'interrupted')
     process.exit(130);
   process.exit(status === 'passed' ? 0 : 1);

--- a/packages/playwright-test/src/common/process.ts
+++ b/packages/playwright-test/src/common/process.ts
@@ -16,7 +16,7 @@
 
 import type { WriteStream } from 'tty';
 import type { ProcessInitParams, TtyParams } from './ipc';
-import { startProfiling, stopProfiling } from './profiler';
+import { startProfiling, stopProfiling } from 'playwright-core/lib/utils';
 import type { TestInfoError } from './types';
 import { serializeError } from '../util';
 


### PR DESCRIPTION
This creates one profile per connection in the specified directory.