### PR TITLE
Prevent Firefox from creating shortcuts

### DIFF
--- a/browser_patches/firefox/preferences/playwright.cfg
+++ b/browser_patches/firefox/preferences/playwright.cfg
@@ -305,3 +305,5 @@ pref("extensions.blocklist.enabled", false);
 // Force Firefox Devtools to open in a separate window.
 pref("devtools.toolbox.host", "window");
 
+// Prevent shortcut creation
+pref("browser.privacySegmentation.createdShortcut", true);


### PR DESCRIPTION
Fixes #27359