### PR TITLE
test: skip and unflake tests

### DIFF
--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -182,7 +182,9 @@ test('should collect two traces', async ({ context, page, server }, testInfo) =>
   }
 });
 
-test('should respect tracesDir and name', async ({ browserType, server }, testInfo) => {
+test('should respect tracesDir and name', async ({ browserType, server, mode }, testInfo) => {
+  test.skip(mode === 'service', 'Service ignores tracesDir');
+
   const tracesDir = testInfo.outputPath('traces');
   const browser = await browserType.launch({ tracesDir });
   const context = await browser.newContext();

--- a/tests/page/locator-is-visible.spec.ts
+++ b/tests/page/locator-is-visible.spec.ts
@@ -88,15 +88,13 @@ it('isVisible inside a role=button', async ({ page }) => {
 
 it('isVisible during navigation should not throw', async ({ page, server }) => {
   for (let i = 0; i < 20; i++) {
-    // Make sure previous navigation finishes, to avoid page.setContent throwing.
-    await page.waitForTimeout(100);
     await page.setContent(`
       <script>
         setTimeout(() => {
           window.location.href = ${JSON.stringify(server.EMPTY_PAGE)};
         }, Math.random(50));
       </script>
-    `);
+    `).catch(() => {});  // Avoid page.setContent throwing becuase of scheduled navigation.
     expect(await page.locator('div').isVisible()).toBe(false);
   }
 });


### PR DESCRIPTION
- `should respect tracesDir and name` does not work with service mode;
- `isVisible during navigation should not throw` had a short timeout.