### PR TITLE
Remove '--disable-sync' arg for pw android sessions

### DIFF
--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -35,7 +35,7 @@ import { gracefullyCloseSet } from '../../utils/processLauncher';
 import { TimeoutSettings } from '../../common/timeoutSettings';
 import type * as channels from '@protocol/channels';
 import { SdkObject, serverSideCallMetadata } from '../instrumentation';
-import { chromiumSwitches } from '../chromium/chromiumSwitches';
+import { androidChromiumSwitches } from '../chromium/chromiumSwitches';
 import { registry } from '../registry';
 
 const ARTIFACTS_FOLDER = path.join(os.tmpdir(), 'playwright-artifacts-');
@@ -278,7 +278,7 @@ export class AndroidDevice extends SdkObject {
       '--disable-fre',
       '--no-default-browser-check',
       `--remote-debugging-socket-name=${socketName}`,
-      ...chromiumSwitches,
+      ...androidChromiumSwitches,
       ...this._innerDefaultArgs(options)
     ];
     return chromeArguments;

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -48,7 +48,7 @@ import type http from 'http';
 import { registry } from '../registry';
 import { ManualPromise } from '../../utils/manualPromise';
 import { validateBrowserContextOptions } from '../browserContext';
-import { chromiumSwitches } from './chromiumSwitches';
+import { desktopChromiumSwitches } from './chromiumSwitches';
 
 const ARTIFACTS_FOLDER = path.join(os.tmpdir(), 'playwright-artifacts-');
 
@@ -283,7 +283,7 @@ export class Chromium extends BrowserType {
       throw new Error('Playwright manages remote debugging connection itself.');
     if (args.find(arg => !arg.startsWith('-')))
       throw new Error('Arguments can not specify page to be opened');
-    const chromeArguments = [...chromiumSwitches];
+    const chromeArguments = [...desktopChromiumSwitches];
 
     if (os.platform() === 'darwin') {
       // See https://github.com/microsoft/playwright/issues/7362

--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -17,7 +17,7 @@
 
 // No dependencies as it is used from the Electron loader.
 
-export const chromiumSwitches = [
+const defaultChromiumSwitches = [
   '--disable-field-trial-config', // https://source.chromium.org/chromium/chromium/src/+/main:testing/variations/README.md
   '--disable-background-networking',
   '--enable-features=NetworkService,NetworkServiceInProcess',
@@ -41,7 +41,6 @@ export const chromiumSwitches = [
   '--disable-popup-blocking',
   '--disable-prompt-on-repost',
   '--disable-renderer-backgrounding',
-  '--disable-sync',
   '--force-color-profile=srgb',
   '--metrics-recording-only',
   '--no-first-run',
@@ -52,3 +51,7 @@ export const chromiumSwitches = [
   '--no-service-autorun',
   '--export-tagged-pdf'
 ];
+
+export const androidChromiumSwitches = [...defaultChromiumSwitches];
+
+export const desktopChromiumSwitches = [...defaultChromiumSwitches, '--disable-sync'];

--- a/packages/playwright-core/src/server/electron/loader.ts
+++ b/packages/playwright-core/src/server/electron/loader.ts
@@ -15,13 +15,13 @@
  */
 
 const { app } = require('electron');
-const { chromiumSwitches } = require('../chromium/chromiumSwitches');
+const { desktopChromiumSwitches } = require('../chromium/chromiumSwitches');
 
 // [Electron, -r, loader.js, --inspect=0, --remote-debugging-port=0, ...args]
 process.argv.splice(1, 4);
 
 
-for (const arg of chromiumSwitches) {
+for (const arg of desktopChromiumSwitches) {
   const match = arg.match(/--([^=]*)=?(.*)/)!;
   app.commandLine.appendSwitch(match[1], match[2]);
 }

--- a/tests/webview2/webView2Test.ts
+++ b/tests/webview2/webView2Test.ts
@@ -23,7 +23,7 @@ import type { TraceViewerFixtures } from '../config/traceViewerFixtures';
 import { traceViewerFixtures } from '../config/traceViewerFixtures';
 export { expect } from '@playwright/test';
 import { TestChildProcess } from '../config/commonFixtures';
-import { chromiumSwitches } from '../../packages/playwright-core/lib/server/chromium/chromiumSwitches';
+import { desktopChromiumSwitches } from '../../packages/playwright-core/lib/server/chromium/chromiumSwitches';
 
 export const webView2Test = baseTest.extend<TraceViewerFixtures>(traceViewerFixtures).extend<PageTestFixtures, PageWorkerFixtures>({
   browserVersion: [process.env.PWTEST_WEBVIEW2_CHROMIUM_VERSION, { scope: 'worker' }],
@@ -39,7 +39,7 @@ export const webView2Test = baseTest.extend<TraceViewerFixtures>(traceViewerFixt
       shell: true,
       env: {
         ...process.env,
-        WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS: `--remote-debugging-port=${cdpPort} ${chromiumSwitches.join(' ')}`,
+        WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS: `--remote-debugging-port=${cdpPort} ${desktopChromiumSwitches.join(' ')}`,
         WEBVIEW2_USER_DATA_FOLDER: path.join(fs.realpathSync.native(os.tmpdir()), `playwright-webview2-tests/user-data-dir-${testInfo.workerIndex}`),
       }
     });


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/22560

**What's the problem?**
Playwright Android is not working with newer chrome versions. Verified the behaviour with chrome v111.

**What's the fix?**
It seems that `--disable-sync` arg is causing the problem here. After removing the flag, chrome launches correctly. Playwright currently has hardcoded chrome args stored at `packages/playwright-core/src/server/chromium/chromiumSwitches.ts`. This PR exports two vars, one for android and one for desktop sessions.

The PR fixes the above mentioned issue and has been verified locally with chrome v111 and older chrome versions such as v108 and v96 (where `--disable-sync` arg was working).