### PR TITLE
test: skip webgl tests on macOS-arm64

### DIFF
--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -108,7 +108,8 @@ it('should play audio @smoke', async ({ page, server, browserName, platform }) =
   expect(await page.$eval('audio', e => e.currentTime)).toBeGreaterThan(0.2);
 });
 
-it('should support webgl @smoke', async ({ page, browserName, headless, browserMajorVersion, channel }) => {
+it('should support webgl @smoke', async ({ page, browserName, platform }) => {
+  it.fixme(browserName === 'chromium' && platform === 'darwin' && os.arch() === 'arm64', 'SwiftShader is not available on macOS-arm64 - https://github.com/microsoft/playwright/issues/28216');
   const hasWebGL = await page.evaluate(() => {
     const canvas = document.createElement('canvas');
     return !!canvas.getContext('webgl');
@@ -116,10 +117,11 @@ it('should support webgl @smoke', async ({ page, browserName, headless, browserM
   expect(hasWebGL).toBe(true);
 });
 
-it('should support webgl 2 @smoke', async ({ page, browserName, headless, isWindows, channel, browserMajorVersion }) => {
+it('should support webgl 2 @smoke', async ({ page, browserName, headless, isWindows, platform }) => {
   it.skip(browserName === 'webkit', 'WebKit doesn\'t have webgl2 enabled yet upstream.');
   it.fixme(browserName === 'firefox' && isWindows);
   it.fixme(browserName === 'chromium' && !headless, 'chromium doesn\'t like webgl2 when running under xvfb');
+  it.fixme(browserName === 'chromium' && platform === 'darwin' && os.arch() === 'arm64', 'SwiftShader is not available on macOS-arm64 - https://github.com/microsoft/playwright/issues/28216');
 
   const hasWebGL2 = await page.evaluate(() => {
     const canvas = document.createElement('canvas');

--- a/tests/library/signals.spec.ts
+++ b/tests/library/signals.spec.ts
@@ -64,7 +64,7 @@ test.describe('signals', () => {
     const pid = await remoteServer.out('pid');
     process.kill(-pid, 'SIGKILL');
     if (isMac && browserName === 'webkit' && parseInt(os.release(), 10) >= 22 && os.arch() === 'arm64') {
-      // WebKit on mac13 exits differently.
+      // WebKit on newer macOS exits differently.
       expect(await remoteServer.out('exitCode')).toBe('137');
       expect(await remoteServer.out('signal')).toBe('null');
     } else {

--- a/tests/library/signals.spec.ts
+++ b/tests/library/signals.spec.ts
@@ -63,7 +63,7 @@ test.describe('signals', () => {
     const remoteServer = await startRemoteServer('launchServer', { url: server.EMPTY_PAGE });
     const pid = await remoteServer.out('pid');
     process.kill(-pid, 'SIGKILL');
-    if (isMac && browserName === 'webkit' && parseInt(os.release(), 10) === 22 && os.arch() === 'arm64') {
+    if (isMac && browserName === 'webkit' && parseInt(os.release(), 10) >= 22 && os.arch() === 'arm64') {
       // WebKit on mac13 exits differently.
       expect(await remoteServer.out('exitCode')).toBe('137');
       expect(await remoteServer.out('signal')).toBe('null');

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import os from 'os';
 import { test as it, expect } from './pageTest';
 import { verifyViewport, attachFrame } from '../config/utils';
 import type { Route } from 'playwright-core';
@@ -308,8 +309,9 @@ it.describe('page screenshot', () => {
     }
   });
 
-  it('should work for webgl', async ({ page, server, browserName, channel, browserMajorVersion }) => {
+  it('should work for webgl', async ({ page, server, browserName, platform }) => {
     it.fixme(browserName === 'firefox');
+    it.fixme(browserName === 'chromium' && platform === 'darwin' && os.arch() === 'arm64', 'SwiftShader is not available on macOS-arm64 - https://github.com/microsoft/playwright/issues/28216');
 
     await page.setViewportSize({ width: 640, height: 480 });
     await page.goto(server.PREFIX + '/screenshots/webgl.html');


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/28216.

Drive-by: adjust signals expectation.