### PR TITLE
feat(codegen): generate multiple selectors to choose from

### DIFF
--- a/packages/playwright-core/src/server/injected/highlight.css
+++ b/packages/playwright-core/src/server/injected/highlight.css
@@ -33,7 +33,30 @@ x-pw-tooltip {
   max-width: 600px;
   position: absolute;
   top: 0;
-  padding: 4px;
+  padding: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+x-pw-tooltip-line {
+  display: flex;
+  max-width: 600px;
+  padding: 6px;
+  user-select: none;
+  cursor: pointer;
+}
+
+x-pw-tooltip-line.selectable:hover {
+  background-color: hsl(0, 0%, 95%);
+  overflow: hidden;
+}
+
+x-pw-tooltip-footer {
+  display: flex;
+  max-width: 600px;
+  padding: 6px;
+  user-select: none;
+  color: #777;
 }
 
 x-pw-dialog {

--- a/packages/playwright-core/src/server/injected/highlight.ts
+++ b/packages/playwright-core/src/server/injected/highlight.ts
@@ -33,6 +33,9 @@ type HighlightEntry = {
 
 export type HighlightOptions = {
   tooltipText?: string;
+  tooltipList?: string[];
+  tooltipFooter?: string;
+  tooltipListItemSelected?: (index: number | undefined) => void;
   color?: string;
 };
 
@@ -40,6 +43,7 @@ export class Highlight {
   private _glassPaneElement: HTMLElement;
   private _glassPaneShadow: ShadowRoot;
   private _highlightEntries: HighlightEntry[] = [];
+  private _highlightOptions: HighlightOptions = {};
   private _actionPointElement: HTMLElement;
   private _isUnderTest: boolean;
   private _injectedScript: InjectedScript;
@@ -64,6 +68,8 @@ export class Highlight {
       this._glassPaneElement.addEventListener(eventName, e => {
         e.stopPropagation();
         e.stopImmediatePropagation();
+        if (e.type === 'click' && (e as MouseEvent).button === 0 && this._highlightOptions.tooltipListItemSelected)
+          this._highlightOptions.tooltipListItemSelected(undefined);
       });
     }
     this._actionPointElement = document.createElement('x-pw-action-point');
@@ -112,6 +118,8 @@ export class Highlight {
       entry.tooltipElement?.remove();
     }
     this._highlightEntries = [];
+    this._highlightOptions = {};
+    this._glassPaneElement.style.pointerEvents = 'none';
   }
 
   updateHighlight(elements: Element[], options: HighlightOptions) {
@@ -130,27 +138,48 @@ export class Highlight {
     // Code below should trigger one layout and leave with the
     // destroyed layout.
 
-    if (this._highlightIsUpToDate(elements, options.tooltipText))
+    if (this._highlightIsUpToDate(elements, options))
       return;
 
     // 1. Destroy the layout
     this.clearHighlight();
+    this._highlightOptions = options;
+    this._glassPaneElement.style.pointerEvents = options.tooltipListItemSelected ? 'initial' : 'none';
 
     for (let i = 0; i < elements.length; ++i) {
       const highlightElement = this._createHighlightElement();
       this._glassPaneShadow.appendChild(highlightElement);
 
       let tooltipElement;
-      if (options.tooltipText) {
+      if (options.tooltipList || options.tooltipText || options.tooltipFooter) {
         tooltipElement = this._injectedScript.document.createElement('x-pw-tooltip');
         this._glassPaneShadow.appendChild(tooltipElement);
-        const suffix = elements.length > 1 ? ` [${i + 1} of ${elements.length}]` : '';
-        tooltipElement.textContent = options.tooltipText + suffix;
         tooltipElement.style.top = '0';
         tooltipElement.style.left = '0';
         tooltipElement.style.display = 'flex';
+        let lines: string[] = [];
+        if (options.tooltipList) {
+          lines = options.tooltipList;
+        } else if (options.tooltipText) {
+          const suffix = elements.length > 1 ? ` [${i + 1} of ${elements.length}]` : '';
+          lines = [options.tooltipText + suffix];
+        }
+        for (let index = 0; index < lines.length; index++) {
+          const element = this._injectedScript.document.createElement('x-pw-tooltip-line');
+          element.textContent = lines[index];
+          tooltipElement.appendChild(element);
+          if (options.tooltipListItemSelected) {
+            element.classList.add('selectable');
+            element.addEventListener('click', () => options.tooltipListItemSelected?.(index));
+          }
+        }
+        if (options.tooltipFooter) {
+          const footer = this._injectedScript.document.createElement('x-pw-tooltip-footer');
+          footer.textContent = options.tooltipFooter;
+          tooltipElement.appendChild(footer);
+        }
       }
-      this._highlightEntries.push({ targetElement: elements[i], tooltipElement, highlightElement, tooltipText: options.tooltipText });
+      this._highlightEntries.push({ targetElement: elements[i], tooltipElement, highlightElement });
     }
 
     // 2. Trigger layout while positioning tooltips and computing bounding boxes.
@@ -212,12 +241,26 @@ export class Highlight {
     return { anchorLeft, anchorTop };
   }
 
-  private _highlightIsUpToDate(elements: Element[], tooltipText: string | undefined): boolean {
+  private _highlightIsUpToDate(elements: Element[], options: HighlightOptions): boolean {
+    if (options.tooltipText !== this._highlightOptions.tooltipText)
+      return false;
+    if (options.tooltipListItemSelected !== this._highlightOptions.tooltipListItemSelected)
+      return false;
+    if (options.tooltipFooter !== this._highlightOptions.tooltipFooter)
+      return false;
+
+    if (options.tooltipList?.length !== this._highlightOptions.tooltipList?.length)
+      return false;
+    if (options.tooltipList && this._highlightOptions.tooltipList) {
+      for (let i = 0; i < options.tooltipList.length; i++) {
+        if (options.tooltipList[i] !== this._highlightOptions.tooltipList[i])
+          return false;
+      }
+    }
+
     if (elements.length !== this._highlightEntries.length)
       return false;
     for (let i = 0; i < this._highlightEntries.length; ++i) {
-      if (tooltipText !== this._highlightEntries[i].tooltipText)
-        return false;
       if (elements[i] !== this._highlightEntries[i].targetElement)
         return false;
       const oldBox = this._highlightEntries[i].box;
@@ -227,6 +270,7 @@ export class Highlight {
       if (box.top !== oldBox.top || box.right !== oldBox.right || box.bottom !== oldBox.bottom || box.left !== oldBox.left)
         return false;
     }
+
     return true;
   }
 

--- a/packages/playwright-core/src/server/injected/selectorGenerator.ts
+++ b/packages/playwright-core/src/server/injected/selectorGenerator.ts
@@ -67,17 +67,18 @@ export type GenerateSelectorOptions = {
   omitInternalEngines?: boolean;
   root?: Element | Document;
   forTextExpect?: boolean;
+  multiple?: boolean;
 };
 
-export function generateSelector(injectedScript: InjectedScript, targetElement: Element, options: GenerateSelectorOptions): { selector: string, elements: Element[] } {
+export function generateSelector(injectedScript: InjectedScript, targetElement: Element, options: GenerateSelectorOptions): { selector: string, selectors: string[], elements: Element[] } {
   injectedScript._evaluator.begin();
   beginAriaCaches();
   try {
-    let targetTokens: SelectorToken[];
+    let selectors: string[] = [];
     if (options.forTextExpect) {
-      targetTokens = cssFallback(injectedScript, targetElement.ownerDocument.documentElement, options);
+      let targetTokens = cssFallback(injectedScript, targetElement.ownerDocument.documentElement, options);
       for (let element: Element | undefined = targetElement; element; element = parentElementOrShadowHost(element)) {
-        const tokens = generateSelectorFor(injectedScript, element, options);
+        const tokens = generateSelectorFor(injectedScript, element, { ...options, noText: true });
         if (!tokens)
           continue;
         const score = combineScores(tokens);
@@ -86,14 +87,41 @@ export function generateSelector(injectedScript: InjectedScript, targetElement: 
           break;
         }
       }
+      selectors = [joinTokens(targetTokens)];
     } else {
       targetElement = closestCrossShadow(targetElement, 'button,select,input,[role=button],[role=checkbox],[role=radio],a,[role=link]', options.root) || targetElement;
-      targetTokens = generateSelectorFor(injectedScript, targetElement, options) || cssFallback(injectedScript, targetElement, options);
+      if (options.multiple) {
+        const withText = generateSelectorFor(injectedScript, targetElement, options);
+        const withoutText = generateSelectorFor(injectedScript, targetElement, { ...options, noText: true });
+        let tokens = [withText, withoutText];
+
+        // Clear cache to re-generate without css id.
+        cacheAllowText.clear();
+        cacheDisallowText.clear();
+
+        if (withText && hasCSSIdToken(withText))
+          tokens.push(generateSelectorFor(injectedScript, targetElement, { ...options, noCSSId: true }));
+        if (withoutText && hasCSSIdToken(withoutText))
+          tokens.push(generateSelectorFor(injectedScript, targetElement, { ...options, noText: true, noCSSId: true }));
+
+        tokens = tokens.filter(Boolean);
+        if (!tokens.length) {
+          const css = cssFallback(injectedScript, targetElement, options);
+          tokens.push(css);
+          if (hasCSSIdToken(css))
+            tokens.push(cssFallback(injectedScript, targetElement, { ...options, noCSSId: true }));
+        }
+        selectors = [...new Set(tokens.map(t => joinTokens(t!)))];
+      } else {
+        const targetTokens = generateSelectorFor(injectedScript, targetElement, options) || cssFallback(injectedScript, targetElement, options);
+        selectors = [joinTokens(targetTokens)];
+      }
     }
-    const selector = joinTokens(targetTokens);
+    const selector = selectors[0];
     const parsedSelector = injectedScript.parseSelector(selector);
     return {
       selector,
+      selectors,
       elements: injectedScript.querySelectorAll(parsedSelector, options.root ?? targetElement.ownerDocument)
     };
   } finally {
@@ -109,7 +137,9 @@ function filterRegexTokens(textCandidates: SelectorToken[][]): SelectorToken[][]
   return textCandidates.filter(c => c[0].selector[0] !== '/');
 }
 
-function generateSelectorFor(injectedScript: InjectedScript, targetElement: Element, options: GenerateSelectorOptions): SelectorToken[] | null {
+type InternalOptions = GenerateSelectorOptions & { noText?: boolean, noCSSId?: boolean };
+
+function generateSelectorFor(injectedScript: InjectedScript, targetElement: Element, options: InternalOptions): SelectorToken[] | null {
   if (options.root && !isInsideScope(options.root, targetElement))
     throw new Error(`Target element must belong to the root's subtree`);
 
@@ -188,10 +218,10 @@ function generateSelectorFor(injectedScript: InjectedScript, targetElement: Elem
     return value;
   };
 
-  return calculate(targetElement, !options.forTextExpect);
+  return calculate(targetElement, !options.noText);
 }
 
-function buildNoTextCandidates(injectedScript: InjectedScript, element: Element, options: GenerateSelectorOptions): SelectorToken[] {
+function buildNoTextCandidates(injectedScript: InjectedScript, element: Element, options: InternalOptions): SelectorToken[] {
   const candidates: SelectorToken[] = [];
 
   // CSS selectors are applicable to elements via locator() and iframes via frameLocator().
@@ -201,9 +231,11 @@ function buildNoTextCandidates(injectedScript: InjectedScript, element: Element,
         candidates.push({ engine: 'css', selector: `[${attr}=${quoteCSSAttributeValue(element.getAttribute(attr)!)}]`, score: kOtherTestIdScore });
     }
 
-    const idAttr = element.getAttribute('id');
-    if (idAttr && !isGuidLike(idAttr))
-      candidates.push({ engine: 'css', selector: makeSelectorForId(idAttr), score: kCSSIdScore });
+    if (!options.noCSSId) {
+      const idAttr = element.getAttribute('id');
+      if (idAttr && !isGuidLike(idAttr))
+        candidates.push({ engine: 'css', selector: makeSelectorForId(idAttr), score: kCSSIdScore });
+    }
 
     candidates.push({ engine: 'css', selector: cssEscape(element.nodeName.toLowerCase()), score: kCSSTagNameScore });
   }
@@ -315,7 +347,11 @@ function makeSelectorForId(id: string) {
   return /^[a-zA-Z][a-zA-Z0-9\-\_]+$/.test(id) ? '#' + id : `[id="${cssEscape(id)}"]`;
 }
 
-function cssFallback(injectedScript: InjectedScript, targetElement: Element, options: GenerateSelectorOptions): SelectorToken[] {
+function hasCSSIdToken(tokens: SelectorToken[]) {
+  return tokens.some(token => token.engine === 'css' && (token.selector.startsWith('#') || token.selector.startsWith('[id="')));
+}
+
+function cssFallback(injectedScript: InjectedScript, targetElement: Element, options: InternalOptions): SelectorToken[] {
   const root: Node = options.root ?? targetElement.ownerDocument;
   const tokens: string[] = [];
 
@@ -342,9 +378,10 @@ function cssFallback(injectedScript: InjectedScript, targetElement: Element, opt
   for (let element: Element | undefined = targetElement; element && element !== root; element = parentElementOrShadowHost(element)) {
     const nodeName = element.nodeName.toLowerCase();
 
-    // Element ID is the strongest signal, use it.
     let bestTokenForLevel: string = '';
-    if (element.id) {
+
+    // Element ID is the strongest signal, use it.
+    if (element.id && !options.noCSSId) {
       const token = makeSelectorForId(element.id);
       const selector = uniqueCSSSelector(token);
       if (selector)


### PR DESCRIPTION
When possible, "pick locator" generates:
- default locator;
- locator without any text;
- locator without css `#id`.

Fixes #27875, fixes #5178.