### PR TITLE
fix(driver): add external commands only for JS binding

### DIFF
--- a/packages/playwright-core/src/cli/cli.ts
+++ b/packages/playwright-core/src/cli/cli.ts
@@ -53,13 +53,18 @@ const kExternalPlaywrightTestCommands = [
   ['show-report', 'Show Playwright Test HTML report.'],
   ['merge-reports', 'Merge Playwright Test Blob reports'],
 ];
-for (const [command, description] of kExternalPlaywrightTestCommands) {
-  const playwrightTest = program.command(command).allowUnknownOption(true);
-  playwrightTest.description(`${description} Available in @playwright/test package.`);
-  playwrightTest.action(async () => {
-    printPlaywrightTestError(command);
-    gracefullyProcessExitDoNotHang(1);
-  });
+function addExternalPlaywrightTestCommands() {
+  for (const [command, description] of kExternalPlaywrightTestCommands) {
+    const playwrightTest = program.command(command).allowUnknownOption(true);
+    playwrightTest.description(`${description} Available in @playwright/test package.`);
+    playwrightTest.action(async () => {
+      printPlaywrightTestError(command);
+      gracefullyProcessExitDoNotHang(1);
+    });
+  }
 }
+
+if (!process.env.PW_LANG_NAME)
+  addExternalPlaywrightTestCommands();
 
 program.parse(process.argv);


### PR DESCRIPTION
Motivation: Before this change if a language binding invoked the CLI with `--help` or without any arguments (which will also show the help text) it was suggesting that test/merge-reports/show-report is something we support. After this change this does not get shown anymore.