### PR TITLE
chore(ct): optional framework plugin factory

### DIFF
--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -47,7 +47,7 @@ const compiledReactRE = /(const|var)\s+React\s*=/;
 
 export function createPlugin(
   registerSourceFile: string,
-  frameworkPluginFactory: () => Promise<Plugin>): TestRunnerPlugin {
+  frameworkPluginFactory?: () => Promise<Plugin>): TestRunnerPlugin {
   let configDir: string;
   let config: FullConfig;
   return {
@@ -127,9 +127,10 @@ export function createPlugin(
       }
       const { build, preview } = require('vite');
       // Build config unconditionally, either build or build & preview will use it.
-      viteConfig.plugins = viteConfig.plugins || [
-        await frameworkPluginFactory()
-      ];
+      viteConfig.plugins ??= [];
+      if (frameworkPluginFactory && !viteConfig.plugins.length)
+        viteConfig.plugins = [await frameworkPluginFactory()];
+
       // But only add out own plugin when we actually build / transform.
       if (sourcesDirty)
         viteConfig.plugins.push(vitePlugin(registerSource, relativeTemplateDir, buildInfo, componentRegistry));


### PR DESCRIPTION
Made it optional because [native web components](https://github.com/sand4rt/playwright-ct-web/blob/master/playwright-ct-web/index.js#L26) don't have a Vite plugin aka. `frameworkPluginFactory`. I am now passing an empty function, but would like to remove that:

```typescript
function plugin() {
  const { createPlugin } = require('@playwright/test/lib/plugins/vitePlugin');
  return createPlugin(
    path.join(__dirname, 'registerSource.mjs'),
    () => {} // <-- empty frameworkPluginFactory
  );
};
```