### PR TITLE
chore(ct): revert export mount result

### DIFF
--- a/packages/playwright-ct-react/index.d.ts
+++ b/packages/playwright-ct-react/index.d.ts
@@ -22,7 +22,7 @@ export interface MountOptions<HooksConfig extends JsonObject> {
   hooksConfig?: HooksConfig;
 }
 
-export interface MountResult extends Locator {
+interface MountResult extends Locator {
   unmount(): Promise<void>;
   update(component: JSX.Element): Promise<void>;
 }


### PR DESCRIPTION
I checked the `MountResult`'s of the other frameworks and they are not exposed