### PR TITLE
Improve type safety of `Serializable` type

### DIFF
--- a/packages/playwright-core/types/structs.d.ts
+++ b/packages/playwright-core/types/structs.d.ts
@@ -19,7 +19,7 @@ import { JSHandle, ElementHandle, Frame, Page, BrowserContext } from './types';
 /**
  * Can be converted to JSON
  */
-export type Serializable = any;
+export type Serializable = unknown;
 /**
  * Can be converted to JSON, but may also contain JSHandles.
  */


### PR DESCRIPTION
I need to fix the build but first I wanted to make sure that we're happy to make this change?