### PR TITLE
docs(class-testoptions.md): Update launchOptions docs

### DIFF
--- a/docs/src/test-api/class-testoptions.md
+++ b/docs/src/test-api/class-testoptions.md
@@ -355,10 +355,12 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-      launchOptions: {
-        args: ['--start-maximized'],
-    },
+      use: { 
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: ['--start-maximized']
+        }
+      }
     }
   ]
 });

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -3518,10 +3518,12 @@ export interface PlaywrightWorkerOptions {
    *   projects: [
    *     {
    *       name: 'chromium',
-   *       use: { ...devices['Desktop Chrome'] },
-   *       launchOptions: {
-   *         args: ['--start-maximized'],
-   *     },
+   *       use: {
+   *         ...devices['Desktop Chrome'],
+   *         launchOptions: {
+   *           args: ['--start-maximized']
+   *         }
+   *       }
    *     }
    *   ]
    * });


### PR DESCRIPTION
Launch options need to be specified inside the `use` block, updated the docs to match