### PR TITLE
feat: BrowserContext.on('dialog')

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -154,6 +154,42 @@ context.Console += async (_, msg) =>
 await page.EvaluateAsync("console.log('hello', 5, { foo: 'bar' })");
 ```
 
+
+## event: BrowserContext.dialog
+* since: v1.33
+- argument: <[Dialog]>
+
+Emitted when a JavaScript dialog appears, such as `alert`, `prompt`, `confirm` or `beforeunload`. Listener **must** either [`method: Dialog.accept`] or [`method: Dialog.dismiss`] the dialog - otherwise the page will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the dialog, and actions like click will never finish.
+
+**Usage**
+
+```js
+context.on('dialog', dialog => {
+  dialog.accept();
+});
+```
+
+```java
+context.onDialog(dialog -> {
+  dialog.accept();
+});
+```
+
+```python
+context.on("dialog", lambda dialog: dialog.accept())
+```
+
+```csharp
+context.RequestFailed += (_, request) =>
+{
+    Console.WriteLine(request.Url + " " + request.Failure);
+};
+```
+
+:::note
+When no [`event: Page.dialog`] or [`event: BrowserContext.dialog`] listeners are present, all dialogs are automatically dismissed.
+:::
+
 ## event: BrowserContext.page
 * since: v1.8
 - argument: <[Page]>

--- a/docs/src/api/class-dialog.md
+++ b/docs/src/api/class-dialog.md
@@ -137,6 +137,12 @@ Returns when the dialog has been dismissed.
 
 A message displayed in the dialog.
 
+## method: Dialog.page
+* since: v1.33
+- returns: <[Page]|[null]>
+
+The page that initiated this dialog, if available.
+
 ## method: Dialog.type
 * since: v1.8
 - returns: <[string]>

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -285,6 +285,8 @@ try {
 
 Emitted when a JavaScript dialog appears, such as `alert`, `prompt`, `confirm` or `beforeunload`. Listener **must** either [`method: Dialog.accept`] or [`method: Dialog.dismiss`] the dialog - otherwise the page will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the dialog, and actions like click will never finish.
 
+**Usage**
+
 ```js
 page.on('dialog', dialog => {
   dialog.accept();
@@ -309,7 +311,7 @@ page.RequestFailed += (_, request) =>
 ```
 
 :::note
-When no [`event: Page.dialog`] listeners are present, all dialogs are automatically dismissed.
+When no [`event: Page.dialog`] or [`event: BrowserContext.dialog`] listeners are present, all dialogs are automatically dismissed.
 :::
 
 ## event: Page.DOMContentLoaded

--- a/packages/playwright-core/src/client/dialog.ts
+++ b/packages/playwright-core/src/client/dialog.ts
@@ -17,14 +17,24 @@
 import type * as channels from '@protocol/channels';
 import { ChannelOwner } from './channelOwner';
 import type * as api from '../../types/types';
+import { Page } from './page';
 
 export class Dialog extends ChannelOwner<channels.DialogChannel> implements api.Dialog {
   static from(dialog: channels.DialogChannel): Dialog {
     return (dialog as any)._object;
   }
 
+  private _page: Page | null;
+
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.DialogInitializer) {
     super(parent, type, guid, initializer);
+    // Note: dialogs that open early during page initialization block it.
+    // Therefore, we must report the dialog without a page to be able to handle it.
+    this._page = Page.fromNullable(initializer.page);
+  }
+
+  page() {
+    return this._page;
   }
 
   type(): string {

--- a/packages/playwright-core/src/client/events.ts
+++ b/packages/playwright-core/src/client/events.ts
@@ -37,6 +37,7 @@ export const Events = {
   BrowserContext: {
     Console: 'console',
     Close: 'close',
+    Dialog: 'dialog',
     Page: 'page',
     BackgroundPage: 'backgroundpage',
     ServiceWorker: 'serviceworker',

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -32,7 +32,6 @@ import type { BrowserContext } from './browserContext';
 import { ChannelOwner } from './channelOwner';
 import { evaluationScript } from './clientHelper';
 import { Coverage } from './coverage';
-import { Dialog } from './dialog';
 import { Download } from './download';
 import { determineScreenshotType, ElementHandle } from './elementHandle';
 import { Events } from './events';
@@ -124,15 +123,6 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     this._channel.on('bindingCall', ({ binding }) => this._onBinding(BindingCall.from(binding)));
     this._channel.on('close', () => this._onClose());
     this._channel.on('crash', () => this._onCrash());
-    this._channel.on('dialog', ({ dialog }) => {
-      const dialogObj = Dialog.from(dialog);
-      if (!this.emit(Events.Page.Dialog, dialogObj)) {
-        if (dialogObj.type() === 'beforeunload')
-          dialog.accept({}).catch(() => {});
-        else
-          dialog.dismiss().catch(() => {});
-      }
-    });
     this._channel.on('download', ({ url, suggestedFilename, artifact }) => {
       const artifactObject = Artifact.from(artifact);
       this.emit(Events.Page.Download, new Download(this, url, suggestedFilename, artifactObject));

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -759,6 +759,9 @@ scheme.BrowserContextConsoleEvent = tObject({
   message: tChannel(['ConsoleMessage']),
 });
 scheme.BrowserContextCloseEvent = tOptional(tObject({}));
+scheme.BrowserContextDialogEvent = tObject({
+  dialog: tChannel(['Dialog']),
+});
 scheme.BrowserContextPageEvent = tObject({
   page: tChannel(['Page']),
 });
@@ -933,9 +936,6 @@ scheme.PageBindingCallEvent = tObject({
 });
 scheme.PageCloseEvent = tOptional(tObject({}));
 scheme.PageCrashEvent = tOptional(tObject({}));
-scheme.PageDialogEvent = tObject({
-  dialog: tChannel(['Dialog']),
-});
 scheme.PageDownloadEvent = tObject({
   url: tString,
   suggestedFilename: tString,
@@ -2097,6 +2097,7 @@ scheme.BindingCallResolveParams = tObject({
 });
 scheme.BindingCallResolveResult = tOptional(tObject({}));
 scheme.DialogInitializer = tObject({
+  page: tOptional(tChannel(['Page'])),
   type: tString,
   message: tString,
   defaultValue: tString,

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -46,6 +46,7 @@ export abstract class BrowserContext extends SdkObject {
   static Events = {
     Console: 'console',
     Close: 'close',
+    Dialog: 'dialog',
     Page: 'page',
     Request: 'request',
     Response: 'response',

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -845,7 +845,7 @@ class FrameSession {
   _onDialog(event: Protocol.Page.javascriptDialogOpeningPayload) {
     if (!this._page._frameManager.frame(this._targetId))
       return; // Our frame/subtree may be gone already.
-    this._page.emit(Page.Events.Dialog, new dialog.Dialog(
+    this._page.emitOnContext(BrowserContext.Events.Dialog, new dialog.Dialog(
         this._page,
         event.type,
         event.message,

--- a/packages/playwright-core/src/server/dialog.ts
+++ b/packages/playwright-core/src/server/dialog.ts
@@ -41,6 +41,10 @@ export class Dialog extends SdkObject {
     this._page._frameManager.dialogDidOpen(this);
   }
 
+  page() {
+    return this._page;
+  }
+
   type(): string {
     return this._type;
   }

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -34,6 +34,7 @@ import * as path from 'path';
 import { createGuid, urlMatches } from '../../utils';
 import { WritableStreamDispatcher } from './writableStreamDispatcher';
 import { ConsoleMessageDispatcher } from './consoleMessageDispatcher';
+import { DialogDispatcher } from './dialogDispatcher';
 
 export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channels.BrowserContextChannel, DispatcherScope> implements channels.BrowserContextChannel {
   _type_EventTarget = true;
@@ -80,7 +81,8 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
       this._dispatchEvent('close');
       this._dispose();
     });
-    this.addObjectListener(BrowserContext.Events.Console, message => this._dispatchEvent('console', { message: new ConsoleMessageDispatcher(this, message) }));
+    this.addObjectListener(BrowserContext.Events.Console, message => this._dispatchEvent('console', { message: new ConsoleMessageDispatcher(PageDispatcher.from(this, message.page()), message) }));
+    this.addObjectListener(BrowserContext.Events.Dialog, dialog => this._dispatchEvent('dialog', { dialog: new DialogDispatcher(this, dialog) }));
 
     if (context._browser.options.name === 'chromium') {
       for (const page of (context as CRBrowserContext).backgroundPages())

--- a/packages/playwright-core/src/server/dispatchers/consoleMessageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/consoleMessageDispatcher.ts
@@ -16,17 +16,15 @@
 
 import type { ConsoleMessage } from '../console';
 import type * as channels from '@protocol/channels';
-import { PageDispatcher } from './pageDispatcher';
-import type { BrowserContextDispatcher } from './browserContextDispatcher';
+import type { PageDispatcher } from './pageDispatcher';
 import { Dispatcher } from './dispatcher';
 import { ElementHandleDispatcher } from './elementHandlerDispatcher';
 
-export class ConsoleMessageDispatcher extends Dispatcher<ConsoleMessage, channels.ConsoleMessageChannel, BrowserContextDispatcher> implements channels.ConsoleMessageChannel {
+export class ConsoleMessageDispatcher extends Dispatcher<ConsoleMessage, channels.ConsoleMessageChannel, PageDispatcher> implements channels.ConsoleMessageChannel {
   _type_ConsoleMessage = true;
 
-  constructor(scope: BrowserContextDispatcher, message: ConsoleMessage) {
-    const page = PageDispatcher.from(scope, message.page());
-    super(scope, message, 'ConsoleMessage', {
+  constructor(page: PageDispatcher, message: ConsoleMessage) {
+    super(page, message, 'ConsoleMessage', {
       type: message.type(),
       text: message.text(),
       args: message.args().map(a => ElementHandleDispatcher.fromJSHandle(page, a)),

--- a/packages/playwright-core/src/server/dispatchers/dialogDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dialogDispatcher.ts
@@ -17,13 +17,17 @@
 import type { Dialog } from '../dialog';
 import type * as channels from '@protocol/channels';
 import { Dispatcher } from './dispatcher';
-import type { PageDispatcher } from './pageDispatcher';
+import { PageDispatcher } from './pageDispatcher';
+import type { BrowserContextDispatcher } from './browserContextDispatcher';
 
-export class DialogDispatcher extends Dispatcher<Dialog, channels.DialogChannel, PageDispatcher> implements channels.DialogChannel {
+export class DialogDispatcher extends Dispatcher<Dialog, channels.DialogChannel, BrowserContextDispatcher | PageDispatcher> implements channels.DialogChannel {
   _type_Dialog = true;
 
-  constructor(scope: PageDispatcher, dialog: Dialog) {
-    super(scope, dialog, 'Dialog', {
+  constructor(scope: BrowserContextDispatcher, dialog: Dialog) {
+    const page = PageDispatcher.fromNullable(scope, dialog.page().initializedOrUndefined());
+    // Prefer scoping to the page, unless we don't have one.
+    super(page || scope, dialog, 'Dialog', {
+      page,
       type: dialog.type(),
       message: dialog.message(),
       defaultValue: dialog.defaultValue(),

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -20,7 +20,6 @@ import { Page, Worker } from '../page';
 import type * as channels from '@protocol/channels';
 import { Dispatcher, existingDispatcher } from './dispatcher';
 import { parseError, serializeError } from '../../protocol/serializers';
-import { DialogDispatcher } from './dialogDispatcher';
 import { FrameDispatcher } from './frameDispatcher';
 import { RequestDispatcher } from './networkDispatchers';
 import { ResponseDispatcher } from './networkDispatchers';
@@ -76,7 +75,6 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
       this._dispose();
     });
     this.addObjectListener(Page.Events.Crash, () => this._dispatchEvent('crash'));
-    this.addObjectListener(Page.Events.Dialog, dialog => this._dispatchEvent('dialog', { dialog: new DialogDispatcher(this, dialog) }));
     this.addObjectListener(Page.Events.Download, (download: Download) => {
       // Artifact can outlive the page, so bind to the context scope.
       this._dispatchEvent('download', { url: download.url, suggestedFilename: download.suggestedFilename(), artifact: ArtifactDispatcher.from(parentScope, download.artifact) });

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -34,6 +34,7 @@ import type { Progress } from '../progress';
 import { splitErrorMessage } from '../../utils/stackTrace';
 import { debugLogger } from '../../common/debugLogger';
 import { ManualPromise } from '../../utils/manualPromise';
+import { BrowserContext } from '../browserContext';
 
 export const UTILITY_WORLD_NAME = '__playwright_utility_world__';
 
@@ -257,7 +258,7 @@ export class FFPage implements PageDelegate {
   }
 
   _onDialogOpened(params: Protocol.Page.dialogOpenedPayload) {
-    this._page.emit(Page.Events.Dialog, new dialog.Dialog(
+    this._page.emitOnContext(BrowserContext.Events.Dialog, new dialog.Dialog(
         this._page,
         params.type,
         params.message,

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -121,7 +121,6 @@ export class Page extends SdkObject {
   static Events = {
     Close: 'close',
     Crash: 'crash',
-    Dialog: 'dialog',
     Download: 'download',
     FileChooser: 'filechooser',
     // Can't use just 'error' due to node.js special treatment of error events.
@@ -140,7 +139,7 @@ export class Page extends SdkObject {
   private _closedPromise = new ManualPromise<void>();
   private _disconnected = false;
   private _initialized = false;
-  private _consoleMessagesBeforeInitialized: ConsoleMessage[] = [];
+  private _eventsToEmitAfterInitialized: { event: string | symbol, args: any[] }[] = [];
   readonly _disconnectedPromise = new ManualPromise<Error>();
   readonly _crashedPromise = new ManualPromise<Error>();
   readonly _browserContext: BrowserContext;
@@ -209,9 +208,9 @@ export class Page extends SdkObject {
     this._initialized = true;
     this.emitOnContext(contextEvent, this);
 
-    for (const message of this._consoleMessagesBeforeInitialized)
-      this.emitOnContext(BrowserContext.Events.Console, message);
-    this._consoleMessagesBeforeInitialized = [];
+    for (const { event, args } of this._eventsToEmitAfterInitialized)
+      this._browserContext.emit(event, ...args);
+    this._eventsToEmitAfterInitialized = [];
 
     // It may happen that page initialization finishes after Close event has already been sent,
     // in that case we fire another Close event to ensure that each reported Page will have
@@ -230,6 +229,19 @@ export class Page extends SdkObject {
     if (this._isServerSideOnly)
       return;
     this._browserContext.emit(event, ...args);
+  }
+
+  emitOnContextOnceInitialized(event: string | symbol, ...args: any[]) {
+    if (this._isServerSideOnly)
+      return;
+    // Some events, like console messages, may come before page is ready.
+    // In this case, postpone the event until page is initialized,
+    // and dispatch it to the client later, either on the live Page,
+    // or on the "errored" Page.
+    if (this._initialized)
+      this._browserContext.emit(event, ...args);
+    else
+      this._eventsToEmitAfterInitialized.push({ event, args });
   }
 
   async resetForReuse(metadata: CallMetadata) {
@@ -361,14 +373,7 @@ export class Page extends SdkObject {
       args.forEach(arg => arg.dispose());
       return;
     }
-
-    // Console message may come before page is ready. In this case, postpone the message
-    // until page is initialized, and dispatch it to the client later, either on the live Page,
-    // or on the "errored" Page.
-    if (this._initialized)
-      this.emitOnContext(BrowserContext.Events.Console, message);
-    else
-      this._consoleMessagesBeforeInitialized.push(message);
+    this.emitOnContextOnceInitialized(BrowserContext.Events.Console, message);
   }
 
   async reload(metadata: CallMetadata, options: types.NavigateOptions): Promise<network.Response | null> {

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -43,6 +43,7 @@ import { raceAgainstTimeout } from '../utils/timeoutRunner';
 import type { Language, LanguageGenerator } from './recorder/language';
 import { locatorOrSelectorAsSelector } from '../utils/isomorphic/locatorParser';
 import { eventsHelper, type RegisteredListener } from './../utils/eventsHelper';
+import type { Dialog } from './dialog';
 
 type BindingSource = { frame: Frame, page: Page };
 
@@ -425,9 +426,10 @@ class ContextRecorder extends EventEmitter {
   }
 
   async install() {
-    this._context.on(BrowserContext.Events.Page, page => this._onPage(page));
+    this._context.on(BrowserContext.Events.Page, (page: Page) => this._onPage(page));
     for (const page of this._context.pages())
       this._onPage(page);
+    this._context.on(BrowserContext.Events.Dialog, (dialog: Dialog) => this._onDialog(dialog.page()));
 
     // Input actions that potentially lead to navigation are intercepted on the page and are
     // performed by the Playwright.
@@ -471,7 +473,6 @@ class ContextRecorder extends EventEmitter {
         this._onFrameNavigated(frame, page);
     });
     page.on(Page.Events.Download, () => this._onDownload(page));
-    page.on(Page.Events.Dialog, () => this._onDialog(page));
     const suffix = this._pageAliases.size ? String(++this._lastPopupOrdinal) : '';
     const pageAlias = 'page' + suffix;
     this._pageAliases.set(page, pageAlias);

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -44,6 +44,7 @@ import { WKProvisionalPage } from './wkProvisionalPage';
 import { WKWorkers } from './wkWorkers';
 import { debugLogger } from '../../common/debugLogger';
 import { ManualPromise } from '../../utils/manualPromise';
+import { BrowserContext } from '../browserContext';
 
 const UTILITY_WORLD_NAME = '__playwright_utility_world__';
 
@@ -607,7 +608,7 @@ export class WKPage implements PageDelegate {
   }
 
   _onDialog(event: Protocol.Dialog.javascriptDialogOpeningPayload) {
-    this._page.emit(Page.Events.Dialog, new dialog.Dialog(
+    this._page.emitOnContext(BrowserContext.Events.Dialog, new dialog.Dialog(
         this._page,
         event.type as dialog.DialogType,
         event.message,

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -922,14 +922,17 @@ export interface Page {
    * will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the
    * dialog, and actions like click will never finish.
    *
+   * **Usage**
+   *
    * ```js
    * page.on('dialog', dialog => {
    *   dialog.accept();
    * });
    * ```
    *
-   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) listeners are
-   * present, all dialogs are automatically dismissed.
+   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) or
+   * [browserContext.on('dialog')](https://playwright.dev/docs/api/class-browsercontext#browser-context-event-dialog)
+   * listeners are present, all dialogs are automatically dismissed.
    */
   on(event: 'dialog', listener: (dialog: Dialog) => void): this;
 
@@ -1215,14 +1218,17 @@ export interface Page {
    * will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the
    * dialog, and actions like click will never finish.
    *
+   * **Usage**
+   *
    * ```js
    * page.on('dialog', dialog => {
    *   dialog.accept();
    * });
    * ```
    *
-   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) listeners are
-   * present, all dialogs are automatically dismissed.
+   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) or
+   * [browserContext.on('dialog')](https://playwright.dev/docs/api/class-browsercontext#browser-context-event-dialog)
+   * listeners are present, all dialogs are automatically dismissed.
    */
   addListener(event: 'dialog', listener: (dialog: Dialog) => void): this;
 
@@ -1603,14 +1609,17 @@ export interface Page {
    * will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the
    * dialog, and actions like click will never finish.
    *
+   * **Usage**
+   *
    * ```js
    * page.on('dialog', dialog => {
    *   dialog.accept();
    * });
    * ```
    *
-   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) listeners are
-   * present, all dialogs are automatically dismissed.
+   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) or
+   * [browserContext.on('dialog')](https://playwright.dev/docs/api/class-browsercontext#browser-context-event-dialog)
+   * listeners are present, all dialogs are automatically dismissed.
    */
   prependListener(event: 'dialog', listener: (dialog: Dialog) => void): this;
 
@@ -4241,14 +4250,17 @@ export interface Page {
    * will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the
    * dialog, and actions like click will never finish.
    *
+   * **Usage**
+   *
    * ```js
    * page.on('dialog', dialog => {
    *   dialog.accept();
    * });
    * ```
    *
-   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) listeners are
-   * present, all dialogs are automatically dismissed.
+   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) or
+   * [browserContext.on('dialog')](https://playwright.dev/docs/api/class-browsercontext#browser-context-event-dialog)
+   * listeners are present, all dialogs are automatically dismissed.
    */
   waitForEvent(event: 'dialog', optionsOrPredicate?: { predicate?: (dialog: Dialog) => boolean | Promise<boolean>, timeout?: number } | ((dialog: Dialog) => boolean | Promise<boolean>)): Promise<Dialog>;
 
@@ -7471,6 +7483,27 @@ export interface BrowserContext {
   on(event: 'console', listener: (consoleMessage: ConsoleMessage) => void): this;
 
   /**
+   * Emitted when a JavaScript dialog appears, such as `alert`, `prompt`, `confirm` or `beforeunload`. Listener **must**
+   * either [dialog.accept([promptText])](https://playwright.dev/docs/api/class-dialog#dialog-accept) or
+   * [dialog.dismiss()](https://playwright.dev/docs/api/class-dialog#dialog-dismiss) the dialog - otherwise the page
+   * will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the
+   * dialog, and actions like click will never finish.
+   *
+   * **Usage**
+   *
+   * ```js
+   * context.on('dialog', dialog => {
+   *   dialog.accept();
+   * });
+   * ```
+   *
+   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) or
+   * [browserContext.on('dialog')](https://playwright.dev/docs/api/class-browsercontext#browser-context-event-dialog)
+   * listeners are present, all dialogs are automatically dismissed.
+   */
+  on(event: 'dialog', listener: (dialog: Dialog) => void): this;
+
+  /**
    * The event is emitted when a new Page is created in the BrowserContext. The page may still be loading. The event
    * will also fire for popup pages. See also
    * [page.on('popup')](https://playwright.dev/docs/api/class-page#page-event-popup) to receive events about popups
@@ -7556,6 +7589,11 @@ export interface BrowserContext {
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
+  once(event: 'dialog', listener: (dialog: Dialog) => void): this;
+
+  /**
+   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
+   */
   once(event: 'page', listener: (page: Page) => void): this;
 
   /**
@@ -7623,6 +7661,27 @@ export interface BrowserContext {
    *
    */
   addListener(event: 'console', listener: (consoleMessage: ConsoleMessage) => void): this;
+
+  /**
+   * Emitted when a JavaScript dialog appears, such as `alert`, `prompt`, `confirm` or `beforeunload`. Listener **must**
+   * either [dialog.accept([promptText])](https://playwright.dev/docs/api/class-dialog#dialog-accept) or
+   * [dialog.dismiss()](https://playwright.dev/docs/api/class-dialog#dialog-dismiss) the dialog - otherwise the page
+   * will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the
+   * dialog, and actions like click will never finish.
+   *
+   * **Usage**
+   *
+   * ```js
+   * context.on('dialog', dialog => {
+   *   dialog.accept();
+   * });
+   * ```
+   *
+   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) or
+   * [browserContext.on('dialog')](https://playwright.dev/docs/api/class-browsercontext#browser-context-event-dialog)
+   * listeners are present, all dialogs are automatically dismissed.
+   */
+  addListener(event: 'dialog', listener: (dialog: Dialog) => void): this;
 
   /**
    * The event is emitted when a new Page is created in the BrowserContext. The page may still be loading. The event
@@ -7710,6 +7769,11 @@ export interface BrowserContext {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  removeListener(event: 'dialog', listener: (dialog: Dialog) => void): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   removeListener(event: 'page', listener: (page: Page) => void): this;
 
   /**
@@ -7751,6 +7815,11 @@ export interface BrowserContext {
    * Removes an event listener added by `on` or `addListener`.
    */
   off(event: 'console', listener: (consoleMessage: ConsoleMessage) => void): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
+  off(event: 'dialog', listener: (dialog: Dialog) => void): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
@@ -7822,6 +7891,27 @@ export interface BrowserContext {
    *
    */
   prependListener(event: 'console', listener: (consoleMessage: ConsoleMessage) => void): this;
+
+  /**
+   * Emitted when a JavaScript dialog appears, such as `alert`, `prompt`, `confirm` or `beforeunload`. Listener **must**
+   * either [dialog.accept([promptText])](https://playwright.dev/docs/api/class-dialog#dialog-accept) or
+   * [dialog.dismiss()](https://playwright.dev/docs/api/class-dialog#dialog-dismiss) the dialog - otherwise the page
+   * will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the
+   * dialog, and actions like click will never finish.
+   *
+   * **Usage**
+   *
+   * ```js
+   * context.on('dialog', dialog => {
+   *   dialog.accept();
+   * });
+   * ```
+   *
+   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) or
+   * [browserContext.on('dialog')](https://playwright.dev/docs/api/class-browsercontext#browser-context-event-dialog)
+   * listeners are present, all dialogs are automatically dismissed.
+   */
+  prependListener(event: 'dialog', listener: (dialog: Dialog) => void): this;
 
   /**
    * The event is emitted when a new Page is created in the BrowserContext. The page may still be loading. The event
@@ -8382,6 +8472,27 @@ export interface BrowserContext {
    *
    */
   waitForEvent(event: 'console', optionsOrPredicate?: { predicate?: (consoleMessage: ConsoleMessage) => boolean | Promise<boolean>, timeout?: number } | ((consoleMessage: ConsoleMessage) => boolean | Promise<boolean>)): Promise<ConsoleMessage>;
+
+  /**
+   * Emitted when a JavaScript dialog appears, such as `alert`, `prompt`, `confirm` or `beforeunload`. Listener **must**
+   * either [dialog.accept([promptText])](https://playwright.dev/docs/api/class-dialog#dialog-accept) or
+   * [dialog.dismiss()](https://playwright.dev/docs/api/class-dialog#dialog-dismiss) the dialog - otherwise the page
+   * will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the
+   * dialog, and actions like click will never finish.
+   *
+   * **Usage**
+   *
+   * ```js
+   * context.on('dialog', dialog => {
+   *   dialog.accept();
+   * });
+   * ```
+   *
+   * **NOTE** When no [page.on('dialog')](https://playwright.dev/docs/api/class-page#page-event-dialog) or
+   * [browserContext.on('dialog')](https://playwright.dev/docs/api/class-browsercontext#browser-context-event-dialog)
+   * listeners are present, all dialogs are automatically dismissed.
+   */
+  waitForEvent(event: 'dialog', optionsOrPredicate?: { predicate?: (dialog: Dialog) => boolean | Promise<boolean>, timeout?: number } | ((dialog: Dialog) => boolean | Promise<boolean>)): Promise<Dialog>;
 
   /**
    * The event is emitted when a new Page is created in the BrowserContext. The page may still be loading. The event
@@ -16385,6 +16496,11 @@ export interface Dialog {
    * A message displayed in the dialog.
    */
   message(): string;
+
+  /**
+   * The page that initiated this dialog, if available.
+   */
+  page(): Page|null;
 
   /**
    * Returns dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prompt`.

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1396,6 +1396,7 @@ export interface BrowserContextEventTarget {
   on(event: 'bindingCall', callback: (params: BrowserContextBindingCallEvent) => void): this;
   on(event: 'console', callback: (params: BrowserContextConsoleEvent) => void): this;
   on(event: 'close', callback: (params: BrowserContextCloseEvent) => void): this;
+  on(event: 'dialog', callback: (params: BrowserContextDialogEvent) => void): this;
   on(event: 'page', callback: (params: BrowserContextPageEvent) => void): this;
   on(event: 'route', callback: (params: BrowserContextRouteEvent) => void): this;
   on(event: 'video', callback: (params: BrowserContextVideoEvent) => void): this;
@@ -1440,6 +1441,9 @@ export type BrowserContextConsoleEvent = {
   message: ConsoleMessageChannel,
 };
 export type BrowserContextCloseEvent = {};
+export type BrowserContextDialogEvent = {
+  dialog: DialogChannel,
+};
 export type BrowserContextPageEvent = {
   page: PageChannel,
 };
@@ -1683,6 +1687,7 @@ export interface BrowserContextEvents {
   'bindingCall': BrowserContextBindingCallEvent;
   'console': BrowserContextConsoleEvent;
   'close': BrowserContextCloseEvent;
+  'dialog': BrowserContextDialogEvent;
   'page': BrowserContextPageEvent;
   'route': BrowserContextRouteEvent;
   'video': BrowserContextVideoEvent;
@@ -1708,7 +1713,6 @@ export interface PageEventTarget {
   on(event: 'bindingCall', callback: (params: PageBindingCallEvent) => void): this;
   on(event: 'close', callback: (params: PageCloseEvent) => void): this;
   on(event: 'crash', callback: (params: PageCrashEvent) => void): this;
-  on(event: 'dialog', callback: (params: PageDialogEvent) => void): this;
   on(event: 'download', callback: (params: PageDownloadEvent) => void): this;
   on(event: 'fileChooser', callback: (params: PageFileChooserEvent) => void): this;
   on(event: 'frameAttached', callback: (params: PageFrameAttachedEvent) => void): this;
@@ -1760,9 +1764,6 @@ export type PageBindingCallEvent = {
 };
 export type PageCloseEvent = {};
 export type PageCrashEvent = {};
-export type PageDialogEvent = {
-  dialog: DialogChannel,
-};
 export type PageDownloadEvent = {
   url: string,
   suggestedFilename: string,
@@ -2203,7 +2204,6 @@ export interface PageEvents {
   'bindingCall': PageBindingCallEvent;
   'close': PageCloseEvent;
   'crash': PageCrashEvent;
-  'dialog': PageDialogEvent;
   'download': PageDownloadEvent;
   'fileChooser': PageFileChooserEvent;
   'frameAttached': PageFrameAttachedEvent;
@@ -3740,6 +3740,7 @@ export interface BindingCallEvents {
 
 // ----------- Dialog -----------
 export type DialogInitializer = {
+  page?: PageChannel,
   type: string,
   message: string,
   defaultValue: string,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1163,6 +1163,10 @@ BrowserContext:
 
     close:
 
+    dialog:
+      parameters:
+        dialog: Dialog
+
     page:
       parameters:
         page: Page
@@ -1578,10 +1582,6 @@ Page:
     close:
 
     crash:
-
-    dialog:
-      parameters:
-        dialog: Dialog
 
     download:
       parameters:
@@ -2918,6 +2918,7 @@ Dialog:
   type: interface
 
   initializer:
+    page: Page?
     type: string
     message: string
     defaultValue: string


### PR DESCRIPTION
Dialogs created early during page initialization are only reported on the context, with `page()` being `null`.