### PR TITLE
test: kill CLI if test kept running after timeout

### DIFF
--- a/tests/library/inspector/inspectorTest.ts
+++ b/tests/library/inspector/inspectorTest.ts
@@ -73,8 +73,8 @@ export const test = contextTest.extend<CLITestArgs>({
       cli = new CLIMock(childProcess, browserName, channel, headless, cliArgs, launchOptions.executablePath, noAutoExit);
       return cli;
     });
-    if (cli)
-      await cli.exited.catch(() => {});
+    // Discard any exit error and let childProcess fixture report leaking processes (processwes which do not exit).
+    cli?.exited.catch(() => {});
   },
 
   openRecorder: async ({ page, recorderPageGetter }, run) => {


### PR DESCRIPTION
What happens was the following:
1. CLI codegen test was running (does not play a role if it passed or failed)
2. `runCLI` fixture after the `run` was waiting for `cli.exited`. But the process was never exiting. Reasoning unclear, most likely some bug, but should be fixed separately imo.
3. This ended up in a `Test finished within timeout of 30000ms, but tearing down "runCLI" ran out of time. Please allow more time for the test, since teardown is attributed towards the test timeout budget.` error

How to fix? Still wait for the CLI process to exit, race against a timeout tho, if the process was not exited afterwards kill the process (to cleanup) and throw an Error that there was a leaking process.

https://github.com/microsoft/playwright/issues/21654