### PR TITLE
docs(trace-viewer.md): include trace options with object

### DIFF
--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -160,6 +160,13 @@ Available options to record a trace:
 
 You can also use `trace: 'retain-on-failure'` if you do not enable retries but still want traces for failed tests.
 
+To save disk space, you can use an object to configure the trace options and disable features like screenshots:
+- `'mode'` - Specify the trace mode, e.g. `'on-first-retry'`.
+- `'snapshots'` -  Set to `true` to capture snapshots during tracing.
+- `'screenshots'` - Set to `true` to capture screenshots during tracing.
+- `'sources'` - Set to `true` to capture source code during tracing.
+- `'attachments'` - Set to `true` to include additional attachments during tracing.
+
 If you are not using Playwright as a Test Runner, use the [`property: BrowserContext.tracing`] API instead.
 
 ## Recording a trace


### PR DESCRIPTION
I'm limited to 1gb artifacts space on gitlab and I've got the useful advice to disable some trace options like screenshots and sources from a discord user.
This PR adds the missing information in the docs, that you can pass an object to `trace`.
