### PR TITLE
Fix tags on jammy stable images

### DIFF
--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -49,8 +49,8 @@ JAMMY_TAGS=(
 )
 
 if [[ "$RELEASE_CHANNEL" == "stable" ]]; then
-  FOCAL_TAGS+=("latest")
-  FOCAL_TAGS+=("jammy")
+  JAMMY_TAGS+=("latest")
+  JAMMY_TAGS+=("jammy")
 fi
 
 tag_and_push() {


### PR DESCRIPTION
It looks to me like some tags meant for jammy images are being added to focal ones.