### PR TITLE
Add function to add items to localStorage when page initializes

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -430,6 +430,27 @@ Path to the JavaScript file. If `path` is a relative path, then it is resolved r
 
 Script to be evaluated in all pages in the browser context. Optional.
 
+## async method: BrowserContext.addInitLocalStorageItems
+* since: v1.8
+
+Adds items to be added to `localStorage` in the same scenarios as `BrowserContext.addInitScript`
+
+### param: BrowserContext.addInitLocalStorageItems.items
+* since: v1.8
+* langs: js
+- `items` <[Array]<[Object]>>
+  - `name` <string> Key of the item
+  - `value` <unknown> Value of the item
+
+Items to add to the `localStorage`.
+
+### param: BrowserContext.addInitLocalStorageItems.overwrite
+* since: v1.8
+* langs: js
+- `overwrite` <boolean> 
+
+Enabled by default. It will overwrite existing items in `localStorage`.
+
 ## method: BrowserContext.backgroundPages
 * since: v1.11
 * langs: js, python

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -654,6 +654,27 @@ Path to the JavaScript file. If `path` is a relative path, then it is resolved r
 
 Script to be evaluated in all pages in the browser context. Optional.
 
+## async method: Page.addInitLocalStorageItems
+* since: v1.8
+
+Adds items to be added to `localStorage` in the same scenarios as `BrowserContext.addInitScript`
+
+### param: Page.addInitLocalStorageItems.items
+* since: v1.8
+* langs: js
+- `items` <[Array]<[Object]>>
+  - `name` <string> Key of the item
+  - `value` <unknown> Value of the item
+
+Items to add to the `localStorage`.
+
+### param: Page.addInitLocalStorageItems.overwrite
+* since: v1.8
+* langs: js
+- `overwrite` <boolean> 
+
+Enabled by default. It will overwrite existing items in `localStorage`.
+
 ## async method: Page.addScriptTag
 * since: v1.8
 - returns: <[ElementHandle]>

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -295,8 +295,6 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     this.addInitScript(
         ([items, overwrite]: [{name: string, value: unknown}[], boolean]) => {
           items.forEach(({ name, value }) => {
-            // eslint-disable-next-line no-console
-            console.log('check', name, window.localStorage.getItem(name));
             if (overwrite || !window.localStorage.getItem(name)) window.localStorage.setItem(name, String(value));
           });
         },

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -288,6 +288,22 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     await this._channel.addInitScript({ source });
   }
 
+  async addInitLocalStorageItems(
+    items: Array<{name: string, value: unknown}>,
+    overwrite = true
+  ) {
+    this.addInitScript(
+        ([items, overwrite]: [{name: string, value: unknown}[], boolean]) => {
+          items.forEach(({ name, value }) => {
+            // eslint-disable-next-line no-console
+            console.log('check', name, window.localStorage.getItem(name));
+            if (overwrite || !window.localStorage.getItem(name)) window.localStorage.setItem(name, String(value));
+          });
+        },
+        [items, overwrite]
+    );
+  }
+
   async exposeBinding(name: string, callback: (source: structs.BindingSource, ...args: any[]) => any, options: { handle?: boolean } = {}): Promise<void> {
     await this._channel.exposeBinding({ name, needsHandle: options.handle });
     this._bindings.set(name, callback);

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -443,6 +443,10 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     await this._channel.addInitScript({ source });
   }
 
+  async addInitLocalStorageItems(items: Array<{name: string, value: unknown}>, overwrite?: boolean | undefined): Promise<void> {
+    await this._browserContext.addInitLocalStorageItems(items, overwrite);
+  }
+
   async route(url: URLMatch, handler: RouteHandlerCallback, options: { times?: number } = {}): Promise<void> {
     this._routes.unshift(new RouteHandler(this._browserContext._options.baseURL, url, handler, options.times));
     await this._updateInterceptionPatterns();

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -294,6 +294,12 @@ export interface Page {
    * @param arg Optional argument to pass to `script` (only supported when passing a function).
    */
   addInitScript<Arg>(script: PageFunction<Arg, any> | { path?: string, content?: string }, arg?: Arg): Promise<void>;
+  /**
+   * Adds items to be added to `localStorage` in the same scenarios as `BrowserContext.addInitScript`
+   * @param items Items to add to the `localStorage`.
+   * @param overwrite Enabled by default. It will overwrite existing items in `localStorage`.
+   */
+  addInitLocalStorageItems(items: Array<{name: string, value: unknown}>, overwrite?: boolean | undefined): Promise<void>;
 
   /**
    * **NOTE** Use locator-based [page.locator(selector[, options])](https://playwright.dev/docs/api/class-page#page-locator)
@@ -1782,23 +1788,6 @@ export interface Page {
    * by the page.
    */
   prependListener(event: 'worker', listener: (worker: Worker) => void): this;
-
-  /**
-   * Adds items to be added to `localStorage` in the same scenarios as `BrowserContext.addInitScript`
-   * @param items Items to add to the `localStorage`.
-   * @param overwrite Enabled by default. It will overwrite existing items in `localStorage`.
-   */
-  addInitLocalStorageItems(items: Array<{
-    /**
-     * Key of the item
-     */
-    name: string;
-
-    /**
-     * Value of the item
-     */
-    value: unknown;
-  }>, overwrite: boolean): Promise<void>;
 
   /**
    * Adds a `<script>` tag into the page with the desired url or content. Returns the added tag when the script's onload
@@ -7558,6 +7547,12 @@ export interface BrowserContext {
    */
   addInitScript<Arg>(script: PageFunction<Arg, any> | { path?: string, content?: string }, arg?: Arg): Promise<void>;
   /**
+   * Adds items to be added to `localStorage` in the same scenarios as `BrowserContext.addInitScript`
+   * @param items Items to add to the `localStorage`.
+   * @param overwrite Enabled by default. It will overwrite existing items in `localStorage`.
+   */
+  addInitLocalStorageItems(items: Array<{name: string, value: unknown}>, overwrite?: boolean | undefined): Promise<void>;
+  /**
    * **NOTE** Only works with Chromium browser's persistent context.
    *
    * Emitted when new background page is created in the context.
@@ -8188,23 +8183,6 @@ export interface BrowserContext {
      */
     sameSite?: "Strict"|"Lax"|"None";
   }>): Promise<void>;
-
-  /**
-   * Adds items to be added to `localStorage` in the same scenarios as `BrowserContext.addInitScript`
-   * @param items Items to add to the `localStorage`.
-   * @param overwrite Enabled by default. It will overwrite existing items in `localStorage`.
-   */
-  addInitLocalStorageItems(items: Array<{
-    /**
-     * Key of the item
-     */
-    name: string;
-
-    /**
-     * Value of the item
-     */
-    value: unknown;
-  }>, overwrite: boolean): Promise<void>;
 
   /**
    * **NOTE** Background pages are only supported on Chromium-based browsers.

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -1784,6 +1784,23 @@ export interface Page {
   prependListener(event: 'worker', listener: (worker: Worker) => void): this;
 
   /**
+   * Adds items to be added to `localStorage` in the same scenarios as `BrowserContext.addInitScript`
+   * @param items Items to add to the `localStorage`.
+   * @param overwrite Enabled by default. It will overwrite existing items in `localStorage`.
+   */
+  addInitLocalStorageItems(items: Array<{
+    /**
+     * Key of the item
+     */
+    name: string;
+
+    /**
+     * Value of the item
+     */
+    value: unknown;
+  }>, overwrite: boolean): Promise<void>;
+
+  /**
    * Adds a `<script>` tag into the page with the desired url or content. Returns the added tag when the script's onload
    * fires or when the script content was injected into frame.
    * @param options
@@ -8171,6 +8188,23 @@ export interface BrowserContext {
      */
     sameSite?: "Strict"|"Lax"|"None";
   }>): Promise<void>;
+
+  /**
+   * Adds items to be added to `localStorage` in the same scenarios as `BrowserContext.addInitScript`
+   * @param items Items to add to the `localStorage`.
+   * @param overwrite Enabled by default. It will overwrite existing items in `localStorage`.
+   */
+  addInitLocalStorageItems(items: Array<{
+    /**
+     * Key of the item
+     */
+    name: string;
+
+    /**
+     * Value of the item
+     */
+    value: unknown;
+  }>, overwrite: boolean): Promise<void>;
 
   /**
    * **NOTE** Background pages are only supported on Chromium-based browsers.

--- a/tests/library/browsercontext-add-init-local-storage-items.spec.ts
+++ b/tests/library/browsercontext-add-init-local-storage-items.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { contextTest as it, expect } from '../config/browserTest';
+
+async function goToExample(page) {
+  await page.route('**/*', route => {
+    route.fulfill({ body: '<html></html>' }).catch(() => {});
+  });
+  await page.goto('https://www.example.com');
+}
+
+it('should overwrite existing items by default', async ({
+  contextFactory,
+}) => {
+  const context = await contextFactory({
+    storageState: {
+      cookies: [],
+      origins: [
+        {
+          origin: 'https://www.example.com',
+          localStorage: [{
+            name: 'predefined-name',
+            value: 'predefined-value'
+          }]
+        },
+      ]
+    }
+  });
+
+  const page = await context.newPage();
+
+  await page.addInitLocalStorageItems([
+    {
+      name: 'predefined-name',
+      value: 'new-element-value',
+    }
+  ]);
+
+  await goToExample(page);
+
+  const localStorage = await page.evaluate(() => window.localStorage);
+  await expect(localStorage['predefined-name']).toBe('new-element-value');
+});
+
+
+it('should not overwrite existing items if overwrite flag is false', async ({
+  contextFactory,
+  server,
+}) => {
+  const context = await contextFactory({
+    storageState: {
+      cookies: [],
+      origins: [
+        {
+          origin: 'https://www.example.com',
+          localStorage: [{
+            name: 'predefined-name',
+            value: 'predefined-value'
+          }]
+        },
+      ]
+    }
+  });
+
+  const page = await context.newPage();
+
+  await page.addInitLocalStorageItems([
+    {
+      name: 'predefined-name',
+      value: 'new-element-value',
+    },
+    {
+      name: 'new-element-2-name',
+      value: 'new-element-2-value',
+    }
+  ], false);
+
+  await goToExample(page);
+
+  const localStorage = await page.evaluate(() => window.localStorage);
+  await expect(localStorage['predefined-name']).toBe('predefined-value');
+  await expect(localStorage['new-element-2-name']).toBe('new-element-2-value');
+});

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -35,6 +35,7 @@ export interface Page {
   evaluateHandle<R>(pageFunction: PageFunction<void, R>, arg?: any): Promise<SmartHandle<R>>;
 
   addInitScript<Arg>(script: PageFunction<Arg, any> | { path?: string, content?: string }, arg?: Arg): Promise<void>;
+  addInitLocalStorageItems(items: Array<{name: string, value: unknown}>, overwrite?: boolean | undefined): Promise<void>;
 
   $<K extends keyof HTMLElementTagNameMap>(selector: K, options?: { strict: boolean }): Promise<ElementHandleForTag<K> | null>;
   $(selector: string, options?: { strict: boolean }): Promise<ElementHandle<SVGElement | HTMLElement> | null>;
@@ -101,6 +102,7 @@ export interface BrowserContext {
   exposeBinding(name: string, playwrightBinding: (source: BindingSource, ...args: any[]) => any, options?: { handle?: boolean }): Promise<void>;
 
   addInitScript<Arg>(script: PageFunction<Arg, any> | { path?: string, content?: string }, arg?: Arg): Promise<void>;
+  addInitLocalStorageItems(items: Array<{name: string, value: unknown}>, overwrite?: boolean | undefined): Promise<void>;
 }
 
 export interface Worker {


### PR DESCRIPTION
For applications that use `localStorage` heavily, it is useful to be able to initialize the state of `localStorage` in certain tests, before navigating to any page. This MR adds a method, `addInitLocalStorageItems`, that provides a way of setting `localStorage` items using `addInitScript`. It also supports an `overwrite` flag. Use this to override any `localStorage` item that was already set through the browser context. 