### PR TITLE
cherry-pick(#27117): fix: custom expect matchers on Locator/Page/APIResponse instance

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5072,12 +5072,12 @@ type FunctionAssertions = {
 };
 
 type BaseMatchers<R, T> = GenericAssertions<R> & PlaywrightTest.Matchers<R, T> & SnapshotAssertions;
-type AllowedGenericMatchers<R> = Pick<GenericAssertions<R>, 'toBe' | 'toBeDefined' | 'toBeFalsy' | 'toBeNull' | 'toBeTruthy' | 'toBeUndefined'>;
+type AllowedGenericMatchers<R, T> = PlaywrightTest.Matchers<R, T> & Pick<GenericAssertions<R>, 'toBe' | 'toBeDefined' | 'toBeFalsy' | 'toBeNull' | 'toBeTruthy' | 'toBeUndefined'>;
 
 type SpecificMatchers<R, T> =
-  T extends Page ? PageAssertions & AllowedGenericMatchers<R> :
-  T extends Locator ? LocatorAssertions & AllowedGenericMatchers<R> :
-  T extends APIResponse ? APIResponseAssertions & AllowedGenericMatchers<R> :
+  T extends Page ? PageAssertions & AllowedGenericMatchers<R, T> :
+  T extends Locator ? LocatorAssertions & AllowedGenericMatchers<R, T> :
+  T extends APIResponse ? APIResponseAssertions & AllowedGenericMatchers<R, T> :
   BaseMatchers<R, T> & (T extends Function ? FunctionAssertions : {});
 type AllMatchers<R, T> = PageAssertions & LocatorAssertions & APIResponseAssertions & FunctionAssertions & BaseMatchers<R, T>;
 

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -272,10 +272,20 @@ test('should work with custom PlaywrightTest namespace', async ({ runTSC }) => {
       }
     `,
     'a.spec.ts': `
-      import { test, expect } from '@playwright/test';
+      import { test, expect, type Page, type APIResponse } from '@playwright/test';
       test.expect.extend({
         toBeWithinRange() { },
       });
+
+      const page = {} as Page;
+      const locator = page.locator('');
+      const apiResponse = {} as APIResponse;
+      test.expect(page).toBeEmpty();
+      test.expect(page).not.toBeEmpty();
+      test.expect(locator).toBeEmpty();
+      test.expect(locator).not.toBeEmpty();
+      test.expect(apiResponse).toBeEmpty();
+      test.expect(apiResponse).not.toBeEmpty();
 
       test.expect('').toBeEmpty();
       test.expect('hello').not.toBeEmpty();

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -330,12 +330,12 @@ type FunctionAssertions = {
 };
 
 type BaseMatchers<R, T> = GenericAssertions<R> & PlaywrightTest.Matchers<R, T> & SnapshotAssertions;
-type AllowedGenericMatchers<R> = Pick<GenericAssertions<R>, 'toBe' | 'toBeDefined' | 'toBeFalsy' | 'toBeNull' | 'toBeTruthy' | 'toBeUndefined'>;
+type AllowedGenericMatchers<R, T> = PlaywrightTest.Matchers<R, T> & Pick<GenericAssertions<R>, 'toBe' | 'toBeDefined' | 'toBeFalsy' | 'toBeNull' | 'toBeTruthy' | 'toBeUndefined'>;
 
 type SpecificMatchers<R, T> =
-  T extends Page ? PageAssertions & AllowedGenericMatchers<R> :
-  T extends Locator ? LocatorAssertions & AllowedGenericMatchers<R> :
-  T extends APIResponse ? APIResponseAssertions & AllowedGenericMatchers<R> :
+  T extends Page ? PageAssertions & AllowedGenericMatchers<R, T> :
+  T extends Locator ? LocatorAssertions & AllowedGenericMatchers<R, T> :
+  T extends APIResponse ? APIResponseAssertions & AllowedGenericMatchers<R, T> :
   BaseMatchers<R, T> & (T extends Function ? FunctionAssertions : {});
 type AllMatchers<R, T> = PageAssertions & LocatorAssertions & APIResponseAssertions & FunctionAssertions & BaseMatchers<R, T>;
 


### PR DESCRIPTION
This PR cherry-picks the following commits:

- 0d444057624b9970e0b5d4bdb302cd8efae39edb