### PR TITLE
fix imageDiffView.css

### DIFF
--- a/packages/html-reporter/src/imageDiffView.css
+++ b/packages/html-reporter/src/imageDiffView.css
@@ -22,7 +22,7 @@
 }
 
 .image-diff-view .image-wrapper img {
-  flex: auto;
+  flex: 0 0 auto;
   box-shadow: none;
   margin: 24px auto;
   min-width: 200px;


### PR DESCRIPTION
If the screenshots are not the same size, then the actual screenshot is stretched or compressed