### PR TITLE
fix: collect all errors in removeFolders

### DIFF
--- a/packages/playwright-core/src/utils/fileUtils.ts
+++ b/packages/playwright-core/src/utils/fileUtils.ts
@@ -28,8 +28,8 @@ export async function mkdirIfNeeded(filePath: string) {
 
 export async function removeFolders(dirs: string[]): Promise<Error[]> {
   return await Promise.all(dirs.map((dir: string) =>
-    fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 10 })
-  )).catch(e => e);
+    fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 10 }).catch(e => e)
+  ));
 }
 
 export function canAccessFile(file: string) {


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/playwright/pull/27790#pullrequestreview-1738958803. Previously this function returns only the first error when some of the promises fail. But the type annotation suggests that the original intention was to collect all the errors. This commit fixes the error values, and unexpected `TypeError: object is not iterable`.