### PR TITLE
chore: implement modifiers as hooks

### DIFF
--- a/packages/playwright-test/src/common/fixtures.ts
+++ b/packages/playwright-test/src/common/fixtures.ts
@@ -199,12 +199,16 @@ export class FixturePool {
     return hash.digest('hex');
   }
 
-  validateFunction(fn: Function, prefix: string, location: Location) {
+  validateFunction(fn: Function, prefix: string, location: Location): { dependsOnWorkerFixturesOnly: boolean } {
+    let dependsOnWorkerFixturesOnly = true;
     for (const name of fixtureParameterNames(fn, location, e => this._onLoadError(e))) {
       const registration = this.registrations.get(name);
       if (!registration)
         this._addLoadError(`${prefix} has unknown parameter "${name}".`, location);
+      if (registration?.scope === 'test')
+        dependsOnWorkerFixturesOnly = false;
     }
+    return { dependsOnWorkerFixturesOnly };
   }
 
   resolveDependency(registration: FixtureRegistration, name: string): FixtureRegistration | undefined {

--- a/packages/playwright-test/src/common/poolBuilder.ts
+++ b/packages/playwright-test/src/common/poolBuilder.ts
@@ -63,8 +63,11 @@ export class PoolBuilder {
         pool = new FixturePool(parent._use, e => this._handleLoadError(e, testErrors), pool, parent._type === 'describe');
       for (const hook of parent._hooks)
         pool.validateFunction(hook.fn, hook.type + ' hook', hook.location);
-      for (const modifier of parent._modifiers)
-        pool.validateFunction(modifier.fn, modifier.type + ' modifier', modifier.location);
+      for (const modifier of parent._modifiers) {
+        // Turn modifiers into hooks.
+        const { dependsOnWorkerFixturesOnly } = pool.validateFunction(modifier.fn, modifier.type + ' modifier', modifier.location);
+        parent._hooks.unshift({ type: dependsOnWorkerFixturesOnly ? 'beforeAll' : 'beforeEach', modifier: { type: modifier.type, description: modifier.description }, fn: modifier.fn, location: modifier.location });
+      }
     }
 
     pool.validateFunction(test.fn, 'Test', test.location);

--- a/packages/playwright-test/src/common/test.ts
+++ b/packages/playwright-test/src/common/test.ts
@@ -40,12 +40,22 @@ export type Modifier = {
   description: string | undefined
 };
 
+type Hook = {
+  type: 'beforeEach' | 'afterEach' | 'beforeAll' | 'afterAll',
+  fn: Function,
+  location: Location,
+  modifier?: {
+    type: 'slow' | 'fixme' | 'skip' | 'fail',
+    description: string | undefined,
+  },
+};
+
 export class Suite extends Base implements SuitePrivate {
   location?: Location;
   parent?: Suite;
   _use: FixturesWithLocation[] = [];
   _entries: (Suite | TestCase)[] = [];
-  _hooks: { type: 'beforeEach' | 'afterEach' | 'beforeAll' | 'afterAll', fn: Function, location: Location }[] = [];
+  _hooks: Hook[] = [];
   _timeout: number | undefined;
   _retries: number | undefined;
   _staticAnnotations: Annotation[] = [];
@@ -171,7 +181,7 @@ export class Suite extends Base implements SuitePrivate {
       staticAnnotations: this._staticAnnotations.slice(),
       modifiers: this._modifiers.slice(),
       parallelMode: this._parallelMode,
-      hooks: this._hooks.map(h => ({ type: h.type, location: h.location })),
+      hooks: this._hooks.map(h => ({ type: h.type, modifier: h.modifier, location: h.location })),
     };
   }
 
@@ -185,7 +195,7 @@ export class Suite extends Base implements SuitePrivate {
     suite._staticAnnotations = data.staticAnnotations;
     suite._modifiers = data.modifiers;
     suite._parallelMode = data.parallelMode;
-    suite._hooks = data.hooks.map((h: any) => ({ type: h.type, location: h.location, fn: () => { } }));
+    suite._hooks = data.hooks.map((h: any) => ({ type: h.type, modifier: h.modifier, location: h.location, fn: () => { } }));
     return suite;
   }
 
@@ -194,6 +204,7 @@ export class Suite extends Base implements SuitePrivate {
     const suite = Suite._parse(data);
     suite._use = this._use.slice();
     suite._hooks = this._hooks.slice();
+    suite._modifiers = this._modifiers.slice();
     suite._fullProject = this._fullProject;
     return suite;
   }

--- a/packages/playwright-test/src/worker/fixtureRunner.ts
+++ b/packages/playwright-test/src/worker/fixtureRunner.ts
@@ -246,16 +246,6 @@ export class FixtureRunner {
     await fixture.setup(testInfo);
     return fixture;
   }
-
-  dependsOnWorkerFixturesOnly(fn: Function, location: Location): boolean {
-    const names = getRequiredFixtureNames(fn, location);
-    for (const name of names) {
-      const registration = this.pool!.registrations.get(name)!;
-      if (registration.scope !== 'worker')
-        return false;
-    }
-    return true;
-  }
 }
 
 function getRequiredFixtureNames(fn: Function, location?: Location) {

--- a/tests/playwright-test/test-modifiers.spec.ts
+++ b/tests/playwright-test/test-modifiers.spec.ts
@@ -526,7 +526,7 @@ test('should not run hooks if modifier throws', async ({ runInlineTest }) => {
         throw new Error('Oh my');
       });
       test.beforeAll(() => {
-        console.log('%%beforeEach');
+        console.log('%%beforeAll');
       });
       test.beforeEach(() => {
         console.log('%%beforeEach');
@@ -535,7 +535,7 @@ test('should not run hooks if modifier throws', async ({ runInlineTest }) => {
         console.log('%%afterEach');
       });
       test.afterAll(() => {
-        console.log('%%beforeEach');
+        console.log('%%afterAll');
       });
       test('skipped1', () => {
         console.log('%%skipped1');


### PR DESCRIPTION
This will make it easier to support "beforeAll" modifiers that will be equivalent to "beforeAll" hooks.