### PR TITLE
fix(ct): vue jsx mount options type

### DIFF
--- a/packages/playwright-ct-vue/index.d.ts
+++ b/packages/playwright-ct-vue/index.d.ts
@@ -53,6 +53,10 @@ export interface MountOptions<HooksConfig extends JsonObject, Component> {
   hooksConfig?: HooksConfig;
 }
 
+export interface MountOptionsJsx<HooksConfig extends JsonObject> {
+  hooksConfig?: HooksConfig;
+}
+
 interface MountResult<Component> extends Locator {
   unmount(): Promise<void>;
   update(options: {
@@ -68,7 +72,10 @@ interface MountResultJsx extends Locator {
 }
 
 export interface ComponentFixtures {
-  mount(component: JSX.Element): Promise<MountResultJsx>;
+  mount<HooksConfig extends JsonObject>(
+    component: JSX.Element,
+    options: MountOptionsJsx<HooksConfig>
+  ): Promise<MountResultJsx>;
   mount<HooksConfig extends JsonObject, Component = unknown>(
     component: Component,
     options?: MountOptions<HooksConfig, Component>

--- a/packages/playwright-ct-vue2/index.d.ts
+++ b/packages/playwright-ct-vue2/index.d.ts
@@ -53,6 +53,10 @@ export interface MountOptions<HooksConfig extends JsonObject, Component> {
   hooksConfig?: HooksConfig;
 }
 
+export interface MountOptionsJsx<HooksConfig extends JsonObject> {
+  hooksConfig?: HooksConfig;
+}
+
 interface MountResult<Component> extends Locator {
   unmount(): Promise<void>;
   update(options: {
@@ -68,7 +72,10 @@ interface MountResultJsx extends Locator {
 }
 
 export interface ComponentFixtures {
-  mount(component: JSX.Element): Promise<MountResultJsx>;
+  mount<HooksConfig extends JsonObject>(
+    component: JSX.Element,
+    options?: MountOptionsJsx<HooksConfig>
+  ): Promise<MountResultJsx>;
   mount<HooksConfig extends JsonObject, Component = unknown>(
     component: Component,
     options?: MountOptions<HooksConfig, Component>


### PR DESCRIPTION
Removes the `props`, `on` and `slots` properties from the `.tsx` API:

```tsx
const component = await mount(<App />, {
  hooksConfig: { routing: true },
  props: { boop: '' } // Should not work in `.tsx`. This is only allowed in `.ts`
  ...
});
```