### PR TITLE
docs: fix various syntax errors in .NET documentation

### DIFF
--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -45,14 +45,15 @@ context.tracing.stop(path = "trace.zip")
 ```
 
 ```csharp
-await using var browser = playwright.Chromium.LaunchAsync();
+using var playwright = await Playwright.CreateAsync();
+var browser = await playwright.Chromium.LaunchAsync();
 await using var context = await browser.NewContextAsync();
 await context.Tracing.StartAsync(new()
 {
   Screenshots = true,
   Snapshots = true
 });
-var page = context.NewPageAsync();
+var page = await context.NewPageAsync();
 await page.GotoAsync("https://playwright.dev");
 await context.Tracing.StopAsync(new()
 {
@@ -99,14 +100,15 @@ context.tracing.stop(path = "trace.zip")
 ```
 
 ```csharp
-await using var browser = playwright.Chromium.LaunchAsync();
+using var playwright = await Playwright.CreateAsync();
+var browser = await playwright.Chromium.LaunchAsync();
 await using var context = await browser.NewContextAsync();
 await context.Tracing.StartAsync(new()
 {
   Screenshots = true,
   Snapshots = true
 });
-var page = context.NewPageAsync();
+var page = await context.NewPageAsync();
 await page.GotoAsync("https://playwright.dev");
 await context.Tracing.StopAsync(new()
 {
@@ -234,14 +236,15 @@ context.tracing.stop_chunk(path = "trace2.zip")
 ```
 
 ```csharp
-await using var browser = playwright.Chromium.LaunchAsync();
+using var playwright = await Playwright.CreateAsync();
+var browser = await playwright.Chromium.LaunchAsync();
 await using var context = await browser.NewContextAsync();
 await context.Tracing.StartAsync(new()
 {
   Screenshots = true,
   Snapshots = true
 });
-var page = context.NewPageAsync();
+var page = await context.NewPageAsync();
 await page.GotoAsync("https://playwright.dev");
 
 await context.Tracing.StartChunkAsync();

--- a/docs/src/browser-contexts.md
+++ b/docs/src/browser-contexts.md
@@ -65,6 +65,7 @@ page = context.new_page()
 
 ```csharp
 await using var browser = playwright.Chromium.LaunchAsync();
+var browser = await playwright.Chromium.LaunchAsync();
 var context = await browser.NewContextAsync();
 var page = await context.NewPageAsync();
 ```

--- a/docs/src/browser-contexts.md
+++ b/docs/src/browser-contexts.md
@@ -64,7 +64,7 @@ page = context.new_page()
 ```
 
 ```csharp
-await using var browser = playwright.Chromium.LaunchAsync();
+using var playwright = await Playwright.CreateAsync();
 var browser = await playwright.Chromium.LaunchAsync();
 var context = await browser.NewContextAsync();
 var page = await context.NewPageAsync();

--- a/docs/src/trace-viewer-intro-csharp-java-python.md
+++ b/docs/src/trace-viewer-intro-csharp-java-python.md
@@ -85,7 +85,8 @@ context.tracing().stop(new Tracing.StopOptions()
 ```
 
 ```csharp
-await using var browser = await Playwright.Chromium.LaunchAsync();
+using var playwright = await Playwright.CreateAsync();
+var browser = await playwright.Chromium.LaunchAsync();
 await using var context = await browser.NewContextAsync();
 
 // Start tracing before creating / navigating a page.

--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -241,9 +241,9 @@ await using var context = await browser.NewContextAsync();
 // Start tracing before creating / navigating a page.
 await context.Tracing.StartAsync(new()
 {
-    Screenshots = true,
-    Snapshots = true,
-    Sources = true
+  Screenshots = true,
+  Snapshots = true,
+  Sources = true
 });
 
 var page = await context.NewPageAsync();
@@ -252,7 +252,7 @@ await page.GotoAsync("https://playwright.dev");
 // Stop tracing and export it into a zip archive.
 await context.Tracing.StopAsync(new()
 {
-    Path = "trace.zip"
+  Path = "trace.zip"
 });
 ```
 

--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -234,24 +234,25 @@ context.tracing().stop(new Tracing.StopOptions()
 ```
 
 ```csharp
-await using var browser = playwright.Chromium.LaunchAsync();
+using var playwright = await Playwright.CreateAsync();
+var browser = await playwright.Chromium.LaunchAsync();
 await using var context = await browser.NewContextAsync();
 
 // Start tracing before creating / navigating a page.
 await context.Tracing.StartAsync(new()
 {
-  Screenshots = true,
-  Snapshots = true,
-  Sources = true
+    Screenshots = true,
+    Snapshots = true,
+    Sources = true
 });
 
-var page = context.NewPageAsync();
+var page = await context.NewPageAsync();
 await page.GotoAsync("https://playwright.dev");
 
 // Stop tracing and export it into a zip archive.
 await context.Tracing.StopAsync(new()
 {
-  Path = "trace.zip"
+    Path = "trace.zip"
 });
 ```
 


### PR DESCRIPTION
As found [here](https://github.com/microsoft/playwright-dotnet/issues/2774) - current code is not syntactically correct