### PR TITLE
feat: propagate env changes to teardown

### DIFF
--- a/packages/playwright-test/src/runner/runner.ts
+++ b/packages/playwright-test/src/runner/runner.ts
@@ -64,6 +64,7 @@ export class Runner {
       config,
       reporter,
       phases: [],
+      envProducedByAllWorkers: {},
     };
 
     reporter.onConfigure(config);

--- a/packages/playwright-test/src/runner/uiMode.ts
+++ b/packages/playwright-test/src/runner/uiMode.ts
@@ -74,6 +74,7 @@ class UIMode {
       config: this._config,
       reporter,
       phases: [],
+      envProducedByAllWorkers: {},
     };
     const { status, cleanup: globalCleanup } = await taskRunner.runDeferCleanup(context, 0);
     await reporter.onExit({ status });
@@ -149,7 +150,7 @@ class UIMode {
     this._config._internal.listOnly = true;
     this._config._internal.testIdMatcher = undefined;
     const taskRunner = createTaskRunnerForList(this._config, reporter, 'out-of-process');
-    const context: TaskRunnerState = { config: this._config, reporter, phases: [] };
+    const context: TaskRunnerState = { config: this._config, reporter, phases: [], envProducedByAllWorkers: {} };
     clearCompilationCache();
     reporter.onConfigure(this._config);
     const status = await taskRunner.run(context, 0);
@@ -171,7 +172,7 @@ class UIMode {
     const runReporter = new TeleReporterEmitter(e => this._dispatchEvent(e));
     const reporter = await createReporter(this._config, 'ui', [runReporter]);
     const taskRunner = createTaskRunnerForWatch(this._config, reporter);
-    const context: TaskRunnerState = { config: this._config, reporter, phases: [] };
+    const context: TaskRunnerState = { config: this._config, reporter, phases: [], envProducedByAllWorkers: {} };
     clearCompilationCache();
     reporter.onConfigure(this._config);
     const stop = new ManualPromise();

--- a/packages/playwright-test/src/runner/watchMode.ts
+++ b/packages/playwright-test/src/runner/watchMode.ts
@@ -119,6 +119,7 @@ export async function runWatchModeLoop(config: FullConfigInternal): Promise<Full
     config,
     reporter,
     phases: [],
+    envProducedByAllWorkers: {},
   };
   const taskRunner = createTaskRunnerForWatchSetup(config, reporter);
   reporter.onConfigure(config);
@@ -288,6 +289,7 @@ async function runTests(config: FullConfigInternal, failedTestIdCollector: Set<s
     config,
     reporter,
     phases: [],
+    envProducedByAllWorkers: {},
   };
   clearCompilationCache();
   reporter.onConfigure(config);


### PR DESCRIPTION
All env variables set in test workers will be available in the global teardown. This is especially handy for migrating global setup to deps projects.