### PR TITLE
chore: prefer import over require

### DIFF
--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -123,7 +123,7 @@ export function createPlugin(
           }
         };
       }
-      const { build, preview } = require('vite');
+      const { build, preview } = await import('vite');
       // Build config unconditionally, either build or build & preview will use it.
       viteConfig.plugins ??= [];
       if (frameworkPluginFactory && !viteConfig.plugins.length)

--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -75,7 +75,7 @@ export function createPlugin(
       const registerSource = await fs.promises.readFile(registerSourceFile, 'utf-8');
       const registerSourceHash = calculateSha1(registerSource);
 
-      const { version: viteVersion } = require('vite/package.json');
+      const { version: viteVersion } = await import('vite');
       try {
         buildInfo = JSON.parse(await fs.promises.readFile(buildInfoFile, 'utf-8')) as BuildInfo;
         assert(buildInfo.version === playwrightVersion);


### PR DESCRIPTION
The next major version of Vite may start producing warnings when Vite is required to encourage people to move off of the legacy CJS syntax and onto modern ESM. We should make a change now to get ahead of it and ensure users don't see this warning