### PR TITLE
chore: markdown report details

### DIFF
--- a/packages/playwright-test/src/reporters/base.ts
+++ b/packages/playwright-test/src/reporters/base.ts
@@ -275,7 +275,7 @@ export function formatFailure(config: FullConfig, test: TestCase, options: {inde
   lines.push(colors.red(header));
   for (const result of test.results) {
     const resultLines: string[] = [];
-    const errors = formatResultFailure(config, test, result, '    ', colors.enabled);
+    const errors = formatResultFailure(test, result, '    ', colors.enabled);
     if (!errors.length)
       continue;
     const retryLines = [];
@@ -342,7 +342,7 @@ export function formatFailure(config: FullConfig, test: TestCase, options: {inde
   };
 }
 
-export function formatResultFailure(config: FullConfig, test: TestCase, result: TestResult, initialIndent: string, highlightCode: boolean): ErrorDetails[] {
+export function formatResultFailure(test: TestCase, result: TestResult, initialIndent: string, highlightCode: boolean): ErrorDetails[] {
   const errorDetails: ErrorDetails[] = [];
 
   if (result.status === 'passed' && test.expectedStatus === 'failed') {
@@ -357,7 +357,7 @@ export function formatResultFailure(config: FullConfig, test: TestCase, result: 
   }
 
   for (const error of result.errors) {
-    const formattedError = formatError(config, error, highlightCode);
+    const formattedError = formatError(error, highlightCode);
     errorDetails.push({
       message: indent(formattedError.message, initialIndent),
       location: formattedError.location,
@@ -418,7 +418,7 @@ function formatTestHeader(config: FullConfig, test: TestCase, options: { indent?
   return separator(fullHeader);
 }
 
-export function formatError(config: FullConfig, error: TestError, highlightCode: boolean): ErrorDetails {
+export function formatError(error: TestError, highlightCode: boolean): ErrorDetails {
   const message = error.message || error.value || '';
   const stack = error.stack;
   if (!stack && !error.location)

--- a/packages/playwright-test/src/reporters/dot.ts
+++ b/packages/playwright-test/src/reporters/dot.ts
@@ -66,7 +66,7 @@ class DotReporter extends BaseReporter {
 
   override onError(error: TestError): void {
     super.onError(error);
-    console.log('\n' + formatError(this.config, error, colors.enabled).message);
+    console.log('\n' + formatError(error, colors.enabled).message);
     this._counter = 0;
   }
 

--- a/packages/playwright-test/src/reporters/github.ts
+++ b/packages/playwright-test/src/reporters/github.ts
@@ -69,7 +69,7 @@ export class GitHubReporter extends BaseReporter {
   }
 
   override onError(error: TestError) {
-    const errorMessage = formatError(this.config, error, false).message;
+    const errorMessage = formatError(error, false).message;
     this.githubLogger.error(errorMessage);
   }
 

--- a/packages/playwright-test/src/reporters/json.ts
+++ b/packages/playwright-test/src/reporters/json.ts
@@ -208,7 +208,7 @@ class JSONReporter extends EmptyReporter {
   }
 
   private _serializeError(error: TestError): JSONReportError {
-    return formatError(this.config, error, true);
+    return formatError(error, true);
   }
 
   private _serializeTestStep(step: TestStep): JSONReportTestStep {

--- a/packages/playwright-test/src/reporters/line.ts
+++ b/packages/playwright-test/src/reporters/line.ts
@@ -106,7 +106,7 @@ class LineReporter extends BaseReporter {
   override onError(error: TestError): void {
     super.onError(error);
 
-    const message = formatError(this.config, error, colors.enabled).message + '\n\n';
+    const message = formatError(error, colors.enabled).message + '\n\n';
     if (!process.env.PW_TEST_DEBUG_REPORTERS)
       process.stdout.write(`\u001B[1A\u001B[2K`);
     process.stdout.write(message);

--- a/packages/playwright-test/src/reporters/list.ts
+++ b/packages/playwright-test/src/reporters/list.ts
@@ -243,7 +243,7 @@ class ListReporter extends BaseReporter {
   override onError(error: TestError): void {
     super.onError(error);
     this._maybeWriteNewLine();
-    const message = formatError(this.config, error, colors.enabled).message + '\n';
+    const message = formatError(error, colors.enabled).message + '\n';
     this._updateLineCountAndNewLineFlagForOutput(message);
     process.stdout.write(message);
   }

--- a/packages/playwright-test/src/reporters/raw.ts
+++ b/packages/playwright-test/src/reporters/raw.ts
@@ -246,7 +246,7 @@ class RawReporter {
       startTime: result.startTime.toISOString(),
       duration: result.duration,
       status: result.status,
-      errors: formatResultFailure(this.config, test, result, '', true).map(error => error.message),
+      errors: formatResultFailure(test, result, '', true).map(error => error.message),
       attachments: this.generateAttachments(result.attachments, result),
       steps: dedupeSteps(result.steps.map(step => this._serializeStep(test, step)))
     };

--- a/packages/playwright-test/src/runner/reporters.ts
+++ b/packages/playwright-test/src/runner/reporters.ts
@@ -102,6 +102,6 @@ class ListModeReporter extends EmptyReporter {
 
   override onError(error: TestError) {
     // eslint-disable-next-line no-console
-    console.error('\n' + formatError(this.config, error, false).message);
+    console.error('\n' + formatError(error, false).message);
   }
 }

--- a/tests/playwright-test/reporter-markdown.spec.ts
+++ b/tests/playwright-test/reporter-markdown.spec.ts
@@ -62,17 +62,34 @@ test('simple report', async ({ runInlineTest }) => {
   const { exitCode } = await runInlineTest(files);
   expect(exitCode).toBe(1);
   const reportFile = await fs.promises.readFile(test.info().outputPath('report.md'));
-  expect(reportFile.toString()).toBe(`:x: <b>failed: 2</b>
- - a.test.js:6:11 › failing 1
- - b.test.js:6:11 › failing 2
+  expect(reportFile.toString()).toContain(`**2 failed**
+:x: a.test.js:6:11 › failing 1
+:x: b.test.js:6:11 › failing 2
 
-:warning: <b>flaky: 2</b>
- - a.test.js:9:11 › flaky 1
- - c.test.js:6:11 › flaky 2
+**2 flaky**
+:warning: a.test.js:9:11 › flaky 1
+:warning: c.test.js:6:11 › flaky 2
 
-:ballot_box_with_check: <b>skipped: 3</b>
+**3 passed, 3 skipped**
+:heavy_check_mark::heavy_check_mark::heavy_check_mark:
 
-:white_check_mark: <b>passed: 3</b>
+<details>
+
+:x: <b> a.test.js:6:11 › failing 1 </b>
+`);
+
+  expect(reportFile.toString()).toContain(`Error: expect(received).toBe(expected) // Object.is equality
+
+Expected: 2
+Received: 1
+
+   5 |       });
+   6 |       test('failing 1', async ({}) => {
+>  7 |         expect(1).toBe(2);
+     |                   ^
+   8 |       });
+   9 |       test('flaky 1', async ({}) => {
+  10 |         expect(test.info().retry).toBe(1);
 `);
 });
 
@@ -94,8 +111,7 @@ test('custom report file', async ({ runInlineTest }) => {
   const { exitCode } = await runInlineTest(files);
   expect(exitCode).toBe(0);
   const reportFile = await fs.promises.readFile(test.info().outputPath('my-report.md'));
-  expect(reportFile.toString()).toBe(`:x: <b>failed: 0</b>
-
-:white_check_mark: <b>passed: 1</b>
+  expect(reportFile.toString()).toBe(`**1 passed**
+:heavy_check_mark::heavy_check_mark::heavy_check_mark:
 `);
 });


### PR DESCRIPTION
Sample report:

**2 failed**
:x: a.test.js:6:11 › failing 1
:x: b.test.js:6:11 › failing 2

**2 flaky**
:warning: a.test.js:9:11 › flaky 1
:warning: c.test.js:6:11 › flaky 2

**3 passed, 3 skipped**
:heavy_check_mark::heavy_check_mark::heavy_check_mark:

<details>

:x: <b> a.test.js:6:11 › failing 1 </b>

```
Error: expect(received).toBe(expected) // Object.is equality

Expected: 2
Received: 1

   5 |       });
   6 |       test('failing 1', async ({}) => {
>  7 |         expect(1).toBe(2);
     |                   ^
   8 |       });
   9 |       test('flaky 1', async ({}) => {
  10 |         expect(test.info().retry).toBe(1);

    at fn (/Users/yurys/playwright/test-results/reporter-markdown-simple-report-playwright-test/a.test.js:7:19)
```

<b>Retry 1:</b>

```
Error: expect(received).toBe(expected) // Object.is equality

Expected: 2
Received: 1

   5 |       });
   6 |       test('failing 1', async ({}) => {
>  7 |         expect(1).toBe(2);
     |                   ^
   8 |       });
   9 |       test('flaky 1', async ({}) => {
  10 |         expect(test.info().retry).toBe(1);

    at fn (/Users/yurys/playwright/test-results/reporter-markdown-simple-report-playwright-test/a.test.js:7:19)
```


:x: <b> b.test.js:6:11 › failing 2 </b>

```
Error: expect(received).toBe(expected) // Object.is equality

Expected: 2
Received: 1

   5 |       });
   6 |       test('failing 2', async ({}) => {
>  7 |         expect(1).toBe(2);
     |                   ^
   8 |       });
   9 |       test.skip('skipped 2', async ({}) => {});
  10 |     

    at fn (/Users/yurys/playwright/test-results/reporter-markdown-simple-report-playwright-test/b.test.js:7:19)
```

<b>Retry 1:</b>

```
Error: expect(received).toBe(expected) // Object.is equality

Expected: 2
Received: 1

   5 |       });
   6 |       test('failing 2', async ({}) => {
>  7 |         expect(1).toBe(2);
     |                   ^
   8 |       });
   9 |       test.skip('skipped 2', async ({}) => {});
  10 |     

    at fn (/Users/yurys/playwright/test-results/reporter-markdown-simple-report-playwright-test/b.test.js:7:19)
```


:warning: <b> a.test.js:9:11 › flaky 1 </b>

```
Error: expect(received).toBe(expected) // Object.is equality

Expected: 1
Received: 0

   8 |       });
   9 |       test('flaky 1', async ({}) => {
> 10 |         expect(test.info().retry).toBe(1);
     |                                   ^
  11 |       });
  12 |       test.skip('skipped 1', async ({}) => {});
  13 |     

    at fn (/Users/yurys/playwright/test-results/reporter-markdown-simple-report-playwright-test/a.test.js:10:35)
```


:warning: <b> c.test.js:6:11 › flaky 2 </b>

```
Error: expect(received).toBe(expected) // Object.is equality

Expected: 1
Received: 0

   5 |       });
   6 |       test('flaky 2', async ({}) => {
>  7 |         expect(test.info().retry).toBe(1);
     |                                   ^
   8 |       });
   9 |       test.skip('skipped 3', async ({}) => {});
  10 |     

    at fn (/Users/yurys/playwright/test-results/reporter-markdown-simple-report-playwright-test/c.test.js:7:35)
```


</details>