### PR TITLE
test: unflake 'android.launchServer' WS leak test

### DIFF
--- a/tests/android/launch-server.spec.ts
+++ b/tests/android/launch-server.spec.ts
@@ -118,9 +118,11 @@ test('android.launchServer should terminate WS connection when device gets disco
   const forwardingServer = new ws.Server({ port: 0, path: '/connect' });
   let receivedConnection: ws.WebSocket | undefined;
   forwardingServer.on('connection', connection => {
+    // Pause the connection until we establish the actual connection to the browser server.
     connection.pause();
     receivedConnection = connection;
     const actualConnection = new ws.WebSocket(browserServer.wsEndpoint());
+    // We need to wait for the actual connection to be established before resuming
     actualConnection.on('open', () => connection.resume());
     actualConnection.on('message', message => connection.send(message));
     connection.on('message', message => actualConnection.send(message));

--- a/tests/android/launch-server.spec.ts
+++ b/tests/android/launch-server.spec.ts
@@ -118,14 +118,14 @@ test('android.launchServer should terminate WS connection when device gets disco
   const forwardingServer = new ws.Server({ port: 0, path: '/connect' });
   let receivedConnection: ws.WebSocket | undefined;
   forwardingServer.on('connection', connection => {
+    connection.pause();
     receivedConnection = connection;
     const actualConnection = new ws.WebSocket(browserServer.wsEndpoint());
-    actualConnection.on('open', () => {
-      actualConnection.on('message', message => connection.send(message));
-      connection.on('message', message => actualConnection.send(message));
-      connection.on('close', () => actualConnection.close());
-      actualConnection.on('close', () => connection.close());
-    });
+    actualConnection.on('open', () => connection.resume());
+    actualConnection.on('message', message => connection.send(message));
+    connection.on('message', message => actualConnection.send(message));
+    connection.on('close', () => actualConnection.close());
+    actualConnection.on('close', () => connection.close());
   });
   try {
     const device = await playwright._android.connect(`ws://localhost:${(forwardingServer.address() as ws.AddressInfo).port}/connect`);


### PR DESCRIPTION
This test was flaky all the time. The problem was that we were sending messages on a WS connection which wasn't ready yet, so we lost some.