### PR TITLE
fix(recorder): inspect element when starting typing in locator editor

### DIFF
--- a/packages/recorder/src/recorder.tsx
+++ b/packages/recorder/src/recorder.tsx
@@ -109,9 +109,11 @@ export const Recorder: React.FC<RecorderProps> = ({
   }, [paused]);
 
   const onEditorChange = React.useCallback((selector: string) => {
+    if (mode === 'none')
+      window.dispatch({ event: 'setMode', params: { mode: 'standby' } });
     setLocator(selector);
     window.dispatch({ event: 'selectorUpdated', params: { selector } });
-  }, []);
+  }, [mode]);
 
   return <div className='recorder'>
     <Toolbar>


### PR DESCRIPTION
What does it fix?

1. npx playwright open
1. enter something in the inspector under the locator tab.

Expected: It starts highlighting
Actual: It does not do anything
Why? Because mode is none