### PR TITLE
fix(css): relative-to-scope selectors work

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/cssParser.ts
+++ b/packages/playwright-core/src/utils/isomorphic/cssParser.ts
@@ -143,7 +143,7 @@ export function parseCSS(selector: string, customNames: Set<string>): { selector
     const result: CSSComplexSelector = { simples: [] };
     skipWhitespace();
     if (isClauseCombinator()) {
-      // Put implicit ":scope" at the start. https://drafts.csswg.org/selectors-4/#absolutize
+      // Put implicit ":scope" at the start. https://drafts.csswg.org/selectors-4/#relative
       result.simples.push({ selector: { functions: [{ name: 'scope', args: [] }] }, combinator: '' });
     } else {
       result.simples.push({ selector: consumeSimpleSelector(), combinator: '' });


### PR DESCRIPTION
Chained selectors where the second part starts with a scope did not work before:

```ts
page.locator('div').locator(':scope + span')
page.locator('div >> +span')
```