### PR TITLE
Revert "chore: remove fake `error` from expect calls (#28112)"

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -262,6 +262,8 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
     const result = await this._frame.expect(metadata, params.selector, { ...params, expectedValue });
     if (result.received !== undefined)
       result.received = serializeResult(result.received);
+    if (result.matches === params.isNot)
+      metadata.error = { error: { name: 'Expect', message: 'Expect failed' } };
     return result;
   }
 }


### PR DESCRIPTION
This reverts commit 2c3955a28c2af6b97a430dfc97fe756d40fcfbda.

Relates https://github.com/microsoft/playwright-python/issues/2258