### PR TITLE
devops: drop  --attachments missing option

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -31,18 +31,13 @@ jobs:
 
     - name: Merge reports
       run: |
-        npx playwright merge-reports --reporter markdown,html --attachments missing blob-report
+        npx playwright merge-reports --reporter markdown,html blob-report
 
     - name: Upload HTML report to Azure
       run: |
         REPORT_DIR='run-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}-${{ github.sha }}'
         az storage blob upload-batch -s playwright-report -d "\$web/$REPORT_DIR" --connection-string "${{ secrets.AZURE_CONNECTION_STRING_FOR_BLOB_REPORT }}"
         echo "Report url: https://mspwblobreport.z1.web.core.windows.net/$REPORT_DIR/index.html"
-
-    - name: Upload blob report to Azure
-      run: |
-        REPORT_DIR='run-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}-${{ github.sha }}'
-        az storage blob upload-batch -s blob-report -d "\$web/$REPORT_DIR" --connection-string "${{ secrets.AZURE_CONNECTION_STRING_FOR_BLOB_REPORT }}"
 
     - name: Read pull request number
       uses: ./.github/actions/download-artifact


### PR DESCRIPTION
Since all resources are uploaded in the separate workflow anyway there is not much point in passing the options and uploading blob reports as a separate step.