### PR TITLE
devops: do not use broken overwrite: true for uploads

### DIFF
--- a/.github/actions/upload-blob-report/action.yml
+++ b/.github/actions/upload-blob-report/action.yml
@@ -29,6 +29,5 @@ runs:
       if: always() && github.event_name == 'pull_request'
       uses: actions/upload-artifact@v4
       with:
-        name: pull-request-number
+        name: pull-request-${{ inputs.job_name }}
         path: pull_request_number.txt
-        overwrite: true

--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Read pull request number
       uses: ./.github/actions/download-artifact
       with:
-        namePrefix: 'pull-request-number'
+        namePrefix: 'pull-request'
         path: '.'
 
     - name: Comment on PR


### PR DESCRIPTION
Reverting parts of https://github.com/microsoft/playwright/pull/29080 related to use of overwrite: true as it is racy and [fails](https://github.com/microsoft/playwright/actions/runs/7641699534/job/20819588957?pr=28932#step:10:63) time to time with parallel jobs:

![image](https://github.com/microsoft/playwright/assets/9798949/cd484e2d-2875-4950-9247-5ea033c6e92d)


Reference https://github.com/actions/upload-artifact/issues/506