### PR TITLE
chore: replace sigint handler per browser with a single one

### DIFF
--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -103,6 +103,7 @@ export class RemoteServer implements PlaywrightServer {
     };
     this._process = childProcess({
       command: ['node', path.join(__dirname, 'remote-server-impl.js'), JSON.stringify(options)],
+      env: { ...process.env, PWTEST_UNDER_TEST: '1' },
     });
 
     let index = 0;

--- a/tests/library/signals.spec.ts
+++ b/tests/library/signals.spec.ts
@@ -119,7 +119,8 @@ test.describe('signals', () => {
     expect(await remoteServer.childExitCode()).toBe(0);
   });
 
-  test('should kill the browser on SIGTERM + SIGINT', async ({ startRemoteServer, server }) => {
+  test('should kill the browser on SIGTERM + SIGINT', async ({ startRemoteServer, server, isMac, browserName }) => {
+    test.fixme(isMac && browserName === 'webkit' && parseInt(os.release(), 10) >= 22, 'https://github.com/microsoft/playwright/issues/22226');
     const remoteServer = await startRemoteServer('launchServer', { stallOnClose: true, url: server.EMPTY_PAGE });
     process.kill(remoteServer.child().pid, 'SIGTERM');
     await remoteServer.out('stalled');


### PR DESCRIPTION
Otherwise, multiple sigint handlers (one from each browser) would try to `process.exit(130)` each.