### PR TITLE
cherry-pick(#26475): docs: terminate img tag

### DIFF
--- a/docs/src/test-sharding-js.md
+++ b/docs/src/test-sharding-js.md
@@ -123,7 +123,7 @@ jobs:
 
 To ensure the execution order, we make `merge-reports` job [depend](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#defining-prerequisite-jobs) on our sharded `playwright-tests` job.
 
-<img width="875" alt="image" src="https://github.com/microsoft/playwright/assets/9798949/b69dac59-fc19-4b98-8f49-814b1c29ca02">
+<img width="875" alt="image" src="https://github.com/microsoft/playwright/assets/9798949/b69dac59-fc19-4b98-8f49-814b1c29ca02" />
 
 ## Publishing report on the web
 


### PR DESCRIPTION
This PR cherry-picks the following commits:

- 6e51b95e2c15e714b98ec0f6dfeedcb6613a58cc