### PR TITLE
feat(test runner): do not mock tty in the worker process

### DIFF
--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -46,15 +46,7 @@ export type SerializedConfig = {
   compilationCache?: SerializedCompilationCache;
 };
 
-export type TtyParams = {
-  rows: number | undefined;
-  columns: number | undefined;
-  colorDepth: number;
-};
-
 export type ProcessInitParams = {
-  stdoutParams: TtyParams;
-  stderrParams: TtyParams;
   processName: string;
 };
 

--- a/packages/playwright/src/runner/processHost.ts
+++ b/packages/playwright/src/runner/processHost.ts
@@ -112,16 +112,6 @@ export class ProcessHost extends EventEmitter {
       return error;
 
     const processParams: ProcessInitParams = {
-      stdoutParams: {
-        rows: process.stdout.rows,
-        columns: process.stdout.columns,
-        colorDepth: process.stdout.getColorDepth?.() || 8
-      },
-      stderrParams: {
-        rows: process.stderr.rows,
-        columns: process.stderr.columns,
-        colorDepth: process.stderr.getColorDepth?.() || 8
-      },
       processName: this._processName
     };
 


### PR DESCRIPTION
This was historically done to make `console.log()` have colors. However, this makes any other code that checks `process.stdout.isTTY` incorrectly assume real TTY support.

Node18 and Node20 now respect `FORCE_COLOR=1` in console, so our default behavior of forcing colors in the worker process just works out of the box. See https://github.com/nodejs/node/pull/48034.