### PR TITLE
fix: desiredCapabilities removed

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -202,7 +202,6 @@ export class Chromium extends BrowserType {
         ...headers,
       },
       data: JSON.stringify({
-        desiredCapabilities,
         capabilities: { alwaysMatch: desiredCapabilities }
       }),
       timeout: progress.timeUntilDeadline(),


### PR DESCRIPTION
DesiredCapabilities field was removed in selenium grid > 4.8.2
Without this field removed it's impossible to connect to grid.
Grid throws exception on POST /session
[stackoverflow issue](https://stackoverflow.com/a/76695833)

Fixes #27276