### PR TITLE
fix: postDataJSON without Content-Type header

### DIFF
--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -141,7 +141,7 @@ export class Request extends ChannelOwner<channels.RequestChannel> implements ap
       return null;
 
     const contentType = this.headers()['content-type'];
-    if (contentType.includes('application/x-www-form-urlencoded')) {
+    if (contentType?.includes('application/x-www-form-urlencoded')) {
       const entries: Record<string, string> = {};
       const parsed = new URLSearchParams(postData);
       for (const [k, v] of parsed.entries())


### PR DESCRIPTION
Regressed after https://github.com/microsoft/playwright/commit/38fc74db7c24398095632fa2e65e913c80df99f4.

Test coverage: Some tests were failing on the flakiness dashboard