### PR TITLE
chore: attempt to fix firefox-beta WebGL tests on MacOS 12.6

### DIFF
--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -98,7 +98,9 @@ export class Firefox extends BrowserType {
 
 // Prefs for quick fixes that didn't make it to the build.
 // Should all be moved to `playwright.cfg`.
-const kBandaidFirefoxUserPrefs = {};
+const kBandaidFirefoxUserPrefs = {
+  'webgl.forbid-software': false
+};
 
 const kDisableFissionFirefoxUserPrefs = {
   'browser.tabs.remote.useCrossOriginEmbedderPolicy': false,


### PR DESCRIPTION
Looks like https://phabricator.services.mozilla.com/D164016
disabled software rendering.

If Firefox-beta passes on MacOS, then this bandaid setting will be migrated to the firefox-beta default settings. 
