### PR TITLE
fix(trace viewer): retain `currentSrc` of all images

### DIFF
--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -46,6 +46,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string) {
   const kStyleSheetAttribute = '__playwright_style_sheet_';
   const kTargetAttribute = '__playwright_target__';
   const kCustomElementsAttribute = '__playwright_custom_elements__';
+  const kCurrentSrcAttribute = '__playwright_current_src__';
 
   // Symbols for our own info on Nodes/StyleSheets.
   const kSnapshotFrameId = Symbol('__playwright_snapshot_frameid_');
@@ -483,6 +484,14 @@ export function frameSnapshotStreamer(snapshotStreamer: string) {
           expectValue(kCustomElementsAttribute);
           expectValue(value);
           attrs[kCustomElementsAttribute] = value;
+        }
+
+        // Process currentSrc before bailing out since it depends on JS, not the DOM.
+        if (nodeName === 'IMG' || nodeName === 'PICTURE') {
+          const value = nodeName === 'PICTURE' ? '' : this._sanitizeUrl((node as HTMLImageElement).currentSrc);
+          expectValue(kCurrentSrcAttribute);
+          expectValue(value);
+          attrs[kCurrentSrcAttribute] = value;
         }
 
         // We can skip attributes comparison because nothing else has changed,


### PR DESCRIPTION
When `<source>` or `srcset=` are involved, the actual image src is determinted at runtime based on factors like `devicePixelRatio` and media queries that depend on width/height.

Since these factors may differ in the Trace Viewer itself, we should preserve the `currentSrc`, use it as an actual `src`, and disable various `<source>` and `srcset=`.