### PR TITLE
test: unskip 'msedge' tests

### DIFF
--- a/tests/library/browsertype-launch-server.spec.ts
+++ b/tests/library/browsertype-launch-server.spec.ts
@@ -80,9 +80,7 @@ it.describe('launch server', () => {
     await browserServer.close();
   });
 
-  it('should fire close event', async ({ browserType, channel }) => {
-    it.fixme(channel?.startsWith('msedge'), 'https://github.com/microsoft/playwright/issues/26711');
-
+  it('should fire close event', async ({ browserType }) => {
     const browserServer = await browserType.launchServer();
     const [result] = await Promise.all([
       // @ts-expect-error The signal parameter is not documented.

--- a/tests/page/page-accessibility.spec.ts
+++ b/tests/page/page-accessibility.spec.ts
@@ -143,9 +143,8 @@ it('should not report text nodes inside controls', async function({ page, browse
   expect(await page.accessibility.snapshot()).toEqual(golden);
 });
 
-it('rich text editable fields should have children', async function({ page, browserName, browserVersion, channel, isWebView2 }) {
+it('rich text editable fields should have children', async function({ page, browserName, browserVersion, isWebView2 }) {
   it.skip(browserName === 'webkit', 'WebKit rich text accessibility is iffy');
-  it.skip(channel && channel.startsWith('msedge'), 'Edge is missing a Chromium fix');
   it.skip(isWebView2, 'WebView2 is missing a Chromium fix');
 
   await page.setContent(`
@@ -178,9 +177,8 @@ it('rich text editable fields should have children', async function({ page, brow
   expect(snapshot.children[0]).toEqual(golden);
 });
 
-it('rich text editable fields with role should have children', async function({ page, browserName, browserMajorVersion, browserVersion, channel, isWebView2 }) {
+it('rich text editable fields with role should have children', async function({ page, browserName, browserMajorVersion, browserVersion, isWebView2 }) {
   it.skip(browserName === 'webkit', 'WebKit rich text accessibility is iffy');
-  it.skip(channel && channel.startsWith('msedge'), 'Edge is missing a Chromium fix');
   it.skip(isWebView2, 'WebView2 is missing a Chromium fix');
 
   await page.setContent(`

--- a/tests/page/page-click-scroll.spec.ts
+++ b/tests/page/page-click-scroll.spec.ts
@@ -78,9 +78,8 @@ it('should scroll into view display:contents with position', async ({ page, brow
   expect(await page.evaluate('window._clicked')).toBe(true);
 });
 
-it('should not crash when force-clicking hidden input', async ({ page, browserName, channel, browserMajorVersion }) => {
+it('should not crash when force-clicking hidden input', async ({ page }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/18183' });
-  it.skip(browserName === 'chromium' && browserMajorVersion < 109 || channel && channel.startsWith('msedge') && browserMajorVersion < 110);
 
   await page.setContent(`<input type=hidden>`);
   const error = await page.locator('input').click({ force: true, timeout: 2000 }).catch(e => e);


### PR DESCRIPTION
This removes all msedge skips again and makes msedge equal with chromium skip wise.

Fixes https://github.com/microsoft/playwright/issues/26711