### PR TITLE
fix(test runner): make sure static annotations are reported for skipped tests

### DIFF
--- a/packages/playwright-test/src/common/suiteUtils.ts
+++ b/packages/playwright-test/src/common/suiteUtils.ts
@@ -68,6 +68,7 @@ export function bindFileSuiteToProject(project: FullProjectInternal, suite: Suit
     }
     test.retries = inheritedRetries ?? project.project.retries;
     test.timeout = inheritedTimeout ?? project.project.timeout;
+    test.annotations = [...test._staticAnnotations];
 
     // Skip annotations imply skipped expectedStatus.
     if (test._staticAnnotations.some(a => a.type === 'skip' || a.type === 'fixme'))

--- a/packages/playwright-test/src/common/test.ts
+++ b/packages/playwright-test/src/common/test.ts
@@ -292,6 +292,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
       poolDigest: this._poolDigest,
       workerHash: this._workerHash,
       staticAnnotations: this._staticAnnotations.slice(),
+      annotations: this.annotations.slice(),
       projectId: this._projectId,
     };
   }
@@ -307,6 +308,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
     test._poolDigest = data.poolDigest;
     test._workerHash = data.workerHash;
     test._staticAnnotations = data.staticAnnotations;
+    test.annotations = data.annotations;
     test._projectId = data.projectId;
     return test;
   }

--- a/packages/playwright-test/src/runner/dispatcher.ts
+++ b/packages/playwright-test/src/runner/dispatcher.ts
@@ -76,7 +76,6 @@ export class Dispatcher {
         const result = test._appendTestResult();
         result.status = 'skipped';
         this._reporter.onTestBegin(test, result);
-        test.annotations = [...test._staticAnnotations];
         this._reportTestEnd(test, result);
       }
       this._queue.shift();


### PR DESCRIPTION
Fixes #26397.