### PR TITLE
test: use platform specific path separator

### DIFF
--- a/tests/playwright-test/list-files.spec.ts
+++ b/tests/playwright-test/list-files.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import path from 'path';
 import { test, expect } from './playwright-test-fixtures';
 
 test('should list files', async ({ runListFiles }) => {
@@ -31,7 +32,7 @@ test('should list files', async ({ runListFiles }) => {
       {
         name: 'foo',
         testDir: expect.stringContaining('list-files-should-list-files-playwright-test'),
-        outputDir: expect.stringContaining('list-files-should-list-files-playwright-test/test-results'),
+        outputDir: expect.stringContaining(path.join('list-files-should-list-files-playwright-test', 'test-results')),
         use: {},
         files: [
           expect.stringContaining('a.test.js')
@@ -40,7 +41,7 @@ test('should list files', async ({ runListFiles }) => {
       {
         name: 'bar',
         testDir: expect.stringContaining('list-files-should-list-files-playwright-test'),
-        outputDir: expect.stringContaining('list-files-should-list-files-playwright-test/test-results'),
+        outputDir: expect.stringContaining(path.join('list-files-should-list-files-playwright-test', 'test-results')),
         use: {},
         files: [
           expect.stringContaining('a.test.js')
@@ -67,7 +68,7 @@ test('should include testIdAttribute', async ({ runListFiles }) => {
       {
         name: '',
         testDir: expect.stringContaining('list-files-should-include-testIdAttribute-playwright-test'),
-        outputDir: expect.stringContaining('list-files-should-include-testIdAttribute-playwright-test/test-results'),
+        outputDir: expect.stringContaining(path.join('list-files-should-include-testIdAttribute-playwright-test', 'test-results')),
         use: {
           testIdAttribute: 'myid'
         },


### PR DESCRIPTION
The test has been failing recently https://devops.playwright.dev/flakiness.html#filter_spec=should+list+files&timestamp=1685115453114