### PR TITLE
feat(webkit): roll to r1818, freeze webkit version on macos 11

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "webkit",
-      "revision": "1816",
+      "revision": "1818",
       "installByDefault": true,
       "revisionOverrides": {
         "mac10.14": "1446",

--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -38,6 +38,8 @@
       "revisionOverrides": {
         "mac10.14": "1446",
         "mac10.15": "1616",
+        "mac11": "1816",
+        "mac11-arm64": "1816",
         "ubuntu18.04": "1728"
       },
       "browserVersion": "16.4"


### PR DESCRIPTION
https://github.com/WebKit/WebKit/commit/1267923bb07eea806df5bf31091c7f6e8d08834b broke the WebSocket functionality on macOS 11. They don't support macOS 11 on trunk anymore, hence we freeze it for now.