### PR TITLE
docs: note that opacity:0 still counts as visible element

### DIFF
--- a/docs/src/actionability.md
+++ b/docs/src/actionability.md
@@ -82,7 +82,12 @@ Element is considered attached when it is [connected](https://developer.mozilla.
 
 ## Visible
 
-Element is considered visible when it has non-empty bounding box and does not have `visibility:hidden` computed style. Note that elements of zero size or with `display:none` are not considered visible.
+Element is considered visible when it has non-empty bounding box and does not have `visibility:hidden` computed style.
+
+Note that according to this definition:
+* Elements of zero size **are not** considered visible.
+* Elements with `display:none` **are not** considered visible.
+* Elements with `opacity:0` **are** considered visible.
 
 ## Stable
 


### PR DESCRIPTION
Closes #28954.