### PR TITLE
chore: opt out from the compact mode in babel

### DIFF
--- a/packages/playwright-test/bundles/babel/src/babelBundleImpl.ts
+++ b/packages/playwright-test/bundles/babel/src/babelBundleImpl.ts
@@ -99,6 +99,7 @@ export function babelTransform(filename: string, isTypeScript: boolean, isModule
       [require('@babel/preset-typescript'), { onlyRemoveTypeImports: false }],
     ],
     plugins,
+    compact: false,
     sourceMaps: 'both',
   } as babel.TransformOptions)!;
 }


### PR DESCRIPTION
Partial fix for https://github.com/microsoft/playwright/issues/22874