### PR TITLE
fix: process host early exit race

### DIFF
--- a/packages/playwright-test/src/runner/processHost.ts
+++ b/packages/playwright-test/src/runner/processHost.ts
@@ -28,7 +28,7 @@ export type ProcessExitData = {
 };
 
 export class ProcessHost extends EventEmitter {
-  private process!: child_process.ChildProcess;
+  private process: child_process.ChildProcess | undefined;
   private _didSendStop = false;
   private _didFail = false;
   private didExit = false;
@@ -85,7 +85,7 @@ export class ProcessHost extends EventEmitter {
     });
 
     await new Promise<void>((resolve, reject) => {
-      this.process.once('exit', (code, signal) => reject(new Error(`process exited with code "${code}" and signal "${signal}" before it became ready`)));
+      this.process!.once('exit', (code, signal) => reject(new Error(`process exited with code "${code}" and signal "${signal}" before it became ready`)));
       this.once('ready', () => resolve());
     });
 
@@ -154,6 +154,6 @@ export class ProcessHost extends EventEmitter {
   private send(message: { method: string, params?: any }) {
     if (debug.enabled('pw:test:protocol'))
       debug('pw:test:protocol')('SEND ► ' + JSON.stringify(message));
-    this.process.send(message);
+    this.process?.send(message);
   }
 }


### PR DESCRIPTION
If you start the test-runner and return directly after, then sometimes I hit the following:

```ts
root@codespaces-cc8eed:/workspaces/playwright# npm run etest -- --headed age-goto.spec.ts:266

> playwright-internal@1.38.0-next etest
> playwright test --config=tests/electron/playwright.config.ts --headed age-goto.spec.ts:266

^C
Running 1 test using 1 worker
TypeError: Cannot read properties of undefined (reading 'send')

   at ../packages/playwright-test/src/runner/processHost.ts:157

  155 |     if (debug.enabled('pw:test:protocol'))
  156 |       debug('pw:test:protocol')('SEND ► ' + JSON.stringify(message));
> 157 |     this.process.send(message);
      |                  ^
  158 |   }
  159 | }
  160 |

    at WorkerHost.send (/workspaces/playwright/packages/playwright-test/src/runner/processHost.ts:157:18)
    at WorkerHost.stop (/workspaces/playwright/packages/playwright-test/src/runner/processHost.ts:136:12)
    at WorkerHost.stop (/workspaces/playwright/packages/playwright-test/src/runner/workerHost.ts:61:17)
    at map (/workspaces/playwright/packages/playwright-test/src/runner/dispatcher.ts:513:69)
    at Array.map (<anonymous>)
    at Dispatcher.stop (/workspaces/playwright/packages/playwright-test/src/runner/dispatcher.ts:513:41)
    at Object.call [as setup] (/workspaces/playwright/packages/playwright-test/src/runner/tasks.ts:310:26)
    at taskLoop (/workspaces/playwright/packages/playwright-test/src/runner/taskRunner.ts:68:17)
    at TaskRunner.runDeferCleanup (/workspaces/playwright/packages/playwright-test/src/runner/taskRunner.ts:86:7)
    at cleanup (/workspaces/playwright/packages/playwright-test/src/runner/taskRunner.ts:110:42)
    at TaskRunner.run (/workspaces/playwright/packages/playwright-test/src/runner/taskRunner.ts:46:34)
    at Runner.runAllTests (/workspaces/playwright/packages/playwright-test/src/runner/runner.ts:89:24)
    at runTests (/workspaces/playwright/packages/playwright-test/src/cli.ts:144:14)
    at _Command.<anonymous> (/workspaces/playwright/packages/playwright-test/src/cli.ts:44:7)
```