### PR TITLE
fix: update path to cli.js in run-driver-win.cmd

### DIFF
--- a/utils/build/run-driver-win.cmd
+++ b/utils/build/run-driver-win.cmd
@@ -1,4 +1,4 @@
 @echo off
 setlocal
 if not defined PLAYWRIGHT_NODEJS_PATH set PLAYWRIGHT_NODEJS_PATH=%~dp0node.exe
-"%PLAYWRIGHT_NODEJS_PATH%" "%~dp0package\lib\cli\cli.js" %*
+"%PLAYWRIGHT_NODEJS_PATH%" "%~dp0package\cli.js" %*


### PR DESCRIPTION
This was missed in https://github.com/microsoft/playwright/pull/29131

Fixes the following error in java on windows:

```
Error: Cannot find module 'C:\Users\RUNNER~1\AppData\Local\Temp\playwright-java-910508779801292985\package\lib\cli\cli.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
    at Module._load (node:internal/modules/cjs/loader:985:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```