### PR TITLE
fix: call `focus()` twice to workaround firefox not focusing element

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -793,6 +793,9 @@ export class InjectedScript {
       // contenteditable to the new element. However, blurring the previous one helps.
       (activeElement as HTMLElement | SVGElement).blur();
     }
+    // On firefox, we have to call focus() twice to actually focus an element in certain
+    // scenarios.
+    (node as HTMLElement | SVGElement).focus();
     (node as HTMLElement | SVGElement).focus();
 
     if (resetSelectionIfNotFocused && !wasFocused && node.nodeName.toLowerCase() === 'input') {


### PR DESCRIPTION
When focus is moved from one tab to another, it might require calling
`focus()` twice to actually focus an element in Firefox.

Fixes https://github.com/microsoft/playwright/issues/23117
