### PR TITLE
chore: fix parameterized tests on the flakiness dashboard

### DIFF
--- a/utils/flakiness-dashboard/README.md
+++ b/utils/flakiness-dashboard/README.md
@@ -3,9 +3,33 @@
 This directory contains source code for the Azure function that we use to aggregate test reports.
 The data is consumed by https://devops.playwright.dev/flakiness.html
 
-To publish function:
-- Install [Azure Functions Core Tools version 4.x.](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local).
-  - This is as of Nov 2023 not available for macOS M1. So you can either use Rosetta or use GitHub Codespaces.
-- Install Azure CLI (`brew update && brew install azure-cli`) && login via `az login`
-- Make sure to run `npm install` to populate `node_modules/` folder (this folder will be published as-is).
-- Run `/tmp/azure-functions-cli/func azure functionapp publish folio-flakiness-dashboard --javascript`
+## Publish
+
+Azure Functions Core Tools is not available on macOS M1 yet, so we use GitHub Codespaces to publish the function.
+
+### Via GitHub Codespaces:
+
+- Install [Azure Functions Core Tools version 4](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=linux%2Cisolated-process%2Cnode-v4%2Cpython-v2%2Chttp-trigger%2Ccontainer-apps&pivots=programming-language-javascript):
+  ```
+  curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+  mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+  sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list'
+  apt-get update && apt-get install azure-functions-core-tools-4
+  ```
+- Install Azure CLI:
+  ```bash
+  curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+  ```
+- Login to Azure:
+  ```bash
+  az login --use-device-code
+  ```
+- Install NPM Deps (`node_modules/` folder will be published as-is):
+  ```
+  cd utils/flakiness-dashboard/
+  npm install
+  ```
+- Publish:
+  ```bash
+  func azure functionapp publish folio-flakiness-dashboard --javascript
+  ```

--- a/utils/flakiness-dashboard/README.md
+++ b/utils/flakiness-dashboard/README.md
@@ -1,10 +1,11 @@
 # Flakiness Dashboard Backend
 
 This directory contains source code for the Azure function that we use to aggregate test reports.
-The data is consumed by https://devops.aslushnikov.com/flakiness2.html
+The data is consumed by https://devops.playwright.dev/flakiness.html
 
 To publish function:
-- install [Azure Functions Core Tools version 4.x.](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Cmacos%2Ccsharp%2Cportal%2Cbash#v2).
-- install Azure CLI && login via `az login`
-- make sure to run `npm install` to populate `node_modules/` folder (this folder will be published as-is).
-- run `func azure functionapp publish folio-flakiness-dashboard --javascript`
+- Install [Azure Functions Core Tools version 4.x.](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local).
+  - This is as of Nov 2023 not available for macOS M1. So you can either use Rosetta or use GitHub Codespaces.
+- Install Azure CLI (`brew update && brew install azure-cli`) && login via `az login`
+- Make sure to run `npm install` to populate `node_modules/` folder (this folder will be published as-is).
+- Run `/tmp/azure-functions-cli/func azure functionapp publish folio-flakiness-dashboard --javascript`

--- a/utils/flakiness-dashboard/package-lock.json
+++ b/utils/flakiness-dashboard/package-lock.json
@@ -4,8 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "flakiness-dashboard",
       "dependencies": {
-        "@azure/storage-blob": "^12.2.1"
+        "@azure/storage-blob": "^12.16.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -121,9 +122,9 @@
       }
     },
     "node_modules/@azure/storage-blob": {
-      "version": "12.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.13.0.tgz",
-      "integrity": "sha512-t3Q2lvBMJucgTjQcP5+hvEJMAsJSk0qmAnjDLie2td017IiduZbbC9BOcFfmwzR6y6cJdZOuewLCNFmEx9IrXA==",
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.16.0.tgz",
+      "integrity": "sha512-jz33rUSUGUB65FgYrTRgRDjG6hdPHwfvHe+g/UrwVG8MsyLqSxg9TaW7Yuhjxu1v1OZ5xam2NU6+IpCN0xJO8Q==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-http": "^3.0.0",
@@ -428,9 +429,9 @@
       }
     },
     "@azure/storage-blob": {
-      "version": "12.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.13.0.tgz",
-      "integrity": "sha512-t3Q2lvBMJucgTjQcP5+hvEJMAsJSk0qmAnjDLie2td017IiduZbbC9BOcFfmwzR6y6cJdZOuewLCNFmEx9IrXA==",
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.16.0.tgz",
+      "integrity": "sha512-jz33rUSUGUB65FgYrTRgRDjG6hdPHwfvHe+g/UrwVG8MsyLqSxg9TaW7Yuhjxu1v1OZ5xam2NU6+IpCN0xJO8Q==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-http": "^3.0.0",

--- a/utils/flakiness-dashboard/package.json
+++ b/utils/flakiness-dashboard/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "flakiness-dashboard",
   "version": "",
   "description": "",
   "scripts": {
@@ -7,6 +7,6 @@
   },
   "author": "",
   "dependencies": {
-    "@azure/storage-blob": "^12.2.1"
+    "@azure/storage-blob": "^12.16.0"
   }
 }

--- a/utils/flakiness-dashboard/processing/dashboard_compressed_v1.js
+++ b/utils/flakiness-dashboard/processing/dashboard_compressed_v1.js
@@ -60,7 +60,7 @@ function compressReports(reports) {
         specs = new Map();
         files[spec.file] = specs;
       }
-      const specId = spec.file + '---' + spec.title + ' --- ' + spec.line;
+      const specId = spec.file + '---' + spec.titlePath.join('-') + ' --- ' + spec.line;
       let specObject = specs.get(specId);
       if (!specObject) {
         specObject = {

--- a/utils/flakiness-dashboard/processing/index.js
+++ b/utils/flakiness-dashboard/processing/index.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const {blobServiceClient, gunzipAsync, deleteBlob} = require('./utils.js');
+const {gunzipAsync, deleteBlob} = require('./utils.js');
 const {processDashboardRaw} = require('./dashboard_raw.js');
 const {processDashboardCompressedV1} = require('./dashboard_compressed_v1.js');
 


### PR DESCRIPTION
Abstract issue: I have parameterised tests via the titlePath (describe) and they are not shown on the flakiness dashboard. Before #24486 only title() was shown, after #24486 titlePath() will be displayed, but we still did have the testId based on the test.title() and not test.titlePath(). This ends up that they will still be treated as a single spec.

After this change they are not treated as a single spec anymore and treated as different ones:

<img width="891" alt="image" src="https://github.com/microsoft/playwright/assets/17984549/f24284cd-5d94-4f7e-a45d-8c8e5eb537ef">

Note: This is tested.

Follow-up on https://github.com/microsoft/playwright/pull/24486.