### PR TITLE
test: skip dispatchEvent(deviceOrientation) tests on Android

### DIFF
--- a/tests/page/page-dispatchevent.spec.ts
+++ b/tests/page/page-dispatchevent.spec.ts
@@ -172,7 +172,8 @@ it('should dispatch wheel event', async ({ page, server }) => {
   expect(await eventsHandle.evaluate(e => ({ deltaX: e[0].deltaX, deltaY: e[0].deltaY }))).toEqual({ deltaX: 100, deltaY: 200 });
 });
 
-it('should dispatch device orientation event', async ({ page, server }) => {
+it('should dispatch device orientation event', async ({ page, server, isAndroid }) => {
+  it.skip(isAndroid, 'DeviceOrientationEvent is only available in a secure context. While Androids loopback is not treated as secure.');
   await page.goto(server.PREFIX + '/device-orientation.html');
   await page.locator('html').dispatchEvent('deviceorientation', { alpha: 10, beta: 20, gamma: 30 });
   expect(await page.evaluate('result')).toBe('Oriented');
@@ -182,7 +183,8 @@ it('should dispatch device orientation event', async ({ page, server }) => {
   expect(await page.evaluate('absolute')).toBeFalsy();
 });
 
-it('should dispatch absolute device orientation event', async ({ page, server }) => {
+it('should dispatch absolute device orientation event', async ({ page, server, isAndroid }) => {
+  it.skip(isAndroid, 'DeviceOrientationEvent is only available in a secure context. While Androids loopback is not treated as secure.');
   await page.goto(server.PREFIX + '/device-orientation.html');
   await page.locator('html').dispatchEvent('deviceorientationabsolute', { alpha: 10, beta: 20, gamma: 30, absolute: true });
   expect(await page.evaluate('result')).toBe('Oriented');


### PR DESCRIPTION
Its [only available to SecureContexts](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/device_orientation/device_orientation_event.idl;l=34?q=device_orientation_event.idl&ss=chromium%2Fchromium%2Fsrc) which our loopback in Android is not treated as a SecureContext.

We could either move it into the library tests, but then loose page test coverage or just skip it. I decided for the latter.

Relates https://github.com/microsoft/playwright/pull/27960.