### PR TITLE
docs: syntax corrections in expect.extend documentation

### DIFF
--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -165,6 +165,7 @@ export { test } from '@playwright/test';
 
 export const expect = baseExpect.extend({
   async toHaveAmount(locator: Locator, expected: number, options?: { timeout?: number }) {
+    const assertionName = 'toHaveAmount';
     let pass: boolean;
     let matcherResult: any;
     try {
@@ -176,21 +177,21 @@ export const expect = baseExpect.extend({
     }
 
     const message = pass
-      ? () => this.utils.matcherHint('toHaveAmount', undefined, undefined, { isNot: this.isNot }) +
+      ? () => this.utils.matcherHint(assertionName, undefined, undefined, { isNot: this.isNot }) +
           '\n\n' +
-          `Locator: ${locator}\n`,
+          `Locator: ${locator}\n` +
           `Expected: ${this.isNot ? 'not' : ''}${this.utils.printExpected(expected)}\n` +
           (matcherResult ? `Received: ${this.utils.printReceived(matcherResult.actual)}` : '')
-      : () =>  this.utils.matcherHint('toHaveAmount', undefined, undefined, expectOptions) +
+      : () =>  this.utils.matcherHint(assertionName, undefined, undefined, options) +
           '\n\n' +
-          `Locator: ${locator}\n`,
+          `Locator: ${locator}\n` +
           `Expected: ${this.utils.printExpected(expected)}\n` +
           (matcherResult ? `Received: ${this.utils.printReceived(matcherResult.actual)}` : '');
 
     return {
       message,
       pass,
-      name: 'toHaveAmount',
+      name: assertionName,
       expected,
       actual: matcherResult?.actual,
     };

--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -182,7 +182,7 @@ export const expect = baseExpect.extend({
           `Locator: ${locator}\n` +
           `Expected: ${this.isNot ? 'not' : ''}${this.utils.printExpected(expected)}\n` +
           (matcherResult ? `Received: ${this.utils.printReceived(matcherResult.actual)}` : '')
-      : () =>  this.utils.matcherHint(assertionName, undefined, undefined, options) +
+      : () =>  this.utils.matcherHint(assertionName, undefined, undefined, { isNot: this.isNot }) +
           '\n\n' +
           `Locator: ${locator}\n` +
           `Expected: ${this.utils.printExpected(expected)}\n` +


### PR DESCRIPTION
There were three syntax errors in the sample code for expect.extend:

- there was a `,` instead of `+` after both instances of `Locator: ${locator}\n`
- `expectOptions` instead of `options` was being sent to `matcherHint`.

I also put the assertion name, `'toHaveAmount'`, in a constant so it's easier to change it when using the code as basis for a new custom assertion.

This might not be the correct place to mention this, *but* following the steps in the documentation did not work for me — after importing the new `expect` in a test file, the assertions were not found. The solution that worked for me was placing `expect.extend({...})` inside `playwright.config`.

![image 1](https://github.com/microsoft/playwright/assets/5760386/8890e0df-da40-4551-948c-a4dd9bc47d16)
(`customExpect` contains exactly the code from the documentation with the two aforementioned corrections)