### PR TITLE
docs: fix duplicate java release note metadata

### DIFF
--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -4,12 +4,6 @@ title: "Release notes"
 toc_max_heading_level: 2
 ---
 
----
-id: release-notes
-title: "Release notes"
-toc_max_heading_level: 2
----
-
 import LiteYouTube from '@site/src/components/LiteYouTube';
 
 ## Version 1.37

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -4,7 +4,6 @@ title: "Release notes"
 toc_max_heading_level: 2
 ---
 
-
 ## Version 1.37
 
 ### New APIs

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -4,7 +4,6 @@ title: "Release notes"
 toc_max_heading_level: 2
 ---
 
-import LiteYouTube from '@site/src/components/LiteYouTube';
 
 ## Version 1.37
 


### PR DESCRIPTION
Removes error in Java docs release notes.

See error here: https://playwright.dev/java/docs/release-notes#version-137

<img width="423" alt="Screenshot 2023-08-19 at 13 24 21" src="https://github.com/microsoft/playwright/assets/744973/642a5826-b6de-4f52-b813-f11b9c9291c0">

Error introduced in https://github.com/microsoft/playwright/pull/23272/files#diff-c1b54f88858fed99e46accdabfad715ec26a04cfe558a5b679ff812e0a37df5fR7-R11