### PR TITLE
chore: enhance download/install logic of branded browsers

### DIFF
--- a/packages/playwright-core/bin/reinstall_chrome_beta_win.ps1
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_win.ps1
@@ -1,8 +1,6 @@
-$url = 'https://dl.google.com/tag/s/dl/chrome/install/beta/googlechromebetastandaloneenterprise.msi';
+$ErrorActionPreference = 'Stop'
 
-if ([Environment]::Is64BitProcess) {
-    $url = 'https://dl.google.com/tag/s/dl/chrome/install/beta/googlechromebetastandaloneenterprise64.msi'
-}
+$url = 'https://dl.google.com/tag/s/dl/chrome/install/beta/googlechromebetastandaloneenterprise64.msi'
 
 Write-Host "Downloading Google Chrome Beta"
 $wc = New-Object net.webclient
@@ -20,6 +18,6 @@ if (Test-Path "${env:ProgramFiles(x86)}$suffix") {
 } elseif (Test-Path "${env:ProgramFiles}$suffix") {
     (Get-Item "${env:ProgramFiles}$suffix").VersionInfo
 } else {
-    write-host "ERROR: failed to install Google Chrome Beta"
+    Write-Host "ERROR: failed to install Google Chrome Beta"
     exit 1
 }

--- a/packages/playwright-core/bin/reinstall_chrome_stable_win.ps1
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_win.ps1
@@ -1,8 +1,5 @@
-$url = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi';
-
-if ([Environment]::Is64BitProcess) {
-    $url = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi'
-}
+$ErrorActionPreference = 'Stop'
+$url = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi'
 
 $wc = New-Object net.webclient
 $msiInstaller = "$env:temp\google-chrome.msi"
@@ -21,6 +18,6 @@ if (Test-Path "${env:ProgramFiles(x86)}$suffix") {
 } elseif (Test-Path "${env:ProgramFiles}$suffix") {
     (Get-Item "${env:ProgramFiles}$suffix").VersionInfo
 } else {
-    write-host "ERROR: failed to install Google Chrome"
+    Write-Host "ERROR: failed to install Google Chrome"
     exit 1
 }

--- a/packages/playwright-core/bin/reinstall_msedge_beta_win.ps1
+++ b/packages/playwright-core/bin/reinstall_msedge_beta_win.ps1
@@ -1,3 +1,4 @@
+$ErrorActionPreference = 'Stop'
 $url = $args[0]
 
 Write-Host "Downloading Microsoft Edge Beta"
@@ -16,6 +17,6 @@ if (Test-Path "${env:ProgramFiles(x86)}$suffix") {
 } elseif (Test-Path "${env:ProgramFiles}$suffix") {
     (Get-Item "${env:ProgramFiles}$suffix").VersionInfo
 } else {
-    write-host "ERROR: failed to install Microsoft Edge"
+    Write-Host "ERROR: failed to install Microsoft Edge"
     exit 1
 }

--- a/packages/playwright-core/bin/reinstall_msedge_dev_win.ps1
+++ b/packages/playwright-core/bin/reinstall_msedge_dev_win.ps1
@@ -1,3 +1,4 @@
+$ErrorActionPreference = 'Stop'
 $url = $args[0]
 
 Write-Host "Downloading Microsoft Edge Dev"
@@ -16,6 +17,6 @@ if (Test-Path "${env:ProgramFiles(x86)}$suffix") {
 } elseif (Test-Path "${env:ProgramFiles}$suffix") {
     (Get-Item "${env:ProgramFiles}$suffix").VersionInfo
 } else {
-    write-host "ERROR: failed to install Microsoft Edge"
+    Write-Host "ERROR: failed to install Microsoft Edge"
     exit 1
 }

--- a/packages/playwright-core/bin/reinstall_msedge_stable_win.ps1
+++ b/packages/playwright-core/bin/reinstall_msedge_stable_win.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = 'Stop'
+
 $url = $args[0]
 
 Write-Host "Downloading Microsoft Edge"
@@ -16,6 +18,6 @@ if (Test-Path "${env:ProgramFiles(x86)}$suffix") {
 } elseif (Test-Path "${env:ProgramFiles}$suffix") {
     (Get-Item "${env:ProgramFiles}$suffix").VersionInfo
 } else {
-    write-host "ERROR: failed to install Microsoft Edge"
+    Write-Host "ERROR: failed to install Microsoft Edge"
     exit 1
 }


### PR DESCRIPTION
- Remove the check for 32 vs. 64 bit, since we only support 64 Windows since a while
- Introduce `$ErrorActionPreference = 'Stop'` which is a best practice otherwise the code would have continued running even a statement/line was failing. E.g. download failed, it would still try to install
- `$ms.DownloadFile` checks for the status code internally, so we are safe regarding this, it will throw otherwise.

This won't fix https://github.com/microsoft/playwright/issues/26591 but makes the code more safe and might be related.