### PR TITLE
chore: ignore SIGINT inside driver process

### DIFF
--- a/packages/playwright-core/src/protocol/transport.ts
+++ b/packages/playwright-core/src/protocol/transport.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { ChildProcess } from 'child_process';
 import { makeWaitForNextTask } from '../utils';
 
 export interface WritableStream {
@@ -101,30 +100,5 @@ export class PipeTransport {
           this.onmessage(message.toString('utf-8'));
       });
     }
-  }
-}
-
-export class IpcTransport {
-  private _process: NodeJS.Process | ChildProcess;
-  private _waitForNextTask = makeWaitForNextTask();
-  onmessage?: (message: string) => void;
-  onclose?: () => void;
-
-  constructor(process: NodeJS.Process | ChildProcess) {
-    this._process = process;
-    this._process.on('message', message => this._waitForNextTask(() => {
-      if (message === '<eof>')
-        this.onclose?.();
-      else
-        this.onmessage?.(message);
-    }));
-  }
-
-  send(message: string) {
-    this._process.send!(message);
-  }
-
-  close() {
-    this._process.send!('<eof>');
   }
 }

--- a/tests/installation/driver-should-work.spec.ts
+++ b/tests/installation/driver-should-work.spec.ts
@@ -13,10 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { test } from './npmTest';
+import { test, expect } from './npmTest';
 
 test('driver should work', async ({ exec }) => {
   await exec('npm i --foreground-scripts playwright', { env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' } });
   await exec('npx playwright install');
   await exec('node driver-client.js');
+});
+
+test('driver should ignore SIGINT', async ({ exec }) => {
+  test.skip(process.platform === 'win32', 'Only relevant for POSIX');
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright-python/issues/1843' });
+  await exec('npm i --foreground-scripts playwright', { env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' } });
+  await exec('npx playwright install chromium');
+  const output = await exec('node driver-client-sigint.js');
+  const lines = output.split('\n').filter(l => l.trim());
+  expect(lines).toEqual([
+    'launching driver',
+    'launched driver',
+    'closing gracefully',
+    'closed page',
+    'closed context',
+    'closed browser',
+    'stopped driver',
+    'SUCCESS',
+  ]);
 });

--- a/tests/installation/fixture-scripts/driver-client-sigint.js
+++ b/tests/installation/fixture-scripts/driver-client-sigint.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// @ts-check
+
+const pw = require.resolve('playwright');
+const oop = require.resolve('playwright-core/lib/outofprocess', { paths: [pw] });
+const { start } = require(oop);
+
+(async () => {
+  console.log('launching driver')
+  const { playwright, stop } = await start();
+  console.log('launched driver')
+  try {
+    const browser = await playwright.chromium.launch({ handleSIGINT: false });
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    // let things settle down
+    await page.waitForTimeout(100);
+    // send SIGINT to driver
+    process.kill(playwright.driverProcess.pid, 'SIGINT');
+    // wait and see if driver exits
+    await page.waitForTimeout(100);
+    console.log(`closing gracefully`)
+    await page.close();
+    console.log('closed page');
+    await context.close();
+    console.log('closed context');
+    await browser.close();
+    console.log('closed browser');
+    await stop();
+    console.log('stopped driver');
+  } catch (e) {
+    console.error(`Should be able to launch from ${process.cwd()}`);
+    console.error(e);
+    process.exit(1);
+  }
+  console.log(`SUCCESS`);
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
https://github.com/microsoft/playwright-python/issues/1843

Almost reverts https://github.com/microsoft/playwright/pull/11826 since this is not used by VSCode anymore and was legacy.