### PR TITLE
chore: Updated fs imports to use async/await promises

### DIFF
--- a/packages/playwright-test/src/runner/projectUtils.ts
+++ b/packages/playwright-test/src/runner/projectUtils.ts
@@ -13,16 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { promises as fs } from 'fs';
 
-import fs from 'fs';
 import path from 'path';
 import { minimatch } from 'playwright-core/lib/utilsBundle';
-import { promisify } from 'util';
 import type { FullProjectInternal } from '../common/config';
 import { createFileMatcher } from '../util';
-
-const readFileAsync = promisify(fs.readFile);
-const readDirAsync = promisify(fs.readdir);
 
 export function filterProjects(projects: FullProjectInternal[], projectNames?: string[]): FullProjectInternal[] {
   if (!projectNames)
@@ -175,13 +171,13 @@ async function collectFiles(testDir: string, respectGitIgnore: boolean): Promise
   const files: string[] = [];
 
   const visit = async (dir: string, rules: Rule[], status: IgnoreStatus) => {
-    const entries = await readDirAsync(dir, { withFileTypes: true });
+    const entries = await fs.readdir(dir, { withFileTypes: true });
     entries.sort((a, b) => a.name.localeCompare(b.name));
 
     if (respectGitIgnore) {
       const gitignore = entries.find(e => e.isFile() && e.name === '.gitignore');
       if (gitignore) {
-        const content = await readFileAsync(path.join(dir, gitignore.name), 'utf8');
+        const content = await fs.readFile(path.join(dir, gitignore.name), 'utf8');
         const newRules: Rule[] = content.split(/\r?\n/).map(s => {
           s = s.trim();
           if (!s)

--- a/packages/playwright-test/src/runner/tasks.ts
+++ b/packages/playwright-test/src/runner/tasks.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
+import { promises as fs } from 'fs';
 import path from 'path';
-import { promisify } from 'util';
 import { debug, rimraf } from 'playwright-core/lib/utilsBundle';
 import { Dispatcher, type EnvByProjectId } from './dispatcher';
 import type { TestRunnerPluginRegistration } from '../plugins';
@@ -30,8 +29,6 @@ import type { Matcher } from '../util';
 import type { Suite } from '../common/test';
 import { buildDependentProjects, buildTeardownToSetupsMap } from './projectUtils';
 import { monotonicTime } from 'playwright-core/lib/utils';
-
-const readDirAsync = promisify(fs.readdir);
 
 type ProjectWithTestGroups = {
   project: FullProjectInternal;
@@ -161,7 +158,7 @@ function createRemoveOutputDirsTask(): Task<TestRun> {
         // We failed to remove folder, might be due to the whole folder being mounted inside a container:
         //   https://github.com/microsoft/playwright/issues/12106
         // Do a best-effort to remove all files inside of it instead.
-        const entries = await readDirAsync(outputDir).catch(e => []);
+        const entries = await fs.readdir(outputDir).catch(e => []);
         await Promise.all(entries.map(entry => rimraf(path.join(outputDir, entry))));
       } else {
         throw error;

--- a/utils/linux-browser-dependencies/inside_docker/list_dependencies.js
+++ b/utils/linux-browser-dependencies/inside_docker/list_dependencies.js
@@ -1,13 +1,9 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const util = require('util');
+const fs = require('fs').promises;
 const path = require('path');
 const {spawn} = require('child_process');
 const {registryDirectory} = require('playwright-core/lib/server');
-
-const readdirAsync = util.promisify(fs.readdir.bind(fs));
-const readFileAsync = util.promisify(fs.readFile.bind(fs));
 
 const readline = require('readline');
 
@@ -27,7 +23,7 @@ const DL_OPEN_LIBRARIES = {
 (async () => {
   console.log('Working on:', await getDistributionName());
   console.log('Started at:', currentTime());
-  const browserDescriptors = (await readdirAsync(registryDirectory)).filter(dir => !dir.startsWith('.')).map(dir => ({
+  const browserDescriptors = (await fs.readdir(registryDirectory)).filter(dir => !dir.startsWith('.')).map(dir => ({
     // Full browser name, e.g. `webkit-1144`
     name: dir,
     // Full patch to browser files
@@ -261,7 +257,7 @@ function runCommand(command, args, options = {}) {
 }
 
 async function getDistributionName() {
-  const osReleaseText = await readFileAsync('/etc/os-release', 'utf8');
+  const osReleaseText = await fs.readFile('/etc/os-release', 'utf8');
   const fields = new Map();
   for (const line of osReleaseText.split('\n')) {
     const tokens = line.split('=');

--- a/utils/ts_to_java.js
+++ b/utils/ts_to_java.js
@@ -17,7 +17,7 @@
 // The script does basic transformation of .spec.ts code to .java unit tests.
 
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs').promises;
 const os = require('os');
 const util = require('util');
 const { argv } = require('process');
@@ -27,7 +27,7 @@ const { argv } = require('process');
   const file = argv[2];
   if (!file.endsWith('.spec.ts')) throw new Error("Unexpected input: " + file);
   console.log('Reading: ' + file);
-  let content = await util.promisify(fs.readFile)(file);
+  let content = await fs.readFile(file);
   content = content.toString();
 
   function toCamelCase(match, p1, offset, string) {
@@ -157,7 +157,7 @@ void ${name}() {`;
 
   const output = file.replace(/\.spec\.ts$/, ".java")
   console.log('Writing: ' + output);
-  await util.promisify(fs.writeFile)(output, content)
+  await fs.writeFile(output, content)
 })();
 
 function toTitleCase(s) {


### PR DESCRIPTION
Rather than using `promisify` , let's use the build in `promises` part of the fs library.

This works as of nodeJS 10+ so we are good here (y)