### PR TITLE
fix: quote trace file path when printing error message

### DIFF
--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -331,7 +331,7 @@ export function formatFailure(config: FullConfig, test: TestCase, options: {inde
             const packageManagerCommand = getPackageManagerExecCommand();
             resultLines.push(colors.cyan(`    Usage:`));
             resultLines.push('');
-            resultLines.push(colors.cyan(`        ${packageManagerCommand} playwright show-trace ${relativePath}`));
+            resultLines.push(colors.cyan(`        ${packageManagerCommand} playwright show-trace "${relativePath}"`));
             resultLines.push('');
           }
         } else {

--- a/tests/playwright-test/reporter-attachment.spec.ts
+++ b/tests/playwright-test/reporter-attachment.spec.ts
@@ -66,7 +66,7 @@ test('render trace attachment', async ({ runInlineTest }) => {
       test('one', async ({}, testInfo) => {
         testInfo.attachments.push({
           name: 'trace',
-          path: testInfo.outputPath('trace.zip'),
+          path: testInfo.outputPath('my dir with space', 'trace.zip'),
           contentType: 'application/zip'
         });
         expect(1).toBe(0);
@@ -75,8 +75,8 @@ test('render trace attachment', async ({ runInlineTest }) => {
   }, { reporter: 'line' });
   const text = result.output.replace(/\\/g, '/');
   expect(text).toContain('    attachment #1: trace (application/zip) ─────────────────────────────────────────────────────────');
-  expect(text).toContain('    test-results/a-one/trace.zip');
-  expect(text).toContain('npx playwright show-trace test-results/a-one/trace.zip');
+  expect(text).toContain('    test-results/a-one/my dir with space/trace.zip');
+  expect(text).toContain('npx playwright show-trace "test-results/a-one/my dir with space/trace.zip"');
   expect(text).toContain('    ────────────────────────────────────────────────────────────────────────────────────────────────');
   expect(result.exitCode).toBe(1);
 });


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/29039