### PR TITLE
fix(server): explicit allowlist for launch options

### DIFF
--- a/packages/playwright-core/src/remote/playwrightConnection.ts
+++ b/packages/playwright-core/src/remote/playwrightConnection.ts
@@ -57,6 +57,7 @@ export class PlaywrightConnection {
     this._ws = ws;
     this._preLaunched = preLaunched;
     this._options = options;
+    options.launchOptions = filterLaunchOptions(options.launchOptions);
     if (clientType === 'reuse-browser' || clientType === 'pre-launched-browser-or-android')
       assert(preLaunched.playwright);
     if (clientType === 'pre-launched-browser-or-android')
@@ -269,6 +270,21 @@ function launchOptionsHash(options: LaunchOptions) {
   for (const key of optionsThatAllowBrowserReuse)
     delete copy[key];
   return JSON.stringify(copy);
+}
+
+function filterLaunchOptions(options: LaunchOptions) {
+  return {
+    channel: options.channel,
+    args: options.args,
+    ignoreAllDefaultArgs: options.ignoreAllDefaultArgs,
+    ignoreDefaultArgs: options.ignoreDefaultArgs,
+    timeout: options.timeout,
+    headless: options.headless,
+    proxy: options.proxy,
+    chromiumSandbox: options.chromiumSandbox,
+    firefoxUserPrefs: options.firefoxUserPrefs,
+    slowMo: options.slowMo,
+  };
 }
 
 const defaultLaunchOptions: LaunchOptions = {

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -576,6 +576,19 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       expect(entry.request.url).toBe(server.EMPTY_PAGE);
     });
 
+    test('should filter launch options', async ({ connect, startRemoteServer, server, browserType }, testInfo) => {
+      const tracesDir = testInfo.outputPath('traces');
+      const oldTracesDir = (browserType as any)._defaultLaunchOptions.tracesDir;
+      (browserType as any)._defaultLaunchOptions.tracesDir = tracesDir;
+      const remoteServer = await startRemoteServer(kind);
+      const browser = await connect(remoteServer.wsEndpoint());
+      const page = await browser.newPage();
+      await page.goto(server.EMPTY_PAGE);
+      await browser.close();
+      (browserType as any)._defaultLaunchOptions.tracesDir = oldTracesDir;
+      expect(fs.existsSync(tracesDir)).toBe(false);
+    });
+
     test('should record trace with sources', async ({ connect, startRemoteServer, server, trace }, testInfo) => {
       test.skip(trace === 'on');
       const remoteServer = await startRemoteServer(kind);


### PR DESCRIPTION
Some options, usually paths, do not make sense when running remotely.

Fixes #22844.