### PR TITLE
docs: add grep scripts examples for windows terminals

### DIFF
--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -87,7 +87,7 @@ Or if you want the opposite, you can skip the tests with a certain tag:
 npx playwright test --grep-invert @slow
 ```
 
-Or run tests containing either tag (logical `OR` operator):
+To run tests containing either tag (logical `OR` operator):
 
 ```bash
 npx playwright test --grep "@fast|@slow"
@@ -105,7 +105,7 @@ for Windows terminals:
   npx playwright test --grep "@fast^|@slow"
   ```
 
-To run tests containing both tags (logical `AND` operator) using regex lookaheads:
+Or run tests containing both tags (logical `AND` operator) using regex lookaheads:
 
 ```bash
 npx playwright test --grep "(?=.*@fast)(?=.*@slow)"

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -105,21 +105,12 @@ for Windows terminals:
   npx playwright test --grep "@fast^|@slow"
   ```
 
-- as NPM script:
-  ```json
-  "npx playwright test --grep /"@fast|@slow/""
-  ```
-
 To run tests containing both tags (logical `AND` operator) using regex lookaheads:
 
 ```bash
 npx playwright test --grep "(?=.*@fast)(?=.*@slow)"
 ```
 
-for Windows terminals:
-```bash
-npx playwright test --grep "@fast.+@slow"
-```
 
 ## Conditionally skip a group of tests
 

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -93,14 +93,14 @@ To run tests containing either tag (logical `OR` operator):
 npx playwright test --grep "@fast|@slow"
 ```
 
-for Windows terminals:
+On Windows shells:
 
 - PowerShell
   ```powershell
   npx playwright test --grep --% "@fast^|@slow"
   ```
 
-- CMD:
+- Command Prompt(cmd.exe) / Git Bash:
   ```cmd
   npx playwright test --grep "@fast^|@slow"
   ```

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -87,7 +87,7 @@ Or if you want the opposite, you can skip the tests with a certain tag:
 npx playwright test --grep-invert @slow
 ```
 
-To run tests containing either tag (logical `OR` operator):
+Or run tests containing either tag (logical `OR` operator):
 
 ```bash
 npx playwright test --grep "@fast|@slow"

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -111,7 +111,6 @@ To run tests containing both tags (logical `AND` operator) using regex lookahead
 npx playwright test --grep "(?=.*@fast)(?=.*@slow)"
 ```
 
-
 ## Conditionally skip a group of tests
 
 For example, you can run a group of tests just in Chromium by passing a callback.

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -101,7 +101,7 @@ for Windows terminals:
   ```
 
 - CMD:
-  ```bash
+  ```cmd
   npx playwright test --grep "@fast^|@slow"
   ```
 

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -93,10 +93,32 @@ To run tests containing either tag (logical `OR` operator):
 npx playwright test --grep "@fast|@slow"
 ```
 
-Or run tests containing both tags (logical `AND` operator) using regex lookaheads:
+for Windows terminals:
+
+- PowerShell
+  ```powershell
+  npx playwright test --grep --% "@fast^|@slow"
+  ```
+
+- CMD:
+  ```bash
+  npx playwright test --grep "@fast^|@slow"
+  ```
+
+- as NPM script:
+  ```json
+  "npx playwright test --grep /"@fast|@slow/""
+  ```
+
+To run tests containing both tags (logical `AND` operator) using regex lookaheads:
 
 ```bash
 npx playwright test --grep "(?=.*@fast)(?=.*@slow)"
+```
+
+for Windows terminals:
+```bash
+npx playwright test --grep "@fast.+@slow"
 ```
 
 ## Conditionally skip a group of tests


### PR DESCRIPTION
Windows Playwright users struggling to find a good command for grouping tags with OR and AND operations, so some examples in official docs can help with this problem.
Adding pull request as discussed here https://github.com/microsoft/playwright/issues/9667#issuecomment-1641818170