### PR TITLE
fix(devops): remove 10 minutes timeout from merge workflow

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -9,7 +9,6 @@ jobs:
     permissions:
       pull-requests: write
       checks: write
-    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Downloading 457Mb of reports with traces (for tracing tests) takes >3 minutes, uploading it to Azure takes >5 minutes which easily exceeds 10 minutes budget.