### PR TITLE
docs: improve by adding teardown and examples

### DIFF
--- a/docs/src/test-global-setup-teardown-js.md
+++ b/docs/src/test-global-setup-teardown-js.md
@@ -56,7 +56,7 @@ This example will show you how to use project dependencies to create a global se
 
 The setup project will write the storage state into an 'auth.json' file in a '.auth' folder inside the playwright folder. By exporting a const of `STORAGE_STATE` we can then easily share the location of the storage file between projects with the [`method: BrowserContext.storageState`] method. This returns the storage state for the browser context and contains the current cookies and a local storage snapshot.
 
-In this example the 'logged in chromium' project depends on the setup project whereas the 'logged out chromium' project ignores anything with 'loggedin' or 'setup' in it's file name.
+In this example the 'logged in chromium' project depends on the setup project whereas the 'logged out chromium' project does not depend on the setup project, and does not use the `storageState` option.
 
 ```js title="playwright.config.ts"
 import { defineConfig } from '@playwright/test';
@@ -90,7 +90,7 @@ export default defineConfig({
 });
 ```
 
-We then create a setup test, stored at route level of your project, that logs in to an application and populates the context with the storage state after the login actions have been performed. By doing this you only have to log in once and the credentials will be stored in the `STORAGE_STATE` file, meaning you don't need to log in again for every test. Start by importing the `STORAGE_STATE` from the Playwright config file and then use this as the path to save your storage state to the page's context.
+We then create a setup test, stored at root level of your project, that logs in to an application and populates the context with the storage state after the login actions have been performed. By doing this you only have to log in once and the credentials will be stored in the `STORAGE_STATE` file, meaning you don't need to log in again for every test. Start by importing the `STORAGE_STATE` from the Playwright config file and then use this as the path to save your storage state to the page's context.
 
 ```js title="global.setup.ts"
 import { test as setup, expect } from '@playwright/test';

--- a/docs/src/test-global-setup-teardown-js.md
+++ b/docs/src/test-global-setup-teardown-js.md
@@ -160,9 +160,9 @@ export default defineConfig({
       name: 'cleanup db',
       testMatch: /global\.teardown\.ts/,
     },
-    {
-      // other project
-    }
+    // {
+    //   other project
+    // }
   ]
 });
 ```

--- a/docs/src/test-global-setup-teardown-js.md
+++ b/docs/src/test-global-setup-teardown-js.md
@@ -51,7 +51,7 @@ export default defineConfig({
 
 This example will show you how to use project dependencies to create a global setup that logins into an application and saves the state in storage state. This is useful if you want to run multiple tests that require a sign sign-in state and you want to avoid login for each test.
 
-The setup project will write the storage state into an 'auth.json' file in a '.auth' folder inside the playwright folder. By exporting a const of `STORAGE_STATE` we can then easily share the location of the storage file between projects with the [`StorageState`](./test-use-options#basic-options) method. This applies the storage state on the browser context with its cookies and a local storage snapshot.
+The setup project will write the storage state into an 'playwright/.auth/user.json' file next to your playwright.config. By exporting a const of `STORAGE_STATE` we can then easily share the location of the storage file between projects with the [`StorageState`](./test-use-options#basic-options) method. This applies the storage state on the browser context with its cookies and a local storage snapshot.
 
 In this example the 'logged in chromium' project depends on the setup project whereas the 'logged out chromium' project does not depend on the setup project, and does not use the `storageState` option.
 
@@ -131,16 +131,16 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   projects: [
-    {
-      // setup project
-    },
+    // {
+    //   setup project
+    // },
     {
       name: 'cleanup db',
       testMatch: /global.teardown\.ts/,
     },
-    {
-      // other project
-    }
+    // {
+    //   other project
+    // }
   ]
 });
 ```
@@ -153,12 +153,12 @@ export default defineConfig({
   projects: [
     {
       name: 'setup db',
-      testMatch: /global.setup\.ts/,
+      testMatch: /global\.setup\.ts/,
       teardown: 'cleanup db',
     },
     {
       name: 'cleanup db',
-      testMatch: /global.teardown\.ts/,
+      testMatch: /global\.teardown\.ts/,
     },
     {
       // other project
@@ -194,12 +194,12 @@ export default defineConfig({
   projects: [
     {
       name: 'setup db',
-      testMatch: /global.setup\.ts/,
+      testMatch: /global\.setup\.ts/,
       teardown: 'cleanup db',
     },
     {
       name: 'cleanup db',
-      testMatch: /global.teardown\.ts/,
+      testMatch: /global\.teardown\.ts/,
     },
     {
       name: 'chromium',

--- a/docs/src/test-global-setup-teardown-js.md
+++ b/docs/src/test-global-setup-teardown-js.md
@@ -52,9 +52,9 @@ export default defineConfig({
 ```
 ### Setup Example
 
-This example will show you how to use project dependencies to create a global setup that logs into an application and saves the state in storage state. This is useful if you want to run multiple tests that require a sign in state and you want to avoid logging in for each test.
+This example will show you how to use project dependencies to create a global setup that logins into an application and saves the state in storage state. This is useful if you want to run multiple tests that require a sign sign-in state and you want to avoid login for each test.
 
-The setup project will write the storage state into an 'auth.json' file in a '.auth' folder inside the playwright folder. By exporting a const of `STORAGE_STATE` we can then easily share the location of the storage file between projects with the [`StorageState`](https://playwright.dev/docs/test-use-options#basic-options) method. This returns the storage state for the browser context and contains the current cookies and a local storage snapshot.
+The setup project will write the storage state into an 'auth.json' file in a '.auth' folder inside the playwright folder. By exporting a const of `STORAGE_STATE` we can then easily share the location of the storage file between projects with the [`StorageState`](./test-use-options#basic-options) method. This applies the storage state on the browser context with its cookies and a local storage snapshot.
 
 In this example the 'logged in chromium' project depends on the setup project whereas the 'logged out chromium' project does not depend on the setup project, and does not use the `storageState` option.
 

--- a/docs/src/test-global-setup-teardown-js.md
+++ b/docs/src/test-global-setup-teardown-js.md
@@ -3,13 +3,32 @@ id: test-global-setup-teardown
 title: "Global setup and teardown"
 ---
 
-There are two ways to configure global setup and teardown: using a global setup file and setting it in the config under [`globalSetup`](#configure-globalsetup-and-globalteardown) or using [project dependencies](#project-dependencies). With project dependencies, you define a project that runs before all other projects. This is the recommended way to configure global setup as with Project dependencies your HTML report will show the global setup, trace viewer will record a trace of the setup and fixtures can be used.
+There are two ways to configure global setup and teardown: using a global setup file and setting it in the config under [`globalSetup`](#configure-globalsetup-and-globalteardown) or using [project dependencies](#project-dependencies). With project dependencies, you define a project that runs before all other projects and a teardown project that runs after the dependencies. This is the recommended way to configure global setup as with Project dependencies your HTML report will show the global setup, trace viewer will record a trace of the setup and fixtures can be used.
 
 ## Project Dependencies
 
 [Project dependencies](./api/class-testproject#test-project-dependencies) are a list of projects that need to run before the tests in another project run. They can be useful for configuring the global setup actions so that one project depends on this running first. Using dependencies allows global setup to produce traces and other artifacts.
 
-In this example the chromium, firefox and webkit projects depend on the setup project.
+### Setup
+
+First we add a new project with the name 'setup'. We then give it a [`property: TestProject.testMatch`] property in order to match the file called `global.setup.ts`:
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /global.setup\.ts/,
+    },
+    {
+      // other project
+    }
+  ]
+});
+```
+Then we add the [`property: TestProject.dependencies`] property to our projects that depend on the setup project and pass into the array the name of of our dependency project, which we defined in the previous step:
 
 ```js title="playwright.config.ts"
 import { defineConfig } from '@playwright/test';
@@ -26,24 +45,187 @@ export default defineConfig({
       dependencies: ['setup'],
     },
     {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-      dependencies: ['setup'],
+      // other project
+    }
+  ]
+});
+```
+### Setup Example
+
+This example will show you how to use project dependencies to create a global setup that logs into an application and saves the state in storage state. This is useful if you want to run multiple tests that require a sign in state and you want to avoid logging in for each test.
+
+The setup project will write the storage state into an 'auth.json' file in a '.auth' folder inside the playwright folder. By exporting a const of `STORAGE_STATE` we can then easily share the location of the storage file between projects with the [`method: BrowserContext.storageState`] method. This returns the storage state for the browser context and contains the current cookies and a local storage snapshot.
+
+In this example the 'logged in chromium' project depends on the setup project whereas the 'logged out chromium' project ignores anything with 'loggedin' or 'setup' in it's file name.
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export const STORAGE_STATE = path.join(__dirname, 'playwright/.auth/user.json');
+
+export default defineConfig({
+  use: {
+    baseURL: 'https://en.wikipedia.org',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /global.setup\.ts/,
     },
     {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      name: 'logged in chromium',
+      use: { ...devices['Desktop Chrome'] },
+      testMatch: '**/*.loggedin.spec.ts',
       dependencies: ['setup'],
+      use: {
+        storageState: STORAGE_STATE,
+      },
+    },
+    {
+      name: 'logged out chromium',
+      use: { ...devices['Desktop Chrome'] },
+      testIgnore: ['**/*loggedin.spec.ts', '**/*.setup.ts']
     },
   ],
 });
-
 ```
+
+We then create a setup test, stored at route level of your project, that logs in to an application and populates the context with the storage state after the login actions have been performed. By doing this you only have to log in once and the credentials will be stored in the `STORAGE_STATE` file, meaning you don't need to log in again for every test. Start by importing the `STORAGE_STATE` from the Playwright config file and then use this as the path to save your storage state to the page's context.
+
+```js title="global.setup.ts"
+import { test as setup, expect } from '@playwright/test';
+import { STORAGE_STATE } from '../playwright.config';
+
+setup('do login', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('link', { name: 'Log in' }).click();
+  await page.getByPlaceholder('Enter your username').fill('your_username');
+  await page.getByPlaceholder('Enter your password').fill('your_password');
+  await page.getByRole('button', { name: 'Log in' }).click();
+
+  await expect(page.getByRole('button', { name: 'Personal tools' })).toBeVisible();
+
+  await page.context().storageState({ path: STORAGE_STATE });
+});
+```
+
+```js title="tests/menu.loggedin.spec.ts"
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('menu', async ({ page }) => {
+  await page.getByRole('link', { name: 'TestingLogin' }).click();
+  await expect(page.getByRole('heading', { name: /TestingLogin/i })).toBeVisible();
+  await page.getByRole('link', { name: /alerts/i  }).click();
+  await page.getByText('Alerts', { exact: true }).click();
+  await page.getByRole('button', { name: /notice/i  }).click();
+  await page.getByText('Notices').click();
+  await page.getByRole('link', { name: /watchlist/i  }).click();
+})
+```
+
+### Teardown
+
+You can teardown your setup by adding a [`property: TestProject.teardown`] property to your setup project. This will run after all dependencies have run.
+
+First we add a new project into the projects array and give it a name such as 'cleanup db'. We then give it a [`property: TestProject.testMatch`] property in order to match the file called `global.teardown.ts`:
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      // setup project
+    },
+    {
+      name: 'cleanup db',
+      testMatch: /global.teardown\.ts/,
+    },
+    {
+      // other project
+    }
+  ]
+});
+```
+Then we add the [`property: TestProject.teardown`] property to our setup project with the name 'cleanup db' which is the name we gave to our teardown project in the previous step:
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'setup db',
+      testMatch: /global.setup\.ts/,
+      teardown: 'cleanup db',
+    },
+    {
+      name: 'cleanup db',
+      testMatch: /global.teardown\.ts/,
+    },
+    {
+      // other project
+    }
+  ]
+});
+```
+
+### Teardown Example
+
+Start by creating a `global.setup.ts` file at the root level of your project. This will be used to seed the database with some data before all tests have run.
+
+```js title="global.setup.ts"
+// seed the database with some data
+```
+Then create a `global.teardown.ts` file at the root level of your project. This will be used to delete the data from the database after all tests have run. 
+
+```js title="global.teardown.ts"
+// delete the data from the database
+```
+In the Playwright config file:
+ - Add a project into the projects array and give it a name such as 'setup db'. Give it a [`property: TestProject.testMatch`] property in order to match the file called `global.setup.ts`.
+
+ - Create another project and give it a name such as 'cleanup db'. Give it a [`property: TestProject.testMatch`] property in order to match the file called `global.teardown.ts`.
+
+ - Add the [`property: TestProject.teardown`] property to our setup project with the name 'cleanup db' which is the name given to our teardown project in the previous step. Finally add the 'chromium' project with the [`property: TestProject.dependencies`] on the 'setup db' project.
+
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'setup db',
+      testMatch: /global.setup\.ts/,
+      teardown: 'cleanup db',
+    },
+    {
+      name: 'cleanup db',
+      testMatch: /global.teardown\.ts/,
+    },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup db'],
+    },
+  ]
+});
+```
+
 ## Configure globalSetup and globalTeardown
 
 You can use the `globalSetup` option in the [configuration file](#configuration-object) to set something up once before running all tests. The global setup file must export a single function that takes a config object. This function will be run once before all the tests.
 
 Similarly, use `globalTeardown` to run something once after all the tests. Alternatively, let `globalSetup` return a function that will be used as a global teardown. You can pass data such as port number, authentication tokens, etc. from your global setup to your tests using environment variables.
+
+:::note
+Using globalSetup and globalTeardown will not produce traces or artifacts. If you want to produce traces and artifacts, use [project dependencies](#project-dependencies).
+:::
 
 ```js title="playwright.config.ts"
 import { defineConfig } from '@playwright/test';

--- a/docs/src/test-global-setup-teardown-js.md
+++ b/docs/src/test-global-setup-teardown-js.md
@@ -22,9 +22,9 @@ export default defineConfig({
       name: 'setup',
       testMatch: /global.setup\.ts/,
     },
-    {
-      // other project
-    }
+    // {
+    //   other project
+    // }
   ]
 });
 ```
@@ -44,9 +44,6 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
       dependencies: ['setup'],
     },
-    {
-      // other project
-    }
   ]
 });
 ```

--- a/docs/src/test-global-setup-teardown-js.md
+++ b/docs/src/test-global-setup-teardown-js.md
@@ -65,7 +65,7 @@ export const STORAGE_STATE = path.join(__dirname, 'playwright/.auth/user.json');
 
 export default defineConfig({
   use: {
-    baseURL: 'https://en.wikipedia.org',
+    baseURL: 'http://localhost:3000/',
   },
   projects: [
     {
@@ -98,12 +98,9 @@ import { STORAGE_STATE } from '../playwright.config';
 
 setup('do login', async ({ page }) => {
   await page.goto('/');
-  await page.getByRole('link', { name: 'Log in' }).click();
-  await page.getByPlaceholder('Enter your username').fill('your_username');
-  await page.getByPlaceholder('Enter your password').fill('your_password');
-  await page.getByRole('button', { name: 'Log in' }).click();
-
-  await expect(page.getByRole('button', { name: 'Personal tools' })).toBeVisible();
+  await page.getByLabel('User Name').fill('user');
+  await page.getByLabel('Password').fill('password');
+  await page.getByText('Sign in').click();
 
   await page.context().storageState({ path: STORAGE_STATE });
 });
@@ -117,15 +114,11 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('menu', async ({ page }) => {
-  await page.getByRole('link', { name: 'TestingLogin' }).click();
-  await expect(page.getByRole('heading', { name: /TestingLogin/i })).toBeVisible();
-  await page.getByRole('link', { name: /alerts/i  }).click();
-  await page.getByText('Alerts', { exact: true }).click();
-  await page.getByRole('button', { name: /notice/i  }).click();
-  await page.getByText('Notices').click();
-  await page.getByRole('link', { name: /watchlist/i  }).click();
+  // You are signed in!
 })
 ```
+
+For a more detailed example check out our blog post: [A better global setup in Playwright reusing login with project dependencies](https://dev.to/playwright/a-better-global-setup-in-playwright-reusing-login-with-project-dependencies-14) or check the [v1.31 release video](https://youtu.be/PI50YAPTAs4) to see the demo.
 
 ### Teardown
 

--- a/docs/src/test-global-setup-teardown-js.md
+++ b/docs/src/test-global-setup-teardown-js.md
@@ -3,7 +3,7 @@ id: test-global-setup-teardown
 title: "Global setup and teardown"
 ---
 
-There are two ways to configure global setup and teardown: using a global setup file and setting it in the config under [`globalSetup`](#configure-globalsetup-and-globalteardown) or using [project dependencies](#project-dependencies). With project dependencies, you define a project that runs before all other projects and a teardown project that runs after the dependencies. This is the recommended way to configure global setup as with Project dependencies your HTML report will show the global setup, trace viewer will record a trace of the setup and fixtures can be used.
+There are two ways to configure global setup and teardown: using a global setup file and setting it in the config under [`globalSetup`](#configure-globalsetup-and-globalteardown) or using [project dependencies](#project-dependencies). With project dependencies, you define a project that runs before all other projects. This is the recommended way to configure global setup as with Project dependencies your HTML report will show the global setup, trace viewer will record a trace of the setup and fixtures can be used.
 
 ## Project Dependencies
 
@@ -102,6 +102,9 @@ setup('do login', async ({ page }) => {
   await page.getByLabel('Password').fill('password');
   await page.getByText('Sign in').click();
 
+  // Wait until the page actually signs in.
+  await expect(page.getByText('Hello, user!')).toBeVisible();
+
   await page.context().storageState({ path: STORAGE_STATE });
 });
 ```
@@ -122,7 +125,7 @@ For a more detailed example check out our blog post: [A better global setup in P
 
 ### Teardown
 
-You can teardown your setup by adding a [`property: TestProject.teardown`] property to your setup project. This will run after all dependencies have run.
+You can teardown your setup by adding a [`property: TestProject.teardown`] property to your setup project. This will run after all dependent projects have run.
 
 First we add a new project into the projects array and give it a name such as 'cleanup db'. We then give it a [`property: TestProject.testMatch`] property in order to match the file called `global.teardown.ts`:
 
@@ -217,7 +220,7 @@ You can use the `globalSetup` option in the [configuration file](#configuration-
 Similarly, use `globalTeardown` to run something once after all the tests. Alternatively, let `globalSetup` return a function that will be used as a global teardown. You can pass data such as port number, authentication tokens, etc. from your global setup to your tests using environment variables.
 
 :::note
-Using globalSetup and globalTeardown will not produce traces or artifacts. If you want to produce traces and artifacts, use [project dependencies](#project-dependencies).
+Using `globalSetup` and `globalTeardown` will not produce traces or artifacts. If you want to produce traces and artifacts, use [project dependencies](#project-dependencies).
 :::
 
 ```js title="playwright.config.ts"

--- a/docs/src/test-global-setup-teardown-js.md
+++ b/docs/src/test-global-setup-teardown-js.md
@@ -54,7 +54,7 @@ export default defineConfig({
 
 This example will show you how to use project dependencies to create a global setup that logs into an application and saves the state in storage state. This is useful if you want to run multiple tests that require a sign in state and you want to avoid logging in for each test.
 
-The setup project will write the storage state into an 'auth.json' file in a '.auth' folder inside the playwright folder. By exporting a const of `STORAGE_STATE` we can then easily share the location of the storage file between projects with the [`method: BrowserContext.storageState`] method. This returns the storage state for the browser context and contains the current cookies and a local storage snapshot.
+The setup project will write the storage state into an 'auth.json' file in a '.auth' folder inside the playwright folder. By exporting a const of `STORAGE_STATE` we can then easily share the location of the storage file between projects with the [`StorageState`](https://playwright.dev/docs/test-use-options#basic-options) method. This returns the storage state for the browser context and contains the current cookies and a local storage snapshot.
 
 In this example the 'logged in chromium' project depends on the setup project whereas the 'logged out chromium' project does not depend on the setup project, and does not use the `storageState` option.
 
@@ -84,7 +84,7 @@ export default defineConfig({
     {
       name: 'logged out chromium',
       use: { ...devices['Desktop Chrome'] },
-      testIgnore: ['**/*loggedin.spec.ts', '**/*.setup.ts']
+      testIgnore: ['**/*loggedin.spec.ts']
     },
   ],
 });

--- a/docs/src/test-projects-js.md
+++ b/docs/src/test-projects-js.md
@@ -207,7 +207,7 @@ Running order:
 
 ### Teardown
 
-You can also teardown your setup by adding a teardown property to your setup project. This will run after all dependent projects have run.
+You can also [`property: TestProject.teardown`] your setup by adding a teardown property to your setup project. This will run after all dependent projects have run.
 
 First we add a new project called teardown and give it a name such as `cleanup db`. We then give it a `testMatch` property in order to match the file called `global.teardown.ts`:
 

--- a/docs/src/test-projects-js.md
+++ b/docs/src/test-projects-js.md
@@ -207,7 +207,7 @@ Running order:
 
 ### Teardown
 
-You can also teardown your setup by adding a teardown property to your setup project. This will run after all dependencies have run.
+You can also teardown your setup by adding a teardown property to your setup project. This will run after all dependent projects have run.
 
 First we add a new project called teardown and give it a name such as `cleanup db`. We then give it a `testMatch` property in order to match the file called `global.teardown.ts`:
 

--- a/docs/src/test-projects-js.md
+++ b/docs/src/test-projects-js.md
@@ -207,55 +207,8 @@ Running order:
 
 ### Teardown
 
-You can also [`property: TestProject.teardown`] your setup by adding a teardown property to your setup project. This will run after all dependent projects have run.
+You can also [`property: TestProject.teardown`] your setup by adding a teardown property to your setup project. This will run after all dependent projects have run. See the [teardown guide](./test-teardown.md) for more information.
 
-First we add a new project called teardown and give it a name such as `cleanup db`. We then give it a `testMatch` property in order to match the file called `global.teardown.ts`:
-
-```js
-{
-  name: 'cleanup db',
-  testMatch: /global.teardown\.ts/,
-},
-```
-Then we add the [`property: TestProject.teardown`] property to our setup project with the name `cleanup db` which is the name we gave to our teardown project in the previous step:
-
-```js
-{
-  name: 'setup',
-  testMatch: /global.setup\.ts/,
-  teardown: 'cleanup db',
-},
-```
-The complete project setup will look something like this:
-
-```js title="playwright.config.ts"
-import { defineConfig } from '@playwright/test';
-
-export default defineConfig({
-  projects: [
-    {
-      name: 'setup db',
-      testMatch: /global.setup\.ts/,
-      teardown: 'cleanup db',
-    },
-    {
-      name: 'cleanup db',
-      testMatch: /global.teardown\.ts/,
-    },
-    {
-      name: 'chromium',
-      use: devices['Desktop Chrome'],
-      dependencies: ['setup'],
-    },
-    {
-      name: 'webkit',
-      use: devices['Desktop Safari'],
-      dependencies: ['setup'],
-    },
-  ],
-});
-```
-First the setup project will run, then the chromium and webkit projects will run in parallel and finally the teardown project will run.
 
 <img style={{display: 'flex', margin: 'auto'}} alt="global setup and teardown" loading="lazy" src="https://github.com/microsoft/playwright/assets/13063165/dfcf10a9-f601-4d0c-bd8d-9490e6efbf7a" />
 

--- a/docs/src/test-projects-js.md
+++ b/docs/src/test-projects-js.md
@@ -207,7 +207,7 @@ Running order:
 
 ### Teardown
 
-You can also [`property: TestProject.teardown`] your setup by adding a teardown property to your setup project. This will run after all dependent projects have run. See the [teardown guide](./test-teardown.md) for more information.
+You can also [`property: TestProject.teardown`] your setup by adding a teardown property to your setup project. This will run after all dependent projects have run. See the [teardown guide](./test-global-setup-teardown.md#teardown) for more information.
 
 
 <img style={{display: 'flex', margin: 'auto'}} alt="global setup and teardown" loading="lazy" src="https://github.com/microsoft/playwright/assets/13063165/dfcf10a9-f601-4d0c-bd8d-9490e6efbf7a" />

--- a/docs/src/test-projects-js.md
+++ b/docs/src/test-projects-js.md
@@ -183,7 +183,6 @@ export default defineConfig({
   ],
 });
 ```
-
 ### Running Sequence
 
 When working with tests that have a dependency, the dependency will always run first and once all tests from this project have passed, then the other projects will run in parallel.
@@ -205,6 +204,61 @@ Running order:
 1. “e2e tests” is not run!
 
 <img width="70%" style={{display: 'flex', margin: 'auto'}} alt="Browser login project is blue, database is red and e2e tests relies on both" loading="lazy" src="https://user-images.githubusercontent.com/13063165/225938262-33c1b78f-f092-4762-a478-7f8cbc1e3b21.jpg" />
+
+### Teardown
+
+You can also teardown your setup by adding a teardown property to your setup project. This will run after all dependencies have run.
+
+First we add a new project called teardown and give it a name such as `cleanup db`. We then give it a `testMatch` property in order to match the file called `global.teardown.ts`:
+
+```js
+{
+  name: 'cleanup db',
+  testMatch: /global.teardown\.ts/,
+},
+```
+Then we add the [`property: TestProject.teardown`] property to our setup project with the name `cleanup db` which is the name we gave to our teardown project in the previous step:
+
+```js
+{
+  name: 'setup',
+  testMatch: /global.setup\.ts/,
+  teardown: 'cleanup db',
+},
+```
+The complete project setup will look something like this:
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'setup db',
+      testMatch: /global.setup\.ts/,
+      teardown: 'cleanup db',
+    },
+    {
+      name: 'cleanup db',
+      testMatch: /global.teardown\.ts/,
+    },
+    {
+      name: 'chromium',
+      use: devices['Desktop Chrome'],
+      dependencies: ['setup'],
+    },
+    {
+      name: 'webkit',
+      use: devices['Desktop Safari'],
+      dependencies: ['setup'],
+    },
+  ],
+});
+```
+First the setup project will run, then the chromium and webkit projects will run in parallel and finally the teardown project will run.
+
+<img style={{display: 'flex', margin: 'auto'}} alt="global setup and teardown" loading="lazy" src="https://github.com/microsoft/playwright/assets/13063165/dfcf10a9-f601-4d0c-bd8d-9490e6efbf7a" />
+
 
 ## Custom project parameters
 


### PR DESCRIPTION
- adds teardown explanation to both projects doc and global setup doc
- adds an example for global setup and teardown with dependencies as previously only had example for global setup
- added a note to warn people that using dependencies is better than global method