### PR TITLE
feat(ui-mode): add key shortcuts for playwright uI test runner

### DIFF
--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -117,27 +117,6 @@ export const UIModeView: React.FC<{}> = ({
     });
   }, [reloadTests]);
 
-  React.useEffect(() => {
-    const onShortcutEvent = (e: KeyboardEvent) => {
-      if (e.code === 'KeyR' && (e.metaKey || e.ctrlKey)){
-        e.preventDefault();
-        runTests('bounce-if-busy', visibleTestIds)
-      } else if (e.code === 'KeyS' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        sendMessageNoReply('stop')
-      } else if (e.code === 'KeyU' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        reloadTests()
-      }
-    }
-
-    addEventListener("keydown", onShortcutEvent);
-
-    return () => {
-      removeEventListener("keydown", onShortcutEvent)
-    }
-  }, [visibleTestIds]);
-
   updateRootSuite = React.useCallback((config: reporterTypes.FullConfig, rootSuite: reporterTypes.Suite, loadErrors: reporterTypes.TestError[], newProgress: Progress | undefined) => {
     const selectedProjects = config.configFile ? settings.getObject<string[] | undefined>(config.configFile + ':projects', undefined) : undefined;
     for (const projectName of projectFilters.keys()) {
@@ -197,6 +176,27 @@ export const UIModeView: React.FC<{}> = ({
       setRunningState(undefined);
     });
   }, [projectFilters, runningState, testModel]);
+
+  React.useEffect(() => {
+    const onShortcutEvent = (e: KeyboardEvent) => {
+      if (e.code === 'KeyR' && (e.metaKey || e.ctrlKey)){
+        e.preventDefault();
+        runTests('bounce-if-busy', visibleTestIds);
+      } else if (e.code === 'KeyS' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        sendMessageNoReply('stop');
+      } else if (e.code === 'KeyU' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        reloadTests();
+      }
+    };
+
+    addEventListener('keydown', onShortcutEvent);
+
+    return () => {
+      removeEventListener('keydown', onShortcutEvent);
+    };
+  }, [runTests, reloadTests, visibleTestIds]);
 
   const isRunningTest = !!runningState;
   const dialogRef = React.useRef<HTMLDialogElement>(null);

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -179,13 +179,10 @@ export const UIModeView: React.FC<{}> = ({
 
   React.useEffect(() => {
     const onShortcutEvent = (e: KeyboardEvent) => {
-      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        runTests('bounce-if-busy', visibleTestIds);
-      } else if (e.code === 'KeyS' && (e.metaKey || e.ctrlKey)) {
+      if (e.code === 'F6') {
         e.preventDefault();
         sendMessageNoReply('stop');
-      } else if (e.code === 'KeyU' && (e.metaKey || e.ctrlKey)) {
+      } else if (e.code === 'F5') {
         e.preventDefault();
         reloadTests();
       }

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -193,7 +193,7 @@ export const UIModeView: React.FC<{}> = ({
     return () => {
       removeEventListener('keydown', onShortcutEvent);
     };
-  }, [runTests, reloadTests, visibleTestIds]);
+  }, [runTests, reloadTests]);
 
   const isRunningTest = !!runningState;
   const dialogRef = React.useRef<HTMLDialogElement>(null);

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -179,7 +179,7 @@ export const UIModeView: React.FC<{}> = ({
 
   React.useEffect(() => {
     const onShortcutEvent = (e: KeyboardEvent) => {
-      if (e.code === 'KeyR' && (e.metaKey || e.ctrlKey)){
+      if (e.key === 'Enter' && e.shiftKey) {
         e.preventDefault();
         runTests('bounce-if-busy', visibleTestIds);
       } else if (e.code === 'KeyS' && (e.metaKey || e.ctrlKey)) {

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -117,6 +117,27 @@ export const UIModeView: React.FC<{}> = ({
     });
   }, [reloadTests]);
 
+  React.useEffect(() => {
+    const onShortcutEvent = (e: KeyboardEvent) => {
+      if (e.code === 'KeyR' && (e.metaKey || e.ctrlKey)){
+        e.preventDefault();
+        runTests('bounce-if-busy', visibleTestIds)
+      } else if (e.code === 'KeyS' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        sendMessageNoReply('stop')
+      } else if (e.code === 'KeyU' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        reloadTests()
+      }
+    }
+
+    addEventListener("keydown", onShortcutEvent);
+
+    return () => {
+      removeEventListener("keydown", onShortcutEvent)
+    }
+  }, [visibleTestIds]);
+
   updateRootSuite = React.useCallback((config: reporterTypes.FullConfig, rootSuite: reporterTypes.Suite, loadErrors: reporterTypes.TestError[], newProgress: Progress | undefined) => {
     const selectedProjects = config.configFile ? settings.getObject<string[] | undefined>(config.configFile + ':projects', undefined) : undefined;
     for (const projectName of projectFilters.keys()) {

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -179,7 +179,7 @@ export const UIModeView: React.FC<{}> = ({
 
   React.useEffect(() => {
     const onShortcutEvent = (e: KeyboardEvent) => {
-      if (e.key === 'Enter' && e.shiftKey) {
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         runTests('bounce-if-busy', visibleTestIds);
       } else if (e.code === 'KeyS' && (e.metaKey || e.ctrlKey)) {

--- a/tests/playwright-test/ui-mode-test-shortcut.spec.ts
+++ b/tests/playwright-test/ui-mode-test-shortcut.spec.ts
@@ -26,7 +26,7 @@ const basicTestTree = {
     test('test 2', async () => { await new Promise(() => {}); });
     test('test 3', async () => {});
   `
-}
+};
 
 test('should run on Meta(command) with R', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree);

--- a/tests/playwright-test/ui-mode-test-shortcut.spec.ts
+++ b/tests/playwright-test/ui-mode-test-shortcut.spec.ts
@@ -28,13 +28,24 @@ const basicTestTree = {
   `
 };
 
-test('should run on Enter with Shift', async ({ runUITest }) => {
+test('should run on Meta(command) with Enter', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree);
 
   await expect(page.getByTitle('Run all')).toBeEnabled();
   await expect(page.getByTitle('Stop')).toBeDisabled();
 
-  await page.keyboard.press('Enter+Shift');
+  await page.keyboard.press('Meta+Enter');
+
+  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
+});
+
+test('should run on Control with Enter', async ({ runUITest }) => {
+  const { page } = await runUITest(basicTestTree);
+
+  await expect(page.getByTitle('Run all')).toBeEnabled();
+  await expect(page.getByTitle('Stop')).toBeDisabled();
+
+  await page.keyboard.press('Control+Enter');
 
   await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
 });

--- a/tests/playwright-test/ui-mode-test-shortcut.spec.ts
+++ b/tests/playwright-test/ui-mode-test-shortcut.spec.ts
@@ -28,29 +28,7 @@ const basicTestTree = {
   `
 };
 
-test('should run on Meta(command) with Enter', async ({ runUITest }) => {
-  const { page } = await runUITest(basicTestTree);
-
-  await expect(page.getByTitle('Run all')).toBeEnabled();
-  await expect(page.getByTitle('Stop')).toBeDisabled();
-
-  await page.keyboard.press('Meta+Enter');
-
-  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
-});
-
-test('should run on Control with Enter', async ({ runUITest }) => {
-  const { page } = await runUITest(basicTestTree);
-
-  await expect(page.getByTitle('Run all')).toBeEnabled();
-  await expect(page.getByTitle('Stop')).toBeDisabled();
-
-  await page.keyboard.press('Control+Enter');
-
-  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
-});
-
-test('should stop on Meta(command) with S', async ({ runUITest }) => {
+test('should stop on F6', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree);
 
   await expect(page.getByTitle('Run all')).toBeEnabled();
@@ -69,7 +47,7 @@ test('should stop on Meta(command) with S', async ({ runUITest }) => {
   await expect(page.getByTitle('Run all')).toBeDisabled();
   await expect(page.getByTitle('Stop')).toBeEnabled();
 
-  await page.keyboard.press('Meta+s');
+  await page.keyboard.press('F6');
 
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ◯ a.test.ts
@@ -80,52 +58,12 @@ test('should stop on Meta(command) with S', async ({ runUITest }) => {
   `);
 });
 
-test('should stop on Control with S', async ({ runUITest }) => {
-  const { page } = await runUITest(basicTestTree);
-
-  await expect(page.getByTitle('Run all')).toBeEnabled();
-  await expect(page.getByTitle('Stop')).toBeDisabled();
-
-  await page.getByTitle('Run all').click();
-
-  await expect.poll(dumpTestTree(page)).toBe(`
-    ▼ ↻ a.test.ts
-        ⊘ test 0
-        ✅ test 1
-        ↻ test 2
-        🕦 test 3
-  `);
-
-  await expect(page.getByTitle('Run all')).toBeDisabled();
-  await expect(page.getByTitle('Stop')).toBeEnabled();
-
-  await page.keyboard.press('Control+s');
-
-  await expect.poll(dumpTestTree(page)).toBe(`
-    ▼ ◯ a.test.ts
-        ⊘ test 0
-        ✅ test 1
-        ◯ test 2
-        ◯ test 3
-  `);
-});
-
-test('should reload on Meta(command) with U', async ({ runUITest }) => {
+test('should reload on F5', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree);
 
   await page.getByTitle('Run all').click();
   await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
 
-  await page.keyboard.press('Meta+u');
-  await expect(page.getByTestId('status-line')).toBeHidden();
-});
-
-test('should reload on Control with U', async ({ runUITest }) => {
-  const { page } = await runUITest(basicTestTree);
-
-  await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
-
-  await page.keyboard.press('Control+u');
+  await page.keyboard.press('F5');
   await expect(page.getByTestId('status-line')).toBeHidden();
 });

--- a/tests/playwright-test/ui-mode-test-shortcut.spec.ts
+++ b/tests/playwright-test/ui-mode-test-shortcut.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, retries, dumpTestTree } from './ui-mode-fixtures';
+
+test.describe.configure({ mode: 'parallel', retries });
+
+const basicTestTree = {
+  'a.test.ts': `
+    import { test, expect } from '@playwright/test';
+    test('test 0', () => { test.skip(); });
+    test('test 1', () => {});
+    test('test 2', async () => { await new Promise(() => {}); });
+    test('test 3', async () => {});
+  `
+}
+
+test('should run on Meta(command) with R', async ({ runUITest }) => {
+  const { page } = await runUITest(basicTestTree);
+
+  await expect(page.getByTitle('Run all')).toBeEnabled();
+  await expect(page.getByTitle('Stop')).toBeDisabled();
+
+  await page.keyboard.press('Meta+r');
+
+  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
+});
+
+test('should run on Control with R', async ({ runUITest }) => {
+  const { page } = await runUITest(basicTestTree);
+
+  await expect(page.getByTitle('Run all')).toBeEnabled();
+  await expect(page.getByTitle('Stop')).toBeDisabled();
+
+  await page.keyboard.press('Control+r');
+
+  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
+});
+
+test('should stop on Meta(command) with S', async ({ runUITest }) => {
+  const { page } = await runUITest(basicTestTree);
+
+  await expect(page.getByTitle('Run all')).toBeEnabled();
+  await expect(page.getByTitle('Stop')).toBeDisabled();
+
+  await page.getByTitle('Run all').click();
+
+  await expect.poll(dumpTestTree(page)).toBe(`
+    ▼ ↻ a.test.ts
+        ⊘ test 0
+        ✅ test 1
+        ↻ test 2
+        🕦 test 3
+  `);
+
+  await expect(page.getByTitle('Run all')).toBeDisabled();
+  await expect(page.getByTitle('Stop')).toBeEnabled();
+
+  await page.keyboard.press('Meta+s');
+
+  await expect.poll(dumpTestTree(page)).toBe(`
+    ▼ ◯ a.test.ts
+        ⊘ test 0
+        ✅ test 1
+        ◯ test 2
+        ◯ test 3
+  `);
+});
+
+test('should stop on Control with S', async ({ runUITest }) => {
+  const { page } = await runUITest(basicTestTree);
+
+  await expect(page.getByTitle('Run all')).toBeEnabled();
+  await expect(page.getByTitle('Stop')).toBeDisabled();
+
+  await page.getByTitle('Run all').click();
+
+  await expect.poll(dumpTestTree(page)).toBe(`
+    ▼ ↻ a.test.ts
+        ⊘ test 0
+        ✅ test 1
+        ↻ test 2
+        🕦 test 3
+  `);
+
+  await expect(page.getByTitle('Run all')).toBeDisabled();
+  await expect(page.getByTitle('Stop')).toBeEnabled();
+
+  await page.keyboard.press('Control+s');
+
+  await expect.poll(dumpTestTree(page)).toBe(`
+    ▼ ◯ a.test.ts
+        ⊘ test 0
+        ✅ test 1
+        ◯ test 2
+        ◯ test 3
+  `);
+});
+
+test('should reload on Meta(command) with U', async ({ runUITest }) => {
+  const { page } = await runUITest(basicTestTree);
+
+  await page.getByTitle('Run all').click();
+  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
+
+  await page.keyboard.press('Meta+u');
+  await expect(page.getByTestId('status-line')).toBeHidden();
+});
+
+test('should reload on Control with U', async ({ runUITest }) => {
+  const { page } = await runUITest(basicTestTree);
+
+  await page.getByTitle('Run all').click();
+  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
+
+  await page.keyboard.press('Control+u');
+  await expect(page.getByTestId('status-line')).toBeHidden();
+});

--- a/tests/playwright-test/ui-mode-test-shortcut.spec.ts
+++ b/tests/playwright-test/ui-mode-test-shortcut.spec.ts
@@ -28,24 +28,13 @@ const basicTestTree = {
   `
 };
 
-test('should run on Meta(command) with R', async ({ runUITest }) => {
+test('should run on Enter with Shift', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree);
 
   await expect(page.getByTitle('Run all')).toBeEnabled();
   await expect(page.getByTitle('Stop')).toBeDisabled();
 
-  await page.keyboard.press('Meta+r');
-
-  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
-});
-
-test('should run on Control with R', async ({ runUITest }) => {
-  const { page } = await runUITest(basicTestTree);
-
-  await expect(page.getByTitle('Run all')).toBeEnabled();
-  await expect(page.getByTitle('Stop')).toBeDisabled();
-
-  await page.keyboard.press('Control+r');
+  await page.keyboard.press('Enter+Shift');
 
   await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
 });


### PR DESCRIPTION
related issue: #28899 

## Motivation: 

Introduce keyboard shortcuts for common actions in the Playwright UI test runner to enhance developer productivity and streamline the test execution process.

## Modification:

Make shortcut keydown event in `uiModeView.tsx`

## Result:

- add three shortcut in ui test runner
  - Run Tests: Ctrl/Cmd + R
  - Stop Tests: Ctrl/Cmd + S
  - Refresh Tests: Ctrl/Cmd + U
- Close #28899 