### PR TITLE
feat(pwt): add reporting of Error.cause

### DIFF
--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -35,6 +35,12 @@ export function filterStackTrace(e: Error): { message: string, stack: string } {
     return { message: e.name + ': ' + e.message, stack: e.stack || '' };
 
   const stackLines = stringifyStackFrames(filteredStackTrace(e.stack?.split('\n') || []));
+  let cause: Error = e.cause as any;
+  while (cause) {
+    stackLines.push('[cause]: ' + cause.toString());
+    stackLines.push(...stringifyStackFrames(filteredStackTrace(cause.stack?.split('\n') || [])));
+    cause = cause.cause as any;
+  }
   return {
     message: e.name + ': ' + e.message,
     stack: `${e.name}: ${e.message}\n${stackLines.join('\n')}`


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/26848

Thats us:
```
Error: Third level error

  30 |     }
  31 |   } catch (error) {
> 32 |     throw new Error('Third level error', { cause: error });
     |           ^
  33 |   }
  34 | });

    at fn (/Users/maxschmitt/Developer/playwright/tests/page/wheel.spec.ts:32:11)
[cause]: Error: Second level error
    at fn (/Users/maxschmitt/Developer/playwright/tests/page/wheel.spec.ts:29:13)
[cause]: Error: First level error
    at /Users/maxschmitt/Developer/playwright/tests/page/wheel.spec.ts:22:13
    at myFunc (/Users/maxschmitt/Developer/playwright/tests/page/wheel.spec.ts:23:6)
    at fn (/Users/maxschmitt/Developer/playwright/tests/page/wheel.spec.ts:27:7)
```

Thats by Node.js:

```
❯ node test.mjs 
file:///Users/maxschmitt/Developer/playwright/test.mjs:23
  throw new Error('Third level error', { cause: error });
        ^

Error: Third level error
    at file:///Users/maxschmitt/Developer/playwright/test.mjs:23:9
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25) {
  [cause]: Error: Second level error
      at file:///Users/maxschmitt/Developer/playwright/test.mjs:20:11
      at ModuleJob.run (node:internal/modules/esm/module_job:194:25) {
    [cause]: Error: First level error
        at file:///Users/maxschmitt/Developer/playwright/test.mjs:18:11
        at ModuleJob.run (node:internal/modules/esm/module_job:194:25)
  }
}

Node.js v18.18.2
```