### PR TITLE
chore(chromium): remove --disable-sync CLI switch

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -41,7 +41,6 @@ export const chromiumSwitches = [
   '--disable-popup-blocking',
   '--disable-prompt-on-repost',
   '--disable-renderer-backgrounding',
-  '--disable-sync',
   '--force-color-profile=srgb',
   '--metrics-recording-only',
   '--no-first-run',


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/pull/22583
Fixes https://github.com/microsoft/playwright/issues/22560

Not relevant anymore, it only takes effect when profiles is signed in.

See https://bugs.chromium.org/p/chromium/issues/detail?id=1439737.