### PR TITLE
chore: cleanup bandaid firefox pref

### DIFF
--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -98,9 +98,7 @@ export class Firefox extends BrowserType {
 
 // Prefs for quick fixes that didn't make it to the build.
 // Should all be moved to `playwright.cfg`.
-const kBandaidFirefoxUserPrefs = {
-  'webgl.forbid-software': false
-};
+const kBandaidFirefoxUserPrefs = {};
 
 const kDisableFissionFirefoxUserPrefs = {
   'browser.tabs.remote.useCrossOriginEmbedderPolicy': false,


### PR DESCRIPTION
This patch removes the bandaid preferences that got migrated
to the build.
