### PR TITLE
Add Warning about Github Annotations

### DIFF
--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -289,7 +289,9 @@ export default defineConfig({
 
 You can use the built in `github` reporter to get automatic failure annotations when running in GitHub actions.
 
-Note that all other reporters work on GitHub Actions as well, but do not provide annotations.
+Note that all other reporters work on GitHub Actions as well, but do not provide annotations. Also, it is not recommended to
+use this annotation type if running your tests with a matrix strategy as the stack trace failures will multiply and obscure the
+GitHub file view.
 
 ```js title="playwright.config.ts"
 import { defineConfig } from '@playwright/test';


### PR DESCRIPTION
Github Annotations should not be used with github actions matrix strategy. At present, a duplicate stacktrace is added to the annotation and causes PR review problems. In one case, we had a single review comment buried in 3000x pixels of scrollable height.

https://github.com/microsoft/playwright/issues/19817