### PR TITLE
fix(trace viewer): prefer latest resource with the same url

### DIFF
--- a/packages/trace-viewer/src/snapshotRenderer.ts
+++ b/packages/trace-viewer/src/snapshotRenderer.ts
@@ -123,8 +123,9 @@ export class SnapshotRenderer {
       if (resource._frameref !== snapshot.frameId)
         continue;
       if (resource.request.url === url) {
+        // Pick the last resource with matching url - most likely it was used
+        // at the time of snapshot, not the earlier aborted resource with the same url.
         result = resource;
-        break;
       }
     }
 
@@ -133,8 +134,11 @@ export class SnapshotRenderer {
       for (const resource of this._resources) {
         if (typeof resource._monotonicTime === 'number' && resource._monotonicTime >= snapshot.timestamp)
           break;
-        if (resource.request.url === url)
-          return resource;
+        if (resource.request.url === url) {
+          // Pick the last resource with matching url - most likely it was used
+          // at the time of snapshot, not the earlier aborted resource with the same url.
+          result = resource;
+        }
       }
     }
 


### PR DESCRIPTION
When rendering snapshot, disregard earlier resources with the same url, because it's most likely that the latest one was used for rendering.

An example would be reloading the page before the stylesheet has finished loading. In this case, the stylesheet will be requested twice, and the second copy that was not aborted should be used for the snapshot.

Fixes #23709.