### PR TITLE
fix: interrupt request.allHeaders()/response() on page.close()

### DIFF
--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -165,8 +165,7 @@ export class Request extends ChannelOwner<channels.RequestChannel> implements ap
 
     if (!this._actualHeadersPromise) {
       this._actualHeadersPromise = this._wrapApiCall(async () => {
-        const protocolHeaders = await this._targetClosedScope().race(this._channel.rawRequestHeaders());
-        return new RawHeaders(protocolHeaders.headers);
+        return new RawHeaders((await this._channel.rawRequestHeaders()).headers);
       });
     }
     return this._actualHeadersPromise;
@@ -185,8 +184,7 @@ export class Request extends ChannelOwner<channels.RequestChannel> implements ap
   }
 
   async response(): Promise<Response | null> {
-    const protocolResponse = await this._targetClosedScope().race(this._channel.response());
-    return Response.fromNullable(protocolResponse.response);
+    return Response.fromNullable((await this._channel.response()).response);
   }
 
   async _internalResponse(): Promise<Response | null> {

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -165,7 +165,8 @@ export class Request extends ChannelOwner<channels.RequestChannel> implements ap
 
     if (!this._actualHeadersPromise) {
       this._actualHeadersPromise = this._wrapApiCall(async () => {
-        return new RawHeaders((await this._channel.rawRequestHeaders()).headers);
+        const protocolHeaders = await this._targetClosedScope().race(this._channel.rawRequestHeaders());
+        return new RawHeaders(protocolHeaders.headers);
       });
     }
     return this._actualHeadersPromise;
@@ -184,7 +185,8 @@ export class Request extends ChannelOwner<channels.RequestChannel> implements ap
   }
 
   async response(): Promise<Response | null> {
-    return Response.fromNullable((await this._channel.response()).response);
+    const protocolResponse = await this._targetClosedScope().race(this._channel.response());
+    return Response.fromNullable(protocolResponse.response);
   }
 
   async _internalResponse(): Promise<Response | null> {

--- a/tests/page/page-event-network.spec.ts
+++ b/tests/page/page-event-network.spec.ts
@@ -139,7 +139,7 @@ it('should resolve responses after a navigation', async ({ page, server, browser
   expect(await responsePromise).toBe(null);
 });
 
-it('interrupt request.response() and request.allHeaders() on page.close', async ({ page, server }) => {
+it('interrupt request.response() and request.allHeaders() on page.close', async ({ page, server, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27227' });
   server.setRoute('/one-style.css', (req, res) => {
     res.setHeader('Content-Type', 'text/css');
@@ -151,5 +151,10 @@ it('interrupt request.response() and request.allHeaders() on page.close', async 
   const headersPromise = req.allHeaders().catch(e => e);
   await page.close();
   expect((await respPromise).message).toContain(kTargetClosedErrorMessage);
-  expect((await headersPromise).message).toContain(kTargetClosedErrorMessage);
+  // All headers are the same as "provisional" headers in Firefox.
+  if (browserName === 'firefox')
+    expect((await headersPromise)['user-agent']).toBeTruthy();
+  else
+    expect((await headersPromise).message).toContain(kTargetClosedErrorMessage);
+
 });

--- a/tests/page/page-event-network.spec.ts
+++ b/tests/page/page-event-network.spec.ts
@@ -17,6 +17,7 @@
 
 import type { ServerResponse } from 'http';
 import { test as it, expect } from './pageTest';
+import { kTargetClosedErrorMessage } from '../config/errors';
 
 it('Page.Events.Request @smoke', async ({ page, server }) => {
   const requests = [];
@@ -136,4 +137,19 @@ it('should resolve responses after a navigation', async ({ page, server, browser
   responseFromServer.end('done');
   // the response should resolve to null, because the page navigated.
   expect(await responsePromise).toBe(null);
+});
+
+it('interrupt request.response() and request.allHeaders() on page.close', async ({ page, server }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27227' });
+  server.setRoute('/one-style.css', (req, res) => {
+    res.setHeader('Content-Type', 'text/css');
+  });
+  const reqPromise = page.waitForRequest('**/one-style.css');
+  await page.goto(server.PREFIX + '/one-style.html', { waitUntil: 'domcontentloaded' });
+  const req = await reqPromise;
+  const respPromise = req.response().catch(e => e);
+  const headersPromise = req.allHeaders().catch(e => e);
+  await page.close();
+  expect((await respPromise).message).toContain(kTargetClosedErrorMessage);
+  expect((await headersPromise).message).toContain(kTargetClosedErrorMessage);
 });


### PR DESCRIPTION
Reference https://github.com/microsoft/playwright/issues/27227