### PR TITLE
fix: --list should not print twice with dot reporter

### DIFF
--- a/packages/playwright/src/runner/reporters.ts
+++ b/packages/playwright/src/runner/reporters.ts
@@ -104,4 +104,8 @@ class ListModeReporter extends EmptyReporter {
     // eslint-disable-next-line no-console
     console.error('\n' + formatError(error, false).message);
   }
+
+  override printsToStdio(): boolean {
+    return true;
+  }
 }

--- a/tests/playwright-test/list-mode.spec.ts
+++ b/tests/playwright-test/list-mode.spec.ts
@@ -44,6 +44,27 @@ test('should list tests', async ({ runInlineTest }) => {
   ].join('\n'));
 });
 
+test('should list tests (not twice)', async ({ runInlineTest }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27087' });
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { reporter: 'dot' };
+    `,
+    'a.test.js': `
+      const { test, expect } = require('@playwright/test');
+      test('example1', ({}) => {});
+    `
+  }, { 'list': true });
+  expect(result.exitCode).toBe(0);
+  expect(result.output).toContain([
+    `Listing tests:`,
+    `  a.test.js:3:7 › example1`,
+    `Total: 1 test in 1 file`
+  ].join('\n'));
+  expect(result.output.match(/Listing tests:/g)).toHaveLength(1);
+  expect(result.output.match(/Total: 1 test in 1 file/g)).toHaveLength(1);
+});
+
 test('should list tests to stdout when JSON reporter outputs to a file', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
As per https://github.com/microsoft/playwright/blob/46093f197d81bed3f9d121b779bb4268500c552d/packages/playwright/src/runner/reporters.ts#L67-L74


Fixes https://github.com/microsoft/playwright/issues/27087