### PR TITLE
fix: Google Chrome Beta/Stable install on macOS

### DIFF
--- a/packages/playwright-core/bin/reinstall_chrome_beta_mac.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_mac.sh
@@ -6,7 +6,7 @@ rm -rf "/Applications/Google Chrome Beta.app"
 cd /tmp
 curl -o ./googlechromebeta.dmg -k https://dl.google.com/chrome/mac/universal/beta/googlechromebeta.dmg
 hdiutil attach -nobrowse -quiet -noautofsck -noautoopen -mountpoint /Volumes/googlechromebeta.dmg ./googlechromebeta.dmg
-cp -rf "/Volumes/googlechromebeta.dmg/Google Chrome Beta.app" /Applications
+cp -pR "/Volumes/googlechromebeta.dmg/Google Chrome Beta.app" /Applications
 hdiutil detach /Volumes/googlechromebeta.dmg
 rm -rf /tmp/googlechromebeta.dmg
 

--- a/packages/playwright-core/bin/reinstall_chrome_stable_mac.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_mac.sh
@@ -6,7 +6,7 @@ rm -rf "/Applications/Google Chrome.app"
 cd /tmp
 curl -o ./googlechrome.dmg -k https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg
 hdiutil attach -nobrowse -quiet -noautofsck -noautoopen -mountpoint /Volumes/googlechrome.dmg ./googlechrome.dmg
-cp -rf "/Volumes/googlechrome.dmg/Google Chrome.app" /Applications
+cp -pR "/Volumes/googlechrome.dmg/Google Chrome.app" /Applications
 hdiutil detach /Volumes/googlechrome.dmg
 rm -rf /tmp/googlechrome.dmg
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version


### PR DESCRIPTION
This pull request addresses and resolves an issue where applications, such as Google Chrome Beta, became unusable after being copied via the Terminal. This issue was primarily due to the loss of extended attributes, specifically the `com.apple.quarantine` attribute, during the copying process.

#### Changes:

- Updated the copying command in our script to use `cp -pR`.

```bash
cp -pR "/Volumes/googlechromebeta.dmg/Google Chrome Beta.app" /Applications/
```

#### Background:

When files are downloaded from the internet, macOS tags them with the `com.apple.quarantine` attribute as a security measure. This attribute triggers Gatekeeper to verify the application's integrity, signature, and source before the application is allowed to run. 

We discovered that when copying applications via the Terminal using a plain `cp` command, essential extended attributes like `com.apple.quarantine` were not preserved, leading macOS to consider the application broken or damaged.

#### Benefits of `-pR` Options:

- **`-p` (Preserve):** Ensures that the extended attributes, including `com.apple.quarantine`, and Access Control Lists (ACLs) are preserved during the copy, maintaining the file’s integrity and original security attributes.
  
- **`-R` (Recursive):** Ensures that directories, or in the case of macOS, application bundles, are copied recursively, preserving the structure and content.

#### Conclusion:

By incorporating the `cp -pR` command, we maintain the necessary security attributes and metadata, ensuring that applications remain functional and recognized as secure by macOS after the copying process. This approach aligns the behavior of the copying process closer to that observed when using the Finder’s GUI for copying, thus ensuring consistent application behavior and integrity.

Drive-by: remove the `-f`, since we before removed the folder already.

Fixes https://github.com/microsoft/playwright/issues/27764