### PR TITLE
chore: fix grammar mistake in docs

### DIFF
--- a/docs/src/ci-intro.md
+++ b/docs/src/ci-intro.md
@@ -8,7 +8,7 @@ title: "CI GitHub Actions"
 
 Playwright tests can be run on any CI provider. In this section we will cover running tests on GitHub using GitHub actions. If you would like to see how to configure other CI providers check out our detailed [doc on Continuous Integration](./ci.md).
 
-When [installing Playwright](./intro.md) using the [VS Code extension](./getting-started-vscode.md) or with `npm init playwright@latest` you are given the option to add a [GitHub Actions](https://docs.github.com/en/actions). This creates a `playwright.yml` file inside a `.github/workflows` folder containing everything you need so that your tests run on each push and pull request into the main/master branch.
+When [installing Playwright](./intro.md) using the [VS Code extension](./getting-started-vscode.md) or with `npm init playwright@latest` you are given the option to add a [GitHub Actions](https://docs.github.com/en/actions) workflow. This creates a `playwright.yml` file inside a `.github/workflows` folder containing everything you need so that your tests run on each push and pull request into the main/master branch.
 
 #### You will learn
 * langs: js


### PR DESCRIPTION
Spotted this teeny tiny grammar thing. It currently says "to add a Github Actions", mixing plural and singular. It should either say "a GitHub Action" or "a GitHub Actions workflow" or "add GitHub Actions" or something along those lines, where both the article and the noun are in singular/plural form.