### PR TITLE
Clarify how vscode plugin feature "Record at Cursor" works.

### DIFF
--- a/docs/src/codegen.md
+++ b/docs/src/codegen.md
@@ -44,7 +44,7 @@ Once you are done recording click the **cancel** button or close the browser win
 
 To record from a specific point in your test move your cursor to where you want to record more actions and then click the **Record at cursor** button from the Testing sidebar.
 
-**Important:** This feature does not start the test and execute the lines before the cursor. It only attaches to an existing VSCode web view and gets it into recording mode. You have to get VSCode web view into a correct state manually. The easiest way to do this is by adding a breakpoint where you want to continue recording, starting the test in debugging mode and exiting the debugger after it stops at your breakpoint. You have to have 'Show browser' checked in the sidebar in order for VSCode web view to remain open after exiting the debugger.
+**Important:** This feature does not start the test and execute the lines before the cursor. It only attaches to an existing VSCode-launched browser instance and gets it into recording mode. You have to get the browser into a correct state manually before starting to record. The easiest way to do this is by adding a breakpoint where you want to continue recording, starting the test in debugging mode and stopping the debugger after it pauses at you breakpoint. After stopping debugger you can start recording the test at cursor. You have to have 'Show browser' checked in the sidebar in order for VSCode-launched browser to remain open after exiting the debugger.
 
 ![record at cursor in vs code](https://github.com/microsoft/playwright/assets/13063165/77948ab8-92a2-435f-9833-0944da5ae664)
 

--- a/docs/src/codegen.md
+++ b/docs/src/codegen.md
@@ -42,8 +42,9 @@ Once you are done recording click the **cancel** button or close the browser win
 
 ### Record at Cursor
 
-To record from a specific point in your test move your cursor to where you want to record more actions and then click the **Record at cursor** button from the Testing sidebar. If your browser window is not already open then first run the test with 'Show browser' checked and then click the **Record at cursor** button.
+To record from a specific point in your test move your cursor to where you want to record more actions and then click the **Record at cursor** button from the Testing sidebar.
 
+**Important:** This feature does not start the test and execute the lines before the cursor. It only attaches to an existing VSCode web view and gets it into recording mode. You have to get VSCode web view into a correct state manually. The easiest way to do this is by adding a breakpoint where you want to continue recording, starting the test in debugging mode and exiting the debugger after it stops at your breakpoint. You have to have 'Show browser' checked in the sidebar in order for VSCode web view to remain open after exiting the debugger.
 
 ![record at cursor in vs code](https://github.com/microsoft/playwright/assets/13063165/77948ab8-92a2-435f-9833-0944da5ae664)
 


### PR DESCRIPTION
After clicking "Record at Cursor" I expected that recording window would start, execute the test until the cursor and allow me to continue recording with my application being at the same state as if I was debugging the test and had a breakpoint on that line. I've clarified in the docs that it doesn't work like that and added instructions on how to achieve this using an alternative approach.