### PR TITLE
feat: take screenshots in the exact moment of expect.soft() failure

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -51,6 +51,8 @@ export default defineConfig({
     - `threshold` ?<[float]> an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and `1` (lax). `"pixelmatch"` comparator computes color difference in [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`.
     - `maxDiffPixels` ?<[int]> an acceptable amount of pixels that could be different, unset by default.
     - `maxDiffPixelRatio` ?<[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
+  - `soft` ?<[Object]> Configuration for the `expect.soft()` method.
+    - `screenshotOnSoftFailure` ?<[boolean]> Take a screenshot on a soft assertions failure (by default soft assertions do not take screenshots on failure).
 
 Configuration for the `expect` assertion library. Learn more about [various timeouts](../test-timeouts.md).
 

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -101,6 +101,8 @@ export default defineConfig({
     - `threshold` ?<[float]> an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and `1` (lax). `"pixelmatch"` comparator computes color difference in [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`.
     - `maxDiffPixels` ?<[int]> an acceptable amount of pixels that could be different, unset by default.
     - `maxDiffPixelRatio` ?<[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
+  - `soft` ?<[Object]> Configuration for the `expect.soft()` method.
+    - `screenshotOnSoftFailure` ?<[boolean]> Take a screenshot on a soft assertions failure (by default soft assertions do not take screenshots on failure).
 
 Configuration for the `expect` assertion library.
 

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -136,15 +136,15 @@ If you want to playwright make screenshot for failed soft assertion (by default 
 you can use `screenshotOnSoftFailure` config:
 
 ```js
-await expect.soft(page.getByTestId('status'), { 
-    screenshotOnSoftFailure: true 
-  }).toHaveText('Success');
+await expect.soft(page.getByTestId('status'), {
+  screenshotOnSoftFailure: true
+}).toHaveText('Success');
 ```
 or combine it with 
 [Custom Expect Message](https://playwright.dev/docs/test-assertions#custom-expect-message):
 
 ```js
-await expect.soft(page.getByTestId('status'), { 
+await expect.soft(page.getByTestId('status'), {
   screenshotOnSoftFailure: true,
   message: 'Status should be Success'
 }).toHaveText('Success');

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -132,12 +132,16 @@ await expect.soft(page.getByTestId('eta')).toHaveText('1 day');
 expect(test.info().errors).toHaveLength(0);
 ```
 
-If you want to playwright make screenshot for failed soft assertion (by default it will not), you can use `screenshotOnSoftFailure` config:
+If you want to playwright make screenshot for failed soft assertion (by default it will not), 
+you can use `screenshotOnSoftFailure` config:
 
 ```js
-await expect.soft(page.getByTestId('status'), { screenshotOnSoftFailure: true }).toHaveText('Success');
+await expect.soft(page.getByTestId('status'), { 
+    screenshotOnSoftFailure: true 
+  }).toHaveText('Success');
 ```
-or combine it with [Custom Expect Message](https://playwright.dev/docs/test-assertions#custom-expect-message):
+or combine it with 
+[Custom Expect Message](https://playwright.dev/docs/test-assertions#custom-expect-message):
 
 ```js
 await expect.soft(page.getByTestId('status'), { 
@@ -145,7 +149,8 @@ await expect.soft(page.getByTestId('status'), {
   message: 'Status should be Success'
 }).toHaveText('Success');
 ```
-Also you can configure `screenshotOnFailure` for `expect.soft` globally for all expectations in your project in your `playwright.config.ts` file:
+Also you can configure `screenshotOnFailure` for `expect.soft` globally for all expectations 
+in your project in your `playwright.config.ts` file:
 
 ```js title="playwright.config.ts"
 import { defineConfig } from '@playwright/test';

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -132,6 +132,54 @@ await expect.soft(page.getByTestId('eta')).toHaveText('1 day');
 expect(test.info().errors).toHaveLength(0);
 ```
 
+If you want to playwright make screenshot for failed soft assertion (by default it will not), you can use `screenshotOnSoftFailure` config:
+
+```js
+await expect.soft(page.getByTestId('status'), { screenshotOnSoftFailure: true }).toHaveText('Success');
+```
+or combine it with [Custom Expect Message](https://playwright.dev/docs/test-assertions#custom-expect-message):
+
+```js
+await expect.soft(page.getByTestId('status'), { 
+  screenshotOnSoftFailure: true,
+  message: 'Status should be Success'
+}).toHaveText('Success');
+```
+Also you can configure `screenshotOnFailure` for `expect.soft` globally for all expectations in your project in your `playwright.config.ts` file:
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  expect: {
+    soft: {
+      screenshotOnSoftFailure: true,
+    }
+  }
+});
+```
+or in project section of `playwright.config.ts` file:
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'Chrome Stable',
+      use: {
+        browserName: 'chromium',
+      },
+      expect: {
+        soft: {
+          screenshotOnSoftFailure: true,
+        }
+      }
+    },
+  ],
+});
+```
+
 Note that soft assertions only work with Playwright test runner.
 
 ## Custom Expect Message

--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -141,7 +141,8 @@ export default defineConfig({
     },
 
     soft: {
-      // Take a screenshot on a soft assertions failure (by default soft assertions do not take screenshots on failure)
+      // Take a screenshot on a soft assertions failure
+      // (by default soft assertions do not take screenshots on failure)
       screenshotOnSoftFailure: true,
     }
   },

--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -139,6 +139,11 @@ export default defineConfig({
       // total amount of pixels, between 0 and 1.
       maxDiffPixelRatio: 0.1,
     },
+
+    soft: {
+      // Take a screenshot on a soft assertions failure (by default soft assertions do not take screenshots on failure)
+      screenshotOnSoftFailure: true,
+    }
   },
 
 });

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -520,6 +520,7 @@ class ArtifactsRecorder {
   async willStartTest(testInfo: TestInfoImpl) {
     this._testInfo = testInfo;
     testInfo._onDidFinishTestFunction = () => this.didFinishTestFunction();
+    testInfo._onSoftExpectFailedFunction =  () => this.onSoftExpectFailed();
     this._captureTrace = shouldCaptureTrace(this._traceMode, testInfo) && !process.env.PW_TEST_DISABLE_TRACING;
     if (this._captureTrace)
       this._testInfo._tracing.start(this._createTemporaryArtifact('traces', `${this._testInfo.testId}-test.trace`), this._traceOptions);
@@ -634,6 +635,11 @@ class ArtifactsRecorder {
 
     for (const file of this._temporaryArtifacts)
       await fs.promises.unlink(file).catch(() => {});
+  }
+
+  async onSoftExpectFailed() {
+    if (this._testInfo._isFailure() && (this._screenshotMode === 'on' || this._screenshotMode === 'only-on-failure'))
+      await this._screenshotOnTestFailure();
   }
 
   private _createScreenshotAttachmentPath() {

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -133,7 +133,9 @@ function createExpect(info: ExpectMetaInfo) {
 
       if (property === 'soft') {
         return (actual: unknown, messageOrOptions?: ExpectMessage & { screenshotOnSoftFailure?: boolean }) => {
-          const soft = isString(messageOrOptions) ? {} : messageOrOptions || {};
+          const testInfo = currentTestInfo();
+          const softFromConfig = testInfo?._projectInternal.expect?.soft || {};
+          const soft = isString(messageOrOptions) ? {} : { ...softFromConfig, ...messageOrOptions || {} };
           return configure({ _soft: soft })(actual, messageOrOptions) as any;
         };
       }

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -136,7 +136,7 @@ function createExpect(info: ExpectMetaInfo) {
           const testInfo = currentTestInfo();
           const softFromConfig = testInfo?._projectInternal.expect?.soft || {};
           const soft = isString(messageOrOptions) ? {} : { ...softFromConfig, ...messageOrOptions || {} };
-          return configure({ _soft: soft })(actual, messageOrOptions) as any;
+          return configure({ soft: soft })(actual, messageOrOptions) as any;
         };
       }
 
@@ -150,16 +150,16 @@ function createExpect(info: ExpectMetaInfo) {
     },
   });
 
-  const configure = (configuration: { message?: string, timeout?: number, _soft?: boolean | { screenshotOnSoftFailure?: boolean }, _poll?: boolean | { timeout?: number, intervals?: number[] } }) => {
+  const configure = (configuration: { message?: string, timeout?: number, soft?: boolean | { screenshotOnSoftFailure?: boolean }, _poll?: boolean | { timeout?: number, intervals?: number[] } }) => {
     const newInfo = { ...info };
     if ('message' in configuration)
       newInfo.message = configuration.message;
     if ('timeout' in configuration)
       newInfo.timeout = configuration.timeout;
-    if ('_soft' in configuration) {
-      newInfo.isSoft = !!configuration._soft;
-      if (typeof configuration._soft === 'object')
-        newInfo.screenshotOnSoftFailure = configuration._soft.screenshotOnSoftFailure;
+    if ('soft' in configuration) {
+      newInfo.isSoft = !!configuration.soft;
+      if (typeof configuration.soft === 'object')
+        newInfo.screenshotOnSoftFailure = configuration.soft.screenshotOnSoftFailure;
 
     }
     if ('_poll' in configuration) {

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -249,7 +249,7 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
         throw new Error(`\`expect.poll()\` does not support "${matcherName}" matcher.`);
       matcher = (...args: any[]) => pollMatcher(matcherName, !!this._info.isNot, this._info.pollIntervals, currentExpectTimeout({ timeout: this._info.pollTimeout }), this._info.generator!, ...args);
     }
-    return async (...args: any[]) => {
+    return (...args: any[]) => {
       const testInfo = currentTestInfo();
       if (!testInfo)
         return matcher.call(target, ...args);
@@ -272,7 +272,7 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
         laxParent: true,
       }) : undefined;
 
-      const reportStepError = async (jestError: ExpectError) => {
+      const reportStepError = (jestError: ExpectError) => {
         const error = new ExpectError(jestError, customMessage, stackFrames);
         const serializedError = {
           message: error.message,
@@ -282,7 +282,7 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
         if (this._info.isSoft) {
           testInfo._failWithError(serializedError, false /* isHardError */);
           if (this._info.screenshotOnSoftFailure)
-            await testInfo._onSoftExpectFailedFunction?.();
+            testInfo._onSoftExpectFailedFunction?.().then(() => {}).catch(() => {});
         } else {throw error;}
       };
 
@@ -300,7 +300,7 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
         finalizer();
         return result;
       } catch (e) {
-        await reportStepError(e);
+        reportStepError(e);
       }
     };
   }

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -65,6 +65,7 @@ export class TestInfoImpl implements TestInfo {
   _beforeHooksStep: TestStepInternal | undefined;
   _afterHooksStep: TestStepInternal | undefined;
   _onDidFinishTestFunction: (() => Promise<void>) | undefined;
+  _onSoftExpectFailedFunction: () => Promise<void> | undefined = () => undefined;
 
   // ------------ TestInfo fields ------------
   readonly testId: string;

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -65,7 +65,7 @@ export class TestInfoImpl implements TestInfo {
   _beforeHooksStep: TestStepInternal | undefined;
   _afterHooksStep: TestStepInternal | undefined;
   _onDidFinishTestFunction: (() => Promise<void>) | undefined;
-  _onSoftExpectFailedFunction: () => Promise<void> | undefined = () => undefined;
+  _onSoftExpectFailedFunction: (() => Promise<void>) | undefined;
 
   // ------------ TestInfo fields ------------
   readonly testId: string;

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -649,19 +649,19 @@ interface TestConfig {
        * See `animations` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot).
        * Defaults to `"disabled"`.
        */
-      animations?: "allow"|"disabled";
+      animations?: 'allow'|'disabled';
 
       /**
        * See `caret` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot). Defaults
        * to `"hide"`.
        */
-      caret?: "hide"|"initial";
+      caret?: 'hide'|'initial';
 
       /**
        * See `scale` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot). Defaults
        * to `"css"`.
        */
-      scale?: "css"|"device";
+      scale?: 'css'|'device';
     };
 
     /**
@@ -965,7 +965,7 @@ interface TestConfig {
    * ```
    *
    */
-  preserveOutput?: "always"|"never"|"failures-only";
+  preserveOutput?: 'always'|'never'|'failures-only';
 
   /**
    * Playwright Test supports running multiple test projects at the same time. See {@link TestProject} for more
@@ -1330,7 +1330,7 @@ interface TestConfig {
    * ```
    *
    */
-  updateSnapshots?: "all"|"none"|"missing";
+  updateSnapshots?: 'all'|'none'|'missing';
 
   /**
    * The maximum number of concurrent worker processes to use for parallelizing tests. Can also be set as percentage of
@@ -2186,7 +2186,7 @@ export interface TestInfo {
    * ```
    *
    */
-  expectedStatus: "passed"|"failed"|"timedOut"|"skipped"|"interrupted";
+  expectedStatus: 'passed'|'failed'|'timedOut'|'skipped'|'interrupted';
 
   /**
    * Absolute path to a file where the currently running test is declared.
@@ -2290,7 +2290,7 @@ export interface TestInfo {
    * ```
    *
    */
-  status?: "passed"|"failed"|"timedOut"|"skipped"|"interrupted";
+  status?: 'passed'|'failed'|'timedOut'|'skipped'|'interrupted';
 
   /**
    * Output written to `process.stderr` or `console.error` during the test execution.
@@ -5270,7 +5270,7 @@ type MakeMatchers<R, T, ExtendedMatchers> = {
 
 export type Expect<ExtendedMatchers> = {
   <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }): MakeMatchers<void, T, ExtendedMatchers>;
-  soft: <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }) => MakeMatchers<void, T, ExtendedMatchers>;
+  soft: <T = unknown>(actual: T, messageOrOptions?: string | { message?: string, screenshotOnSoftFailure?: boolean }) => MakeMatchers<void, T, ExtendedMatchers>;
   poll: <T = unknown>(actual: () => T | Promise<T>, messageOrOptions?: string | { message?: string, timeout?: number, intervals?: number[] }) => BaseMatchers<Promise<void>, T> & {
     /**
      * If you know how to test something, `.not` lets you test its opposite.
@@ -5874,13 +5874,13 @@ interface LocatorAssertions {
      *
      * Defaults to `"disabled"` that disables animations.
      */
-    animations?: "disabled"|"allow";
+    animations?: 'disabled'|'allow';
 
     /**
      * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be
      * changed.  Defaults to `"hide"`.
      */
-    caret?: "hide"|"initial";
+    caret?: 'hide'|'initial';
 
     /**
      * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink
@@ -5919,7 +5919,7 @@ interface LocatorAssertions {
      *
      * Defaults to `"css"`.
      */
-    scale?: "css"|"device";
+    scale?: 'css'|'device';
 
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
@@ -5957,13 +5957,13 @@ interface LocatorAssertions {
      *
      * Defaults to `"disabled"` that disables animations.
      */
-    animations?: "disabled"|"allow";
+    animations?: 'disabled'|'allow';
 
     /**
      * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be
      * changed.  Defaults to `"hide"`.
      */
-    caret?: "hide"|"initial";
+    caret?: 'hide'|'initial';
 
     /**
      * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink
@@ -6002,7 +6002,7 @@ interface LocatorAssertions {
      *
      * Defaults to `"css"`.
      */
-    scale?: "css"|"device";
+    scale?: 'css'|'device';
 
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
@@ -6185,13 +6185,13 @@ interface PageAssertions {
      *
      * Defaults to `"disabled"` that disables animations.
      */
-    animations?: "disabled"|"allow";
+    animations?: 'disabled'|'allow';
 
     /**
      * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be
      * changed.  Defaults to `"hide"`.
      */
-    caret?: "hide"|"initial";
+    caret?: 'hide'|'initial';
 
     /**
      * An object which specifies clipping of the resulting image.
@@ -6261,7 +6261,7 @@ interface PageAssertions {
      *
      * Defaults to `"css"`.
      */
-    scale?: "css"|"device";
+    scale?: 'css'|'device';
 
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
@@ -6298,13 +6298,13 @@ interface PageAssertions {
      *
      * Defaults to `"disabled"` that disables animations.
      */
-    animations?: "disabled"|"allow";
+    animations?: 'disabled'|'allow';
 
     /**
      * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be
      * changed.  Defaults to `"hide"`.
      */
-    caret?: "hide"|"initial";
+    caret?: 'hide'|'initial';
 
     /**
      * An object which specifies clipping of the resulting image.
@@ -6374,7 +6374,7 @@ interface PageAssertions {
      *
      * Defaults to `"css"`.
      */
-    scale?: "css"|"device";
+    scale?: 'css'|'device';
 
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
@@ -6713,19 +6713,19 @@ interface TestProject {
        * See `animations` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot).
        * Defaults to `"disabled"`.
        */
-      animations?: "allow"|"disabled";
+      animations?: 'allow'|'disabled';
 
       /**
        * See `caret` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot). Defaults
        * to `"hide"`.
        */
-      caret?: "hide"|"initial";
+      caret?: 'hide'|'initial';
 
       /**
        * See `scale` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot). Defaults
        * to `"css"`.
        */
-      scale?: "css"|"device";
+      scale?: 'css'|'device';
     };
 
     /**
@@ -7130,12 +7130,12 @@ interface TestConfigWebServer {
    * If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout
    * of the command. Default to `"ignore"`.
    */
-  stdout?: "pipe"|"ignore";
+  stdout?: 'pipe'|'ignore';
 
   /**
    * Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`.
    */
-  stderr?: "pipe"|"ignore";
+  stderr?: 'pipe'|'ignore';
 
   /**
    * Current working directory of the spawned process, defaults to the directory of the configuration file.

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -649,19 +649,19 @@ interface TestConfig {
        * See `animations` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot).
        * Defaults to `"disabled"`.
        */
-      animations?: 'allow'|'disabled';
+      animations?: "allow"|"disabled";
 
       /**
        * See `caret` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot). Defaults
        * to `"hide"`.
        */
-      caret?: 'hide'|'initial';
+      caret?: "hide"|"initial";
 
       /**
        * See `scale` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot). Defaults
        * to `"css"`.
        */
-      scale?: 'css'|'device';
+      scale?: "css"|"device";
     };
 
     /**
@@ -687,6 +687,16 @@ interface TestConfig {
        * default.
        */
       maxDiffPixelRatio?: number;
+    };
+
+    /**
+     * Configuration for the `expect.soft()` method.
+     */
+    soft?: {
+      /**
+       * Take a screenshot on a soft assertions failure (by default soft assertions do not take screenshots on failure).
+       */
+      screenshotOnSoftFailure?: boolean;
     };
   };
 
@@ -965,7 +975,7 @@ interface TestConfig {
    * ```
    *
    */
-  preserveOutput?: 'always'|'never'|'failures-only';
+  preserveOutput?: "always"|"never"|"failures-only";
 
   /**
    * Playwright Test supports running multiple test projects at the same time. See {@link TestProject} for more
@@ -1330,7 +1340,7 @@ interface TestConfig {
    * ```
    *
    */
-  updateSnapshots?: 'all'|'none'|'missing';
+  updateSnapshots?: "all"|"none"|"missing";
 
   /**
    * The maximum number of concurrent worker processes to use for parallelizing tests. Can also be set as percentage of
@@ -2186,7 +2196,7 @@ export interface TestInfo {
    * ```
    *
    */
-  expectedStatus: 'passed'|'failed'|'timedOut'|'skipped'|'interrupted';
+  expectedStatus: "passed"|"failed"|"timedOut"|"skipped"|"interrupted";
 
   /**
    * Absolute path to a file where the currently running test is declared.
@@ -2290,7 +2300,7 @@ export interface TestInfo {
    * ```
    *
    */
-  status?: 'passed'|'failed'|'timedOut'|'skipped'|'interrupted';
+  status?: "passed"|"failed"|"timedOut"|"skipped"|"interrupted";
 
   /**
    * Output written to `process.stderr` or `console.error` during the test execution.
@@ -5874,13 +5884,13 @@ interface LocatorAssertions {
      *
      * Defaults to `"disabled"` that disables animations.
      */
-    animations?: 'disabled'|'allow';
+    animations?: "disabled"|"allow";
 
     /**
      * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be
      * changed.  Defaults to `"hide"`.
      */
-    caret?: 'hide'|'initial';
+    caret?: "hide"|"initial";
 
     /**
      * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink
@@ -5919,7 +5929,7 @@ interface LocatorAssertions {
      *
      * Defaults to `"css"`.
      */
-    scale?: 'css'|'device';
+    scale?: "css"|"device";
 
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
@@ -5957,13 +5967,13 @@ interface LocatorAssertions {
      *
      * Defaults to `"disabled"` that disables animations.
      */
-    animations?: 'disabled'|'allow';
+    animations?: "disabled"|"allow";
 
     /**
      * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be
      * changed.  Defaults to `"hide"`.
      */
-    caret?: 'hide'|'initial';
+    caret?: "hide"|"initial";
 
     /**
      * Specify locators that should be masked when the screenshot is taken. Masked elements will be overlaid with a pink
@@ -6002,7 +6012,7 @@ interface LocatorAssertions {
      *
      * Defaults to `"css"`.
      */
-    scale?: 'css'|'device';
+    scale?: "css"|"device";
 
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
@@ -6185,13 +6195,13 @@ interface PageAssertions {
      *
      * Defaults to `"disabled"` that disables animations.
      */
-    animations?: 'disabled'|'allow';
+    animations?: "disabled"|"allow";
 
     /**
      * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be
      * changed.  Defaults to `"hide"`.
      */
-    caret?: 'hide'|'initial';
+    caret?: "hide"|"initial";
 
     /**
      * An object which specifies clipping of the resulting image.
@@ -6261,7 +6271,7 @@ interface PageAssertions {
      *
      * Defaults to `"css"`.
      */
-    scale?: 'css'|'device';
+    scale?: "css"|"device";
 
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
@@ -6298,13 +6308,13 @@ interface PageAssertions {
      *
      * Defaults to `"disabled"` that disables animations.
      */
-    animations?: 'disabled'|'allow';
+    animations?: "disabled"|"allow";
 
     /**
      * When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be
      * changed.  Defaults to `"hide"`.
      */
-    caret?: 'hide'|'initial';
+    caret?: "hide"|"initial";
 
     /**
      * An object which specifies clipping of the resulting image.
@@ -6374,7 +6384,7 @@ interface PageAssertions {
      *
      * Defaults to `"css"`.
      */
-    scale?: 'css'|'device';
+    scale?: "css"|"device";
 
     /**
      * An acceptable perceived color difference in the [YIQ color space](https://en.wikipedia.org/wiki/YIQ) between the
@@ -6713,19 +6723,19 @@ interface TestProject {
        * See `animations` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot).
        * Defaults to `"disabled"`.
        */
-      animations?: 'allow'|'disabled';
+      animations?: "allow"|"disabled";
 
       /**
        * See `caret` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot). Defaults
        * to `"hide"`.
        */
-      caret?: 'hide'|'initial';
+      caret?: "hide"|"initial";
 
       /**
        * See `scale` in [page.screenshot([options])](https://playwright.dev/docs/api/class-page#page-screenshot). Defaults
        * to `"css"`.
        */
-      scale?: 'css'|'device';
+      scale?: "css"|"device";
     };
 
     /**
@@ -6751,6 +6761,16 @@ interface TestProject {
        * default.
        */
       maxDiffPixelRatio?: number;
+    };
+
+    /**
+     * Configuration for the `expect.soft()` method.
+     */
+    soft?: {
+      /**
+       * Take a screenshot on a soft assertions failure (by default soft assertions do not take screenshots on failure).
+       */
+      screenshotOnSoftFailure?: boolean;
     };
   };
 
@@ -7130,12 +7150,12 @@ interface TestConfigWebServer {
    * If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout
    * of the command. Default to `"ignore"`.
    */
-  stdout?: 'pipe'|'ignore';
+  stdout?: "pipe"|"ignore";
 
   /**
    * Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`.
    */
-  stderr?: 'pipe'|'ignore';
+  stderr?: "pipe"|"ignore";
 
   /**
    * Current working directory of the spawned process, defaults to the directory of the configuration file.

--- a/tests/playwright-test/expect-soft.spec.ts
+++ b/tests/playwright-test/expect-soft.spec.ts
@@ -18,7 +18,7 @@ import { test, expect } from './playwright-test-fixtures';
 import fs from 'fs';
 import path from 'path';
 
-export function listFiles(dir: string): string[] {
+function listFiles(dir: string): string[] {
   const result: string[] = [];
   const entries = fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
   for (const entry of entries) {

--- a/tests/playwright-test/playwright.artifacts.spec.ts
+++ b/tests/playwright-test/playwright.artifacts.spec.ts
@@ -18,7 +18,7 @@ import { test, expect } from './playwright-test-fixtures';
 import fs from 'fs';
 import path from 'path';
 
-export function listFiles(dir: string): string[] {
+function listFiles(dir: string): string[] {
   const result: string[] = [];
   const entries = fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
   for (const entry of entries) {

--- a/tests/playwright-test/playwright.artifacts.spec.ts
+++ b/tests/playwright-test/playwright.artifacts.spec.ts
@@ -18,7 +18,7 @@ import { test, expect } from './playwright-test-fixtures';
 import fs from 'fs';
 import path from 'path';
 
-function listFiles(dir: string): string[] {
+export function listFiles(dir: string): string[] {
   const result: string[] = [];
   const entries = fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
   for (const entry of entries) {

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -404,7 +404,7 @@ type MakeMatchers<R, T, ExtendedMatchers> = {
 
 export type Expect<ExtendedMatchers> = {
   <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }): MakeMatchers<void, T, ExtendedMatchers>;
-  soft: <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }) => MakeMatchers<void, T, ExtendedMatchers>;
+  soft: <T = unknown>(actual: T, messageOrOptions?: string | { message?: string, screenshotOnSoftFailure?: boolean }) => MakeMatchers<void, T, ExtendedMatchers>;
   poll: <T = unknown>(actual: () => T | Promise<T>, messageOrOptions?: string | { message?: string, timeout?: number, intervals?: number[] }) => BaseMatchers<Promise<void>, T> & {
     /**
      * If you know how to test something, `.not` lets you test its opposite.


### PR DESCRIPTION
related to #23191


If you want to playwright make screenshot for failed soft assertion (by default it will not), you can use `screenshotOnSoftFailure` config:

```js
await expect.soft(page.getByTestId('status'), { screenshotOnSoftFailure: true }).toHaveText('Success');
```
or combine it with [Custom Expect Message](https://playwright.dev/docs/test-assertions#custom-expect-message):

```js
await expect.soft(page.getByTestId('status'), { 
  screenshotOnSoftFailure: true,
  message: 'Status should be Success'
}).toHaveText('Success');
```
Also you can configure `screenshotOnFailure` for `expect.soft` globally for all expectations in your project in your `playwright.config.ts` file:

```js title="playwright.config.ts"
import { defineConfig } from '@playwright/test';

export default defineConfig({
  expect: {
    soft: {
      screenshotOnSoftFailure: true,
    }
  }
});
```
or in project section of `playwright.config.ts` file:

```js title="playwright.config.ts"
import { defineConfig } from '@playwright/test';

export default defineConfig({
  projects: [
    {
      name: 'Chrome Stable',
      use: {
        browserName: 'chromium',
      },
      expect: {
        soft: {
          screenshotOnSoftFailure: true,
        }
      }
    },
  ],
});
```