### PR TITLE
feat(browser download): add env option to disable progress bar in situations like CI

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -780,6 +780,88 @@ $Env:PLAYWRIGHT_DOWNLOAD_HOST="192.0.2.1"
 $Env:PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST="203.0.113.3"
 pwsh bin/Debug/netX/playwright.ps1 install
 ```
+
+## Downloading silently
+
+By default, Playwright downloads browsers with a progress bar animation.
+
+Sometimes this can cause a lot of console output span in a CI/CD environment.
+
+Playwright can be configured to disable this animation using the PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS env variable.
+
+```bash tab=bash-bash lang=js
+# For Playwright Test
+PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0 npx playwright install
+
+# For Playwright Library
+PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0 npm install playwright
+```
+
+```batch tab=bash-batch lang=js
+# For Playwright Test
+set PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0
+npx playwright install
+
+# For Playwright Library
+set PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0
+npm install playwright
+```
+
+```powershell tab=bash-powershell lang=js
+# For Playwright Test
+$Env:PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS="0"
+npx playwright install
+
+# For Playwright Library
+$Env:PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS="0"
+npm install playwright
+```
+
+```bash tab=bash-bash lang=python
+pip install playwright
+PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0 playwright install
+```
+
+```batch tab=bash-batch lang=python
+set PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0
+pip install playwright
+playwright install
+```
+
+```powershell tab=bash-powershell lang=python
+$Env:PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS="0"
+pip install playwright
+playwright install
+```
+
+```bash tab=bash-bash lang=java
+PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0 mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+```
+
+```batch tab=bash-batch lang=java
+set PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0
+mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+```
+
+```powershell tab=bash-powershell lang=java
+$Env:PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS="0"
+mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+```
+
+```bash tab=bash-bash lang=csharp
+PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0 pwsh bin/Debug/netX/playwright.ps1 install
+```
+
+```batch tab=bash-batch lang=csharp
+set PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0
+pwsh bin/Debug/netX/playwright.ps1 install
+```
+
+```powershell tab=bash-powershell lang=csharp
+$Env:PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS="0"
+pwsh bin/Debug/netX/playwright.ps1 install
+```
+
 ## Managing browser binaries
 
 Playwright downloads Chromium, WebKit and Firefox browsers into the OS-specific cache folders:

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -30,7 +30,7 @@ import { spawnAsync } from '../../utils/spawnAsync';
 import type { DependencyGroup } from './dependencies';
 import { transformCommandsForRoot, dockerVersion, readDockerVersionSync } from './dependencies';
 import { installDependenciesLinux, installDependenciesWindows, validateDependenciesLinux, validateDependenciesWindows } from './dependencies';
-import { downloadBrowserWithProgressBar, logPolitely } from './browserFetcher';
+import { downloadBrowser, logPolitely } from './browserFetcher';
 export { writeDockerVersion } from './dependencies';
 
 const PACKAGE_PATH = path.join(__dirname, '..', '..', '..');
@@ -848,9 +848,13 @@ export class Registry {
       : `${displayName} playwright build v${descriptor.revision}`;
 
     const downloadFileName = `playwright-download-${descriptor.name}-${hostPlatform}-${descriptor.revision}.zip`;
+
+    const downloadProgressBarEnv = getFromENV('PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS');
+    const downloadProgressBar = downloadProgressBarEnv ? downloadProgressBarEnv === "1" ? true : false : true;
+
     const downloadConnectionTimeoutEnv = getFromENV('PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT');
     const downloadConnectionTimeout = +(downloadConnectionTimeoutEnv || '0') || 30_000;
-    await downloadBrowserWithProgressBar(title, descriptor.dir, executablePath, downloadURLs, downloadFileName, downloadConnectionTimeout).catch(e => {
+    await downloadBrowser(title, descriptor.dir, executablePath, downloadURLs, downloadFileName, downloadConnectionTimeout, downloadProgressBar).catch(e => {
       throw new Error(`Failed to download ${title}, caused by\n${e.stack}`);
     });
   }

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -850,10 +850,8 @@ export class Registry {
     const downloadFileName = `playwright-download-${descriptor.name}-${hostPlatform}-${descriptor.revision}.zip`;
 
     const downloadProgressBarEnv = getFromENV('PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS');
-    let downloadProgressBar = true;
-    if(downloadProgressBarEnv !== undefined){
-      downloadProgressBar = downloadProgressBarEnv === '1' ? true : false;
-    }
+    // Default to true for show download progress bar.
+    const downloadProgressBar = downloadProgressBarEnv ? downloadProgressBarEnv === '1' ? true : false : true;
 
     const downloadConnectionTimeoutEnv = getFromENV('PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT');
     const downloadConnectionTimeout = +(downloadConnectionTimeoutEnv || '0') || 30_000;

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -850,7 +850,10 @@ export class Registry {
     const downloadFileName = `playwright-download-${descriptor.name}-${hostPlatform}-${descriptor.revision}.zip`;
 
     const downloadProgressBarEnv = getFromENV('PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS');
-    const downloadProgressBar = downloadProgressBarEnv ? downloadProgressBarEnv === '1' ? true : false : true;
+    let downloadProgressBar = true;
+    if(downloadProgressBarEnv !== undefined){
+      downloadProgressBar = downloadProgressBarEnv === '1' ? true : false;
+    }
 
     const downloadConnectionTimeoutEnv = getFromENV('PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT');
     const downloadConnectionTimeout = +(downloadConnectionTimeoutEnv || '0') || 30_000;

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -850,7 +850,7 @@ export class Registry {
     const downloadFileName = `playwright-download-${descriptor.name}-${hostPlatform}-${descriptor.revision}.zip`;
 
     const downloadProgressBarEnv = getFromENV('PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS');
-    const downloadProgressBar = downloadProgressBarEnv ? downloadProgressBarEnv === "1" ? true : false : true;
+    const downloadProgressBar = downloadProgressBarEnv ? downloadProgressBarEnv === '1' ? true : false : true;
 
     const downloadConnectionTimeoutEnv = getFromENV('PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT');
     const downloadConnectionTimeout = +(downloadConnectionTimeoutEnv || '0') || 30_000;

--- a/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
+++ b/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
@@ -146,7 +146,7 @@ async function main() {
   const log = (message: string) => process.send?.({ method: 'log', params: { message } });
   const [title, browserDirectory, url, zipPath, executablePath, downloadConnectionTimeout, downloadShowProgress] = process.argv.slice(2);
   await downloadFile(url, zipPath, {
-    progressCallback:downloadShowProgress === "true" ?  getDownloadProgress() : () => {},
+    progressCallback: downloadShowProgress === 'true' ?  getDownloadProgress() : () => {},
     userAgent: getUserAgent(),
     log,
     connectionTimeout: +downloadConnectionTimeout,

--- a/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
+++ b/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
@@ -144,9 +144,9 @@ function toMegabytes(bytes: number) {
 
 async function main() {
   const log = (message: string) => process.send?.({ method: 'log', params: { message } });
-  const [title, browserDirectory, url, zipPath, executablePath, downloadConnectionTimeout] = process.argv.slice(2);
+  const [title, browserDirectory, url, zipPath, executablePath, downloadConnectionTimeout, downloadShowProgress] = process.argv.slice(2);
   await downloadFile(url, zipPath, {
-    progressCallback: getDownloadProgress(),
+    progressCallback:downloadShowProgress === "true" ?  getDownloadProgress() : () => {},
     userAgent: getUserAgent(),
     log,
     connectionTimeout: +downloadConnectionTimeout,


### PR DESCRIPTION
## What?

Adds the option to disable the progress bar when downloading browsers:

```
Downloading Chromium 115.0.5790.98 (playwright build v1045) from https://playwright.azureedge.net/builds/chromium/1045/chromium-mac-arm64.zip
123.8 Mb [==                  ] 11% 10.5s^C
```

## Why?

In situations like CI , this can lead to a lot of console spam so its better to have this functionality configurable. Fixes #22074 

The below is actually from this PR's Build! ( Let me know if you want me to also enable this ENV in the YAML :) )
<img width="1280" alt="image" src="https://github.com/microsoft/playwright/assets/37447884/4ae1174a-d885-4261-bc45-4441fb108ffb">

## How did I test this?

I leveraged the `roll_browser.js` NodeJS script to verify this functionalilty.


`PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0 node roll_browser.js chromium 1045 build` -> Doesn't show progress bar

`PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=1 node roll_browser.js chromium 1045 build` -> Shows progress bar

`PLAYWRIGHT_SHOW_DOWNLOAD_PROGRESS=0 node roll_browser.js chromium 1045 build` -> Default , shows progress bar
