### PR TITLE
cherry-pick(#29271): Revert "chore: remove fake `error` from expect calls (#28112)"

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -262,6 +262,8 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
     const result = await this._frame.expect(metadata, params.selector, { ...params, expectedValue });
     if (result.received !== undefined)
       result.received = serializeResult(result.received);
+    if (result.matches === params.isNot)
+      metadata.error = { error: { name: 'Expect', message: 'Expect failed' } };
     return result;
   }
 }


### PR DESCRIPTION
This PR cherry-picks the following commits:

- 622153db1822f71afe9efddc35023953a9f16b40