### PR TITLE
test: unflake 'should return url with basic auth info' test

### DIFF
--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -800,9 +800,9 @@ it('should wait for load when iframe attaches and detaches', async ({ page, serv
   expect(await page.$('iframe')).toBe(null);
 });
 
-it('should return url with basic auth info', async ({ page, server }) => {
+it('should return url with basic auth info', async ({ page, server, loopback }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23138' });
-  const url = `http://admin:admin@localhost:${server.PORT}/empty.html`;
+  const url = `http://admin:admin@${loopback || 'localhost'}:${server.PORT}/empty.html`;
   await page.goto(url);
-  expect(await page.url()).toBe(url);
+  expect(page.url()).toBe(url);
 });


### PR DESCRIPTION
On android there is no localhost. We should never use just localhost.