### PR TITLE
fix(routeFromHar): prefer valid responses

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
@@ -306,9 +306,8 @@ class HarBackend {
           const matchingHeaders = countMatchingHeaders(candidate.request.headers, headers);
           list.push({ candidate, matchingHeaders });
         }
+        list.reverse();
         list.sort((a, b) => b.matchingHeaders - a.matchingHeaders);
-        while (list[0].candidate.time < 0 && list.some(entry => entry.candidate.time >= 0))
-          list.shift();
         entry = list[0].candidate;
       }
 

--- a/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
@@ -307,6 +307,8 @@ class HarBackend {
           list.push({ candidate, matchingHeaders });
         }
         list.sort((a, b) => b.matchingHeaders - a.matchingHeaders);
+        while (list[0].candidate.time < 0 && list.some(entry => entry.candidate.time >= 0))
+          list.shift();
         entry = list[0].candidate;
       }
 

--- a/tests/assets/har-unstable-network.har
+++ b/tests/assets/har-unstable-network.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "Playwright",
+      "version": "1.32.3"
+    },
+    "browser": {
+      "name": "chromium",
+      "version": "112.0.5615.29"
+    },
+    "entries": [
+      {
+        "startedDateTime": "2022-06-16T21:41:23.951Z",
+        "time": -1,
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:8907/api",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Accept-Encoding", "value": "gzip, deflate, br" },
+            { "name": "Accept-Language", "value": "en-US" },
+            { "name": "Connection", "value": "keep-alive" },
+            { "name": "Host", "value": "localhost:8907" },
+            { "name": "Referer", "value": "http://localhost:8907/" },
+            { "name": "Sec-Fetch-Dest", "value": "empty" },
+            { "name": "Sec-Fetch-Mode", "value": "cors" },
+            { "name": "Sec-Fetch-Site", "value": "same-origin" },
+            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.29 Safari/537.36" }
+          ],
+          "queryString": [],
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "response": {
+          "status": -1,
+          "statusText": "",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [],
+          "content": {
+            "size": -1,
+            "mimeType": "x-unknown"
+          },
+          "headersSize": -1,
+          "bodySize": -1,
+          "redirectURL": ""
+        },
+        "cache": {},
+        "timings": { "send": -1, "wait": -1, "receive": -1 }
+      },
+      {
+        "startedDateTime": "2023-04-11T06:05:46.243Z",
+        "time": 0.578,
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:8907/api",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Accept-Encoding", "value": "gzip, deflate, br" },
+            { "name": "Accept-Language", "value": "en-US" },
+            { "name": "Connection", "value": "keep-alive" },
+            { "name": "Host", "value": "localhost:8907" },
+            { "name": "Referer", "value": "http://localhost:8907/" },
+            { "name": "Sec-Fetch-Dest", "value": "empty" },
+            { "name": "Sec-Fetch-Mode", "value": "cors" },
+            { "name": "Sec-Fetch-Site", "value": "same-origin" },
+            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.29 Safari/537.36" }
+          ],
+          "queryString": [],
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            { "name": "Connection", "value": "keep-alive" },
+            { "name": "Content-Length", "value": "13" },
+            { "name": "Content-Type", "value": "text/html; charset=utf-8" },
+            { "name": "Date", "value": "Tue, 11 Apr 2023 06:05:46 GMT" },
+            { "name": "Keep-Alive", "value": "timeout=5" },
+            { "name": "X-Powered-By", "value": "Express" }
+          ],
+          "content": {
+            "size": -1,
+            "mimeType": "text/html; charset=utf-8",
+            "text": "hello, world!"
+          },
+          "headersSize": -1,
+          "bodySize": -1,
+          "redirectURL": ""
+        },
+        "cache": {},
+        "timings": { "send": -1, "wait": -1, "receive": 0.578 }
+      }
+    ]
+  }
+}

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -170,6 +170,23 @@ it('should change document URL after redirected navigation on click', async ({ s
   expect(await page.evaluate(() => location.href)).toBe('https://www.theverge.com/');
 });
 
+it('should change prefer responding vith valid content', async ({ server, context, asset }) => {
+  const path = asset('har-unstable-network.har');
+  await context.routeFromHAR(path, { url: /api/ });
+  const page = await context.newPage();
+  await page.goto(server.EMPTY_PAGE);
+  await page.setContent(`
+    <script>
+        setInterval(() => {
+            fetch('/api')
+                .then(res => res.text())
+                .then(text => document.body.innerHTML = text);
+        }, 1000);
+    </script>
+  `);
+  await page.waitForSelector('text=hello world');
+});
+
 it('should goBack to redirected navigation', async ({ context, asset, server }) => {
   const path = asset('har-redirect.har');
   await context.routeFromHAR(path, { url: /.*theverge.*/ });

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -170,7 +170,7 @@ it('should change document URL after redirected navigation on click', async ({ s
   expect(await page.evaluate(() => location.href)).toBe('https://www.theverge.com/');
 });
 
-it('should change prefer responding vith valid content', async ({ server, context, asset }) => {
+it('should prefer responding with valid content', async ({ server, context, asset }) => {
   // when some responses are not valid, we should return response with valid content at least once.
   // Otherwise, clients with retry logic will get stuck in an infinite loop.
   const path = asset('har-unstable-network.har');

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -171,6 +171,8 @@ it('should change document URL after redirected navigation on click', async ({ s
 });
 
 it('should change prefer responding vith valid content', async ({ server, context, asset }) => {
+  // when some responses are not valid, we should return response with valid content at least once.
+  // Otherwise, clients with retry logic will get stuck in an infinite loop.
   const path = asset('har-unstable-network.har');
   await context.routeFromHAR(path, { url: /api/ });
   const page = await context.newPage();

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -178,13 +178,13 @@ it('should change prefer responding vith valid content', async ({ server, contex
   await page.setContent(`
     <script>
         setInterval(() => {
-            fetch('/api')
+            fetch('http://localhost:8907/api')
                 .then(res => res.text())
                 .then(text => document.body.innerHTML = text);
         }, 1000);
     </script>
   `);
-  await page.waitForSelector('text=hello world');
+  await page.waitForSelector('text=hello');
 });
 
 it('should goBack to redirected navigation', async ({ context, asset, server }) => {


### PR DESCRIPTION
In case:
a. few HAR entries are valid routing match candidates and
b. some of them have no response
I suggest we should always prefer to route to the entry with a valid response over the entries having exceptions.

It will solve a problem that we have with unstable services - occasionally when requests are failing we make retries, and we need a way to prefer the successful try over the failing ones.