### PR TITLE
docs(java): fix syntax error in Java example of JSHandle.getProperties

### DIFF
--- a/docs/src/api/class-jshandle.md
+++ b/docs/src/api/class-jshandle.md
@@ -140,7 +140,7 @@ await handle.dispose();
 ```
 
 ```java
-JSHandle handle = page.evaluateHandle("() => ({window, document}"););
+JSHandle handle = page.evaluateHandle("() => ({window, document})");
 Map<String, JSHandle> properties = handle.getProperties();
 JSHandle windowHandle = properties.get("window");
 JSHandle documentHandle = properties.get("document");


### PR DESCRIPTION
Fix syntax error in Java example of JSHandle.getProperties

https://playwright.dev/java/docs/api/class-jshandle#js-handle-get-properties


![playwright-docs-jshandle](https://user-images.githubusercontent.com/460302/227085236-f654d7ea-f1aa-4b36-9cee-f3f08665f870.png)

![playwright-java-syntax-error](https://user-images.githubusercontent.com/460302/227084540-7ed6a4e6-d192-4835-b825-996d7202b6f6.png)