### PR TITLE
fix(ct-react+ct-react17): only pass `children` to `React.createElement` when they are defined

### DIFF
--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -40,7 +40,13 @@ function __pwRender(value) {
     if (isJsxComponent(v)) {
       const component = v;
       const props = component.props ? __pwRender(component.props) : {};
-      return { result: __pwReact.createElement(/** @type { any } */ (component.type), { ...props, children: undefined }, props.children) };
+      const {children, ...propsWithoutChildren} = props;
+      /** @type {[any, any, any?]} */
+      const createElementArguments = [component.type, propsWithoutChildren];
+      if(children){
+        createElementArguments.push(children);
+      }
+      return { result: __pwReact.createElement(...createElementArguments) };
     }
   });
 }

--- a/packages/playwright-ct-react17/registerSource.mjs
+++ b/packages/playwright-ct-react17/registerSource.mjs
@@ -40,7 +40,14 @@ function __pwRender(value) {
     if (isJsxComponent(v)) {
       const component = v;
       const props = component.props ? __pwRender(component.props) : {};
-      return { result: __pwReact.createElement(/** @type { any } */ (component.type), { ...props, children: undefined }, props.children) };
+
+      const {children, ...propsWithoutChildren} = props;
+      /** @type {[any, any, any?]} */
+      const createElementArguments = [component.type, propsWithoutChildren];
+      if(children){
+        createElementArguments.push(children);
+      }
+      return { result: __pwReact.createElement(...createElementArguments) };
     }
   });
 }

--- a/tests/components/ct-react-vite/src/components/CheckChildrenProp.tsx
+++ b/tests/components/ct-react-vite/src/components/CheckChildrenProp.tsx
@@ -1,0 +1,16 @@
+type DefaultChildrenProps = {
+  children?: any;
+}
+
+export default function CheckChildrenProp(props: DefaultChildrenProps) {
+  const content = 'children' in props ? props.children : 'No Children';
+  return <div>
+    <h1>Welcome!</h1>
+    <main>
+      {content}
+    </main>
+    <footer>
+      Thanks for visiting.
+    </footer>
+  </div>
+}

--- a/tests/components/ct-react-vite/tests/children.spec.tsx
+++ b/tests/components/ct-react-vite/tests/children.spec.tsx
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/experimental-ct-react';
 import Button from '@/components/Button';
+import CheckChildrenProp from '@/components/CheckChildrenProp';
 import DefaultChildren from '@/components/DefaultChildren';
 import MultipleChildren from '@/components/MultipleChildren';
 
@@ -57,4 +58,9 @@ test('render array as child', async ({ mount }) => {
 test('render number as child', async ({ mount }) => {
   const component = await mount(<DefaultChildren>{1337}</DefaultChildren>);
   await expect(component).toContainText('1337');
+});
+
+test('render without children', async ({ mount }) => {
+  const component = await mount(<CheckChildrenProp />);
+  await expect(component).toContainText('No Children');
 });

--- a/tests/components/ct-react17/src/components/CheckChildrenProp.tsx
+++ b/tests/components/ct-react17/src/components/CheckChildrenProp.tsx
@@ -1,0 +1,16 @@
+type DefaultChildrenProps = {
+  children?: any;
+}
+
+export default function CheckChildrenProp(props: DefaultChildrenProps) {
+  const content = 'children' in props ? props.children : 'No Children';
+  return <div>
+    <h1>Welcome!</h1>
+    <main>
+      {content}
+    </main>
+    <footer>
+      Thanks for visiting.
+    </footer>
+  </div>
+}

--- a/tests/components/ct-react17/tests/children.spec.tsx
+++ b/tests/components/ct-react17/tests/children.spec.tsx
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/experimental-ct-react17';
 import Button from '@/components/Button';
+import CheckChildrenProp from '@/components/CheckChildrenProp';
 import DefaultChildren from '@/components/DefaultChildren';
 import MultipleChildren from '@/components/MultipleChildren';
 
@@ -57,4 +58,9 @@ test('render array as child', async ({ mount }) => {
 test('render number as child', async ({ mount }) => {
   const component = await mount(<DefaultChildren>{1337}</DefaultChildren>);
   await expect(component).toContainText('1337');
+});
+
+test('render without children', async ({ mount }) => {
+  const component = await mount(<CheckChildrenProp />);
+  await expect(component).toContainText('No Children');
 });


### PR DESCRIPTION
This PR fixes a minor bug when mounting React components without children in component testing.

## Problem

With the previous implementation a component would _always_ get `props: { children: undefined }` when children were not defined, where as the `children` property should just be omitted completely. Thus mounting with eg. `mount(<MyComponent />)` would actually become `mount(<MyComponent>{undefined}</MyComponent>)` from the perspective of the component.

See the added tests for an example of a situation where that would behave unexpectedly.

## Use case

I admit that a React component checking children with `if('children' in props){...}` seems unlikely, but there is a use case where a component wants to allow a parent to remove default children by passing `undefined` explicitly with `<MyComponent>{undefined}</MyComponent>`.

## In Storybook

In reality we discovered this bug while implementing support for Playwright CT in Storybook.

Internally in Storybook we construct the components like this (psuedo):

```ts
const Wrapper = (incomingProps) => {
  const props = {
    ...initialProps,
    ...incomingProps
  };
  return Component(props)
}
```

In this case, Playwright always passing `{ children: undefined }` at `incomingProps` would always overwrite any `children` defined in `initialProps`, a problem we don't have with any of the other test-runners. [The actual implementation is here](https://github.com/storybookjs/storybook/blob/feature/portable-stories-improvements/code/lib/preview-api/src/modules/store/csf/portable-stories.ts#L90-L97).

## Additonal Context

See the implementation of `React.createElement` that specifically counts the number of arguments passed, and not just if they are defined or not:

https://github.com/facebook/react/blob/4ea424e63d1a74ce57ef675b64a8c4eabfdb2fdc/packages/react/src/jsx/ReactJSXElement.js#L717-L733