### PR TITLE
Updated documentation URLs to use Playwright Homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ To learn how to run these Playwright Test examples, check out our [getting start
 
 #### Page screenshot
 
-This code snippet navigates to whatsmyuseragent.org and saves a screenshot.
+This code snippet navigates to Playwright homepage and saves a screenshot.
 
 ```TypeScript
 import { test } from '@playwright/test';
 
 test('Page Screenshot', async ({ page }) => {
-  await page.goto('http://whatsmyuseragent.org/');
+  await page.goto('https://playwright.dev/');
   await page.screenshot({ path: `example.png` });
 });
 ```

--- a/docs/src/api/class-playwright.md
+++ b/docs/src/api/class-playwright.md
@@ -283,7 +283,7 @@ Terminates this instance of Playwright in case it was created bypassing the Pyth
 
 >>> browser = playwright.chromium.launch()
 >>> page = browser.new_page()
->>> page.goto("http://whatsmyuseragent.org/")
+>>> page.goto("https://playwright.dev/")
 >>> page.screenshot(path="example.png")
 >>> browser.close()
 

--- a/docs/src/intro-java.md
+++ b/docs/src/intro-java.md
@@ -90,7 +90,7 @@ Running it downloads the Playwright package and installs browser binaries for Ch
 
 ## First script
 
-In our first script, we will navigate to `whatsmyuseragent.org` and take a screenshot in WebKit.
+In our first script, we will navigate to `playwright.dev` and take a screenshot in WebKit.
 
 ```java
 package org.example;
@@ -103,7 +103,7 @@ public class App {
     try (Playwright playwright = Playwright.create()) {
       Browser browser = playwright.webkit().launch();
       Page page = browser.newPage();
-      page.navigate("http://whatsmyuseragent.org/");
+      page.navigate("https://playwright.dev/");
       page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("example.png")));
     }
   }

--- a/docs/src/library-js.md
+++ b/docs/src/library-js.md
@@ -149,7 +149,7 @@ Playwright APIs are asynchronous and return Promise objects. Our code examples u
 
 ## First script
 
-In our first script, we will navigate to `whatsmyuseragent.org` and take a screenshot in WebKit.
+In our first script, we will navigate to `https://playwright.dev/` and take a screenshot in WebKit.
 
 ```js
 const { webkit } = require('playwright');
@@ -157,7 +157,7 @@ const { webkit } = require('playwright');
 (async () => {
   const browser = await webkit.launch();
   const page = await browser.newPage();
-  await page.goto('http://whatsmyuseragent.org/');
+  await page.goto('https://playwright.dev/');
   await page.screenshot({ path: `example.png` });
   await browser.close();
 })();

--- a/docs/src/library-python.md
+++ b/docs/src/library-python.md
@@ -62,7 +62,7 @@ asyncio.run(main())
 
 ## First script
 
-In our first script, we will navigate to `whatsmyuseragent.org` and take a screenshot in WebKit.
+In our first script, we will navigate to `https://playwright.dev/` and take a screenshot in WebKit.
 
 ```py
 from playwright.sync_api import sync_playwright
@@ -70,7 +70,7 @@ from playwright.sync_api import sync_playwright
 with sync_playwright() as p:
     browser = p.webkit.launch()
     page = browser.new_page()
-    page.goto("http://whatsmyuseragent.org/")
+    page.goto("https://playwright.dev/")
     page.screenshot(path="example.png")
     browser.close()
 ```
@@ -98,7 +98,7 @@ and then launch Playwright within it for quick experimentation:
 # Pass headless=False to launch() to see the browser UI
 >>> browser = playwright.chromium.launch()
 >>> page = browser.new_page()
->>> page.goto("http://whatsmyuseragent.org/")
+>>> page.goto("https://playwright.dev/")
 >>> page.screenshot(path="example.png")
 >>> browser.close()
 >>> playwright.stop()
@@ -115,7 +115,7 @@ python -m asyncio
 >>> playwright = await async_playwright().start()
 >>> browser = await playwright.chromium.launch()
 >>> page = await browser.new_page()
->>> await page.goto("http://whatsmyuseragent.org/")
+>>> await page.goto("https://playwright.dev/")
 >>> await page.screenshot(path="example.png")
 >>> await browser.close()
 >>> await playwright.stop()
@@ -131,7 +131,7 @@ from playwright.sync_api import sync_playwright
 with sync_playwright() as p:
     browser = p.chromium.launch()
     page = browser.new_page()
-    page.goto("http://whatsmyuseragent.org/")
+    page.goto("https://playwright.dev/")
     page.screenshot(path="example.png")
     browser.close()
 ```

--- a/docs/src/puppeteer-js.md
+++ b/docs/src/puppeteer-js.md
@@ -60,7 +60,7 @@ const puppeteer = require('puppeteer');
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
   await page.setViewport({ width: 1280, height: 800 });
-  await page.goto('http://whatsmyuseragent.org/', {
+  await page.goto('https://playwright.dev/', {
     waitUntil: 'networkidle2',
   });
   await page.screenshot({ path: 'example.png' });
@@ -77,7 +77,7 @@ const { chromium } = require('playwright'); // 1
   const browser = await chromium.launch();
   const page = await browser.newPage(); // 2
   await page.setViewportSize({ width: 1280, height: 800 }); // 3
-  await page.goto('http://whatsmyuseragent.org/', {
+  await page.goto('https://playwright.dev/', {
     waitUntil: 'networkidle', // 4
   });
   await page.screenshot({ path: 'example.png' });

--- a/docs/src/threading-java.md
+++ b/docs/src/threading-java.md
@@ -37,7 +37,7 @@ public class PlaywrightThread extends Thread {
       BrowserType browserType = getBrowserType(playwright, browserName);
       Browser browser = browserType.launch();
       Page page = browser.newPage();
-      page.navigate("http://whatsmyuseragent.org/");
+      page.navigate("https://playwright.dev/");
       page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("user-agent-" + browserName + ".png")));
     }
   }


### PR DESCRIPTION
As discussed in this PR: https://github.com/microsoft/playwright-java/pull/1285 , Playwright is using `http://whatsmyuseragent.org/` in some documentation which is a dead link full of ads

![image](https://github.com/microsoft/playwright/assets/59550818/8ed437e5-cf35-4409-a1a8-ade3be0d2536)

I have raised a PR to replace these URLs to use the Playwright homepage in the Java version and it was approved. I am now raising it here.