### PR TITLE
fix(getByLabel): ignore empty aria-label

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -328,7 +328,7 @@ export class InjectedScript {
           let labels: Element[] | NodeListOf<Element> | null | undefined = getAriaLabelledByElements(element);
           if (labels === null) {
             const ariaLabel = element.getAttribute('aria-label');
-            if (ariaLabel !== null)
+            if (ariaLabel !== null && !!ariaLabel.trim())
               return matcher({ full: ariaLabel, immediate: [ariaLabel] });
           }
           if (labels === null)

--- a/tests/page/selectors-get-by.spec.ts
+++ b/tests/page/selectors-get-by.spec.ts
@@ -117,6 +117,11 @@ it('getByLabel should work with aria-label', async ({ page }) => {
   expect(await page.getByLabel('Name').evaluate(e => e.id)).toBe('target');
 });
 
+it('getByLabel should ignore empty aria-label', async ({ page }) => {
+  await page.setContent(`<label for=target>Last Name</label><input id=target type=text aria-label>`);
+  expect(await page.getByLabel('Last Name').evaluate(e => e.id)).toBe('target');
+});
+
 it('getByLabel should prioritize aria-labelledby over aria-label', async ({ page }) => {
   await page.setContent(`<label id=other-label>Other</label><input id=target aria-label="Name" aria-labelledby=other-label>`);
   expect(await page.getByLabel('Other').evaluate(e => e.id)).toBe('target');


### PR DESCRIPTION
Accessible name computation ignores empty aria-label, and so should getByLabel.

Fixes #22915.