### PR TITLE
docs(class-coverage.md): Add example for V8 coverage report

### DIFF
--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -17132,9 +17132,9 @@ export interface ConsoleMessage {
 /**
  * Coverage gathers information about parts of JavaScript and CSS that were used by the page.
  *
- * An example of using JavaScript coverage to produce Istanbul report for page load:
- *
  * **NOTE** Coverage APIs are only supported on Chromium-based browsers.
+ *
+ * An example of using JavaScript coverage to produce Istanbul report for page load:
  *
  * ```js
  * const { chromium } = require('playwright');
@@ -17152,6 +17152,46 @@ export interface ConsoleMessage {
  *     converter.applyCoverage(entry.functions);
  *     console.log(JSON.stringify(converter.toIstanbul()));
  *   }
+ *   await browser.close();
+ * })();
+ * ```
+ *
+ * Another example is generating native V8 coverage reports with
+ * [monocart-coverage-reports](https://github.com/cenfun/monocart-coverage-reports)
+ *
+ * ```js
+ * const { chromium } = require('playwright');
+ * const MCR = require('monocart-coverage-reports');
+ *
+ * (async () => {
+ *   const browser = await chromium.launch();
+ *   const page = await browser.newPage();
+ *
+ *   await Promise.all([
+ *     page.coverage.startJSCoverage({
+ *       resetOnNavigation: false
+ *     }),
+ *     page.coverage.startCSSCoverage({
+ *       resetOnNavigation: false
+ *     })
+ *   ]);
+ *
+ *   await page.goto('https://playwright.dev/');
+ *
+ *   const [jsCoverage, cssCoverage] = await Promise.all([
+ *     page.coverage.stopJSCoverage(),
+ *     page.coverage.stopCSSCoverage()
+ *   ]);
+ *   const coverageData = [... jsCoverage, ... cssCoverage];
+ *
+ *   const coverageReport = MCR({
+ *     name: 'My Coverage Report',
+ *     outputDir: './coverage-reports',
+ *     reports: ['v8', 'console-details']
+ *   });
+ *   await coverageReport.add(coverageData);
+ *   await coverageReport.generate();
+ *
  *   await browser.close();
  * })();
  * ```


### PR DESCRIPTION
Hi, Can I add a simple example to the docs, which is used to generate the V8 coverage report? Thanks,