### PR TITLE
docs(chrome-extensions-js-python.md): remove conflict import

### DIFF
--- a/docs/src/chrome-extensions-js-python.md
+++ b/docs/src/chrome-extensions-js-python.md
@@ -102,7 +102,7 @@ To have the extension loaded when running tests you can use a test fixture to se
 First, add fixtures that will load the extension:
 
 ```js title="fixtures.ts"
-import { test as base, expect, chromium, type BrowserContext } from '@playwright/test';
+import { test as base, chromium, type BrowserContext } from '@playwright/test';
 import path from 'path';
 
 export const test = base.extend<{


### PR DESCRIPTION
Hi there,

The `expect` in the import is conflict with the exported `expect`. And we don't need to import `expect` here: 

`import { test as base, expect, chromium, type BrowserContext } from '@playwright/test';`

since we will `export const expect = test.expect;`