### PR TITLE
chore: fix .only in dependent tests

### DIFF
--- a/packages/playwright-test/src/plugins/webServerPlugin.ts
+++ b/packages/playwright-test/src/plugins/webServerPlugin.ts
@@ -116,7 +116,6 @@ export class WebServerPlugin implements TestRunnerPlugin {
         this._reporter!.onStdErr?.(colors.dim('[WebServer] ') + line.toString());
     });
     launchedProcess.stdout!.on('data', line => {
-      process.stdout.write(line);
       if (debugWebServer.enabled || this._options.stdout === 'pipe')
         this._reporter!.onStdOut?.(colors.dim('[WebServer] ') + line.toString());
     });

--- a/packages/playwright-test/src/runner/projectUtils.ts
+++ b/packages/playwright-test/src/runner/projectUtils.ts
@@ -70,8 +70,7 @@ export function buildProjectsClosure(projects: FullProjectInternal[], hasTests?:
       throw error;
     }
 
-    const projectHasTests = hasTests ? hasTests(project) : true;
-    if (!projectHasTests && depth === 0)
+    if (depth === 0 && hasTests && !hasTests(project))
       return;
 
     if (result.get(project) !== 'dependency')


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/26492
Fixes https://github.com/microsoft/playwright/issues/26496