### PR TITLE
Document more default config values

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -76,7 +76,8 @@ export default defineConfig({
 * since: v1.10
 - type: ?<[boolean]>
 
-Whether to exit with an error if any tests or groups are marked as [`method: Test.only`] or [`method: Test.describe.only`]. Useful on CI.
+Whether to exit with an error if any tests or groups are marked as [`method: Test.only`] or [`method: Test.describe.only`].
+Defaults to `false`. Useful on CI.
 
 **Usage**
 
@@ -93,7 +94,7 @@ export default defineConfig({
 - type: ?<[boolean]>
 
 Playwright Test runs tests in parallel. In order to achieve that, it runs several worker processes that run at the same time.
-By default, **test files** are run in parallel. Tests in a single file are run in order, in the same worker process.
+Defaults to `false` - by default **test files** are run in parallel. Tests in a single file are run in order, in the same worker process.
 
 You can configure entire test run to concurrently execute all tests in all files using this option.
 


### PR DESCRIPTION
Hi, first of all, thanks for the continued work in the Playwright ecosystem, amazing!

Quick PR to document a few more undocumented default config values, on these docs pages (hope I have the correct file, I didn't see a straightforward way to edit the docs from these pages):

- https://playwright.dev/docs/api/class-testconfig#test-config-forbid-only
- https://playwright.dev/docs/api/class-testconfig#test-config-fully-parallel