### PR TITLE
chore: remove fake `error` from expect calls

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -256,8 +256,6 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
     const result = await this._frame.expect(metadata, params.selector, { ...params, expectedValue });
     if (result.received !== undefined)
       result.received = serializeResult(result.received);
-    if (result.matches === params.isNot)
-      metadata.error = { error: { name: 'Expect', message: 'Expect failed' } };
     return result;
   }
 }


### PR DESCRIPTION
We used to have a fake `error` property, so that trace viewer shows failed expectes as such. Today, we have a step for each expect that contains a proper error. Sending the fake error to the client confuses language ports.