### PR TITLE
fix(webkit): define window.GestureEvent

### DIFF
--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -787,6 +787,7 @@ export class WKPage implements PageDelegate {
       scripts.push('delete window.ondeviceorientation');
     }
     scripts.push('if (!window.safari) window.safari = {};');
+    scripts.push('if (!window.GestureEvent) window.GestureEvent = function GestureEvent() {};');
 
     for (const binding of this._page.allBindings())
       scripts.push(binding.source);

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -241,3 +241,12 @@ it('loading in HTMLImageElement.prototype', async ({ page, server, browserName }
   const defined = await page.evaluate(() => 'loading' in HTMLImageElement.prototype);
   expect(defined).toBeTruthy();
 });
+
+it('window.GestureEvent in WebKit', async ({ page, server, browserName }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22735' });
+  await page.goto(server.EMPTY_PAGE);
+  const defined = await page.evaluate(() => 'GestureEvent' in window);
+  expect(defined).toBe(browserName === 'webkit');
+  const type = await page.evaluate(() => typeof (window as any).GestureEvent);
+  expect(type).toBe(browserName === 'webkit' ? 'function' : 'undefined');
+});


### PR DESCRIPTION
Polyfill GestureEvent so that Safari detection works.

Fixes #22735