### PR TITLE
test: fix component tests

### DIFF
--- a/tests/components/ct-vue-vite/tsconfig.test.json
+++ b/tests/components/ct-vue-vite/tsconfig.test.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "composite": true,
     "lib": [],
-    "types": ["node"]
+    "types": ["node"],
+    "ignoreDeprecations": "5.0"
   }
 }


### PR DESCRIPTION
TypeScript in v5 emits a warning and this ends up in exit code 1. See https://github.com/vuejs/tsconfig/issues/6 for more information. This CL will make TypeScript still end up in exit code 0 even tho these warnings are emitted until they fixed it upstream and released a new version of their config.