### PR TITLE
fix(selector generator): do not produce `has-text="foo"s`

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/locatorGenerators.ts
+++ b/packages/playwright-core/src/utils/isomorphic/locatorGenerators.ts
@@ -75,8 +75,11 @@ function innerAsLocator(factory: LocatorFactory, parsed: ParsedSelector, isFrame
     }
     if (part.name === 'internal:has-text') {
       const { exact, text } = detectExact(part.body as string);
-      tokens.push(factory.generateLocator(base, 'has-text', text, { exact }));
-      continue;
+      // There is no locator equivalent for strict has-text, leave it as is.
+      if (!exact) {
+        tokens.push(factory.generateLocator(base, 'has-text', text, { exact }));
+        continue;
+      }
     }
     if (part.name === 'internal:has') {
       const inner = innerAsLocator(factory, (part.body as NestedSelectorBody).parsed);

--- a/tests/library/locator-generator.spec.ts
+++ b/tests/library/locator-generator.spec.ts
@@ -347,6 +347,8 @@ it.describe(() => {
       javascript: `locator('div').filter({ hasText: 'Goodbye world' }).locator('span')`,
       python: 'locator("div").filter(has_text="Goodbye world").locator("span")',
     });
+
+    expect.soft(asLocator('javascript', 'div >> internal:has-text="foo"s', false)).toBe(`locator('div').locator('internal:has-text="foo"s')`);
   });
 });
 

--- a/tests/library/selector-generator.spec.ts
+++ b/tests/library/selector-generator.spec.ts
@@ -162,6 +162,15 @@ it.describe('selector generator', () => {
     expect(await generate(page, 'a:has-text("Hello")')).toBe(`a >> internal:has-text="Hello world"i`);
   });
 
+  it('should use internal:has-text with regexp', async ({ page }) => {
+    await page.setContent(`
+      <span>Hello world</span>
+      <div><div>Hello <span>world</span></div>extra</div>
+      <a>Goodbye <span>world</span></a>
+    `);
+    expect(await generate(page, 'div div')).toBe(`div >> internal:has-text=/^Hello world$/`);
+  });
+
   it('should chain text after parent', async ({ page }) => {
     await page.setContent(`
       <div>Hello <span>world</span></div>


### PR DESCRIPTION
There is no locator counterpart for it. Instead, produce a regex.

Also fix locator generator to not produce incorrect locator in this case.

Fixes #21649.