### PR TITLE
docs(trace-viewer): fix <details><summary> syntax

### DIFF
--- a/docs/src/trace-viewer-intro-csharp-java-python.md
+++ b/docs/src/trace-viewer-intro-csharp-java-python.md
@@ -28,8 +28,8 @@ Options for tracing are:
 
 This will record the trace and place it into the file named `trace.zip` in your `test-results` directory.
 
-<details><summary>If you are not using Pytest, click here to learn how to record traces.
-</summary>
+<details>
+<summary>If you are not using Pytest, click here to learn how to record traces.</summary>
 
 ```python async
 browser = await chromium.launch()

--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -177,8 +177,8 @@ Options for tracing are:
 
 This will record the trace and place it into the file named `trace.zip` in your `test-results` directory.
 
-<details><summary>If you are not using Pytest, click here to learn how to record traces.
-</summary>
+<details>
+<summary>If you are not using Pytest, click here to learn how to record traces.</summary>
 
 ```python async
 browser = await chromium.launch()


### PR DESCRIPTION
Docusaurus v3 requires this, otherwise it throws.