### PR TITLE
chore(test): expose expect matchers from @playwright/test

### DIFF
--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -23,6 +23,7 @@
     "./lib/transform/esmLoader": "./lib/transform/esmLoader.js",
     "./lib/internalsForTest": "./lib/internalsForTest.js",
     "./lib/plugins": "./lib/plugins/index.js",
+    "./lib/matchers/expect": "./lib/matchers/expect.js",
     "./jsx-runtime": {
       "import": "./jsx-runtime.mjs",
       "require": "./jsx-runtime.js",

--- a/packages/playwright-test/src/matchers/expect.ts
+++ b/packages/playwright-test/src/matchers/expect.ts
@@ -17,7 +17,9 @@
 import {
   captureRawStack,
   isString,
-  pollAgainstDeadline } from 'playwright-core/lib/utils';
+  pollAgainstDeadline,
+  zones,
+} from 'playwright-core/lib/utils';
 import type { ExpectZone } from 'playwright-core/lib/utils';
 import {
   toBeAttached,
@@ -56,7 +58,6 @@ import {
   printReceived,
 } from '../common/expectBundle';
 export type { ExpectMatcherContext } from '../common/expectBundle';
-import { zones } from 'playwright-core/lib/utils';
 import { TestInfoImpl } from '../worker/testInfo';
 
 // from expect/build/types


### PR DESCRIPTION
+ fix https://github.com/microsoft/playwright/issues/24501
+ Allows libraries building on top of the `playwright-core` to use the extended expect matchers from the `@playwright/test`. 