### PR TITLE
feat: Support intervals arg for toPass

### DIFF
--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -29,7 +29,7 @@ await page.getByRole('link', { name: 'Collection of blue and white' }).click();
 await expect(page.getByRole('heading', { name: 'Light and easy' })).toBeVisible();
 ```
 
-- `expect(callback).toPass()` timeout and intervals can now be configured by `expect.toPass.timeout` and `expect.toPass.intervals` options [globally](./api/class-testconfig#test-config-expect) or in [project config](./api/class-testproject#test-project-expect)
+- `expect(callback).toPass()` timeout can now be configured by `expect.toPass.timeout` option [globally](./api/class-testconfig#test-config-expect) or in [project config](./api/class-testproject#test-project-expect)
 
 - [`event: ElectronApplication.console`] event is emitted when Electron main process calls console API methods.
 ```js

--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -29,7 +29,7 @@ await page.getByRole('link', { name: 'Collection of blue and white' }).click();
 await expect(page.getByRole('heading', { name: 'Light and easy' })).toBeVisible();
 ```
 
-- `expect(callback).toPass()` timeout can now be configured by `expect.toPass.timeout` option [globally](./api/class-testconfig#test-config-expect) or in [project config](./api/class-testproject#test-project-expect)
+- `expect(callback).toPass()` timeout and intervals can now be configured by `expect.toPass.timeout` and `expect.toPass.intervals` options [globally](./api/class-testconfig#test-config-expect) or in [project config](./api/class-testproject#test-project-expect)
 
 - [`event: ElectronApplication.console`] event is emitted when Electron main process calls console API methods.
 ```js

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -54,6 +54,7 @@ export default defineConfig({
     - `maxDiffPixelRatio` ?<[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
   - `toPass` ?<[Object]> Configuration for the [expect(value).toPass()](../test-assertions.md#expecttopass) method.
     - `timeout` ?<[int]> timeout for toPass method in milliseconds.
+    - `intervals` ?<[Array]<[int]>> probe intervals for toPass method in milliseconds.
 
 Configuration for the `expect` assertion library. Learn more about [various timeouts](../test-timeouts.md).
 

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -104,6 +104,7 @@ export default defineConfig({
     - `maxDiffPixelRatio` ?<[float]> an acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.
   - `toPass` ?<[Object]> Configuration for the [expect(value).toPass()](../test-assertions.md) method.
     - `timeout` ?<[int]> timeout for toPass method in milliseconds.
+    - `intervals` ?<[Array]<[int]>> probe intervals for toPass method in milliseconds.
 
 Configuration for the `expect` assertion library.
 

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -369,6 +369,7 @@ export async function toPass(
 ) {
   const testInfo = currentTestInfo();
   const timeout = takeFirst(options.timeout, testInfo?._projectInternal.expect?.toPass?.timeout, 0);
+  const intervals = takeFirst(options.intervals, testInfo?._projectInternal.expect?.toPass?.intervals, [100, 250, 500, 1000]);
 
   const { deadline, timeoutMessage } = testInfo ? testInfo._deadlineForMatcher(timeout) : TestInfoImpl._defaultDeadlineForMatcher(timeout);
   const result = await pollAgainstDeadline<Error|undefined>(async () => {
@@ -380,7 +381,7 @@ export async function toPass(
     } catch (e) {
       return { continuePolling: !this.isNot, result: e };
     }
-  }, deadline, options.intervals || [100, 250, 500, 1000]);
+  }, deadline, intervals);
 
   if (result.timedOut) {
     const message = result.result ? [

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -702,6 +702,11 @@ interface TestConfig {
        * timeout for toPass method in milliseconds.
        */
       timeout?: number;
+
+      /**
+       * probe intervals for toPass method in milliseconds.
+       */
+      intervals?: Array<number>;
     };
   };
 
@@ -8596,11 +8601,6 @@ interface TestProject {
        * timeout for toPass method in milliseconds.
        */
       timeout?: number;
-
-      /**
-       * interval for toPass method in milliseconds.
-       */
-      intervals?: number[];
     };
   };
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -702,6 +702,11 @@ interface TestConfig {
        * timeout for toPass method in milliseconds.
        */
       timeout?: number;
+
+      /**
+       * intervals for toPass method in milliseconds.
+       */
+      intervals?: number[];
     };
   };
 
@@ -8596,6 +8601,11 @@ interface TestProject {
        * timeout for toPass method in milliseconds.
        */
       timeout?: number;
+
+      /**
+       * interval for toPass method in milliseconds.
+       */
+      intervals?: number[];
     };
   };
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -8601,6 +8601,11 @@ interface TestProject {
        * timeout for toPass method in milliseconds.
        */
       timeout?: number;
+
+      /**
+       * probe intervals for toPass method in milliseconds.
+       */
+      intervals?: Array<number>;
     };
   };
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -702,11 +702,6 @@ interface TestConfig {
        * timeout for toPass method in milliseconds.
        */
       timeout?: number;
-
-      /**
-       * intervals for toPass method in milliseconds.
-       */
-      intervals?: number[];
     };
   };
 

--- a/tests/playwright-test/expect-to-pass.spec.ts
+++ b/tests/playwright-test/expect-to-pass.spec.ts
@@ -263,32 +263,38 @@ test('should give priority to timeout parameter over timeout in config file', as
 
 test('should respect intervals in config file when intervals parameter is not passed', async ({ runInlineTest }) => {
   const result = await runInlineTest({
-    'playwright.config.js': `module.exports = { expect: { toPass: { intervals: [100, 200] } } }`,
+    'playwright.config.js': `module.exports = { expect: { toPass: { timeout: 2000, intervals: [100, 1000] } } }`,
     'a.spec.ts': `
       import { test, expect } from '@playwright/test';
       test('should fail', async () => {
+        let attempt = 0;
         await test.expect(() => {
-          expect(1).toBe(2);
+          expect(++attempt).toBe(-1);
         }).toPass();
       });
     `
   });
-  expect(result.exitCode).toBe('TODO');
-  // TODO
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Error: expect(received).toBe(expected) // Object.is equality');
+  expect(result.output).toContain('Expected: -1');
+  expect(result.output).toContain('Received: 3');
 });
 
 test('should give priority to intervals parameter over intervals in config file', async ({ runInlineTest }) => {
   const result = await runInlineTest({
-    'playwright.config.js': `module.exports = { expect: { toPass: { intervals: [100, 200] } } }`,
+    'playwright.config.js': `module.exports = { expect: { toPass: { timeout: 2000, intervals: [100] } } }`,
     'a.spec.ts': `
       import { test, expect } from '@playwright/test';
       test('should fail', async () => {
+        let attempt = 0;
         await test.expect(() => {
-          expect(1).toBe(2);
-        }).toPass({ intervals: [500] });
+          expect(++attempt).toBe(-1);
+        }).toPass({ intervals: [100, 1000] });
       });
     `
   });
-  expect(result.exitCode).toBe('TODO');
-  // TODO
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Error: expect(received).toBe(expected) // Object.is equality');
+  expect(result.output).toContain('Expected: -1');
+  expect(result.output).toContain('Received: 3');
 });

--- a/tests/playwright-test/expect-to-pass.spec.ts
+++ b/tests/playwright-test/expect-to-pass.spec.ts
@@ -260,3 +260,35 @@ test('should give priority to timeout parameter over timeout in config file', as
   4 |         await test.expect(() => {
   `.trim());
 });
+
+test('should respect intervals in config file when intervals parameter is not passed', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.js': `module.exports = { expect: { toPass: { intervals: [100, 200] } } }`,
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail', async () => {
+        await test.expect(() => {
+          expect(1).toBe(2);
+        }).toPass();
+      });
+    `
+  });
+  expect(result.exitCode).toBe('TODO');
+  // TODO
+});
+
+test('should give priority to intervals parameter over intervals in config file', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.js': `module.exports = { expect: { toPass: { intervals: [100, 200] } } }`,
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail', async () => {
+        await test.expect(() => {
+          expect(1).toBe(2);
+        }).toPass({ intervals: [500] });
+      });
+    `
+  });
+  expect(result.exitCode).toBe('TODO');
+  // TODO
+});


### PR DESCRIPTION
Fixes #30040

# Context

In the `playwright.config` file, we can custom the default `timeout` property for `expect.toPass` by the property:

```ts title='playwright.config.ts'
export default defineConfig({
  // ...
  expect: {
    toPass: {
      timeout: 60_000,
    },
  },
});
```

However, we can't customize the `intervals` option. So the default value is always `[100, 250, 500, 1000]`.

# Goal

Add the possibility to customize the intervals option from the `playwright.config` file.

```ts title='playwright.config.ts'
export default defineConfig({
  // ...
  expect: {
    toPass: {
      timeout: 60_000,
      intervals: [1000, 2000, 3000]
    },
  },
});
```