### PR TITLE
test: unskip passing test

### DIFF
--- a/tests/library/browsercontext-viewport-mobile.spec.ts
+++ b/tests/library/browsercontext-viewport-mobile.spec.ts
@@ -190,7 +190,7 @@ it.describe('mobile viewport', () => {
     await context.close();
   });
 
-  it('view scale should reset after navigation', async ({ browser, browserName }) => {
+  it('view scale should reset after navigation', async ({ browser, browserName, isLinux, isWindows }) => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/26876' });
     const context = await browser.newContext({
       viewport: { width: 390, height: 664 },
@@ -224,8 +224,16 @@ it.describe('mobile viewport', () => {
     });
     await page.goto('http://localhost/button.html');
     await page.getByText('Click me').click({ force: true });
-    expect(await page.evaluate(() => (window as any).clicks)).toEqual(
-        browserName === 'chromium' ? [{ x: 41, y: 18 }] : [{ x: 37, y: 15 }]);
+    let expected = [{ x: 41, y: 18 }];
+    if (browserName === 'webkit') {
+      if (isLinux)
+        expected = [{ x: 50, y: 20 }];
+      else if (isWindows)
+        expected = [{ x: 40, y: 20 }];
+      else
+        expected = [{ x: 37, y: 15 }];
+    }
+    expect(await page.evaluate(() => (window as any).clicks)).toEqual(expected);
     await context.close();
   });
 });

--- a/tests/library/browsercontext-viewport-mobile.spec.ts
+++ b/tests/library/browsercontext-viewport-mobile.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import { browserTest as it, expect } from '../config/browserTest';
+import os from 'os';
 
 it.describe('mobile viewport', () => {
   it.skip(({ browserName }) => browserName === 'firefox');
@@ -190,7 +191,7 @@ it.describe('mobile viewport', () => {
     await context.close();
   });
 
-  it('view scale should reset after navigation', async ({ browser, browserName, isLinux, isWindows }) => {
+  it('view scale should reset after navigation', async ({ browser, browserName, isLinux, isWindows, isMac, headless }) => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/26876' });
     const context = await browser.newContext({
       viewport: { width: 390, height: 664 },
@@ -226,12 +227,19 @@ it.describe('mobile viewport', () => {
     await page.getByText('Click me').click({ force: true });
     let expected = [{ x: 41, y: 18 }];
     if (browserName === 'webkit') {
-      if (isLinux)
-        expected = [{ x: 50, y: 20 }];
-      else if (isWindows)
+      if (isLinux) {
+        if (headless)
+          expected = [{ x: 50, y: 20 }];
+        else
+          expected = [{ x: 45, y: 20 }];
+      } else if (isWindows) {
         expected = [{ x: 40, y: 20 }];
-      else
-        expected = [{ x: 37, y: 15 }];
+      } else if (isMac) {
+        if (parseInt(os.release(), 10) === 21)
+          expected = [{ x: 40, y: 17 }];
+        else
+          expected = [{ x: 37, y: 15 }];
+      }
     }
     expect(await page.evaluate(() => (window as any).clicks)).toEqual(expected);
     await context.close();

--- a/tests/library/browsercontext-viewport-mobile.spec.ts
+++ b/tests/library/browsercontext-viewport-mobile.spec.ts
@@ -192,7 +192,6 @@ it.describe('mobile viewport', () => {
 
   it('view scale should reset after navigation', async ({ browser, browserName }) => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/26876' });
-    it.fixme(browserName === 'webkit');
     const context = await browser.newContext({
       viewport: { width: 390, height: 664 },
       isMobile: true,


### PR DESCRIPTION
The functionality was fixed in [webkit](https://github.com/microsoft/playwright-browsers/pull/625) and should be available with [recent roll](https://github.com/microsoft/playwright/pull/26953).

Fixes #26876