### PR TITLE
test: worker network attribution is still not fixed in Firefox 113

### DIFF
--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -93,7 +93,7 @@ it('should work with glob', async () => {
 });
 
 it('should intercept network activity from worker', async function({ page, server, isAndroid, browserName, browserMajorVersion }) {
-  it.fixme(browserName === 'firefox' && browserMajorVersion === 112, 'https://github.com/microsoft/playwright/issues/21760');
+  it.fixme(browserName === 'firefox' && browserMajorVersion >= 112, 'https://github.com/microsoft/playwright/issues/21760');
   it.skip(isAndroid);
 
   await page.goto(server.EMPTY_PAGE);

--- a/tests/page/workers.spec.ts
+++ b/tests/page/workers.spec.ts
@@ -143,7 +143,7 @@ it('should attribute network activity for worker inside iframe to the iframe', a
 });
 
 it('should report network activity', async function({ page, server, browserName, browserMajorVersion }) {
-  it.fixme(browserName === 'firefox' && browserMajorVersion === 112, 'https://github.com/microsoft/playwright/issues/21760');
+  it.fixme(browserName === 'firefox' && browserMajorVersion >= 112, 'https://github.com/microsoft/playwright/issues/21760');
   const [worker] = await Promise.all([
     page.waitForEvent('worker'),
     page.goto(server.PREFIX + '/worker/worker.html'),
@@ -160,7 +160,7 @@ it('should report network activity', async function({ page, server, browserName,
 });
 
 it('should report network activity on worker creation', async function({ page, server, browserName, browserMajorVersion }) {
-  it.fixme(browserName === 'firefox' && browserMajorVersion === 112, 'https://github.com/microsoft/playwright/issues/21760');
+  it.fixme(browserName === 'firefox' && browserMajorVersion >= 112, 'https://github.com/microsoft/playwright/issues/21760');
   // Chromium needs waitForDebugger enabled for this one.
   await page.goto(server.EMPTY_PAGE);
   const url = server.PREFIX + '/one-style.css';


### PR DESCRIPTION
We'll need to wait until it is fixed upstream.

References https://github.com/microsoft/playwright/issues/21760
