### PR TITLE
exporting Devices type

### DIFF
--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -509,7 +509,7 @@ class TypesGenerator {
     let types = await generator.generateTypes(path.join(__dirname, 'overrides.d.ts'));
     const namedDevices = Object.keys(devices).map(name => `  ${JSON.stringify(name)}: DeviceDescriptor;`).join('\n');
     types += [
-      `type Devices = {`,
+      `export type Devices = {`,
       namedDevices,
       `  [key: string]: DeviceDescriptor;`,
       `}`,


### PR DESCRIPTION
This pr exports the auto-generated `Devices` type. 

Without exporting, you can only access the more generic version with `type Devices = typeof devices` which results in the type `[key: string]: DeviceDescriptor` which doesn't have the 'autocompleted' keys