### PR TITLE
fix(firefox): properly handle navigations

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -200,7 +200,8 @@ export class FrameManager {
       // Do not override request with undefined.
       return;
     }
-    frame.setPendingDocument({ documentId, request: undefined });
+    const request = Array.from(frame._inflightRequests).find(request => request._documentId === documentId);
+    frame.setPendingDocument({ documentId, request });
   }
 
   frameCommittedNewDocumentNavigation(frameId: string, url: string, name: string, documentId: string, initial: boolean) {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -200,7 +200,8 @@ export class FrameManager {
       // Do not override request with undefined.
       return;
     }
-    const request = Array.from(frame._inflightRequests).find(request => request._documentId === documentId);
+
+    const request = documentId ? Array.from(frame._inflightRequests).find(request => request._documentId === documentId) : undefined;
     frame.setPendingDocument({ documentId, request });
   }
 


### PR DESCRIPTION
In firefox, the `frameRequestedNavigation` is coming from renderer and
thus can happen **after** the `Network.requestWillBeSent`, which is
dispatched from the browser process.

Fixes https://github.com/microsoft/playwright/issues/24132
