### PR TITLE
fix: regex selectors containing >> (#23540)

### DIFF
--- a/docs/src/other-locators.md
+++ b/docs/src/other-locators.md
@@ -906,7 +906,7 @@ document
   .querySelector('span[attr=value]')
 ```
 
-If a selector needs to include `>>` in the body, it should be escaped inside a string to not be confused with chaining separator, e.g. `text="some >> text"`.
+If a selector needs to include `>>` in the body, it should be escaped inside a string or a regex to not be confused with chaining separator, e.g. `text="some >> text"` or `text=/some >> text/`.
 
 ### Intermediate matches
 

--- a/packages/playwright-core/src/utils/isomorphic/selectorParser.ts
+++ b/packages/playwright-core/src/utils/isomorphic/selectorParser.ts
@@ -137,7 +137,7 @@ export function allEngineNames(selector: ParsedSelector): Set<string> {
 
 function parseSelectorString(selector: string): ParsedSelectorStrings {
   let index = 0;
-  let quote: string | undefined;
+  let quoteOrForwardSlash: string | undefined;
   let start = 0;
   const result: ParsedSelectorStrings = { parts: [] };
   const append = () => {
@@ -183,7 +183,7 @@ function parseSelectorString(selector: string): ParsedSelectorStrings {
     return result;
   }
 
-  const shouldIgnoreTextSelectorQuote = () => {
+  const shouldIgnoreTextSelectorQuoteOrForwardSlash = () => {
     const prefix = selector.substring(start, index);
     const match = prefix.match(/^\s*text\s*=(.*)$/);
     // Must be a text selector with some text before the quote.
@@ -194,13 +194,13 @@ function parseSelectorString(selector: string): ParsedSelectorStrings {
     const c = selector[index];
     if (c === '\\' && index + 1 < selector.length) {
       index += 2;
-    } else if (c === quote) {
-      quote = undefined;
+    } else if (c === quoteOrForwardSlash) {
+      quoteOrForwardSlash = undefined;
       index++;
-    } else if (!quote && (c === '"' || c === '\'' || c === '`') && !shouldIgnoreTextSelectorQuote()) {
-      quote = c;
+    } else if (!quoteOrForwardSlash && (c === '"' || c === '\'' || c === '`' || c === '\/') && !shouldIgnoreTextSelectorQuoteOrForwardSlash()) {
+      quoteOrForwardSlash = c;
       index++;
-    } else if (!quote && c === '>' && selector[index + 1] === '>') {
+    } else if (!quoteOrForwardSlash && c === '>' && selector[index + 1] === '>') {
       append();
       index += 2;
       start = index;

--- a/tests/library/selector-parser.spec.ts
+++ b/tests/library/selector-parser.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { playwrightTest as it, expect } from '../config/browserTest';
+import { parseSelector } from '../../packages/playwright-core/lib/utils/isomorphic/selectorParser';
+
+function parse(selector: string) {
+  return parseSelector(selector).parts.map(({ name, source }) => ({ name, source }));
+}
+
+it('should parse selector', async () => {
+  expect(parse(`:has-text=/Playwright$/`)).toEqual([{ name: ':has-text', source: '/Playwright$/' }]);
+  expect(parse(`:has-text=">> breaks Playwright"`)).toEqual([{ name: ':has-text', source: '">> breaks Playwright"' }]);
+  // #23540
+  expect(parse(`:has-text=/>> breaks Playwright$/`)).toEqual([{ name: ':has-text', source: '/>> breaks Playwright$/' }]);
+});

--- a/tests/page/locator-query.spec.ts
+++ b/tests/page/locator-query.spec.ts
@@ -90,6 +90,14 @@ it('should filter by regex and regexp flags', async ({ page }) => {
   await expect(page.locator('div', { hasText: /hElLo "world"/i })).toHaveText('Hello "world"');
 });
 
+it('should filter by regex and regexp flags with >>', async ({ page }) => {
+  await page.setContent(`<div>Hello >> world</div><div>Hello world</div>`);
+  await expect(page.locator('div', { hasText: /Hello >> world/ })).toHaveText('Hello >> world');
+  await expect(page.locator('div >> text=/Hello >> world/')).toHaveText('Hello >> world');
+  await expect(page.locator('div', { hasText: /hElLo >> world/i })).toHaveText('Hello >> world');
+  await expect(page.locator('div >> text=/hElLo >> world/i')).toHaveText('Hello >> world');
+});
+
 it('should filter by case-insensitive regex in a child', async ({ page }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/15348' });
   await page.setContent(`<div class="test"><h5>Title Text</h5></div>`);


### PR DESCRIPTION
Only quotes were considered when splitting chained selectors