### PR TITLE
devops(docker): add base image ARG to Jammy Dockerfile

### DIFF
--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -1,4 +1,6 @@
-FROM ubuntu:jammy
+ARG base_image=ubuntu:jammy
+
+FROM ${base_image}
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=America/Los_Angeles


### PR DESCRIPTION
This change adds a base_image ARG to the Dockerfile for Jammy to allow building the Docker image on custom base images

Fixes #28383