### PR TITLE
cherry-pick(#22035): fix(webServer): follow relative redirects when checking the url

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -595,7 +595,7 @@ export default defineConfig({
 - type: ?<[Object]|[Array]<[Object]>>
   - `command` <[string]> Shell command to start. For example `npm run start`..
   - `port` ?<[int]> The port that your http server is expected to appear on. It does wait until it accepts connections. Exactly one of `port` or `url` is required.
-  - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Exactly one of `port` or `url` is required.
+  - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is checked. Exactly one of `port` or `url` is required.
   - `ignoreHTTPSErrors` ?<[boolean]> Whether to ignore HTTPS errors when fetching the `url`. Defaults to `false`.
   - `timeout` ?<[int]> How long to wait for the process to start up and be available in milliseconds. Defaults to 60000.
   - `reuseExistingServer` ?<[boolean]> If true, it will re-use an existing server on the `port` or `url` when available. If no server is running on that `port` or `url`, it will run the command to start a new server. If `false`, it will throw if an existing process is listening on the `port` or `url`. This should be commonly set to `!process.env.CI` to allow the local dev server when running tests locally.

--- a/packages/playwright-core/src/utils/network.ts
+++ b/packages/playwright-core/src/utils/network.ts
@@ -80,7 +80,7 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
   const requestCallback = (res: http.IncomingMessage) => {
     const statusCode = res.statusCode || 0;
     if (statusCode >= 300 && statusCode < 400 && res.headers.location)
-      httpRequest({ ...params, url: res.headers.location }, onResponse, onError);
+      httpRequest({ ...params, url: new URL.URL(res.headers.location, params.url).toString() }, onResponse, onError);
     else
       onResponse(res);
   };

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -5887,7 +5887,8 @@ interface TestConfigWebServer {
 
   /**
    * The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the
-   * server is ready to accept connections. Exactly one of `port` or `url` is required.
+   * server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is
+   * checked. Exactly one of `port` or `url` is required.
    */
   url?: string;
 


### PR DESCRIPTION
This PR cherry-picks the following commits:

- bd698efaef0994871d99b6367c268f812f5cd357