### PR TITLE
docs(auth): fix session storage example (Node.js)

### DIFF
--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -579,7 +579,7 @@ import fs from 'fs';
  * This function should be invoked in the auth setup file.
  * If you don't have multiple roles, you can set the file path fixed in the function.
  */
-export async function writeSessionStorageToJSON (page, filePath) {
+export async function writeSessionStorageToJSON(page, filePath) {
   const sessionStorage = await page.evaluate(() => JSON.stringify(window.sessionStorage));
   // we should use `writeFile` here instead of `writeFileSync`, especially if the file doesn't exist.
   fs.writeFile(filePath, sessionStorage, { encoding: 'utf-8' }, (err) => {
@@ -593,7 +593,7 @@ export async function writeSessionStorageToJSON (page, filePath) {
  * This function should be invoked in the test (spec) file.
  * If you don't have multiple roles, you can set the file path fixed in the function.
  */
-export async function readSessionStorageFromJSON (context, filePath) {
+export async function readSessionStorageFromJSON(context, filePath) {
   const buffers = fs.readFileSync(filePath, { encoding: 'utf-8' });
   if(buffers?.length > 0) {
     const sessionStorage = JSON.parse(buffers);
@@ -618,7 +618,7 @@ import { Page, BrowserContext } from '@playwright/test'
  * This function should be invoked in the auth setup file.
  * If you don't have multiple roles, you can set the file path fixed in the function.
  */
-export async function writeSessionStorageToJSON (page: Page, filePath: string) {
+export async function writeSessionStorageToJSON(page: Page, filePath: string) {
   const sessionStorage = await page.evaluate(() => JSON.stringify(window.sessionStorage));
   // we should use `writeFile` here instead of `writeFileSync`, especially if the file doesn't exist.
   fs.writeFile(filePath, sessionStorage, { encoding: 'utf-8' }, (err) => {
@@ -632,7 +632,7 @@ export async function writeSessionStorageToJSON (page: Page, filePath: string) {
  * This function should be invoked in the test (spec) file.
  * If you don't have multiple roles, you can set the file path fixed in the function.
  */
-export async function readSessionStorageFromJSON (context: Context, filePath: string) {
+export async function readSessionStorageFromJSON(context: Context, filePath: string) {
   const buffers = fs.readFileSync(filePath, { encoding: 'utf-8' });
   if(buffers && buffers.length > 0) {
     const sessionStorage = JSON.parse(buffers);

--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -571,7 +571,7 @@ test('admin and user', async ({ adminPage, userPage }) => {
 Reusing authenticated state covers [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) and [local storage](https://developer.mozilla.org/en-US/docs/Web/API/Storage) based authentication. Rarely, [session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) is used for storing information associated with the signed-in state. Session storage is specific to a particular domain and is not persisted across page loads. Playwright does not provide API to persist session storage, but the following snippet can be used to save/load session storage.
 
 ```js
-// this file is for reading/writing session storage (langs: js)
+// For reading/writing session storage (langs: js)
 import fs from 'fs';
 
 /**
@@ -581,7 +581,8 @@ import fs from 'fs';
  */
 export async function writeSessionStorageToJSON(page, filePath) {
   const sessionStorage = await page.evaluate(() => JSON.stringify(window.sessionStorage));
-  // we should use `writeFile` here instead of `writeFileSync`, especially if the file doesn't exist.
+  // we should use `writeFile` here instead of `writeFileSync`,
+  // especially if the file doesn't exist.
   fs.writeFile(filePath, sessionStorage, { encoding: 'utf-8' }, (err) => {
     console.error(err);
   });
@@ -609,7 +610,7 @@ export async function readSessionStorageFromJSON(context, filePath) {
 ```
 
 ```ts
-// this file is for reading/writing session storage (langs: ts)
+// For reading/writing session storage (langs: ts)
 import fs from 'fs';
 import { Page, BrowserContext } from '@playwright/test'
 
@@ -620,7 +621,8 @@ import { Page, BrowserContext } from '@playwright/test'
  */
 export async function writeSessionStorageToJSON(page: Page, filePath: string) {
   const sessionStorage = await page.evaluate(() => JSON.stringify(window.sessionStorage));
-  // we should use `writeFile` here instead of `writeFileSync`, especially if the file doesn't exist.
+  // we should use `writeFile` here instead of `writeFileSync`,
+  // especially if the file doesn't exist.
   fs.writeFile(filePath, sessionStorage, { encoding: 'utf-8' }, (err) => {
     console.error(err);
   });

--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -583,7 +583,7 @@ export async function writeSessionStorageToJSON(page, filePath) {
   const sessionStorage = await page.evaluate(() => JSON.stringify(window.sessionStorage));
   // we should use `writeFile` here instead of `writeFileSync`,
   // especially if the file doesn't exist.
-  fs.writeFile(filePath, sessionStorage, { encoding: 'utf-8' }, (err) => {
+  fs.writeFile(filePath, sessionStorage, { encoding: 'utf-8' }, err => {
     console.error(err);
   });
 }
@@ -596,13 +596,12 @@ export async function writeSessionStorageToJSON(page, filePath) {
  */
 export async function readSessionStorageFromJSON(context, filePath) {
   const buffers = fs.readFileSync(filePath, { encoding: 'utf-8' });
-  if(buffers?.length > 0) {
+  if (buffers?.length > 0) {
     const sessionStorage = JSON.parse(buffers);
     await context.addInitScript(storage => {
       if (window.location.hostname === 'example.com') {
-        for (const [key, value] of Object.entries(storage)) {
+        for (const [key, value] of Object.entries(storage))
           window.sessionStorage.setItem(key, value);
-        }
       }
     }, sessionStorage);
   }
@@ -623,7 +622,7 @@ export async function writeSessionStorageToJSON(page: Page, filePath: string) {
   const sessionStorage = await page.evaluate(() => JSON.stringify(window.sessionStorage));
   // we should use `writeFile` here instead of `writeFileSync`,
   // especially if the file doesn't exist.
-  fs.writeFile(filePath, sessionStorage, { encoding: 'utf-8' }, (err) => {
+  fs.writeFile(filePath, sessionStorage, { encoding: 'utf-8' }, err => {
     console.error(err);
   });
 }
@@ -636,13 +635,12 @@ export async function writeSessionStorageToJSON(page: Page, filePath: string) {
  */
 export async function readSessionStorageFromJSON(context: Context, filePath: string) {
   const buffers = fs.readFileSync(filePath, { encoding: 'utf-8' });
-  if(buffers && buffers.length > 0) {
+  if (buffers && buffers.length > 0) {
     const sessionStorage = JSON.parse(buffers);
     await context.addInitScript(storage => {
       if (window.location.hostname === 'example.com') {
-        for (const [key, value] of Object.entries(storage)) {
+        for (const [key, value] of Object.entries(storage))
           window.sessionStorage.setItem(key, value as string);
-        }
       }
     }, sessionStorage);
   }

--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -570,7 +570,7 @@ test('admin and user', async ({ adminPage, userPage }) => {
 
 Reusing authenticated state covers [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) and [local storage](https://developer.mozilla.org/en-US/docs/Web/API/Storage) based authentication. Rarely, [session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) is used for storing information associated with the signed-in state. Session storage is specific to a particular domain and is not persisted across page loads. Playwright does not provide API to persist session storage, but the following snippet can be used to save/load session storage.
 
-```javascript
+```js
 // this file is for reading/writing session storage (langs: js)
 import fs from 'fs';
 
@@ -608,7 +608,7 @@ export async function readSessionStorageFromJSON (context, filePath) {
 }
 ```
 
-```typescript
+```ts
 // this file is for reading/writing session storage (langs: ts)
 import fs from 'fs';
 import { Page, BrowserContext } from '@playwright/test'

--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -571,7 +571,7 @@ test('admin and user', async ({ adminPage, userPage }) => {
 Reusing authenticated state covers [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) and [local storage](https://developer.mozilla.org/en-US/docs/Web/API/Storage) based authentication. Rarely, [session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) is used for storing information associated with the signed-in state. Session storage is specific to a particular domain and is not persisted across page loads. Playwright does not provide API to persist session storage, but the following snippet can be used to save/load session storage.
 
 ```js
-// For reading/writing session storage (langs: js)
+// For reading/writing session storage
 import fs from 'fs';
 
 /**
@@ -602,45 +602,6 @@ export async function readSessionStorageFromJSON(context, filePath) {
       if (window.location.hostname === 'example.com') {
         for (const [key, value] of Object.entries(storage))
           window.sessionStorage.setItem(key, value);
-      }
-    }, sessionStorage);
-  }
-}
-```
-
-```ts
-// For reading/writing session storage (langs: ts)
-import fs from 'fs';
-import { Page, BrowserContext } from '@playwright/test'
-
-/**
- * Get session storage and store to a JSON file as env variable.
- * This function should be invoked in the auth setup file.
- * If you don't have multiple roles, you can set the file path fixed in the function.
- */
-export async function writeSessionStorageToJSON(page: Page, filePath: string) {
-  const sessionStorage = await page.evaluate(() => JSON.stringify(window.sessionStorage));
-  // we should use `writeFile` here instead of `writeFileSync`,
-  // especially if the file doesn't exist.
-  fs.writeFile(filePath, sessionStorage, { encoding: 'utf-8' }, err => {
-    console.error(err);
-  });
-}
-
-
-/**
- * Set session storage in a new context from the JSON file.
- * This function should be invoked in the test (spec) file.
- * If you don't have multiple roles, you can set the file path fixed in the function.
- */
-export async function readSessionStorageFromJSON(context: Context, filePath: string) {
-  const buffers = fs.readFileSync(filePath, { encoding: 'utf-8' });
-  if (buffers && buffers.length > 0) {
-    const sessionStorage = JSON.parse(buffers);
-    await context.addInitScript(storage => {
-      if (window.location.hostname === 'example.com') {
-        for (const [key, value] of Object.entries(storage))
-          window.sessionStorage.setItem(key, value as string);
       }
     }, sessionStorage);
   }


### PR DESCRIPTION
### What's Changed

- Fix and enhance session storage example for NodeJS (JavaScript)
- ~~Add session storage example for NodeJS (TypeScript)~~