### PR TITLE
feat(ct): hooksConfig types less strict

### DIFF
--- a/packages/playwright-ct-core/index.d.ts
+++ b/packages/playwright-ct-core/index.d.ts
@@ -23,7 +23,7 @@ import type {
   PlaywrightWorkerOptions,
   Locator,
 } from '@playwright/test';
-import type { JsonObject } from './types/component';
+import type { SerializableObject } from './types/component';
 import type { InlineConfig } from 'vite';
 
 export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig<T, W>, 'use'> & {
@@ -35,7 +35,7 @@ export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig
   };
 };
 
-export interface MountOptions<HooksConfig extends JsonObject> {
+export interface MountOptions<HooksConfig extends SerializableObject> {
   hooksConfig?: HooksConfig;
 }
 
@@ -45,7 +45,7 @@ interface MountResult extends Locator {
 }
 
 export interface ComponentFixtures {
-  mount<HooksConfig extends JsonObject>(
+  mount<HooksConfig extends SerializableObject>(
     component: JSX.Element,
     options?: MountOptions<HooksConfig>
   ): Promise<MountResult>;

--- a/packages/playwright-ct-core/types/component.d.ts
+++ b/packages/playwright-ct-core/types/component.d.ts
@@ -14,10 +14,22 @@
  * limitations under the License.
  */
 
-type JsonPrimitive = string | number | boolean | null;
-type JsonValue = JsonPrimitive | JsonObject | JsonArray;
-type JsonArray = JsonValue[];
-export type JsonObject = { [Key in string]?: JsonValue };
+
+type SerializablePrimitive =
+  | string
+  | number
+  | boolean
+  | null
+  | BigInt
+  | RegExp
+  | Date
+  | Error
+  | URL
+  | Map<SerializableValue, SerializableValue>
+  | Set<SerializableValue>;
+type SerializableArray = SerializableValue[];
+type SerializableValue = SerializablePrimitive | SerializableObject | SerializableArray;
+export type SerializableObject = { [Key in string]?: SerializableValue };
 
 export type JsxComponent = {
   kind: 'jsx',
@@ -46,10 +58,10 @@ declare global {
     playwrightMount(component: Component, rootElement: Element, hooksConfig?: any): Promise<void>;
     playwrightUnmount(rootElement: Element): Promise<void>;
     playwrightUpdate(rootElement: Element, component: Component): Promise<void>;
-    __pw_hooks_before_mount?: (<HooksConfig extends JsonObject = JsonObject>(
+    __pw_hooks_before_mount?: (<HooksConfig extends SerializableObject = SerializableObject>(
       params: { hooksConfig?: HooksConfig; [key: string]: any }
     ) => Promise<any>)[];
-    __pw_hooks_after_mount?: (<HooksConfig extends JsonObject = JsonObject>(
+    __pw_hooks_after_mount?: (<HooksConfig extends SerializableObject = SerializableObject>(
       params: { hooksConfig?: HooksConfig; [key: string]: any }
     ) => Promise<void>)[];
   }

--- a/packages/playwright-ct-react/hooks.d.ts
+++ b/packages/playwright-ct-react/hooks.d.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 
-export declare function beforeMount<HooksConfig extends JsonObject>(
+export declare function beforeMount<HooksConfig extends SerializableObject>(
   callback: (params: { hooksConfig?: HooksConfig; App: () => JSX.Element }) => Promise<void | JSX.Element>
 ): void;
-export declare function afterMount<HooksConfig extends JsonObject>(
+export declare function afterMount<HooksConfig extends SerializableObject>(
   callback: (params: { hooksConfig?: HooksConfig }) => Promise<void>
 ): void;

--- a/packages/playwright-ct-react/index.d.ts
+++ b/packages/playwright-ct-react/index.d.ts
@@ -23,7 +23,7 @@ import type {
   PlaywrightWorkerOptions,
   Locator,
 } from '@playwright/test';
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 import type { InlineConfig } from 'vite';
 
 export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig<T, W>, 'use'> & {
@@ -35,7 +35,7 @@ export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig
   };
 };
 
-export interface MountOptions<HooksConfig extends JsonObject> {
+export interface MountOptions<HooksConfig extends SerializableObject> {
   hooksConfig?: HooksConfig;
 }
 
@@ -45,7 +45,7 @@ interface MountResult extends Locator {
 }
 
 export interface ComponentFixtures {
-  mount<HooksConfig extends JsonObject>(
+  mount<HooksConfig extends SerializableObject>(
     component: JSX.Element,
     options?: MountOptions<HooksConfig>
   ): Promise<MountResult>;

--- a/packages/playwright-ct-react17/hooks.d.ts
+++ b/packages/playwright-ct-react17/hooks.d.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 
-export declare function beforeMount<HooksConfig extends JsonObject>(
+export declare function beforeMount<HooksConfig extends SerializableObject>(
   callback: (params: { hooksConfig?: HooksConfig; App: () => JSX.Element }) => Promise<void | JSX.Element>
 ): void;
-export declare function afterMount<HooksConfig extends JsonObject>(
+export declare function afterMount<HooksConfig extends SerializableObject>(
   callback: (params: { hooksConfig?: HooksConfig }) => Promise<void>
 ): void;

--- a/packages/playwright-ct-react17/index.d.ts
+++ b/packages/playwright-ct-react17/index.d.ts
@@ -23,7 +23,7 @@ import type {
   PlaywrightWorkerOptions,
   Locator,
 } from '@playwright/test';
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 import type { InlineConfig } from 'vite';
 
 export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig<T, W>, 'use'> & {
@@ -35,7 +35,7 @@ export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig
   };
 };
 
-export interface MountOptions<HooksConfig extends JsonObject> {
+export interface MountOptions<HooksConfig extends SerializableObject> {
   hooksConfig?: HooksConfig;
 }
 
@@ -45,7 +45,7 @@ interface MountResult extends Locator {
 }
 
 export interface ComponentFixtures {
-  mount<HooksConfig extends JsonObject>(
+  mount<HooksConfig extends SerializableObject>(
     component: JSX.Element,
     options?: MountOptions<HooksConfig>
   ): Promise<MountResult>;

--- a/packages/playwright-ct-solid/hooks.d.ts
+++ b/packages/playwright-ct-solid/hooks.d.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { JSXElement } from "solid-js";
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { JSXElement } from 'solid-js';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 
-export declare function beforeMount<HooksConfig extends JsonObject>(
+export declare function beforeMount<HooksConfig extends SerializableObject>(
   callback: (params: { hooksConfig?: HooksConfig, App: () => JSXElement }) => Promise<void | JSXElement>
 ): void;
-export declare function afterMount<HooksConfig extends JsonObject>(
+export declare function afterMount<HooksConfig extends SerializableObject>(
   callback: (params: { hooksConfig?: HooksConfig }) => Promise<void>
 ): void;

--- a/packages/playwright-ct-solid/index.d.ts
+++ b/packages/playwright-ct-solid/index.d.ts
@@ -23,7 +23,7 @@ import type {
   PlaywrightWorkerOptions,
   Locator,
 } from '@playwright/test';
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 import type { InlineConfig } from 'vite';
 
 export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig<T, W>, 'use'> & {
@@ -35,7 +35,7 @@ export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig
   };
 };
 
-export interface MountOptions<HooksConfig extends JsonObject> {
+export interface MountOptions<HooksConfig extends SerializableObject> {
   hooksConfig?: HooksConfig;
 }
 
@@ -45,7 +45,7 @@ interface MountResult extends Locator {
 }
 
 export interface ComponentFixtures {
-  mount<HooksConfig extends JsonObject>(
+  mount<HooksConfig extends SerializableObject>(
     component: JSX.Element,
     options?: MountOptions<HooksConfig>
   ): Promise<MountResult>;

--- a/packages/playwright-ct-svelte/hooks.d.ts
+++ b/packages/playwright-ct-svelte/hooks.d.ts
@@ -15,15 +15,15 @@
  */
 
 import type { ComponentConstructorOptions, SvelteComponent } from 'svelte';
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 
-export declare function beforeMount<HooksConfig extends JsonObject>(
+export declare function beforeMount<HooksConfig extends SerializableObject>(
   callback: (params: {
     hooksConfig?: HooksConfig,
     App: new (options: Partial<ComponentConstructorOptions>) => SvelteComponent
   }) => Promise<SvelteComponent | void>
 ): void;
-export declare function afterMount<HooksConfig extends JsonObject>(
+export declare function afterMount<HooksConfig extends SerializableObject>(
   callback: (params: {
     hooksConfig?: HooksConfig;
     svelteComponent: SvelteComponent;

--- a/packages/playwright-ct-svelte/index.d.ts
+++ b/packages/playwright-ct-svelte/index.d.ts
@@ -23,7 +23,7 @@ import type {
   PlaywrightWorkerOptions,
   Locator,
 } from '@playwright/test';
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 import type { InlineConfig } from 'vite';
 import type { SvelteComponent, ComponentProps } from 'svelte/types/runtime';
 
@@ -40,7 +40,7 @@ type ComponentSlot = string | string[];
 type ComponentSlots = Record<string, ComponentSlot> & { default?: ComponentSlot };
 type ComponentEvents = Record<string, Function>;
 
-export interface MountOptions<HooksConfig extends JsonObject, Component extends SvelteComponent> {
+export interface MountOptions<HooksConfig extends SerializableObject, Component extends SvelteComponent> {
   props?: ComponentProps<Component>;
   slots?: ComponentSlots;
   on?: ComponentEvents;
@@ -56,7 +56,7 @@ interface MountResult<Component extends SvelteComponent> extends Locator {
 }
 
 interface ComponentFixtures {
-  mount<HooksConfig extends JsonObject, Component extends SvelteComponent = SvelteComponent>(
+  mount<HooksConfig extends SerializableObject, Component extends SvelteComponent = SvelteComponent>(
     component: new (...args: any[]) => Component,
     options?: MountOptions<HooksConfig, Component>
   ): Promise<MountResult<Component>>;

--- a/packages/playwright-ct-vue/hooks.d.ts
+++ b/packages/playwright-ct-vue/hooks.d.ts
@@ -15,12 +15,12 @@
  */
 
 import type { App, ComponentPublicInstance } from 'vue';
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 
-export declare function beforeMount<HooksConfig extends JsonObject>(
+export declare function beforeMount<HooksConfig extends SerializableObject>(
   callback: (params: { app: App; hooksConfig?: HooksConfig }) => Promise<void>
 ): void;
-export declare function afterMount<HooksConfig extends JsonObject>(
+export declare function afterMount<HooksConfig extends SerializableObject>(
   callback: (params: {
     app: App;
     hooksConfig?: HooksConfig;

--- a/packages/playwright-ct-vue/index.d.ts
+++ b/packages/playwright-ct-vue/index.d.ts
@@ -23,7 +23,7 @@ import type {
   PlaywrightWorkerOptions,
   Locator,
 } from '@playwright/test';
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 import type { InlineConfig } from 'vite';
 
 export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig<T, W>, 'use'> & {
@@ -46,14 +46,14 @@ type ComponentProps<T> =
 	T extends (props: infer P, ...args: any) => any ? P :
 	{};
 
-export interface MountOptions<HooksConfig extends JsonObject, Component> {
+export interface MountOptions<HooksConfig extends SerializableObject, Component> {
   props?: ComponentProps<Component>;
   slots?: ComponentSlots;
   on?: ComponentEvents;
   hooksConfig?: HooksConfig;
 }
 
-export interface MountOptionsJsx<HooksConfig extends JsonObject> {
+export interface MountOptionsJsx<HooksConfig extends SerializableObject> {
   hooksConfig?: HooksConfig;
 }
 
@@ -72,11 +72,11 @@ interface MountResultJsx extends Locator {
 }
 
 export interface ComponentFixtures {
-  mount<HooksConfig extends JsonObject>(
+  mount<HooksConfig extends SerializableObject>(
     component: JSX.Element,
     options: MountOptionsJsx<HooksConfig>
   ): Promise<MountResultJsx>;
-  mount<HooksConfig extends JsonObject, Component = unknown>(
+  mount<HooksConfig extends SerializableObject, Component = unknown>(
     component: Component,
     options?: MountOptions<HooksConfig, Component>
   ): Promise<MountResult<Component>>;

--- a/packages/playwright-ct-vue2/hooks.d.ts
+++ b/packages/playwright-ct-vue2/hooks.d.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import { ComponentOptions } from 'vue';
-import { CombinedVueInstance, Vue, VueConstructor } from 'vue/types/vue';
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { ComponentOptions } from 'vue';
+import type { CombinedVueInstance, Vue, VueConstructor } from 'vue/types/vue';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 
-export declare function beforeMount<HooksConfig extends JsonObject>(
-  callback: (params: { 
-    hooksConfig?: HooksConfig, 
-    Vue: VueConstructor<Vue>, 
+export declare function beforeMount<HooksConfig extends SerializableObject>(
+  callback: (params: {
+    hooksConfig?: HooksConfig,
+    Vue: VueConstructor<Vue>,
   }) => Promise<void | ComponentOptions<Vue> & Record<string, unknown>>
 ): void;
-export declare function afterMount<HooksConfig extends JsonObject>(
+export declare function afterMount<HooksConfig extends SerializableObject>(
   callback: (params: {
     hooksConfig?: HooksConfig;
     instance: CombinedVueInstance<

--- a/packages/playwright-ct-vue2/index.d.ts
+++ b/packages/playwright-ct-vue2/index.d.ts
@@ -23,7 +23,7 @@ import type {
   PlaywrightWorkerOptions,
   Locator,
 } from '@playwright/test';
-import type { JsonObject } from '@playwright/experimental-ct-core/types/component';
+import type { SerializableObject } from '@playwright/experimental-ct-core/types/component';
 import type { InlineConfig } from 'vite';
 
 export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig<T, W>, 'use'> & {
@@ -46,14 +46,14 @@ type ComponentProps<T> =
 	T extends (props: infer P, ...args: any) => any ? P :
 	{};
 
-export interface MountOptions<HooksConfig extends JsonObject, Component> {
+export interface MountOptions<HooksConfig extends SerializableObject, Component> {
   props?: ComponentProps<Component>;
   slots?: ComponentSlots;
   on?: ComponentEvents;
   hooksConfig?: HooksConfig;
 }
 
-export interface MountOptionsJsx<HooksConfig extends JsonObject> {
+export interface MountOptionsJsx<HooksConfig extends SerializableObject> {
   hooksConfig?: HooksConfig;
 }
 
@@ -72,11 +72,11 @@ interface MountResultJsx extends Locator {
 }
 
 export interface ComponentFixtures {
-  mount<HooksConfig extends JsonObject>(
+  mount<HooksConfig extends SerializableObject>(
     component: JSX.Element,
     options?: MountOptionsJsx<HooksConfig>
   ): Promise<MountResultJsx>;
-  mount<HooksConfig extends JsonObject, Component = unknown>(
+  mount<HooksConfig extends SerializableObject, Component = unknown>(
     component: Component,
     options?: MountOptions<HooksConfig, Component>
   ): Promise<MountResult<Component>>;

--- a/tests/components/ct-svelte-vite/playwright/index.ts
+++ b/tests/components/ct-svelte-vite/playwright/index.ts
@@ -2,16 +2,14 @@ import '../src/assets/index.css';
 import { beforeMount, afterMount } from '@playwright/experimental-ct-svelte/hooks';
 
 export type HooksConfig = {
-  context?: string;
   route?: string;
+  context: Map<any, any>;
 }
 
 beforeMount<HooksConfig>(async ({ hooksConfig, App }) => {
   console.log(`Before mount: ${JSON.stringify(hooksConfig)}`);
   return new App({
-    context: new Map([
-      ['context-key', hooksConfig?.context]
-    ]),
+    context: hooksConfig?.context
   });
 });
 

--- a/tests/components/ct-svelte-vite/tests/render.spec.ts
+++ b/tests/components/ct-svelte-vite/tests/render.spec.ts
@@ -23,7 +23,9 @@ test('get textContent of the empty component', async ({ mount }) => {
 test('render context', async ({ mount }) => {
   const component = await mount<HooksConfig>(Context, {
     hooksConfig: {
-      context: 'context-value',
+      context: new Map([
+        ['context-key', 'context-value']
+      ]),
     }
   });
   await expect(component).toContainText('context-value');


### PR DESCRIPTION
Svelte's `context` is a `Map`, would be great if i could pass that directly to the `hooksConfig`:

```typescript
test('render context', async ({ mount }) => {
  const component = await mount<HooksConfig>(Context, {
    hooksConfig: {
      context: new Map([
        ['context-key', 'context-value']
      ]),
    }
});
```

related to:
- https://github.com/microsoft/playwright/issues/24040
- https://github.com/microsoft/playwright/issues/26529