### PR TITLE
fix(trace viewer): reveal error location when it comes from the test

### DIFF
--- a/packages/trace-viewer/src/ui/errorsTab.tsx
+++ b/packages/trace-viewer/src/ui/errorsTab.tsx
@@ -45,7 +45,7 @@ export function useErrorsTabModel(model: modelUtil.MultiTraceModel | undefined):
 export const ErrorsTab: React.FunctionComponent<{
   errorsModel: ErrorsTabModel,
   sdkLanguage: Language,
-  revealInSource: (action: modelUtil.ActionTraceEventInContext) => void,
+  revealInSource: (error: ErrorDescription) => void,
 }> = ({ errorsModel, sdkLanguage, revealInSource }) => {
   if (!errorsModel.errors.size)
     return <PlaceholderPanel text='No errors' />;
@@ -70,7 +70,7 @@ export const ErrorsTab: React.FunctionComponent<{
         }}>
           {error.action && renderAction(error.action, { sdkLanguage })}
           {location && <div className='action-location'>
-            @ <span title={longLocation} onClick={() => error.action && revealInSource(error.action)}>{location}</span>
+            @ <span title={longLocation} onClick={() => revealInSource(error)}>{location}</span>
           </div>}
         </div>
         <ErrorMessage error={message} />

--- a/packages/trace-viewer/src/ui/stackTrace.tsx
+++ b/packages/trace-viewer/src/ui/stackTrace.tsx
@@ -16,18 +16,17 @@
 
 import * as React from 'react';
 import './stackTrace.css';
-import type { ActionTraceEvent } from '@trace/trace';
 import { ListView } from '@web/components/listView';
 import type { StackFrame } from '@protocol/channels';
 
 const StackFrameListView = ListView<StackFrame>;
 
 export const StackTraceView: React.FunctionComponent<{
-  action: ActionTraceEvent | undefined,
+  stack: StackFrame[] | undefined,
   selectedFrame: number,
   setSelectedFrame: (index: number) => void
-}> = ({ action, setSelectedFrame, selectedFrame }) => {
-  const frames = action?.stack || [];
+}> = ({ stack, setSelectedFrame, selectedFrame }) => {
+  const frames = stack || [];
   return <StackFrameListView
     name='stack-trace'
     items={frames}

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -258,3 +258,29 @@ test('should not show caught errors in the errors tab', async ({ runUITest }, te
   await page.getByText('Errors', { exact: true }).click();
   await expect(page.locator('.tab-errors')).toHaveText('No errors');
 });
+
+test('should reveal errors in the sourcetab', async ({ runUITest }) => {
+  const { page } = await runUITest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async ({ page }) => {
+        throw new Error('Oh my');
+      });
+    `,
+  });
+
+  await page.getByText('pass').dblclick();
+  const listItem = page.getByTestId('actions-tree').getByRole('listitem');
+
+  await expect(
+      listItem,
+      'action list'
+  ).toContainText([
+    /Before Hooks/,
+    /After Hooks/,
+  ]);
+
+  await page.getByText('Errors', { exact: true }).click();
+  await page.getByText('a.spec.ts:4', { exact: true }).click();
+  await expect(page.locator('.source-line-running')).toContainText(`throw new Error('Oh my');`);
+});


### PR DESCRIPTION
Errors coming from the test runner do not have an associated `action`, but have a `stack` that we can reveal.