### PR TITLE
chore: do not rely on zones for predefined steps

### DIFF
--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -263,7 +263,7 @@ export class TestTypeImpl {
     const testInfo = currentTestInfo();
     if (!testInfo)
       throw new Error(`test.step() can only be called from a test`);
-    return testInfo._runAsStep({ category: 'test.step', title, box: options.box, isFixed: false }, 'strict', async () => {
+    return testInfo._runAsStep({ category: 'test.step', title, box: options.box }, async () => {
       // Make sure that internal "step" is not leaked to the user callback.
       return await body();
     });

--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -263,7 +263,7 @@ export class TestTypeImpl {
     const testInfo = currentTestInfo();
     if (!testInfo)
       throw new Error(`test.step() can only be called from a test`);
-    return testInfo._runAsStep({ category: 'test.step', title, box: options.box }, async () => {
+    return testInfo._runAsStep({ category: 'test.step', title, box: options.box, isFixed: false }, 'strict', async () => {
       // Make sure that internal "step" is not leaked to the user callback.
       return await body();
     });

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -256,8 +256,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
           apiName,
           params,
           wallTime,
-          isFixed: false,
-        }, 'lax');
+        });
         userData.userObject = step;
       },
       onApiCallEnd: (userData: any, error?: Error) => {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -256,8 +256,8 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
           apiName,
           params,
           wallTime,
-          laxParent: true,
-        });
+          isFixed: false,
+        }, 'lax');
         userData.userObject = step;
       },
       onApiCallEnd: (userData: any, error?: Error) => {

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -268,10 +268,9 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
         wallTime,
         infectParentStepsWithError: this._info.isSoft,
         isSoft: this._info.isSoft,
-        isFixed: false,
       };
 
-      const step = testInfo._addStep(stepInfo, 'lax');
+      const step = testInfo._addStep(stepInfo);
 
       const reportStepError = (jestError: ExpectError) => {
         const error = new ExpectError(jestError, customMessage, stackFrames);

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -267,11 +267,11 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
         params: args[0] ? { expected: args[0] } : undefined,
         wallTime,
         infectParentStepsWithError: this._info.isSoft,
-        laxParent: true,
         isSoft: this._info.isSoft,
+        isFixed: false,
       };
 
-      const step = testInfo._addStep(stepInfo);
+      const step = testInfo._addStep(stepInfo, 'lax');
 
       const reportStepError = (jestError: ExpectError) => {
         const error = new ExpectError(jestError, customMessage, stackFrames);

--- a/packages/playwright/src/worker/fixtureRunner.ts
+++ b/packages/playwright/src/worker/fixtureRunner.ts
@@ -99,7 +99,8 @@ class Fixture {
           title: `fixture: ${this.registration.name}`,
           category: 'fixture',
           location: isInternalFixture ? this.registration.location : undefined,
-        }, testInfo._afterHooksStep);
+          isFixed: false,
+        }, 'fixedOnly');
         mutableStepOnStack!.stepId = afterStep.stepId;
       }
     };
@@ -124,7 +125,8 @@ class Fixture {
           title: `fixture: ${this.registration.name}`,
           category: 'fixture',
           location: isInternalFixture ? this.registration.location : undefined,
-        }, async step => {
+          isFixed: false,
+        }, 'fixedOnly', async step => {
           mutableStepOnStack = step;
           return await this.registration.fn(params, useFunc, info);
         });

--- a/packages/playwright/src/worker/fixtureRunner.ts
+++ b/packages/playwright/src/worker/fixtureRunner.ts
@@ -99,8 +99,7 @@ class Fixture {
           title: `fixture: ${this.registration.name}`,
           category: 'fixture',
           location: isInternalFixture ? this.registration.location : undefined,
-          isFixed: false,
-        }, 'fixedOnly');
+        });
         mutableStepOnStack!.stepId = afterStep.stepId;
       }
     };
@@ -125,8 +124,7 @@ class Fixture {
           title: `fixture: ${this.registration.name}`,
           category: 'fixture',
           location: isInternalFixture ? this.registration.location : undefined,
-          isFixed: false,
-        }, 'fixedOnly', async step => {
+        }, async step => {
           mutableStepOnStack = step;
           return await this.registration.fn(params, useFunc, info);
         });

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -357,7 +357,7 @@ export class WorkerMain extends ProcessRunner {
       await removeFolders([testInfo.outputDir]);
 
       let testFunctionParams: object | null = null;
-      await testInfo._runAsStep({ category: 'hook', title: 'Before Hooks', isFixed: true }, 'fixedOnly', async step => {
+      await testInfo._runAsStep({ category: 'hook', title: 'Before Hooks' }, async step => {
         // Run "beforeAll" hooks, unless already run during previous tests.
         for (const suite of suites) {
           didFailBeforeAllForSuite = suite;  // Assume failure, unless reset below.
@@ -414,7 +414,7 @@ export class WorkerMain extends ProcessRunner {
 
     // A timed-out test gets a full additional timeout to run after hooks.
     const afterHooksSlot = testInfo._didTimeout ? { timeout: this._project.project.timeout, elapsed: 0 } : undefined;
-    await testInfo._runAsStepWithRunnable({ category: 'hook', title: 'After Hooks', runnableType: 'afterHooks', runnableSlot: afterHooksSlot }, 'none', async step => {
+    await testInfo._runAsStepWithRunnable({ category: 'hook', title: 'After Hooks', runnableType: 'afterHooks', runnableSlot: afterHooksSlot, forceNoParent: true }, async step => {
       let firstAfterHooksError: Error | undefined;
       await testInfo._runWithTimeout(async () => {
         // Note: do not wrap all teardown steps together, because failure in any of them
@@ -548,7 +548,7 @@ export class WorkerMain extends ProcessRunner {
           location: hook.location,
           runnableType: hook.type,
           runnableSlot: timeSlot,
-        }, 'fixedOnly', async () => {
+        }, async () => {
           const existingAnnotations = new Set(testInfo.annotations);
           try {
             await this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo, 'all-hooks-only');
@@ -590,7 +590,7 @@ export class WorkerMain extends ProcessRunner {
           title: hook.title,
           location: hook.location,
           runnableType: hook.type,
-        }, 'fixedOnly', () => this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo, 'test'));
+        }, () => this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo, 'test'));
       } catch (e) {
         // Always run all the hooks, and capture the first error.
         error = error || e;

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -330,8 +330,8 @@ test('should not override trace file in afterAll', async ({ runInlineTest, serve
     '    fixture: request',
     '      apiRequest.newContext',
     '    apiRequestContext.get',
-    '  fixture: request',
-    '    apiRequestContext.dispose',
+    '    fixture: request',
+    '      apiRequestContext.dispose',
     '  fixture: browser',
   ]);
   expect(trace1.errors).toEqual([`'oh no!'`]);
@@ -835,4 +835,156 @@ test('should not throw when merging traces multiple times', async ({ runInlineTe
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
   expect(fs.existsSync(testInfo.outputPath('test-results', 'a-foo', 'trace.zip'))).toBe(true);
+});
+
+test('should record nested steps, even after timeout', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = {
+        use: { trace: { mode: 'on' } },
+        timeout: 5000,
+      };
+    `,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        fooPage: async ({ page }, use) => {
+          expect(1, 'fooPage setup').toBe(1);
+          await new Promise(f => setTimeout(f, 1));  // To avoid same-wall-time sorting issues.
+          await page.setContent('hello');
+          await test.step('step in fooPage setup', async () => {
+            await page.setContent('bar');
+          });
+          await use(page);
+          expect(1, 'fooPage teardown').toBe(1);
+          await new Promise(f => setTimeout(f, 1));  // To avoid same-wall-time sorting issues.
+          await page.setContent('hi');
+          await test.step('step in fooPage teardown', async () => {
+            await page.setContent('bar');
+          });
+        },
+        barPage: async ({ browser }, use) => {
+          expect(1, 'barPage setup').toBe(1);
+          await new Promise(f => setTimeout(f, 1));  // To avoid same-wall-time sorting issues.
+          const page = await browser.newPage();
+          await test.step('step in barPage setup', async () => {
+            await page.setContent('bar');
+          });
+          await use(page);
+          expect(1, 'barPage teardown').toBe(1);
+          await new Promise(f => setTimeout(f, 1));  // To avoid same-wall-time sorting issues.
+          await test.step('step in barPage teardown', async () => {
+            await page.close();
+          });
+        },
+      });
+
+      test.beforeAll(async ({ barPage }) => {
+        expect(1, 'beforeAll start').toBe(1);
+        await new Promise(f => setTimeout(f, 1));  // To avoid same-wall-time sorting issues.
+        await barPage.setContent('hello');
+        await test.step('step in beforeAll', async () => {
+          await barPage.setContent('bar');
+        });
+      });
+
+      test.beforeEach(async ({ fooPage }) => {
+        expect(1, 'beforeEach start').toBe(1);
+        await new Promise(f => setTimeout(f, 1));  // To avoid same-wall-time sorting issues.
+        await fooPage.setContent('hello');
+        await test.step('step in beforeEach', async () => {
+          await fooPage.setContent('hi');
+          // Next line times out. We make sure that after hooks steps
+          // form the expected step tree even when some previous steps have not finished.
+          await new Promise(() => {});
+        });
+      });
+
+      test('example', async ({ fooPage }) => {
+      });
+
+      test.afterEach(async ({ fooPage }) => {
+        expect(1, 'afterEach start').toBe(1);
+        await new Promise(f => setTimeout(f, 1));  // To avoid same-wall-time sorting issues.
+        await fooPage.setContent('hello');
+        await test.step('step in afterEach', async () => {
+          await fooPage.setContent('bar');
+        });
+      });
+
+      test.afterAll(async ({ barPage }) => {
+        expect(1, 'afterAll start').toBe(1);
+        await new Promise(f => setTimeout(f, 1));  // To avoid same-wall-time sorting issues.
+        await barPage.setContent('hello');
+        await test.step('step in afterAll', async () => {
+          await barPage.setContent('bar');
+        });
+      });
+    `,
+  }, { workers: 1 }, { DEBUG: 'pw:test' });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  const trace = await parseTrace(testInfo.outputPath('test-results', 'a-example', 'trace.zip'));
+  expect(trace.actionTree).toEqual([
+    'Before Hooks',
+    '  beforeAll hook',
+    '    fixture: browser',
+    '      browserType.launch',
+    '    fixture: barPage',
+    '      barPage setup',
+    '      browser.newPage',
+    '      step in barPage setup',
+    '        page.setContent',
+    '    beforeAll start',
+    '    page.setContent',
+    '    step in beforeAll',
+    '      page.setContent',
+    '    fixture: barPage',
+    '      barPage teardown',
+    '      step in barPage teardown',
+    '        page.close',
+    '  beforeEach hook',
+    '    fixture: context',
+    '      browser.newContext',
+    '    fixture: page',
+    '      browserContext.newPage',
+    '    fixture: fooPage',
+    '      fooPage setup',
+    '      page.setContent',
+    '      step in fooPage setup',
+    '        page.setContent',
+    '    beforeEach start',
+    '    page.setContent',
+    '    step in beforeEach',
+    '      page.setContent',
+    'After Hooks',
+    '  afterEach hook',
+    '    afterEach start',
+    '    page.setContent',
+    '    step in afterEach',
+    '      page.setContent',
+    '  fixture: fooPage',
+    '    fooPage teardown',
+    '    page.setContent',
+    '    step in fooPage teardown',
+    '      page.setContent',
+    '  fixture: page',
+    '  fixture: context',
+    '  afterAll hook',
+    '    fixture: barPage',
+    '      barPage setup',
+    '      browser.newPage',
+    '      step in barPage setup',
+    '        page.setContent',
+    '    afterAll start',
+    '    page.setContent',
+    '    step in afterAll',
+    '      page.setContent',
+    '    fixture: barPage',
+    '      barPage teardown',
+    '      step in barPage teardown',
+    '        page.close',
+    '  fixture: browser',
+  ]);
 });

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -921,7 +921,7 @@ test('should record nested steps, even after timeout', async ({ runInlineTest },
         });
       });
     `,
-  }, { workers: 1 }, { DEBUG: 'pw:test' });
+  }, { workers: 1 });
 
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);


### PR DESCRIPTION
This fixes some edge cases where fixtures and steps inside them were attached to the wrong parent (see the new test).
This will also allow to replace some `runAsStep` calls with a flat list of tasks to do that do not rely on lexical scope.