### PR TITLE
docs(test-reporters-js.md): sorted alphabetically and added Testmo

### DIFF
--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -326,8 +326,9 @@ export default defineConfig({
 ## Third party reporter showcase
 
 * [Allure](https://www.npmjs.com/package/allure-playwright)
-* [Monocart](https://github.com/cenfun/monocart-reporter)
-* [Tesults](https://www.tesults.com/docs/playwright)
-* [ReportPortal](https://github.com/reportportal/agent-js-playwright)
 * [Currents](https://www.npmjs.com/package/@currents/playwright)
+* [Monocart](https://github.com/cenfun/monocart-reporter)
+* [ReportPortal](https://github.com/reportportal/agent-js-playwright)
 * [Serenity/JS](https://serenity-js.org/handbook/test-runners/playwright-test)
+* [Testmo](https://github.com/jonasclaes/playwright-testmo-reporter)
+* [Tesults](https://www.tesults.com/docs/playwright)


### PR DESCRIPTION
docs(test-reporters-js.md): sorted alphabetically and added Testmo

This patch sorts the Third party reporters alphabetically and adds the Testmo reporter plugin to the docs.