### PR TITLE
test: fix android test

### DIFF
--- a/tests/android/browser.spec.ts
+++ b/tests/android/browser.spec.ts
@@ -21,7 +21,8 @@ test.afterAll(async ({ androidDevice }) => {
 });
 
 test('androidDevice.model', async function({ androidDevice }) {
-  expect(androidDevice.model()).toBe('sdk_gphone64_x86_64');
+  expect(androidDevice.model()).toContain('sdk_gphone');
+  expect(androidDevice.model()).toContain('x86_64');
 });
 
 test('androidDevice.launchBrowser', async function({ androidDevice }) {


### PR DESCRIPTION
For some reason, Android model changed from `sdk_gphone64_x86_64` to `sdk_gphone_x86_64`.

Relax the test to test the model name & architecture.
