### PR TITLE
Revert "feat(trace): allow Trace Viewer to include credentials when fetching traces cross-origin (#28502)"

### DIFF
--- a/packages/trace-viewer/src/traceModelBackends.ts
+++ b/packages/trace-viewer/src/traceModelBackends.ts
@@ -32,7 +32,7 @@ export class ZipTraceModelBackend implements TraceModelBackend {
     this._traceURL = traceURL;
     zipjs.configure({ baseURL: self.location.href } as any);
     this._zipReader = new zipjs.ZipReader(
-        new zipjs.HttpReader(formatUrl(traceURL), { mode: 'cors', credentials: 'include', preventHeadRequest: true } as any),
+        new zipjs.HttpReader(formatUrl(traceURL), { mode: 'cors', preventHeadRequest: true } as any),
         { useWebWorkers: false });
     this._entriesPromise = this._zipReader.getEntries({ onprogress: progress }).then(entries => {
       const map = new Map<string, zip.Entry>();


### PR DESCRIPTION
This reverts commit 3f3f33206004d7d1b46b614e1db5cc13fc384b79.

References #29019.