### PR TITLE
tet: unflake some test runner tests

### DIFF
--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -673,7 +673,7 @@ test('unhandled rejection during beforeAll should be reported and prevent more t
         Promise.resolve().then(() => {
           throw new Error('Oh my');
         });
-        await new Promise(f => setTimeout(f, 100));
+        await new Promise(f => setTimeout(f, 1000));
       });
       test.afterAll(() => {
         console.log('\\n%%afterAll');

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -296,6 +296,8 @@ export const test = base
       },
 
       runTSC: async ({ childProcess }, use, testInfo) => {
+        testInfo.slow();
+
         await use(async files => {
           const baseDir = await writeFiles(testInfo, { 'tsconfig.json': JSON.stringify(TSCONFIG), ...files }, true);
           const tsc = childProcess({

--- a/tests/playwright-test/types-2.spec.ts
+++ b/tests/playwright-test/types-2.spec.ts
@@ -16,8 +16,6 @@
 
 import { test, expect } from './playwright-test-fixtures';
 
-test.slow();
-
 test('basics should work', async ({ runTSC }) => {
   const result = await runTSC({
     'a.spec.ts': `

--- a/tests/playwright-test/types.spec.ts
+++ b/tests/playwright-test/types.spec.ts
@@ -16,8 +16,6 @@
 
 import { test, expect } from './playwright-test-fixtures';
 
-test.slow();
-
 test('should check types of fixtures', async ({ runTSC }) => {
   const result = await runTSC({
     'helper.ts': `


### PR DESCRIPTION
- `unhandled rejection during beforeAll should be reported and prevent more tests` had timeout of 100ms that is too short on busy system;
- `runTSC` is always slow, so mark as such.