### PR TITLE
chore: Allow to filter defaultArgs by parameter name alone and not full parameter value

### DIFF
--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -198,7 +198,14 @@ export abstract class BrowserType extends SdkObject {
     if (ignoreAllDefaultArgs)
       browserArguments.push(...args);
     else if (ignoreDefaultArgs)
-      browserArguments.push(...this._defaultArgs(options, isPersistent, userDataDir).filter(arg => ignoreDefaultArgs.indexOf(arg) === -1));
+      browserArguments.push(
+        ...this._defaultArgs(options, isPersistent, userDataDir).filter(
+          (arg) =>
+            !ignoreDefaultArgs.some(
+              (ida) => ida === arg || arg.startsWith(`${arg}=`)
+            )
+        )
+      );
     else
       browserArguments.push(...this._defaultArgs(options, isPersistent, userDataDir));
 


### PR DESCRIPTION
This avoid needing to specify full --enable-features=xxx or --disable-features=xxx command to be able to disable it

I was trying to be sure tu enable NetworkServiceInProcess2 which is the "new" name of NetworkServiceInProcess (I'll push a PR about that later) but struggle to do it until I found explanation in #22186

Specifying the complete parameter could stop working after an update if the defaultArg value has changed and that could be unfortunate