### PR TITLE
chore: provide better message for unhandled internal server errors

### DIFF
--- a/packages/playwright-core/src/server/chromium/crConnection.ts
+++ b/packages/playwright-core/src/server/chromium/crConnection.ts
@@ -190,6 +190,7 @@ export class CRSession extends EventEmitter {
     this._closed = true;
     this._connection._sessions.delete(this._sessionId);
     for (const callback of this._callbacks.values()) {
+      callback.error.setMessage(`Internal server error, session closed.`);
       callback.error.type = this._crashed ? 'crashed' : 'closed';
       callback.error.logs = this._connection._browserDisconnectedLogs;
       callback.reject(callback.error);


### PR DESCRIPTION
This changes error message from `Error: ` to `Error: Protocol error (Fetch.continueRequest): Internal server error, session closed.` when running  `npm run ctest -- --repeat-each 100 -x --headed --timeout 3000 --workers 1 library/browsercontext-route.spec.ts:172`   prior to 9d91b7caf51003cb5c11ec0cdeb8431ca0411aa9.