### PR TITLE
feat(ui): trace view network tab add simple filter section

### DIFF
--- a/packages/trace-viewer/src/ui/networkTab.css
+++ b/packages/trace-viewer/src/ui/networkTab.css
@@ -140,3 +140,12 @@
 .network-request-header.filter-size.negative .network-request-size .codicon-triangle-up {
   display: initial !important;
 }
+
+.tab-network-filter {
+  padding: 8px;
+  background-color: var(--vscode-sideBar-background);
+}
+
+.tab-network-filter input[type=search] {
+  min-width: 200px;
+}

--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -52,6 +52,7 @@ export const NetworkTab: React.FunctionComponent<{
 }> = ({ boundaries, networkModel, onEntryHovered }) => {
   const [resource, setResource] = React.useState<Entry | undefined>();
   const [sorting, setSorting] = React.useState<Sorting | undefined>(undefined);
+  const [textFilter, setTextFilter] = React.useState<string>('');
 
   React.useMemo(() => {
     if (sorting)
@@ -67,10 +68,11 @@ export const NetworkTab: React.FunctionComponent<{
 
   return <>
     {!resource && <div className='vbox'>
+      <NetworkFilters textFilter={textFilter} setTextFilter={setTextFilter} />
       <NetworkHeader sorting={sorting} toggleSorting={toggleSorting} />
       <NetworkListView
         name='network'
-        items={networkModel.resources}
+        items={networkModel.resources.filter(r => r.request.url.includes(textFilter))}
         render={entry => <NetworkResource boundaries={boundaries} resource={entry}></NetworkResource>}
         onSelected={setResource}
         onHighlighted={onEntryHovered}
@@ -163,6 +165,28 @@ const NetworkResource: React.FunctionComponent<{
       {routeStatus && <div className={`status-route ${routeStatus}`}>{routeStatus}</div>}
     </div>
   </div>;
+};
+
+const NetworkFilters: React.FunctionComponent<{
+  textFilter: string,
+  setTextFilter: React.Dispatch<React.SetStateAction<string>>,
+}> = ({
+  textFilter,
+  setTextFilter,
+}) => {
+  return (
+    <div className='tab-network-filter'>
+      <input
+        type="search"
+        placeholder="Filter"
+        spellCheck={false}
+        value={textFilter}
+        onChange={e => {
+          setTextFilter(e.target.value);
+        }}
+      />
+    </div>
+  );
 };
 
 function formatStatus(status: number): string {

--- a/packages/web/src/components/tabbedPane.css
+++ b/packages/web/src/components/tabbedPane.css
@@ -31,6 +31,10 @@
   position: relative;
 }
 
+.tabbed-pane .tab-content.tab-network {
+  flex-direction: column;
+}
+
 .tabbed-pane-tab {
   padding: 2px 6px 0 6px;
   cursor: pointer;

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -37,6 +37,7 @@ export type TraceViewerFixtures = {
 class TraceViewerPage {
   actionTitles: Locator;
   callLines: Locator;
+  filtersContainer: Locator;
   consoleLines: Locator;
   logLines: Locator;
   consoleLineMessages: Locator;
@@ -48,6 +49,7 @@ class TraceViewerPage {
   constructor(public page: Page) {
     this.actionTitles = page.locator('.action-title');
     this.callLines = page.locator('.call-tab .call-line');
+    this.filtersContainer = page.locator('.tab-network-filter');
     this.logLines = page.getByTestId('log-list').locator('.list-view-entry');
     this.consoleLines = page.locator('.console-line');
     this.consoleLineMessages = page.locator('.console-line-message');

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -246,7 +246,7 @@ test('should have network requests', async ({ showTraceViewer }) => {
   await expect(traceViewer.networkRequests).toContainText([/200GET\/frames\/script.jsapplication\/javascript/]);
 });
 
-test('should filtering a request in network tab', async ({ showTraceViewer }) => {
+test('should filter a request in network tab', async ({ showTraceViewer }) => {
   const traceViewer = await showTraceViewer([traceFile]);
   await traceViewer.selectAction('http://localhost');
   await traceViewer.showNetworkTab();

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -246,6 +246,31 @@ test('should have network requests', async ({ showTraceViewer }) => {
   await expect(traceViewer.networkRequests).toContainText([/200GET\/frames\/script.jsapplication\/javascript/]);
 });
 
+test('should filtering a request in network tab', async ({ showTraceViewer }) => {
+  const traceViewer = await showTraceViewer([traceFile]);
+  await traceViewer.selectAction('http://localhost');
+  await traceViewer.showNetworkTab();
+
+  await traceViewer.filtersContainer.getByPlaceholder('Filter').fill('style');
+
+  await expect(traceViewer.networkRequests).not.toContainText([/200GET\/frames\/frame.htmltext\/html/]);
+  await expect(traceViewer.networkRequests).not.toContainText([/200GET\/frames\/script.jsapplication\/javascript/]);
+  await expect(traceViewer.networkRequests).toContainText([/200GET\/frames\/style.csstext\/css/]);
+});
+
+test('should clear filter request in network tab', async ({ showTraceViewer }) => {
+  const traceViewer = await showTraceViewer([traceFile]);
+  await traceViewer.selectAction('http://localhost');
+  await traceViewer.showNetworkTab();
+
+  await traceViewer.filtersContainer.getByPlaceholder('Filter').fill('style');
+  await traceViewer.filtersContainer.getByPlaceholder('Filter').fill('');
+
+  await expect(traceViewer.networkRequests).toContainText([/200GET\/frames\/frame.htmltext\/html/]);
+  await expect(traceViewer.networkRequests).toContainText([/200GET\/frames\/script.jsapplication\/javascript/]);
+  await expect(traceViewer.networkRequests).toContainText([/200GET\/frames\/style.csstext\/css/]);
+});
+
 test('should have network request overrides', async ({ page, server, runAndTrace }) => {
   const traceViewer = await runAndTrace(async () => {
     await page.route('**/style.css', route => route.abort());


### PR DESCRIPTION
Proposed feat for #27530 

I added a simple search input to improve the experience of searching for a particular request (filtering by request url).
For the future I'd like to add more ways to filter requests, for example filtering by type (fetch, js, css, doc etc..), like Chrome DevTools or similar

[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)