### PR TITLE
feat(connect): support special headers for debug/attachments

### DIFF
--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -19,7 +19,7 @@ import { BrowserContext, prepareBrowserContextParams } from './browserContext';
 import type { Page } from './page';
 import { ChannelOwner } from './channelOwner';
 import { Events } from './events';
-import type { LaunchOptions, BrowserContextOptions } from './types';
+import type { LaunchOptions, BrowserContextOptions, HeadersArray } from './types';
 import { isSafeCloseError, kBrowserClosedError } from '../common/errors';
 import type * as api from '../../types/types';
 import { CDPSession } from './cdpSession';
@@ -33,6 +33,9 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
   _browserType!: BrowserType;
   _options: LaunchOptions = {};
   readonly _name: string;
+
+  // Used from @playwright/test fixtures.
+  _connectHeaders?: HeadersArray;
 
   static from(browser: channels.BrowserChannel): Browser {
     return (browser as any)._object;

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -28,6 +28,7 @@ import type * as api from '../../types/types';
 import { kBrowserClosedError } from '../common/errors';
 import { raceAgainstTimeout } from '../utils/timeoutRunner';
 import type { Playwright } from './playwright';
+import { debugLogger } from '../common/debugLogger';
 
 export interface BrowserServerLauncher {
   launchServer(options?: LaunchServerOptions): Promise<api.BrowserServer>;
@@ -154,7 +155,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
       };
       if ((params as any).__testHookRedirectPortForwarding)
         connectParams.socksProxyRedirectPortForTest = (params as any).__testHookRedirectPortForwarding;
-      const { pipe } = await localUtils._channel.connect(connectParams);
+      const { pipe, headers: connectHeaders } = await localUtils._channel.connect(connectParams);
       const closePipe = () => pipe.close().catch(() => {});
       const connection = new Connection(localUtils);
       connection.markAsRemote();
@@ -198,6 +199,11 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
         browser = Browser.from(playwright._initializer.preLaunchedBrowser!);
         this._didLaunchBrowser(browser, {}, logger);
         browser._shouldCloseConnectionOnClose = true;
+        browser._connectHeaders = connectHeaders;
+        for (const header of connectHeaders) {
+          if (header.name === 'x-playwright-debug-log')
+            debugLogger.log('browser', header.value);
+        }
         browser.on(Events.Browser.Disconnected, closePipe);
         return browser;
       }, deadline ? deadline - monotonicTime() : 0);

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -267,6 +267,7 @@ scheme.LocalUtilsConnectParams = tObject({
 });
 scheme.LocalUtilsConnectResult = tObject({
   pipe: tChannel(['JsonPipe']),
+  headers: tArray(tType('NameValue')),
 });
 scheme.LocalUtilsTracingStartedParams = tObject({
   tracesDir: tOptional(tString),

--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -88,6 +88,11 @@ export class PlaywrightServer {
     const browserSemaphore = new Semaphore(this._options.maxConnections);
     const controllerSemaphore = new Semaphore(1);
     const reuseBrowserSemaphore = new Semaphore(1);
+    if (process.env.PWTEST_SERVER_WS_HEADERS) {
+      this._wsServer.on('headers', (headers, request) => {
+        headers.push(process.env.PWTEST_SERVER_WS_HEADERS!);
+      });
+    }
     this._wsServer.on('connection', (ws, request) => {
       const url = new URL('http://localhost' + (request.url || ''));
       const browserHeader = request.headers['x-playwright-browser'];

--- a/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
@@ -228,7 +228,7 @@ export class LocalUtilsDispatcher extends Dispatcher<{ guid: string }, channels.
         pipe.wasClosed();
       };
       pipe.on('close', () => transport.close());
-      return { pipe };
+      return { pipe, headers: transport.headers };
     }, params.timeout || 0);
   }
 

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -478,6 +478,7 @@ export type LocalUtilsConnectOptions = {
 };
 export type LocalUtilsConnectResult = {
   pipe: JsonPipeChannel,
+  headers: NameValue[],
 };
 export type LocalUtilsTracingStartedParams = {
   tracesDir?: string,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -561,6 +561,9 @@ LocalUtils:
         socksProxyRedirectPortForTest: number?
       returns:
         pipe: JsonPipe
+        headers:
+          type: array
+          items: NameValue
 
     tracingStarted:
       parameters:


### PR DESCRIPTION
`x-playwright-debug-log: value` headers are printed to `pw:browser` debug log.
`x-playwright-attachment: name=value` headers are attached to each test.

Fixes #21619.