### PR TITLE
fix: do not create empty directories for successful snapshot tests

### DIFF
--- a/packages/playwright-test/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright-test/src/matchers/toMatchSnapshot.ts
@@ -124,8 +124,8 @@ class SnapshotHelper<T extends ImageComparatorOptions> {
     const inputPathSegments = Array.isArray(name) ? name : [addSuffixToFilePath(name, '', undefined, true)];
     const outputPathSegments = Array.isArray(name) ? name : [addSuffixToFilePath(name, actualModifier, undefined, true)];
     this.snapshotPath = snapshotPathResolver(...inputPathSegments);
-    const inputFile = testInfo.outputPath(...inputPathSegments);
-    const outputFile = testInfo.outputPath(...outputPathSegments);
+    const inputFile = testInfo._getOutputPath(...inputPathSegments);
+    const outputFile = testInfo._getOutputPath(...outputPathSegments);
     this.expectedPath = addSuffixToFilePath(inputFile, '-expected');
     this.previousPath = addSuffixToFilePath(outputFile, '-previous');
     this.actualPath = addSuffixToFilePath(outputFile, '-actual');

--- a/packages/playwright-test/src/worker/testInfo.ts
+++ b/packages/playwright-test/src/worker/testInfo.ts
@@ -382,7 +382,12 @@ export class TestInfoImpl implements TestInfo {
   }
 
   outputPath(...pathSegments: string[]){
+    const outputPath = this._getOutputPath(...pathSegments);
     fs.mkdirSync(this.outputDir, { recursive: true });
+    return outputPath;
+  }
+
+  _getOutputPath(...pathSegments: string[]){
     const joinedPath = path.join(...pathSegments);
     const outputPath = getContainedPath(this.outputDir, joinedPath);
     if (outputPath)

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -283,6 +283,7 @@ test('should support clip option for page', async ({ runInlineTest }, testInfo) 
       });
     `
   });
+  expect(fs.existsSync(testInfo.outputPath('test-results', 'a-is-a-test'))).toBe(false);
   expect(result.exitCode).toBe(0);
 });
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/15600
