### PR TITLE
chore: add reportName to base reporter test title reporting

### DIFF
--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -396,7 +396,12 @@ export function formatTestTitle(config: FullConfig, test: TestCase, step?: TestS
     location = `${relativeTestPath(config, test)}`;
   else
     location = `${relativeTestPath(config, test)}:${step?.location?.line ?? test.location.line}:${step?.location?.column ?? test.location.column}`;
-  const projectTitle = projectName ? `[${projectName}] › ` : '';
+  let projectSuite = test.parent;
+  while (projectSuite.parent && projectSuite.parent.parent)
+    projectSuite = projectSuite.parent;
+  const reportName = projectSuite.project()?.metadata?.reportName;
+  const projectTitleParts = [reportName, projectName].filter(Boolean) as string[];
+  const projectTitle = projectTitleParts.length ? `[${projectTitleParts.join(' › ')}] › ` : '';
   return `${projectTitle}${location} › ${titles.join(' › ')}${stepSuffix(step)}`;
 }
 

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -1211,6 +1211,30 @@ test('same project different suffixes', async ({ runInlineTest, mergeReports }) 
   expect(output).toContain(`reportNames: first,second`);
 });
 
+test('should add report name to test title reporting', async ({ runInlineTest, mergeReports }) => {
+  const files = {
+    'playwright.config.ts': `
+      module.exports = {
+        reporter: 'blob',
+        projects: [
+          { name: 'chromium' },
+        ]
+      };
+    `,
+    'a.test.js': `
+      import { test } from '@playwright/test';
+      test('math 1', ({}) => {});
+    `,
+  };
+
+  await runInlineTest(files, undefined, { PWTEST_BLOB_REPORT_NAME: 'msedge-dev-windows' });
+
+  const reportDir = test.info().outputPath('blob-report');
+  const { exitCode, output } = await mergeReports(reportDir, {}, { additionalArgs: ['--reporter', 'list'] });
+  expect(exitCode).toBe(0);
+  expect(output).toContain(`[msedge-dev-windows › chromium] › a.test.js:3:11 › math 1`);
+});
+
 test('no reports error', async ({ runInlineTest, mergeReports }) => {
   const reportDir = test.info().outputPath('blob-report');
   fs.mkdirSync(reportDir, { recursive: true });


### PR DESCRIPTION
Motivation: Our markdown reports which we attach to our PRs usually only contain `chromium` but I want to see `msedge-beta-windows`.

https://github.com/microsoft/playwright/issues/27284