### PR TITLE
fix: content editable retarget

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -459,7 +459,7 @@ export class InjectedScript {
       return null;
     if (behavior === 'none')
       return element;
-    if (!element.matches('input, textarea, select')) {
+    if (!element.matches('input, textarea, select') && !(element as any).isContentEditable) {
       if (behavior === 'button-link')
         element = element.closest('button, [role=button], a, [role=link]') || element;
       else

--- a/tests/page/retarget.spec.ts
+++ b/tests/page/retarget.spec.ts
@@ -250,7 +250,7 @@ it('input value retargeting', async ({ page, browserName }) => {
   }
 });
 
-it.fixme('selection retargeting', async ({ page, browserName }) => {
+it('selection retargeting', async ({ page, browserName }) => {
   const cases = [
     { dom: domStandalone(`<div contenteditable id=target>content</div>`), locator: 'div' },
     { dom: domInButton(`<div contenteditable id=target>content</div>`), locator: 'div' },


### PR DESCRIPTION
If `contenteditable` is wrapped into a button or `[role=button]`, `element.fill` will incorrectly retarget the closest button element.

fix https://github.com/microsoft/playwright/issues/29813