### PR TITLE
feat(test runner): rework how tsconfig is applied

### DIFF
--- a/docs/src/test-typescript-js.md
+++ b/docs/src/test-typescript-js.md
@@ -5,9 +5,9 @@ title: "TypeScript"
 
 ## Introduction
 
-Playwright supports TypeScript out of the box. You just write tests in TypeScript, and Playwright will read them, transform to JavaScript and run. Note that Playwright does not check the types and will run tests even if there are non-critical TypeScript compilation errors.
+Playwright supports TypeScript out of the box. You just write tests in TypeScript, and Playwright will read them, transform to JavaScript and run.
 
-We recommend you run TypeScript compiler alongside Playwright. For example on GitHub actions:
+Note that Playwright does not check the types and will run tests even if there are non-critical TypeScript compilation errors. We recommend you run TypeScript compiler alongside Playwright. For example on GitHub actions:
 
 ```yaml
 jobs:
@@ -28,31 +28,65 @@ npx tsc -p tsconfig.json --noEmit -w
 
 ## tsconfig.json
 
-Playwright will pick up `tsconfig.json` for each source file it loads. Note that Playwright **only supports** the following tsconfig options: `paths` and `baseUrl`.
+Playwright will pick up `tsconfig.json` and consult it for each source file it loads. Note that Playwright **only supports** the following tsconfig options: `allowJs`, `baseUrl`, `exclude`, `files`, `include`, `paths`, `references`.
 
-We recommend setting up a separate `tsconfig.json` in the tests directory so that you can change some preferences specifically for the tests. Here is an example directory structure.
+We recommend to use the [`references` option](https://www.typescriptlang.org/tsconfig#references), so that you can configure TypeScript differently for source and test files.
+
+Below is an example directory structure and `tsconfig` file templates.
 
 ```txt
 src/
     source.ts
 
 tests/
-    tsconfig.json  # test-specific tsconfig
     example.spec.ts
 
-tsconfig.json  # generic tsconfig for all typescript sources
-
+tsconfig.json
+tsconfig.app.json
+tsconfig.test.json
 playwright.config.ts
 ```
+
+```json title="tsconfig.json"
+// This file just references two other configs.
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
+}
+```
+
+```json title="tsconfig.app.json"
+{
+  "include": ["./src"],
+  "compilerOptions": {
+    // Configure TypeScript for the app here.
+  }
+}
+```
+
+```json title="tsconfig.test.json"
+{
+  "include": ["./tests"],
+  "compilerOptions": {
+    // Configure TypeScript for tests here.
+  }
+}
+```
+
+Note that `include` should be configured in each config to only apply to respective files.
 
 ### tsconfig path mapping
 
 Playwright supports [path mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) declared in the `tsconfig.json`. Make sure that `baseUrl` is also set.
 
-Here is an example `tsconfig.json` that works with Playwright Test:
+Here is an example `tsconfig.json` that works with Playwright:
 
-```json
+```json title="tsconfig.test.json"
 {
+  "include": ["tests/**/*.ts"],
   "compilerOptions": {
     "baseUrl": ".", // This must be specified if "paths" is.
     "paths": {
@@ -74,23 +108,32 @@ test('example', async ({ page }) => {
 });
 ```
 
+### tsconfig resolution in Playwright
+
+Before loading `playwright.config.ts`, Playwright will search for `tsconfig.json` file next to it and in parent directories up to the package root containing `package.json`. This `tsconfig.json` will be used to load `playwright.config.ts`.
+
+Then, if you specify [`property: TestConfig.testDir`], and it contains a `tsconfig.json` file, Playwright will use it instead of the root `tsconfig.json`. This is **not recommended** and is left for backwards compatibility only. See above for the [recommended `references` setup](#tsconfigjson).
+
+Playwright consults `include`, `exclude` and `files` properties of the `tsconfig.json` before loading any typescript file, either through `require` or `import`, to determine whether to apply `tsconfig` to this particular file.
+
 ## Manually compile tests with TypeScript
 
 Sometimes, Playwright Test will not be able to transform your TypeScript code correctly, for example when you are using experimental or very recent features of TypeScript, usually configured in `tsconfig.json`.
 
 In this case, you can perform your own TypeScript compilation before sending the tests to Playwright.
 
-First add a `tsconfig.json` file inside the tests directory:
+First configure `tsconfig.test.json` to compile your tests:
 
-```json
+```json title="tsconfig.test.json"
 {
-    "compilerOptions": {
-        "target": "ESNext",
-        "module": "commonjs",
-        "moduleResolution": "Node",
-        "sourceMap": true,
-        "outDir": "../tests-out",
-    }
+  "include": ["tests/**/*.ts"],
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "commonjs",
+    "moduleResolution": "Node",
+    "sourceMap": true,
+    "outDir": "./tests-out",
+  }
 }
 ```
 
@@ -99,7 +142,7 @@ In `package.json`, add two scripts:
 ```json
 {
   "scripts": {
-    "pretest": "tsc --incremental -p tests/tsconfig.json",
+    "pretest": "tsc --incremental -p tsconfig.test.json",
     "test": "playwright test -c tests-out"
   }
 }

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -24,7 +24,6 @@ import { getPackageJsonPath, mergeObjects } from '../util';
 import type { Matcher } from '../util';
 import type { ConfigCLIOverrides } from './ipc';
 import type { FullConfig, FullProject } from '../../types/test';
-import { setTransformConfig } from '../transform/transform';
 
 export type ConfigLocation = {
   resolvedConfigFile?: string;
@@ -133,10 +132,6 @@ export class FullConfigInternal {
     this.projects = projectConfigs.map(p => new FullProjectInternal(configDir, userConfig, this, p, this.configCLIOverrides, throwawayArtifactsPath));
     resolveProjectDependencies(this.projects);
     this._assignUniqueProjectIds(this.projects);
-    setTransformConfig({
-      babelPlugins: privateConfiguration?.babelPlugins || [],
-      external: userConfig.build?.external || [],
-    });
     this.config.projects = this.projects.map(p => p.project);
   }
 

--- a/packages/playwright/src/common/esmLoaderHost.ts
+++ b/packages/playwright/src/common/esmLoaderHost.ts
@@ -67,7 +67,7 @@ export async function incorporateCompilationCache() {
   addToCompilationCache(result.cache);
 }
 
-export async function initializeEsmLoader() {
+export async function configureESMLoader() {
   if (!loaderChannel)
     return;
   await loaderChannel.send('setTransformConfig', { config: transformConfig() });

--- a/packages/playwright/src/runner/loaderHost.ts
+++ b/packages/playwright/src/runner/loaderHost.ts
@@ -22,7 +22,7 @@ import { loadTestFile } from '../common/testLoader';
 import type { FullConfigInternal } from '../common/config';
 import { PoolBuilder } from '../common/poolBuilder';
 import { addToCompilationCache } from '../transform/compilationCache';
-import { incorporateCompilationCache, initializeEsmLoader } from '../common/esmLoaderHost';
+import { incorporateCompilationCache } from '../common/esmLoaderHost';
 
 export class InProcessLoaderHost {
   private _config: FullConfigInternal;
@@ -34,7 +34,6 @@ export class InProcessLoaderHost {
   }
 
   async start(errors: TestError[]) {
-    await initializeEsmLoader();
     return true;
   }
 

--- a/tests/components/test-all.spec.js
+++ b/tests/components/test-all.spec.js
@@ -22,7 +22,7 @@ for (const dir of fs.readdirSync(__dirname)) {
       test(project, async () => {
         await run('npx', ['playwright', 'test', '--project=' + project, '--reporter=list'], folder);
       });
-    } 
+    }
   });
 }
 

--- a/tests/playwright-test/esm.spec.ts
+++ b/tests/playwright-test/esm.spec.ts
@@ -105,8 +105,9 @@ test('should respect path resolver in experimental mode', async ({ runInlineTest
   const result = await runInlineTest({
     'package.json': JSON.stringify({ type: 'module' }),
     'playwright.config.ts': `
+      import { foo } from 'util/b.js';
       export default {
-        projects: [{name: 'foo'}],
+        projects: [{ name: foo }],
       };
     `,
     'tsconfig.json': `{
@@ -124,7 +125,8 @@ test('should respect path resolver in experimental mode', async ({ runInlineTest
       import { foo } from 'util/b.js';
       import { test, expect } from '@playwright/test';
       test('check project name', ({}, testInfo) => {
-        expect(testInfo.project.name).toBe(foo);
+        expect(testInfo.project.name).toBe('foo');
+        expect(foo).toBe('foo');
       });
     `,
     'foo/bar/util/b.ts': `


### PR DESCRIPTION
Previously, test runner would load tsconfig for each imported file based on its location, going up the directory tree.

Now, test runner mostly uses a single tsconfig for all imported files and respects `files`, `include` and `exclude` properties to determine whether to apply tsconfig to a particular file or not.

For backwards compatibility, root tsconfig is used to load `playwright.config.ts`, but when `testDir` has its own tsconfig, it used for loading all tests instead of the root tsconfig.