### PR TITLE
fix: use most recent stable debian release browser binaries in case of debian testing and unstable

### DIFF
--- a/packages/playwright-core/src/utils/hostPlatform.ts
+++ b/packages/playwright-core/src/utils/hostPlatform.ts
@@ -72,6 +72,10 @@ export const hostPlatform = ((): HostPlatform => {
       return ('debian11' + archSuffix) as HostPlatform;
     if (distroInfo?.id === 'debian' && distroInfo?.version === '12')
       return ('debian12' + archSuffix) as HostPlatform;
+    // use most recent supported release for 'debian testing' and 'unstable'.
+    // they never include a numeric version entry in /etc/os-release.
+    if (distroInfo?.id === 'debian' && distroInfo?.version === '')
+      return ('debian12' + archSuffix) as HostPlatform;
     return ('generic-linux' + archSuffix) as HostPlatform;
   }
   if (platform === 'win32')


### PR DESCRIPTION
Please use the most recent stable release of debian on machines running debian 'testing' and 'unstable' instead of the Ubuntu default dependencies. 

debian unstable and testing installations do not contain numeric version information in /etc/os-release.

The 'testing' branch is very often used by developers as rolling release, because the stable debian release cycles are rather long.

debian stable binaries are usually well-supported by this newer development branches. 
On my machine this change fixed all the dependency issues caused by the 'linux-generic' webkit binary.
And even in case of missing libs, it's much easier to install the needed dependencies from the stable repositories than mixing debian and Ubuntu releases.

Fixes: #27398