### PR TITLE
feat - add readIntoBuffer() method to download class

### DIFF
--- a/packages/playwright-core/src/client/download.ts
+++ b/packages/playwright-core/src/client/download.ts
@@ -60,6 +60,10 @@ export class Download implements api.Download {
     return await this._artifact.createReadStream();
   }
 
+  async readIntoBuffer(): Promise<Buffer> {
+    return await this._artifact.readIntoBuffer();
+  }
+
   async cancel(): Promise<void> {
     return await this._artifact.cancel();
   }


### PR DESCRIPTION
I want to attach download directly to `test.info` instead of saving to `path` then attach `path` to `test.info`. `test.info.attach` can attach Buffer. I saw there's a method `readIntoBuffer()` in `Artifact`, and `Download` have access to `Artifact` method like `createReadStream()`. So I did the same thing as `createReadStream()` to make `readIntoBuffer()` accessible to `Download`. 

Hope this explains my intention, please let me know anything I'm missing, thanks!