### PR TITLE
chore: keep UI Mode running when used with browser mode

### DIFF
--- a/packages/playwright-core/src/server/index.ts
+++ b/packages/playwright-core/src/server/index.ts
@@ -29,5 +29,5 @@ export { createPlaywright } from './playwright';
 
 export type { DispatcherScope } from './dispatchers/dispatcher';
 export type { Playwright } from './playwright';
-export { showTraceViewer, openTraceViewerApp } from './trace/viewer/traceViewer';
+export { openTraceInBrowser, openTraceViewerApp } from './trace/viewer/traceViewer';
 export { serverSideCallMetadata } from './instrumentation';

--- a/packages/playwright-test/src/runner/uiMode.ts
+++ b/packages/playwright-test/src/runner/uiMode.ts
@@ -124,7 +124,6 @@ class UIMode {
     const exitPromise = new ManualPromise<void>();
     if (options.host !== undefined || options.port !== undefined) {
       await openTraceInBrowser([], openOptions);
-      process.on('SIGINT', () => exitPromise.resolve());
     } else {
       const page = await openTraceViewerApp([], 'chromium', openOptions);
       page.on('close', () => exitPromise.resolve());

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -168,7 +168,8 @@ export const UIModeView: React.FC<{}> = ({
 
   return <div className='vbox ui-mode'>
     {isDisconnected && <div className='drop-target'>
-      <div className='title'>Process disconnected</div>
+      <div className='title'>UI Mode disconnected</div>
+      <div><a href='#' onClick={() => window.location.reload()}>Reload the page</a> to reconnect</div>
     </div>}
     <SplitView sidebarSize={250} orientation='horizontal' sidebarIsFirst={true}>
       <div className='vbox'>


### PR DESCRIPTION
This will keep UI Mode running in browser mode. When launched in normal persistent context mode, we know when the persistent context closes, so we can run the project teardown code.

Fixes https://github.com/microsoft/playwright/issues/23801