### PR TITLE
docs: remove unrouteAll.behavior option from java

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -735,6 +735,7 @@ Whether to allow sites to register Service workers. Defaults to `'allow'`.
 * `'block'`: Playwright will block all registration of Service Workers.
 
 ## unroute-all-options-behavior
+* langs: js, csharp, python
 * since: v1.41
 - `behavior` <[UnrouteBehavior]<"wait"|"ignoreErrors"|"default">>
 


### PR DESCRIPTION
This option does not make sense in the synchronous API where all active routes would be on the same call stack any way.

Reference https://github.com/microsoft/playwright/issues/23781