### PR TITLE
fix: do not wait for navigations after certain actions

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -177,7 +177,7 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: ElementHandle.check.force = %%-input-force-%%
 * since: v1.8
 
-### option: ElementHandle.check.noWaitAfter = %%-input-no-wait-after-%%
+### option: ElementHandle.check.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: ElementHandle.check.timeout = %%-input-timeout-%%
@@ -522,7 +522,7 @@ Value to set for the `<input>`, `<textarea>` or `[contenteditable]` element.
 ### option: ElementHandle.fill.force = %%-input-force-%%
 * since: v1.13
 
-### option: ElementHandle.fill.noWaitAfter = %%-input-no-wait-after-%%
+### option: ElementHandle.fill.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: ElementHandle.fill.timeout = %%-input-timeout-%%
@@ -686,7 +686,7 @@ Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
 
 Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 
-### option: ElementHandle.press.noWaitAfter = %%-input-no-wait-after-%%
+### option: ElementHandle.press.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: ElementHandle.press.timeout = %%-input-timeout-%%
@@ -832,7 +832,7 @@ await handle.SelectOptionAsync(new[] {
 ### option: ElementHandle.selectOption.force = %%-input-force-%%
 * since: v1.13
 
-### option: ElementHandle.selectOption.noWaitAfter = %%-input-no-wait-after-%%
+### option: ElementHandle.selectOption.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: ElementHandle.selectOption.timeout = %%-input-timeout-%%
@@ -892,7 +892,7 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: ElementHandle.setChecked.force = %%-input-force-%%
 * since: v1.15
 
-### option: ElementHandle.setChecked.noWaitAfter = %%-input-no-wait-after-%%
+### option: ElementHandle.setChecked.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.15
 
 ### option: ElementHandle.setChecked.position = %%-input-position-%%
@@ -919,7 +919,7 @@ This method expects [ElementHandle] to point to an
 ### param: ElementHandle.setInputFiles.files = %%-input-files-%%
 * since: v1.8
 
-### option: ElementHandle.setInputFiles.noWaitAfter = %%-input-no-wait-after-%%
+### option: ElementHandle.setInputFiles.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: ElementHandle.setInputFiles.timeout = %%-input-timeout-%%
@@ -1051,7 +1051,7 @@ A text to type into a focused element.
 
 Time to wait between key presses in milliseconds. Defaults to 0.
 
-### option: ElementHandle.type.noWaitAfter = %%-input-no-wait-after-%%
+### option: ElementHandle.type.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: ElementHandle.type.timeout = %%-input-timeout-%%
@@ -1083,7 +1083,7 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: ElementHandle.uncheck.force = %%-input-force-%%
 * since: v1.8
 
-### option: ElementHandle.uncheck.noWaitAfter = %%-input-no-wait-after-%%
+### option: ElementHandle.uncheck.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: ElementHandle.uncheck.timeout = %%-input-timeout-%%

--- a/docs/src/api/class-filechooser.md
+++ b/docs/src/api/class-filechooser.md
@@ -65,7 +65,7 @@ they are resolved relative to the current working directory. For empty array, cl
 ### param: FileChooser.setFiles.files = %%-input-files-%%
 * since: v1.8
 
-### option: FileChooser.setFiles.noWaitAfter = %%-input-no-wait-after-%%
+### option: FileChooser.setFiles.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: FileChooser.setFiles.timeout = %%-input-timeout-%%

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -210,7 +210,7 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.check.force = %%-input-force-%%
 * since: v1.8
 
-### option: Frame.check.noWaitAfter = %%-input-no-wait-after-%%
+### option: Frame.check.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Frame.check.position = %%-input-position-%%
@@ -460,7 +460,7 @@ Optional event-specific initialization properties.
 ### option: Frame.dragAndDrop.force = %%-input-force-%%
 * since: v1.13
 
-### option: Frame.dragAndDrop.noWaitAfter = %%-input-no-wait-after-%%
+### option: Frame.dragAndDrop.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.13
 
 ### option: Frame.dragAndDrop.strict = %%-input-strict-%%
@@ -849,7 +849,7 @@ Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
 ### option: Frame.fill.force = %%-input-force-%%
 * since: v1.13
 
-### option: Frame.fill.noWaitAfter = %%-input-no-wait-after-%%
+### option: Frame.fill.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Frame.fill.strict = %%-input-strict-%%
@@ -1411,7 +1411,7 @@ Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
 
 Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 
-### option: Frame.press.noWaitAfter = %%-input-no-wait-after-%%
+### option: Frame.press.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Frame.press.strict = %%-input-strict-%%
@@ -1537,7 +1537,7 @@ await frame.SelectOptionAsync("select#colors", new[] { "red", "green", "blue" })
 ### option: Frame.selectOption.force = %%-input-force-%%
 * since: v1.13
 
-### option: Frame.selectOption.noWaitAfter = %%-input-no-wait-after-%%
+### option: Frame.selectOption.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Frame.selectOption.strict = %%-input-strict-%%
@@ -1589,7 +1589,7 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.setChecked.force = %%-input-force-%%
 * since: v1.15
 
-### option: Frame.setChecked.noWaitAfter = %%-input-no-wait-after-%%
+### option: Frame.setChecked.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.15
 
 ### option: Frame.setChecked.position = %%-input-position-%%
@@ -1641,7 +1641,7 @@ This method expects [`param: selector`] to point to an
 ### param: Frame.setInputFiles.files = %%-input-files-%%
 * since: v1.8
 
-### option: Frame.setInputFiles.noWaitAfter = %%-input-no-wait-after-%%
+### option: Frame.setInputFiles.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Frame.setInputFiles.strict = %%-input-strict-%%
@@ -1778,7 +1778,7 @@ A text to type into a focused element.
 
 Time to wait between key presses in milliseconds. Defaults to 0.
 
-### option: Frame.type.noWaitAfter = %%-input-no-wait-after-%%
+### option: Frame.type.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Frame.type.strict = %%-input-strict-%%
@@ -1815,7 +1815,7 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.uncheck.force = %%-input-force-%%
 * since: v1.8
 
-### option: Frame.uncheck.noWaitAfter = %%-input-no-wait-after-%%
+### option: Frame.uncheck.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Frame.uncheck.position = %%-input-position-%%

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -260,7 +260,7 @@ await page.GetByRole(AriaRole.Checkbox).CheckAsync();
 ### option: Locator.check.force = %%-input-force-%%
 * since: v1.14
 
-### option: Locator.check.noWaitAfter = %%-input-no-wait-after-%%
+### option: Locator.check.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.14
 
 ### option: Locator.check.timeout = %%-input-timeout-%%
@@ -310,7 +310,7 @@ await page.GetByRole(AriaRole.Textbox).ClearAsync();
 ### option: Locator.clear.force = %%-input-force-%%
 * since: v1.28
 
-### option: Locator.clear.noWaitAfter = %%-input-no-wait-after-%%
+### option: Locator.clear.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.28
 
 ### option: Locator.clear.timeout = %%-input-timeout-%%
@@ -695,7 +695,7 @@ Locator of the element to drag to.
 ### option: Locator.dragTo.force = %%-input-force-%%
 * since: v1.18
 
-### option: Locator.dragTo.noWaitAfter = %%-input-no-wait-after-%%
+### option: Locator.dragTo.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.18
 
 ### option: Locator.dragTo.timeout = %%-input-timeout-%%
@@ -925,7 +925,7 @@ Value to set for the `<input>`, `<textarea>` or `[contenteditable]` element.
 ### option: Locator.fill.force = %%-input-force-%%
 * since: v1.14
 
-### option: Locator.fill.noWaitAfter = %%-input-no-wait-after-%%
+### option: Locator.fill.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.14
 
 ### option: Locator.fill.timeout = %%-input-timeout-%%
@@ -1685,7 +1685,7 @@ Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
 
 Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 
-### option: Locator.press.noWaitAfter = %%-input-no-wait-after-%%
+### option: Locator.press.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.14
 
 ### option: Locator.press.timeout = %%-input-timeout-%%
@@ -1862,7 +1862,7 @@ await element.SelectOptionAsync(new[] { "red", "green", "blue" });
 ### option: Locator.selectOption.force = %%-input-force-%%
 * since: v1.14
 
-### option: Locator.selectOption.noWaitAfter = %%-input-no-wait-after-%%
+### option: Locator.selectOption.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.14
 
 ### option: Locator.selectOption.timeout = %%-input-timeout-%%
@@ -1948,7 +1948,7 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Locator.setChecked.force = %%-input-force-%%
 * since: v1.15
 
-### option: Locator.setChecked.noWaitAfter = %%-input-no-wait-after-%%
+### option: Locator.setChecked.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.15
 
 ### option: Locator.setChecked.position = %%-input-position-%%
@@ -2070,7 +2070,7 @@ This method expects [Locator] to point to an
 ### param: Locator.setInputFiles.files = %%-input-files-%%
 * since: v1.14
 
-### option: Locator.setInputFiles.noWaitAfter = %%-input-no-wait-after-%%
+### option: Locator.setInputFiles.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.14
 
 ### option: Locator.setInputFiles.timeout = %%-input-timeout-%%
@@ -2212,7 +2212,7 @@ A text to type into a focused element.
 
 Time to wait between key presses in milliseconds. Defaults to 0.
 
-### option: Locator.type.noWaitAfter = %%-input-no-wait-after-%%
+### option: Locator.type.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.14
 
 ### option: Locator.type.timeout = %%-input-timeout-%%
@@ -2270,7 +2270,7 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Locator.uncheck.force = %%-input-force-%%
 * since: v1.14
 
-### option: Locator.uncheck.noWaitAfter = %%-input-no-wait-after-%%
+### option: Locator.uncheck.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.14
 
 ### option: Locator.uncheck.timeout = %%-input-timeout-%%

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -743,7 +743,7 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Page.check.force = %%-input-force-%%
 * since: v1.8
 
-### option: Page.check.noWaitAfter = %%-input-no-wait-after-%%
+### option: Page.check.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Page.check.position = %%-input-position-%%
@@ -1079,7 +1079,7 @@ await Page.DragAndDropAsync("#source", "#target", new()
 ### option: Page.dragAndDrop.force = %%-input-force-%%
 * since: v1.13
 
-### option: Page.dragAndDrop.noWaitAfter = %%-input-no-wait-after-%%
+### option: Page.dragAndDrop.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.13
 
 ### option: Page.dragAndDrop.strict = %%-input-strict-%%
@@ -2106,7 +2106,7 @@ Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
 ### option: Page.fill.force = %%-input-force-%%
 * since: v1.13
 
-### option: Page.fill.noWaitAfter = %%-input-no-wait-after-%%
+### option: Page.fill.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Page.fill.strict = %%-input-strict-%%
@@ -3074,7 +3074,7 @@ Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
 
 Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 
-### option: Page.press.noWaitAfter = %%-input-no-wait-after-%%
+### option: Page.press.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Page.press.strict = %%-input-strict-%%
@@ -3458,7 +3458,7 @@ await page.SelectOptionAsync("select#colors", new[] { "red", "green", "blue" });
 ### option: Page.selectOption.force = %%-input-force-%%
 * since: v1.13
 
-### option: Page.selectOption.noWaitAfter = %%-input-no-wait-after-%%
+### option: Page.selectOption.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Page.selectOption.strict = %%-input-strict-%%
@@ -3510,7 +3510,7 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Page.setChecked.force = %%-input-force-%%
 * since: v1.15
 
-### option: Page.setChecked.noWaitAfter = %%-input-no-wait-after-%%
+### option: Page.setChecked.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.15
 
 ### option: Page.setChecked.position = %%-input-position-%%
@@ -3615,7 +3615,7 @@ This method expects [`param: selector`] to point to an
 ### param: Page.setInputFiles.files = %%-input-files-%%
 * since: v1.8
 
-### option: Page.setInputFiles.noWaitAfter = %%-input-no-wait-after-%%
+### option: Page.setInputFiles.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Page.setInputFiles.strict = %%-input-strict-%%
@@ -3817,7 +3817,7 @@ A text to type into a focused element.
 
 Time to wait between key presses in milliseconds. Defaults to 0.
 
-### option: Page.type.noWaitAfter = %%-input-no-wait-after-%%
+### option: Page.type.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Page.type.strict = %%-input-strict-%%
@@ -3854,7 +3854,7 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Page.uncheck.force = %%-input-force-%%
 * since: v1.8
 
-### option: Page.uncheck.noWaitAfter = %%-input-no-wait-after-%%
+### option: Page.uncheck.noWaitAfter = %%-input-no-wait-after-ignored-%%
 * since: v1.8
 
 ### option: Page.uncheck.position = %%-input-position-%%

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -68,6 +68,11 @@ Actions that initiate navigations are waiting for these navigations to happen an
 opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating
 to inaccessible pages. Defaults to `false`.
 
+## input-no-wait-after-ignored
+- `noWaitAfter` <[boolean]>
+
+This option is ignored. Playwright will not auto-wait at the end of this action, but instead [auto-wait](../actionability.md) before the next action or assertion.
+
 ## input-force
 - `force` <[boolean]>
 
@@ -307,7 +312,7 @@ When using [`method: Page.goto`], [`method: Page.route`], [`method: Page.waitFor
   - `width` <[int]> page width in pixels.
   - `height` <[int]> page height in pixels.
 
-Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. 
+Emulates consistent viewport for each page. Defaults to an 1280x720 viewport.
 Use `null` to disable the consistent viewport emulation. Learn more about [viewport emulation](../emulation#viewport).
 
 :::note

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1172,6 +1172,7 @@ export class Frame extends SdkObject {
           ...options,
           position: options.sourcePosition,
           timeout: progress.timeUntilDeadline(),
+          noWaitAfter: true,
         });
       }));
       dom.assertDone(await this._retryWithProgressIfNotConnected(progress, target, options.strict, async handle => {
@@ -1182,6 +1183,7 @@ export class Frame extends SdkObject {
           ...options,
           position: options.targetPosition,
           timeout: progress.timeUntilDeadline(),
+          noWaitAfter: true,
         });
       }));
     }, this._page._timeoutSettings.timeout(options));

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -1865,9 +1865,8 @@ export interface Page {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -2181,9 +2180,8 @@ export interface Page {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -2362,9 +2360,8 @@ export interface Page {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -3482,9 +3479,8 @@ export interface Page {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -3725,9 +3721,8 @@ export interface Page {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -3777,9 +3772,8 @@ export interface Page {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -3932,9 +3926,8 @@ export interface Page {
     buffer: Buffer;
   }>, options?: {
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -4124,9 +4117,8 @@ export interface Page {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -4174,9 +4166,8 @@ export interface Page {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -5484,9 +5475,8 @@ export interface Frame {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -5765,9 +5755,8 @@ export interface Frame {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -5839,9 +5828,8 @@ export interface Frame {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -6716,9 +6704,8 @@ export interface Frame {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -6810,9 +6797,8 @@ export interface Frame {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -6862,9 +6848,8 @@ export interface Frame {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -6975,9 +6960,8 @@ export interface Frame {
     buffer: Buffer;
   }>, options?: {
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -7128,9 +7112,8 @@ export interface Frame {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -7178,9 +7161,8 @@ export interface Frame {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -9379,9 +9361,8 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -9616,9 +9597,8 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -9796,9 +9776,8 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -9979,9 +9958,8 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -10042,9 +10020,8 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -10116,9 +10093,8 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     buffer: Buffer;
   }>, options?: {
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -10228,9 +10204,8 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -10267,9 +10242,8 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -10608,9 +10582,8 @@ export interface Locator {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -10667,9 +10640,8 @@ export interface Locator {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -10946,9 +10918,8 @@ export interface Locator {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -11063,9 +11034,8 @@ export interface Locator {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -11878,9 +11848,8 @@ export interface Locator {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -12018,9 +11987,8 @@ export interface Locator {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -12091,9 +12059,8 @@ export interface Locator {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -12189,9 +12156,8 @@ export interface Locator {
     buffer: Buffer;
   }>, options?: {
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -12314,9 +12280,8 @@ export interface Locator {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -12363,9 +12328,8 @@ export interface Locator {
     force?: boolean;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -12958,7 +12922,7 @@ export interface BrowserType<Unused = {}> {
     videosPath?: string;
 
     /**
-     * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport.  Use `null` to disable the consistent
+     * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use `null` to disable the consistent
      * viewport emulation. Learn more about [viewport emulation](https://playwright.dev/docs/emulation#viewport).
      *
      * **NOTE** The `null` value opts out from the default presets, makes viewport depend on the host window size defined
@@ -14348,7 +14312,7 @@ export interface AndroidDevice {
     videosPath?: string;
 
     /**
-     * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport.  Use `null` to disable the consistent
+     * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use `null` to disable the consistent
      * viewport emulation. Learn more about [viewport emulation](https://playwright.dev/docs/emulation#viewport).
      *
      * **NOTE** The `null` value opts out from the default presets, makes viewport depend on the host window size defined
@@ -16283,7 +16247,7 @@ export interface Browser extends EventEmitter {
     videosPath?: string;
 
     /**
-     * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport.  Use `null` to disable the consistent
+     * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use `null` to disable the consistent
      * viewport emulation. Learn more about [viewport emulation](https://playwright.dev/docs/emulation#viewport).
      *
      * **NOTE** The `null` value opts out from the default presets, makes viewport depend on the host window size defined
@@ -17065,9 +17029,8 @@ export interface FileChooser {
     buffer: Buffer;
   }>, options?: {
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
+     * This option is ignored. Playwright will not auto-wait at the end of this action, but instead
+     * [auto-wait](https://playwright.dev/docs/actionability) before the next action or assertion.
      */
     noWaitAfter?: boolean;
 
@@ -19415,7 +19378,7 @@ export interface BrowserContextOptions {
   videosPath?: string;
 
   /**
-   * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport.  Use `null` to disable the consistent
+   * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use `null` to disable the consistent
    * viewport emulation. Learn more about [viewport emulation](https://playwright.dev/docs/emulation#viewport).
    *
    * **NOTE** The `null` value opts out from the default presets, makes viewport depend on the host window size defined

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -4024,7 +4024,7 @@ export interface PlaywrightTestOptions {
    * });
    * ```
    *
-   * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport.  Use `null` to disable the consistent
+   * Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use `null` to disable the consistent
    * viewport emulation. Learn more about [viewport emulation](https://playwright.dev/docs/emulation#viewport).
    *
    * **NOTE** The `null` value opts out from the default presets, makes viewport depend on the host window size defined


### PR DESCRIPTION
Do not wait for navigations anymore:
- `check`/`uncheck`/`setChecked`
- `fill`/`type`/`press`
- `selectOption`
- `setInputFiles`
- `dragTo`/`dragAndDrop`

Keep waiting for navigations:
- `click`/`hover`/`dblclick`
- `tap`