### PR TITLE
fix: render actions in ui mode with browsers from selenium

### DIFF
--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -149,12 +149,9 @@ export abstract class BrowserType extends SdkObject {
 
     const env = options.env ? envArrayToObject(options.env) : process.env;
 
-    const tempDirectories = [];
-    if (options.downloadsPath)
-      await fs.promises.mkdir(options.downloadsPath, { recursive: true });
-    if (options.tracesDir)
-      await fs.promises.mkdir(options.tracesDir, { recursive: true });
+    await this._createArtifactDirs(options);
 
+    const tempDirectories = [];
     const artifactsDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'playwright-artifacts-'));
     tempDirectories.push(artifactsDir);
 
@@ -258,6 +255,13 @@ export abstract class BrowserType extends SdkObject {
       transport = new PipeTransport(stdio[3], stdio[4]);
     }
     return { browserProcess, artifactsDir, userDataDir, transport };
+  }
+
+  async _createArtifactDirs(options: types.LaunchOptions): Promise<void> {
+    if (options.downloadsPath)
+      await fs.promises.mkdir(options.downloadsPath, { recursive: true });
+    if (options.tracesDir)
+      await fs.promises.mkdir(options.tracesDir, { recursive: true });
   }
 
   async connectOverCDP(metadata: CallMetadata, endpointURL: string, options: { slowMo?: number }, timeout?: number): Promise<Browser> {

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -70,7 +70,7 @@ export class Chromium extends BrowserType {
     }, TimeoutSettings.timeout({ timeout }));
   }
 
-  async _connectOverCDPInternal(progress: Progress, endpointURL: string, options: { slowMo?: number, headers?: types.HeadersArray }, onClose?: () => Promise<void>) {
+  async _connectOverCDPInternal(progress: Progress, endpointURL: string, options: types.LaunchOptions & { headers?: types.HeadersArray }, onClose?: () => Promise<void>) {
     let headersMap: { [key: string]: string; } | undefined;
     if (options.headers)
       headersMap = headersArrayToObject(options.headers, false);
@@ -108,8 +108,8 @@ export class Chromium extends BrowserType {
       protocolLogger: helper.debugProtocolLogger(),
       browserLogsCollector: new RecentLogsCollector(),
       artifactsDir,
-      downloadsPath: artifactsDir,
-      tracesDir: artifactsDir,
+      downloadsPath: options.downloadsPath || artifactsDir,
+      tracesDir: options.tracesDir || artifactsDir,
       // On Windows context level proxies only work, if there isn't a global proxy
       // set. This is currently a bug in the CR/Windows networking stack. By
       // passing an arbitrary value we disable the check in PW land which warns
@@ -168,6 +168,8 @@ export class Chromium extends BrowserType {
   }
 
   override async _launchWithSeleniumHub(progress: Progress, hubUrl: string, options: types.LaunchOptions): Promise<CRBrowser> {
+    await this._createArtifactDirs(options);
+
     if (!hubUrl.endsWith('/'))
       hubUrl = hubUrl + '/';
 
@@ -253,7 +255,7 @@ export class Chromium extends BrowserType {
         }
       }
 
-      return await this._connectOverCDPInternal(progress, endpointURL.toString(), { slowMo: options.slowMo }, disconnectFromSelenium);
+      return await this._connectOverCDPInternal(progress, endpointURL.toString(), options, disconnectFromSelenium);
     } catch (e) {
       await disconnectFromSelenium();
       throw e;


### PR DESCRIPTION
## What's done

When using pwt with browsers from selenium in UI mode got an error like:
```
Error: ENOENT: no such file or directory, open '/cwd/test-results/.playwright-artifacts-0/traces/918d8d30525e50c3ae85-95e264cac83d4e6b2fcf.stacks'
```

So i fixed it.