### PR TITLE
fix(ct): allow importing json files

### DIFF
--- a/packages/playwright-ct-core/src/tsxTransform.ts
+++ b/packages/playwright-ct-core/src/tsxTransform.ts
@@ -193,7 +193,4 @@ const artifactExtensions = new Set([
   '.ttf',
   '.otf',
   '.eot',
-
-  // Other assets
-  '.json',
 ]);

--- a/tests/playwright-test/playwright.ct-build.spec.ts
+++ b/tests/playwright-test/playwright.ct-build.spec.ts
@@ -497,6 +497,24 @@ test('should render component via re-export', async ({ runInlineTest }, testInfo
   expect(result.passed).toBe(1);
 });
 
+test('should import json', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': playwrightCtConfigText,
+    'playwright/index.html': `<script type="module" src="./index.ts"></script>`,
+    'playwright/index.ts': ``,
+    'src/some.json': `{ "some": "value" }`,
+    'src/button.test.tsx': `
+      import { test, expect } from '@playwright/experimental-ct-react';
+      import json from './some.json';
+      test('pass', async ({}) => {
+        expect(json.some).toBe('value');
+      });
+    `,
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
 test('should render component exported via fixture', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'playwright.config.ts': playwrightCtConfigText,


### PR DESCRIPTION
While we are not fully resolving imports during compilation, do not treat `json` as a non-importable asset.

Fixes #29926.