### PR TITLE
fix(esm): >= Node.js 21 globalPreload -> initialize

### DIFF
--- a/packages/playwright/src/cli.ts
+++ b/packages/playwright/src/cli.ts
@@ -21,7 +21,7 @@ import fs from 'fs';
 import path from 'path';
 import { Runner } from './runner/runner';
 import { stopProfiling, startProfiling, gracefullyProcessExitDoNotHang } from 'playwright-core/lib/utils';
-import { execArgvWithoutExperimentalLoaderOptions, execArgvWithExperimentalLoaderOptions, fileIsModule, serializeError } from './util';
+import { fileIsModule, serializeError } from './util';
 import { showHTMLReport } from './reporters/html';
 import { createMergedReport } from './reporters/merge';
 import { ConfigLoader, resolveConfigFile } from './common/configLoader';
@@ -33,6 +33,8 @@ import type { FullConfigInternal } from './common/config';
 import program from 'playwright-core/lib/cli/program';
 import type { ReporterDescription } from '../types/test';
 import { prepareErrorStack } from './reporters/base';
+import { registerESMLoader } from './common/esmLoaderHost';
+import { execArgvWithExperimentalLoaderOptions, execArgvWithoutExperimentalLoaderOptions, kSupportsModuleRegister } from './transform/esmUtils';
 
 function addTestCommand(program: Command) {
   const command = program.command('test [test-filter...]');
@@ -277,26 +279,33 @@ function restartWithExperimentalTsEsm(configFile: string | null): boolean {
     return false;
   if (process.env.PW_DISABLE_TS_ESM)
     return false;
-  if (process.env.PW_TS_ESM_ON) {
+  // Node.js < 21
+  if ((globalThis as any).__legacyEsmLoaderPort) {
     // clear execArgv after restart, so that childProcess.fork in user code does not inherit our loader.
     process.execArgv = execArgvWithoutExperimentalLoaderOptions();
     return false;
   }
   if (!fileIsModule(configFile))
     return false;
-  const innerProcess = (require('child_process') as typeof import('child_process')).fork(require.resolve('./cli'), process.argv.slice(2), {
-    env: {
-      ...process.env,
-      PW_TS_ESM_ON: '1',
-    },
-    execArgv: execArgvWithExperimentalLoaderOptions(),
-  });
+    // Node.js < 21
+  if (!kSupportsModuleRegister) {
+    const innerProcess = (require('child_process') as typeof import('child_process')).fork(require.resolve('./cli'), process.argv.slice(2), {
+      env: {
+        ...process.env,
+        PW_TS_ESM_LEGACY_LOADER_ON: '1',
+      },
+      execArgv: execArgvWithExperimentalLoaderOptions(),
+    });
 
-  innerProcess.on('close', (code: number | null) => {
-    if (code !== 0 && code !== null)
-      gracefullyProcessExitDoNotHang(code);
-  });
-  return true;
+    innerProcess.on('close', (code: number | null) => {
+      if (code !== 0 && code !== null)
+        gracefullyProcessExitDoNotHang(code);
+    });
+    return true;
+  }
+  // Nodejs >= 21
+  registerESMLoader();
+  return false;
 }
 
 const kTraceModes: TraceMode[] = ['on', 'off', 'on-first-retry', 'on-all-retries', 'retain-on-failure'];

--- a/packages/playwright/src/cli.ts
+++ b/packages/playwright/src/cli.ts
@@ -34,7 +34,7 @@ import program from 'playwright-core/lib/cli/program';
 import type { ReporterDescription } from '../types/test';
 import { prepareErrorStack } from './reporters/base';
 import { registerESMLoader } from './common/esmLoaderHost';
-import { execArgvWithExperimentalLoaderOptions, execArgvWithoutExperimentalLoaderOptions, kSupportsModuleRegister } from './transform/esmUtils';
+import { execArgvWithExperimentalLoaderOptions, execArgvWithoutExperimentalLoaderOptions } from './transform/esmUtils';
 
 function addTestCommand(program: Command) {
   const command = program.command('test [test-filter...]');
@@ -280,7 +280,7 @@ function restartWithExperimentalTsEsm(configFile: string | null): boolean {
   if (process.env.PW_DISABLE_TS_ESM)
     return false;
   // Node.js < 20
-  if ((globalThis as any).__legacyEsmLoaderPort) {
+  if ((globalThis as any).__esmLoaderPortPreV20) {
     // clear execArgv after restart, so that childProcess.fork in user code does not inherit our loader.
     process.execArgv = execArgvWithoutExperimentalLoaderOptions();
     return false;
@@ -288,7 +288,7 @@ function restartWithExperimentalTsEsm(configFile: string | null): boolean {
   if (!fileIsModule(configFile))
     return false;
     // Node.js < 20
-  if (!kSupportsModuleRegister) {
+  if (!require('node:module').register) {
     const innerProcess = (require('child_process') as typeof import('child_process')).fork(require.resolve('./cli'), process.argv.slice(2), {
       env: {
         ...process.env,

--- a/packages/playwright/src/cli.ts
+++ b/packages/playwright/src/cli.ts
@@ -279,7 +279,7 @@ function restartWithExperimentalTsEsm(configFile: string | null): boolean {
     return false;
   if (process.env.PW_DISABLE_TS_ESM)
     return false;
-  // Node.js < 21
+  // Node.js < 20
   if ((globalThis as any).__legacyEsmLoaderPort) {
     // clear execArgv after restart, so that childProcess.fork in user code does not inherit our loader.
     process.execArgv = execArgvWithoutExperimentalLoaderOptions();
@@ -287,7 +287,7 @@ function restartWithExperimentalTsEsm(configFile: string | null): boolean {
   }
   if (!fileIsModule(configFile))
     return false;
-    // Node.js < 21
+    // Node.js < 20
   if (!kSupportsModuleRegister) {
     const innerProcess = (require('child_process') as typeof import('child_process')).fork(require.resolve('./cli'), process.argv.slice(2), {
       env: {

--- a/packages/playwright/src/common/esmLoaderHost.ts
+++ b/packages/playwright/src/common/esmLoaderHost.ts
@@ -18,17 +18,14 @@ import url from 'url';
 import { addToCompilationCache, serializeCompilationCache } from '../transform/compilationCache';
 import { transformConfig } from '../transform/transform';
 import { PortTransport } from '../transform/portTransport';
-import { kSupportsModuleRegister } from '../transform/esmUtils';
 
 let loaderChannel: PortTransport | undefined;
-// Node.js < 21
+// Node.js < 20
 if ((globalThis as any).__legacyEsmLoaderPort)
   loaderChannel = createPortTransport((globalThis as any).__legacyEsmLoaderPort);
 
+// Node.js >= 20
 export function registerESMLoader() {
-  if (!kSupportsModuleRegister)
-    return;
-  // Node.js >= 21
   const { port1, port2 } = new MessageChannel();
   // register will wait until the loader is initialized.
   require('node:module').register(require.resolve('../transform/esmLoader'), {

--- a/packages/playwright/src/common/esmLoaderHost.ts
+++ b/packages/playwright/src/common/esmLoaderHost.ts
@@ -21,8 +21,8 @@ import { PortTransport } from '../transform/portTransport';
 
 let loaderChannel: PortTransport | undefined;
 // Node.js < 20
-if ((globalThis as any).__legacyEsmLoaderPort)
-  loaderChannel = createPortTransport((globalThis as any).__legacyEsmLoaderPort);
+if ((globalThis as any).__esmLoaderPortPreV20)
+  loaderChannel = createPortTransport((globalThis as any).__esmLoaderPortPreV20);
 
 // Node.js >= 20
 export let esmLoaderRegistered = false;

--- a/packages/playwright/src/common/esmLoaderHost.ts
+++ b/packages/playwright/src/common/esmLoaderHost.ts
@@ -25,15 +25,17 @@ if ((globalThis as any).__legacyEsmLoaderPort)
   loaderChannel = createPortTransport((globalThis as any).__legacyEsmLoaderPort);
 
 // Node.js >= 20
+export let esmLoaderRegistered = false;
 export function registerESMLoader() {
   const { port1, port2 } = new MessageChannel();
   // register will wait until the loader is initialized.
-  require('node:module').register(require.resolve('../transform/esmLoader'), {
+  require('node:module').register(url.pathToFileURL(require.resolve('../transform/esmLoader')), {
     parentURL: url.pathToFileURL(__filename),
     data: { port: port2 },
     transferList: [port2],
   });
   loaderChannel = createPortTransport(port1);
+  esmLoaderRegistered = true;
 }
 
 function createPortTransport(port: MessagePort) {

--- a/packages/playwright/src/common/process.ts
+++ b/packages/playwright/src/common/process.ts
@@ -18,7 +18,9 @@ import type { WriteStream } from 'tty';
 import type { EnvProducedPayload, ProcessInitParams, TtyParams } from './ipc';
 import { startProfiling, stopProfiling } from 'playwright-core/lib/utils';
 import type { TestInfoError } from '../../types/test';
-import { execArgvWithoutExperimentalLoaderOptions, serializeError } from '../util';
+import { serializeError } from '../util';
+import { registerESMLoader } from './esmLoaderHost';
+import { execArgvWithoutExperimentalLoaderOptions } from '../transform/esmUtils';
 
 export type ProtocolRequest = {
   id: number;
@@ -53,6 +55,7 @@ process.on('SIGTERM', () => {});
 
 // Clear execArgv immediately, so that the user-code does not inherit our loader.
 process.execArgv = execArgvWithoutExperimentalLoaderOptions();
+registerESMLoader();
 
 let processRunner: ProcessRunner | undefined;
 let processName: string | undefined;

--- a/packages/playwright/src/common/process.ts
+++ b/packages/playwright/src/common/process.ts
@@ -20,7 +20,7 @@ import { startProfiling, stopProfiling } from 'playwright-core/lib/utils';
 import type { TestInfoError } from '../../types/test';
 import { serializeError } from '../util';
 import { registerESMLoader } from './esmLoaderHost';
-import { execArgvWithoutExperimentalLoaderOptions } from '../transform/esmUtils';
+import { execArgvWithoutExperimentalLoaderOptions, kSupportsModuleRegister } from '../transform/esmUtils';
 
 export type ProtocolRequest = {
   id: number;
@@ -55,7 +55,10 @@ process.on('SIGTERM', () => {});
 
 // Clear execArgv immediately, so that the user-code does not inherit our loader.
 process.execArgv = execArgvWithoutExperimentalLoaderOptions();
-registerESMLoader();
+
+// Node.js >= 20
+if (kSupportsModuleRegister)
+  registerESMLoader();
 
 let processRunner: ProcessRunner | undefined;
 let processName: string | undefined;

--- a/packages/playwright/src/common/process.ts
+++ b/packages/playwright/src/common/process.ts
@@ -20,7 +20,7 @@ import { startProfiling, stopProfiling } from 'playwright-core/lib/utils';
 import type { TestInfoError } from '../../types/test';
 import { serializeError } from '../util';
 import { registerESMLoader } from './esmLoaderHost';
-import { execArgvWithoutExperimentalLoaderOptions, kSupportsModuleRegister } from '../transform/esmUtils';
+import { execArgvWithoutExperimentalLoaderOptions } from '../transform/esmUtils';
 
 export type ProtocolRequest = {
   id: number;
@@ -57,7 +57,7 @@ process.on('SIGTERM', () => {});
 process.execArgv = execArgvWithoutExperimentalLoaderOptions();
 
 // Node.js >= 20
-if (kSupportsModuleRegister)
+if (process.env.PW_TS_ESM_LOADER_ON)
   registerESMLoader();
 
 let processRunner: ProcessRunner | undefined;

--- a/packages/playwright/src/runner/processHost.ts
+++ b/packages/playwright/src/runner/processHost.ts
@@ -19,7 +19,7 @@ import { EventEmitter } from 'events';
 import { debug } from 'playwright-core/lib/utilsBundle';
 import type { EnvProducedPayload, ProcessInitParams } from '../common/ipc';
 import type { ProtocolResponse } from '../common/process';
-import { execArgvWithExperimentalLoaderOptions } from '../util';
+import { execArgvWithExperimentalLoaderOptions } from '../transform/esmUtils';
 import { assert } from 'playwright-core/lib/utils';
 
 export type ProcessExitData = {
@@ -58,7 +58,7 @@ export class ProcessHost extends EventEmitter {
         (options.onStdErr && !process.env.PW_RUNNER_DEBUG) ? 'pipe' : 'inherit',
         'ipc',
       ],
-      ...(process.env.PW_TS_ESM_ON ? { execArgv: execArgvWithExperimentalLoaderOptions() } : {}),
+      ...(process.env.PW_TS_ESM_LEGACY_LOADER_ON ? { execArgv: execArgvWithExperimentalLoaderOptions() } : {}),
     });
     this.process.on('exit', async (code, signal) => {
       this._processDidExit = true;

--- a/packages/playwright/src/runner/processHost.ts
+++ b/packages/playwright/src/runner/processHost.ts
@@ -21,6 +21,7 @@ import type { EnvProducedPayload, ProcessInitParams } from '../common/ipc';
 import type { ProtocolResponse } from '../common/process';
 import { execArgvWithExperimentalLoaderOptions } from '../transform/esmUtils';
 import { assert } from 'playwright-core/lib/utils';
+import { esmLoaderRegistered } from '../common/esmLoaderHost';
 
 export type ProcessExitData = {
   unexpectedly: boolean;
@@ -51,7 +52,11 @@ export class ProcessHost extends EventEmitter {
     assert(!this.process, 'Internal error: starting the same process twice');
     this.process = child_process.fork(require.resolve('../common/process'), {
       detached: false,
-      env: { ...process.env, ...this._extraEnv },
+      env: {
+        ...process.env,
+        ...this._extraEnv,
+        ...(esmLoaderRegistered ? { PW_TS_ESM_LOADER_ON: '1' } : {}),
+      },
       stdio: [
         'ignore',
         options.onStdOut ? 'pipe' : 'inherit',

--- a/packages/playwright/src/transform/esmLoader.ts
+++ b/packages/playwright/src/transform/esmLoader.ts
@@ -70,7 +70,7 @@ let transport: PortTransport | undefined;
 function globalPreload(context: { port: MessagePort }) {
   transport = createTransport(context.port);
   return `
-    globalThis.__legacyEsmLoaderPort = port;
+    globalThis.__esmLoaderPortPreV20 = port;
   `;
 }
 

--- a/packages/playwright/src/transform/esmLoader.ts
+++ b/packages/playwright/src/transform/esmLoader.ts
@@ -66,7 +66,7 @@ async function load(moduleUrl: string, context: { format?: string }, defaultLoad
 
 let transport: PortTransport | undefined;
 
-// Node.js < 21
+// Node.js < 20
 function globalPreload(context: { port: MessagePort }) {
   transport = createTransport(context.port);
   return `
@@ -74,7 +74,7 @@ function globalPreload(context: { port: MessagePort }) {
   `;
 }
 
-// Node.js >= 21
+// Node.js >= 20
 function initialize(data: { port: MessagePort }) {
   transport = createTransport(data?.port);
 }

--- a/packages/playwright/src/transform/esmLoader.ts
+++ b/packages/playwright/src/transform/esmLoader.ts
@@ -66,8 +66,21 @@ async function load(moduleUrl: string, context: { format?: string }, defaultLoad
 
 let transport: PortTransport | undefined;
 
+// Node.js < 21
 function globalPreload(context: { port: MessagePort }) {
-  transport = new PortTransport(context.port, async (method, params) => {
+  transport = createTransport(context.port);
+  return `
+    globalThis.__legacyEsmLoaderPort = port;
+  `;
+}
+
+// Node.js >= 21
+function initialize(data: { port: MessagePort }) {
+  transport = createTransport(data?.port);
+}
+
+function createTransport(port: MessagePort) {
+  return new PortTransport(port, async (method, params) => {
     if (method === 'setTransformConfig') {
       setTransformConfig(params.config);
       return;
@@ -91,10 +104,7 @@ function globalPreload(context: { port: MessagePort }) {
       return;
     }
   });
-
-  return `
-    globalThis.__esmLoaderPort = port;
-  `;
 }
 
-module.exports = { resolve, load, globalPreload };
+
+module.exports = { resolve, load, globalPreload, initialize };

--- a/packages/playwright/src/transform/esmUtils.ts
+++ b/packages/playwright/src/transform/esmUtils.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import url from 'url';
+
+const kExperimentalLoaderOptions = [
+  '--no-warnings',
+  `--experimental-loader=${url.pathToFileURL(require.resolve('playwright/lib/transform/esmLoader')).toString()}`,
+];
+
+export const kSupportsModuleRegister = !!require('node:module').register;
+
+export function execArgvWithExperimentalLoaderOptions() {
+  return [
+    ...process.execArgv,
+    ...kExperimentalLoaderOptions,
+  ];
+}
+
+export function execArgvWithoutExperimentalLoaderOptions() {
+  return process.execArgv.filter(arg => !kExperimentalLoaderOptions.includes(arg));
+}

--- a/packages/playwright/src/transform/esmUtils.ts
+++ b/packages/playwright/src/transform/esmUtils.ts
@@ -21,8 +21,6 @@ const kExperimentalLoaderOptions = [
   `--experimental-loader=${url.pathToFileURL(require.resolve('playwright/lib/transform/esmLoader')).toString()}`,
 ];
 
-export const kSupportsModuleRegister = !!require('node:module').register;
-
 export function execArgvWithExperimentalLoaderOptions() {
   return [
     ...process.execArgv,

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -286,22 +286,6 @@ function folderIsModule(folder: string): boolean {
   return require(packageJsonPath).type === 'module';
 }
 
-const kExperimentalLoaderOptions = [
-  '--no-warnings',
-  `--experimental-loader=${url.pathToFileURL(require.resolve('playwright/lib/transform/esmLoader')).toString()}`,
-];
-
-export function execArgvWithExperimentalLoaderOptions() {
-  return [
-    ...process.execArgv,
-    ...kExperimentalLoaderOptions,
-  ];
-}
-
-export function execArgvWithoutExperimentalLoaderOptions() {
-  return process.execArgv.filter(arg => !kExperimentalLoaderOptions.includes(arg));
-}
-
 // This follows the --moduleResolution=bundler strategy from tsc.
 // https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#moduleresolution-bundler
 const kExtLookups = new Map([


### PR DESCRIPTION
https://github.com/microsoft/playwright/issues/28524
https://github.com/microsoft/playwright/issues/28732

https://nodejs.org/en/blog/announcements/v21-release-announce#module-customization-hook-globalpreload-removed-use-register-and-initialize-instead