### PR TITLE
feat(trace mode): add retain-on-first-failure mode for traces

### DIFF
--- a/docs/src/test-api/class-testoptions.md
+++ b/docs/src/test-api/class-testoptions.md
@@ -546,8 +546,8 @@ export default defineConfig({
 
 ## property: TestOptions.trace
 * since: v1.10
-- type: <[Object]|[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-first-failure">>
-  - `mode` <[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"on-first-failure">> Trace recording mode.
+- type: <[Object]|[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"retain-on-first-failure">>
+  - `mode` <[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"retain-on-first-failure">> Trace recording mode.
   - `attachments` ?<[boolean]> Whether to include test attachments. Defaults to true. Optional.
   - `screenshots` ?<[boolean]> Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Defaults to true. Optional.
   - `snapshots` ?<[boolean]> Whether to capture DOM snapshot on every action. Defaults to true. Optional.
@@ -559,7 +559,7 @@ Whether to record trace for each test. Defaults to `'off'`.
 * `'retain-on-failure'`: Record trace for each test, but remove all traces from successful test runs.
 * `'on-first-retry'`: Record trace only when retrying a test for the first time.
 * `'on-all-retries'`: Record traces only when retrying for all retries.
-* `'on-first-failure'`: Record traces only when the test fails for the first time.
+* `'retain-on-first-failure'`: Record traces only when the test fails for the first time.
 
 For more control, pass an object that specifies `mode` and trace features to enable.
 

--- a/docs/src/test-api/class-testoptions.md
+++ b/docs/src/test-api/class-testoptions.md
@@ -546,7 +546,7 @@ export default defineConfig({
 
 ## property: TestOptions.trace
 * since: v1.10
-- type: <[Object]|[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry">>
+- type: <[Object]|[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-first-failure">>
   - `mode` <[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"on-first-failure">> Trace recording mode.
   - `attachments` ?<[boolean]> Whether to include test attachments. Defaults to true. Optional.
   - `screenshots` ?<[boolean]> Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Defaults to true. Optional.

--- a/docs/src/test-api/class-testoptions.md
+++ b/docs/src/test-api/class-testoptions.md
@@ -547,7 +547,7 @@ export default defineConfig({
 ## property: TestOptions.trace
 * since: v1.10
 - type: <[Object]|[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry">>
-  - `mode` <[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries">> Trace recording mode.
+  - `mode` <[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"on-first-failure">> Trace recording mode.
   - `attachments` ?<[boolean]> Whether to include test attachments. Defaults to true. Optional.
   - `screenshots` ?<[boolean]> Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Defaults to true. Optional.
   - `snapshots` ?<[boolean]> Whether to capture DOM snapshot on every action. Defaults to true. Optional.
@@ -559,6 +559,7 @@ Whether to record trace for each test. Defaults to `'off'`.
 * `'retain-on-failure'`: Record trace for each test, but remove all traces from successful test runs.
 * `'on-first-retry'`: Record trace only when retrying a test for the first time.
 * `'on-all-retries'`: Record traces only when retrying for all retries.
+* `'on-first-failure'`: Record traces only when the test fails for the first time.
 
 For more control, pass an object that specifies `mode` and trace features to enable.
 

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -16,24 +16,25 @@
 
 /* eslint-disable no-console */
 
+import type { Command } from 'playwright-core/lib/utilsBundle';
 import fs from 'fs';
 import path from 'path';
-import { program } from 'playwright-core/lib/cli/program';
-import { gracefullyProcessExitDoNotHang, startProfiling, stopProfiling } from 'playwright-core/lib/utils';
-import type { Command } from 'playwright-core/lib/utilsBundle';
-import type { ReporterDescription, TraceMode } from '../types/test';
-import type { FullResult, TestError } from '../types/testReporter';
-import { builtInReporters, defaultReporter, defaultTimeout } from './common/config';
-import { loadConfigFromFileRestartIfNeeded, loadEmptyConfigForMergeReports } from './common/configLoader';
-import type { ConfigCLIOverrides } from './common/ipc';
-import { prepareErrorStack } from './reporters/base';
+import { Runner } from './runner/runner';
+import { stopProfiling, startProfiling, gracefullyProcessExitDoNotHang } from 'playwright-core/lib/utils';
+import { serializeError } from './util';
 import { showHTMLReport } from './reporters/html';
 import { createMergedReport } from './reporters/merge';
-import { Runner } from './runner/runner';
-import { runTestServer } from './runner/testServer';
-import { cacheDir } from './transform/compilationCache';
-import { serializeError } from './util';
+import { loadConfigFromFileRestartIfNeeded, loadEmptyConfigForMergeReports } from './common/configLoader';
+import type { ConfigCLIOverrides } from './common/ipc';
+import type { FullResult, TestError } from '../types/testReporter';
+import type { TraceMode } from '../types/test';
+import { builtInReporters, defaultReporter, defaultTimeout } from './common/config';
+import { program } from 'playwright-core/lib/cli/program';
 export { program } from 'playwright-core/lib/cli/program';
+import type { ReporterDescription } from '../types/test';
+import { prepareErrorStack } from './reporters/base';
+import { cacheDir } from './transform/compilationCache';
+import { runTestServer } from './runner/testServer';
 
 function addTestCommand(program: Command) {
   const command = program.command('test [test-filter...]');

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -289,7 +289,7 @@ function resolveReporter(id: string) {
   return require.resolve(id, { paths: [process.cwd()] });
 }
 
-const kTraceModes: TraceMode[] = ['on', 'off', 'on-first-retry', 'on-all-retries', 'retain-on-failure', 'on-first-failure'];
+const kTraceModes: TraceMode[] = ['on', 'off', 'on-first-retry', 'on-all-retries', 'retain-on-failure', 'retain-on-first-failure'];
 
 const testOptions: [string, string][] = [
   ['--browser <browser>', `Browser to use for tests, one of "all", "chromium", "firefox" or "webkit" (default: "chromium")`],

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -16,25 +16,24 @@
 
 /* eslint-disable no-console */
 
-import type { Command } from 'playwright-core/lib/utilsBundle';
 import fs from 'fs';
 import path from 'path';
-import { Runner } from './runner/runner';
-import { stopProfiling, startProfiling, gracefullyProcessExitDoNotHang } from 'playwright-core/lib/utils';
-import { serializeError } from './util';
-import { showHTMLReport } from './reporters/html';
-import { createMergedReport } from './reporters/merge';
+import { program } from 'playwright-core/lib/cli/program';
+import { gracefullyProcessExitDoNotHang, startProfiling, stopProfiling } from 'playwright-core/lib/utils';
+import type { Command } from 'playwright-core/lib/utilsBundle';
+import type { ReporterDescription, TraceMode } from '../types/test';
+import type { FullResult, TestError } from '../types/testReporter';
+import { builtInReporters, defaultReporter, defaultTimeout } from './common/config';
 import { loadConfigFromFileRestartIfNeeded, loadEmptyConfigForMergeReports } from './common/configLoader';
 import type { ConfigCLIOverrides } from './common/ipc';
-import type { FullResult, TestError } from '../types/testReporter';
-import type { TraceMode } from '../types/test';
-import { builtInReporters, defaultReporter, defaultTimeout } from './common/config';
-import { program } from 'playwright-core/lib/cli/program';
-export { program } from 'playwright-core/lib/cli/program';
-import type { ReporterDescription } from '../types/test';
 import { prepareErrorStack } from './reporters/base';
-import { cacheDir } from './transform/compilationCache';
+import { showHTMLReport } from './reporters/html';
+import { createMergedReport } from './reporters/merge';
+import { Runner } from './runner/runner';
 import { runTestServer } from './runner/testServer';
+import { cacheDir } from './transform/compilationCache';
+import { serializeError } from './util';
+export { program } from 'playwright-core/lib/cli/program';
 
 function addTestCommand(program: Command) {
   const command = program.command('test [test-filter...]');
@@ -290,7 +289,7 @@ function resolveReporter(id: string) {
   return require.resolve(id, { paths: [process.cwd()] });
 }
 
-const kTraceModes: TraceMode[] = ['on', 'off', 'on-first-retry', 'on-all-retries', 'retain-on-failure'];
+const kTraceModes: TraceMode[] = ['on', 'off', 'on-first-retry', 'on-all-retries', 'retain-on-failure', 'on-first-failure'];
 
 const testOptions: [string, string][] = [
   ['--browser <browser>', `Browser to use for tests, one of "all", "chromium", "firefox" or "webkit" (default: "chromium")`],

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -48,15 +48,14 @@ export class TestTracing {
   }
 
   private _shouldCaptureTrace() {
-    let capture = false;
+    if (process.env.PW_TEST_DISABLE_TRACING) return false;
+    if (this._options?.mode === 'on') return true;
+    if (this._options?.mode === 'retain-on-failure') return true;
+    if (this._options?.mode === 'on-first-retry' && this._testInfo.retry === 1) return true;
+    if (this._options?.mode === 'on-all-retries' && this._testInfo.retry > 0) return true;
+    if (this._options?.mode === 'retain-on-first-failure' && this._testInfo.retry === 0) return true;
 
-    if (this._options?.mode === 'on') capture = true;
-    if (this._options?.mode === 'retain-on-failure') capture = true;
-    if (this._options?.mode === 'on-first-retry' && this._testInfo.retry === 1) capture = true;
-    if (this._options?.mode === 'on-all-retries' && this._testInfo.retry > 0) capture = true;
-    if (this._options?.mode === 'retain-on-first-failure' && this._testInfo.retry === 0) capture = true;
-
-    return capture && !process.env.PW_TEST_DISABLE_TRACING;
+    return false;
   }
 
   async startIfNeeded(value: TraceFixtureValue) {

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -54,7 +54,7 @@ export class TestTracing {
     if (this._options?.mode === 'retain-on-failure') capture = true;
     if (this._options?.mode === 'on-first-retry' && this._testInfo.retry === 1) capture = true;
     if (this._options?.mode === 'on-all-retries' && this._testInfo.retry > 0) capture = true;
-    if (this._options?.mode === 'on-first-failure' && this._testInfo.retry === 0) capture = true;
+    if (this._options?.mode === 'retain-on-first-failure' && this._testInfo.retry === 0) capture = true;
 
     return capture && !process.env.PW_TEST_DISABLE_TRACING;
   }
@@ -120,7 +120,7 @@ export class TestTracing {
       return;
 
     const testFailed = this._testInfo.status !== this._testInfo.expectedStatus;
-    const shouldAbandonTrace = !testFailed && (this._options.mode === 'retain-on-failure' || this._options.mode === 'on-first-failure');
+    const shouldAbandonTrace = !testFailed && (this._options.mode === 'retain-on-failure' || this._options.mode === 'retain-on-first-failure');
 
     if (shouldAbandonTrace) {
       for (const file of this._temporaryTraceFiles)

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -70,7 +70,7 @@ export class TestTracing {
       this._options = { ...defaultTraceOptions, ...value, mode: (mode as string) === 'retry-with-trace' ? 'on-first-retry' : mode };
     }
 
-    if (this._shouldCaptureTrace() === false) {
+    if (!this._shouldCaptureTrace()) {
       this._options = undefined;
       return;
     }

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -48,12 +48,24 @@ export class TestTracing {
   }
 
   private _shouldCaptureTrace() {
-    if (process.env.PW_TEST_DISABLE_TRACING) return false;
-    if (this._options?.mode === 'on') return true;
-    if (this._options?.mode === 'retain-on-failure') return true;
-    if (this._options?.mode === 'on-first-retry' && this._testInfo.retry === 1) return true;
-    if (this._options?.mode === 'on-all-retries' && this._testInfo.retry > 0) return true;
-    if (this._options?.mode === 'retain-on-first-failure' && this._testInfo.retry === 0) return true;
+    if (process.env.PW_TEST_DISABLE_TRACING)
+      return false;
+
+    if (this._options?.mode === 'on')
+      return true;
+
+    if (this._options?.mode === 'retain-on-failure')
+      return true;
+
+    if (this._options?.mode === 'on-first-retry' && this._testInfo.retry === 1)
+      return true;
+
+    if (this._options?.mode === 'on-all-retries' && this._testInfo.retry > 0)
+      return true;
+
+    if (this._options?.mode === 'retain-on-first-failure' && this._testInfo.retry === 0)
+      return true;
+
     return false;
   }
 

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -54,7 +54,6 @@ export class TestTracing {
     if (this._options?.mode === 'on-first-retry' && this._testInfo.retry === 1) return true;
     if (this._options?.mode === 'on-all-retries' && this._testInfo.retry > 0) return true;
     if (this._options?.mode === 'retain-on-first-failure' && this._testInfo.retry === 0) return true;
-
     return false;
   }
 

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -19,10 +19,11 @@ import type * as trace from '@trace/trace';
 import type EventEmitter from 'events';
 import fs from 'fs';
 import path from 'path';
-import { ManualPromise, calculateSha1, createGuid, monotonicTime } from 'playwright-core/lib/utils';
+import { ManualPromise, calculateSha1, monotonicTime, createGuid } from 'playwright-core/lib/utils';
 import { yauzl, yazl } from 'playwright-core/lib/zipBundle';
-import type { PlaywrightWorkerOptions, TestInfo, TestInfoError, TraceMode } from '../../types/test';
+import type { TestInfo, TestInfoError } from '../../types/test';
 import { filteredStackTrace } from '../util';
+import type { TraceMode, PlaywrightWorkerOptions } from '../../types/test';
 import type { TestInfoImpl } from './testInfo';
 
 export type Attachment = TestInfo['attachments'][0];

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -54,6 +54,7 @@ export class TestTracing {
     if (this._options?.mode === 'retain-on-failure') capture = true;
     if (this._options?.mode === 'on-first-retry' && this._testInfo.retry === 1) capture = true;
     if (this._options?.mode === 'on-all-retries' && this._testInfo.retry > 0) capture = true;
+    if (this._options?.mode === 'on-first-failure' && this._testInfo.retry === 0) capture = true;
 
     return capture && !process.env.PW_TEST_DISABLE_TRACING;
   }
@@ -119,7 +120,8 @@ export class TestTracing {
       return;
 
     const testFailed = this._testInfo.status !== this._testInfo.expectedStatus;
-    const shouldAbandonTrace = !testFailed && this._options.mode === 'retain-on-failure';
+    const shouldAbandonTrace = !testFailed && (this._options.mode === 'retain-on-failure' || this._options.mode === 'on-first-failure');
+
     if (shouldAbandonTrace) {
       for (const file of this._temporaryTraceFiles)
         await fs.promises.unlink(file).catch(() => {});

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -47,7 +47,7 @@ export class TestTracing {
     this._tracesDir = path.join(this._artifactsDir, 'traces');
   }
 
-  private shouldCaptureTrace() {
+  private _shouldCaptureTrace() {
     let capture = false;
 
     if (this._options?.mode === 'on') capture = true;
@@ -71,7 +71,7 @@ export class TestTracing {
       this._options = { ...defaultTraceOptions, ...value, mode: (mode as string) === 'retry-with-trace' ? 'on-first-retry' : mode };
     }
 
-    if (this.shouldCaptureTrace() === false) {
+    if (this._shouldCaptureTrace() === false) {
       this._options = undefined;
       return;
     }

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5586,6 +5586,7 @@ export interface PlaywrightWorkerOptions {
    * - `'retain-on-failure'`: Record trace for each test, but remove all traces from successful test runs.
    * - `'on-first-retry'`: Record trace only when retrying a test for the first time.
    * - `'on-all-retries'`: Record traces only when retrying for all retries.
+   * - `'on-first-failure'`: Record trace only when the test fails for the first time.
    *
    * For more control, pass an object that specifies `mode` and trace features to enable.
    *

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import type { APIRequestContext, Browser, BrowserContext, BrowserContextOptions, Page, LaunchOptions, ViewportSize, Geolocation, HTTPCredentials, Locator, APIResponse, PageScreenshotOptions } from 'playwright-core';
+import type { APIRequestContext, APIResponse, Browser, BrowserContext, BrowserContextOptions, Geolocation, HTTPCredentials, LaunchOptions, Locator, Page, PageScreenshotOptions, ViewportSize } from 'playwright-core';
 export * from 'playwright-core';
 
 export type ReporterDescription =
@@ -5636,7 +5636,7 @@ export interface PlaywrightWorkerOptions {
 }
 
 export type ScreenshotMode = 'off' | 'on' | 'only-on-failure';
-export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries';
+export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'on-first-failure';
 export type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry';
 
 /**
@@ -7099,7 +7099,7 @@ type MergedExpect<List> = Expect<MergedExpectMatchers<List>>;
 export function mergeExpects<List extends any[]>(...expects: List): MergedExpect<List>;
 
 // This is required to not export everything by default. See https://github.com/Microsoft/TypeScript/issues/19545#issuecomment-340490459
-export {};
+export { };
 
 
 /**

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5586,7 +5586,7 @@ export interface PlaywrightWorkerOptions {
    * - `'retain-on-failure'`: Record trace for each test, but remove all traces from successful test runs.
    * - `'on-first-retry'`: Record trace only when retrying a test for the first time.
    * - `'on-all-retries'`: Record traces only when retrying for all retries.
-   * - `'on-first-failure'`: Record trace only when the test fails for the first time.
+   * - `'on-first-failure'`: Record traces only when the test fails for the first time.
    *
    * For more control, pass an object that specifies `mode` and trace features to enable.
    *
@@ -7101,6 +7101,7 @@ export function mergeExpects<List extends any[]>(...expects: List): MergedExpect
 
 // This is required to not export everything by default. See https://github.com/Microsoft/TypeScript/issues/19545#issuecomment-340490459
 export { };
+
 
 
 /**

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5586,7 +5586,7 @@ export interface PlaywrightWorkerOptions {
    * - `'retain-on-failure'`: Record trace for each test, but remove all traces from successful test runs.
    * - `'on-first-retry'`: Record trace only when retrying a test for the first time.
    * - `'on-all-retries'`: Record traces only when retrying for all retries.
-   * - `'on-first-failure'`: Record traces only when the test fails for the first time.
+   * - `'retain-on-first-failure'`: Record traces only when the test fails for the first time.
    *
    * For more control, pass an object that specifies `mode` and trace features to enable.
    *

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import type { APIRequestContext, APIResponse, Browser, BrowserContext, BrowserContextOptions, Geolocation, HTTPCredentials, LaunchOptions, Locator, Page, PageScreenshotOptions, ViewportSize } from 'playwright-core';
+import type { APIRequestContext, Browser, BrowserContext, BrowserContextOptions, Page, LaunchOptions, ViewportSize, Geolocation, HTTPCredentials, Locator, APIResponse, PageScreenshotOptions } from 'playwright-core';
 export * from 'playwright-core';
 
 export type ReporterDescription =

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5637,7 +5637,7 @@ export interface PlaywrightWorkerOptions {
 }
 
 export type ScreenshotMode = 'off' | 'on' | 'only-on-failure';
-export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'on-first-failure';
+export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'retain-on-first-failure';
 export type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry';
 
 /**

--- a/tests/page/pageTestApi.ts
+++ b/tests/page/pageTestApi.ts
@@ -27,7 +27,7 @@ export type PageWorkerFixtures = {
   headless: boolean;
   channel: string;
   screenshot: ScreenshotMode | { mode: ScreenshotMode } & Pick<PageScreenshotOptions, 'fullPage' | 'omitBackground'>;
-  trace: 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-first-failure' | 'on-all-retries' | /** deprecated */ 'retry-with-trace';
+  trace: 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'retain-on-first-failure' | 'on-all-retries' | /** deprecated */ 'retry-with-trace';
   video: VideoMode | { mode: VideoMode, size: ViewportSize };
   browserName: 'chromium' | 'firefox' | 'webkit';
   browserVersion: string;

--- a/tests/page/pageTestApi.ts
+++ b/tests/page/pageTestApi.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { Page, ViewportSize } from 'playwright-core';
 import type { PageScreenshotOptions, ScreenshotMode, VideoMode } from '@playwright/test';
+import type { Page, ViewportSize } from 'playwright-core';
 export { expect } from '@playwright/test';
 
 // Page test does not guarantee an isolated context, just a new page (because Android).
@@ -27,7 +27,7 @@ export type PageWorkerFixtures = {
   headless: boolean;
   channel: string;
   screenshot: ScreenshotMode | { mode: ScreenshotMode } & Pick<PageScreenshotOptions, 'fullPage' | 'omitBackground'>;
-  trace: 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | /** deprecated */ 'retry-with-trace';
+  trace: 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-first-failure' | 'on-all-retries' | /** deprecated */ 'retry-with-trace';
   video: VideoMode | { mode: VideoMode, size: ViewportSize };
   browserName: 'chromium' | 'firefox' | 'webkit';
   browserVersion: string;

--- a/tests/page/pageTestApi.ts
+++ b/tests/page/pageTestApi.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { PageScreenshotOptions, ScreenshotMode, VideoMode } from '@playwright/test';
 import type { Page, ViewportSize } from 'playwright-core';
+import type { PageScreenshotOptions, ScreenshotMode, VideoMode } from '@playwright/test';
 export { expect } from '@playwright/test';
 
 // Page test does not guarantee an isolated context, just a new page (because Android).

--- a/tests/playwright-test/playwright.artifacts.spec.ts
+++ b/tests/playwright-test/playwright.artifacts.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import { test, expect } from './playwright-test-fixtures';
 import fs from 'fs';
 import path from 'path';
-import { expect, test } from './playwright-test-fixtures';
 
 function listFiles(dir: string): string[] {
   const result: string[] = [];

--- a/tests/playwright-test/playwright.artifacts.spec.ts
+++ b/tests/playwright-test/playwright.artifacts.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { test, expect } from './playwright-test-fixtures';
 import fs from 'fs';
 import path from 'path';
+import { expect, test } from './playwright-test-fixtures';
 
 function listFiles(dir: string): string[] {
   const result: string[] = [];
@@ -334,6 +334,31 @@ test('should work with trace: on-all-retries', async ({ runInlineTest }, testInf
     'artifacts-two-contexts-failing-retry1',
     '  trace.zip',
     'artifacts-two-contexts-failing-retry2',
+    '  trace.zip',
+  ]);
+});
+
+test('should work with trace: on-first-failure', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...testFiles,
+    'playwright.config.ts': `
+      module.exports = { use: { trace: 'on-first-failure' } };
+    `,
+  }, { workers: 1, retries: 2 });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(5);
+  expect(result.failed).toBe(5);
+  expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
+    'artifacts-failing',
+    '  trace.zip',
+    'artifacts-own-context-failing',
+    '  trace.zip',
+    'artifacts-persistent-failing',
+    '  trace.zip',
+    'artifacts-shared-shared-failing',
+    '  trace.zip',
+    'artifacts-two-contexts-failing',
     '  trace.zip',
   ]);
 });

--- a/tests/playwright-test/playwright.artifacts.spec.ts
+++ b/tests/playwright-test/playwright.artifacts.spec.ts
@@ -338,11 +338,11 @@ test('should work with trace: on-all-retries', async ({ runInlineTest }, testInf
   ]);
 });
 
-test('should work with trace: on-first-failure', async ({ runInlineTest }, testInfo) => {
+test('should work with trace: retain-on-first-failure', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     ...testFiles,
     'playwright.config.ts': `
-      module.exports = { use: { trace: 'on-first-failure' } };
+      module.exports = { use: { trace: 'retain-on-first-failure' } };
     `,
   }, { workers: 1, retries: 2 });
 

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
+import { test, expect } from './playwright-test-fixtures';
 import { parseTrace, parseTraceRaw } from '../config/utils';
-import { expect, test } from './playwright-test-fixtures';
+import fs from 'fs';
 
 test.describe.configure({ mode: 'parallel' });
 

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -402,7 +402,6 @@ test('should respect PW_TEST_DISABLE_TRACING', async ({ runInlineTest }, testInf
 });
 
 for (const mode of ['off', 'retain-on-failure', 'on-first-retry', 'on-all-retries', 'on-first-failure']) {
-for (const mode of ['off', 'retain-on-failure', 'on-first-retry', 'on-all-retries', 'on-first-failure']) {
   test(`trace:${mode} should not create trace zip artifact if page test passed`, async ({ runInlineTest }) => {
     const result = await runInlineTest({
       'a.spec.ts': `
@@ -1033,68 +1032,6 @@ test('should attribute worker fixture teardown to the right test', async ({ runI
     '  fixture: foo',
     '    step in foo teardown',
   ]);
-});
-
-test('trace:on-first-failure should create trace if context is closed before failure in the test', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'playwright.config.ts': `
-      module.exports = { use: { trace: 'on-first-failure' } };
-    `,
-    'a.spec.ts': `
-      import { test, expect } from '@playwright/test';
-      test('passing test', async ({ page, context }) => {
-        await page.goto('about:blank');
-        await context.close();
-        expect(1).toBe(2);
-      });
-    `,
-  }, { trace: 'retain-on-failure' });
-  const tracePath = test.info().outputPath('test-results', 'a-passing-test', 'trace.zip');
-  const trace = await parseTrace(tracePath);
-  expect(trace.apiNames).toContain('page.goto');
-  expect(result.failed).toBe(1);
-});
-
-test('trace:on-first-failure should create trace if context is closed before failure in afterEach', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'playwright.config.ts': `
-      module.exports = { use: { trace: 'on-first-failure' } };
-    `,
-    'a.spec.ts': `
-      import { test, expect } from '@playwright/test';
-      test('passing test', async ({ page, context }) => {
-      });
-      test.afterEach(async ({ page, context }) => {
-        await page.goto('about:blank');
-        await context.close();
-        expect(1).toBe(2);
-      });
-    `,
-  }, { trace: 'retain-on-failure' });
-  const tracePath = test.info().outputPath('test-results', 'a-passing-test', 'trace.zip');
-  const trace = await parseTrace(tracePath);
-  expect(trace.apiNames).toContain('page.goto');
-  expect(result.failed).toBe(1);
-});
-
-test('trace:on-first-failure should create trace if request context is disposed before failure', async ({ runInlineTest, server }) => {
-  const result = await runInlineTest({
-    'playwright.config.ts': `
-      module.exports = { use: { trace: 'on-first-failure' } };
-    `,
-    'a.spec.ts': `
-      import { test, expect } from '@playwright/test';
-      test('passing test', async ({ request }) => {
-        expect(await request.get('${server.EMPTY_PAGE}')).toBeOK();
-        await request.dispose();
-        expect(1).toBe(2);
-      });
-    `,
-  }, { trace: 'retain-on-failure' });
-  const tracePath = test.info().outputPath('test-results', 'a-passing-test', 'trace.zip');
-  const trace = await parseTrace(tracePath);
-  expect(trace.apiNames).toContain('apiRequestContext.get');
-  expect(result.failed).toBe(1);
 });
 
 test('trace:on-first-failure should create trace but only on first failure', async ({ runInlineTest }) => {

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { test, expect } from './playwright-test-fixtures';
-import { parseTrace, parseTraceRaw } from '../config/utils';
 import fs from 'fs';
+import { parseTrace, parseTraceRaw } from '../config/utils';
+import { expect, test } from './playwright-test-fixtures';
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -402,7 +402,7 @@ test('should respect PW_TEST_DISABLE_TRACING', async ({ runInlineTest }, testInf
   expect(fs.existsSync(testInfo.outputPath('test-results', 'a-test-1', 'trace.zip'))).toBe(false);
 });
 
-for (const mode of ['off', 'retain-on-failure', 'on-first-retry', 'on-all-retries']) {
+for (const mode of ['off', 'retain-on-failure', 'on-first-retry', 'on-all-retries', 'on-first-failure']) {
   test(`trace:${mode} should not create trace zip artifact if page test passed`, async ({ runInlineTest }) => {
     const result = await runInlineTest({
       'a.spec.ts': `
@@ -1033,4 +1033,66 @@ test('should attribute worker fixture teardown to the right test', async ({ runI
     '  fixture: foo',
     '    step in foo teardown',
   ]);
+});
+
+test('trace:on-first-failure should create trace if context is closed before failure in the test', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { use: { trace: 'on-first-failure' } };
+    `,
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('passing test', async ({ page, context }) => {
+        await page.goto('about:blank');
+        await context.close();
+        expect(1).toBe(2);
+      });
+    `,
+  }, { trace: 'on-first-failure' });
+  const tracePath = test.info().outputPath('test-results', 'a-passing-test', 'trace.zip');
+  const trace = await parseTrace(tracePath);
+  expect(trace.apiNames).toContain('page.goto');
+  expect(result.failed).toBe(1);
+});
+
+test('trace:on-first-failure should create trace if context is closed before failure in afterEach', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { use: { trace: 'on-first-failure' } };
+    `,
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('passing test', async ({ page, context }) => {
+      });
+      test.afterEach(async ({ page, context }) => {
+        await page.goto('about:blank');
+        await context.close();
+        expect(1).toBe(2);
+      });
+    `,
+  }, { trace: 'on-first-failure' });
+  const tracePath = test.info().outputPath('test-results', 'a-passing-test', 'trace.zip');
+  const trace = await parseTrace(tracePath);
+  expect(trace.apiNames).toContain('page.goto');
+  expect(result.failed).toBe(1);
+});
+
+test('trace:on-first-failure should create trace if request context is disposed before failure', async ({ runInlineTest, server }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { use: { trace: 'on-first-failure' } };
+    `,
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('passing test', async ({ request }) => {
+        expect(await request.get('${server.EMPTY_PAGE}')).toBeOK();
+        await request.dispose();
+        expect(1).toBe(2);
+      });
+    `,
+  }, { trace: 'on-first-failure' });
+  const tracePath = test.info().outputPath('test-results', 'a-passing-test', 'trace.zip');
+  const trace = await parseTrace(tracePath);
+  expect(trace.apiNames).toContain('apiRequestContext.get');
+  expect(result.failed).toBe(1);
 });

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -401,7 +401,7 @@ test('should respect PW_TEST_DISABLE_TRACING', async ({ runInlineTest }, testInf
   expect(fs.existsSync(testInfo.outputPath('test-results', 'a-test-1', 'trace.zip'))).toBe(false);
 });
 
-for (const mode of ['off', 'retain-on-failure', 'on-first-retry', 'on-all-retries', 'on-first-failure']) {
+for (const mode of ['off', 'retain-on-failure', 'on-first-retry', 'on-all-retries', 'retain-on-first-failure']) {
   test(`trace:${mode} should not create trace zip artifact if page test passed`, async ({ runInlineTest }) => {
     const result = await runInlineTest({
       'a.spec.ts': `
@@ -1034,7 +1034,7 @@ test('should attribute worker fixture teardown to the right test', async ({ runI
   ]);
 });
 
-test('trace:on-first-failure should create trace but only on first failure', async ({ runInlineTest }) => {
+test('trace:retain-on-first-failure should create trace but only on first failure', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.ts': `
       import { test, expect } from '@playwright/test';
@@ -1043,7 +1043,7 @@ test('trace:on-first-failure should create trace but only on first failure', asy
         expect(true).toBe(false);
       });
     `,
-  }, { trace: 'on-first-failure', retries: 1 });
+  }, { trace: 'retain-on-first-failure', retries: 1 });
 
   const retryTracePath = test.info().outputPath('test-results', 'a-fail-retry1', 'trace.zip');
   const retryTraceExists = fs.existsSync(retryTracePath);
@@ -1055,7 +1055,7 @@ test('trace:on-first-failure should create trace but only on first failure', asy
   expect(result.failed).toBe(1);
 });
 
-test('trace:on-first-failure should create trace if context is closed before failure in the test', async ({ runInlineTest }) => {
+test('trace:retain-on-first-failure should create trace if context is closed before failure in the test', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.ts': `
       import { test, expect } from '@playwright/test';
@@ -1065,14 +1065,14 @@ test('trace:on-first-failure should create trace if context is closed before fai
         expect(1).toBe(2);
       });
     `,
-  }, { trace: 'on-first-failure' });
+  }, { trace: 'retain-on-first-failure' });
   const tracePath = test.info().outputPath('test-results', 'a-fail', 'trace.zip');
   const trace = await parseTrace(tracePath);
   expect(trace.apiNames).toContain('page.goto');
   expect(result.failed).toBe(1);
 });
 
-test('trace:on-first-failure should create trace if context is closed before failure in afterEach', async ({ runInlineTest }) => {
+test('trace:retain-on-first-failure should create trace if context is closed before failure in afterEach', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.ts': `
       import { test, expect } from '@playwright/test';
@@ -1084,14 +1084,14 @@ test('trace:on-first-failure should create trace if context is closed before fai
         expect(1).toBe(2);
       });
     `,
-  }, { trace: 'on-first-failure' });
+  }, { trace: 'retain-on-first-failure' });
   const tracePath = test.info().outputPath('test-results', 'a-fail', 'trace.zip');
   const trace = await parseTrace(tracePath);
   expect(trace.apiNames).toContain('page.goto');
   expect(result.failed).toBe(1);
 });
 
-test('trace:on-first-failure should create trace if request context is disposed before failure', async ({ runInlineTest, server }) => {
+test('trace:retain-on-first-failure should create trace if request context is disposed before failure', async ({ runInlineTest, server }) => {
   const result = await runInlineTest({
     'a.spec.ts': `
       import { test, expect } from '@playwright/test';
@@ -1101,7 +1101,7 @@ test('trace:on-first-failure should create trace if request context is disposed 
         expect(1).toBe(2);
       });
     `,
-  }, { trace: 'on-first-failure' });
+  }, { trace: 'retain-on-first-failure' });
   const tracePath = test.info().outputPath('test-results', 'a-fail', 'trace.zip');
   const trace = await parseTrace(tracePath);
   expect(trace.apiNames).toContain('apiRequestContext.get');

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -133,7 +133,6 @@ test('should record api trace', async ({ runInlineTest, server }, testInfo) => {
   ]);
 });
 
-
 test('should not throw with trace: on-first-retry and two retries in the same worker', async ({ runInlineTest }, testInfo) => {
   const files = {};
   for (let i = 0; i < 6; i++) {
@@ -1048,7 +1047,7 @@ test('trace:on-first-failure should create trace if context is closed before fai
         expect(1).toBe(2);
       });
     `,
-  }, { trace: 'on-first-failure' });
+  }, { trace: 'retain-on-failure' });
   const tracePath = test.info().outputPath('test-results', 'a-passing-test', 'trace.zip');
   const trace = await parseTrace(tracePath);
   expect(trace.apiNames).toContain('page.goto');
@@ -1070,7 +1069,7 @@ test('trace:on-first-failure should create trace if context is closed before fai
         expect(1).toBe(2);
       });
     `,
-  }, { trace: 'on-first-failure' });
+  }, { trace: 'retain-on-failure' });
   const tracePath = test.info().outputPath('test-results', 'a-passing-test', 'trace.zip');
   const trace = await parseTrace(tracePath);
   expect(trace.apiNames).toContain('page.goto');
@@ -1090,7 +1089,7 @@ test('trace:on-first-failure should create trace if request context is disposed 
         expect(1).toBe(2);
       });
     `,
-  }, { trace: 'on-first-failure' });
+  }, { trace: 'retain-on-failure' });
   const tracePath = test.info().outputPath('test-results', 'a-passing-test', 'trace.zip');
   const trace = await parseTrace(tracePath);
   expect(trace.apiNames).toContain('apiRequestContext.get');

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -248,7 +248,7 @@ export interface PlaywrightWorkerOptions {
 }
 
 export type ScreenshotMode = 'off' | 'on' | 'only-on-failure';
-export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'on-first-failure';
+export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'retain-on-first-failure';
 export type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry';
 
 export interface PlaywrightTestOptions {

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { APIRequestContext, Browser, BrowserContext, BrowserContextOptions, Page, LaunchOptions, ViewportSize, Geolocation, HTTPCredentials, Locator, APIResponse, PageScreenshotOptions } from 'playwright-core';
+import type { APIRequestContext, APIResponse, Browser, BrowserContext, BrowserContextOptions, Geolocation, HTTPCredentials, LaunchOptions, Locator, Page, PageScreenshotOptions, ViewportSize } from 'playwright-core';
 export * from 'playwright-core';
 
 export type ReporterDescription =
@@ -248,7 +248,7 @@ export interface PlaywrightWorkerOptions {
 }
 
 export type ScreenshotMode = 'off' | 'on' | 'only-on-failure';
-export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries';
+export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'on-first-failure';
 export type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry';
 
 export interface PlaywrightTestOptions {
@@ -484,4 +484,5 @@ type MergedExpect<List> = Expect<MergedExpectMatchers<List>>;
 export function mergeExpects<List extends any[]>(...expects: List): MergedExpect<List>;
 
 // This is required to not export everything by default. See https://github.com/Microsoft/TypeScript/issues/19545#issuecomment-340490459
-export {};
+export { };
+

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { APIRequestContext, APIResponse, Browser, BrowserContext, BrowserContextOptions, Geolocation, HTTPCredentials, LaunchOptions, Locator, Page, PageScreenshotOptions, ViewportSize } from 'playwright-core';
+import type { APIRequestContext, Browser, BrowserContext, BrowserContextOptions, Page, LaunchOptions, ViewportSize, Geolocation, HTTPCredentials, Locator, APIResponse, PageScreenshotOptions } from 'playwright-core';
 export * from 'playwright-core';
 
 export type ReporterDescription =


### PR DESCRIPTION
## Related Issue
Implements the changes suggested in #29531 

## Summary of Changes

- Updated `docs/src/test-api/class-testoptions.md` to include new `on-first-failure` mode including a description of the modes function
- Updated `packages/playwright/src/program.ts` to include `on-first-failure` as a valid trace mode.
- Updated `packages/playwright/src/worker/testTracing.ts` to include logic for capturing trace and abandoning trace when using `on-first-failure` mode
- Updated `packages/playwright/types/test.d.ts` and `utils/generate_types/overrides-test.d.ts` to include new mode.
- Updated `tests/page/pageTestApi.ts` to include new mode as valid option
- Updated `tests/playwright-test/playwright.artifacts.spec.ts` with test to validate trace is captured using the new mode.
- Updated `tests/playwright-test/playwright.trace.spec.ts` with tests to validate that a trace is captured under similar conditions as in the `retain-on-failure` mode, but also a test to validate that the trace is only captured on the first failure when retrying tests.