### PR TITLE
fix(html-reporter): annotations.size rendered 0 on UI

### DIFF
--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -44,7 +44,7 @@ export const TestCaseView: React.FC<{
     {test && <div className='test-case-title'>{test?.title}</div>}
     {test && <div className='test-case-location'>{test.location.file}:{test.location.line}</div>}
     {test && !!test.projectName && <ProjectLink projectNames={projectNames} projectName={test.projectName}></ProjectLink>}
-    {annotations.size && <AutoChip header='Annotations'>
+    {!annotations.values().next().done && <AutoChip header='Annotations'>
       {[...annotations].map(annotation => <TestCaseAnnotationView type={annotation[0]} descriptions={annotation[1]} />)}
     </AutoChip>}
     {test && <TabbedPane tabs={

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -44,7 +44,7 @@ export const TestCaseView: React.FC<{
     {test && <div className='test-case-title'>{test?.title}</div>}
     {test && <div className='test-case-location'>{test.location.file}:{test.location.line}</div>}
     {test && !!test.projectName && <ProjectLink projectNames={projectNames} projectName={test.projectName}></ProjectLink>}
-    {!annotations.values().next().done && <AutoChip header='Annotations'>
+    {annotations.size > 0 && <AutoChip header='Annotations'>
       {[...annotations].map(annotation => <TestCaseAnnotationView type={annotation[0]} descriptions={annotation[1]} />)}
     </AutoChip>}
     {test && <TabbedPane tabs={


### PR DESCRIPTION
related to #21580 
this PR fixing conditional rendering annotations.size = 0
code below render as "0" when 
```ts 
{annotations.size && <AutoChip header='Annotations'>
      {[...annotations].map(annotation => <TestCaseAnnotationView type={annotation[0]} descriptions={annotation[1]} />)}
    </AutoChip>}
```
below project link
<img width="628" alt="Screenshot 2023-03-13 at 20 57 34" src="https://user-images.githubusercontent.com/11705902/224802431-36090bf4-e9bb-415d-9311-4a1a4666cbcb.png">


