### PR TITLE
fix: make trace viewer not use 301 to redirect

### DIFF
--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -125,7 +125,7 @@ async function startTraceViewerServer(traceUrls: string[], options?: Options): P
   const urlPath  = `/trace/${app || 'index.html'}${searchQuery}`;
 
   server.routePath('/', (_, response) => {
-    response.statusCode = 301;
+    response.statusCode = 302;
     response.setHeader('Location', urlPath);
     response.end();
     return true;


### PR DESCRIPTION
This fixes an issue in the web ui, that causes the web app to get stuck after a restart, because it tries to connect to a websocket using an id that no longer exists. 

The only change I made is to use a `302 Found` status instead of a `301 Moved Permanently`, so browser doesn't indefinitely cache the redirect from root to a transient websocket id based route. 

Fixes #23752