### PR TITLE
fix: restore portable bash paths

### DIFF
--- a/browser_patches/webkit/pw_run.sh
+++ b/browser_patches/webkit/pw_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function runOSX() {
   # if script is run as-is

--- a/browser_patches/winldd/archive.sh
+++ b/browser_patches/winldd/archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 

--- a/browser_patches/winldd/build.sh
+++ b/browser_patches/winldd/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 

--- a/browser_patches/winldd/clean.sh
+++ b/browser_patches/winldd/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set +x
 


### PR DESCRIPTION
This PR restores the portable paths that were included in #23889 but were later broken by #24079
