### PR TITLE
docs: add example to run multiple tags at a time

### DIFF
--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -87,6 +87,12 @@ Or if you want the opposite, you can skip the tests with a certain tag:
 npx playwright test --grep-invert @slow
 ```
 
+To run tests containing either tag:
+
+```bash
+npx playwright test --grep "@fast|@slow"
+```
+
 ## Conditionally skip a group of tests
 
 For example, you can run a group of tests just in Chromium by passing a callback.


### PR DESCRIPTION
I checked the [docs](https://playwright.dev/docs/test-annotations#tag-tests) for how to do this but I didn't see anything. I first tried adding multiple grep params but that didn't work, only the last grep param was applied. I had to search for a workaround and found [this](https://github.com/microsoft/playwright/issues/9682) issue showing it's already supported so I've updated the docs to reflect that.