### PR TITLE
fix(test runner): rework compilation cache logic

### DIFF
--- a/packages/playwright/src/transform/DEPS.list
+++ b/packages/playwright/src/transform/DEPS.list
@@ -2,3 +2,4 @@
 ../util.ts
 ../utilsBundle.ts
 ../third_party/tsconfig-loader.ts
+../common/globals.ts


### PR DESCRIPTION
- Do not write from workers.
- Remove marker files.
- Always try/catch reading from fs.

This mostly reverts https://github.com/microsoft/playwright/pull/26830 and https://github.com/microsoft/playwright/pull/26353.

Fixes #27592.