### PR TITLE
devops(merge): validate zip before uploading

### DIFF
--- a/.github/actions/upload-blob-report/action.yml
+++ b/.github/actions/upload-blob-report/action.yml
@@ -12,6 +12,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Integrity check
+      shell: bash
+      run: |
+        for file in ${{ inputs.report_dir }}/*.zip; do
+          unzip -t $file
+        done
     - name: Upload blob report to GitHub
       if: ${{ !cancelled() && github.event_name == 'pull_request' }}
       uses: actions/upload-artifact@v4

--- a/.github/actions/upload-blob-report/action.yml
+++ b/.github/actions/upload-blob-report/action.yml
@@ -14,10 +14,7 @@ runs:
   steps:
     - name: Integrity check
       shell: bash
-      run: |
-        for file in ${{ inputs.report_dir }}/*.zip; do
-          unzip -t $file
-        done
+      run: find "${{ inputs.report_dir }}" -name "*.zip" -exec unzip -t {} \;
     - name: Upload blob report to GitHub
       if: ${{ !cancelled() && github.event_name == 'pull_request' }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Follow-up on https://github.com/microsoft/playwright/pull/30060.

manpage of unzip for what `-t` does:

    test archive files.  This option extracts each specified file in memory and compares the CRC (cyclic redundancy check, an enhanced checksum) of the expanded file with the original file's stored CRC value.