### PR TITLE
fix(plugins): follow redirects when checking the webServer url

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -595,7 +595,7 @@ export default defineConfig({
 - type: ?<[Object]|[Array]<[Object]>>
   - `command` <[string]> Shell command to start. For example `npm run start`..
   - `port` ?<[int]> The port that your http server is expected to appear on. It does wait until it accepts connections. Exactly one of `port` or `url` is required.
-  - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Exactly one of `port` or `url` is required.
+  - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is checked. Exactly one of `port` or `url` is required.
   - `ignoreHTTPSErrors` ?<[boolean]> Whether to ignore HTTPS errors when fetching the `url`. Defaults to `false`.
   - `timeout` ?<[int]> How long to wait for the process to start up and be available in milliseconds. Defaults to 60000.
   - `reuseExistingServer` ?<[boolean]> If true, it will re-use an existing server on the `port` or `url` when available. If no server is running on that `port` or `url`, it will run the command to start a new server. If `false`, it will throw if an existing process is listening on the `port` or `url`. This should be commonly set to `!process.env.CI` to allow the local dev server when running tests locally.

--- a/packages/playwright-core/src/utils/network.ts
+++ b/packages/playwright-core/src/utils/network.ts
@@ -71,7 +71,7 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
   const requestCallback = (res: http.IncomingMessage) => {
     const statusCode = res.statusCode || 0;
     if (statusCode >= 300 && statusCode < 400 && res.headers.location)
-      httpRequest({ ...params, url: res.headers.location }, onResponse, onError);
+      httpRequest({ ...params, url: new URL.URL(res.headers.location, params.url).toString() }, onResponse, onError);
     else
       onResponse(res);
   };

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -5891,7 +5891,8 @@ interface TestConfigWebServer {
 
   /**
    * The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the
-   * server is ready to accept connections. Exactly one of `port` or `url` is required.
+   * server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is
+   * checked. Exactly one of `port` or `url` is required.
    */
   url?: string;
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/22144

This change implements following redirects when a 3xx HTTP status code is received, when probing the `url` of a `webServer` config.

Without this change (i.e., currently), playwright still _tries_ to follow the redirect, but often fails, since it incorrectly uses the received `Location` header as new URL, instead of combining it with the URL from the previous request.

For example, if the URL is `http://localhost:8080/some-path` and a redirect with `Location: /some-other-path` is received, playwright incorrectly tries to query `http://localhost:80/some-other-path`, which of course fails, due to the incorrect port.

An alternative solution would be to not follow redirects at all when probing the URL, and just consider a 3xx status code as "server is available". This is actually what the documentation claims will happen right now, but it's incorrect. I chose this solution over not following the redirect, since it makes sense, in my opinion, and not following the redirect would require more code changes (`httpRequest` would need some kind of option that prevents it from following redirects). But if that solution would be preferred, I am happy to change the implementation.