### PR TITLE
docs: permissions example should be an array

### DIFF
--- a/docs/src/emulation.md
+++ b/docs/src/emulation.md
@@ -346,7 +346,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   use: {
     // Grants specified permissions to the browser context.
-    permissions: 'notifications',
+    permissions: ['notifications'],
   },
 });
 ```

--- a/docs/src/test-use-options-js.md
+++ b/docs/src/test-use-options-js.md
@@ -49,7 +49,7 @@ export default defineConfig({
     locale: 'en-GB',
 
     // Grants specified permissions to the browser context.
-    permissions: 'geolocation',
+    permissions: ['geolocation'],
 
     // Emulates the user timezone.
     timezoneId: 'Europe/Paris',


### PR DESCRIPTION
On the page https://playwright.dev/docs/test-use-options, the `permissions` example is a string instead of a string array.