### PR TITLE
fix(core): ElectronApplication.evaluate arg wrong type

### DIFF
--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -13855,7 +13855,7 @@ type AccessibilityNode = {
 export const devices: Devices;
 
 //@ts-ignore this will be any if electron is not installed
-type ElectronType = typeof import('electron');
+type ElectronType = Electron.RemoteMainInterface;
 
 /**
  * Electron application representation. You can use


### PR DESCRIPTION
The first argument to the function passed to `evaluate` should be `Electron.RemoteMainInterface`, not `typeof Electron.CrossProcessExports`

If keeping `typeof import('electron')` is important it should be changed to:
```ts
type ElectronType = typeof import('electron');
type Remote = ElectronType.RemoteMainInterface;
```