### PR TITLE
devops: merge paginated results when downloading blobs

### DIFF
--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -18,17 +18,17 @@ runs:
       shell: bash
       run: mkdir -p '${{ inputs.path }}/artifacts'
     - name: Download artifacts
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           console.log(`downloading artifacts for workflow_run: ${context.payload.workflow_run.id}`);
           console.log(`workflow_run: ${JSON.stringify(context.payload.workflow_run, null, 2)}`);
-          const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+          const allArtifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
             ...context.repo,
             run_id: context.payload.workflow_run.id
           });
-          console.log('total = ', data.total_count);
-          const artifacts = data.artifacts.filter(a => a.name.startsWith('${{ inputs.namePrefix }}'));
+          console.log('total = ', allArtifacts.length);
+          const artifacts = allArtifacts.filter(a => a.name.startsWith('${{ inputs.namePrefix }}'));
           const fs = require('fs');
           for (const artifact of artifacts) {
             const result = await github.rest.actions.downloadArtifact({


### PR DESCRIPTION
* The results are paginated by default to return max 30 entries, see [this page](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28). We use [octakit.paginate](https://octokit.github.io/rest.js/v20#pagination), wrapped into [github-script](https://github.com/actions/github-script/tree/60a0d83039c74a4aee543508d2ffcb1c3799cdea) to automatically load all artifacts urls.

* Also bumped github-script to v7