### PR TITLE
chore(junit): fallback to path extension for attachment name

### DIFF
--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -205,10 +205,11 @@ class JUnitReporter implements Reporter {
           }
 
           if (contents) {
+            const attachmentName = attachment.name + ((attachment.path && !path.extname(attachment.name)) ? path.extname(attachment.path) : '');
             const item: XMLEntry = {
               name: 'item',
               attributes: {
-                name: attachment.name
+                name: attachmentName,
               },
               text: contents
             };

--- a/tests/playwright-test/reporter-junit.spec.ts
+++ b/tests/playwright-test/reporter-junit.spec.ts
@@ -404,9 +404,8 @@ test('should embed attachments to a custom testcase property, if explicitly requ
         const file = testInfo.outputPath('evidence1.txt');
         require('fs').writeFileSync(file, 'hello', 'utf8');
         testInfo.attachments.push({ name: 'evidence1.txt', path: file, contentType: 'text/plain' });
+        testInfo.attachments.push({ name: 'evidence1_without_extension', path: file, contentType: 'text/plain' });
         testInfo.attachments.push({ name: 'evidence2.txt', body: Buffer.from('world'), contentType: 'text/plain' });
-        // await testInfo.attach('evidence1.txt', { path: file, contentType: 'text/plain' });
-        // await testInfo.attach('evidence2.txt', { body: Buffer.from('world'), contentType: 'text/plain' });
         console.log('log here');
       });
     `
@@ -418,8 +417,10 @@ test('should embed attachments to a custom testcase property, if explicitly requ
   expect(testcase['properties'][0]['property'][0]['$']['name']).toBe('testrun_evidence');
   expect(testcase['properties'][0]['property'][0]['item'][0]['$']['name']).toBe('evidence1.txt');
   expect(testcase['properties'][0]['property'][0]['item'][0]['_']).toBe('\naGVsbG8=\n');
-  expect(testcase['properties'][0]['property'][0]['item'][1]['$']['name']).toBe('evidence2.txt');
-  expect(testcase['properties'][0]['property'][0]['item'][1]['_']).toBe('\nd29ybGQ=\n');
+  expect(testcase['properties'][0]['property'][0]['item'][1]['$']['name']).toBe('evidence1_without_extension.txt');
+  expect(testcase['properties'][0]['property'][0]['item'][1]['_']).toBe('\naGVsbG8=\n');
+  expect(testcase['properties'][0]['property'][0]['item'][2]['$']['name']).toBe('evidence2.txt');
+  expect(testcase['properties'][0]['property'][0]['item'][2]['_']).toBe('\nd29ybGQ=\n');
   expect(testcase['system-out'].length).toBe(1);
   expect(testcase['system-out'][0].trim()).toBe([
     `log here`


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/22396

Before this change we were always using `attachment.name` when putting the attachments into the junit report. In the case of a trace, this is e.g. `trace`. After this change we try a best effort there, since attach the trace via a path to the junit report, we put the extension from the path to the attachment name, if there is none.