### PR TITLE
feat(chromium): Expose parameters to generate outline in pdf.

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2989,13 +2989,13 @@ Give any CSS `@page` size declared in the page priority over what is declared in
 size.
 
 ### option: Page.pdf.tagged
-* since: v1.X
+* since: v1.42
 - `tagged` <[boolean]>
 
 Whether or not to generate tagged (accessible) PDF. Defaults to `false`.
 
 ### option: Page.pdf.outline
-* since: v1.X
+* since: v1.42
 - `outline` <[boolean]>
 
 Whether or not to embed the document outline into the PDF. Defaults to `false`.

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2988,6 +2988,18 @@ Give any CSS `@page` size declared in the page priority over what is declared in
 [`option: height`] or [`option: format`] options. Defaults to `false`, which will scale the content to fit the paper
 size.
 
+### option: Page.pdf.tagged
+* since: v1.X
+- `tagged` <[boolean]>
+
+Whether or not to generate tagged (accessible) PDF. Defaults to `false`.
+
+### option: Page.pdf.outline
+* since: v1.X
+- `outline` <[boolean]>
+
+Whether or not to embed the document outline into the PDF. Defaults to `false`.
+
 ## async method: Page.press
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.press`] instead. Read more about [locators](../locators.md).

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1203,6 +1203,8 @@ scheme.PagePdfParams = tObject({
     left: tOptional(tString),
     right: tOptional(tString),
   })),
+  tagged: tOptional(tBoolean),
+  outline: tOptional(tBoolean),
 });
 scheme.PagePdfResult = tObject({
   pdf: tBinary,

--- a/packages/playwright-core/src/server/chromium/crPdf.ts
+++ b/packages/playwright-core/src/server/chromium/crPdf.ts
@@ -78,6 +78,8 @@ export class CRPDF {
       pageRanges = '',
       preferCSSPageSize = false,
       margin = {},
+      tagged = false,
+      outline = false
     } = options;
 
     let paperWidth = 8.5;
@@ -96,7 +98,8 @@ export class CRPDF {
     const marginLeft = convertPrintParameterToInches(margin.left) || 0;
     const marginBottom = convertPrintParameterToInches(margin.bottom) || 0;
     const marginRight = convertPrintParameterToInches(margin.right) || 0;
-
+    const generateDocumentOutline = outline;
+    const generateTaggedPDF = tagged;
     const result = await this._client.send('Page.printToPDF', {
       transferMode: 'ReturnAsStream',
       landscape,
@@ -112,7 +115,9 @@ export class CRPDF {
       marginLeft,
       marginRight,
       pageRanges,
-      preferCSSPageSize
+      preferCSSPageSize,
+      generateTaggedPDF,
+      generateDocumentOutline
     });
     return await readProtocolStream(this._client, result.stream!);
   }

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -3493,6 +3493,11 @@ export interface Page {
     };
 
     /**
+     * Whether or not to embed the document outline into the PDF. Defaults to `false`.
+     */
+    outline?: boolean;
+
+    /**
      * Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
      */
     pageRanges?: string;
@@ -3518,6 +3523,11 @@ export interface Page {
      * Scale of the webpage rendering. Defaults to `1`. Scale amount must be between 0.1 and 2.
      */
     scale?: number;
+
+    /**
+     * Whether or not to generate tagged (accessible) PDF. Defaults to `false`.
+     */
+    tagged?: boolean;
 
     /**
      * Paper width, accepts values labeled with units.

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -2174,6 +2174,8 @@ export type PagePdfParams = {
     left?: string,
     right?: string,
   },
+  tagged?: boolean,
+  outline?: boolean,
 };
 export type PagePdfOptions = {
   scale?: number,
@@ -2193,6 +2195,8 @@ export type PagePdfOptions = {
     left?: string,
     right?: string,
   },
+  tagged?: boolean,
+  outline?: boolean,
 };
 export type PagePdfResult = {
   pdf: Binary,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1560,6 +1560,8 @@ Page:
             bottom: string?
             left: string?
             right: string?
+        tagged: boolean?
+        outline: boolean?
       returns:
         pdf: binary
 

--- a/tests/assets/headings.html
+++ b/tests/assets/headings.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Headings</title>
+</head>
+
+<body>
+    <h1>Title</h1>
+    <h2>Subtitle</h2>
+    <h3>Subsubtitle</h3>
+    <h2>Subtitle</h2>
+</body>
+
+</html>

--- a/tests/library/pdf.spec.ts
+++ b/tests/library/pdf.spec.ts
@@ -26,3 +26,18 @@ it('should be able to save file', async ({ contextFactory, headless, browserName
   await page.pdf({ path: outputFile });
   expect(fs.readFileSync(outputFile).byteLength).toBeGreaterThan(0);
 });
+
+it('should be able to generate outline', async ({ contextFactory, server, headless, browserName }, testInfo) => {
+  it.skip(!headless || browserName !== 'chromium', 'Printing to pdf is currently only supported in headless chromium.');
+  // const context = await contextFactory();
+  const context = await contextFactory({
+    baseURL: server.PREFIX,
+  });
+  const page = await context.newPage();
+  await page.goto('/headings.html');
+  const outputFileNoOutline = testInfo.outputPath('outputNoOutline.pdf');
+  const outputFileOutline = testInfo.outputPath('outputOutline.pdf');
+  await page.pdf({ path: outputFileNoOutline });
+  await page.pdf({ path: outputFileOutline, tagged: true, outline: true });
+  expect(fs.readFileSync(outputFileOutline).byteLength).toBeGreaterThan(fs.readFileSync(outputFileNoOutline).byteLength);
+});


### PR DESCRIPTION
Expose the new parameters in [Page.printToPDF](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF):
- `generateTaggedPDF`
  Whether or not to generate tagged (accessible) PDF. Defaults to embedder choice.
- `generateDocumentOutline`
  Whether or not to embed the document outline into the PDF.

This should close #29417 