### PR TITLE
chore: Remove old webpack folder structure

### DIFF
--- a/packages/html-reporter/bundle.js
+++ b/packages/html-reporter/bundle.js
@@ -45,7 +45,7 @@ export function bundle() {
     },
     closeBundle: () => {
       if (existsSync(path.join(config.build.outDir, 'index.html'))) {
-        const targetDir = path.join(__dirname, '..', 'playwright-core', 'lib', 'webpack', 'htmlReport');
+        const targetDir = path.join(__dirname, '..', 'playwright-core', 'lib', 'vite', 'htmlReport');
         fs.mkdirSync(targetDir, { recursive: true });
         fs.copyFileSync(
           path.join(config.build.outDir, 'index.html'),

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -85,7 +85,7 @@ export class RecorderApp extends EventEmitter implements IRecorderApp {
         return false;
 
       const uri = route.request().url().substring('https://playwright/'.length);
-      const file = require.resolve('../../webpack/vite/' + uri);
+      const file = require.resolve('../../vite/recorder/' + uri);
       fs.promises.readFile(file).then(buffer => {
         route.fulfill({
           requestUrl: route.request().url(),

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -85,7 +85,7 @@ export class RecorderApp extends EventEmitter implements IRecorderApp {
         return false;
 
       const uri = route.request().url().substring('https://playwright/'.length);
-      const file = require.resolve('../../webpack/recorder/' + uri);
+      const file = require.resolve('../../webpack/vite/' + uri);
       fs.promises.readFile(file).then(buffer => {
         route.fulfill({
           requestUrl: route.request().url(),

--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -81,7 +81,7 @@ async function startTraceViewerServer(traceUrls: string[], options?: OpenTraceVi
         return false;
       }
     }
-    const absolutePath = path.join(__dirname, '..', '..', '..', 'webpack', 'traceViewer', ...relativePath.split('/'));
+    const absolutePath = path.join(__dirname, '..', '..', '..', 'vite', 'traceViewer', ...relativePath.split('/'));
     return server.serveFile(request, response, absolutePath);
   });
 

--- a/packages/playwright-test/src/reporters/html.ts
+++ b/packages/playwright-test/src/reporters/html.ts
@@ -287,12 +287,12 @@ class HtmlBuilder {
     this._addDataFile('report.json', htmlReport);
 
     // Copy app.
-    const appFolder = path.join(require.resolve('playwright-core'), '..', 'lib', 'webpack', 'htmlReport');
+    const appFolder = path.join(require.resolve('playwright-core'), '..', 'lib', 'vite', 'htmlReport');
     await copyFileAndMakeWritable(path.join(appFolder, 'index.html'), path.join(this._reportFolder, 'index.html'));
 
     // Copy trace viewer.
     if (this._hasTraces) {
-      const traceViewerFolder = path.join(require.resolve('playwright-core'), '..', 'lib', 'webpack', 'traceViewer');
+      const traceViewerFolder = path.join(require.resolve('playwright-core'), '..', 'lib', 'vite', 'traceViewer');
       const traceViewerTargetFolder = path.join(this._reportFolder, 'trace');
       const traceViewerAssetsTargetFolder = path.join(traceViewerTargetFolder, 'assets');
       fs.mkdirSync(traceViewerAssetsTargetFolder, { recursive: true });

--- a/packages/recorder/vite.config.ts
+++ b/packages/recorder/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: path.resolve(__dirname, '../playwright-core/lib/webpack/recorder'),
+    outDir: path.resolve(__dirname, '../playwright-core/lib/vite/recorder'),
     emptyOutDir: true,
     rollupOptions: {
       output: {

--- a/packages/trace-viewer/vite.config.ts
+++ b/packages/trace-viewer/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: path.resolve(__dirname, '../playwright-core/lib/webpack/traceViewer'),
+    outDir: path.resolve(__dirname, '../playwright-core/lib/vite/traceViewer'),
     // Output dir is shared with vite.sw.config.ts, clearing it here is racy.
     emptyOutDir: false,
     rollupOptions: {

--- a/packages/trace-viewer/vite.sw.config.ts
+++ b/packages/trace-viewer/vite.sw.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: path.resolve(__dirname, '../playwright-core/lib/webpack/traceViewer'),
+    outDir: path.resolve(__dirname, '../playwright-core/lib/vite/traceViewer'),
     // Output dir is shared with vite.config.ts, clearing it here is racy.
     emptyOutDir: false,
     rollupOptions: {

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -348,7 +348,7 @@ copyFiles.push({
   files: 'packages/playwright-core/src/**/*.js',
   from: 'packages/playwright-core/src',
   to: 'packages/playwright-core/lib',
-  ignored: ['**/.eslintrc.js', '**/webpack*.config.js', '**/injected/**/*']
+  ignored: ['**/.eslintrc.js', '**/injected/**/*']
 });
 
 // Sometimes we require JSON files that babel ignores.

--- a/utils/build/deploy-trace-viewer.sh
+++ b/utils/build/deploy-trace-viewer.sh
@@ -35,7 +35,7 @@ git clone "https://${GH_SERVICE_ACCOUNT_TOKEN}@github.com/microsoft/trace.playwr
 if [[ "${RELEASE_CHANNEL}" == "--stable" ]]; then
   rm -rf trace.playwright.dev/docs/
   mkdir trace.playwright.dev/docs/
-  cp -r packages/playwright-core/lib/webpack/traceViewer/* trace.playwright.dev/docs/
+  cp -r packages/playwright-core/lib/vite/* trace.playwright.dev/docs/
 
   # Restore CNAME, beta/ & next/ branches.
   cd trace.playwright.dev/
@@ -47,11 +47,11 @@ if [[ "${RELEASE_CHANNEL}" == "--stable" ]]; then
   echo "Updated stable version"
 elif [[ "${RELEASE_CHANNEL}" == "--canary" ]]; then
   rm -rf trace.playwright.dev/docs/next/
-  cp -r packages/playwright-core/lib/webpack/traceViewer/ trace.playwright.dev/docs/next/
+  cp -r packages/playwright-core/lib/vite/ trace.playwright.dev/docs/next/
   echo "Updated canary version"
 elif [[ "${RELEASE_CHANNEL}" == "--beta" ]]; then
   rm -rf trace.playwright.dev/docs/beta/
-  cp -r packages/playwright-core/lib/webpack/traceViewer/ trace.playwright.dev/docs/beta/
+  cp -r packages/playwright-core/lib/vite/traceViewer/ trace.playwright.dev/docs/beta/
   echo "Updated beta version"
 else
   echo "ERROR: unknown environment - ${RELEASE_CHANNEL}"

--- a/utils/build/deploy-trace-viewer.sh
+++ b/utils/build/deploy-trace-viewer.sh
@@ -35,7 +35,7 @@ git clone "https://${GH_SERVICE_ACCOUNT_TOKEN}@github.com/microsoft/trace.playwr
 if [[ "${RELEASE_CHANNEL}" == "--stable" ]]; then
   rm -rf trace.playwright.dev/docs/
   mkdir trace.playwright.dev/docs/
-  cp -r packages/playwright-core/lib/vite/* trace.playwright.dev/docs/
+  cp -r packages/playwright-core/lib/vite/traceViewer/* trace.playwright.dev/docs/
 
   # Restore CNAME, beta/ & next/ branches.
   cd trace.playwright.dev/
@@ -47,7 +47,7 @@ if [[ "${RELEASE_CHANNEL}" == "--stable" ]]; then
   echo "Updated stable version"
 elif [[ "${RELEASE_CHANNEL}" == "--canary" ]]; then
   rm -rf trace.playwright.dev/docs/next/
-  cp -r packages/playwright-core/lib/vite/ trace.playwright.dev/docs/next/
+  cp -r packages/playwright-core/lib/vite/traceViewer/ trace.playwright.dev/docs/next/
   echo "Updated canary version"
 elif [[ "${RELEASE_CHANNEL}" == "--beta" ]]; then
   rm -rf trace.playwright.dev/docs/beta/


### PR DESCRIPTION
Renamed the output folders from `webpack` to `vite` to remove some confusion with how the build system works internally in Playwright.

Also removed the `webpack.config` filter since there are no longer any webpack config files present.