### PR TITLE
fix(tracing): make sure resetForReuse does not throw

### DIFF
--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -113,6 +113,8 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
   }
 
   async resetForReuse() {
+    // Discard previous chunk if any and ignore any errors there.
+    await this.stopChunk({ mode: 'discard' }).catch(() => {});
     await this.stop();
     this._snapshotter?.resetForReuse();
   }

--- a/tests/library/browsercontext-reuse.spec.ts
+++ b/tests/library/browsercontext-reuse.spec.ts
@@ -234,3 +234,18 @@ test('should reset mouse position', async ({ reusedContext, browserName, platfor
   await expect(page.locator('#one')).toHaveCSS('background-color', 'rgb(0, 0, 255)');
   await expect(page.locator('#two')).toHaveCSS('background-color', 'rgb(0, 0, 255)');
 });
+
+test('should reset tracing', async ({ reusedContext }, testInfo) => {
+  let context = await reusedContext();
+  await context.tracing.start();
+
+  let page = await context.newPage();
+  await page.evaluate('1 + 1');
+
+  context = await reusedContext();
+  page = context.pages()[0];
+  await page.evaluate('2 + 2');
+
+  const error = await context.tracing.stopChunk({ path: testInfo.outputPath('trace.zip') }).catch(e => e);
+  expect(error.message).toContain('tracing.stopChunk: Must start tracing before stopping');
+});


### PR DESCRIPTION
When trace chunk recording is in progress, calling `stop()` throws `Error: Must stop trace file before stopping tracing`.
