### PR TITLE
feat: support importing client-only files (like scss) for ESM

### DIFF
--- a/packages/playwright/src/transform/clientExtensions.ts
+++ b/packages/playwright/src/transform/clientExtensions.ts
@@ -1,0 +1,11 @@
+export const CLIENT_EXTENSIONS = [
+  '.scss',
+  '.css',
+  '.svg',
+  '.png',
+  '.jpg',
+  '.eot',
+  '.ttf',
+  '.woff',
+  '.woff2',
+]

--- a/packages/playwright/src/transform/clientExtensions.ts
+++ b/packages/playwright/src/transform/clientExtensions.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const CLIENT_EXTENSIONS = [
   '.scss',
   '.css',
@@ -8,4 +24,4 @@ export const CLIENT_EXTENSIONS = [
   '.ttf',
   '.woff',
   '.woff2',
-]
+];

--- a/packages/playwright/src/transform/esmLoader.ts
+++ b/packages/playwright/src/transform/esmLoader.ts
@@ -19,10 +19,25 @@ import url from 'url';
 import { addToCompilationCache, currentFileDepsCollector, serializeCompilationCache, startCollectingFileDeps, stopCollectingFileDeps } from './compilationCache';
 import { transformHook, resolveHook, setTransformConfig, shouldTransform } from './transform';
 import { PortTransport } from './portTransport';
+import { CLIENT_EXTENSIONS } from './clientExtensions.js'
 
 // Node < 18.6: defaultResolve takes 3 arguments.
 // Node >= 18.6: nextResolve from the chain takes 2 arguments.
 async function resolve(specifier: string, context: { parentURL?: string }, defaultResolve: Function) {
+  const isClientExtension = CLIENT_EXTENSIONS.some((ext) => specifier.endsWith(ext))
+
+  // Short-circuit the resolver to be able to load client extensions.
+  if (isClientExtension) {
+    const nextResult = await defaultResolve(specifier, context, defaultResolve)
+    const specifierSegments = specifier.split('.')
+
+    return {
+      format: '.' + specifierSegments[specifierSegments.length - 1],
+      shortCircuit: true,
+      url: nextResult.url,
+    }
+  }
+
   if (context.parentURL && context.parentURL.startsWith('file://')) {
     const filename = url.fileURLToPath(context.parentURL);
     const resolved = resolveHook(filename, specifier);
@@ -41,6 +56,20 @@ async function resolve(specifier: string, context: { parentURL?: string }, defau
 // Node < 18.6: defaultLoad takes 3 arguments.
 // Node >= 18.6: nextLoad from the chain takes 2 arguments.
 async function load(moduleUrl: string, context: { format?: string }, defaultLoad: Function) {
+  const isClientExtension = CLIENT_EXTENSIONS.some((ext) => context.format === ext)
+
+  // If the module is a client extension, we need to short-circuit the loader and return the raw source.
+  if (isClientExtension) {
+    const rawSource = '' + fs.readFileSync(url.fileURLToPath(moduleUrl), 'utf-8')
+
+    return {
+      format: 'json',
+      shortCircuit: true,
+      source: JSON.stringify(rawSource),
+    }
+  }
+
+
   // Bail out for wasm, json, etc.
   // non-js files have context.format === undefined
   if (context.format !== 'commonjs' && context.format !== 'module' && context.format !== undefined)

--- a/packages/playwright/src/transform/esmLoader.ts
+++ b/packages/playwright/src/transform/esmLoader.ts
@@ -19,23 +19,23 @@ import url from 'url';
 import { addToCompilationCache, currentFileDepsCollector, serializeCompilationCache, startCollectingFileDeps, stopCollectingFileDeps } from './compilationCache';
 import { transformHook, resolveHook, setTransformConfig, shouldTransform } from './transform';
 import { PortTransport } from './portTransport';
-import { CLIENT_EXTENSIONS } from './clientExtensions.js'
+import { CLIENT_EXTENSIONS } from './clientExtensions.js';
 
 // Node < 18.6: defaultResolve takes 3 arguments.
 // Node >= 18.6: nextResolve from the chain takes 2 arguments.
 async function resolve(specifier: string, context: { parentURL?: string }, defaultResolve: Function) {
-  const isClientExtension = CLIENT_EXTENSIONS.some((ext) => specifier.endsWith(ext))
+  const isClientExtension = CLIENT_EXTENSIONS.some((ext) => specifier.endsWith(ext));
 
   // Short-circuit the resolver to be able to load client extensions.
   if (isClientExtension) {
-    const nextResult = await defaultResolve(specifier, context, defaultResolve)
-    const specifierSegments = specifier.split('.')
+    const nextResult = await defaultResolve(specifier, context, defaultResolve);
+    const specifierSegments = specifier.split('.');
 
     return {
       format: '.' + specifierSegments[specifierSegments.length - 1],
       shortCircuit: true,
       url: nextResult.url,
-    }
+    };
   }
 
   if (context.parentURL && context.parentURL.startsWith('file://')) {
@@ -56,17 +56,17 @@ async function resolve(specifier: string, context: { parentURL?: string }, defau
 // Node < 18.6: defaultLoad takes 3 arguments.
 // Node >= 18.6: nextLoad from the chain takes 2 arguments.
 async function load(moduleUrl: string, context: { format?: string }, defaultLoad: Function) {
-  const isClientExtension = CLIENT_EXTENSIONS.some((ext) => context.format === ext)
+  const isClientExtension = CLIENT_EXTENSIONS.some((ext) => context.format === ext);
 
   // If the module is a client extension, we need to short-circuit the loader and return the raw source.
   if (isClientExtension) {
-    const rawSource = '' + fs.readFileSync(url.fileURLToPath(moduleUrl), 'utf-8')
+    const rawSource = '' + fs.readFileSync(url.fileURLToPath(moduleUrl), 'utf-8');
 
     return {
       format: 'json',
       shortCircuit: true,
       source: JSON.stringify(rawSource),
-    }
+    };
   }
 
 

--- a/packages/playwright/src/transform/esmLoader.ts
+++ b/packages/playwright/src/transform/esmLoader.ts
@@ -24,7 +24,7 @@ import { CLIENT_EXTENSIONS } from './clientExtensions.js';
 // Node < 18.6: defaultResolve takes 3 arguments.
 // Node >= 18.6: nextResolve from the chain takes 2 arguments.
 async function resolve(specifier: string, context: { parentURL?: string }, defaultResolve: Function) {
-  const isClientExtension = CLIENT_EXTENSIONS.some((ext) => specifier.endsWith(ext));
+  const isClientExtension = CLIENT_EXTENSIONS.some(ext => specifier.endsWith(ext));
 
   // Short-circuit the resolver to be able to load client extensions.
   if (isClientExtension) {
@@ -56,7 +56,7 @@ async function resolve(specifier: string, context: { parentURL?: string }, defau
 // Node < 18.6: defaultLoad takes 3 arguments.
 // Node >= 18.6: nextLoad from the chain takes 2 arguments.
 async function load(moduleUrl: string, context: { format?: string }, defaultLoad: Function) {
-  const isClientExtension = CLIENT_EXTENSIONS.some((ext) => context.format === ext);
+  const isClientExtension = CLIENT_EXTENSIONS.some(ext => context.format === ext);
 
   // If the module is a client extension, we need to short-circuit the loader and return the raw source.
   if (isClientExtension) {


### PR DESCRIPTION
Issue this fixes: https://github.com/microsoft/playwright/issues/30153

Related issue: #26822 (doesn't close it, being able to provide your own loader would still be cool and needed)

Currently, if you import client extension files like scss within playwright and use ESM, it throws an `"Unknown file extension: .scss"` error. This PR fixes this issue and allows playwright to support importing those out-of-the-box.

This is unfortunate, because our own webpack loader is indeed able to import and bundle those scss files. Back when we used CJS, we were able to skip requiring client files using [this simple trick](https://github.com/payloadcms/payload/blob/1c0d43c61a0e29bc9de50a4e608cb7dff9d5cd48/packages/payload/src/config/load.ts#L21).

With ESM imports, this is no longer possible and there is no way for us to get playwright to support it. The "ESM-way" to do this is to use a custom loader which skips resolving those client files and loads them as raw JSON. That way, they won't error out and a bundler can then handle them accordingly. This is what this PR does.

Currently, we are patching playwright in order to get playwright to actually work in our project: https://github.com/payloadcms/payload/blob/alpha/patches/playwright%401.42.1.patch. Getting client file imports to work is one out of three things we had to patch in order for playwright to support ESM. This PR will relieve some burden for us to patch it after each version, until hopefully in the future this is not needed at all anymore.

I'm aware the alternative to this is to either compile our project beforehand and run playwright on `dist`, or to run next.js in a separate process and make sure no client files are imported within playwright itself. This, however, is a very bad developer experience for us, especially since we cannot use a debugger that way.
