### PR TITLE
devops: bump Node.js versions 16->18

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
     - run: npm run build

--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         registry-url: 'https://registry.npmjs.org'
     - run: npm i -g npm@8
     - run: npm ci
@@ -75,7 +75,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - name: Deploy Canary
       run: bash utils/build/deploy-trace-viewer.sh --canary

--- a/.github/workflows/publish_release_docker.yml
+++ b/.github/workflows/publish_release_docker.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         registry-url: 'https://registry.npmjs.org'
     - uses: azure/docker-login@v1
       with:

--- a/.github/workflows/publish_release_driver.yml
+++ b/.github/workflows/publish_release_driver.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         registry-url: 'https://registry.npmjs.org'
     - run: npm i -g npm@8
     - run: npm ci

--- a/.github/workflows/publish_release_npm.yml
+++ b/.github/workflows/publish_release_npm.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         registry-url: 'https://registry.npmjs.org'
     - run: npm i -g npm@8
     - run: npm ci

--- a/.github/workflows/publish_release_traceviewer.yml
+++ b/.github/workflows/publish_release_traceviewer.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - name: Deploy Stable
       run: bash utils/build/deploy-trace-viewer.sh --stable

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
     - run: npm run build

--- a/.github/workflows/tests_components.yml
+++ b/.github/workflows/tests_components.yml
@@ -29,8 +29,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        # Component tests require Node.js 16+ (they require ESM via TS)
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
     - run: npm run build

--- a/.github/workflows/tests_electron.yml
+++ b/.github/workflows/tests_electron.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -33,13 +33,13 @@ jobs:
       matrix:
         browser: [chromium, firefox, webkit]
         os: [ubuntu-22.04]
-        node-version: [14]
+        node-version: [18]
         include:
           - os: ubuntu-22.04
             node-version: 16
             browser: chromium
           - os: ubuntu-22.04
-            node-version: 18
+            node-version: 20
             browser: chromium
     runs-on: ${{ matrix.os }}
     steps:
@@ -76,7 +76,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -102,12 +102,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [16]
+        node-version: [18]
         include:
           - os: ubuntu-latest
-            node-version: 14
+            node-version: 16
           - os: ubuntu-latest
-            node-version: 18
+            node-version: 20
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -135,8 +135,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        # Component tests require Node.js 16+ (they require ESM via TS)
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -158,7 +157,7 @@ jobs:
         - macos-latest
         - windows-latest
         node_version:
-        - "^14.1.0"  # pre 14.1, zip extraction was broken (https://github.com/microsoft/playwright/issues/1988)
+        - 18
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -57,14 +57,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-12, macos-13]
         browser: [chromium, firefox, webkit]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -93,7 +93,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -120,9 +120,9 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          node_version: "^18.0.0"
+          node_version: 16
         - os: ubuntu-latest
-          node_version: "^16.0.0"
+          node_version: 20
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
@@ -155,7 +155,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -187,7 +187,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -223,7 +223,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -246,7 +246,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -272,7 +272,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -299,7 +299,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -329,7 +329,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -364,7 +364,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -395,7 +395,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -421,7 +421,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -448,7 +448,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -474,7 +474,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -501,7 +501,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -528,7 +528,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -554,7 +554,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -580,7 +580,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -607,7 +607,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -633,7 +633,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -659,7 +659,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -686,7 +686,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -712,7 +712,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -738,7 +738,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -765,7 +765,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:
@@ -791,7 +791,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
     - run: npm run build

--- a/.github/workflows/tests_video.yml
+++ b/.github/workflows/tests_video.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: npm i -g npm@8
     - run: npm ci
       env:

--- a/.github/workflows/trigger_build_chromium_with_symbols.yml
+++ b/.github/workflows/trigger_build_chromium_with_symbols.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: '18'
     - name: Get Chromium revision
       id: chromium-version
       run: |


### PR DESCRIPTION
Its like https://github.com/microsoft/playwright/pull/20800 2 months ago.

Fixes https://github.com/microsoft/playwright/issues/22582.