### PR TITLE
cherry-pick(#22765): docs: set docker version to 1.33 in release notes

### DIFF
--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -44,8 +44,8 @@ toc_max_heading_level: 2
 
 ### ⚠️ Breaking change
 
-* The `mcr.microsoft.com/playwright/dotnet:v1.34.0` now serves a Playwright image based on Ubuntu Jammy.
-  To use the focal-based image, please use `mcr.microsoft.com/playwright/dotnet:v1.34.0-focal` instead.
+* The `mcr.microsoft.com/playwright/dotnet:v1.33.0` now serves a Playwright image based on Ubuntu Jammy.
+  To use the focal-based image, please use `mcr.microsoft.com/playwright/dotnet:v1.33.0-focal` instead.
 
 ### Browser Versions
 

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -51,8 +51,8 @@ toc_max_heading_level: 2
 
 ### ⚠️ Breaking change
 
-* The `mcr.microsoft.com/playwright/java:v1.34.0` now serves a Playwright image based on Ubuntu Jammy.
-  To use the focal-based image, please use `mcr.microsoft.com/playwright/java:v1.34.0-focal` instead.
+* The `mcr.microsoft.com/playwright/java:v1.33.0` now serves a Playwright image based on Ubuntu Jammy.
+  To use the focal-based image, please use `mcr.microsoft.com/playwright/java:v1.33.0-focal` instead.
 
 ### Browser Versions
 

--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -47,8 +47,8 @@ import LiteYouTube from '@site/src/components/LiteYouTube';
 
 ### ⚠️ Breaking change
 
-* The `mcr.microsoft.com/playwright:v1.34.0` now serves a Playwright image based on Ubuntu Jammy.
-  To use the focal-based image, please use `mcr.microsoft.com/playwright:v1.34.0-focal` instead.
+* The `mcr.microsoft.com/playwright:v1.33.0` now serves a Playwright image based on Ubuntu Jammy.
+  To use the focal-based image, please use `mcr.microsoft.com/playwright:v1.33.0-focal` instead.
 
 ### Browser Versions
 

--- a/docs/src/release-notes-python.md
+++ b/docs/src/release-notes-python.md
@@ -44,8 +44,8 @@ toc_max_heading_level: 2
 
 ### ⚠️ Breaking change
 
-* The `mcr.microsoft.com/playwright/python:v1.34.0` now serves a Playwright image based on Ubuntu Jammy.
-  To use the focal-based image, please use `mcr.microsoft.com/playwright/python:v1.34.0-focal` instead.
+* The `mcr.microsoft.com/playwright/python:v1.33.0` now serves a Playwright image based on Ubuntu Jammy.
+  To use the focal-based image, please use `mcr.microsoft.com/playwright/python:v1.33.0-focal` instead.
 
 ### Browser Versions
 


### PR DESCRIPTION
This PR cherry-picks the following commits:

- 5e02022dff77e1e8a5d33ecfeddba4585fd01763