### PR TITLE
docs(debug): remove incorrect console APIs

### DIFF
--- a/docs/src/debug.md
+++ b/docs/src/debug.md
@@ -369,22 +369,6 @@ Locator ()
   - elements: [button]
 ```
 
-#### playwright.highlight(selector)
-
-Highlight the first occurrence of the locator:
-
-```bash
-playwright.highlight('.auth-form');
-```
-
-#### playwright.clear()
-
-```bash
-playwright.clear()
-```
-
-Clear existing highlights.
-
 #### playwright.selector(element)
 
 Generates selector for the given element. For example, select an element in the Elements panel and pass `$0`:


### PR DESCRIPTION
This got accidentally added in https://github.com/microsoft/playwright/commit/54f7141877600cd396f882a685b95dad875422d6.

Fixes https://github.com/microsoft/playwright/issues/24562