### PR TITLE
feat(ct): code split for better performance and isolation

### DIFF
--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -140,6 +140,7 @@ export function createPlugin(
       viteConfig.css.devSourcemap = true;
       viteConfig.build = {
         ...viteConfig.build,
+        outDir,
         target: 'esnext',
         minify: false,
         rollupOptions: {

--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -320,18 +320,11 @@ function vitePlugin(registerSource: string, relativeTemplateDir: string, buildIn
       lines.push(registerSource);
 
       for (const [alias, value] of componentRegistry) {
-        const importPath = value.isModuleOrAlias
-          ? value.importPath
-          : './' + path.relative(folder, value.importPath).replace(/\\/g, '/');
-        if (value.importedName) {
-          lines.push(
-              `const ${alias} = () => import('${importPath}').then((mod) => mod.${value.importedName});`
-          );
-        } else {
-          lines.push(
-              `const ${alias} = () => import('${importPath}').then((mod) => mod.default)`
-          );
-        }
+        const importPath = value.isModuleOrAlias ? value.importPath : './' + path.relative(folder, value.importPath).replace(/\\/g, '/');
+        if (value.importedName)
+          lines.push(`const ${alias} = () => import('${importPath}').then((mod) => mod.${value.importedName});`);
+        else
+          lines.push(`const ${alias} = () => import('${importPath}').then((mod) => mod.default);`);
       }
 
       lines.push(`pwRegister({ ${[...componentRegistry.keys()].join(',\n  ')} });`);

--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -23,13 +23,17 @@ import { createRoot as __pwCreateRoot } from 'react-dom/client';
 /** @typedef {import('../playwright-ct-core/types/component').Component} Component */
 /** @typedef {import('react').FunctionComponent} FrameworkComponent */
 
-/** @type {Map<string, FrameworkComponent>} */
+/** @type {Map<string, Promise<FrameworkComponent>} */
 const __pwRegistry = new Map();
+
+/** @type {Map<string, FrameworkComponent} */
+const __pwRegistryResolved = new Map();
+
 /** @type {Map<Element, import('react-dom/client').Root>} */
 const __pwRootRegistry = new Map();
 
 /**
- * @param {{[key: string]: FrameworkComponent}} components
+ * @param {{[key: string]: () => Promise<FrameworkComponent>}} components
  */
 export function pwRegister(components) {
   for (const [name, value] of Object.entries(components))
@@ -39,14 +43,42 @@ export function pwRegister(components) {
 /**
  * @param {Component} component
  */
+async function __pwResolveAllComponents(component) {
+  if (typeof component !== 'object' || Array.isArray(component))
+    return
+
+  let __pwRegistryKey = component.type
+
+  let componentLoaderFunc = __pwRegistry.get(component.type);
+
+  if (!componentLoaderFunc) {
+    // Lookup by shorthand.
+    for (const [name, value] of __pwRegistry) {
+      if (component.type.endsWith(`_${name}`)) {
+        __pwRegistryKey = name
+        componentLoaderFunc = value;
+        break;
+      }
+    }
+  }
+
+  if(componentLoaderFunc) {
+    __pwRegistryResolved.set(__pwRegistryKey, await componentLoaderFunc())
+  } else {
+    __pwRegistryResolved.set(__pwRegistryKey, component.type)
+  }
+
+  await Promise.all(component.children.map(child => __pwResolveAllComponents(child)))
+}
+
 function __pwRender(component) {
   if (typeof component !== 'object' || Array.isArray(component))
     return component;
 
-  let componentFunc = __pwRegistry.get(component.type);
+  let componentFunc = __pwRegistryResolved.get(component.type);
   if (!componentFunc) {
     // Lookup by shorthand.
-    for (const [name, value] of __pwRegistry) {
+    for (const [name, value] of __pwRegistryResolved) {
       if (component.type.endsWith(`_${name}`)) {
         componentFunc = value;
         break;
@@ -55,7 +87,7 @@ function __pwRender(component) {
   }
 
   if (!componentFunc && component.type[0].toUpperCase() === component.type[0])
-    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistry.keys()]}`);
+    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistryResolved.keys()]}`);
 
   const componentFuncOrString = componentFunc || component.type;
 
@@ -74,7 +106,9 @@ function __pwRender(component) {
 }
 
 window.playwrightMount = async (component, rootElement, hooksConfig) => {
+  await __pwResolveAllComponents(component);
   let App = () => __pwRender(component);
+
   for (const hook of window.__pw_hooks_before_mount || []) {
     const wrapper = await hook({ App, hooksConfig });
     if (wrapper)
@@ -105,6 +139,7 @@ window.playwrightUnmount = async rootElement => {
 };
 
 window.playwrightUpdate = async (rootElement, component) => {
+  await __pwResolveAllComponents(component);
   const root = __pwRootRegistry.get(rootElement);
   if (root === undefined)
     throw new Error('Component was not mounted');

--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -23,11 +23,11 @@ import { createRoot as __pwCreateRoot } from 'react-dom/client';
 /** @typedef {import('../playwright-ct-core/types/component').Component} Component */
 /** @typedef {import('react').FunctionComponent} FrameworkComponent */
 
-/** @type {Map<string, Promise<FrameworkComponent>} */
-const __pwRegistry = new Map();
+/** @type {Map<string, () => Promise<FrameworkComponent>>} */
+const __pwLoaderRegistry = new Map();
 
-/** @type {Map<string, FrameworkComponent} */
-const __pwRegistryResolved = new Map();
+/** @type {Map<string, FrameworkComponent>} */
+const __pwRegistry = new Map();
 
 /** @type {Map<Element, import('react-dom/client').Root>} */
 const __pwRootRegistry = new Map();
@@ -37,48 +37,42 @@ const __pwRootRegistry = new Map();
  */
 export function pwRegister(components) {
   for (const [name, value] of Object.entries(components))
-    __pwRegistry.set(name, value);
+    __pwLoaderRegistry.set(name, value);
 }
 
 /**
  * @param {Component} component
  */
-async function __pwResolveAllComponents(component) {
+async function __pwResolveComponent(component) {
   if (typeof component !== 'object' || Array.isArray(component))
     return
 
-  let __pwRegistryKey = component.type
-
-  let componentLoaderFunc = __pwRegistry.get(component.type);
-
-  if (!componentLoaderFunc) {
+  let componentFuncLoader = __pwLoaderRegistry.get(component.type);
+  if (!componentFuncLoader) {
     // Lookup by shorthand.
-    for (const [name, value] of __pwRegistry) {
+    for (const [name, value] of __pwLoaderRegistry) {
       if (component.type.endsWith(`_${name}`)) {
-        __pwRegistryKey = name
-        componentLoaderFunc = value;
+        componentFuncLoader = value;
         break;
       }
     }
   }
 
-  if(componentLoaderFunc) {
-    __pwRegistryResolved.set(__pwRegistryKey, await componentLoaderFunc())
-  } else {
-    __pwRegistryResolved.set(__pwRegistryKey, component.type)
-  }
+  if(componentFuncLoader)
+    __pwRegistry.set(component.type, await componentFuncLoader())
 
-  await Promise.all(component.children.map(child => __pwResolveAllComponents(child)))
+  if ('children' in component)
+    await Promise.all(component.children.map(child => __pwResolveComponent(child)))
 }
 
 function __pwRender(component) {
   if (typeof component !== 'object' || Array.isArray(component))
     return component;
 
-  let componentFunc = __pwRegistryResolved.get(component.type);
+  let componentFunc = __pwRegistry.get(component.type);
   if (!componentFunc) {
     // Lookup by shorthand.
-    for (const [name, value] of __pwRegistryResolved) {
+    for (const [name, value] of __pwRegistry) {
       if (component.type.endsWith(`_${name}`)) {
         componentFunc = value;
         break;
@@ -87,7 +81,7 @@ function __pwRender(component) {
   }
 
   if (!componentFunc && component.type[0].toUpperCase() === component.type[0])
-    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistryResolved.keys()]}`);
+    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistry.keys()]}`);
 
   const componentFuncOrString = componentFunc || component.type;
 
@@ -106,9 +100,8 @@ function __pwRender(component) {
 }
 
 window.playwrightMount = async (component, rootElement, hooksConfig) => {
-  await __pwResolveAllComponents(component);
+  await __pwResolveComponent(component);
   let App = () => __pwRender(component);
-
   for (const hook of window.__pw_hooks_before_mount || []) {
     const wrapper = await hook({ App, hooksConfig });
     if (wrapper)
@@ -139,7 +132,7 @@ window.playwrightUnmount = async rootElement => {
 };
 
 window.playwrightUpdate = async (rootElement, component) => {
-  await __pwResolveAllComponents(component);
+  await __pwResolveComponent(component);
   const root = __pwRootRegistry.get(rootElement);
   if (root === undefined)
     throw new Error('Component was not mounted');

--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -21,14 +21,14 @@ import * as __pwReact from 'react';
 import { createRoot as __pwCreateRoot } from 'react-dom/client';
 
 /** @typedef {import('../playwright-ct-core/types/component').Component} Component */
+/** @typedef {import('../playwright-ct-core/types/component').JsxComponent} JsxComponent */
+/** @typedef {import('../playwright-ct-core/types/component').ObjectComponent} ObjectComponent */
 /** @typedef {import('react').FunctionComponent} FrameworkComponent */
 
 /** @type {Map<string, () => Promise<FrameworkComponent>>} */
 const __pwLoaderRegistry = new Map();
-
 /** @type {Map<string, FrameworkComponent>} */
 const __pwRegistry = new Map();
-
 /** @type {Map<Element, import('react-dom/client').Root>} */
 const __pwRootRegistry = new Map();
 
@@ -42,53 +42,53 @@ export function pwRegister(components) {
 
 /**
  * @param {Component} component
+ * @returns {component is JsxComponent | ObjectComponent}
+ */
+function isComponent(component) {
+  return !(typeof component !== 'object' || Array.isArray(component));
+}
+
+/**
+ * @param {Component} component
  */
 async function __pwResolveComponent(component) {
-  if (typeof component !== 'object' || Array.isArray(component))
+  if (!isComponent(component))
     return
 
-  let componentFuncLoader = __pwLoaderRegistry.get(component.type);
-  if (!componentFuncLoader) {
+  let componentFactory = __pwLoaderRegistry.get(component.type);
+  if (!componentFactory) {
     // Lookup by shorthand.
     for (const [name, value] of __pwLoaderRegistry) {
       if (component.type.endsWith(`_${name}`)) {
-        componentFuncLoader = value;
+        componentFactory = value;
         break;
       }
     }
   }
 
-  if(componentFuncLoader)
-    __pwRegistry.set(component.type, await componentFuncLoader())
+  if (!componentFactory && component.type[0].toUpperCase() === component.type[0])
+    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistry.keys()]}`);
+
+  if(componentFactory)
+    __pwRegistry.set(component.type, await componentFactory())
 
   if ('children' in component)
     await Promise.all(component.children.map(child => __pwResolveComponent(child)))
 }
 
+/**
+ * @param {Component} component
+ */
 function __pwRender(component) {
-  if (typeof component !== 'object' || Array.isArray(component))
+  if (!isComponent(component))
     return component;
 
-  let componentFunc = __pwRegistry.get(component.type);
-  if (!componentFunc) {
-    // Lookup by shorthand.
-    for (const [name, value] of __pwRegistry) {
-      if (component.type.endsWith(`_${name}`)) {
-        componentFunc = value;
-        break;
-      }
-    }
-  }
-
-  if (!componentFunc && component.type[0].toUpperCase() === component.type[0])
-    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistry.keys()]}`);
-
-  const componentFuncOrString = componentFunc || component.type;
+  const componentFunc = __pwRegistry.get(component.type);
 
   if (component.kind !== 'jsx')
     throw new Error('Object mount notation is not supported');
 
-  return __pwReact.createElement(componentFuncOrString, component.props, ...component.children.map(child => {
+  return __pwReact.createElement(componentFunc || component.type, component.props, ...component.children.map(child => {
     if (typeof child === 'string')
       return child;
     return __pwRender(child);

--- a/packages/playwright-ct-react17/registerSource.mjs
+++ b/packages/playwright-ct-react17/registerSource.mjs
@@ -24,49 +24,43 @@ import __pwReactDOM from 'react-dom';
 /** @typedef {import('../playwright-ct-core/types/component').Component} Component */
 /** @typedef {import('react').FunctionComponent} FrameworkComponent */
 
-/** @type {Map<string, Promise<FrameworkComponent>} */
-const __pwRegistry = new Map();
+/** @type {Map<string, () => Promise<FrameworkComponent>>} */
+const __pwLoaderRegistry = new Map();
 
 /** @type {Map<string, FrameworkComponent} */
-const __pwRegistryResolved = new Map();
+const __pwRegistry = new Map();
 
 /**
  * @param {{[key: string]: () => Promise<FrameworkComponent>}} components
  */
 export function pwRegister(components) {
   for (const [name, value] of Object.entries(components))
-    __pwRegistry.set(name, value);
+    __pwLoaderRegistry.set(name, value);
 }
 
 /**
  * @param {Component} component
  */
-async function __pwResolveAllComponents(component) {
+async function __pwResolveComponent(component) {
   if (typeof component !== 'object' || Array.isArray(component))
     return
 
-  let __pwRegistryKey = component.type
-
-  let componentLoaderFunc = __pwRegistry.get(component.type);
-
-  if (!componentLoaderFunc) {
+  let componentFuncLoader = __pwLoaderRegistry.get(component.type);
+  if (!componentFuncLoader) {
     // Lookup by shorthand.
-    for (const [name, value] of __pwRegistry) {
+    for (const [name, value] of __pwLoaderRegistry) {
       if (component.type.endsWith(`_${name}`)) {
-        __pwRegistryKey = name
-        componentLoaderFunc = value;
+        componentFuncLoader = value;
         break;
       }
     }
   }
 
-  if(componentLoaderFunc) {
-    __pwRegistryResolved.set(__pwRegistryKey, await componentLoaderFunc())
-  } else {
-    __pwRegistryResolved.set(__pwRegistryKey, component.type)
-  }
+  if(componentFuncLoader)
+    __pwRegistry.set(component.type, await componentFuncLoader())
 
-  await Promise.all(component.children.map(child => __pwResolveAllComponents(child)))
+  if ('children' in component)
+    await Promise.all(component.children.map(child => __pwResolveComponent(child)))
 }
 
 /**
@@ -76,10 +70,10 @@ function __pwRender(component) {
   if (typeof component !== 'object' || Array.isArray(component))
     return component;
 
-  let componentFunc = __pwRegistryResolved.get(component.type);
+  let componentFunc = __pwRegistry.get(component.type);
   if (!componentFunc) {
     // Lookup by shorthand.
-    for (const [name, value] of __pwRegistryResolved) {
+    for (const [name, value] of __pwRegistry) {
       if (component.type.endsWith(`_${name}`)) {
         componentFunc = value;
         break;
@@ -88,7 +82,7 @@ function __pwRender(component) {
   }
 
   if (!componentFunc && component.type[0].toUpperCase() === component.type[0])
-    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistryResolved.keys()]}`);
+    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistry.keys()]}`);
 
   const componentFuncOrString = componentFunc || component.type;
 
@@ -107,7 +101,7 @@ function __pwRender(component) {
 }
 
 window.playwrightMount = async (component, rootElement, hooksConfig) => {
-  await __pwResolveAllComponents(component);
+  await __pwResolveComponent(component);
   let App = () => __pwRender(component);
   for (const hook of window.__pw_hooks_before_mount || []) {
     const wrapper = await hook({ App, hooksConfig });
@@ -127,6 +121,6 @@ window.playwrightUnmount = async rootElement => {
 };
 
 window.playwrightUpdate = async (rootElement, component) => {
-  await __pwResolveAllComponents(component);
+  await __pwResolveComponent(component);
   __pwReactDOM.render(__pwRender(/** @type {Component} */(component)), rootElement);
 };

--- a/packages/playwright-ct-react17/registerSource.mjs
+++ b/packages/playwright-ct-react17/registerSource.mjs
@@ -24,11 +24,14 @@ import __pwReactDOM from 'react-dom';
 /** @typedef {import('../playwright-ct-core/types/component').Component} Component */
 /** @typedef {import('react').FunctionComponent} FrameworkComponent */
 
-/** @type {Map<string, FrameworkComponent>} */
+/** @type {Map<string, Promise<FrameworkComponent>} */
 const __pwRegistry = new Map();
 
+/** @type {Map<string, FrameworkComponent} */
+const __pwRegistryResolved = new Map();
+
 /**
- * @param {{[key: string]: FrameworkComponent}} components
+ * @param {{[key: string]: () => Promise<FrameworkComponent>}} components
  */
 export function pwRegister(components) {
   for (const [name, value] of Object.entries(components))
@@ -38,14 +41,45 @@ export function pwRegister(components) {
 /**
  * @param {Component} component
  */
+async function __pwResolveAllComponents(component) {
+  if (typeof component !== 'object' || Array.isArray(component))
+    return
+
+  let __pwRegistryKey = component.type
+
+  let componentLoaderFunc = __pwRegistry.get(component.type);
+
+  if (!componentLoaderFunc) {
+    // Lookup by shorthand.
+    for (const [name, value] of __pwRegistry) {
+      if (component.type.endsWith(`_${name}`)) {
+        __pwRegistryKey = name
+        componentLoaderFunc = value;
+        break;
+      }
+    }
+  }
+
+  if(componentLoaderFunc) {
+    __pwRegistryResolved.set(__pwRegistryKey, await componentLoaderFunc())
+  } else {
+    __pwRegistryResolved.set(__pwRegistryKey, component.type)
+  }
+
+  await Promise.all(component.children.map(child => __pwResolveAllComponents(child)))
+}
+
+/**
+ * @param {Component} component
+ */
 function __pwRender(component) {
   if (typeof component !== 'object' || Array.isArray(component))
     return component;
 
-  let componentFunc = __pwRegistry.get(component.type);
+  let componentFunc = __pwRegistryResolved.get(component.type);
   if (!componentFunc) {
     // Lookup by shorthand.
-    for (const [name, value] of __pwRegistry) {
+    for (const [name, value] of __pwRegistryResolved) {
       if (component.type.endsWith(`_${name}`)) {
         componentFunc = value;
         break;
@@ -54,7 +88,7 @@ function __pwRender(component) {
   }
 
   if (!componentFunc && component.type[0].toUpperCase() === component.type[0])
-    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistry.keys()]}`);
+    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistryResolved.keys()]}`);
 
   const componentFuncOrString = componentFunc || component.type;
 
@@ -73,6 +107,7 @@ function __pwRender(component) {
 }
 
 window.playwrightMount = async (component, rootElement, hooksConfig) => {
+  await __pwResolveAllComponents(component);
   let App = () => __pwRender(component);
   for (const hook of window.__pw_hooks_before_mount || []) {
     const wrapper = await hook({ App, hooksConfig });
@@ -92,5 +127,6 @@ window.playwrightUnmount = async rootElement => {
 };
 
 window.playwrightUpdate = async (rootElement, component) => {
+  await __pwResolveAllComponents(component);
   __pwReactDOM.render(__pwRender(/** @type {Component} */(component)), rootElement);
 };

--- a/packages/playwright-ct-solid/registerSource.mjs
+++ b/packages/playwright-ct-solid/registerSource.mjs
@@ -23,15 +23,43 @@ import __pwH from 'solid-js/h';
 /** @typedef {import('../playwright-ct-core/types/component').Component} Component */
 /** @typedef {() => import('solid-js').JSX.Element} FrameworkComponent */
 
+/** @type {Map<string, () => Promise<FrameworkComponent>>} */
+const __pwLoaderRegistry = new Map();
+
 /** @type {Map<string, FrameworkComponent>} */
 const __pwRegistry = new Map();
 
 /**
- * @param {{[key: string]: FrameworkComponent}} components
+ * @param {{[key: string]: () => Promise<FrameworkComponent>}} components
  */
 export function pwRegister(components) {
   for (const [name, value] of Object.entries(components))
-    __pwRegistry.set(name, value);
+    __pwLoaderRegistry.set(name, value);
+}
+
+/**
+ * @param {Component} component
+ */
+async function __pwResolveComponent(component) {
+  if (typeof component !== 'object' || Array.isArray(component))
+    return
+
+  let componentFuncLoader = __pwLoaderRegistry.get(component.type);
+  if (!componentFuncLoader) {
+    // Lookup by shorthand.
+    for (const [name, value] of __pwLoaderRegistry) {
+      if (component.type.endsWith(`_${name}`)) {
+        componentFuncLoader = value;
+        break;
+      }
+    }
+  }
+
+  if(componentFuncLoader)
+    __pwRegistry.set(component.type, await componentFuncLoader())
+
+  if ('children' in component)
+    await Promise.all(component.children.map(child => __pwResolveComponent(child)))
 }
 
 function __pwCreateChild(child) {
@@ -78,6 +106,7 @@ function __pwCreateComponent(component) {
 const __pwUnmountKey = Symbol('unmountKey');
 
 window.playwrightMount = async (component, rootElement, hooksConfig) => {
+  await __pwResolveComponent(component);
   let App = () => __pwCreateComponent(component);
   for (const hook of window.__pw_hooks_before_mount || []) {
     const wrapper = await hook({ App, hooksConfig });

--- a/packages/playwright-ct-svelte/registerSource.mjs
+++ b/packages/playwright-ct-svelte/registerSource.mjs
@@ -21,12 +21,13 @@
 import { detach as __pwDetach, insert as __pwInsert, noop as __pwNoop } from 'svelte/internal';
 
 /** @typedef {import('../playwright-ct-core/types/component').Component} Component */
+/** @typedef {import('../playwright-ct-core/types/component').JsxComponent} JsxComponent */
+/** @typedef {import('../playwright-ct-core/types/component').ObjectComponent} ObjectComponent */
 /** @typedef {any} FrameworkComponent */
 /** @typedef {import('svelte').SvelteComponent} SvelteComponent */
 
 /** @type {Map<string, () => Promise<FrameworkComponent>>} */
 const __pwLoaderRegistry = new Map();
-
 /** @type {Map<string, FrameworkComponent>} */
 const __pwRegistry = new Map();
 
@@ -40,24 +41,35 @@ export function pwRegister(components) {
 
 /**
  * @param {Component} component
+ * @returns {component is JsxComponent | ObjectComponent}
+ */
+function isComponent(component) {
+  return !(typeof component !== 'object' || Array.isArray(component));
+}
+
+/**
+ * @param {Component} component
  */
 async function __pwResolveComponent(component) {
-  if (typeof component !== 'object' || Array.isArray(component))
+  if (!isComponent(component))
     return
 
-  let componentFuncLoader = __pwLoaderRegistry.get(component.type);
-  if (!componentFuncLoader) {
+  let componentFactory = __pwLoaderRegistry.get(component.type);
+  if (!componentFactory) {
     // Lookup by shorthand.
     for (const [name, value] of __pwLoaderRegistry) {
-      if (component.type.endsWith(`_${name}`)) {
-        componentFuncLoader = value;
+      if (component.type.endsWith(`_${name}_svelte`)) {
+        componentFactory = value;
         break;
       }
     }
   }
 
-  if(componentFuncLoader)
-    __pwRegistry.set(component.type, await componentFuncLoader())
+  if (!componentFactory)
+    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistry.keys()]}`);
+
+  if(componentFactory)
+    __pwRegistry.set(component.type, await componentFactory())
 
   if ('children' in component)
     await Promise.all(component.children.map(child => __pwResolveComponent(child)))
@@ -98,20 +110,8 @@ const __pwSvelteComponentKey = Symbol('svelteComponent');
 
 window.playwrightMount = async (component, rootElement, hooksConfig) => {
   await __pwResolveComponent(component);
-  let componentCtor = __pwRegistry.get(component.type);
-  if (!componentCtor) {
-    // Lookup by shorthand.
-    for (const [name, value] of __pwRegistry) {
-      if (component.type.endsWith(`_${name}_svelte`)) {
-        componentCtor = value;
-        break;
-      }
-    }
-  }
-
-  if (!componentCtor)
-    throw new Error(`Unregistered component: ${component.type}. Following components are registered: ${[...__pwRegistry.keys()]}`);
-
+  const componentCtor = __pwRegistry.get(component.type);
+  
   if (component.kind !== 'object')
     throw new Error('JSX mount notation is not supported');
 

--- a/packages/playwright-ct-vue/registerSource.mjs
+++ b/packages/playwright-ct-vue/registerSource.mjs
@@ -24,15 +24,43 @@ import * as __pwVue from 'vue';
 /** @typedef {import('@playwright/test/types/experimentalComponent').Component} Component */
 /** @typedef {import('vue').Component} FrameworkComponent */
 
+/** @type {Map<string, () => Promise<FrameworkComponent>>} */
+const __pwLoaderRegistry = new Map();
+
 /** @type {Map<string, FrameworkComponent>} */
 const __pwRegistry = new Map();
 
 /**
- * @param {{[key: string]: FrameworkComponent}} components
+ * @param {{[key: string]: () => Promise<FrameworkComponent>}} components
  */
 export function pwRegister(components) {
   for (const [name, value] of Object.entries(components))
-    __pwRegistry.set(name, value);
+    __pwLoaderRegistry.set(name, value);
+}
+
+/**
+ * @param {Component} component
+ */
+async function __pwResolveComponent(component) {
+  if (typeof component !== 'object' || Array.isArray(component))
+    return
+
+  let componentFuncLoader = __pwLoaderRegistry.get(component.type);
+  if (!componentFuncLoader) {
+    // Lookup by shorthand.
+    for (const [name, value] of __pwLoaderRegistry) {
+      if (component.type.endsWith(`_${name}`)) {
+        componentFuncLoader = value;
+        break;
+      }
+    }
+  }
+
+  if(componentFuncLoader)
+    __pwRegistry.set(component.type, await componentFuncLoader())
+
+  if ('children' in component)
+    await Promise.all(component.children.map(child => __pwResolveComponent(child)))
 }
 
 const __pwAllListeners = new Map();
@@ -223,6 +251,7 @@ const __pwAppKey = Symbol('appKey');
 const __pwWrapperKey = Symbol('wrapperKey');
 
 window.playwrightMount = async (component, rootElement, hooksConfig) => {
+  await __pwResolveComponent(component);
   const app = __pwCreateApp({
     render: () => {
       const wrapper = __pwCreateWrapper(component);
@@ -248,7 +277,8 @@ window.playwrightUnmount = async rootElement => {
   app.unmount();
 };
 
-window.playwrightUpdate = async (rootElement, options) => {
+window.playwrightUpdate = async (rootElement, component) => {
+  await __pwResolveComponent(component);
   const wrapper = rootElement[__pwWrapperKey];
   if (!wrapper)
     throw new Error('Component was not mounted');
@@ -256,7 +286,7 @@ window.playwrightUpdate = async (rootElement, options) => {
   if (!wrapper.component)
     throw new Error('Updating a native HTML element is not supported');
   
-  const { slots, listeners, props } = __pwCreateComponent(options);
+  const { slots, listeners, props } = __pwCreateComponent(component);
 
   wrapper.component.slots = __pwWrapFunctions(slots);
   __pwAllListeners.set(wrapper, listeners);

--- a/packages/playwright-ct-vue2/registerSource.mjs
+++ b/packages/playwright-ct-vue2/registerSource.mjs
@@ -220,7 +220,7 @@ window.playwrightUpdate = async (rootElement, component) => {
     throw new Error('Component was not mounted');
 
   const componentInstance = wrapper.componentInstance;
-  if (!component)
+  if (!componentInstance)
     throw new Error('Updating a native HTML element is not supported');
 
   const { nodeData, slots } = __pwCreateComponent(component);

--- a/packages/playwright-ct-vue2/registerSource.mjs
+++ b/packages/playwright-ct-vue2/registerSource.mjs
@@ -23,15 +23,43 @@ import __pwVue, { h as __pwH } from 'vue';
 /** @typedef {import('../playwright-ct-core/types/component').Component} Component */
 /** @typedef {import('vue').Component} FrameworkComponent */
 
+/** @type {Map<string, () => Promise<FrameworkComponent>>} */
+const __pwLoaderRegistry = new Map();
+
 /** @type {Map<string, FrameworkComponent>} */
 const __pwRegistry = new Map();
 
 /**
- * @param {{[key: string]: FrameworkComponent}} components
+ * @param {{[key: string]: () => Promise<FrameworkComponent>}} components
  */
 export function pwRegister(components) {
   for (const [name, value] of Object.entries(components))
-    __pwRegistry.set(name, value);
+    __pwLoaderRegistry.set(name, value);
+}
+
+/**
+ * @param {Component} component
+ */
+async function __pwResolveComponent(component) {
+  if (typeof component !== 'object' || Array.isArray(component))
+    return
+
+  let componentFuncLoader = __pwLoaderRegistry.get(component.type);
+  if (!componentFuncLoader) {
+    // Lookup by shorthand.
+    for (const [name, value] of __pwLoaderRegistry) {
+      if (component.type.endsWith(`_${name}`)) {
+        componentFuncLoader = value;
+        break;
+      }
+    }
+  }
+
+  if(componentFuncLoader)
+    __pwRegistry.set(component.type, await componentFuncLoader())
+
+  if ('children' in component)
+    await Promise.all(component.children.map(child => __pwResolveComponent(child)))
 }
 
 /**
@@ -157,6 +185,7 @@ const instanceKey = Symbol('instanceKey');
 const wrapperKey = Symbol('wrapperKey');
 
 window.playwrightMount = async (component, rootElement, hooksConfig) => {
+  await __pwResolveComponent(component);
   let options = {};
   for (const hook of window.__pw_hooks_before_mount || [])
     options = await hook({ hooksConfig, Vue: __pwVue });
@@ -184,28 +213,29 @@ window.playwrightUnmount = async rootElement => {
   component.$el.remove();
 };
 
-window.playwrightUpdate = async (element, options) => {
-  const wrapper = /** @type {any} */(element)[wrapperKey];
+window.playwrightUpdate = async (rootElement, component) => {
+  await __pwResolveComponent(component);
+  const wrapper = /** @type {any} */(rootElement)[wrapperKey];
   if (!wrapper)
     throw new Error('Component was not mounted');
 
-  const component = wrapper.componentInstance;
+  const componentInstance = wrapper.componentInstance;
   if (!component)
     throw new Error('Updating a native HTML element is not supported');
 
-  const { nodeData, slots } = __pwCreateComponent(options);
+  const { nodeData, slots } = __pwCreateComponent(component);
 
   for (const [name, value] of Object.entries(nodeData.on || {})) {
-    component.$on(name, value);
-    component.$listeners[name] = value;
+    componentInstance.$on(name, value);
+    componentInstance.$listeners[name] = value;
   }
 
-  Object.assign(component.$scopedSlots, nodeData.scopedSlots);
-  component.$slots.default = slots;
+  Object.assign(componentInstance.$scopedSlots, nodeData.scopedSlots);
+  componentInstance.$slots.default = slots;
 
   for (const [key, value] of Object.entries(nodeData.props || {}))
-    component[key] = value;
+    componentInstance[key] = value;
 
   if (!Object.keys(nodeData.props || {}).length)
-    component.$forceUpdate();
+    componentInstance.$forceUpdate();
 };

--- a/packages/web/playwright/index.ts
+++ b/packages/web/playwright/index.ts
@@ -17,3 +17,4 @@
 import '../src/common.css';
 import '../src/theme.ts';
 import '../src/third_party/vscode/codicon.css';
+import '../src/third_party/vscode/colors.css';


### PR DESCRIPTION
> "Code splitting ensures that the test JS / CSS is the minimal required for a test to run in isolation, which should ease up memory and CPU when executing tests.
>
> Code splitting also introduces script boundaries, which means that a runtime error in the global code of another component would not lead to the entire test suite blowing up.
>
> This comes at a price of a slight increase in bundling time if your module graph is large and you have a lot of components, but this should be offset by the fact that once compilation happens, running individual tests is a lot faster.
>
> When running with an without code-splitting on a large real-world test suite at Atlassian with 900+ tests, I noticed that the average time per test dropped from ~5 seconds / test to < 2 seconds / test when code-splitting. Browsers also consumed less memory and CPU which meant we could push for better parallelisation on the same hardware."

~ https://github.com/pastelsky