### PR TITLE
devops: make sure uploaded reports always contain directory

### DIFF
--- a/.github/actions/upload-blob-report/action.yml
+++ b/.github/actions/upload-blob-report/action.yml
@@ -19,7 +19,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: blob-report-${{ inputs.job_name }}
-        path: ${{ inputs.report_dir }}
+        path: ${{ inputs.report_dir }}/**
         retention-days: 7
     - name: Write triggering pull request number in a file
       if: always() && github.event_name == 'pull_request'
@@ -29,5 +29,6 @@ runs:
       if: always() && github.event_name == 'pull_request'
       uses: actions/upload-artifact@v4
       with:
-        name: pull-request-${{ inputs.job_name }}
+        name: pull-request-number
         path: pull_request_number.txt
+        overwrite: true

--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Read pull request number
       uses: ./.github/actions/download-artifact
       with:
-        namePrefix: 'pull-request'
+        namePrefix: 'pull-request-number'
         path: '.'
 
     - name: Comment on PR


### PR DESCRIPTION
* Before the change if if uploaded artifact path contained just one file it would be [archived directly](https://github.com/actions/upload-artifact/blob/694cdabd8bdb0f10b2cea11669e1bf5453eed0a6/src/search.ts#L142-L151), but if there is a sister folder it would be an archive of the entire dir. According to the action docs "If a wildcard pattern is used, the path hierarchy will be preserved after the first wildcard pattern", so hopefully it means that the directory is always compressed even if there is a single file in it.
* Use `overwrite: true` to have only one artifact with pull request number.