### PR TITLE
chore: ensure the file operations are async in the junit reporter

### DIFF
--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -96,7 +96,7 @@ class JUnitReporter extends EmptyReporter {
     let duration = 0;
     const children: XMLEntry[] = [];
 
-    for(const test of suite.allTests()){
+    for (const test of suite.allTests()){
       ++tests;
       if (test.outcome() === 'skipped')
         ++skipped;
@@ -190,15 +190,15 @@ class JUnitReporter extends EmptyReporter {
       for (const attachment of result.attachments) {
         if (!attachment.path)
           continue;
-          const attachmentPath = path.relative(this.config.rootDir, attachment.path);
+        const attachmentPath = path.relative(this.config.rootDir, attachment.path);
 
-          try {
-            await fs.promises.access(attachment.path);
-            systemOut.push(`\n[[ATTACHMENT|${attachmentPath}]]\n`);
-          } catch {
-            systemErr.push(`\nWarning: attachment ${attachmentPath} is missing`);
-            continue;
-          }
+        try {
+          await fs.promises.access(attachment.path);
+          systemOut.push(`\n[[ATTACHMENT|${attachmentPath}]]\n`);
+        } catch {
+          systemErr.push(`\nWarning: attachment ${attachmentPath} is missing`);
+          continue;
+        }
       }
     }
     // Note: it is important to only produce a single system-out/system-err entry

--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -58,7 +58,7 @@ class JUnitReporter extends EmptyReporter {
     const children: XMLEntry[] = [];
     for (const projectSuite of this.suite.suites) {
       for (const fileSuite of projectSuite.suites)
-        children.push(this._buildTestSuite(projectSuite.title, fileSuite));
+        children.push(await this._buildTestSuite(projectSuite.title, fileSuite));
     }
     const tokens: string[] = [];
 
@@ -82,21 +82,21 @@ class JUnitReporter extends EmptyReporter {
     if (this.outputFile) {
       assert(this.config.configFile || path.isAbsolute(this.outputFile), 'Expected fully resolved path if not using config file.');
       const outputFile = this.config.configFile ? path.resolve(path.dirname(this.config.configFile), this.outputFile) : this.outputFile;
-      fs.mkdirSync(path.dirname(outputFile), { recursive: true });
-      fs.writeFileSync(outputFile, reportString);
+      await fs.promises.mkdir(path.dirname(outputFile), { recursive: true });
+      await fs.promises.writeFile(outputFile, reportString);
     } else {
       console.log(reportString);
     }
   }
 
-  private _buildTestSuite(projectName: string, suite: Suite): XMLEntry {
+  private async _buildTestSuite(projectName: string, suite: Suite): Promise<XMLEntry> {
     let tests = 0;
     let skipped = 0;
     let failures = 0;
     let duration = 0;
     const children: XMLEntry[] = [];
 
-    suite.allTests().forEach(test => {
+    for(const test of suite.allTests()){
       ++tests;
       if (test.outcome() === 'skipped')
         ++skipped;
@@ -104,8 +104,9 @@ class JUnitReporter extends EmptyReporter {
         ++failures;
       for (const result of test.results)
         duration += result.duration;
-      this._addTestCase(suite.title, test, children);
-    });
+      await this._addTestCase(suite.title, test, children);
+    }
+
     this.totalTests += tests;
     this.totalSkipped += skipped;
     this.totalFailures += failures;
@@ -128,7 +129,7 @@ class JUnitReporter extends EmptyReporter {
     return entry;
   }
 
-  private _addTestCase(suiteName: string, test: TestCase, entries: XMLEntry[]) {
+  private async _addTestCase(suiteName: string, test: TestCase, entries: XMLEntry[]) {
     const entry = {
       name: 'testcase',
       attributes: {
@@ -189,14 +190,15 @@ class JUnitReporter extends EmptyReporter {
       for (const attachment of result.attachments) {
         if (!attachment.path)
           continue;
-        try {
           const attachmentPath = path.relative(this.config.rootDir, attachment.path);
-          if (fs.existsSync(attachment.path))
+
+          try {
+            await fs.promises.access(attachment.path);
             systemOut.push(`\n[[ATTACHMENT|${attachmentPath}]]\n`);
-          else
+          } catch {
             systemErr.push(`\nWarning: attachment ${attachmentPath} is missing`);
-        } catch (e) {
-        }
+            continue;
+          }
       }
     }
     // Note: it is important to only produce a single system-out/system-err entry

--- a/packages/playwright-test/src/reporters/junit.ts
+++ b/packages/playwright-test/src/reporters/junit.ts
@@ -197,7 +197,6 @@ class JUnitReporter extends EmptyReporter {
           systemOut.push(`\n[[ATTACHMENT|${attachmentPath}]]\n`);
         } catch {
           systemErr.push(`\nWarning: attachment ${attachmentPath} is missing`);
-          continue;
         }
       }
     }


### PR DESCRIPTION
# What ?

Converts the file system operations in the json reporter to be async.
  
# Why?

Although I doubt it how profound this will ever be , there could be some performance bottleneck with multiple reporters at once here eventually.

## existsSync

There is no equivalent in async so I leveraged the reccomended `access` one, see doc string for more info -> 

```
     * Tests a user's permissions for the file or directory specified by `path`.
     * The `mode` argument is an optional integer that specifies the accessibility
     * checks to be performed. Check `File access constants` for possible values
     * of `mode`. It is possible to create a mask consisting of the bitwise OR of
     * two or more values (e.g. `fs.constants.W_OK | fs.constants.R_OK`).
     *
     * If the accessibility check is successful, the promise is resolved with no
     * value. If any of the accessibility checks fail, the promise is rejected
     * with an [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) object. The following example checks if the file`/etc/passwd` can be read and
     * written by the current process.
     *
     * ```js
     * import { access } from 'fs/promises';
     * import { constants } from 'fs';
     *
     * try {
     *   await access('/etc/passwd', constants.R_OK | constants.W_OK);
     *   console.log('can access');
     * } catch {
     *   console.error('cannot access');
     * }
```

# Verified?

I ran `npm run build` and then `CI=1 npm run test` with `    ['junit', { outputFile: path.join(outputDir, 'report.xml') }],` and once finished I see the report
<img width="1103" alt="image" src="https://github.com/microsoft/playwright/assets/37447884/e27d40a1-8fc1-47b5-8ea2-83c37d30f72d">



