### PR TITLE
docs: Improve clarity on toHaveText and toContainText assertions

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -933,7 +933,7 @@ await Expect(
 * langs:
   - alias-java: containsText
 
-Ensures the [Locator] points to an element that contains the given text. You can use regular expressions for the value as well.
+Ensures the [Locator] points to an element that contains the given text. All children of the element are evaluated for the specified text. You can use regular expressions for the value as well.
 
 **Details**
 
@@ -1613,7 +1613,7 @@ Note that screenshot assertions only work with Playwright test runner.
 * langs:
   - alias-java: hasText
 
-Ensures the [Locator] points to an element with the given text. You can use regular expressions for the value as well.
+Ensures the [Locator] points to an element with the given text. All children of the element are evaluated for the specified text. You can use regular expressions for the value as well.
 
 **Details**
 

--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -933,7 +933,7 @@ await Expect(
 * langs:
   - alias-java: containsText
 
-Ensures the [Locator] points to an element that contains the given text. All children of the element are evaluated for the specified text. You can use regular expressions for the value as well.
+Ensures the [Locator] points to an element that contains the given text. All nested elements will be considered when computing the text content of the element. You can use regular expressions for the value as well.
 
 **Details**
 
@@ -1613,7 +1613,7 @@ Note that screenshot assertions only work with Playwright test runner.
 * langs:
   - alias-java: hasText
 
-Ensures the [Locator] points to an element with the given text. All children of the element are evaluated for the specified text. You can use regular expressions for the value as well.
+Ensures the [Locator] points to an element with the given text. All nested elements will be considered when computing the text content of the element. You can use regular expressions for the value as well.
 
 **Details**
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5689,8 +5689,8 @@ interface LocatorAssertions {
   }): Promise<void>;
 
   /**
-   * Ensures the {@link Locator} points to an element that contains the given text. All children of the element are evaluated for the specified text. You can use regular expressions for
-   * the value as well.
+   * Ensures the {@link Locator} points to an element that contains the given text. All children of the element are
+   * evaluated for the specified text. You can use regular expressions for the value as well.
    *
    * **Details**
    *
@@ -6103,8 +6103,8 @@ interface LocatorAssertions {
   }): Promise<void>;
 
   /**
-   * Ensures the {@link Locator} points to an element with the given text. All children of the element are evaluated for the specified text. You can use regular expressions for the value
-   * as well.
+   * Ensures the {@link Locator} points to an element with the given text. All children of the element are evaluated for
+   * the specified text. You can use regular expressions for the value as well.
    *
    * **Details**
    *

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5689,8 +5689,8 @@ interface LocatorAssertions {
   }): Promise<void>;
 
   /**
-   * Ensures the {@link Locator} points to an element that contains the given text. All children of the element are
-   * evaluated for the specified text. You can use regular expressions for the value as well.
+   * Ensures the {@link Locator} points to an element that contains the given text. All nested elements will be
+   * considered when computing the text content of the element. You can use regular expressions for the value as well.
    *
    * **Details**
    *
@@ -6103,8 +6103,8 @@ interface LocatorAssertions {
   }): Promise<void>;
 
   /**
-   * Ensures the {@link Locator} points to an element with the given text. All children of the element are evaluated for
-   * the specified text. You can use regular expressions for the value as well.
+   * Ensures the {@link Locator} points to an element with the given text. All nested elements will be considered when
+   * computing the text content of the element. You can use regular expressions for the value as well.
    *
    * **Details**
    *

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5689,7 +5689,7 @@ interface LocatorAssertions {
   }): Promise<void>;
 
   /**
-   * Ensures the {@link Locator} points to an element that contains the given text. You can use regular expressions for
+   * Ensures the {@link Locator} points to an element that contains the given text. All children of the element are evaluated for the specified text. You can use regular expressions for
    * the value as well.
    *
    * **Details**
@@ -6103,7 +6103,7 @@ interface LocatorAssertions {
   }): Promise<void>;
 
   /**
-   * Ensures the {@link Locator} points to an element with the given text. You can use regular expressions for the value
+   * Ensures the {@link Locator} points to an element with the given text. All children of the element are evaluated for the specified text. You can use regular expressions for the value
    * as well.
    *
    * **Details**


### PR DESCRIPTION
This closes https://github.com/microsoft/playwright/issues/28058.
