### PR TITLE
chore: quote path only if contains whitespaces

### DIFF
--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -374,7 +374,7 @@ export function formatFailure(config: FullConfig, test: TestCase, options: {inde
 }
 
 function quotePathIfNeeded(path: string): string {
-  if (/\W/.test(path))
+  if (/\s/.test(path))
     return `"${path}"`;
   return path;
 }


### PR DESCRIPTION
Otherwise we always quote as `trace.zip` matches \W.

This is a follow-up to 674988c633fb39b1d66a6bda55e96aaaa172dde5
Reference https://github.com/microsoft/playwright/issues/29039