### PR TITLE
feat(shard): introduce `mode: 'default'`

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -284,9 +284,27 @@ Learn more about the execution modes [here](../test-parallel.md).
   test('runs second', async ({ page }) => {});
   ```
 
+* Run multiple describes in parallel, but tests inside each describe in order.
+
+  ```js
+  test.describe.configure({ mode: 'parallel' });
+
+  test.describe('A, runs in parallel with B', () => {
+    test.describe.configure({ mode: 'default' });
+    test('in order A1', async ({ page }) => {});
+    test('in order A2', async ({ page }) => {});
+  });
+
+  test.describe('B, runs in parallel with A', () => {
+    test.describe.configure({ mode: 'default' });
+    test('in order B1', async ({ page }) => {});
+    test('in order B2', async ({ page }) => {});
+  });
+  ```
+
 ### option: Test.describe.configure.mode
 * since: v1.10
-- `mode` <[TestMode]<"parallel"|"serial">>
+- `mode` <[TestMode]<"default"|"parallel"|"serial">>
 
 Execution mode. Learn more about the execution modes [here](../test-parallel.md).
 

--- a/packages/playwright-test/src/common/test.ts
+++ b/packages/playwright-test/src/common/test.ts
@@ -50,7 +50,7 @@ export class Suite extends Base implements SuitePrivate {
   _retries: number | undefined;
   _staticAnnotations: Annotation[] = [];
   _modifiers: Modifier[] = [];
-  _parallelMode: 'default' | 'serial' | 'parallel' = 'default';
+  _parallelMode: 'none' | 'default' | 'serial' | 'parallel' = 'none';
   _fullProject: FullProjectInternal | undefined;
   _fileId: string | undefined;
   readonly _type: 'root' | 'project' | 'file' | 'describe';

--- a/packages/playwright-test/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright-test/src/isomorphic/teleReceiver.ts
@@ -61,7 +61,7 @@ export type JsonSuite = {
   suites: JsonSuite[];
   tests: JsonTestCase[];
   fileId: string | undefined;
-  parallelMode: 'default' | 'serial' | 'parallel';
+  parallelMode: 'none' | 'default' | 'serial' | 'parallel';
 };
 
 export type JsonTestCase = {
@@ -380,7 +380,7 @@ export class TeleSuite implements SuitePrivate {
   _timeout: number | undefined;
   _retries: number | undefined;
   _fileId: string | undefined;
-  _parallelMode: 'default' | 'serial' | 'parallel' = 'default';
+  _parallelMode: 'none' | 'default' | 'serial' | 'parallel' = 'none';
   readonly _type: 'root' | 'project' | 'file' | 'describe';
 
   constructor(title: string, type: 'root' | 'project' | 'file' | 'describe') {

--- a/packages/playwright-test/src/runner/testGroups.ts
+++ b/packages/playwright-test/src/runner/testGroups.ts
@@ -79,20 +79,20 @@ export function createTestGroups(projectSuite: Suite, workers: number): TestGrou
 
     // Note that a parallel suite cannot be inside a serial suite. This is enforced in TestType.
     let insideParallel = false;
-    let outerMostSerialSuite: Suite | undefined;
+    let outerMostSequentialSuite: Suite | undefined;
     let hasAllHooks = false;
     for (let parent: Suite | undefined = test.parent; parent; parent = parent.parent) {
-      if (parent._parallelMode === 'serial')
-        outerMostSerialSuite = parent;
+      if (parent._parallelMode === 'serial' || parent._parallelMode === 'default')
+        outerMostSequentialSuite = parent;
       insideParallel = insideParallel || parent._parallelMode === 'parallel';
       hasAllHooks = hasAllHooks || parent._hooks.some(hook => hook.type === 'beforeAll' || hook.type === 'afterAll');
     }
 
     if (insideParallel) {
-      if (hasAllHooks && !outerMostSerialSuite) {
+      if (hasAllHooks && !outerMostSequentialSuite) {
         withRequireFile.parallelWithHooks.tests.push(test);
       } else {
-        const key = outerMostSerialSuite || test;
+        const key = outerMostSequentialSuite || test;
         let group = withRequireFile.parallel.get(key);
         if (!group) {
           group = createGroup(test);

--- a/packages/playwright-test/types/reporterPrivate.ts
+++ b/packages/playwright-test/types/reporterPrivate.ts
@@ -18,5 +18,5 @@ import type { Suite } from './testReporter';
 
 export interface SuitePrivate extends Suite {
   _fileId: string | undefined;
-  _parallelMode: 'default' | 'serial' | 'parallel';
+  _parallelMode: 'none' | 'default' | 'serial' | 'parallel';
 }

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -2626,9 +2626,27 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    *   test('runs second', async ({ page }) => {});
    *   ```
    *
+   * - Run multiple describes in parallel, but tests inside each describe in order.
+   *
+   *   ```js
+   *   test.describe.configure({ mode: 'parallel' });
+   *
+   *   test.describe('A, runs in parallel with B', () => {
+   *     test.describe.configure({ mode: 'default' });
+   *     test('in order A1', async ({ page }) => {});
+   *     test('in order A2', async ({ page }) => {});
+   *   });
+   *
+   *   test.describe('B, runs in parallel with A', () => {
+   *     test.describe.configure({ mode: 'default' });
+   *     test('in order B1', async ({ page }) => {});
+   *     test('in order B2', async ({ page }) => {});
+   *   });
+   *   ```
+   *
    * @param options
    */
-  configure: (options: { mode?: 'parallel' | 'serial', retries?: number, timeout?: number }) => void;
+  configure: (options: { mode?: 'default' | 'parallel' | 'serial', retries?: number, timeout?: number }) => void;
   };
   /**
    * Declares a skipped test, similarly to

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -131,7 +131,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
     parallel: SuiteFunction & {
       only: SuiteFunction;
     };
-    configure: (options: { mode?: 'parallel' | 'serial', retries?: number, timeout?: number }) => void;
+    configure: (options: { mode?: 'default' | 'parallel' | 'serial', retries?: number, timeout?: number }) => void;
   };
   skip(title: string, testFunction: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
   skip(): void;


### PR DESCRIPTION
This mode allows a suite to opt-out from parallelism. Useful to setup multiple suites running in parallel, with each suite not being sharded.

References #22891.