### PR TITLE
fix(matchers): improve types with explicitly readonly arrays

### DIFF
--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -157,7 +157,7 @@ export function toBeInViewport(
 export function toContainText(
   this: ExpectMatcherContext,
   locator: LocatorEx,
-  expected: string | RegExp | (string | RegExp)[],
+  expected: string | RegExp | readonly (string | RegExp)[],
   options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean } = {},
 ) {
   if (Array.isArray(expected)) {
@@ -201,7 +201,7 @@ export function toHaveAttribute(
 export function toHaveClass(
   this: ExpectMatcherContext,
   locator: LocatorEx,
-  expected: string | RegExp | (string | RegExp)[],
+  expected: string | RegExp | readonly (string | RegExp)[],
   options?: { timeout?: number },
 ) {
   if (Array.isArray(expected)) {
@@ -268,7 +268,7 @@ export function toHaveJSProperty(
 export function toHaveText(
   this: ExpectMatcherContext,
   locator: LocatorEx,
-  expected: string | RegExp | (string | RegExp)[],
+  expected: string | RegExp | readonly (string | RegExp)[],
   options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean } = {},
 ) {
   if (Array.isArray(expected)) {
@@ -299,7 +299,7 @@ export function toHaveValue(
 export function toHaveValues(
   this: ExpectMatcherContext,
   locator: LocatorEx,
-  expected: (string | RegExp)[],
+  expected: readonly (string | RegExp)[],
   options?: { timeout?: number },
 ) {
   return toEqual.call(this, 'toHaveValues', locator, 'Locator', async (isNot, timeout) => {
@@ -362,7 +362,7 @@ export async function toPass(
   this: ExpectMatcherContext,
   callback: () => any,
   options: {
-    intervals?: number[];
+    intervals?: readonly number[];
     timeout?: number,
   } = {},
 ) {

--- a/packages/playwright/src/matchers/toMatchText.ts
+++ b/packages/playwright/src/matchers/toMatchText.ts
@@ -109,7 +109,7 @@ export async function toMatchText(
   };
 }
 
-export function toExpectedTextValues(items: (string | RegExp)[], options: { matchSubstring?: boolean, normalizeWhiteSpace?: boolean, ignoreCase?: boolean } = {}): ExpectedTextValue[] {
+export function toExpectedTextValues(items: readonly (string | RegExp)[], options: { matchSubstring?: boolean, normalizeWhiteSpace?: boolean, ignoreCase?: boolean } = {}): ExpectedTextValue[] {
   return items.map(i => ({
     string: isString(i) ? i : undefined,
     regexSource: isRegExp(i) ? i.source : undefined,


### PR DESCRIPTION
Shouldn't be a breaking change; the existing non-explicitly-readonly arrays will keep working.