### PR TITLE
Add Bun support

### DIFF
--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
+      "bun": "./index.js",
       "import": "./index.mjs",
       "require": "./index.js",
       "default": "./index.js"
@@ -27,6 +28,7 @@
     "./lib/internalsForTest": "./lib/internalsForTest.js",
     "./lib/plugins": "./lib/plugins/index.js",
     "./jsx-runtime": {
+      "bun": "./jsx-runtime.js",
       "import": "./jsx-runtime.mjs",
       "require": "./jsx-runtime.js",
       "default": "./jsx-runtime.js"
@@ -41,6 +43,7 @@
     },
     "./test": {
       "types": "./test.d.ts",
+      "bun": "./test.js",
       "import": "./test.mjs",
       "require": "./test.js",
       "default": "./test.js"


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/27139

This adds a `package.json` `"exports"` condition for Bun which always chooses the CommonJS version of the module (for both ESM & CJS).

The built version of playwright uses `__esModule` to tell bundlers the code was ESM transplied into CommonJS. Bun supports this both at runtime and when using the bundler, but Node.js does not support this at runtime and that causes a compatibility issue when importing `@playwright/test`. It's unfortunately a compatibility issue whether or not we support `__esModule`, because choosing to not support it breaks libraries which otherwise only work when using a bundler.

Since Bun automatically converts CommonJS <> ESM and `module.exports` with dynamic properties are supported, we can choose to always use the CommonJS entry point for Playwright in Bun.

There were other changes necessary to get Playwright to work, which are mostly in https://github.com/oven-sh/bun/pull/7958. After this PR, the remaining blocker for using Playwright in Bun is a stability issue when multiple workers are in use, which we are working on fixing.

![image](https://github.com/microsoft/playwright/assets/709451/1d33f3b5-9014-4447-b1a6-39e697d660d4)

