### PR TITLE
fix(keyboard): event order for Escape key

### DIFF
--- a/packages/playwright-core/src/server/input.ts
+++ b/packages/playwright-core/src/server/input.ts
@@ -114,19 +114,15 @@ export class Keyboard {
     }
 
     const tokens = split(key);
-    const promises = [];
     key = tokens[tokens.length - 1];
     for (let i = 0; i < tokens.length - 1; ++i)
-      promises.push(this.down(tokens[i]));
-    promises.push(this.down(key));
-    if (options.delay) {
-      await Promise.all(promises);
+      await this.down(tokens[i]);
+    await this.down(key);
+    if (options.delay)
       await new Promise(f => setTimeout(f, options.delay));
-    }
-    promises.push(this.up(key));
+    await this.up(key);
     for (let i = tokens.length - 2; i >= 0; --i)
-      promises.push(this.up(tokens[i]));
-    await Promise.all(promises);
+      await this.up(tokens[i]);
   }
 
   async _ensureModifiers(modifiers: types.KeyboardModifier[]): Promise<types.KeyboardModifier[]> {
@@ -135,16 +131,14 @@ export class Keyboard {
         throw new Error('Unknown modifier ' + modifier);
     }
     const restore: types.KeyboardModifier[] = Array.from(this._pressedModifiers);
-    const promises: Promise<void>[] = [];
     for (const key of kModifiers) {
       const needDown = modifiers.includes(key);
       const isDown = this._pressedModifiers.has(key);
       if (needDown && !isDown)
-        promises.push(this.down(key));
+        await this.down(key);
       else if (!needDown && isDown)
-        promises.push(this.up(key));
+        await this.up(key);
     }
-    await Promise.all(promises);
     return restore;
   }
 

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -702,3 +702,14 @@ it('should type after context menu was opened', async ({ server, page, browserNa
 
   await expect.poll(() => page.evaluate('window.keys')).toEqual(['ArrowDown']);
 });
+
+it('should have correct Keydown/Keyup order when pressing Escape key', async ({ page, server, browserName }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27709' });
+
+  await page.goto(server.PREFIX + '/input/keyboard.html');
+  await page.keyboard.press('Escape');
+  expect(await page.evaluate('getResult()')).toBe(`
+Keydown: Escape Escape 27 []
+Keyup: Escape Escape 27 []
+`.trim());
+});


### PR DESCRIPTION
This test was failing in Chromium before this change.

Caused by https://github.com/microsoft/playwright/blob/40d5e3a3c9957b8d7c22dfc69c4df0789974abc3/packages/playwright-core/src/server/chromium/crInput.ts#L54-L55

which messes up the order of the protocol calls.

Fixes https://github.com/microsoft/playwright/issues/27709.