### PR TITLE
docs: use absolute paths for file uploads

### DIFF
--- a/docs/src/api/class-filechooser.md
+++ b/docs/src/api/class-filechooser.md
@@ -8,7 +8,7 @@
 const fileChooserPromise = page.waitForEvent('filechooser');
 await page.getByText('Upload file').click();
 const fileChooser = await fileChooserPromise;
-await fileChooser.setFiles('myfile.pdf');
+await fileChooser.setFiles(path.join(__dirname, 'myfile.pdf'));
 ```
 
 ```java

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -1974,7 +1974,10 @@ Upload file or multiple files into `<input type=file>`.
 await page.getByLabel('Upload file').setInputFiles(path.join(__dirname, 'myfile.pdf'));
 
 // Select multiple files
-await page.getByLabel('Upload files').setInputFiles([path.join(__dirname, 'file1.txt'), path.join(__dirname, 'file2.txt')]);
+await page.getByLabel('Upload files').setInputFiles([
+  path.join(__dirname, 'file1.txt'),
+  path.join(__dirname, 'file2.txt'),
+]);
 
 // Remove all the selected files
 await page.getByLabel('Upload file').setInputFiles([]);

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -1971,10 +1971,10 @@ Upload file or multiple files into `<input type=file>`.
 
 ```js
 // Select one file
-await page.getByLabel('Upload file').setInputFiles('myfile.pdf');
+await page.getByLabel('Upload file').setInputFiles(path.join(__dirname, 'myfile.pdf'));
 
 // Select multiple files
-await page.getByLabel('Upload files').setInputFiles(['file1.txt', 'file2.txt']);
+await page.getByLabel('Upload files').setInputFiles([path.join(__dirname, 'file1.txt'), path.join(__dirname, 'file2.txt')]);
 
 // Remove all the selected files
 await page.getByLabel('Upload file').setInputFiles([]);

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -339,7 +339,7 @@ respond to it via setting the input files using [`method: FileChooser.setFiles`]
 
 ```js
 page.on('filechooser', async fileChooser => {
-  await fileChooser.setFiles('/tmp/myfile.pdf');
+  await fileChooser.setFiles(path.join(__dirname, '/tmp/myfile.pdf'));
 });
 ```
 

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -516,10 +516,10 @@ You can select input files for upload using the [`method: Locator.setInputFiles`
 
 ```js
 // Select one file
-await page.getByLabel('Upload file').setInputFiles('myfile.pdf');
+await page.getByLabel('Upload file').setInputFiles(path.join(__dirname, 'myfile.pdf'));
 
 // Select multiple files
-await page.getByLabel('Upload files').setInputFiles(['file1.txt', 'file2.txt']);
+await page.getByLabel('Upload files').setInputFiles([path.join(__dirname, 'file1.txt'), path.join(__dirname, 'file2.txt')]);
 
 // Remove all the selected files
 await page.getByLabel('Upload file').setInputFiles([]);
@@ -610,7 +610,7 @@ or use a corresponding waiting method upon your action:
 const fileChooserPromise = page.waitForEvent('filechooser');
 await page.getByLabel('Upload file').click();
 const fileChooser = await fileChooserPromise;
-await fileChooser.setFiles('myfile.pdf');
+await fileChooser.setFiles(path.join(__dirname, 'myfile.pdf'));
 ```
 
 ```java

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -520,8 +520,8 @@ await page.getByLabel('Upload file').setInputFiles(path.join(__dirname, 'myfile.
 
 // Select multiple files
 await page.getByLabel('Upload files').setInputFiles([
-    path.join(__dirname, 'file1.txt'),
-    path.join(__dirname, 'file2.txt'),
+  path.join(__dirname, 'file1.txt'),
+  path.join(__dirname, 'file2.txt'),
 ]);
 
 // Remove all the selected files

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -519,7 +519,10 @@ You can select input files for upload using the [`method: Locator.setInputFiles`
 await page.getByLabel('Upload file').setInputFiles(path.join(__dirname, 'myfile.pdf'));
 
 // Select multiple files
-await page.getByLabel('Upload files').setInputFiles([path.join(__dirname, 'file1.txt'), path.join(__dirname, 'file2.txt')]);
+await page.getByLabel('Upload files').setInputFiles([
+    path.join(__dirname, 'file1.txt'),
+    path.join(__dirname, 'file2.txt'),
+]);
 
 // Remove all the selected files
 await page.getByLabel('Upload file').setInputFiles([]);

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -12227,7 +12227,10 @@ export interface Locator {
    * await page.getByLabel('Upload file').setInputFiles(path.join(__dirname, 'myfile.pdf'));
    *
    * // Select multiple files
-   * await page.getByLabel('Upload files').setInputFiles([path.join(__dirname, 'file1.txt'), path.join(__dirname, 'file2.txt')]);
+   * await page.getByLabel('Upload files').setInputFiles([
+   *   path.join(__dirname, 'file1.txt'),
+   *   path.join(__dirname, 'file2.txt'),
+   * ]);
    *
    * // Remove all the selected files
    * await page.getByLabel('Upload file').setInputFiles([]);

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -982,7 +982,7 @@ export interface Page {
    *
    * ```js
    * page.on('filechooser', async fileChooser => {
-   *   await fileChooser.setFiles('/tmp/myfile.pdf');
+   *   await fileChooser.setFiles(path.join(__dirname, '/tmp/myfile.pdf'));
    * });
    * ```
    *
@@ -1278,7 +1278,7 @@ export interface Page {
    *
    * ```js
    * page.on('filechooser', async fileChooser => {
-   *   await fileChooser.setFiles('/tmp/myfile.pdf');
+   *   await fileChooser.setFiles(path.join(__dirname, '/tmp/myfile.pdf'));
    * });
    * ```
    *
@@ -1669,7 +1669,7 @@ export interface Page {
    *
    * ```js
    * page.on('filechooser', async fileChooser => {
-   *   await fileChooser.setFiles('/tmp/myfile.pdf');
+   *   await fileChooser.setFiles(path.join(__dirname, '/tmp/myfile.pdf'));
    * });
    * ```
    *
@@ -4334,7 +4334,7 @@ export interface Page {
    *
    * ```js
    * page.on('filechooser', async fileChooser => {
-   *   await fileChooser.setFiles('/tmp/myfile.pdf');
+   *   await fileChooser.setFiles(path.join(__dirname, '/tmp/myfile.pdf'));
    * });
    * ```
    *
@@ -12224,10 +12224,10 @@ export interface Locator {
    *
    * ```js
    * // Select one file
-   * await page.getByLabel('Upload file').setInputFiles('myfile.pdf');
+   * await page.getByLabel('Upload file').setInputFiles(path.join(__dirname, 'myfile.pdf'));
    *
    * // Select multiple files
-   * await page.getByLabel('Upload files').setInputFiles(['file1.txt', 'file2.txt']);
+   * await page.getByLabel('Upload files').setInputFiles([path.join(__dirname, 'file1.txt'), path.join(__dirname, 'file2.txt')]);
    *
    * // Remove all the selected files
    * await page.getByLabel('Upload file').setInputFiles([]);
@@ -17122,7 +17122,7 @@ export interface Electron {
  * const fileChooserPromise = page.waitForEvent('filechooser');
  * await page.getByText('Upload file').click();
  * const fileChooser = await fileChooserPromise;
- * await fileChooser.setFiles('myfile.pdf');
+ * await fileChooser.setFiles(path.join(__dirname, 'myfile.pdf'));
  * ```
  *
  */


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/26536

This makes it a bit harder for MJS customers, but I guess they know that they can do

    const dirname = path.dirname(url.fileURLToPath(import.meta.url));
