### PR TITLE
resolves microsoft/playwright#23690

### DIFF
--- a/packages/playwright-core/src/utils/comparators.ts
+++ b/packages/playwright-core/src/utils/comparators.ts
@@ -111,11 +111,10 @@ function compareText(actual: Buffer | string, expectedBuffer: Buffer): Comparato
   const expected = expectedBuffer.toString('utf-8');
   const expectedNormalized = expected.replace('\r\n', '\n');
   const actualNormalized = actual.replace('\r\n', '\n');
-  if (expectedNormalized === actualNormalized) {
+  if (expectedNormalized === actualNormalized)
     return null;
-  }
   const dmp = new diff_match_patch();
-  const d = dmp.diff_main(expected, actual);
+  const d = dmp.diff_main(expectedNormalized, actualNormalized);
   dmp.diff_cleanupSemantic(d);
   return {
     errorMessage: diff_prettyTerminal(d)

--- a/packages/playwright-core/src/utils/comparators.ts
+++ b/packages/playwright-core/src/utils/comparators.ts
@@ -109,8 +109,11 @@ function compareText(actual: Buffer | string, expectedBuffer: Buffer): Comparato
   if (typeof actual !== 'string')
     return { errorMessage: 'Actual result should be a string' };
   const expected = expectedBuffer.toString('utf-8');
-  if (expected === actual)
+  const expectedNormalized = expected.replace('\r\n', '\n');
+  const actualNormalized = actual.replace('\r\n', '\n');
+  if (expectedNormalized === actualNormalized) {
     return null;
+  }
   const dmp = new diff_match_patch();
   const d = dmp.diff_main(expected, actual);
   dmp.diff_cleanupSemantic(d);


### PR DESCRIPTION
i think this code might do the trick to fix #23690.

normalizing both strings by replacing `\r\n` with `\n` should eliminate newline differences.