### PR TITLE
chore: roll stable test runner to 1.35.0-alpha-jun-7-2023

### DIFF
--- a/tests/playwright-test/stable-test-runner/package-lock.json
+++ b/tests/playwright-test/stable-test-runner/package-lock.json
@@ -5,22 +5,22 @@
   "packages": {
     "": {
       "dependencies": {
-        "@playwright/test": "1.35.0-alpha-1685109821000"
+        "@playwright/test": "1.35.0-alpha-jun-7-2023"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.35.0-alpha-1685109821000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.0-alpha-1685109821000.tgz",
-      "integrity": "sha512-FX1g4UHazT58jr4FbPKyr+Iw87umRz4jxlViZiS1x4FB87XW6VYRaViaXOPnI+sD/p8c4SMde+vSetHwkBLwpQ==",
+      "version": "1.35.0-alpha-jun-7-2023",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.0-alpha-jun-7-2023.tgz",
+      "integrity": "sha512-XCqnVaXRdtsstihswURbho2mjv4LW5uPeGd88GDPDvc9Z6KAdcucC/K010FAQj2oCXqnb+o6kR2EXeIzBaKOPw==",
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.35.0-alpha-1685109821000"
+        "playwright-core": "1.35.0-alpha-jun-7-2023"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -45,26 +45,26 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.35.0-alpha-1685109821000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.0-alpha-1685109821000.tgz",
-      "integrity": "sha512-IuaxLekxpKacjz3g7weJAfUQoj0Uz/viWBADJTFXuyP3wMviqRqUgaat/i2H4vfOvvQeYmGpi9MXs8d3olE6cQ==",
+      "version": "1.35.0-alpha-jun-7-2023",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.0-alpha-jun-7-2023.tgz",
+      "integrity": "sha512-vNtbVIcRlrpIT0U8ALpB8/BH3NSFQyeGRyDQdLYV+j8QI1iW8vAaA6DlExeKgb0bEwFVgttexqP+NfzCiQEskA==",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     }
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.35.0-alpha-1685109821000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.0-alpha-1685109821000.tgz",
-      "integrity": "sha512-FX1g4UHazT58jr4FbPKyr+Iw87umRz4jxlViZiS1x4FB87XW6VYRaViaXOPnI+sD/p8c4SMde+vSetHwkBLwpQ==",
+      "version": "1.35.0-alpha-jun-7-2023",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.0-alpha-jun-7-2023.tgz",
+      "integrity": "sha512-XCqnVaXRdtsstihswURbho2mjv4LW5uPeGd88GDPDvc9Z6KAdcucC/K010FAQj2oCXqnb+o6kR2EXeIzBaKOPw==",
       "requires": {
         "@types/node": "*",
         "fsevents": "2.3.2",
-        "playwright-core": "1.35.0-alpha-1685109821000"
+        "playwright-core": "1.35.0-alpha-jun-7-2023"
       }
     },
     "@types/node": {
@@ -79,9 +79,9 @@
       "optional": true
     },
     "playwright-core": {
-      "version": "1.35.0-alpha-1685109821000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.0-alpha-1685109821000.tgz",
-      "integrity": "sha512-IuaxLekxpKacjz3g7weJAfUQoj0Uz/viWBADJTFXuyP3wMviqRqUgaat/i2H4vfOvvQeYmGpi9MXs8d3olE6cQ=="
+      "version": "1.35.0-alpha-jun-7-2023",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.0-alpha-jun-7-2023.tgz",
+      "integrity": "sha512-vNtbVIcRlrpIT0U8ALpB8/BH3NSFQyeGRyDQdLYV+j8QI1iW8vAaA6DlExeKgb0bEwFVgttexqP+NfzCiQEskA=="
     }
   }
 }

--- a/tests/playwright-test/stable-test-runner/package.json
+++ b/tests/playwright-test/stable-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "@playwright/test": "1.35.0-alpha-1685109821000"
+    "@playwright/test": "1.35.0-alpha-jun-7-2023"
   }
 }


### PR DESCRIPTION
This fixes following error in the merged reports:

```
(index):9825 TypeError: Cannot read properties of null (reading 'toFixed')
    at msToString ((index):18917:15)
    at TestFilesView ((index):19373:9)
    at Uh ((index):9372:7)
    at kj ((index):10444:7)
    at Uk ((index):12508:86)
    at Tk ((index):12134:11)
```