### PR TITLE
fix: change default color-scheme to no-preference

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -445,7 +445,7 @@ export class Page extends SdkObject {
     const contextOptions = this._browserContext._options;
     return {
       media: this._emulatedMedia.media || 'no-override',
-      colorScheme: this._emulatedMedia.colorScheme !== undefined ? this._emulatedMedia.colorScheme : contextOptions.colorScheme ?? 'light',
+      colorScheme: this._emulatedMedia.colorScheme !== undefined ? this._emulatedMedia.colorScheme : contextOptions.colorScheme ?? 'no-preference',
       reducedMotion: this._emulatedMedia.reducedMotion !== undefined ? this._emulatedMedia.reducedMotion : contextOptions.reducedMotion ?? 'no-preference',
       forcedColors: this._emulatedMedia.forcedColors !== undefined ? this._emulatedMedia.forcedColors : contextOptions.forcedColors ?? 'none',
     };


### PR DESCRIPTION
When connecting to an existing endpoint, Playwright will enforce the page to use a `light` color scheme.

https://github.com/microsoft/playwright/blob/76ace0fc09d92fedf2137cebd9a8a1427daa9911/packages/playwright-core/src/server/chromium/crPage.ts#L1080-L1093

because the default colorScheme is `light` rather than `no-preference`:
https://github.com/microsoft/playwright/blob/76ace0fc09d92fedf2137cebd9a8a1427daa9911/packages/playwright-core/src/server/page.ts#L444-L452

test code:
```ts
chromium.connectOverCDP('http://127.0.0.1:62374/'); // an existing dark page
```