### PR TITLE
fix: avoid using `os.userInfo()`

### DIFF
--- a/packages/playwright-test/src/common/compilationCache.ts
+++ b/packages/playwright-test/src/common/compilationCache.ts
@@ -28,12 +28,14 @@ export type MemoryCache = {
 
 const version = 13;
 
-const DEFAULT_CACHE_DIR_WIN32 = path.join(os.tmpdir(), `playwright-transform-cache`);
+const DEFAULT_CACHE_DIR_WIN32 = () => path.join(os.tmpdir(), `playwright-transform-cache`);
 // Use geteuid() instead of more natural os.userInfo().username
+// Also note, that process.geteuid() is not available on windows,
+// so this is a function to be called on POSIX only.
 // See https://github.com/microsoft/playwright/issues/22721
-const DEFAULT_CACHE_DIR_POSIX = path.join(os.tmpdir(), `playwright-transform-cache-` + process.geteuid());
+const DEFAULT_CACHE_DIR_POSIX = () => path.join(os.tmpdir(), `playwright-transform-cache-` + process.geteuid());
 
-const cacheDir = process.env.PWTEST_CACHE_DIR || (process.platform === 'win32' ? DEFAULT_CACHE_DIR_WIN32 : DEFAULT_CACHE_DIR_POSIX);
+const cacheDir = process.env.PWTEST_CACHE_DIR || (process.platform === 'win32' ? DEFAULT_CACHE_DIR_WIN32() : DEFAULT_CACHE_DIR_POSIX());
 
 const sourceMaps: Map<string, string> = new Map();
 const memoryCache = new Map<string, MemoryCache>();

--- a/packages/playwright-test/src/common/compilationCache.ts
+++ b/packages/playwright-test/src/common/compilationCache.ts
@@ -28,14 +28,15 @@ export type MemoryCache = {
 
 const version = 13;
 
-const DEFAULT_CACHE_DIR_WIN32 = () => path.join(os.tmpdir(), `playwright-transform-cache`);
-// Use geteuid() instead of more natural os.userInfo().username
-// Also note, that process.geteuid() is not available on windows,
-// so this is a function to be called on POSIX only.
-// See https://github.com/microsoft/playwright/issues/22721
-const DEFAULT_CACHE_DIR_POSIX = () => path.join(os.tmpdir(), `playwright-transform-cache-` + process.geteuid());
-
-const cacheDir = process.env.PWTEST_CACHE_DIR || (process.platform === 'win32' ? DEFAULT_CACHE_DIR_WIN32() : DEFAULT_CACHE_DIR_POSIX());
+const cacheDir = process.env.PWTEST_CACHE_DIR || (() => {
+  if (process.platform === 'win32')
+    return path.join(os.tmpdir(), `playwright-transform-cache`);
+  // Use `geteuid()` instead of more natural `os.userInfo().username`
+  // since `os.userInfo()` is not always available.
+  // Note: `process.geteuid()` is not available on windows.
+  // See https://github.com/microsoft/playwright/issues/22721
+  return path.join(os.tmpdir(), `playwright-transform-cache-` + process.geteuid());
+})();
 
 const sourceMaps: Map<string, string> = new Map();
 const memoryCache = new Map<string, MemoryCache>();

--- a/packages/playwright-test/src/common/compilationCache.ts
+++ b/packages/playwright-test/src/common/compilationCache.ts
@@ -19,7 +19,6 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { sourceMapSupport } from '../utilsBundle';
-import { sanitizeForFilePath } from '../util';
 
 export type MemoryCache = {
   codePath: string;

--- a/packages/playwright-test/src/common/compilationCache.ts
+++ b/packages/playwright-test/src/common/compilationCache.ts
@@ -30,7 +30,9 @@ export type MemoryCache = {
 const version = 13;
 
 const DEFAULT_CACHE_DIR_WIN32 = path.join(os.tmpdir(), `playwright-transform-cache`);
-const DEFAULT_CACHE_DIR_POSIX = path.join(os.tmpdir(), `playwright-transform-cache-` + sanitizeForFilePath(os.userInfo().username));
+// Use geteuid() instead of more natural os.userInfo().username
+// See https://github.com/microsoft/playwright/issues/22721
+const DEFAULT_CACHE_DIR_POSIX = path.join(os.tmpdir(), `playwright-transform-cache-` + process.geteuid());
 
 const cacheDir = process.env.PWTEST_CACHE_DIR || (process.platform === 'win32' ? DEFAULT_CACHE_DIR_WIN32 : DEFAULT_CACHE_DIR_POSIX);
 


### PR DESCRIPTION
The `os.userInfo()` call might throw on POSIX if there is no
user info for the current `uid`. This might happen, if the docker
is launched like this:

```
docker run --rm -u 1234:1234  -it mcr.microsoft.com/playwright:v1.32.0 node -e 'console.log(os.userInfo().username)'
```

So instead of using `os.userInfo()`, rely on effective user id.

Fixes https://github.com/microsoft/playwright/issues/22721
