### PR TITLE
test: unskip selenium driver test

### DIFF
--- a/packages/playwright-core/src/outofprocess.ts
+++ b/packages/playwright-core/src/outofprocess.ts
@@ -43,7 +43,6 @@ class PlaywrightClient {
       },
     });
     this._driverProcess.unref();
-    this._driverProcess.on('exit', this._onExit.bind(this));
 
     const connection = new Connection();
     connection.markAsRemote();
@@ -56,14 +55,9 @@ class PlaywrightClient {
   }
 
   async stop() {
-    this._driverProcess.removeListener('exit', this._onExit);
     this._driverProcess.stdin!.destroy();
     this._driverProcess.stdout!.destroy();
     this._driverProcess.stderr!.destroy();
     await this._closePromise;
-  }
-
-  private _onExit(exitCode: number | null, signal: string | null) {
-    throw new Error(`Server closed with exitCode=${exitCode} signal=${signal}`);
   }
 }

--- a/tests/library/browsertype-launch-selenium.spec.ts
+++ b/tests/library/browsertype-launch-selenium.spec.ts
@@ -180,7 +180,6 @@ test('selenium grid 3.141.59 standalone non-chromium', async ({ browserName, bro
 
 test('selenium grid 3.141.59 standalone chromium through run-driver', async ({ browserName, childProcess, waitForPort }, testInfo) => {
   test.skip(browserName !== 'chromium');
-  test.fixme(true, 'https://github.com/microsoft/playwright/issues/23110');
 
   const port = testInfo.workerIndex + 15123;
   const grid = childProcess({


### PR DESCRIPTION
Issue is that [when `stop()` is called](https://github.com/microsoft/playwright/blob/28504f6dc7ffbd920244365c6f890410f1a5d9a1/tests/library/browsertype-launch-selenium.spec.ts#L202), `onExit()` gets called and then it throws an unhandled rejection.

This regressed in https://github.com/microsoft/playwright/pull/23028.

I didn't find a reason to keep onExit, so removed it for now since transport should handle these scenarios.

Fixes https://github.com/microsoft/playwright/issues/23110