### PR TITLE
chore: pin node to 20.5 to work around https://github.com/nodejs/node/issues/49497

### DIFF
--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -39,7 +39,7 @@ jobs:
             node-version: 18
             browser: chromium
           - os: ubuntu-22.04
-            node-version: 20
+            node-version: 20.5.x
             browser: chromium
     runs-on: ${{ matrix.os }}
     steps:
@@ -113,10 +113,10 @@ jobs:
             node-version: 18
             shard: 2/2
           - os: ubuntu-latest
-            node-version: 20
+            node-version: 20.5.x
             shard: 1/2
           - os: ubuntu-latest
-            node-version: 20
+            node-version: 20.5.x
             shard: 2/2
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -125,7 +125,7 @@ jobs:
         - os: ubuntu-latest
           node_version: 18
         - os: ubuntu-latest
-          node_version: 20
+          node_version: 20.5.x
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
https://github.com/nodejs/node/issues/49497