### PR TITLE
fix(snapshot): broken snapshot after use of setInputFiles

### DIFF
--- a/packages/trace-viewer/src/snapshotRenderer.ts
+++ b/packages/trace-viewer/src/snapshotRenderer.ts
@@ -223,7 +223,9 @@ function snapshotScript(...targetIds: (string | undefined)[]) {
         scrollLefts.push(e);
 
       for (const element of root.querySelectorAll(`[__playwright_value_]`)) {
-        (element as HTMLInputElement | HTMLTextAreaElement).value = element.getAttribute('__playwright_value_')!;
+        const inputElement = element as HTMLInputElement | HTMLTextAreaElement;
+        if (inputElement.type !== 'file')
+          inputElement.value = inputElement.getAttribute('__playwright_value_')!;
         element.removeAttribute('__playwright_value_');
       }
       for (const element of root.querySelectorAll(`[__playwright_checked_]`)) {

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -438,12 +438,13 @@ test('should restore scroll positions', async ({ page, runAndTrace, browserName 
   expect(await frame.locator('div').evaluate(div => div.scrollTop)).toBe(136);
 });
 
-test('should restore control values', async ({ page, runAndTrace }) => {
+test('should restore control values', async ({ page, runAndTrace, asset }) => {
   const traceViewer = await runAndTrace(async () => {
     await page.setContent(`
       <input type=text value=old>
       <input type=checkbox checked>
       <input type=radio>
+      <input type=file>
       <textarea>old</textarea>
       <select multiple>
         <option value=opt1>Hi</option>
@@ -460,6 +461,7 @@ test('should restore control values', async ({ page, runAndTrace }) => {
         document.querySelector('[value=opt3]').selected = true;
       </script>
     `);
+    await page.locator('input[type="file"]').setInputFiles(asset('file-to-upload.txt'));
     await page.click('input');
   });
 
@@ -486,6 +488,8 @@ test('should restore control values', async ({ page, runAndTrace }) => {
   expect(await frame.locator('option >> nth=1').evaluate(o => o.hasAttribute('selected'))).toBe(true);
   expect(await frame.locator('option >> nth=2').evaluate(o => o.hasAttribute('selected'))).toBe(false);
   await expect(frame.locator('select')).toHaveValues(['opt1', 'opt3']);
+
+  await expect(frame.locator('input[type=file]')).toHaveValue('');
 });
 
 test('should work with meta CSP', async ({ page, runAndTrace, browserName }) => {


### PR DESCRIPTION
This fixes _"Problem_ 3" of https://github.com/microsoft/playwright/issues/28314.

What happened was the following: 
<img width="1270" alt="image" src="https://github.com/microsoft/playwright/assets/17984549/1ebf1a29-eeca-4e40-9c48-d00b87ab9811">

Which ended up that snapshots after the setInputFiles action did not restore other values since it threw.