### PR TITLE
cherry-pick(#23140): docs: add dialog/consoleMessage helper methods for language bindings

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -180,10 +180,7 @@ context.on("dialog", lambda dialog: dialog.accept())
 ```
 
 ```csharp
-context.RequestFailed += (_, request) =>
-{
-    Console.WriteLine(request.Url + " " + request.Failure);
-};
+context.Dialog += (_, dialog) => dialog.AcceptAsync();
 ```
 
 :::note
@@ -1455,6 +1452,37 @@ Condition to wait for.
 
 ### option: BrowserContext.waitForCondition.timeout = %%-wait-for-function-timeout-%%
 * since: v1.32
+
+## async method: BrowserContext.waitForConsoleMessage
+* since: v1.34
+* langs: java, python, csharp
+  - alias-python: expect_console_message
+  - alias-csharp: RunAndWaitForConsoleMessage
+- returns: <[ConsoleMessage]>
+
+Performs action and waits for a [ConsoleMessage] to be logged by in the pages in the context. If predicate is provided, it passes
+[ConsoleMessage] value into the `predicate` function and waits for `predicate(message)` to return a truthy value.
+Will throw an error if the page is closed before the [`event: BrowserContext.console`] event is fired.
+
+## async method: BrowserContext.waitForConsoleMessage
+* since: v1.34
+* langs: python
+- returns: <[EventContextManager]<[ConsoleMessage]>>
+
+### param: BrowserContext.waitForConsoleMessage.action = %%-csharp-wait-for-event-action-%%
+* since: v1.34
+
+### option: BrowserContext.waitForConsoleMessage.predicate
+* since: v1.34
+- `predicate` <[function]\([ConsoleMessage]\):[boolean]>
+
+Receives the [ConsoleMessage] object and resolves to truthy value when the waiting should resolve.
+
+### option: BrowserContext.waitForConsoleMessage.timeout = %%-wait-for-event-timeout-%%
+* since: v1.34
+
+### param: BrowserContext.waitForConsoleMessage.callback = %%-java-wait-for-event-callback-%%
+* since: v1.34
 
 ## async method: BrowserContext.waitForEvent
 * since: v1.8

--- a/docs/src/api/class-consolemessage.md
+++ b/docs/src/api/class-consolemessage.md
@@ -127,7 +127,7 @@ URL of the resource followed by 0-based line and column numbers in the resource 
 
 ## method: ConsoleMessage.page
 * since: v1.33
-- returns: <[Page]|[null]>
+- returns: <[null]|[Page]>
 
 The page that produced this console message, if any.
 

--- a/docs/src/api/class-dialog.md
+++ b/docs/src/api/class-dialog.md
@@ -139,7 +139,7 @@ A message displayed in the dialog.
 
 ## method: Dialog.page
 * since: v1.33
-- returns: <[Page]|[null]>
+- returns: <[null]|[Page]>
 
 The page that initiated this dialog, if available.
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -16435,7 +16435,7 @@ export interface ConsoleMessage {
   /**
    * The page that produced this console message, if any.
    */
-  page(): Page|null;
+  page(): null|Page;
 
   /**
    * The text of the console message.
@@ -16637,7 +16637,7 @@ export interface Dialog {
   /**
    * The page that initiated this dialog, if available.
    */
-  page(): Page|null;
+  page(): null|Page;
 
   /**
    * Returns dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prompt`.


### PR DESCRIPTION
This PR cherry-picks the following commits:

- 9b4f9b11368cdee370ac22286cd260af990b5a4d