### PR TITLE
feat(webkit): roll to r1908

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "webkit",
-      "revision": "1907",
+      "revision": "1908",
       "installByDefault": true,
       "revisionOverrides": {
         "mac10.14": "1446",

--- a/packages/playwright-core/src/server/registry/nativeDeps.ts
+++ b/packages/playwright-core/src/server/registry/nativeDeps.ts
@@ -464,6 +464,7 @@ export const deps: any = {
       'libxtst6'
     ],
     webkit: [
+      'libsoup-3.0-0',
       'libenchant-2-2',
       'gstreamer1.0-libav',
       'gstreamer1.0-plugins-bad',
@@ -521,6 +522,7 @@ export const deps: any = {
       'libevent-2.1-7',
     ],
     lib2package: {
+      'libsoup-3.0.so.0': 'libsoup-3.0-0',
       'libasound.so.2': 'libasound2',
       'libatk-1.0.so.0': 'libatk1.0-0',
       'libatk-bridge-2.0.so.0': 'libatk-bridge2.0-0',
@@ -885,6 +887,7 @@ export const deps: any = {
       'libxtst6'
     ],
     webkit: [
+      'libsoup-3.0-0',
       'gstreamer1.0-libav',
       'gstreamer1.0-plugins-bad',
       'gstreamer1.0-plugins-base',
@@ -941,6 +944,7 @@ export const deps: any = {
       'libevent-2.1-7',
     ],
     lib2package: {
+      'libsoup-3.0.so.0': 'libsoup-3.0-0',
       'libasound.so.2': 'libasound2',
       'libatk-1.0.so.0': 'libatk1.0-0',
       'libatk-bridge-2.0.so.0': 'libatk-bridge2.0-0',


### PR DESCRIPTION
For the record, these are the platforms which ship libsoup3 now:

Ubuntu20/Debian11.

```
❯ find . -name \*libsoup\*
./webkit-ubuntu-20.04-arm64/minibrowser-gtk/sys/lib/libsoup-3.0.so.0.0.5
./webkit-ubuntu-20.04-arm64/minibrowser-gtk/sys/lib/libsoup-3.0.so.0
./webkit-ubuntu-20.04-arm64/minibrowser-wpe/sys/lib/libsoup-3.0.so.0.0.5
./webkit-ubuntu-20.04-arm64/minibrowser-wpe/sys/lib/libsoup-3.0.so.0
./webkit-ubuntu-20.04/minibrowser-gtk/sys/lib/libsoup-3.0.so.0.0.5
./webkit-ubuntu-20.04/minibrowser-gtk/sys/lib/libsoup-3.0.so.0
./webkit-ubuntu-20.04/minibrowser-wpe/sys/lib/libsoup-3.0.so.0.0.5
./webkit-ubuntu-20.04/minibrowser-wpe/sys/lib/libsoup-3.0.so.0
./webkit-debian-11/minibrowser-gtk/sys/lib/libsoup-3.0.so.0.0.5
./webkit-debian-11/minibrowser-gtk/sys/lib/libsoup-3.0.so.0
./webkit-debian-11/minibrowser-wpe/sys/lib/libsoup-3.0.so.0.0.5
./webkit-debian-11/minibrowser-wpe/sys/lib/libsoup-3.0.so.0
./webkit-debian-11-arm64/minibrowser-gtk/sys/lib/libsoup-3.0.so.0.0.5
./webkit-debian-11-arm64/minibrowser-gtk/sys/lib/libsoup-3.0.so.0
./webkit-debian-11-arm64/minibrowser-wpe/sys/lib/libsoup-3.0.so.0.0.5
./webkit-debian-11-arm64/minibrowser-wpe/sys/lib/libsoup-3.0.so.0
```