### PR TITLE
feat(test runner): tags/annotations

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -19,6 +19,9 @@ test('basic test', async ({ page }) => {
 
 Declares a test.
 
+* `test(title, body)`
+* `test(title, details, body)`
+
 **Usage**
 
 ```js
@@ -30,11 +33,68 @@ test('basic test', async ({ page }) => {
 });
 ```
 
+**Tags**
+
+You can tag tests by providing additional test details. Note that each tag must start with `@` symbol.
+
+```js
+import { test, expect } from '@playwright/test';
+
+test('basic test', {
+  tag: '@smoke',
+}, async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+  // ...
+});
+```
+
+Test tags are displayed in the test report, and are available to a custom reporter via `TestCase.tags` property.
+
+You can also filter tests by their tags during test execution:
+* in the [command line](../test-cli.md#reference);
+* in the config with [`property: TestConfig.tagFilter`] and [`property: TestProject.tagFilter`];
+
+Learn more about [tagging](../test-annotations.md#tag-tests).
+
+**Annotations**
+
+You can annotate tests by providing additional test details.
+
+```js
+import { test, expect } from '@playwright/test';
+
+test('basic test', {
+  annotation: {
+    type: 'issue',
+    description: 'https://github.com/microsoft/playwright/issues/23180',
+  },
+}, async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+  // ...
+});
+```
+
+Test annotations are displayed in the test report, and are available to a custom reporter via `TestCase.annotations` property.
+
+You can also add dynamic annotations by manipulating [`property: TestInfo.annotations`].
+
+Learn more about [test annotations](../test-annotations.md).
+
 ### param: Test.(call).title
 * since: v1.10
 - `title` <[string]>
 
 Test title.
+
+### param: Test.(call).details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]> Annotation type, for example `'issue'`.
+    - `description` ?<[string]> Optional annotation description, for example an issue url.
+
+Additional test details.
 
 ### param: Test.(call).body
 * since: v1.10
@@ -279,6 +339,7 @@ Declares a group of tests.
 
 * `test.describe(title, callback)`
 * `test.describe(callback)`
+* `test.describe(title, details, callback)`
 
 **Usage**
 
@@ -296,7 +357,9 @@ test.describe('two tests', () => {
 });
 ```
 
-Without a title, this method declares an **anonymous** group of tests. This is convenient to give a group of tests a common option with [`method: Test.use`].
+**Anonymous group**
+
+You can also declare a test group without a title. This is convenient to give a group of tests a common option with [`method: Test.use`].
 
 ```js
 test.describe(() => {
@@ -312,11 +375,68 @@ test.describe(() => {
 });
 ```
 
+**Tags**
+
+You can tag all tests in a group by providing additional details. Note that each tag must start with `@` symbol.
+
+```js
+import { test, expect } from '@playwright/test';
+
+test.describe('two tagged tests', {
+  tag: '@smoke',
+}, () => {
+  test('one', async ({ page }) => {
+    // ...
+  });
+
+  test('two', async ({ page }) => {
+    // ...
+  });
+});
+```
+
+Learn more about [tagging](../test-annotations.md#tag-tests).
+
+**Annotations**
+
+You can annotate all tests in a group by providing additional details.
+
+```js
+import { test, expect } from '@playwright/test';
+
+test.describe('two annotated tests', {
+  annotation: {
+    type: 'issue',
+    description: 'https://github.com/microsoft/playwright/issues/23180',
+  },
+}, () => {
+  test('one', async ({ page }) => {
+    // ...
+  });
+
+  test('two', async ({ page }) => {
+    // ...
+  });
+});
+```
+
+Learn more about [test annotations](../test-annotations.md).
+
 ### param: Test.describe.title
 * since: v1.10
 - `title` ?<[string]>
 
 Group title.
+
+### param: Test.describe.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+Additional details for all tests in the group.
 
 ### param: Test.describe.callback
 * since: v1.10
@@ -410,6 +530,7 @@ Declares a test group similarly to [`method: Test.describe`]. Tests in this grou
 
 * `test.describe.fixme(title, callback)`
 * `test.describe.fixme(callback)`
+* `test.describe.fixme(title, details, callback)`
 
 **Usage**
 
@@ -435,6 +556,16 @@ test.describe.fixme(() => {
 
 Group title.
 
+### param: Test.describe.fixme.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.describe`] for details description.
+
 ### param: Test.describe.fixme.callback
 * since: v1.25
 - `callback` <[function]>
@@ -450,6 +581,7 @@ Declares a focused group of tests. If there are some focused tests or suites, al
 
 * `test.describe.only(title, callback)`
 * `test.describe.only(callback)`
+* `test.describe.only(title, details, callback)`
 
 **Usage**
 
@@ -479,6 +611,16 @@ test.describe.only(() => {
 
 Group title.
 
+### param: Test.describe.only.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.describe`] for details description.
+
 ### param: Test.describe.only.callback
 * since: v1.10
 - `callback` <[function]>
@@ -495,6 +637,7 @@ Declares a group of tests that could be run in parallel. By default, tests in a 
 
 * `test.describe.parallel(title, callback)`
 * `test.describe.parallel(callback)`
+* `test.describe.parallel(title, details, callback)`
 
 **Usage**
 
@@ -521,6 +664,16 @@ test.describe.parallel(() => {
 
 Group title.
 
+### param: Test.describe.parallel.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.describe`] for details description.
+
 ### param: Test.describe.parallel.callback
 * since: v1.10
 - `callback` <[function]>
@@ -537,6 +690,7 @@ Declares a focused group of tests that could be run in parallel. This is similar
 
 * `test.describe.parallel.only(title, callback)`
 * `test.describe.parallel.only(callback)`
+* `test.describe.parallel.only(title, details, callback)`
 
 **Usage**
 
@@ -561,6 +715,16 @@ test.describe.parallel.only(() => {
 
 Group title.
 
+### param: Test.describe.parallel.only.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.describe`] for details description.
+
 ### param: Test.describe.parallel.only.callback
 * since: v1.10
 - `callback` <[function]>
@@ -581,6 +745,7 @@ Using serial is not recommended. It is usually better to make your tests isolate
 
 * `test.describe.serial(title, callback)`
 * `test.describe.serial(title)`
+* `test.describe.serial(title, details, callback)`
 
 **Usage**
 
@@ -605,6 +770,16 @@ test.describe.serial(() => {
 
 Group title.
 
+### param: Test.describe.serial.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.describe`] for details description.
+
 ### param: Test.describe.serial.callback
 * since: v1.10
 - `callback` <[function]>
@@ -625,6 +800,7 @@ Using serial is not recommended. It is usually better to make your tests isolate
 
 * `test.describe.serial.only(title, callback)`
 * `test.describe.serial.only(title)`
+* `test.describe.serial.only(title, details, callback)`
 
 **Usage**
 
@@ -651,6 +827,16 @@ test.describe.serial.only(() => {
 
 Group title.
 
+### param: Test.describe.serial.only.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.describe`] for details description.
+
 ### param: Test.describe.serial.only.callback
 * since: v1.10
 - `callback` <[function]>
@@ -667,6 +853,7 @@ Declares a skipped test group, similarly to [`method: Test.describe`]. Tests in 
 
 * `test.describe.skip(title, callback)`
 * `test.describe.skip(title)`
+* `test.describe.skip(title, details, callback)`
 
 **Usage**
 
@@ -691,6 +878,16 @@ test.describe.skip(() => {
 - `title` <[string]>
 
 Group title.
+
+### param: Test.describe.skip.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.describe`] for details description.
 
 ### param: Test.describe.skip.callback
 * since: v1.10
@@ -837,6 +1034,7 @@ An object containing fixtures and/or options. Learn more about [fixtures format]
 Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful for documentation purposes to acknowledge that some functionality is broken until it is fixed.
 
 * `test.fail(title, body)`
+* `test.fail(title, details, body)`
 * `test.fail()`
 * `test.fail(condition, description)`
 * `test.fail(callback, description)`
@@ -896,6 +1094,16 @@ test('less readable', async ({ page }) => {
 
 Test title.
 
+### param: Test.fail.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.(call)`] for test details description.
+
 ### param: Test.fail.body
 * since: v1.42
 - `body` ?<[function]\([Fixtures], [TestInfo]\)>
@@ -928,6 +1136,7 @@ Optional description that will be reflected in a test report.
 Mark a test as "fixme", with the intention to fix it. Playwright will not run the test past the `test.fixme()` call.
 
 * `test.fixme(title, body)`
+* `test.fixme(title, details, body)`
 * `test.fixme()`
 * `test.fixme(condition, description)`
 * `test.fixme(callback, description)`
@@ -987,6 +1196,16 @@ test('less readable', async ({ page }) => {
 
 Test title.
 
+### param: Test.fixme.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.(call)`] for test details description.
+
 ### param: Test.fixme.body
 * since: v1.10
 - `body` ?<[function]\([Fixtures], [TestInfo]\)>
@@ -1037,6 +1256,9 @@ test('example test', async ({ page }) => {
 
 Declares a focused test. If there are some focused tests or suites, all of them will be run but nothing else.
 
+* `test.only(title, body)`
+* `test.only(title, details, body)`
+
 **Usage**
 
 ```js
@@ -1050,6 +1272,16 @@ test.only('focus this test', async ({ page }) => {
 - `title` <[string]>
 
 Test title.
+
+### param: Test.only.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.(call)`] for test details description.
 
 ### param: Test.only.body
 * since: v1.10
@@ -1123,6 +1355,7 @@ Skip a test. Playwright will not run the test past the `test.skip()` call.
 Skipped tests are not supposed to be ever run. If you intent to fix the test, use [`method: Test.fixme`] instead.
 
 * `test.skip(title, body)`
+* `test.skip(title, details, body)`
 * `test.skip()`
 * `test.skip(condition, description)`
 * `test.skip(callback, description)`
@@ -1181,6 +1414,16 @@ test('less readable', async ({ page }) => {
 - `title` ?<[string]>
 
 Test title.
+
+### param: Test.skip.details
+* since: v1.42
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.(call)`] for test details description.
 
 ### param: Test.skip.body
 * since: v1.10

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -474,6 +474,31 @@ export default defineConfig({
 });
 ```
 
+
+## property: TestConfig.tagFilter
+* since: v1.42
+- type: ?<[string]>
+
+Filter to only run tests with or without particular tag(s). This property must be a logical expression containing tags, parenthesis `(` and `)`, and operators `and`, `or` and `not`.
+
+Learn more about [tagging](../test-annotations.md#tag-tests).
+
+**Usage**
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  tagFilter: '@smoke',
+});
+```
+
+Tag expression examples:
+* `tagFilter: '@smoke'` - run only "smoke" tests;
+* `tagFilter: '@smoke and not @production'` - run only "smoke" tests that are not tagged as "production";
+* `tagFilter: '(@smoke or @fast) and @v2'` - run "v2" tests that are tagged as "smoke", "fast" or both.
+
+
 ## property: TestConfig.testDir
 * since: v1.10
 - type: ?<[string]>

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -199,6 +199,35 @@ Use [`method: Test.describe.configure`] to change the number of retries for a sp
 
 Use [`property: TestConfig.retries`] to change this option for all projects.
 
+
+## property: TestProject.tagFilter
+* since: v1.42
+- type: ?<[string]>
+
+Filter to only run tests with or without particular tag(s). This property must be a logical expression containing tags, parenthesis `(` and `)`, and operators `and`, `or` and `not`.
+
+Learn more about [tagging](../test-annotations.md#tag-tests).
+
+**Usage**
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'tests',
+      tagFilter: '@smoke',
+    },
+  ],
+});
+```
+
+Tag expression examples:
+* `tagFilter: '@smoke'` - run only "smoke" tests;
+* `tagFilter: '@smoke and not @production'` - run only "smoke" tests that are not tagged as "production";
+* `tagFilter: '(@smoke or @fast) and @v2'` - run "v2" tests that are tagged as "smoke", "fast" or both.
+
 ## property: TestProject.teardown
 * since: v1.34
 - type: ?<[string]>

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -98,6 +98,7 @@ Complete set of Playwright Test options is available in the [configuration file]
 | `--reporter <reporter>` | Choose a reporter: minimalist `dot`, concise `line` or detailed `list`. See [reporters](./test-reporters.md) for more information. |
 | `--retries <number>` | The maximum number of [retries](./test-retries.md#retries) for flaky tests, defaults to zero (no retries). |
 | `--shard <shard>` | [Shard](./test-parallel.md#shard-tests-between-multiple-machines) tests and execute only selected shard, specified in the form `current/all`, 1-based, for example `3/5`.|
+| `--tag <tag>` | Only run tests with a tag matching this tag expression. Learn more about [tagging](./test-annotations.md#tag-tests). |
 | `--timeout <number>` | Maximum timeout in milliseconds for each test, defaults to 30 seconds. Learn more about [various timeouts](./test-timeouts.md).|
 | `--trace <mode>` | Force tracing mode, can be `on`, `off`, `on-first-retry`, `on-all-retries`, `retain-on-failure` |
 | `--ignore-snapshots` | Whether to ignore [snapshots](./test-snapshots.md). Use this when snapshot expectations are known to be different, e.g. running tests on Linux against Windows screenshots. |

--- a/docs/src/test-reporter-api/class-testcase.md
+++ b/docs/src/test-reporter-api/class-testcase.md
@@ -10,7 +10,10 @@
   - `type` <[string]> Annotation type, for example `'skip'` or `'fail'`.
   - `description` ?<[string]> Optional description.
 
-The list of annotations applicable to the current test. Includes annotations from the test, annotations from all [`method: Test.describe`] groups the test belongs to and file-level annotations for the test file.
+The list of annotations applicable to the current test. Includes:
+* annotations defined on the test or suite via [`method: Test.(call)`] and [`method: Test.describe`];
+* annotations implicitly added by methods [`method: Test.skip`], [`method: Test.fixme`] and [`method: Test.fail`];
+* annotations appended to [`property: TestInfo.annotations`] during the test execution.
 
 Annotations are available during test execution through [`property: TestInfo.annotations`].
 
@@ -78,6 +81,14 @@ Results for each run of this test.
 The maximum number of retries given to this test in the configuration.
 
 Learn more about [test retries](../test-retries.md#retries).
+
+## property: TestCase.tags
+* since: v1.42
+- type: <[Array]<[string]>>
+
+The list of tags defined on the test or suite via [`method: Test.(call)`] or [`method: Test.describe`].
+
+Learn more about [test tags](../test-annotations.md#tag-tests).
 
 ## property: TestCase.timeout
 * since: v1.10

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import { escapeRegExp } from './labelUtils';
+import { testCaseLabels } from './labelUtils';
 import type { TestCaseSummary } from './types';
 
 export class Filter {
@@ -114,6 +114,7 @@ export class Filter {
         file: test.location.file,
         line: String(test.location.line),
         column: String(test.location.column),
+        labels: testCaseLabels(test).map(label => label.toLowerCase()),
       };
       (test as any).searchValues = searchValues;
     }
@@ -140,7 +141,7 @@ export class Filter {
       }
     }
     if (this.labels.length) {
-      const matches = this.labels.every(l => searchValues.text?.match(new RegExp(`(\\s|^)${escapeRegExp(l)}(\\s|$)`, 'g')));
+      const matches = this.labels.every(l => searchValues.labels.includes(l));
       if (!matches)
         return false;
     }
@@ -156,5 +157,6 @@ type SearchValues = {
   file: string;
   line: string;
   column: string;
+  labels: string[];
 };
 

--- a/packages/html-reporter/src/labelUtils.tsx
+++ b/packages/html-reporter/src/labelUtils.tsx
@@ -16,20 +16,19 @@
 
 import type { TestCaseSummary } from './types';
 
-export function escapeRegExp(string: string) {
-  const reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
-  const reHasRegExpChar = RegExp(reRegExpChar.source);
+const labelsSymbol = Symbol('labels');
 
-  return (string && reHasRegExpChar.test(string))
-    ? string.replace(reRegExpChar, '\\$&')
-    : (string || '');
-}
-
+// Note: all labels start with "@"
 export function testCaseLabels(test: TestCaseSummary): string[] {
-  const tags = matchTags(test.path.join(' ') + ' ' + test.title).sort((a, b) => a.localeCompare(b));
-  if (test.botName)
-    tags.unshift(test.botName);
-  return tags;
+  if (!(test as any)[labelsSymbol]) {
+    const labels: string[] = [];
+    if (test.botName)
+      labels.push('@' + test.botName);
+    labels.push(...test.tags);
+    labels.push(...matchTags(test.path.join(' ') + ' ' + test.title).sort((a, b) => a.localeCompare(b)));
+    (test as any)[labelsSymbol] = labels;
+  }
+  return (test as any)[labelsSymbol];
 }
 
 // match all tags in test title

--- a/packages/html-reporter/src/testCaseView.spec.tsx
+++ b/packages/html-reporter/src/testCaseView.spec.tsx
@@ -55,6 +55,7 @@ const testCase: TestCase = {
     { type: 'annotation', description: 'Annotation text' },
     { type: 'annotation', description: 'Another annotation text' },
   ],
+  tags: [],
   outcome: 'expected',
   duration: 10,
   ok: true,

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -95,7 +95,7 @@ const LabelsLinkView: React.FC<React.PropsWithChildren<{
       {labels.map(label => (
         <a key={label} style={{ textDecoration: 'none', color: 'var(--color-fg-default)' }} href={`#?q=${label}`} >
           <span style={{ margin: '6px 0 0 6px', cursor: 'pointer' }} className={'label label-color-' + (hashStringToInt(label))}>
-            {label.startsWith('@') ? label.slice(1) : label}
+            {label.slice(1)}
           </span>
         </a>
       ))}

--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -98,8 +98,7 @@ const LabelsClickView: React.FC<React.PropsWithChildren<{
 
     // If metaKey or ctrlKey is pressed, add tag to search query without replacing existing tags.
     // If metaKey or ctrlKey is pressed and tag is already in search query, remove tag from search query.
-    // Always toggle non-@-tag labels.
-    if (e.metaKey || e.ctrlKey || !label.startsWith('@')) {
+    if (e.metaKey || e.ctrlKey) {
       if (!q.includes(label))
         q = `${q} ${label}`.trim();
       else
@@ -118,7 +117,7 @@ const LabelsClickView: React.FC<React.PropsWithChildren<{
     <>
       {labels.map(label => (
         <span key={label} style={{ margin: '6px 0 0 6px', cursor: 'pointer' }} className={'label label-color-' + (hashStringToInt(label))} onClick={e => onClickHandle(e, label)}>
-          {label.startsWith('@') ? label.slice(1) : label}
+          {label.slice(1)}
         </span>
       ))}
     </>

--- a/packages/html-reporter/src/types.ts
+++ b/packages/html-reporter/src/types.ts
@@ -69,6 +69,7 @@ export type TestCaseSummary = {
   botName?: string;
   location: Location;
   annotations: TestCaseAnnotation[];
+  tags: string[];
   outcome: 'skipped' | 'expected' | 'unexpected' | 'flaky';
   duration: number;
   ok: boolean;

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -47,6 +47,7 @@ export class FullConfigInternal {
   cliArgs: string[] = [];
   cliGrep: string | undefined;
   cliGrepInvert: string | undefined;
+  cliTagFilter: string | undefined;
   cliProjectFilter?: string[];
   cliListOnly = false;
   cliPassWithNoTests?: boolean;
@@ -160,6 +161,7 @@ export class FullProjectInternal {
   id = '';
   deps: FullProjectInternal[] = [];
   teardown: FullProjectInternal | undefined;
+  tagFilter: string | undefined;
 
   constructor(configDir: string, config: Config, fullConfig: FullConfigInternal, projectConfig: Project, configCLIOverrides: ConfigCLIOverrides, throwawayArtifactsPath: string) {
     this.fullConfig = fullConfig;
@@ -188,6 +190,7 @@ export class FullProjectInternal {
     };
     this.fullyParallel = takeFirst(configCLIOverrides.fullyParallel, projectConfig.fullyParallel, config.fullyParallel, undefined);
     this.expect = takeFirst(projectConfig.expect, config.expect, {});
+    this.tagFilter = takeFirst(projectConfig.tagFilter, config.tagFilter, undefined);
     if (this.expect.toHaveScreenshot?.stylePath) {
       const stylePaths = Array.isArray(this.expect.toHaveScreenshot.stylePath) ? this.expect.toHaveScreenshot.stylePath : [this.expect.toHaveScreenshot.stylePath];
       this.expect.toHaveScreenshot.stylePath = stylePaths.map(stylePath => path.resolve(configDir, stylePath));

--- a/packages/playwright/src/common/suiteUtils.ts
+++ b/packages/playwright/src/common/suiteUtils.ts
@@ -62,7 +62,10 @@ export function bindFileSuiteToProject(project: FullProjectInternal, suite: Suit
     let inheritedRetries: number | undefined;
     let inheritedTimeout: number | undefined;
     for (let parentSuite: Suite | undefined = suite; parentSuite; parentSuite = parentSuite.parent) {
-      test._staticAnnotations.push(...parentSuite._staticAnnotations);
+      if (parentSuite._staticAnnotations.length)
+        test._staticAnnotations = [...parentSuite._staticAnnotations, ...test._staticAnnotations];
+      if (parentSuite._tags.length)
+        test.tags = [...parentSuite._tags, ...test.tags];
       if (inheritedRetries === undefined && parentSuite._retries !== undefined)
         inheritedRetries = parentSuite._retries;
       if (inheritedTimeout === undefined && parentSuite._timeout !== undefined)

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -49,6 +49,7 @@ export class Suite extends Base implements SuitePrivate {
   _timeout: number | undefined;
   _retries: number | undefined;
   _staticAnnotations: Annotation[] = [];
+  _tags: string[] = [];
   _modifiers: Modifier[] = [];
   _parallelMode: 'none' | 'default' | 'serial' | 'parallel' = 'none';
   _fullProject: FullProjectInternal | undefined;
@@ -187,6 +188,7 @@ export class Suite extends Base implements SuitePrivate {
       timeout: this._timeout,
       retries: this._retries,
       staticAnnotations: this._staticAnnotations.slice(),
+      tags: this._tags.slice(),
       modifiers: this._modifiers.slice(),
       parallelMode: this._parallelMode,
       hooks: this._hooks.map(h => ({ type: h.type, location: h.location, title: h.title })),
@@ -202,6 +204,7 @@ export class Suite extends Base implements SuitePrivate {
     suite._timeout = data.timeout;
     suite._retries = data.retries;
     suite._staticAnnotations = data.staticAnnotations;
+    suite._tags = data.tags;
     suite._modifiers = data.modifiers;
     suite._parallelMode = data.parallelMode;
     suite._hooks = data.hooks.map((h: any) => ({ type: h.type, location: h.location, title: h.title, fn: () => { } }));
@@ -234,6 +237,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   annotations: Annotation[] = [];
   retries = 0;
   repeatEachIndex = 0;
+  tags: string[] = [];
 
   _testType: TestTypeImpl;
   id = '';
@@ -295,6 +299,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
       workerHash: this._workerHash,
       staticAnnotations: this._staticAnnotations.slice(),
       annotations: this.annotations.slice(),
+      tags: this.tags.slice(),
       projectId: this._projectId,
     };
   }
@@ -311,6 +316,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
     test._workerHash = data.workerHash;
     test._staticAnnotations = data.staticAnnotations;
     test.annotations = data.annotations;
+    test.tags = data.tags;
     test._projectId = data.projectId;
     return test;
   }

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -73,6 +73,7 @@ export type JsonTestCase = {
   title: string;
   location: JsonLocation;
   retries: number;
+  tags: string[];
 };
 
 export type JsonTestEnd = {
@@ -394,6 +395,7 @@ export class TeleReporterReceiver {
     test.id = payload.testId;
     test.location = this._absoluteLocation(payload.location);
     test.retries = payload.retries;
+    test.tags = payload.tags;
     return test;
   }
 
@@ -475,6 +477,7 @@ export class TeleTestCase implements reporterTypes.TestCase {
   timeout = 0;
   annotations: Annotation[] = [];
   retries = 0;
+  tags: string[] = [];
   repeatEachIndex = 0;
   id: string;
 

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -133,6 +133,7 @@ async function runTests(args: string[], opts: { [key: string]: any }) {
   config.cliArgs = args;
   config.cliGrep = opts.grep as string | undefined;
   config.cliGrepInvert = opts.grepInvert as string | undefined;
+  config.cliTagFilter = opts.tag;
   config.cliListOnly = !!opts.list;
   config.cliProjectFilter = opts.project || undefined;
   config.cliPassWithNoTests = !!opts.passWithNoTests;
@@ -333,6 +334,7 @@ const testOptions: [string, string][] = [
   ['--reporter <reporter>', `Reporter to use, comma-separated, can be ${builtInReporters.map(name => `"${name}"`).join(', ')} (default: "${defaultReporter}")`],
   ['--retries <retries>', `Maximum retry count for flaky tests, zero for no retries (default: no retries)`],
   ['--shard <shard>', `Shard tests and execute only the selected shard, specify in the form "current/all", 1-based, for example "3/5"`],
+  ['--tag <tag expression>', `Only run tests with a tag(s) matching the specified expression (default: no filtering)`],
   ['--timeout <timeout>', `Specify test timeout threshold in milliseconds, zero for unlimited (default: ${defaultTimeout})`],
   ['--trace <mode>', `Force tracing mode, can be ${kTraceModes.map(mode => `"${mode}"`).join(', ')}`],
   ['--ui', `Run tests in interactive UI mode`],

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -363,6 +363,7 @@ class HtmlBuilder {
         duration,
         // Annotations can be pushed directly, with a wrong type.
         annotations: test.annotations.map(a => ({ type: a.type, description: a.description ? String(a.description) : a.description })),
+        tags: test.tags,
         outcome: test.outcome(),
         path,
         results,
@@ -377,6 +378,7 @@ class HtmlBuilder {
         duration,
         // Annotations can be pushed directly, with a wrong type.
         annotations: test.annotations.map(a => ({ type: a.type, description: a.description ? String(a.description) : a.description })),
+        tags: test.tags,
         outcome: test.outcome(),
         path,
         ok: test.outcome() === 'expected' || test.outcome() === 'flaky',

--- a/packages/playwright/src/reporters/json.ts
+++ b/packages/playwright/src/reporters/json.ts
@@ -169,7 +169,7 @@ class JSONReporter extends EmptyReporter {
     return {
       title: test.title,
       ok: test.ok(),
-      tags: (test.title.match(/@[\S]+/g) || []).map(t => t.substring(1)),
+      tags: extractTags(test),
       tests: [this._serializeTest(projectId, projectName, test)],
       id: test.id,
       ...this._relativeLocation(test.location),
@@ -254,6 +254,13 @@ function reportOutputNameFromEnv(): string | undefined {
   if (process.env[`PLAYWRIGHT_JSON_OUTPUT_NAME`])
     return path.resolve(process.cwd(), process.env[`PLAYWRIGHT_JSON_OUTPUT_NAME`]);
   return undefined;
+}
+
+function extractTags(test: TestCase) {
+  return [
+    ...test.tags,
+    ...(test.title.match(/@[\S]+/g) || []),
+  ];
 }
 
 export function serializePatterns(patterns: string | RegExp | (string | RegExp)[]): string[] {

--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -202,6 +202,7 @@ export class TeleReporterEmitter implements ReporterV2 {
       title: test.title,
       location: this._relativeLocation(test.location),
       retries: test.retries,
+      tags: test.tags,
     };
   }
 

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -21,8 +21,8 @@ import { Suite } from '../common/test';
 import type { TestCase } from '../common/test';
 import type { FullProjectInternal } from '../common/config';
 import type { FullConfigInternal } from '../common/config';
-import { createFileMatcherFromArguments, createFileFiltersFromArguments, createTitleMatcher, errorWithFile, forceRegExp } from '../util';
-import type { Matcher, TestFileFilter } from '../util';
+import { createFileMatcherFromArguments, createFileFiltersFromArguments, createTitleMatcher, errorWithFile, forceRegExp, createTagMatcher } from '../util';
+import type { Matcher, TagMatcher, TestFileFilter } from '../util';
 import { buildProjectsClosure, collectFilesForProject, filterProjects } from './projectUtils';
 import type { TestRun } from './tasks';
 import { requireOrImport } from '../transform/transform';
@@ -135,12 +135,13 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
     const grepMatcher = config.cliGrep ? createTitleMatcher(forceRegExp(config.cliGrep)) : () => true;
     const grepInvertMatcher = config.cliGrepInvert ? createTitleMatcher(forceRegExp(config.cliGrepInvert)) : () => false;
     const cliTitleMatcher = (title: string) => !grepInvertMatcher(title) && grepMatcher(title);
+    const cliTagMatcher = config.cliTagFilter ? createTagMatcher(config.cliTagFilter) : undefined;
 
     // Filter file suites for all projects.
     for (const [project, fileSuites] of testRun.projectSuites) {
       const projectSuite = createProjectSuite(project, fileSuites);
       projectSuites.set(project, projectSuite);
-      const filteredProjectSuite = filterProjectSuite(projectSuite, { cliFileFilters, cliTitleMatcher, testIdMatcher: config.testIdMatcher });
+      const filteredProjectSuite = filterProjectSuite(projectSuite, { cliFileFilters, cliTitleMatcher, cliTagMatcher, testIdMatcher: config.testIdMatcher });
       filteredProjectSuites.set(project, filteredProjectSuite);
     }
   }
@@ -217,21 +218,21 @@ function createProjectSuite(project: FullProjectInternal, fileSuites: Suite[]): 
 
   const grepMatcher = createTitleMatcher(project.project.grep);
   const grepInvertMatcher = project.project.grepInvert ? createTitleMatcher(project.project.grepInvert) : null;
-
-  const titleMatcher = (test: TestCase) => {
+  const tagMatcher = project.tagFilter ? createTagMatcher(project.tagFilter) : undefined;
+  filterTestsRemoveEmptySuites(projectSuite, (test: TestCase) => {
+    if (tagMatcher && !tagMatcher(test.tags))
+      return false;
     const grepTitle = test.titlePath().join(' ');
     if (grepInvertMatcher?.(grepTitle))
       return false;
     return grepMatcher(grepTitle);
-  };
-
-  filterTestsRemoveEmptySuites(projectSuite, titleMatcher);
+  });
   return projectSuite;
 }
 
-function filterProjectSuite(projectSuite: Suite, options: { cliFileFilters: TestFileFilter[], cliTitleMatcher?: Matcher, testIdMatcher?: Matcher }): Suite {
+function filterProjectSuite(projectSuite: Suite, options: { cliFileFilters: TestFileFilter[], cliTitleMatcher?: Matcher, cliTagMatcher?: TagMatcher, testIdMatcher?: Matcher }): Suite {
   // Fast path.
-  if (!options.cliFileFilters.length && !options.cliTitleMatcher && !options.testIdMatcher)
+  if (!options.cliFileFilters.length && !options.cliTitleMatcher && !options.testIdMatcher && !options.cliTagMatcher)
     return projectSuite;
 
   const result = projectSuite._deepClone();
@@ -239,10 +240,13 @@ function filterProjectSuite(projectSuite: Suite, options: { cliFileFilters: Test
     filterByFocusedLine(result, options.cliFileFilters);
   if (options.testIdMatcher)
     filterByTestIds(result, options.testIdMatcher);
-  const titleMatcher = (test: TestCase) => {
-    return !options.cliTitleMatcher || options.cliTitleMatcher(test.titlePath().join(' '));
-  };
-  filterTestsRemoveEmptySuites(result, titleMatcher);
+  filterTestsRemoveEmptySuites(result, (test: TestCase) => {
+    if (options.cliTagMatcher && !options.cliTagMatcher(test.tags))
+      return false;
+    if (options.cliTitleMatcher && !options.cliTitleMatcher(test.titlePath().join(' ')))
+      return false;
+    return true;
+  });
   return result;
 }
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -707,9 +707,9 @@ interface TestConfig {
 
   /**
    * Whether to exit with an error if any tests or groups are marked as
-   * [test.only(title, body)](https://playwright.dev/docs/api/class-test#test-only) or
-   * [test.describe.only([title, callback])](https://playwright.dev/docs/api/class-test#test-describe-only). Useful on
-   * CI.
+   * [test.only(title[, details, body])](https://playwright.dev/docs/api/class-test#test-only) or
+   * [test.describe.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-only).
+   * Useful on CI.
    *
    * **Usage**
    *
@@ -1245,6 +1245,30 @@ interface TestConfig {
   snapshotPathTemplate?: string;
 
   /**
+   * Filter to only run tests with or without particular tag(s). This property must be a logical expression containing
+   * tags, parenthesis `(` and `)`, and operators `and`, `or` and `not`.
+   *
+   * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
+   *
+   * **Usage**
+   *
+   * ```js
+   * // playwright.config.ts
+   * import { defineConfig } from '@playwright/test';
+   *
+   * export default defineConfig({
+   *   tagFilter: '@smoke',
+   * });
+   * ```
+   *
+   * Tag expression examples:
+   * - `tagFilter: '@smoke'` - run only "smoke" tests;
+   * - `tagFilter: '@smoke and not @production'` - run only "smoke" tests that are not tagged as "production";
+   * - `tagFilter: '(@smoke or @fast) and @v2'` - run "v2" tests that are tagged as "smoke", "fast" or both.
+   */
+  tagFilter?: string;
+
+  /**
    * Directory that will be recursively scanned for test files. Defaults to the directory of the configuration file.
    *
    * **Usage**
@@ -1464,9 +1488,9 @@ export type Metadata = { [key: string]: any };
 export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
   /**
    * Whether to exit with an error if any tests or groups are marked as
-   * [test.only(title, body)](https://playwright.dev/docs/api/class-test#test-only) or
-   * [test.describe.only([title, callback])](https://playwright.dev/docs/api/class-test#test-describe-only). Useful on
-   * CI.
+   * [test.only(title[, details, body])](https://playwright.dev/docs/api/class-test#test-only) or
+   * [test.describe.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-only).
+   * Useful on CI.
    *
    * **Usage**
    *
@@ -2001,13 +2025,13 @@ export interface TestInfo {
    * Marks the currently running test as "should fail". Playwright Test runs this test and ensures that it is actually
    * failing. This is useful for documentation purposes to acknowledge that some functionality is broken until it is
    * fixed. This is similar to
-   * [test.fail([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fail).
+   * [test.fail([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fail).
    */
   fail(): void;
 
   /**
    * Conditionally mark the currently running test as "should fail" with an optional description. This is similar to
-   * [test.fail([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fail).
+   * [test.fail([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fail).
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param description Optional description that will be reflected in a test report.
    */
@@ -2015,13 +2039,13 @@ export interface TestInfo {
 
   /**
    * Mark a test as "fixme", with the intention to fix it. Test is immediately aborted. This is similar to
-   * [test.fixme([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme).
+   * [test.fixme([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme).
    */
   fixme(): void;
 
   /**
    * Conditionally mark the currently running test as "fixme" with an optional description. This is similar to
-   * [test.fixme([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme).
+   * [test.fixme([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme).
    * @param condition Test is marked as "fixme" when the condition is `true`.
    * @param description Optional description that will be reflected in a test report.
    */
@@ -2073,13 +2097,13 @@ export interface TestInfo {
 
   /**
    * Unconditionally skip the currently running test. Test is immediately aborted. This is similar to
-   * [test.skip([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-skip).
+   * [test.skip([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-skip).
    */
   skip(): void;
 
   /**
    * Conditionally skips the currently running test with an optional description. This is similar to
-   * [test.skip([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-skip).
+   * [test.skip([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-skip).
    * @param condition A skip condition. Test is skipped when the condition is `true`.
    * @param description Optional description that will be reflected in a test report.
    */
@@ -2115,8 +2139,8 @@ export interface TestInfo {
 
   /**
    * The list of annotations applicable to the current test. Includes annotations from the test, annotations from all
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) groups the test
-   * belongs to and file-level annotations for the test file.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) groups the
+   * test belongs to and file-level annotations for the test file.
    *
    * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
    */
@@ -2188,9 +2212,9 @@ export interface TestInfo {
   /**
    * Expected status for the currently running test. This is usually `'passed'`, except for a few cases:
    * - `'skipped'` for skipped tests, e.g. with
-   *   [test.skip([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-skip);
+   *   [test.skip([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-skip);
    * - `'failed'` for tests marked as failed with
-   *   [test.fail([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fail).
+   *   [test.fail([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fail).
    *
    * Expected status is usually compared with the actual
    * [testInfo.status](https://playwright.dev/docs/api/class-testinfo#test-info-status):
@@ -2355,11 +2379,22 @@ export interface TestInfo {
   workerIndex: number;
 }
 
+type TestDetailsAnnotation = {
+  type: string;
+  description?: string;
+};
+
+export type TestDetails = {
+  tag?: string | string[];
+  annotation?: TestDetailsAnnotation | TestDetailsAnnotation[];
+}
+
 interface SuiteFunction {
   /**
    * Declares a group of tests.
    * - `test.describe(title, callback)`
    * - `test.describe(callback)`
+   * - `test.describe(title, details, callback)`
    *
    * **Usage**
    *
@@ -2378,8 +2413,10 @@ interface SuiteFunction {
    * });
    * ```
    *
-   * Without a title, this method declares an **anonymous** group of tests. This is convenient to give a group of tests
-   * a common option with [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
+   * **Anonymous group**
+   *
+   * You can also declare a test group without a title. This is convenient to give a group of tests a common option with
+   * [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
    *
    * ```js
    * test.describe(() => {
@@ -2395,16 +2432,64 @@ interface SuiteFunction {
    * });
    * ```
    *
+   * **Tags**
+   *
+   * You can tag all tests in a group by providing additional details. Note that each tag must start with `@` symbol.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.describe('two tagged tests', {
+   *   tag: '@smoke',
+   * }, () => {
+   *   test('one', async ({ page }) => {
+   *     // ...
+   *   });
+   *
+   *   test('two', async ({ page }) => {
+   *     // ...
+   *   });
+   * });
+   * ```
+   *
+   * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
+   *
+   * **Annotations**
+   *
+   * You can annotate all tests in a group by providing additional details.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.describe('two annotated tests', {
+   *   annotation: {
+   *     type: 'issue',
+   *     description: 'https://github.com/microsoft/playwright/issues/23180',
+   *   },
+   * }, () => {
+   *   test('one', async ({ page }) => {
+   *     // ...
+   *   });
+   *
+   *   test('two', async ({ page }) => {
+   *     // ...
+   *   });
+   * });
+   * ```
+   *
+   * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
    * @param title Group title.
+   * @param details Additional details for all tests in the group.
    * @param callback A callback that is run immediately when calling
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests declared in
-   * this callback will belong to the group.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests
+   * declared in this callback will belong to the group.
    */
   (title: string, callback: () => void): void;
   /**
    * Declares a group of tests.
    * - `test.describe(title, callback)`
    * - `test.describe(callback)`
+   * - `test.describe(title, details, callback)`
    *
    * **Usage**
    *
@@ -2423,8 +2508,10 @@ interface SuiteFunction {
    * });
    * ```
    *
-   * Without a title, this method declares an **anonymous** group of tests. This is convenient to give a group of tests
-   * a common option with [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
+   * **Anonymous group**
+   *
+   * You can also declare a test group without a title. This is convenient to give a group of tests a common option with
+   * [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
    *
    * ```js
    * test.describe(() => {
@@ -2440,16 +2527,299 @@ interface SuiteFunction {
    * });
    * ```
    *
+   * **Tags**
+   *
+   * You can tag all tests in a group by providing additional details. Note that each tag must start with `@` symbol.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.describe('two tagged tests', {
+   *   tag: '@smoke',
+   * }, () => {
+   *   test('one', async ({ page }) => {
+   *     // ...
+   *   });
+   *
+   *   test('two', async ({ page }) => {
+   *     // ...
+   *   });
+   * });
+   * ```
+   *
+   * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
+   *
+   * **Annotations**
+   *
+   * You can annotate all tests in a group by providing additional details.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.describe('two annotated tests', {
+   *   annotation: {
+   *     type: 'issue',
+   *     description: 'https://github.com/microsoft/playwright/issues/23180',
+   *   },
+   * }, () => {
+   *   test('one', async ({ page }) => {
+   *     // ...
+   *   });
+   *
+   *   test('two', async ({ page }) => {
+   *     // ...
+   *   });
+   * });
+   * ```
+   *
+   * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
    * @param title Group title.
+   * @param details Additional details for all tests in the group.
    * @param callback A callback that is run immediately when calling
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests declared in
-   * this callback will belong to the group.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests
+   * declared in this callback will belong to the group.
    */
   (callback: () => void): void;
+  /**
+   * Declares a group of tests.
+   * - `test.describe(title, callback)`
+   * - `test.describe(callback)`
+   * - `test.describe(title, details, callback)`
+   *
+   * **Usage**
+   *
+   * You can declare a group of tests with a title. The title will be visible in the test report as a part of each
+   * test's title.
+   *
+   * ```js
+   * test.describe('two tests', () => {
+   *   test('one', async ({ page }) => {
+   *     // ...
+   *   });
+   *
+   *   test('two', async ({ page }) => {
+   *     // ...
+   *   });
+   * });
+   * ```
+   *
+   * **Anonymous group**
+   *
+   * You can also declare a test group without a title. This is convenient to give a group of tests a common option with
+   * [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
+   *
+   * ```js
+   * test.describe(() => {
+   *   test.use({ colorScheme: 'dark' });
+   *
+   *   test('one', async ({ page }) => {
+   *     // ...
+   *   });
+   *
+   *   test('two', async ({ page }) => {
+   *     // ...
+   *   });
+   * });
+   * ```
+   *
+   * **Tags**
+   *
+   * You can tag all tests in a group by providing additional details. Note that each tag must start with `@` symbol.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.describe('two tagged tests', {
+   *   tag: '@smoke',
+   * }, () => {
+   *   test('one', async ({ page }) => {
+   *     // ...
+   *   });
+   *
+   *   test('two', async ({ page }) => {
+   *     // ...
+   *   });
+   * });
+   * ```
+   *
+   * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
+   *
+   * **Annotations**
+   *
+   * You can annotate all tests in a group by providing additional details.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.describe('two annotated tests', {
+   *   annotation: {
+   *     type: 'issue',
+   *     description: 'https://github.com/microsoft/playwright/issues/23180',
+   *   },
+   * }, () => {
+   *   test('one', async ({ page }) => {
+   *     // ...
+   *   });
+   *
+   *   test('two', async ({ page }) => {
+   *     // ...
+   *   });
+   * });
+   * ```
+   *
+   * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
+   * @param title Group title.
+   * @param details Additional details for all tests in the group.
+   * @param callback A callback that is run immediately when calling
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests
+   * declared in this callback will belong to the group.
+   */
+  (title: string, details: TestDetails, callback: () => void): void;
 }
 
 interface TestFunction<TestArgs> {
-  (title: string, testFunction: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  /**
+   * Declares a test.
+   * - `test(title, body)`
+   * - `test(title, details, body)`
+   *
+   * **Usage**
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('basic test', async ({ page }) => {
+   *   await page.goto('https://playwright.dev/');
+   *   // ...
+   * });
+   * ```
+   *
+   * **Tags**
+   *
+   * You can tag tests by providing additional test details. Note that each tag must start with `@` symbol.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('basic test', {
+   *   tag: '@smoke',
+   * }, async ({ page }) => {
+   *   await page.goto('https://playwright.dev/');
+   *   // ...
+   * });
+   * ```
+   *
+   * Test tags are displayed in the test report, and are available to a custom reporter via `TestCase.tags` property.
+   *
+   * You can also filter tests by their tags during test execution:
+   * - in the [command line](https://playwright.dev/docs/test-cli#reference);
+   * - in the config with
+   *   [testConfig.tagFilter](https://playwright.dev/docs/api/class-testconfig#test-config-tag-filter) and
+   *   [testProject.tagFilter](https://playwright.dev/docs/api/class-testproject#test-project-tag-filter);
+   *
+   * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
+   *
+   * **Annotations**
+   *
+   * You can annotate tests by providing additional test details.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('basic test', {
+   *   annotation: {
+   *     type: 'issue',
+   *     description: 'https://github.com/microsoft/playwright/issues/23180',
+   *   },
+   * }, async ({ page }) => {
+   *   await page.goto('https://playwright.dev/');
+   *   // ...
+   * });
+   * ```
+   *
+   * Test annotations are displayed in the test report, and are available to a custom reporter via
+   * `TestCase.annotations` property.
+   *
+   * You can also add dynamic annotations by manipulating
+   * [testInfo.annotations](https://playwright.dev/docs/api/class-testinfo#test-info-annotations).
+   *
+   * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
+   * @param title Test title.
+   * @param details Additional test details.
+   * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
+   */
+  (title: string, body: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  /**
+   * Declares a test.
+   * - `test(title, body)`
+   * - `test(title, details, body)`
+   *
+   * **Usage**
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('basic test', async ({ page }) => {
+   *   await page.goto('https://playwright.dev/');
+   *   // ...
+   * });
+   * ```
+   *
+   * **Tags**
+   *
+   * You can tag tests by providing additional test details. Note that each tag must start with `@` symbol.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('basic test', {
+   *   tag: '@smoke',
+   * }, async ({ page }) => {
+   *   await page.goto('https://playwright.dev/');
+   *   // ...
+   * });
+   * ```
+   *
+   * Test tags are displayed in the test report, and are available to a custom reporter via `TestCase.tags` property.
+   *
+   * You can also filter tests by their tags during test execution:
+   * - in the [command line](https://playwright.dev/docs/test-cli#reference);
+   * - in the config with
+   *   [testConfig.tagFilter](https://playwright.dev/docs/api/class-testconfig#test-config-tag-filter) and
+   *   [testProject.tagFilter](https://playwright.dev/docs/api/class-testproject#test-project-tag-filter);
+   *
+   * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
+   *
+   * **Annotations**
+   *
+   * You can annotate tests by providing additional test details.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('basic test', {
+   *   annotation: {
+   *     type: 'issue',
+   *     description: 'https://github.com/microsoft/playwright/issues/23180',
+   *   },
+   * }, async ({ page }) => {
+   *   await page.goto('https://playwright.dev/');
+   *   // ...
+   * });
+   * ```
+   *
+   * Test annotations are displayed in the test report, and are available to a custom reporter via
+   * `TestCase.annotations` property.
+   *
+   * You can also add dynamic annotations by manipulating
+   * [testInfo.annotations](https://playwright.dev/docs/api/class-testinfo#test-info-annotations).
+   *
+   * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
+   * @param title Test title.
+   * @param details Additional test details.
+   * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
+   */
+  (title: string, details: TestDetails, body: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
 }
 
 /**
@@ -2469,6 +2839,8 @@ interface TestFunction<TestArgs> {
 export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue> extends TestFunction<TestArgs & WorkerArgs> {
   /**
    * Declares a focused test. If there are some focused tests or suites, all of them will be run but nothing else.
+   * - `test.only(title, body)`
+   * - `test.only(title, details, body)`
    *
    * **Usage**
    *
@@ -2479,6 +2851,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    */
   only: TestFunction<TestArgs & WorkerArgs>;
@@ -2486,6 +2860,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Declares a group of tests.
    * - `test.describe(title, callback)`
    * - `test.describe(callback)`
+   * - `test.describe(title, details, callback)`
    *
    * **Usage**
    *
@@ -2504,8 +2879,10 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * });
    * ```
    *
-   * Without a title, this method declares an **anonymous** group of tests. This is convenient to give a group of tests
-   * a common option with [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
+   * **Anonymous group**
+   *
+   * You can also declare a test group without a title. This is convenient to give a group of tests a common option with
+   * [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
    *
    * ```js
    * test.describe(() => {
@@ -2521,10 +2898,57 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * });
    * ```
    *
+   * **Tags**
+   *
+   * You can tag all tests in a group by providing additional details. Note that each tag must start with `@` symbol.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.describe('two tagged tests', {
+   *   tag: '@smoke',
+   * }, () => {
+   *   test('one', async ({ page }) => {
+   *     // ...
+   *   });
+   *
+   *   test('two', async ({ page }) => {
+   *     // ...
+   *   });
+   * });
+   * ```
+   *
+   * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
+   *
+   * **Annotations**
+   *
+   * You can annotate all tests in a group by providing additional details.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.describe('two annotated tests', {
+   *   annotation: {
+   *     type: 'issue',
+   *     description: 'https://github.com/microsoft/playwright/issues/23180',
+   *   },
+   * }, () => {
+   *   test('one', async ({ page }) => {
+   *     // ...
+   *   });
+   *
+   *   test('two', async ({ page }) => {
+   *     // ...
+   *   });
+   * });
+   * ```
+   *
+   * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
    * @param title Group title.
+   * @param details Additional details for all tests in the group.
    * @param callback A callback that is run immediately when calling
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests declared in
-   * this callback will belong to the group.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests
+   * declared in this callback will belong to the group.
    */
   describe: SuiteFunction & {
     /**
@@ -2532,6 +2956,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * else.
    * - `test.describe.only(title, callback)`
    * - `test.describe.only(callback)`
+   * - `test.describe.only(title, details, callback)`
    *
    * **Usage**
    *
@@ -2555,17 +2980,20 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Group title.
+   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+   * details description.
    * @param callback A callback that is run immediately when calling
-   * [test.describe.only([title, callback])](https://playwright.dev/docs/api/class-test#test-describe-only). Any tests
-   * added in this callback will belong to the group.
+   * [test.describe.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-only).
+   * Any tests added in this callback will belong to the group.
    */
   only: SuiteFunction;
     /**
    * Declares a skipped test group, similarly to
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in the skipped
-   * group are never run.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in the
+   * skipped group are never run.
    * - `test.describe.skip(title, callback)`
    * - `test.describe.skip(title)`
+   * - `test.describe.skip(title, details, callback)`
    *
    * **Usage**
    *
@@ -2586,17 +3014,20 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Group title.
+   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+   * details description.
    * @param callback A callback that is run immediately when calling
-   * [test.describe.skip(title, callback)](https://playwright.dev/docs/api/class-test#test-describe-skip). Any tests
-   * added in this callback will belong to the group, and will not be run.
+   * [test.describe.skip(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-skip).
+   * Any tests added in this callback will belong to the group, and will not be run.
    */
   skip: SuiteFunction;
     /**
    * Declares a test group similarly to
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in this group
-   * are marked as "fixme" and will not be executed.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in
+   * this group are marked as "fixme" and will not be executed.
    * - `test.describe.fixme(title, callback)`
    * - `test.describe.fixme(callback)`
+   * - `test.describe.fixme(title, details, callback)`
    *
    * **Usage**
    *
@@ -2617,9 +3048,11 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Group title.
+   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+   * details description.
    * @param callback A callback that is run immediately when calling
-   * [test.describe.fixme([title, callback])](https://playwright.dev/docs/api/class-test#test-describe-fixme). Any tests
-   * added in this callback will belong to the group, and will not be run.
+   * [test.describe.fixme([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-fixme).
+   * Any tests added in this callback will belong to the group, and will not be run.
    */
   fixme: SuiteFunction;
     /**
@@ -2633,6 +3066,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * independently.
    * - `test.describe.serial(title, callback)`
    * - `test.describe.serial(title)`
+   * - `test.describe.serial(title, details, callback)`
    *
    * **Usage**
    *
@@ -2652,9 +3086,11 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Group title.
+   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+   * details description.
    * @param callback A callback that is run immediately when calling
-   * [test.describe.serial([title, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial). Any
-   * tests added in this callback will belong to the group.
+   * [test.describe.serial([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial).
+   * Any tests added in this callback will belong to the group.
    */
   serial: SuiteFunction & {
       /**
@@ -2669,6 +3105,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * independently.
    * - `test.describe.serial.only(title, callback)`
    * - `test.describe.serial.only(title)`
+   * - `test.describe.serial.only(title, details, callback)`
    *
    * **Usage**
    *
@@ -2690,8 +3127,10 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Group title.
+   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+   * details description.
    * @param callback A callback that is run immediately when calling
-   * [test.describe.serial.only(title, callback)](https://playwright.dev/docs/api/class-test#test-describe-serial-only).
+   * [test.describe.serial.only(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial-only).
    * Any tests added in this callback will belong to the group.
    */
   only: SuiteFunction;
@@ -2702,10 +3141,11 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    *
    * Declares a group of tests that could be run in parallel. By default, tests in a single test file run one after
    * another, but using
-   * [test.describe.parallel([title, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel)
+   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel)
    * allows them to run in parallel.
    * - `test.describe.parallel(title, callback)`
    * - `test.describe.parallel(callback)`
+   * - `test.describe.parallel(title, details, callback)`
    *
    * **Usage**
    *
@@ -2728,9 +3168,11 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Group title.
+   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+   * details description.
    * @param callback A callback that is run immediately when calling
-   * [test.describe.parallel([title, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel). Any
-   * tests added in this callback will belong to the group.
+   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel).
+   * Any tests added in this callback will belong to the group.
    */
   parallel: SuiteFunction & {
       /**
@@ -2738,10 +3180,11 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * the preferred way of configuring the execution mode.
    *
    * Declares a focused group of tests that could be run in parallel. This is similar to
-   * [test.describe.parallel([title, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel), but
-   * focuses the group. If there are some focused tests or suites, all of them will be run but nothing else.
+   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel),
+   * but focuses the group. If there are some focused tests or suites, all of them will be run but nothing else.
    * - `test.describe.parallel.only(title, callback)`
    * - `test.describe.parallel.only(callback)`
+   * - `test.describe.parallel.only(title, details, callback)`
    *
    * **Usage**
    *
@@ -2761,8 +3204,10 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Group title.
+   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+   * details description.
    * @param callback A callback that is run immediately when calling
-   * [test.describe.parallel.only([title, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel-only).
+   * [test.describe.parallel.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel-only).
    * Any tests added in this callback will belong to the group.
    */
   only: SuiteFunction;
@@ -2830,9 +3275,10 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Skip a test. Playwright will not run the test past the `test.skip()` call.
    *
    * Skipped tests are not supposed to be ever run. If you intent to fix the test, use
-   * [test.fixme([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
+   * [test.fixme([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
    * instead.
    * - `test.skip(title, body)`
+   * - `test.skip(title, details, body)`
    * - `test.skip()`
    * - `test.skip(condition, description)`
    * - `test.skip(callback, description)`
@@ -2863,8 +3309,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can skip all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group based on some
-   * condition with a single `test.skip(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group based
+   * on some condition with a single `test.skip(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -2892,20 +3338,23 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
    * "should fail" when the return value is `true`.
    * @param description Optional description that will be reflected in a test report.
    */
-  skip(title: string, testFunction: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  skip(title: string, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
   /**
    * Skip a test. Playwright will not run the test past the `test.skip()` call.
    *
    * Skipped tests are not supposed to be ever run. If you intent to fix the test, use
-   * [test.fixme([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
+   * [test.fixme([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
    * instead.
    * - `test.skip(title, body)`
+   * - `test.skip(title, details, body)`
    * - `test.skip()`
    * - `test.skip(condition, description)`
    * - `test.skip(callback, description)`
@@ -2936,8 +3385,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can skip all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group based on some
-   * condition with a single `test.skip(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group based
+   * on some condition with a single `test.skip(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -2965,6 +3414,84 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
+   * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
+   * @param condition Test is marked as "should fail" when the condition is `true`.
+   * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
+   * "should fail" when the return value is `true`.
+   * @param description Optional description that will be reflected in a test report.
+   */
+  skip(title: string, details: TestDetails, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  /**
+   * Skip a test. Playwright will not run the test past the `test.skip()` call.
+   *
+   * Skipped tests are not supposed to be ever run. If you intent to fix the test, use
+   * [test.fixme([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
+   * instead.
+   * - `test.skip(title, body)`
+   * - `test.skip(title, details, body)`
+   * - `test.skip()`
+   * - `test.skip(condition, description)`
+   * - `test.skip(callback, description)`
+   *
+   * **Usage**
+   *
+   * You can declare a skipped test, and Playwright will not run it.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.skip('never run', async ({ page }) => {
+   *   // ...
+   * });
+   * ```
+   *
+   * If your test should be skipped in some configurations, but not all, you can skip the test inside the test body
+   * based on some condition. We recommend passing a `description` argument in this case. Playwright will run the test,
+   * but abort it immediately after the `test.skip` call.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('Safari-only test', async ({ page, browserName }) => {
+   *   test.skip(browserName !== 'webkit', 'This feature is Safari-only');
+   *   // ...
+   * });
+   * ```
+   *
+   * You can skip all tests in a file or
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group based
+   * on some condition with a single `test.skip(callback, description)` call.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.skip(({ browserName }) => browserName !== 'webkit', 'Safari-only');
+   *
+   * test('Safari-only test 1', async ({ page }) => {
+   *   // ...
+   * });
+   * test('Safari-only test 2', async ({ page }) => {
+   *   // ...
+   * });
+   * ```
+   *
+   * You can also call `test.skip()` without arguments inside the test body to always mark the test as failed. We
+   * recommend using `test.skip(title, body)` instead.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('less readable', async ({ page }) => {
+   *   test.skip();
+   *   // ...
+   * });
+   * ```
+   *
+   * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
@@ -2976,9 +3503,10 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Skip a test. Playwright will not run the test past the `test.skip()` call.
    *
    * Skipped tests are not supposed to be ever run. If you intent to fix the test, use
-   * [test.fixme([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
+   * [test.fixme([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
    * instead.
    * - `test.skip(title, body)`
+   * - `test.skip(title, details, body)`
    * - `test.skip()`
    * - `test.skip(condition, description)`
    * - `test.skip(callback, description)`
@@ -3009,8 +3537,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can skip all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group based on some
-   * condition with a single `test.skip(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group based
+   * on some condition with a single `test.skip(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3038,6 +3566,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
@@ -3049,9 +3579,10 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Skip a test. Playwright will not run the test past the `test.skip()` call.
    *
    * Skipped tests are not supposed to be ever run. If you intent to fix the test, use
-   * [test.fixme([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
+   * [test.fixme([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
    * instead.
    * - `test.skip(title, body)`
+   * - `test.skip(title, details, body)`
    * - `test.skip()`
    * - `test.skip(condition, description)`
    * - `test.skip(callback, description)`
@@ -3082,8 +3613,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can skip all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group based on some
-   * condition with a single `test.skip(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group based
+   * on some condition with a single `test.skip(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3111,6 +3642,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
@@ -3122,6 +3655,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Mark a test as "fixme", with the intention to fix it. Playwright will not run the test past the `test.fixme()`
    * call.
    * - `test.fixme(title, body)`
+   * - `test.fixme(title, details, body)`
    * - `test.fixme()`
    * - `test.fixme(condition, description)`
    * - `test.fixme(callback, description)`
@@ -3152,8 +3686,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can mark all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as "fixme" based
-   * on some condition with a single `test.fixme(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "fixme" based on some condition with a single `test.fixme(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3181,17 +3715,20 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
    * "should fail" when the return value is `true`.
    * @param description Optional description that will be reflected in a test report.
    */
-  fixme(title: string, testFunction: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  fixme(title: string, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
   /**
    * Mark a test as "fixme", with the intention to fix it. Playwright will not run the test past the `test.fixme()`
    * call.
    * - `test.fixme(title, body)`
+   * - `test.fixme(title, details, body)`
    * - `test.fixme()`
    * - `test.fixme(condition, description)`
    * - `test.fixme(callback, description)`
@@ -3222,8 +3759,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can mark all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as "fixme" based
-   * on some condition with a single `test.fixme(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "fixme" based on some condition with a single `test.fixme(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3251,6 +3788,81 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
+   * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
+   * @param condition Test is marked as "should fail" when the condition is `true`.
+   * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
+   * "should fail" when the return value is `true`.
+   * @param description Optional description that will be reflected in a test report.
+   */
+  fixme(title: string, details: TestDetails, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  /**
+   * Mark a test as "fixme", with the intention to fix it. Playwright will not run the test past the `test.fixme()`
+   * call.
+   * - `test.fixme(title, body)`
+   * - `test.fixme(title, details, body)`
+   * - `test.fixme()`
+   * - `test.fixme(condition, description)`
+   * - `test.fixme(callback, description)`
+   *
+   * **Usage**
+   *
+   * You can declare a test as to be fixed, and Playwright will not run it.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.fixme('to be fixed', async ({ page }) => {
+   *   // ...
+   * });
+   * ```
+   *
+   * If your test should be fixed in some configurations, but not all, you can mark the test as "fixme" inside the test
+   * body based on some condition. We recommend passing a `description` argument in this case. Playwright will run the
+   * test, but abort it immediately after the `test.fixme` call.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('to be fixed in Safari', async ({ page, browserName }) => {
+   *   test.fixme(browserName === 'webkit', 'This feature breaks in Safari for some reason');
+   *   // ...
+   * });
+   * ```
+   *
+   * You can mark all tests in a file or
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "fixme" based on some condition with a single `test.fixme(callback, description)` call.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.fixme(({ browserName }) => browserName === 'webkit', 'Should figure out the issue');
+   *
+   * test('to be fixed in Safari 1', async ({ page }) => {
+   *   // ...
+   * });
+   * test('to be fixed in Safari 2', async ({ page }) => {
+   *   // ...
+   * });
+   * ```
+   *
+   * You can also call `test.fixme()` without arguments inside the test body to always mark the test as failed. We
+   * recommend using `test.fixme(title, body)` instead.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('less readable', async ({ page }) => {
+   *   test.fixme();
+   *   // ...
+   * });
+   * ```
+   *
+   * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
@@ -3262,6 +3874,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Mark a test as "fixme", with the intention to fix it. Playwright will not run the test past the `test.fixme()`
    * call.
    * - `test.fixme(title, body)`
+   * - `test.fixme(title, details, body)`
    * - `test.fixme()`
    * - `test.fixme(condition, description)`
    * - `test.fixme(callback, description)`
@@ -3292,8 +3905,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can mark all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as "fixme" based
-   * on some condition with a single `test.fixme(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "fixme" based on some condition with a single `test.fixme(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3321,6 +3934,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
@@ -3332,6 +3947,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Mark a test as "fixme", with the intention to fix it. Playwright will not run the test past the `test.fixme()`
    * call.
    * - `test.fixme(title, body)`
+   * - `test.fixme(title, details, body)`
    * - `test.fixme()`
    * - `test.fixme(condition, description)`
    * - `test.fixme(callback, description)`
@@ -3362,8 +3978,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can mark all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as "fixme" based
-   * on some condition with a single `test.fixme(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "fixme" based on some condition with a single `test.fixme(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3391,6 +4007,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
@@ -3402,6 +4020,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
    * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
    * - `test.fail(title, body)`
+   * - `test.fail(title, details, body)`
    * - `test.fail()`
    * - `test.fail(condition, description)`
    * - `test.fail(callback, description)`
@@ -3431,8 +4050,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can mark all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as "should fail"
-   * based on some condition with a single `test.fail(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "should fail" based on some condition with a single `test.fail(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3460,17 +4079,20 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
    * "should fail" when the return value is `true`.
    * @param description Optional description that will be reflected in a test report.
    */
-  fail(title: string, testFunction: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  fail(title: string, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
   /**
    * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
    * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
    * - `test.fail(title, body)`
+   * - `test.fail(title, details, body)`
    * - `test.fail()`
    * - `test.fail(condition, description)`
    * - `test.fail(callback, description)`
@@ -3500,8 +4122,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can mark all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as "should fail"
-   * based on some condition with a single `test.fail(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "should fail" based on some condition with a single `test.fail(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3529,6 +4151,80 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
+   * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
+   * @param condition Test is marked as "should fail" when the condition is `true`.
+   * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
+   * "should fail" when the return value is `true`.
+   * @param description Optional description that will be reflected in a test report.
+   */
+  fail(title: string, details: TestDetails, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  /**
+   * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
+   * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
+   * - `test.fail(title, body)`
+   * - `test.fail(title, details, body)`
+   * - `test.fail()`
+   * - `test.fail(condition, description)`
+   * - `test.fail(callback, description)`
+   *
+   * **Usage**
+   *
+   * You can declare a test as failing, so that Playwright ensures it actually fails.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.fail('not yet ready', async ({ page }) => {
+   *   // ...
+   * });
+   * ```
+   *
+   * If your test fails in some configurations, but not all, you can mark the test as failing inside the test body based
+   * on some condition. We recommend passing a `description` argument in this case.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('fail in WebKit', async ({ page, browserName }) => {
+   *   test.fail(browserName === 'webkit', 'This feature is not implemented for Mac yet');
+   *   // ...
+   * });
+   * ```
+   *
+   * You can mark all tests in a file or
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "should fail" based on some condition with a single `test.fail(callback, description)` call.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test.fail(({ browserName }) => browserName === 'webkit', 'not implemented yet');
+   *
+   * test('fail in WebKit 1', async ({ page }) => {
+   *   // ...
+   * });
+   * test('fail in WebKit 2', async ({ page }) => {
+   *   // ...
+   * });
+   * ```
+   *
+   * You can also call `test.fail()` without arguments inside the test body to always mark the test as failed. We
+   * recommend declaring a failing test with `test.fail(title, body)` instead.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('less readable', async ({ page }) => {
+   *   test.fail();
+   *   // ...
+   * });
+   * ```
+   *
+   * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
@@ -3540,6 +4236,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
    * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
    * - `test.fail(title, body)`
+   * - `test.fail(title, details, body)`
    * - `test.fail()`
    * - `test.fail(condition, description)`
    * - `test.fail(callback, description)`
@@ -3569,8 +4266,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can mark all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as "should fail"
-   * based on some condition with a single `test.fail(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "should fail" based on some condition with a single `test.fail(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3598,6 +4295,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
@@ -3609,6 +4308,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
    * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
    * - `test.fail(title, body)`
+   * - `test.fail(title, details, body)`
    * - `test.fail()`
    * - `test.fail(condition, description)`
    * - `test.fail(callback, description)`
@@ -3638,8 +4338,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can mark all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as "should fail"
-   * based on some condition with a single `test.fail(callback, description)` call.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "should fail" based on some condition with a single `test.fail(callback, description)` call.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3667,6 +4367,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * @param title Test title.
+   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+   * description.
    * @param body Test body that takes one or two arguments: an object with fixtures and optional {@link TestInfo}.
    * @param condition Test is marked as "should fail" when the condition is `true`.
    * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
@@ -3710,8 +4412,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can mark all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as "slow" based
-   * on some condition by passing a callback.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "slow" based on some condition by passing a callback.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3768,8 +4470,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can mark all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as "slow" based
-   * on some condition by passing a callback.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "slow" based on some condition by passing a callback.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3826,8 +4528,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * ```
    *
    * You can mark all tests in a file or
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as "slow" based
-   * on some condition by passing a callback.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+   * "slow" based on some condition by passing a callback.
    *
    * ```js
    * import { test, expect } from '@playwright/test';
@@ -3885,7 +4587,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    *   ```
    *
    * - Changing timeout for all tests in a
-   *   [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group.
+   *   [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group.
    *
    *   ```js
    *   test.describe('group', () => {
@@ -3905,8 +4607,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Declares a `beforeEach` hook that is executed before each test.
    *
    * When called in the scope of a test file, runs before each test in the file. When called inside a
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs before
-   * each test in the group.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs
+   * before each test in the group.
    *
    * You can access all the same {@link Fixtures} as the test body itself, and also the {@link TestInfo} object that
    * gives a lot of useful information. For example, you can navigate the page before starting the test.
@@ -3956,8 +4658,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Declares a `beforeEach` hook that is executed before each test.
    *
    * When called in the scope of a test file, runs before each test in the file. When called inside a
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs before
-   * each test in the group.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs
+   * before each test in the group.
    *
    * You can access all the same {@link Fixtures} as the test body itself, and also the {@link TestInfo} object that
    * gives a lot of useful information. For example, you can navigate the page before starting the test.
@@ -4007,8 +4709,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Declares an `afterEach` hook that is executed after each test.
    *
    * When called in the scope of a test file, runs after each test in the file. When called inside a
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs after each
-   * test in the group.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs
+   * after each test in the group.
    *
    * You can access all the same {@link Fixtures} as the test body itself, and also the {@link TestInfo} object that
    * gives a lot of useful information. For example, you can check whether the test succeeded or failed.
@@ -4057,8 +4759,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Declares an `afterEach` hook that is executed after each test.
    *
    * When called in the scope of a test file, runs after each test in the file. When called inside a
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs after each
-   * test in the group.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs
+   * after each test in the group.
    *
    * You can access all the same {@link Fixtures} as the test body itself, and also the {@link TestInfo} object that
    * gives a lot of useful information. For example, you can check whether the test succeeded or failed.
@@ -4107,8 +4809,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Declares a `beforeAll` hook that is executed once per worker process before all tests.
    *
    * When called in the scope of a test file, runs before all tests in the file. When called inside a
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs before all
-   * tests in the group.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs
+   * before all tests in the group.
    *
    * You can use [test.afterAll([title, hookFunction])](https://playwright.dev/docs/api/class-test#test-after-all) to
    * teardown any resources set up in `beforeAll`.
@@ -4160,8 +4862,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Declares a `beforeAll` hook that is executed once per worker process before all tests.
    *
    * When called in the scope of a test file, runs before all tests in the file. When called inside a
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs before all
-   * tests in the group.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs
+   * before all tests in the group.
    *
    * You can use [test.afterAll([title, hookFunction])](https://playwright.dev/docs/api/class-test#test-after-all) to
    * teardown any resources set up in `beforeAll`.
@@ -4213,8 +4915,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Declares an `afterAll` hook that is executed once per worker after all tests.
    *
    * When called in the scope of a test file, runs after all tests in the file. When called inside a
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs after all
-   * tests in the group.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs
+   * after all tests in the group.
    *
    * **Details**
    *
@@ -4253,8 +4955,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Declares an `afterAll` hook that is executed once per worker after all tests.
    *
    * When called in the scope of a test file, runs after all tests in the file. When called inside a
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs after all
-   * tests in the group.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group, runs
+   * after all tests in the group.
    *
    * **Details**
    *
@@ -4291,8 +4993,8 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
   afterAll(title: string, inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   /**
    * Specifies options or fixtures to use in a single test file or a
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group. Most useful to
-   * set an option, for example set `locale` to configure `context` fixture.
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group. Most
+   * useful to set an option, for example set `locale` to configure `context` fixture.
    *
    * **Usage**
    *
@@ -8022,6 +8724,35 @@ interface TestProject {
    * 1. Forward slashes `"/"` can be used as path separators on any platform.
    */
   snapshotPathTemplate?: string;
+
+  /**
+   * Filter to only run tests with or without particular tag(s). This property must be a logical expression containing
+   * tags, parenthesis `(` and `)`, and operators `and`, `or` and `not`.
+   *
+   * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
+   *
+   * **Usage**
+   *
+   * ```js
+   * // playwright.config.ts
+   * import { defineConfig } from '@playwright/test';
+   *
+   * export default defineConfig({
+   *   projects: [
+   *     {
+   *       name: 'tests',
+   *       tagFilter: '@smoke',
+   *     },
+   *   ],
+   * });
+   * ```
+   *
+   * Tag expression examples:
+   * - `tagFilter: '@smoke'` - run only "smoke" tests;
+   * - `tagFilter: '@smoke and not @production'` - run only "smoke" tests that are not tagged as "production";
+   * - `tagFilter: '(@smoke or @fast) and @v2'` - run "v2" tests that are tagged as "smoke", "fast" or both.
+   */
+  tagFilter?: string;
 
   /**
    * Name of a project that needs to run after this and all dependent projects have finished. Teardown is useful to

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -26,7 +26,8 @@ export type { FullConfig, TestStatus } from './test';
  *       - {@link TestCase} #1
  *       - {@link TestCase} #2
  *       - Suite corresponding to a
- *         [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) group
+ *         [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe)
+ *         group
  *         - {@link TestCase} #1 in a group
  *         - {@link TestCase} #2 in a group
  *       - < more test cases ... >
@@ -71,8 +72,9 @@ export interface Suite {
 
   /**
    * Test cases in the suite. Note that only test cases defined directly in this suite are in the list. Any test cases
-   * defined in nested [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe)
-   * groups are listed in the child [suite.suites](https://playwright.dev/docs/api/class-suite#suite-suites).
+   * defined in nested
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) groups are
+   * listed in the child [suite.suites](https://playwright.dev/docs/api/class-suite#suite-suites).
    */
   tests: Array<TestCase>;
 
@@ -81,28 +83,30 @@ export interface Suite {
    * - Empty for root suite.
    * - Project name for project suite.
    * - File path for file suite.
-   * - Title passed to [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe)
-   *   for a group suite.
+   * - Title passed to
+   *   [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for a
+   *   group suite.
    */
   title: string;
 }
 
 /**
- * `TestCase` corresponds to every [test.(call)(title, body)](https://playwright.dev/docs/api/class-test#test-call)
- * call in a test file. When a single [test.(call)(title, body)](https://playwright.dev/docs/api/class-test#test-call)
- * is running in multiple projects or repeated multiple times, it will have multiple `TestCase` objects in
- * corresponding projects' suites.
+ * `TestCase` corresponds to every
+ * [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) call in a test file.
+ * When a single [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) is
+ * running in multiple projects or repeated multiple times, it will have multiple `TestCase` objects in corresponding
+ * projects' suites.
  */
 export interface TestCase {
   /**
    * Expected test status.
    * - Tests marked as
-   *   [test.skip([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-skip)
+   *   [test.skip([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-skip)
    *   or
-   *   [test.fixme([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
+   *   [test.fixme([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
    *   are expected to be `'skipped'`.
    * - Tests marked as
-   *   [test.fail([title, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fail)
+   *   [test.fail([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fail)
    *   are expected to be `'failed'`.
    * - Other tests are expected to be `'passed'`.
    *
@@ -129,9 +133,18 @@ export interface TestCase {
   titlePath(): Array<string>;
 
   /**
-   * The list of annotations applicable to the current test. Includes annotations from the test, annotations from all
-   * [test.describe([title, callback])](https://playwright.dev/docs/api/class-test#test-describe) groups the test
-   * belongs to and file-level annotations for the test file.
+   * The list of annotations applicable to the current test. Includes:
+   * - annotations defined on the test or suite via
+   *   [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) and
+   *   [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe);
+   * - annotations implicitly added by methods
+   *   [test.skip([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-skip),
+   *   [test.fixme([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fixme)
+   *   and
+   *   [test.fail([title, details, body, condition, callback, description])](https://playwright.dev/docs/api/class-test#test-fail);
+   * - annotations appended to
+   *   [testInfo.annotations](https://playwright.dev/docs/api/class-testinfo#test-info-annotations) during the test
+   *   execution.
    *
    * Annotations are available during test execution through
    * [testInfo.annotations](https://playwright.dev/docs/api/class-testinfo#test-info-annotations).
@@ -185,6 +198,15 @@ export interface TestCase {
   retries: number;
 
   /**
+   * The list of tags defined on the test or suite via
+   * [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) or
+   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe).
+   *
+   * Learn more about [test tags](https://playwright.dev/docs/test-annotations#tag-tests).
+   */
+  tags: Array<string>;
+
+  /**
    * The timeout given to the test. Affected by
    * [testConfig.timeout](https://playwright.dev/docs/api/class-testconfig#test-config-timeout),
    * [testProject.timeout](https://playwright.dev/docs/api/class-testproject#test-project-timeout),
@@ -195,7 +217,8 @@ export interface TestCase {
   timeout: number;
 
   /**
-   * Test title as passed to the [test.(call)(title, body)](https://playwright.dev/docs/api/class-test#test-call) call.
+   * Test title as passed to the
+   * [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) call.
    */
   title: string;
 }

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1126,7 +1126,7 @@ for (const useIntermediateMergeReport of [false, true] as const) {
           `,
           'c.test.js': `
             const { expect, test } = require('@playwright/test');
-            test('@regression @failed failed', async ({}) => {
+            test('@regression @failed failed', { tag: '@foo' }, async ({}) => {
               expect(1).toBe(2);
             });
             test('@regression @flaky flaky', async ({}, testInfo) => {
@@ -1135,7 +1135,7 @@ for (const useIntermediateMergeReport of [false, true] as const) {
               else
                 expect(1).toBe(2);
             });
-            test.skip('@regression skipped', async ({}) => {
+            test.skip('@regression skipped', { tag: ['@foo', '@bar'] }, async ({}) => {
               expect(1).toBe(2);
             });
           `,
@@ -1147,15 +1147,17 @@ for (const useIntermediateMergeReport of [false, true] as const) {
 
         await showReport();
 
-        await expect(page.locator('.test-file-test .label')).toHaveCount(42);
         await expect(page.locator('.test-file-test', { has: page.getByText('@regression @failed failed', { exact: true }) }).locator('.label')).toHaveText([
           'chromium',
+          'foo',
           'failed',
           'regression',
           'firefox',
+          'foo',
           'failed',
           'regression',
           'webkit',
+          'foo',
           'failed',
           'regression'
         ]);
@@ -1172,10 +1174,16 @@ for (const useIntermediateMergeReport of [false, true] as const) {
         ]);
         await expect(page.locator('.test-file-test', { has: page.getByText('@regression skipped', { exact: true }) }).locator('.label')).toHaveText([
           'chromium',
+          'foo',
+          'bar',
           'regression',
           'firefox',
+          'foo',
+          'bar',
           'regression',
           'webkit',
+          'foo',
+          'bar',
           'regression',
         ]);
         await expect(page.locator('.test-file-test', { has: page.getByText('@smoke @passed passed', { exact: true }) }).locator('.label')).toHaveText([

--- a/tests/playwright-test/reporter-json.spec.ts
+++ b/tests/playwright-test/reporter-json.spec.ts
@@ -160,29 +160,15 @@ test('should display tags separately from title', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
       import { test, expect } from '@playwright/test';
-      test('math works! @USR-MATH-001 @USR-MATH-002', async ({}) => {
-        expect(1 + 1).toBe(2);
-        await test.step('math works in a step', async () => {
-          expect(2 + 2).toBe(4);
-          await test.step('nested step', async () => {
-            expect(2 + 2).toBe(4);
-            await test.step('deeply nested step', async () => {
-              expect(2 + 2).toBe(4);
-            });
-          })
-        })
+      test('math works! @USR-MATH-001 @USR-MATH-002', { tag: '@foo' }, async ({}) => {
+        test.info().annotations.push({ type: 'issue', description: 'issue-link' });
+        test.info().annotations.push({ type: 'novalue' });
       });
     `
   });
 
   expect(result.exitCode).toBe(0);
-  expect(result.report.suites.length).toBe(1);
-  expect(result.report.suites[0].specs.length).toBe(1);
-  // Ensure the length is as expected
-  expect(result.report.suites[0].specs[0].tags.length).toBe(2);
-  // Ensure that the '@' value is stripped
-  expect(result.report.suites[0].specs[0].tags[0]).toBe('USR-MATH-001');
-  expect(result.report.suites[0].specs[0].tags[1]).toBe('USR-MATH-002');
+  expect(result.report.suites[0].specs[0].tags).toEqual(['@foo', '@USR-MATH-001', '@USR-MATH-002']);
 });
 
 test('should have relative always-posix paths', async ({ runInlineTest }) => {

--- a/tests/playwright-test/test-modifiers.spec.ts
+++ b/tests/playwright-test/test-modifiers.spec.ts
@@ -189,7 +189,7 @@ test.describe('test modifier annotations', () => {
     expect(result.passed).toBe(0);
     expect(result.skipped).toBe(6);
     expectTest('no marker', 'skipped', 'skipped', ['fixme']);
-    expectTest('skip wrap', 'skipped', 'skipped', ['skip', 'fixme']);
+    expectTest('skip wrap', 'skipped', 'skipped', ['fixme', 'skip']);
     expectTest('skip inner', 'skipped', 'skipped', ['fixme']);
     expectTest('fixme wrap', 'skipped', 'skipped', ['fixme', 'fixme']);
     expectTest('fixme inner', 'skipped', 'skipped', ['fixme']);
@@ -220,7 +220,7 @@ test.describe('test modifier annotations', () => {
     expectTest('no marker', 'skipped', 'skipped', ['skip']);
     expectTest('skip wrap', 'skipped', 'skipped', ['skip', 'skip']);
     expectTest('skip inner', 'skipped', 'skipped', ['skip']);
-    expectTest('fixme wrap', 'skipped', 'skipped', ['fixme', 'skip']);
+    expectTest('fixme wrap', 'skipped', 'skipped', ['skip', 'fixme']);
     expectTest('fixme inner', 'skipped', 'skipped', ['skip']);
     expectTest('example', 'passed', 'expected', []);
   });
@@ -251,7 +251,7 @@ test.describe('test modifier annotations', () => {
     expect(result.exitCode).toBe(0);
     expect(result.passed).toBe(0);
     expect(result.skipped).toBe(2);
-    expectTest('fixme wrap', 'skipped', 'skipped', ['fixme', 'fixme', 'skip', 'skip', 'fixme']);
+    expectTest('fixme wrap', 'skipped', 'skipped', ['fixme', 'skip', 'skip', 'fixme', 'fixme']);
     expectTest('fixme inner', 'skipped', 'skipped', ['fixme', 'skip', 'skip', 'fixme']);
   });
 

--- a/tests/playwright-test/test-tag.spec.ts
+++ b/tests/playwright-test/test-tag.spec.ts
@@ -1,0 +1,245 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './playwright-test-fixtures';
+
+test('should have correct tags', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': `
+      export default class Reporter {
+        onBegin(config, suite) {
+          const visit = suite => {
+            for (const test of suite.tests || [])
+              console.log('\\n%%title=' + test.title + ', tags=' + test.tags.join(','));
+            for (const child of suite.suites || [])
+              visit(child);
+          };
+          visit(suite);
+        }
+        onError(error) {
+          console.log(error);
+        }
+      }
+    `,
+    'playwright.config.ts': `
+      module.exports = {
+        reporter: './reporter',
+      };
+    `,
+    'stdio.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('no-tags', () => {
+        expect(test.info()._test.tags).toEqual([]);
+      });
+      test('foo-tag', { tag: '@foo' }, () => {
+        expect(test.info()._test.tags).toEqual(['@foo']);
+      });
+      test('foo-bar-tags', { tag: ['@foo', '@bar'] }, () => {
+        expect(test.info()._test.tags).toEqual(['@foo', '@bar']);
+      });
+      test.skip('skip-foo-tag', { tag: '@foo' }, () => {
+      });
+      test.fixme('fixme-bar-tag', { tag: '@bar' }, () => {
+      });
+      test.fail('fail-foo-bar-tags', { tag: ['@foo', '@bar'] }, () => {
+        expect(1).toBe(2);
+      });
+      test.describe('suite', { tag: '@foo' }, () => {
+        test('foo-suite', () => {
+          expect(test.info()._test.tags).toEqual(['@foo']);
+        });
+        test.describe('inner', { tag: '@bar' }, () => {
+          test('foo-bar-suite', () => {
+            expect(test.info()._test.tags).toEqual(['@foo', '@bar']);
+          });
+        });
+      });
+      test.describe.skip('skip-foo-suite', { tag: '@foo' }, () => {
+        test('skip-foo-suite', () => {
+        });
+      });
+      test.describe.fixme('fixme-bar-suite', { tag: '@bar' }, () => {
+        test('fixme-bar-suite', () => {
+        });
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    `title=no-tags, tags=`,
+    `title=foo-tag, tags=@foo`,
+    `title=foo-bar-tags, tags=@foo,@bar`,
+    `title=skip-foo-tag, tags=@foo`,
+    `title=fixme-bar-tag, tags=@bar`,
+    `title=fail-foo-bar-tags, tags=@foo,@bar`,
+    `title=foo-suite, tags=@foo`,
+    `title=foo-bar-suite, tags=@foo,@bar`,
+    `title=skip-foo-suite, tags=@foo`,
+    `title=fixme-bar-suite, tags=@bar`,
+  ]);
+});
+
+test('config.tagFilter should work', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { tagFilter: '@tag1' };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('test1', { tag: '@tag1' }, async () => { console.log('\\n%% test1'); });
+      test('test2', async () => { console.log('\\n%% test2'); });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.outputLines).toEqual(['test1']);
+});
+
+test('config.project.tag should work', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { projects: [
+        { name: 'p1' },
+        { name: 'p2', tagFilter: '@tag1' }
+      ] };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('test1', { tag: '@tag1' }, async () => { console.log('\\n%% test1-' + test.info().project.name); });
+      test('test2', async () => { console.log('\\n%% test2-' + test.info().project.name); });
+    `,
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+  expect(result.outputLines).toEqual(['test1-p1', 'test2-p1', 'test1-p2']);
+});
+
+test('--tag should work', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('test1', { tag: '@tag1' }, async () => { console.log('\\n%% test1'); });
+      test('test2', async () => { console.log('\\n%% test2'); });
+    `,
+  }, { tag: '@tag1' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.outputLines).toEqual(['test1']);
+});
+
+test('should parse tag expressions', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = {
+        projects: [
+          { name: 'p1', tagFilter: '@foo' },
+          { name: 'p2', tagFilter: 'not @foo' },
+          { name: 'p3', tagFilter: '    @foo and @bar' },
+          { name: 'p4', tagFilter: '@bar or not @foo' },
+          { name: 'p5', tagFilter: '@bar and (@foo or not @foo)' },
+          { name: 'p6', tagFilter: '@qux or @foo and @bar' },
+          { name: 'p7', tagFilter: '@qux and (@foo or @bar)' },
+          { name: 'p8', tagFilter: 'not not not @foo' },
+        ]
+      };
+    `,
+    'stdio.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('test1', { tag: '@foo' }, () => {
+        console.log('\\n%% foo-' + test.info().project.name);
+      });
+      test('test2', { tag: '@bar' }, () => {
+        console.log('\\n%% bar-' + test.info().project.name);
+      });
+      test('test3', { tag: ['@foo', '@bar'] }, () => {
+        console.log('\\n%% foobar-' + test.info().project.name);
+      });
+    `
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    `foo-p1`,
+    `foobar-p1`,
+    `bar-p2`,
+    `foobar-p3`,
+    `bar-p4`,
+    `foobar-p4`,
+    `bar-p5`,
+    `foobar-p5`,
+    `foobar-p6`,
+    `bar-p8`,
+  ]);
+});
+
+test('should enforce @ symbol', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'stdio.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('test1', { tag: 'foo' }, () => {
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`Error: Tag must start with "@" symbol, got "foo" instead.`);
+});
+
+test('should report tag expression error 1', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'stdio.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('test1', { tag: '@foo' }, () => {
+      });
+    `
+  }, { tag: '(@foo' });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`Error: Expected matching ")" when parsing tag expression: (@foo`);
+});
+
+test('should report tag expression error 2', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'stdio.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('test1', { tag: '@foo' }, () => {
+      });
+    `
+  }, { tag: '(@foo)@bar' });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`Error: Unexpected extra tokens in the tag expression: (@foo)@bar`);
+});
+
+test('should report tag expression error 3', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'stdio.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('test1', { tag: '@foo' }, () => {
+      });
+    `
+  }, { tag: '@foo and' });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`Error: Unexpected end of tag expression: @foo and`);
+});
+
+test('should report tag expression error 4', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'stdio.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('test1', { tag: '@foo' }, () => {
+      });
+    `
+  }, { tag: '@foo @bar' });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`Error: Unexpected extra tokens in the tag expression: @foo @bar`);
+});

--- a/tests/playwright-test/types-2.spec.ts
+++ b/tests/playwright-test/types-2.spec.ts
@@ -47,6 +47,25 @@ test('basics should work', async ({ runTSC }) => {
       test.foo();
       test.describe.configure({ mode: 'parallel' });
       test.describe.configure({ retries: 3, timeout: 123 });
+      test('title', { tag: '@foo' }, () => {});
+      test('title', { tag: ['@foo', '@bar'] }, () => {});
+      test('title', { annotation: { type: 'issue' } }, () => {});
+      test('title', { annotation: [{ type: 'issue' }, { type: 'foo', description: 'bar' }] }, () => {});
+      test('title', {
+        tag: '@foo',
+        annotation: { type: 'issue' },
+      }, () => {});
+      test.skip('title', { tag: '@foo' }, () => {});
+      test.fixme('title', { tag: '@foo' }, () => {});
+      test.only('title', { tag: '@foo' }, () => {});
+      test.fail('title', { tag: '@foo' }, () => {});
+      test.describe('title', { tag: '@foo' }, () => {});
+      test.describe('title', { annotation: { type: 'issue' } }, () => {});
+      // @ts-expect-error
+      test.describe({ tag: '@foo' }, () => {});
+      test.describe.skip('title', { tag: '@foo' }, () => {});
+      test.describe.fixme('title', { tag: '@foo' }, () => {});
+      test.describe.only('title', { tag: '@foo' }, () => {});
     `
   });
   expect(result.exitCode).toBe(0);

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -101,6 +101,11 @@ class TypesGenerator {
         const method = cls.membersArray.find(m => m.alias === 'describe');
         return this.memberJSDOC(method, '  ').trimLeft();
       }
+      if (className === 'TestFunction' && methodName === '__call') {
+        const cls = this.documentation.classes.get('Test');
+        const method = cls.membersArray.find(m => m.alias === '(call)');
+        return this.memberJSDOC(method, '  ').trimLeft();
+      }
 
       const docClass = this.docClassForName(className);
       let method;

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -111,13 +111,25 @@ export interface TestInfo {
   project: FullProject;
 }
 
+type TestDetailsAnnotation = {
+  type: string;
+  description?: string;
+};
+
+export type TestDetails = {
+  tag?: string | string[];
+  annotation?: TestDetailsAnnotation | TestDetailsAnnotation[];
+}
+
 interface SuiteFunction {
   (title: string, callback: () => void): void;
   (callback: () => void): void;
+  (title: string, details: TestDetails, callback: () => void): void;
 }
 
 interface TestFunction<TestArgs> {
-  (title: string, testFunction: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  (title: string, body: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  (title: string, details: TestDetails, body: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
 }
 
 export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue> extends TestFunction<TestArgs & WorkerArgs> {
@@ -134,15 +146,18 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
     };
     configure: (options: { mode?: 'default' | 'parallel' | 'serial', retries?: number, timeout?: number }) => void;
   };
-  skip(title: string, testFunction: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  skip(title: string, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  skip(title: string, details: TestDetails, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
   skip(): void;
   skip(condition: boolean, description?: string): void;
   skip(callback: (args: TestArgs & WorkerArgs) => boolean, description?: string): void;
-  fixme(title: string, testFunction: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  fixme(title: string, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  fixme(title: string, details: TestDetails, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
   fixme(): void;
   fixme(condition: boolean, description?: string): void;
   fixme(callback: (args: TestArgs & WorkerArgs) => boolean, description?: string): void;
-  fail(title: string, testFunction: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  fail(title: string, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
+  fail(title: string, details: TestDetails, body: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<void> | void): void;
   fail(condition: boolean, description?: string): void;
   fail(callback: (args: TestArgs & WorkerArgs) => boolean, description?: string): void;
   fail(): void;


### PR DESCRIPTION
API changes:
- `test(title, details, body)` where details contain `tag` and `annotation`.
- similar `details` property added to `test.skip`, `test.fail`, `test.fixme`, `test.only`, `test.describe` and other `test.describe.*` variations.
- `TestProject.tagFilter`/`TestConfig.tagFilter` that supports logical tag expressions with `(`, `)`, `and`, `or` and `not`.
- `--tag` CLI option to filter by tags.
- New annotations are available in `TestInfo.annotations` and `TestCase.annotations`.
- New tags are available in `TestCase.tags`.
    
Reporter changes:
- `json` reporter includes new tags in addition to old `@smoke`-style tags. **Breaking**: tags are now listed with the leading `@` symbol.
- `html` reporter filters by old and new tags with the same `@smoke` token.

Fixes #29229, fixes #23180.