### PR TITLE
chore: use ReactDOM.createrRoot to render

### DIFF
--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -19,7 +19,7 @@ import type zip from '@zip.js/zip.js';
 // @ts-ignore
 import * as zipImport from '@zip.js/zip.js/lib/zip-no-worker-inflate.js';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import './colors.css';
 import type { LoadedReport } from './loadedReport';
 import { ReportView } from './reportView';
@@ -38,7 +38,7 @@ const ReportLoader: React.FC = () => {
 };
 
 window.onload = () => {
-  ReactDOM.render(<ReportLoader />, document.querySelector('#root'));
+  ReactDOM.createRoot(document.querySelector('#root')!).render(<ReportLoader />);
 };
 
 class ZipReport implements LoadedReport {

--- a/packages/recorder/src/index.tsx
+++ b/packages/recorder/src/index.tsx
@@ -18,10 +18,10 @@ import '@web/common.css';
 import { applyTheme } from '@web/theme';
 import '@web/third_party/vscode/codicon.css';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import { Main } from './main';
 
 (async () => {
   applyTheme();
-  ReactDOM.render(<Main/>, document.querySelector('#root'));
+  ReactDOM.createRoot(document.querySelector('#root')!).render(<Main />);
 })();

--- a/packages/recorder/src/main.tsx
+++ b/packages/recorder/src/main.tsx
@@ -30,12 +30,14 @@ export const Main: React.FC = ({
   window.playwrightSetSources = setSources;
   window.playwrightSetPaused = setPaused;
   window.playwrightUpdateLogs = callLogs => {
-    const newLog = new Map<string, CallLog>(log);
-    for (const callLog of callLogs) {
-      callLog.reveal = !log.has(callLog.id);
-      newLog.set(callLog.id, callLog);
-    }
-    setLog(newLog);
+    setLog(oldLog => {
+      const newLog = new Map<string, CallLog>(oldLog);
+      for (const callLog of callLogs) {
+        callLog.reveal = !log.has(callLog.id);
+        newLog.set(callLog.id, callLog);
+      }
+      return newLog;
+    });
   };
 
   window.playwrightSourcesEchoForTest = sources;

--- a/packages/trace-viewer/src/index.tsx
+++ b/packages/trace-viewer/src/index.tsx
@@ -18,7 +18,7 @@ import '@web/common.css';
 import { applyTheme } from '@web/theme';
 import '@web/third_party/vscode/codicon.css';
 import React from 'react';
-import * as ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import { WorkbenchLoader } from './ui/workbenchLoader';
 
 (async () => {
@@ -37,5 +37,5 @@ import { WorkbenchLoader } from './ui/workbenchLoader';
     setInterval(function() { fetch('ping'); }, 10000);
   }
 
-  ReactDOM.render(<WorkbenchLoader/>, document.querySelector('#root'));
+  ReactDOM.createRoot(document.querySelector('#root')!).render(<WorkbenchLoader />);
 })();

--- a/packages/trace-viewer/src/watch.tsx
+++ b/packages/trace-viewer/src/watch.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import '@web/common.css';
 import { applyTheme } from '@web/theme';
 import '@web/third_party/vscode/codicon.css';
-import * as ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import { WatchModeView } from './ui/watchMode';
 
 (async () => {
@@ -37,5 +37,5 @@ import { WatchModeView } from './ui/watchMode';
     setInterval(function() { fetch('ping'); }, 10000);
   }
 
-  ReactDOM.render(<WatchModeView></WatchModeView>, document.querySelector('#root'));
+  ReactDOM.createRoot(document.querySelector('#root')!).render(<WatchModeView />);
 })();

--- a/utils/check_deps.js
+++ b/utils/check_deps.js
@@ -141,13 +141,11 @@ async function innerCheckDeps(root) {
         return;
       }
 
-      if (importName.startsWith('@'))
-        deps.add(importName.split('/').slice(0, 2).join('/'));
-      else
-        deps.add(importName.split('/')[0]);
+      const dependencyName = importName.startsWith('@') ? importName.split('/').slice(0, 2).join('/') : importName.split('/')[0];
+      deps.add(dependencyName);
 
-      if (!allowExternalImport(importName, packageJSON))
-        errors.push(`Disallowed external dependency ${importName} from ${path.relative(root, fileName)}`);
+      if (!allowExternalImport(dependencyName, packageJSON))
+        errors.push(`Disallowed external dependency ${dependencyName} from ${path.relative(root, fileName)}`);
     }
     ts.forEachChild(node, x => visit(x, fileName));
   }


### PR DESCRIPTION
`ReactDOM.render` is deprecated, see [here](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#deprecations).