### PR TITLE
fix(check-deps): normalize paths in posix

### DIFF
--- a/utils/check_deps.js
+++ b/utils/check_deps.js
@@ -20,7 +20,7 @@
 
 const fs = require('fs');
 const ts = require('typescript');
-const path = require('path');
+const path = require('path').posix;
 
 const packagesDir = path.normalize(path.join(__dirname, '..', 'packages'));
 


### PR DESCRIPTION
Running `check-deps` in windows kept failing due to path inconsistencies:

```
Checking DEPS for protocol
Checking DEPS for trace
Error: ENOENT: no such file or directory, open 'C:\dev\workspace\playwright\packages\playwright-core\src\utils\isomorphic\DEPS.list'
    at Object.openSync (node:fs:601:3)
    at Object.readFileSync (node:fs:469:35)
    at allowImport (C:\dev\workspace\playwright\utils\check_deps.js:179:29)
    at visit (C:\dev\workspace\playwright\utils\check_deps.js:146:14)
    at C:\dev\workspace\playwright\utils\check_deps.js:159:32
    at visitNodes (C:\dev\workspace\playwright\node_modules\typescript\lib\typescript.js:27716:24)
    at forEachChildInSourceFile (C:\dev\workspace\playwright\node_modules\typescript\lib\typescript.js:28338:18)
    at Object.forEachChild (C:\dev\workspace\playwright\node_modules\typescript\lib\typescript.js:27801:37)
    at visit (C:\dev\workspace\playwright\utils\check_deps.js:159:8)
    at C:\dev\workspace\playwright\utils\check_deps.js:82:74
```

Fixed by using node `path.posix` instead of SO path implementation.