### PR TITLE
feat(uimode) uses relative paths to establish websocket connection

### DIFF
--- a/packages/trace-viewer/src/ui/wsPort.ts
+++ b/packages/trace-viewer/src/ui/wsPort.ts
@@ -21,8 +21,8 @@ const callbacks = new Map<number, { resolve: (arg: any) => void, reject: (arg: E
 export async function connect(options: { onEvent: (method: string, params?: any) => void, onClose: () => void }): Promise<(method: string, params?: any) => Promise<any>> {
   const guid = new URLSearchParams(window.location.search).get('ws');
   const wsURL = new URL(`../${guid}`, window.location.toString());
-  wsURL.protocol = (window.location.protocol === 'https:' ? 'wss:' : 'ws:')
-  const ws = new WebSocket(wsURL)
+  wsURL.protocol = (window.location.protocol === 'https:' ? 'wss:' : 'ws:');
+  const ws = new WebSocket(wsURL);
   await new Promise(f => ws.addEventListener('open', f));
   ws.addEventListener('close', options.onClose);
   ws.addEventListener('message', event => {

--- a/packages/trace-viewer/src/ui/wsPort.ts
+++ b/packages/trace-viewer/src/ui/wsPort.ts
@@ -20,7 +20,9 @@ const callbacks = new Map<number, { resolve: (arg: any) => void, reject: (arg: E
 
 export async function connect(options: { onEvent: (method: string, params?: any) => void, onClose: () => void }): Promise<(method: string, params?: any) => Promise<any>> {
   const guid = new URLSearchParams(window.location.search).get('ws');
-  const ws = new WebSocket(`${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.hostname}:${window.location.port}/${guid}`);
+  const wsURL = new URL(`../${guid}`, window.location.toString());
+  wsURL.protocol = (window.location.protocol === 'https:' ? 'wss:' : 'ws:')
+  const ws = new WebSocket(wsURL)
   await new Promise(f => ws.addEventListener('open', f));
   ws.addEventListener('close', options.onClose);
   ws.addEventListener('message', event => {


### PR DESCRIPTION
Implements the changes discussed in https://github.com/microsoft/playwright/issues/29564 

Uses relative paths to establish the WebSocket connection.
This shouldn't change the behavior in cases where the UI mode is exposed via domain proxying - in cases where there is no preceding subpath.

**Testing**
- I didn't find any related tests that I could adapt
- I didn't find a guide on how to build and install Playwright to validate manually

Happy to do the work if you can point me in the right direction