### PR TITLE
feat(page): Pick best locator for existing element.

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -845,6 +845,39 @@ Gets the full HTML contents of the page, including the doctype.
 
 Get the browser context that the page belongs to.
 
+## method: Page.pickBestLocator
+* since: v1.36
+- returns: <[Promise<{ locator: string; selector: string}>]>
+
+Get the best locator and selector for the specified selector.
+
+**Usage**
+
+```js
+await page.pickBestLocator('#id');
+```
+
+```java
+page.pickBestLocator("#id");
+```
+
+```python async
+await page.pickBestLocator("#id")
+```
+
+```python sync
+page.pickBestLocator("#id")
+```
+
+```csharp
+await page.PickBestLocatorAsync("#id");
+```
+
+Will pick the most stable locator available for the element defined by the selector parameter and return it.
+
+### param: Page.pickBestLocator.selector = %%-input-selector-%%
+* since: v1.36
+
 ## property: Page.coverage
 * since: v1.8
 * langs: js

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -711,6 +711,10 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     }
     return result.pdf;
   }
+
+  pickBestLocator(selector: string): Promise<{ locator: string; selector: string }> {
+    return this._channel.pickBestLocator({ selector });
+  }
 }
 
 export class BindingCall extends ChannelOwner<channels.BindingCallChannel> {

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -972,6 +972,13 @@ scheme.PageWebSocketEvent = tObject({
 scheme.PageWorkerEvent = tObject({
   worker: tChannel(['Worker']),
 });
+scheme.PagePickBestLocatorParams = tObject({
+  selector: tString,
+});
+scheme.PagePickBestLocatorResult = tObject({
+  selector: tString,
+  locator: tString,
+});
 scheme.PageSetDefaultNavigationTimeoutNoReplyParams = tObject({
   timeout: tOptional(tNumber),
 });

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -35,6 +35,7 @@ import { ArtifactDispatcher } from './artifactDispatcher';
 import type { Download } from '../download';
 import { createGuid, urlMatches } from '../../utils';
 import type { BrowserContextDispatcher } from './browserContextDispatcher';
+import type { PagePickBestLocatorResult } from '@protocol/channels';
 
 export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, BrowserContextDispatcher> implements channels.PageChannel {
   _type_EventTarget = true;
@@ -99,6 +100,10 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
 
   page(): Page {
     return this._page;
+  }
+
+  async pickBestLocator(params: channels.PagePickBestLocatorParams, metadata: CallMetadata): Promise<PagePickBestLocatorResult> {
+    return this._page.pickBestLocator(params.selector);
   }
 
   async setDefaultNavigationTimeoutNoReply(params: channels.PageSetDefaultNavigationTimeoutNoReplyParams, metadata: CallMetadata): Promise<void> {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -3430,6 +3430,21 @@ export interface Page {
   }): Promise<Buffer>;
 
   /**
+   * Get the best locator and selector for the specified selector.
+   *
+   * **Usage**
+   *
+   * ```js
+   * await page.pickBestLocator('#id');
+   * ```
+   *
+   * Will pick the most stable locator available for the element defined by the selector parameter and return it.
+   * @param selector A selector to search for an element. If there are multiple elements satisfying the selector, the first will be
+   * used.
+   */
+  pickBestLocator(selector: string): Promise<{ locator: string; selector: string}>;
+
+  /**
    * **NOTE** Use locator-based [locator.press(key[, options])](https://playwright.dev/docs/api/class-locator#locator-press)
    * instead. Read more about [locators](https://playwright.dev/docs/locators).
    *

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1734,6 +1734,7 @@ export interface PageEventTarget {
 }
 export interface PageChannel extends PageEventTarget, EventTargetChannel {
   _type_Page: boolean;
+  pickBestLocator(params: PagePickBestLocatorParams, metadata?: CallMetadata): Promise<PagePickBestLocatorResult>;
   setDefaultNavigationTimeoutNoReply(params: PageSetDefaultNavigationTimeoutNoReplyParams, metadata?: CallMetadata): Promise<PageSetDefaultNavigationTimeoutNoReplyResult>;
   setDefaultTimeoutNoReply(params: PageSetDefaultTimeoutNoReplyParams, metadata?: CallMetadata): Promise<PageSetDefaultTimeoutNoReplyResult>;
   addInitScript(params: PageAddInitScriptParams, metadata?: CallMetadata): Promise<PageAddInitScriptResult>;
@@ -1802,6 +1803,16 @@ export type PageWebSocketEvent = {
 };
 export type PageWorkerEvent = {
   worker: WorkerChannel,
+};
+export type PagePickBestLocatorParams = {
+  selector: string,
+};
+export type PagePickBestLocatorOptions = {
+
+};
+export type PagePickBestLocatorResult = {
+  selector: string,
+  locator: string,
 };
 export type PageSetDefaultNavigationTimeoutNoReplyParams = {
   timeout?: number,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1238,6 +1238,12 @@ Page:
     opener: Page?
 
   commands:
+    pickBestLocator:
+      parameters:
+        selector: string
+      returns:
+        selector: string
+        locator: string
 
     setDefaultNavigationTimeoutNoReply:
       parameters:

--- a/tests/page/locator-convenience.spec.ts
+++ b/tests/page/locator-convenience.spec.ts
@@ -17,6 +17,37 @@
 
 import { test as it, expect } from './pageTest';
 
+it.describe('picking the best available locator for an existing element', () => {
+
+  const html = '<div><input id="inputId" placeholder="somePlaceholder"/><button id="buttonId">Some Text</button></div>';
+
+  const testCases = [
+    {
+      originalSelector: '#buttonId',
+      expectedSelector: 'internal:role=button[name="Some Text"i]',
+      expectedLocator: "getByRole('button', { name: 'Some Text' })"
+    },
+    {
+      originalSelector: '#inputId',
+      expectedSelector: 'internal:attr=[placeholder="somePlaceholder"i]',
+      expectedLocator: "getByPlaceholder('somePlaceholder')"
+    }];
+
+  for (const testCase of testCases) {
+    it(`should allow selecting the best locator from an existing selector ${testCase.originalSelector}`, async ({ page }) => {
+      await page.setContent(html);
+
+      const locatorReference = await page.pickBestLocator(testCase.originalSelector);
+
+      expect(locatorReference.locator).toEqual(testCase.expectedLocator);
+      expect(locatorReference.selector).toEqual(testCase.expectedSelector);
+      await page.close();
+    });
+  }
+
+});
+
+
 it('should have a nice preview', async ({ page, server }) => {
   await page.goto(`${server.PREFIX}/dom.html`);
   const outer = page.locator('#outer');


### PR DESCRIPTION
Improve programmatic API of accessing the "pick locator" functionality as exposed by the playwright trace viewer/codegenerator.

Fixes #13900


I am not sure if this is the both the best way to implement it (sorry in advance, first time contributing here) nor the best API, so would love some feedback on both.

Overall: it would be super helpful for us (octomind) to programmatically be able to pick the "best" locator/selector for a certain HTMLElement we have in-memory already. Our use-case is a little different than the one referenced in the issue: we want to be able to auto-generate playwright tests using some form of AI/smart exploration. To do that effectively we would like to be able to choose the "best" selector/locator for a certain element that we already hold in-memory from our exploration process so that the resulting test case is as robust as possible. 

If you need more information we can go also go into more detail. We in general would love to help give playwright a programmatic API if allowed , e.g. test execution and introspection of test results is something we are very interested in as well (see https://github.com/microsoft/playwright/issues/7275).

Re: this specific change: I was looking to build an API that works on a certain HTMLElement directly, but found it a) difficult to get that through the serialization between client/server and b) thought that a selector -> "better" selector API might be more generic anyways.

