### PR TITLE
fix(test runner): separate test fixture scope for beforeAll/afterAll hooks

### DIFF
--- a/tests/playwright-test/fixtures.spec.ts
+++ b/tests/playwright-test/fixtures.spec.ts
@@ -388,26 +388,26 @@ test('automatic fixtures should work', async ({ runInlineTest }) => {
       test.beforeEach(async ({}) => {
         expect(counterWorker).toBe(1);
         expect(counterTest === 1 || counterTest === 2).toBe(true);
-        expect(counterHooksIncluded === 1 || counterHooksIncluded === 2).toBe(true);
+        expect(counterHooksIncluded === 2 || counterHooksIncluded === 3).toBe(true);
       });
       test('test 1', async ({}) => {
         expect(counterWorker).toBe(1);
-        expect(counterHooksIncluded).toBe(1);
+        expect(counterHooksIncluded).toBe(2);
         expect(counterTest).toBe(1);
       });
       test('test 2', async ({}) => {
         expect(counterWorker).toBe(1);
-        expect(counterHooksIncluded).toBe(2);
+        expect(counterHooksIncluded).toBe(3);
         expect(counterTest).toBe(2);
       });
       test.afterEach(async ({}) => {
         expect(counterWorker).toBe(1);
         expect(counterTest === 1 || counterTest === 2).toBe(true);
-        expect(counterHooksIncluded === 1 || counterHooksIncluded === 2).toBe(true);
+        expect(counterHooksIncluded === 2 || counterHooksIncluded === 3).toBe(true);
       });
       test.afterAll(async ({}) => {
         expect(counterWorker).toBe(1);
-        expect(counterHooksIncluded).toBe(2);
+        expect(counterHooksIncluded).toBe(4);
         expect(counterTest).toBe(2);
       });
     `

--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -44,8 +44,14 @@ test('hooks should work with fixtures', async ({ runInlineTest }) => {
         test.beforeAll(async ({ w, t }) => {
           global.logs.push('beforeAll-' + w + '-' + t);
         });
+        test.beforeAll(async ({ w, t }) => {
+          global.logs.push('beforeAll2-' + w + '-' + t);
+        });
         test.afterAll(async ({ w, t }) => {
           global.logs.push('afterAll-' + w + '-' + t);
+        });
+        test.afterAll(async ({ w, t }) => {
+          global.logs.push('afterAll2-' + w + '-' + t);
         });
 
         test.beforeEach(async ({ w, t }) => {
@@ -65,10 +71,20 @@ test('hooks should work with fixtures', async ({ runInlineTest }) => {
           '+w',
           '+t',
           'beforeAll-17-42',
-          'beforeEach-17-42',
-          'test-17-42',
-          'afterEach-17-42',
-          'afterAll-17-42',
+          '-t',
+          '+t',
+          'beforeAll2-17-43',
+          '-t',
+          '+t',
+          'beforeEach-17-44',
+          'test-17-44',
+          'afterEach-17-44',
+          '-t',
+          '+t',
+          'afterAll-17-45',
+          '-t',
+          '+t',
+          'afterAll2-17-46',
           '-t',
           '+t',
         ]);

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -701,6 +701,10 @@ test('should nest steps based on zones', async ({ runInlineTest }) => {
           location: { file: 'a.test.ts', line: 'number', column: 'number' }
         },
         {
+          title: 'browserContext.close',
+          category: 'pw:api'
+        },
+        {
           title: 'afterAll hook',
           category: 'hook',
           steps: [
@@ -712,10 +716,6 @@ test('should nest steps based on zones', async ({ runInlineTest }) => {
           ],
           location: { file: 'a.test.ts', line: 'number', column: 'number' }
         },
-        {
-          title: 'browserContext.close',
-          category: 'pw:api'
-        }
       ]
     }
   ]);

--- a/tests/playwright-test/timeout.spec.ts
+++ b/tests/playwright-test/timeout.spec.ts
@@ -331,6 +331,9 @@ test('test timeout should still run hooks before fixtures teardown', async ({ ru
         await new Promise(f => setTimeout(f, 500));
         console.log('\\n%%afterAll-2');
       });
+      test.afterEach(async () => {
+        console.log('\\n%%afterEach');
+      });
       test('test fail', async ({}) => {
         test.setTimeout(100);
         console.log('\\n%%test');
@@ -344,9 +347,10 @@ test('test timeout should still run hooks before fixtures teardown', async ({ ru
   expect(result.outputLines).toEqual([
     'before-auto',
     'test',
+    'afterEach',
+    'after-auto',
     'afterAll-1',
     'afterAll-2',
-    'after-auto',
   ]);
 });
 


### PR DESCRIPTION
There was a single test fixture scope that covers all hooks, modifiers and test function. Now beforeAll-like modifiers, beforeAll and afterAll hooks get a scope each.

Fixes #22256.