### PR TITLE
docs: configuration of junit reporter in ci.md

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -227,7 +227,7 @@ Note: The JUnit reporter needs to be configured accordingly via
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  reporter: ['junit', { outputFile: 'test-results/e2e-junit-results.xml' }],
+  reporter: [['junit', { outputFile: 'test-results/e2e-junit-results.xml' }]],
 });
 ```
 in `playwright.config.ts`.


### PR DESCRIPTION
The example configuration of the `junit` reporter in the azure pipeline section in `ci.md` is missing square brackets.