### PR TITLE
feat(ct): svelte partial update

### DIFF
--- a/packages/playwright-ct-svelte/index.d.ts
+++ b/packages/playwright-ct-svelte/index.d.ts
@@ -36,30 +36,27 @@ export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig
   };
 };
 
-type Slot = string | string[];
+type ComponentSlot = string | string[];
+type ComponentSlots = Record<string, ComponentSlot> & { default?: ComponentSlot };
+type ComponentEvents = Record<string, Function>;
 
-export interface MountOptions<
-  HooksConfig extends JsonObject,
-  Component extends SvelteComponent
-> {
+export interface MountOptions<HooksConfig extends JsonObject, Component extends SvelteComponent> {
   props?: ComponentProps<Component>;
-  slots?: Record<string, Slot> & { default?: Slot };
-  on?: Record<string, Function>;
+  slots?: ComponentSlots;
+  on?: ComponentEvents;
   hooksConfig?: HooksConfig;
 }
 
 interface MountResult<Component extends SvelteComponent> extends Locator {
   unmount(): Promise<void>;
-  update(
-    options: Omit<MountOptions<never, Component>, 'hooksConfig' | 'slots'>
-  ): Promise<void>;
+  update(options: {
+    props?: Partial<ComponentProps<Component>>;
+    on?: Partial<ComponentEvents>;
+  }): Promise<void>;
 }
 
 interface ComponentFixtures {
-  mount<
-    HooksConfig extends JsonObject,
-    Component extends SvelteComponent = SvelteComponent
-  >(
+  mount<HooksConfig extends JsonObject, Component extends SvelteComponent = SvelteComponent>(
     component: new (...args: any[]) => Component,
     options?: MountOptions<HooksConfig, Component>
   ): Promise<MountResult<Component>>;
@@ -70,9 +67,6 @@ export const test: TestType<
   PlaywrightWorkerArgs & PlaywrightWorkerOptions
 >;
 
-/**
- * Defines Playwright config
- */
 export function defineConfig(config: PlaywrightTestConfig): PlaywrightTestConfig;
 export function defineConfig<T>(config: PlaywrightTestConfig<T>): PlaywrightTestConfig<T>;
 export function defineConfig<T, W>(config: PlaywrightTestConfig<T, W>): PlaywrightTestConfig<T, W>;

--- a/packages/playwright-ct-svelte/register.d.ts
+++ b/packages/playwright-ct-svelte/register.d.ts
@@ -15,7 +15,7 @@
  */
 
 export default function(
-  components: { [key: string]: any },
+  components: Record<string, any>,
   options?: {
     window?: Window
   }


### PR DESCRIPTION
The component is already rendered with the required props/events/slots when calling `component.update`. This makes it unnecessary to specify all required props/events/slots again when updating a single prop/event/slot.

related: https://github.com/microsoft/playwright/pull/23151, https://github.com/microsoft/playwright/pull/23194