### PR TITLE
test: unskip loading in HTMLImageElement.prototype in WebKit

### DIFF
--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -234,9 +234,9 @@ it('make sure that XMLHttpRequest upload events are emitted correctly', async ({
   expect(events).toEqual(['loadstart', 'progress', 'load', 'loadend']);
 });
 
-it('loading in HTMLImageElement.prototype', async ({ page, server, browserName }) => {
+it('loading in HTMLImageElement.prototype', async ({ page, server, browserName, isMac }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22738' });
-  it.fixme(browserName === 'webkit');
+  it.skip(browserName === 'webkit' && isMac && parseInt(os.release(), 10) < 21, 'Does not work on macOS 11');
   await page.goto(server.EMPTY_PAGE);
   const defined = await page.evaluate(() => 'loading' in HTMLImageElement.prototype);
   expect(defined).toBeTruthy();


### PR DESCRIPTION
It was fixed by roll to r1841.

Fixes https://github.com/microsoft/playwright/issues/22738