### PR TITLE
fix(launch): default to non-zero launch timeout

### DIFF
--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -239,7 +239,7 @@ export class Electron extends SdkObject {
       app = new ElectronApplication(this, browser, nodeConnection, launchedProcess);
       await app.initialize();
       return app;
-    }, TimeoutSettings.timeout(options));
+    }, TimeoutSettings.launchTimeout(options));
   }
 }
 

--- a/packages/playwright-test/src/index.ts
+++ b/packages/playwright-test/src/index.ts
@@ -94,7 +94,6 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
   _browserOptions: [async ({ playwright, headless, channel, launchOptions, connectOptions, _artifactsDir }, use) => {
     const options: LaunchOptions = {
       handleSIGINT: false,
-      timeout: 0,
       ...launchOptions,
     };
     if (headless !== undefined)


### PR DESCRIPTION
When not specified, launch timeout is 3 minutes, taken from the `DEFAULT_LAUNCH_TIMEOUT` constant.
Also, use the default launch timeout for `electron.launch()` instead of default regular timeout.