### PR TITLE
chore: run 'npm pkg fix'

### DIFF
--- a/.github/workflows/tests_components.yml
+++ b/.github/workflows/tests_components.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   test_components:
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }} - Node.js ${{ matrix.node-version }}
     strategy:
       fail-fast: false
       matrix:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {

--- a/packages/playwright-browser-chromium/package.json
+++ b/packages/playwright-browser-chromium/package.json
@@ -4,7 +4,7 @@
   "description": "Playwright package that automatically installs Chromium",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {

--- a/packages/playwright-browser-firefox/package.json
+++ b/packages/playwright-browser-firefox/package.json
@@ -4,7 +4,7 @@
   "description": "Playwright package that automatically installs Firefox",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {

--- a/packages/playwright-browser-webkit/package.json
+++ b/packages/playwright-browser-webkit/package.json
@@ -4,7 +4,7 @@
   "description": "Playwright package that automatically installs WebKit",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {

--- a/packages/playwright-chromium/package.json
+++ b/packages/playwright-chromium/package.json
@@ -4,7 +4,7 @@
   "description": "A high-level API to automate Chromium",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -24,7 +24,7 @@
     "./package.json": "./package.json"
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   },
   "scripts": {
     "install": "node install.js"

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -4,7 +4,7 @@
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -39,7 +39,7 @@
     "./types/structs": "./types/structs.d.ts"
   },
   "bin": {
-    "playwright-core": "./cli.js"
+    "playwright-core": "cli.js"
   },
   "types": "types/types.d.ts"
 }

--- a/packages/playwright-ct-core/package.json
+++ b/packages/playwright-ct-core/package.json
@@ -4,7 +4,7 @@
   "description": "Playwright Component Testing Helpers",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -32,6 +32,6 @@
     "playwright": "1.39.0-next"
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   }
 }

--- a/packages/playwright-ct-react/package.json
+++ b/packages/playwright-ct-react/package.json
@@ -4,7 +4,7 @@
   "description": "Playwright Component Testing for React",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -33,6 +33,6 @@
     "@vitejs/plugin-react": "^4.0.0"
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   }
 }

--- a/packages/playwright-ct-react17/package.json
+++ b/packages/playwright-ct-react17/package.json
@@ -4,7 +4,7 @@
   "description": "Playwright Component Testing for React",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -33,6 +33,6 @@
     "@vitejs/plugin-react": "^4.0.0"
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   }
 }

--- a/packages/playwright-ct-solid/package.json
+++ b/packages/playwright-ct-solid/package.json
@@ -4,7 +4,7 @@
   "description": "Playwright Component Testing for Solid",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -36,6 +36,6 @@
     "solid-js": "^1.7.0"
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   }
 }

--- a/packages/playwright-ct-svelte/package.json
+++ b/packages/playwright-ct-svelte/package.json
@@ -4,7 +4,7 @@
   "description": "Playwright Component Testing for Svelte",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -36,6 +36,6 @@
     "svelte": "^3.55.1"
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   }
 }

--- a/packages/playwright-ct-vue/package.json
+++ b/packages/playwright-ct-vue/package.json
@@ -4,7 +4,7 @@
   "description": "Playwright Component Testing for Vue",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -33,6 +33,6 @@
     "@vitejs/plugin-vue": "^4.2.1"
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   }
 }

--- a/packages/playwright-ct-vue2/package.json
+++ b/packages/playwright-ct-vue2/package.json
@@ -4,7 +4,7 @@
   "description": "Playwright Component Testing for Vue2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -36,6 +36,6 @@
     "vue": "^2.7.14"
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   }
 }

--- a/packages/playwright-firefox/package.json
+++ b/packages/playwright-firefox/package.json
@@ -4,7 +4,7 @@
   "description": "A high-level API to automate Firefox",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -24,7 +24,7 @@
     "./package.json": "./package.json"
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   },
   "scripts": {
     "install": "node install.js"

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -4,7 +4,7 @@
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -26,7 +26,7 @@
     "./reporter": "./reporter.js"
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   },
   "scripts": {},
   "dependencies": {

--- a/packages/playwright-webkit/package.json
+++ b/packages/playwright-webkit/package.json
@@ -4,7 +4,7 @@
   "description": "A high-level API to automate WebKit",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -24,7 +24,7 @@
     "./package.json": "./package.json"
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   },
   "scripts": {
     "install": "node install.js"

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -4,7 +4,7 @@
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/playwright.git"
+    "url": "git+https://github.com/microsoft/playwright.git"
   },
   "homepage": "https://playwright.dev",
   "engines": {
@@ -47,7 +47,7 @@
     }
   },
   "bin": {
-    "playwright": "./cli.js"
+    "playwright": "cli.js"
   },
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
As per

```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish Removed invalid "scripts"
npm WARN publish "bin[playwright-core]" script name was cleaned
npm WARN publish "repository.url" was normalized to "git+https://github.com/microsoft/playwright.git
```

works now as per https://www.npmjs.com/package/@playwright/test/v/1.39.0-alpha-1696547902000 when you scroll down.

https://github.com/microsoft/playwright/issues/22555