### PR TITLE
docs(class-locator.md): fix incorrect version of locator-and

### DIFF
--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -106,7 +106,7 @@ var texts = await page.GetByRole(AriaRole.Link).AllTextContentsAsync();
 
 
 ## method: Locator.and
-* since: v1.33
+* since: v1.34
 * langs:
   - alias-python: and_
 - returns: <[Locator]>
@@ -138,7 +138,7 @@ var button = page.GetByRole(AriaRole.Button).And(page.GetByTitle("Subscribe"));
 ```
 
 ### param: Locator.and.locator
-* since: v1.33
+* since: v1.34
 - `locator` <[Locator]>
 
 Additional locator to match.


### PR DESCRIPTION
The locator-and feature was added in v1.34, but it is mistakenly documented as v1.33.
This PR modifies the documentation to accurately reflect the additions made in v1.34.
https://playwright.dev/docs/api/class-locator#locator-and