### PR TITLE
chore: test on Node.js 20

### DIFF
--- a/.github/workflows/tests_components.yml
+++ b/.github/workflows/tests_components.yml
@@ -29,7 +29,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        # Component tests require Node.js 16+ (they require ESM via TS)
         node-version: 16
     - run: npm i -g npm@8
     - run: npm ci

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -38,6 +38,9 @@ jobs:
           - os: ubuntu-22.04
             node-version: 18
             browser: chromium
+          - os: ubuntu-22.04
+            node-version: 20
+            browser: chromium
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -241,7 +244,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        # Component tests require Node.js 16+ (they require ESM via TS)
         node-version: 16
     - run: npm ci
       env:

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -102,9 +102,9 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          node_version: "^18.0.0"
+          node_version: 18
         - os: ubuntu-latest
-          node_version: "^16.0.0"
+          node_version: 20
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3

--- a/tests/config/testserver/index.ts
+++ b/tests/config/testserver/index.ts
@@ -256,7 +256,7 @@ export class TestServer {
     if (err) {
       response.statusCode = 404;
       response.setHeader('Content-Type', 'text/plain');
-      response.end(`File not found: ${filePath}`);
+      response.end(request.method !== 'HEAD' ? `File not found: ${filePath}` : null);
       return;
     }
     const extension = filePath.substring(filePath.lastIndexOf('.') + 1);
@@ -269,9 +269,9 @@ export class TestServer {
       const result = await gzipAsync(data);
       // The HTTP transaction might be already terminated after async hop here.
       if (!response.writableEnded)
-        response.end(result);
+        response.end(request.method !== 'HEAD' ? result : null);
     } else {
-      response.end(data);
+      response.end(request.method !== 'HEAD' ? data : null);
     }
   }
 

--- a/tests/library/browsercontext-storage-state.spec.ts
+++ b/tests/library/browsercontext-storage-state.spec.ts
@@ -209,5 +209,8 @@ it('should handle malformed file', async ({ contextFactory }, testInfo) => {
   const error = await contextFactory({
     storageState: file,
   }).catch(e => e);
-  expect(error.message).toContain(`Error reading storage state from ${file}:\nUnexpected token o in JSON at position 1`);
+  if (+process.versions.node.split('.')[0] > 18)
+    expect(error.message).toContain(`Error reading storage state from ${file}:\nUnexpected token 'o', \"not-json\" is not valid JSON`);
+  else
+    expect(error.message).toContain(`Error reading storage state from ${file}:\nUnexpected token o in JSON at position 1`);
 });


### PR DESCRIPTION
As per offline discussion we keep the majority of our bots on Node.js 16 for now, since thats where most of our users are.

This patch does remove Node.js 14 bots, since 14 goes EOL before our next release, see [here](https://github.com/nodejs/Release#release-schedule) and adds Node.js 20 bots.

Node.js 20 tests are failing since https://github.com/nodejs/node/commit/5ec0f39a7a565b5a82fe90ba9f095731a7b8b005 so we had to adjust TestServer a bit.

Fixes https://github.com/microsoft/playwright/issues/22582