### PR TITLE
fix(dispatcher): only remove stale dispatcher after sending "create"

### DIFF
--- a/.github/workflows/tests_stress.yml
+++ b/.github/workflows/tests_stress.yml
@@ -40,13 +40,19 @@ jobs:
       if: always()
     - run: npm run stest browsers -- --project=chromium
       if: always()
+    - run: npm run stest frames -- --project=chromium
+      if: always()
     - run: npm run stest contexts -- --project=webkit
       if: always()
     - run: npm run stest browsers -- --project=webkit
       if: always()
+    - run: npm run stest frames -- --project=webkit
+      if: always()
     - run: npm run stest contexts -- --project=firefox
       if: always()
     - run: npm run stest browsers -- --project=firefox
+      if: always()
+    - run: npm run stest frames -- --project=firefox
       if: always()
     - run: npm run stest heap -- --project=chromium
       if: always()

--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -74,6 +74,7 @@ export class Dispatcher<Type extends { guid: string }, ChannelType, ParentScopeT
 
     if (this._parent)
       this._connection.sendCreate(this._parent, type, guid, initializer, this._parent._object);
+    this._connection.maybeDisposeStaleDispatchers(type);
   }
 
   parentScope(): ParentScopeType {
@@ -255,7 +256,11 @@ export class DispatcherConnection {
       this._dispatchersByType.set(type, list);
     }
     list.add(dispatcher._guid);
-    if (list.size > maxDispatchers)
+  }
+
+  maybeDisposeStaleDispatchers(type: string) {
+    const list = this._dispatchersByType.get(type);
+    if (list && list.size > maxDispatchers)
       this._disposeStaleDispatchers(type, list);
   }
 

--- a/tests/stress/frames.spec.ts
+++ b/tests/stress/frames.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { contextTest as test } from '../config/browserTest';
+
+test('cycle frames', async ({ page, server }) => {
+  const kFrameCount = 1200;
+
+  await page.goto(server.EMPTY_PAGE);
+  let cb;
+  const promise = new Promise(f => cb = f);
+  let counter = 0;
+  page.on('frameattached', () => {
+    if (++counter === kFrameCount)
+      cb();
+  });
+
+  page.evaluate(async ({ url, count }) => {
+    for (let i = 0; i < count; i++) {
+      const frame = document.createElement('iframe');
+      frame.src = url;
+      document.body.appendChild(frame);
+      await new Promise(f => setTimeout(f, 10));
+      frame.remove();
+    }
+  }, { url: server.PREFIX + '/one-style.html', count: kFrameCount }).catch(() => {});
+  await promise;
+  await new Promise(f => setTimeout(f, 500));
+});


### PR DESCRIPTION
Otherwise, we might dispose objects referenced in the initializer of the new object being created, which triggers an exception on the client.