### PR TITLE
feat(ct): support for multiple vite plugins

### DIFF
--- a/packages/playwright-ct-react/index.js
+++ b/packages/playwright-ct-react/index.js
@@ -22,7 +22,10 @@ const plugin = () => {
   const { createPlugin } = require('@playwright/experimental-ct-core/lib/vitePlugin');
   return createPlugin(
     path.join(__dirname, 'registerSource.mjs'),
-    () => import('@vitejs/plugin-react').then(plugin => plugin.default()));
+    () => ({
+      plugins: [import('@vitejs/plugin-react').then(plugin => plugin.default())]
+    })
+  );
 };
 const defineConfig = config => originalDefineConfig({ ...config, _plugins: [plugin] });
 

--- a/packages/playwright-ct-react17/index.js
+++ b/packages/playwright-ct-react17/index.js
@@ -22,7 +22,10 @@ const plugin = () => {
   const { createPlugin } = require('@playwright/experimental-ct-core/lib/vitePlugin');
   return createPlugin(
     path.join(__dirname, 'registerSource.mjs'),
-    () => import('@vitejs/plugin-react').then(plugin => plugin.default()));
+    () => ({
+      plugins: [import('@vitejs/plugin-react').then(plugin => plugin.default())]
+    })
+  );
 };
 const defineConfig = config => originalDefineConfig({ ...config, _plugins: [plugin] });
 

--- a/packages/playwright-ct-solid/index.js
+++ b/packages/playwright-ct-solid/index.js
@@ -22,7 +22,10 @@ const plugin = () => {
   const { createPlugin } = require('@playwright/experimental-ct-core/lib/vitePlugin');
   return createPlugin(
     path.join(__dirname, 'registerSource.mjs'),
-    () => import('vite-plugin-solid').then(plugin => plugin.default()));
+    () => ({
+      plugins: [import('vite-plugin-solid').then(plugin => plugin.default())]
+    })
+  );
 };
 const defineConfig = config => originalDefineConfig({ ...config, _plugins: [plugin] });
 

--- a/packages/playwright-ct-svelte/index.js
+++ b/packages/playwright-ct-svelte/index.js
@@ -22,7 +22,10 @@ const plugin = () => {
   const { createPlugin } = require('@playwright/experimental-ct-core/lib/vitePlugin');
   return createPlugin(
     path.join(__dirname, 'registerSource.mjs'),
-    () => import('@sveltejs/vite-plugin-svelte').then(plugin => plugin.svelte()));
+    () => ({
+      plugins: [import('@sveltejs/vite-plugin-svelte').then(plugin => plugin.svelte())]
+    })
+  );
 };
 const defineConfig = config => originalDefineConfig({ ...config, _plugins: [plugin] });
 

--- a/packages/playwright-ct-vue/index.js
+++ b/packages/playwright-ct-vue/index.js
@@ -22,7 +22,13 @@ const plugin = () => {
   const { createPlugin } = require('@playwright/experimental-ct-core/lib/vitePlugin');
   return createPlugin(
     path.join(__dirname, 'registerSource.mjs'),
-    () => import('@vitejs/plugin-vue').then(plugin => plugin.default()));
+    () => ({
+      plugins: [import('@vitejs/plugin-vue').then(plugin => plugin.default())],
+      define: {
+        __VUE_PROD_DEVTOOLS__: true
+      }
+    })
+  );
 }
 const defineConfig = config => originalDefineConfig({ ...config, _plugins: [plugin] });
 

--- a/packages/playwright-ct-vue2/index.js
+++ b/packages/playwright-ct-vue2/index.js
@@ -22,7 +22,10 @@ const plugin = () => {
   const { createPlugin } = require('@playwright/experimental-ct-core/lib/vitePlugin');
   return createPlugin(
     path.join(__dirname, 'registerSource.mjs'),
-    () => import('@vitejs/plugin-vue2').then(plugin => plugin.default()));
+    () => ({ 
+      plugins: [import('@vitejs/plugin-vue2').then(plugin => plugin.default())] 
+    })
+  );
 };
 const defineConfig = config => originalDefineConfig({ ...config, _plugins: [plugin] });
 


### PR DESCRIPTION
Some frameworks _(like SvelteKit & Qwik)_ require multiple Vite plugins. It can also be useful to provide framework specific Vite config, such as with Vue: 

```ts
return createPlugin(
  path.join(__dirname, 'registerSource.mjs'),
  () => ({
    plugins: [import('@vitejs/plugin-vue').then(plugin => plugin.default())],
    define: {
      __VUE_PROD_DEVTOOLS__: true
    }
  })
);
```

closes: https://github.com/microsoft/playwright/issues/23463