### PR TITLE
feat(cli): introduce npx playwright uninstall

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -991,3 +991,41 @@ mvn test
 Playwright keeps track of the clients that use its browsers. When there are no more clients that require a particular version of the browser, that version is deleted from the system. That way you can safely use Playwright instances of different versions and at the same time, you don't waste disk space for the browsers that are no longer in use.
 
 To opt-out from the unused browser removal, you can set the `PLAYWRIGHT_SKIP_BROWSER_GC=1` environment variable.
+
+### Remove browsers
+
+This will remove the browsers (chromium, firefox, webkit) of the current Playwright installation:
+
+```bash js
+npx playwright uninstall
+```
+
+```bash java
+mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="uninstall"
+```
+
+```bash python
+playwright uninstall
+```
+
+```bash csharp
+pwsh bin/Debug/netX/playwright.ps1 uninstall
+```
+
+To remove browsers of other Playwright installations as well, pass `--all` flag:
+
+```bash js
+npx playwright uninstall --all
+```
+
+```bash java
+mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="uninstall --all"
+```
+
+```bash python
+playwright uninstall --all
+```
+
+```bash csharp
+pwsh bin/Debug/netX/playwright.ps1 uninstall --all
+```

--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -173,6 +173,18 @@ Examples:
   - $ install chrome firefox
     Install custom browsers, supports ${suggestedBrowsersToInstall()}.`);
 
+program
+    .command('uninstall')
+    .description('Removes all default Playwright browsers from the system (chromium, firefox, webkit, ffmpeg). This does not include branded channels.')
+    .option('--all', 'Removes all Playwright browsers from the system. Not just the browsers for the current Playwright version.')
+    .action(async (options: { all?: boolean }) => {
+      await registry.uninstall(!!options.all).then(({ browsersRemainingOnFileSystem }) => {
+        if (!options.all && browsersRemainingOnFileSystem) {
+          console.log('Successfully uninstalled Playwright browsers for the current Playwright installation.');
+          console.log('To uninstall Playwright browsers for all versions, run it with --all.');
+        }
+      }).catch(logErrorAndExit);
+    });
 
 program
     .command('install-deps [browser...]')

--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -178,8 +178,8 @@ program
     .description('Removes browsers used by this version of Playwright from the system (chromium, firefox, webkit, ffmpeg). This does not include branded channels.')
     .option('--all', 'Removes all browsers used by any Playwright version from the system.')
     .action(async (options: { all?: boolean }) => {
-      await registry.uninstall(!!options.all).then(({ browsersRemainingOnFileSystem }) => {
-        if (!options.all && browsersRemainingOnFileSystem) {
+      await registry.uninstall(!!options.all).then(({ numberOfBrowsersLeft }) => {
+        if (!options.all && numberOfBrowsersLeft > 0) {
           console.log('Successfully uninstalled Playwright browsers for the current Playwright installation.');
           console.log(`There are still ${numberOfBrowsersLeft} browsers left, used by other Playwright installations.\nTo uninstall Playwright browsers for all versions, re-run with --all flag.`);
         }

--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -175,13 +175,13 @@ Examples:
 
 program
     .command('uninstall')
-    .description('Removes all default Playwright browsers from the system (chromium, firefox, webkit, ffmpeg). This does not include branded channels.')
-    .option('--all', 'Removes all Playwright browsers from the system. Not just the browsers for the current Playwright version.')
+    .description('Removes browsers used by this version of Playwright from the system (chromium, firefox, webkit, ffmpeg). This does not include branded channels.')
+    .option('--all', 'Removes all browsers used by any Playwright version from the system.')
     .action(async (options: { all?: boolean }) => {
       await registry.uninstall(!!options.all).then(({ browsersRemainingOnFileSystem }) => {
         if (!options.all && browsersRemainingOnFileSystem) {
           console.log('Successfully uninstalled Playwright browsers for the current Playwright installation.');
-          console.log('To uninstall Playwright browsers for all versions, run it with --all.');
+          console.log(`There are still ${numberOfBrowsersLeft} browsers left, used by other Playwright installations.\nTo uninstall Playwright browsers for all versions, re-run with --all flag.`);
         }
       }).catch(logErrorAndExit);
     });

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -767,7 +767,7 @@ export class Registry {
     }
   }
 
-  async uninstall(all: boolean): Promise<{ browsersRemainingOnFileSystem: boolean }> {
+  async uninstall(all: boolean): Promise<{ numberOfBrowsersLeft: number }> {
     const linksDir = path.join(registryDirectory, '.links');
     if (all) {
       const links = await fs.promises.readdir(linksDir).catch(() => []);
@@ -780,7 +780,7 @@ export class Registry {
     // Remove stale browsers.
     await this._validateInstallationCache(linksDir);
     return {
-      browsersRemainingOnFileSystem: (await fs.promises.readdir(linksDir).catch(() => [])).length > 0
+      numberOfBrowsersLeft: (await fs.promises.readdir(registryDirectory).catch(() => [])).filter(browserDirectory => isBrowserDirectory(browserDirectory)).length
     };
   }
 

--- a/tests/installation/playwright-cli-install-should-work.spec.ts
+++ b/tests/installation/playwright-cli-install-should-work.spec.ts
@@ -33,3 +33,11 @@ test('codegen should work', async ({ exec, installedSoftwareOnDisk }) => {
   await exec('node sanity.js playwright none', { env: {  PLAYWRIGHT_BROWSERS_PATH: undefined } });
   await exec('node sanity.js playwright');
 });
+
+test('should be able to remove browsers', async ({ exec, installedSoftwareOnDisk }) => {
+  await exec('npm i --foreground-scripts playwright', { env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' } });
+  await exec('npx playwright install chromium');
+  expect(await installedSoftwareOnDisk()).toEqual(['chromium', 'ffmpeg']);
+  await exec('npx playwright uninstall');
+  expect(await installedSoftwareOnDisk()).toEqual([]);
+});


### PR DESCRIPTION
As per offline discussion:

- removes the backlink to the current folder
- runs prune
- if more browsers are there, print message and run with --all

Fixes https://github.com/microsoft/playwright/issues/23072