### PR TITLE
fix(textContent): make it work for ShadowRoot

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -208,6 +208,12 @@ export class InjectedScript {
       throw this.createStacklessError('Internal error: there should not be a capture in the selector.');
     }
 
+    // Workaround so that ":scope" matches the ShadowRoot.
+    // This is, unfortunately, because an ElementHandle can point to any Node (including ShadowRoot/Document/etc),
+    // and not just to an Element, and we support various APIs on ElementHandle like "textContent()".
+    if (root.nodeType === 11 /* Node.DOCUMENT_FRAGMENT_NODE */ && selector.parts.length === 1 && selector.parts[0].name === 'css' && selector.parts[0].source === ':scope')
+      return [root as Element];
+
     this._evaluator.begin();
     try {
       let roots = new Set<Element>([root as Element]);

--- a/tests/page/elementhandle-convenience.spec.ts
+++ b/tests/page/elementhandle-convenience.spec.ts
@@ -88,6 +88,20 @@ it('textContent should work', async ({ page, server }) => {
   expect(await page.textContent('#inner')).toBe('Text,\nmore text');
 });
 
+it('textContent should work on ShadowRoot', async ({ page, server }) => {
+  await page.setContent(`
+    <div></div>
+    <script>
+      document.querySelector('div').attachShadow({ mode: 'open' }).innerHTML = '<div>hello</div>';
+    </script>
+  `);
+  const div = await page.$('div');
+  const root = await div.evaluateHandle(div => div.shadowRoot);
+  expect(await root.textContent()).toBe('hello');
+  // We do not match ShadowRoot as ":scope".
+  expect(await root.$$(':scope div')).toEqual([]);
+});
+
 it('isVisible and isHidden should work', async ({ page }) => {
   await page.setContent(`<div>Hi</div><span></span>`);
 


### PR DESCRIPTION
It used to work, but regressed in v1.36.

Fixes #26636.