### PR TITLE
feat(test runner): show multiple errors, at most one per stage

### DIFF
--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -267,7 +267,6 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
         params: args[0] ? { expected: args[0] } : undefined,
         wallTime,
         infectParentStepsWithError: this._info.isSoft,
-        isSoft: this._info.isSoft,
       };
 
       const step = testInfo._addStep(stepInfo);
@@ -275,7 +274,9 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
       const reportStepError = (jestError: ExpectError) => {
         const error = new ExpectError(jestError, customMessage, stackFrames);
         step.complete({ error });
-        if (!this._info.isSoft)
+        if (this._info.isSoft)
+          testInfo._failWithError(error);
+        else
           throw error;
       };
 

--- a/packages/playwright/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchSnapshot.ts
@@ -232,7 +232,8 @@ class SnapshotHelper {
       return this.createMatcherResult(message, true);
     }
     if (this.updateSnapshots === 'missing') {
-      this.testInfo._failWithError(new Error(message), false /* isHardError */, false /* retriable */);
+      this.testInfo._hasNonRetriableError = true;
+      this.testInfo._failWithError(new Error(message));
       return this.createMatcherResult('', true);
     }
     return this.createMatcherResult(message, false);

--- a/tests/playwright-test/fixture-errors.spec.ts
+++ b/tests/playwright-test/fixture-errors.spec.ts
@@ -733,3 +733,24 @@ test('should not continue with scope teardown after fixture teardown timeout', a
   expect(result.output).toContain('Test finished within timeout of 1000ms, but tearing down "fixture2" ran out of time.');
   expect(result.output).not.toContain('in fixture teardown');
 });
+
+test('should report fixture teardown error after test error', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        foo: async ({ }, use) => {
+          await use();
+          throw new Error('Error from the fixture foo');
+        },
+      });
+      test('fails', async ({ foo }) => {
+        throw new Error('Error from the test');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.output).toContain('Error from the fixture foo');
+  expect(result.output).toContain('Error from the test');
+});


### PR DESCRIPTION
Previously, there was at most one "hard error", as opposite to multiple "soft errors". This was done to preserve the historic behavior at the time of introducing multiple `TestInfo.errors`.

With this change, every user callback that is executed `withRunnable()` can throw an error and/or timeout, and both of these will end up in `TestInfo.errors`.

Additionally, there is at most one "unhandled exception" error, to avoid flooding the report with mass failures.

Drive-by: remove boolean arguments from `_failWithError()`.

Fixes #29876.