### PR TITLE
fix(expect): mark step as failed when async custom matcher throws

### DIFF
--- a/packages/playwright-test/src/matchers/expect.ts
+++ b/packages/playwright-test/src/matchers/expect.ts
@@ -312,6 +312,8 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
       } else {
         try {
           const result = matcher.call(target, ...args);
+          if (result instanceof Promise)
+            return result.then(finalizer).catch(reportStepError);
           finalizer();
           return result;
         } catch (e) {


### PR DESCRIPTION
Fixes #23021.