### PR TITLE
fix(recorder): rework extendInjectedScript

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -560,8 +560,8 @@ export abstract class BrowserContext extends SdkObject {
     }
   }
 
-  async extendInjectedScript(source: string, arg?: any) {
-    const installInFrame = (frame: frames.Frame) => frame.extendInjectedScript(source, arg).catch(() => {});
+  async extendInjectedScript(source: string) {
+    const installInFrame = (frame: frames.Frame) => frame.extendInjectedScript(source).catch(() => {});
     const installInPage = (page: Page) => {
       page.on(Page.Events.InternalFrameNavigatedToNewDocument, installInFrame);
       return Promise.all(page.frames().map(installInFrame));

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1639,12 +1639,9 @@ export class Frame extends SdkObject {
     this._firedNetworkIdleSelf = false;
   }
 
-  async extendInjectedScript(source: string, arg?: any): Promise<js.JSHandle> {
+  async extendInjectedScript(source: string): Promise<js.JSHandle> {
     const context = await this._context('main');
-    const injectedScriptHandle = await context.injectedScript();
-    return injectedScriptHandle.evaluateHandle((injectedScript, { source, arg }) => {
-      return injectedScript.extend(source, arg);
-    }, { source, arg });
+    return context.instantiateWithInjectedScriptCreationParams(source);
   }
 
   async resetStorageForCurrentOriginBestEffort(newStorage: channels.OriginStorage | undefined) {

--- a/packages/playwright-core/src/server/injected/consoleApi.ts
+++ b/packages/playwright-core/src/server/injected/consoleApi.ts
@@ -19,7 +19,7 @@ import { getByAltTextSelector, getByLabelSelector, getByPlaceholderSelector, get
 import { escapeForTextSelector } from '../../utils/isomorphic/stringUtils';
 import { asLocator } from '../../utils/isomorphic/locatorGenerators';
 import type { Language } from '../../utils/isomorphic/locatorGenerators';
-import type { InjectedScript } from './injectedScript';
+import { InjectedScript, type InjectedScriptCreationParams } from './injectedScript';
 
 const selectorSymbol = Symbol('selector');
 const injectedScriptSymbol = Symbol('injectedScript');
@@ -76,8 +76,8 @@ declare global {
 class ConsoleAPI {
   private _injectedScript: InjectedScript;
 
-  constructor(injectedScript: InjectedScript) {
-    this._injectedScript = injectedScript;
+  constructor(params: InjectedScriptCreationParams) {
+    this._injectedScript = new InjectedScript(params);
     if (this._injectedScript.window.playwright)
       return;
     this._injectedScript.window.playwright = {
@@ -87,7 +87,7 @@ class ConsoleAPI {
       selector: (element: Element) => this._selector(element),
       generateLocator: (element: Element, language?: Language) => this._generateLocator(element, language),
       resume: () => this._resume(),
-      ...new Locator(injectedScript, ''),
+      ...new Locator(this._injectedScript, ''),
     };
     delete this._injectedScript.window.playwright.filter;
     delete this._injectedScript.window.playwright.first;

--- a/packages/playwright-core/src/server/injected/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder.ts
@@ -15,7 +15,7 @@
  */
 
 import type * as actions from '../recorder/recorderActions';
-import type { InjectedScript } from '../injected/injectedScript';
+import { InjectedScript, type InjectedScriptCreationParams } from '../injected/injectedScript';
 import { generateSelector } from '../injected/selectorGenerator';
 import type { Point } from '../../common/types';
 import type { Mode, OverlayState, UIState } from '@recorder/recorderTypes';
@@ -863,7 +863,8 @@ export class Recorder {
   readonly document: Document;
   delegate: RecorderDelegate = {};
 
-  constructor(injectedScript: InjectedScript) {
+  constructor(params: InjectedScriptCreationParams) {
+    const injectedScript = new InjectedScript(params);
     this.document = injectedScript.document;
     this.injectedScript = injectedScript;
     this.highlight = new Highlight(injectedScript);
@@ -1189,11 +1190,11 @@ export class PollingRecorder implements RecorderDelegate {
   private _embedder: Embedder;
   private _pollRecorderModeTimer: NodeJS.Timeout | undefined;
 
-  constructor(injectedScript: InjectedScript) {
-    this._recorder = new Recorder(injectedScript);
-    this._embedder = injectedScript.window as any;
+  constructor(params: InjectedScriptCreationParams) {
+    this._recorder = new Recorder(params);
+    this._embedder = this._recorder.injectedScript.window as any;
 
-    injectedScript.onGlobalListenersRemoved.add(() => this._recorder.installListeners());
+    this._recorder.injectedScript.onGlobalListenersRemoved.add(() => this._recorder.installListeners());
 
     const refreshOverlay = () => {
       this._pollRecorderMode().catch(e => console.log(e)); // eslint-disable-line no-console

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -21,7 +21,6 @@ import { context, prevInList } from './modelUtil';
 import { Toolbar } from '@web/components/toolbar';
 import { ToolbarButton } from '@web/components/toolbarButton';
 import { useMeasure } from '@web/uiUtils';
-import { InjectedScript } from '@injected/injectedScript';
 import { Recorder  } from '@injected/recorder';
 import ConsoleAPI from '@injected/consoleApi';
 import { asLocator } from '@isomorphic/locatorGenerators';
@@ -192,8 +191,15 @@ export const SnapshotTab: React.FunctionComponent<{
       <ToolbarButton icon='link-external' title='Open snapshot in a new tab' disabled={!popoutUrl} onClick={() => {
         const win = window.open(popoutUrl || '', '_blank');
         win?.addEventListener('DOMContentLoaded', () => {
-          const injectedScript = new InjectedScript(win as any, false, sdkLanguage, testIdAttributeName, 1, 'chromium', []);
-          new ConsoleAPI(injectedScript);
+          new ConsoleAPI({
+            window: win as any,
+            isUnderTest: false,
+            sdkLanguage,
+            testIdAttributeName,
+            stableRafCount: 1,
+            browserName: 'chromium',
+            customEngines: []
+          });
         });
       }}></ToolbarButton>
     </Toolbar>
@@ -270,9 +276,16 @@ function createRecorders(recorders: { recorder: Recorder, frameSelector: string 
     return;
   const win = frameWindow as any;
   if (!win._recorder) {
-    const injectedScript = new InjectedScript(frameWindow as any, isUnderTest, sdkLanguage, testIdAttributeName, 1, 'chromium', []);
-    const recorder = new Recorder(injectedScript);
-    win._injectedScript = injectedScript;
+    const recorder = new Recorder({
+      window: frameWindow as any,
+      isUnderTest,
+      sdkLanguage,
+      testIdAttributeName,
+      stableRafCount: 1,
+      browserName: 'chromium',
+      customEngines: []
+    });
+    win._injectedScript = recorder.injectedScript;
     win._recorder = { recorder, frameSelector: parentFrameSelector };
   }
   recorders.push(win._recorder);


### PR DESCRIPTION
Previously, new `Recorder` instance was given an existing `InjectedScript`. However, we built a separate source for `InjectedScript` vs `Recorder`, and both bundles contain their own copy of all helper modules, e.g. `roleUtils`.

This resulted in two copies of helper modules, which is troublesome for any module-level globals like a top-level cache. Depending on whether `Recorder` or `InjectedScript` called into the helper, they would access the different value of a module global, which lead to bugs.

New approach creates a separate `InjectedScript` instance for the `Recorder`, with its own universe of modules. This way we may end up with two `InjectedScript` instances, but there should be no issues with that since they are isolated.

Alternative approach considered was to bundle everything together all the time. This approach increases the size of `InjectedScriptSource` from 240k to 280k, which is acceptible. However, we may not be able to include things like `CodeMirror` in the recorder anymore.