### PR TITLE
docs: add stderr and stdout to example

### DIFF
--- a/docs/src/test-webserver-js.md
+++ b/docs/src/test-webserver-js.md
@@ -18,6 +18,8 @@ export default defineConfig({
     command: 'npm run start',
     url: 'http://127.0.0.1:3000',
     reuseExistingServer: !process.env.CI,
+    stdout: 'ignore',
+    stderr: 'pipe',
   },
 });
 ```


### PR DESCRIPTION
add stderr and stdout to the main example where table of explanation is underneath