### PR TITLE
test: unskip "should capture full viewport"

### DIFF
--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -695,7 +695,6 @@ it.describe('screencast', () => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22411' });
     it.fixme(browserName === 'chromium' && (!headless || !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW), 'The square is not on the video');
     it.fixme(browserName === 'firefox' && isWindows, 'https://github.com/microsoft/playwright/issues/14405');
-    it.fixme(browserName === 'webkit' && !headless, 'https://github.com/microsoft/playwright-browsers/issues/637');
     const size = { width: 600, height: 400 };
     const browser = await browserType.launch();
 


### PR DESCRIPTION
This is fixed by https://github.com/microsoft/playwright-browsers/pull/643

Fixes https://github.com/microsoft/playwright-browsers/issues/637