### PR TITLE
fix(route): silently catch errors when handling route on server

### DIFF
--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -119,7 +119,7 @@ export class CRServiceWorker extends Worker {
       const r = new network.Route(request, route);
       if (this._browserContext._requestInterceptor?.(r, request))
         return;
-      r.continue({ isFallback: true });
+      r.continue({ isFallback: true }).catch(() => {});
     }
   }
 

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -296,7 +296,7 @@ export class FrameManager {
       frame.setPendingDocument({ documentId: request._documentId, request });
     if (request._isFavicon) {
       if (route)
-        route.continue(request, { isFallback: true });
+        route.continue(request, { isFallback: true }).catch(() => {});
       return;
     }
     this._page.emitOnContext(BrowserContext.Events.Request, request);
@@ -308,7 +308,7 @@ export class FrameManager {
         return;
       if (this._page._browserContext._requestInterceptor?.(r, request))
         return;
-      r.continue({ isFallback: true });
+      r.continue({ isFallback: true }).catch(() => {});
     }
   }
 

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -97,7 +97,7 @@ export class RecorderApp extends EventEmitter implements IRecorderApp {
           ],
           body: buffer.toString('base64'),
           isBase64: true
-        });
+        }).catch(() => {});
       });
       return true;
     });


### PR DESCRIPTION
This is a follow-up to 119afdf788f4fec0eaae0def91a95aee84971eae Since continue/fulfill/abort now may throw on the server after page has been closed, we need to catch the errors manually. On the client it's fixed by the original change.

This fixes errors in the existing tests:
```
  1) [chromium] › library/browsercontext-route.spec.ts:172:3 › should support Set-Cookie header ────

    Error: 

       at ../packages/playwright-core/src/server/chromium/crConnection.ts:147

      145 |     const id = this._connection._rawSend(this._sessionId, method, params);
      146 |     return new Promise((resolve, reject) => {
    > 147 |       this._callbacks.set(id, { resolve, reject, error: new ProtocolError('error', method) });
          |                                                         ^
      148 |     });
      149 |   }
      150 |

        at /Users/yurys/playwright/packages/playwright-core/src/server/chromium/crConnection.ts:147:57
        at new Promise (<anonymous>)
        at CRSession.send (/Users/yurys/playwright/packages/playwright-core/src/server/chromium/crConnection.ts:146:12)
        at RouteImpl.continue (/Users/yurys/playwright/packages/playwright-core/src/server/chromium/crNetworkManager.ts:566:25)
        at FrameManager.requestStarted (/Users/yurys/playwright/packages/playwright-core/src/server/frames.ts:299:23)
        at CRNetworkManager._onRequest (/Users/yurys/playwright/packages/playwright-core/src/server/chromium/crNetworkManager.ts:314:57)
        at CRNetworkManager._onRequestPaused (/Users/yurys/playwright/packages/playwright-core/src/server/chromium/crNetworkManager.ts:202:12)
        at CRSession.emit (node:events:517:28)
        at /Users/yurys/playwright/packages/playwright-core/src/server/chromium/crConnection.ts:172:14
        at runNextTicks (node:internal/process/task_queues:60:5)
        at processImmediate (node:internal/timers:447:9)
```

![image](https://github.com/microsoft/playwright/assets/9798949/1c436dc2-f113-4ba6-952c-dca5a8c5fa62)

Reference https://github.com/microsoft/playwright/issues/28490