### PR TITLE
fix: make processRunner nullable

### DIFF
--- a/packages/playwright/src/common/process.ts
+++ b/packages/playwright/src/common/process.ts
@@ -54,8 +54,8 @@ process.on('SIGTERM', () => {});
 // Clear execArgv immediately, so that the user-code does not inherit our loader.
 process.execArgv = execArgvWithoutExperimentalLoaderOptions();
 
-let processRunner: ProcessRunner;
-let processName: string;
+let processRunner: ProcessRunner | undefined;
+let processName: string | undefined;
 const startingEnv = { ...process.env };
 
 process.on('message', async (message: any) => {
@@ -97,8 +97,9 @@ async function gracefullyCloseAndExit() {
   // eslint-disable-next-line no-restricted-properties
   setTimeout(() => process.exit(0), 30000);
   // Meanwhile, try to gracefully shutdown.
-  await processRunner.gracefullyClose().catch(() => {});
-  await stopProfiling(processName).catch(() => {});
+  await processRunner?.gracefullyClose().catch(() => {});
+  if (processName)
+    await stopProfiling(processName).catch(() => {});
   // eslint-disable-next-line no-restricted-properties
   process.exit(0);
 }


### PR DESCRIPTION
This fixes:
```
D:\a\playwright\playwright\packages\playwright\lib\common\process.js:119
  await processRunner.gracefullyClose().catch(() => {});
                      ^

TypeError: Cannot read properties of undefined (reading 'gracefullyClose')
    at gracefullyCloseAndExit (D:\a\playwright\playwright\packages\playwright\lib\common\process.js:119:23)
    at process.<anonymous> (D:\a\playwright\playwright\packages\playwright\lib\common\process.js:81:11)
    at process.emit (node:events:513:28)
    at emit (node:internal/child_process:946:14)
    at processTicksAndRejections (node:internal/process/task_queues:84:21)
```

from [here](https://github.com/microsoft/playwright/actions/runs/6424299724/job/17444659548#step:7:2936).

`gracefullyCloseAndExit` gets called via `__stop__` and wants to use `processRunner` var which gets created during `__init__`. So its `undefined` when `__stop__` gets called.