### PR TITLE
feat(core): allow more fine granulary control over har files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,8 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     plugins: ["@typescript-eslint", "notice"],
     parserOptions: {
+      // needed for intellij to map tsconfig correctly
+      tsconfigRootDir: __dirname,
       ecmaVersion: 9,
       sourceType: "module",
     },

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1225,9 +1225,13 @@ Defaults to abort.
 
 ### option: BrowserContext.routeFromHAR.update
 * since: v1.23
-- `update` ?<[HarUpdateType]<boolean|"ifNotExists">>
+- `update` ?<[HarUpdate]<"always"|"never"|"ifNotExists">>
+* If set to 'always' the har files will be updated at every run.
+* If set to 'never' the har files will not be updated.
+* If set to 'ifNotExists' the har files will be created if they not exist.
 
-If specified as `true`, updates the given HAR with the actual network information instead of serving from file. If we specify it to `ifNotExists` it only updates the har-file if it not exists. The file is written to disk when [`method: BrowserContext.close`] is called.
+The file is written to disk when [`method: BrowserContext.close`] is called.
+
 
 ### option: BrowserContext.routeFromHAR.url
 * since: v1.23
@@ -1249,7 +1253,6 @@ Optional setting to control resource content management. If `attach` is specifie
 
 ### option: BrowserContext.routeFromHAR.saveHarFilesOn
 * since: v1.42
-* langs: js
 - `saveHarFilesOn` <[function]\([BrowserContext]\):[Promise]<[boolean]>|[boolean]>
 
 Optional setting to control when to save the updated har files to disk. Defaults to `() => true`

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1247,6 +1247,13 @@ When set to `minimal`, only record information necessary for routing from HAR. T
 
 Optional setting to control resource content management. If `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file.
 
+### option: BrowserContext.routeFromHAR.saveHarFilesOn
+* since: v1.42
+* langs: js
+- `saveHarFilesOn` <[function]\([BrowserContext]\):[Promise]<[boolean]>|[boolean]>
+
+Optional setting to control when to save the updated har files to disk. Defaults to `() => true`
+
 ## method: BrowserContext.serviceWorkers
 * since: v1.11
 * langs: js, python

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1225,7 +1225,7 @@ Defaults to abort.
 
 ### option: BrowserContext.routeFromHAR.update
 * since: v1.23
-- `update` ?<boolean|"ifNotExists">
+- `update` ?<[HarUpdateType]<boolean|"ifNotExists">>
 
 If specified as `true`, updates the given HAR with the actual network information instead of serving from file. If we specify it to `ifNotExists` it only updates the har-file if it not exists. The file is written to disk when [`method: BrowserContext.close`] is called.
 

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1225,9 +1225,9 @@ Defaults to abort.
 
 ### option: BrowserContext.routeFromHAR.update
 * since: v1.23
-- `update` ?<boolean>
+- `update` ?<boolean|"ifNotExists">
 
-If specified, updates the given HAR with the actual network information instead of serving from file. The file is written to disk when [`method: BrowserContext.close`] is called.
+If specified as `true`, updates the given HAR with the actual network information instead of serving from file. If we specify it to `ifNotExists` it only updates the har-file if it not exists. The file is written to disk when [`method: BrowserContext.close`] is called.
 
 ### option: BrowserContext.routeFromHAR.url
 * since: v1.23

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3351,10 +3351,14 @@ Path to a [HAR](http://www.softwareishard.com/blog/har-12-spec) file with prerec
 
 Defaults to abort.
 
-### option: BrowserContext.routeFromHAR.update
+### option: Page.routeFromHAR.update
 * since: v1.23
-- `update` ?<[HarUpdateType]<boolean|"ifNotExists">>
-If specified as `true`, updates the given HAR with the actual network information instead of serving from file. If we specify it to `ifNotExists` it only updates the har-file if it not exists. The file is written to disk when [`method: BrowserContext.close`] is called.
+- `update` ?<[HarUpdate]<"always"|"never"|"ifNotExists">>
+* If set to 'always' the har files will be updated at every run.
+* If set to 'never' the har files will not be updated.
+* If set to 'ifNotExists' the har files will be created if they not exist.
+
+The file is written to disk when [`method: BrowserContext.close`] is called.
 
 ### option: Page.routeFromHAR.url
 * since: v1.23

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3375,6 +3375,13 @@ When set to `minimal`, only record information necessary for routing from HAR. T
 
 Optional setting to control resource content management. If `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file.
 
+### option: Page.routeFromHAR.saveHarFilesOn
+* since: v1.42
+* langs: js
+- `saveHarFilesOn` <[function]\([BrowserContext]\):[Promise]<[boolean]>|[boolean]>
+
+Optional setting to control when to save the updated har files to disk. Defaults to `() => true`
+
 ## async method: Page.screenshot
 * since: v1.8
 - returns: <[Buffer]>

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3353,9 +3353,9 @@ Defaults to abort.
 
 ### option: Page.routeFromHAR.update
 * since: v1.23
-- `update` ?<boolean>
+- `update` ?<boolean|"ifNotExists">
 
-If specified, updates the given HAR with the actual network information instead of serving from file. The file is written to disk when [`method: BrowserContext.close`] is called.
+If specified as `true`, updates the given HAR with the actual network information instead of serving from file. If we specify it to `ifNotExists` it only updates the har-file if it not exists. The file is written to disk when [`method: BrowserContext.close`] is called.
 
 ### option: Page.routeFromHAR.url
 * since: v1.23

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3351,10 +3351,9 @@ Path to a [HAR](http://www.softwareishard.com/blog/har-12-spec) file with prerec
 
 Defaults to abort.
 
-### option: Page.routeFromHAR.update
+### option: BrowserContext.routeFromHAR.update
 * since: v1.23
-- `update` ?<boolean|"ifNotExists">
-
+- `update` ?<[HarUpdateType]<boolean|"ifNotExists">>
 If specified as `true`, updates the given HAR with the actual network information instead of serving from file. If we specify it to `ifNotExists` it only updates the har-file if it not exists. The file is written to disk when [`method: BrowserContext.close`] is called.
 
 ### option: Page.routeFromHAR.url

--- a/docs/src/mock.md
+++ b/docs/src/mock.md
@@ -237,7 +237,7 @@ test('records or updates the HAR file', async ({ page }) => {
   // Get the response from the HAR file
   await page.routeFromHAR('./hars/fruit.har', {
     url: '*/**/api/v1/fruits',
-    update: true,
+    update: 'always',
   });
 
   // Go to the page
@@ -302,7 +302,7 @@ assertThat(page.getByText("Strawberry")).isVisible();
 
 ### Modifying a HAR file
 
-Once you have recorded a HAR file you can modify it by opening the hashed .txt file inside your 'hars' folder and editing the JSON. This file should be committed to your source control. Anytime you run this test with `update: true` it will update your HAR file with the request from the API.
+Once you have recorded a HAR file you can modify it by opening the hashed .txt file inside your 'hars' folder and editing the JSON. This file should be committed to your source control. Anytime you run this test with `update: 'always'` it will update your HAR file with the request from the API.
 
 ```json
 [
@@ -325,7 +325,7 @@ test('gets the json from HAR and checks the new fruit has been added', async ({ 
   // or abort the request if nothing matches.
   await page.routeFromHAR('./hars/fruit.har', {
     url: '*/**/api/v1/fruits',
-    update: false,
+    update: 'never',
   });
 
   // Go to the page

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -45,6 +45,8 @@ import { Dialog } from './dialog';
 import { WebError } from './webError';
 import { parseError, TargetClosedError } from './errors';
 
+type HarUpdateType = boolean | 'ifNotExists';
+
 export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel> implements api.BrowserContext {
   _pages = new Set<Page>();
   _routes: network.RouteHandler[] = [];
@@ -347,7 +349,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
   async _recordIntoHAR(har: string, page: Page | null, options: {
     url?: string | RegExp,
     notFound?: 'abort' | 'fallback',
-    update?: boolean | 'always' | 'ifNotExists',
+    update?: HarUpdateType,
     updateContent?: 'attach' | 'embed',
     updateMode?: 'minimal' | 'full',
     saveHarFilesOn?: (context: BrowserContext) => (boolean | Promise<boolean>)
@@ -372,11 +374,11 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     url?: string | RegExp,
     saveHarFilesOn?: (context: BrowserContext) => (boolean | Promise<boolean>),
     notFound?: 'abort' | 'fallback',
-    update?: boolean | 'ifNotExists',
+    update?: HarUpdateType,
     updateContent?: 'attach' | 'embed',
     updateMode?: 'minimal' | 'full'
   } = {}): Promise<void> {
-    if (this.shouldUpdate(har, options.update)) {
+    if (this._shouldUpdate(har, options.update)) {
       await this._recordIntoHAR(har, null, options);
       return;
     }
@@ -385,7 +387,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     await harRouter.addContextRoute(this);
   }
 
-  shouldUpdate(harPath: string, update?: boolean | 'ifNotExists'): boolean {
+  private _shouldUpdate(harPath: string, update?: HarUpdateType): boolean {
     if (update === 'ifNotExists')
       return !fs.existsSync(harPath);
 

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -15,35 +15,35 @@
  * limitations under the License.
  */
 
-import { BindingCall, Page } from './page';
-import { Frame } from './frame';
+import {BindingCall, Page} from './page';
+import {Frame} from './frame';
 import * as network from './network';
 import type * as channels from '@protocol/channels';
 import fs from 'fs';
 import path from 'path';
-import { ChannelOwner } from './channelOwner';
-import { evaluationScript } from './clientHelper';
-import { Browser } from './browser';
-import { Worker } from './worker';
-import { Events } from './events';
-import { TimeoutSettings } from '../common/timeoutSettings';
-import { Waiter } from './waiter';
-import type { BrowserContextOptions, Headers, LaunchOptions, StorageState, URLMatch, WaitForEventOptions } from './types';
-import { headersObjectToArray, isRegExp, isString, urlMatchesEqual } from '../utils';
-import { mkdirIfNeeded } from '../utils/fileUtils';
+import {ChannelOwner} from './channelOwner';
+import {evaluationScript} from './clientHelper';
+import {Browser} from './browser';
+import {Worker} from './worker';
+import {Events} from './events';
+import {TimeoutSettings} from '../common/timeoutSettings';
+import {Waiter} from './waiter';
+import type {BrowserContextOptions, Headers, LaunchOptions, StorageState, URLMatch, WaitForEventOptions} from './types';
+import {headersObjectToArray, isRegExp, isString, urlMatchesEqual} from '../utils';
+import {mkdirIfNeeded} from '../utils/fileUtils';
 import type * as api from '../../types/types';
 import type * as structs from '../../types/structs';
-import { CDPSession } from './cdpSession';
-import { Tracing } from './tracing';
-import type { BrowserType } from './browserType';
-import { Artifact } from './artifact';
-import { APIRequestContext } from './fetch';
-import { rewriteErrorMessage } from '../utils/stackTrace';
-import { HarRouter } from './harRouter';
-import { ConsoleMessage } from './consoleMessage';
-import { Dialog } from './dialog';
-import { WebError } from './webError';
-import { parseError, TargetClosedError } from './errors';
+import {CDPSession} from './cdpSession';
+import {Tracing} from './tracing';
+import type {BrowserType} from './browserType';
+import {Artifact} from './artifact';
+import {APIRequestContext} from './fetch';
+import {rewriteErrorMessage} from '../utils/stackTrace';
+import {HarRouter} from './harRouter';
+import {ConsoleMessage} from './consoleMessage';
+import {Dialog} from './dialog';
+import {WebError} from './webError';
+import {parseError, TargetClosedError} from './errors';
 
 export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel> implements api.BrowserContext {
   _pages = new Set<Page>();
@@ -87,16 +87,16 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     this.tracing = Tracing.from(initializer.tracing);
     this.request = APIRequestContext.from(initializer.requestContext);
 
-    this._channel.on('bindingCall', ({ binding }) => this._onBinding(BindingCall.from(binding)));
+    this._channel.on('bindingCall', ({binding}) => this._onBinding(BindingCall.from(binding)));
     this._channel.on('close', () => this._onClose());
-    this._channel.on('page', ({ page }) => this._onPage(Page.from(page)));
-    this._channel.on('route', ({ route }) => this._onRoute(network.Route.from(route)));
-    this._channel.on('backgroundPage', ({ page }) => {
+    this._channel.on('page', ({page}) => this._onPage(Page.from(page)));
+    this._channel.on('route', ({route}) => this._onRoute(network.Route.from(route)));
+    this._channel.on('backgroundPage', ({page}) => {
       const backgroundPage = Page.from(page);
       this._backgroundPages.add(backgroundPage);
       this.emit(Events.BrowserContext.BackgroundPage, backgroundPage);
     });
-    this._channel.on('serviceWorker', ({ worker }) => {
+    this._channel.on('serviceWorker', ({worker}) => {
       const serviceWorker = Worker.from(worker);
       serviceWorker._context = this;
       this._serviceWorkers.add(serviceWorker);
@@ -109,14 +109,14 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
       if (page)
         page.emit(Events.Page.Console, consoleMessage);
     });
-    this._channel.on('pageError', ({ error, page }) => {
+    this._channel.on('pageError', ({error, page}) => {
       const pageObject = Page.from(page);
       const parsedError = parseError(error);
       this.emit(Events.BrowserContext.WebError, new WebError(pageObject, parsedError));
       if (pageObject)
         pageObject.emit(Events.Page.PageError, parsedError);
     });
-    this._channel.on('dialog', ({ dialog }) => {
+    this._channel.on('dialog', ({dialog}) => {
       const dialogObject = Dialog.from(dialog);
       let hasListeners = this.emit(Events.BrowserContext.Dialog, dialogObject);
       const page = dialogObject.page();
@@ -137,20 +137,20 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
       }
     });
     this._channel.on('request', ({
-      request,
-      page
-    }) => this._onRequest(network.Request.from(request), Page.fromNullable(page)));
+                                   request,
+                                   page
+                                 }) => this._onRequest(network.Request.from(request), Page.fromNullable(page)));
     this._channel.on('requestFailed', ({
-      request,
-      failureText,
-      responseEndTiming,
-      page
-    }) => this._onRequestFailed(network.Request.from(request), responseEndTiming, failureText, Page.fromNullable(page)));
+                                         request,
+                                         failureText,
+                                         responseEndTiming,
+                                         page
+                                       }) => this._onRequestFailed(network.Request.from(request), responseEndTiming, failureText, Page.fromNullable(page)));
     this._channel.on('requestFinished', params => this._onRequestFinished(params));
     this._channel.on('response', ({
-      response,
-      page
-    }) => this._onResponse(network.Response.from(response), Page.fromNullable(page)));
+                                    response,
+                                    page
+                                  }) => this._onResponse(network.Response.from(response), Page.fromNullable(page)));
     this._closedPromise = new Promise(f => this.once(Events.BrowserContext.Close, f));
 
     this._setEventToSubscriptionMapping(new Map<string, channels.BrowserContextUpdateSubscriptionParams['event']>([
@@ -202,7 +202,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
   }
 
   private _onRequestFinished(params: channels.BrowserContextRequestFinishedEvent) {
-    const { responseEndTiming } = params;
+    const {responseEndTiming} = params;
     const request = network.Request.from(params.request);
     const response = network.Response.fromNullable(params.response);
     const page = Page.fromNullable(params.page);
@@ -253,7 +253,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
   setDefaultNavigationTimeout(timeout: number | undefined) {
     this._timeoutSettings.setDefaultNavigationTimeout(timeout);
     this._wrapApiCall(async () => {
-      this._channel.setDefaultNavigationTimeoutNoReply({ timeout }).catch(() => {
+      this._channel.setDefaultNavigationTimeoutNoReply({timeout}).catch(() => {
       });
     }, true);
   }
@@ -261,7 +261,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
   setDefaultTimeout(timeout: number | undefined) {
     this._timeoutSettings.setDefaultTimeout(timeout);
     this._wrapApiCall(async () => {
-      this._channel.setDefaultTimeoutNoReply({ timeout }).catch(() => {
+      this._channel.setDefaultTimeoutNoReply({timeout}).catch(() => {
       });
     }, true);
   }
@@ -285,11 +285,11 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
       urls = [];
     if (urls && typeof urls === 'string')
       urls = [urls];
-    return (await this._channel.cookies({ urls: urls as string[] })).cookies;
+    return (await this._channel.cookies({urls: urls as string[]})).cookies;
   }
 
   async addCookies(cookies: network.SetNetworkCookieParam[]): Promise<void> {
-    await this._channel.addCookies({ cookies });
+    await this._channel.addCookies({cookies});
   }
 
   async clearCookies(): Promise<void> {
@@ -297,7 +297,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
   }
 
   async grantPermissions(permissions: string[], options?: { origin?: string }): Promise<void> {
-    await this._channel.grantPermissions({ permissions, ...options });
+    await this._channel.grantPermissions({permissions, ...options});
   }
 
   async clearPermissions(): Promise<void> {
@@ -305,36 +305,36 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
   }
 
   async setGeolocation(geolocation: { longitude: number, latitude: number, accuracy?: number } | null): Promise<void> {
-    await this._channel.setGeolocation({ geolocation: geolocation || undefined });
+    await this._channel.setGeolocation({geolocation: geolocation || undefined});
   }
 
   async setExtraHTTPHeaders(headers: Headers): Promise<void> {
     network.validateHeaders(headers);
-    await this._channel.setExtraHTTPHeaders({ headers: headersObjectToArray(headers) });
+    await this._channel.setExtraHTTPHeaders({headers: headersObjectToArray(headers)});
   }
 
   async setOffline(offline: boolean): Promise<void> {
-    await this._channel.setOffline({ offline });
+    await this._channel.setOffline({offline});
   }
 
   async setHTTPCredentials(httpCredentials: { username: string, password: string } | null): Promise<void> {
-    await this._channel.setHTTPCredentials({ httpCredentials: httpCredentials || undefined });
+    await this._channel.setHTTPCredentials({httpCredentials: httpCredentials || undefined});
   }
 
   async addInitScript(script: Function | string | { path?: string, content?: string }, arg?: any): Promise<void> {
     const source = await evaluationScript(script, arg);
-    await this._channel.addInitScript({ source });
+    await this._channel.addInitScript({source});
   }
 
   async exposeBinding(name: string, callback: (source: structs.BindingSource, ...args: any[]) => any, options: {
     handle?: boolean
   } = {}): Promise<void> {
-    await this._channel.exposeBinding({ name, needsHandle: options.handle });
+    await this._channel.exposeBinding({name, needsHandle: options.handle});
     this._bindings.set(name, callback);
   }
 
   async exposeFunction(name: string, callback: Function): Promise<void> {
-    await this._channel.exposeBinding({ name });
+    await this._channel.exposeBinding({name});
     const binding = (source: structs.BindingSource, ...args: any[]) => callback(...args);
     this._bindings.set(name, binding);
   }
@@ -347,12 +347,12 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
   async _recordIntoHAR(har: string, page: Page | null, options: {
     url?: string | RegExp,
     notFound?: 'abort' | 'fallback',
-    update?: boolean,
+    update?: boolean | 'always' | 'ifNotExists',
     updateContent?: 'attach' | 'embed',
     updateMode?: 'minimal' | 'full',
     saveHarFilesOn?: (context: BrowserContext) => (boolean | Promise<boolean>)
   } = {}): Promise<void> {
-    const { harId } = await this._channel.harStart({
+    const {harId} = await this._channel.harStart({
       page: page?._channel,
       options: prepareRecordHarOptions({
         path: har,
@@ -372,17 +372,24 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     url?: string | RegExp,
     saveHarFilesOn?: (context: BrowserContext) => (boolean | Promise<boolean>),
     notFound?: 'abort' | 'fallback',
-    update?: boolean,
+    update?: boolean | 'ifNotExists',
     updateContent?: 'attach' | 'embed',
     updateMode?: 'minimal' | 'full'
   } = {}): Promise<void> {
-    if (options.update) {
+    if (this.shouldUpdate(har, options.update)) {
       await this._recordIntoHAR(har, null, options);
       return;
     }
-    const harRouter = await HarRouter.create(this._connection.localUtils(), har, options.notFound || 'abort', { urlMatch: options.url });
+    const harRouter = await HarRouter.create(this._connection.localUtils(), har, options.notFound || 'abort', {urlMatch: options.url});
     this._harRouters.push(harRouter);
     await harRouter.addContextRoute(this);
+  }
+
+  shouldUpdate(harPath: string, update?: boolean | 'ifNotExists'): boolean {
+    if (update === 'ifNotExists') {
+      return !fs.existsSync(harPath);
+    }
+    return !!update;
   }
 
   private _disposeHarRouters() {
@@ -418,7 +425,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
 
   private async _updateInterceptionPatterns() {
     const patterns = network.RouteHandler.prepareInterceptionPatterns(this._routes);
-    await this._channel.setNetworkInterceptionPatterns({ patterns });
+    await this._channel.setNetworkInterceptionPatterns({patterns});
   }
 
   _effectiveCloseReason(): string | undefined {
@@ -460,7 +467,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     // channelOwner.ts's validation messages don't handle the pseudo-union type, so we're explicit here
     if (!(page instanceof Page) && !(page instanceof Frame))
       throw new Error('page: expected Page or Frame');
-    const result = await this._channel.newCDPSession(page instanceof Page ? { page: page._channel } : { frame: page._channel });
+    const result = await this._channel.newCDPSession(page instanceof Page ? {page: page._channel} : {frame: page._channel});
     return CDPSession.from(result.session);
   }
 
@@ -485,12 +492,12 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
       await this._browserType?._willCloseContext(this);
       for (const [harId, harParams] of this._harRecorders) {
 
-        const { path, content } = harParams;
+        const {path, content} = harParams;
         const saveHarFiles = harParams.saveHarFilesOn ? await harParams.saveHarFilesOn(this) : () => true;
         if (!saveHarFiles)
           continue;
 
-        const har = await this._channel.harExport({ harId });
+        const har = await this._channel.harExport({harId});
         const artifact = Artifact.from(har.artifact);
         // Server side will compress artifact if content is attach or if file is .zip.
         const needCompressed = path.endsWith('.zip');

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -136,13 +136,11 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
         // on the client side due to a possible race condition between two async calls:
         // a) removing "dialog" listener subscription (client->server)
         // b) actual "dialog" event (server->client)
-        if (dialogObject.type() === 'beforeunload') {
-          dialog.accept({}).catch(() => {
-          });
-        } else {
-          dialog.dismiss().catch(() => {
-          });
-        }
+        if (dialogObject.type() === 'beforeunload')
+          dialog.accept({}).catch(() => {});
+        else
+          dialog.dismiss().catch(() => {});
+
       }
     });
     this._channel.on('request', ({

--- a/packages/playwright-core/src/client/harHelper.ts
+++ b/packages/playwright-core/src/client/harHelper.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from 'fs';
+import type { HarUpdateType } from 'playwright-core/lib/client/types';
+
+export const shouldUpdate = (harPath: string, update?: HarUpdateType): boolean => {
+  if (update === 'ifNotExists')
+    return !fs.existsSync(harPath);
+
+  return update === 'always';
+};

--- a/packages/playwright-core/src/client/harRouter.ts
+++ b/packages/playwright-core/src/client/harRouter.ts
@@ -25,7 +25,7 @@ type HarNotFoundAction = 'abort' | 'fallback';
 
 export class HarRouter {
   private _localUtils: LocalUtils;
-  private _harId: string;
+  harId: string;
   private _notFoundAction: HarNotFoundAction;
   private _options: { urlMatch?: URLMatch; baseURL?: string; };
 
@@ -38,7 +38,7 @@ export class HarRouter {
 
   private constructor(localUtils: LocalUtils, harId: string, notFoundAction: HarNotFoundAction, options: { urlMatch?: URLMatch }) {
     this._localUtils = localUtils;
-    this._harId = harId;
+    this.harId = harId;
     this._options = options;
     this._notFoundAction = notFoundAction;
   }
@@ -47,7 +47,7 @@ export class HarRouter {
     const request = route.request();
 
     const response = await this._localUtils._channel.harLookup({
-      harId: this._harId,
+      harId: this.harId,
       url: request.url(),
       method: request.method(),
       headers: (await request.headersArray()),
@@ -95,6 +95,6 @@ export class HarRouter {
   }
 
   dispose() {
-    this._localUtils._channel.harClose({ harId: this._harId }).catch(() => {});
+    this._localUtils._channel.harClose({ harId: this.harId }).catch(() => {});
   }
 }

--- a/packages/playwright-core/src/client/harRouter.ts
+++ b/packages/playwright-core/src/client/harRouter.ts
@@ -25,7 +25,7 @@ type HarNotFoundAction = 'abort' | 'fallback';
 
 export class HarRouter {
   private _localUtils: LocalUtils;
-  harId: string;
+  private _harId: string;
   private _notFoundAction: HarNotFoundAction;
   private _options: { urlMatch?: URLMatch; baseURL?: string; };
 
@@ -38,7 +38,7 @@ export class HarRouter {
 
   private constructor(localUtils: LocalUtils, harId: string, notFoundAction: HarNotFoundAction, options: { urlMatch?: URLMatch }) {
     this._localUtils = localUtils;
-    this.harId = harId;
+    this._harId = harId;
     this._options = options;
     this._notFoundAction = notFoundAction;
   }
@@ -47,7 +47,7 @@ export class HarRouter {
     const request = route.request();
 
     const response = await this._localUtils._channel.harLookup({
-      harId: this.harId,
+      harId: this._harId,
       url: request.url(),
       method: request.method(),
       headers: (await request.headersArray()),
@@ -95,6 +95,6 @@ export class HarRouter {
   }
 
   dispose() {
-    this._localUtils._channel.harClose({ harId: this.harId }).catch(() => {});
+    this._localUtils._channel.harClose({ harId: this._harId }).catch(() => {});
   }
 }

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -465,9 +465,9 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
 
 
   shouldUpdate(harPath: string, update?: boolean | 'ifNotExists'): boolean {
-    if (update === 'ifNotExists') {
+    if (update === 'ifNotExists')
       return !fs.existsSync(harPath);
-    }
+
     return !!update;
   }
 

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -463,8 +463,17 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     await this._updateInterceptionPatterns();
   }
 
+
+  shouldUpdate(harPath: string, update?: boolean | 'ifNotExists'): boolean {
+    if (update === 'ifNotExists') {
+      return !fs.existsSync(harPath);
+    }
+    return !!update;
+  }
+
+
   async routeFromHAR(har: string, options: { url?: string | RegExp, notFound?: 'abort' | 'fallback', update?: boolean, updateContent?: 'attach' | 'embed', updateMode?: 'minimal' | 'full'} = {}): Promise<void> {
-    if (options.update) {
+    if (this.shouldUpdate(har, options.update)) {
       await this._browserContext._recordIntoHAR(har, this, options);
       return;
     }

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -463,23 +463,21 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     await this._updateInterceptionPatterns();
   }
 
-
-  shouldUpdate(harPath: string, update?: boolean | 'ifNotExists'): boolean {
-    if (update === 'ifNotExists')
-      return !fs.existsSync(harPath);
-
-    return !!update;
-  }
-
-
   async routeFromHAR(har: string, options: { url?: string | RegExp, notFound?: 'abort' | 'fallback', update?: boolean, updateContent?: 'attach' | 'embed', updateMode?: 'minimal' | 'full'} = {}): Promise<void> {
-    if (this.shouldUpdate(har, options.update)) {
+    if (this._shouldUpdate(har, options.update)) {
       await this._browserContext._recordIntoHAR(har, this, options);
       return;
     }
     const harRouter = await HarRouter.create(this._connection.localUtils(), har, options.notFound || 'abort', { urlMatch: options.url });
     this._harRouters.push(harRouter);
     await harRouter.addPageRoute(this);
+  }
+
+  private _shouldUpdate(harPath: string, update?: boolean | 'ifNotExists'): boolean {
+    if (update === 'ifNotExists')
+      return !fs.existsSync(harPath);
+
+    return !!update;
   }
 
   private _disposeHarRouters() {

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -47,6 +47,8 @@ export type SetStorageState = {
 export type LifecycleEvent = channels.LifecycleEvent;
 export const kLifecycleEvents: Set<LifecycleEvent> = new Set(['load', 'domcontentloaded', 'networkidle', 'commit']);
 
+export type HarUpdateType = 'always' | 'never' | 'ifNotExists';
+
 export type BrowserContextOptions = Omit<channels.BrowserNewContextOptions, 'viewport' | 'noDefaultViewport' | 'extraHTTPHeaders' | 'storageState' | 'recordHar' | 'colorScheme' | 'reducedMotion' | 'forcedColors' | 'acceptDownloads'> & {
   viewport?: Size | null;
   extraHTTPHeaders?: Headers;

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -3643,14 +3643,6 @@ export interface Page {
     saveHarFilesOn?: ((browsercontext: BrowserContext) => Promise<boolean>|boolean);
 
     /**
-     * If specified, updates the given HAR with the actual network information instead of serving from file. The file is
-     * written to disk when
-     * [browserContext.close([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) is
-     * called.
-     */
-    update?: boolean|"ifNotExists";
-
-    /**
      * Optional setting to control resource content management. If `attach` is specified, resources are persisted as
      * separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file.
      */
@@ -8451,12 +8443,14 @@ export interface BrowserContext {
     saveHarFilesOn?: ((browsercontext: BrowserContext) => Promise<boolean>|boolean);
 
     /**
-     * If specified, updates the given HAR with the actual network information instead of serving from file. The file is
-     * written to disk when
+     * If specified as `true`, updates the given HAR with the actual network information instead of serving from file. If
+     * we specify it to `ifNotExists` it only updates the har-file if it not exists. The file is written to disk when
      * [browserContext.close([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) is
      * called.
      */
-    update?: boolean|"ifNotExists";
+    update?: HarUpdateType<boolean|"ifNotExists">;
+
+    update?: HarUpdateType<boolean|"ifNotExists">;
 
     /**
      * Optional setting to control resource content management. If `attach` is specified, resources are persisted as

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -3643,6 +3643,17 @@ export interface Page {
     saveHarFilesOn?: ((browsercontext: BrowserContext) => Promise<boolean>|boolean);
 
     /**
+     * - If set to 'always' the har files will be updated at every run.
+     * - If set to 'never' the har files will not be updated.
+     * - If set to 'ifNotExists' the har files will be created if they not exist.
+     *
+     * The file is written to disk when
+     * [browserContext.close([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) is
+     * called.
+     */
+    update?: "always"|"never"|"ifNotExists";
+
+    /**
      * Optional setting to control resource content management. If `attach` is specified, resources are persisted as
      * separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file.
      */
@@ -8443,14 +8454,15 @@ export interface BrowserContext {
     saveHarFilesOn?: ((browsercontext: BrowserContext) => Promise<boolean>|boolean);
 
     /**
-     * If specified as `true`, updates the given HAR with the actual network information instead of serving from file. If
-     * we specify it to `ifNotExists` it only updates the har-file if it not exists. The file is written to disk when
+     * - If set to 'always' the har files will be updated at every run.
+     * - If set to 'never' the har files will not be updated.
+     * - If set to 'ifNotExists' the har files will be created if they not exist.
+     *
+     * The file is written to disk when
      * [browserContext.close([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) is
      * called.
      */
-    update?: HarUpdateType<boolean|"ifNotExists">;
-
-    update?: HarUpdateType<boolean|"ifNotExists">;
+    update?: "always"|"never"|"ifNotExists";
 
     /**
      * Optional setting to control resource content management. If `attach` is specified, resources are persisted as

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -3638,6 +3638,11 @@ export interface Page {
     notFound?: "abort"|"fallback";
 
     /**
+     * Optional setting to control when to save the updated har files to disk. Defaults to `() => true`
+     */
+    saveHarFilesOn?: ((browsercontext: BrowserContext) => Promise<boolean>|boolean);
+
+    /**
      * If specified, updates the given HAR with the actual network information instead of serving from file. The file is
      * written to disk when
      * [browserContext.close([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) is
@@ -8439,6 +8444,11 @@ export interface BrowserContext {
      * Defaults to abort.
      */
     notFound?: "abort"|"fallback";
+
+    /**
+     * Optional setting to control when to save the updated har files to disk. Defaults to `() => true`
+     */
+    saveHarFilesOn?: ((browsercontext: BrowserContext) => Promise<boolean>|boolean);
 
     /**
      * If specified, updates the given HAR with the actual network information instead of serving from file. The file is

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -3648,7 +3648,7 @@ export interface Page {
      * [browserContext.close([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) is
      * called.
      */
-    update?: boolean;
+    update?: boolean|"ifNotExists";
 
     /**
      * Optional setting to control resource content management. If `attach` is specified, resources are persisted as
@@ -8456,7 +8456,7 @@ export interface BrowserContext {
      * [browserContext.close([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) is
      * called.
      */
-    update?: boolean;
+    update?: boolean|"ifNotExists";
 
     /**
      * Optional setting to control resource content management. If `attach` is specified, resources are persisted as

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -388,6 +388,16 @@ it('should update har.zip for page with different options', async ({ contextFact
   await expect(page2.locator('body')).toHaveCSS('background-color', 'rgb(255, 192, 203)');
 });
 
+it('should not update har.zip for page with different options', async ({ contextFactory, server, asset }, testInfo) => {
+  const harPath = asset('har-fulfill.har');
+  const context1 = await contextFactory();
+  const page1 = await context1.newPage();
+  await page1.routeFromHAR(harPath, { update: 'ifNotExists', updateContent: 'embed', updateMode: 'full' });
+  const error = await page1.goto(server.PREFIX + '/one-style.html').catch(e => e);
+  await context1.close();
+  expect(error instanceof Error).toBe(true);
+});
+
 it('should update har.zip on passed test', async ({ contextFactory, server }, testInfo) => {
   const harPath = testInfo.outputPath('har.zip');
   const context1 = await contextFactory();

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -388,6 +388,66 @@ it('should update har.zip for page with different options', async ({ contextFact
   await expect(page2.locator('body')).toHaveCSS('background-color', 'rgb(255, 192, 203)');
 });
 
+it('should update har.zip on passed test', async ({ contextFactory, server }, testInfo) => {
+  const harPath = testInfo.outputPath('har.zip');
+  const context1 = await contextFactory();
+  const page1 = await context1.newPage();
+  await page1.routeFromHAR(harPath, {
+    update: true,
+    updateContent: 'embed',
+    updateMode: 'full',
+    saveHarFilesOn: _ => testInfo.status === 'passed'
+  });
+  await page1.goto(server.PREFIX + '/one-style.html');
+  await context1.close();
+  expect(fs.existsSync(harPath)).toBeTruthy();
+});
+
+it('should not update har.zip on passed test', async ({ contextFactory, server }, testInfo) => {
+  const harPath = testInfo.outputPath('har.zip');
+  const context1 = await contextFactory();
+  const page1 = await context1.newPage();
+  await page1.routeFromHAR(harPath, {
+    update: true,
+    updateContent: 'embed',
+    updateMode: 'full',
+    saveHarFilesOn: _ => testInfo.status !== 'passed'
+  });
+  await page1.goto(server.PREFIX + '/one-style.html');
+  await context1.close();
+  expect(fs.existsSync(harPath)).toBeFalsy();
+});
+
+it('should not update har.zip on true resolved promise', async ({ contextFactory, server }, testInfo) => {
+  const harPath = testInfo.outputPath('har.zip');
+  const context1 = await contextFactory();
+  const page1 = await context1.newPage();
+  await page1.routeFromHAR(harPath, {
+    update: true,
+    updateContent: 'embed',
+    updateMode: 'full',
+    saveHarFilesOn: _ => Promise.resolve(true)
+  });
+  await page1.goto(server.PREFIX + '/one-style.html');
+  await context1.close();
+  expect(fs.existsSync(harPath)).toBeTruthy();
+});
+
+it('should not update har.zip on false resolved promise', async ({ contextFactory, server }, testInfo) => {
+  const harPath = testInfo.outputPath('har.zip');
+  const context1 = await contextFactory();
+  const page1 = await context1.newPage();
+  await page1.routeFromHAR(harPath, {
+    update: true,
+    updateContent: 'embed',
+    updateMode: 'full',
+    saveHarFilesOn: _ => Promise.resolve(false)
+  });
+  await page1.goto(server.PREFIX + '/one-style.html');
+  await context1.close();
+  expect(fs.existsSync(harPath)).toBeFalsy();
+});
+
 it('should update extracted har.zip for page', async ({ contextFactory, server }, testInfo) => {
   const harPath = testInfo.outputPath('har.har');
   const context1 = await contextFactory();

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -398,6 +398,23 @@ it('should not update har.zip for page with different options', async ({ context
   expect(error instanceof Error).toBe(true);
 });
 
+it('should update har.zip for ifNotExists page with different options', async ({ contextFactory, server, asset }, testInfo) => {
+  const harPath = testInfo.outputPath('har.zip');
+  expect(fs.existsSync(harPath)).toBeFalsy();
+  const context1 = await contextFactory();
+  const page1 = await context1.newPage();
+  await page1.routeFromHAR(harPath, { update: 'ifNotExists', updateContent: 'embed', updateMode: 'full' });
+  await page1.goto(server.PREFIX + '/one-style.html');
+  await context1.close();
+  expect(fs.existsSync(harPath)).toBeTruthy();
+  const context2 = await contextFactory();
+  const page2 = await context2.newPage();
+  await page2.routeFromHAR(harPath, { notFound: 'abort' });
+  await page2.goto(server.PREFIX + '/one-style.html');
+  expect(await page2.content()).toContain('hello, world!');
+  await expect(page2.locator('body')).toHaveCSS('background-color', 'rgb(255, 192, 203)');
+});
+
 it('should update har.zip on passed test', async ({ contextFactory, server }, testInfo) => {
   const harPath = testInfo.outputPath('har.zip');
   const context1 = await contextFactory();

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -342,7 +342,7 @@ it('should disambiguate by header', async ({ contextFactory, server }, testInfo)
 it('should update har.zip for context', async ({ contextFactory, server }, testInfo) => {
   const harPath = testInfo.outputPath('har.zip');
   const context1 = await contextFactory();
-  await context1.routeFromHAR(harPath, { update: true });
+  await context1.routeFromHAR(harPath, { update: 'always' });
   const page1 = await context1.newPage();
   await page1.goto(server.PREFIX + '/one-style.html');
   await context1.close();
@@ -359,7 +359,7 @@ it('should update har.zip for page', async ({ contextFactory, server }, testInfo
   const harPath = testInfo.outputPath('har.zip');
   const context1 = await contextFactory();
   const page1 = await context1.newPage();
-  await page1.routeFromHAR(harPath, { update: true });
+  await page1.routeFromHAR(harPath, { update: 'always' });
   await page1.goto(server.PREFIX + '/one-style.html');
   await context1.close();
 
@@ -376,7 +376,7 @@ it('should update har.zip for page with different options', async ({ contextFact
   const harPath = testInfo.outputPath('har.zip');
   const context1 = await contextFactory();
   const page1 = await context1.newPage();
-  await page1.routeFromHAR(harPath, { update: true, updateContent: 'embed', updateMode: 'full' });
+  await page1.routeFromHAR(harPath, { update: 'always', updateContent: 'embed', updateMode: 'full' });
   await page1.goto(server.PREFIX + '/one-style.html');
   await context1.close();
 
@@ -403,7 +403,7 @@ it('should update har.zip on passed test', async ({ contextFactory, server }, te
   const context1 = await contextFactory();
   const page1 = await context1.newPage();
   await page1.routeFromHAR(harPath, {
-    update: true,
+    update: 'always',
     updateContent: 'embed',
     updateMode: 'full',
     saveHarFilesOn: _ => testInfo.status === 'passed'
@@ -418,7 +418,7 @@ it('should not update har.zip on passed test', async ({ contextFactory, server }
   const context1 = await contextFactory();
   const page1 = await context1.newPage();
   await page1.routeFromHAR(harPath, {
-    update: true,
+    update: 'always',
     updateContent: 'embed',
     updateMode: 'full',
     saveHarFilesOn: _ => testInfo.status !== 'passed'
@@ -433,7 +433,7 @@ it('should not update har.zip on true resolved promise', async ({ contextFactory
   const context1 = await contextFactory();
   const page1 = await context1.newPage();
   await page1.routeFromHAR(harPath, {
-    update: true,
+    update: 'always',
     updateContent: 'embed',
     updateMode: 'full',
     saveHarFilesOn: _ => Promise.resolve(true)
@@ -448,7 +448,7 @@ it('should not update har.zip on false resolved promise', async ({ contextFactor
   const context1 = await contextFactory();
   const page1 = await context1.newPage();
   await page1.routeFromHAR(harPath, {
-    update: true,
+    update: 'always',
     updateContent: 'embed',
     updateMode: 'full',
     saveHarFilesOn: _ => Promise.resolve(false)
@@ -462,7 +462,7 @@ it('should update extracted har.zip for page', async ({ contextFactory, server }
   const harPath = testInfo.outputPath('har.har');
   const context1 = await contextFactory();
   const page1 = await context1.newPage();
-  await page1.routeFromHAR(harPath, { update: true });
+  await page1.routeFromHAR(harPath, { update: 'always' });
   await page1.goto(server.PREFIX + '/one-style.html');
   await context1.close();
 


### PR DESCRIPTION
This PR solves two not so nice things about the har recorder. 

This partially solves the issue: https://github.com/microsoft/playwright/issues/22791


## Manual handling of updating HAR-files
We currently always have to change the `update` property when using `routeFromHar` manually, to enable and disable the update of our har-files.
This often gets overlooked and we recreate the har-files sometimes even when we don't want to or forget to update them. 
Currently we have to check if the files exist ourselfes.
With `ifNotExists` we allow the users to only update the har-files if they not exist.
```typescript
await page1.routeFromHAR(harPath, { update: 'ifNotExists', updateContent: 'embed', updateMode: 'full' });
```

## Handle saving of har-files 
Currently all har-files get recorded regardless if a testcase failes or not. 
By having an additional `saveHarFileOn` function we can check if we want to save the files. 
One example would be to check for the testCase result:

```typescript
await page1.routeFromHAR(harPath, {
    update: true,
    updateContent: 'embed',
    updateMode: 'full',
    saveHarFilesOn: _ => testInfo.status === 'passed'
  });
```

## Both new features combined

By combining these two features, we can now easily record new har files but only if the testcase was successful.
The users do no longer need to do this themselfes.

```typescript
await page1.routeFromHAR(harPath, {
    update: 'ifNotExists',
    updateContent: 'embed',
    updateMode: 'full',
    saveHarFilesOn: _ => testInfo.status === 'passed'
  });
``` 

## Breaking?
The `update` property has to be changed from `true` to `always` and `false` to `never`
