### PR TITLE
chore(firefox): rewrite error message for $HOME directory ownership mismatch

### DIFF
--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -40,6 +40,9 @@ export class Firefox extends BrowserType {
   _doRewriteStartupLog(error: ProtocolError): ProtocolError {
     if (!error.logs)
       return error;
+    // https://github.com/microsoft/playwright/issues/6500
+    if (error.logs.includes(`as root in a regular user's session is not supported.`))
+      error.logs = '\n' + wrapInASCIIBox(`Firefox is unable to launch if the $HOME folder isn't owned by the current user.\nWorkaround: Set the HOME=/root environment variable${process.env.GITHUB_ACTION ? ' in your GitHub Actions workflow file' : ''} when running Playwright.`, 1);
     if (error.logs.includes('no DISPLAY environment variable specified'))
       error.logs = '\n' + wrapInASCIIBox(kNoXServerRunningError, 1);
     return error;


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/28896

Looks like this: 
<img width="1447" alt="image" src="https://github.com/microsoft/playwright/assets/17984549/d9ddac2a-3d14-4e65-ab99-5721bcccade6">
