### PR TITLE
chore: remove /ms-playwright-agent in focal Docker image

### DIFF
--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -43,5 +43,6 @@ RUN mkdir /ms-playwright && \
     npm exec --no -- playwright-core mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
     npm exec --no -- playwright-core install --with-deps && rm -rf /var/lib/apt/lists/* && \
     rm /tmp/playwright-core.tar.gz && \
+    rm -rf /ms-playwright-agent && \
     rm -rf ~/.npm/ && \
     chmod -R 777 /ms-playwright


### PR DESCRIPTION
This was missing in focal but was there in Jammy.

https://github.com/microsoft/playwright/blob/6b31b30df9edc4c0b64a89ed5c29222ee4dea5a0/utils/docker/Dockerfile.jammy#L44