### PR TITLE
docs: Add `files` to list of ways to include global.d.ts

### DIFF
--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -215,7 +215,7 @@ test('numeric ranges', () => {
 Do not confuse Playwright's `expect` with the [`expect` library](https://jestjs.io/docs/expect). The latter is not fully integrated with Playwright test runner, so make sure to use Playwright's own `expect`.
 :::
 
-For TypeScript, also add the following to your [`global.d.ts`](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-d-ts.html). If it does not exist, you need to create it inside your repository. Make sure that your `global.d.ts` gets included inside your `tsconfig.json` via the `include` or `compilerOptions.typeRoots` option so that your IDE will pick it up.
+For TypeScript, also add the following to your [`global.d.ts`](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-d-ts.html). If it does not exist, you need to create it inside your repository. Make sure that your `global.d.ts` gets included inside your `tsconfig.json` via the `files`, `include` or `compilerOptions.typeRoots` option so that your IDE will pick it up.
 
 You don't need it for JavaScript.
 


### PR DESCRIPTION
As TypeScript overwrites, rather than merges, options when using `extends`, SvelteKit users who are adding custom matchers can't use `includes` or `compilerOptions.typeRoots` without duplicating their existing values; `includes` is automatically generated by SvelteKit and may change over time, and `compilerOptions.typeRoots` does not seem to have its defaults documented in the TypeScript docs.

However, the global.d.ts file can also be included by adding it to the `files` array, but new TypeScript users might not realise this.

This commit adds `files` to the list of options in the documentation.