### PR TITLE
fix: drop `expect.configure({ poll })` from types

### DIFF
--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -4786,7 +4786,6 @@ export type Expect = {
     message?: string,
     timeout?: number,
     soft?: boolean,
-    poll?: boolean | { timeout?: number, intervals?: number[] },
   }) => Expect;
   getState(): {
     expand?: boolean;

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -347,7 +347,6 @@ export type Expect = {
     message?: string,
     timeout?: number,
     soft?: boolean,
-    poll?: boolean | { timeout?: number, intervals?: number[] },
   }) => Expect;
   getState(): {
     expand?: boolean;


### PR DESCRIPTION
`poll` option is not actually supported as of June 12, 2023.

Fixes https://github.com/microsoft/playwright/issues/23622
