### PR TITLE
fix: do not retry missing snapshot errors

### DIFF
--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -84,6 +84,7 @@ export type TestEndPayload = {
   duration: number;
   status: TestStatus;
   errors: TestInfoError[];
+  hasNonRetriableError: boolean;
   expectedStatus: TestStatus;
   annotations: { type: string, description?: string }[];
   timeout: number;

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -54,7 +54,6 @@ export class Suite extends Base implements SuitePrivate {
   _fullProject: FullProjectInternal | undefined;
   _fileId: string | undefined;
   readonly _type: 'root' | 'project' | 'file' | 'describe';
-  _hasNonRetriableError: boolean | undefined;
 
   constructor(title: string, type: 'root' | 'project' | 'file' | 'describe') {
     super(title);
@@ -242,7 +241,6 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   _projectId = '';
   // Annotations known statically before running the test, e.g. `test.skip()` or `test.describe.skip()`.
   _staticAnnotations: Annotation[] = [];
-  _hasNonRetriableError: boolean | undefined;
 
   constructor(title: string, fn: Function, testType: TestTypeImpl, location: Location) {
     super(title);

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -54,6 +54,7 @@ export class Suite extends Base implements SuitePrivate {
   _fullProject: FullProjectInternal | undefined;
   _fileId: string | undefined;
   readonly _type: 'root' | 'project' | 'file' | 'describe';
+  _hasNonRetriableError: boolean | undefined;
 
   constructor(title: string, type: 'root' | 'project' | 'file' | 'describe') {
     super(title);
@@ -241,6 +242,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   _projectId = '';
   // Annotations known statically before running the test, e.g. `test.skip()` or `test.describe.skip()`.
   _staticAnnotations: Annotation[] = [];
+  _hasNonRetriableError: boolean | undefined;
 
   constructor(title: string, fn: Function, testType: TestTypeImpl, location: Location) {
     super(title);

--- a/packages/playwright/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchSnapshot.ts
@@ -29,7 +29,7 @@ import { colors } from 'playwright-core/lib/utilsBundle';
 import fs from 'fs';
 import path from 'path';
 import { mime } from 'playwright-core/lib/utilsBundle';
-import { NonRetriableError, type TestInfoImpl } from '../worker/testInfo';
+import type { TestInfoImpl } from '../worker/testInfo';
 import type { ExpectMatcherContext } from './expect';
 import type { MatcherResult } from './matcherHint';
 
@@ -204,7 +204,7 @@ class SnapshotHelper<T extends ImageComparatorOptions> {
       return this.createMatcherResult(message, true);
     }
     if (this.updateSnapshots === 'missing') {
-      this.testInfo._failWithError(new NonRetriableError(message), false /* isHardError */);
+      this.testInfo._failWithError(new Error(message), false /* isHardError */, false /* retriable */);
       return this.createMatcherResult('', true);
     }
     return this.createMatcherResult(message, false);

--- a/packages/playwright/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchSnapshot.ts
@@ -29,7 +29,7 @@ import { colors } from 'playwright-core/lib/utilsBundle';
 import fs from 'fs';
 import path from 'path';
 import { mime } from 'playwright-core/lib/utilsBundle';
-import type { TestInfoImpl } from '../worker/testInfo';
+import { NonRetriableError, type TestInfoImpl } from '../worker/testInfo';
 import type { ExpectMatcherContext } from './expect';
 import type { MatcherResult } from './matcherHint';
 
@@ -141,8 +141,6 @@ class SnapshotHelper<T extends ImageComparatorOptions> {
     this.locator = locator;
 
     this.updateSnapshots = testInfo.config.updateSnapshots;
-    if (this.updateSnapshots === 'missing' && testInfo.retry < testInfo.project.retries)
-      this.updateSnapshots = 'none';
     this.mimeType = mime.getType(path.basename(this.snapshotPath)) ?? 'application/octet-string';
     this.comparator = getComparator(this.mimeType);
 
@@ -206,7 +204,7 @@ class SnapshotHelper<T extends ImageComparatorOptions> {
       return this.createMatcherResult(message, true);
     }
     if (this.updateSnapshots === 'missing') {
-      this.testInfo._failWithError(new Error(message), false /* isHardError */);
+      this.testInfo._failWithError(new NonRetriableError(message), false /* isHardError */);
       return this.createMatcherResult('', true);
     }
     return this.createMatcherResult(message, false);

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -349,6 +349,8 @@ export class TestInfoImpl implements TestInfo {
   }
 
   _failWithError(error: Error, isHardError: boolean, retriable: boolean) {
+    if (!retriable)
+      this._hasNonRetriableError = true;
     // Do not overwrite any previous hard errors.
     // Some (but not all) scenarios include:
     //   - expect() that fails after uncaught exception.
@@ -363,8 +365,6 @@ export class TestInfoImpl implements TestInfo {
     const step = (error as any)[stepSymbol] as TestStepInternal | undefined;
     if (step && step.boxedStack)
       serialized.stack = `${error.name}: ${error.message}\n${stringifyStackFrames(step.boxedStack).join('\n')}`;
-    if (!retriable)
-      this._hasNonRetriableError = true;
     this.errors.push(serialized);
     this._tracing.appendForError(serialized);
   }

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -69,6 +69,8 @@ export class TestInfoImpl implements TestInfo {
   _afterHooksStep: TestStepInternal | undefined;
   _onDidFinishTestFunction: (() => Promise<void>) | undefined;
 
+  _hasNonRetriableError = false;
+
   // ------------ TestInfo fields ------------
   readonly testId: string;
   readonly repeatEachIndex: number;
@@ -92,6 +94,7 @@ export class TestInfoImpl implements TestInfo {
   readonly outputDir: string;
   readonly snapshotDir: string;
   errors: TestInfoError[] = [];
+
   readonly _attachmentsPush: (...items: TestInfo['attachments']) => number;
 
   get error(): TestInfoError | undefined {
@@ -361,6 +364,8 @@ export class TestInfoImpl implements TestInfo {
     const step = (error as any)[stepSymbol] as TestStepInternal | undefined;
     if (step && step.boxedStack)
       serialized.stack = `${error.name}: ${error.message}\n${stringifyStackFrames(step.boxedStack).join('\n')}`;
+    if (error instanceof NonRetriableError)
+      this._hasNonRetriableError = true;
     this.errors.push(serialized);
     this._tracing.appendForError(serialized);
   }
@@ -489,3 +494,6 @@ class SkipError extends Error {
 }
 
 const stepSymbol = Symbol('step');
+
+export class NonRetriableError extends Error {
+}

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -624,6 +624,7 @@ function buildTestEndPayload(testInfo: TestInfoImpl): TestEndPayload {
     duration: testInfo.duration,
     status: testInfo.status!,
     errors: testInfo.errors,
+    hasNonRetriableError: testInfo._hasNonRetriableError,
     expectedStatus: testInfo.expectedStatus,
     annotations: testInfo.annotations,
     timeout: testInfo.timeout,

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -169,7 +169,7 @@ export class WorkerMain extends ProcessRunner {
     // and unhandled errors - both lead to the test failing. This is good for regular tests,
     // so that you can, e.g. expect() from inside an event handler. The test fails,
     // and we restart the worker.
-    this._currentTest._failWithError(error, true /* isHardError */);
+    this._currentTest._failWithError(error, true /* isHardError */, true /* retriable */);
 
     // For tests marked with test.fail(), this might be a problem when unhandled error
     // is not coming from the user test code (legit failure), but from fixtures or test runner.


### PR DESCRIPTION
When `updateSnapshots === 'missing'` we generate new expectations on the first attempt and don't retry the test afterwards instead of trying it retries-1 times and only writing new expectation on the last attempt. This logic infects all serial mode suites that contain the test with missing expectations, so they also will not be retried.

Reference https://github.com/microsoft/playwright/issues/29073