### PR TITLE
Fix for weird "Promise was collected" error (Masked by Execution context was destroyed)

### DIFF
--- a/packages/playwright-ct-core/src/mount.ts
+++ b/packages/playwright-ct-core/src/mount.ts
@@ -133,7 +133,7 @@ async function innerMount(page: Page, jsxOrType: JsxComponent | string, options:
 
     await window.playwrightMount(component, rootElement, hooksConfig);
 
-    return '#root >> internal:control=component';
+    return Promise.resolve('#root >> internal:control=component');
   }, { component, hooksConfig: options.hooksConfig });
   return selector;
 }


### PR DESCRIPTION
When doing a `mount` on a fairly large component with a large enough props payload, I'm randomly getting an "Error: Execution context was destroyed, most likely because of a navigation.". Which by looking at `DEBUG` logs, seems to happen due to a "Promise was collected" error from the CDP `Runtime.callFunctionOn` request.

There was no navigation involved at this point. Rather it seems like the actual `Promise` that is invoked by `Runtime.callFunctionOn` is getting somehow collected by the GC, which is likely trigged by either the size of the component bundle or whatever it does with the props that creates enough garbage.

This is fairly difficult to reproduce outside of our proprietary project, but I might be able to show this happening on a video call if you wish to (And my company agrees). Though will let you know if I manage to make a standalone reproduction.

It seems that just wrapping the return value in `Promise.resolve` made this go away, somehow making the VM hold the Promise alive long enough instead of collecting while it's not done yet. Of course, finding and fixing why something weird like this happens in the first place is likely a good idea if anyone is up for the challenge.

Contributed by courtesy of [swimm.io](https://swimm.io/)

cc @hollykurt @eran-swimm @ShaulAmranS