### PR TITLE
fix: send aditional headers to delete session method

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -216,6 +216,7 @@ export class Chromium extends BrowserType {
       await fetchData({
         url: hubUrl + 'session/' + sessionId,
         method: 'DELETE',
+        headers,
       }).catch(error => progress.log(`<error disconnecting from selenium>: ${error}`));
       progress.log(`<selenium> disconnected from sessionId=${sessionId}`);
       gracefullyCloseSet.delete(disconnectFromSelenium);

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -253,6 +253,7 @@ export class Chromium extends BrowserType {
               url: sessionInfoUrl,
               method: 'GET',
               timeout: progress.timeUntilDeadline(),
+              headers,
             }, seleniumErrorHandler);
             const proxyId = JSON.parse(sessionResponse).proxyId;
             endpointURL.hostname = new URL(proxyId).hostname;


### PR DESCRIPTION
In the process of completing the task - https://github.com/microsoft/playwright/pull/23348, I didn't notice the need to pass headers to the session deletion method. So I fixed it here. And support headers for selenium@3.