### PR TITLE
test: skip Intl.ListFormat test on ubuntu20.04

### DIFF
--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -17,6 +17,7 @@
 import os from 'os';
 import url from 'url';
 import { contextTest as it, expect } from '../config/browserTest';
+const { hostPlatform } = require('../../packages/playwright-core/lib/utils') as typeof import('../../packages/playwright-core/src/utils');
 
 it('SharedArrayBuffer should work @smoke', async function({ contextFactory, httpsServer, browserName }) {
   it.fail(browserName === 'webkit', 'no shared array buffer on webkit');
@@ -284,8 +285,9 @@ it('should send no Content-Length header for GET requests with a Content-Type', 
   expect(request.headers['content-length']).toBe(undefined);
 });
 
-it('Intl.ListFormat should work', async ({ page, server }) => {
+it('Intl.ListFormat should work', async ({ page, server, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23978' });
+  it.skip(browserName === 'webkit' && hostPlatform.startsWith('ubuntu20.04'), 'libicu is too low and WebKit disables it by default then');
   await page.goto(server.EMPTY_PAGE);
   const formatted = await page.evaluate(() => {
     const data = ['first', 'second', 'third'];

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -17,7 +17,7 @@
 import os from 'os';
 import url from 'url';
 import { contextTest as it, expect } from '../config/browserTest';
-import { hostPlatform } from '../../packages/playwright-core/src/utils';
+import { hostPlatform } from '../../packages/playwright-core/src/utils/hostPlatform';
 
 it('SharedArrayBuffer should work @smoke', async function({ contextFactory, httpsServer, browserName }) {
   it.fail(browserName === 'webkit', 'no shared array buffer on webkit');

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -17,7 +17,7 @@
 import os from 'os';
 import url from 'url';
 import { contextTest as it, expect } from '../config/browserTest';
-const { hostPlatform } = require('../../packages/playwright-core/lib/utils') as typeof import('../../packages/playwright-core/src/utils');
+import { hostPlatform } from '../../packages/playwright-core/src/utils';
 
 it('SharedArrayBuffer should work @smoke', async function({ contextFactory, httpsServer, browserName }) {
   it.fail(browserName === 'webkit', 'no shared array buffer on webkit');
@@ -287,7 +287,7 @@ it('should send no Content-Length header for GET requests with a Content-Type', 
 
 it('Intl.ListFormat should work', async ({ page, server, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23978' });
-  it.skip(browserName === 'webkit' && hostPlatform.startsWith('ubuntu20.04'), 'libicu is too low and WebKit disables it by default then');
+  it.skip(browserName === 'webkit' && hostPlatform.startsWith('ubuntu20.04'), 'libicu is too old and WebKit disables Intl.ListFormat by default then');
   await page.goto(server.EMPTY_PAGE);
   const formatted = await page.evaluate(() => {
     const data = ['first', 'second', 'third'];


### PR DESCRIPTION
It was failing across the Ubuntu 20.04 bots:

![image](https://github.com/microsoft/playwright/assets/17984549/3b80f04d-cae8-4288-8fd3-b94d9bf1ce03)

This is most likely because on Ubuntu 20 libicu-dev has version 66.1.
And according to
https://wksearch.azurewebsites.net/#path=%2Fhome%2Fjoe%2Fwebkit%2FSource%2FJavaScriptCore%2Fruntime%2FIntlListFormat.h&line=32
the ListFormatter requires 67 which is the case in Ubuntu 22 (70).