### PR TITLE
fix typo in docs: "toHaveScreeshot()"

### DIFF
--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -147,6 +147,6 @@ export default defineConfig({
 | Option | Description |
 | :- | :- |
 | [`property: TestConfig.expect`] | [Web first assertions](./test-assertions.md) like `expect(locator).toHaveText()` have a separate timeout of 5 seconds by default. This is the maximum time the `expect()` should wait for the condition to be met. Learn more about [test and expect timeouts](./test-timeouts.md) and how to set them for a single test. |
-| [`method: PageAssertions.toHaveScreenshot#1`] | Configuration for the `expect(locator).toHaveScreeshot()` method. |
+| [`method: PageAssertions.toHaveScreenshot#1`] | Configuration for the `expect(locator).toHaveScreenshot()` method. |
 | [`method: SnapshotAssertions.toMatchSnapshot#1`]| Configuration for the `expect(locator).toMatchSnapshot()` method.|
 


### PR DESCRIPTION
toHaveScreeshot -> toHaveScreenshot