### PR TITLE
docs: fix the path in snapshotPathTemplate

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -1723,7 +1723,7 @@ Consider the following config:
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  snapshotPathTemplate: '__screenshots__{/projectName}/{testFilePath}/{arg}{ext}',
+  snapshotPathTemplate: '__screenshots__/{projectName}/{testFilePath}/{arg}{ext}',
   testMatch: 'example.spec.ts',
   projects: [
     { use: { browserName: 'firefox' } },

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1214,7 +1214,7 @@ interface TestConfig {
    * import { defineConfig } from '@playwright/test';
    *
    * export default defineConfig({
-   *   snapshotPathTemplate: '__screenshots__{/projectName}/{testFilePath}/{arg}{ext}',
+   *   snapshotPathTemplate: '__screenshots__/{projectName}/{testFilePath}/{arg}{ext}',
    *   testMatch: 'example.spec.ts',
    *   projects: [
    *     { use: { browserName: 'firefox' } },
@@ -7001,7 +7001,7 @@ interface TestProject {
    * import { defineConfig } from '@playwright/test';
    *
    * export default defineConfig({
-   *   snapshotPathTemplate: '__screenshots__{/projectName}/{testFilePath}/{arg}{ext}',
+   *   snapshotPathTemplate: '__screenshots__/{projectName}/{testFilePath}/{arg}{ext}',
    *   testMatch: 'example.spec.ts',
    *   projects: [
    *     { use: { browserName: 'firefox' } },


### PR DESCRIPTION
This PR is to correct a path description error in the `snapshotPathTemplate`.
https://playwright.dev/docs/api/class-testproject#test-project-snapshot-path-template

![image](https://github.com/microsoft/playwright/assets/58202202/b28e60ef-d621-4543-89d6-fe7a89d2a5c8)

Also fixed `TestConfig` and `TestProject` Doc comments.