### PR TITLE
fix(defineConfig): do not add an empty project list to project-less configs

### DIFF
--- a/packages/playwright/src/common/configLoader.ts
+++ b/packages/playwright/src/common/configLoader.ts
@@ -48,6 +48,9 @@ export const defineConfig = (...configs: any[]) => {
       ]
     };
 
+    if (!result.projects && !config.projects)
+      continue;
+
     const projectOverrides = new Map<string, any>();
     for (const project of config.projects || [])
       projectOverrides.set(project.name, project);

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -546,6 +546,9 @@ test('should merge configs', async ({ runInlineTest }) => {
           command: 'echo 123',
         }]
       }));
+
+      // Should not add an empty project list.
+      expect(defineConfig({}, {}).projects).toBeUndefined();
     `,
     'a.test.ts': `
       import { test } from '@playwright/test';


### PR DESCRIPTION
Otherwise, merging two configs without `projects` property will create a config with an empty project list, which is semantically different and always leads to "No tests found".