### PR TITLE
feat(goto): better navigation error message

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -682,7 +682,7 @@ export class Frame extends SdkObject {
       if (event.newDocument!.documentId !== navigateResult.newDocumentId) {
         // This is just a sanity check. In practice, new navigation should
         // cancel the previous one and report "request cancelled"-like error.
-        throw new NavigationAbortedError(navigateResult.newDocumentId, 'Navigation interrupted by another one');
+        throw new NavigationAbortedError(navigateResult.newDocumentId, `Navigation to "${url}" is interrupted by another navigation to "${event.url}"`);
       }
       if (event.error)
         throw event.error;

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -410,10 +410,10 @@ it('should fail when replaced by another navigation', async ({ page, server, bro
   if (browserName === 'chromium') {
     expect(error.message).toContain('net::ERR_ABORTED');
   } else if (browserName === 'webkit') {
-    expect(error.message).toContain('Navigation interrupted by another one');
+    expect(error.message).toContain(`page.goto: Navigation to "${server.PREFIX + '/empty.html'}" is interrupted by another navigation to "${server.PREFIX + '/one-style.html'}"`);
   } else if (browserName === 'firefox') {
     // Firefox might yield either NS_BINDING_ABORTED or 'navigation interrupted by another one'
-    expect(error.message.includes('Navigation interrupted by another one') || error.message.includes('NS_BINDING_ABORTED')).toBe(true);
+    expect(error.message.includes(`page.goto: Navigation to "${server.PREFIX + '/empty.html'}" is interrupted by another navigation to "${server.PREFIX + '/one-style.html'}"`) || error.message.includes('NS_BINDING_ABORTED')).toBe(true);
   }
 });
 
@@ -460,7 +460,7 @@ it('js redirect overrides url bar navigation ', async ({ page, server, browserNa
     expect(error).toBeFalsy();
     await expect(page).toHaveURL(server.PREFIX + '/b');
   } else if (browserName === 'webkit') {
-    expect(error.message).toContain(`Navigation to "${server.PREFIX + '/a'}" is interrupted by another navigation to "${server.PREFIX + '/b'}"`);
+    expect(error.message).toContain(`page.goto: Navigation to "${server.PREFIX + '/b'}" is interrupted by another navigation to "${server.PREFIX + '/c'}"`);
     await expect(page).toHaveURL(server.PREFIX + '/c');
   } else if (browserName === 'firefox') {
     expect(error.message).toContain('NS_BINDING_ABORTED');

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -460,7 +460,7 @@ it('js redirect overrides url bar navigation ', async ({ page, server, browserNa
     expect(error).toBeFalsy();
     await expect(page).toHaveURL(server.PREFIX + '/b');
   } else if (browserName === 'webkit') {
-    expect(error.message).toContain('Navigation interrupted by another one');
+    expect(error.message).toContain(`Navigation to "${server.PREFIX + '/a'}" is interrupted by another navigation to "${server.PREFIX + '/b'}"`);
     await expect(page).toHaveURL(server.PREFIX + '/c');
   } else if (browserName === 'firefox') {
     expect(error.message).toContain('NS_BINDING_ABORTED');


### PR DESCRIPTION
While this log message is only a sanity check, it is still beneficial to have a message that can better inform what is happening when this occurs.