### PR TITLE
chore: export MakeMatchers type

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5083,7 +5083,7 @@ type AllMatchers<R, T> = PageAssertions & LocatorAssertions & APIResponseAsserti
 
 type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
-type MakeMatchers<R, T> = {
+export type MakeMatchers<R, T> = {
   /**
    * If you know how to test something, `.not` lets you test its opposite.
    */


### PR DESCRIPTION
Export `MakeMatchers` type

I am developing npm package with custom `expect` matchers, and always extending `global` is not suitable, because user might not want to extend `expect` with all of them. I found out how to easily extend `expect` only with chosen matchers, but i need to extend `MakeMatchers` type to do this.