### PR TITLE
fix(playwright-ct-core): added missing exported test type

### DIFF
--- a/packages/playwright-ct-core/index.d.ts
+++ b/packages/playwright-ct-core/index.d.ts
@@ -38,6 +38,8 @@ export type TestType<ComponentFixtures> = BaseTestType<
   PlaywrightWorkerArgs & PlaywrightWorkerOptions
 >;
 
+export const test: TestType<ComponentFixtures>;
+
 export function defineConfig(config: PlaywrightTestConfig): PlaywrightTestConfig;
 export function defineConfig<T>(config: PlaywrightTestConfig<T>): PlaywrightTestConfig<T>;
 export function defineConfig<T, W>(config: PlaywrightTestConfig<T, W>): PlaywrightTestConfig<T, W>;


### PR DESCRIPTION
This PR fixes the misalignment between `playwright-ct-core/index.js` and `playwright-ct-core/index.ts` and ensures the latter export `const test`.

https://github.com/microsoft/playwright/blob/7f6f17d1c343f88400c498fd1c3defbd7f420056/packages/playwright-ct-core/index.js#L42

https://github.com/microsoft/playwright/blob/7f6f17d1c343f88400c498fd1c3defbd7f420056/packages/playwright-ct-core/index.d.ts#L48