### PR TITLE
fix(esmLoader): do not serialize the whole compilation cache after each import

### DIFF
--- a/packages/playwright/src/common/esmLoaderHost.ts
+++ b/packages/playwright/src/common/esmLoaderHost.ts
@@ -60,6 +60,9 @@ export async function stopCollectingFileDeps(file: string) {
 export async function incorporateCompilationCache() {
   if (!loaderChannel)
     return;
+  // This is needed to gather dependency information from the esm loader
+  // that is populated from the resovle hook. We do not need to push
+  // this information proactively during load, but gather it at the end.
   const result = await loaderChannel.send('getCompilationCache', {});
   addToCompilationCache(result.cache);
 }

--- a/tests/playwright-test/esm.spec.ts
+++ b/tests/playwright-test/esm.spec.ts
@@ -157,6 +157,32 @@ test('should use source maps', async ({ runInlineTest }) => {
   expect(output).toContain('[foo] › a.test.ts:4:7 › check project name');
 });
 
+test('should use source maps when importing a file throws an error', async ({ runInlineTest }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/29418' });
+
+  const result = await runInlineTest({
+    'package.json': `{ "type": "module" }`,
+    'playwright.config.ts': `
+      export default {};
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+
+      throw new Error('Oh my!');
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`Error: Oh my!
+
+   at a.test.ts:4
+
+  2 |       import { test, expect } from '@playwright/test';
+  3 |
+> 4 |       throw new Error('Oh my!');
+    |             ^
+  `);
+});
+
 test('should show the codeframe in errors', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'package.json': `{ "type": "module" }`,

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -1706,6 +1706,5 @@ test('TestSuite.project() should return owning project', async ({ runInlineTest,
 
   const { exitCode, output } = await mergeReports(test.info().outputPath('blob-report'), undefined, { additionalArgs: ['--config', 'merge.config.ts'] });
   expect(exitCode).toBe(0);
-  console.log(output);
   expect(output).toContain(`test project: my-project`);
 });


### PR DESCRIPTION
Instead, send the newly created cache entry only.

References #29418.