### PR TITLE
Revert "fix(inspector): fix leaking event listeners (#22535)"

### DIFF
--- a/packages/web/src/components/codeMirrorWrapper.tsx
+++ b/packages/web/src/components/codeMirrorWrapper.tsx
@@ -107,7 +107,7 @@ export const CodeMirrorWrapper: React.FC<SourceProps> = ({
   React.useEffect(() => {
     if (!codemirror)
       return;
-    codemirror.off('change', (codemirror as any)[listenerSymbol]);
+    codemirror.off('change', (codemirror as any).listenerSymbol);
     (codemirror as any)[listenerSymbol] = undefined;
     if (onChange) {
       (codemirror as any)[listenerSymbol] = () => onChange(codemirror.getValue());


### PR DESCRIPTION
This reverts commit 58b3c31f3e57ad2429e61798238063679e7f668d.

Reason for revert: UI rendering hits an infinite tight loop.
Reproduces locally with `npm run ctest pause.spec:357` (test hangs)
Also observed on dashboard:

<img width="1467" alt="image" src="https://user-images.githubusercontent.com/746130/233541521-1f30338d-dd83-405c-bb0d-c890611c33e3.png">


https://github.com/microsoft/playwright/issues/22348
