### PR TITLE
fix(trace viewer): break out of loop when finding a resource that matches url

### DIFF
--- a/packages/trace-viewer/src/snapshotRenderer.ts
+++ b/packages/trace-viewer/src/snapshotRenderer.ts
@@ -123,9 +123,8 @@ export class SnapshotRenderer {
       if (resource._frameref !== snapshot.frameId)
         continue;
       if (resource.request.url === url) {
-        // Pick the last resource with matching url - most likely it was used
-        // at the time of snapshot, not the earlier aborted resource with the same url.
         result = resource;
+        break;
       }
     }
 


### PR DESCRIPTION
### Description:
I have been getting missed up styles in my iframes ever since that #23763 was merged. When I inspected the network I found that some of the styles resources requests come back with empty CSS files. 

**Reproduce the problem:** 
1. clone the playwright repo
2. `npm ci` and `npm run build`
3. cd packages/trace-viewer and `npm run preview`
4. drop and drag a trace.zip file

---

### Before:

![missedupstyles](https://github.com/microsoft/playwright/assets/43090330/0a1507bd-0dd6-41e9-9a71-8b7fff2871e8)

https://github.com/microsoft/playwright/assets/43090330/808a0c69-67d6-4f46-908b-630e9375520c

---

### After

<img width="1508" alt="Screen Shot 2023-07-11 at 1 12 16 AM" src="https://github.com/microsoft/playwright/assets/43090330/4a204edf-1527-4efc-8532-de6098c9e43f">


https://github.com/microsoft/playwright/assets/43090330/ea98d67a-193f-47de-8921-406551e7bee3


