### PR TITLE
fix: when closing all pages, context close event not triggered

### DIFF
--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -275,6 +275,8 @@ export class CRBrowser extends Browser {
   }
 
   async _closePage(crPage: CRPage) {
+    if (this._platform() !== 'mac' && this._crPages.size === 1)
+      await this.close({ reason: 'Last Page closed' });
     await this._session.send('Target.closeTarget', { targetId: crPage._targetId });
   }
 

--- a/tests/library/chromium/chromium.spec.ts
+++ b/tests/library/chromium/chromium.spec.ts
@@ -630,3 +630,13 @@ test.describe('PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1', () => {
     expect(req.headers['x-custom-header']).toBe('custom!');
   });
 });
+
+playwrightTest('should trigger context close event when last page closed if not mac', async ({ browserType, createUserDataDir, isMac }, testInfo) => {
+  if (!isMac) {
+    const context = await browserType.launchPersistentContext(await createUserDataDir());
+    let closed = false;
+    context.on('close', () => closed = true);
+    await context.pages()[0].close();
+    expect(closed).toBe(true);
+  }
+});


### PR DESCRIPTION
related issue: https://github.com/microsoft/playwright/issues/29726

## Motivation:
On https://github.com/microsoft/playwright/issues/29726, we found that closing all pages of launchPersistentContext causes crash without triggering context close event

## Problem:
I have checked this issue on Mac, Windows, and Ubuntu.

And I thought the problem was this:

When the last page is closed,  
In Windows and Ubuntu, Chrome is completely terminated.  (context is closed)  
However, Playwright is not aware of this state.  
Therefore, the context close event is not triggered.  

On the other hand, in Mac, Chrome remains in the background (context is not closed)  
So, even after closing the last page on Mac, we can still create new pages without any errors occurring.

## Modification:
If the context was closed, we expected the context close event to be triggered.
To accomplish this, I modified that when a non-Mac device attempts to close the last page, it close the context itself.

## Result:
Close https://github.com/microsoft/playwright/issues/29726 issue