### PR TITLE
chore: call `onEnd(result)` on InternalReporter

### DIFF
--- a/packages/playwright-test/src/runner/runner.ts
+++ b/packages/playwright-test/src/runner/runner.ts
@@ -91,7 +91,8 @@ export class Runner {
       status = 'failed';
     if (status === 'passed' && taskStatus !== 'passed')
       status = taskStatus;
-    await reporter.onExit({ status });
+    await reporter.onEnd({ status });
+    await reporter.onExit();
 
     // Calling process.exit() might truncate large stdout/stderr output.
     // See https://github.com/nodejs/node/issues/6456.

--- a/packages/playwright-test/src/runner/uiMode.ts
+++ b/packages/playwright-test/src/runner/uiMode.ts
@@ -72,7 +72,8 @@ class UIMode {
     reporter.onConfigure(this._config);
     const testRun = new TestRun(this._config, reporter);
     const { status, cleanup: globalCleanup } = await taskRunner.runDeferCleanup(testRun, 0);
-    await reporter.onExit({ status });
+    await reporter.onEnd({ status });
+    await reporter.onExit();
     if (status !== 'passed') {
       await globalCleanup();
       return status;
@@ -168,7 +169,8 @@ class UIMode {
     clearCompilationCache();
     reporter.onConfigure(this._config);
     const status = await taskRunner.run(testRun, 0);
-    await reporter.onExit({ status });
+    await reporter.onEnd({ status });
+    await reporter.onExit();
 
     const projectDirs = new Set<string>();
     for (const p of this._config.projects)
@@ -192,7 +194,8 @@ class UIMode {
     reporter.onConfigure(this._config);
     const stop = new ManualPromise();
     const run = taskRunner.run(testRun, 0, stop).then(async status => {
-      await reporter.onExit({ status });
+      await reporter.onEnd({ status });
+      await reporter.onExit();
       this._testRun = undefined;
       this._config.testIdMatcher = undefined;
       return status;

--- a/packages/playwright-test/src/runner/watchMode.ts
+++ b/packages/playwright-test/src/runner/watchMode.ts
@@ -118,7 +118,11 @@ export async function runWatchModeLoop(config: FullConfigInternal): Promise<Full
   reporter.onConfigure(config);
   const { status, cleanup: globalCleanup } = await taskRunner.runDeferCleanup(testRun, 0);
   if (status !== 'passed')
-    return await globalCleanup();
+    await globalCleanup();
+  await reporter.onEnd({ status });
+  await reporter.onExit();
+  if (status !== 'passed')
+    return status;
 
   // Prepare projects that will be watched, set up watcher.
   const failedTestIdCollector = new Set<string>();
@@ -248,7 +252,8 @@ export async function runWatchModeLoop(config: FullConfigInternal): Promise<Full
     }
   }
 
-  return result === 'passed' ? await globalCleanup() : result;
+  const cleanupStatus = await globalCleanup();
+  return result === 'passed' ? cleanupStatus : result;
 }
 
 async function runChangedTests(config: FullConfigInternal, failedTestIdCollector: Set<string>, filesByProject: Map<FullProjectInternal, Set<string>>, title?: string) {
@@ -297,7 +302,8 @@ async function runTests(config: FullConfigInternal, failedTestIdCollector: Set<s
     status = 'failed';
   if (status === 'passed' && taskStatus !== 'passed')
     status = taskStatus;
-  await reporter.onExit({ status });
+  await reporter.onEnd({ status });
+  await reporter.onExit();
 }
 
 function affectedProjectsClosure(projectClosure: FullProjectInternal[], affected: FullProjectInternal[]): Set<FullProjectInternal> {


### PR DESCRIPTION
Drive-by: fix watch mode not running global teardown.