### PR TITLE
chore: error on unused eslint disables

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ttest": "node ./tests/playwright-test/stable-test-runner/node_modules/@playwright/test/cli test --config=tests/playwright-test/playwright.config.ts",
     "ct": "playwright test tests/components/test-all.spec.js --reporter=list",
     "test": "playwright test --config=tests/library/playwright.config.ts",
-    "eslint": "eslint --cache --ext ts,tsx .",
+    "eslint": "eslint --cache --report-unused-disable-directives --ext ts,tsx .",
     "tsc": "tsc -p .",
     "build-installer": "babel -s --extensions \".ts\" --out-dir packages/playwright-core/lib/utils/ packages/playwright-core/src/utils",
     "doc": "node utils/doclint/cli.js",

--- a/packages/playwright-core/src/cli/driver.ts
+++ b/packages/playwright-core/src/cli/driver.ts
@@ -70,7 +70,7 @@ export async function runServer(options: RunServerOptions) {
   const server = new PlaywrightServer({ mode: extension ? 'extension' : 'default', path, maxConnections });
   const wsEndpoint = await server.listen(port);
   process.on('exit', () => server.close().catch(console.error));
-  console.log('Listening on ' + wsEndpoint);  // eslint-disable-line no-console
+  console.log('Listening on ' + wsEndpoint);
   process.stdin.on('close', () => gracefullyProcessExitDoNotHang(0));
 }
 

--- a/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
+++ b/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
@@ -121,7 +121,6 @@ function getAnimatedDownloadProgress(): OnProgressCallback {
 }
 
 function getBasicDownloadProgress(): OnProgressCallback {
-  // eslint-disable-next-line no-console
   const totalRows = 10;
   const stepWidth = 8;
   let lastRow = -1;

--- a/packages/playwright-test/src/plugins/webServerPlugin.ts
+++ b/packages/playwright-test/src/plugins/webServerPlugin.ts
@@ -207,7 +207,6 @@ function getIsAvailableFunction(url: string, checkPortOnly: boolean, ignoreHTTPS
 }
 
 export const webServer = (options: WebServerPluginOptions): TestRunnerPlugin => {
-  // eslint-disable-next-line no-console
   return new WebServerPlugin(options, false);
 };
 

--- a/packages/playwright-test/src/reporters/list.ts
+++ b/packages/playwright-test/src/reporters/list.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-console */
 import { colors, ms as milliseconds } from 'playwright-core/lib/utilsBundle';
 import { BaseReporter, formatError, formatTestTitle, stepSuffix, stripAnsiEscapes } from './base';
 import type { FullResult, Suite, TestCase, TestError, TestResult, TestStep } from '../../types/testReporter';

--- a/packages/trace-viewer/src/ui/stackTrace.tsx
+++ b/packages/trace-viewer/src/ui/stackTrace.tsx
@@ -18,7 +18,6 @@ import * as React from 'react';
 import './stackTrace.css';
 import type { ActionTraceEvent } from '@trace/trace';
 import { ListView } from '@web/components/listView';
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import type { StackFrame } from '@protocol/channels';
 
 const StackFrameListView = ListView<StackFrame>;


### PR DESCRIPTION
# What?

Fail the CI/Local build if we are using eslint-disable spuriously .


More information -> [here](https://eslint.org/docs/latest/use/command-line-interface#:~:text=%2D%2Dreport%2Dunused%2Ddisable%2Ddirectives,-This%20option%20causes&text=This%20can%20be%20useful%20to,which%20are%20no%20longer%20applicable.&text=When%20using%20this%20option%2C%20it,or%20custom%20rules%20are%20upgraded.)

# Why?

It can be confusing seeing an `eslint-disable` in code and there is no actual violation. Like found here : 

```
export const webServer = (options: WebServerPluginOptions): TestRunnerPlugin => {
  // eslint-disable-next-line no-console
  return new WebServerPlugin(options, false);
};
```

This most likely was a re-factoring or debt reduction which the author forgot to remove the `eslint-disable` statement.



