### PR TITLE
docs(test-typescript): rename transpilation issues doc

### DIFF
--- a/docs/src/test-typescript-js.md
+++ b/docs/src/test-typescript-js.md
@@ -88,15 +88,15 @@ The `pretest` script runs typescript on the tests. `test` will run the tests tha
 
 Then `npm run test` will build the tests and run them.
 
-## Transpilation issues
+## Using `import` inside `evaluate()`
 
 Using dynamic imports inside a function passed to various `evaluate()` methods is not supported. This is because Playwright uses `Function.prototype.toString()` to serialize functions, and transpiler will sometimes replace dynamic imports with `require()` calls, which are not valid inside the web page.
 
 To work around this issue, use a string template instead of a function:
 
 ```js
-await page.evaluate(`async () => {
+await page.evaluate(`(async () => {
   const { value } = await import('some-module');
   console.log(value);
-}`);
+})()`);
 ```


### PR DESCRIPTION
Tested it using:

```ts
import { chromium } from 'playwright';

(async () => {
  const browser = await chromium.launch();
  const context = await browser.newContext();
  const page = await context.newPage();

  await page.goto('https://example.com');
  await page.route('**/some-module.js', route => {
    route.fulfill({
      contentType: 'application/javascript',
      body: 'export const value = 42;'
    });
  });
  await page.addScriptTag({
    type: 'importmap',
    content: JSON.stringify({
      imports: {
        'some-module': './some-module.js'
      }
    })
  });
  const result = await page.evaluate(`(async () => {
    const { value } = await import('some-module');
    return value;
  })()`);
  console.log(result);

  await context.close();
  await browser.close();
})();
```

Fixes https://github.com/microsoft/playwright/issues/26851