### PR TITLE
Update imageDiffView.css

### DIFF
--- a/packages/html-reporter/src/imageDiffView.css
+++ b/packages/html-reporter/src/imageDiffView.css
@@ -30,7 +30,7 @@
 }
 
 .image-diff-view .image-wrapper {
-  flex: auto;
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
fix imageDiffView
If the screenshots are not the same size, then the actual screenshot is stretched or compressed