### PR TITLE
fix(playwright-core): increase randomness during guid generation

### DIFF
--- a/packages/playwright-core/src/utils/crypto.ts
+++ b/packages/playwright-core/src/utils/crypto.ts
@@ -16,8 +16,13 @@
 
 import crypto from 'crypto';
 
+/**
+ * Creates a random identifier, biased by the current timestamp.
+ *
+ * @returns A string representing cryptographically strong pseudorandom data
+ */
 export function createGuid(): string {
-  return crypto.randomBytes(16).toString('hex');
+  return crypto.randomBytes(16).toString('hex') + Date.now().toString();
 }
 
 export function calculateSha1(buffer: Buffer | string): string {


### PR DESCRIPTION
This introduces a timestamp into guid generation, which attempts to avoid conflicts when storing fetch responses within the [response body storage](https://github.com/microsoft/playwright/blob/a023cd1f5723b88e064a914449049b6b56842769/packages/playwright-core/src/server/fetch.ts#L131-L135).

This stems from an issue we saw when authoring tests that leverage multiple instances of `ApiRequestContext`. We observed that the response body from a separate request was being leveraged instead of the one from our existing test. This issue is difficult to reproduce reliably.