### PR TITLE
Fix various spelling mistakes in the docs project directory.

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -134,7 +134,7 @@ pwsh bin/Debug/netX/playwright.ps1 install --with-deps chromium
 
 See [system requirements](./intro.md#system-requirements) for officially supported operating systems.
 
-## Update Playwright regulary
+## Update Playwright regularly
 * langs: js
 
 By keeping your Playwright version up to date you will be able to use new features and test your app on the latest browser versions and catch failures before the latest browser version is released to the public.

--- a/docs/src/codegen.md
+++ b/docs/src/codegen.md
@@ -354,7 +354,7 @@ After performing authentication and closing the browser, `auth.json` will contai
 
 <img width="1394" alt="login to Github screen" src="https://user-images.githubusercontent.com/13063165/220561688-04b2b984-4ba6-4446-8b0a-8058876e2a02.png" />
 
-Make sure you only use the `auth.json` locally as it contains sensative information. Add it to your `.gitignore` or delete it once you have finished generating your tests.
+Make sure you only use the `auth.json` locally as it contains sensitive information. Add it to your `.gitignore` or delete it once you have finished generating your tests.
 
 #### Load authenticated state
 

--- a/docs/src/test-reporter-api/class-reporter.md
+++ b/docs/src/test-reporter-api/class-reporter.md
@@ -133,7 +133,7 @@ The error.
 * since: v1.33
 
 Called immediately before test runner exists. At this point all the reporters
-have recived the [`method: Reporter.onEnd`] signal, so all the reports should
+have received the [`method: Reporter.onEnd`] signal, so all the reports should
 be build. You can run the code that uploads the reports in this hook.
 
 ## optional method: Reporter.onStdErr

--- a/packages/playwright-test/types/testReporter.d.ts
+++ b/packages/playwright-test/types/testReporter.d.ts
@@ -413,7 +413,7 @@ export interface Reporter {
   onError?(error: TestError): void;
 
   /**
-   * Called immediately before test runner exists. At this point all the reporters have recived the
+   * Called immediately before test runner exists. At this point all the reporters have received the
    * [reporter.onEnd(result)](https://playwright.dev/docs/api/class-reporter#reporter-on-end) signal, so all the reports
    * should be build. You can run the code that uploads the reports in this hook.
    */


### PR DESCRIPTION
These changes fix various spelling mistakes identified within the `docs` project directory.

In `docs/src/browsers.md`, a misspelled word - `regulary` - has been changed to `regularly`, [following the Merriam-Webster spelling of the word.](https://www.merriam-webster.com/dictionary/regularly)

In `docs/src/codegen.md`, a misspelled word - `sensative` - has been changed to `sensitive`, [following the Merriam-Webster spelling of the word.](https://www.merriam-webster.com/dictionary/sensitive)

In `docs/src/test-reporter-api/class-reporter.md`, a misspelled word - `recived` - has been changed to `received`, [following the Merriam-Webster spelling of the word.](https://www.merriam-webster.com/dictionary/received)