### PR TITLE
feat(playwright-core): add remove cookies api

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1014,6 +1014,7 @@ Returns all open pages in the context.
 * since: v1.43
 
 Removes cookies from context.
+The method will throw an error if either name, domain or path has not been passed.
 
 **Usage**
 
@@ -1024,9 +1025,9 @@ await browserContext.removeCookies({ path: '/api/v1' });
 await browserContext.removeCookies({ name: 'session-id', domain: 'my-origin.com' });
 ```
 
-### param: BrowserContext.removeCookies.criteria
+### param: BrowserContext.removeCookies.filter
 * since: v1.43
-- `criteria` <[Object]>
+- `filter` <[Object]>
   - `name` ?<[string]>
   - `domain` ?<[string]>
   - `path` ?<[string]>

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1010,6 +1010,21 @@ Creates a new page in the browser context.
 
 Returns all open pages in the context.
 
+## async method: BrowserContext.removeCookies
+* since: v1.42
+
+Removes cookies from context.
+
+**Usage**
+
+```js
+await browserContext.removeCookies([cookieName1, cookieName2]);
+```
+
+### param: BrowserContext.removeCookies.cookieNames
+* since: v1.42
+- `cookieNames` <[string]|[Array]<[string]>> - list of cookie names to remove from context
+
 ## property: BrowserContext.request
 * since: v1.16
 * langs:

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1011,19 +1011,25 @@ Creates a new page in the browser context.
 Returns all open pages in the context.
 
 ## async method: BrowserContext.removeCookies
-* since: v1.42
+* since: v1.43
 
 Removes cookies from context.
 
 **Usage**
 
 ```js
-await browserContext.removeCookies([cookieName1, cookieName2]);
+await browserContext.removeCookies({ name: 'session-id' });
+await browserContext.removeCookies({ domain: 'my-origin.com' });
+await browserContext.removeCookies({ path: '/api/v1' });
+await browserContext.removeCookies({ name: 'session-id', domain: 'my-origin.com' });
 ```
 
-### param: BrowserContext.removeCookies.cookieNames
-* since: v1.42
-- `cookieNames` <[string]|[Array]<[string]>> - list of cookie names to remove from context
+### param: BrowserContext.removeCookies.cookies
+* since: v1.43
+- `cookies` <[Object]>
+  - `name` ?<[string]>
+  - `domain` ?<[string]>
+  - `path` ?<[string]>
 
 ## property: BrowserContext.request
 * since: v1.16

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1024,9 +1024,9 @@ await browserContext.removeCookies({ path: '/api/v1' });
 await browserContext.removeCookies({ name: 'session-id', domain: 'my-origin.com' });
 ```
 
-### param: BrowserContext.removeCookies.cookies
+### param: BrowserContext.removeCookies.criteria
 * since: v1.43
-- `cookies` <[Object]>
+- `criteria` <[Object]>
   - `name` ?<[string]>
   - `domain` ?<[string]>
   - `path` ?<[string]>

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1013,8 +1013,7 @@ Returns all open pages in the context.
 ## async method: BrowserContext.removeCookies
 * since: v1.43
 
-Removes cookies from context.
-The method will throw an error if either name, domain or path has not been passed.
+Removes cookies from context. At least one of the removal criteria should be provided.
 
 **Usage**
 

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -269,11 +269,8 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     await this._channel.clearCookies();
   }
 
-  async removeCookies(cookieNames: string | string[]): Promise<void> {
-    if (typeof cookieNames === 'string')
-      cookieNames = [cookieNames];
-
-    await this._channel.removeCookies({ cookieNames: cookieNames as string[] });
+  async removeCookies(cookies: network.RemoveNetworkCookieParam): Promise<void> {
+    await this._channel.removeCookies({ cookies });
   }
 
   async grantPermissions(permissions: string[], options?: { origin?: string }): Promise<void> {

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -269,6 +269,13 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     await this._channel.clearCookies();
   }
 
+  async removeCookies(cookieNames: string | string[]): Promise<void> {
+    if (typeof cookieNames === 'string')
+      cookieNames = [cookieNames];
+
+    await this._channel.removeCookies({ cookieNames: cookieNames as string[] });
+  }
+
   async grantPermissions(permissions: string[], options?: { origin?: string }): Promise<void> {
     await this._channel.grantPermissions({ permissions, ...options });
   }

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -269,8 +269,8 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     await this._channel.clearCookies();
   }
 
-  async removeCookies(cookies: network.RemoveNetworkCookieParam): Promise<void> {
-    await this._channel.removeCookies({ cookies });
+  async removeCookies(criteria: network.RemoveNetworkCookieParam): Promise<void> {
+    await this._channel.removeCookies({ criteria });
   }
 
   async grantPermissions(permissions: string[], options?: { origin?: string }): Promise<void> {

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -269,8 +269,8 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     await this._channel.clearCookies();
   }
 
-  async removeCookies(criteria: network.RemoveNetworkCookieParam): Promise<void> {
-    await this._channel.removeCookies({ criteria });
+  async removeCookies(filter: network.RemoveNetworkCookieParam): Promise<void> {
+    await this._channel.removeCookies({ filter });
   }
 
   async grantPermissions(permissions: string[], options?: { origin?: string }): Promise<void> {

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -58,6 +58,12 @@ export type SetNetworkCookieParam = {
   sameSite?: 'Strict' | 'Lax' | 'None'
 };
 
+export type RemoveNetworkCookieParam = {
+  name?: string,
+  domain?: string,
+  path?: string,
+};
+
 type SerializedFallbackOverrides = {
   url?: string;
   method?: string;

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -829,7 +829,7 @@ scheme.BrowserContextAddInitScriptResult = tOptional(tObject({}));
 scheme.BrowserContextClearCookiesParams = tOptional(tObject({}));
 scheme.BrowserContextClearCookiesResult = tOptional(tObject({}));
 scheme.BrowserContextRemoveCookiesParams = tObject({
-  criteria: tObject({
+  filter: tObject({
     name: tOptional(tString),
     domain: tOptional(tString),
     path: tOptional(tString),

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -828,6 +828,10 @@ scheme.BrowserContextAddInitScriptParams = tObject({
 scheme.BrowserContextAddInitScriptResult = tOptional(tObject({}));
 scheme.BrowserContextClearCookiesParams = tOptional(tObject({}));
 scheme.BrowserContextClearCookiesResult = tOptional(tObject({}));
+scheme.BrowserContextRemoveCookiesParams = tObject({
+  cookieNames: tArray(tString),
+});
+scheme.BrowserContextRemoveCookiesResult = tOptional(tObject({}));
 scheme.BrowserContextClearPermissionsParams = tOptional(tObject({}));
 scheme.BrowserContextClearPermissionsResult = tOptional(tObject({}));
 scheme.BrowserContextCloseParams = tObject({

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -829,7 +829,7 @@ scheme.BrowserContextAddInitScriptResult = tOptional(tObject({}));
 scheme.BrowserContextClearCookiesParams = tOptional(tObject({}));
 scheme.BrowserContextClearCookiesResult = tOptional(tObject({}));
 scheme.BrowserContextRemoveCookiesParams = tObject({
-  cookies: tObject({
+  criteria: tObject({
     name: tOptional(tString),
     domain: tOptional(tString),
     path: tOptional(tString),

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -829,7 +829,11 @@ scheme.BrowserContextAddInitScriptResult = tOptional(tObject({}));
 scheme.BrowserContextClearCookiesParams = tOptional(tObject({}));
 scheme.BrowserContextClearCookiesResult = tOptional(tObject({}));
 scheme.BrowserContextRemoveCookiesParams = tObject({
-  cookieNames: tArray(tString),
+  cookies: tObject({
+    name: tOptional(tString),
+    domain: tOptional(tString),
+    path: tOptional(tString),
+  }),
 });
 scheme.BrowserContextRemoveCookiesResult = tOptional(tObject({}));
 scheme.BrowserContextClearPermissionsParams = tOptional(tObject({}));

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -279,7 +279,8 @@ export abstract class BrowserContext extends SdkObject {
   async removeCookies(cookies: {name?: string, domain?: string, path?: string}): Promise<void> {
     const setCookies = await this.cookies();
 
-    if (!cookies.name && !cookies.domain && !cookies.path) return;
+    if (!cookies.name && !cookies.domain && !cookies.path)
+      return;
 
     const filteredCookies = setCookies.filter(cookie => {
       return !((!cookies.name || cookies.name === cookie.name) &&

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -276,6 +276,15 @@ export abstract class BrowserContext extends SdkObject {
     return await this.doGetCookies(urls as string[]);
   }
 
+  async removeCookies(cookieNames: string | string[]): Promise<void> {
+    const setCookies = await this.cookies();
+
+    const newCookiesSet = setCookies.filter(c => !cookieNames.includes(c.name));
+
+    await this.clearCookies();
+    await this.addCookies(newCookiesSet);
+  }
+
   setHTTPCredentials(httpCredentials?: types.Credentials): Promise<void> {
     return this.doSetHTTPCredentials(httpCredentials);
   }

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -276,20 +276,20 @@ export abstract class BrowserContext extends SdkObject {
     return await this.doGetCookies(urls as string[]);
   }
 
-  async removeCookies(cookies: {name?: string, domain?: string, path?: string}): Promise<void> {
-    const setCookies = await this.cookies();
-
-    if (!cookies.name && !cookies.domain && !cookies.path)
+  async removeCookies(criteria: {name?: string, domain?: string, path?: string}): Promise<void> {
+    if (!criteria.name && !criteria.domain && !criteria.path)
       return;
 
-    const filteredCookies = setCookies.filter(cookie => {
-      return !((!cookies.name || cookies.name === cookie.name) &&
-        (!cookies.domain || cookies.domain === cookie.domain) &&
-        (!cookies.path || cookies.path === cookie.path));
+    const currentCookies = await this.cookies();
+
+    const cookiesToKeep = currentCookies.filter(cookie => {
+      return !((!criteria.name || criteria.name === cookie.name) &&
+        (!criteria.domain || criteria.domain === cookie.domain) &&
+        (!criteria.path || criteria.path === cookie.path));
     });
 
     await this.clearCookies();
-    await this.addCookies(filteredCookies);
+    await this.addCookies(cookiesToKeep);
   }
 
   setHTTPCredentials(httpCredentials?: types.Credentials): Promise<void> {

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -276,13 +276,19 @@ export abstract class BrowserContext extends SdkObject {
     return await this.doGetCookies(urls as string[]);
   }
 
-  async removeCookies(cookieNames: string | string[]): Promise<void> {
+  async removeCookies(cookies: {name?: string, domain?: string, path?: string}): Promise<void> {
     const setCookies = await this.cookies();
 
-    const newCookiesSet = setCookies.filter(c => !cookieNames.includes(c.name));
+    if (!cookies.name && !cookies.domain && !cookies.path) return;
+
+    const filteredCookies = setCookies.filter(cookie => {
+      return !((!cookies.name || cookies.name === cookie.name) &&
+        (!cookies.domain || cookies.domain === cookie.domain) &&
+        (!cookies.path || cookies.path === cookie.path));
+    });
 
     await this.clearCookies();
-    await this.addCookies(newCookiesSet);
+    await this.addCookies(filteredCookies);
   }
 
   setHTTPCredentials(httpCredentials?: types.Credentials): Promise<void> {

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -276,16 +276,16 @@ export abstract class BrowserContext extends SdkObject {
     return await this.doGetCookies(urls as string[]);
   }
 
-  async removeCookies(criteria: {name?: string, domain?: string, path?: string}): Promise<void> {
-    if (!criteria.name && !criteria.domain && !criteria.path)
-      return;
+  async removeCookies(filter: {name?: string, domain?: string, path?: string}): Promise<void> {
+    if (!filter.name && !filter.domain && !filter.path)
+      throw new Error(`Either name, domain or path are required`);
 
     const currentCookies = await this.cookies();
 
     const cookiesToKeep = currentCookies.filter(cookie => {
-      return !((!criteria.name || criteria.name === cookie.name) &&
-        (!criteria.domain || criteria.domain === cookie.domain) &&
-        (!criteria.path || criteria.path === cookie.path));
+      return !((!filter.name || filter.name === cookie.name) &&
+        (!filter.domain || filter.domain === cookie.domain) &&
+        (!filter.path || filter.path === cookie.path));
     });
 
     await this.clearCookies();

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -225,7 +225,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   }
 
   async removeCookies(params: channels.BrowserContextRemoveCookiesParams): Promise<void> {
-    await this._context.removeCookies(params.cookies);
+    await this._context.removeCookies(params.criteria);
   }
 
   async grantPermissions(params: channels.BrowserContextGrantPermissionsParams): Promise<void> {

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -225,7 +225,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   }
 
   async removeCookies(params: channels.BrowserContextRemoveCookiesParams): Promise<void> {
-    await this._context.removeCookies(params.cookieNames);
+    await this._context.removeCookies(params.cookies);
   }
 
   async grantPermissions(params: channels.BrowserContextGrantPermissionsParams): Promise<void> {

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -225,7 +225,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   }
 
   async removeCookies(params: channels.BrowserContextRemoveCookiesParams): Promise<void> {
-    await this._context.removeCookies(params.criteria);
+    await this._context.removeCookies(params.filter);
   }
 
   async grantPermissions(params: channels.BrowserContextGrantPermissionsParams): Promise<void> {

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -224,6 +224,10 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     await this._context.clearCookies();
   }
 
+  async removeCookies(params: channels.BrowserContextRemoveCookiesParams): Promise<void> {
+    await this._context.removeCookies(params.cookieNames);
+  }
+
   async grantPermissions(params: channels.BrowserContextGrantPermissionsParams): Promise<void> {
     await this._context.grantPermissions(params.permissions, params.origin);
   }

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8439,6 +8439,19 @@ export interface BrowserContext {
   pages(): Array<Page>;
 
   /**
+   * Removes cookies from context.
+   *
+   * **Usage**
+   *
+   * ```js
+   * await browserContext.removeCookies([cookieName1, cookieName2]);
+   * ```
+   *
+   * @param cookieNames
+   */
+  removeCookies(cookieNames: string|ReadonlyArray<string>): Promise<void>;
+
+  /**
    * Routing provides the capability to modify network requests that are made by any page in the browser context. Once
    * route is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
    *

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8450,9 +8450,9 @@ export interface BrowserContext {
    * await browserContext.removeCookies({ name: 'session-id', domain: 'my-origin.com' });
    * ```
    *
-   * @param cookies
+   * @param criteria
    */
-  removeCookies(cookies: {
+  removeCookies(criteria: {
     name?: string;
 
     domain?: string;

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8444,12 +8444,21 @@ export interface BrowserContext {
    * **Usage**
    *
    * ```js
-   * await browserContext.removeCookies([cookieName1, cookieName2]);
+   * await browserContext.removeCookies({ name: 'session-id' });
+   * await browserContext.removeCookies({ domain: 'my-origin.com' });
+   * await browserContext.removeCookies({ path: '/api/v1' });
+   * await browserContext.removeCookies({ name: 'session-id', domain: 'my-origin.com' });
    * ```
    *
-   * @param cookieNames
+   * @param cookies
    */
-  removeCookies(cookieNames: string|ReadonlyArray<string>): Promise<void>;
+  removeCookies(cookies: {
+    name?: string;
+
+    domain?: string;
+
+    path?: string;
+  }): Promise<void>;
 
   /**
    * Routing provides the capability to modify network requests that are made by any page in the browser context. Once

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8439,7 +8439,7 @@ export interface BrowserContext {
   pages(): Array<Page>;
 
   /**
-   * Removes cookies from context.
+   * Removes cookies from context. The method will throw an error if either name, domain or path has not been passed.
    *
    * **Usage**
    *
@@ -8450,9 +8450,9 @@ export interface BrowserContext {
    * await browserContext.removeCookies({ name: 'session-id', domain: 'my-origin.com' });
    * ```
    *
-   * @param criteria
+   * @param filter
    */
-  removeCookies(criteria: {
+  removeCookies(filter: {
     name?: string;
 
     domain?: string;

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1525,7 +1525,11 @@ export type BrowserContextClearCookiesParams = {};
 export type BrowserContextClearCookiesOptions = {};
 export type BrowserContextClearCookiesResult = void;
 export type BrowserContextRemoveCookiesParams = {
-  cookieNames: string[],
+  cookies: {
+    name?: string,
+    domain?: string,
+    path?: string,
+  },
 };
 export type BrowserContextRemoveCookiesOptions = {
 

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1427,6 +1427,7 @@ export interface BrowserContextChannel extends BrowserContextEventTarget, EventT
   addCookies(params: BrowserContextAddCookiesParams, metadata?: CallMetadata): Promise<BrowserContextAddCookiesResult>;
   addInitScript(params: BrowserContextAddInitScriptParams, metadata?: CallMetadata): Promise<BrowserContextAddInitScriptResult>;
   clearCookies(params?: BrowserContextClearCookiesParams, metadata?: CallMetadata): Promise<BrowserContextClearCookiesResult>;
+  removeCookies(params: BrowserContextRemoveCookiesParams, metadata?: CallMetadata): Promise<BrowserContextRemoveCookiesResult>;
   clearPermissions(params?: BrowserContextClearPermissionsParams, metadata?: CallMetadata): Promise<BrowserContextClearPermissionsResult>;
   close(params: BrowserContextCloseParams, metadata?: CallMetadata): Promise<BrowserContextCloseResult>;
   cookies(params: BrowserContextCookiesParams, metadata?: CallMetadata): Promise<BrowserContextCookiesResult>;
@@ -1523,6 +1524,13 @@ export type BrowserContextAddInitScriptResult = void;
 export type BrowserContextClearCookiesParams = {};
 export type BrowserContextClearCookiesOptions = {};
 export type BrowserContextClearCookiesResult = void;
+export type BrowserContextRemoveCookiesParams = {
+  cookieNames: string[],
+};
+export type BrowserContextRemoveCookiesOptions = {
+
+};
+export type BrowserContextRemoveCookiesResult = void;
 export type BrowserContextClearPermissionsParams = {};
 export type BrowserContextClearPermissionsOptions = {};
 export type BrowserContextClearPermissionsResult = void;

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1525,7 +1525,7 @@ export type BrowserContextClearCookiesParams = {};
 export type BrowserContextClearCookiesOptions = {};
 export type BrowserContextClearCookiesResult = void;
 export type BrowserContextRemoveCookiesParams = {
-  cookies: {
+  criteria: {
     name?: string,
     domain?: string,
     path?: string,

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1525,7 +1525,7 @@ export type BrowserContextClearCookiesParams = {};
 export type BrowserContextClearCookiesOptions = {};
 export type BrowserContextClearCookiesResult = void;
 export type BrowserContextRemoveCookiesParams = {
-  criteria: {
+  filter: {
     name?: string,
     domain?: string,
     path?: string,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1034,9 +1034,12 @@ BrowserContext:
 
     removeCookies:
       parameters:
-        cookieNames:
-          type: array
-          items: string
+        cookies:
+          type: object
+          properties:
+            name: string?
+            domain: string?
+            path: string?
 
     clearPermissions:
 

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1032,6 +1032,12 @@ BrowserContext:
 
     clearCookies:
 
+    removeCookies:
+      parameters:
+        cookieNames:
+          type: array
+          items: string
+
     clearPermissions:
 
     close:
@@ -3222,7 +3228,7 @@ ElectronApplication:
   events:
     close:
     console:
-      parameters: 
+      parameters:
         $mixin: ConsoleMessage
 
 Android:

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1034,7 +1034,7 @@ BrowserContext:
 
     removeCookies:
       parameters:
-        criteria:
+        filter:
           type: object
           properties:
             name: string?

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1034,7 +1034,7 @@ BrowserContext:
 
     removeCookies:
       parameters:
-        cookies:
+        criteria:
           type: object
           properties:
             name: string?

--- a/tests/library/browsercontext-remove-cookies.spec.ts
+++ b/tests/library/browsercontext-remove-cookies.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ * Modifications copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { contextTest as it, expect } from '../config/browserTest';
+
+it('should remove cookies', async ({ context, page, server }) => {
+  await page.goto(server.EMPTY_PAGE);
+  await context.addCookies([{
+    url: server.EMPTY_PAGE,
+    name: 'cookie1',
+    value: '1'
+  },
+  {
+    url: server.EMPTY_PAGE,
+    name: 'cookie2',
+    value: '2'
+  },
+  {
+    url: server.EMPTY_PAGE,
+    name: 'cookie3',
+    value: '3'
+  }]);
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie2=2; cookie3=3');
+  await context.removeCookies(['cookie1', 'cookie2']);
+  expect(await page.evaluate('document.cookie')).toBe('cookie3=3');
+  await page.reload();
+  expect(await page.evaluate('document.cookie')).toBe('cookie3=3');
+  await context.removeCookies('cookie3');
+  expect(await page.evaluate('document.cookie')).toBe('');
+  await page.reload();
+  expect(await page.evaluate('document.cookie')).toBe('');
+});
+

--- a/tests/library/browsercontext-remove-cookies.spec.ts
+++ b/tests/library/browsercontext-remove-cookies.spec.ts
@@ -209,7 +209,7 @@ it('should remove cookies by name, domain and path', async ({ context, page, ser
   expect(await page.evaluate('document.cookie')).toBe('cookie1=1');
 });
 
-it('should not remove cookies when empty object passed', async ({ context, page, server }) => {
+it('should throw if empty object is passed', async ({ context, page, server }) => {
   await context.addCookies([{
     name: 'cookie1',
     value: '1',
@@ -225,6 +225,7 @@ it('should not remove cookies when empty object passed', async ({ context, page,
   ]);
   await page.goto('https://www.example.com/');
   expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie2=2');
-  await context.removeCookies({ });
+  const error = await context.removeCookies({ }).catch(e => e);
+  expect(error.message).toContain(`Either name, domain or path are required`);
   expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie2=2');
 });

--- a/tests/library/browsercontext-remove-cookies.spec.ts
+++ b/tests/library/browsercontext-remove-cookies.spec.ts
@@ -17,31 +17,214 @@
 
 import { contextTest as it, expect } from '../config/browserTest';
 
-it('should remove cookies', async ({ context, page, server }) => {
-  await page.goto(server.EMPTY_PAGE);
+it('should remove cookies by name', async ({ context, page, server }) => {
   await context.addCookies([{
-    url: server.EMPTY_PAGE,
     name: 'cookie1',
-    value: '1'
+    value: '1',
+    domain: 'www.example.com',
+    path: '/',
   },
   {
-    url: server.EMPTY_PAGE,
     name: 'cookie2',
-    value: '2'
-  },
-  {
-    url: server.EMPTY_PAGE,
-    name: 'cookie3',
-    value: '3'
-  }]);
-  expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie2=2; cookie3=3');
-  await context.removeCookies(['cookie1', 'cookie2']);
-  expect(await page.evaluate('document.cookie')).toBe('cookie3=3');
-  await page.reload();
-  expect(await page.evaluate('document.cookie')).toBe('cookie3=3');
-  await context.removeCookies('cookie3');
-  expect(await page.evaluate('document.cookie')).toBe('');
-  await page.reload();
-  expect(await page.evaluate('document.cookie')).toBe('');
+    value: '2',
+    domain: 'www.example.com',
+    path: '/',
+  }
+  ]);
+  await page.goto('https://www.example.com');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie2=2');
+  await context.removeCookies({ name: 'cookie1' });
+  expect(await page.evaluate('document.cookie')).toBe('cookie2=2');
 });
 
+it('should remove cookies by domain', async ({ context, page, server }) => {
+  await context.addCookies([{
+    name: 'cookie1',
+    value: '1',
+    domain: 'www.example.com',
+    path: '/',
+  },
+  {
+    name: 'cookie2',
+    value: '2',
+    domain: 'www.example.org',
+    path: '/',
+  }
+  ]);
+  await page.goto('https://www.example.com');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1');
+  await page.goto('https://www.example.org');
+  expect(await page.evaluate('document.cookie')).toBe('cookie2=2');
+  await context.removeCookies({ domain: 'www.example.org' });
+  expect(await page.evaluate('document.cookie')).toBe('');
+  await page.goto('https://www.example.com');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1');
+});
+
+it('should remove cookies by path', async ({ context, page, server }) => {
+  await context.addCookies([{
+    name: 'cookie1',
+    value: '1',
+    domain: 'www.example.com',
+    path: '/api/v1',
+  },
+  {
+    name: 'cookie2',
+    value: '2',
+    domain: 'www.example.com',
+    path: '/api/v2',
+  },
+  {
+    name: 'cookie3',
+    value: '3',
+    domain: 'www.example.com',
+    path: '/',
+  }
+  ]);
+  await page.goto('https://www.example.com/api/v1');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie3=3');
+  await context.removeCookies({ path: '/api/v1' });
+  expect(await page.evaluate('document.cookie')).toBe('cookie3=3');
+  await page.goto('https://www.example.com/api/v2');
+  expect(await page.evaluate('document.cookie')).toBe('cookie2=2; cookie3=3');
+  await page.goto('https://www.example.com/');
+  expect(await page.evaluate('document.cookie')).toBe('cookie3=3');
+});
+
+it('should remove cookies by name and domain', async ({ context, page, server }) => {
+  await context.addCookies([{
+    name: 'cookie1',
+    value: '1',
+    domain: 'www.example.com',
+    path: '/',
+  },
+  {
+    name: 'cookie1',
+    value: '1',
+    domain: 'www.example.org',
+    path: '/',
+  }
+  ]);
+  await page.goto('https://www.example.com');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1');
+  await context.removeCookies({ name: 'cookie1', domain: 'www.example.com' });
+  expect(await page.evaluate('document.cookie')).toBe('');
+  await page.goto('https://www.example.org');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1');
+});
+
+it('should remove cookies by name and path', async ({ context, page, server }) => {
+  await context.addCookies([{
+    name: 'cookie1',
+    value: '1',
+    domain: 'www.example.com',
+    path: '/api/v1',
+  },
+  {
+    name: 'cookie1',
+    value: '1',
+    domain: 'www.example.com',
+    path: '/api/v2',
+  },
+  {
+    name: 'cookie3',
+    value: '3',
+    domain: 'www.example.com',
+    path: '/',
+  }
+  ]);
+  await page.goto('https://www.example.com/api/v1');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie3=3');
+  await context.removeCookies({ name: 'cookie1', path: '/api/v1' });
+  expect(await page.evaluate('document.cookie')).toBe('cookie3=3');
+  await page.goto('https://www.example.com/api/v2');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie3=3');
+  await page.goto('https://www.example.com/');
+  expect(await page.evaluate('document.cookie')).toBe('cookie3=3');
+});
+
+it('should remove cookies by domain and path', async ({ context, page, server }) => {
+  await context.addCookies([{
+    name: 'cookie1',
+    value: '1',
+    domain: 'www.example.com',
+    path: '/api/v1',
+  },
+  {
+    name: 'cookie2',
+    value: '2',
+    domain: 'www.example.com',
+    path: '/api/v2',
+  },
+  {
+    name: 'cookie3',
+    value: '3',
+    domain: 'www.example.org',
+    path: '/api/v1',
+  },
+  {
+    name: 'cookie4',
+    value: '4',
+    domain: 'www.example.org',
+    path: '/api/v2',
+  }
+  ]);
+  await page.goto('https://www.example.com/api/v1');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1');
+  await context.removeCookies({ domain: 'www.example.com', path: '/api/v1' });
+  expect(await page.evaluate('document.cookie')).toBe('');
+  await page.goto('https://www.example.com/api/v2');
+  expect(await page.evaluate('document.cookie')).toBe('cookie2=2');
+  await page.goto('https://www.example.org/api/v2');
+  expect(await page.evaluate('document.cookie')).toBe('cookie4=4');
+});
+
+it('should remove cookies by name, domain and path', async ({ context, page, server }) => {
+  await context.addCookies([{
+    name: 'cookie1',
+    value: '1',
+    domain: 'www.example.com',
+    path: '/api/v1',
+  },
+  {
+    name: 'cookie2',
+    value: '2',
+    domain: 'www.example.com',
+    path: '/api/v2',
+  },
+  {
+    name: 'cookie1',
+    value: '1',
+    domain: 'www.example.org',
+    path: '/api/v1',
+  },
+  ]);
+  await page.goto('https://www.example.com/api/v1');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1');
+  await context.removeCookies({ name: 'cookie1', domain: 'www.example.com', path: '/api/v1' });
+  expect(await page.evaluate('document.cookie')).toBe('');
+  await page.goto('https://www.example.com/api/v2');
+  expect(await page.evaluate('document.cookie')).toBe('cookie2=2');
+  await page.goto('https://www.example.org/api/v1');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1');
+});
+
+it('should not remove cookies when empty object passed', async ({ context, page, server }) => {
+  await context.addCookies([{
+    name: 'cookie1',
+    value: '1',
+    domain: 'www.example.com',
+    path: '/',
+  },
+  {
+    name: 'cookie2',
+    value: '2',
+    domain: 'www.example.com',
+    path: '/',
+  },
+  ]);
+  await page.goto('https://www.example.com/');
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie2=2');
+  await context.removeCookies({ });
+  expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie2=2');
+});


### PR DESCRIPTION
Implements the changes suggested in https://github.com/microsoft/playwright/issues/29662

This patch contains removeCookies method to remove cookies from BrowserContext by it's names