### PR TITLE
fix: throw if fuliflled with unsupported status code

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -563,18 +563,14 @@ class RouteImpl implements network.RouteDelegate {
       method: overrides.method,
       postData: overrides.postData ? overrides.postData.toString('base64') : undefined
     };
-    // In certain cases, protocol will return error if the request was already canceled
-    // or the page was closed. We should tolerate these errors.
-    await this._session._sendMayFail('Fetch.continueRequest', this._alreadyContinuedParams);
+    await this._session.send('Fetch.continueRequest', this._alreadyContinuedParams);
   }
 
   async fulfill(response: types.NormalizedFulfillResponse) {
     const body = response.isBase64 ? response.body : Buffer.from(response.body).toString('base64');
 
     const responseHeaders = splitSetCookieHeader(response.headers);
-    // In certain cases, protocol will return error if the request was already canceled
-    // or the page was closed. We should tolerate these errors.
-    await this._session._sendMayFail('Fetch.fulfillRequest', {
+    await this._session.send('Fetch.fulfillRequest', {
       requestId: this._interceptionId!,
       responseCode: response.status,
       responsePhrase: network.STATUS_TEXTS[String(response.status)],

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -261,8 +261,8 @@ export class Route extends SdkObject {
     await Promise.race([
       this._delegate.abort(errorCode),
       // If the request is already cancelled by the page before we handle the route,
-      // we'll receive loading failed error and throw it here.
-      this._waitForFailure()
+      // we'll receive loading failed event and will ignore route handling error.
+      this._request.response()
     ]);
 
     this._endHandling();
@@ -300,16 +300,10 @@ export class Route extends SdkObject {
         isBase64,
       }),
       // If the request is already cancelled by the page before we handle the route,
-      // we'll receive loading failed error and throw it here.
-      this._waitForFailure()
+      // we'll receive loading failed event and will ignore route handling error.
+      this._request.response()
     ]);
     this._endHandling();
-  }
-
-  private async _waitForFailure() {
-    const response = await this._request.response();
-    if (!response)
-      throw new Error(this._request._failureText || 'Request was cancelled');
   }
 
   // See https://github.com/microsoft/playwright/issues/12929
@@ -344,8 +338,8 @@ export class Route extends SdkObject {
     await Promise.race([
       this._delegate.continue(this._request, overrides),
       // If the request is already cancelled by the page before we handle the route,
-      // we'll receive loading failed error and throw it here.
-      this._waitForFailure()
+      // we'll receive loading failed event and will ignore route handling error.
+      this._request.response()
     ]);
 
     this._endHandling();

--- a/tests/page/page-request-fulfill.spec.ts
+++ b/tests/page/page-request-fulfill.spec.ts
@@ -18,6 +18,7 @@
 import { test as base, expect } from './pageTest';
 import fs from 'fs';
 import type * as har from '../../packages/trace/src/har';
+import type { Route } from 'playwright-core';
 
 const it = base.extend<{
   // We access test servers at 10.0.2.2 from inside the browser on Android,
@@ -75,6 +76,51 @@ it('should work with status code 422', async ({ page, server }) => {
   expect(response.status()).toBe(422);
   expect(response.statusText()).toBe('Unprocessable Entity');
   expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
+});
+
+it('should throw exception if status code is not supported', async ({ page, server, browserName }) => {
+  let fulfillPromiseCallback;
+  const fulfillPromise = new Promise<Error|undefined>(f => fulfillPromiseCallback = f);
+  await page.route('**/data.json', route => {
+    fulfillPromiseCallback(route.fulfill({
+      status: 430,
+      body: 'Yo, page!'
+    }).catch(e => e));
+  });
+  await page.goto(server.EMPTY_PAGE);
+  page.evaluate(url => fetch(url), server.PREFIX + '/data.json').catch(() => {});
+  const error = await fulfillPromise;
+  if (browserName === 'chromium') {
+    expect(error).toBeTruthy();
+    expect(error.message).toContain(' Invalid http status code or phrase');
+  } else {
+    expect(error).toBe(undefined);
+  }
+});
+
+it('should throw if request was cancelled by the page', async ({ page, server, browserName }) => {
+  let interceptCallback;
+  const interceptPromise = new Promise<Route>(f => interceptCallback = f);
+  await page.route('**/data.json', route => interceptCallback(route), { noWaitForFinish: true });
+  await page.goto(server.EMPTY_PAGE);
+  page.evaluate(url => {
+    globalThis.controller = new AbortController();
+    return fetch(url, { signal: globalThis.controller.signal });
+  }, server.PREFIX + '/data.json').catch(() => {});
+  const route = await interceptPromise;
+  const failurePromise = page.waitForEvent('requestfailed');
+  await page.evaluate(() => globalThis.controller.abort());
+  const cancelledRequest = await failurePromise;
+  console.log('cancelledRequest', cancelledRequest.failure());
+  let error;
+  if (browserName === 'chromium')
+    error = 'net::ERR_ABORTED';
+  else if (browserName === 'webkit')
+    error = 'cancelled';
+  else if (browserName === 'firefox')
+    error = 'NS_BINDING_ABORTED';
+  expect(cancelledRequest.failure().errorText).toBe(error);
+  await expect(route.fulfill({ status: 200 })).rejects.toThrow(new RegExp(error));
 });
 
 it('should allow mocking binary responses', async ({ page, server, browserName, headless, asset, isAndroid, mode }) => {

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -375,7 +375,8 @@ it('should be abortable with custom error codes', async ({ page, server, browser
     expect(failedRequest.failure().errorText).toBe('net::ERR_INTERNET_DISCONNECTED');
 });
 
-it('should throw if request was cancelled by the page', async ({ page, server, browserName }) => {
+it('should not throw if request was cancelled by the page', async ({ page, server }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/28490' });
   let interceptCallback;
   const interceptPromise = new Promise<Route>(f => interceptCallback = f);
   await page.route('**/data.json', route => interceptCallback(route), { noWaitForFinish: true });
@@ -385,19 +386,11 @@ it('should throw if request was cancelled by the page', async ({ page, server, b
     return fetch(url, { signal: globalThis.controller.signal });
   }, server.PREFIX + '/data.json').catch(() => {});
   const route = await interceptPromise;
-  // const failurePromise = page.waitForEvent('requestfailed');
-  // await page.evaluate(() => globalThis.controller.abort());
-  // const cancelledRequest = await failurePromise;
-  // console.log('cancelledRequest', cancelledRequest.failure());
-  let error;
-  if (browserName === 'chromium')
-    error = 'net::ERR_ABORTED';
-  else if (browserName === 'webkit')
-    error = 'cancelled';
-  else if (browserName === 'firefox')
-    error = 'NS_BINDING_ABORTED';
-  // expect(cancelledRequest.failure().errorText).toBe(error);
-  await expect(route.abort()).rejects.toThrow(new RegExp(error));
+  const failurePromise = page.waitForEvent('requestfailed');
+  await page.evaluate(() => globalThis.controller.abort());
+  const cancelledRequest = await failurePromise;
+  expect(cancelledRequest.failure().errorText).toMatch(/cancelled|aborted/i);
+  await route.abort(); // Should not throw.
 });
 
 it('should send referer', async ({ page, server }) => {

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -375,6 +375,31 @@ it('should be abortable with custom error codes', async ({ page, server, browser
     expect(failedRequest.failure().errorText).toBe('net::ERR_INTERNET_DISCONNECTED');
 });
 
+it('should throw if request was cancelled by the page', async ({ page, server, browserName }) => {
+  let interceptCallback;
+  const interceptPromise = new Promise<Route>(f => interceptCallback = f);
+  await page.route('**/data.json', route => interceptCallback(route), { noWaitForFinish: true });
+  await page.goto(server.EMPTY_PAGE);
+  page.evaluate(url => {
+    globalThis.controller = new AbortController();
+    return fetch(url, { signal: globalThis.controller.signal });
+  }, server.PREFIX + '/data.json').catch(() => {});
+  const route = await interceptPromise;
+  // const failurePromise = page.waitForEvent('requestfailed');
+  // await page.evaluate(() => globalThis.controller.abort());
+  // const cancelledRequest = await failurePromise;
+  // console.log('cancelledRequest', cancelledRequest.failure());
+  let error;
+  if (browserName === 'chromium')
+    error = 'net::ERR_ABORTED';
+  else if (browserName === 'webkit')
+    error = 'cancelled';
+  else if (browserName === 'firefox')
+    error = 'NS_BINDING_ABORTED';
+  // expect(cancelledRequest.failure().errorText).toBe(error);
+  await expect(route.abort()).rejects.toThrow(new RegExp(error));
+});
+
 it('should send referer', async ({ page, server }) => {
   await page.setExtraHTTPHeaders({
     referer: 'http://google.com/'


### PR DESCRIPTION
If request gets cancelled by the page before we fulfill it, we receive `loadingFailed` event. In that case we'll ignore interception error if any, otherwise the error will be propagated to the caller.

Fixes https://github.com/microsoft/playwright/issues/28490