### PR TITLE
docs: fix typo

### DIFF
--- a/docs/src/browser-contexts.md
+++ b/docs/src/browser-contexts.md
@@ -7,7 +7,7 @@ Tests written with Playwright execute in isolated clean-slate environments calle
 
 ## What is Test Isolation? 
 
-Test Isolation is when each test is completely isolated from another test. Every test runs independently from any other test. This means that each test has it's own local storage, session storage, cookies etc. Playwright achieves this using [BrowserContext]s which are equivalent to incognito-like profiles. They are fast and cheap to create and are completely isolated, even when running in a single browser. Playwright creates a context for each test, and provides a default [Page] in that context.
+Test Isolation is when each test is completely isolated from another test. Every test runs independently from any other test. This means that each test has its own local storage, session storage, cookies etc. Playwright achieves this using [BrowserContext]s which are equivalent to incognito-like profiles. They are fast and cheap to create and are completely isolated, even when running in a single browser. Playwright creates a context for each test, and provides a default [Page] in that context.
 
 ## Why is Test Isolation Important? 
 
@@ -21,7 +21,7 @@ There are two different strategies when it comes to Test Isolation: start from s
 
 ## How Playwright Achieves Test Isolation
 
-Playwright uses browser contexts to achieve Test Isolation. Each test has it's own Browser Context. Running the test creates a new browser context each time.  When using Playwright as a Test Runner, browser contexts are created by default. Otherwise, you can create browser contexts manually.
+Playwright uses browser contexts to achieve Test Isolation. Each test has its own Browser Context. Running the test creates a new browser context each time.  When using Playwright as a Test Runner, browser contexts are created by default. Otherwise, you can create browser contexts manually.
 
 ```js tab=js-test
 import { test } from '@playwright/test';


### PR DESCRIPTION
"it's own" is equivalent to "it is own", when it should be "its own". See https://www.grammarly.com/blog/its-vs-its/.