### PR TITLE
fix(routes): catch route handlers upon respective page closure

### DIFF
--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -59,7 +59,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
   readonly _serviceWorkers = new Set<Worker>();
   readonly _isChromium: boolean;
   private _harRecorders = new Map<string, { path: string, content: 'embed' | 'attach' | 'omit' | undefined }>();
-  private _closeWasCalled = false;
+  _closeWasCalled = false;
 
   static from(context: channels.BrowserContextChannel): BrowserContext {
     return (context as any)._object;

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -78,6 +78,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
   private _frames = new Set<Frame>();
   _workers = new Set<Worker>();
   private _closed = false;
+  private _closeWasCalled = false;
   readonly _closedOrCrashedRace = new ScopedRace();
   private _viewportSize: Size | null;
   private _routes: RouteHandler[] = [];
@@ -513,7 +514,12 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     await this._channel.bringToFront();
   }
 
+  _shouldCatchAllRouteHandlers() {
+    return this._closeWasCalled || this._browserContext._closeWasCalled;
+  }
+
   async close(options: { runBeforeUnload?: boolean } = { runBeforeUnload: undefined }) {
+    this._closeWasCalled = true;
     try {
       if (this._ownedContext)
         await this._ownedContext.close();


### PR DESCRIPTION
Currently, route handler can throw when page is closed in the middle of it's execution, especially with `route.fetch()` call inside.

Since you cannot really control when the route hanlder is called, it is hard to handle this situation. However, Playwright can just ignore exceptions in routes after page closure. This would eliminate any potential issues with using Playwright APIs from the route handler.

There is a small chance of unrelated exception being unnoticed in the ignored route handlers, but that seems like small price.

Fixes #23781.