### PR TITLE
chore: add docker documentation back to Visual comparisons

### DIFF
--- a/docs/src/test-snapshots-js.md
+++ b/docs/src/test-snapshots-js.md
@@ -55,6 +55,15 @@ npx playwright test --update-snapshots
 > Note that `snapshotName` also accepts an array of path segments to the snapshot file such as `expect().toHaveScreenshot(['relative', 'path', 'to', 'snapshot.png'])`.
 > However, this path must stay within the snapshots directory for each test file (i.e. `a.spec.js-snapshots`), otherwise it will throw.
 
+If you are not on the same operating system as your CI system, you can use Docker to generate/update the screenshots:
+
+```bash
+docker run --rm --network host -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/playwright:v%%VERSION%%-jammy /bin/bash
+npm install
+npx playwright test --update-snapshots
+```
+
+
 ## Options
 
 ### maxDiffPixels


### PR DESCRIPTION
Hello @pavelfeldman, We noticed that the update to the snapshot section using Docker was removed for reasons unknown. However, upon reviewing the original PR(https://github.com/microsoft/playwright/pull/28636) [modifications](https://github.com/microsoft/playwright/pull/28636/files#diff-e31b2be556e0eaa5f86f7d454d80796f0276712b4760b61e8207aeac49c48f14L45-L51), it seems unrelated to Docker. I propose reinstating the documentation, as having a unified golden standard for snapshots across different systems would be immensely beneficial.

@rayeedanwar @johnson-liang also proposed restoring the document [here](https://github.com/microsoft/playwright/commit/d242ff67ef3f3bd2bc3644b1c71068d20cb54d61#r137285360).
