### PR TITLE
docs(dotnet): don't use C# option names

### DIFF
--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -67,7 +67,7 @@ using Microsoft.Playwright;
 
 using var playwright = await Playwright.CreateAsync();
 var firefox = playwright.Firefox;
-var browser = await firefox.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+var browser = await firefox.LaunchAsync(new() { Headless = false });
 var page = await browser.NewPageAsync();
 await page.GotoAsync("https://www.bing.com");
 await browser.CloseAsync();

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -52,7 +52,7 @@ context.close()
 
 ```csharp
 using var playwright = await Playwright.CreateAsync();
-var browser = await playwright.Firefox.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+var browser = await playwright.Firefox.LaunchAsync(new() { Headless = false });
 // Create a new incognito browser context
 var context = await browser.NewContextAsync();
 // Create a new page inside context.
@@ -280,7 +280,7 @@ browser_context.add_init_script(path="preload.js")
 ```
 
 ```csharp
-await context.AddInitScriptAsync(new BrowserContextAddInitScriptOptions { ScriptPath = "preload.js" });
+await context.AddInitScriptAsync(scriptPath: "preload.js");
 ```
 
 :::note
@@ -538,7 +538,7 @@ with sync_playwright() as playwright:
 using Microsoft.Playwright;
 
 using var playwright = await Playwright.CreateAsync();
-var browser = await playwright.Webkit.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+var browser = await playwright.Webkit.LaunchAsync(new() { Headless = false });
 var context = await browser.NewContextAsync();
 
 await context.ExposeBindingAsync("pageURL", source => source.Page.Url);
@@ -800,7 +800,7 @@ class BrowserContextExamples
     public static async Task Main()
     {
         using var playwright = await Playwright.CreateAsync();
-        var browser = await playwright.Webkit.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+        var browser = await playwright.Webkit.LaunchAsync(new() { Headless = false });
         var context = await browser.NewContextAsync();
 
         await context.ExposeFunctionAsync("sha256", (string input) =>

--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -249,7 +249,7 @@ browser = playwright.chromium.launch( # or "firefox" or "webkit".
 ```
 
 ```csharp
-var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions {
+var browser = await playwright.Chromium.LaunchAsync(new() {
     IgnoreDefaultArgs = new[] { "--mute-audio" }
 })
 ```

--- a/docs/src/api/class-keyboard.md
+++ b/docs/src/api/class-keyboard.md
@@ -286,11 +286,11 @@ browser.close()
 ```csharp
 await page.GotoAsync("https://keycode.info");
 await page.Keyboard.PressAsync("A");
-await page.ScreenshotAsync(new PageScreenshotOptions { Path = "A.png" });
+await page.ScreenshotAsync(new() { Path = "A.png" });
 await page.Keyboard.PressAsync("ArrowLeft");
-await page.ScreenshotAsync(new PageScreenshotOptions { Path = "ArrowLeft.png" });
+await page.ScreenshotAsync(new() { Path = "ArrowLeft.png" });
 await page.Keyboard.PressAsync("Shift+O");
-await page.ScreenshotAsync(new PageScreenshotOptions { Path = "O.png" });
+await page.ScreenshotAsync(new() { Path = "O.png" });
 await browser.CloseAsync();
 ```
 
@@ -341,7 +341,7 @@ page.keyboard.type("World", delay=100) # types slower, like a user
 
 ```csharp
 await page.Keyboard.TypeAsync("Hello"); // types instantly
-await page.Keyboard.TypeAsync("World", new KeyboardTypeOptions { Delay = 100 }); // types slower, like a user
+await page.Keyboard.TypeAsync("World", new() { Delay = 100 }); // types slower, like a user
 ```
 
 :::note

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -939,8 +939,8 @@ row_locator
 var rowLocator = page.Locator("tr");
 // ...
 await rowLocator
-    .Filter(new LocatorFilterOptions { HasText = "text in column 1" })
-    .Filter(new LocatorFilterOptions {
+    .Filter(new() { HasText = "text in column 1" })
+    .Filter(new() {
         Has = page.GetByRole(AriaRole.Button, new() { Name = "column 2 button" } )
     })
     .ScreenshotAsync();

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -86,7 +86,7 @@ class PageExamples
         await using var browser = await playwright.Webkit.LaunchAsync();
         var page = await browser.NewPageAsync();
         await page.GotoAsync("https://www.theverge.com");
-        await page.ScreenshotAsync(new PageScreenshotOptions { Path = "theverge.png" });
+        await page.ScreenshotAsync(new() { Path = "theverge.png" });
     }
 }
 ```
@@ -599,7 +599,7 @@ page.add_init_script(path="./preload.js")
 ```
 
 ```csharp
-await page.AddInitScriptAsync("./preload.js");
+await page.AddInitScriptAsync(scriptPath: "./preload.js");
 ```
 
 :::note
@@ -1180,13 +1180,13 @@ await page.EvaluateAsync("() => matchMedia('screen').matches");
 await page.EvaluateAsync("() => matchMedia('print').matches");
 // → false
 
-await page.EmulateMediaAsync(new PageEmulateMediaOptions { Media = Media.Print });
+await page.EmulateMediaAsync(new() { Media = Media.Print });
 await page.EvaluateAsync("() => matchMedia('screen').matches");
 // → false
 await page.EvaluateAsync("() => matchMedia('print').matches");
 // → true
 
-await page.EmulateMediaAsync(new PageEmulateMediaOptions { Media = Media.Screen });
+await page.EmulateMediaAsync(new() { Media = Media.Screen });
 await page.EvaluateAsync("() => matchMedia('screen').matches");
 // → true
 await page.EvaluateAsync("() => matchMedia('print').matches");
@@ -1233,7 +1233,7 @@ page.evaluate("matchMedia('(prefers-color-scheme: no-preference)').matches")
 ```
 
 ```csharp
-await page.EmulateMediaAsync(new PageEmulateMediaOptions { ColorScheme = ColorScheme.Dark });
+await page.EmulateMediaAsync(new() { ColorScheme = ColorScheme.Dark });
 await page.EvaluateAsync("matchMedia('(prefers-color-scheme: dark)').matches");
 // → true
 await page.EvaluateAsync("matchMedia('(prefers-color-scheme: light)').matches");
@@ -2805,8 +2805,8 @@ page.pdf(path="page.pdf")
 
 ```csharp
 // Generates a PDF with 'screen' media type
-await page.EmulateMediaAsync(new PageEmulateMediaOptions { Media = Media.Screen });
-await page.PdfAsync(new PagePdfOptions { Path = "page.pdf" });
+await page.EmulateMediaAsync(new() { Media = Media.Screen });
+await page.PdfAsync(new() { Path = "page.pdf" });
 ```
 
 The [`option: width`], [`option: height`], and [`option: margin`] options accept values labeled with units. Unlabeled
@@ -3037,11 +3037,11 @@ browser.close()
 var page = await browser.NewPageAsync();
 await page.GotoAsync("https://keycode.info");
 await page.PressAsync("body", "A");
-await page.ScreenshotAsync(new PageScreenshotOptions { Path = "A.png" });
+await page.ScreenshotAsync(new() { Path = "A.png" });
 await page.PressAsync("body", "ArrowLeft");
-await page.ScreenshotAsync(new PageScreenshotOptions { Path = "ArrowLeft.png" });
+await page.ScreenshotAsync(new() { Path = "ArrowLeft.png" });
 await page.PressAsync("body", "Shift+O");
-await page.ScreenshotAsync(new PageScreenshotOptions { Path = "O.png" });
+await page.ScreenshotAsync(new() { Path = "O.png" });
 ```
 
 ### param: Page.press.selector = %%-input-selector-%%
@@ -3259,7 +3259,7 @@ page.route("/api/**", handle_route)
 await page.RouteAsync("/api/**", async r =>
 {
   if (r.Request.PostData.Contains("my-string"))
-      await r.FulfillAsync(new RouteFulfillOptions { Body = "mocked-data" });
+      await r.FulfillAsync(new() { Body = "mocked-data" });
   else
       await r.ContinueAsync();
 });

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -317,7 +317,7 @@ using Microsoft.Playwright;
 using var playwright = await Playwright.CreateAsync();
 var chromium = playwright.Chromium;
 // Make sure to run headed.
-var browser = await chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+var browser = await chromium.LaunchAsync(new() { Headless = false });
 
 // Setup context however you like.
 var context = await browser.NewContextAsync(); // Pass any options

--- a/docs/src/codegen.md
+++ b/docs/src/codegen.md
@@ -480,7 +480,7 @@ using Microsoft.Playwright;
 using var playwright = await Playwright.CreateAsync();
 var chromium = playwright.Chromium;
 // Make sure to run headed.
-var browser = await chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+var browser = await chromium.LaunchAsync(new() { Headless = false });
 
 // Setup context however you like.
 var context = await browser.NewContextAsync(); // Pass any options

--- a/docs/src/emulation.md
+++ b/docs/src/emulation.md
@@ -658,7 +658,7 @@ context = browser.new_context(
 ```
 
 ```csharp
-var context = await browser.NewContextAsync(new BrowserNewContextOptions { UserAgent = "My User Agent" });
+var context = await browser.NewContextAsync(new() { UserAgent = "My User Agent" });
 ```
 ## JavaScript Enabled
 

--- a/docs/src/navigations.md
+++ b/docs/src/navigations.md
@@ -86,7 +86,7 @@ page.goto("https://example.com", wait_until="networkidle")
 
 ```csharp
 // Navigate and wait until network is idle
-await page.GotoAsync("https://example.com", new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+await page.GotoAsync("https://example.com", new() { WaitUntil = WaitUntilState.NetworkIdle });
 ```
 
 ### Wait for element

--- a/docs/src/network.md
+++ b/docs/src/network.md
@@ -539,7 +539,7 @@ page.route("**/*", lambda route: route.continue_(method="POST"))
 await page.RouteAsync("**/*", async route => {
     var headers = new Dictionary<string, string>(route.Request.Headers.ToDictionary(x => x.Key, x => x.Value));
     headers.Remove("X-Secret");
-    await route.ContinueAsync(new RouteContinueOptions { Headers = headers });
+    await route.ContinueAsync(new() { Headers = headers });
 });
 
 // Continue requests as POST.

--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -437,7 +437,7 @@ Note that the new methods [`method: Page.routeFromHAR`] and [`method: BrowserCon
   ```csharp
   var buttons = page.Locator("role=button");
   // ...
-  var submitLocator = buttons.Filter(new LocatorFilterOptions { HasText = "Sign up" });
+  var submitLocator = buttons.Filter(new() { HasText = "Sign up" });
   await submitLocator.ClickAsync();
   ```
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-dotnet/issues/2513

Drive-by: hide C# option names