### PR TITLE
chore: install source map support lazily

### DIFF
--- a/packages/playwright-test/src/transform/compilationCache.ts
+++ b/packages/playwright-test/src/transform/compilationCache.ts
@@ -43,23 +43,31 @@ const fileDependencies = new Map<string, Set<string>>();
 // Dependencies resolved by the external bundler.
 const externalDependencies = new Map<string, Set<string>>();
 
-Error.stackTraceLimit = 200;
+let sourceMapSupportInstalled = false;
 
-sourceMapSupport.install({
-  environment: 'node',
-  handleUncaughtExceptions: false,
-  retrieveSourceMap(source) {
-    if (!sourceMaps.has(source))
-      return null;
-    const sourceMapPath = sourceMaps.get(source)!;
-    if (!fs.existsSync(sourceMapPath))
-      return null;
-    return {
-      map: JSON.parse(fs.readFileSync(sourceMapPath, 'utf-8')),
-      url: source
-    };
-  }
-});
+export function installSourceMapSupportIfNeeded() {
+  if (sourceMapSupportInstalled)
+    return;
+  sourceMapSupportInstalled = true;
+
+  Error.stackTraceLimit = 200;
+
+  sourceMapSupport.install({
+    environment: 'node',
+    handleUncaughtExceptions: false,
+    retrieveSourceMap(source) {
+      if (!sourceMaps.has(source))
+        return null;
+      const sourceMapPath = sourceMaps.get(source)!;
+      if (!fs.existsSync(sourceMapPath))
+        return null;
+      return {
+        map: JSON.parse(fs.readFileSync(sourceMapPath, 'utf-8')),
+        url: source
+      };
+    }
+  });
+}
 
 function _innerAddToCompilationCache(filename: string, options: { codePath: string, sourceMapPath: string, moduleUrl?: string }) {
   sourceMaps.set(options.moduleUrl || filename, options.sourceMapPath);

--- a/packages/playwright-test/src/transform/transform.ts
+++ b/packages/playwright-test/src/transform/transform.ts
@@ -25,7 +25,7 @@ import Module from 'module';
 import type { BabelPlugin, BabelTransformFunction } from './babelBundle';
 import { createFileMatcher, fileIsModule, resolveImportSpecifierExtension } from '../util';
 import type { Matcher } from '../util';
-import { getFromCompilationCache, currentFileDepsCollector, belongsToNodeModules } from './compilationCache';
+import { getFromCompilationCache, currentFileDepsCollector, belongsToNodeModules, installSourceMapSupportIfNeeded } from './compilationCache';
 
 const version = require('../../package.json').version;
 
@@ -213,6 +213,8 @@ export async function requireOrImport(file: string) {
 }
 
 function installTransform(): () => void {
+  installSourceMapSupportIfNeeded();
+
   let reverted = false;
 
   const originalResolveFilename = (Module as any)._resolveFilename;


### PR DESCRIPTION
This way we allow importing from `@playwright/test` without affecting stack traces.

Fixes #26346.