### PR TITLE
[Component testing / Vite plugin]  Update regex to cater for minified JS files

### DIFF
--- a/packages/playwright-test/src/plugins/vitePlugin.ts
+++ b/packages/playwright-test/src/plugins/vitePlugin.ts
@@ -41,7 +41,7 @@ type CtConfig = BasePlaywrightTestConfig['use'] & {
   ctViteConfig?: InlineConfig | (() => Promise<InlineConfig>);
 };
 
-const importReactRE = /(^|\n)import\s+(\*\s+as\s+)?React(,|\s+)/;
+const importReactRE = /(^|\n|;)import\s+(\*\s+as\s+)?React(,|\s+)/;
 const compiledReactRE = /(const|var)\s+React\s*=/;
 
 export function createPlugin(


### PR DESCRIPTION
Minified JS will typically have a ";" character between imports.

This avoids a duplicate import for "react" being added in the case where the distributed JS is minified and React is not the first import (e.g. `react-tabs`).