### PR TITLE
Handle response error in `oopDownloadBrowserMain.ts`

### DIFF
--- a/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
+++ b/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
@@ -85,6 +85,7 @@ function downloadFile(options: DownloadParams): Promise<void> {
     file.on('error', error => promise.reject(error));
     response.pipe(file);
     response.on('data', onData);
+    response.on('error', error => promise.reject(error));
     response.on('close', () => {
       if (response.complete)
         return;


### PR DESCRIPTION
Mitigates https://github.com/microsoft/playwright/issues/22878#issuecomment-1826406962

## Before 

```sh
pnpm exec playwright install chromium

Downloading Chromium 120.0.6099.28 (playwright build v1091) from https://playwright.azureedge.net/builds/chromium/1091/chromium-mac-arm64.zip
131 Mb [=================== ] 97% 2.1s

(stuck forever)
```

## After

```sh
pnpm exec playwright install chromium

Downloading Chromium 120.0.6099.28 (playwright build v1091) from https://playwright.azureedge.net/builds/chromium/1091/chromium-mac-arm64.zip
131 Mb [=================== ] 97% 2.3sError: aborted
    at connResetException (node:internal/errors:787:14)
    at TLSSocket.socketCloseListener (node:_http_client:455:19)
    at TLSSocket.emit (node:events:526:35)
    at node:net:337:12
    at TCP.done (node:_tls_wrap:657:7) {
  code: 'ECONNRESET'
}
Downloading Chromium 120.0.6099.28 (playwright build v1091) from https://playwright-akamai.azureedge.net/builds/chromium/1091/chromium-mac-arm64.zip
131 Mb [====================] 97% 1.6sError: aborted
    at connResetException (node:internal/errors:787:14)
    at TLSSocket.socketCloseListener (node:_http_client:455:19)
    at TLSSocket.emit (node:events:526:35)
    at node:net:337:12
    at TCP.done (node:_tls_wrap:657:7) {
  code: 'ECONNRESET'
}
Downloading Chromium 120.0.6099.28 (playwright build v1091) from https://playwright-verizon.azureedge.net/builds/chromium/1091/chromium-mac-arm64.zip
131 Mb [====================] 97% 1.7sError: aborted
    at connResetException (node:internal/errors:787:14)
    at TLSSocket.socketCloseListener (node:_http_client:455:19)
    at TLSSocket.emit (node:events:526:35)
    at node:net:337:12
    at TCP.done (node:_tls_wrap:657:7) {
  code: 'ECONNRESET'
}
Failed to install browsers
Error: Failed to download Chromium 120.0.6099.28 (playwright build v1091), caused by
Error: Download failure, code=1
    at ChildProcess.<anonymous> (/path/to/project/.pnpm/playwright-core@1.40.0/node_modules/playwright-core/lib/server/registry/browserFetcher.js:94:16)
    at ChildProcess.emit (node:events:514:28)
    at ChildProcess._handle.onexit (node:internal/child_process:294:12)

(exit code 1)
```
