### PR TITLE
fix(ct-vue): allow use of props with null

### DIFF
--- a/packages/playwright-ct-core/src/mount.ts
+++ b/packages/playwright-ct-core/src/mount.ts
@@ -89,7 +89,11 @@ const jsonType: Record<string, Function> = {
 };
 
 function isJson(value: any): boolean {
-  const valueType = Array.isArray(value) ? 'array' : typeof value;
+  let valueType: string = typeof value;
+  if (Array.isArray(value))
+    valueType = 'array';
+  else if (value === null)
+    valueType = 'null';
   const validate = jsonType[valueType];
   if (validate)
     return validate(value);

--- a/tests/components/ct-vue-vite/src/components/MultiProps.vue
+++ b/tests/components/ct-vue-vite/src/components/MultiProps.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <span data-testid="propsTNumber">{{ tNumber }}</span>
+    <span data-testid="propsTString">{{ tString }}</span>
+    <span data-testid="propsTNullable">{{ tNullable === null ? 'nullValue' : tNullable }}</span>
+    <span data-testid="propsTObject">{{ tObject.foo }}</span>
+    <span data-testid="propsTArray">{{ tArray.length }}</span>
+  </div>
+</template>
+
+<script lang="ts">
+let remountCount = 0
+</script>
+
+<script lang="ts" setup>
+defineProps<{ tNumber: number, tString: number, tNullable: null | string, tObject: {foo: number}, tArray: number[] }>()
+
+remountCount++
+</script>
+

--- a/tests/components/ct-vue-vite/tests/props/props.spec.js
+++ b/tests/components/ct-vue-vite/tests/props/props.spec.js
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/experimental-ct-vue';
+import MultiProps from '@/components/MultiProps.vue';
+
+test('render a props', async ({ mount }) => {
+  const component = await mount(MultiProps, {
+    props: {
+      tNumber: 42, tString: "one", tNullable: null, tObject: {foo: 12}, tArray: [5, 6, 7]
+    }
+  });
+  await expect(component.getByTestId('propsTNumber')).toContainText('42');
+  await expect(component.getByTestId('propsTString')).toContainText('one');
+  await expect(component.getByTestId('propsTNullable')).toContainText('nullValue');
+  await expect(component.getByTestId('propsTObject')).toContainText('12');
+  await expect(component.getByTestId('propsTArray')).toContainText('3');
+});

--- a/tests/components/ct-vue-vite/tests/props/props.spec.ts
+++ b/tests/components/ct-vue-vite/tests/props/props.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/experimental-ct-vue';
+import MultiProps from '@/components/MultiProps.vue';
+
+test('render a props', async ({ mount }) => {
+  const component = await mount(MultiProps, {
+    props: {
+      tNumber: 42, tString: "one", tNullable: null, tObject: {foo: 12}, tArray: [5, 6, 7]
+    }
+  });
+  await expect(component.getByTestId('propsTNumber')).toContainText('42');
+  await expect(component.getByTestId('propsTString')).toContainText('one');
+  await expect(component.getByTestId('propsTNullable')).toContainText('nullValue');
+  await expect(component.getByTestId('propsTObject')).toContainText('12');
+  await expect(component.getByTestId('propsTArray')).toContainText('3');
+});

--- a/tests/components/ct-vue-vite/tests/props/props.spec.tsx
+++ b/tests/components/ct-vue-vite/tests/props/props.spec.tsx
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/experimental-ct-vue';
+import MultiProps from '@/components/MultiProps.vue';
+
+test('render a props', async ({ mount }) => {
+  const component = await mount(
+  <MultiProps tNumber={42} tString="one" tNullable={null} tObject={{foo: 12}} tArray={[ 5, 6, 7]} ></MultiProps>
+  );
+  await expect(component.getByTestId('propsTNumber')).toContainText('42');
+  await expect(component.getByTestId('propsTString')).toContainText('one');
+  await expect(component.getByTestId('propsTNullable')).toContainText('nullValue');
+  await expect(component.getByTestId('propsTObject')).toContainText('12');
+  await expect(component.getByTestId('propsTArray')).toContainText('3');
+});


### PR DESCRIPTION
During validation of props typeof null was assumed to be "null". typeof null is "object", therefore validation of props with null failed.

The PR adds tests in vue to capture the error.