### PR TITLE
fix: cross-origin Page.goto referer

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -587,7 +587,7 @@ class FrameSession {
   }
 
   async _navigate(frame: frames.Frame, url: string, referrer: string | undefined): Promise<frames.GotoResult> {
-    const response = await this._client.send('Page.navigate', { url, referrer, frameId: frame._id });
+    const response = await this._client.send('Page.navigate', { url, referrer, frameId: frame._id, referrerPolicy: 'unsafeUrl' });
     if (response.errorText)
       throw new frames.NavigationAbortedError(response.loaderId, `${response.errorText} at ${url}`);
     return { newDocumentId: response.loaderId };

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -632,6 +632,21 @@ it('should send referer', async ({ page, server }) => {
   expect(page.url()).toBe(server.PREFIX + '/grid.html');
 });
 
+it('should send referer of cross-origin URL', async ({ page, server }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27765' });
+  const [request1, request2] = await Promise.all([
+    server.waitForRequest('/grid.html'),
+    server.waitForRequest('/digits/1.png'),
+    page.goto(server.PREFIX + '/grid.html', {
+      referer: 'https://microsoft.com/xbox/'
+    }),
+  ]);
+  expect(request1.headers['referer']).toBe('https://microsoft.com/xbox/');
+  // Make sure subresources do not inherit referer.
+  expect(request2.headers['referer']).toBe(server.PREFIX + '/grid.html');
+  expect(page.url()).toBe(server.PREFIX + '/grid.html');
+});
+
 it('should reject referer option when setExtraHTTPHeaders provides referer', async ({ page, server }) => {
   await page.setExtraHTTPHeaders({ 'referer': 'http://microsoft.com/' });
   let error;


### PR DESCRIPTION
- WebKit was working
- Firefox did not pass a refererPolicy before.
- Chromium requires a new parameter as per [here](https://chromedevtools.github.io/devtools-protocol/tot/Page/#type-ReferrerPolicy).

Draft: Waiting for Firefox roll to land.

Fixes https://github.com/microsoft/playwright/issues/27765