### PR TITLE
devops: custom blob report name for test runner tests

### DIFF
--- a/tests/playwright-test/playwright.config.ts
+++ b/tests/playwright-test/playwright.config.ts
@@ -25,7 +25,7 @@ const reporters = () => {
   const result: ReporterDescription[] = process.env.CI ? [
     ['dot'],
     ['json', { outputFile: path.join(outputDir, 'report.json') }],
-    ['blob', { outputDir: path.join(__dirname, '..', '..', 'blob-report') }],
+    ['blob', { outputDir: path.join(__dirname, '..', '..', 'blob-report'), fileName: `${process.env.PWTEST_BOT_NAME}.zip` }],
   ] : [
     ['list']
   ];


### PR DESCRIPTION
Otherwise uploaded reports all have clashing names report-1.zip and report-2.zip.