### PR TITLE
fix: replacing oauth tokens from headers

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -391,11 +391,17 @@ function streamToString(stream: stream.Readable): Promise<string> {
 }
 
 function parseSeleniumRemoteParams(env: {name: string, value: string}, progress: Progress) {
+  let value = env.value;
+
+  if (/authorization/i.test(env.value)) {
+    value = value.replace(/OAuth [^"]*/i, 'OAuth <token>');
+  }
+
   try {
     const parsed = JSON.parse(env.value);
-    progress.log(`<selenium> using additional ${env.name} "${env.value}"`);
+    progress.log(`<selenium> using additional ${env.name} "${value}"`);
     return parsed;
   } catch (e) {
-    progress.log(`<selenium> ignoring additional ${env.name} "${env.value}": ${e}`);
+    progress.log(`<selenium> ignoring additional ${env.name} "${value}": ${e}`);
   }
 }


### PR DESCRIPTION
## What's done

Implement replacing oauth token from stdout in order to avoid compromising them in CI tasks in case when used `process.env.DEBUG = "pw:browser,pw:api"`.