### PR TITLE
Revert "fix: respect .only in --list mode"

### DIFF
--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -102,7 +102,7 @@ function addRunTasks(taskRunner: TaskRunner<TestRun>, config: FullConfigInternal
 
 export function createTaskRunnerForList(config: FullConfigInternal, reporter: ReporterV2, mode: 'in-process' | 'out-of-process', options: { failOnLoadErrors: boolean }): TaskRunner<TestRun> {
   const taskRunner = new TaskRunner<TestRun>(reporter, config.config.globalTimeout);
-  taskRunner.addTask('load tests', createLoadTask(mode, { ...options, filterOnly: true }));
+  taskRunner.addTask('load tests', createLoadTask(mode, { ...options, filterOnly: false }));
   taskRunner.addTask('report begin', createReportBeginTask());
   return taskRunner;
 }

--- a/tests/playwright-test/list-mode.spec.ts
+++ b/tests/playwright-test/list-mode.spec.ts
@@ -152,8 +152,7 @@ test('should report errors', async ({ runInlineTest }) => {
   expect(result.output).toContain('> 3 |       oh = 2;');
 });
 
-test('should respect .only', async ({ runInlineTest }) => {
-  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/28709' });
+test('should ignore .only', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
       const { test, expect } = require('@playwright/test');
@@ -168,8 +167,9 @@ test('should respect .only', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
   expect(result.output).toContain([
     `Listing tests:`,
+    `  a.test.js:3:7 › example1`,
     `  a.test.js:6:12 › example2`,
-    `Total: 1 test in 1 file`
+    `Total: 2 tests in 1 file`
   ].join('\n'));
 });
 


### PR DESCRIPTION
This reverts commit 9a5bfc54e5af2ee0ad7308fb5abcd57e0562e97c.

As it breaks extension.

Reference #28709