### PR TITLE
fix: collect stdio from forked processes

### DIFF
--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import util from 'util';
 import { serializeCompilationCache } from '../transform/compilationCache';
 import type { FullConfigInternal } from './config';
 import type { ReporterDescription, TestInfoError, TestStatus } from '../../types/test';
@@ -140,4 +141,12 @@ export function serializeConfig(config: FullConfigInternal): SerializedConfig {
     compilationCache: serializeCompilationCache(),
   };
   return result;
+}
+
+export function chunkToParams(chunk: Uint8Array | string): TestOutputPayload {
+  if (chunk instanceof Uint8Array)
+    return { buffer: Buffer.from(chunk).toString('base64') };
+  if (typeof chunk !== 'string')
+    return { text: util.inspect(chunk) };
+  return { text: chunk };
 }

--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -143,7 +143,7 @@ export function serializeConfig(config: FullConfigInternal): SerializedConfig {
   return result;
 }
 
-export function chunkToParams(chunk: Uint8Array | string): TestOutputPayload {
+export function stdioChunkToParams(chunk: Uint8Array | string): TestOutputPayload {
   if (chunk instanceof Uint8Array)
     return { buffer: Buffer.from(chunk).toString('base64') };
   if (typeof chunk !== 'string')

--- a/packages/playwright/src/runner/loaderHost.ts
+++ b/packages/playwright/src/runner/loaderHost.ts
@@ -58,7 +58,7 @@ export class OutOfProcessLoaderHost {
   }
 
   async start() {
-    await this._processHost.startRunner(serializeConfig(this._config), true);
+    await this._processHost.startRunner(serializeConfig(this._config));
   }
 
   async loadTestFile(file: string, testErrors: TestError[]): Promise<Suite> {

--- a/packages/playwright/src/runner/workerHost.ts
+++ b/packages/playwright/src/runner/workerHost.ts
@@ -17,6 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 import type { TestGroup } from './testGroups';
+import { chunkToParams } from '../common/ipc';
 import type { RunPayload, SerializedConfig, WorkerInitParams } from '../common/ipc';
 import { ProcessHost } from './processHost';
 import { artifactsFolderName } from '../isomorphic/folders';
@@ -54,7 +55,10 @@ export class WorkerHost extends ProcessHost {
 
   async start() {
     await fs.promises.mkdir(this._params.artifactsDir, { recursive: true });
-    await this.startRunner(this._params, false);
+    await this.startRunner(this._params, {
+      onStdOut: chunk => this.emit('stdOut', chunkToParams(chunk)),
+      onStdErr: chunk => this.emit('stdErr', chunkToParams(chunk)),
+    });
   }
 
   override async stop(didFail?: boolean) {

--- a/packages/playwright/src/runner/workerHost.ts
+++ b/packages/playwright/src/runner/workerHost.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 import type { TestGroup } from './testGroups';
-import { chunkToParams } from '../common/ipc';
+import { stdioChunkToParams } from '../common/ipc';
 import type { RunPayload, SerializedConfig, WorkerInitParams } from '../common/ipc';
 import { ProcessHost } from './processHost';
 import { artifactsFolderName } from '../isomorphic/folders';
@@ -56,8 +56,8 @@ export class WorkerHost extends ProcessHost {
   async start() {
     await fs.promises.mkdir(this._params.artifactsDir, { recursive: true });
     await this.startRunner(this._params, {
-      onStdOut: chunk => this.emit('stdOut', chunkToParams(chunk)),
-      onStdErr: chunk => this.emit('stdErr', chunkToParams(chunk)),
+      onStdOut: chunk => this.emit('stdOut', stdioChunkToParams(chunk)),
+      onStdErr: chunk => this.emit('stdErr', stdioChunkToParams(chunk)),
     });
   }
 

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -15,9 +15,8 @@
  */
 
 import { colors, rimraf } from 'playwright-core/lib/utilsBundle';
-import util from 'util';
 import { debugTest, formatLocation, relativeFilePath, serializeError } from '../util';
-import type { TestBeginPayload, TestEndPayload, RunPayload, DonePayload, WorkerInitParams, TeardownErrorsPayload, TestOutputPayload } from '../common/ipc';
+import { type TestBeginPayload, type TestEndPayload, type RunPayload, type DonePayload, type WorkerInitParams, type TeardownErrorsPayload, type TestOutputPayload, chunkToParams } from '../common/ipc';
 import { setCurrentTestInfo, setIsWorkerProcess } from '../common/globals';
 import { ConfigLoader } from '../common/configLoader';
 import type { Suite, TestCase } from '../common/test';
@@ -650,14 +649,6 @@ function formatTestTitle(test: TestCase, projectName: string) {
   const location = `${relativeFilePath(test.location.file)}:${test.location.line}:${test.location.column}`;
   const projectTitle = projectName ? `[${projectName}] › ` : '';
   return `${projectTitle}${location} › ${titles.join(' › ')}`;
-}
-
-function chunkToParams(chunk: Uint8Array | string, encoding?: BufferEncoding):  { text?: string, buffer?: string } {
-  if (chunk instanceof Uint8Array)
-    return { buffer: Buffer.from(chunk).toString('base64') };
-  if (typeof chunk !== 'string')
-    return { text: util.inspect(chunk) };
-  return { text: chunk };
 }
 
 export const create = (params: WorkerInitParams) => new WorkerMain(params);

--- a/tests/playwright-test/exit-code.spec.ts
+++ b/tests/playwright-test/exit-code.spec.ts
@@ -40,6 +40,30 @@ test('should collect stdio', async ({ runInlineTest }) => {
   expect(stderr).toEqual([{ text: 'stderr text' }, { buffer: Buffer.from('stderr buffer').toString('base64') }]);
 });
 
+test('should collect stdio from forked process', async ({ runInlineTest }) => {
+  const { exitCode, report } = await runInlineTest({
+    'stdio.spec.js': `
+      import { test } from '@playwright/test';
+      import { fork } from 'child_process';
+      test('stdio', async () => {
+        const child = fork('fork.js');
+        await new Promise((resolve) => child.on('exit', (code) => resolve(code)));
+      });
+    `,
+    'fork.js': `
+      process.stdout.write('stdout text');
+      process.stdout.write(Buffer.from('stdout buffer'));
+      process.stderr.write('stderr text');
+      process.stderr.write(Buffer.from('stderr buffer'));
+    `
+  });
+  expect(exitCode).toBe(0);
+  const testResult = report.suites[0].specs[0].tests[0].results[0];
+  const { stdout, stderr } = testResult;
+  expect(stdout.map(e => Buffer.from((e as any).buffer, 'base64').toString()).join('')).toEqual('stdout textstdout buffer');
+  expect(stderr.map(e => Buffer.from((e as any).buffer, 'base64').toString()).join('')).toEqual('stderr textstderr buffer');
+});
+
 test('should work with not defined errors', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'is-not-defined-error.spec.ts': `


### PR DESCRIPTION
A summary about the attempts we tried in https://github.com/microsoft/playwright/pull/26931 for https://github.com/microsoft/playwright/issues/26859 and https://github.com/microsoft/playwright/issues/24591.

1. attempt: collect all the stdio from the worker host.
    - this made it hard to capture the live console logs for the live trace
2. attempt: collect all the stdio from the worker host, but keep proxying `process.{stdout,stderr}.write`.
    - this solved the live console logs problem, since we could still listen on them
    - we found out about a race that the stdout/stderr streams can still buffer data while the test already had finished
    - we created a best effort flush implementation but didn't like the complexity it introduced to the project
 3. attempt: keep things like they are but also listen to stdio from the worker host
    - this solves the race of console.log in the test (things stay like they are)
    - this keeps live trace working (things stay like they are)
    - a known pitfall is that it could result in logs which don't end up in the reporter onStdOut/onStdErr, but it is already a significant improvement over how it was before.
      - before: they were not getting displayed
      - after: they are getting displayed and there is a low likelihood that they don't end up in the reporter API if the write happens slightly before a test finished.

Closes #26931
Fixes #26859
Fixes #24591