### PR TITLE
chore: remove `@types/node` from deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1559,7 +1559,8 @@
     "node_modules/@types/node": {
       "version": "16.18.34",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.34.tgz",
-      "integrity": "sha512-VmVm7gXwhkUimRfBwVI1CHhwp86jDWR04B5FGebMMyxV90SlCmFujwUHrxTD4oO+SOYU86SoxvhgeRQJY7iXFg=="
+      "integrity": "sha512-VmVm7gXwhkUimRfBwVI1CHhwp86jDWR04B5FGebMMyxV90SlCmFujwUHrxTD4oO+SOYU86SoxvhgeRQJY7iXFg==",
+      "devOptional": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.3",
@@ -6588,7 +6589,6 @@
       "version": "1.38.0-next",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "*",
         "playwright-core": "1.38.0-next"
       },
       "bin": {
@@ -7575,7 +7575,6 @@
     "@playwright/test": {
       "version": "file:packages/playwright-test",
       "requires": {
-        "@types/node": "*",
         "fsevents": "2.3.2",
         "playwright-core": "1.38.0-next"
       }
@@ -7682,7 +7681,8 @@
     "@types/node": {
       "version": "16.18.34",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.34.tgz",
-      "integrity": "sha512-VmVm7gXwhkUimRfBwVI1CHhwp86jDWR04B5FGebMMyxV90SlCmFujwUHrxTD4oO+SOYU86SoxvhgeRQJY7iXFg=="
+      "integrity": "sha512-VmVm7gXwhkUimRfBwVI1CHhwp86jDWR04B5FGebMMyxV90SlCmFujwUHrxTD4oO+SOYU86SoxvhgeRQJY7iXFg==",
+      "devOptional": true
     },
     "@types/prop-types": {
       "version": "15.7.3",

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -40,7 +40,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/node": "*",
     "playwright-core": "1.38.0-next"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This effectively reverts #14230. We will install `@types/node` in `npm init playwright` instead.