### PR TITLE
docs: do not call custom expect message an "error message"

### DIFF
--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -1520,7 +1520,7 @@ This version was also tested against the following stable channels:
 
   Read more in [our documentation](./test-assertions#soft-assertions)
 
-- You can now specify a **custom error message** as a second argument to the `expect` and `expect.soft` functions, for example:
+- You can now specify a **custom expect message** as a second argument to the `expect` and `expect.soft` functions, for example:
 
   ```js
   await expect(page.locator('text=Name'), 'should be logged in').toBeVisible();

--- a/docs/src/test-assertions-csharp-java-python.md
+++ b/docs/src/test-assertions-csharp-java-python.md
@@ -34,13 +34,13 @@ title: "Assertions"
 ## Custom Expect Message
 * langs: python
 
-You can specify a custom error message as a second argument to the `expect` function, for example:
+You can specify a custom expect message as a second argument to the `expect` function, for example:
 
 ```python
 expect(page.get_by_text("Name"), "should be logged in").to_be_visible()
 ```
 
-The error would look like this:
+When expect fails, the error would look like this:
 
 ```bash
     def test_foobar(page: Page) -> None:

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -136,13 +136,21 @@ Note that soft assertions only work with Playwright test runner.
 
 ## Custom expect message
 
-You can specify a custom error message as a second argument to the `expect` function, for example:
+You can specify a custom expect message as a second argument to the `expect` function, for example:
 
 ```js
 await expect(page.getByText('Name'), 'should be logged in').toBeVisible();
 ```
 
-The error would look like this:
+This message will be shown in reporters, both for passing and failing expects, providing more context about the assertion.
+
+When expect passes, you might see a successful step like this:
+
+```txt
+✅ should be logged in    @example.spec.ts:18
+```
+
+When expect fails, the error would look like this:
 
 ```bash
     Error: should be logged in
@@ -160,7 +168,7 @@ The error would look like this:
       6 |
 ```
 
-The same works with soft assertions:
+Soft assertions also support custom message:
 
 ```js
 expect.soft(value, 'my soft assertion').toBe(56);
@@ -191,8 +199,8 @@ await expect.poll(async () => {
   const response = await page.request.get('https://api.example.com');
   return response.status();
 }, {
-  // Custom error message, optional.
-  message: 'make sure API eventually succeeds', // custom error message
+  // Custom expect message for reporting, optional.
+  message: 'make sure API eventually succeeds',
   // Poll for 10 seconds; defaults to 5 seconds. Pass 0 to disable timeout.
   timeout: 10000,
 }).toBe(200);

--- a/tests/playwright-test/expect-soft.spec.ts
+++ b/tests/playwright-test/expect-soft.spec.ts
@@ -22,8 +22,8 @@ test('soft expects should compile', async ({ runTSC }) => {
       import { test, expect } from '@playwright/test';
       test('should work', () => {
         test.expect.soft(1+1).toBe(3);
-        test.expect.soft(1+1, 'custom error message').toBe(3);
-        test.expect.soft(1+1, { message: 'custom error message' }).toBe(3);
+        test.expect.soft(1+1, 'custom expect message').toBe(3);
+        test.expect.soft(1+1, { message: 'custom expect message' }).toBe(3);
       });
     `
   });

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -70,26 +70,26 @@ test('should not expand huge arrays', async ({ runInlineTest }) => {
   expect(result.output.length).toBeLessThan(100000);
 });
 
-test('should include custom error message', async ({ runInlineTest }) => {
+test('should include custom expect message', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'expect-test.spec.ts': `
       import { test, expect } from '@playwright/test';
       test('custom expect message', () => {
-        test.expect(1+1, 'one plus one is two!').toEqual(3);
+        test.expect(1+1, 'one plus one should be two!').toEqual(3);
       });
     `
   });
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
   expect(result.output).toContain([
-    `    Error: one plus one is two!\n`,
+    `    Error: one plus one should be two!\n`,
     `    expect(received).toEqual(expected) // deep equality\n`,
     `    Expected: 3`,
     `    Received: 2`,
   ].join('\n'));
 });
 
-test('should include custom error message with web-first assertions', async ({ runInlineTest }) => {
+test('should include custom expect message with web-first assertions', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'expect-test.spec.ts': `
       import { test, expect } from '@playwright/test';
@@ -989,7 +989,7 @@ test('should respect timeout from configured expect when used outside of the tes
       finally {
         await browser?.close();
       }
-    
+
     `
   };
   const baseDir = await writeFiles(files);


### PR DESCRIPTION
Fixes #29378.