### PR TITLE
fix(devops): pass pr number in a file

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -30,6 +30,13 @@ jobs:
         name: 'blob-report-${{ github.event.workflow_run.run_attempt }}'
         path: 'blob-report'
 
+    - name: Read pull request number
+      if: ${{ always() && github.event.workflow_run.event == 'pull_request' }}
+      uses: ./.github/actions/download-artifact
+      with:
+        name: 'pull-request'
+        path: './'
+
     - name: Download blob report from Azure
       if: ${{ always() && github.event.workflow_run.event == 'push' }}
       uses: ./.github/actions/download-blob-report-from-azure
@@ -59,20 +66,27 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          let prs = [];
+          let prNumber;
           if (context.payload.workflow_run.event === 'pull_request') {
-            prs = context.payload.workflow_run.pull_requests;
+            const prs = context.payload.workflow_run.pull_requests;
+            if (prs.length) {
+              prNumber = prs[0].number;
+            } else {
+              const fs = require('fs');
+              prNumber = parseInt(fs.readFileSync('pull_request_number.txt').toString());
+              console.log('Read pull request number from file: ' + prNumber);
+            }
           } else if (context.payload.workflow_run.event === 'push') {
             const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               ...context.repo,
               commit_sha: context.sha,
             });
-            prs = data;
+            prNumber = data[0].number;
           } else {
             core.error('Unsupported workflow trigger event: ' + context.payload.workflow_run.event);
             return;
           }
-          if (prs.length === 0) {
+          if (!prNumber) {
             core.error('No pull request found for commit ' + context.sha + ' and workflow triggered by: ' + context.payload.workflow_run.event);
             return;
           }
@@ -81,7 +95,7 @@ jobs:
           core.notice('Report url: ' + reportUrl);
           const { data: response } = await github.rest.issues.createComment({
             ...context.repo,
-            issue_number: prs[0].number,
+            issue_number: prNumber,
             body: `"${{ github.event.workflow_run.name }}" [report](${reportUrl}).`,
           });
           core.info('Posted comment: ' + response.html_url);

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -71,6 +71,15 @@ jobs:
         name: blob-report-${{ github.run_attempt }}
         path: test-results/blob-report
         retention-days: 30
+    - name: Write the pull request number in an file
+      if: always() && github.event_name == 'pull_request'
+      run: echo '${{ github.event.number }}' > pull_request_number.txt;
+    - name: Upload artifact with pull request number
+      uses: actions/upload-artifact@v3
+      if: always() && github.event_name == 'pull_request'
+      with:
+        name: pull-request
+        path: pull_request_number.txt
 
   test_linux_chromium_tot:
     name: ${{ matrix.os }} (chromium tip-of-tree)
@@ -152,6 +161,15 @@ jobs:
         name: blob-report-${{ github.run_attempt }}
         path: test-results/blob-report
         retention-days: 30
+    - name: Write the pull request number in an file
+      if: always() && github.event_name == 'pull_request'
+      run: echo '${{ github.event.number }}' > pull_request_number.txt;
+    - name: Upload artifact with pull request number
+      uses: actions/upload-artifact@v3
+      if: always() && github.event_name == 'pull_request'
+      with:
+        name: pull-request
+        path: pull_request_number.txt
 
   test_web_components:
     name: Web Components

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -218,6 +218,15 @@ jobs:
         name: blob-report-${{ github.run_attempt }}
         path: test-results/blob-report
         retention-days: 30
+    - name: Write the pull request number in an file
+      if: always() && github.event_name == 'pull_request'
+      run: echo '${{ github.event.number }}' > pull_request_number.txt;
+    - name: Upload artifact with pull request number
+      uses: actions/upload-artifact@v3
+      if: always() && github.event_name == 'pull_request'
+      with:
+        name: pull-request
+        path: pull_request_number.txt
 
   chrome_stable_linux:
     name: "Chrome Stable (Linux)"


### PR DESCRIPTION
For some reason pull_requests field on workflow_run is empty for pull requests created from branches in forked repositories, see https://github.com/orgs/community/discussions/25220. As a workaround we store triggering pull request number in a file.