### PR TITLE
feat: make it possible to filter by column in HTML report

### DIFF
--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -134,9 +134,7 @@ export class Filter {
         if (searchValues.text.includes(text))
           continue;
         const [fileName, line, column] = text.split(':');
-        if (line && typeof column === 'string' && searchValues.file.includes(fileName) && searchValues.line === line && searchValues.column === column)
-          continue;
-        else if (line && typeof column === 'undefined' && searchValues.file.includes(fileName) && searchValues.line === line)
+        if (searchValues.file.includes(fileName) && searchValues.line === line && (column === undefined || searchValues.column === column))
           continue;
         return false;
       }

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -113,6 +113,7 @@ export class Filter {
         status: status as any,
         file: test.location.file,
         line: String(test.location.line),
+        column: String(test.location.column),
       };
       (test as any).searchValues = searchValues;
     }
@@ -132,8 +133,10 @@ export class Filter {
       for (const text of this.text) {
         if (searchValues.text.includes(text))
           continue;
-        const location = text.split(':');
-        if (location.length === 2 && searchValues.file.includes(location[0]) && searchValues.line.includes(location[1]))
+        const [fileName, line, column] = text.split(':');
+        if (line && typeof column === 'string' && searchValues.file.includes(fileName) && searchValues.line === line && searchValues.column === column)
+          continue;
+        else if (line && typeof column === 'undefined' && searchValues.file.includes(fileName) && searchValues.line === line)
           continue;
         return false;
       }
@@ -154,5 +157,6 @@ type SearchValues = {
   status: 'passed' | 'failed' | 'flaky' | 'skipped';
   file: string;
   line: string;
+  column: string;
 };
 

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2085,6 +2085,10 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       await expect(page.getByText('a.test.js:3', { exact: true })).toBeVisible();
       await expect(page.getByText('a.test.js:4', { exact: true })).toBeHidden();
 
+      await searchInput.fill('a.test.js:3');
+      await expect(page.getByText('a.test.js:3', { exact: true })).toBeVisible();
+      await expect(page.getByText('a.test.js:4', { exact: true })).toBeHidden();
+
       await searchInput.fill('a.test.js:4:15');
       await expect(page.getByText('a.test.js:3', { exact: true })).toBeHidden();
       await expect(page.getByText('a.test.js:4', { exact: true })).toBeVisible();

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2064,6 +2064,32 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       await expect(page.getByText('passes title')).toBeVisible();
     });
 
+    test('tests should filter by fileName:line/column', async ({ runInlineTest, showReport, page }) => {
+      const result = await runInlineTest({
+        'a.test.js': `
+          const { test, expect } = require('@playwright/test');
+          test('test1', async ({}) => { expect(1).toBe(1); });
+              test('test2', async ({}) => { expect(1).toBe(2); });
+        `,
+      }, { reporter: 'dot,html' }, { PW_TEST_HTML_REPORT_OPEN: 'never' });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.passed).toBe(1);
+      expect(result.failed).toBe(1);
+
+      await showReport();
+
+      const searchInput = page.locator('.subnav-search-input');
+
+      await searchInput.fill('a.test.js:3:11');
+      await expect(page.getByText('a.test.js:3', { exact: true })).toBeVisible();
+      await expect(page.getByText('a.test.js:4', { exact: true })).toBeHidden();
+
+      await searchInput.fill('a.test.js:4:15');
+      await expect(page.getByText('a.test.js:3', { exact: true })).toBeHidden();
+      await expect(page.getByText('a.test.js:4', { exact: true })).toBeVisible();
+    });
+
     test('should properly display beforeEach with and without title', async ({ runInlineTest, showReport, page }) => {
       const result = await runInlineTest({
         'a.test.js': `


### PR DESCRIPTION
Our CLI can filter by column, users (at least me) copy the full fileName:line:column into their clipboard and expect that this will end up in a match.