### PR TITLE
fit(ct): remove unused type import

### DIFF
--- a/packages/playwright-ct-core/types/component.d.ts
+++ b/packages/playwright-ct-core/types/component.d.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import type { ImportRegistry } from '../src/injected/importRegistry';
-
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonObject | JsonArray;
 type JsonArray = JsonValue[];


### PR DESCRIPTION
I think this was overlooked in https://github.com/microsoft/playwright/pull/29463 when fixing https://github.com/microsoft/playwright/issues/29461 as the error still exists in `@playwright/experimental-ct-react@1.42.0`

I don't understand the test failure, I can't see a relation to the proposed change.