### PR TITLE
chore: allow force reload in traceviewer/watch mode

### DIFF
--- a/packages/trace-viewer/popout.html
+++ b/packages/trace-viewer/popout.html
@@ -18,6 +18,13 @@
   <body>
     <script>
       (async () => {
+        // If a user does a force reload (Cmd+R), there might be an old service worker
+        // that is still running BUT it is NOT controlling the page which is by spec.
+        // In this case, we unregister all service workers first.
+        if (!navigator.serviceWorker.controller) {
+          const registrations = await navigator.serviceWorker.getRegistrations();
+          await Promise.all(registrations.map(r => r.unregister()));
+        }
         navigator.serviceWorker.register('sw.bundle.js');
         if (!navigator.serviceWorker.controller)
           await new Promise(f => navigator.serviceWorker.oncontrollerchange = f);

--- a/packages/trace-viewer/src/index.tsx
+++ b/packages/trace-viewer/src/index.tsx
@@ -26,6 +26,13 @@ import { WorkbenchLoader } from './ui/workbenchLoader';
   if (window.location.protocol !== 'file:') {
     if (window.location.href.includes('isUnderTest=true'))
       await new Promise(f => setTimeout(f, 1000));
+    // If a user does a force reload (Cmd+R), there might be an old service worker
+    // that is still running BUT it is NOT controlling the page which is by spec.
+    // In this case, we unregister all service workers first.
+    if (!navigator.serviceWorker.controller) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(registrations.map(r => r.unregister()));
+    }
     navigator.serviceWorker.register('sw.bundle.js');
     if (!navigator.serviceWorker.controller) {
       await new Promise<void>(f => {

--- a/packages/trace-viewer/src/watch.tsx
+++ b/packages/trace-viewer/src/watch.tsx
@@ -26,6 +26,13 @@ import { WatchModeView } from './ui/watchMode';
   if (window.location.protocol !== 'file:') {
     if (window.location.href.includes('isUnderTest=true'))
       await new Promise(f => setTimeout(f, 1000));
+    // If a user does a force reload (Cmd+R), there might be an old service worker
+    // that is still running BUT it is NOT controlling the page which is by spec.
+    // In this case, we unregister all service workers first.
+    if (!navigator.serviceWorker.controller) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(registrations.map(r => r.unregister()));
+    }
     navigator.serviceWorker.register('sw.bundle.js');
     if (!navigator.serviceWorker.controller) {
       await new Promise<void>(f => {


### PR DESCRIPTION
According to the [spec](https://w3c.github.io/ServiceWorker/#navigator-service-worker-controller) if a user does a force refresh, navigator.serviceWorker.controller is `null` which is why it was hanging before. So we need to first unregister the SW and the register a new one to be controlled and have access to a SW.

Fixes https://github.com/microsoft/playwright/issues/22097