### PR TITLE
test: run crash tests in separate worker

### DIFF
--- a/tests/page/page-event-crash.spec.ts
+++ b/tests/page/page-event-crash.spec.ts
@@ -15,64 +15,69 @@
  * limitations under the License.
  */
 
-import { test as it, expect } from './pageTest';
+import { contextTest as testBase, expect } from '../config/browserTest';
 
-function crash({ page, toImpl, browserName, platform, mode }: any) {
-  if (browserName === 'chromium')
-    page.goto('chrome://crash').catch(e => {});
-  else if (browserName === 'webkit')
-    toImpl(page)._delegate._session.send('Page.crash', {}).catch(e => {});
-  else if (browserName === 'firefox')
-    toImpl(page)._delegate._session.send('Page.crash', {}).catch(e => {});
-}
+const test = testBase.extend<{ crash: () => void }>({
+  crash: async ({ page, toImpl, browserName }, run) => {
+    run(() => {
+      if (browserName === 'chromium')
+        page.goto('chrome://crash').catch(e => {});
+      else if (browserName === 'webkit')
+        toImpl(page)._delegate._session.send('Page.crash', {}).catch(e => {});
+      else if (browserName === 'firefox')
+        toImpl(page)._delegate._session.send('Page.crash', {}).catch(e => {});
+    });
+  }
+});
 
-it.describe('', () => {
-  it('should emit crash event when page crashes', async ({ page, toImpl, browserName, platform, mode }) => {
-    await page.setContent(`<div>This page should crash</div>`);
-    crash({ page, toImpl, browserName, platform, mode });
-    const crashedPage = await new Promise(f => page.on('crash', f));
-    expect(crashedPage).toBe(page);
-  });
+// Force a separate worker to avoid messing up with other tests.
+test.use({ launchOptions: {} });
 
-  it('should throw on any action after page crashes', async ({ page, toImpl, browserName, platform, mode }) => {
-    await page.setContent(`<div>This page should crash</div>`);
-    crash({ page, toImpl, browserName, platform, mode });
-    await page.waitForEvent('crash');
-    const err = await page.evaluate(() => {}).then(() => null, e => e);
-    expect(err).toBeTruthy();
-    // In Firefox, crashed page is sometimes "closed".
-    if (browserName === 'firefox')
-      expect(err.message.includes('Target page, context or browser has been closed') || err.message.includes('Target crashed'), err.message).toBe(true);
-    else
-      expect(err.message).toContain('Target crashed');
-  });
+test('should emit crash event when page crashes', async ({ page, crash }) => {
+  await page.setContent(`<div>This page should crash</div>`);
+  crash();
+  const crashedPage = await new Promise(f => page.on('crash', f));
+  expect(crashedPage).toBe(page);
+});
 
-  it('should cancel waitForEvent when page crashes', async ({ page, toImpl, browserName, platform, mode }) => {
-    await page.setContent(`<div>This page should crash</div>`);
-    const promise = page.waitForEvent('response').catch(e => e);
-    crash({ page, toImpl, browserName, platform, mode });
-    const error = await promise;
-    expect(error.message).toContain('Page crashed');
-  });
+test('should throw on any action after page crashes', async ({ page, crash, browserName }) => {
+  await page.setContent(`<div>This page should crash</div>`);
+  crash();
+  await page.waitForEvent('crash');
+  const err = await page.evaluate(() => {}).then(() => null, e => e);
+  expect(err).toBeTruthy();
+  // In Firefox, crashed page is sometimes "closed".
+  if (browserName === 'firefox')
+    expect(err.message.includes('Target page, context or browser has been closed') || err.message.includes('Target crashed'), err.message).toBe(true);
+  else
+    expect(err.message).toContain('Target crashed');
+});
 
-  it('should cancel navigation when page crashes', async ({ server, page, toImpl, browserName, platform, mode }) => {
-    await page.setContent(`<div>This page should crash</div>`);
-    server.setRoute('/one-style.css', () => {});
-    const promise = page.goto(server.PREFIX + '/one-style.html').catch(e => e);
-    await page.waitForNavigation({ waitUntil: 'domcontentloaded' });
-    crash({ page, toImpl, browserName, platform, mode });
-    const error = await promise;
-    expect(error.message).toContain('Navigation failed because page crashed');
-  });
+test('should cancel waitForEvent when page crashes', async ({ page, crash }) => {
+  await page.setContent(`<div>This page should crash</div>`);
+  const promise = page.waitForEvent('response').catch(e => e);
+  crash();
+  const error = await promise;
+  expect(error.message).toContain('Page crashed');
+});
 
-  it('should be able to close context when page crashes', async ({ isAndroid, isElectron, isWebView2, page, toImpl, browserName, platform, mode }) => {
-    it.skip(isAndroid);
-    it.skip(isElectron);
-    it.skip(isWebView2, 'Page.close() is not supported in WebView2');
+test('should cancel navigation when page crashes', async ({ server, page, crash }) => {
+  await page.setContent(`<div>This page should crash</div>`);
+  server.setRoute('/one-style.css', () => {});
+  const promise = page.goto(server.PREFIX + '/one-style.html').catch(e => e);
+  await page.waitForNavigation({ waitUntil: 'domcontentloaded' });
+  crash();
+  const error = await promise;
+  expect(error.message).toContain('Navigation failed because page crashed');
+});
 
-    await page.setContent(`<div>This page should crash</div>`);
-    crash({ page, toImpl, browserName, platform, mode });
-    await page.waitForEvent('crash');
-    await page.context().close();
-  });
+test('should be able to close context when page crashes', async ({ isAndroid, isElectron, isWebView2, page, crash }) => {
+  test.skip(isAndroid);
+  test.skip(isElectron);
+  test.skip(isWebView2, 'Page.close() is not supported in WebView2');
+
+  await page.setContent(`<div>This page should crash</div>`);
+  crash();
+  await page.waitForEvent('crash');
+  await page.context().close();
 });


### PR DESCRIPTION
Running crash tests in its own worker should ensure that the browser logs from different tests are not interleaved: 

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/9798949/225965857-9152a88e-a775-4935-955a-dd7e6b88409a.png">
