### PR TITLE
fix(trace): EPERM on windows

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
@@ -139,7 +139,7 @@ export class LocalUtilsDispatcher extends Dispatcher<{ guid: string }, channels.
               zipFile.outputStream.pipe(fs.createWriteStream(params.zipFile)).on('close', () => {
                 fs.promises.unlink(tempFile).then(() => {
                   promise.resolve();
-                });
+                }).catch(error => promise.reject(error));
               });
             });
           }

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -204,15 +204,18 @@ export async function mergeTraceFiles(fileName: string, temporaryTraceFiles: str
         } else if (entry.fileName.match(/[\d-]*trace\./)) {
           entryName = i + '-' + entry.fileName;
         }
+        if (entryNames.has(entryName)) {
+          if (--pendingEntries === 0)
+            promise.resolve();
+          return;
+        }
+        entryNames.add(entryName);
         inZipFile.openReadStream(entry, (err, readStream) => {
           if (err) {
             promise.reject(err);
             return;
           }
-          if (!entryNames.has(entryName)) {
-            entryNames.add(entryName);
-            zipFile.addReadStream(readStream!, entryName);
-          }
+          zipFile.addReadStream(readStream!, entryName);
           if (--pendingEntries === 0)
             promise.resolve();
         });
@@ -225,7 +228,7 @@ export async function mergeTraceFiles(fileName: string, temporaryTraceFiles: str
     zipFile.outputStream.pipe(fs.createWriteStream(fileName)).on('close', () => {
       void Promise.all(temporaryTraceFiles.map(tempFile => fs.promises.unlink(tempFile))).then(() => {
         mergePromise.resolve();
-      });
+      }).catch(error => mergePromise.reject(error));
     }).on('error', error => mergePromise.reject(error));
   });
   await mergePromise;


### PR DESCRIPTION
When merging trace files, we sometimes left open read streams from the zip, which prevents it from being removed.

Fixes #27286.