### PR TITLE
docs(emulation.md): Add a missing closing bracket

### DIFF
--- a/docs/src/emulation.md
+++ b/docs/src/emulation.md
@@ -210,6 +210,7 @@ await page.set_viewport_size({"width": 1600, "height": 1200})
 context = browser.new_context(
   viewport={ 'width': 2560, 'height': 1440 },
   device_scale_factor=2,
+)
 ```
 
 ```csharp


### PR DESCRIPTION
Add a missing closing bracket in the sample code under the Viewport section of the Emulation chapter in the Python documentation.

```python sync
# Create context with given viewport
context = browser.new_context(
  viewport={ 'width': 1280, 'height': 1024 }
)

# Resize viewport for individual page
await page.set_viewport_size({"width": 1600, "height": 1200})

# Emulate high-DPI
context = browser.new_context(
  viewport={ 'width': 2560, 'height': 1440 },
  device_scale_factor=2, # FIXME Missing closing bracket
```