### PR TITLE
fix(blob): store startTime as a number

### DIFF
--- a/packages/playwright-test/src/reporters/teleEmitter.ts
+++ b/packages/playwright-test/src/reporters/teleEmitter.ts
@@ -199,7 +199,7 @@ export class TeleReporterEmitter implements ReporterV2 {
       retry: result.retry,
       workerIndex: result.workerIndex,
       parallelIndex: result.parallelIndex,
-      startTime: result.startTime.toISOString(),
+      startTime: +result.startTime,
     };
   }
 
@@ -229,7 +229,7 @@ export class TeleReporterEmitter implements ReporterV2 {
       parentStepId: (step.parent as any)?.[idSymbol],
       title: step.title,
       category: step.category,
-      startTime: step.startTime.toISOString(),
+      startTime: +step.startTime,
       location: this._relativeLocation(step.location),
     };
   }

--- a/tests/playwright-test/reporter.spec.ts
+++ b/tests/playwright-test/reporter.spec.ts
@@ -48,6 +48,7 @@ class Reporter {
   distillStep(step) {
     return {
       ...step,
+      _startTime: undefined,
       startTime: undefined,
       duration: undefined,
       parent: undefined,


### PR DESCRIPTION
Turns out the Date objects have noticeable footprint on large suites and storing them as umber is much cheaper, e.g.:

![image](https://github.com/microsoft/playwright/assets/9798949/539028d0-3ef8-46f7-be2b-752f24604d18)
