### PR TITLE
fix(ct): vue update slots

### DIFF
--- a/packages/playwright-ct-vue/registerSource.mjs
+++ b/packages/playwright-ct-vue/registerSource.mjs
@@ -288,6 +288,9 @@ window.playwrightUpdate = async (rootElement, component) => {
   wrapper.component.slots = __pwWrapFunctions(slots);
   __pwAllListeners.set(wrapper, listeners);
 
+  if (typeof slots !== 'undefined')
+    wrapper.component.effect.run();
+
   for (const [key, value] of Object.entries(props))
     wrapper.component.props[key] = value;
 

--- a/tests/components/ct-vue-vite/package.json
+++ b/tests/components/ct-vue-vite/package.json
@@ -8,7 +8,7 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
-    "vue": "^3.2.31",
+    "vue": "^3.4.0",
     "vue-router": "^4.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Due to [Vue 3.4](https://blog.vuejs.org/posts/vue-3-4):  _"refactored reactivity system that makes effect triggering more accurate and efficient"_

closes: https://github.com/microsoft/playwright/issues/28830

/CC @mxschmitt