### PR TITLE
fix(chromium): can get correct orientation angle on non-mobile devices

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -1008,7 +1008,7 @@ class FrameSession {
       return;
     const viewportSize = emulatedSize.viewport;
     const screenSize = emulatedSize.screen;
-    const isLandscape = viewportSize.width > viewportSize.height;
+    const isLandscape = screenSize.width > screenSize.height;
     const metricsOverride: Protocol.Emulation.setDeviceMetricsOverrideParameters = {
       mobile: !!options.isMobile,
       width: viewportSize.width,
@@ -1016,7 +1016,9 @@ class FrameSession {
       screenWidth: screenSize.width,
       screenHeight: screenSize.height,
       deviceScaleFactor: options.deviceScaleFactor || 1,
-      screenOrientation: isLandscape ? { angle: 90, type: 'landscapePrimary' } : { angle: 0, type: 'portraitPrimary' },
+      screenOrientation: !!options.isMobile ? (
+        isLandscape ? { angle: 90, type: 'landscapePrimary' } : { angle: 0, type: 'portraitPrimary' }
+      ) : { angle: 0, type: 'landscapePrimary' },
       dontSetVisibleSize: preserveWindowBoundaries
     };
     if (JSON.stringify(this._metricsOverride) === JSON.stringify(metricsOverride))

--- a/tests/library/browsercontext-viewport.spec.ts
+++ b/tests/library/browsercontext-viewport.spec.ts
@@ -163,3 +163,15 @@ it('WebKit Windows headed should have a minimal viewport', async ({ contextFacto
   await expect(page.setViewportSize({ width: 100, height: 100 })).rejects.toThrow('WebKit on Windows has a minimal viewport of 250x240.');
   await context.close();
 });
+
+browserTest('should be able to get correct orientation angle on non-mobile devices', async ({ browser, browserName, server }) => {
+  browserTest.skip(browserName === 'webkit', 'Desktop webkit dont support orientation API');
+
+  const context = await browser.newContext({ viewport: { width: 300, height: 400 }, isMobile: false });
+  const page = await context.newPage();
+  await page.goto(server.PREFIX + '/index.html');
+  expect(await page.evaluate(() => window.screen.orientation.angle)).toBe(0);
+  await page.setViewportSize({ width: 400, height: 300 });
+  expect(await page.evaluate(() => window.screen.orientation.angle)).toBe(0);
+  await context.close();
+});


### PR DESCRIPTION
Fix #23772 