### PR TITLE
docs(trace-viewer-intro): fix code snippet for C#

### DIFF
--- a/docs/src/trace-viewer-intro-csharp-java-python.md
+++ b/docs/src/trace-viewer-intro-csharp-java-python.md
@@ -62,24 +62,24 @@ context.tracing.stop(path = "trace.zip")
 ```
 
 ```csharp
-await using var browser = playwright.Chromium.LaunchAsync();
+await using var browser = await Playwright.Chromium.LaunchAsync();
 await using var context = await browser.NewContextAsync();
 
 // Start tracing before creating / navigating a page.
 await context.Tracing.StartAsync(new()
 {
-  Screenshots = true,
-  Snapshots = true,
-  Sources = true
+    Screenshots = true,
+    Snapshots = true,
+    Sources = true
 });
 
-var page = context.NewPageAsync();
+var page = await context.NewPageAsync();
 await page.GotoAsync("https://playwright.dev");
 
 // Stop tracing and export it into a zip archive.
 await context.Tracing.StopAsync(new()
 {
-  Path = "trace.zip"
+    Path = "trace.zip"
 });
 ```
 


### PR DESCRIPTION
Following the bug https://github.com/microsoft/playwright-dotnet/issues/2562, I changed the csharp snippet code to help reader to "copy/paste" a good codeß

Fixes https://github.com/microsoft/playwright-dotnet/issues/2562