### PR TITLE
docs(running-tests-*.md): Correct "running tests" typos

### DIFF
--- a/docs/src/running-tests-csharp.md
+++ b/docs/src/running-tests-csharp.md
@@ -5,7 +5,7 @@ title: "Running and debugging tests"
 
 ## Introduction
 
-You can run a single test, a set of tests or all tests. Tests can be run on different browsers. By default tests are run in a headless manner meaning no browser window will be opened while running the tests and results will be seen in the terminal. If you prefer you can run your tests in headed mode by using the `headless` test run parameter.
+You can run a single test, a set of tests or all tests. Tests can be run on different browsers. By default, tests are run in a headless manner, meaning no browser window will be opened while running the tests and results will be seen in the terminal. If you prefer, you can run your tests in headed mode by using the `headless` test run parameter.
 
 - Running all tests
 
@@ -39,7 +39,7 @@ You can run a single test, a set of tests or all tests. Tests can be run on diff
 
 - Running Tests on multiple browsers
 
-  To run your test on multiple browsers or configurations you need to invoke the `dotnet test` command multiple times. There you can then either specify the `BROWSER` environment variable or set the `Playwright.BrowserName` via the runsettings file:
+  To run your test on multiple browsers or configurations, you need to invoke the `dotnet test` command multiple times. There you can then either specify the `BROWSER` environment variable or set the `Playwright.BrowserName` via the runsettings file:
 
   ```bash
   dotnet test --settings:chromium.runsettings

--- a/docs/src/running-tests-java.md
+++ b/docs/src/running-tests-java.md
@@ -5,12 +5,12 @@ title: "Running and debugging tests"
 
 ## Introduction
 
-Playwright tests can be run in a variety of ways. We recommend hooking it up to your favorite test runner, e.g. [JUnit](./test-runners.md) since it gives you the ability to run tests in parallel, run single test, etc.
+Playwright tests can be run in a variety of ways. We recommend hooking it up to your favorite test runner, e.g., [JUnit](./test-runners.md), since it gives you the ability to run tests in parallel, run single test, etc.
 
-You can run a single test, a set of tests or all tests. Tests can be run on one browser or multiple browsers. By default tests are run in a headless manner meaning no browser window will be opened while running the tests and results will be seen in the terminal. If you prefer you can run your tests in headed mode by using the `launch(new BrowserType.LaunchOptions().setHeadless(false))` option.
+You can run a single test, a set of tests or all tests. Tests can be run on one browser or multiple browsers. By default tests are run in a headless manner meaning no browser window will be opened while running the tests and results will be seen in the terminal. If you prefer, you can run your tests in headed mode by using the `launch(new BrowserType.LaunchOptions().setHeadless(false))` option.
 
-In [JUnit](https://junit.org/junit5/) you can initialize [Playwright] and [Browser] in [@BeforeAll](https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/BeforeAll.html) method and
-destroy them in [@AfterAll](https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/AfterAll.html). In the example below all three test methods use the same
+In [JUnit](https://junit.org/junit5/), you can initialize [Playwright] and [Browser] in [@BeforeAll](https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/BeforeAll.html) method and
+destroy them in [@AfterAll](https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/AfterAll.html). In the example below, all three test methods use the same
 [Browser]. Each test uses its own [BrowserContext] and [Page].
 
 ```java
@@ -81,7 +81,7 @@ public class TestExample {
 }
 ```
 
-See [here](./test-runners.md) for further details on how to run tests in parallel etc..
+See [here](./test-runners.md) for further details on how to run tests in parallel, etc.
 
 ## What's Next
 

--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -37,7 +37,7 @@ Check out or [detailed guide on UI Mode](./test-ui-mode.md) to learn more about 
 
 ### Run tests in headed mode
 
-To run your tests in headed mode use the `--headed` flag. This will give you the ability to visually see, how Playwright interacts with the website.
+To run your tests in headed mode use the `--headed` flag. This will give you the ability to visually see how Playwright interacts with the website.
 
 ```bash
 npx playwright test --headed

--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -4,7 +4,7 @@ title: "Running and debugging tests"
 ---
 ## Introduction
 
-With Playwright you can run a single test, a set of tests or all tests. Tests can be run on one browser or multiple browsers by using the `--project` flag. Tests are run in parallel by default and are run in a headless manner meaning no browser window will be opened while running the tests and results will be seen in the terminal. However you can run tests in headed mode by using the `--headed` CLI argument or you can run your tests in [UI mode](./test-ui-mode.md), by using the `--ui` flag, and see a full trace of your tests complete with watch mode, time travel debugging and more.
+With Playwright you can run a single test, a set of tests or all tests. Tests can be run on one browser or multiple browsers by using the `--project` flag. Tests are run in parallel by default and are run in a headless manner, meaning no browser window will be opened while running the tests and results will be seen in the terminal. However, you can run tests in headed mode by using the `--headed` CLI argument, or you can run your tests in [UI mode](./test-ui-mode.md) by using the `--ui` flag. See a full trace of your tests complete with watch mode, time travel debugging and more.
 
 **You will learn**
 

--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -25,7 +25,7 @@ npx playwright test
 
 ### Run tests in UI mode
 
-We highly recommend running your tests with [UI Mode](./test-ui-mode.md) for a better developer experience where you can easily walk through each step of the test and visually see what was happening before, during, and after each step. UI mode also comes with many other features such as the locator picker, watch mode and more.
+We highly recommend running your tests with [UI Mode](./test-ui-mode.md) for a better developer experience where you can easily walk through each step of the test and visually see what was happening before, during and after each step. UI mode also comes with many other features such as the locator picker, watch mode and more.
 
 ```bash
 npx playwright test --ui
@@ -95,7 +95,7 @@ Since Playwright runs in Node.js, you can debug it with your debugger of choice 
 
 ### Debug tests in UI mode
 
-We highly recommend debugging your tests with [UI Mode](./test-ui-mode.md) for a better developer experience where you can easily walk through each step of the test and visually see what was happening before, during, and after each step. UI mode also comes with many other features such as the locator picker, watch mode and more.
+We highly recommend debugging your tests with [UI Mode](./test-ui-mode.md) for a better developer experience where you can easily walk through each step of the test and visually see what was happening before, during and after each step. UI mode also comes with many other features such as the locator picker, watch mode and more.
 
 ```bash
 npx playwright test --ui

--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -111,7 +111,7 @@ Check out our [detailed guide on UI Mode](./test-ui-mode.md) to learn more about
 
 ### Debug tests with the Playwright Inspector
 
-To debug all tests run the Playwright test command followed by the `--debug` flag.
+To debug all tests, run the Playwright test command followed by the `--debug` flag.
 
 ```bash
 npx playwright test --debug
@@ -121,13 +121,13 @@ npx playwright test --debug
 
 This command will open up a Browser window as well as the Playwright Inspector. You can use the step over button at the top of the inspector to step through your test. Or, press the play button to run your test from start to finish. Once the test has finished, the browser window will close.
 
-To debug one test file run the Playwright test command with the name of the test file that you want to debug followed by the `--debug` flag.
+To debug one test file, run the Playwright test command with the name of the test file that you want to debug followed by the `--debug` flag.
 
 ```bash
 npx playwright test example.spec.ts --debug
 ```
 
-To debug a specific test from the line number where the `test(..` is defined add a colon followed by the line number at the end of the test file name, followed by the `--debug` flag.
+To debug a specific test from the line number where the `test(..` is defined, add a colon followed by the line number at the end of the test file name, followed by the `--debug` flag.
 
 ```bash
 npx playwright test example.spec.ts:10 --debug

--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -91,7 +91,7 @@ Tests can be run right from VS Code using the [VS Code extension](https://market
 
 ## Debugging tests
 
-Since Playwright runs in Node.js, you can debug it with your debugger of choice e.g. using `console.log` or inside your IDE or directly in VS Code with the [VS Code Extension](./getting-started-vscode.md). Playwright comes with [UI Mode](./test-ui-mode.md), where you can easily walk through each step of the test, see logs, errors, network requests, inspect the DOM snapshot and more. You can also use the [Playwright Inspector](./debug.md#playwright-inspector) which allows you to step through Playwright API calls, see their debug logs and explore [locators](./locators.md).
+Since Playwright runs in Node.js, you can debug it with your debugger of choice e.g. using `console.log` or inside your IDE or directly in VS Code with the [VS Code Extension](./getting-started-vscode.md). Playwright comes with [UI Mode](./test-ui-mode.md), where you can easily walk through each step of the test, see logs, errors, network requests, inspect the DOM snapshot and more. You can also use the [Playwright Inspector](./debug.md#playwright-inspector), which allows you to step through Playwright API calls, see their debug logs and explore [locators](./locators.md).
 
 ### Debug tests in UI mode
 

--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -103,11 +103,11 @@ npx playwright test --ui
 
 ![showing errors in ui mode](https://github.com/microsoft/playwright/assets/13063165/ffca2fd1-5349-41fb-ade9-ace143bb2c58)
 
-While debugging you can use the Pick Locator button to select an element on the page and see the locator that Playwright would use to find that element. You an also edit the locator in the locator playground and see it highlighting live on the Browser window. Use the Copy Locator button to copy the locator to your clipboard and then paste it into you test.
+While debugging you can use the Pick Locator button to select an element on the page and see the locator that Playwright would use to find that element. You can also edit the locator in the locator playground and see it highlighting live on the Browser window. Use the Copy Locator button to copy the locator to your clipboard and then paste it into you test.
 
 ![pick locator in ui mode](https://github.com/microsoft/playwright/assets/13063165/9e7eeb84-bd26-4010-8614-75e24b56c716)
 
-Check out or [detailed guide on UI Mode](./test-ui-mode.md) to learn more about it's features.
+Check out our [detailed guide on UI Mode](./test-ui-mode.md) to learn more about it's features.
 
 ### Debug tests with the Playwright Inspector
 

--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -119,7 +119,7 @@ npx playwright test --debug
 
 ![Debugging Tests with the Playwright inspector](https://github.com/microsoft/playwright/assets/13063165/6b3b3caa-d258-4cb8-aa05-cd407f501626)
 
-This command will open up a Browser window as well as the Playwright Inspector. You can use the step over button at the top of the inspector to step through your test. Or press the play button to run your test from start to finish. Once the test has finished the browser window will close.
+This command will open up a Browser window as well as the Playwright Inspector. You can use the step over button at the top of the inspector to step through your test. Or, press the play button to run your test from start to finish. Once the test has finished, the browser window will close.
 
 To debug one test file run the Playwright test command with the name of the test file that you want to debug followed by the `--debug` flag.
 

--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -37,7 +37,7 @@ Check out or [detailed guide on UI Mode](./test-ui-mode.md) to learn more about 
 
 ### Run tests in headed mode
 
-To run your tests in headed mode use the `--headed` flag. This will give you the ability to visually see how Playwright interacts with the website.
+To run your tests in headed mode, use the `--headed` flag. This will give you the ability to visually see how Playwright interacts with the website.
 
 ```bash
 npx playwright test --headed
@@ -45,13 +45,13 @@ npx playwright test --headed
 
 ### Run tests on different browsers
 
-To specify which browser you would like to run your tests on use the `--project` flag followed by the name of the browser.
+To specify which browser you would like to run your tests on, use the `--project` flag followed by the name of the browser.
 
 ```bash
 npx playwright test --project webkit
 ```
 
-To specify multiple browsers to run your tests on use the `--project` flag multiple times followed by the name of each browser.
+To specify multiple browsers to run your tests on, use the `--project` flag multiple times followed by the name of each browser.
 
 ```bash
 npx playwright test --project webkit --project firefox
@@ -59,25 +59,25 @@ npx playwright test --project webkit --project firefox
 
 ### Run specific tests
 
-To run a single test file pass in the name of the test file that you want to run.
+To run a single test file, pass in the name of the test file that you want to run.
 
 ```bash
 npx playwright test landing-page.spec.ts
 ```
 
-To run a set of test files from different directories pass in the names of the directories that you want to run the tests in.
+To run a set of test files from different directories, pass in the names of the directories that you want to run the tests in.
 
 ```bash
 npx playwright test tests/todo-page/ tests/landing-page/
 ```
 
-To run files that have `landing` or `login` in the file name simply pass in these keywords to the CLI.
+To run files that have `landing` or `login` in the file name, simply pass in these keywords to the CLI.
 
 ```bash
 npx playwright test landing login
 ```
 
-To run a test with a specific title use the `-g` flag followed by the title of the test.
+To run a test with a specific title, use the `-g` flag followed by the title of the test.
 
 ```bash
 npx playwright test -g "add a todo item"

--- a/docs/src/running-tests-python.md
+++ b/docs/src/running-tests-python.md
@@ -4,7 +4,7 @@ title: "Running and debugging tests"
 ---
 ## Introduction
 
-You can run a single test, a set of tests or all tests. Tests can be run on one browser or multiple browsers by using the `--browser` flag. By default tests are run in a headless manner meaning no browser window will be opened while running the tests and results will be seen in the terminal. If you prefer you can run your tests in headed mode by using the `--headed` CLI argument.
+You can run a single test, a set of tests or all tests. Tests can be run on one browser or multiple browsers by using the `--browser` flag. By default, tests are run in a headless manner, meaning no browser window will be opened while running the tests and results will be seen in the terminal. If you prefer, you can run your tests in headed mode by using the `--headed` CLI argument.
 
 **You will learn**
 
@@ -15,7 +15,7 @@ You can run a single test, a set of tests or all tests. Tests can be run on one 
 
 ### Command Line
 
-To run your tests use the `pytest` command. This will run your tests on the Chromium browser by default. Tests run in headless mode by default meaning no browser window will be opened while running the tests and results will be seen in the terminal.
+To run your tests, use the `pytest` command. This will run your tests on the Chromium browser by default. Tests run in headless mode by default meaning no browser window will be opened while running the tests and results will be seen in the terminal.
 
 ```bash
 pytest
@@ -23,20 +23,20 @@ pytest
 
 ### Run tests in headed mode
 
-To run your tests in headed mode use the `--headed` flag. This will open up a browser window while running your tests and once finished the browser window will close.
+To run your tests in headed mode, use the `--headed` flag. This will open up a browser window while running your tests and once finished the browser window will close.
 
 ```bash
 pytest --headed
 ```
 ### Run tests on different browsers
 
-To specify which browser you would like to run your tests on use the `--browser` flag followed by the name of the browser.
+To specify which browser you would like to run your tests on, use the `--browser` flag followed by the name of the browser.
 
 ```bash
 pytest --browser webkit
 ```
 
-To specify multiple browsers to run your tests on use the `--browser` flag multiple times followed by the name of each browser.
+To specify multiple browsers to run your tests on, use the `--browser` flag multiple times followed by the name of each browser.
 
 
 ```bash
@@ -45,19 +45,19 @@ pytest --browser webkit --browser firefox
 
 ### Run specific tests
 
-To run a single test file pass in the name of the test file that you want to run.
+To run a single test file, pass in the name of the test file that you want to run.
 
   ```bash
   pytest test_login.py
   ```
 
-To run a set of test files pass in the names of the test files that you want to run.
+To run a set of test files, pass in the names of the test files that you want to run.
 
   ```bash
   pytest tests/test_todo_page.py tests/test_landing_page.py
   ```
 
-To run a specific test pass in the function name of the test you want to run.
+To run a specific test, pass in the function name of the test you want to run.
 
   ```bash
   pytest -k test_add_a_todo_item
@@ -65,7 +65,7 @@ To run a specific test pass in the function name of the test you want to run.
 
 ### Run tests in parallel
 
-To run your tests in parallel use the `--numprocesses` flag followed by the number of processes you would like to run your tests on. We recommend half of logical CPU cores.
+To run your tests in parallel, use the `--numprocesses` flag followed by the number of processes you would like to run your tests on. We recommend half of logical CPU cores.
 
   ```bash
   pytest --numprocesses 2
@@ -73,7 +73,7 @@ To run your tests in parallel use the `--numprocesses` flag followed by the numb
 
   (This assumes `pytest-xdist` is installed. For more information see [here](./test-runners.md#parallelism-running-multiple-tests-at-once).)
 
-For more information see [Playwright Pytest usage](./test-runners.md) or the Pytest documentation for [general CLI usage](https://docs.pytest.org/en/stable/usage.html).
+For more information, see [Playwright Pytest usage](./test-runners.md) or the Pytest documentation for [general CLI usage](https://docs.pytest.org/en/stable/usage.html).
 
 ## Debugging tests
 

--- a/docs/src/running-tests-python.md
+++ b/docs/src/running-tests-python.md
@@ -77,9 +77,9 @@ For more information, see [Playwright Pytest usage](./test-runners.md) or the Py
 
 ## Debugging tests
 
-Since Playwright runs in Python, you can debug it with your debugger of choice with e.g. the [Python extension](https://code.visualstudio.com/docs/python/python-tutorial) in Visual Studio Code. Playwright comes with the Playwright Inspector which allows you to step through Playwright API calls, see their debug logs and explore [locators](./locators.md).
+Since Playwright runs in Python, you can debug it with your debugger of choice, e.g., with the [Python extension](https://code.visualstudio.com/docs/python/python-tutorial) in Visual Studio Code. Playwright comes with the Playwright Inspector which allows you to step through Playwright API calls, see their debug logs and explore [locators](./locators.md).
 
-To debug all tests run the following command.
+To debug all tests, run the following command.
 
 ```bash tab=bash-bash lang=python
 PWDEBUG=1 pytest -s
@@ -127,7 +127,7 @@ $env:PWDEBUG=1
 pytest -s -k test_get_started_link
 ```
 
-This command will open up a Browser window as well as the Playwright Inspector. You can use the step over button at the top of the inspector to step through your test. Or press the play button to run your test from start to finish. Once the test has finished the browser window will close.
+This command will open up a Browser window as well as the Playwright Inspector. You can use the step over button at the top of the inspector to step through your test. Or press the play button to run your test from start to finish. Once the test has finished, the browser window will close.
 
 While debugging you can use the Pick Locator button to select an element on the page and see the locator that Playwright would use to find that element. You an also edit the locator and see it highlighting live on the Browser window. Use the Copy Locator button to copy the locator to your clipboard and then paste it into you test.
 

--- a/docs/src/running-tests-python.md
+++ b/docs/src/running-tests-python.md
@@ -95,7 +95,7 @@ $env:PWDEBUG=1
 pytest -s
 ```
 
-To debug one test file run the command followed by the name of the test file that you want to debug.
+To debug one test file, run the command followed by the name of the test file that you want to debug.
 
 ```bash tab=bash-bash lang=python
 PWDEBUG=1 pytest -s test_example.py
@@ -111,7 +111,7 @@ $env:PWDEBUG=1
 pytest -s test_example.py
 ```
 
-To debug a specific test add `-k` followed by the name of the test that you want to debug.
+To debug a specific test, add `-k` followed by the name of the test that you want to debug.
 
 ```bash tab=bash-bash lang=python
 PWDEBUG=1 pytest -s -k test_get_started_link


### PR DESCRIPTION
I have corrected some typos and grammar issues that I found when reading your documentation.