### PR TITLE
Fix various typos (Fixes #27396)

### DIFF
--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -1302,7 +1302,7 @@ Throws elements that are not an input, textarea or a select. However, if the ele
 Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
 
 :::caution Asserting checked state
-If you need to assert that checkobx is checked, prefer [`method: LocatorAssertions.toBeChecked`] to avoid flakiness. See [assertions guide](../test-assertions.md) for more details.
+If you need to assert that checkbox is checked, prefer [`method: LocatorAssertions.toBeChecked`] to avoid flakiness. See [assertions guide](../test-assertions.md) for more details.
 :::
 
 **Usage**

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -4791,8 +4791,8 @@ class FrameExamples
 * since: v1.32
 * langs: java
 
-The method will block until the codition returns true. All Playwright events will
-be dispatched while the method is waiting for the codition.
+The method will block until the condition returns true. All Playwright events will
+be dispatched while the method is waiting for the condition.
 
 **Usage**
 
@@ -4809,7 +4809,7 @@ page.waitForCondition(() -> messages.size() > 3);
 * since: v1.32
 - `condition` <[BooleanSupplier]>
 
-Codition to wait for.
+Condition to wait for.
 
 ### option: Page.waitForCondition.timeout = %%-wait-for-function-timeout-%%
 * since: v1.32

--- a/docs/src/api/class-weberror.md
+++ b/docs/src/api/class-weberror.md
@@ -1,7 +1,7 @@
 # class: WebError
 * since: v1.38
 
-[WebError] class represents an unhandled exeception thrown in the page. It is dispatched via the [`event: BrowserContext.webError`] event.
+[WebError] class represents an unhandled exception thrown in the page. It is dispatched via the [`event: BrowserContext.webError`] event.
 
 ```js
 // Log all uncaught errors to the terminal

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -85,7 +85,7 @@ Prefer [auto-retrying](#auto-retrying-assertions) assertions whenever possible. 
 | [`method: GenericAssertions.toStrictEqual`] | Value is similar, including property types |
 | [`method: GenericAssertions.toThrow`] | Function throws an error |
 | [`method: GenericAssertions.any`] | Matches any instance of a class/primitive |
-| [`method: GenericAssertions.anything`] | Matches antyhing |
+| [`method: GenericAssertions.anything`] | Matches anything |
 | [`method: GenericAssertions.arrayContaining`] | Array contains specific elements |
 | [`method: GenericAssertions.closeTo`] | Number is approximately equal |
 | [`method: GenericAssertions.objectContaining`] | Object contains specific properties |

--- a/packages/playwright-core/src/client/electron.ts
+++ b/packages/playwright-core/src/client/electron.ts
@@ -93,7 +93,7 @@ export class ElectronApplication extends ChannelOwner<channels.ElectronApplicati
   }
 
   windows(): Page[] {
-    // TODO: add ElectronPage class inherting from Page.
+    // TODO: add ElectronPage class inheriting from Page.
     return [...this._windows];
   }
 

--- a/packages/playwright-core/src/image_tools/colorUtils.ts
+++ b/packages/playwright-core/src/image_tools/colorUtils.ts
@@ -24,10 +24,10 @@ export function rgb2gray(r: number, g: number, b: number): number {
   return (77 * r + 150 * g + 29 * b + 128) >> 8;
 }
 
-// Percieved color difference defined by CIE94.
+// Perceived color difference defined by CIE94.
 // See https://en.wikipedia.org/wiki/Color_difference#CIE94
 //
-// The result of 1.0 is a "just-noticiable difference".
+// The result of 1.0 is a "just-noticeable difference".
 //
 // Other results interpretation (taken from http://zschuessler.github.io/DeltaE/learn/):
 //   < 1.0     Not perceptible by human eyes.

--- a/packages/playwright-core/src/image_tools/compare.ts
+++ b/packages/playwright-core/src/image_tools/compare.ts
@@ -106,8 +106,8 @@ export function compare(actual: Buffer, expected: Buffer, diff: Buffer|null, wid
       const [ssimX1, ssimY1] = r1.boundXY(x - SSIM_WINDOW_RADIUS, y - SSIM_WINDOW_RADIUS);
       const [ssimX2, ssimY2] = r1.boundXY(x + SSIM_WINDOW_RADIUS, y + SSIM_WINDOW_RADIUS);
       const ssimRGB = (ssim(fastR, ssimX1, ssimY1, ssimX2, ssimY2) + ssim(fastG, ssimX1, ssimY1, ssimX2, ssimY2) + ssim(fastB, ssimX1, ssimY1, ssimX2, ssimY2)) / 3.0;
-      const isAntialiassed = ssimRGB >= 0.99;
-      if (isAntialiassed) {
+      const isAntialiased = ssimRGB >= 0.99;
+      if (isAntialiased) {
         drawYellowPixel(x, y);
       } else {
         drawRedPixel(x, y);

--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -137,7 +137,7 @@ export class PlaywrightServer {
       }
 
       const connection = new PlaywrightConnection(
-          semaphore.aquire(),
+          semaphore.acquire(),
           clientType, ws,
           { socksProxyPattern: proxyValue, browserName, launchOptions },
           {
@@ -184,7 +184,7 @@ export class PlaywrightServer {
 
 export class Semaphore {
   private _max: number;
-  private _aquired = 0;
+  private _acquired = 0;
   private _queue: ManualPromise[] = [];
 
   constructor(max: number) {
@@ -195,7 +195,7 @@ export class Semaphore {
     this._max = max;
   }
 
-  aquire(): Promise<void> {
+  acquire(): Promise<void> {
     const lock = new ManualPromise();
     this._queue.push(lock);
     this._flush();
@@ -203,13 +203,13 @@ export class Semaphore {
   }
 
   release() {
-    --this._aquired;
+    --this._acquired;
     this._flush();
   }
 
   private _flush() {
-    while (this._aquired < this._max && this._queue.length) {
-      ++this._aquired;
+    while (this._acquired < this._max && this._queue.length) {
+      ++this._acquired;
       this._queue.shift()!.resolve();
     }
   }

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -178,7 +178,7 @@ export class AndroidDevice extends SdkObject {
     debug('pw:android')('Stopping the old driver');
     await this.shell(`am force-stop com.microsoft.playwright.androiddriver`);
 
-    // uninstall and install driver on every excution
+    // uninstall and install driver on every execution
     if (!this._options.omitDriverInstall) {
       debug('pw:android')('Uninstalling the old driver');
       await this.shell(`cmd package uninstall com.microsoft.playwright.androiddriver`);

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -537,7 +537,7 @@ export class CRBrowserContext extends BrowserContext {
       // When closing a browser context, service workers are shutdown
       // asynchronously and we get detached from them later.
       // To avoid the wrong order of notifications, we manually fire
-      // "close" event here and forget about the serivce worker.
+      // "close" event here and forget about the service worker.
       serviceWorker.didClose();
       this._browser._serviceWorkers.delete(targetId);
     }

--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -188,7 +188,7 @@ export class CRNetworkManager {
 
   _onRequestPaused(sessionInfo: SessionInfo, event: Protocol.Fetch.requestPausedPayload) {
     if (!event.networkId) {
-      // Fetch without networkId means that request was not recongnized by inspector, and
+      // Fetch without networkId means that request was not recognized by inspector, and
       // it will never receive Network.requestWillBeSent. Most likely, this is an internal request
       // that we can safely fail.
       this._session._sendMayFail('Fetch.failRequest', {
@@ -310,7 +310,7 @@ export class CRNetworkManager {
       if (response.body || !expectedLength)
         return Buffer.from(response.body, response.base64Encoded ? 'base64' : 'utf8');
 
-      // For <link prefetch we are going to receive empty body with non-emtpy content-length expectation. Reach out for the actual content.
+      // For <link prefetch we are going to receive empty body with non-empty content-length expectation. Reach out for the actual content.
       const resource = await session.send('Network.loadNetworkResource', { url: request.request.url(), frameId: this._serviceWorker ? undefined : request.request.frame()!._id, options: { disableCache: false, includeCredentials: true } });
       const chunks: Buffer[] = [];
       while (resource.resource.stream) {

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -130,7 +130,7 @@ export class CRPage implements PageDelegate {
       if (frameSession._isMainFrame())
         return cb(frameSession);
       return cb(frameSession).catch(e => {
-        // Broadcasting a message to the closed iframe shoule be a noop.
+        // Broadcasting a message to the closed iframe should be a noop.
         if (e.message && e.message.includes('Target closed'))
           return;
         throw e;
@@ -668,7 +668,7 @@ class FrameSession {
 
   _onFrameDetached(frameId: string, reason: 'remove' | 'swap') {
     if (this._crPage._sessions.has(frameId)) {
-      // This is a local -> remote frame transtion, where
+      // This is a local -> remote frame transition, where
       // Page.frameDetached arrives after Target.attachedToTarget.
       // We've already handled the new target and frame reattach - nothing to do here.
       return;
@@ -777,7 +777,7 @@ class FrameSession {
     }
 
     // However, sometimes we get detachedFromTarget before frameAttached.
-    // In this case we don't know wheter this is a remote frame detach,
+    // In this case we don't know whether this is a remote frame detach,
     // or just a remote -> local transition. In the latter case, frameAttached
     // is already inflight, so let's make a safe roundtrip to ensure it arrives.
     this._client.send('Page.enable').catch(e => null).then(() => {
@@ -953,7 +953,7 @@ class FrameSession {
     this._videoRecorder = null;
     await this._stopScreencast(recorder);
     await recorder.stop().catch(() => {});
-    // Keep the video artifact in the map utntil encoding is fully finished, if the context
+    // Keep the video artifact in the map until encoding is fully finished, if the context
     // starts closing before the video is fully written to disk it will wait for it.
     const video = this._crPage._browserContext._browser._takeVideo(screencastId);
     video?.reportFinished();

--- a/packages/playwright-core/src/server/chromium/protocol.d.ts
+++ b/packages/playwright-core/src/server/chromium/protocol.d.ts
@@ -245,7 +245,7 @@ If omitted, the full tree is returned.
       depth?: number;
       /**
        * The frame for whose document the AX tree should be retrieved.
-If omited, the root frame is used.
+If omitted, the root frame is used.
        */
       frameId?: Page.FrameId;
     }
@@ -1101,7 +1101,7 @@ Munich 81456
      */
     export interface AddressUI {
       /**
-       * A two dimension array containing the repesentation of values from an address profile.
+       * A two dimension array containing the representation of values from an address profile.
        */
       addressFields: AddressFields[];
     }
@@ -1505,7 +1505,7 @@ Note that userVisibleOnly = true is the only currently supported type.
       /**
        * Whether to allow all or deny all download requests, or use default Chrome behavior if
 available (otherwise deny). |allowAndName| allows download and names files according to
-their dowmload guids.
+their download guides.
        */
       behavior: "deny"|"allow"|"allowAndName"|"default";
       /**
@@ -1853,7 +1853,7 @@ pseudo-classes.
       frameId: Page.FrameId;
       /**
        * Stylesheet resource URL. Empty if this is a constructed stylesheet created using
-new CSSStyleSheet() (but non-empty if this is a constructed sylesheet imported
+new CSSStyleSheet() (but non-empty if this is a constructed stylesheet imported
 as a CSS module script).
        */
       sourceURL: string;
@@ -3549,7 +3549,7 @@ The property is always undefined now.
        */
       nodeId: NodeId;
       /**
-       * A ttribute name.
+       * Attribute name.
        */
       name: string;
     }
@@ -3860,7 +3860,7 @@ be called for that search.
      */
     export type getAttributesParameters = {
       /**
-       * Id of the node to retrieve attibutes for.
+       * Id of the node to retrieve attributes for.
        */
       nodeId: NodeId;
     }
@@ -5995,7 +5995,7 @@ on Android.
        */
       userAgent: string;
       /**
-       * Browser langugage to emulate.
+       * Browser language to emulate.
        */
       acceptLanguage?: string;
       /**
@@ -7258,7 +7258,7 @@ transform/scrolling purposes only.
     }
     export type layerTreeDidChangePayload = {
       /**
-       * Layer tree, absent if not in the comspositing mode.
+       * Layer tree, absent if not in the compositing mode.
        */
       layers?: Layer[];
     }
@@ -7869,7 +7869,7 @@ passed by the developer (e.g. via "fetch") as understood by the backend.
       trustTokenParams?: TrustTokenParams;
       /**
        * True if this resource request is considered to be the 'same site' as the
-request correspondinfg to the main frame.
+request corresponding to the main frame.
        */
       isSameSite?: boolean;
     }
@@ -8581,7 +8581,7 @@ https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-
        */
       securityDetails?: SecurityDetails;
       /**
-       * Errors occurred while handling the signed exchagne.
+       * Errors occurred while handling the signed exchange.
        */
       errors?: SignedExchangeError[];
     }
@@ -9847,7 +9847,7 @@ continueInterceptedRequest call.
        */
       userAgent: string;
       /**
-       * Browser langugage to emulate.
+       * Browser language to emulate.
        */
       acceptLanguage?: string;
       /**
@@ -9917,7 +9917,7 @@ should be omitted for worker targets.
      */
     export interface SourceOrderConfig {
       /**
-       * the color to outline the givent element in.
+       * the color to outline the given element in.
        */
       parentOutlineColor: DOM.RGBA;
       /**
@@ -10401,7 +10401,7 @@ user manually inspects an element.
     }
     /**
      * Highlights owner element of the frame with given id.
-Deprecated: Doesn't work reliablity and cannot be fixed due to process
+Deprecated: Doesn't work reliably and cannot be fixed due to process
 separatation (the owner node might be in a different process). Determine
 the owner node in the client and use highlightNode.
      */
@@ -11003,7 +11003,7 @@ Example URLs: http://www.google.com/file.html -> "google.com"
        */
       message: string;
       /**
-       * If criticial, this is a non-recoverable parse error.
+       * If critical, this is a non-recoverable parse error.
        */
       critical: number;
       /**
@@ -11210,7 +11210,7 @@ Example URLs: http://www.google.com/file.html -> "google.com"
       eager?: boolean;
     }
     /**
-     * Enum of possible auto-reponse for permisison / prompt dialogs.
+     * Enum of possible auto-response for permission / prompt dialogs.
      */
     export type AutoResponseMode = "none"|"autoAccept"|"autoReject"|"autoOptOut";
     /**
@@ -12468,7 +12468,7 @@ https://github.com/WICG/web-lifecycle/
     }
     /**
      * Requests backend to produce compilation cache for the specified scripts.
-`scripts` are appeneded to the list of scripts for which the cache
+`scripts` are appended to the list of scripts for which the cache
 would be produced. The list may be reset during page navigation.
 When script with a matching URL is encountered, the cache is optionally
 produced upon backend discretion, based on internal heuristics.
@@ -12687,7 +12687,7 @@ https://w3c.github.io/performance-timeline/#dom-performanceobserver.
       frameId: Page.FrameId;
       /**
        * The event type, as specified in https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype
-This determines which of the optional "details" fiedls is present.
+This determines which of the optional "details" fields is present.
        */
       type: string;
       /**
@@ -12797,7 +12797,7 @@ https://www.w3.org/TR/mixed-content/#categories
        */
       certificateNetworkError?: string;
       /**
-       * True if the certificate uses a weak signature aglorithm.
+       * True if the certificate uses a weak signature algorithm.
        */
       certificateHasWeakSignature: boolean;
       /**
@@ -14146,7 +14146,7 @@ the type of "page", this may be set to "portal" or "prerender".
      */
     export interface FilterEntry {
       /**
-       * If set, causes exclusion of mathcing targets from the list.
+       * If set, causes exclusion of matching targets from the list.
        */
       exclude?: boolean;
       /**
@@ -15918,7 +15918,7 @@ still keyed with the initial URL.
 that had a speculation rule that triggered the attempt, and the
 BackendNodeIds of <a href> or <area href> elements that triggered the
 attempt (in the case of attempts triggered by a document rule). It is
-possible for mulitple rule sets and links to trigger a single attempt.
+possible for multiple rule sets and links to trigger a single attempt.
      */
     export interface PreloadingAttemptSource {
       key: PreloadingAttemptKey;
@@ -16781,7 +16781,7 @@ will return errors.
      * Restarts particular call frame from the beginning. The old, deprecated
 behavior of `restartFrame` is to stay paused and allow further CDP commands
 after a restart was scheduled. This can cause problems with restarting, so
-we now continue execution immediatly after it has been scheduled until we
+we now continue execution immediately after it has been scheduled until we
 reach the beginning of the restarted frame.
 
 To stay back-wards compatible, `restartFrame` now expects a `mode`
@@ -18240,7 +18240,7 @@ execution. Overrides `setPauseOnException` state.
       silent?: boolean;
       /**
        * Whether the result is expected to be a JSON object which should be sent by value.
-Can be overriden by `serializationOptions`.
+Can be overridden by `serializationOptions`.
        */
       returnByValue?: boolean;
       /**

--- a/packages/playwright-core/src/server/debugController.ts
+++ b/packages/playwright-core/src/server/debugController.ts
@@ -98,7 +98,7 @@ export class DebugController extends SdkObject {
 
     if (params.mode === 'none') {
       for (const recorder of await this._allRecorders()) {
-        recorder.hideHighlightedSelecor();
+        recorder.hideHighlightedSelector();
         recorder.setMode('none');
       }
       this.setAutoCloseEnabled(true);
@@ -121,7 +121,7 @@ export class DebugController extends SdkObject {
     }
     // Toggle the mode.
     for (const recorder of await this._allRecorders()) {
-      recorder.hideHighlightedSelecor();
+      recorder.hideHighlightedSelector();
       if (params.mode === 'recording')
         recorder.setOutput(this._codegenId, params.file);
       recorder.setMode(params.mode);
@@ -153,7 +153,7 @@ export class DebugController extends SdkObject {
   async hideHighlight() {
     // Hide all active recorder highlights.
     for (const recorder of await this._allRecorders())
-      recorder.hideHighlightedSelecor();
+      recorder.hideHighlightedSelector();
     // Hide all locator.highlight highlights.
     await this._playwright.hideHighlight();
   }

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -843,7 +843,7 @@ export class InjectedScriptPollHandler<T> {
     this._poll = poll;
     // Ensure we cancel the poll before progress aborts and returns:
     //   - no unnecessary work in the page;
-    //   - no possible side effects after progress promsie rejects.
+    //   - no possible side effects after progress promise rejects.
     this._progress.cleanupWhenAborted(() => this.cancel());
     this._streamLogs();
   }

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -484,7 +484,7 @@ export class HarTracer {
       this._recordRequestHeadersAndCookies(harEntry, headers);
     }));
     // Record available headers including redirect location in case the tracing is stopped before
-    // reponse extra info is received (in Chromium).
+    // response extra info is received (in Chromium).
     this._recordResponseHeaders(harEntry, response.headers());
     this._addBarrier(page || request.serviceWorker(), response.rawResponseHeaders().then(headers => {
       this._recordResponseHeaders(harEntry, headers);

--- a/packages/playwright-core/src/server/injected/selectorEvaluator.ts
+++ b/packages/playwright-core/src/server/injected/selectorEvaluator.ts
@@ -24,7 +24,7 @@ import { normalizeWhiteSpace } from '../../utils/isomorphic/stringUtils';
 type QueryContext = {
   scope: Element | Document;
   pierceShadow: boolean;
-  // When context expands to accomodate :scope matching, original scope is saved here.
+  // When context expands to accommodate :scope matching, original scope is saved here.
   originalScope?: Element | Document;
   // Place for more options, e.g. normalizing whitespace.
 };

--- a/packages/playwright-core/src/server/injected/selectorGenerator.ts
+++ b/packages/playwright-core/src/server/injected/selectorGenerator.ts
@@ -176,7 +176,7 @@ function generateSelectorFor(injectedScript: InjectedScript, targetElement: Elem
 function buildNoTextCandidates(injectedScript: InjectedScript, element: Element, options: GenerateSelectorOptions): SelectorToken[] {
   const candidates: SelectorToken[] = [];
 
-  // CSS selectors are applicale to elements via locator() and iframes via frameLocator().
+  // CSS selectors are applicable to elements via locator() and iframes via frameLocator().
   {
     for (const attr of ['data-testid', 'data-test-id', 'data-test']) {
       if (attr !== options.testIdAttributeName && element.getAttribute(attr))

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -685,7 +685,7 @@ export class Page extends SdkObject {
     this._frameThrottler.ack(ack);
   }
 
-  temporarlyDisableTracingScreencastThrottling() {
+  temporarilyDisableTracingScreencastThrottling() {
     this._frameThrottler.recharge();
   }
 

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -239,7 +239,7 @@ export class Recorder implements InstrumentationListener {
     this._refreshOverlay();
   }
 
-  hideHighlightedSelecor() {
+  hideHighlightedSelector() {
     this._highlightedSelector = '';
     this._refreshOverlay();
   }
@@ -260,7 +260,7 @@ export class Recorder implements InstrumentationListener {
     this._updateUserSources();
     this.updateCallLog([metadata]);
     if (isScreenshotCommand(metadata)) {
-      this.hideHighlightedSelecor();
+      this.hideHighlightedSelector();
     } else if (metadata.params && metadata.params.selector) {
       this._highlightedSelector = metadata.params.selector;
       this._recorderApp?.setSelector(this._highlightedSelector).catch(() => {});

--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -341,7 +341,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string) {
           return;
         if (nodeName === 'META' && (node as HTMLMetaElement).httpEquiv.toLowerCase() === 'content-security-policy')
           return;
-        // Skip iframes which are inside document's head as they are not visisble.
+        // Skip iframes which are inside document's head as they are not visible.
         // See https://github.com/microsoft/playwright/issues/12005.
         if ((nodeName === 'IFRAME' || nodeName === 'FRAME') && headNesting)
           return;

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -348,7 +348,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     const event = createBeforeActionTraceEvent(metadata);
     if (!event)
       return Promise.resolve();
-    sdkObject.attribution.page?.temporarlyDisableTracingScreencastThrottling();
+    sdkObject.attribution.page?.temporarilyDisableTracingScreencastThrottling();
     event.beforeSnapshot = `before@${metadata.id}`;
     this._state?.callIds.add(metadata.id);
     this._appendTraceEvent(event);
@@ -362,7 +362,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     const event = createInputActionTraceEvent(metadata);
     if (!event)
       return Promise.resolve();
-    sdkObject.attribution.page?.temporarlyDisableTracingScreencastThrottling();
+    sdkObject.attribution.page?.temporarilyDisableTracingScreencastThrottling();
     event.inputSnapshot = `input@${metadata.id}`;
     this._appendTraceEvent(event);
     return this._captureSnapshot(event.inputSnapshot, sdkObject, metadata, element);
@@ -375,7 +375,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     const event = createAfterActionTraceEvent(metadata);
     if (!event)
       return;
-    sdkObject.attribution.page?.temporarlyDisableTracingScreencastThrottling();
+    sdkObject.attribution.page?.temporarilyDisableTracingScreencastThrottling();
     event.afterSnapshot = `after@${metadata.id}`;
     this._appendTraceEvent(event);
     return this._captureSnapshot(event.afterSnapshot, sdkObject, metadata);

--- a/packages/playwright-core/src/server/webkit/protocol.d.ts
+++ b/packages/playwright-core/src/server/webkit/protocol.d.ts
@@ -907,7 +907,7 @@ export module Protocol {
      */
     export interface FontVariationAxis {
       /**
-       * The name, generally human-readable, of the variation axis. Some axes may not provide a human-readable name distiguishable from the tag. This field is ommited when there is no name, or the name matches the tag exactly.
+       * The name, generally human-readable, of the variation axis. Some axes may not provide a human-readable name distinguishable from the tag. This field is omitted when there is no name, or the name matches the tag exactly.
        */
       name?: string;
       /**
@@ -1209,7 +1209,7 @@ export module Protocol {
     export type forcePseudoStateReturnValue = {
     }
     /**
-     * Change how layout context type changes are handled for nodes. When the new mode would observe nodes the frontend has not yet recieved, those nodes will be sent to the frontend immediately.
+     * Change how layout context type changes are handled for nodes. When the new mode would observe nodes the frontend has not yet received, those nodes will be sent to the frontend immediately.
      */
     export type setLayoutContextTypeChangedModeParameters = {
       /**
@@ -1908,7 +1908,7 @@ export module Protocol {
        */
       binding: string;
       /**
-       * A more descriptive name for the type of binding that represents this paritcular data relationship
+       * A more descriptive name for the type of binding that represents this particular data relationship
        */
       type?: string;
       /**
@@ -6311,7 +6311,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
      */
     export type Setting = "PrivateClickMeasurementDebugModeEnabled"|"AuthorAndUserStylesEnabled"|"ICECandidateFilteringEnabled"|"ITPDebugModeEnabled"|"ImagesEnabled"|"MediaCaptureRequiresSecureConnection"|"MockCaptureDevicesEnabled"|"NeedsSiteSpecificQuirks"|"ScriptEnabled"|"ShowDebugBorders"|"ShowRepaintCounter"|"WebSecurityEnabled"|"DeviceOrientationEventEnabled"|"SpeechRecognitionEnabled"|"PointerLockEnabled"|"NotificationsEnabled"|"FullScreenEnabled"|"InputTypeMonthEnabled"|"InputTypeWeekEnabled";
     /**
-     * A user preference that can be overriden by Web Inspector, like an accessibility preference.
+     * A user preference that can be overridden by Web Inspector, like an accessibility preference.
      */
     export interface UserPreference {
       /**
@@ -6602,7 +6602,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
        */
       children?: AXNode[];
       /**
-       * True if this AXNode corresponds with the ObjectId passed into acessibilitySnapshot.
+       * True if this AXNode corresponds with the ObjectId passed into accessibilitySnapshot.
        */
       found?: boolean;
     }
@@ -6689,7 +6689,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
        */
       delay: number;
       /**
-       * Whether the naviation will happen in the same frame.
+       * Whether the navigation will happen in the same frame.
        */
       targetIsCurrentFrame: boolean;
     }
@@ -6720,7 +6720,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
      */
     export type defaultUserPreferencesDidChangePayload = {
       /**
-       * List of user preferences that can be overriden and their new system (default) values.
+       * List of user preferences that can be overridden and their new system (default) values.
        */
       preferences: UserPreference[];
     }
@@ -7489,7 +7489,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
       browserContextId: ContextID;
     }
     /**
-     * Deletes browser context previously created with createContect. The command will automatically close all pages that use the context.
+     * Deletes browser context previously created with createContext. The command will automatically close all pages that use the context.
      */
     export type deleteContextParameters = {
       /**
@@ -7756,7 +7756,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
       version: number;
       type: Type;
       /**
-       * JSON data of inital state of object before recording.
+       * JSON data of initial state of object before recording.
        */
       initialState: InitialState;
       /**
@@ -8096,7 +8096,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
      */
     export interface TypeDescription {
       /**
-       * If true, we were able to correlate the offset successfuly with a program location. If false, the offset may be bogus or the offset may be from a CodeBlock that hasn't executed.
+       * If true, we were able to correlate the offset successfully with a program location. If false, the offset may be bogus or the offset may be from a CodeBlock that hasn't executed.
        */
       isValid: boolean;
       /**
@@ -8594,7 +8594,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     }
     
     /**
-     * Starts recoring video to speified file.
+     * Starts recording video to specified file.
      */
     export type startVideoParameters = {
       /**

--- a/packages/playwright-core/src/server/webkit/wkAccessibility.ts
+++ b/packages/playwright-core/src/server/webkit/wkAccessibility.ts
@@ -148,7 +148,7 @@ class WKAXNode implements accessibility.AXNode {
     return this.isLeafNode() && !!name;
   }
 
-  _hasRendundantTextChild() {
+  _hasRedundantTextChild() {
     if (this._children.length !== 1)
       return false;
     const child = this._children[0];
@@ -162,7 +162,7 @@ class WKAXNode implements accessibility.AXNode {
     if (this._isTextControl())
       return true;
       // WebKit for mac has text nodes inside heading, li, menuitem, a, and p nodes
-    if (this._hasRendundantTextChild())
+    if (this._hasRedundantTextChild())
       return true;
     return false;
   }
@@ -217,7 +217,7 @@ class WKAXNode implements accessibility.AXNode {
       'selected',
     ];
     for (const booleanProperty of booleanProperties) {
-      // WebArea and ScorllArea treat focus differently than other nodes. They report whether their frame  has focus,
+      // WebArea and ScrollArea treat focus differently than other nodes. They report whether their frame  has focus,
       // not whether focus is specifically on the root node.
       if (booleanProperty === 'focused' && (this._payload.role === 'WebArea' || this._payload.role === 'ScrollArea'))
         continue;

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -122,7 +122,7 @@ export class WKBrowser extends Browser {
     // here by simulating cancelled provisional load which matches downloads from network.
     //
     // TODO: this is racy, because download might be unrelated any navigation, and we will
-    // abort navgitation that is still running. We should be able to fix this by
+    // abort navigation that is still running. We should be able to fix this by
     // instrumenting policy decision start/proceed/cancel.
     page._page._frameManager.frameAbortedNavigation(payload.frameId, 'Download is starting');
     let originPage = page._initializedPage;

--- a/packages/playwright-core/src/server/webkit/wkInterceptableRequest.ts
+++ b/packages/playwright-core/src/server/webkit/wkInterceptableRequest.ts
@@ -101,7 +101,7 @@ export class WKInterceptableRequest {
         headers['Host'] = new URL(this.request.url()).host;
       this.request.setRawRequestHeaders(headersObjectToArray(headers));
     } else {
-      // No raw headers avaialable, use provisional ones.
+      // No raw headers available, use provisional ones.
       this.request.setRawRequestHeaders(null);
     }
     return response;

--- a/packages/playwright-core/src/utils/happy-eyeballs.ts
+++ b/packages/playwright-core/src/utils/happy-eyeballs.ts
@@ -133,7 +133,7 @@ async function lookupAddresses(hostname: string): Promise<dns.LookupAddress[]> {
     secondFamily = tmp;
   }
   const result = [];
-  // Alternate ipv6 and ipv4 addreses.
+  // Alternate ipv6 and ipv4 addresses.
   for (let i = 0; i < Math.max(firstFamily.length, secondFamily.length); i++) {
     if (firstFamily[i])
       result.push(firstFamily[i]);

--- a/packages/playwright-core/src/utils/isomorphic/selectorParser.ts
+++ b/packages/playwright-core/src/utils/isomorphic/selectorParser.ts
@@ -302,7 +302,7 @@ export function parseAttributeSelector(selector: string, allowUnquotedStrings: b
       if (next() === '\\') {
         source += eat1();
         if (EOL)
-          syntaxError('parsing regular expressiion');
+          syntaxError('parsing regular expression');
       } else if (inClass && next() === ']') {
         inClass = false;
       } else if (!inClass && next() === '[') {

--- a/packages/playwright-core/src/utils/processLauncher.ts
+++ b/packages/playwright-core/src/utils/processLauncher.ts
@@ -200,7 +200,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     // reentrancy to this function, for example user sends SIGINT second time.
     // In this case, let's forcefully kill the process.
     if (gracefullyClosing) {
-      options.log(`[pid=${spawnedProcess.pid}] <forecefully close>`);
+      options.log(`[pid=${spawnedProcess.pid}] <forcefully close>`);
       killProcess();
       await waitForCleanup;  // Ensure the process is dead and we have cleaned up.
       return;

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -11716,7 +11716,7 @@ export interface Locator {
   /**
    * Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
    *
-   * **NOTE** If you need to assert that checkobx is checked, prefer
+   * **NOTE** If you need to assert that checkbox is checked, prefer
    * [locatorAssertions.toBeChecked([options])](https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-be-checked)
    * to avoid flakiness. See [assertions guide](https://playwright.dev/docs/test-assertions) for more details.
    *
@@ -19055,7 +19055,7 @@ export interface Video {
 }
 
 /**
- * {@link WebError} class represents an unhandled exeception thrown in the page. It is dispatched via the
+ * {@link WebError} class represents an unhandled exception thrown in the page. It is dispatched via the
  * [browserContext.on('weberror')](https://playwright.dev/docs/api/class-browsercontext#browser-context-event-web-error)
  * event.
  *

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -452,7 +452,7 @@ class JobDispatcher {
     this._massSkipTestsFromRemaining(new Set(testsBelongingToSomeSerialSuiteWithFailures.map(test => test.id)), []);
 
     for (const serialSuite of serialSuitesWithFailures) {
-      // Add all tests from faiiled serial suites for possible retry.
+      // Add all tests from failed serial suites for possible retry.
       // These will only be retried together, because they have the same
       // "retries" setting and the same number of previous runs.
       serialSuite.allTests().forEach(test => retryCandidates.add(test));

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -100,7 +100,7 @@ export async function loadFileSuites(testRun: TestRun, mode: 'out-of-process' | 
   }
 
   // Check that no test file imports another test file.
-  // Loader must be stopped first, since it popuplates the dependency tree.
+  // Loader must be stopped first, since it populates the dependency tree.
   for (const file of allTestFiles) {
     for (const dependency of dependenciesForTestFile(file)) {
       if (allTestFiles.has(dependency)) {

--- a/packages/playwright/src/runner/reporters.ts
+++ b/packages/playwright/src/runner/reporters.ts
@@ -66,7 +66,7 @@ export async function createReporters(config: FullConfigInternal, mode: 'list' |
   const someReporterPrintsToStdio = reporters.some(r => r.printsToStdio());
   if (reporters.length && !someReporterPrintsToStdio) {
     // Add a line/dot/list-mode reporter for convenience.
-    // Important to put it first, jsut in case some other reporter stalls onEnd.
+    // Important to put it first, just in case some other reporter stalls onEnd.
     if (mode === 'list')
       reporters.unshift(new ListModeReporter());
     else if (mode !== 'merge')

--- a/packages/playwright/src/runner/taskRunner.ts
+++ b/packages/playwright/src/runner/taskRunner.ts
@@ -106,7 +106,7 @@ export class TaskRunner<Context> {
     }
     cancelPromise?.resolve();
     // Note that upon hitting deadline, we "run cleanup", but it exits immediately
-    // because of the same deadline. Essentially, we're not perfomring any cleanup.
+    // because of the same deadline. Essentially, we're not performing any cleanup.
     const cleanup = () => teardownRunner.runDeferCleanup(context, deadline).then(r => r.status);
     return { status, cleanup };
   }

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -261,11 +261,11 @@ function createRunTestsTask(): Task<TestRun> {
 
       for (const { dispatcher, projects } of phases) {
         // Each phase contains dispatcher and a set of test groups.
-        // We don't want to run the test groups beloning to the projects
+        // We don't want to run the test groups belonging to the projects
         // that depend on the projects that failed previously.
         const phaseTestGroups: TestGroup[] = [];
         for (const { project, testGroups } of projects) {
-          // Inherit extra enviroment variables from dependencies.
+          // Inherit extra environment variables from dependencies.
           let extraEnv: Record<string, string | undefined> = {};
           for (const dep of project.deps)
             extraEnv = { ...extraEnv, ...extraEnvByProjectId.get(dep.id) };

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -340,7 +340,7 @@ export function resolveImportSpecifierExtension(resolved: string): string | unde
       if (fileExists(modified))
         return modified;
     }
-    break;  // Do not try '' when a more specific extesion like '.jsx' matched.
+    break;  // Do not try '' when a more specific extension like '.jsx' matched.
   }
 
   if (dirExists(resolved)) {

--- a/tests/assets/download-blob.html
+++ b/tests/assets/download-blob.html
@@ -24,6 +24,6 @@
       download("Hello world", "example.txt");
     }
     </script>
-    <a onclick="javascipt:downloadIt();">Download</a>
+    <a onclick="javascript:downloadIt();">Download</a>
   </body>
 </html>

--- a/tests/config/commonFixtures.ts
+++ b/tests/config/commonFixtures.ts
@@ -33,7 +33,7 @@ import childProcess from 'child_process';
 
 type ProcessData = {
   pid: number, // process ID
-  pgrp: number, // process groupd ID
+  pgrp: number, // process group ID
   children: Set<ProcessData>, // direct children of the process
 };
 

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -62,7 +62,7 @@ export class TestProxy {
       // MITM connect requests otherwise, unless the system/browser is configured
       // to ignore HTTPS errors (or the host has been configured to trust the test
       // certs), Playwright will crash in funny ways. (e.g. CR Headful tries to connect
-      // to accounts.google.com as part of its starup routine and fatally complains of "Invalid method encountered".)
+      // to accounts.google.com as part of its startup routine and fatally complains of "Invalid method encountered".)
       if (options?.skipConnectRequests)
         return;
       this.connectHosts.push(req.url);

--- a/tests/config/utils.ts
+++ b/tests/config/utils.ts
@@ -83,7 +83,7 @@ export function suppressCertificateWarning() {
   if (didSuppressUnverifiedCertificateWarning)
     return;
   didSuppressUnverifiedCertificateWarning = true;
-  // Supress one-time warning:
+  // Suppress one-time warning:
   // https://github.com/nodejs/node/blob/1bbe66f432591aea83555d27dd76c55fea040a0d/lib/internal/options.js#L37-L49
   originalEmitWarning = process.emitWarning;
   process.emitWarning = (warning, ...args) => {

--- a/tests/installation/registry.ts
+++ b/tests/installation/registry.ts
@@ -30,7 +30,7 @@ const kContentTypeAbbreviatedMetadata = 'application/vnd.npm.install-v1+json';
  * This is useful in test installation behavior of packages that aren't yet published. It's particularly helpful
  * when your installation requires transitive dependencies that are also not yet published.
  *
- * See https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md for information on the offical APIs.
+ * See https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md for information on the official APIs.
  */
 export class Registry {
   private _workDir: string;

--- a/tests/library/browsercontext-add-cookies.spec.ts
+++ b/tests/library/browsercontext-add-cookies.spec.ts
@@ -455,9 +455,9 @@ it('should allow unnamed cookies', async ({ page, context, server, browserName, 
 });
 
 it('should set secure cookies on secure WebSocket', async ({ contextFactory, httpsServer }) => {
-  let resolveResceivedWebSocketHeaders = (headers: IncomingHttpHeaders) => { };
-  const receivedWebSocketHeaders = new Promise<IncomingHttpHeaders>(resolve => resolveResceivedWebSocketHeaders = resolve);
-  httpsServer.onceWebSocketConnection((ws, req) => resolveResceivedWebSocketHeaders(req.headers));
+  let resolveReceivedWebSocketHeaders = (headers: IncomingHttpHeaders) => { };
+  const receivedWebSocketHeaders = new Promise<IncomingHttpHeaders>(resolve => resolveReceivedWebSocketHeaders = resolve);
+  httpsServer.onceWebSocketConnection((ws, req) => resolveReceivedWebSocketHeaders(req.headers));
   const context = await contextFactory({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
   await page.goto(httpsServer.EMPTY_PAGE);

--- a/tests/library/browsercontext-events.spec.ts
+++ b/tests/library/browsercontext-events.spec.ts
@@ -120,7 +120,7 @@ test('dialog event should work in popup 2', async ({ page, browserName }) => {
   await promise;
 });
 
-test('dialog event should work in immdiately closed popup', async ({ page }) => {
+test('dialog event should work in immediately closed popup', async ({ page }) => {
   const promise = page.evaluate(async () => {
     const win = window.open();
     const result = (win as any).prompt('hey?');

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -558,7 +558,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       expect((await page.waitForNavigation().catch(e => e)).message).toContain('Navigation failed because page was closed');
     });
 
-    test('should be able to connect when the wsEndpont is passed as an option', async ({ browserType, startRemoteServer }) => {
+    test('should be able to connect when the wsEndpoint is passed as an option', async ({ browserType, startRemoteServer }) => {
       const remoteServer = await startRemoteServer(kind);
       const browser = await browserType.connect({
         wsEndpoint: remoteServer.wsEndpoint(),

--- a/tests/library/chromium/chromium.spec.ts
+++ b/tests/library/chromium/chromium.spec.ts
@@ -470,7 +470,7 @@ test.describe('PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1', () => {
 
               // 3. Prevent tracker.js from being retrieved, and returns a placeholder response
               if (event.request.url.endsWith("tracker.js"))
-                return new Response('conosole.log("no trackers!")', {
+                return new Response('console.log("no trackers!")', {
                   status: 200,
                   headers: { "Content-Type": "text/javascript" },
                 });

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -199,7 +199,7 @@ test('should connect over a ws endpoint', async ({ browserType, server }, testIn
     expect(contexts.length).toBe(1);
     await cdpBrowser.close();
 
-    // also connect with the depercreated wsEndpoint option
+    // also connect with the deprecated wsEndpoint option
     const cdpBrowser2 = await browserType.connectOverCDP({
       wsEndpoint: JSON.parse(json).webSocketDebuggerUrl,
     });

--- a/tests/library/component-parser.spec.ts
+++ b/tests/library/component-parser.spec.ts
@@ -94,7 +94,7 @@ it('should parse float values', async () => {
   expect(serialize(parse(`ColorButton  [    'nested' .value =4.1]`))).toBe('ColorButton[nested.value = 4.1]');
 });
 
-it('shoulud parse bool', async () => {
+it('should parse bool', async () => {
   expect(serialize(parse(`ColorButton[enabled= false] `))).toBe('ColorButton[enabled = false]');
   expect(serialize(parse(`ColorButton[enabled  =true] `))).toBe('ColorButton[enabled = true]');
   expect(serialize(parse(`ColorButton[enabled  =true][ color = "red"]`))).toBe('ColorButton[enabled = true][color = "red"]');
@@ -114,7 +114,7 @@ it('should parse identifiers', async () => {
   expect(serialize(parse('[😀=true]'))).toBe('["😀" = true]');
 });
 
-it('should parse unqouted string', async () => {
+it('should parse unquoted string', async () => {
   expect(serialize(parseAttributeSelector('[hey=foo]', true))).toBe('[hey = "foo"]');
   expect(serialize(parseAttributeSelector('[yay=and😀more]', true))).toBe('[yay = "and😀more"]');
   expect(serialize(parseAttributeSelector('[yay= trims  ]', true))).toBe('[yay = "trims"]');

--- a/tests/library/download.spec.ts
+++ b/tests/library/download.spec.ts
@@ -708,9 +708,9 @@ it('should convert navigation to a resource with unsupported mime type into down
 it('should download links with data url', async ({ page }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/21892' });
   await page.setContent('<a download="SomeFile.txt" href="data:text/plain;charset=utf8;,hello world">Download!</a>');
-  const donwloadPromise = page.waitForEvent('download');
+  const downloadPromise = page.waitForEvent('download');
   await page.getByText('Download').click();
-  const download = await donwloadPromise;
+  const download = await downloadPromise;
   expect(download.suggestedFilename()).toBe('SomeFile.txt');
 });
 

--- a/tests/library/global-fetch.spec.ts
+++ b/tests/library/global-fetch.spec.ts
@@ -166,7 +166,7 @@ it('should propagate ignoreHTTPSErrors on redirects', async ({ playwright, https
   expect(response.status()).toBe(200);
 });
 
-it('should resolve url relative to gobal baseURL option', async ({ playwright, server }) => {
+it('should resolve url relative to global baseURL option', async ({ playwright, server }) => {
   const request = await playwright.request.newContext({ baseURL: server.PREFIX });
   const response = await request.get('/empty.html');
   expect(response.url()).toBe(server.EMPTY_PAGE);

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -716,7 +716,7 @@ it('should filter favicon and favicon redirects', async ({ server, browserName, 
 
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
 
-  // Browsers aggresively cache favicons, so force bust with the
+  // Browsers aggressively cache favicons, so force bust with the
   // `d` parameter to make iterating on this test more predictable and isolated.
   const favicon = `/no-cache-2/favicon.ico`;
   const hashedFaviconUrl = `/favicon-hashed.ico`;

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -759,7 +759,7 @@ test('should open two trace files', async ({ context, page, request, server, sho
   const callLine = traceViewer.page.locator('.call-line');
   // Should get metadata from the context trace
   await expect(callLine.getByText('start time')).toHaveText(/start time:[\d/,: ]+/);
-  // duration in the metatadata section
+  // duration in the metadata section
   await expect(callLine.getByText('duration').first()).toHaveText(/duration:[\dms]+/);
   await expect(callLine.getByText('engine')).toHaveText(/engine:[\w]+/);
   await expect(callLine.getByText('platform')).toHaveText(/platform:[\w]+/);

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -155,7 +155,7 @@ function expectRedFrames(videoFile: string, size: { width: number, height: numbe
 
 it.describe('screencast', () => {
   it.slow();
-  it.skip(({ mode }) => mode !== 'default', 'video.path() is not avaialble in remote mode');
+  it.skip(({ mode }) => mode !== 'default', 'video.path() is not available in remote mode');
 
   it('videoSize should require videosPath', async ({ browser }) => {
     const error = await browser.newContext({ videoSize: { width: 100, height: 100 } }).catch(e => e);

--- a/tests/page/locator-is-visible.spec.ts
+++ b/tests/page/locator-is-visible.spec.ts
@@ -94,7 +94,7 @@ it('isVisible during navigation should not throw', async ({ page, server }) => {
           window.location.href = ${JSON.stringify(server.EMPTY_PAGE)};
         }, Math.random(50));
       </script>
-    `).catch(() => {});  // Avoid page.setContent throwing becuase of scheduled navigation.
+    `).catch(() => {});  // Avoid page.setContent throwing because of scheduled navigation.
     expect(await page.locator('div').isVisible()).toBe(false);
   }
 });

--- a/tests/page/page-event-request.spec.ts
+++ b/tests/page/page-event-request.spec.ts
@@ -174,7 +174,7 @@ it('should return response body when Cross-Origin-Opener-Policy is set', async (
 it('should fire requestfailed when intercepting race', async ({ page, server, browserName }) => {
   it.skip(browserName !== 'chromium', 'This test is specifically testing Chromium race');
 
-  const promsie = new Promise<void>(resolve => {
+  const promise = new Promise<void>(resolve => {
     let counter = 0;
     const failures = new Set();
     const alive = new Set();
@@ -217,7 +217,7 @@ it('should fire requestfailed when intercepting race', async ({ page, server, br
     </script>
   `);
 
-  await promsie;
+  await promise;
 });
 
 it('main resource xhr should have type xhr', async ({ page, server }) => {

--- a/tests/page/selectors-vue.spec.ts
+++ b/tests/page/selectors-vue.spec.ts
@@ -74,11 +74,11 @@ for (const [name, url] of Object.entries(vues)) {
     it('should exact match by props', async ({ page }) => {
       await expect(page.locator(`_vue=book-item[name = "The Great Gatsby"]`)).toHaveText('The Great Gatsby');
       await expect(page.locator(`_vue=book-item[name = "The Great Gatsby"]`)).toHaveCount(1);
-      // case sensetive by default
+      // case sensitive by default
       await expect(page.locator(`_vue=book-item[name = "the great gatsby"]`)).toHaveCount(0);
       await expect(page.locator(`_vue=book-item[name = "the great gatsby" s]`)).toHaveCount(0);
       await expect(page.locator(`_vue=book-item[name = "the great gatsby" S]`)).toHaveCount(0);
-      // case insensetive with flag
+      // case insensitive with flag
       await expect(page.locator(`_vue=book-item[name = "the great gatsby" i]`)).toHaveCount(1);
       await expect(page.locator(`_vue=book-item[name = "the great gatsby" I]`)).toHaveCount(1);
       await expect(page.locator(`_vue=book-item[name = "  The Great Gatsby  "]`)).toHaveCount(0);

--- a/tests/playwright-test/deps.spec.ts
+++ b/tests/playwright-test/deps.spec.ts
@@ -452,7 +452,7 @@ test('should run project with teardown', async ({ runInlineTest }) => {
   expect(result.outputLines).toEqual(['A', 'B']);
 });
 
-test('should run teardown after depedents', async ({ runInlineTest }) => {
+test('should run teardown after dependents', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
       module.exports = {

--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -276,7 +276,7 @@ test('run hooks after failure', async ({ runInlineTest }) => {
     'a.test.js': `
       import { test, expect } from '@playwright/test';
       test.describe('suite', () => {
-        test('faled', ({}) => {
+        test('failed', ({}) => {
           console.log('\\n%%test');
           expect(1).toBe(2);
         });

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -217,7 +217,7 @@ export function cleanEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     PW_TEST_SOURCE_TRANSFORM_SCOPE: undefined,
     PWTEST_BLOB_REPORT_NAME: undefined,
     TEST_WORKER_INDEX: undefined,
-    TEST_PARLLEL_INDEX: undefined,
+    TEST_PARALLEL_INDEX: undefined,
     NODE_OPTIONS: undefined,
     ...env,
   };

--- a/tests/playwright-test/playwright.connect.spec.ts
+++ b/tests/playwright-test/playwright.connect.spec.ts
@@ -110,7 +110,7 @@ test('should respect connectOptions.timeout', async ({ runInlineTest }) => {
       module.exports = {
         use: {
           connectOptions: {
-            wsEndpoint: 'wss://locahost:5678',
+            wsEndpoint: 'wss://localhost:5678',
             timeout: 1,
           },
         },

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1568,7 +1568,7 @@ for (const useIntermediateMergeReport of [false, true] as const) {
         await expect(page.locator('.subnav-item:has-text("Skipped") .counter')).toHaveText('0');
       });
 
-      test('labels whould be applied together with status filter', async ({ runInlineTest, showReport, page }) => {
+      test('labels should be applied together with status filter', async ({ runInlineTest, showReport, page }) => {
         const result = await runInlineTest({
           'a.test.js': `
             const { expect, test } = require('@playwright/test');

--- a/tests/playwright-test/shard.spec.ts
+++ b/tests/playwright-test/shard.spec.ts
@@ -179,7 +179,7 @@ test('should work with workers=1 and --fully-parallel', async ({ runInlineTest }
     `,
     'a2.spec.ts': `
     import { test } from '@playwright/test';
-    test('shoul pass', async ({ }) => {
+    test('should pass', async ({ }) => {
     });
   `,
   };

--- a/tests/playwright-test/test-grep.spec.ts
+++ b/tests/playwright-test/test-grep.spec.ts
@@ -80,7 +80,7 @@ test('project.grepInvert should work', async ({ runInlineTest }) => {
   expect(result.output).toContain('%% test2');
 });
 
-test('config.grep should intercect with --grep and --grepInvert', async ({ runInlineTest }) => {
+test('config.grep should intersect with --grep and --grepInvert', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
       module.exports = { grep: /test./, grepInvert: /test4/ };

--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -137,9 +137,9 @@ async function run() {
         if (lang === 'js') {
           const testDocumentation = parseApi(path.join(documentationRoot, 'test-api'), path.join(documentationRoot, 'api', 'params.md'));
           testDocumentation.filterForLanguage('js');
-          const testRerpoterDocumentation = parseApi(path.join(documentationRoot, 'test-reporter-api'));
-          testRerpoterDocumentation.filterForLanguage('js');
-          documentation = documentation.mergeWith(testDocumentation).mergeWith(testRerpoterDocumentation);
+          const testReporterDocumentation = parseApi(path.join(documentationRoot, 'test-reporter-api'));
+          testReporterDocumentation.filterForLanguage('js');
+          documentation = documentation.mergeWith(testDocumentation).mergeWith(testReporterDocumentation);
         }
 
         // This validates member links.


### PR DESCRIPTION
I ran cspell locally, and fixed various typos.  The first commit affects:
- documentation (code comments, test descriptions, etc.)
- variable names (changes made consistently across all instances of the variable)

The second commit fixes an error in some sample code caused by a typo

Fixes https://github.com/microsoft/playwright/issues/27396