### PR TITLE
fix(html): rendered '0' in the header

### DIFF
--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -52,7 +52,7 @@ export const TestCaseView: React.FC<{
       {test && !!test.projectName && <ProjectLink projectNames={projectNames} projectName={test.projectName}></ProjectLink>}
       {labels && <LabelsLinkView labels={labels} />}
     </div>}
-    {test && !!test.annotations.length && <AutoChip header='Annotations'>
+    {test && test.annotations.length > 0 && <AutoChip header='Annotations'>
       {test?.annotations.map(annotation => <TestCaseAnnotationView annotation={annotation} />)}
     </AutoChip>}
     {test && <TabbedPane tabs={

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -50,7 +50,7 @@ export const TestFilesView: React.FC<{
       <div data-testid="overall-time" style={{ color: 'var(--color-fg-subtle)', marginRight: '10px' }}>{report ? new Date(report.startTime).toLocaleString() : ''}</div>
       <div data-testid="overall-duration" style={{ color: 'var(--color-fg-subtle)' }}>Total time: {msToString(filteredStats.duration)}</div>
     </div>
-    {report && report.errors.length && <AutoChip header='Errors' dataTestId='report-errors'>
+    {report && report.errors.length > 0 && <AutoChip header='Errors' dataTestId='report-errors'>
       {report.errors.map((error, index) => <TestErrorView key={'test-report-error-message-' + index} error={error}></TestErrorView>)}
     </AutoChip>}
     {report && filteredFiles.map(({ file, defaultExpanded }) => {

--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -93,10 +93,10 @@ export const TestResultView: React.FC<{
   }, [scrolled, anchor, setScrolled, videoRef]);
 
   return <div className='test-result'>
-    {!!result.errors.length && <AutoChip header='Errors'>
+    {result.errors.length > 0 && <AutoChip header='Errors'>
       {result.errors.map((error, index) => <TestErrorView key={'test-result-error-message-' + index} error={error}></TestErrorView>)}
     </AutoChip>}
-    {!!result.steps.length && <AutoChip header='Test Steps'>
+    {result.steps.length > 0 && <AutoChip header='Test Steps'>
       {result.steps.map((step, i) => <StepTreeItem key={`step-${i}`} step={step} depth={0}></StepTreeItem>)}
     </AutoChip>}
 
@@ -106,7 +106,7 @@ export const TestResultView: React.FC<{
       </AutoChip>
     )}
 
-    {!!screenshots.length && <AutoChip header='Screenshots'>
+    {screenshots.length > 0 && <AutoChip header='Screenshots'>
       {screenshots.map((a, i) => {
         return <div key={`screenshot-${i}`}>
           <a href={a.path}>
@@ -117,7 +117,7 @@ export const TestResultView: React.FC<{
       })}
     </AutoChip>}
 
-    {!!traces.length && <AutoChip header='Traces'>
+    {traces.length > 0 && <AutoChip header='Traces'>
       {<div>
         <a href={generateTraceUrl(traces)}>
           <img src={traceImage} style={{ width: 192, height: 117, marginLeft: 20 }} />
@@ -126,7 +126,7 @@ export const TestResultView: React.FC<{
       </div>}
     </AutoChip>}
 
-    {!!videos.length && <AutoChip header='Videos' targetRef={videoRef}>
+    {videos.length > 0 && <AutoChip header='Videos' targetRef={videoRef}>
       {videos.map((a, i) => <div key={`video-${i}`}>
         <video controls>
           <source src={a.path} type={a.contentType}/>


### PR DESCRIPTION
This regressed in https://github.com/microsoft/playwright/commit/c8134bca5df3f6e460c5c7f30b0e421dd9c6cec6.

Note: 00 && <Some Element /> will render a 0 in React. Always check for length > 0.

Drive-by: Aligned it to `foo.length > 0` check while `!!foo.length` works too, just to keep it consistent.