### PR TITLE
fix: provisional fix for Trace Viewer source 404

### DIFF
--- a/packages/trace-viewer/src/ui/sourceTab.tsx
+++ b/packages/trace-viewer/src/ui/sourceTab.tsx
@@ -67,7 +67,10 @@ export const SourceTab: React.FunctionComponent<{
         let response = await fetch(`sha1/src@${sha1}.txt`);
         if (response.status === 404)
           response = await fetch(`file?path=${encodeURIComponent(file)}`);
-        source.content = await response.text();
+        if (response.status === 404)
+          source.content = `<Unable to read "${file}">`;
+        else
+          source.content = await response.text();
       } catch {
         source.content = `<Unable to read "${file}">`;
       }

--- a/packages/trace-viewer/src/ui/sourceTab.tsx
+++ b/packages/trace-viewer/src/ui/sourceTab.tsx
@@ -67,7 +67,7 @@ export const SourceTab: React.FunctionComponent<{
         let response = await fetch(`sha1/src@${sha1}.txt`);
         if (response.status === 404)
           response = await fetch(`file?path=${encodeURIComponent(file)}`);
-        if (response.status === 404)
+        if (response.status >= 400)
           source.content = `<Unable to read "${file}">`;
         else
           source.content = await response.text();


### PR DESCRIPTION
Motivation: Sometimes the files are not available anymore on the Service Worker side. The Trace Viewer frontend then falls back to `file?path=` and uses its response, no matter what the response status is.

This patch checks for the response status code before using its response.

e.g. https://github.com/microsoft/playwright-dotnet/issues/2775 after some time / and some other reports.