### PR TITLE
fix(ui-mode): disconnected error styling

### DIFF
--- a/packages/trace-viewer/src/ui/uiModeView.css
+++ b/packages/trace-viewer/src/ui/uiModeView.css
@@ -74,13 +74,25 @@
 }
 
 .ui-mode .disconnected {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: auto;
+  flex-direction: column;
+  background-color: var(--vscode-editor-background);
   position: absolute;
   top: 0;
-  left: 0;
   right: 0;
   bottom: 0;
+  left: 0;
   z-index: 1000;
-  background-color: rgba(0, 0, 0, 0.5);
+  line-height: 24px;
+}
+
+.disconnected .title {
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 30px;
 }
 
 .status-line {

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -207,9 +207,9 @@ export const UIModeView: React.FC<{}> = ({
         <button className='button secondary' onClick={closeInstallDialog}>Dismiss</button>
       </div>
     </dialog>}
-    {isDisconnected && <div className='drop-target'>
+    {isDisconnected && <div className='disconnected'>
       <div className='title'>UI Mode disconnected</div>
-      <div><a href='#' onClick={() => window.location.reload()}>Reload the page</a> to reconnect</div>
+      <div><a href='#' onClick={() => window.location.href = '/'}>Reload the page</a> to reconnect</div>
     </div>}
     <SplitView sidebarSize={250} minSidebarSize={150} orientation='horizontal' sidebarIsFirst={true} settingName='testListSidebar'>
       <div className='vbox'>


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/28679
Fixes https://github.com/microsoft/playwright/issues/28680

Looks like this:

<img width="539" alt="Screenshot 2023-12-18 at 16 42 34" src="https://github.com/microsoft/playwright/assets/17984549/262d22a1-3a1d-48e8-aabf-fe66527655e7">

or

<img width="511" alt="Screenshot 2023-12-18 at 16 42 25" src="https://github.com/microsoft/playwright/assets/17984549/266ca0cf-5f8b-40ab-9e6c-fa2f3e0e1e0a">

Tested on localhost and on GitHub Codespaces.