### PR TITLE
fix(ct): viteConfig commonjsOptions doesn't work

### DIFF
--- a/packages/playwright-test/src/plugins/vitePlugin.ts
+++ b/packages/playwright-test/src/plugins/vitePlugin.ts
@@ -104,9 +104,6 @@ export function createPlugin(
 
       viteConfig.root = rootDir;
       viteConfig.preview = { port, ...viteConfig.preview };
-      viteConfig.build = {
-        outDir
-      };
 
       // React heuristic. If we see a component in a file with .js extension,
       // consider it a potential JSX-in-JS scenario and enable JSX loader for all
@@ -138,6 +135,7 @@ export function createPlugin(
       viteConfig.css.devSourcemap = true;
       viteConfig.build = {
         ...viteConfig.build,
+        outDir,
         target: 'esnext',
         minify: false,
         rollupOptions: {


### PR DESCRIPTION
fixes: https://github.com/microsoft/playwright/issues/22032. the `use.ctViteConfig.build` config was ignored:

```typescript
export default defineConfig({
  use: {
    ctViteConfig: {
      build: {
        commonjsOptions: {
          include: undefined
        },
      }
    }
  }
});

```