### PR TITLE
feat: separate timeout for after hooks

### DIFF
--- a/tests/playwright-test/fixture-errors.spec.ts
+++ b/tests/playwright-test/fixture-errors.spec.ts
@@ -425,6 +425,38 @@ test('should give enough time for fixture teardown', async ({ runInlineTest }) =
       });
     `,
   });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.outputLines).toEqual([
+    'teardown start',
+    'teardown finished',
+  ]);
+});
+
+test('should not give enough time for second fixture teardown after timeout', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        fixture2: async ({ }, use) => {
+          await use();
+          console.log('\\n%%teardown2 start');
+          await new Promise(f => setTimeout(f, 3000));
+          console.log('\\n%%teardown2 finished');
+        },
+        fixture: async ({ fixture2 }, use) => {
+          await use();
+          console.log('\\n%%teardown start');
+          await new Promise(f => setTimeout(f, 3000));
+          console.log('\\n%%teardown finished');
+        },
+      });
+      test('fast enough but close', async ({ fixture }) => {
+        test.setTimeout(3000);
+        await new Promise(f => setTimeout(f, 2000));
+      });
+    `,
+  }, { timeout: 2000 });
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
   expect(result.output).toContain('Test finished within timeout of 3000ms, but tearing down "fixture" ran out of time.');

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2019,9 +2019,9 @@ for (const useIntermediateMergeReport of [false, true] as const) {
 
       // Failing test first, then sorted by the run order.
       await expect(page.locator('.test-file-test')).toHaveText([
-        /main › fails\d+m?smain.spec.ts:9/,
-        /main › first › passes\d+m?sfirst.ts:12/,
-        /main › second › passes\d+m?ssecond.ts:5/,
+        /main › fails\d+m?s?main.spec.ts:9/,
+        /main › first › passes\d+m?s?first.ts:12/,
+        /main › second › passes\d+m?s?second.ts:5/,
       ]);
     });
 


### PR DESCRIPTION
Instead of sharing the timeout with the test, and then extending it when test times out, we give after hooks a separate timeout.