### PR TITLE
fix: timeoutRunner with large monotonicTime

### DIFF
--- a/packages/playwright-core/src/utils/timeoutRunner.ts
+++ b/packages/playwright-core/src/utils/timeoutRunner.ts
@@ -25,13 +25,11 @@ type TimeoutRunnerData = {
   timeoutPromise: ManualPromise<any>,
 };
 
-export const MaxTime = 2147483647; // 2^31-1
-
 export class TimeoutRunner {
   private _running: TimeoutRunnerData | undefined;
   private _timeout: number;
   private _elapsed: number;
-  private _deadline = MaxTime;
+  private _deadline = 0;
 
   constructor(timeout: number) {
     this._timeout = timeout;
@@ -96,7 +94,7 @@ export class TimeoutRunner {
       running.timer = undefined;
     }
     this._syncElapsedAndStart();
-    this._deadline = timeout ? monotonicTime() + timeout : MaxTime;
+    this._deadline = timeout ? monotonicTime() + timeout : 0;
     if (timeout === 0)
       return;
     timeout = timeout - this._elapsed;
@@ -108,7 +106,7 @@ export class TimeoutRunner {
 }
 
 export async function raceAgainstDeadline<T>(cb: () => Promise<T>, deadline: number): Promise<{ result: T, timedOut: false } | { timedOut: true }> {
-  const runner = new TimeoutRunner((deadline || MaxTime) - monotonicTime());
+  const runner = new TimeoutRunner(deadline ? deadline - monotonicTime() : 0);
   try {
     return { result: await runner.run(cb), timedOut: false };
   } catch (e) {

--- a/packages/playwright-test/src/worker/testInfo.ts
+++ b/packages/playwright-test/src/worker/testInfo.ts
@@ -113,7 +113,15 @@ export class TestInfoImpl implements TestInfo {
     const testDeadline = this._timeoutManager.currentSlotDeadline() - 100;
     const matcherMessage = `Timeout ${timeout}ms exceeded while waiting on the predicate`;
     const testMessage = `Test timeout of ${this.timeout}ms exceeded`;
-    return { deadline: TimeoutManager.calculateMinimalTimeout(matcherDeadline, testDeadline), timeoutMessage: testDeadline < matcherDeadline ? testMessage : matcherMessage };
+    const deadline = this._calculateEarliestDeadline(matcherDeadline, testDeadline);
+    return { deadline, timeoutMessage: deadline === matcherDeadline ? matcherMessage : testMessage };
+  }
+
+  _calculateEarliestDeadline(...deadline: number[]): number {
+    const positiveDeadlines = deadline.filter(deadline => deadline > 0);
+    if (!positiveDeadlines.length)
+      return 0;
+    return Math.min(...positiveDeadlines);
   }
 
   static _defaultDeadlineForMatcher(timeout: number): { deadline: any; timeoutMessage: any; } {

--- a/packages/playwright-test/src/worker/testInfo.ts
+++ b/packages/playwright-test/src/worker/testInfo.ts
@@ -16,7 +16,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { MaxTime, captureRawStack, createAfterActionTraceEventForStep, createBeforeActionTraceEventForStep, monotonicTime, zones } from 'playwright-core/lib/utils';
+import { captureRawStack, createAfterActionTraceEventForStep, createBeforeActionTraceEventForStep, monotonicTime, zones } from 'playwright-core/lib/utils';
 import type { TestInfoError, TestInfo, TestStatus, FullProject, FullConfig } from '../../types/test';
 import type { AttachmentPayload, StepBeginPayload, StepEndPayload, WorkerInitParams } from '../common/ipc';
 import type { TestCase } from '../common/test';
@@ -109,11 +109,11 @@ export class TestInfoImpl implements TestInfo {
 
   _deadlineForMatcher(timeout: number): { deadline: number, timeoutMessage: string } {
     const startTime = monotonicTime();
-    const matcherDeadline = timeout ? startTime + timeout : MaxTime;
+    const matcherDeadline = timeout ? startTime + timeout : 0;
     const testDeadline = this._timeoutManager.currentSlotDeadline() - 100;
     const matcherMessage = `Timeout ${timeout}ms exceeded while waiting on the predicate`;
     const testMessage = `Test timeout of ${this.timeout}ms exceeded`;
-    return { deadline: Math.min(testDeadline, matcherDeadline), timeoutMessage: testDeadline < matcherDeadline ? testMessage : matcherMessage };
+    return { deadline: TimeoutManager.calculateMinimalTimeout(matcherDeadline, testDeadline), timeoutMessage: testDeadline < matcherDeadline ? testMessage : matcherMessage };
   }
 
   static _defaultDeadlineForMatcher(timeout: number): { deadline: any; timeoutMessage: any; } {

--- a/packages/playwright-test/src/worker/timeoutManager.ts
+++ b/packages/playwright-test/src/worker/timeoutManager.ts
@@ -166,4 +166,11 @@ export class TimeoutManager {
       stack: location ? message + `\n    at ${location.file}:${location.line}:${location.column}` : undefined
     };
   }
+
+  static calculateMinimalTimeout(...timeouts: number[]): number {
+    const positiveTimeouts = timeouts.filter(deadline => deadline > 0);
+    if (!positiveTimeouts.length)
+      return 0;
+    return Math.min(...positiveTimeouts);
+  }
 }

--- a/packages/playwright-test/src/worker/timeoutManager.ts
+++ b/packages/playwright-test/src/worker/timeoutManager.ts
@@ -166,11 +166,4 @@ export class TimeoutManager {
       stack: location ? message + `\n    at ${location.file}:${location.line}:${location.column}` : undefined
     };
   }
-
-  static calculateMinimalTimeout(...timeouts: number[]): number {
-    const positiveTimeouts = timeouts.filter(deadline => deadline > 0);
-    if (!positiveTimeouts.length)
-      return 0;
-    return Math.min(...positiveTimeouts);
-  }
 }


### PR DESCRIPTION
The issue was that the monotonicTime on some of our servers was `4832315541.968` while the `MaxTime` was `2147483647`.  This created a negative timeout for the TimeoutRunner and caused the timeout exceeded error.

Fixes https://github.com/microsoft/playwright/issues/24432.