### PR TITLE
fix(test.fail): expect() failure should not skip future tests

### DIFF
--- a/packages/playwright-test/src/worker/workerMain.ts
+++ b/packages/playwright-test/src/worker/workerMain.ts
@@ -193,7 +193,7 @@ export class WorkerMain extends ProcessRunner {
     // The only exception is the expect() error that we still consider ok.
     const isExpectError = (error instanceof Error) && !!(error as any).matcherResult;
     if (isExpectError) {
-      // Note: do not stop the worker, because test.fail() that fails an assertion
+      // Note: do not stop the worker, because test marked with test.fail() that fails an assertion
       // is perfectly fine.
       this._currentTest._failWithError(serializeError(error), true /* isHardError */);
     } else {


### PR DESCRIPTION
We used to stop the worker that would skip future tests. Regressed in https://github.com/microsoft/playwright/pull/11850.

Fixes #26435.