### PR TITLE
cherry-pick(#23171): fix(tracing): when zipping remotely, use correct file name

### DIFF
--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -324,7 +324,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     for (const entry of entries)
       zipFile.addFile(entry.value, entry.name);
     zipFile.end();
-    const zipFileName = state.traceFile + '.zip';
+    const zipFileName = state.traceFile.file + '.zip';
     zipFile.outputStream.pipe(fs.createWriteStream(zipFileName)).on('close', () => {
       const artifact = new Artifact(this._context, zipFileName);
       artifact.reportFinished();

--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -578,7 +578,6 @@ test('should record global request trace', async ({ request, context, server }, 
 });
 
 test('should store global request traces separately', async ({ request, server, playwright, browserName, mode }, testInfo) => {
-  test.fixme(browserName === 'chromium' && mode === 'driver', 'https://github.com/microsoft/playwright/issues/23108');
   const request2 = await playwright.request.newContext();
   await Promise.all([
     (request as any)._tracing.start({ snapshots: true }),


### PR DESCRIPTION
Fixes #23108.