### PR TITLE
add tolerances for the image size and floating point errors, when comparing images

### DIFF
--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -942,14 +942,14 @@ test('should attach expected/actual/diff for different sizes', async ({ runInlin
         console.log('## ' + JSON.stringify(testInfo.attachments));
       });
       test('is a test', ({}) => {
-        expect(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII==', 'base64')).toMatchSnapshot('snapshot.png');
+        expect(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAAXNSR0IArs4c6QAAAIRlWElmTU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAABIAAAAAQAAAEgAAAABAAOgAQADAAAAAQABAACgAgAEAAAAAQAAAASgAwAEAAAAAQAAAAQAAAAANlaTAQAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDYuMC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KGV7hBwAAABVJREFUCB1j/M/AAEQIwIRgQliEBQCD0QIGEDviFwAAAABJRU5ErkJggg==', 'base64')).toMatchSnapshot('snapshot.png');
       });
     `
   });
 
   const outputText = result.output;
-  expect(outputText).toContain('Expected an image 2px by 2px, received 1px by 1px.');
-  expect(outputText).toContain('4 pixels (ratio 1.00 of all image pixels) are different.');
+  expect(outputText).toContain('Expected an image 2px by 2px, received 4px by 4px.');
+  expect(outputText).toContain('12 pixels (ratio 0.75 of all image pixels) are different.');
   const attachments = outputText.split('\n').filter(l => l.startsWith('## ')).map(l => l.substring(3)).map(l => JSON.parse(l))[0];
   for (const attachment of attachments)
     attachment.path = attachment.path.replace(/\\/g, '/').replace(/.*test-results\//, '');

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -1033,7 +1033,7 @@ test('should attach expected/actual/diff when sizes are different', async ({ run
   expect(result.exitCode).toBe(1);
   const outputText = result.output;
   expect(outputText).toContain('Expected an image 2px by 2px, received 1280px by 720px.');
-  expect(outputText).toContain('4 pixels (ratio 0.01 of all image pixels) are different.');
+  expect(outputText).toContain('4 pixels (ratio 1.00 of all image pixels) are different.');
   const attachments = outputText.split('\n').filter(l => l.startsWith('## ')).map(l => l.substring(3)).map(l => JSON.parse(l))[0];
   for (const attachment of attachments)
     attachment.path = attachment.path.replace(/\\/g, '/').replace(/.*test-results\//, '');


### PR DESCRIPTION
Proposed fix for https://github.com/microsoft/playwright/issues/18827 and https://github.com/microsoft/playwright/issues/28221

Due to floating point error in both CSS and JS, it isn't practical/possible to ensure exact pixel sizing in the vast ecosystem of tools and frameworks. This changeset allows for 1px tolerances in the size of the image.

Changes requested:

1. Allow images to differ in size by up to 1.5 pixels in size, to account for floating point rounding errors
2. Allow an additional 0.5 pixels to differ, for the sake of avoiding rounding errors
3. Use the max size of the two images when computing the difference ratio, instead of the size of the expected image