### PR TITLE
feat(ui): add accept screenshot button to the UI mode

### DIFF
--- a/docs/src/test-api/class-testinfo.md
+++ b/docs/src/test-api/class-testinfo.md
@@ -31,6 +31,7 @@ Learn more about [test annotations](../test-annotations.md).
   - `contentType` <[string]> Content type of this attachment to properly present in the report, for example `'application/json'` or `'image/png'`.
   - `path` ?<[string]> Optional path on the filesystem to the attached file.
   - `body` ?<[Buffer]> Optional attachment body used instead of a file.
+  - `targetPath` ?<[string]> Path on the filesystem to the original file in project to which this attachment relates to.
 
 The list of files or buffers attached to the current test. Some reporters show test attachments.
 

--- a/docs/src/test-reporter-api/class-testresult.md
+++ b/docs/src/test-reporter-api/class-testresult.md
@@ -11,6 +11,7 @@ A result of a single [TestCase] run.
   - `contentType` <[string]> Content type of this attachment to properly present in the report, for example `'application/json'` or `'image/png'`.
   - `path` ?<[string]> Optional path on the filesystem to the attached file.
   - `body` ?<[Buffer]> Optional attachment body used instead of a file.
+  - `targetPath` ?<[string]> Path on the filesystem to the original file in project to which this attachment relates to.
 
 The list of files or buffers attached during the test execution through [`property: TestInfo.attachments`].
 

--- a/packages/playwright-test/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright-test/src/isomorphic/teleReceiver.ts
@@ -526,7 +526,7 @@ export class TeleTestCase implements reporterTypes.TestCase {
 
 export type TeleTestResult = reporterTypes.TestResult & {
   stepMap: Map<string, reporterTypes.TestStep>;
-  statusEx: reporterTypes.TestResult['status'] | 'scheduled' | 'running';
+  statusEx: reporterTypes.TestResult['status'] | 'scheduled' | 'running' | 'modified';
 };
 
 export type TeleFullProject = FullProject & { id: string };

--- a/packages/playwright-test/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright-test/src/matchers/toMatchSnapshot.ts
@@ -212,19 +212,20 @@ class SnapshotHelper<T extends ImageComparatorOptions> {
     else
       output.push('');
 
+    const targetPath = path.relative(process.cwd(), this.snapshotPath);
     if (expected !== undefined) {
       writeFileSync(this.expectedPath, expected);
-      this.testInfo.attachments.push({ name: addSuffixToFilePath(this.snapshotName, '-expected'), contentType: this.mimeType, path: this.expectedPath });
+      this.testInfo.attachments.push({ name: addSuffixToFilePath(this.snapshotName, '-expected'), contentType: this.mimeType, path: this.expectedPath, targetPath });
       output.push(`Expected: ${colors.yellow(this.expectedPath)}`);
     }
     if (previous !== undefined) {
       writeFileSync(this.previousPath, previous);
-      this.testInfo.attachments.push({ name: addSuffixToFilePath(this.snapshotName, '-previous'), contentType: this.mimeType, path: this.previousPath });
+      this.testInfo.attachments.push({ name: addSuffixToFilePath(this.snapshotName, '-previous'), contentType: this.mimeType, path: this.previousPath, targetPath });
       output.push(`Previous: ${colors.yellow(this.previousPath)}`);
     }
     if (actual !== undefined) {
       writeFileSync(this.actualPath, actual);
-      this.testInfo.attachments.push({ name: addSuffixToFilePath(this.snapshotName, '-actual'), contentType: this.mimeType, path: this.actualPath });
+      this.testInfo.attachments.push({ name: addSuffixToFilePath(this.snapshotName, '-actual'), contentType: this.mimeType, path: this.actualPath, targetPath });
       output.push(`Received: ${colors.yellow(this.actualPath)}`);
     }
     if (diff !== undefined) {

--- a/packages/playwright-test/src/runner/uiMode.ts
+++ b/packages/playwright-test/src/runner/uiMode.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+import path from 'path';
 import { openTraceViewerApp, openTraceInBrowser } from 'playwright-core/lib/server';
 import { isUnderTest, ManualPromise } from 'playwright-core/lib/utils';
 import type { FullResult } from '../../reporter';
@@ -153,6 +155,8 @@ class UIMode {
       await this._listTests();
     if (method === 'run')
       await this._runTests(params.testIds, params.projects);
+    if (method === 'accept-screenshot')
+      await this._acceptScreenshot(params.screenshotPath, params.content);
   }
 
   private _dispatchEvent(method: string, params?: any) {
@@ -202,6 +206,15 @@ class UIMode {
     });
     this._testRun = { run, stop };
     await run;
+  }
+
+  private async _acceptScreenshot(screenshotPath: string, content: string) {
+    const absoluteScreenshotPath = path.resolve(screenshotPath);
+
+    const contentRawData = Buffer.from(content, 'base64');
+
+    fs.mkdirSync(path.dirname(absoluteScreenshotPath), { recursive: true });
+    fs.writeFileSync(absoluteScreenshotPath, contentRawData);
   }
 
   private _watchFiles(fileNames: string[]) {

--- a/packages/playwright-test/src/worker/testInfo.ts
+++ b/packages/playwright-test/src/worker/testInfo.ts
@@ -473,6 +473,7 @@ function serializeAttachments(attachments: TestInfo['attachments'], initialAttac
       contentType: a.contentType,
       path: a.path,
       base64: a.body?.toString('base64'),
+      targetPath: a.targetPath
     };
   });
 }

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -2137,6 +2137,11 @@ export interface TestInfo {
      * Optional attachment body used instead of a file.
      */
     body?: Buffer;
+
+    /**
+     * Path on the filesystem to the original file in project to which this attachment relates to.
+     */
+    targetPath?: string;
   }>;
 
   /**

--- a/packages/playwright-test/types/testReporter.d.ts
+++ b/packages/playwright-test/types/testReporter.d.ts
@@ -233,6 +233,11 @@ export interface TestResult {
      * Optional attachment body used instead of a file.
      */
     body?: Buffer;
+
+    /**
+     * Path on the filesystem to the original file in project to which this attachment relates to.
+     */
+    targetPath?: string;
   }>;
 
   /**

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import type { ActionTraceEvent } from '@trace/trace';
+import type { ActionTraceEvent, Attachment } from '@trace/trace';
 import { msToString } from '@web/uiUtils';
 import * as React from 'react';
 import './actionList.css';
@@ -23,12 +23,15 @@ import { asLocator } from '@isomorphic/locatorGenerators';
 import type { Language } from '@isomorphic/locatorGenerators';
 import type { TreeState } from '@web/components/treeView';
 import { TreeView } from '@web/components/treeView';
-import type { ActionTraceEventInContext, ActionTreeItem } from './modelUtil';
+import { ToolbarButton } from '@web/components/toolbarButton';
+import type { ActionTraceEventInContext, ActionTreeItem, ScreenshotUpdateHandler } from './modelUtil';
+import { AppContext } from './uiModeView';
 
 export interface ActionListProps {
   actions: ActionTraceEventInContext[],
   selectedAction: ActionTraceEventInContext | undefined,
   sdkLanguage: Language | undefined;
+  onScreenshotUpdated?: ScreenshotUpdateHandler;
   onSelected: (action: ActionTraceEventInContext) => void,
   onHighlighted: (action: ActionTraceEventInContext | undefined) => void,
   revealConsole: () => void,
@@ -41,13 +44,17 @@ export const ActionList: React.FC<ActionListProps> = ({
   actions,
   selectedAction,
   sdkLanguage,
+  onScreenshotUpdated,
   onSelected,
   onHighlighted,
   revealConsole,
   isLive,
 }) => {
   const [treeState, setTreeState] = React.useState<TreeState>({ expandedItems: new Map() });
+  const [attachmentsState, setAttachmentsState] = React.useState<AttachmentsState>({});
   const { rootItem, itemMap } = React.useMemo(() => modelUtil.buildActionTree(actions), [actions]);
+  const { isUIMode } = React.useContext(AppContext);
+  const [updateScreenshot, isUpdating] = useScreenshotUpdater(onScreenshotUpdated, attachmentsState, setAttachmentsState);
 
   const { selectedItem } = React.useMemo(() => {
     const selectedItem = selectedAction ? itemMap.get(selectedAction.callId) : undefined;
@@ -63,8 +70,174 @@ export const ActionList: React.FC<ActionListProps> = ({
     onSelected={item => onSelected(item.action!)}
     onHighlighted={item => onHighlighted(item?.action)}
     isError={item => !!item.action?.error?.message}
-    render={item => renderAction(item.action!, sdkLanguage, revealConsole, isLive || false)}
+    isWarning={item => shouldDisplayToggleButton(item) && getStatusFromState(attachmentsState, item) === AttachmentStatus.ACTUAL}
+    render={item => {
+      const buttons = isUIMode ? renderButtons(item, isUpdating, attachmentsState, updateScreenshot) : [];
+
+      return renderAction(item.action!, sdkLanguage, revealConsole, isLive || false, buttons);
+    }}
   />;
+};
+
+type AttachmentsState = Record<string, Record<string, AttachmentStatus>>;
+
+const TO_HAVE_SCREENSHOT_API_NAME = 'expect.toHaveScreenshot';
+
+const getStatusFromState = (attachmentsState: AttachmentsState, treeItem: ActionTreeItem): AttachmentStatus => {
+  const toHaveScreenshotAction = findParentByApiName(treeItem, TO_HAVE_SCREENSHOT_API_NAME);
+
+  const attachment = getAttachment(toHaveScreenshotAction);
+  const resultHash = getActionHash(toHaveScreenshotAction);
+
+  return attachmentsState[attachment?.targetPath ?? '']?.[resultHash] ?? AttachmentStatus.EXPECTED;
+};
+
+const setStatusFromState = (attachmentsState: AttachmentsState, setAttachmentsState: React.Dispatch<AttachmentsState>, treeItem: ActionTreeItem, newStatus: AttachmentStatus): void => {
+  const toHaveScreenshotAction = findParentByApiName(treeItem, TO_HAVE_SCREENSHOT_API_NAME);
+
+  const attachment = getAttachment(toHaveScreenshotAction);
+  const resultHash = getActionHash(toHaveScreenshotAction);
+
+  if (!attachment?.targetPath || !resultHash)
+    return;
+
+  setAttachmentsState({
+    ...attachmentsState,
+    [attachment.targetPath]: {
+      [resultHash]: newStatus,
+    },
+  });
+};
+
+const shouldDisplayAcceptButton = (item: ActionTreeItem) => {
+  return item.parent?.action?.apiName === TO_HAVE_SCREENSHOT_API_NAME &&
+    item.parent.action.error &&
+    item.action?.attachments?.[0].name.match(/expected|actual/) &&
+    item.action.attachments?.[0].targetPath &&
+    item.action.attachments?.[0].sha1 &&
+    item.action?.context.traceUrl;
+};
+
+const shouldDisplayToggleButton = (item: ActionTreeItem): boolean => {
+  return Boolean(item.action?.apiName === TO_HAVE_SCREENSHOT_API_NAME &&
+    item.action.error &&
+    item.action.attachments?.filter(attach =>
+      attach.name.match(/expected|actual/) &&
+      attach.targetPath
+    ).length === 2);
+};
+
+const findParentByApiName = (treeItem: ActionTreeItem, apiName: string, searchLimit = 1): ActionTreeItem | null => {
+  let attemptNumber = 0;
+  let currentTreeItem: ActionTreeItem | undefined = treeItem;
+
+  do {
+    if (currentTreeItem.action?.apiName === apiName)
+      return currentTreeItem;
+    currentTreeItem = currentTreeItem.parent;
+    attemptNumber++;
+  } while (currentTreeItem && attemptNumber <= searchLimit);
+
+  return null;
+};
+
+const getAttachment = (item: ActionTreeItem | null, status: AttachmentStatus | null = null): Attachment | undefined => {
+  return item?.action?.attachments?.find(attach => status ? attach.name.includes(status) : attach);
+};
+
+const getActionHash = (item: ActionTreeItem | null): string => {
+  return (item?.action?.startTime! + item?.action?.endTime!)?.toString();
+};
+
+const getStatusFromAttachment = (attachment: Attachment): AttachmentStatus => {
+  return attachment.name.match(/expected|actual|diff|previous/)?.[0] as AttachmentStatus ?? AttachmentStatus.UNKNOWN;
+};
+
+enum AttachmentStatus {
+  EXPECTED='expected',
+  ACTUAL = 'actual',
+  DIFF = 'diff',
+  PREVIOUS = 'previous',
+  UNKNOWN = 'unknown'
+}
+
+const getScreenshotUrl = (sha1: string, traceUrl: string): string => {
+  return 'sha1/' + sha1 + '?trace=' + encodeURIComponent(traceUrl);
+};
+
+type UpdateScreenshotFn = (targetPath: string, newScreenshotUrl: string, newStatus: AttachmentStatus, item: ActionTreeItem) => Promise<void>;
+
+const useScreenshotUpdater = (onScreenshotUpdated: ScreenshotUpdateHandler | undefined, attachmentsState: AttachmentsState, setAttachmentsState: React.Dispatch<AttachmentsState>) => {
+  const [isUpdating, setIsUpdating] = React.useState(false);
+
+  const updateScreenshot: UpdateScreenshotFn = async (targetPath, newScreenshotUrl, newStatus, item) => {
+    setIsUpdating(true);
+
+    const response = await fetch(newScreenshotUrl);
+    const contentArrayBuffer = await response.arrayBuffer();
+    const contentBase64 = btoa(String.fromCharCode(...new Uint8Array(contentArrayBuffer)));
+
+    setStatusFromState(attachmentsState, setAttachmentsState, item, newStatus);
+
+    await onScreenshotUpdated?.(targetPath, contentBase64, newStatus);
+
+    setIsUpdating(false);
+  };
+
+  return [updateScreenshot, isUpdating] as const;
+};
+
+const renderButtons = (item: ActionTreeItem, isUpdating: boolean, attachmentsState: AttachmentsState, updateScreenshot: UpdateScreenshotFn) => {
+  const buttons: JSX.Element[] = [];
+
+  if (shouldDisplayAcceptButton(item)) {
+    const attachment = getAttachment(item, null)!;
+    const newStatus = getStatusFromAttachment(attachment);
+
+    const screenshotUrl = getScreenshotUrl(attachment.sha1!, item.action?.context.traceUrl!);
+    const isDisabled = isUpdating || getStatusFromState(attachmentsState, item) === newStatus;
+
+    buttons.push(
+        <ToolbarButton
+          icon='save'
+          title='Save'
+          onClick={() => updateScreenshot(attachment.targetPath!, screenshotUrl, newStatus, item)}
+          disabled={isDisabled}
+        />
+    );
+  }
+
+  if (shouldDisplayToggleButton(item)) {
+    const currentStatus = getStatusFromState(attachmentsState, item);
+
+    if (currentStatus === 'expected') {
+      const attachment = getAttachment(item, AttachmentStatus.ACTUAL)!;
+      const screenshotUrl = getScreenshotUrl(attachment.sha1!, item.action?.context.traceUrl!);
+
+      buttons.push(
+          <ToolbarButton
+            icon='check'
+            title='Accept'
+            onClick={() => updateScreenshot(attachment.targetPath!, screenshotUrl, AttachmentStatus.ACTUAL, item)}
+            disabled={isUpdating}
+          />
+      );
+    } else if (currentStatus === 'actual') {
+      const attachment = getAttachment(item, AttachmentStatus.EXPECTED)!;
+      const screenshotUrl = getScreenshotUrl(attachment.sha1!, item.action?.context.traceUrl!);
+
+      buttons.push(
+          <ToolbarButton
+            icon='discard'
+            title='Undo accepting'
+            onClick={() => updateScreenshot(attachment.targetPath!, screenshotUrl, AttachmentStatus.EXPECTED, item)}
+            disabled={isUpdating}
+          />
+      );
+    }
+  }
+
+  return buttons;
 };
 
 const renderAction = (
@@ -72,6 +245,7 @@ const renderAction = (
   sdkLanguage: Language | undefined,
   revealConsole: () => void,
   isLive: boolean,
+  buttons: JSX.Element[]
 ) => {
   const { errors, warnings } = modelUtil.stats(action);
   const locator = action.params.selector ? asLocator(sdkLanguage || 'javascript', action.params.selector, false /* isFrameLocator */, true /* playSafe */) : undefined;
@@ -89,6 +263,7 @@ const renderAction = (
       {locator && <div className='action-selector' title={locator}>{locator}</div>}
       {action.method === 'goto' && action.params.url && <div className='action-url' title={action.params.url}>{action.params.url}</div>}
     </div>
+    {buttons}
     <div className='action-duration' style={{ flex: 'none' }}>{time || <span className='codicon codicon-loading'></span>}</div>
     <div className='action-icons' onClick={() => revealConsole()}>
       {!!errors && <div className='action-icon'><span className='codicon codicon-error'></span><span className="action-icon-value">{errors}</span></div>}

--- a/packages/trace-viewer/src/ui/modelUtil.ts
+++ b/packages/trace-viewer/src/ui/modelUtil.ts
@@ -48,6 +48,8 @@ export type ActionTreeItem = {
   action?: ActionTraceEventInContext;
 };
 
+export type ScreenshotUpdateHandler = (targetPath: string, screenshotBase64: string, state: string) => void | Promise<void>;
+
 export class MultiTraceModel {
   readonly startTime: number;
   readonly endTime: number;

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -20,7 +20,7 @@ import { ActionList } from './actionList';
 import { CallTab } from './callTab';
 import { ConsoleTab } from './consoleTab';
 import type * as modelUtil from './modelUtil';
-import type { ActionTraceEventInContext, MultiTraceModel } from './modelUtil';
+import type { ActionTraceEventInContext, MultiTraceModel, ScreenshotUpdateHandler } from './modelUtil';
 import { NetworkTab } from './networkTab';
 import { SnapshotTab } from './snapshotTab';
 import { SourceTab } from './sourceTab';
@@ -39,10 +39,11 @@ export const Workbench: React.FunctionComponent<{
   rootDir?: string,
   fallbackLocation?: modelUtil.SourceLocation,
   initialSelection?: ActionTraceEventInContext,
+  onScreenshotUpdated?: ScreenshotUpdateHandler,
   onSelectionChanged?: (action: ActionTraceEventInContext) => void,
   isLive?: boolean,
   drawer?: 'bottom' | 'right',
-}> = ({ model, hideTimelineBars, hideStackFrames, showSourcesFirst, rootDir, fallbackLocation, initialSelection, onSelectionChanged, isLive, drawer }) => {
+}> = ({ model, hideTimelineBars, hideStackFrames, showSourcesFirst, rootDir, fallbackLocation, initialSelection, onScreenshotUpdated, onSelectionChanged, isLive, drawer }) => {
   const [selectedAction, setSelectedAction] = React.useState<ActionTraceEventInContext | undefined>(undefined);
   const [highlightedAction, setHighlightedAction] = React.useState<ActionTraceEventInContext | undefined>();
   const [selectedNavigatorTab, setSelectedNavigatorTab] = React.useState<string>('actions');
@@ -135,6 +136,7 @@ export const Workbench: React.FunctionComponent<{
                 sdkLanguage={sdkLanguage}
                 actions={model?.actions || []}
                 selectedAction={model ? selectedAction : undefined}
+                onScreenshotUpdated={onScreenshotUpdated}
                 onSelected={onActionSelected}
                 onHighlighted={setHighlightedAction}
                 revealConsole={() => setSelectedPropertiesTab('console')}

--- a/packages/trace/src/trace.ts
+++ b/packages/trace/src/trace.ts
@@ -73,6 +73,15 @@ export type InputActionTraceEvent = {
   point?: Point;
 };
 
+export interface Attachment {
+  name: string;
+  contentType: string;
+  path?: string;
+  sha1?: string;
+  base64?: string;
+  targetPath?: string;
+}
+
 export type AfterActionTraceEvent = {
   type: 'after',
   callId: string;
@@ -80,13 +89,7 @@ export type AfterActionTraceEvent = {
   afterSnapshot?: string;
   log: string[];
   error?: SerializedError['error'];
-  attachments?: {
-    name: string;
-    contentType: string;
-    path?: string;
-    sha1?: string;
-    base64?: string;
-  }[];
+  attachments?: Attachment[];
   result?: any;
 };
 

--- a/packages/web/src/common.css
+++ b/packages/web/src/common.css
@@ -103,6 +103,10 @@ svg {
   color: var(--vscode-disabledForeground);
 }
 
+.codicon-circle-outline-modified {
+  color: var(--vscode-list-warningForeground);
+}
+
 input[type=text], input[type=search] {
   color: var(--vscode-input-foreground);
   background-color: var(--vscode-input-background);

--- a/packages/web/src/components/treeView.tsx
+++ b/packages/web/src/components/treeView.tsx
@@ -32,6 +32,7 @@ export type TreeViewProps<T> = {
   render: (item: T) => React.ReactNode,
   icon?: (item: T) => string | undefined,
   isError?: (item: T) => boolean,
+  isWarning?: (item: T) => boolean,
   selectedItem?: T,
   onAccepted?: (item: T) => void,
   onSelected?: (item: T) => void,
@@ -50,6 +51,7 @@ export function TreeView<T extends TreeItem>({
   render,
   icon,
   isError,
+  isWarning,
   selectedItem,
   onAccepted,
   onSelected,
@@ -83,6 +85,7 @@ export function TreeView<T extends TreeItem>({
         return expanded ? 'codicon-chevron-down' : 'codicon-chevron-right';
     }}
     isError={item => isError?.(item as T) || false}
+    isWarning={item => isWarning?.(item as T) || false}
     indent={item => treeItems.get(item as T)!.depth}
     selectedItem={selectedItem}
     onAccepted={item => onAccepted?.(item as T)}

--- a/packages/web/src/third_party/vscode/codicon.css
+++ b/packages/web/src/third_party/vscode/codicon.css
@@ -194,6 +194,7 @@
 .codicon-chrome-minimize:before { content: '\eaba'; }
 .codicon-chrome-restore:before { content: '\eabb'; }
 .codicon-circle-outline:before { content: '\eabc'; }
+.codicon-circle-outline-modified:before { content: '\eabc'; }
 .codicon-debug-breakpoint-unverified:before { content: '\eabc'; }
 .codicon-circle-slash:before { content: '\eabd'; }
 .codicon-circuit-board:before { content: '\eabe'; }


### PR DESCRIPTION
### Overview & Demo
This PR implements an ability to accept screenshots in UI mode.

![](https://s11.gifyu.com/images/ScH3C.gif)

### What's done
- A tick appears next to a failed screenshot. If you click on it, the actual screenshot is accepted and the button is changed to "undo".
- Save buttons appear next to actual and expected attachments of a failed screenshot. Button is disabled if the click won't change anything (screenshot's already accepted)
- If some screenshots are modified, corresponding tests are marked as modified in the test tree with yellow circle
- A "modified" filter has been added

### Why
This PR partially addresses #24310.
In short, it's highly inconvenient to switch between CLI mode and UI mode to accept screenshots. As of now, you can't interact with screenshots state in UI mode which makes its use very limited