### PR TITLE
chore: bump node/types to v16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/babel__core": "^7.20.0",
         "@types/codemirror": "^5.60.7",
         "@types/formidable": "^2.0.4",
-        "@types/node": "=14.18.34",
+        "@types/node": "=16.7.0",
         "@types/react": "^18.0.12",
         "@types/react-dom": "^18.0.5",
         "@types/resize-observer-browser": "^0.1.7",
@@ -1505,9 +1505,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
-      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA=="
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.0.tgz",
+      "integrity": "sha512-e66BrnjWQ3BRBZ2+iA5e85fcH9GLNe4S0n1H0T3OalK2sXg5XWEFTO4xvmGrYQ3edy+q6fdOh5t0/HOY8OAqBg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -7472,9 +7472,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
-      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA=="
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.0.tgz",
+      "integrity": "sha512-e66BrnjWQ3BRBZ2+iA5e85fcH9GLNe4S0n1H0T3OalK2sXg5XWEFTO4xvmGrYQ3edy+q6fdOh5t0/HOY8OAqBg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/babel__core": "^7.20.0",
     "@types/codemirror": "^5.60.7",
     "@types/formidable": "^2.0.4",
-    "@types/node": "=14.18.34",
+    "@types/node": "=16.7.0",
     "@types/react": "^18.0.12",
     "@types/react-dom": "^18.0.5",
     "@types/resize-observer-browser": "^0.1.7",


### PR DESCRIPTION
Minimal supported version is 16 today. Node 14 types do not contain `fs.promises.cp`.