### PR TITLE
chore: export MatcherReturnType type

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -7033,7 +7033,7 @@ export type ExpectMatcherState = {
   utils: ExpectMatcherUtils;
 };
 
-type MatcherReturnType = {
+export type MatcherReturnType = {
   message: () => string;
   pass: boolean;
   name?: string;

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -409,7 +409,7 @@ export type ExpectMatcherState = {
   utils: ExpectMatcherUtils;
 };
 
-type MatcherReturnType = {
+export type MatcherReturnType = {
   message: () => string;
   pass: boolean;
   name?: string;


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/30131