### PR TITLE
feat: allows specifying own file to be used for babel transform options

### DIFF
--- a/packages/playwright/bundles/babel/src/babelBundleImpl.ts
+++ b/packages/playwright/bundles/babel/src/babelBundleImpl.ts
@@ -123,10 +123,10 @@ export function babelTransform(code: string, filename: string, isTypeScript: boo
   let options: TransformOptions;
 
   try {
-    if(process.env.PW_TEST_BABEL_TRANSFORM_OPTIONS_FILE) {
+    if (process.env.PW_TEST_BABEL_TRANSFORM_OPTIONS_FILE) {
       const importedBabelTransformOptions = require(process.env.PW_TEST_BABEL_TRANSFORM_OPTIONS_FILE);
       options = importedBabelTransformOptions(isTypeScript, isModule, pluginsPrologue, pluginsEpilogue);
-    }else {
+    } else {
       options = babelTransformOptions(isTypeScript, isModule, pluginsPrologue, pluginsEpilogue);
     }
     return babel.transform(code, { filename, ...options })!;

--- a/packages/playwright/bundles/babel/src/babelBundleImpl.ts
+++ b/packages/playwright/bundles/babel/src/babelBundleImpl.ts
@@ -120,8 +120,15 @@ export function babelTransform(code: string, filename: string, isTypeScript: boo
 
   // Prevent reentry while requiring plugins lazily.
   isTransforming = true;
+  let options: TransformOptions;
+
   try {
-    const options = babelTransformOptions(isTypeScript, isModule, pluginsPrologue, pluginsEpilogue);
+    if(process.env.PW_TEST_BABEL_TRANSFORM_OPTIONS_FILE) {
+      const importedBabelTransformOptions = require(process.env.PW_TEST_BABEL_TRANSFORM_OPTIONS_FILE);
+      options = importedBabelTransformOptions(isTypeScript, isModule, pluginsPrologue, pluginsEpilogue);
+    }else {
+      options = babelTransformOptions(isTypeScript, isModule, pluginsPrologue, pluginsEpilogue);
+    }
     return babel.transform(code, { filename, ...options })!;
   } finally {
     isTransforming = false;


### PR DESCRIPTION
This adds a new `PW_TEST_BABEL_TRANSFORM_OPTIONS_FILE` environment variable, which lets you specify an own path to be used to get the babel transform options.

**Here is WHY we need this:** https://github.com/microsoft/playwright/pull/30015

Now, this PR does NOT fix the issue which #30015 fixes. That's why it is a separate PR.

Instead, this PR allows us to provide our own babel config and experiment with it by specifying the `PW_TEST_BABEL_TRANSFORM_OPTIONS_FILE` environment variable without having to patch playwright!

I mean why not - more configurability is great! Even once the underlying issue is fixed, this may be very helpful for some in the future if you, for whatever reason, need to mess with babel (maybe their unique project configuration requires that). 

If we have this ability to provide our own babel config, we have the option to fix the issue ourselves while it's not merged yet. This will also give us the ability to do the same for future issues OR for potential, unique configuration needs we might have