### PR TITLE
fix(html-reporter): Include specified host and port in the logged instructions to launch the HTML report

### DIFF
--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -134,10 +134,12 @@ class HtmlReporter extends EmptyReporter {
     } else if (!FullConfigInternal.from(this.config)?.cliListOnly) {
       const packageManagerCommand = getPackageManagerExecCommand();
       const relativeReportPath = this._outputFolder === standaloneDefaultFolder() ? '' : ' ' + path.relative(process.cwd(), this._outputFolder);
+      const hostArg = this._options.host ? ` --host ${this._options.host}` : '';
+      const portArg = this._options.port ? ` --port ${this._options.port}` : '';
       console.log('');
       console.log('To open last HTML report run:');
       console.log(colors.cyan(`
-  ${packageManagerCommand} playwright show-report${relativeReportPath}
+  ${packageManagerCommand} playwright show-report${relativeReportPath}${hostArg}${portArg}
 `));
     }
   }


### PR DESCRIPTION
Previously, options used to specify the host and port would be dropped from the logged-out command which starts the HTML report server. This is an issue for some scenarios (ex. Codespaces) which perform port-forwarding to specific addresses and ports to provide access to the service.

This change appends these options when provided using the `--host` and `--port` args.

Confirmed locally that the `--host` and `--port` args work as expected when passed into the `npx` command