### PR TITLE
chore: migrate builtin reporters to ReporterV2

### DIFF
--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -16,9 +16,10 @@
 
 import { colors, ms as milliseconds, parseStackTraceLine } from 'playwright-core/lib/utilsBundle';
 import path from 'path';
-import type { FullConfig, TestCase, Suite, TestResult, TestError, FullResult, TestStep, Location, Reporter } from '../../types/testReporter';
+import type { FullConfig, TestCase, Suite, TestResult, TestError, FullResult, TestStep, Location } from '../../types/testReporter';
 import type { SuitePrivate } from '../../types/reporterPrivate';
 import { monotonicTime } from 'playwright-core/lib/utils';
+import type { ReporterV2 } from './reporterV2';
 export type TestResultOutput = { chunk: string | Buffer, type: 'stdout' | 'stderr' };
 export const kOutputSymbol = Symbol('output');
 
@@ -43,7 +44,7 @@ type TestSummary = {
   fatalErrors: TestError[];
 };
 
-export class BaseReporter implements Reporter {
+export class BaseReporter implements ReporterV2 {
   duration = 0;
   config!: FullConfig;
   suite!: Suite;
@@ -60,9 +61,16 @@ export class BaseReporter implements Reporter {
     this._ttyWidthForTest = parseInt(process.env.PWTEST_TTY_WIDTH || '', 10);
   }
 
-  onBegin(config: FullConfig, suite: Suite) {
-    this.monotonicStartTime = monotonicTime();
+  version(): 'v2' {
+    return 'v2';
+  }
+
+  onConfigure(config: FullConfig) {
     this.config = config;
+  }
+
+  onBegin(suite: Suite) {
+    this.monotonicStartTime = monotonicTime();
     this.suite = suite;
     this.totalTestCount = suite.allTests().length;
   }
@@ -80,6 +88,9 @@ export class BaseReporter implements Reporter {
       return;
     (result as any)[kOutputSymbol] = (result as any)[kOutputSymbol] || [];
     (result as any)[kOutputSymbol].push(output);
+  }
+
+  onTestBegin(test: TestCase, result: TestResult): void {
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
@@ -102,6 +113,19 @@ export class BaseReporter implements Reporter {
   async onEnd(result: FullResult) {
     this.duration = monotonicTime() - this.monotonicStartTime;
     this.result = result;
+  }
+
+  onStepBegin(test: TestCase, result: TestResult, step: TestStep): void {
+  }
+
+  onStepEnd(test: TestCase, result: TestResult, step: TestStep): void {
+  }
+
+  async onExit() {
+  }
+
+  printsToStdio() {
+    return true;
   }
 
   protected ttyWidth() {

--- a/packages/playwright-test/src/reporters/dot.ts
+++ b/packages/playwright-test/src/reporters/dot.ts
@@ -16,17 +16,17 @@
 
 import { colors } from 'playwright-core/lib/utilsBundle';
 import { BaseReporter, formatError } from './base';
-import type { FullResult, TestCase, TestResult, FullConfig, Suite, TestError } from '../../types/testReporter';
+import type { FullResult, TestCase, TestResult, Suite, TestError } from '../../types/testReporter';
 
 class DotReporter extends BaseReporter {
   private _counter = 0;
 
-  printsToStdio() {
+  override printsToStdio() {
     return true;
   }
 
-  override onBegin(config: FullConfig, suite: Suite) {
-    super.onBegin(config, suite);
+  override onBegin(suite: Suite) {
+    super.onBegin(suite);
     console.log(this.generateStartingMessage());
   }
 

--- a/packages/playwright-test/src/reporters/empty.ts
+++ b/packages/playwright-test/src/reporters/empty.ts
@@ -14,9 +14,50 @@
  * limitations under the License.
  */
 
-import type { Reporter } from '../../types/testReporter';
+import type { ReporterV2 } from './reporterV2';
+import type { FullConfig, TestCase, TestError, TestResult, FullResult, TestStep, Suite } from '../../types/testReporter';
 
-class EmptyReporter implements Reporter {
+class EmptyReporter implements ReporterV2 {
+  onConfigure(config: FullConfig) {
+  }
+
+  onBegin(suite: Suite) {
+  }
+
+  onTestBegin(test: TestCase, result: TestResult) {
+  }
+
+  onStdOut(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+  }
+
+  onStdErr(chunk: string | Buffer, test?: TestCase, result?: TestResult) {
+  }
+
+  onTestEnd(test: TestCase, result: TestResult) {
+  }
+
+  async onEnd(result: FullResult) {
+  }
+
+  async onExit() {
+  }
+
+  onError(error: TestError) {
+  }
+
+  onStepBegin(test: TestCase, result: TestResult, step: TestStep) {
+  }
+
+  onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
+  }
+
+  printsToStdio() {
+    return false;
+  }
+
+  version(): 'v2' {
+    return 'v2';
+  }
 }
 
 export default EmptyReporter;

--- a/packages/playwright-test/src/reporters/github.ts
+++ b/packages/playwright-test/src/reporters/github.ts
@@ -59,7 +59,7 @@ class GitHubLogger {
 export class GitHubReporter extends BaseReporter {
   githubLogger = new GitHubLogger();
 
-  printsToStdio() {
+  override printsToStdio() {
     return false;
   }
 

--- a/packages/playwright-test/src/reporters/line.ts
+++ b/packages/playwright-test/src/reporters/line.ts
@@ -16,19 +16,19 @@
 
 import { colors } from 'playwright-core/lib/utilsBundle';
 import { BaseReporter, formatError, formatFailure, formatTestTitle } from './base';
-import type { FullConfig, TestCase, Suite, TestResult, FullResult, TestStep, TestError } from '../../types/testReporter';
+import type { TestCase, Suite, TestResult, FullResult, TestStep, TestError } from '../../types/testReporter';
 
 class LineReporter extends BaseReporter {
   private _current = 0;
   private _failures = 0;
   private _lastTest: TestCase | undefined;
 
-  printsToStdio() {
+  override printsToStdio() {
     return true;
   }
 
-  override onBegin(config: FullConfig, suite: Suite) {
-    super.onBegin(config, suite);
+  override onBegin(suite: Suite) {
+    super.onBegin(suite);
     console.log(this.generateStartingMessage());
     console.log();
   }
@@ -62,17 +62,20 @@ class LineReporter extends BaseReporter {
     console.log();
   }
 
-  onTestBegin(test: TestCase, result: TestResult) {
+  override onTestBegin(test: TestCase, result: TestResult) {
+    super.onTestBegin(test, result);
     ++this._current;
     this._updateLine(test, result, undefined);
   }
 
-  onStepBegin(test: TestCase, result: TestResult, step: TestStep) {
+  override onStepBegin(test: TestCase, result: TestResult, step: TestStep) {
+    super.onStepBegin(test, result, step);
     if (step.category === 'test.step')
       this._updateLine(test, result, step);
   }
 
-  onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
+  override onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
+    super.onStepEnd(test, result, step);
     if (step.category === 'test.step')
       this._updateLine(test, result, step.parent);
   }

--- a/packages/playwright-test/src/reporters/list.ts
+++ b/packages/playwright-test/src/reporters/list.ts
@@ -17,7 +17,7 @@
 /* eslint-disable no-console */
 import { colors, ms as milliseconds } from 'playwright-core/lib/utilsBundle';
 import { BaseReporter, formatError, formatTestTitle, stepSuffix, stripAnsiEscapes } from './base';
-import type { FullConfig, FullResult, Suite, TestCase, TestError, TestResult, TestStep } from '../../types/testReporter';
+import type { FullResult, Suite, TestCase, TestError, TestResult, TestStep } from '../../types/testReporter';
 
 // Allow it in the Visual Studio Code Terminal and the new Windows Terminal
 const DOES_NOT_SUPPORT_UTF8_IN_TERMINAL = process.platform === 'win32' && process.env.TERM_PROGRAM !== 'vscode' && !process.env.WT_SESSION;
@@ -41,12 +41,12 @@ class ListReporter extends BaseReporter {
     this._liveTerminal = process.stdout.isTTY || !!process.env.PWTEST_TTY_WIDTH;
   }
 
-  printsToStdio() {
+  override printsToStdio() {
     return true;
   }
 
-  override onBegin(config: FullConfig, suite: Suite) {
-    super.onBegin(config, suite);
+  override onBegin(suite: Suite) {
+    super.onBegin(suite);
     const startingMessage = this.generateStartingMessage();
     if (startingMessage) {
       console.log(startingMessage);
@@ -54,7 +54,8 @@ class ListReporter extends BaseReporter {
     }
   }
 
-  onTestBegin(test: TestCase, result: TestResult) {
+  override onTestBegin(test: TestCase, result: TestResult) {
+    super.onTestBegin(test, result);
     if (this._liveTerminal)
       this._maybeWriteNewLine();
     this._resultIndex.set(result, String(this._resultIndex.size + 1));
@@ -77,7 +78,8 @@ class ListReporter extends BaseReporter {
     this._dumpToStdio(test, chunk, process.stderr);
   }
 
-  onStepBegin(test: TestCase, result: TestResult, step: TestStep) {
+  override onStepBegin(test: TestCase, result: TestResult, step: TestStep) {
+    super.onStepBegin(test, result, step);
     if (step.category !== 'test.step')
       return;
     const testIndex = this._resultIndex.get(result)!;
@@ -102,7 +104,8 @@ class ListReporter extends BaseReporter {
     }
   }
 
-  onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
+  override onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
+    super.onStepEnd(test, result, step);
     if (step.category !== 'test.step')
       return;
 

--- a/packages/playwright-test/src/reporters/markdown.ts
+++ b/packages/playwright-test/src/reporters/markdown.ts
@@ -33,7 +33,7 @@ class MarkdownReporter extends BaseReporter {
     this._options = options;
   }
 
-  printsToStdio() {
+  override printsToStdio() {
     return false;
   }
 

--- a/packages/playwright-test/src/reporters/multiplexer.ts
+++ b/packages/playwright-test/src/reporters/multiplexer.ts
@@ -25,6 +25,10 @@ export class Multiplexer implements ReporterV2 {
     this._reporters = reporters;
   }
 
+  version(): 'v2' {
+    return 'v2';
+  }
+
   onConfigure(config: FullConfig) {
     for (const reporter of this._reporters)
       wrap(() => reporter.onConfigure(config));

--- a/packages/playwright-test/src/reporters/reporterV2.ts
+++ b/packages/playwright-test/src/reporters/reporterV2.ts
@@ -29,6 +29,7 @@ export interface ReporterV2 {
   onStepBegin(test: TestCase, result: TestResult, step: TestStep): void;
   onStepEnd(test: TestCase, result: TestResult, step: TestStep): void;
   printsToStdio(): boolean;
+  version(): 'v2';
 }
 
 type StdIOChunk = {
@@ -37,13 +38,26 @@ type StdIOChunk = {
   result?: TestResult;
 };
 
-export class ReporterV2Wrapper implements ReporterV2 {
+export function wrapReporterAsV2(reporter: Reporter | ReporterV2): ReporterV2 {
+  try {
+    if ('version' in reporter && reporter.version() === 'v2')
+      return reporter as ReporterV2;
+  } catch (e) {
+  }
+  return new ReporterV2Wrapper(reporter as Reporter);
+}
+
+class ReporterV2Wrapper implements ReporterV2 {
   private _reporter: Reporter;
   private _deferred: { error?: TestError, stdout?: StdIOChunk, stderr?: StdIOChunk }[] | null = [];
   private _config!: FullConfig;
 
   constructor(reporter: Reporter) {
     this._reporter = reporter;
+  }
+
+  version(): 'v2' {
+    return 'v2';
   }
 
   onConfigure(config: FullConfig) {

--- a/packages/playwright-test/src/reporters/teleEmitter.ts
+++ b/packages/playwright-test/src/reporters/teleEmitter.ts
@@ -34,6 +34,10 @@ export class TeleReporterEmitter implements ReporterV2 {
     this._skipBuffers = skipBuffers;
   }
 
+  version(): 'v2' {
+    return 'v2';
+  }
+
   onConfigure(config: FullConfig) {
     this._rootDir = config.rootDir;
     this._messageSink({ method: 'onConfigure', params: { config: this._serializeConfig(config) } });

--- a/packages/playwright-test/src/runner/runner.ts
+++ b/packages/playwright-test/src/runner/runner.ts
@@ -26,6 +26,7 @@ import { colors } from 'playwright-core/lib/utilsBundle';
 import { runWatchModeLoop } from './watchMode';
 import { runUIMode } from './uiMode';
 import { InternalReporter } from '../reporters/internalReporter';
+import { Multiplexer } from '../reporters/multiplexer';
 
 type ProjectConfigWithFiles = {
   name: string;
@@ -69,7 +70,7 @@ export class Runner {
     // Legacy webServer support.
     webServerPluginsForConfig(config).forEach(p => config.plugins.push({ factory: p }));
 
-    const reporter = new InternalReporter(await createReporters(config, listOnly ? 'list' : 'run'));
+    const reporter = new InternalReporter(new Multiplexer(await createReporters(config, listOnly ? 'list' : 'run')));
     const taskRunner = listOnly ? createTaskRunnerForList(config, reporter, 'in-process', { failOnLoadErrors: true })
       : createTaskRunner(config, reporter);
 

--- a/packages/playwright-test/src/runner/watchMode.ts
+++ b/packages/playwright-test/src/runner/watchMode.ts
@@ -31,7 +31,6 @@ import { enquirer } from '../utilsBundle';
 import { separator } from '../reporters/base';
 import { PlaywrightServer } from 'playwright-core/lib/remote/playwrightServer';
 import ListReporter from '../reporters/list';
-import { ReporterV2Wrapper } from '../reporters/reporterV2';
 
 class FSWatcher {
   private _dirtyTestFiles = new Map<FullProjectInternal, Set<string>>();
@@ -113,7 +112,7 @@ export async function runWatchModeLoop(config: FullConfigInternal): Promise<Full
     p.project.retries = 0;
 
   // Perform global setup.
-  const reporter = new InternalReporter([new ReporterV2Wrapper(new ListReporter())]);
+  const reporter = new InternalReporter(new ListReporter());
   const testRun = new TestRun(config, reporter);
   const taskRunner = createTaskRunnerForWatchSetup(config, reporter);
   reporter.onConfigure(config.config);
@@ -281,7 +280,7 @@ async function runTests(config: FullConfigInternal, failedTestIdCollector: Set<s
     title?: string,
   }) {
   printConfiguration(config, options?.title);
-  const reporter = new InternalReporter([new ReporterV2Wrapper(new ListReporter())]);
+  const reporter = new InternalReporter(new ListReporter());
   const taskRunner = createTaskRunnerForWatch(config, reporter, options?.additionalFileMatcher);
   const testRun = new TestRun(config, reporter);
   clearCompilationCache();

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -606,6 +606,8 @@ const refreshRootSuite = (eraseResults: boolean): Promise<void> => {
   };
   let config: FullConfig;
   receiver = new TeleReporterReceiver(pathSeparator, {
+    version: () => 'v2',
+
     onConfigure: (c: FullConfig) => {
       config = c;
     },


### PR DESCRIPTION
This allows builtin reporters to handle stdio between onConfigure and onBegin.

Fixes #23539.