### PR TITLE
fix(trace-viewer): report upload error as aria-role=alert

### DIFF
--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -162,7 +162,7 @@ export const WorkbenchLoader: React.FunctionComponent<{
       </div>
     </div>}
     {showFileUploadDropArea && <div className='drop-target'>
-      <div className='processing-error' aria-live='assertive'>{processingErrorMessage}</div>
+      <div className='processing-error' role='alert'>{processingErrorMessage}</div>
       <div className='title' role='heading' aria-level={1}>Drop Playwright Trace to load</div>
       <div>or</div>
       <button onClick={() => {


### PR DESCRIPTION
Turns out NVDA and Narrator work differently. This is a follow-up to https://github.com/microsoft/playwright/pull/29838 which was not working in NVDA before - looks like a NVDA bug. Using alert instead.

Relates https://github.com/microsoft/playwright/issues/29095#issuecomment-1999332067