### PR TITLE
fix(test runner): do not show TimeoutError for unhandled rejection

### DIFF
--- a/packages/playwright-test/src/worker/workerMain.ts
+++ b/packages/playwright-test/src/worker/workerMain.ts
@@ -99,12 +99,7 @@ export class WorkerMain extends ProcessRunner {
   private _stop(): Promise<void> {
     if (!this._isStopped) {
       this._isStopped = true;
-
-      // Interrupt current action.
-      this._currentTest?._timeoutManager.interrupt();
-
-      if (this._currentTest && this._currentTest.status === 'passed')
-        this._currentTest.status = 'interrupted';
+      this._currentTest?._interrupt();
     }
     return this._runFinished;
   }

--- a/tests/playwright-test/basic.spec.ts
+++ b/tests/playwright-test/basic.spec.ts
@@ -394,6 +394,24 @@ test('test.{skip,fixme} should define a skipped test', async ({ runInlineTest })
   expect(result.output).not.toContain('%%dontseethis');
 });
 
+test('should report unhandled error during test and not report timeout', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('unhandled rejection', async () => {
+        setTimeout(() => {
+          throw new Error('Unhandled');
+        }, 0);
+        await new Promise(f => setTimeout(f, 100));
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.output).toContain('Error: Unhandled');
+  expect(result.output).not.toContain('Test timeout of 30000ms exceeded');
+});
+
 test('should report unhandled rejection during worker shutdown', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `


### PR DESCRIPTION
Unhandled error/rejection interrupts current test and produces a TimeoutError for it that should be ignored.