### PR TITLE
feat: Allow for passing --disable-gpu to Chromium

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -271,6 +271,8 @@ export class Chromium extends BrowserType {
       chromeArguments.push('about:blank');
     else
       chromeArguments.push('--no-startup-window');
+    if (process.env.PWTEST_DISABLE_GPU)
+      chromeArguments.push('--disable-gpu');
     return chromeArguments;
   }
 


### PR DESCRIPTION
Playwright works under Microsoft WSL *except* where Chromium is involved. Running Chromium in WSL involves passing the --disable-gpu argument. Without this, any Chromium window remain black or entirely transparent. This patch adds support for the PWTEST_DISABLE_GPU environment variable, which, if set to any value, automatically passes the argument whenever Chromium is invoked.