### PR TITLE
devops: zip blob report artifact before uploading

### DIFF
--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -1,5 +1,5 @@
-name: 'Download blob report'
-description: 'Download blob report from GitHub artifacts'
+name: 'Download artifact'
+description: 'Download artifact from GitHub'
 inputs:
   name:
     description: 'Name of the artifact to download'
@@ -10,11 +10,11 @@ inputs:
     description: 'Directory with downloaded artifacts'
     required: true
     type: string
-    default: 'blob-report'
+    default: '.'
 runs:
   using: "composite"
   steps:
-    - name: Download blob report
+    - name: Download artifact
       uses: actions/github-script@v6
       with:
         script: |
@@ -35,6 +35,6 @@ runs:
           console.log('download result', result);
           const fs = require('fs');
           fs.writeFileSync(`${name}.zip`, Buffer.from(result.data));
-    - name: Unzip blob report
+    - name: Unzip artifact
       shell: bash
       run: unzip ${{ inputs.name }}.zip -d ${{ inputs.path }}

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -64,12 +64,18 @@ jobs:
     - name: Upload blob report to Azure
       if: always() && github.event_name == 'push'
       run: az storage blob upload-batch -s test-results/blob-report -d '$web/run-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}' --connection-string "${{ secrets.AZURE_CONNECTION_STRING_FOR_BLOB_REPORT }}"
+    - name: Zip blob report
+      if: always() && github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        cd test-results
+        zip -r ${{ github.workspace }}/blob-report.zip blob-report
     - name: Upload blob report to GitHub
       uses: actions/upload-artifact@v3
       if: always() && github.event_name == 'pull_request'
       with:
         name: blob-report-${{ github.run_attempt }}
-        path: test-results/blob-report
+        path: blob-report.zip
         retention-days: 30
     - name: Write the pull request number in an file
       if: always() && github.event_name == 'pull_request'
@@ -154,12 +160,18 @@ jobs:
     - name: Upload blob report to Azure
       if: always() && github.event_name == 'push'
       run: az storage blob upload-batch -s test-results/blob-report -d '$web/run-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}' --connection-string "${{ secrets.AZURE_CONNECTION_STRING_FOR_BLOB_REPORT }}"
+    - name: Zip blob report
+      if: always() && github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        cd test-results
+        zip -r ${{ github.workspace }}/blob-report.zip blob-report
     - name: Upload blob report to GitHub
       uses: actions/upload-artifact@v3
       if: always() && github.event_name == 'pull_request'
       with:
         name: blob-report-${{ github.run_attempt }}
-        path: test-results/blob-report
+        path: blob-report.zip
         retention-days: 30
     - name: Write the pull request number in an file
       if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -211,12 +211,18 @@ jobs:
     - name: Upload blob report to Azure
       if: always() && github.event_name == 'push'
       run: az storage blob upload-batch -s test-results/blob-report -d '$web/run-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}' --connection-string "${{ secrets.AZURE_CONNECTION_STRING_FOR_BLOB_REPORT }}"
+    - name: Zip blob report
+      if: always() && github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        cd test-results
+        zip -r ${{ github.workspace }}/blob-report.zip blob-report
     - name: Upload blob report to GitHub
       uses: actions/upload-artifact@v3
       if: always() && github.event_name == 'pull_request'
       with:
         name: blob-report-${{ github.run_attempt }}
-        path: test-results/blob-report
+        path: blob-report.zip
         retention-days: 30
     - name: Write the pull request number in an file
       if: always() && github.event_name == 'pull_request'


### PR DESCRIPTION
Compressed size for `tests 1` blob report is 19Mb whil uncompressed one is 211Mb. Also according to [GitHub policy](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
) it is uncompressed size that is used for billing:

"Artifacts are uploaded during a workflow run, and you can view an artifact's name and size in the UI. When an artifact is downloaded using the GitHub UI, all files that were individually uploaded as part of the artifact get zipped together into a single file. This means that billing is calculated based on the size of the uploaded artifact and not the size of the zip file."

