### PR TITLE
fix(msedge): install with multiple artifacts

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -918,7 +918,7 @@ export class Registry {
         darwin: { platform: 'MacOS', arch: 'universal', artifact: 'pkg' },
         win32: { platform: 'Windows', arch: 'x64', artifact: 'msi' },
       } as any)[process.platform];
-      const release = searchConfig ? product.releases.find((release: any) => release.platform === searchConfig.platform && release.architecture === searchConfig.arch) : null;
+      const release = searchConfig ? product.releases.find((release: any) => release.platform === searchConfig.platform && release.architecture === searchConfig.arch && release.artifacts.length > 0) : null;
       const artifact = release ? release.artifacts.find((artifact: any) => artifact.artifactname === searchConfig.artifact) : null;
       if (artifact)
         scriptArgs.push(artifact.location /* url */);


### PR DESCRIPTION
The API response looked like this:

https://edgeupdates.microsoft.com/api/products

<img width="1584" alt="image" src="https://github.com/microsoft/playwright/assets/17984549/89d32ad4-8770-48c3-b562-231ae7b9ef3b">

-> multiple entries for `Windows` and `X64`, but some without artifacts. -> We filter now for `artifacts.length > 0` which seems like a healthy change.

Fixes https://github.com/microsoft/playwright/issues/22841