### PR TITLE
Allow for manual downloads

### DIFF
--- a/packages/playwright-core/src/utils/network.ts
+++ b/packages/playwright-core/src/utils/network.ts
@@ -82,7 +82,7 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
   request.on('error', onError);
   if (timeout !== undefined) {
     const rejectOnTimeout = () =>  {
-      onError(new Error(`Request to ${params.url} timed out after ${timeout}ms`));
+      onError(new Error(`Request to ${params.url} timed out after ${timeout}ms. Consider setting PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT if you haven't already.`));
       request.abort();
     };
     if (timeout <= 0) {


### PR DESCRIPTION
Setting the `PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT` environment variable does not work as expected for me because the download still stalls after approximately 30 seconds. I have not managed to debug why this is, but I figure it would be good to allow for manual workarounds on slow internet connections.

At the very least, I would appreciate some way of making it easier for me to fix the download issue myself by including better logging messages.