### PR TITLE
fix(storageState): try to collect storage state on existing pages first

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -914,6 +914,12 @@ export class Frame extends SdkObject {
     return this._url;
   }
 
+  origin(): string | undefined {
+    if (!this._url.startsWith('http'))
+      return;
+    return network.parsedURL(this._url)?.origin;
+  }
+
   parentFrame(): Frame | null {
     return this._parentFrame;
   }

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -19,7 +19,7 @@ import type * as dom from './dom';
 import * as frames from './frames';
 import * as input from './input';
 import * as js from './javascript';
-import * as network from './network';
+import type * as network from './network';
 import type * as channels from '@protocol/channels';
 import type { ScreenshotOptions } from './screenshotter';
 import { Screenshotter, validateScreenshotOptions } from './screenshotter';
@@ -706,12 +706,9 @@ export class Page extends SdkObject {
 
   frameNavigatedToNewDocument(frame: frames.Frame) {
     this.emit(Page.Events.InternalFrameNavigatedToNewDocument, frame);
-    const url = frame.url();
-    if (!url.startsWith('http'))
-      return;
-    const purl = network.parsedURL(url);
-    if (purl)
-      this._browserContext.addVisitedOrigin(purl.origin);
+    const origin = frame.origin();
+    if (origin)
+      this._browserContext.addVisitedOrigin(origin);
   }
 
   allBindings() {


### PR DESCRIPTION
This helps in a case where navigating to an origin fails for some reason, for example because a registered service worker loads some content into the supposedly blank page.

Fixes #29402.