### PR TITLE
devops: call merge-reports with explicit config

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Merge reports
       run: |
-        npx playwright merge-reports --reporter markdown,html ./all-blob-reports
+        npx playwright merge-reports --config .github/workflows/merge.config.ts ./all-blob-reports
       env:
         NODE_OPTIONS: --max-old-space-size=4096
 

--- a/.github/workflows/merge.config.ts
+++ b/.github/workflows/merge.config.ts
@@ -1,0 +1,4 @@
+export default {
+  testDir: '../../tests',
+  reporter: [['markdown'], ['html']]
+};


### PR DESCRIPTION
After https://github.com/microsoft/playwright/pull/27963 we have to provide explicit merge config to disambiguate testDir.