### PR TITLE
fix: patch project names and ids when merging reports

### DIFF
--- a/packages/playwright-test/src/reporters/blob.ts
+++ b/packages/playwright-test/src/reporters/blob.ts
@@ -21,6 +21,7 @@ import { mime } from 'playwright-core/lib/utilsBundle';
 import { Readable } from 'stream';
 import type { FullConfig, FullResult, TestResult } from '../../types/testReporter';
 import type { Suite } from '../common/test';
+import type { JsonEvent } from '../isomorphic/teleReceiver';
 import { TeleReporterEmitter } from './teleEmitter';
 
 
@@ -29,8 +30,12 @@ type BlobReporterOptions = {
   outputDir?: string;
 };
 
+export type BlobReportMetadata = {
+  projectSuffix?: string;
+};
+
 export class BlobReporter extends TeleReporterEmitter {
-  private _messages: any[] = [];
+  private _messages: JsonEvent[] = [];
   private _options: BlobReporterOptions;
   private _salt: string;
   private _copyFilePromises = new Set<Promise<void>>();
@@ -42,6 +47,13 @@ export class BlobReporter extends TeleReporterEmitter {
     super(message => this._messages.push(message));
     this._options = options;
     this._salt = createGuid();
+
+    this._messages.push({
+      method: 'onBlobReportMetadata',
+      params: {
+        projectSuffix: process.env.PWTEST_BLOB_SUFFIX,
+      }
+    });
   }
 
   printsToStdio() {
@@ -64,11 +76,6 @@ export class BlobReporter extends TeleReporterEmitter {
       // Requires Node v14.18.0+
       fs.promises.writeFile(this._reportFile, content as any).catch(e => console.error(`Failed to write report ${this._reportFile}: ${e}`))
     ]);
-  }
-
-  override _serializeProjectName(name: string): string {
-    const suffix = process.env.PWTEST_BLOB_SUFFIX;
-    return name + (suffix ? suffix : '');
   }
 
   override _serializeAttachments(attachments: TestResult['attachments']): TestResult['attachments'] {

--- a/packages/playwright-test/src/reporters/teleEmitter.ts
+++ b/packages/playwright-test/src/reporters/teleEmitter.ts
@@ -14,32 +14,26 @@
  * limitations under the License.
  */
 
-import type { FullConfig, FullResult, Reporter, TestError, TestResult, TestStep, Location } from '../../types/testReporter';
-import type { Suite, TestCase } from '../common/test';
-import type { JsonConfig, JsonProject, JsonSuite, JsonTestCase, JsonTestEnd, JsonTestResultEnd, JsonTestResultStart, JsonTestStepEnd, JsonTestStepStart } from '../isomorphic/teleReceiver';
-import type { SuitePrivate } from '../../types/reporterPrivate';
-import { FullConfigInternal } from '../common/config';
-import { createGuid } from 'playwright-core/lib/utils';
-import { serializeRegexPatterns } from '../isomorphic/teleReceiver';
 import path from 'path';
-import type { FullProject } from '../../types/test';
+import { createGuid } from 'playwright-core/lib/utils';
+import type { SuitePrivate } from '../../types/reporterPrivate';
+import type { FullConfig, FullResult, Location, Reporter, TestError, TestResult, TestStep } from '../../types/testReporter';
+import { FullConfigInternal, FullProjectInternal } from '../common/config';
+import type { Suite, TestCase } from '../common/test';
+import type { JsonConfig, JsonEvent, JsonProject, JsonSuite, JsonTestCase, JsonTestEnd, JsonTestResultEnd, JsonTestResultStart, JsonTestStepEnd, JsonTestStepStart } from '../isomorphic/teleReceiver';
+import { serializeRegexPatterns } from '../isomorphic/teleReceiver';
 
 export class TeleReporterEmitter implements Reporter {
-  private _messageSink: (message: any) => void;
+  private _messageSink: (message: JsonEvent) => void;
   private _rootDir!: string;
 
-  constructor(messageSink: (message: any) => void) {
+  constructor(messageSink: (message: JsonEvent) => void) {
     this._messageSink = messageSink;
   }
 
   onBegin(config: FullConfig, suite: Suite) {
     this._rootDir = config.rootDir;
-    const projects: any[] = [];
-    const projectIds = this._uniqueProjectIds(config.projects);
-    for (const projectSuite of suite.suites) {
-      const report = this._serializeProject(projectSuite, projectIds);
-      projects.push(report);
-    }
+    const projects = suite.suites.map(projectSuite => this._serializeProject(projectSuite));
     this._messageSink({ method: 'onBegin', params: { config: this._serializeConfig(config), projects } });
   }
 
@@ -138,29 +132,12 @@ export class TeleReporterEmitter implements Reporter {
     };
   }
 
-  private _uniqueProjectIds(projects: FullProject[]): Map<FullProject, string> {
-    const usedNames = new Set<string>();
-    const result = new Map<FullProject, string>();
-    for (const p of projects) {
-      const name = this._serializeProjectName(p.name);
-      for (let i = 0; i < projects.length; ++i) {
-        const candidate = name + (i ? i : '');
-        if (usedNames.has(candidate))
-          continue;
-        result.set(p, candidate);
-        usedNames.add(candidate);
-        break;
-      }
-    }
-    return result;
-  }
-
-  private _serializeProject(suite: Suite, projectIds: Map<FullProject, string>): JsonProject {
+  private _serializeProject(suite: Suite): JsonProject {
     const project = suite.project()!;
     const report: JsonProject = {
-      id: projectIds.get(project)!,
+      id: FullProjectInternal.from(project).id,
       metadata: project.metadata,
-      name: this._serializeProjectName(project.name),
+      name: project.name,
       outputDir: this._relativePath(project.outputDir),
       repeatEach: project.repeatEach,
       retries: project.retries,
@@ -178,10 +155,6 @@ export class TeleReporterEmitter implements Reporter {
       teardown: project.teardown,
     };
     return report;
-  }
-
-  _serializeProjectName(name: string): string {
-    return name;
   }
 
   private _serializeSuite(suite: Suite): JsonSuite {


### PR DESCRIPTION
Project name is used in testId calculation, so patching it in the reporter is too late. Instead we now save project suffix to the blob report file and patch all project and test ids as well as project names in the report merger