### PR TITLE
feat(webkit): roll to r1868

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "webkit",
-      "revision": "1865",
+      "revision": "1868",
       "installByDefault": true,
       "revisionOverrides": {
         "mac10.14": "1446",


### PR DESCRIPTION
GitHub had an outage so the PR didn't get created automatically.

Closes https://github.com/microsoft/playwright/pull/23931.