### PR TITLE
refactor(routeFromHar): content to updateContent

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -624,8 +624,8 @@ Logger sink for Playwright logging.
 - `recordHar` <[Object]>
   - `omitContent` ?<[boolean]> Optional setting to control whether to omit request content from the HAR. Defaults to
     `false`. Deprecated, use `content` policy instead.
-  - `content` ?<[HarContentPolicy]<"omit"|"embed"|"attach">> Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output files and to `embed` for all other file extensions.
-  - `path` <[path]> Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by default.
+  - `updateContent` ?<[HarContentPolicy]<"omit"|"embed"|"attach">> Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output files and to `embed` for all other file extensions.
+  - `path` <[path]> Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is used by default.
   - `mode` ?<[HarMode]<"full"|"minimal">> When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
   - `urlFilter` ?<[string]|[RegExp]> A glob or regex pattern to filter requests that are stored in the HAR. When a [`option: baseURL`] via the context options was provided and the passed URL is a path, it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
 

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -399,7 +399,7 @@ function prepareRecordHarOptions(options: BrowserContextOptions['recordHar']): c
     return;
   return {
     path: options.path,
-    content: options.content || (options.omitContent ? 'omit' : undefined),
+    content: options.updateContent || (options.omitContent ? 'omit' : undefined),
     urlGlob: isString(options.urlFilter) ? options.urlFilter : undefined,
     urlRegexSource: isRegExp(options.urlFilter) ? options.urlFilter.source : undefined,
     urlRegexFlags: isRegExp(options.urlFilter) ? options.urlFilter.flags : undefined,

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -62,7 +62,7 @@ export type BrowserContextOptions = Omit<channels.BrowserNewContextOptions, 'vie
   recordHar?: {
     path: string,
     omitContent?: boolean,
-    content?: 'omit' | 'embed' | 'attach',
+    updateContent?: 'omit' | 'embed' | 'attach',
     mode?: 'full' | 'minimal',
     urlFilter?: string | RegExp,
   };

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -150,7 +150,7 @@ scheme.SerializedError = tObject({
 });
 scheme.RecordHarOptions = tObject({
   path: tString,
-  content: tOptional(tEnum(['embed', 'attach', 'omit'])),
+  updateContent: tOptional(tEnum(['embed', 'attach', 'omit'])),
   mode: tOptional(tEnum(['full', 'minimal'])),
   urlGlob: tOptional(tString),
   urlRegexSource: tOptional(tString),

--- a/packages/playwright-core/src/server/har/harRecorder.ts
+++ b/packages/playwright-core/src/server/har/harRecorder.ts
@@ -40,9 +40,9 @@ export class HarRecorder {
     this._artifact = new Artifact(context, path.join(context._browser.options.artifactsDir, `${createGuid()}.har`));
     const urlFilterRe = options.urlRegexSource !== undefined && options.urlRegexFlags !== undefined ? new RegExp(options.urlRegexSource, options.urlRegexFlags) : undefined;
     const expectsZip = options.path.endsWith('.zip');
-    const content = options.content || (expectsZip ? 'attach' : 'embed');
+    const updateContent = options.updateContent || (expectsZip ? 'attach' : 'embed');
     this._tracer = new HarTracer(context, page, this, {
-      content,
+      updateContent,
       slimMode: options.mode === 'minimal',
       includeTraceInfo: false,
       recordRequestOverrides: true,
@@ -50,7 +50,7 @@ export class HarRecorder {
       skipScripts: false,
       urlFilter: urlFilterRe ?? options.urlGlob,
     });
-    this._zipFile = content === 'attach' || expectsZip ? new yazl.ZipFile() : null;
+    this._zipFile = updateContent === 'attach' || expectsZip ? new yazl.ZipFile() : null;
     this._tracer.start();
   }
 

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -42,7 +42,7 @@ export interface HarTracerDelegate {
 }
 
 type HarTracerOptions = {
-  content: 'omit' | 'attach' | 'embed';
+  updateContent: 'omit' | 'attach' | 'embed';
   skipScripts: boolean;
   includeTraceInfo: boolean;
   recordRequestOverrides: boolean;

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -195,7 +195,7 @@ export class HarTracer {
     if (!this._options.omitCookies)
       harEntry.request.cookies = event.cookies;
     harEntry.request.headers = Object.entries(event.headers).map(([name, value]) => ({ name, value }));
-    harEntry.request.postData = this._postDataForBuffer(event.postData || null, event.headers['content-type'],  this._options.content);
+    harEntry.request.postData = this._postDataForBuffer(event.postData || null, event.headers['content-type'],  this._options.updateContent);
     if (!this._options.omitSizes)
       harEntry.request.bodySize = event.postData?.length || 0;
     (event as any)[this._entrySymbol] = harEntry;
@@ -250,7 +250,7 @@ export class HarTracer {
     if (pageEntry)
       harEntry.pageref = pageEntry.id;
     this._recordRequestHeadersAndCookies(harEntry, request.headers());
-    harEntry.request.postData = this._postDataForRequest(request, this._options.content);
+    harEntry.request.postData = this._postDataForRequest(request, this._options.updateContent);
     if (!this._options.omitSizes)
       harEntry.request.bodySize = request.bodySize();
     if (request.redirectedFrom()) {
@@ -277,7 +277,7 @@ export class HarTracer {
       return;
     harEntry.request.method = request.method();
     harEntry.request.url = request.url();
-    harEntry.request.postData = this._postDataForRequest(request, this._options.content);
+    harEntry.request.postData = this._postDataForRequest(request, this._options.updateContent);
     this._recordRequestHeadersAndCookies(harEntry, request.headers());
   }
 
@@ -386,7 +386,7 @@ export class HarTracer {
     if (!this._options.omitSizes)
       content.size = buffer.length;
 
-    if (this._options.content === 'embed') {
+    if (this._options.updateContent === 'embed') {
       // Sometimes, we can receive a font/media file with textual mime type. Browser
       // still interprets them correctly, but the 'content-type' header is obviously wrong.
       if (isTextualMimeType(content.mimeType) && resourceType !== 'font') {
@@ -395,7 +395,7 @@ export class HarTracer {
         content.text = buffer.toString('base64');
         content.encoding = 'base64';
       }
-    } else if (this._options.content === 'attach') {
+    } else if (this._options.updateContent === 'attach') {
       const sha1 = calculateSha1(buffer) + '.' + (mime.getExtension(content.mimeType) || 'dat');
       if (this._options.includeTraceInfo)
         content._sha1 = sha1;

--- a/packages/playwright-core/src/server/recorder/csharp.ts
+++ b/packages/playwright-core/src/server/recorder/csharp.ts
@@ -278,7 +278,7 @@ function convertContextOptions(options: BrowserContextOptions): any {
   const result: any = { ...options };
   if (options.recordHar) {
     result['recordHarPath'] = options.recordHar.path;
-    result['recordHarContent'] = options.recordHar.content;
+    result['recordHarContent'] = options.recordHar.updateContent;
     result['recordHarMode'] = options.recordHar.mode;
     result['recordHarOmitContent'] = options.recordHar.omitContent;
     result['recordHarUrlFilter'] = options.recordHar.urlFilter;

--- a/packages/playwright-core/src/server/recorder/java.ts
+++ b/packages/playwright-core/src/server/recorder/java.ts
@@ -213,8 +213,8 @@ function formatContextOptions(contextOptions: BrowserContextOptions, deviceName:
     lines.push(`  .setLocale(${quote(options.locale)})`);
   if (options.proxy)
     lines.push(`  .setProxy(new Proxy(${quote(options.proxy.server)}))`);
-  if (options.recordHar?.content)
-    lines.push(`  .setRecordHarContent(HarContentPolicy.${options.recordHar?.content.toUpperCase()})`);
+  if (options.recordHar?.updateContent)
+    lines.push(`  .setRecordHarContent(HarContentPolicy.${options.recordHar?.updateContent.toUpperCase()})`);
   if (options.recordHar?.mode)
     lines.push(`  .setRecordHarMode(HarMode.${options.recordHar?.mode.toUpperCase()})`);
   if (options.recordHar?.omitContent)

--- a/packages/playwright-core/src/server/recorder/python.ts
+++ b/packages/playwright-core/src/server/recorder/python.ts
@@ -246,7 +246,7 @@ function convertContextOptions(options: BrowserContextOptions): any {
   const result: any = { ...options };
   if (options.recordHar) {
     result['record_har_path'] = options.recordHar.path;
-    result['record_har_content'] = options.recordHar.content;
+    result['record_har_content'] = options.recordHar.updateContent;
     result['record_har_mode'] = options.recordHar.mode;
     result['record_har_omit_content'] = options.recordHar.omitContent;
     result['record_har_url_filter'] = options.recordHar.urlFilter;

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -84,7 +84,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     this._context = context;
     this._precreatedTracesDir = tracesDir;
     this._harTracer = new HarTracer(context, null, this, {
-      content: 'attach',
+      updateContent: 'attach',
       includeTraceInfo: true,
       recordRequestOverrides: false,
       waitForContentOnStop: false,

--- a/packages/playwright-core/src/server/trace/test/inMemorySnapshotter.ts
+++ b/packages/playwright-core/src/server/trace/test/inMemorySnapshotter.ts
@@ -37,7 +37,7 @@ export class InMemorySnapshotter implements SnapshotterDelegate, HarTracerDelega
 
   constructor(context: BrowserContext) {
     this._snapshotter = new Snapshotter(context, this);
-    this._harTracer = new HarTracer(context, null, this, { content: 'attach', includeTraceInfo: true, recordRequestOverrides: false, waitForContentOnStop: false, skipScripts: true });
+    this._harTracer = new HarTracer(context, null, this, { updateContent: 'attach', includeTraceInfo: true, recordRequestOverrides: false, waitForContentOnStop: false, skipScripts: true });
     this._storage = new SnapshotStorage();
   }
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -12438,11 +12438,11 @@ export interface BrowserType<Unused = {}> {
        * specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output
        * files and to `embed` for all other file extensions.
        */
-      content?: "omit"|"embed"|"attach";
+      updateContent?: "omit"|"embed"|"attach";
 
       /**
-       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is used by
-       * default.
+       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is
+       * used by default.
        */
       path: string;
 
@@ -13825,11 +13825,11 @@ export interface AndroidDevice {
        * specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output
        * files and to `embed` for all other file extensions.
        */
-      content?: "omit"|"embed"|"attach";
+      updateContent?: "omit"|"embed"|"attach";
 
       /**
-       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is used by
-       * default.
+       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is
+       * used by default.
        */
       path: string;
 
@@ -15686,11 +15686,11 @@ export interface Browser extends EventEmitter {
        * specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output
        * files and to `embed` for all other file extensions.
        */
-      content?: "omit"|"embed"|"attach";
+      updateContent?: "omit"|"embed"|"attach";
 
       /**
-       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is used by
-       * default.
+       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is
+       * used by default.
        */
       path: string;
 
@@ -16494,11 +16494,11 @@ export interface Electron {
        * specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output
        * files and to `embed` for all other file extensions.
        */
-      content?: "omit"|"embed"|"attach";
+      updateContent?: "omit"|"embed"|"attach";
 
       /**
-       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is used by
-       * default.
+       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is
+       * used by default.
        */
       path: string;
 
@@ -18765,11 +18765,11 @@ export interface BrowserContextOptions {
      * specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output
      * files and to `embed` for all other file extensions.
      */
-    content?: "omit"|"embed"|"attach";
+    updateContent?: "omit"|"embed"|"attach";
 
     /**
-     * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is used by
-     * default.
+     * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is
+     * used by default.
      */
     path: string;
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -12441,7 +12441,7 @@ export interface BrowserType<Unused = {}> {
       content?: "omit"|"embed"|"attach";
 
       /**
-       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by
+       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is used by
        * default.
        */
       path: string;
@@ -13828,7 +13828,7 @@ export interface AndroidDevice {
       content?: "omit"|"embed"|"attach";
 
       /**
-       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by
+       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is used by
        * default.
        */
       path: string;
@@ -15689,7 +15689,7 @@ export interface Browser extends EventEmitter {
       content?: "omit"|"embed"|"attach";
 
       /**
-       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by
+       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is used by
        * default.
        */
       path: string;
@@ -16497,7 +16497,7 @@ export interface Electron {
       content?: "omit"|"embed"|"attach";
 
       /**
-       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by
+       * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is used by
        * default.
        */
       path: string;
@@ -18768,7 +18768,7 @@ export interface BrowserContextOptions {
     content?: "omit"|"embed"|"attach";
 
     /**
-     * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by
+     * Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `updateContent: 'attach'` is used by
      * default.
      */
     path: string;

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -281,7 +281,7 @@ export type SerializedError = {
 
 export type RecordHarOptions = {
   path: string,
-  content?: 'embed' | 'attach' | 'omit',
+  updateContent?: 'embed' | 'attach' | 'omit',
   mode?: 'full' | 'minimal',
   urlGlob?: string,
   urlRegexSource?: string,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -239,7 +239,7 @@ RecordHarOptions:
   type: object
   properties:
     path: string
-    content:
+    updateContent:
       type: enum?
       literals:
       - embed

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -45,7 +45,7 @@ type BrowserTestTestFixtures = PageTestFixtures & {
   launchPersistent: (options?: Parameters<BrowserType['launchPersistentContext']>[1]) => Promise<{ context: BrowserContext, page: Page }>;
   startRemoteServer: StartRemoteServer;
   contextFactory: (options?: BrowserContextOptions) => Promise<BrowserContext>;
-  pageWithHar(options?: { outputPath?: string, content?: 'embed' | 'attach' | 'omit', omitContent?: boolean }): Promise<{ context: BrowserContext, page: Page, getLog: () => Promise<Log>, getZip: () => Promise<Map<string, Buffer>> }>
+  pageWithHar(options?: { outputPath?: string, updateContent?: 'embed' | 'attach' | 'omit', omitContent?: boolean }): Promise<{ context: BrowserContext, page: Page, getLog: () => Promise<Log>, getZip: () => Promise<Map<string, Buffer>> }>
 };
 
 const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>({
@@ -146,9 +146,9 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
     }
   },
   pageWithHar: async ({ contextFactory }, use, testInfo) => {
-    const pageWithHar = async (options: { outputPath?: string, content?: 'embed' | 'attach' | 'omit', omitContent?: boolean } = {}) => {
+    const pageWithHar = async (options: { outputPath?: string, updateContent?: 'embed' | 'attach' | 'omit', omitContent?: boolean } = {}) => {
       const harPath = testInfo.outputPath(options.outputPath || 'test.har');
-      const context = await contextFactory({ recordHar: { path: harPath, content: options.content, omitContent: options.omitContent }, ignoreHTTPSErrors: true });
+      const context = await contextFactory({ recordHar: { path: harPath, updateContent: options.updateContent, omitContent: options.omitContent }, ignoreHTTPSErrors: true });
       const page = await context.newPage();
       return {
         page,

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -236,7 +236,7 @@ it('should round-trip har.zip', async ({ contextFactory, server }, testInfo) => 
 
 it('should produce extracted zip', async ({ contextFactory, server }, testInfo) => {
   const harPath = testInfo.outputPath('har.har');
-  const context1 = await contextFactory({ recordHar: { mode: 'minimal', path: harPath, content: 'attach' } });
+  const context1 = await contextFactory({ recordHar: { mode: 'minimal', path: harPath, updateContent: 'attach' } });
   const page1 = await context1.newPage();
   await page1.goto(server.PREFIX + '/one-style.html');
   await context1.close();

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -318,7 +318,7 @@ it('should use attach mode for zip extension', async ({ contextFactory, server }
 });
 
 it('should omit content', async ({ contextFactory, server }, testInfo) => {
-  const { page, getLog } = await pageWithHar(contextFactory, testInfo, { content: 'omit', outputPath: 'test.har' });
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo, { updateContent: 'omit', outputPath: 'test.har' });
   await page.goto(server.PREFIX + '/har.html');
   await page.evaluate(() => fetch('/pptr.png').then(r => r.arrayBuffer()));
   const log = await getLog();
@@ -336,7 +336,7 @@ it('should omit content legacy', async ({ contextFactory, server }, testInfo) =>
 });
 
 it('should attach content', async ({ contextFactory, server }, testInfo) => {
-  const { page, getZip } = await pageWithHar(contextFactory, testInfo, { content: 'attach', outputPath: 'test.har.zip' });
+  const { page, getZip } = await pageWithHar(contextFactory, testInfo, { updateContent: 'attach', outputPath: 'test.har.zip' });
   await page.goto(server.PREFIX + '/har.html');
   await page.evaluate(() => fetch('/pptr.png').then(r => r.arrayBuffer()));
   const zip = await getZip();

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -24,9 +24,9 @@ import type { AddressInfo } from 'net';
 import type { Log } from '../../packages/trace/src/har';
 import { parseHar } from '../config/utils';
 
-async function pageWithHar(contextFactory: (options?: BrowserContextOptions) => Promise<BrowserContext>, testInfo: any, options: { outputPath?: string, content?: 'embed' | 'attach' | 'omit', omitContent?: boolean } = {}) {
+async function pageWithHar(contextFactory: (options?: BrowserContextOptions) => Promise<BrowserContext>, testInfo: any, options: { outputPath?: string, updateContent?: 'embed' | 'attach' | 'omit', omitContent?: boolean } = {}) {
   const harPath = testInfo.outputPath(options.outputPath || 'test.har');
-  const context = await contextFactory({ recordHar: { path: harPath, content: options.content, omitContent: options.omitContent }, ignoreHTTPSErrors: true });
+  const context = await contextFactory({ recordHar: { path: harPath, updateContent: options.updateContent, omitContent: options.omitContent }, ignoreHTTPSErrors: true });
   const page = await context.newPage();
   return {
     page,


### PR DESCRIPTION
During PR #21764, the behavior of `routeFromHar` changed.

before #21764 the following code:
```ts
page.routeFromHAR(
        `/networks_cache/file.har`,
        {
            url: /api/,
            content: "embed",
            update: true
        }
    );
```
was used to create a single file.
now, to achieve the same behavior, the user has to do the following:
```ts
page.routeFromHAR(
        `/networks_cache/file.har`,
        {
            url: /api/,
            updateContent: "embed",
            update: true
        } as any
    );
```

by finishing the incomplete refactor, `updateContent: "embed"` will be functional again.
