### PR TITLE
fix: exclude `tracesDir` option from `launchOptions` fixture

### DIFF
--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -3530,7 +3530,7 @@ export interface PlaywrightWorkerOptions {
    * ```
    *
    */
-  launchOptions: LaunchOptions;
+  launchOptions: Omit<LaunchOptions, 'tracesDir'>;
   /**
    * **Usage**
    *

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -480,3 +480,20 @@ test('should have correct types for the config', async ({ runTSC }) => {
   });
   expect(result.exitCode).toBe(0);
 });
+
+test('should not allow tracesDir in launchOptions', async ({ runTSC }) => {
+  const result = await runTSC({
+    'playwright.config.ts': `
+      import { defineConfig } from '@playwright/test';
+
+      export default defineConfig({
+        use: {
+          launchOptions: {
+            tracesDir: 'foo',
+          },
+        },
+      });
+  `
+  });
+  expect(result.exitCode).not.toBe(0);
+});

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -203,7 +203,7 @@ export interface PlaywrightWorkerOptions {
   defaultBrowserType: BrowserName;
   headless: boolean;
   channel: BrowserChannel | undefined;
-  launchOptions: LaunchOptions;
+  launchOptions: Omit<LaunchOptions, 'tracesDir'>;
   connectOptions: ConnectOptions | undefined;
   screenshot: ScreenshotMode | { mode: ScreenshotMode } & Pick<PageScreenshotOptions, 'fullPage' | 'omitBackground'>;
   trace: TraceMode | /** deprecated */ 'retry-with-trace' | { mode: TraceMode, snapshots?: boolean, screenshots?: boolean, sources?: boolean, attachments?: boolean };


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/23645
