### PR TITLE
docs: addInitScript workaround for Worker

### DIFF
--- a/docs/src/api/class-worker.md
+++ b/docs/src/api/class-worker.md
@@ -54,7 +54,7 @@ foreach(var pageWorker in page.Workers)
 
 **addInitScript for Worker**
 
-Currently, methods like [`method: Page.addInitScript`] is not supported for worker. See issue [#28029](https://github.com/microsoft/playwright/issues/28029).
+To implement something like [`method: Page.addInitScript`] for workers, use request routing:
 
 However, there is a workaround by routing the main worker script. For code example, see [this comment](https://github.com/microsoft/playwright/issues/28029#issuecomment-1802788239). For full repository demo, see [this repository](https://github.com/doehyunbaek/monkeypatch-worker).
 

--- a/docs/src/api/class-worker.md
+++ b/docs/src/api/class-worker.md
@@ -52,6 +52,12 @@ foreach(var pageWorker in page.Workers)
 }
 ```
 
+**addInitScript for Worker**
+
+Currently, methods like [`method: Page.addInitScript`] is not supported for worker. See issue [#28029](https://github.com/microsoft/playwright/issues/28029).
+
+However, there is a workaround by routing the main worker script. For code example, see [this comment](https://github.com/microsoft/playwright/issues/28029#issuecomment-1802788239). For full repository demo, see [this repository](https://github.com/doehyunbaek/monkeypatch-worker).
+
 ## event: Worker.close
 * since: v1.8
 - argument: <[Worker]>


### PR DESCRIPTION
As per https://github.com/microsoft/playwright/issues/28029#issuecomment-1803977813 by @dgozman, I made docs change that documents current capabilities of Worker api. 

I ran the documentation linter, but unfortunately could not get the docusaurus working as it kept serving the old site.

If there is any deficiencies or inadequacies, please tell me.

fixes https://github.com/microsoft/playwright/issues/28029