### PR TITLE
fix(reuse): make sure newly created page is not "server-side-only"

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -495,7 +495,12 @@ export abstract class BrowserContext extends SdkObject {
     let page = this.pages()[0];
 
     const internalMetadata = serverSideCallMetadata();
-    page = page || await this.newPage(internalMetadata);
+    page = page || await this.newPage({
+      ...internalMetadata,
+      // Do not mark this page as internal, because we will leave it for later reuse
+      // as a user-visible page.
+      isServerSide: false,
+    });
     await page._setServerRequestInterceptor(handler => {
       handler.fulfill({ body: '<html></html>', requestUrl: handler.request().url() }).catch(() => {});
       return true;

--- a/tests/library/browsercontext-reuse.spec.ts
+++ b/tests/library/browsercontext-reuse.spec.ts
@@ -251,3 +251,25 @@ test('should reset tracing', async ({ reusedContext, trace }, testInfo) => {
   const error = await context.tracing.stopChunk({ path: testInfo.outputPath('trace.zip') }).catch(e => e);
   expect(error.message).toContain('tracing.stopChunk: Must start tracing before stopping');
 });
+
+test('should continue issuing events after closing the reused page', async ({ reusedContext, server }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/24574' });
+
+  {
+    const context = await reusedContext();
+    const page = await context.newPage();
+    await Promise.all([
+      page.waitForRequest(server.PREFIX + '/one-style.css'),
+      page.goto(server.PREFIX + '/one-style.html'),
+    ]);
+    await page.close();
+  }
+  {
+    const context = await reusedContext();
+    const page = context.pages()[0];
+    await Promise.all([
+      page.waitForRequest(server.PREFIX + '/one-style.css', { timeout: 10000 }),
+      page.goto(server.PREFIX + '/one-style.html'),
+    ]);
+  }
+});


### PR DESCRIPTION
This page is going to be the "page for reuse", so it should not be marked as "server-side-only" and should issue all required events.

Fixes #24574.