### PR TITLE
fix(chromium): get response status from extra info

### DIFF
--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -489,6 +489,11 @@ export class Response extends SdkObject {
       this._rawResponseHeadersPromise.resolve(headers || this._headers);
   }
 
+  setRawStatus(status: number, statusText: string) {
+    this._status = status;
+    this._statusText = statusText;
+  }
+
   setTransferSize(size: number | null) {
     this._transferSizePromise.resolve(size);
   }

--- a/tests/page/page-network-request.spec.ts
+++ b/tests/page/page-network-request.spec.ts
@@ -451,16 +451,13 @@ it('should not allow to access frame on popup main request', async ({ page, serv
 
 it('page.reload return 304 status code', async ({ page, server, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/28779' });
-  it.fixme(browserName === 'chromium', 'Returns 200 instead of 304');
   it.fixme(browserName === 'firefox', 'Does not send second request');
   let requestNumber = 0;
   server.setRoute('/test.html', (req, res) => {
     ++requestNumber;
     const headers = {
-      'cf-cache-status': 'DYNAMIC',
       'Content-Type': 'text/html;charset=UTF-8',
       'Last-Modified': 'Fri, 05 Jan 2024 01:56:20 GMT',
-      'Vary': 'Access-Control-Request-Headers',
     };
     if (requestNumber === 1)
       res.writeHead(200, headers);


### PR DESCRIPTION
response/requestfinished/requestfailed events are deferred until `Network.responseReceivedExtraInfo` CDP event is received (if the response has `hasExtraInfo=true`).

In case of a redirect chain, it's safe to dispatch all pending events for a response once both of its Network.responseReceived and Network.responseReceivedExtraInfo events received, since by that time all previous (redirected) response events should have been received already. Otherwise it would mean that we received both Network.responseReceived and Network.responseReceivedExtraInfo for an earlier event before the current one.

Fixes https://github.com/microsoft/playwright/issues/28779