### PR TITLE
cherry-pick(#27630): fix: merge{Tests,Expects} via ESM imports

### DIFF
--- a/packages/playwright/test.mjs
+++ b/packages/playwright/test.mjs
@@ -28,4 +28,6 @@ export const _android = playwright._android;
 export const test = playwright.test;
 export const expect = playwright.expect;
 export const defineConfig = playwright.defineConfig;
+export const mergeTests = playwright.mergeTests;
+export const mergeExpects = playwright.mergeExpects;
 export default playwright.test;


### PR DESCRIPTION
This PR cherry-picks the following commits:

- fd2fbe9d2f8e0df5b46c558fdd71ef677f969309