### PR TITLE
docs: note that pytest CLI args only apply to default fixtures

### DIFF
--- a/docs/src/test-runners-python.md
+++ b/docs/src/test-runners-python.md
@@ -26,6 +26,9 @@ addopts = --headed --browser firefox
 
 ## CLI arguments
 
+Note that CLI arguments are only applied to the default `browser`, `context` and `page` fixtures.
+If you create a browser, a context or a page with the API call like [`method: Browser.newContext`], the CLI arguments are not applied.
+
 - `--headed`: Run tests in headed mode (default: headless).
 - `--browser`: Run tests in a different browser `chromium`, `firefox`, or `webkit`. It can be specified multiple times (default: `chromium`).
 - `--browser-channel` [Browser channel](./browsers.md) to be used.
@@ -113,7 +116,7 @@ Run tests with slow mo with the `--slowmo` argument.
 pytest --slowmo 100
 ```
 
-Slows down Playwright operations by 100 milliseconds. 
+Slows down Playwright operations by 100 milliseconds.
 
 ### Skip test by browser
 


### PR DESCRIPTION
Fixes #27413.