### PR TITLE
fix(locators): allow identical frameLocators inside and/or/has

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -21,7 +21,7 @@ import { VueEngine } from './vueSelectorEngine';
 import { createRoleEngine } from './roleSelectorEngine';
 import { parseAttributeSelector } from '../../utils/isomorphic/selectorParser';
 import type { NestedSelectorBody, ParsedSelector, ParsedSelectorPart } from '../../utils/isomorphic/selectorParser';
-import { allEngineNames, parseSelector, stringifySelector } from '../../utils/isomorphic/selectorParser';
+import { visitAllSelectorParts, parseSelector, stringifySelector } from '../../utils/isomorphic/selectorParser';
 import { type TextMatcher, elementMatchesText, elementText, type ElementText } from './selectorUtils';
 import { SelectorEvaluatorImpl, sortInDOMOrder } from './selectorEvaluator';
 import { enclosingShadowRootOrDocument, isElementVisible, parentElementOrShadowHost } from './domUtils';
@@ -146,10 +146,10 @@ export class InjectedScript {
 
   parseSelector(selector: string): ParsedSelector {
     const result = parseSelector(selector);
-    for (const name of allEngineNames(result)) {
-      if (!this._engines.has(name))
-        throw this.createStacklessError(`Unknown engine "${name}" while parsing selector ${selector}`);
-    }
+    visitAllSelectorParts(result, part => {
+      if (!this._engines.has(part.name))
+        throw this.createStacklessError(`Unknown engine "${part.name}" while parsing selector ${selector}`);
+    });
     return result;
   }
 

--- a/packages/playwright-core/src/server/selectors.ts
+++ b/packages/playwright-core/src/server/selectors.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { allEngineNames, InvalidSelectorError, type ParsedSelector, parseSelector, stringifySelector } from '../utils/isomorphic/selectorParser';
+import { visitAllSelectorParts, InvalidSelectorError, type ParsedSelector, parseSelector, stringifySelector } from '../utils/isomorphic/selectorParser';
 import { createGuid } from '../utils';
 
 export class Selectors {
@@ -73,7 +73,8 @@ export class Selectors {
   parseSelector(selector: string | ParsedSelector, strict: boolean) {
     const parsed = typeof selector === 'string' ? parseSelector(selector) : selector;
     let needsMainWorld = false;
-    for (const name of allEngineNames(parsed)) {
+    visitAllSelectorParts(parsed, part => {
+      const name = part.name;
       const custom = this._engines.get(name);
       if (!custom && !this._builtinEngines.has(name))
         throw new InvalidSelectorError(`Unknown engine "${name}" while parsing selector ${stringifySelector(parsed)}`);
@@ -81,7 +82,7 @@ export class Selectors {
         needsMainWorld = true;
       if (this._builtinEnginesInMainWorld.has(name))
         needsMainWorld = true;
-    }
+    });
     return {
       parsed,
       world: needsMainWorld ? 'main' as const : 'utility' as const,


### PR DESCRIPTION
So, the following will work:

```
page.frameLocator('iframe').locator('span').or(page.frameLoactor('iframe').locator('div'))
```

The following will not work, because frame locators are not exactly the same:

```
page.frameLocator('#iframe1').locator('span').or(page.frameLoactor('#iframe2').locator('div'))
```

Also improve the error message to be more readable and include the locator.

Fixes #23697.