### PR TITLE
Handle tsconfig paths without a baseUrl

### DIFF
--- a/packages/playwright/src/transform/transform.ts
+++ b/packages/playwright/src/transform/transform.ts
@@ -58,11 +58,14 @@ export function transformConfig(): TransformConfig {
 }
 
 function validateTsConfig(tsconfig: TsConfigLoaderResult): ParsedTsConfigData | undefined {
-  if (!tsconfig.tsConfigPath || !tsconfig.baseUrl)
+  if (!tsconfig.tsConfigPath)
     return;
   // Make 'baseUrl' absolute, because it is relative to the tsconfig.json, not to cwd.
-  const absoluteBaseUrl = path.resolve(path.dirname(tsconfig.tsConfigPath), tsconfig.baseUrl);
-  const pathsFallback = [{ key: '*', values: ['*'] }];
+  // When no explicit baseUrl is set, resolve paths relative to the tsconfig file.
+  // See https://www.typescriptlang.org/tsconfig#paths
+  const absoluteBaseUrl = path.resolve(path.dirname(tsconfig.tsConfigPath), tsconfig.baseUrl ?? '.');
+  // Only add the catch-all mapping when baseUrl is specified
+  const pathsFallback = tsconfig.baseUrl ? [{ key: '*', values: ['*'] }] : [];
   return {
     allowJs: tsconfig.allowJs,
     absoluteBaseUrl,

--- a/packages/web/src/components/tabbedPane.tsx
+++ b/packages/web/src/components/tabbedPane.tsx
@@ -57,7 +57,7 @@ export const TabbedPane: React.FunctionComponent<{
           ]}
         </div>}
         {mode === 'select' && <div style={{ flex: 'auto', display: 'flex', height: '100%', overflow: 'hidden' }}>
-          <select style={{width: '100%', background: 'none', cursor: 'pointer'}} onChange={e => {
+          <select style={{ width: '100%', background: 'none', cursor: 'pointer' }} onChange={e => {
             setSelectedTab(tabs[e.currentTarget.selectedIndex].id);
           }}>
             {tabs.map(tab => {

--- a/tests/playwright-test/resolver.spec.ts
+++ b/tests/playwright-test/resolver.spec.ts
@@ -201,6 +201,34 @@ test('should fallback to *:* when baseurl and paths are specified', async ({ run
   expect(result.output).not.toContain(`Could not`);
 });
 
+test('should use the location of the tsconfig as the paths root when no baseUrl is specified', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'foo/bar/util/b.ts': `
+      export const foo = 42;
+    `,
+    'dir2/tsconfig.json': `{
+      "compilerOptions": {
+        "target": "ES2019",
+        "module": "commonjs",
+        "lib": ["esnext", "dom", "DOM.Iterable"],
+        "paths": {"foo/*": ["../foo/*"]},
+      },
+    }`,
+    'dir2/inner.spec.ts': `
+      // This import should pick up ../foo/bar/util/b due to paths.
+      import { foo } from 'foo/bar/util/b';
+      import { test, expect } from '@playwright/test';
+      test('test', ({}, testInfo) => {
+        expect(foo).toBe(42);
+      });
+    `,
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.output).not.toContain(`Could not`);
+});
+
 test('should respect complex path resolver', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
Partial fix for #27933

Since TS 4.1, a tsconfig may specify paths without requiring a baseUrl. In that case, paths should be resolved relative to the tsconfig file the paths were specified in.

See https://www.typescriptlang.org/tsconfig#paths
See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#paths-without-baseurl

This PR makes playwright handle cases where paths are specified without a baseUrl, such as:

```json
{
  "compilerOptions": {
    "paths": {
      "~/*": ["./app/*"],
    }
  }
}
```



---


There is an edge case that this doesn't handle - if you specify paths without a baseUrl in an config that is extended from then the paths should be relative to the file that paths was specified in (i.e. the path looks right in the file that it was written in). In other words, adding the following test case to `tests/playwright-test/resolver.spec.ts` should pass, but it does not:

```ts
test('should use the location of the extended tsconfig as paths root when no baseUrl is specified', async ({ runInlineTest }) => {
  const result = await runInlineTest({
    'tsconfig.json': `{
      "extends": ["./other/tsconfig.base.json"],
    }`,
    'other/tsconfig.base.json': `{
      "compilerOptions": {
        // paths without a baseUrl should resolve relative to the file they're in, which means
        // the base for these paths should be "other/". However playwright will currently
        // resolve them relative to the top-level tsconfig, not the extended from config
        // Note that adding baseurl:'.', fixes this within playwright but has the undesireable
        // effect of enabling the wildcard matching for additional top-level folders in the
        // "other" directory
        // "baseUrl": ".",
        "paths": {
          "util/*": ["../dir/foo/bar/util/*"],
        },
      },
    }`,
    'a.test.ts': `
      const { foo } = require('util/file');
      import { test, expect } from '@playwright/test';
      test('test', ({}, testInfo) => {
        expect(foo).toBe('foo');
      });
    `,
    'dir/foo/bar/util/file.ts': `
      module.exports = { foo: 'foo' };
    `,
  });

  expect(result.passed).toBe(1);
  expect(result.exitCode).toBe(0);
});
```


To fix this edge case would require greater refactoring than I'm comfortable doing. I'm ok with the idea that this PR is an incremental improvement - we fix paths without a baseUrl in base tsconfigs, while leaving paths without a baseUrl in extended configs as not working for the moment"