### PR TITLE
fix(codegen): generate no Enter keyboard events for textareas

### DIFF
--- a/packages/playwright-core/src/server/injected/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder.ts
@@ -315,6 +315,9 @@ export class Recorder {
   }
 
   private _shouldGenerateKeyPressFor(event: KeyboardEvent): boolean {
+    // Enter aka. new line is handled in input event.
+    if (event.key === 'Enter' && event.target && ((event.target as HTMLElement).nodeName === 'TEXTAREA') || (event.target as HTMLElement).isContentEditable)
+      return false;
     // Backspace, Delete, AltGraph are changing input, will handle it there.
     if (['Backspace', 'Delete', 'AltGraph'].includes(event.key))
       return false;

--- a/packages/playwright-core/src/server/injected/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder.ts
@@ -316,7 +316,7 @@ export class Recorder {
 
   private _shouldGenerateKeyPressFor(event: KeyboardEvent): boolean {
     // Enter aka. new line is handled in input event.
-    if (event.key === 'Enter' && event.target && ((event.target as HTMLElement).nodeName === 'TEXTAREA') || (event.target as HTMLElement).isContentEditable)
+    if (event.key === 'Enter' && (this._deepEventTarget(event).nodeName === 'TEXTAREA' || this._deepEventTarget(event).isContentEditable))
       return false;
     // Backspace, Delete, AltGraph are changing input, will handle it there.
     if (['Backspace', 'Delete', 'AltGraph'].includes(event.key))


### PR DESCRIPTION
After this patch its possible that the following basic typing would work what was before not possible (no new lines got written):

<img width="1589" alt="image" src="https://github.com/microsoft/playwright/assets/17984549/de6d270e-9140-47c2-99b0-a0e58cff1305">


https://github.com/microsoft/playwright/issues/23774