### PR TITLE
feat(test runner): introduce "ignored" test status

### DIFF
--- a/docs/src/test-api/class-testinfo.md
+++ b/docs/src/test-api/class-testinfo.md
@@ -134,7 +134,7 @@ Errors thrown during test execution, if any.
 
 ## property: TestInfo.expectedStatus
 * since: v1.10
-- type: <[TestStatus]<"passed"|"failed"|"timedOut"|"skipped"|"interrupted">>
+- type: <[TestStatus]<"passed"|"failed"|"timedOut"|"skipped"|"interrupted"|"ignored">>
 
 Expected status for the currently running test. This is usually `'passed'`, except for a few cases:
 * `'skipped'` for skipped tests, e.g. with [`method: Test.skip#2`];
@@ -401,7 +401,7 @@ Suffix used to differentiate snapshots between multiple test configurations. For
 
 ## property: TestInfo.status
 * since: v1.10
-- type: ?<[TestStatus]<"passed"|"failed"|"timedOut"|"skipped"|"interrupted">>
+- type: ?<[TestStatus]<"passed"|"failed"|"timedOut"|"skipped"|"interrupted"|"ignored">>
 
 Actual status for the currently running test. Available after the test has finished in [`method: Test.afterEach#1`] hook and fixtures.
 

--- a/docs/src/test-reporter-api/class-testcase.md
+++ b/docs/src/test-reporter-api/class-testcase.md
@@ -18,7 +18,7 @@ Learn more about [test annotations](../test-annotations.md).
 
 ## property: TestCase.expectedStatus
 * since: v1.10
-- type: <[TestStatus]<"passed"|"failed"|"timedOut"|"skipped"|"interrupted">>
+- type: <[TestStatus]<"passed"|"failed"|"timedOut"|"skipped"|"interrupted"|"ignored">>
 
 Expected test status.
 * Tests marked as [`method: Test.skip#1`] or [`method: Test.fixme#1`] are expected to be `'skipped'`.

--- a/docs/src/test-reporter-api/class-testresult.md
+++ b/docs/src/test-reporter-api/class-testresult.md
@@ -49,7 +49,7 @@ Start time of this particular test run.
 
 ## property: TestResult.status
 * since: v1.10
-- type: <[TestStatus]<"passed"|"failed"|"timedOut"|"skipped"|"interrupted">>
+- type: <[TestStatus]<"passed"|"failed"|"timedOut"|"skipped"|"interrupted"|"ignored">>
 
 The status of this test result. See also [`property: TestCase.expectedStatus`].
 

--- a/packages/html-reporter/src/statusIcon.tsx
+++ b/packages/html-reporter/src/statusIcon.tsx
@@ -18,7 +18,7 @@ import * as icons from './icons';
 import './colors.css';
 import './common.css';
 
-export function statusIcon(status: 'failed' | 'timedOut' | 'skipped' | 'passed' | 'expected' | 'unexpected' | 'flaky' | 'interrupted'): JSX.Element {
+export function statusIcon(status: 'failed' | 'timedOut' | 'skipped' | 'passed' | 'expected' | 'unexpected' | 'flaky' | 'interrupted' | 'ignored'): JSX.Element {
   switch (status) {
     case 'failed':
     case 'unexpected':
@@ -32,6 +32,7 @@ export function statusIcon(status: 'failed' | 'timedOut' | 'skipped' | 'passed' 
       return icons.warning();
     case 'skipped':
     case 'interrupted':
+    case 'ignored':
       return icons.blank();
   }
 }

--- a/packages/html-reporter/src/types.ts
+++ b/packages/html-reporter/src/types.ts
@@ -96,7 +96,7 @@ export type TestResult = {
   steps: TestStep[];
   errors: string[];
   attachments: TestAttachment[];
-  status: 'passed' | 'failed' | 'timedOut' | 'skipped' | 'interrupted';
+  status: 'passed' | 'failed' | 'timedOut' | 'skipped' | 'interrupted' | 'ignored';
 };
 
 export type TestStep = {

--- a/packages/playwright/src/common/DEPS.list
+++ b/packages/playwright/src/common/DEPS.list
@@ -2,6 +2,7 @@
 ../util.ts
 ../utilsBundle.ts
 ../transform
+../isomorphic
 
 [testType.ts]
 ../matchers/expect.ts

--- a/packages/playwright/src/isomorphic/outcome.ts
+++ b/packages/playwright/src/isomorphic/outcome.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TestStatus } from '../../types/testReporter';
+
+export function calculateTestOutcome(expectedStatus: TestStatus, results: TestStatus[]) {
+  const executedToCompletion = results.filter(result => !['ignored', 'interrupted'].includes(result));
+  if (executedToCompletion.every(result => result === 'skipped'))
+    return 'skipped';
+  const expected = executedToCompletion.filter(result => result === expectedStatus);
+  if (!expected.length) // all failed
+    return 'unexpected';
+  if (expected.length === executedToCompletion.length) // all passed
+    return 'expected';
+  return 'flaky'; // mixed bag
+}

--- a/packages/playwright/src/reporters/dot.ts
+++ b/packages/playwright/src/reporters/dot.ts
@@ -49,7 +49,7 @@ class DotReporter extends BaseReporter {
       this._counter = 0;
     }
     ++this._counter;
-    if (result.status === 'skipped') {
+    if (result.status === 'skipped' || result.status === 'ignored') {
       process.stdout.write(colors.yellow('°'));
       return;
     }

--- a/packages/playwright/src/reporters/list.ts
+++ b/packages/playwright/src/reporters/list.ts
@@ -169,7 +169,7 @@ class ListReporter extends BaseReporter {
     let prefix = '';
     let text = '';
     const index = this._resultIndex.get(result)!;
-    if (result.status === 'skipped') {
+    if (result.status === 'skipped' || result.status === 'ignored') {
       prefix = this._testPrefix(index, colors.green('-'));
       // Do not show duration for skipped.
       text = colors.cyan(title) + this._retrySuffix(result);

--- a/packages/playwright/src/reporters/markdown.ts
+++ b/packages/playwright/src/reporters/markdown.ts
@@ -63,7 +63,8 @@ class MarkdownReporter extends BaseReporter {
       lines.push(``);
     }
     const skipped = summary.skipped ? `, ${summary.skipped} skipped` : '';
-    lines.push(`**${summary.expected} passed${skipped}**`);
+    const ignored = summary.ignored ? `, ${summary.ignored} ignored` : '';
+    lines.push(`**${summary.expected} passed${skipped}${ignored}**`);
     lines.push(`:heavy_check_mark::heavy_check_mark::heavy_check_mark:`);
     lines.push(``);
 

--- a/packages/playwright/src/runner/failureTracker.ts
+++ b/packages/playwright/src/runner/failureTracker.ts
@@ -31,7 +31,7 @@ export class FailureTracker {
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
-    if (result.status !== 'skipped' && result.status !== test.expectedStatus)
+    if (result.status !== 'ignored' && result.status !== test.expectedStatus)
       ++this._failureCount;
   }
 

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -279,7 +279,7 @@ function createRunTestsTask(): Task<TestRun> {
           } else {
             for (const testGroup of testGroups) {
               for (const test of testGroup.tests)
-                test._appendTestResult().status = 'skipped';
+                test._appendTestResult().status = 'ignored';
             }
           }
         }

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1864,7 +1864,7 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
   configFile?: string;
 }
 
-export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped' | 'interrupted';
+export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped' | 'interrupted' | 'ignored';
 
 /**
  * `WorkerInfo` contains information about the worker that is running tests and is available to worker-scoped
@@ -2186,7 +2186,7 @@ export interface TestInfo {
    * ```
    *
    */
-  expectedStatus: "passed"|"failed"|"timedOut"|"skipped"|"interrupted";
+  expectedStatus: "passed"|"failed"|"timedOut"|"skipped"|"interrupted"|"ignored";
 
   /**
    * Absolute path to a file where the currently running test is declared.
@@ -2290,7 +2290,7 @@ export interface TestInfo {
    * ```
    *
    */
-  status?: "passed"|"failed"|"timedOut"|"skipped"|"interrupted";
+  status?: "passed"|"failed"|"timedOut"|"skipped"|"interrupted"|"ignored";
 
   /**
    * Output written to `process.stderr` or `console.error` during the test execution.

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -885,7 +885,7 @@ function createTree(rootSuite: Suite | undefined, loadErrors: TestError[], proje
         status = 'running';
       else if (result?.status === 'skipped')
         status = 'skipped';
-      else if (result?.status === 'interrupted')
+      else if (result?.status === 'interrupted' || result?.status === 'ignored')
         status = 'none';
       else if (result && test.outcome() !== 'expected')
         status = 'failed';

--- a/tests/playwright-test/deps.spec.ts
+++ b/tests/playwright-test/deps.spec.ts
@@ -133,7 +133,7 @@ test('should not run project if dependency failed', async ({ runInlineTest }) =>
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.output).toContain('Failed project B');
   expect(result.outputLines).toEqual(['A', 'B']);
 });
@@ -318,7 +318,7 @@ test('should report skipped dependent tests', async ({ runInlineTest }) => {
   });
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.results.length).toBe(2);
 });
 
@@ -499,7 +499,7 @@ test('should run teardown after failure', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(2);
+  expect(result.ignored).toBe(2);
   expect(result.outputLines).toEqual(['A', 'D']);
 });
 

--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -370,7 +370,7 @@ test('max-failures should still run afterEach/afterAll', async ({ runInlineTest 
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.outputLines).toEqual([
     'test',
     'afterEach',
@@ -399,7 +399,7 @@ test('beforeAll failure should prevent the test, but not afterAll', async ({ run
   });
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.outputLines).toEqual([
     'beforeAll',
     'afterAll',
@@ -499,7 +499,7 @@ test('beforeAll timeout should be reported and prevent more tests', async ({ run
   }, { timeout: 1000 });
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.outputLines).toEqual([
     'beforeAll',
     'afterAll',
@@ -688,7 +688,7 @@ test('unhandled rejection during beforeAll should be reported and prevent more t
   });
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.outputLines).toEqual([
     'beforeAll',
     'afterAll',
@@ -801,7 +801,7 @@ test('beforeAll failure should only prevent tests that are affected', async ({ r
   });
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.passed).toBe(1);
   expect(result.outputLines).toEqual([
     'beforeAll',

--- a/tests/playwright-test/max-failures.spec.ts
+++ b/tests/playwright-test/max-failures.spec.ts
@@ -111,7 +111,7 @@ test('max-failures should stop workers', async ({ runInlineTest }) => {
   expect(result.passed).toBe(2);
   expect(result.failed).toBe(1);
   expect(result.interrupted).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.output).toContain('%%interrupted');
   expect(result.output).not.toContain('%%skipped');
 });
@@ -177,7 +177,7 @@ test('max-failures should work across phases', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
   expect(result.passed).toBe(2);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.output).toContain('running a');
   expect(result.output).toContain('running b');
   expect(result.output).toContain('running c');

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -43,6 +43,7 @@ export type RunResult = {
   flaky: number,
   skipped: number,
   interrupted: number,
+  ignored: number,
   report: JSONReport,
   results: any[],
 };
@@ -417,6 +418,7 @@ export function parseTestRunnerOutput(output: string) {
   const flaky = summary(/(\d+) flaky/g);
   const skipped = summary(/(\d+) skipped/g);
   const interrupted = summary(/(\d+) interrupted/g);
+  const ignored = summary(/(\d+) ignored/g);
 
   const strippedOutput = stripAnsi(output);
   return {
@@ -428,5 +430,6 @@ export function parseTestRunnerOutput(output: string) {
     flaky,
     skipped,
     interrupted,
+    ignored,
   };
 }

--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -205,7 +205,7 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(result.exitCode).toBe(1);
       expect(result.failed).toBe(1);
       expect(result.passed).toBe(0);
-      expect(result.skipped).toBe(2);
+      expect(result.ignored).toBe(2);
       expect(result.output).toContain('Testing stopped early after 1 maximum allowed failures.');
     });
 

--- a/tests/playwright-test/retry.spec.ts
+++ b/tests/playwright-test/retry.spec.ts
@@ -216,7 +216,7 @@ test('should retry beforeAll failure', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.output.split('\n')[2]).toBe('×°×°F°');
   expect(result.output).toContain('BeforeAll is bugged!');
 });

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -111,7 +111,7 @@ test('should report subprocess creation error', async ({ runInlineTest }, testIn
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.output).toContain('Error: worker process exited unexpectedly (code=42, signal=null)');
 });
 
@@ -150,7 +150,7 @@ test('should ignore subprocess creation error because of SIGINT', async ({ inter
   const result = parseTestRunnerOutput(testProcess.output);
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(0);
-  expect(result.skipped).toBe(2);
+  expect(result.ignored).toBe(2);
   expect(result.output).not.toContain('worker process exited unexpectedly');
 });
 
@@ -190,7 +190,7 @@ test('sigint should stop workers', async ({ interactWithTestRunner }) => {
   const result = parseTestRunnerOutput(testProcess.output);
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(0);
-  expect(result.skipped).toBe(2);
+  expect(result.ignored).toBe(2);
   expect(result.interrupted).toBe(2);
   expect(result.output).toContain('%%SEND-SIGINT%%1');
   expect(result.output).toContain('%%SEND-SIGINT%%2');
@@ -405,7 +405,7 @@ test('should not hang if test suites in worker are inconsistent with runner', as
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.report.suites[0].specs[1].tests[0].results[0].error!.message).toBe('Test(s) not found in the worker process. Make sure test titles do not change:\nproject-name > a.spec.js > Test 1 - bar\nproject-name > a.spec.js > Test 2 - baz');
 });
 
@@ -638,7 +638,7 @@ test('should not hang on worker error in test file', async ({ runInlineTest }) =
   expect(result.exitCode).toBe(1);
   expect(result.results[0].status).toBe('failed');
   expect(result.results[0].error.message).toContain('Error: worker process exited unexpectedly');
-  expect(result.results[1].status).toBe('skipped');
+  expect(result.results[1].status).toBe('ignored');
 });
 
 test('fast double SIGINT should be ignored', async ({ interactWithTestRunner }) => {

--- a/tests/playwright-test/test-modifiers.spec.ts
+++ b/tests/playwright-test/test-modifiers.spec.ts
@@ -640,7 +640,7 @@ test('static modifiers should be added in serial mode', async ({ runInlineTest }
   });
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
-  expect(result.skipped).toBe(3);
+  expect(result.ignored).toBe(3);
   expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'slow' }]);
   expect(result.report.suites[0].specs[1].tests[0].annotations).toEqual([{ type: 'fixme' }]);
   expect(result.report.suites[0].specs[2].tests[0].annotations).toEqual([{ type: 'skip' }]);

--- a/tests/playwright-test/test-serial.spec.ts
+++ b/tests/playwright-test/test-serial.spec.ts
@@ -47,7 +47,7 @@ test('test.describe.serial should work', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(2);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(2);
+  expect(result.ignored).toBe(2);
   expect(result.outputLines).toEqual([
     'test1',
     'test2',
@@ -87,7 +87,7 @@ test('test.describe.serial should work in describe', async ({ runInlineTest }) =
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(2);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(2);
+  expect(result.ignored).toBe(2);
   expect(result.outputLines).toEqual([
     'test1',
     'test2',
@@ -128,7 +128,7 @@ test('test.describe.serial should work with retry', async ({ runInlineTest }) =>
   expect(result.passed).toBe(2);
   expect(result.flaky).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.outputLines).toEqual([
     'test1',
     'test2',
@@ -272,7 +272,7 @@ test('test.describe.serial should work with test.fail', async ({ runInlineTest }
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(2);
   expect(result.failed).toBe(1);
-  expect(result.skipped).toBe(1);
+  expect(result.ignored).toBe(1);
   expect(result.outputLines).toEqual([
     'zero',
     'one',
@@ -393,4 +393,56 @@ test('test.describe.serial should work with fullyParallel', async ({ runInlineTe
     'one',
     'two',
   ]);
+});
+
+test('serial fail + skip is failed', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test.describe.configure({ mode: 'serial', retries: 1 });
+      test.describe.serial('serial suite', () => {
+        test('one', async () => {
+          expect(test.info().retry).toBe(0);
+        });
+        test('two', async () => {
+          expect(1).toBe(2);
+        });
+        test('three', async () => {
+        });
+      });
+    `,
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(0);
+  expect(result.skipped).toBe(0);
+  expect(result.flaky).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.interrupted).toBe(0);
+  expect(result.ignored).toBe(1);
+});
+
+test('serial skip + fail is failed', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test.describe.configure({ mode: 'serial', retries: 1 });
+      test.describe.serial('serial suite', () => {
+        test('one', async () => {
+          expect(test.info().retry).toBe(1);
+        });
+        test('two', async () => {
+          expect(1).toBe(2);
+        });
+        test('three', async () => {
+        });
+      });
+    `,
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(0);
+  expect(result.skipped).toBe(0);
+  expect(result.flaky).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.interrupted).toBe(0);
+  expect(result.ignored).toBe(1);
 });

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -99,7 +99,7 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
   // [internal] !!! DO NOT ADD TO THIS !!! See prior note.
 }
 
-export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped' | 'interrupted';
+export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped' | 'interrupted' | 'ignored';
 
 export interface WorkerInfo {
   config: FullConfig;


### PR DESCRIPTION
New "ignored" status differentiates from the "skipped":
- Test is ignored when the test runner never executed it. For example:
  - Testing was interrupted, and last few tests were ignored.
  - Testing stopped early because of maxFailures.
  - Failure in serial mode prevented following tests from running.
- Test is skipped when it is explicitly marked as skipped.

This resolves confusion around various retry cases:
- skipped + passed = passed
- skipped + failed = flaky
- ignored + passed = passed
- ignored + failed = failed

Changes in this PR:
- new status for `TestResult`, but no new status for `TestCase`;
- terminal reporters print ignored vs skipped separately;
- all other reporters visually treat ignored similar to skipped.