### PR TITLE
chore: separate options fixture vs artifacts fixture

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -49,6 +49,8 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
 
   // Instrumentation.
   _defaultContextOptions?: BrowserContextOptions;
+  _defaultContextTimeout?: number;
+  _defaultContextNavigationTimeout?: number;
   private _defaultLaunchOptions?: LaunchOptions;
   private _defaultConnectOptions?: ConnectOptions;
 
@@ -252,6 +254,10 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
     context._browserType = this;
     this._contexts.add(context);
     context._setOptions(contextOptions, browserOptions);
+    if (this._defaultContextTimeout !== undefined)
+      context.setDefaultTimeout(this._defaultContextTimeout);
+    if (this._defaultContextNavigationTimeout !== undefined)
+      context.setDefaultNavigationTimeout(this._defaultContextNavigationTimeout);
     await this._instrumentation.onDidCreateBrowserContext(context);
   }
 


### PR DESCRIPTION
Later on, artifacts fixture can be made worker-scoped.