### PR TITLE
feat(webkit): roll to r1893

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "webkit",
-      "revision": "1887",
+      "revision": "1893",
       "installByDefault": true,
       "revisionOverrides": {
         "mac10.14": "1446",

--- a/packages/playwright-core/src/server/webkit/protocol.d.ts
+++ b/packages/playwright-core/src/server/webkit/protocol.d.ts
@@ -7532,6 +7532,25 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     export type grantFileReadAccessReturnValue = {
     }
     /**
+     * Capture a snapshot of the page.
+     */
+    export type takePageScreenshotParameters = {
+      /**
+       * Unique identifier of the page proxy.
+       */
+      pageProxyId: PageProxyID;
+      /**
+       * By default, screenshot is inflated by device scale factor to avoid blurry image. This flag disables it.
+       */
+      omitDeviceScaleFactor?: boolean;
+    }
+    export type takePageScreenshotReturnValue = {
+      /**
+       * Base64-encoded image data (PNG).
+       */
+      dataURL: string;
+    }
+    /**
      * Change whether all certificate errors should be ignored.
      */
     export type setIgnoreCertificateErrorsParameters = {
@@ -9419,6 +9438,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     "Playwright.createPage": Playwright.createPageParameters;
     "Playwright.navigate": Playwright.navigateParameters;
     "Playwright.grantFileReadAccess": Playwright.grantFileReadAccessParameters;
+    "Playwright.takePageScreenshot": Playwright.takePageScreenshotParameters;
     "Playwright.setIgnoreCertificateErrors": Playwright.setIgnoreCertificateErrorsParameters;
     "Playwright.getAllCookies": Playwright.getAllCookiesParameters;
     "Playwright.setCookies": Playwright.setCookiesParameters;
@@ -9728,6 +9748,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     "Playwright.createPage": Playwright.createPageReturnValue;
     "Playwright.navigate": Playwright.navigateReturnValue;
     "Playwright.grantFileReadAccess": Playwright.grantFileReadAccessReturnValue;
+    "Playwright.takePageScreenshot": Playwright.takePageScreenshotReturnValue;
     "Playwright.setIgnoreCertificateErrors": Playwright.setIgnoreCertificateErrorsReturnValue;
     "Playwright.getAllCookies": Playwright.getAllCookiesReturnValue;
     "Playwright.setCookies": Playwright.setCookiesReturnValue;

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -274,8 +274,7 @@ it('requestFullscreen', async ({ page, server, browserName, headless, isLinux })
 
 it('should send no Content-Length header for GET requests with a Content-Type', async ({ page, server, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22569' });
-  it.skip(browserName === 'webkit' && hostPlatform === 'ubuntu20.04', 'libsoup2.4 bug');
-  it.fixme(browserName === 'webkit' && hostPlatform === 'ubuntu22.04', 'waiting for libsoup3 upgrade');
+  it.skip(browserName === 'webkit' && hostPlatform?.startsWith('ubuntu20.04'), 'libsoup2.4 bug');
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     server.waitForRequest('/empty.html'),

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -274,7 +274,7 @@ it('requestFullscreen', async ({ page, server, browserName, headless, isLinux })
 
 it('should send no Content-Length header for GET requests with a Content-Type', async ({ page, server, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22569' });
-  it.skip(browserName === 'webkit' && hostPlatform?.startsWith('ubuntu20.04'), 'libsoup2.4 bug');
+  it.skip(browserName === 'webkit' && (hostPlatform.startsWith('ubuntu20.04') || hostPlatform.startsWith('debian11')), 'libsoup2.4 has a bug for this');
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     server.waitForRequest('/empty.html'),

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -23,6 +23,7 @@ import type { BrowserContext, BrowserContextOptions } from 'playwright-core';
 import type { AddressInfo } from 'net';
 import type { Log } from '../../packages/trace/src/har';
 import { parseHar } from '../config/utils';
+const { hostPlatform } = require('playwright-core/lib/utils');
 
 async function pageWithHar(contextFactory: (options?: BrowserContextOptions) => Promise<BrowserContext>, testInfo: any, options: { outputPath?: string, content?: 'embed' | 'attach' | 'omit', omitContent?: boolean } = {}) {
   const harPath = testInfo.outputPath(options.outputPath || 'test.har');
@@ -672,7 +673,7 @@ it('should return security details directly from response', async ({ contextFact
 });
 
 it('should contain http2 for http2 requests', async ({ contextFactory, browserName, platform }, testInfo) => {
-  it.fixme(browserName === 'webkit' && platform === 'linux');
+  it.skip(browserName === 'webkit' && platform === 'linux' && (hostPlatform.startsWith('ubuntu20.04') || hostPlatform.startsWith('debian11')), 'libsoup2.4 does not support http2');
   it.fixme(browserName === 'webkit' && platform === 'win32');
 
   const server = http2.createSecureServer({


### PR DESCRIPTION
This should make it into v1.38 and once its merged one day later it can be tested in [Playwright Canary](https://playwright.dev/docs/canary-releases).

Fixes https://github.com/microsoft/playwright/issues/22569
Fixes https://github.com/microsoft/playwright/issues/23259
