### PR TITLE
test: update webkit test expectations after last roll

### DIFF
--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -695,6 +695,7 @@ it.describe('screencast', () => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22411' });
     it.fixme(browserName === 'chromium' && (!headless || !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW), 'The square is not on the video');
     it.fixme(browserName === 'firefox' && isWindows, 'https://github.com/microsoft/playwright/issues/14405');
+    it.fixme(browserName === 'webkit' && !headless, 'https://github.com/microsoft/playwright-browsers/issues/637');
     const size = { width: 600, height: 400 };
     const browser = await browserType.launch();
 

--- a/tests/page/page-add-init-script.spec.ts
+++ b/tests/page/page-add-init-script.spec.ts
@@ -86,7 +86,6 @@ it('should work after a cross origin navigation', async ({ page, server }) => {
 
 it('init script should run only once in iframe', async ({ page, server, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/26992' });
-  it.fixme(browserName === 'webkit');
   const messages = [];
   page.on('console', event => {
     if (event.text().startsWith('init script:'))


### PR DESCRIPTION
https://github.com/microsoft/playwright/issues/26992 was fixed by https://github.com/microsoft/playwright-browsers/pull/635.

Reference https://github.com/microsoft/playwright-browsers/issues/637
Fixes https://github.com/microsoft/playwright/issues/26992