### PR TITLE
fix: do not throw from fetch when response has invalid cookie

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -286,6 +286,8 @@ export abstract class APIRequestContext extends SdkObject {
           try {
             await this._addCookies(cookies);
           } catch (e) {
+            // Cookie value is limited by 4096 characters in the browsers. If setCookies failed,
+            // we try setting each cookie individually just in case only some of them are bad.
             await Promise.all(cookies.map(c => this._addCookies([c]).catch(() => {})));
           }
         }

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -282,8 +282,13 @@ export abstract class APIRequestContext extends SdkObject {
           progress.log(`  ${name}: ${value}`);
 
         const cookies = this._parseSetCookieHeader(response.url || url.toString(), response.headers['set-cookie']) ;
-        if (cookies.length)
-          await this._addCookies(cookies);
+        if (cookies.length) {
+          try {
+            await this._addCookies(cookies);
+          } catch (e) {
+            await Promise.all(cookies.map(c => this._addCookies([c]).catch(() => {})));
+          }
+        }
 
         if (redirectStatus.includes(response.statusCode!) && options.maxRedirects >= 0) {
           if (!options.maxRedirects) {

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1110,7 +1110,7 @@ it('should fetch long set-cookie value', async ({ context, server, browserName }
     res.setHeader('Set-Cookie', [`foo=${'a'.repeat(4100)}; path=/;`, `bar=val`]);
     res.end();
   });
-  await context.request.get(server.EMPTY_PAGE, {timeout: 5000});
+  await context.request.get(server.EMPTY_PAGE, { timeout: 5000 });
   const cookies = await context.cookies();
   expect(cookies.map(c => c.name)).toEqual(browserName === 'firefox' ? ['foo', 'bar'] : ['bar']);
 });

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1105,14 +1105,15 @@ it('should set domain=localhost cookie', async ({ context, server, browserName, 
   expect(cookie.value).toBe('val');
 });
 
-it('should fetch long set-cookie value', async ({ context, server, browserName }) => {
+it('fetch should not throw on long set-cookie value', async ({ context, server }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27165' });
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('Set-Cookie', [`foo=${'a'.repeat(4100)}; path=/;`, `bar=val`]);
     res.end();
   });
   await context.request.get(server.EMPTY_PAGE, { timeout: 5000 });
   const cookies = await context.cookies();
-  expect(cookies.map(c => c.name)).toEqual(browserName === 'firefox' ? ['foo', 'bar'] : ['bar']);
+  expect(cookies.map(c => c.name)).toContain('bar');
 });
 
 it('should support set-cookie with SameSite and without Secure attribute over HTTP', async ({ page, server, browserName, isWindows }) => {

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1105,6 +1105,15 @@ it('should set domain=localhost cookie', async ({ context, server, browserName, 
   expect(cookie.value).toBe('val');
 });
 
+it('should fetch long set-cookie value', async ({ context, server, browserName }) => {
+  server.setRoute('/empty.html', (req, res) => {
+    res.setHeader('Set-Cookie', [`foo=${'a'.repeat(4100)}; path=/;`, `bar=val`]);
+    res.end();
+  });
+  await context.request.get(server.EMPTY_PAGE, {timeout: 5000});
+  const cookies = await context.cookies();
+  expect(cookies.map(c => c.name)).toEqual(browserName === 'firefox' ? ['foo', 'bar'] : ['bar']);
+});
 
 it('should support set-cookie with SameSite and without Secure attribute over HTTP', async ({ page, server, browserName, isWindows }) => {
   for (const value of ['None', 'Lax', 'Strict']) {


### PR DESCRIPTION
Cookie value is limited by 4096 characters in the browsers. If setCookies failed we try setting each cookie individually just in case only some of them are bad.

Fixes https://github.com/microsoft/playwright/issues/27165