### PR TITLE
fix(electron): make sure user arguments go first

### DIFF
--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -135,7 +135,10 @@ export class Electron extends SdkObject {
     controller.setLogName('browser');
     return controller.run(async progress => {
       let app: ElectronApplication | undefined = undefined;
-      const electronArguments = ['--inspect=0', '--remote-debugging-port=0', ...args];
+      // Always pass user arguments first, see https://github.com/microsoft/playwright/issues/16614 and
+      // https://github.com/microsoft/playwright/issues/29198.
+      // --inspect=0 must be the first playwright's argument, loader.ts relies on it.
+      const electronArguments = [...args, '--inspect=0', '--remote-debugging-port=0'];
 
       if (os.platform() === 'linux') {
         const runningAsRoot = process.geteuid && process.geteuid() === 0;

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -135,15 +135,13 @@ export class Electron extends SdkObject {
     controller.setLogName('browser');
     return controller.run(async progress => {
       let app: ElectronApplication | undefined = undefined;
-      // Always pass user arguments first, see https://github.com/microsoft/playwright/issues/16614 and
-      // https://github.com/microsoft/playwright/issues/29198.
-      // --inspect=0 must be the first playwright's argument, loader.ts relies on it.
-      const electronArguments = [...args, '--inspect=0', '--remote-debugging-port=0'];
+      // --remote-debugging-port=0 must be the last playwright's argument, loader.ts relies on it.
+      const electronArguments = ['--inspect=0', '--remote-debugging-port=0', ...args];
 
       if (os.platform() === 'linux') {
         const runningAsRoot = process.geteuid && process.geteuid() === 0;
         if (runningAsRoot && electronArguments.indexOf('--no-sandbox') === -1)
-          electronArguments.push('--no-sandbox');
+          electronArguments.unshift('--no-sandbox');
       }
 
       const artifactsDir = await fs.promises.mkdtemp(ARTIFACTS_FOLDER);

--- a/packages/playwright-core/src/server/electron/loader.ts
+++ b/packages/playwright-core/src/server/electron/loader.ts
@@ -17,9 +17,9 @@
 const { app } = require('electron');
 const { chromiumSwitches } = require('../chromium/chromiumSwitches');
 
-// [Electron, -r, loader.js, --inspect=0, --remote-debugging-port=0, ...args]
-process.argv.splice(1, 4);
-
+// [Electron, -r, loader.js, ...args, --inspect=0, --remote-debugging-port=0[, --no-sandbox>]]
+process.argv.splice(1, 2);
+process.argv.splice(process.argv.lastIndexOf('--inspect=0'));
 
 for (const arg of chromiumSwitches) {
   const match = arg.match(/--([^=]*)=?(.*)/)!;

--- a/packages/playwright-core/src/server/electron/loader.ts
+++ b/packages/playwright-core/src/server/electron/loader.ts
@@ -17,9 +17,10 @@
 const { app } = require('electron');
 const { chromiumSwitches } = require('../chromium/chromiumSwitches');
 
-// [Electron, -r, loader.js, ...args, --inspect=0, --remote-debugging-port=0[, --no-sandbox>]]
-process.argv.splice(1, 2);
-process.argv.splice(process.argv.lastIndexOf('--inspect=0'));
+// Always pass user arguments first, see https://github.com/microsoft/playwright/issues/16614 and
+// https://github.com/microsoft/playwright/issues/29198.
+// [Electron, -r, loader.js[, --no-sandbox>], --inspect=0, --remote-debugging-port=0, ...args]
+process.argv.splice(1, process.argv.indexOf('--remote-debugging-port=0'));
 
 for (const arg of chromiumSwitches) {
   const match = arg.match(/--([^=]*)=?(.*)/)!;


### PR DESCRIPTION
Previously `--no-sandbox` param could creep in before the args.

Fixes https://github.com/microsoft/playwright/issues/29198