### PR TITLE
devops: fix cherry_pick_into_release_branch permissions

### DIFF
--- a/.github/workflows/cherry_pick_into_release_branch.yml
+++ b/.github/workflows/cherry_pick_into_release_branch.yml
@@ -12,6 +12,9 @@ on:
         description: Comma-separated list of commit hashes to cherry-pick
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   roll:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/actions/runs/8067519245.