### PR TITLE
test: using ServiceWorker on localhost over HTTPS

### DIFF
--- a/tests/library/ignorehttpserrors.spec.ts
+++ b/tests/library/ignorehttpserrors.spec.ts
@@ -95,7 +95,7 @@ it('should fail with WebSocket if not ignored', async ({ browser, httpsServer })
 
 it('serviceWorker should intercept document request', async ({ browser, httpsServer, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27768' });
-  it.skip(browserName === 'chromium');
+  it.fixme(browserName === 'chromium');
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
   await context.route('**/*', route => route.continue());

--- a/tests/library/ignorehttpserrors.spec.ts
+++ b/tests/library/ignorehttpserrors.spec.ts
@@ -92,3 +92,30 @@ it('should fail with WebSocket if not ignored', async ({ browser, httpsServer })
   expect(value).toBe('Error');
   await context.close();
 });
+
+it('serviceWorker should intercept document request', async ({ browser, httpsServer, browserName }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27768' });
+  it.skip(browserName === 'chromium');
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  const page = await context.newPage();
+  await context.route('**/*', route => route.continue());
+  httpsServer.setRoute('/sw.js', (req, res) => {
+    res.setHeader('Content-Type', 'application/javascript');
+    res.end(`
+      self.addEventListener('fetch', event => {
+        event.respondWith(new Response('intercepted'));
+      });
+      self.addEventListener('activate', event => {
+        event.waitUntil(clients.claim());
+      });
+    `);
+  });
+  await page.goto(httpsServer.EMPTY_PAGE);
+  await page.evaluate(async () => {
+    await navigator.serviceWorker.register('/sw.js');
+    await new Promise(resolve => navigator.serviceWorker.oncontrollerchange = resolve);
+  });
+  await page.reload();
+  expect(await page.textContent('body')).toBe('intercepted');
+  await context.close();
+});

--- a/tests/library/ignorehttpserrors.spec.ts
+++ b/tests/library/ignorehttpserrors.spec.ts
@@ -112,8 +112,9 @@ it('serviceWorker should intercept document request', async ({ browser, httpsSer
   });
   await page.goto(httpsServer.EMPTY_PAGE);
   await page.evaluate(async () => {
+    const waitForControllerChange = new Promise(resolve => navigator.serviceWorker.oncontrollerchange = resolve);
     await navigator.serviceWorker.register('/sw.js');
-    await new Promise(resolve => navigator.serviceWorker.oncontrollerchange = resolve);
+    await waitForControllerChange;
   });
   await page.reload();
   expect(await page.textContent('body')).toBe('intercepted');


### PR DESCRIPTION
```
  1) [chromium] › library/ignorehttpserrors.spec.ts:97:3 › serviceWorker should intercept document request 

    Error: page.evaluate: DOMException: Failed to register a ServiceWorker for scope ('https://localhost:8908/') with script ('https://localhost:8908/sw.js'): An SSL certificate error occurred when fetching the script.

      111 |   });
      112 |   await page.goto(httpsServer.EMPTY_PAGE);
    > 113 |   await page.evaluate(async () => {
          |              ^
      114 |     await navigator.serviceWorker.register('/sw.js');
      115 |     await new Promise(resolve => navigator.serviceWorker.oncontrollerchange = resolve);
      116 |   });

        at /Users/maxschmitt/Developer/playwright/tests/library/ignorehttpserrors.spec.ts:113:14

  1 failed
    [chromium] › library/ignorehttpserrors.spec.ts:97:3 › serviceWorker should intercept document request 
  2 passed (4.6s)

playwright on  main [$!] via  v18.17.1 took 5s 
❯ 
```

https://github.com/microsoft/playwright/issues/27768