### PR TITLE
fix: export SuiteFunction and TestFunction

### DIFF
--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -110,12 +110,12 @@ export interface TestInfo {
   project: FullProject;
 }
 
-interface SuiteFunction {
+export interface SuiteFunction {
   (title: string, callback: () => void): void;
   (callback: () => void): void;
 }
 
-interface TestFunction<TestArgs> {
+export interface TestFunction<TestArgs> {
   (title: string, testFunction: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
 }
 


### PR DESCRIPTION
I'm working on improving integration between Playwright Test and [Serenity/JS](https://serenity-js.org/api/playwright-test/) (I need to add a couple of default Serenity/JS-specific fixtures) and noticed the following error when trying to wrap and re-export Playwright Test `describe` function:

```
Exported variable 'describe' has or is using name 'SuiteFunction'
from external module "/[redacted]/serenity-js/node_modules/@playwright/test/types/test"
but cannot be named.
```

I believe the error is caused by `SuiteFunction` and `TestFunction` not being exported despite being part of the public `TestType` interface. This PR should help to address this issue.

I'm not very familiar with the Playwright code generation process, so please let me know if I need to propose changes to any other parts of the codebase.