### PR TITLE
chore: remove `Page._didDisconnect`

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -193,7 +193,7 @@ export abstract class BrowserContext extends SdkObject {
     const [, ...otherPages] = this.pages();
     for (const p of otherPages)
       await p.close(metadata);
-    if (page && page._crashedScope.isClosed()) {
+    if (page && page.hasCrashed()) {
       await page.close(metadata);
       page = undefined;
     }

--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -55,6 +55,11 @@ export class CRServiceWorker extends Worker {
     });
   }
 
+  override didClose() {
+    this._session.dispose();
+    super.didClose();
+  }
+
   async updateOffline(initial: boolean): Promise<void> {
     if (!this._isNetworkInspectionEnabled())
       return;

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -159,6 +159,9 @@ export class FFBrowser extends Browser {
     for (const video of this._idToVideo.values())
       video.artifact.reportFinished(kBrowserClosedError);
     this._idToVideo.clear();
+    for (const ffPage of this._ffPages.values())
+      ffPage.didClose();
+    this._ffPages.clear();
     this._didClose();
   }
 }

--- a/packages/playwright-core/src/server/firefox/ffConnection.ts
+++ b/packages/playwright-core/src/server/firefox/ffConnection.ts
@@ -126,9 +126,6 @@ export class FFConnection extends EventEmitter {
     this._transport.onmessage = undefined;
     this._transport.onclose = undefined;
     const formattedBrowserLogs = helper.formatBrowserLogs(this._browserLogsCollector.recentLogs());
-    for (const session of this._sessions.values())
-      session.dispose();
-    this._sessions.clear();
     for (const callback of this._callbacks.values()) {
       const error = rewriteErrorMessage(callback.error, `Protocol error (${callback.method}): Browser closed.` + formattedBrowserLogs);
       error.sessionClosed =  true;
@@ -149,10 +146,6 @@ export class FFConnection extends EventEmitter {
     return session;
   }
 }
-
-export const FFSessionEvents = {
-  Disconnected: Symbol('Disconnected')
-};
 
 export class FFSession extends EventEmitter {
   _connection: FFConnection;
@@ -228,7 +221,6 @@ export class FFSession extends EventEmitter {
     this._callbacks.clear();
     this._disposed = true;
     this._connection._sessions.delete(this._sessionId);
-    Promise.resolve().then(() => this.emit(FFSessionEvents.Disconnected));
   }
 }
 

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -25,7 +25,7 @@ import { Page, Worker } from '../page';
 import type * as types from '../types';
 import { getAccessibilityTree } from './ffAccessibility';
 import type { FFBrowserContext } from './ffBrowser';
-import { FFSession, FFSessionEvents } from './ffConnection';
+import { FFSession } from './ffConnection';
 import { FFExecutionContext } from './ffExecutionContext';
 import { RawKeyboardImpl, RawMouseImpl, RawTouchscreenImpl } from './ffInput';
 import { FFNetworkManager } from './ffNetworkManager';
@@ -100,10 +100,6 @@ export class FFPage implements PageDelegate {
       eventsHelper.addEventListener(this._session, 'Page.screencastFrame', this._onScreencastFrame.bind(this)),
 
     ];
-    session.once(FFSessionEvents.Disconnected, () => {
-      this._markAsError(new Error('Page closed'));
-      this._page._didDisconnect();
-    });
     this._session.once('Page.ready', async () => {
       await this._page.initOpener(this._opener);
       if (this._initializationFailed)
@@ -346,6 +342,7 @@ export class FFPage implements PageDelegate {
   }
 
   didClose() {
+    this._markAsError(new Error('Page closed'));
     this._session.dispose();
     eventsHelper.removeEventListeners(this._eventListeners);
     this._networkManager.dispose();

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -617,8 +617,7 @@ export class Frame extends SdkObject {
   async raceNavigationAction(progress: Progress, options: types.GotoOptions, action: () => Promise<network.Response | null>): Promise<network.Response | null> {
     return LongStandingScope.raceMultiple([
       this._detachedScope,
-      this._page._disconnectedScope,
-      this._page._crashedScope,
+      this._page.openScope,
     ], action().catch(e => {
       if (e instanceof NavigationAbortedError && e.documentId) {
         const data = this._redirectedNavigations.get(e.documentId);
@@ -1055,8 +1054,7 @@ export class Frame extends SdkObject {
         // We need this to show expected/received values in time.
         const actionPromise = new Promise(f => setTimeout(f, timeout));
         await LongStandingScope.raceMultiple([
-          this._page._disconnectedScope,
-          this._page._crashedScope,
+          this._page.openScope,
           this._detachedScope,
         ], actionPromise);
       }
@@ -1704,8 +1702,7 @@ class SignalBarrier {
       return true;
     });
     await LongStandingScope.raceMultiple([
-      frame._page._disconnectedScope,
-      frame._page._crashedScope,
+      frame._page.openScope,
       frame._detachedScope,
     ], waiter.promise).catch(() => {});
     waiter.dispose();

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -78,7 +78,8 @@ export class WKBrowser extends Browser {
 
   _onDisconnect() {
     for (const wkPage of this._wkPages.values())
-      wkPage.dispose(true);
+      wkPage.didClose();
+    this._wkPages.clear();
     for (const video of this._idToVideo.values())
       video.artifact.reportFinished(kBrowserClosedError);
     this._idToVideo.clear();
@@ -178,7 +179,6 @@ export class WKBrowser extends Browser {
     if (!wkPage)
       return;
     wkPage.didClose();
-    wkPage.dispose(false);
     this._wkPages.delete(pageProxyId);
   }
 

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -247,11 +247,11 @@ export class WKPage implements PageDelegate {
   private _onTargetDestroyed(event: Protocol.Target.targetDestroyedPayload) {
     const { targetId, crashed } = event;
     if (this._provisionalPage && this._provisionalPage._session.sessionId === targetId) {
-      this._provisionalPage._session.dispose(false);
+      this._provisionalPage._session.dispose();
       this._provisionalPage.dispose();
       this._provisionalPage = null;
     } else if (this._session.sessionId === targetId) {
-      this._session.dispose(false);
+      this._session.dispose();
       eventsHelper.removeEventListeners(this._sessionListeners);
       if (crashed) {
         this._session.markAsCrashed();
@@ -261,22 +261,18 @@ export class WKPage implements PageDelegate {
   }
 
   didClose() {
-    this._page._didClose();
-  }
-
-  dispose(disconnected: boolean) {
-    this._pageProxySession.dispose(disconnected);
+    this._pageProxySession.dispose();
     eventsHelper.removeEventListeners(this._sessionListeners);
     eventsHelper.removeEventListeners(this._eventListeners);
     if (this._session)
-      this._session.dispose(disconnected);
+      this._session.dispose();
     if (this._provisionalPage) {
-      this._provisionalPage._session.dispose(disconnected);
+      this._provisionalPage._session.dispose();
       this._provisionalPage.dispose();
       this._provisionalPage = null;
     }
-    this._page._didDisconnect();
     this._firstNonInitialNavigationCommittedReject(new Error('Page closed'));
+    this._page._didClose();
   }
 
   dispatchMessageToSession(message: any) {

--- a/packages/playwright-core/src/server/webkit/wkWorkers.ts
+++ b/packages/playwright-core/src/server/webkit/wkWorkers.ts
@@ -69,7 +69,7 @@ export class WKWorkers {
         const workerSession = this._workerSessions.get(event.workerId)!;
         if (!workerSession)
           return;
-        workerSession.dispose(false);
+        workerSession.dispose();
         this._workerSessions.delete(event.workerId);
         this._page._removeWorker(event.workerId);
       })

--- a/tests/library/beforeunload.spec.ts
+++ b/tests/library/beforeunload.spec.ts
@@ -97,10 +97,10 @@ it('should not stall on evaluate when dismissing beforeunload', async ({ page, s
   await page.click('body');
 
   await Promise.all([
+    page.waitForEvent('dialog').then(dialog => dialog.dismiss()),
     page.evaluate(() => {
       window.location.reload();
     }),
-    page.waitForEvent('dialog').then(dialog => dialog.dismiss()),
   ]);
 });
 

--- a/tests/library/browser.spec.ts
+++ b/tests/library/browser.spec.ts
@@ -49,3 +49,15 @@ test('version should work', async function({ browser, browserName }) {
   else
     expect(version.match(/^\d+\.\d+/)).toBeTruthy();
 });
+
+test('should dispatch page.on(close) upon browser.close and reject evaluate', async ({ browserType }) => {
+  const browser = await browserType.launch();
+  const page = await browser.newPage();
+  let closed = false;
+  page.on('close', () => closed = true);
+  const promise = page.evaluate(() => new Promise<void>(() => {})).catch(e => e);
+  await browser.close();
+  expect(closed).toBe(true);
+  const error = await promise;
+  expect(error.message).toMatch(/(Target|Browser) closed/);
+});

--- a/tests/page/page-close.spec.ts
+++ b/tests/page/page-close.spec.ts
@@ -26,10 +26,11 @@ it('should close page with active dialog', async ({ page }) => {
   await page.close();
 });
 
-it('should not accept after close', async ({ page, mode }) => {
+it('should not accept dialog after close', async ({ page, mode }) => {
   it.fixme(mode.startsWith('service2'), 'Times out');
+  const promise = page.waitForEvent('dialog');
   page.evaluate(() => alert()).catch(() => {});
-  const dialog = await page.waitForEvent('dialog');
+  const dialog = await promise;
   await page.close();
   const e = await dialog.dismiss().catch(e => e);
   expect(e.message).toContain('Target page, context or browser has been closed');

--- a/tests/page/page-event-request.spec.ts
+++ b/tests/page/page-event-request.spec.ts
@@ -47,9 +47,9 @@ it('should report requests and responses handled by service worker', async ({ pa
 
   await page.goto(server.PREFIX + '/serviceworkers/fetchdummy/sw.html');
   await page.evaluate(() => window['activationPromise']);
-  const [swResponse, request] = await Promise.all([
-    page.evaluate(() => window['fetchDummy']('foo')),
+  const [request, swResponse] = await Promise.all([
     page.waitForEvent('request'),
+    page.evaluate(() => window['fetchDummy']('foo')),
   ]);
   expect(swResponse).toBe('responseFromServiceWorker:foo');
   expect(request.url()).toBe(server.PREFIX + '/serviceworkers/fetchdummy/foo');


### PR DESCRIPTION
Instead of having `didClose` based on page creation/destruction and `didDisconnect` based on session lifetime, we make session lifetime being managed by the `CRPage`/`FFPage`/`WKPage` instead.