### PR TITLE
feat: `project.teardown` that runs after all dependents have finished

### DIFF
--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -57,7 +57,7 @@ behaves as if they were not specified.
 Using dependencies allows global setup to produce traces and other artifacts,
 see the setup steps in the test report, etc.
 
-For example:
+**Usage**
 
 ```js
 // playwright.config.ts
@@ -197,6 +197,52 @@ The maximum number of retry attempts given to failed tests. Learn more about [te
 Use [`method: Test.describe.configure`] to change the number of retries for a specific file or a group of tests.
 
 Use [`property: TestConfig.retries`] to change this option for all projects.
+
+## property: TestProject.teardown
+* since: v1.34
+- type: ?<[string]>
+
+Name of a project that needs to run after this and any dependent projects have finished. Teardown is useful to cleanup any resources acquired by this project.
+
+Passing `--no-deps` argument ignores [`property: TestProject.teardown`] and behaves as if it was not specified.
+
+**Usage**
+
+A common pattern is a "setup" dependency that has a corresponding "teardown":
+
+```js
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /global.setup\.ts/,
+      teardown: 'teardown',
+    },
+    {
+      name: 'teardown',
+      testMatch: /global.teardown\.ts/,
+    },
+    {
+      name: 'chromium',
+      use: devices['Desktop Chrome'],
+      dependencies: ['setup'],
+    },
+    {
+      name: 'firefox',
+      use: devices['Desktop Firefox'],
+      dependencies: ['setup'],
+    },
+    {
+      name: 'webkit',
+      use: devices['Desktop Safari'],
+      dependencies: ['setup'],
+    },
+  ],
+});
+```
 
 ## property: TestProject.testDir
 * since: v1.10

--- a/packages/playwright-test/src/common/config.ts
+++ b/packages/playwright-test/src/common/config.ts
@@ -152,6 +152,7 @@ export class FullProjectInternal {
   readonly snapshotPathTemplate: string;
   id = '';
   deps: FullProjectInternal[] = [];
+  teardown: FullProjectInternal | undefined;
 
   constructor(configDir: string, config: Config, fullConfig: FullConfigInternal, projectConfig: Project, configCLIOverrides: ConfigCLIOverrides, throwawayArtifactsPath: string) {
     this.fullConfig = fullConfig;
@@ -174,6 +175,7 @@ export class FullProjectInternal {
       timeout: takeFirst(configCLIOverrides.timeout, projectConfig.timeout, config.timeout, defaultTimeout),
       use: mergeObjects(config.use, projectConfig.use, configCLIOverrides.use),
       dependencies: projectConfig.dependencies || [],
+      teardown: projectConfig.teardown,
     };
     (this.project as any)[projectInternalSymbol] = this;
     this.fullyParallel = takeFirst(configCLIOverrides.fullyParallel, projectConfig.fullyParallel, config.fullyParallel, undefined);
@@ -205,6 +207,7 @@ function resolveReporters(reporters: Config['reporter'], rootDir: string): Repor
 }
 
 function resolveProjectDependencies(projects: FullProjectInternal[]) {
+  const teardownToSetup = new Map<FullProjectInternal, FullProjectInternal>();
   for (const project of projects) {
     for (const dependencyName of project.project.dependencies) {
       const dependencies = projects.filter(p => p.project.name === dependencyName);
@@ -213,6 +216,28 @@ function resolveProjectDependencies(projects: FullProjectInternal[]) {
       if (dependencies.length > 1)
         throw new Error(`Project dependencies should have unique names, reading ${dependencyName}`);
       project.deps.push(...dependencies);
+    }
+    if (project.project.teardown) {
+      const teardowns = projects.filter(p => p.project.name === project.project.teardown);
+      if (!teardowns.length)
+        throw new Error(`Project '${project.project.name}' has unknown teardown project '${project.project.teardown}'`);
+      if (teardowns.length > 1)
+        throw new Error(`Project teardowns should have unique names, reading ${project.project.teardown}`);
+      const teardown = teardowns[0];
+      project.teardown = teardown;
+      if (teardownToSetup.has(teardown))
+        throw new Error(`Project ${teardown.project.name} can not be designated as teardown to multiple projects (${teardownToSetup.get(teardown)!.project.name} and ${project.project.name})`);
+      teardownToSetup.set(teardown, project);
+    }
+  }
+  for (const teardown of teardownToSetup.keys()) {
+    if (teardown.deps.length)
+      throw new Error(`Teardown project ${teardown.project.name} must not have dependencies`);
+  }
+  for (const project of projects) {
+    for (const dep of project.deps) {
+      if (teardownToSetup.has(dep))
+        throw new Error(`Project ${project.project.name} must not depend on a teardown project ${dep.project.name}`);
     }
   }
 }

--- a/packages/playwright-test/src/common/configLoader.ts
+++ b/packages/playwright-test/src/common/configLoader.ts
@@ -55,8 +55,10 @@ export class ConfigLoader {
     const fullConfig = await this._loadConfig(config, path.dirname(file), file);
     setCurrentConfig(fullConfig);
     if (ignoreProjectDependencies) {
-      for (const project of fullConfig.projects)
+      for (const project of fullConfig.projects) {
         project.deps = [];
+        project.teardown = undefined;
+      }
     }
     this._fullConfig = fullConfig;
     return fullConfig;

--- a/packages/playwright-test/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright-test/src/isomorphic/teleReceiver.ts
@@ -48,6 +48,7 @@ export type JsonProject = {
   repeatEach: number;
   retries: number;
   suites: JsonSuite[];
+  teardown?: string;
   testDir: string;
   testIgnore: JsonPattern[];
   testMatch: JsonPattern[];
@@ -303,6 +304,7 @@ export class TeleReporterReceiver {
       grep: parseRegexPatterns(project.grep) as RegExp[],
       grepInvert: parseRegexPatterns(project.grepInvert) as RegExp[],
       dependencies: project.dependencies,
+      teardown: project.teardown,
       snapshotDir: this._absolutePath(project.snapshotDir),
       use: {},
     };

--- a/packages/playwright-test/src/reporters/teleEmitter.ts
+++ b/packages/playwright-test/src/reporters/teleEmitter.ts
@@ -151,6 +151,7 @@ export class TeleReporterEmitter implements Reporter {
       grepInvert: serializeRegexPatterns(project.grepInvert || []),
       dependencies: project.dependencies,
       snapshotDir: this._relativePath(project.snapshotDir),
+      teardown: project.teardown,
     };
     return report;
   }

--- a/packages/playwright-test/src/runner/projectUtils.ts
+++ b/packages/playwright-test/src/runner/projectUtils.ts
@@ -49,6 +49,15 @@ export function filterProjects(projects: FullProjectInternal[], projectNames?: s
   return result;
 }
 
+export function buildTeardownToSetupMap(projects: FullProjectInternal[]): Map<FullProjectInternal, FullProjectInternal> {
+  const result = new Map<FullProjectInternal, FullProjectInternal>();
+  for (const project of projects) {
+    if (project.teardown)
+      result.set(project.teardown, project);
+  }
+  return result;
+}
+
 export function buildProjectsClosure(projects: FullProjectInternal[]): Map<FullProjectInternal, 'top-level' | 'dependency'> {
   const result = new Map<FullProjectInternal, 'top-level' | 'dependency'>();
   const visit = (depth: number, project: FullProjectInternal) => {
@@ -59,11 +68,36 @@ export function buildProjectsClosure(projects: FullProjectInternal[]): Map<FullP
     }
     result.set(project, depth ? 'dependency' : 'top-level');
     project.deps.map(visit.bind(undefined, depth + 1));
+    if (project.teardown)
+      visit(depth + 1, project.teardown);
   };
   for (const p of projects)
     result.set(p, 'top-level');
   for (const p of projects)
     visit(0, p);
+  return result;
+}
+
+export function buildDependentProjects(forProject: FullProjectInternal, projects: FullProjectInternal[]): Set<FullProjectInternal> {
+  const reverseDeps = new Map<FullProjectInternal, FullProjectInternal[]>(projects.map(p => ([p, []])));
+  for (const project of projects) {
+    for (const dep of project.deps)
+      reverseDeps.get(dep)!.push(project);
+  }
+  const result = new Set<FullProjectInternal>();
+  const visit = (depth: number, project: FullProjectInternal) => {
+    if (depth > 100) {
+      const error = new Error('Circular dependency detected between projects.');
+      error.stack = '';
+      throw error;
+    }
+    result.add(project);
+    for (const reverseDep of reverseDeps.get(project)!)
+      visit(depth + 1, reverseDep);
+    if (project.teardown)
+      visit(depth + 1, project.teardown);
+  };
+  visit(0, forProject);
   return result;
 }
 

--- a/packages/playwright-test/src/runner/uiMode.ts
+++ b/packages/playwright-test/src/runner/uiMode.ts
@@ -44,8 +44,10 @@ class UIMode {
     process.env.PW_LIVE_TRACE_STACKS = '1';
     config.cliListOnly = false;
     config.cliPassWithNoTests = true;
-    for (const project of config.projects)
+    for (const project of config.projects) {
       project.deps = [];
+      project.teardown = undefined;
+    }
 
     for (const p of config.projects) {
       p.project.retries = 0;

--- a/packages/playwright-test/src/runner/watchMode.ts
+++ b/packages/playwright-test/src/runner/watchMode.ts
@@ -308,6 +308,8 @@ function affectedProjectsClosure(projectClosure: FullProjectInternal[], affected
         if (result.has(dep))
           result.add(p);
       }
+      if (p.teardown && result.has(p.teardown))
+        result.add(p);
     }
   }
   return result;

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -193,7 +193,7 @@ export interface FullProject<TestArgs = {}, WorkerArgs = {}> {
    * Using dependencies allows global setup to produce traces and other artifacts, see the setup steps in the test
    * report, etc.
    *
-   * For example:
+   * **Usage**
    *
    * ```js
    * // playwright.config.ts
@@ -284,6 +284,54 @@ export interface FullProject<TestArgs = {}, WorkerArgs = {}> {
    * option for all projects.
    */
   retries: number;
+  /**
+   * Name of a project that needs to run after this and any dependent projects have finished. Teardown is useful to
+   * cleanup any resources acquired by this project.
+   *
+   * Passing `--no-deps` argument ignores
+   * [testProject.teardown](https://playwright.dev/docs/api/class-testproject#test-project-teardown) and behaves as if
+   * it was not specified.
+   *
+   * **Usage**
+   *
+   * A common pattern is a "setup" dependency that has a corresponding "teardown":
+   *
+   * ```js
+   * // playwright.config.ts
+   * import { defineConfig } from '@playwright/test';
+   *
+   * export default defineConfig({
+   *   projects: [
+   *     {
+   *       name: 'setup',
+   *       testMatch: /global.setup\.ts/,
+   *       teardown: 'teardown',
+   *     },
+   *     {
+   *       name: 'teardown',
+   *       testMatch: /global.teardown\.ts/,
+   *     },
+   *     {
+   *       name: 'chromium',
+   *       use: devices['Desktop Chrome'],
+   *       dependencies: ['setup'],
+   *     },
+   *     {
+   *       name: 'firefox',
+   *       use: devices['Desktop Firefox'],
+   *       dependencies: ['setup'],
+   *     },
+   *     {
+   *       name: 'webkit',
+   *       use: devices['Desktop Safari'],
+   *       dependencies: ['setup'],
+   *     },
+   *   ],
+   * });
+   * ```
+   *
+   */
+  teardown?: string;
   /**
    * Directory that will be recursively scanned for test files. Defaults to the directory of the configuration file.
    *
@@ -5932,7 +5980,7 @@ interface TestProject {
    * Using dependencies allows global setup to produce traces and other artifacts, see the setup steps in the test
    * report, etc.
    *
-   * For example:
+   * **Usage**
    *
    * ```js
    * // playwright.config.ts
@@ -6244,6 +6292,55 @@ interface TestProject {
    * 1. Forward slashes `"/"` can be used as path separators on any platform.
    */
   snapshotPathTemplate?: string;
+
+  /**
+   * Name of a project that needs to run after this and any dependent projects have finished. Teardown is useful to
+   * cleanup any resources acquired by this project.
+   *
+   * Passing `--no-deps` argument ignores
+   * [testProject.teardown](https://playwright.dev/docs/api/class-testproject#test-project-teardown) and behaves as if
+   * it was not specified.
+   *
+   * **Usage**
+   *
+   * A common pattern is a "setup" dependency that has a corresponding "teardown":
+   *
+   * ```js
+   * // playwright.config.ts
+   * import { defineConfig } from '@playwright/test';
+   *
+   * export default defineConfig({
+   *   projects: [
+   *     {
+   *       name: 'setup',
+   *       testMatch: /global.setup\.ts/,
+   *       teardown: 'teardown',
+   *     },
+   *     {
+   *       name: 'teardown',
+   *       testMatch: /global.teardown\.ts/,
+   *     },
+   *     {
+   *       name: 'chromium',
+   *       use: devices['Desktop Chrome'],
+   *       dependencies: ['setup'],
+   *     },
+   *     {
+   *       name: 'firefox',
+   *       use: devices['Desktop Firefox'],
+   *       dependencies: ['setup'],
+   *     },
+   *     {
+   *       name: 'webkit',
+   *       use: devices['Desktop Safari'],
+   *       dependencies: ['setup'],
+   *     },
+   *   ],
+   * });
+   * ```
+   *
+   */
+  teardown?: string;
 
   /**
    * Directory that will be recursively scanned for test files. Defaults to the directory of the configuration file.

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -36,7 +36,7 @@ export interface Project<TestArgs = {}, WorkerArgs = {}> extends TestProject {
 
 // [internal] !!! DO NOT ADD TO THIS !!!
 // [internal] It is part of the public API and is computed from the user's config.
-// [internal] If you need new fields internally, add them to FullConfigInternal instead.
+// [internal] If you need new fields internally, add them to FullProjectInternal instead.
 export interface FullProject<TestArgs = {}, WorkerArgs = {}> {
   grep: RegExp | RegExp[];
   grepInvert: RegExp | RegExp[] | null;
@@ -47,6 +47,7 @@ export interface FullProject<TestArgs = {}, WorkerArgs = {}> {
   outputDir: string;
   repeatEach: number;
   retries: number;
+  teardown?: string;
   testDir: string;
   testIgnore: string | RegExp | (string | RegExp)[];
   testMatch: string | RegExp | (string | RegExp)[];


### PR DESCRIPTION
This replicates globalTeardown in the deps world.

Fixes #21914.