### PR TITLE
Fixed typo in test-parallel-js.md

### DIFF
--- a/docs/src/test-parallel-js.md
+++ b/docs/src/test-parallel-js.md
@@ -176,7 +176,7 @@ When you **disable parallel test execution**, Playwright Test runs test files in
 ### Use a "test list" file
 
 :::warning
-Tests lists are discouraged and supported as a best-effort only. Some fetures such as VS Code Extension and tracing may not work properly with test lists.
+Tests lists are discouraged and supported as a best-effort only. Some features such as VS Code Extension and tracing may not work properly with test lists.
 :::
 
 You can put your tests in helper functions in multiple files. Consider the following example where tests are not defined directly in the file, but rather in a wrapper function.


### PR DESCRIPTION
Typo spotted in parallel docs

![Screenshot 2023-05-04 at 13 37 47](https://user-images.githubusercontent.com/41478863/236206721-2f31df20-a4f1-4a48-ba0b-2eb60f70fb46.png)
