### PR TITLE
fix: UI Mode tags without theme applied

### DIFF
--- a/packages/trace-viewer/src/ui/tag.css
+++ b/packages/trace-viewer/src/ui/tag.css
@@ -29,32 +29,32 @@
   font-weight: 600;
 }
 
-.light-mode .tag-color-0 {
+.tag-color-0 {
   background-color: #ddf4ff;
   color: #0550ae;
   border: 1px solid #218bff;
 }
-.light-mode .tag-color-1 {
+.tag-color-1 {
   background-color: #fff8c5;
   color: #7d4e00;
   border: 1px solid #bf8700;
 }
-.light-mode .tag-color-2 {
+.tag-color-2 {
   background-color: #fbefff;
   color: #6e40c9;
   border: 1px solid #a475f9;
 }
-.light-mode .tag-color-3 {
+.tag-color-3 {
   background-color: #ffeff7;
   color: #99286e;
   border: 1px solid #e85aad;
 }
-.light-mode .tag-color-4 {
+.tag-color-4 {
   background-color: #FFF0EB;
   color: #9E2F1C;
   border: 1px solid #EA6045;
 }
-.light-mode .tag-color-5 {
+.tag-color-5 {
   background-color: #fff1e5;
   color: #9b4215;
   border: 1px solid #e16f24;


### PR DESCRIPTION
Trace Viewer theming is override based. By default you should have something applied - an optional `dark-mode` class might be there too.