### PR TITLE
fix(test runner): extract FailureTracker helper

### DIFF
--- a/packages/playwright-test/src/runner/failureTracker.ts
+++ b/packages/playwright-test/src/runner/failureTracker.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TestResult } from '../../types/testReporter';
+import type { FullConfigInternal } from '../common/config';
+import type { Suite, TestCase } from '../common/test';
+
+export class FailureTracker {
+  private _failureCount = 0;
+  private _hasWorkerErrors = false;
+  private _rootSuite: Suite | undefined;
+
+  constructor(private _config: FullConfigInternal) {
+  }
+
+  onRootSuite(rootSuite: Suite) {
+    this._rootSuite = rootSuite;
+  }
+
+  onTestEnd(test: TestCase, result: TestResult) {
+    if (result.status !== 'skipped' && result.status !== test.expectedStatus)
+      ++this._failureCount;
+  }
+
+  onWorkerError() {
+    this._hasWorkerErrors = true;
+  }
+
+  hasReachedMaxFailures() {
+    const maxFailures = this._config.config.maxFailures;
+    return maxFailures > 0 && this._failureCount >= maxFailures;
+  }
+
+  hasWorkerErrors() {
+    return this._hasWorkerErrors;
+  }
+
+  result(): 'failed' | 'passed' {
+    return this._hasWorkerErrors || this._rootSuite?.allTests().some(test => !test.ok()) ? 'failed' : 'passed';
+  }
+}

--- a/packages/playwright-test/src/runner/runner.ts
+++ b/packages/playwright-test/src/runner/runner.ts
@@ -87,9 +87,7 @@ export class Runner {
     }
 
     const taskStatus = await taskRunner.run(testRun, deadline);
-    let status: FullResult['status'] = 'passed';
-    if (testRun.phases.find(p => p.dispatcher.hasWorkerErrors()) || testRun.rootSuite?.allTests().some(test => !test.ok()))
-      status = 'failed';
+    let status: FullResult['status'] = testRun.failureTracker.result();
     if (status === 'passed' && taskStatus !== 'passed')
       status = taskStatus;
     await reporter.onEnd({ status });

--- a/packages/playwright-test/src/runner/watchMode.ts
+++ b/packages/playwright-test/src/runner/watchMode.ts
@@ -298,7 +298,7 @@ async function runTests(config: FullConfigInternal, failedTestIdCollector: Set<s
     }
   }
 
-  if (testRun.phases.find(p => p.dispatcher.hasWorkerErrors()) || hasFailedTests)
+  if (testRun.failureTracker.hasWorkerErrors() || hasFailedTests)
     status = 'failed';
   if (status === 'passed' && taskStatus !== 'passed')
     status = taskStatus;


### PR DESCRIPTION
This way we can reuse it for:
- tracking `maxFailures` across phases;
- tracking failures for runner;
- tracking failures for `runJob` helper class later on.

Fixes #26344.