### PR TITLE
docs: add screenshot for attachments

### DIFF
--- a/docs/src/test-ui-mode-js.md
+++ b/docs/src/test-ui-mode-js.md
@@ -101,7 +101,7 @@ The Network tab shows you all the network requests that were made during your te
 
 The "Attachments" tab allows you to explore attachments. If you're doing [visual regression testing](./test-snapshots.md), you'll be able to compare screenshots by examining the image diff, the actual image and the expected image. When you click on the expected image you can use the slider to slide one image over the other so you can easily see the differences in your screenshots.
 
-![ui mode with attachments](https://github.com/microsoft/playwright/assets/13063165/bed993d7-7720-4624-b32f-4d7a543a732d)
+![ui mode with attachments](https://github.com/microsoft/playwright/assets/13063165/bb83b406-84ed-4380-a96c-0e62d1388093)
 
 ### Metadata
 


### PR DESCRIPTION
- update screenshot to be aligned with rest of screenshots showing the todo app instead of example test