### PR TITLE
docs: add examples to run intersection or combination of tags

### DIFF
--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -87,6 +87,18 @@ Or if you want the opposite, you can skip the tests with a certain tag:
 npx playwright test --grep-invert @slow
 ```
 
+To run tests containing either tag (logical `OR` operator):
+
+```bash
+npx playwright test --grep "@fast|@slow"
+```
+
+Or run tests containing both tags (logical `AND` operator) using regex lookaheads:
+
+```bash
+npx playwright test --grep "(?=.*@fast)(?=.*@slow)"
+```
+
 ## Conditionally skip a group of tests
 
 For example, you can run a group of tests just in Chromium by passing a callback.


### PR DESCRIPTION
I checked the [docs](https://playwright.dev/docs/test-annotations#tag-tests) for how to do this but I didn't see anything. For combination of tags, I first tried adding multiple grep params but that didn't work, only the last grep param was applied. I had to search for a workaround and found [this](https://github.com/microsoft/playwright/issues/9682) issue showing it's already supported so I've updated the docs to reflect that.

I also wanted an intersection (`AND`) of tags and found you could do it using regex lookaheads. [Here](https://www.ocpsoft.org/tutorials/regular-expressions/and-in-regex/) is a site explaining how it works. Took me a little while to figure this out so I thought it was worth updating the docs.