### PR TITLE
feat(trace): allow Trace Viewer to include credentials when fetching traces cross-origin

### DIFF
--- a/packages/trace-viewer/src/traceModelBackends.ts
+++ b/packages/trace-viewer/src/traceModelBackends.ts
@@ -32,7 +32,7 @@ export class ZipTraceModelBackend implements TraceModelBackend {
     this._traceURL = traceURL;
     zipjs.configure({ baseURL: self.location.href } as any);
     this._zipReader = new zipjs.ZipReader(
-        new zipjs.HttpReader(formatUrl(traceURL), { mode: 'cors', preventHeadRequest: true } as any),
+        new zipjs.HttpReader(formatUrl(traceURL), { mode: 'cors', credentials: 'include', preventHeadRequest: true } as any),
         { useWebWorkers: false });
     this._entriesPromise = this._zipReader.getEntries({ onprogress: progress }).then(entries => {
       const map = new Map<string, zip.Entry>();


### PR DESCRIPTION
Add the `'credentials': include` option on the trace fetch so the browser can include cookies when fetching from a different origin, assuming the origin returns the correct Access-Control-Allow-Origin and Access-Control-Allow-Credentials headers.

Fixes #28501