### PR TITLE
fix typo params.md

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -1716,7 +1716,7 @@ Consider the following config:
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  snapshotPathTemplate: '__screenshots__{/projectName}/{testFilePath}/{arg}{ext}',
+  snapshotPathTemplate: '__screenshots__/{projectName}/{testFilePath}/{arg}{ext}',
   testMatch: 'example.spec.ts',
   projects: [
     { use: { browserName: 'firefox' } },


### PR DESCRIPTION
fix typo in docs

`{/projectName} -> /{projectName}`



