### PR TITLE
chore: update error message when using wrong cli

### DIFF
--- a/packages/playwright-core/src/cli/cli.ts
+++ b/packages/playwright-core/src/cli/cli.ts
@@ -18,14 +18,41 @@
 
 /* eslint-disable no-console */
 
+import { getPackageManager } from '../utils';
 import program from './program';
+
+function printPlaywrightTestError(command: string) {
+  const packages: string[] = [];
+  for (const pkg of ['playwright', 'playwright-chromium', 'playwright-firefox', 'playwright-webkit']) {
+    try {
+      require.resolve(pkg);
+      packages.push(pkg);
+    } catch (e) {
+    }
+  }
+  if (!packages.length)
+    packages.push('playwright');
+  const packageManager = getPackageManager();
+  if (packageManager === 'yarn') {
+    console.error(`Please install @playwright/test package before running "yarn playwright ${command}"`);
+    console.error(`  yarn remove ${packages.join(' ')}`);
+    console.error('  yarn add -D @playwright/test');
+  } else if (packageManager === 'pnpm') {
+    console.error(`Please install @playwright/test package before running "pnpm exec playwright ${command}"`);
+    console.error(`  pnpm remove ${packages.join(' ')}`);
+    console.error('  pnpm add -D @playwright/test');
+  } else {
+    console.error(`Please install @playwright/test package before running "npx playwright ${command}"`);
+    console.error(`  npm uninstall ${packages.join(' ')}`);
+    console.error('  npm install -D @playwright/test');
+  }
+}
 
 {
   const command = program.command('test').allowUnknownOption(true);
   command.description('Run tests with Playwright Test. Available in @playwright/test package.');
   command.action(async () => {
-    console.error('Please install @playwright/test package to use Playwright Test.');
-    console.error('  npm install -D @playwright/test');
+    printPlaywrightTestError('test');
     process.exit(1);
   });
 }
@@ -34,18 +61,7 @@ import program from './program';
   const command = program.command('show-report').allowUnknownOption(true);
   command.description('Show Playwright Test HTML report. Available in @playwright/test package.');
   command.action(async () => {
-    console.error('Please install @playwright/test package to use Playwright Test.');
-    console.error('  npm install -D @playwright/test');
-    process.exit(1);
-  });
-}
-
-{
-  const command = program.command('show-trace').allowUnknownOption(true);
-  command.description('Show Playwright Trace. Available in @playwright/test package.');
-  command.action(async () => {
-    console.error('Please install @playwright/test package to use Playwright Test.');
-    console.error('  npm install -D @playwright/test');
+    printPlaywrightTestError('show-report');
     process.exit(1);
   });
 }

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -617,7 +617,6 @@ export class Registry {
         return undefined;
 
       const location = prefixes.length ? ` at ${path.join(prefixes[0], suffix)}` : ``;
-      // TODO: language-specific error message
       const installation = install ? `\nRun "${buildPlaywrightCLICommand(sdkLanguage, 'install ' + name)}"` : '';
       throw new Error(`Chromium distribution '${name}' is not found${location}${installation}`);
     };

--- a/packages/playwright-core/src/utils/env.ts
+++ b/packages/playwright-core/src/utils/env.ts
@@ -25,3 +25,12 @@ export function getAsBooleanFromENV(name: string): boolean {
   const value = getFromENV(name);
   return !!value && value !== 'false' && value !== '0';
 }
+
+export function getPackageManager() {
+  const env = process.env.npm_config_user_agent || '';
+  if (env.includes('yarn'))
+    return 'yarn';
+  if (env.includes('pnpm'))
+    return 'pnpm';
+  return 'npm';
+}

--- a/tests/installation/playwright-cdn-failover-should-work.spec.ts
+++ b/tests/installation/playwright-cdn-failover-should-work.spec.ts
@@ -45,6 +45,6 @@ for (const cdn of CDNS) {
     if (nodeMajorVersion >= 14)
       await exec('node esm-playwright.mjs');
     const stdio = await exec('npx playwright', 'test', '-c', '.', { expectToExitWithError: true });
-    expect(stdio).toContain(`Please install @playwright/test package to use Playwright Test.`);
+    expect(stdio).toContain(`Please install @playwright/test package`);
   });
 }

--- a/tests/installation/playwright-should-work.spec.ts
+++ b/tests/installation/playwright-should-work.spec.ts
@@ -23,5 +23,5 @@ test(`playwright should work`, async ({ exec, nodeMajorVersion, installedSoftwar
   if (nodeMajorVersion >= 14)
     await exec('node esm-playwright.mjs');
   const stdio = await exec('npx playwright', 'test', '-c', '.', { expectToExitWithError: true });
-  expect(stdio).toContain(`Please install @playwright/test package to use Playwright Test.`);
+  expect(stdio).toContain(`Please install @playwright/test package`);
 });


### PR DESCRIPTION
Now recommends uninstalling other packages. Fixes #23314.

Example messages:

```
Please install @playwright/test package before running "npx playwright show-report"
  npm uninstall playwright playwright-firefox
  npm install -D @playwright/test
```

```
Please install @playwright/test package before running "yarn playwright show-report"
  yarn remove playwright playwright-chromium playwright-firefox playwright-webkit
  yarn add -D @playwright/test
```

```
Please install @playwright/test package before running "pnpm exec playwright show-report"
  pnpm remove playwright
  pnpm add -D @playwright/test
```