### PR TITLE
fix(recorder): disallow external imports

### DIFF
--- a/packages/playwright-core/src/server/injected/consoleApi.ts
+++ b/packages/playwright-core/src/server/injected/consoleApi.ts
@@ -120,13 +120,13 @@ class ConsoleAPI {
   private _selector(element: Element) {
     if (!(element instanceof Element))
       throw new Error(`Usage: playwright.selector(element).`);
-    return this._injectedScript.generateSelector(element);
+    return this._injectedScript.generateSelectorSimple(element);
   }
 
   private _generateLocator(element: Element, language?: Language) {
     if (!(element instanceof Element))
       throw new Error(`Usage: playwright.locator(element).`);
-    const selector = this._injectedScript.generateSelector(element);
+    const selector = this._injectedScript.generateSelectorSimple(element);
     return asLocator(language || 'javascript', selector);
   }
 

--- a/packages/playwright-core/src/server/injected/recorder/DEPS.list
+++ b/packages/playwright-core/src/server/injected/recorder/DEPS.list
@@ -1,0 +1,4 @@
+# Recorder must use any external dependencies through InjectedScript.
+# Otherwise it will end up with a copy of all modules it uses, and any
+# module-level globals will be duplicated, which leads to subtle bugs.
+[*]

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -739,7 +739,7 @@ async function findFrameSelector(frame: Frame): Promise<string | undefined> {
     const utility = await parent._utilityContext();
     const injected = await utility.injectedScript();
     const selector = await injected.evaluate((injected, element) => {
-      return injected.generateSelector(element as Element, { testIdAttributeName: '', omitInternalEngines: true });
+      return injected.generateSelectorSimple(element as Element, { testIdAttributeName: '', omitInternalEngines: true });
     }, frameElement);
     return selector;
   } catch (e) {

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -22,7 +22,7 @@ import { Toolbar } from '@web/components/toolbar';
 import { ToolbarButton } from '@web/components/toolbarButton';
 import { useMeasure } from '@web/uiUtils';
 import { InjectedScript } from '@injected/injectedScript';
-import { Recorder  } from '@injected/recorder';
+import { Recorder } from '@injected/recorder/recorder';
 import ConsoleAPI from '@injected/consoleApi';
 import { asLocator } from '@isomorphic/locatorGenerators';
 import type { Language } from '@isomorphic/locatorGenerators';
@@ -279,7 +279,7 @@ function createRecorders(recorders: { recorder: Recorder, frameSelector: string 
 
   for (let i = 0; i < frameWindow.frames.length; ++i) {
     const childFrame = frameWindow.frames[i];
-    const frameSelector = childFrame.frameElement ? win._injectedScript.generateSelector(childFrame.frameElement, { omitInternalEngines: true, testIdAttributeName }) + ' >> internal:control=enter-frame >> ' : '';
+    const frameSelector = childFrame.frameElement ? win._injectedScript.generateSelectorSimple(childFrame.frameElement, { omitInternalEngines: true, testIdAttributeName }) + ' >> internal:control=enter-frame >> ' : '';
     createRecorders(recorders, sdkLanguage, testIdAttributeName, isUnderTest, parentFrameSelector + frameSelector, childFrame);
   }
 }

--- a/tests/library/selector-generator.spec.ts
+++ b/tests/library/selector-generator.spec.ts
@@ -519,8 +519,8 @@ it.describe('selector generator', () => {
     const selectors = await page.evaluate(() => {
       const target = document.querySelector('section > span');
       const root = document.querySelector('section');
-      const relative = (window as any).__injectedScript.generateSelector(target, { root });
-      const absolute = (window as any).__injectedScript.generateSelector(target);
+      const relative = (window as any).__injectedScript.generateSelectorSimple(target, { root });
+      const absolute = (window as any).__injectedScript.generateSelectorSimple(target);
       return { relative, absolute };
     });
     expect(selectors).toEqual({

--- a/utils/generate_injected.js
+++ b/utils/generate_injected.js
@@ -45,7 +45,7 @@ const injectedScripts = [
     true,
   ],
   [
-    path.join(ROOT, 'packages', 'playwright-core', 'src', 'server', 'injected', 'recorder.ts'),
+    path.join(ROOT, 'packages', 'playwright-core', 'src', 'server', 'injected', 'recorder', 'recorder.ts'),
     path.join(ROOT, 'packages', 'playwright-core', 'lib', 'server', 'injected', 'packed'),
     path.join(ROOT, 'packages', 'playwright-core', 'src', 'generated'),
     true,


### PR DESCRIPTION
Previously, new `Recorder` instance was given an existing `InjectedScript`. However, we built a separate source for `InjectedScript` vs `Recorder`, and both bundles contain their own copy of all helper modules, e.g. `roleUtils`.

This resulted in two copies of helper modules, which is troublesome for any module-level globals like a top-level cache. Depending on whether `Recorder` or `InjectedScript` called into the helper, they would access the different value of a module global, which lead to bugs.

To prevent this, we force any external dependencies to be imported through the `InjectedScript.utils`.