### PR TITLE
use addEventListener instead of onmessage in portTransport.ts

### DIFF
--- a/packages/playwright/src/transform/portTransport.ts
+++ b/packages/playwright/src/transform/portTransport.ts
@@ -21,7 +21,7 @@ export class PortTransport {
 
   constructor(port: MessagePort, handler: (method: string, params: any) => Promise<any>) {
     this._port = port;
-    port.onmessage = async event => {
+    port.addEventListener('message', async event => {
       const message = event.data;
       const { id, ackId, method, params, result } = message;
       if (id) {
@@ -36,7 +36,7 @@ export class PortTransport {
         callback?.(result);
         return;
       }
-    };
+    });
   }
 
   async send(method: string, params: any) {


### PR DESCRIPTION
When running Playwright 1.42.1 on Node 18.18.2 under `bazel run`, we found an edge case where `ui mode` would start but the list of tests would never render. When debugging with `--inspect-brk` we were unable to reproduce the issue. Upon logging out where the messages were getting lost from the websocket server, we found this line to be the offending line. Switching `onmessage` to `addEventListener('message'` solved the issue for us and the messages were sent over websocket just fine.

Unfortunately, we were unable to reproduce this issue with just Node in a browser, so we believe the core of the issue is in playwright itself. We aren't sure why this fixes the issue in our specific case, but we wanted to upstream it so that the fix is known.