### PR TITLE
fix(isVisible): return `false` during navigation

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1288,7 +1288,11 @@ export class Frame extends SdkObject {
         const state = element ? injected.elementState(element, 'visible') : false;
         return state === 'error:notconnected' ? false : state;
       }, { info: resolved.info });
-    }, this._page._timeoutSettings.timeout({}));
+    }, this._page._timeoutSettings.timeout({})).catch(e => {
+      if (js.isJavaScriptErrorInEvaluate(e) || isInvalidSelectorError(e) || isSessionClosedError(e))
+        throw e;
+      return false;
+    });
   }
 
   async isHidden(metadata: CallMetadata, selector: string, options: types.StrictOptions = {}): Promise<boolean> {

--- a/tests/page/locator-is-visible.spec.ts
+++ b/tests/page/locator-is-visible.spec.ts
@@ -85,3 +85,23 @@ it('isVisible inside a role=button', async ({ page }) => {
   await span.waitFor({ state: 'hidden' });
   await page.locator('[role=button]').waitFor({ state: 'visible' });
 });
+
+it('isVisible during navigation should not throw', async ({ page, server }) => {
+  for (let i = 0; i < 20; i++) {
+    // Make sure previous navigation finishes, to avoid page.setContent throwing.
+    await page.waitForTimeout(100);
+    await page.setContent(`
+      <script>
+        setTimeout(() => {
+          window.location.href = ${JSON.stringify(server.EMPTY_PAGE)};
+        }, Math.random(50));
+      </script>
+    `);
+    expect(await page.locator('div').isVisible()).toBe(false);
+  }
+});
+
+it('isVisible with invalid selector should throw', async ({ page }) => {
+  const error = await page.locator('hey=what').isVisible().catch(e => e);
+  expect(error.message).toContain('Unknown engine "hey" while parsing selector hey=what');
+});


### PR DESCRIPTION
Instead of throwing "Execution context was destroyed" error.

Drive-by: improve internal error messages for `ScopedRace` errors.

Fixes #22925.