### PR TITLE
chore: upgrade @types/node to 16.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,23 @@
 # Contributing
 
 - [How to Contribute](#how-to-contribute)
-  * [Getting Code](#getting-code)
-  * [Code reviews](#code-reviews)
-  * [Code Style](#code-style)
-  * [API guidelines](#api-guidelines)
-  * [Commit Messages](#commit-messages)
-  * [Writing Documentation](#writing-documentation)
-  * [Adding New Dependencies](#adding-new-dependencies)
-  * [Running & Writing Tests](#running--writing-tests)
-  * [Public API Coverage](#public-api-coverage)
+  - [Getting Code](#getting-code)
+  - [Code reviews](#code-reviews)
+  - [Code Style](#code-style)
+  - [API guidelines](#api-guidelines)
+  - [Commit Messages](#commit-messages)
+  - [Writing Documentation](#writing-documentation)
+  - [Adding New Dependencies](#adding-new-dependencies)
+  - [Running & Writing Tests](#running--writing-tests)
+  - [Public API Coverage](#public-api-coverage)
 - [Contributor License Agreement](#contributor-license-agreement)
-  * [Code of Conduct](#code-of-conduct)
+  - [Code of Conduct](#code-of-conduct)
 
 ## How to Contribute
 
 ### Getting Code
 
-Make sure you're running Node.js 14+ and NPM 8+, to verify and upgrade NPM do:
+Make sure you're running Node.js 16+ and NPM 8+, to verify and upgrade NPM do:
 
 ```bash
 node --version
@@ -90,17 +90,17 @@ description
 footer
 ```
 
-1. *label* is one of the following:
-    - `fix` - playwright bug fixes.
-    - `feat` - playwright features.
-    - `docs` - changes to docs, e.g. `docs(api.md): ..` to change documentation.
-    - `test` - changes to playwright tests infrastructure.
-    - `devops` - build-related work, e.g. CI related patches and general changes to the browser build infrastructure
-    - `chore` - everything that doesn't fall under previous categories
-2. *namespace* is put in parenthesis after label and is optional. Must be lowercase.
-3. *title* is a brief summary of changes.
-4. *description* is **optional**, new-line separated from title and is in present tense.
-5. *footer* is **optional**, new-line separated from *description* and contains "fixes" / "references" attribution to github issues.
+1. _label_ is one of the following:
+   - `fix` - playwright bug fixes.
+   - `feat` - playwright features.
+   - `docs` - changes to docs, e.g. `docs(api.md): ..` to change documentation.
+   - `test` - changes to playwright tests infrastructure.
+   - `devops` - build-related work, e.g. CI related patches and general changes to the browser build infrastructure
+   - `chore` - everything that doesn't fall under previous categories
+2. _namespace_ is put in parenthesis after label and is optional. Must be lowercase.
+3. _title_ is a brief summary of changes.
+4. _description_ is **optional**, new-line separated from title and is in present tense.
+5. _footer_ is **optional**, new-line separated from _description_ and contains "fixes" / "references" attribution to github issues.
 
 Example:
 
@@ -131,17 +131,19 @@ To build the documentation site locally and test how your changes will look in p
 ### Adding New Dependencies
 
 For all dependencies (both installation and development):
+
 - **Do not add** a dependency if the desired functionality is easily implementable.
 - If adding a dependency, it should be well-maintained and trustworthy.
 
 A barrier for introducing new installation dependencies is especially high:
+
 - **Do not add** installation dependency unless it's critical to project success.
 
 ### Running & Writing Tests
 
 - Every feature should be accompanied by a test.
 - Every public api event/method should be accompanied by a test.
-- Tests should be *hermetic*. Tests should not depend on external services.
+- Tests should be _hermetic_. Tests should not depend on external services.
 - Tests should work on all three platforms: Mac, Linux and Win. This is especially important for screenshot tests.
 
 Playwright tests are located in [`tests`](https://github.com/microsoft/playwright/blob/main/tests) and use `@playwright/test` test runner.
@@ -154,6 +156,7 @@ npm run test
 ```
 
 - To run all tests in Chromium
+
 ```bash
 npm run ctest # also `ftest` for firefox and `wtest` for WebKit
 ```
@@ -202,7 +205,7 @@ SLOW_MO=500 npm run wtest -- --headed
 
 - When should a test be marked with `skip` or `fail`?
 
-  - **`skip(condition)`**: This test *should ***never*** work* for `condition`
+  - **`skip(condition)`**: This test \*should **_never_** work\* for `condition`
     where `condition` is usually a certain browser like `FFOX` (for Firefox),
     `WEBKIT` (for WebKit), and `CHROMIUM` (for Chromium).
 
@@ -210,8 +213,7 @@ SLOW_MO=500 npm run wtest -- --headed
     with `skip(FFOX)` since an alt-click in Firefox will not produce a download
     even if a person was driving the browser.
 
-
-  - **`fail(condition)`**: This test *should ***eventually*** work* for `condition`
+  - **`fail(condition)`**: This test \*should **_eventually_** work\* for `condition`
     where `condition` is usually a certain browser like `FFOX` (for Firefox),
     `WEBKIT` (for WebKit), and `CHROMIUM` (for Chromium).
 
@@ -222,7 +224,7 @@ SLOW_MO=500 npm run wtest -- --headed
 
 ## Contributor License Agreement
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
 # Contributing
 
 - [How to Contribute](#how-to-contribute)
-  - [Getting Code](#getting-code)
-  - [Code reviews](#code-reviews)
-  - [Code Style](#code-style)
-  - [API guidelines](#api-guidelines)
-  - [Commit Messages](#commit-messages)
-  - [Writing Documentation](#writing-documentation)
-  - [Adding New Dependencies](#adding-new-dependencies)
-  - [Running & Writing Tests](#running--writing-tests)
-  - [Public API Coverage](#public-api-coverage)
+  * [Getting Code](#getting-code)
+  * [Code reviews](#code-reviews)
+  * [Code Style](#code-style)
+  * [API guidelines](#api-guidelines)
+  * [Commit Messages](#commit-messages)
+  * [Writing Documentation](#writing-documentation)
+  * [Adding New Dependencies](#adding-new-dependencies)
+  * [Running & Writing Tests](#running--writing-tests)
+  * [Public API Coverage](#public-api-coverage)
 - [Contributor License Agreement](#contributor-license-agreement)
-  - [Code of Conduct](#code-of-conduct)
+  * [Code of Conduct](#code-of-conduct)
 
 ## How to Contribute
 
@@ -90,17 +90,17 @@ description
 footer
 ```
 
-1. _label_ is one of the following:
-   - `fix` - playwright bug fixes.
-   - `feat` - playwright features.
-   - `docs` - changes to docs, e.g. `docs(api.md): ..` to change documentation.
-   - `test` - changes to playwright tests infrastructure.
-   - `devops` - build-related work, e.g. CI related patches and general changes to the browser build infrastructure
-   - `chore` - everything that doesn't fall under previous categories
-2. _namespace_ is put in parenthesis after label and is optional. Must be lowercase.
-3. _title_ is a brief summary of changes.
-4. _description_ is **optional**, new-line separated from title and is in present tense.
-5. _footer_ is **optional**, new-line separated from _description_ and contains "fixes" / "references" attribution to github issues.
+1. *label* is one of the following:
+    - `fix` - playwright bug fixes.
+    - `feat` - playwright features.
+    - `docs` - changes to docs, e.g. `docs(api.md): ..` to change documentation.
+    - `test` - changes to playwright tests infrastructure.
+    - `devops` - build-related work, e.g. CI related patches and general changes to the browser build infrastructure
+    - `chore` - everything that doesn't fall under previous categories
+2. *namespace* is put in parenthesis after label and is optional. Must be lowercase.
+3. *title* is a brief summary of changes.
+4. *description* is **optional**, new-line separated from title and is in present tense.
+5. *footer* is **optional**, new-line separated from *description* and contains "fixes" / "references" attribution to github issues.
 
 Example:
 
@@ -131,19 +131,17 @@ To build the documentation site locally and test how your changes will look in p
 ### Adding New Dependencies
 
 For all dependencies (both installation and development):
-
 - **Do not add** a dependency if the desired functionality is easily implementable.
 - If adding a dependency, it should be well-maintained and trustworthy.
 
 A barrier for introducing new installation dependencies is especially high:
-
 - **Do not add** installation dependency unless it's critical to project success.
 
 ### Running & Writing Tests
 
 - Every feature should be accompanied by a test.
 - Every public api event/method should be accompanied by a test.
-- Tests should be _hermetic_. Tests should not depend on external services.
+- Tests should be *hermetic*. Tests should not depend on external services.
 - Tests should work on all three platforms: Mac, Linux and Win. This is especially important for screenshot tests.
 
 Playwright tests are located in [`tests`](https://github.com/microsoft/playwright/blob/main/tests) and use `@playwright/test` test runner.
@@ -156,7 +154,6 @@ npm run test
 ```
 
 - To run all tests in Chromium
-
 ```bash
 npm run ctest # also `ftest` for firefox and `wtest` for WebKit
 ```
@@ -205,7 +202,7 @@ SLOW_MO=500 npm run wtest -- --headed
 
 - When should a test be marked with `skip` or `fail`?
 
-  - **`skip(condition)`**: This test \*should **_never_** work\* for `condition`
+  - **`skip(condition)`**: This test *should ***never*** work* for `condition`
     where `condition` is usually a certain browser like `FFOX` (for Firefox),
     `WEBKIT` (for WebKit), and `CHROMIUM` (for Chromium).
 
@@ -213,7 +210,8 @@ SLOW_MO=500 npm run wtest -- --headed
     with `skip(FFOX)` since an alt-click in Firefox will not produce a download
     even if a person was driving the browser.
 
-  - **`fail(condition)`**: This test \*should **_eventually_** work\* for `condition`
+
+  - **`fail(condition)`**: This test *should ***eventually*** work* for `condition`
     where `condition` is usually a certain browser like `FFOX` (for Firefox),
     `WEBKIT` (for WebKit), and `CHROMIUM` (for Chromium).
 
@@ -224,7 +222,7 @@ SLOW_MO=500 npm run wtest -- --headed
 
 ## Contributor License Agreement
 
-This project welcomes contributions and suggestions. Most contributions require you to agree to a
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -28,11 +28,11 @@ await page.evaluate(`(async() => {
 ## Node.js requirements
 * langs: js
 
-Playwright requires Node.js version 14 or above
+Playwright requires Node.js version 16 or above
 
 ### ReferenceError: URL is not defined
 
-Playwright requires Node.js 14 or higher.
+Playwright requires Node.js 16 or higher.
 
 ### Unknown file extension ".ts"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/babel__core": "^7.20.0",
         "@types/codemirror": "^5.60.7",
         "@types/formidable": "^2.0.4",
-        "@types/node": "=14.18.34",
+        "@types/node": "^16.18.34",
         "@types/react": "^18.0.12",
         "@types/react-dom": "^18.0.5",
         "@types/resize-observer-browser": "^0.1.7",
@@ -1505,9 +1505,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
-      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA=="
+      "version": "16.18.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.34.tgz",
+      "integrity": "sha512-VmVm7gXwhkUimRfBwVI1CHhwp86jDWR04B5FGebMMyxV90SlCmFujwUHrxTD4oO+SOYU86SoxvhgeRQJY7iXFg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2776,12 +2776,6 @@
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "16.18.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.6.tgz",
-      "integrity": "sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA==",
-      "dev": true
     },
     "node_modules/electron/node_modules/debug": {
       "version": "2.6.9",
@@ -6227,6 +6221,9 @@
     "packages/playwright-core": {
       "version": "1.35.0-next",
       "license": "Apache-2.0",
+      "bin": {
+        "playwright": "cli.js"
+      },
       "engines": {
         "node": ">=14"
       }
@@ -7472,9 +7469,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
-      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA=="
+      "version": "16.18.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.34.tgz",
+      "integrity": "sha512-VmVm7gXwhkUimRfBwVI1CHhwp86jDWR04B5FGebMMyxV90SlCmFujwUHrxTD4oO+SOYU86SoxvhgeRQJY7iXFg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -8332,12 +8329,6 @@
         "extract-zip": "^1.0.3"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "16.18.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.6.tgz",
-          "integrity": "sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA==",
-          "dev": true
-        },
         "debug": {
           "version": "2.6.9",
           "dev": true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/babel__core": "^7.20.0",
     "@types/codemirror": "^5.60.7",
     "@types/formidable": "^2.0.4",
-    "@types/node": "=14.18.34",
+    "@types/node": "^16.18.34",
     "@types/react": "^18.0.12",
     "@types/react-dom": "^18.0.5",
     "@types/resize-observer-browser": "^0.1.7",

--- a/packages/playwright-chromium/package.json
+++ b/packages/playwright-chromium/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-core/src/common/socksProxy.ts
+++ b/packages/playwright-core/src/common/socksProxy.ts
@@ -421,7 +421,7 @@ export class SocksProxy extends EventEmitter implements SocksConnectionClient {
       const localAddress = socket.localAddress;
       const localPort = socket.localPort;
       this._directSockets.set(request.uid, socket);
-      this._connections.get(request.uid)?.socketConnected(localAddress, localPort);
+      this._connections.get(request.uid)?.socketConnected(localAddress!, localPort!);
     } catch (error) {
       this._connections.get(request.uid)?.socketFailed(error.code);
     }
@@ -557,7 +557,7 @@ export class SocksProxyHandler extends EventEmitter {
       const localAddress = socket.localAddress;
       const localPort = socket.localPort;
       this._sockets.set(uid, socket);
-      const payload: SocksSocketConnectedPayload = { uid, host: localAddress, port: localPort };
+      const payload: SocksSocketConnectedPayload = { uid, host: localAddress!, port: localPort! };
       debugLogger.log('socks', `[${uid}] <= connected to network ${payload.host}:${payload.port}`);
       this.emit(SocksProxyHandler.Events.SocksConnected, payload);
     } catch (error) {

--- a/packages/playwright-ct-core/package.json
+++ b/packages/playwright-ct-core/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-ct-react/package.json
+++ b/packages/playwright-ct-react/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-ct-react17/package.json
+++ b/packages/playwright-ct-react17/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-ct-solid/package.json
+++ b/packages/playwright-ct-solid/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-ct-svelte/package.json
+++ b/packages/playwright-ct-svelte/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-ct-vue/package.json
+++ b/packages/playwright-ct-vue/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-ct-vue2/package.json
+++ b/packages/playwright-ct-vue2/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-firefox/package.json
+++ b/packages/playwright-firefox/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "main": "index.js",
   "exports": {

--- a/packages/playwright-test/src/common/process.ts
+++ b/packages/playwright-test/src/common/process.ts
@@ -55,7 +55,7 @@ let processRunner: ProcessRunner;
 let processName: string;
 const startingEnv = { ...process.env };
 
-process.on('message', async message => {
+process.on('message', async (message: any) => {
   if (message.method === '__init__') {
     const { processParams, runnerParams, runnerScript } = message.params as { processParams: ProcessInitParams, runnerParams: any, runnerScript: string };
     setTtyParams(process.stdout, processParams.stdoutParams);

--- a/packages/playwright-webkit/package.json
+++ b/packages/playwright-webkit/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -5,7 +5,7 @@
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
This PR updates `@types/node` to 16.x in order to get #23254 working