### PR TITLE
fix: add missing fs import

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -65,13 +65,13 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
+          const fs = require('fs');
           let prNumber;
           if (context.payload.workflow_run.event === 'pull_request') {
             const prs = context.payload.workflow_run.pull_requests;
             if (prs.length) {
               prNumber = prs[0].number;
             } else {
-              const fs = require('fs');
               prNumber = parseInt(fs.readFileSync('pull_request_number.txt').toString());
               console.log('Read pull request number from file: ' + prNumber);
             }


### PR DESCRIPTION
Fixes 

```
Notice: Report url: https://mspwblobreport.z1.web.core.windows.net/run-5533005176-1-a0b0752662f8af5f841ff7a65b04d02066474ff2/index.html
ReferenceError: fs is not defined
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:15143:16), <anonymous>:30:18)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:15144:12)
    at main (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:15236:26)
    at /home/runner/work/_actions/actions/github-script/v6/dist/index.js:15217:1
    at /home/runner/work/_actions/actions/github-script/v6/dist/index.js:15268:3
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:152[71](https://github.com/microsoft/playwright/actions/runs/5533535965/jobs/10097205178#step:12:72):12)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
```