### PR TITLE
devops: do not use NPX during docker container build

### DIFF
--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -37,7 +37,7 @@ RUN mkdir /ms-playwright && \
     mkdir /ms-playwright-agent && \
     cd /ms-playwright-agent && npm init -y && \
     npm i /tmp/playwright-core.tar.gz && \
-    npx playwright mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
-    npx playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
+    npm exec --no -- playwright mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    npm exec --no -- playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
     rm /tmp/playwright-core.tar.gz && \
     chmod -R 777 /ms-playwright

--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -35,8 +35,8 @@ RUN mkdir /ms-playwright && \
     mkdir /ms-playwright-agent && \
     cd /ms-playwright-agent && npm init -y && \
     npm i /tmp/playwright-core.tar.gz && \
-    npx playwright mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
-    npx playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
+    npm exec --no -- playwright mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    npm exec --no -- playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
     rm /tmp/playwright-core.tar.gz && \
     rm -rf /ms-playwright-agent && \
     chmod -R 777 /ms-playwright


### PR DESCRIPTION
The postmortem of the broken docker image:
- We use `playwright-core` package when bootstrapping our docker
container.
- Due to accidental removal of `bin` entry in the `playwright-core` (see
  https://github.com/microsoft/playwright/issues/23206), the `npx
  playwright install --with-deps` was using the last published
  Playwright version instead of a locally-built playwright binary

This patch starts using `npx exec --no` to make sure that we never call
remote commands during docker image build.
