### PR TITLE
docs: remove the create method from extensibility

### DIFF
--- a/docs/src/extensibility.md
+++ b/docs/src/extensibility.md
@@ -7,8 +7,6 @@ title: "Extensibility"
 Playwright supports custom selector engines, registered with [`method: Selectors.register`].
 
 Selector engine should have the following properties:
-- `create` function to create a relative selector from `root` (root is either a `Document`, `ShadowRoot` or `Element`)
-  to a `target` element.
 - `query` function to query first element matching `selector` relative to the `root`.
 - `queryAll` function to query all elements matching `selector` relative to the `root`.
 


### PR DESCRIPTION
I saw the `create` method in the [Extensibility](https://playwright.dev/docs/extensibility) section of the document but didn't quite understand its actual purpose. Therefore, I attempted to add this method in the test examples, but it seems that regardless of what this method returns or if it throws an error, it has no effect. Upon further examination of the [selectors.ts](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/client/selectors.ts) and [types.ts](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/client/types.ts#L129) files, I noticed that this method is not defined. Consequently, I opened this pull request to remove the description of this method to prevent any potential misunderstandings by others.

If there are any misunderstandings, feel free to close this pull request. Thank you.

