### PR TITLE
feat: `remote` option in BrowserType.launch

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -128,17 +128,7 @@ Maximum time in milliseconds to wait for the connection to be established. Defau
 * since: v1.37
 - `exposeNetwork` <[string]>
 
-This option exposes network available on the connecting client to the browser being connected to. Consists of a list of rules separated by comma.
-
-Available rules:
-1. Hostname pattern, for example: `example.com`, `*.org:99`, `x.*.y.com`, `*foo.org`.
-1. IP literal, for example: `127.0.0.1`, `0.0.0.0:99`, `[::1]`, `[0:0::1]:99`.
-1. `<loopback>` that matches local loopback interfaces: `localhost`, `*.localhost`, `127.0.0.1`, `[::1]`.
-
-Some common examples:
-1. `"*"` to expose all network.
-1. `"<loopback>"` to expose localhost network.
-1. `"*.test.internal-domain,*.staging.internal-domain,<loopback>"` to expose test/staging deployments and localhost.
+This option exposes network available on the connecting client to the browser being connected to. See the [remote connection](../remote.md#exposing-local-network-to-the-remote-browser) guide for details.
 
 ## async method: BrowserType.connectOverCDP
 * since: v1.9
@@ -302,6 +292,38 @@ describes some differences for Linux users.
 
 ### option: BrowserType.launch.ignoreAllDefaultArgs = %%-csharp-java-browser-option-ignorealldefaultargs-%%
 * since: v1.9
+
+### option: BrowserType.launch.remote
+* since: v1.42
+* langs: js
+- `remote` ?<[Object]>
+  - `wsEndpoint` <[string]> A websocket endpoint to connect to.
+  - `headers` ?<[Object]<[string], [string]>> Additional HTTP headers to be sent with in the remote connection request.
+  - `exposeNetwork` ?<[string]> This option exposes network available on the connecting client to the browser being connected to. See the [remote connection](../remote.md#exposing-local-network-to-the-remote-browser) guide for details.
+
+When [`option: remote`] is present, the browser is not launched locally. Instead, a websocket connection is established to a remote Playwright server that launches the browser upon request. See the [remote connection](../remote.md) guide for details.
+
+### option: BrowserType.launch.remoteEndpoint
+* since: v1.42
+* langs: csharp, java, python
+- `remoteEndpoint` ?<[string]>
+
+When [`option: remoteEndpoint`] is present, the browser is not launched locally. Instead, a websocket connection is established to a remote Playwright server that launches the browser upon request. See the [remote connection](../remote.md) guide for details.
+
+### option: BrowserType.launch.remoteHeaders
+* since: v1.42
+* langs: csharp, java, python
+- `remoteHeaders` ?<[Object]<[string], [string]>>
+
+Additional HTTP headers to be sent with in the remote connection request. Ignored unless [`option: remoteEndpoint`] is set.
+
+### option: BrowserType.launch.remoteExposeNetwork
+* since: v1.42
+* langs: csharp, java, python
+- `remoteExposeNetwork` ?<[string]>
+
+This option exposes network available on the connecting client to the browser being connected to. Ignored unless [`option: remoteEndpoint`] is set.
+
 
 ## async method: BrowserType.launchPersistentContext
 * since: v1.8

--- a/docs/src/remote.md
+++ b/docs/src/remote.md
@@ -1,0 +1,167 @@
+---
+id: remote
+title: "Remote Connection"
+---
+
+## Introduction
+
+Usually, Playwright launches a browser on the same computer before running tests in it. However, Playwright also supports connecting to a browser running remotely, or connecting to a Playwright server and launching a new browser remotely.
+
+## Playwright server
+
+Starting a Playwright server does not launch the browser right away. A new browser is launched for every connected client, and is automatically closed when the client disconnects.
+
+You can start Playwright server by running the following CLI command:
+
+```bash
+$ npx playwright run-server --port=5678 --path=/secretpath
+Listening on ws://localhost:5678/secretpath
+```
+
+When started, the server prints the ws endpoint that you can use to connect to it. We recommend generating a unique path before every server start for security benefits.
+
+Later on, clients can connect to the Playwright server by setting `remote` option in the configuration file or passing [`option: remote`] option(s) to the [`method: BrowserType.launch`] method.
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    launchOptions: {
+      remote: {
+        wsEndpoint: 'ws://<remote-ip>:5678/secretpath',
+      },
+    },
+  },
+});
+```
+
+```java
+Browser browser = playwright.chromium().launch(
+    new BrowserType.LaunchOptions().setRemoteEndpoint("ws://<remote-ip>:5678/secretpath"));
+Page page = browser.newPage();
+```
+
+```python sync
+browser = playwright.chromium.launch(remote_endpoint="ws://<remote-ip>:5678/secretpath")
+page = browser.new_page()
+```
+
+```python async
+browser = await playwright.chromium.launch(remote_endpoint="ws://<remote-ip>:5678/secretpath")
+page = await browser.new_page()
+```
+
+```csharp
+var browser = await Playwright.Chromium.LaunchAsync(new() { RemoteEndpoint = "ws://<remote-ip>:5678/secretpath" });
+var page = await browser.NewPageAsync();
+```
+
+When connecting to a Playwright server, launch options are passed along so that server can launch a requested browser on behalf of the client. Some options are prohibited when launching remotely, for example [`option: executablePath`] and [`option: env`].
+
+## Exposing local network to the remote browser
+
+You can optionally expose local network, for example `localhost` to the remote browser when connecting to it by passing [`option: exposeNetwork`]. This option consists of a list of rules separated by comma, each rule specifies network domain pattern that should be exposed.
+
+Available rules:
+1. Hostname pattern, for example: `example.com`, `*.org:99`, `x.*.y.com`, `*foo.org`, `localhost`.
+1. IP literal, for example: `127.0.0.1`, `0.0.0.0:99`, `[::1]`, `[0:0::1]:99`.
+1. `<loopback>` that matches local loopback interfaces: `localhost`, `*.localhost`, `127.0.0.1`, `[::1]`.
+
+Some common examples:
+1. `"*"` to expose all network.
+1. `"<loopback>"` to expose localhost network.
+1. `"*.test.internal-domain,*.staging.internal-domain,<loopback>"` to expose test/staging deployments and localhost.
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    launchOptions: {
+      remote: {
+        wsEndpoint: '...',
+        exposeNetwork: '<loopback>,*.staging.app.domain',
+      },
+    },
+  },
+});
+```
+
+```java
+Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions()
+    .setRemoteEndpoint("ws://<remote-ip>:5678/secretpath")
+    .setRemoteExposeNetwork("<loopback>,*.staging.app.domain"));
+Page page = browser.newPage();
+```
+
+```python sync
+browser = playwright.chromium.launch(
+    remote_endpoint="ws://<remote-ip>:5678/secretpath",
+    remote_expose_network="<loopback>,*.staging.app.domain",
+)
+page = browser.new_page()
+```
+
+```python async
+browser = await playwright.chromium.launch(
+    remote_endpoint="ws://<remote-ip>:5678/secretpath",
+    remote_expose_network="<loopback>,*.staging.app.domain",
+)
+page = await browser.new_page()
+```
+
+```csharp
+var browser = await Playwright.Chromium.LaunchAsync(new() {
+    RemoteEndpoint = "ws://<remote-ip>:5678/secretpath",
+    RemoteExposeNetwork = "<loopback>,*.staging.app.domain",
+});
+var page = await browser.NewPageAsync();
+```
+
+## Playwright-specific headers
+
+The websocket connection request sent by Playwright to the remote server includes the following headers:
+* `User-Agent` - Playwright's standard user agent that includes Playwright version.
+* `x-playwright-proxy` - the value of [`option: exposeNetwork`].
+* `x-playwright-browser` - the browser type, either `'chromium'`, `'firefox'` or `'webkit'`.
+* `x-playwright-launch-options` - the allowed launch options passed to [`method: BrowserType.launch`] stringified as JSON.
+
+You can also pass custom headers by setting the [`option: headers`] option.
+
+## Single browser server
+
+Single browser server is an alternative to the Playwright server. It launches a single browser right away when you start the server, and all the clients connect to this single browser. Launching a browser right away gives you the most control over it, including all the launch options.
+
+You can start a server by calling [`browserType.launchServer()`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server) method in Node.js. Once the server is running, pass its [`wsEndpoint`](https://playwright.dev/docs/api/class-browserserver#browser-server-ws-endpoint) to the [`method: BrowserType.connect`] method. This will give you a [Browser] where you can create contexts with [`method: Browser.newContext`].
+
+```js
+const browser = await playwright.chromium.connect(wsEndpoint);
+const page = await browser.newPage();
+```
+
+```java
+Browser browser = playwright.chromium().connect("ws://<remote-ip>:5678/secretpath");
+Page page = browser.newPage();
+```
+
+```python sync
+browser = playwright.chromium.connect("ws://<remote-ip>:5678/secretpath")
+page = browser.new_page()
+```
+
+```python async
+browser = await playwright.chromium.connect("ws://<remote-ip>:5678/secretpath")
+page = await browser.new_page()
+```
+
+```csharp
+var browser = await Playwright.Chromium.ConnectAsync("ws://<remote-ip>:5678/secretpath");
+var page = await browser.NewPageAsync();
+```
+
+Multiple clients can connect to the same browser server and create their own isolated contexts. When a client disconnects, all contexts created by the client are automatically closed.
+
+:::note
+Single browser server does not support exposing local network to the browser.
+:::

--- a/docs/src/test-api/class-testoptions.md
+++ b/docs/src/test-api/class-testoptions.md
@@ -155,11 +155,11 @@ export default defineConfig({
 
 ## property: TestOptions.connectOptions
 * since: v1.10
-- type: <[void]|[Object]>
+- type: <[Object]>
   - `wsEndpoint` <[string]> A browser websocket endpoint to connect to.
   - `headers` ?<[void]|[Object]<[string], [string]>> Additional HTTP headers to be sent with web socket connect request. Optional.
   - `timeout` ?<[int]> Timeout in milliseconds for the connection to be established. Optional, defaults to no timeout.
-  - `exposeNetwork` ?<[string]> Option to expose network available on the connecting client to the browser being connected to. See [`method: BrowserType.connect`] for more details.
+  - `exposeNetwork` ?<[string]> Option to expose network available on the connecting client to the browser being connected to. See the [remote connection](../remote.md#exposing-local-network-to-the-remote-browser) guide for details.
 
 
 **Usage**
@@ -176,7 +176,11 @@ export default defineConfig({
 });
 ```
 
-When connect options are specified, default [`property: Fixtures.browser`], [`property: Fixtures.context`] and [`property: Fixtures.page`] use the remote browser instead of launching a browser locally, and any launch options like [`property: TestOptions.headless`] or [`property: TestOptions.channel`] are ignored.
+When connect options are specified, any launched browsers, including the default [`property: Fixtures.browser`], will be instead connecting to a remote browser.
+
+This property takes precedence over the `remote` property in [`property: TestOptions.launchOptions`].
+
+See the [remote connection](../remote.md) guide for details.
 
 ## property: TestOptions.contextOptions
 * since: v1.10

--- a/packages/playwright-core/bundles/utils/src/utilsBundleImpl.ts
+++ b/packages/playwright-core/bundles/utils/src/utilsBundleImpl.ts
@@ -41,7 +41,7 @@ export const open = openLibrary;
 
 export { PNG } from 'pngjs';
 
-export { program } from 'commander';
+export { program, Help as ProgramHelp } from 'commander';
 
 import progressLibrary from 'progress';
 export const progress = progressLibrary;

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -79,7 +79,8 @@ type LaunchOverrides = {
   firefoxUserPrefs?: { [key: string]: string | number | boolean };
 };
 
-export type LaunchOptions = Omit<channels.BrowserTypeLaunchOptions, 'ignoreAllDefaultArgs' | 'ignoreDefaultArgs' | 'env' | 'firefoxUserPrefs'> & LaunchOverrides;
+type LaunchRemote = Pick<ConnectOptions, 'wsEndpoint' | 'headers' | 'exposeNetwork'>;
+export type LaunchOptions = Omit<channels.BrowserTypeLaunchOptions, 'ignoreAllDefaultArgs' | 'ignoreDefaultArgs' | 'env' | 'firefoxUserPrefs'> & LaunchOverrides & { remote?: LaunchRemote };
 export type LaunchPersistentContextOptions = Omit<LaunchOptions & BrowserContextOptions, 'storageState'>;
 
 export type ConnectOptions = {

--- a/packages/playwright-core/src/remote/playwrightConnection.ts
+++ b/packages/playwright-core/src/remote/playwrightConnection.ts
@@ -21,13 +21,14 @@ import { createPlaywright, DispatcherConnection, RootDispatcher, PlaywrightDispa
 import { Browser } from '../server/browser';
 import { serverSideCallMetadata } from '../server/instrumentation';
 import { SocksProxy } from '../common/socksProxy';
-import { assert, isUnderTest } from '../utils';
+import { assert } from '../utils';
 import type { LaunchOptions } from '../server/types';
 import { AndroidDevice } from '../server/android/android';
 import { DebugControllerDispatcher } from '../server/dispatchers/debugControllerDispatcher';
 import { startProfiling, stopProfiling } from '../utils';
 import { monotonicTime } from '../utils';
 import { debugLogger } from '../utils/debugLogger';
+import { filterRemoteLaunchOptions } from '../client/browserType';
 
 export type ClientType = 'controller' | 'launch-browser' | 'reuse-browser' | 'pre-launched-browser-or-android';
 
@@ -60,7 +61,7 @@ export class PlaywrightConnection {
     this._ws = ws;
     this._preLaunched = preLaunched;
     this._options = options;
-    options.launchOptions = filterLaunchOptions(options.launchOptions);
+    options.launchOptions = filterRemoteLaunchOptions(options.launchOptions);
     if (clientType === 'reuse-browser' || clientType === 'pre-launched-browser-or-android')
       assert(preLaunched.playwright);
     if (clientType === 'pre-launched-browser-or-android')
@@ -282,22 +283,6 @@ function launchOptionsHash(options: LaunchOptions) {
   for (const key of optionsThatAllowBrowserReuse)
     delete copy[key];
   return JSON.stringify(copy);
-}
-
-function filterLaunchOptions(options: LaunchOptions): LaunchOptions {
-  return {
-    channel: options.channel,
-    args: options.args,
-    ignoreAllDefaultArgs: options.ignoreAllDefaultArgs,
-    ignoreDefaultArgs: options.ignoreDefaultArgs,
-    timeout: options.timeout,
-    headless: options.headless,
-    proxy: options.proxy,
-    chromiumSandbox: options.chromiumSandbox,
-    firefoxUserPrefs: options.firefoxUserPrefs,
-    slowMo: options.slowMo,
-    executablePath: isUnderTest() ? options.executablePath : undefined,
-  };
 }
 
 const defaultLaunchOptions: LaunchOptions = {

--- a/packages/playwright-core/src/utilsBundle.ts
+++ b/packages/playwright-core/src/utilsBundle.ts
@@ -28,6 +28,7 @@ export const minimatch: typeof import('../bundles/utils/node_modules/@types/mini
 export const open: typeof import('../bundles/utils/node_modules/open') = require('./utilsBundleImpl').open;
 export const PNG: typeof import('../bundles/utils/node_modules/@types/pngjs').PNG = require('./utilsBundleImpl').PNG;
 export const program: typeof import('../bundles/utils/node_modules/commander').program = require('./utilsBundleImpl').program;
+export const ProgramHelp: typeof import('../bundles/utils/node_modules/commander').Help = require('./utilsBundleImpl').ProgramHelp;
 export const progress: typeof import('../bundles/utils/node_modules/@types/progress') = require('./utilsBundleImpl').progress;
 export const SocksProxyAgent: typeof import('../bundles/utils/node_modules/socks-proxy-agent').SocksProxyAgent = require('./utilsBundleImpl').SocksProxyAgent;
 export const ws: typeof import('../bundles/utils/node_modules/@types/ws') = require('./utilsBundleImpl').ws;

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -20284,6 +20284,29 @@ export interface LaunchOptions {
   };
 
   /**
+   * When `remote` is present, the browser is not launched locally. Instead, a websocket connection is established to a
+   * remote Playwright server that launches the browser upon request. See the [remote connection](https://playwright.dev/docs/remote) guide
+   * for details.
+   */
+  remote?: {
+    /**
+     * A websocket endpoint to connect to.
+     */
+    wsEndpoint: string;
+
+    /**
+     * Additional HTTP headers to be sent with in the remote connection request.
+     */
+    headers?: { [key: string]: string; };
+
+    /**
+     * This option exposes network available on the connecting client to the browser being connected to. See the
+     * [remote connection](https://playwright.dev/docs/remote#exposing-local-network-to-the-remote-browser) guide for details.
+     */
+    exposeNetwork?: string;
+  };
+
+  /**
    * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going
    * on.
    */
@@ -20332,19 +20355,8 @@ export interface ConnectOverCDPOptions {
 
 export interface ConnectOptions {
   /**
-   * This option exposes network available on the connecting client to the browser being connected to. Consists of a
-   * list of rules separated by comma.
-   *
-   * Available rules:
-   * 1. Hostname pattern, for example: `example.com`, `*.org:99`, `x.*.y.com`, `*foo.org`.
-   * 1. IP literal, for example: `127.0.0.1`, `0.0.0.0:99`, `[::1]`, `[0:0::1]:99`.
-   * 1. `<loopback>` that matches local loopback interfaces: `localhost`, `*.localhost`, `127.0.0.1`, `[::1]`.
-   *
-   * Some common examples:
-   * 1. `"*"` to expose all network.
-   * 1. `"<loopback>"` to expose localhost network.
-   * 1. `"*.test.internal-domain,*.staging.internal-domain,<loopback>"` to expose test/staging deployments and
-   *    localhost.
+   * This option exposes network available on the connecting client to the browser being connected to. See the
+   * [remote connection](https://playwright.dev/docs/remote#exposing-local-network-to-the-remote-browser) guide for details.
    */
   exposeNetwork?: string;
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5502,13 +5502,14 @@ export interface PlaywrightWorkerOptions {
    * });
    * ```
    *
-   * When connect options are specified, default
-   * [fixtures.browser](https://playwright.dev/docs/api/class-fixtures#fixtures-browser),
-   * [fixtures.context](https://playwright.dev/docs/api/class-fixtures#fixtures-context) and
-   * [fixtures.page](https://playwright.dev/docs/api/class-fixtures#fixtures-page) use the remote browser instead of
-   * launching a browser locally, and any launch options like
-   * [testOptions.headless](https://playwright.dev/docs/api/class-testoptions#test-options-headless) or
-   * [testOptions.channel](https://playwright.dev/docs/api/class-testoptions#test-options-channel) are ignored.
+   * When connect options are specified, any launched browsers, including the default
+   * [fixtures.browser](https://playwright.dev/docs/api/class-fixtures#fixtures-browser), will be instead connecting to
+   * a remote browser.
+   *
+   * This property takes precedence over the `remote` property in
+   * [testOptions.launchOptions](https://playwright.dev/docs/api/class-testoptions#test-options-launch-options).
+   *
+   * See the [remote connection](https://playwright.dev/docs/remote) guide for details.
    */
   connectOptions: ConnectOptions | undefined;
   /**

--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -46,7 +46,7 @@ export class RunServer implements PlaywrightServer {
       const prefix = 'Listening on ';
       const line = data.toString();
       if (line.startsWith(prefix))
-        wsEndpointCallback(line.substr(prefix.length));
+        wsEndpointCallback(line.substr(prefix.length).trim());
     };
 
     this._wsEndpoint = await wsEndpointPromise;


### PR DESCRIPTION
- Make `npx playwright run-server` a public command.
- Add a guide for remote connection.
- Migrate built-in fixtures from `browserType.connect()` to `browserType.launch({ remote })`.

Note: instead of throwing for launch options that cannot be passed to `remote`, we just ignore them. Otherwise, it requires a very inconvenient sanitization on the client side.
