### PR TITLE
feat(webkit): roll to r1875

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "webkit",
-      "revision": "1872",
+      "revision": "1875",
       "installByDefault": true,
       "revisionOverrides": {
         "mac10.14": "1446",

--- a/tests/library/modernizr.spec.ts
+++ b/tests/library/modernizr.spec.ts
@@ -71,8 +71,10 @@ it('safari-14-1', async ({ browser, browserName, platform, server, headless, isM
     expected.inputtypes.time = false;
   }
 
-  if (isMac && parseInt(os.release(), 10) > 20)
+  if (isMac && parseInt(os.release(), 10) > 20) {
     expected.applicationcache = false;
+    expected.inputsearchevent = false;
+  }
 
   expect(actual).toEqual(expected);
 });
@@ -129,8 +131,10 @@ it('mobile-safari-14-1', async ({ playwright, browser, browserName, platform, is
     expected.inputtypes.time = false;
   }
 
-  if (isMac && parseInt(os.release(), 10) > 20)
+  if (isMac && parseInt(os.release(), 10) > 20) {
     expected.applicationcache = false;
+    expected.inputsearchevent = false;
+  }
 
   expect(actual).toEqual(expected);
 });


### PR DESCRIPTION
Since https://github.com/WebKit/WebKit/commit/99ff08340f12db8d867a0ed04f176802b7e0a355 search event is disabled in cocoa. 