### PR TITLE
fix(trace-viewer): encode attachment filenames as UTF-8

### DIFF
--- a/packages/trace-viewer/src/sw.ts
+++ b/packages/trace-viewer/src/sw.ts
@@ -159,7 +159,6 @@ function downloadHeadersForAttachment(traceModel: TraceModel, sha1: string): Hea
   if (!attachment)
     return;
   const headers = new Headers();
-  // Escape non-ascii characters and quotes.
   headers.set('Content-Disposition', `attachment; filename="attachment"; filename*=UTF-8''${encodeURIComponent(attachment.name)}`);
   if (attachment.contentType)
     headers.set('Content-Type', attachment.contentType);

--- a/packages/trace-viewer/src/sw.ts
+++ b/packages/trace-viewer/src/sw.ts
@@ -159,7 +159,8 @@ function downloadHeadersForAttachment(traceModel: TraceModel, sha1: string): Hea
   if (!attachment)
     return;
   const headers = new Headers();
-  headers.set('Content-Disposition', `attachment; filename="${attachment.name}"`);
+  // Escape non-ascii characters and quotes.
+  headers.set('Content-Disposition', `attachment; filename="attachment"; filename*=UTF-8''${encodeURIComponent(attachment.name)}`);
   if (attachment.contentType)
     headers.set('Content-Type', attachment.contentType);
   return headers;


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/29967

Tested in Firefox, Chromium, and Safari. This now leads to "good attachment names" in Chromium and Safari, for Firefox, it won't produce attachments, it will open them inline, but this is not a regression, was before like that already.

See here for the spec: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#filename_2