### PR TITLE
fix(launcher): unregister global process handlers when all browser are closed

### DIFF
--- a/tests/config/remote-server-impl.js
+++ b/tests/config/remote-server-impl.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const cluster = require('cluster');
 
 async function start() {
-  const { browserTypeName, launchOptions, stallOnClose, disconnectOnSIGHUP, exitOnFile, exitOnWarning } = JSON.parse(process.argv[2]);
+  const { browserTypeName, launchOptions, stallOnClose, disconnectOnSIGHUP, exitOnFile, exitOnWarning, startStopAndRunHttp } = JSON.parse(process.argv[2]);
   if (stallOnClose) {
     launchOptions.__testHookGracefullyClose = () => {
       console.log(`(stalled=>true)`);
@@ -11,11 +11,20 @@ async function start() {
   }
   if (exitOnWarning)
     process.on('warning', () => process.exit(43));
+  if (disconnectOnSIGHUP)
+    launchOptions.handleSIGHUP = false;
 
   const playwright = require('playwright-core');
 
-  if (disconnectOnSIGHUP)
-    launchOptions.handleSIGHUP = false;
+  if (startStopAndRunHttp) {
+    const browser = await playwright[browserTypeName].launch(launchOptions);
+    await browser.close();
+    console.log(`(wsEndpoint=>none)`);
+    console.log(`(closed=>success)`);
+    require('http').createServer(() => {}).listen();
+    return;
+  }
+
   const browserServer = await playwright[browserTypeName].launchServer(launchOptions);
   if (disconnectOnSIGHUP)
     process.on('SIGHUP', () => browserServer._disconnectForTest());

--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -68,6 +68,7 @@ export type RemoteServerOptions = {
   exitOnWarning?: boolean;
   inCluster?: boolean;
   url?: string;
+  startStopAndRunHttp?: boolean;
 };
 
 export class RemoteServer implements PlaywrightServer {
@@ -148,6 +149,10 @@ export class RemoteServer implements PlaywrightServer {
 
   async childExitCode() {
     return await this._process.exitCode;
+  }
+
+  async childSignal() {
+    return (await this._process.exited).signal;
   }
 
   async close() {

--- a/tests/library/signals.spec.ts
+++ b/tests/library/signals.spec.ts
@@ -133,4 +133,12 @@ test.describe('signals', () => {
     expect(await remoteServer.out('signal')).toBe('SIGKILL');
     expect(await remoteServer.childExitCode()).toBe(130);
   });
+
+  test('should not prevent default SIGTERM handling after browser close', async ({ startRemoteServer, server, platform }, testInfo) => {
+    const remoteServer = await startRemoteServer('launchServer', { startStopAndRunHttp: true });
+    expect(await remoteServer.out('closed')).toBe('success');
+    process.kill(remoteServer.child().pid, 'SIGTERM');
+    expect(await remoteServer.childExitCode()).toBe(null);
+    expect(await remoteServer.childSignal()).toBe('SIGTERM');
+  });
 });


### PR DESCRIPTION
Otherwise, we forever block SIGTERM and SIGHUP by registering a handler that does not do anything (due to no browsers to close) and prevents default handler that exits from running.

Fixes #28091.