### PR TITLE
test: add test for viewport scaling

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1400",
+      "revision": "1399",
       "installByDefault": true,
       "browserVersion": "112.0"
     },

--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1399",
+      "revision": "1400",
       "installByDefault": true,
       "browserVersion": "112.0"
     },

--- a/tests/library/headful.spec.ts
+++ b/tests/library/headful.spec.ts
@@ -89,8 +89,8 @@ it('should dispatch click events to oversized viewports', async ({ page, browser
   const height = 3067;
   await page.setViewportSize({ width, height });
   await page.evaluate(() => {
-    window.events = [];
-    window.addEventListener('click', event => window.events.push({ x: event.clientX, y: event.clientY }), false);
+    window['events'] = [];
+    window.addEventListener('click', event => window['events'].push({ x: event.clientX, y: event.clientY }), false);
   });
   const expectedEvents = [];
   // Allow a little padding from the edges of viewport.
@@ -102,7 +102,7 @@ it('should dispatch click events to oversized viewports', async ({ page, browser
     await page.mouse.down();
     await page.mouse.up();
   }
-  const actualEvents = await page.evaluate(() => window.events);
+  const actualEvents = await page.evaluate(() => window['events']);
   expect(expectedEvents).toEqual(actualEvents);
 });
 


### PR DESCRIPTION
This test makes sure that the viewport scaling approach we tried in Firefox doesn't work since coordinates are rounded to integers internally before being dispatched to the renderer. 

https://github.com/microsoft/playwright/issues/22082