### PR TITLE
feat(chromium-tip-of-tree): roll to r1095

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -15,9 +15,9 @@
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1094",
+      "revision": "1095",
       "installByDefault": false,
-      "browserVersion": "113.0.5650.0"
+      "browserVersion": "113.0.5653.0"
     },
     {
       "name": "firefox",


### PR DESCRIPTION
crash filed upstream: https://bugs.chromium.org/p/chromium/issues/detail?id=1425099