### PR TITLE
chore: allow calling spawnSync on Node.js file inside test

### DIFF
--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -21,7 +21,7 @@ import fs from 'fs';
 import path from 'path';
 import { Runner } from './runner/runner';
 import { stopProfiling, startProfiling, gracefullyProcessExitDoNotHang } from 'playwright-core/lib/utils';
-import { experimentalLoaderOption, fileIsModule, serializeError } from './util';
+import { execArgvWithoutExperimentalLoaderOptions, experimentalLoaderOptions, fileIsModule, serializeError } from './util';
 import { showHTMLReport } from './reporters/html';
 import { createMergedReport } from './reporters/merge';
 import { ConfigLoader, resolveConfigFile } from './common/configLoader';
@@ -272,17 +272,18 @@ function restartWithExperimentalTsEsm(configFile: string | null): boolean {
     return false;
   if (process.env.PW_DISABLE_TS_ESM)
     return false;
-  if (process.env.PW_TS_ESM_ON)
+  if (process.env.PW_TS_ESM_ON) {
+    process.execArgv = execArgvWithoutExperimentalLoaderOptions();
     return false;
+  }
   if (!fileIsModule(configFile))
     return false;
-  const NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + experimentalLoaderOption();
-  const innerProcess = require('child_process').fork(require.resolve('./cli'), process.argv.slice(2), {
+  const innerProcess = (require('child_process') as typeof import('child_process')).fork(require.resolve('./cli'), process.argv.slice(2), {
     env: {
       ...process.env,
-      NODE_OPTIONS,
       PW_TS_ESM_ON: '1',
-    }
+    },
+    execArgv: experimentalLoaderOptions(),
   });
 
   innerProcess.on('close', (code: number | null) => {

--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -273,6 +273,7 @@ function restartWithExperimentalTsEsm(configFile: string | null): boolean {
   if (process.env.PW_DISABLE_TS_ESM)
     return false;
   if (process.env.PW_TS_ESM_ON) {
+    // clear execArgv after restart, so that childProcess.fork in user code does not inherit our loader.
     process.execArgv = execArgvWithoutExperimentalLoaderOptions();
     return false;
   }

--- a/packages/playwright-test/src/cli.ts
+++ b/packages/playwright-test/src/cli.ts
@@ -21,7 +21,7 @@ import fs from 'fs';
 import path from 'path';
 import { Runner } from './runner/runner';
 import { stopProfiling, startProfiling, gracefullyProcessExitDoNotHang } from 'playwright-core/lib/utils';
-import { execArgvWithoutExperimentalLoaderOptions, experimentalLoaderOptions, fileIsModule, serializeError } from './util';
+import { execArgvWithoutExperimentalLoaderOptions, execArgvWithExperimentalLoaderOptions, fileIsModule, serializeError } from './util';
 import { showHTMLReport } from './reporters/html';
 import { createMergedReport } from './reporters/merge';
 import { ConfigLoader, resolveConfigFile } from './common/configLoader';
@@ -284,7 +284,7 @@ function restartWithExperimentalTsEsm(configFile: string | null): boolean {
       ...process.env,
       PW_TS_ESM_ON: '1',
     },
-    execArgv: experimentalLoaderOptions(),
+    execArgv: execArgvWithExperimentalLoaderOptions(),
   });
 
   innerProcess.on('close', (code: number | null) => {

--- a/packages/playwright-test/src/common/process.ts
+++ b/packages/playwright-test/src/common/process.ts
@@ -51,6 +51,7 @@ process.on('disconnect', gracefullyCloseAndExit);
 process.on('SIGINT', () => {});
 process.on('SIGTERM', () => {});
 
+// Clear execArgv immediately, so that the user-code does not inherit our loader.
 process.execArgv = execArgvWithoutExperimentalLoaderOptions();
 
 let processRunner: ProcessRunner;

--- a/packages/playwright-test/src/common/process.ts
+++ b/packages/playwright-test/src/common/process.ts
@@ -18,7 +18,7 @@ import type { WriteStream } from 'tty';
 import type { EnvProducedPayload, ProcessInitParams, TtyParams } from './ipc';
 import { startProfiling, stopProfiling } from 'playwright-core/lib/utils';
 import type { TestInfoError } from '../../types/test';
-import { serializeError } from '../util';
+import { execArgvWithoutExperimentalLoaderOptions, serializeError } from '../util';
 
 export type ProtocolRequest = {
   id: number;
@@ -50,6 +50,8 @@ sendMessageToParent({ method: 'ready' });
 process.on('disconnect', gracefullyCloseAndExit);
 process.on('SIGINT', () => {});
 process.on('SIGTERM', () => {});
+
+process.execArgv = execArgvWithoutExperimentalLoaderOptions();
 
 let processRunner: ProcessRunner;
 let processName: string;

--- a/packages/playwright-test/src/plugins/webServerPlugin.ts
+++ b/packages/playwright-test/src/plugins/webServerPlugin.ts
@@ -22,7 +22,6 @@ import { raceAgainstDeadline, launchProcess, httpRequest, monotonicTime } from '
 import type { FullConfig } from '../../types/testReporter';
 import type { TestRunnerPlugin } from '.';
 import type { FullConfigInternal } from '../common/config';
-import { envWithoutExperimentalLoaderOptions } from '../util';
 import type { ReporterV2 } from '../reporters/reporterV2';
 
 
@@ -93,7 +92,6 @@ export class WebServerPlugin implements TestRunnerPlugin {
       command: this._options.command,
       env: {
         ...DEFAULT_ENVIRONMENT_VARIABLES,
-        ...envWithoutExperimentalLoaderOptions(),
         ...this._options.env,
       },
       cwd: this._options.cwd,

--- a/packages/playwright-test/src/runner/processHost.ts
+++ b/packages/playwright-test/src/runner/processHost.ts
@@ -51,7 +51,7 @@ export class ProcessHost extends EventEmitter {
       detached: false,
       env: { ...process.env, ...this._extraEnv },
       stdio: inheritStdio ? ['ignore', 'inherit', 'inherit', 'ipc'] : ['ignore', 'ignore', process.env.PW_RUNNER_DEBUG ? 'inherit' : 'ignore', 'ipc'],
-      execArgv: experimentalLoaderOptions(),
+      ...(process.env.PW_TS_ESM_ON ? { execArgv: experimentalLoaderOptions() } : {}),
     });
     this.process.on('exit', (code, signal) => {
       this.didExit = true;

--- a/packages/playwright-test/src/runner/processHost.ts
+++ b/packages/playwright-test/src/runner/processHost.ts
@@ -19,7 +19,7 @@ import { EventEmitter } from 'events';
 import { debug } from 'playwright-core/lib/utilsBundle';
 import type { EnvProducedPayload, ProcessInitParams } from '../common/ipc';
 import type { ProtocolResponse } from '../common/process';
-import { experimentalLoaderOptions } from '../util';
+import { execArgvWithExperimentalLoaderOptions } from '../util';
 
 export type ProcessExitData = {
   unexpectedly: boolean;
@@ -51,7 +51,7 @@ export class ProcessHost extends EventEmitter {
       detached: false,
       env: { ...process.env, ...this._extraEnv },
       stdio: inheritStdio ? ['ignore', 'inherit', 'inherit', 'ipc'] : ['ignore', 'ignore', process.env.PW_RUNNER_DEBUG ? 'inherit' : 'ignore', 'ipc'],
-      ...(process.env.PW_TS_ESM_ON ? { execArgv: experimentalLoaderOptions() } : {}),
+      ...(process.env.PW_TS_ESM_ON ? { execArgv: execArgvWithExperimentalLoaderOptions() } : {}),
     });
     this.process.on('exit', (code, signal) => {
       this.didExit = true;

--- a/packages/playwright-test/src/runner/processHost.ts
+++ b/packages/playwright-test/src/runner/processHost.ts
@@ -19,6 +19,7 @@ import { EventEmitter } from 'events';
 import { debug } from 'playwright-core/lib/utilsBundle';
 import type { EnvProducedPayload, ProcessInitParams } from '../common/ipc';
 import type { ProtocolResponse } from '../common/process';
+import { experimentalLoaderOptions } from '../util';
 
 export type ProcessExitData = {
   unexpectedly: boolean;
@@ -50,6 +51,7 @@ export class ProcessHost extends EventEmitter {
       detached: false,
       env: { ...process.env, ...this._extraEnv },
       stdio: inheritStdio ? ['ignore', 'inherit', 'inherit', 'ipc'] : ['ignore', 'ignore', process.env.PW_RUNNER_DEBUG ? 'inherit' : 'ignore', 'ipc'],
+      execArgv: experimentalLoaderOptions(),
     });
     this.process.on('exit', (code, signal) => {
       this.didExit = true;

--- a/packages/playwright-test/src/util.ts
+++ b/packages/playwright-test/src/util.ts
@@ -307,17 +307,20 @@ function folderIsModule(folder: string): boolean {
   return require(packageJsonPath).type === 'module';
 }
 
+const kExperimentalLoaderOptions = [
+  '--no-warnings',
+  `--experimental-loader=${url.pathToFileURL(require.resolve('@playwright/test/lib/transform/esmLoader')).toString()}`,
+];
+
 export function execArgvWithExperimentalLoaderOptions() {
   return [
     ...process.execArgv,
-    '--no-warnings',
-    `--experimental-loader=${url.pathToFileURL(require.resolve('@playwright/test/lib/transform/esmLoader')).toString()}`,
+    ...kExperimentalLoaderOptions,
   ];
 }
 
 export function execArgvWithoutExperimentalLoaderOptions() {
-  const execArgv = execArgvWithExperimentalLoaderOptions();
-  return process.execArgv.filter(arg => !execArgv.includes(arg));
+  return process.execArgv.filter(arg => !kExperimentalLoaderOptions.includes(arg));
 }
 
 // This follows the --moduleResolution=bundler strategy from tsc.

--- a/packages/playwright-test/src/util.ts
+++ b/packages/playwright-test/src/util.ts
@@ -307,16 +307,13 @@ function folderIsModule(folder: string): boolean {
   return require(packageJsonPath).type === 'module';
 }
 
-export function experimentalLoaderOption() {
-  return ` --no-warnings --experimental-loader=${url.pathToFileURL(require.resolve('@playwright/test/lib/transform/esmLoader')).toString()}`;
+export function experimentalLoaderOptions() {
+  return ['--no-warnings', `--experimental-loader=${url.pathToFileURL(require.resolve('@playwright/test/lib/transform/esmLoader')).toString()}`];
 }
 
-export function envWithoutExperimentalLoaderOptions(): NodeJS.ProcessEnv {
-  const substring = experimentalLoaderOption();
-  const result = { ...process.env };
-  if (result.NODE_OPTIONS)
-    result.NODE_OPTIONS = result.NODE_OPTIONS.replace(substring, '').trim() || undefined;
-  return result;
+export function execArgvWithoutExperimentalLoaderOptions() {
+  const execArgv = experimentalLoaderOptions();
+  return process.execArgv.filter(arg => !execArgv.includes(arg));
 }
 
 // This follows the --moduleResolution=bundler strategy from tsc.

--- a/packages/playwright-test/src/util.ts
+++ b/packages/playwright-test/src/util.ts
@@ -307,12 +307,16 @@ function folderIsModule(folder: string): boolean {
   return require(packageJsonPath).type === 'module';
 }
 
-export function experimentalLoaderOptions() {
-  return ['--no-warnings', `--experimental-loader=${url.pathToFileURL(require.resolve('@playwright/test/lib/transform/esmLoader')).toString()}`];
+export function execArgvWithExperimentalLoaderOptions() {
+  return [
+    ...process.execArgv,
+    '--no-warnings',
+    `--experimental-loader=${url.pathToFileURL(require.resolve('@playwright/test/lib/transform/esmLoader')).toString()}`,
+  ];
 }
 
 export function execArgvWithoutExperimentalLoaderOptions() {
-  const execArgv = experimentalLoaderOptions();
+  const execArgv = execArgvWithExperimentalLoaderOptions();
   return process.execArgv.filter(arg => !execArgv.includes(arg));
 }
 


### PR DESCRIPTION
The issue was that when `spawnSync` gets used, `NODE_OPTIONS` is set with our experimental loader, I think we can't prevent that from happening.
~~So then a Node.js script gets executed with the loader but we never ack the messages we send inside the loader IPC.
This change adds a small `init` method, if its not called, we never initialize the transport.~~

Fixes https://github.com/microsoft/playwright/issues/24516 

Relates https://github.com/microsoft/playwright/pull/16733