### PR TITLE
docs(test-projects-js.md): fix typo in "Test filtering" section

### DIFF
--- a/docs/src/test-projects-js.md
+++ b/docs/src/test-projects-js.md
@@ -216,7 +216,7 @@ You can also teardown your setup by adding a [`property: TestProject.teardown`] 
 
 ### Test filtering
 
-If `--grep/--grep-invert` or `--shard` [option](./test-cli.md#reference) is used, test file name filter is specified in [command line](./test-cli.md) or [test.only()](./api/class-test.md#test-only) is used, it will only apply to the tests from the deepest projects in the project dependency chain. In other words, if a matching test belongs to a project that has project dependencies, Playwright will run all the tests from the project depdencies ignoring the filters.
+If `--grep/--grep-invert` or `--shard` [option](./test-cli.md#reference) is used, test file name filter is specified in [command line](./test-cli.md) or [test.only()](./api/class-test.md#test-only) is used, it will only apply to the tests from the deepest projects in the project dependency chain. In other words, if a matching test belongs to a project that has project dependencies, Playwright will run all the tests from the project dependencies ignoring the filters.
 
 ## Custom project parameters
 


### PR DESCRIPTION
This patch fixes a typo in the **"Test filtering"** section within the **"Playwright Test"** -> **"Projects"** page. See screenshots below.

<details><summary>Two screenshots</summary>

### Before

<img width="981" alt="CleanShot 2024-03-26 at 15 12 06@2x" src="https://github.com/microsoft/playwright/assets/28879318/e606a696-e3e4-402d-b59e-b8804ec2f6f1">

### After

<img width="980" alt="CleanShot 2024-03-26 at 15 12 33@2x" src="https://github.com/microsoft/playwright/assets/28879318/0cf33703-91fd-4c90-b4a8-e9b82505a699">

</details>