### PR TITLE
fix: ubuntu version detection for linux mint

### DIFF
--- a/packages/playwright-core/src/utils/hostPlatform.ts
+++ b/packages/playwright-core/src/utils/hostPlatform.ts
@@ -74,7 +74,7 @@ function calculatePlatform(): { hostPlatform: HostPlatform, isOfficiallySupporte
     }
     // Linux Mint is ubuntu-based but does not have the same versions
     if (distroInfo?.id === 'linuxmint') {
-      if (parseInt(distroInfo.version, 10) < 21)
+      if (parseInt(distroInfo.version, 10) <= 20)
         return { hostPlatform: ('ubuntu20.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
       return { hostPlatform: ('ubuntu22.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
     }

--- a/packages/playwright-core/src/utils/hostPlatform.ts
+++ b/packages/playwright-core/src/utils/hostPlatform.ts
@@ -72,6 +72,12 @@ function calculatePlatform(): { hostPlatform: HostPlatform, isOfficiallySupporte
         return { hostPlatform: ('ubuntu20.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform };
       return { hostPlatform: ('ubuntu22.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform };
     }
+    // Linux Mint is ubuntu-based but does not have the same versions
+    if (distroInfo?.id === 'linuxmint') {
+      if (parseInt(distroInfo.version, 10) < 21)
+        return { hostPlatform: ('ubuntu20.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
+      return { hostPlatform: ('ubuntu22.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
+    }
     if (distroInfo?.id === 'debian' || distroInfo?.id === 'raspbian') {
       const isOfficiallySupportedPlatform = distroInfo?.id === 'debian';
       if (distroInfo?.version === '11')


### PR DESCRIPTION
Add Linux Mint (Ubuntu based distro) version detection for dependency installation
Uses:
Linux Mint 21.x -> Ubuntu 22.04
Linux Mint 20.x -> Ubuntu 20.04

Fixes #28078 
