### PR TITLE
chore: ensure the file operations are async in the json reporter.

### DIFF
--- a/packages/playwright-test/src/reporters/json.ts
+++ b/packages/playwright-test/src/reporters/json.ts
@@ -55,7 +55,7 @@ class JSONReporter extends EmptyReporter {
   }
 
   override async onEnd(result: FullResult) {
-    outputReport(this._serializeReport(), this.config, this._outputFile);
+    await outputReport(this._serializeReport(), this.config, this._outputFile);
   }
 
   private _serializeReport(): JSONReport {
@@ -222,13 +222,13 @@ class JSONReporter extends EmptyReporter {
   }
 }
 
-function outputReport(report: JSONReport, config: FullConfig, outputFile: string | undefined) {
+async function outputReport(report: JSONReport, config: FullConfig, outputFile: string | undefined) {
   const reportString = JSON.stringify(report, undefined, 2);
   if (outputFile) {
     assert(config.configFile || path.isAbsolute(outputFile), 'Expected fully resolved path if not using config file.');
     outputFile = config.configFile ? path.resolve(path.dirname(config.configFile), outputFile) : outputFile;
-    fs.mkdirSync(path.dirname(outputFile), { recursive: true });
-    fs.writeFileSync(outputFile, reportString);
+    await fs.promises.mkdir(path.dirname(outputFile), { recursive: true });
+    await fs.promises.writeFile(outputFile, reportString);
   } else {
     console.log(reportString);
   }


### PR DESCRIPTION
# What ?

Converts the file system operations in the json reporter to be async.
  
# Why?

Although I doubt it how profound this will ever be , there could be some performance bottleneck with multiple reporters at once here eventually.

# Verified?

I ran `npm run build` and then `CI=1 npm run test` and once finished I see the report
<img width="1140" alt="image" src="https://github.com/microsoft/playwright/assets/37447884/aa6a0e73-36f9-41fa-b76d-f40dd8eaee07">