### PR TITLE
devops: publish using NPM provenance feature

### DIFF
--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -16,11 +16,13 @@ jobs:
     name: "publish canary NPM & Publish canary Docker"
     runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         registry-url: 'https://registry.npmjs.org'
     - run: npm i -g npm@8
     - run: npm ci

--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
     permissions:
+      contents: read
       id-token: write
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish_release_npm.yml
+++ b/.github/workflows/publish_release_npm.yml
@@ -12,11 +12,13 @@ jobs:
     name: "publish to NPM"
     runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         registry-url: 'https://registry.npmjs.org'
     - run: npm i -g npm@8
     - run: npm ci

--- a/.github/workflows/publish_release_npm.yml
+++ b/.github/workflows/publish_release_npm.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'microsoft/playwright'
     permissions:
+      contents: read
       id-token: write
     steps:
     - uses: actions/checkout@v3

--- a/utils/publish_all_packages.sh
+++ b/utils/publish_all_packages.sh
@@ -94,7 +94,7 @@ echo "==================== Publishing version ${VERSION} ================"
 node ./utils/workspace.js --ensure-consistent
 node ./utils/workspace.js --list-public-package-paths | while read package
 do
-  npm publish --access=public ${package} --tag="${NPM_PUBLISH_TAG}"
+  npm publish --access=public ${package} --tag="${NPM_PUBLISH_TAG}" --provenance
 done
 
 echo "Done."


### PR DESCRIPTION
As per https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions.

We use Node.js 18 (LTS) to get NPM 9+.

Closes https://github.com/microsoft/playwright/issues/22555