### PR TITLE
devops: fix WebView2 tests

### DIFF
--- a/.github/workflows/tests_webview2.yml
+++ b/.github/workflows/tests_webview2.yml
@@ -38,6 +38,11 @@ jobs:
     - run: npm run build
     - run: dotnet build
       working-directory: tests/webview2/webview2-app/
+    - name: Update to Evergreen WebView2 Runtime
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile 'setup.exe'
+        Start-Process -FilePath setup.exe -Verb RunAs -Wait
     - run: npm run webview2test
     - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
       if: always()

--- a/.github/workflows/tests_webview2.yml
+++ b/.github/workflows/tests_webview2.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Update to Evergreen WebView2 Runtime
       shell: pwsh
       run: |
+        # See here: https://developer.microsoft.com/en-us/microsoft-edge/webview2/
         Invoke-WebRequest -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile 'setup.exe'
         Start-Process -FilePath setup.exe -Verb RunAs -Wait
     - run: npm run webview2test

--- a/tests/webview2/globalSetup.ts
+++ b/tests/webview2/globalSetup.ts
@@ -31,6 +31,7 @@ export default async () => {
       resolve();
   }));
   const browser = await playwright.chromium.connectOverCDP(`http://127.0.0.1:${cdpPort}`);
+  console.log(`Using version ${browser.version()} WebView2 runtime`);
   const page = browser.contexts()[0].pages()[0];
   await page.goto('data:text/html,');
   const chromeVersion = await page.evaluate(() => navigator.userAgent.match(/Chrome\/(.*?) /)[1]);


### PR DESCRIPTION
Turns out we were using version 119.0.2151.58 before where the tests are failing. After this change we are using 122.0.2365.92.

Fixes https://github.com/microsoft/playwright/issues/29695
Relates https://github.com/actions/runner-images/issues/9538