### PR TITLE
docs(ct): pnpm create playwright

### DIFF
--- a/docs/src/test-components-js.md
+++ b/docs/src/test-components-js.md
@@ -69,7 +69,7 @@ yarn create playwright --ct
 <TabItem value="pnpm">
 
 ```bash
-pnpm dlx create-playwright --ct
+pnpm create playwright --ct
 ```
 
  </TabItem>


### PR DESCRIPTION
pnpm supports the `create` command which acts as a shortcut to `pnpm dlx create-*`

related: https://github.com/microsoft/playwright/pull/24397/files#diff-af370723ed754e89d1e69d20f211a5a8249651b1b5692348398bbd105f1ac445R47