### PR TITLE
docs: fix `testConfig.testMatch` markdown escaping

### DIFF
--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -85,7 +85,7 @@ export default defineConfig({
 | Option | Description |
 | :- | :- |
 | [`property: TestConfig.testIgnore`] | Glob patterns or regular expressions that should be ignored when looking for the test files. For example, `'*test-assets'` |
-| [`property: TestConfig.testMatch`] | Glob patterns or regular expressions that match test files. For example, `'*todo-tests/*.spec.ts'`. By default, Playwright runs `.*(test\|spec)\.(js\|ts\|mjs)` files. |
+| [`property: TestConfig.testMatch`] | Glob patterns or regular expressions that match test files. For example, `'*todo-tests/*.spec.ts'`. By default, Playwright runs <code>.*(test&#124;spec)\.(js&#124;ts&#124;mjs)</code> files. |
 
 ## Advanced Configuration
 

--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -85,7 +85,7 @@ export default defineConfig({
 | Option | Description |
 | :- | :- |
 | [`property: TestConfig.testIgnore`] | Glob patterns or regular expressions that should be ignored when looking for the test files. For example, `'*test-assets'` |
-| [`property: TestConfig.testMatch`] | Glob patterns or regular expressions that match test files. For example, `'*todo-tests/*.spec.ts'`. By default, Playwright runs `.*(test|spec)\.(js|ts|mjs)` files. |
+| [`property: TestConfig.testMatch`] | Glob patterns or regular expressions that match test files. For example, `'*todo-tests/*.spec.ts'`. By default, Playwright runs `.*(test\|spec)\.(js\|ts\|mjs)` files. |
 
 ## Advanced Configuration
 


### PR DESCRIPTION
Because the `|` is meaningful in the markdown table, it causes truncated docs:
<img width="775" alt="image" src="https://github.com/microsoft/playwright/assets/107990625/28553884-6151-4af5-875d-e9c9f40c9065">
