### PR TITLE
chore: replace "node.js" mention in shared docs

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -680,7 +680,7 @@ await playwright.Chromium.LaunchAsync(new()
 });
 ```
 
-On Linux agents, headed execution requires [Xvfb](https://en.wikipedia.org/wiki/Xvfb) to be installed. Our [Docker image](./docker.md) and GitHub Action have Xvfb pre-installed. To run browsers in headed mode with Xvfb, add `xvfb-run` before the Node.js command.
+On Linux agents, headed execution requires [Xvfb](https://en.wikipedia.org/wiki/Xvfb) to be installed. Our [Docker image](./docker.md) and GitHub Action have Xvfb pre-installed. To run browsers in headed mode with Xvfb, add `xvfb-run` before the actual command.
 
 ```bash js
 xvfb-run node index.js


### PR DESCRIPTION
Remove "Node.js" mention from the shared part of docs, which are shown in docs for Python and other platforms.