### PR TITLE
chore: better error for trace viewer over http://

### DIFF
--- a/packages/trace-viewer/snapshot.html
+++ b/packages/trace-viewer/snapshot.html
@@ -18,6 +18,8 @@
   <body>
     <script>
       (async () => {
+        if (!navigator.serviceWorker)
+          throw new Error(`Service workers are not supported.\nMake sure to serve the Trace Viewer (${window.location}) via HTTPS or localhost.`);
         navigator.serviceWorker.register('sw.bundle.js');
         if (!navigator.serviceWorker.controller)
           await new Promise(f => navigator.serviceWorker.oncontrollerchange = f);

--- a/packages/trace-viewer/src/index.tsx
+++ b/packages/trace-viewer/src/index.tsx
@@ -26,6 +26,8 @@ import { WorkbenchLoader } from './ui/workbenchLoader';
   if (window.location.protocol !== 'file:') {
     if (window.location.href.includes('isUnderTest=true'))
       await new Promise(f => setTimeout(f, 1000));
+    if (!navigator.serviceWorker)
+      throw new Error(`Service workers are not supported.\nMake sure to serve the Trace Viewer (${window.location}) via HTTPS or localhost.`);
     navigator.serviceWorker.register('sw.bundle.js');
     if (!navigator.serviceWorker.controller) {
       await new Promise<void>(f => {

--- a/packages/trace-viewer/src/uiMode.tsx
+++ b/packages/trace-viewer/src/uiMode.tsx
@@ -26,6 +26,8 @@ import { UIModeView } from './ui/uiModeView';
   if (window.location.protocol !== 'file:') {
     if (window.location.href.includes('isUnderTest=true'))
       await new Promise(f => setTimeout(f, 1000));
+    if (!navigator.serviceWorker)
+      throw new Error(`Service workers are not supported.\nMake sure to serve the website (${window.location}) via HTTPS or localhost.`);
     navigator.serviceWorker.register('sw.bundle.js');
     if (!navigator.serviceWorker.controller) {
       await new Promise<void>(f => {


### PR DESCRIPTION
We saw in the past a lot of users reporting issues like this. Maybe a more readable error helps.

Before they just saw:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'register')
  at index.38834ec3.js:1:3775
  at index.38834ec3.js:1:4006
```

Fixes https://github.com/microsoft/playwright/issues/27655