### PR TITLE
Update default testMatch test-configuration-js.md to match one from h…

### DIFF
--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -85,7 +85,7 @@ export default defineConfig({
 | Option | Description |
 | :- | :- |
 | [`property: TestConfig.testIgnore`] | Glob patterns or regular expressions that should be ignored when looking for the test files. For example, `'*test-assets'` |
-| [`property: TestConfig.testMatch`] | Glob patterns or regular expressions that match test files. For example, `'*todo-tests/*.spec.ts'`. By default, Playwright runs <code>.*(test&#124;spec)\.(js&#124;ts&#124;mjs)</code> files. |
+| [`property: TestConfig.testMatch`] | Glob patterns or regular expressions that match test files. For example, `'*todo-tests/*.spec.ts'`. By default, Playwright runs <code>**/*.@(spec|test).?(c|m)[jt]s?(x)</code> files. |
 
 ## Advanced Configuration
 


### PR DESCRIPTION
…ttps://playwright.dev/docs/api/class-testconfig

I was browsing through the documentation and there are two different values in:
- https://playwright.dev/docs/test-configuration#filtering-tests
- https://playwright.dev/docs/api/class-testconfig#test-config-test-match

This commit unifies it to the version in:
https://playwright.dev/docs/api/class-testconfig#test-config-test-match which is correct based on my testing

NOTE: I'm not sure how to test it, and whether the HTML escaping is actually necessary for the code to work here!