### PR TITLE
fix(test runner): update default testMatch

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -517,7 +517,7 @@ export default defineConfig({
 
 Only the files matching one of these patterns are executed as test files. Matching is performed against the absolute file path. Strings are treated as glob patterns.
 
-By default, Playwright Test looks for files matching `.*(test|spec)\.(js|ts|mjs)`.
+By default, Playwright looks for files matching the following glob pattern: `**/?(*.)@(spec|test).?(m)[jt]s?(x)`. This means JavaScript or TypeScript files with `".test"` or `".spec"` suffix, for example `login-screen.spec.ts`.
 
 **Usage**
 

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -263,7 +263,7 @@ Use [`property: TestConfig.testIgnore`] to change this option for all projects.
 
 Only the files matching one of these patterns are executed as test files. Matching is performed against the absolute file path. Strings are treated as glob patterns.
 
-By default, Playwright Test looks for files matching `.*(test|spec)\.(js|ts|mjs)`.
+By default, Playwright looks for files matching the following glob pattern: `**/?(*.)@(spec|test).?(m)[jt]s?(x)`. This means JavaScript or TypeScript files with `".test"` or `".spec"` suffix, for example `login-screen.spec.ts`.
 
 Use [`property: TestConfig.testMatch`] to change this option for all projects.
 

--- a/packages/playwright-test/src/common/configLoader.ts
+++ b/packages/playwright-test/src/common/configLoader.ts
@@ -234,7 +234,7 @@ export class ConfigLoader {
       snapshotDir,
       snapshotPathTemplate,
       testIgnore: takeFirst(projectConfig.testIgnore, config.testIgnore, []),
-      testMatch: takeFirst(projectConfig.testMatch, config.testMatch, '**/?(*.)@(spec|test).*'),
+      testMatch: takeFirst(projectConfig.testMatch, config.testMatch, '**/?(*.)@(spec|test).?(m)[jt]s?(x)'),
       timeout: takeFirst(projectConfig.timeout, config.timeout, defaultTimeout),
       use: mergeObjects(config.use, projectConfig.use),
       dependencies: projectConfig.dependencies || [],

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -347,7 +347,8 @@ export interface FullProject<TestArgs = {}, WorkerArgs = {}> {
    * Only the files matching one of these patterns are executed as test files. Matching is performed against the
    * absolute file path. Strings are treated as glob patterns.
    *
-   * By default, Playwright Test looks for files matching `.*(test|spec)\.(js|ts|mjs)`.
+   * By default, Playwright looks for files matching the following glob pattern: `**\/?(*.)@(spec|test).?(m)[jt]s?(x)`.
+   * This means JavaScript or TypeScript files with `".test"` or `".spec"` suffix, for example `login-screen.spec.ts`.
    *
    * Use [testConfig.testMatch](https://playwright.dev/docs/api/class-testconfig#test-config-test-match) to change this
    * option for all projects.
@@ -1190,7 +1191,8 @@ interface TestConfig {
    * Only the files matching one of these patterns are executed as test files. Matching is performed against the
    * absolute file path. Strings are treated as glob patterns.
    *
-   * By default, Playwright Test looks for files matching `.*(test|spec)\.(js|ts|mjs)`.
+   * By default, Playwright looks for files matching the following glob pattern: `**\/?(*.)@(spec|test).?(m)[jt]s?(x)`.
+   * This means JavaScript or TypeScript files with `".test"` or `".spec"` suffix, for example `login-screen.spec.ts`.
    *
    * **Usage**
    *
@@ -5853,7 +5855,8 @@ interface TestProject {
    * Only the files matching one of these patterns are executed as test files. Matching is performed against the
    * absolute file path. Strings are treated as glob patterns.
    *
-   * By default, Playwright Test looks for files matching `.*(test|spec)\.(js|ts|mjs)`.
+   * By default, Playwright looks for files matching the following glob pattern: `**\/?(*.)@(spec|test).?(m)[jt]s?(x)`.
+   * This means JavaScript or TypeScript files with `".test"` or `".spec"` suffix, for example `login-screen.spec.ts`.
    *
    * Use [testConfig.testMatch](https://playwright.dev/docs/api/class-testconfig#test-config-test-match) to change this
    * option for all projects.

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -689,3 +689,18 @@ test('should support dynamic import', async ({ runInlineTest, nodeVersion }) => 
   expect(result.passed).toBe(2);
   expect(result.exitCode).toBe(0);
 });
+
+test('should allow test.extend.ts file', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'test.extend.ts': `
+      export { test, expect } from '@playwright/test';
+    `,
+    'a.test.ts': `
+      import { test, expect } from './test.extend';
+      test('pass1', async () => {
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});


### PR DESCRIPTION
The intent of default test match is allowing `example.spec.ts` and `example.test.ts` files. However, it was also matching `test.example.ts` that should not be considered a test by default.

Fixes #21979.