### PR TITLE
cherry-pick(#28271): docs(release-notes): 1.40 nits

### DIFF
--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -35,7 +35,7 @@ await Expect(Page.GetByPlaceholder("Search docs")).ToHaveValueAsync("locator");
 ### Other Changes
 
 - Methods [`method: Download.path`] and [`method: Download.createReadStream`] throw an error for failed and cancelled downloads.
-- Playwright [docker image](./docker.md) now comes with Node.js v20.
+- Playwright [docker image](./docker.md) now comes with .NET 8 (new LTS).
 
 ### Browser Versions
 

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -35,7 +35,6 @@ assertThat(page.getByPlaceholder("Search docs")).hasValue("locator");
 ### Other Changes
 
 - Methods [`method: Download.path`] and [`method: Download.createReadStream`] throw an error for failed and cancelled downloads.
-- Playwright [docker image](./docker.md) now comes with Node.js v20.
 
 ### Browser Versions
 

--- a/docs/src/release-notes-python.md
+++ b/docs/src/release-notes-python.md
@@ -38,7 +38,6 @@ def test_example(page: Page) -> None:
 ### Other Changes
 
 - Method [`method: Download.path`] throws an error for failed and cancelled downloads.
-- Playwright [docker image](./docker.md) now comes with Node.js v20.
 
 ### Browser Versions
 


### PR DESCRIPTION
This PR cherry-picks the following commits:

- 8c880cad7625f07cd43211badb9f36a86da29871