### PR TITLE
docs(webServer): add missing options

### DIFF
--- a/docs/src/test-webserver-js.md
+++ b/docs/src/test-webserver-js.md
@@ -32,8 +32,11 @@ export default defineConfig({
 | `command`| Shell command to start the local dev server of your app. |
 | `url`| URL of your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. |
 | `reuseExistingServer`| If `true`, it will re-use an existing server on the url when available. If no server is running on that url, it will run the command to start a new server. If `false`, it will throw if an existing process is listening on the url. To see the stdout, you can set the `DEBUG=pw:webserver` environment variable. |
+| `ignoreHTTPSErrors` | Whether to ignore HTTPS errors when fetching the `url`. Defaults to `false`. |
+| `cwd` | Current working directory of the spawned process, defaults to the directory of the configuration file. |
 | `stdout` | If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`. |
 | `stderr` | Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`. |
+| `timeout` | `How long to wait for the process to start up and be available in milliseconds. Defaults to 60000. |
 
 ## Adding a server timeout
 


### PR DESCRIPTION
The options were really hidden [here](https://playwright.dev/docs/api/class-testconfig#test-config-web-server).

This syncs them into the "guide doc".

Relates https://github.com/microsoft/playwright/issues/29475.