### PR TITLE
feat(chromium): allow to adjust output video quality

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -679,6 +679,11 @@ When set to `minimal`, only record information necessary for routing from HAR. T
     Actual picture of each page will be scaled down if necessary to fit the specified size.
     - `width` <[int]> Video frame width.
     - `height` <[int]> Video frame height.
+  - `quality` ?<[Object]> Optional quality parameters. If not specified, it will default to `qmin=0,qmax=50,crf=8,bitrate=1M`. Only works on Chromium as for now. [See Documentation](https://trac.ffmpeg.org/wiki/Encode/VP8#VariableBitrate)
+    - `qmin` ?<[int]> The minimum quantizer (default 0, range 0–63).
+    - `qmax` ?<[int]> The maximum quantizer (default 50, range `qmin`–63).
+    - `crf` ?<[int]> Enable constant quality mode.
+    - `bitrate` ?<[string]> Target bitrate.
 
 Enables video recording for all pages into `recordVideo.dir` directory. If not specified videos are not recorded. Make
 sure to await [`method: BrowserContext.close`] for videos to be saved.

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -561,6 +561,12 @@ scheme.BrowserTypeLaunchPersistentContextParams = tObject({
       width: tNumber,
       height: tNumber,
     })),
+    quality: tOptional(tObject({
+      qmin: tOptional(tNumber),
+      qmax: tOptional(tNumber),
+      crf: tOptional(tNumber),
+      bitrate: tOptional(tString),
+    })),
   })),
   recordHar: tOptional(tType('RecordHarOptions')),
   strictSelectors: tOptional(tBoolean),
@@ -633,6 +639,12 @@ scheme.BrowserNewContextParams = tObject({
       width: tNumber,
       height: tNumber,
     })),
+    quality: tOptional(tObject({
+      qmin: tOptional(tNumber),
+      qmax: tOptional(tNumber),
+      crf: tOptional(tNumber),
+      bitrate: tOptional(tString),
+    })),
   })),
   recordHar: tOptional(tType('RecordHarOptions')),
   strictSelectors: tOptional(tBoolean),
@@ -693,6 +705,12 @@ scheme.BrowserNewContextForReuseParams = tObject({
     size: tOptional(tObject({
       width: tNumber,
       height: tNumber,
+    })),
+    quality: tOptional(tObject({
+      qmin: tOptional(tNumber),
+      qmax: tOptional(tNumber),
+      crf: tOptional(tNumber),
+      bitrate: tOptional(tString),
     })),
   })),
   recordHar: tOptional(tType('RecordHarOptions')),
@@ -2437,6 +2455,12 @@ scheme.AndroidDeviceLaunchBrowserParams = tObject({
     size: tOptional(tObject({
       width: tNumber,
       height: tNumber,
+    })),
+    quality: tOptional(tObject({
+      qmin: tOptional(tNumber),
+      qmax: tOptional(tNumber),
+      crf: tOptional(tNumber),
+      bitrate: tOptional(tString),
     })),
   })),
   recordHar: tOptional(tType('RecordHarOptions')),

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -472,6 +472,7 @@ class FrameSession {
       screencastOptions = {
         // validateBrowserContextOptions ensures correct video size.
         ...this._crPage._browserContext._options.recordVideo.size!,
+        ...this._crPage._browserContext._options.recordVideo.quality,
         outputFile,
       };
       await this._crPage._browserContext._ensureVideosPath();

--- a/packages/playwright-core/src/server/chromium/videoRecorder.ts
+++ b/packages/playwright-core/src/server/chromium/videoRecorder.ts
@@ -98,7 +98,12 @@ export class VideoRecorder {
 
     const w = options.width;
     const h = options.height;
-    const args = `-loglevel error -f image2pipe -avioflags direct -fpsprobesize 0 -probesize 32 -analyzeduration 0 -c:v mjpeg -i - -y -an -r ${fps} -c:v vp8 -qmin 0 -qmax 50 -crf 8 -deadline realtime -speed 8 -b:v 1M -threads 1 -vf pad=${w}:${h}:0:0:gray,crop=${w}:${h}:0:0`.split(' ');
+    const qmin = options.qmin ?? 0;
+    const qmax = options.qmax ?? 50;
+    const crf = options.crf ?? 8;
+    const bitrate = options.bitrate ?? '1M';
+
+    const args = `-loglevel error -f image2pipe -avioflags direct -fpsprobesize 0 -probesize 32 -analyzeduration 0 -c:v mjpeg -i - -y -an -r ${fps} -c:v vp8 -qmin ${qmin} -qmax ${qmax} -crf ${crf} -deadline realtime -speed 8 -b:v ${bitrate} -threads 1 -vf pad=${w}:${h}:0:0:gray,crop=${w}:${h}:0:0`.split(' ');
     args.push(options.outputFile);
     const progress = this._progress;
 

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -52,6 +52,10 @@ export type PageScreencastOptions = {
   width: number,
   height: number,
   outputFile: string,
+  qmin?: number,
+  qmax?: number,
+  crf?: number,
+  bitrate?: string,
 };
 
 export type Credentials = {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -12591,6 +12591,32 @@ export interface BrowserType<Unused = {}> {
          */
         height: number;
       };
+
+      /**
+       * Optional quality parameters. If not specified, it will default to `qmin=0,qmax=50,crf=8,bitrate=1M`. Only works on
+       * Chromium as for now. [See Documentation](https://trac.ffmpeg.org/wiki/Encode/VP8#VariableBitrate)
+       */
+      quality?: {
+        /**
+         * The minimum quantizer (default 0, range 0–63).
+         */
+        qmin?: number;
+
+        /**
+         * The maximum quantizer (default 50, range `qmin`–63).
+         */
+        qmax?: number;
+
+        /**
+         * Enable constant quality mode.
+         */
+        crf?: number;
+
+        /**
+         * Target bitrate.
+         */
+        bitrate?: string;
+      };
     };
 
     /**
@@ -13991,6 +14017,32 @@ export interface AndroidDevice {
          * Video frame height.
          */
         height: number;
+      };
+
+      /**
+       * Optional quality parameters. If not specified, it will default to `qmin=0,qmax=50,crf=8,bitrate=1M`. Only works on
+       * Chromium as for now. [See Documentation](https://trac.ffmpeg.org/wiki/Encode/VP8#VariableBitrate)
+       */
+      quality?: {
+        /**
+         * The minimum quantizer (default 0, range 0–63).
+         */
+        qmin?: number;
+
+        /**
+         * The maximum quantizer (default 50, range `qmin`–63).
+         */
+        qmax?: number;
+
+        /**
+         * Enable constant quality mode.
+         */
+        crf?: number;
+
+        /**
+         * Target bitrate.
+         */
+        bitrate?: string;
       };
     };
 
@@ -15865,6 +15917,32 @@ export interface Browser extends EventEmitter {
          */
         height: number;
       };
+
+      /**
+       * Optional quality parameters. If not specified, it will default to `qmin=0,qmax=50,crf=8,bitrate=1M`. Only works on
+       * Chromium as for now. [See Documentation](https://trac.ffmpeg.org/wiki/Encode/VP8#VariableBitrate)
+       */
+      quality?: {
+        /**
+         * The minimum quantizer (default 0, range 0–63).
+         */
+        qmin?: number;
+
+        /**
+         * The maximum quantizer (default 50, range `qmin`–63).
+         */
+        qmax?: number;
+
+        /**
+         * Enable constant quality mode.
+         */
+        crf?: number;
+
+        /**
+         * Target bitrate.
+         */
+        bitrate?: string;
+      };
     };
 
     /**
@@ -16678,6 +16756,32 @@ export interface Electron {
          * Video frame height.
          */
         height: number;
+      };
+
+      /**
+       * Optional quality parameters. If not specified, it will default to `qmin=0,qmax=50,crf=8,bitrate=1M`. Only works on
+       * Chromium as for now. [See Documentation](https://trac.ffmpeg.org/wiki/Encode/VP8#VariableBitrate)
+       */
+      quality?: {
+        /**
+         * The minimum quantizer (default 0, range 0–63).
+         */
+        qmin?: number;
+
+        /**
+         * The maximum quantizer (default 50, range `qmin`–63).
+         */
+        qmax?: number;
+
+        /**
+         * Enable constant quality mode.
+         */
+        crf?: number;
+
+        /**
+         * Target bitrate.
+         */
+        bitrate?: string;
       };
     };
 
@@ -18964,6 +19068,32 @@ export interface BrowserContextOptions {
        * Video frame height.
        */
       height: number;
+    };
+
+    /**
+     * Optional quality parameters. If not specified, it will default to `qmin=0,qmax=50,crf=8,bitrate=1M`. Only works on
+     * Chromium as for now. [See Documentation](https://trac.ffmpeg.org/wiki/Encode/VP8#VariableBitrate)
+     */
+    quality?: {
+      /**
+       * The minimum quantizer (default 0, range 0–63).
+       */
+      qmin?: number;
+
+      /**
+       * The maximum quantizer (default 50, range `qmin`–63).
+       */
+      qmax?: number;
+
+      /**
+       * Enable constant quality mode.
+       */
+      crf?: number;
+
+      /**
+       * Target bitrate.
+       */
+      bitrate?: string;
     };
   };
 

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -972,6 +972,12 @@ export type BrowserTypeLaunchPersistentContextParams = {
       width: number,
       height: number,
     },
+    quality?: {
+      qmin?: number,
+      qmax?: number,
+      crf?: number,
+      bitrate?: string,
+    },
   },
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
@@ -1042,6 +1048,12 @@ export type BrowserTypeLaunchPersistentContextOptions = {
     size?: {
       width: number,
       height: number,
+    },
+    quality?: {
+      qmin?: number,
+      qmax?: number,
+      crf?: number,
+      bitrate?: string,
     },
   },
   recordHar?: RecordHarOptions,
@@ -1139,6 +1151,12 @@ export type BrowserNewContextParams = {
       width: number,
       height: number,
     },
+    quality?: {
+      qmin?: number,
+      qmax?: number,
+      crf?: number,
+      bitrate?: string,
+    },
   },
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
@@ -1196,6 +1214,12 @@ export type BrowserNewContextOptions = {
     size?: {
       width: number,
       height: number,
+    },
+    quality?: {
+      qmin?: number,
+      qmax?: number,
+      crf?: number,
+      bitrate?: string,
     },
   },
   recordHar?: RecordHarOptions,
@@ -1258,6 +1282,12 @@ export type BrowserNewContextForReuseParams = {
       width: number,
       height: number,
     },
+    quality?: {
+      qmin?: number,
+      qmax?: number,
+      crf?: number,
+      bitrate?: string,
+    },
   },
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
@@ -1315,6 +1345,12 @@ export type BrowserNewContextForReuseOptions = {
     size?: {
       width: number,
       height: number,
+    },
+    quality?: {
+      qmin?: number,
+      qmax?: number,
+      crf?: number,
+      bitrate?: string,
     },
   },
   recordHar?: RecordHarOptions,
@@ -4402,6 +4438,12 @@ export type AndroidDeviceLaunchBrowserParams = {
       width: number,
       height: number,
     },
+    quality?: {
+      qmin?: number,
+      qmax?: number,
+      crf?: number,
+      bitrate?: string,
+    },
   },
   recordHar?: RecordHarOptions,
   strictSelectors?: boolean,
@@ -4457,6 +4499,12 @@ export type AndroidDeviceLaunchBrowserOptions = {
     size?: {
       width: number,
       height: number,
+    },
+    quality?: {
+      qmin?: number,
+      qmax?: number,
+      crf?: number,
+      bitrate?: string,
     },
   },
   recordHar?: RecordHarOptions,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -482,6 +482,13 @@ ContextOptions:
           properties:
             width: number
             height: number
+        quality:
+          type: object?
+          properties:
+            qmin: number?
+            qmax: number?
+            crf: number?
+            bitrate: string?
     recordHar: RecordHarOptions?
     strictSelectors: boolean?
     serviceWorkers:


### PR DESCRIPTION
Hello Team,

Thank you for your amazing work on this project. I use it on different projects and it's very powerful.

### Short description

This PR allows to configure output video quality on Chromium.

### Background

Recently, I tried to generate videos based on HTML5 animation. I tried to use playwright to generate the video but unfortunately, the quality is not sufficient.

I also plan to use playwright to generate "support" videos for a product knowledge base.

### Use cases

- Generate videos from HTML5 animation
- Automate "how-to" videos
- Automate "demonstration" videos
- Reduce quality when recording tests

### Additional notes

- This feature is only available for Chromium. It's OK for my use case but maybe we can add it on other platforms.

- It's my first PR on playwright. Do not hesitate to tell me if everything is correct.