### PR TITLE
feat: ability to specify maxFailures relative to total tests

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -215,10 +215,10 @@ export default defineConfig({
 The maximum number of test failures (test retry is also a failure) for the whole test suite run. After reaching this number, testing will stop and exit with an error. Setting to zero (default) disables this behavior.
 
 Can be specified as:
-* static value (positive integer number);
-* dynamic value (positive float number less than 1) relative to the total number of tests.
+* static value - positive integer number;
+* dynamic value - percentage relative to the total number of tests.
 
-For example, if 100 tests are run in the project and the `maxFailures` is set to 0.3 (dynamic value), then when 30 tests are failed, testing will stop. When using a static value you just need to specify 30.
+For example, if 100 tests are run in the project and the `maxFailures` is set to `'30%'` (dynamic value), then when 30 tests are failed, testing will stop. When using a static value you just need to specify `30``.
 
 Use dynamic value if you don't want to keep it up to date as the number of tests increases.
 
@@ -230,7 +230,7 @@ Also available in the [command line](../test-cli.md) with the `--max-failures` a
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  maxFailures: process.env.CI ? 0.3 : 0,
+  maxFailures: process.env.CI ? '30%' : 0,
 });
 ```
 

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -212,7 +212,15 @@ export default defineConfig({
 * since: v1.10
 - type: ?<[int]>
 
-The maximum number of test failures for the whole test suite run. After reaching this number, testing will stop and exit with an error. Setting to zero (default) disables this behavior.
+The maximum number of test failures (test retry is also a failure) for the whole test suite run. After reaching this number, testing will stop and exit with an error. Setting to zero (default) disables this behavior.
+
+Can be specified as:
+* static value (positive integer number);
+* dynamic value (positive float number less than 1) relative to the total number of tests.
+
+For example, if 100 tests are run in the project and the `maxFailures` is set to 0.3 (dynamic value), then when 30 tests are failed, testing will stop. When using a static value you just need to specify 30.
+
+Use dynamic value if you don't want to keep it up to date as the number of tests increases.
 
 Also available in the [command line](../test-cli.md) with the `--max-failures` and `-x` options.
 
@@ -222,7 +230,7 @@ Also available in the [command line](../test-cli.md) with the `--max-failures` a
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  maxFailures: process.env.CI ? 1 : 0,
+  maxFailures: process.env.CI ? 0.3 : 0,
 });
 ```
 

--- a/packages/playwright/src/cli.ts
+++ b/packages/playwright/src/cli.ts
@@ -208,7 +208,7 @@ function overridesFromOptions(options: { [key: string]: any }): ConfigCLIOverrid
     forbidOnly: options.forbidOnly ? true : undefined,
     fullyParallel: options.fullyParallel ? true : undefined,
     globalTimeout: options.globalTimeout ? parseInt(options.globalTimeout, 10) : undefined,
-    maxFailures: options.x ? 1 : (options.maxFailures ? parseFloat(options.maxFailures) : undefined),
+    maxFailures: options.x ? 1 : options.maxFailures,
     outputDir: options.output ? path.resolve(process.cwd(), options.output) : undefined,
     quiet: options.quiet ? options.quiet : undefined,
     repeatEach: options.repeatEach ? parseInt(options.repeatEach, 10) : undefined,

--- a/packages/playwright/src/cli.ts
+++ b/packages/playwright/src/cli.ts
@@ -208,7 +208,7 @@ function overridesFromOptions(options: { [key: string]: any }): ConfigCLIOverrid
     forbidOnly: options.forbidOnly ? true : undefined,
     fullyParallel: options.fullyParallel ? true : undefined,
     globalTimeout: options.globalTimeout ? parseInt(options.globalTimeout, 10) : undefined,
-    maxFailures: options.x ? 1 : (options.maxFailures ? parseInt(options.maxFailures, 10) : undefined),
+    maxFailures: options.x ? 1 : (options.maxFailures ? parseFloat(options.maxFailures) : undefined),
     outputDir: options.output ? path.resolve(process.cwd(), options.output) : undefined,
     quiet: options.quiet ? options.quiet : undefined,
     repeatEach: options.repeatEach ? parseInt(options.repeatEach, 10) : undefined,

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -206,8 +206,13 @@ function pathResolve(baseDir: string, relative: string | undefined): string | un
   return path.resolve(baseDir, relative);
 }
 
-function handleMaxFailures(maxFailures: number): number {
-  return !Number.isInteger(maxFailures) && maxFailures < 1 ? maxFailures : Math.trunc(maxFailures);
+function handleMaxFailures(maxFailures: number | string): number {
+  if (typeof maxFailures === 'string') {
+    const parsedMaxFailures = parseInt(maxFailures, 10);
+    return maxFailures.endsWith('%') ? Math.min(0.99, parsedMaxFailures / 100) : parsedMaxFailures;
+  }
+
+  return maxFailures;
 }
 
 function resolveReporters(reporters: Config['reporter'], rootDir: string): ReporterDescription[] | undefined {

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -83,7 +83,7 @@ export class FullConfigInternal {
       globalTimeout: takeFirst(configCLIOverrides.globalTimeout, config.globalTimeout, 0),
       grep: takeFirst(config.grep, defaultGrep),
       grepInvert: takeFirst(config.grepInvert, null),
-      maxFailures: takeFirst(configCLIOverrides.maxFailures, config.maxFailures, 0),
+      maxFailures: handleMaxFailures(takeFirst(configCLIOverrides.maxFailures, config.maxFailures, 0)),
       metadata: takeFirst(config.metadata, {}),
       preserveOutput: takeFirst(config.preserveOutput, 'always'),
       reporter: takeFirst(configCLIOverrides.reporter, resolveReporters(config.reporter, configDir), [[defaultReporter]]),
@@ -204,6 +204,10 @@ function pathResolve(baseDir: string, relative: string | undefined): string | un
   if (!relative)
     return undefined;
   return path.resolve(baseDir, relative);
+}
+
+function handleMaxFailures(maxFailures: number): number {
+  return !Number.isInteger(maxFailures) && maxFailures < 1 ? maxFailures : Math.trunc(maxFailures);
 }
 
 function resolveReporters(reporters: Config['reporter'], rootDir: string): ReporterDescription[] | undefined {

--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -23,7 +23,7 @@ export type ConfigCLIOverrides = {
   forbidOnly?: boolean;
   fullyParallel?: boolean;
   globalTimeout?: number;
-  maxFailures?: number;
+  maxFailures?: number | string;
   outputDir?: string;
   quiet?: boolean;
   repeatEach?: number;

--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -254,11 +254,14 @@ export class BaseReporter implements ReporterV2 {
   }
 
   private _printMaxFailuresReached() {
-    if (!this.config.maxFailures)
+    let maxFailures = this.config.maxFailures;
+    maxFailures = Number.isInteger(maxFailures) ? maxFailures : Math.ceil(maxFailures * this.totalTestCount);
+
+    if (!maxFailures)
       return;
-    if (this._failureCount < this.config.maxFailures)
+    if (this._failureCount < maxFailures)
       return;
-    console.log(colors.yellow(`Testing stopped early after ${this.config.maxFailures} maximum allowed failures.`));
+    console.log(colors.yellow(`Testing stopped early after ${maxFailures} maximum allowed failures.`));
   }
 
   private _printSummary(summary: string) {

--- a/packages/playwright/src/runner/failureTracker.ts
+++ b/packages/playwright/src/runner/failureTracker.ts
@@ -23,6 +23,7 @@ export class FailureTracker {
   private _failureCount = 0;
   private _hasWorkerErrors = false;
   private _rootSuite: Suite | undefined;
+  private _maxFailures: number = 0;
 
   constructor(private _config: FullConfigInternal) {
   }
@@ -30,6 +31,7 @@ export class FailureTracker {
   onRootSuite(rootSuite: Suite) {
     this._rootSuite = rootSuite;
     this._totalTestCount = this._rootSuite.allTests().length;
+    this._maxFailures = this._calcMaxFailures();
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
@@ -42,10 +44,7 @@ export class FailureTracker {
   }
 
   hasReachedMaxFailures() {
-    let maxFailures = this._config.config.maxFailures;
-    maxFailures = Number.isInteger(maxFailures) ? maxFailures : Math.ceil(maxFailures * this._totalTestCount);
-
-    return maxFailures > 0 && this._failureCount >= maxFailures;
+    return this._maxFailures > 0 && this._failureCount >= this._maxFailures;
   }
 
   hasWorkerErrors() {
@@ -54,5 +53,11 @@ export class FailureTracker {
 
   result(): 'failed' | 'passed' {
     return this._hasWorkerErrors || this._rootSuite?.allTests().some(test => !test.ok()) ? 'failed' : 'passed';
+  }
+
+  private _calcMaxFailures() {
+    const maxFailures = this._config.config.maxFailures;
+
+    return Number.isInteger(maxFailures) ? maxFailures : Math.ceil(maxFailures * this._totalTestCount);
   }
 }

--- a/packages/playwright/src/runner/failureTracker.ts
+++ b/packages/playwright/src/runner/failureTracker.ts
@@ -19,6 +19,7 @@ import type { FullConfigInternal } from '../common/config';
 import type { Suite, TestCase } from '../common/test';
 
 export class FailureTracker {
+  private _totalTestCount = 0;
   private _failureCount = 0;
   private _hasWorkerErrors = false;
   private _rootSuite: Suite | undefined;
@@ -28,6 +29,7 @@ export class FailureTracker {
 
   onRootSuite(rootSuite: Suite) {
     this._rootSuite = rootSuite;
+    this._totalTestCount = this._rootSuite.allTests().length;
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
@@ -40,7 +42,9 @@ export class FailureTracker {
   }
 
   hasReachedMaxFailures() {
-    const maxFailures = this._config.config.maxFailures;
+    let maxFailures = this._config.config.maxFailures;
+    maxFailures = Number.isInteger(maxFailures) ? maxFailures : Math.ceil(maxFailures * this._totalTestCount);
+
     return maxFailures > 0 && this._failureCount >= maxFailures;
   }
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -852,8 +852,17 @@ interface TestConfig {
   ignoreSnapshots?: boolean;
 
   /**
-   * The maximum number of test failures for the whole test suite run. After reaching this number, testing will stop and
-   * exit with an error. Setting to zero (default) disables this behavior.
+   * The maximum number of test failures (test retry is also a failure) for the whole test suite run. After reaching
+   * this number, testing will stop and exit with an error. Setting to zero (default) disables this behavior.
+   *
+   * Can be specified as:
+   * - static value (positive integer number);
+   * - dynamic value (positive float number less than 1) relative to the total number of tests.
+   *
+   * For example, if 100 tests are run in the project and the `maxFailures` is set to 0.3 (dynamic value), then when 30
+   * tests are failed, testing will stop. When using a static value you just need to specify 30.
+   *
+   * Use dynamic value if you don't want to keep it up to date as the number of tests increases.
    *
    * Also available in the [command line](https://playwright.dev/docs/test-cli) with the `--max-failures` and `-x` options.
    *
@@ -864,7 +873,7 @@ interface TestConfig {
    * import { defineConfig } from '@playwright/test';
    *
    * export default defineConfig({
-   *   maxFailures: process.env.CI ? 1 : 0,
+   *   maxFailures: process.env.CI ? 0.3 : 0,
    * });
    * ```
    *
@@ -1583,8 +1592,17 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
    */
   grepInvert: RegExp | RegExp[] | null;
   /**
-   * The maximum number of test failures for the whole test suite run. After reaching this number, testing will stop and
-   * exit with an error. Setting to zero (default) disables this behavior.
+   * The maximum number of test failures (test retry is also a failure) for the whole test suite run. After reaching
+   * this number, testing will stop and exit with an error. Setting to zero (default) disables this behavior.
+   *
+   * Can be specified as:
+   * - static value (positive integer number);
+   * - dynamic value (positive float number less than 1) relative to the total number of tests.
+   *
+   * For example, if 100 tests are run in the project and the `maxFailures` is set to 0.3 (dynamic value), then when 30
+   * tests are failed, testing will stop. When using a static value you just need to specify 30.
+   *
+   * Use dynamic value if you don't want to keep it up to date as the number of tests increases.
    *
    * Also available in the [command line](https://playwright.dev/docs/test-cli) with the `--max-failures` and `-x` options.
    *
@@ -1595,7 +1613,7 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
    * import { defineConfig } from '@playwright/test';
    *
    * export default defineConfig({
-   *   maxFailures: process.env.CI ? 1 : 0,
+   *   maxFailures: process.env.CI ? 0.3 : 0,
    * });
    * ```
    *

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -856,11 +856,11 @@ interface TestConfig {
    * this number, testing will stop and exit with an error. Setting to zero (default) disables this behavior.
    *
    * Can be specified as:
-   * - static value (positive integer number);
-   * - dynamic value (positive float number less than 1) relative to the total number of tests.
+   * - static value - positive integer number;
+   * - dynamic value - percentage relative to the total number of tests.
    *
-   * For example, if 100 tests are run in the project and the `maxFailures` is set to 0.3 (dynamic value), then when 30
-   * tests are failed, testing will stop. When using a static value you just need to specify 30.
+   * For example, if 100 tests are run in the project and the `maxFailures` is set to `'30%'` (dynamic value), then when
+   * 30 tests are failed, testing will stop. When using a static value you just need to specify `30``.
    *
    * Use dynamic value if you don't want to keep it up to date as the number of tests increases.
    *
@@ -873,7 +873,7 @@ interface TestConfig {
    * import { defineConfig } from '@playwright/test';
    *
    * export default defineConfig({
-   *   maxFailures: process.env.CI ? 0.3 : 0,
+   *   maxFailures: process.env.CI ? '30%' : 0,
    * });
    * ```
    *
@@ -1596,11 +1596,11 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
    * this number, testing will stop and exit with an error. Setting to zero (default) disables this behavior.
    *
    * Can be specified as:
-   * - static value (positive integer number);
-   * - dynamic value (positive float number less than 1) relative to the total number of tests.
+   * - static value - positive integer number;
+   * - dynamic value - percentage relative to the total number of tests.
    *
-   * For example, if 100 tests are run in the project and the `maxFailures` is set to 0.3 (dynamic value), then when 30
-   * tests are failed, testing will stop. When using a static value you just need to specify 30.
+   * For example, if 100 tests are run in the project and the `maxFailures` is set to `'30%'` (dynamic value), then when
+   * 30 tests are failed, testing will stop. When using a static value you just need to specify `30``.
    *
    * Use dynamic value if you don't want to keep it up to date as the number of tests increases.
    *
@@ -1613,7 +1613,7 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
    * import { defineConfig } from '@playwright/test';
    *
    * export default defineConfig({
-   *   maxFailures: process.env.CI ? 0.3 : 0,
+   *   maxFailures: process.env.CI ? '30%' : 0,
    * });
    * ```
    *

--- a/tests/playwright-test/max-failures.spec.ts
+++ b/tests/playwright-test/max-failures.spec.ts
@@ -60,7 +60,7 @@ test('max-failures should work with dynamic value', async ({ runInlineTest }) =>
         });
       }
     `
-  }, { 'max-failures': 0.5 });
+  }, { 'max-failures': '50%' });
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(10);
   expect(result.output.split('\n').filter(l => l.includes('expect(')).length).toBe(20);

--- a/tests/playwright-test/max-failures.spec.ts
+++ b/tests/playwright-test/max-failures.spec.ts
@@ -42,6 +42,30 @@ test('max-failures should work', async ({ runInlineTest }) => {
   expect(result.report.suites[1].specs.map(spec => spec.tests[0].results.length)).toEqual(new Array(10).fill(1));
 });
 
+test('max-failures should work with dynamic value', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.js': `
+      import { test, expect } from '@playwright/test';
+      for (let i = 0; i < 10; ++i) {
+        test('fail_' + i, () => {
+          expect(true).toBe(false);
+        });
+      }
+    `,
+    'b.spec.js': `
+      import { test, expect } from '@playwright/test';
+      for (let i = 0; i < 10; ++i) {
+        test('fail_' + i, () => {
+          expect(true).toBe(false);
+        });
+      }
+    `
+  }, { 'max-failures': 0.5 });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(10);
+  expect(result.output.split('\n').filter(l => l.includes('expect(')).length).toBe(20);
+});
+
 test('-x should work', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.js': `


### PR DESCRIPTION
## What's done

Implement ability to specify `maxFailures` relative to total tests in order not to keep track of the relevance of the `maxFailures` value.

Fixes https://github.com/microsoft/playwright/issues/26861