### PR TITLE
test: fix 'exposeFunction should not leak' in video mode

### DIFF
--- a/tests/library/channels.spec.ts
+++ b/tests/library/channels.spec.ts
@@ -256,7 +256,7 @@ it('should work with the domain module', async ({ browserType, server, browserNa
     throw err;
 });
 
-it('exposeFunction should not leak', async ({ page, expectScopeState, server }) => {
+it('exposeFunction should not leak', async ({ page, expectScopeState, server, video }) => {
   await page.goto(server.EMPTY_PAGE);
   let called = 0;
   await page.exposeFunction('myFunction', () => ++called);
@@ -284,6 +284,7 @@ it('exposeFunction should not leak', async ({ page, expectScopeState, server }) 
           {
             '_guid': 'browser',
             'objects': [
+              ...(video === 'on' ? [{ _guid: 'artifact', objects: [] }] : []),
               {
                 '_guid': 'browser-context',
                 'objects': [


### PR DESCRIPTION
This is like how we do it with the other channel tests. In video mode we produce artifacts so we need to add them to our expectation.