### PR TITLE
Add range input recording support

### DIFF
--- a/packages/playwright-core/src/server/injected/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder.ts
@@ -188,7 +188,7 @@ class RecordActionTool implements RecorderTool {
       return;
     if (this._actionInProgress(event))
       return;
-    if (this._consumedDueToNoModel(event, this._hoveredModel))
+    if (this._consumedDueWrongTarget(event, this._hoveredModel))
       return;
 
     const checkbox = asCheckbox(this._recorder.deepEventTarget(event));
@@ -283,7 +283,7 @@ class RecordActionTool implements RecorderTool {
       }
 
       // Non-navigating actions are simply recorded by Playwright.
-      if (this._consumedDueWrongTarget(event))
+      if (this._consumedDueWrongTarget(event, this._activeModel))
         return;
       this._recorder.delegate.recordAction?.({
         name: 'fill',
@@ -313,7 +313,7 @@ class RecordActionTool implements RecorderTool {
       this._expectProgrammaticKeyUp = true;
       return;
     }
-    if (this._consumedDueWrongTarget(event))
+    if (this._consumedDueWrongTarget(event, this._activeModel))
       return;
     // Similarly to click, trigger checkbox on key event, not input.
     if (event.key === ' ') {
@@ -373,7 +373,7 @@ class RecordActionTool implements RecorderTool {
     const nodeName = target.nodeName;
     if (nodeName === 'SELECT' || nodeName === 'OPTION')
       return true;
-    if (nodeName === 'INPUT' && ['date'].includes((target as HTMLInputElement).type))
+    if (nodeName === 'INPUT' && ['date', 'range'].includes((target as HTMLInputElement).type))
       return true;
     return false;
   }
@@ -387,15 +387,8 @@ class RecordActionTool implements RecorderTool {
     return false;
   }
 
-  private _consumedDueToNoModel(event: Event, model: HighlightModel | null): boolean {
-    if (model)
-      return false;
-    consumeEvent(event);
-    return true;
-  }
-
-  private _consumedDueWrongTarget(event: Event): boolean {
-    if (this._activeModel && this._activeModel.elements[0] === this._recorder.deepEventTarget(event))
+  private _consumedDueWrongTarget(event: Event, model: HighlightModel | null): boolean {
+    if (model && model.elements[0] === this._recorder.deepEventTarget(event))
       return false;
     consumeEvent(event);
     return true;

--- a/tests/library/inspector/cli-codegen-1.spec.ts
+++ b/tests/library/inspector/cli-codegen-1.spec.ts
@@ -746,4 +746,32 @@ await page.GetByText("Click me").ClickAsync(new LocatorClickOptions
     Button = MouseButton.Middle,
 });`);
   });
+
+  test('should record slider', async ({ page, openRecorder }) => {
+    const recorder = await openRecorder();
+
+    await recorder.setContentAndWait(`<input type="range" min="0" max="10" value="5">`);
+
+    const dragSlider = async () => {
+      await page.locator('input').focus();
+      const { x, y, width, height } = await page.locator('input').boundingBox();
+      await page.mouse.move(x + width / 2, y + height / 2);
+      await page.mouse.down();
+      await page.mouse.move(x + width, y + height / 2);
+      await page.mouse.up();
+    };
+
+    const [sources] = await Promise.all([
+      recorder.waitForOutput('JavaScript', 'fill'),
+      dragSlider(),
+    ]);
+
+    await expect(page.locator('input')).toHaveValue('10');
+
+    expect(sources.get('JavaScript')!.text).toContain(`
+  await page.getByRole('slider').fill('10');`);
+
+    expect(sources.get('JavaScript')!.text).not.toContain(`
+  await page.getByRole('slider').click();`);
+  });
 });


### PR DESCRIPTION
Playwright doesn't record range inputs because it consumes browser events to prevent the native action execution, and instead triggers a playwright action to replicate that same event. However, things like slider drag and drop on a range input are not properly replicated. That causes the slider not to move at all, because playwright just sends a click action into the center of the slider, while preventing me from manually sliding to the desired value:

![chrome_ahWgoKXidX](https://github.com/microsoft/playwright/assets/1374559/e5c8b5ee-2477-4711-9479-245713ac9e00)

To try it, just run:

```bash
npx playwright codegen 'data:text/html,<input type="range" min="0" max="10" value="5">' 
```

My approach was to discard the playwright action, and instead let all events do their thing, without consuming them. This simplifies the recording logic and the recorded page behaves much better, because it is handling all eventss in the exact same way as if the user was not recording at all. And with this approach, recording a range input automatically works. I just added a few more logic to skip the click action recording there, but that's basically it.

Here's a video of it working with the new changes:

![chrome_i8oDvD74Un](https://github.com/microsoft/playwright/assets/1374559/edf501e8-2ac8-45ea-bc93-f1434677b9cb)

I ran all tests in `tests/library/inspector`, and they all pass with just a minor change in one of the tests (playwright action was triggering more events than the actual browser events).