### PR TITLE
Revert "fix: scroll timeline with multiple pages in context (#23493)"

### DIFF
--- a/packages/trace-viewer/src/ui/timeline.css
+++ b/packages/trace-viewer/src/ui/timeline.css
@@ -23,8 +23,6 @@
   cursor: text;
   user-select: none;
   margin-left: 10px;
-  max-height: 200px;
-  overflow-y: scroll;
 }
 
 .timeline-divider {


### PR DESCRIPTION
This reverts commit a4d361379f7d9cc8be5b61c4e375b6a0dfa14e24.

Reason for revert: this breaks screencast preview (the image
that is shown when you hover over the screencast).
