### PR TITLE
fix: handle worker process sigint before initialization

### DIFF
--- a/packages/playwright-test/src/runner/processHost.ts
+++ b/packages/playwright-test/src/runner/processHost.ts
@@ -83,7 +83,7 @@ export class ProcessHost extends EventEmitter {
     });
 
     await new Promise<void>((resolve, reject) => {
-      this.process.once('exit', (code, signal) => reject(new Error(`process exited with code "${code}" and signal "${signal}" before it became ready`)));
+      this.process.once('exit', (code, signal) => reject(new Error(`unable to start subprocess: code=${code}, signal=${signal}`)));
       this.once('ready', () => resolve());
     });
 

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -605,7 +605,7 @@ test('should print expected/received on Ctrl+C', async ({ interactWithTestRunner
       `,
   }, { workers: 1 });
   await testProcess.waitForOutput('%%SEND-SIGINT%%');
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   const { exitCode } = await testProcess.exited;
   expect(exitCode).toBe(130);
 

--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -660,7 +660,7 @@ test('should not hang and report results when worker process suddenly exits duri
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);
-  expect(result.output).toContain('Internal error: worker process exited unexpectedly');
+  expect(result.output).toContain('Error: worker process exited unexpectedly');
   expect(result.output).toContain('[1/1] a.spec.js:3:11 › failing due to afterall');
 });
 

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -447,7 +447,7 @@ test('should report click error on sigint', async ({ interactWithTestRunner }) =
     `,
   }, { workers: 1 });
   await testProcess.waitForOutput('%%SEND-SIGINT%%');
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   const { exitCode } = await testProcess.exited;
   expect(exitCode).toBe(130);
 

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -92,7 +92,68 @@ test('should continue with other tests after worker process suddenly exits', asy
   expect(result.passed).toBe(4);
   expect(result.failed).toBe(1);
   expect(result.skipped).toBe(0);
-  expect(result.output).toContain('Internal error: worker process exited unexpectedly');
+  expect(result.output).toContain('Error: worker process exited unexpectedly');
+});
+
+test('should report subprocess creation error', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'preload.js': `
+      process.exit(42);
+    `,
+    'a.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('fails', () => {});
+      test('skipped', () => {});
+
+      // Infect subprocesses to immediately exit when spawning a worker.
+      process.env.NODE_OPTIONS = '--require ${JSON.stringify(testInfo.outputPath('preload.js'))}';
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(0);
+  expect(result.failed).toBe(1);
+  expect(result.skipped).toBe(1);
+  expect(result.output).toContain('Error: unable to start subprocess: code=42, signal=null');
+});
+
+test('should ignore subprocess creation error because of SIGINT', async ({ interactWithTestRunner }, testInfo) => {
+  test.skip(process.platform === 'win32', 'No sending SIGINT on Windows');
+
+  const readyFile = testInfo.outputPath('ready.txt');
+  const testProcess = await interactWithTestRunner({
+    'hang.js': `
+      require('fs').writeFileSync(${JSON.stringify(readyFile)}, 'ready');
+      setInterval(() => {}, 1000);
+    `,
+    'preload.js': `
+      require('child_process').spawnSync(
+        process.argv[0],
+        [require('path').resolve('./hang.js')],
+        { env: { ...process.env, NODE_OPTIONS: '' } },
+      );
+    `,
+    'a.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('fails', () => {});
+      test('skipped', () => {});
+
+      // Infect subprocesses to immediately exit when spawning a worker.
+      process.env.NODE_OPTIONS = '--require ${JSON.stringify(testInfo.outputPath('preload.js'))}';
+    `
+  });
+
+  while (!fs.existsSync(readyFile))
+    await new Promise(f => setTimeout(f, 100));
+  process.kill(-testProcess.process.pid!, 'SIGINT');
+
+  const { exitCode } = await testProcess.exited;
+  expect(exitCode).toBe(130);
+
+  const result = parseTestRunnerOutput(testProcess.output);
+  expect(result.passed).toBe(0);
+  expect(result.failed).toBe(0);
+  expect(result.skipped).toBe(2);
+  expect(result.output).not.toContain('unable to start subprocess');
 });
 
 test('sigint should stop workers', async ({ interactWithTestRunner }) => {
@@ -124,7 +185,7 @@ test('sigint should stop workers', async ({ interactWithTestRunner }) => {
     PLAYWRIGHT_JSON_OUTPUT_NAME: 'report.json',
   });
   await testProcess.waitForOutput('%%SEND-SIGINT%%', 2);
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   const { exitCode } = await testProcess.exited;
   expect(exitCode).toBe(130);
 
@@ -200,7 +261,7 @@ test('worker interrupt should report errors', async ({ interactWithTestRunner })
     `,
   });
   await testProcess.waitForOutput('%%SEND-SIGINT%%');
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   const { exitCode } = await testProcess.exited;
   expect(exitCode).toBe(130);
 
@@ -378,7 +439,7 @@ test('sigint should stop global setup', async ({ interactWithTestRunner }) => {
     `,
   }, { 'workers': 1 });
   await testProcess.waitForOutput('%%SEND-SIGINT%%');
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   const { exitCode } = await testProcess.exited;
   expect(exitCode).toBe(130);
 
@@ -425,7 +486,7 @@ test('sigint should stop plugins', async ({ interactWithTestRunner }) => {
     `,
   }, { 'workers': 1 });
   await testProcess.waitForOutput('%%SEND-SIGINT%%');
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   const { exitCode } = await testProcess.exited;
   expect(exitCode).toBe(130);
 
@@ -473,7 +534,7 @@ test('sigint should stop plugins 2', async ({ interactWithTestRunner }) => {
     `,
   }, { 'workers': 1 });
   await testProcess.waitForOutput('%%SEND-SIGINT%%');
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   const { exitCode } = await testProcess.exited;
   expect(exitCode).toBe(130);
 
@@ -578,7 +639,7 @@ test('should not hang on worker error in test file', async ({ runInlineTest }) =
   }, { 'timeout': 3000 });
   expect(result.exitCode).toBe(1);
   expect(result.results[0].status).toBe('failed');
-  expect(result.results[0].error.message).toContain('Internal error: worker process exited unexpectedly');
+  expect(result.results[0].error.message).toContain('Error: worker process exited unexpectedly');
   expect(result.results[1].status).toBe('skipped');
 });
 
@@ -606,8 +667,8 @@ test('fast double SIGINT should be ignored', async ({ interactWithTestRunner }) 
   });
   await testProcess.waitForOutput('%%SEND-SIGINT%%');
   // Send SIGINT twice in quick succession.
-  process.kill(testProcess.process.pid!, 'SIGINT');
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   const { exitCode } = await testProcess.exited;
   expect(exitCode).toBe(130);
 
@@ -639,9 +700,9 @@ test('slow double SIGINT should be respected', async ({ interactWithTestRunner }
     `,
   });
   await testProcess.waitForOutput('%%SEND-SIGINT%%');
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   await new Promise(f => setTimeout(f, 2000));
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   const { exitCode } = await testProcess.exited;
   expect(exitCode).toBe(130);
 
@@ -680,10 +741,10 @@ test('slow double SIGINT should be respected in reporter.onExit', async ({ inter
     `,
   }, { reporter: '' });
   await testProcess.waitForOutput('%%SEND-SIGINT%%');
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   await new Promise(f => setTimeout(f, 2000));
   await testProcess.waitForOutput('MyReporter.onExit started');
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   const { exitCode, signal } = await testProcess.exited;
   expect(exitCode).toBe(null);
   expect(signal).toBe('SIGINT');  // Default handler should report the signal.

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -730,7 +730,7 @@ test('should forward stdout when set to "pipe" before server is ready', async ({
     `,
   }, { workers: 1 });
   await testProcess.waitForOutput('%%SEND-SIGINT%%');
-  process.kill(testProcess.process.pid!, 'SIGINT');
+  process.kill(-testProcess.process.pid!, 'SIGINT');
   await testProcess.exited;
 
   const result = parseTestRunnerOutput(testProcess.output);


### PR DESCRIPTION
When happening during a test, shows as a test error. When happening during stop, this error is ignored.

Drive-by: send SIGINT in tests to the whole tree, to better emulate Ctrl+C behavior.