### PR TITLE
fix: Allow portable bash paths for systems including NixOS

### DIFF
--- a/browser_patches/roll_from_upstream.sh
+++ b/browser_patches/roll_from_upstream.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # A script to roll browser patches from internal repository.
 
 set -e

--- a/browser_patches/webkit/pw_run.sh
+++ b/browser_patches/webkit/pw_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function runOSX() {
   # if script is run as-is

--- a/browser_patches/winldd/archive.sh
+++ b/browser_patches/winldd/archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 

--- a/browser_patches/winldd/build.sh
+++ b/browser_patches/winldd/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 

--- a/browser_patches/winldd/clean.sh
+++ b/browser_patches/winldd/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 

--- a/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/packages/playwright-core/bin/reinstall_chrome_beta_mac.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/packages/playwright-core/bin/reinstall_chrome_stable_mac.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -x

--- a/packages/playwright-core/bin/reinstall_msedge_beta_mac.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_beta_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -x

--- a/packages/playwright-core/bin/reinstall_msedge_dev_mac.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_dev_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -x

--- a/packages/playwright-core/bin/reinstall_msedge_stable_mac.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_stable_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/utils/avd_install.sh
+++ b/utils/avd_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/utils/avd_recreate.sh
+++ b/utils/avd_recreate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/utils/avd_start.sh
+++ b/utils/avd_start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/utils/avd_stop.sh
+++ b/utils/avd_stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/utils/build/build-playwright-driver.sh
+++ b/utils/build/build-playwright-driver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/utils/build/deploy-trace-viewer.sh
+++ b/utils/build/deploy-trace-viewer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/utils/build/upload-playwright-driver.sh
+++ b/utils/build/upload-playwright-driver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 

--- a/utils/build_android_driver.sh
+++ b/utils/build_android_driver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 (cd src/server/android/driver ; ./gradlew assemble)
 if [ "$?" -ne "0" ]; then

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set +x

--- a/utils/draft_release_notes.sh
+++ b/utils/draft_release_notes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 

--- a/utils/linux-browser-dependencies/inside_docker/process.sh
+++ b/utils/linux-browser-dependencies/inside_docker/process.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 

--- a/utils/linux-browser-dependencies/run.sh
+++ b/utils/linux-browser-dependencies/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 

--- a/utils/list_closed_issues.sh
+++ b/utils/list_closed_issues.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 

--- a/utils/publish_all_packages.sh
+++ b/utils/publish_all_packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/utils/upload_flakiness_dashboard.sh
+++ b/utils/upload_flakiness_dashboard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) Microsoft Corporation.
 #


### PR DESCRIPTION
Although very common, bash is not guaranteed to be located at `/bin/bash`. NixOS is an example of this.

More commonly, `/bin/bash` can be quite out of date. An example of this is MacOS's version of `bash`. This realistically won't affect Playwright but it's worth noting. You can technically update MacOS's system version of bash but you need elevated permissions to do so.

By using `/usr/bin/env bash` instead of `/bin/bash` we can execute Playwright's bash scripts in like NixOS and generally improve the selection behaviour for bash in other systems too.

Some discussion of why it's worth favouring `/usr/bin/env bash` over `/bin/bash`:
- Discusses `/bin/bash` missing in NixOS: https://discourse.nixos.org/t/add-bin-bash-to-avoid-unnecessary-pain/5673
- Some general commentary on why `/usr/bin/env bash` is favoured: https://askubuntu.com/a/1402721
- Points out how old bash is in MacOS: https://itnext.io/upgrading-bash-on-macos-7138bd1066ba

Improves situation at #5501