### PR TITLE
Add optional peer depedency on @playwright/test to playwright-core

### DIFF
--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -37,5 +37,13 @@
   "types": "types/types.d.ts",
   "bin": {
     "playwright": "./cli.js"
+  },
+  "peerDependencies": {
+    "@playwright/test": "*"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
In a monorepo using pnpm that has multiple Playwright versions, pnpm will hoist an arbitrary version of `@playwright/test`, which will be the version `playwright-core` gets from `require.resolve`. Leading to the infamous:

```
╔═════════════════════════════════════════════════════════════════════════════════════════════════════════════╗
║ Playwright Test integrity check failed:                                                                     ║
║ You have @playwright/test version '1.32.2' and 'playwright-core' version '1.32.3' installed!                ║
║ You probably added 'playwright-core' into your package.json by accident, remove it and re-run 'npm install' ║
╚═════════════════════════════════════════════════════════════════════════════════════════════════════════════╝
```

So that pnpm knows that `playwright-core` is going to optionally import `@playwright/test`, and as such link the correct `@playwright/test` version alongside it, it needs to be an optional peer dependency.