### PR TITLE
fix: electron video tests

### DIFF
--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -525,7 +525,7 @@ export class CRBrowserContext extends BrowserContext {
     await Promise.all(openedBeforeUnloadDialogs.map(dialog => dialog.dismiss()));
 
     if (!this._browserContextId) {
-      await Promise.all(this._crPages().map(crPage => crPage._mainFrameSession._stopVideoRecording()));
+      await this.stopVideoRecording();
       // Closing persistent context should close the browser.
       await this._browser.close({ reason });
       return;
@@ -543,6 +543,10 @@ export class CRBrowserContext extends BrowserContext {
       serviceWorker.didClose();
       this._browser._serviceWorkers.delete(targetId);
     }
+  }
+
+  async stopVideoRecording() {
+    await Promise.all(this._crPages().map(crPage => crPage._mainFrameSession._stopVideoRecording()));
   }
 
   onClosePersistent() {

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -78,6 +78,7 @@ export class ElectronApplication extends SdkObject {
       });
     });
     this._browserContext.setCustomCloseHandler(async () => {
+      await this._browserContext.stopVideoRecording();
       const electronHandle = await this._nodeElectronHandlePromise;
       await electronHandle.evaluate(({ app }) => app.quit()).catch(() => {});
     });


### PR DESCRIPTION
This test started failing after https://github.com/microsoft/playwright/commit/817a130cdc71140acfafb3aafbab7f3e267a9f08.

If a custom close handler is specified (like we do for Electron) in

https://github.com/microsoft/playwright/blob/0f2de59b7ca62f47395256e885e65717738430f1/packages/playwright-core/src/server/browserContext.ts#L429-L434

we do not run doClose handler which internally stops the video recording:

https://github.com/microsoft/playwright/blob/b9aaa38d3bf6c86029042e3d3ec0470650f5c611/packages/playwright-core/src/server/chromium/crBrowser.ts#L527-L532

Before Pavels patch it was more luck that the videos were saved to disk already. After my patch we guarantee it like we do with normal contexts.