### PR TITLE
docs: maxDiffPixelRatio example value should be between 0 and 1

### DIFF
--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -134,7 +134,7 @@ export default defineConfig({
 
     toMatchSnapshot:  {
       // An acceptable ratio of pixels that are different to the total amount of pixels, between 0 and 1.
-      maxDiffPixelRatio: 10,
+      maxDiffPixelRatio: 0.1,
     },
   },
   

--- a/docs/src/test-use-options-js.md
+++ b/docs/src/test-use-options-js.md
@@ -3,7 +3,7 @@ id: test-use-options
 title: "Test use options"
 ---
 
-In addition to configuring the test runner you can also configure [Emulation](#emulation-options), [Network](#network-options) and [Recording](#recording-options) for the [Browser] or [BrowserContext],. These options are passed to the `use: {}` object in the Playwright config.
+In addition to configuring the test runner you can also configure [Emulation](#emulation-options), [Network](#network-options) and [Recording](#recording-options) for the [Browser] or [BrowserContext]. These options are passed to the `use: {}` object in the Playwright config.
 
 ### Basic Options
 


### PR DESCRIPTION
On the page https://playwright.dev/docs/test-configuration, the `maxDiffPixelRatio` example value is 10 instead of being between 0 and 1. Set it to 0.1 instead.

Fixes https://github.com/microsoft/playwright/pull/23049