### PR TITLE
docs(api): remove confusing async/await in generic assertions example

### DIFF
--- a/docs/src/api/class-genericassertions.md
+++ b/docs/src/api/class-genericassertions.md
@@ -9,7 +9,7 @@ import { test, expect } from '@playwright/test';
 
 test('assert a value', async ({ page }) => {
   const value = 1;
-  await expect(value).toBe(2);
+  expect(value).toBe(2);
 });
 ```
 
@@ -21,7 +21,7 @@ Makes the assertion check for the opposite condition. For example, the following
 
 ```js
 const value = 1;
-await expect(value).not.toBe(2);
+expect(value).not.toBe(2);
 ```
 
 

--- a/packages/playwright-test/types/test.d.ts
+++ b/packages/playwright-test/types/test.d.ts
@@ -4537,7 +4537,7 @@ type ExtraMatchers<T, Type, Matchers> = T extends Type ? Matchers : IfAny<T, Mat
  *
  * test('assert a value', async ({ page }) => {
  *   const value = 1;
- *   await expect(value).toBe(2);
+ *   expect(value).toBe(2);
  * });
  * ```
  *
@@ -4548,7 +4548,7 @@ interface GenericAssertions<R> {
    *
    * ```js
    * const value = 1;
-   * await expect(value).not.toBe(2);
+   * expect(value).not.toBe(2);
    * ```
    *
    */


### PR DESCRIPTION
The use of async/await is confusing, as it implies that `toBe()` is an async assertion.