### PR TITLE
chore: print more accurate MiB instead of Mb when downloading browsers

### DIFF
--- a/packages/playwright-core/src/server/registry/browserFetcher.ts
+++ b/packages/playwright-core/src/server/registry/browserFetcher.ts
@@ -170,5 +170,5 @@ function getBasicDownloadProgress(): OnProgressCallback {
 
 function toMegabytes(bytes: number) {
   const mb = bytes / 1024 / 1024;
-  return `${Math.round(mb * 10) / 10} Mb`;
+  return `${Math.round(mb * 10) / 10} MiB`;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/28283