### PR TITLE
docs: Improved JSDoc for expect.toPass

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6956,7 +6956,24 @@ interface GenericAssertions<R> {
 
 type FunctionAssertions = {
   /**
-   * Retries the callback until it passes.
+   * Retries the callback until all assertions within it pass or the `timeout` value is reached.
+   * The `intervals` parameter can be used to establish the probing frequency or pattern.
+   *
+   * **Usage**
+   * ```js
+   * await expect(async () => {
+   *   const response = await page.request.get('https://api.example.com');
+   *   expect(response.status()).toBe(200);
+   * }).toPass({
+   *   // Probe, wait 1s, probe, wait 2s, probe, wait 10s, probe, wait 10s, probe
+   *   intervals: [1_000, 2_000, 10_000], // Defaults to [100, 250, 500, 1000].
+   *   timeout: 60_000 // Defaults to 0
+   * });
+   * ```
+   *
+   * Note that by default `toPass` does not respect custom expect timeout.
+   *
+   * @param options
    */
   toPass(options?: { timeout?: number, intervals?: number[] }): Promise<void>;
 };

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -341,7 +341,24 @@ interface GenericAssertions<R> {
 
 type FunctionAssertions = {
   /**
-   * Retries the callback until it passes.
+   * Retries the callback until all assertions within it pass or the `timeout` value is reached.
+   * The `intervals` parameter can be used to establish the probing frequency or pattern.
+   *
+   * **Usage**
+   * ```js
+   * await expect(async () => {
+   *   const response = await page.request.get('https://api.example.com');
+   *   expect(response.status()).toBe(200);
+   * }).toPass({
+   *   // Probe, wait 1s, probe, wait 2s, probe, wait 10s, probe, wait 10s, probe
+   *   intervals: [1_000, 2_000, 10_000], // Defaults to [100, 250, 500, 1000].
+   *   timeout: 60_000 // Defaults to 0
+   * });
+   * ```
+   *
+   * Note that by default `toPass` does not respect custom expect timeout.
+   *
+   * @param options
    */
   toPass(options?: { timeout?: number, intervals?: number[] }): Promise<void>;
 };


### PR DESCRIPTION
I added more details and a usage example to the `expect.toPass` function, making it easier to use without having to consult the website. The example is pulled from the [Assertions documentation](https://playwright.dev/docs/test-assertions#expecttopass).