### PR TITLE
chore(types): Add export keyword to MakeMatchers type

### DIFF
--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -4189,7 +4189,7 @@ interface GenericAssertions<R> {
 
 type BaseMatchers<R, T> = GenericAssertions<R> & PlaywrightTest.Matchers<R, T>;
 
-type MakeMatchers<R, T> = BaseMatchers<R, T> & {
+export type MakeMatchers<R, T> = BaseMatchers<R, T> & {
     /**
      * If you know how to test something, `.not` lets you test its opposite.
      */

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -306,7 +306,7 @@ interface GenericAssertions<R> {
 
 type BaseMatchers<R, T> = GenericAssertions<R> & PlaywrightTest.Matchers<R, T>;
 
-type MakeMatchers<R, T> = BaseMatchers<R, T> & {
+export type MakeMatchers<R, T> = BaseMatchers<R, T> & {
     /**
      * If you know how to test something, `.not` lets you test its opposite.
      */


### PR DESCRIPTION
Add the export keyword to the MakeMatchers type. This allows more flexibility to users create their own test frameworks bases on playwright.

Example usage:

    import { Locator, MakeMatchers } from "@playwright/test"; 
    import { expect as exp } from "@playwright/test";

    export class HtmlElement {
       protected _element: Locator;

        expect(message?: string): MakeMatchers<void, Locator> {
            return exp(this._element, { message: message });
        }

    }