### PR TITLE
feat: TestResult.expectedStatus

### DIFF
--- a/docs/src/test-reporter-api/class-testresult.md
+++ b/docs/src/test-reporter-api/class-testresult.md
@@ -53,6 +53,16 @@ Start time of this particular test run.
 
 The status of this test result. See also [`property: TestCase.expectedStatus`].
 
+## property: TestResult.expectedStatus
+* since: v1.35
+- type: <[TestStatus]<"passed"|"failed"|"timedOut"|"skipped"|"interrupted">>
+
+Expected status of this test run. See also [`property: TestResult.status`] and [`property: TestCase.expectedStatus`].
+* Tests marked as [`method: Test.skip#1`] or [`method: Test.fixme#1`] are expected to be `'skipped'`.
+* Tests marked as [`method: Test.fail#1`] are expected to be `'failed'`.
+* Other tests are expected to be `'passed'`.
+
+
 ## property: TestResult.stderr
 * since: v1.10
 - type: <[Array]<[string]|[Buffer]>>

--- a/packages/playwright-test/src/common/test.ts
+++ b/packages/playwright-test/src/common/test.ts
@@ -241,9 +241,9 @@ export class TestCase extends Base implements reporterTypes.TestCase {
     const nonSkipped = this.results.filter(result => result.status !== 'skipped' && result.status !== 'interrupted');
     if (!nonSkipped.length)
       return 'skipped';
-    if (nonSkipped.every(result => result.status === this.expectedStatus))
+    if (nonSkipped.every(result => result.status === result.expectedStatus))
       return 'expected';
-    if (nonSkipped.some(result => result.status === this.expectedStatus))
+    if (nonSkipped.some(result => result.status === result.expectedStatus))
       return 'flaky';
     return 'unexpected';
   }
@@ -295,6 +295,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
       stderr: [],
       attachments: [],
       status: 'skipped',
+      expectedStatus: 'passed',
       steps: [],
       errors: [],
     };

--- a/packages/playwright-test/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright-test/src/isomorphic/teleReceiver.ts
@@ -90,6 +90,7 @@ export type JsonTestResultEnd = {
   id: string;
   duration: number;
   status: TestStatus;
+  expectedStatus: TestStatus;
   errors: TestError[];
   attachments: TestResult['attachments'];
 };
@@ -224,6 +225,7 @@ export class TeleReporterReceiver {
     const result = test.resultsMap.get(payload.id)!;
     result.duration = payload.duration;
     result.status = payload.status;
+    result.expectedStatus = payload.expectedStatus;
     result.statusEx = payload.status;
     result.errors = payload.errors;
     result.attachments = payload.attachments;
@@ -450,9 +452,9 @@ export class TeleTestCase implements reporterTypes.TestCase {
     const nonSkipped = this.results.filter(result => result.status !== 'skipped' && result.status !== 'interrupted');
     if (!nonSkipped.length)
       return 'skipped';
-    if (nonSkipped.every(result => result.status === this.expectedStatus))
+    if (nonSkipped.every(result => result.status === result.expectedStatus))
       return 'expected';
-    if (nonSkipped.some(result => result.status === this.expectedStatus))
+    if (nonSkipped.some(result => result.status === result.expectedStatus))
       return 'flaky';
     return 'unexpected';
   }
@@ -478,6 +480,7 @@ export class TeleTestCase implements reporterTypes.TestCase {
       stderr: [],
       attachments: [],
       status: 'skipped',
+      expectedStatus: 'passed',
       statusEx: 'scheduled',
       steps: [],
       errors: [],

--- a/packages/playwright-test/src/reporters/teleEmitter.ts
+++ b/packages/playwright-test/src/reporters/teleEmitter.ts
@@ -194,6 +194,7 @@ export class TeleReporterEmitter implements Reporter {
       id: (result as any)[idSymbol],
       duration: result.duration,
       status: result.status,
+      expectedStatus: result.expectedStatus,
       errors: result.errors,
       attachments: this._serializeAttachments(result.attachments),
     };

--- a/packages/playwright-test/src/runner/dispatcher.ts
+++ b/packages/playwright-test/src/runner/dispatcher.ts
@@ -247,6 +247,7 @@ export class Dispatcher {
       result.errors = params.errors;
       result.error = result.errors[0];
       result.status = params.status;
+      result.expectedStatus = params.expectedStatus;
       test.expectedStatus = params.expectedStatus;
       test.annotations = params.annotations;
       test.timeout = params.timeout;

--- a/packages/playwright-test/types/testReporter.d.ts
+++ b/packages/playwright-test/types/testReporter.d.ts
@@ -252,6 +252,19 @@ export interface TestResult {
   errors: Array<TestError>;
 
   /**
+   * Expected status of this test run. See also
+   * [testResult.status](https://playwright.dev/docs/api/class-testresult#test-result-status) and
+   * [testCase.expectedStatus](https://playwright.dev/docs/api/class-testcase#test-case-expected-status).
+   * - Tests marked as [test.skip(title, testFunction)](https://playwright.dev/docs/api/class-test#test-skip-1) or
+   *   [test.fixme(title, testFunction)](https://playwright.dev/docs/api/class-test#test-fixme-1) are expected to be
+   *   `'skipped'`.
+   * - Tests marked as [test.fail()](https://playwright.dev/docs/api/class-test#test-fail-1) are expected to be
+   *   `'failed'`.
+   * - Other tests are expected to be `'passed'`.
+   */
+  expectedStatus: "passed"|"failed"|"timedOut"|"skipped"|"interrupted";
+
+  /**
    * The index of the worker between `0` and `workers - 1`. It is guaranteed that workers running at the same time have
    * a different `parallelIndex`.
    */


### PR DESCRIPTION
Tests may be marked as skipped or failed dyanamically, the final outcome should take that into account. This will also be useful in merge report where same test can come from different platforms with different expectations.

Fixes #23201