### PR TITLE
cherry-pick(#28239): fix: collect all errors in removeFolders

### DIFF
--- a/packages/playwright-core/src/utils/fileUtils.ts
+++ b/packages/playwright-core/src/utils/fileUtils.ts
@@ -28,8 +28,8 @@ export async function mkdirIfNeeded(filePath: string) {
 
 export async function removeFolders(dirs: string[]): Promise<Error[]> {
   return await Promise.all(dirs.map((dir: string) =>
-    fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 10 })
-  )).catch(e => e);
+    fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 10 }).catch(e => e)
+  ));
 }
 
 export function canAccessFile(file: string) {


### PR DESCRIPTION
This PR cherry-picks the following commits:

- 440f5e5d2be2e5b251dfed33eb4d65c5c01a97ba