### PR TITLE
chore: do not leak internal page handles after closing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "eslint-plugin-notice": "^0.9.10",
         "eslint-plugin-react-hooks": "^4.3.0",
         "formidable": "^2.1.1",
+        "heapdump": "^0.3.15",
         "license-checker": "^25.0.1",
         "mime": "^3.0.0",
         "ncp": "^2.0.0",
@@ -4000,6 +4001,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/heapdump": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/heapdump/-/heapdump-0.3.15.tgz",
+      "integrity": "sha512-n8aSFscI9r3gfhOcAECAtXFaQ1uy4QSke6bnaL+iymYZ/dWs9cqDqHM+rALfsHUwukUbxsdlECZ0pKmJdQ/4OA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.13.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/hexoid": {
       "version": "1.0.0",
       "dev": true,
@@ -4530,6 +4544,12 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -9070,6 +9090,15 @@
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
     },
+    "heapdump": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/heapdump/-/heapdump-0.3.15.tgz",
+      "integrity": "sha512-n8aSFscI9r3gfhOcAECAtXFaQ1uy4QSke6bnaL+iymYZ/dWs9cqDqHM+rALfsHUwukUbxsdlECZ0pKmJdQ/4OA==",
+      "dev": true,
+      "requires": {
+        "nan": "^2.13.2"
+      }
+    },
     "hexoid": {
       "version": "1.0.0",
       "dev": true
@@ -9427,6 +9456,12 @@
     },
     "ms": {
       "version": "2.1.2"
+    },
+    "nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "dev": true
     },
     "nanoid": {
       "version": "3.3.6",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint-plugin-notice": "^0.9.10",
     "eslint-plugin-react-hooks": "^4.3.0",
     "formidable": "^2.1.1",
+    "heapdump": "^0.3.15",
     "license-checker": "^25.0.1",
     "mime": "^3.0.0",
     "ncp": "^2.0.0",

--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -80,6 +80,8 @@ export class Dispatcher<Type extends { guid: string }, ChannelType, ParentScopeT
   }
 
   adopt(child: DispatcherScope) {
+    if (child._parent === this)
+      return;
     const oldParent = child._parent!;
     oldParent._dispatchers.delete(child._guid);
     this._dispatchers.set(child._guid, child);

--- a/packages/playwright-core/src/server/dispatchers/jsHandleDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/jsHandleDispatcher.ts
@@ -21,8 +21,9 @@ import { ElementHandleDispatcher } from './elementHandlerDispatcher';
 import { parseSerializedValue, serializeValue } from '../../protocol/serializers';
 import type { PageDispatcher, WorkerDispatcher } from './pageDispatcher';
 import type { ElectronApplicationDispatcher } from './electronDispatcher';
+import type { FrameDispatcher } from './frameDispatcher';
 
-export type JSHandleDispatcherParentScope = PageDispatcher | WorkerDispatcher | ElectronApplicationDispatcher;
+export type JSHandleDispatcherParentScope = PageDispatcher | FrameDispatcher | WorkerDispatcher | ElectronApplicationDispatcher;
 
 export class JSHandleDispatcher extends Dispatcher<js.JSHandle, channels.JSHandleChannel, JSHandleDispatcherParentScope> implements channels.JSHandleChannel {
   _type_JSHandle = true;

--- a/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
+++ b/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
@@ -27,8 +27,9 @@ import type { PageDispatcher } from './pageDispatcher';
 import { FrameDispatcher } from './frameDispatcher';
 import { WorkerDispatcher } from './pageDispatcher';
 
-export class RequestDispatcher extends Dispatcher<Request, channels.RequestChannel, BrowserContextDispatcher> implements channels.RequestChannel {
+export class RequestDispatcher extends Dispatcher<Request, channels.RequestChannel, BrowserContextDispatcher | PageDispatcher | FrameDispatcher> implements channels.RequestChannel {
   _type_Request: boolean;
+  private _browserContextDispatcher: BrowserContextDispatcher;
 
   static from(scope: BrowserContextDispatcher, request: Request): RequestDispatcher {
     const result = existingDispatcher<RequestDispatcher>(request);
@@ -41,8 +42,13 @@ export class RequestDispatcher extends Dispatcher<Request, channels.RequestChann
 
   private constructor(scope: BrowserContextDispatcher, request: Request) {
     const postData = request.postDataBuffer();
-    super(scope, request, 'Request', {
-      frame: FrameDispatcher.fromNullable(scope as any as PageDispatcher, request.frame()),
+    // Always try to attach request to the page, if not, frame.
+    const frame = request.frame();
+    const page = request.frame()?._page;
+    const pageDispatcher = page ? existingDispatcher<PageDispatcher>(page) : null;
+    const frameDispatcher = frame ? FrameDispatcher.from(scope, frame) : null;
+    super(pageDispatcher || frameDispatcher || scope, request, 'Request', {
+      frame: FrameDispatcher.fromNullable(scope, request.frame()),
       serviceWorker: WorkerDispatcher.fromNullable(scope, request.serviceWorker()),
       url: request.url(),
       resourceType: request.resourceType(),
@@ -53,6 +59,7 @@ export class RequestDispatcher extends Dispatcher<Request, channels.RequestChann
       redirectedFrom: RequestDispatcher.fromNullable(scope, request.redirectedFrom()),
     });
     this._type_Request = true;
+    this._browserContextDispatcher = scope;
   }
 
   async rawRequestHeaders(params?: channels.RequestRawRequestHeadersParams): Promise<channels.RequestRawRequestHeadersResult> {
@@ -60,26 +67,27 @@ export class RequestDispatcher extends Dispatcher<Request, channels.RequestChann
   }
 
   async response(): Promise<channels.RequestResponseResult> {
-    return { response: ResponseDispatcher.fromNullable(this.parentScope(), await this._object.response()) };
+    return { response: ResponseDispatcher.fromNullable(this._browserContextDispatcher, await this._object.response()) };
   }
 }
 
-export class ResponseDispatcher extends Dispatcher<Response, channels.ResponseChannel, BrowserContextDispatcher> implements channels.ResponseChannel {
+export class ResponseDispatcher extends Dispatcher<Response, channels.ResponseChannel, RequestDispatcher> implements channels.ResponseChannel {
   _type_Response = true;
 
   static from(scope: BrowserContextDispatcher, response: Response): ResponseDispatcher {
     const result = existingDispatcher<ResponseDispatcher>(response);
-    return result || new ResponseDispatcher(scope, response);
+    const requestDispatcher = RequestDispatcher.from(scope, response.request());
+    return result || new ResponseDispatcher(requestDispatcher, response);
   }
 
   static fromNullable(scope: BrowserContextDispatcher, response: Response | null): ResponseDispatcher | undefined {
     return response ? ResponseDispatcher.from(scope, response) : undefined;
   }
 
-  private constructor(scope: BrowserContextDispatcher, response: Response) {
+  private constructor(scope: RequestDispatcher, response: Response) {
     super(scope, response, 'Response', {
       // TODO: responses in popups can point to non-reported requests.
-      request: RequestDispatcher.from(scope, response.request()),
+      request: scope,
       url: response.url(),
       status: response.status(),
       statusText: response.statusText(),

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -58,7 +58,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     // If we split pageCreated and pageReady, there should be no main frame during pageCreated.
 
     // We will reparent it to the page below using adopt.
-    const mainFrame = FrameDispatcher.from(parentScope as any as PageDispatcher, page.mainFrame());
+    const mainFrame = FrameDispatcher.from(parentScope, page.mainFrame());
 
     super(parentScope, page, 'Page', {
       mainFrame,
@@ -80,7 +80,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
       this._dispatchEvent('download', { url: download.url, suggestedFilename: download.suggestedFilename(), artifact: ArtifactDispatcher.from(parentScope, download.artifact) });
     });
     this.addObjectListener(Page.Events.FileChooser, (fileChooser: FileChooser) => this._dispatchEvent('fileChooser', {
-      element: ElementHandleDispatcher.from(this, fileChooser.element()),
+      element: ElementHandleDispatcher.from(mainFrame, fileChooser.element()),
       isMultiple: fileChooser.isMultiple()
     }));
     this.addObjectListener(Page.Events.FrameAttached, frame => this._onFrameAttached(frame));
@@ -297,11 +297,11 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
   }
 
   _onFrameAttached(frame: Frame) {
-    this._dispatchEvent('frameAttached', { frame: FrameDispatcher.from(this, frame) });
+    this._dispatchEvent('frameAttached', { frame: FrameDispatcher.from(this.parentScope(), frame) });
   }
 
   _onFrameDetached(frame: Frame) {
-    this._dispatchEvent('frameDetached', { frame: FrameDispatcher.from(this, frame) });
+    this._dispatchEvent('frameDetached', { frame: FrameDispatcher.from(this.parentScope(), frame) });
   }
 
   override _onDispose() {
@@ -346,7 +346,7 @@ export class BindingCallDispatcher extends Dispatcher<{ guid: string }, channels
 
   constructor(scope: PageDispatcher, name: string, needsHandle: boolean, source: { context: BrowserContext, page: Page, frame: Frame }, args: any[]) {
     super(scope, { guid: 'bindingCall@' + createGuid() }, 'BindingCall', {
-      frame: FrameDispatcher.from(scope, source.frame),
+      frame: FrameDispatcher.from(scope.parentScope(), source.frame),
       name,
       args: needsHandle ? undefined : args.map(serializeResult),
       handle: needsHandle ? ElementHandleDispatcher.fromJSHandle(scope, args[0] as JSHandle) : undefined,

--- a/tests/assets/title.html
+++ b/tests/assets/title.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <title>Woof-Woof</title>

--- a/tests/library/channels.spec.ts
+++ b/tests/library/channels.spec.ts
@@ -69,10 +69,11 @@ it('should scope context handles', async ({ browserType, server, expectScopeStat
       { _guid: 'browser-type', objects: [
         { _guid: 'browser', objects: [
           { _guid: 'browser-context', objects: [
-            { _guid: 'request', objects: [] },
-            { _guid: 'response', objects: [] },
             { _guid: 'page', objects: [
               { _guid: 'frame', objects: [] },
+              { _guid: 'request', objects: [
+                { _guid: 'response', objects: [] },
+              ] },
             ] },
             { _guid: 'request-context', objects: [] },
             { _guid: 'tracing', objects: [] }
@@ -204,12 +205,13 @@ it('should not generate dispatchers for subresources w/o listeners', async ({ pa
             { _guid: 'browser-context', objects: [
               {
                 _guid: 'page', objects: [
-                  { _guid: 'frame', objects: [] }
+                  { _guid: 'frame', objects: [] },
+                  { _guid: 'request', objects: [
+                    { _guid: 'response', objects: [] },
+                  ] },
                 ]
               },
-              { _guid: 'request', objects: [] },
               { _guid: 'request-context', objects: [] },
-              { _guid: 'response', objects: [] },
               { _guid: 'tracing', objects: [] }
             ] },
           ]


### PR DESCRIPTION
Partial fix for https://github.com/microsoft/playwright/issues/6319

After this fix, the following scenario won't leak and the context state (cookies, storage, etc) can be reused by the new page sessions:

```js
  for (let i = 0; i < 1000; ++i) {
    const page = await context.newPage();
    await page.goto('...');
    await page.close('...');
  }
```