### PR TITLE
fix(types): evaluate should not unpack return unions

### DIFF
--- a/packages/playwright-core/types/structs.d.ts
+++ b/packages/playwright-core/types/structs.d.ts
@@ -40,6 +40,6 @@ export type Unboxed<Arg> =
 export type PageFunction0<R> = string | (() => R | Promise<R>);
 export type PageFunction<Arg, R> = string | ((arg: Unboxed<Arg>) => R | Promise<R>);
 export type PageFunctionOn<On, Arg2, R> = string | ((on: On, arg2: Unboxed<Arg2>) => R | Promise<R>);
-export type SmartHandle<T> = T extends Node ? ElementHandle<T> : JSHandle<T>;
+export type SmartHandle<T> = [T] extends [Node] ? ElementHandle<T> : JSHandle<T>;
 export type ElementHandleForTag<K extends keyof HTMLElementTagNameMap> = ElementHandle<HTMLElementTagNameMap[K]>;
 export type BindingSource = { context: BrowserContext, page: Page, frame: Frame };

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -331,9 +331,9 @@ playwright.chromium.launch().then(async browser => {
   }
   // evaluteHandle with two different return types (ElementHandle)
   {
-    const handle = await page.evaluateHandle(() => '' as HTMLInputElement | HTMLTextAreaElement);
+    const handle = await page.evaluateHandle(() => '' as any as HTMLInputElement | HTMLTextAreaElement);
     await handle.evaluate(element => element.value);
-    const assertion: AssertType<ElementHandle<HTMLInputElement | HTMLTextAreaElement>, typeof handle> = true;
+    const assertion: AssertType<playwright.ElementHandle<HTMLInputElement | HTMLTextAreaElement>, typeof handle> = true;
   }
 
 

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -323,6 +323,13 @@ playwright.chromium.launch().then(async browser => {
   console.log(await resultHandle.jsonValue());
   await resultHandle.dispose();
 
+  // evaluteHandle with two different return types
+  {
+    const handle = await page.evaluateHandle(() => '' as string | number);
+    const result = await handle.evaluate(value => value);
+    const assertion: AssertType<string | number, typeof result> = true;
+  }
+
   await browser.close();
 })();
 
@@ -606,7 +613,7 @@ playwright.chromium.launch().then(async browser => {
   {
     const handle = await page.waitForSelector('*');
     const value = await handle.evaluateHandle((e: HTMLInputElement, x) => e.disabled || x, 123);
-    const assertion: AssertType<playwright.JSHandle<boolean> | playwright.JSHandle<number>, typeof value> = true;
+    const assertion: AssertType<playwright.JSHandle<boolean | number>, typeof value> = true;
   }
 
   {

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -323,12 +323,19 @@ playwright.chromium.launch().then(async browser => {
   console.log(await resultHandle.jsonValue());
   await resultHandle.dispose();
 
-  // evaluteHandle with two different return types
+  // evaluteHandle with two different return types (JSHandle)
   {
     const handle = await page.evaluateHandle(() => '' as string | number);
     const result = await handle.evaluate(value => value);
     const assertion: AssertType<string | number, typeof result> = true;
   }
+  // evaluteHandle with two different return types (ElementHandle)
+  {
+    const handle = await page.evaluateHandle(() => '' as HTMLInputElement | HTMLTextAreaElement);
+    await handle.evaluate(element => element.value);
+    const assertion: AssertType<ElementHandle<HTMLInputElement | HTMLTextAreaElement>, typeof handle> = true;
+  }
+
 
   await browser.close();
 })();


### PR DESCRIPTION
Motivation: https://github.com/nuxt/nuxt/blob/977377777afcc38186c7a309a86e9e5613470652/test/basic.test.ts#L1340