### PR TITLE
feat: explain that argument is a regex

### DIFF
--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -78,6 +78,7 @@ Complete set of Playwright Test options is available in the [configuration file]
 
 | Option | Description |
 | :- | :- |
+| Non-option arguments | Each argument is treated as a regular expression matched against the full test file path. Only tests from the files matching the pattern will be executed. Special symbols like `$` or `*` should be escaped with `\`. In many shells/terminals you may need to quote the arguments. |
 | `--headed` | Run tests in headed browsers. Useful for debugging. |
 |`--browser`| Run test in a specific browser. Available options are  `"chromium"`, `"firefox"`, `"webkit"` or `"all"` to run tests in all three browsers at the same time. |
 | `--debug`| Run tests with Playwright Inspector. Shortcut for `PWDEBUG=1` environment variable and `--timeout=0 --max-failures=1 --headed --workers=1` options.|

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -198,8 +198,16 @@ function createLoadTask(mode: 'out-of-process' | 'in-process', options: { filter
       testRun.rootSuite = await createRootSuite(testRun, options.failOnLoadErrors ? errors : softErrors, !!options.filterOnly);
       testRun.failureTracker.onRootSuite(testRun.rootSuite);
       // Fail when no tests.
-      if (options.failOnLoadErrors && !testRun.rootSuite.allTests().length && !testRun.config.cliPassWithNoTests && !testRun.config.config.shard)
+      if (options.failOnLoadErrors && !testRun.rootSuite.allTests().length && !testRun.config.cliPassWithNoTests && !testRun.config.config.shard) {
+        if (testRun.config.cliArgs.length) {
+          throw new Error([
+            `No tests found.`,
+            `Make sure that arguments are regular expressions matching test files.`,
+            `You may need to escape symbols like "$" or "*" and quote the arguments.`,
+          ].join('\n'));
+        }
         throw new Error(`No tests found`);
+      }
     },
   };
 }


### PR DESCRIPTION
- in docs;
- in the error message.

Terminal output:

```
$ npx playwright test foobar
Error: No tests found.
Make sure that arguments are regular expressions matching test files.
You may need to escape symbols like "$" or "*" and quote the arguments.
```

References #28551.