### PR TITLE
fix: remove `window.stop()` from `page.setContent()` implementation

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -896,7 +896,6 @@ export class Frame extends SdkObject {
           });
         });
         const contentPromise = context.evaluate(({ html, tag }) => {
-          window.stop();
           document.open();
           console.debug(tag);  // eslint-disable-line no-console
           document.write(html);


### PR DESCRIPTION
The call was added back in 2019 to stop network loading. See commit: https://github.com/microsoft/playwright/commit/56a48559c20ad7f1ab95c12a811e5969f983c057

However, there's no evidence that this call is needed any more:
- all the tests pass without it
- `window.stop()` behavior is poorly defined, so relying on it is unfortunate.

The `window.stop()` call, however, causes trouble while rolling firefox: under certain condititions, the call prevents document from firing the `load` event in the `document.open().write(..).close()` sequence that comes immediately after the call. While this does look like a bug in Firefox itself, we failed to reproduce it in isolation.

For the reference, the following tests fail with the Firefox 116 (using `PWTEST_TRACE=1` triggers the race condition somewhere):

```bash
PWTEST_TRACE=1 npm run ftest cli-codegen
```