### PR TITLE
Revert "devops: zip blob report artifact before uploading (#23667)"

### DIFF
--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -1,5 +1,5 @@
-name: 'Download artifact'
-description: 'Download artifact from GitHub'
+name: 'Download blob report'
+description: 'Download blob report from GitHub artifacts'
 inputs:
   name:
     description: 'Name of the artifact to download'
@@ -10,11 +10,11 @@ inputs:
     description: 'Directory with downloaded artifacts'
     required: true
     type: string
-    default: '.'
+    default: 'blob-report'
 runs:
   using: "composite"
   steps:
-    - name: Download artifact
+    - name: Download blob report
       uses: actions/github-script@v6
       with:
         script: |
@@ -35,6 +35,6 @@ runs:
           console.log('download result', result);
           const fs = require('fs');
           fs.writeFileSync(`${name}.zip`, Buffer.from(result.data));
-    - name: Unzip artifact
+    - name: Unzip blob report
       shell: bash
       run: unzip ${{ inputs.name }}.zip -d ${{ inputs.path }}

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -64,18 +64,12 @@ jobs:
     - name: Upload blob report to Azure
       if: always() && github.event_name == 'push'
       run: az storage blob upload-batch -s test-results/blob-report -d '$web/run-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}' --connection-string "${{ secrets.AZURE_CONNECTION_STRING_FOR_BLOB_REPORT }}"
-    - name: Zip blob report
-      if: always() && github.event_name == 'pull_request'
-      shell: bash
-      run: |
-        cd test-results
-        zip -r ${{ github.workspace }}/blob-report.zip blob-report
     - name: Upload blob report to GitHub
       uses: actions/upload-artifact@v3
       if: always() && github.event_name == 'pull_request'
       with:
         name: blob-report-${{ github.run_attempt }}
-        path: blob-report.zip
+        path: test-results/blob-report
         retention-days: 30
     - name: Write the pull request number in an file
       if: always() && github.event_name == 'pull_request'
@@ -160,18 +154,12 @@ jobs:
     - name: Upload blob report to Azure
       if: always() && github.event_name == 'push'
       run: az storage blob upload-batch -s test-results/blob-report -d '$web/run-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}' --connection-string "${{ secrets.AZURE_CONNECTION_STRING_FOR_BLOB_REPORT }}"
-    - name: Zip blob report
-      if: always() && github.event_name == 'pull_request'
-      shell: bash
-      run: |
-        cd test-results
-        zip -r ${{ github.workspace }}/blob-report.zip blob-report
     - name: Upload blob report to GitHub
       uses: actions/upload-artifact@v3
       if: always() && github.event_name == 'pull_request'
       with:
         name: blob-report-${{ github.run_attempt }}
-        path: blob-report.zip
+        path: test-results/blob-report
         retention-days: 30
     - name: Write the pull request number in an file
       if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -211,18 +211,12 @@ jobs:
     - name: Upload blob report to Azure
       if: always() && github.event_name == 'push'
       run: az storage blob upload-batch -s test-results/blob-report -d '$web/run-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}' --connection-string "${{ secrets.AZURE_CONNECTION_STRING_FOR_BLOB_REPORT }}"
-    - name: Zip blob report
-      if: always() && github.event_name == 'pull_request'
-      shell: bash
-      run: |
-        cd test-results
-        zip -r ${{ github.workspace }}/blob-report.zip blob-report
     - name: Upload blob report to GitHub
       uses: actions/upload-artifact@v3
       if: always() && github.event_name == 'pull_request'
       with:
         name: blob-report-${{ github.run_attempt }}
-        path: blob-report.zip
+        path: test-results/blob-report
         retention-days: 30
     - name: Write the pull request number in an file
       if: always() && github.event_name == 'pull_request'


### PR DESCRIPTION
This reverts commit a1cdae6bffcea5fd16c5bc56633e0949bfcc6315.

The problem with this approach is that each job overwrites the zip artifact whereas previously it was merging all reports in the same directory. We are going to zip .jsonl files instead.