### PR TITLE
fix(pause): ignore `page.pause` on the server

### DIFF
--- a/packages/playwright-core/src/server/debugger.ts
+++ b/packages/playwright-core/src/server/debugger.ts
@@ -120,6 +120,8 @@ export class Debugger extends EventEmitter implements InstrumentationListener {
 }
 
 function shouldPauseOnCall(sdkObject: SdkObject, metadata: CallMetadata): boolean {
+  if (sdkObject.attribution.playwright.options.isServer)
+    return false;
   if (!sdkObject.attribution.browser?.options.headful && !isUnderTest())
     return false;
   return metadata.method === 'pause';

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -157,6 +157,18 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       await browser.close();
     });
 
+    test('should ignore page.pause when headed', async ({ connect, startRemoteServer, browserType }) => {
+      const headless = (browserType as any)._defaultLaunchOptions.headless;
+      (browserType as any)._defaultLaunchOptions.headless = false;
+      const remoteServer = await startRemoteServer(kind);
+      const browser = await connect(remoteServer.wsEndpoint());
+      const browserContext = await browser.newContext();
+      const page = await browserContext.newPage();
+      await page.pause();
+      await browser.close();
+      (browserType as any)._defaultLaunchOptions.headless = headless;
+    });
+
     test('should be able to visit ipv6 through localhost', async ({ connect, startRemoteServer, ipV6ServerPort }) => {
       test.fail(!!process.env.INSIDE_DOCKER, 'docker does not support IPv6 by default');
       const remoteServer = await startRemoteServer(kind);

--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -230,19 +230,6 @@ test('test', async ({ page }) => {
   });
 });
 
-
-test('should pause and resume', async ({ backend, connectedBrowser }) => {
-  const events = [];
-  backend.on('paused', event => events.push(event));
-  const context = await connectedBrowser._newContextForReuse();
-  const page = await context.newPage();
-  await page.setContent('<button>Submit</button>');
-  const pausePromise = page.pause();
-  await expect.poll(() => events[events.length - 1]).toEqual({ paused: true });
-  await backend.resume();
-  await pausePromise;
-});
-
 test('should reset routes before reuse', async ({ server, connectedBrowserFactory }) => {
   const browser1 = await connectedBrowserFactory();
   const context1 = await browser1._newContextForReuse();


### PR DESCRIPTION
Fixes #23051.