### PR TITLE
fix(tsconfig): fallback to default `*:*` path mapping when `baseUrl` is present

### DIFF
--- a/packages/playwright-test/src/common/transform.ts
+++ b/packages/playwright-test/src/common/transform.ts
@@ -38,11 +38,11 @@ function validateTsConfig(tsconfig: TsConfigLoaderResult): ParsedTsConfigData | 
     return;
   // Make 'baseUrl' absolute, because it is relative to the tsconfig.json, not to cwd.
   const absoluteBaseUrl = path.resolve(path.dirname(tsconfig.tsConfigPath), tsconfig.baseUrl);
-  const paths = tsconfig.paths || { '*': ['*'] };
+  const pathsFallback = [{ key: '*', values: ['*'] }];
   return {
     allowJs: tsconfig.allowJs,
     absoluteBaseUrl,
-    paths: Object.entries(paths).map(([key, values]) => ({ key, values }))
+    paths: Object.entries(tsconfig.paths || {}).map(([key, values]) => ({ key, values })).concat(pathsFallback)
   };
 }
 

--- a/tests/playwright-test/resolver.spec.ts
+++ b/tests/playwright-test/resolver.spec.ts
@@ -164,6 +164,43 @@ test('should respect baseurl w/o paths', async ({ runInlineTest }) => {
   expect(result.output).not.toContain(`Could not`);
 });
 
+test('should fallback to *:* when baseurl and paths are specified', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'foo/bar/util/b.ts': `
+      export const foo = 42;
+    `,
+    'shared/x.ts': `
+      export const x = 43;
+    `,
+    'dir2/tsconfig.json': `{
+      "compilerOptions": {
+        "target": "ES2019",
+        "module": "commonjs",
+        "lib": ["esnext", "dom", "DOM.Iterable"],
+        "baseUrl": "..",
+        "paths": {
+          "shared/*": ["./shared/*"],
+        },
+      },
+    }`,
+    'dir2/inner.spec.ts': `
+      // This import should pick up ../foo/bar/util/b due to baseUrl and *:* fallback.
+      import { foo } from 'foo/bar/util/b';
+      // This import should pick up ../shared/x due to baseUrl+paths.
+      import { x } from 'shared/x';
+      import { test, expect } from '@playwright/test';
+      test('test', ({}, testInfo) => {
+        expect(foo).toBe(42);
+        expect(x).toBe(43);
+      });
+    `,
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.output).not.toContain(`Could not`);
+});
+
 test('should respect complex path resolver', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
According to https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url, `baseUrl` affects all non-relative imports. Additional `paths` mapping can be specified for more control. However, if none of the `paths` matches, it still falls back to the default `*:*` mapping. Confirmed by invoking `tsc` with different configs.

Fixes #22663.