### PR TITLE
chore(test runner): refactor beforeAll/afterAll hooks and modifiers

### DIFF
--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -231,6 +231,10 @@ export function fixtureParameterNames(fn: Function | any, location: Location, on
   return fn[signatureSymbol];
 }
 
+export function inheritFixutreNames(from: Function, to: Function) {
+  (to as any)[signatureSymbol] = (from as any)[signatureSymbol];
+}
+
 function innerFixtureParameterNames(fn: Function, location: Location, onError: LoadErrorSink): string[] {
   const text = filterOutComments(fn.toString());
   const match = text.match(/(?:async)?(?:\s+function)?[^(]*\(([^)]*)/);

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -489,7 +489,7 @@ export class TestInfoImpl implements TestInfo {
   }
 }
 
-class SkipError extends Error {
+export class SkipError extends Error {
 }
 
 const stepSymbol = Symbol('step');

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -489,7 +489,7 @@ export class TestInfoImpl implements TestInfo {
   }
 }
 
-export class SkipError extends Error {
+class SkipError extends Error {
 }
 
 const stepSymbol = Symbol('step');

--- a/tests/playwright-test/test-modifiers.spec.ts
+++ b/tests/playwright-test/test-modifiers.spec.ts
@@ -521,7 +521,7 @@ test('modifier timeout should be reported', async ({ runInlineTest }) => {
   expect(result.output).toContain('3 |       test.skip(async () => new Promise(() => {}));');
 });
 
-test('should not run hooks if modifier throws', async ({ runInlineTest }) => {
+test('should run beforeAll/afterAll hooks if modifier throws', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
@@ -530,7 +530,7 @@ test('should not run hooks if modifier throws', async ({ runInlineTest }) => {
         throw new Error('Oh my');
       });
       test.beforeAll(() => {
-        console.log('%%beforeEach');
+        console.log('%%beforeAll');
       });
       test.beforeEach(() => {
         console.log('%%beforeEach');
@@ -539,7 +539,7 @@ test('should not run hooks if modifier throws', async ({ runInlineTest }) => {
         console.log('%%afterEach');
       });
       test.afterAll(() => {
-        console.log('%%beforeEach');
+        console.log('%%afterAll');
       });
       test('skipped1', () => {
         console.log('%%skipped1');
@@ -550,7 +550,46 @@ test('should not run hooks if modifier throws', async ({ runInlineTest }) => {
   expect(result.failed).toBe(1);
   expect(result.outputLines).toEqual([
     'modifier',
+    'beforeAll',
+    'afterAll',
   ]);
+});
+
+test('should skip all tests from beforeAll', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test.beforeAll(() => {
+        console.log('%%beforeAll');
+        test.skip(true, 'reason');
+      });
+      test.beforeAll(() => {
+        console.log('%%beforeAll2');
+      });
+      test.beforeEach(() => {
+        console.log('%%beforeEach');
+      });
+      test.afterEach(() => {
+        console.log('%%afterEach');
+      });
+      test.afterAll(() => {
+        console.log('%%afterAll');
+      });
+      test('skipped1', () => {
+        console.log('%%skipped1');
+      });
+      test('skipped2', () => {
+        console.log('%%skipped2');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'beforeAll',
+    'afterAll',
+  ]);
+  expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'skip', description: 'reason' }]);
+  expect(result.report.suites[0].specs[1].tests[0].annotations).toEqual([{ type: 'skip', description: 'reason' }]);
 });
 
 test('should report skipped tests in-order with correct properties', async ({ runInlineTest }) => {


### PR DESCRIPTION
- Modifiers that only depend on the worker fixtures are implemented as `beforeAll` hooks.
- Modifiers that depend on test fixtures are implemented as `beforeEach` hooks.
- Pushed `_runAndFailOnError` down the stack, wrapping individual hooks instead of the whole "before hooks" section.
- Reused the same code to run `beforeAll` and `afterAll` hooks and modifiers.

**Behavior change**: `test.skip()` inside a `beforeAll` now skips the hook and all tests in the suite.