### PR TITLE
chore: use separator when printing titles in the list mode

### DIFF
--- a/packages/playwright-test/src/runner/reporters.ts
+++ b/packages/playwright-test/src/runner/reporters.ts
@@ -92,7 +92,7 @@ export class ListModeReporter implements Reporter {
       const location = `${path.relative(config.rootDir, test.location.file)}:${test.location.line}:${test.location.column}`;
       const projectTitle = projectName ? `[${projectName}] › ` : '';
       // eslint-disable-next-line no-console
-      console.log(`  ${projectTitle}${location} › ${titles.join(' ')}`);
+      console.log(`  ${projectTitle}${location} › ${titles.join(' › ')}`);
       files.add(test.location.file);
     }
     // eslint-disable-next-line no-console


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/22267