### PR TITLE
test: unflake 'should not include trace resources from the previous chunks' test

### DIFF
--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -432,7 +432,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
       this._browser._contexts.delete(this);
     this._browserType?._contexts?.delete(this);
     this._disposeHarRouters();
-    this.tracing._resetStackCounterIfNeeded();
+    this.tracing._resetStackCounter();
     this.emit(Events.BrowserContext.Close, this);
   }
 

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -432,6 +432,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
       this._browser._contexts.delete(this);
     this._browserType?._contexts?.delete(this);
     this._disposeHarRouters();
+    this.tracing._resetStackCounterIfNeeded();
     this.emit(Events.BrowserContext.Close, this);
   }
 

--- a/packages/playwright-core/src/client/fetch.ts
+++ b/packages/playwright-core/src/client/fetch.ts
@@ -102,6 +102,7 @@ export class APIRequestContext extends ChannelOwner<channels.APIRequestContextCh
   async dispose(): Promise<void> {
     await this._instrumentation.onWillCloseRequestContext(this);
     await this._channel.dispose();
+    this._tracing._resetStackCounter();
     this._request?._contexts.delete(this);
   }
 

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -76,10 +76,7 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
   }
 
   private async _doStopChunk(filePath: string | undefined) {
-    if (this._isTracing) {
-      this._isTracing = false;
-      this._connection.setIsTracing(false);
-    }
+    this._resetStackCounterIfNeeded();
 
     if (!filePath) {
       // Not interested in artifacts.
@@ -112,5 +109,12 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
     await artifact.delete();
 
     await this._connection.localUtils()._channel.zip({ zipFile: filePath, entries: [], mode: 'append', stacksId: this._stacksId, includeSources: this._includeSources });
+  }
+
+  _resetStackCounterIfNeeded() {
+    if (this._isTracing) {
+      this._isTracing = false;
+      this._connection.setIsTracing(false);
+    }
   }
 }

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -76,7 +76,7 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
   }
 
   private async _doStopChunk(filePath: string | undefined) {
-    this._resetStackCounterIfNeeded();
+    this._resetStackCounter();
 
     if (!filePath) {
       // Not interested in artifacts.
@@ -111,7 +111,7 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
     await this._connection.localUtils()._channel.zip({ zipFile: filePath, entries: [], mode: 'append', stacksId: this._stacksId, includeSources: this._includeSources });
   }
 
-  _resetStackCounterIfNeeded() {
+  _resetStackCounter() {
     if (this._isTracing) {
       this._isTracing = false;
       this._connection.setIsTracing(false);

--- a/tests/library/browsercontext-reuse.spec.ts
+++ b/tests/library/browsercontext-reuse.spec.ts
@@ -17,19 +17,17 @@
 import { browserTest, expect } from '../config/browserTest';
 import type { BrowserContext, BrowserContextOptions } from '@playwright/test';
 
-const test = browserTest.extend<{}, { reusedContext: (options?: BrowserContextOptions) => Promise<BrowserContext> }>({
-  reusedContext: [async ({ browserType, browser }, use) => {
-    let context;
+const test = browserTest.extend<{ reusedContext: (options?: BrowserContextOptions) => Promise<BrowserContext> }>({
+  reusedContext: async ({ browserType, browser }, use) => {
     await use(async (options: BrowserContextOptions = {}) => {
       const defaultContextOptions = (browserType as any)._defaultContextOptions;
-      context = await (browser as any)._newContextForReuse({
+      const context = await (browser as any)._newContextForReuse({
         ...defaultContextOptions,
         ...options,
       });
       return context;
     });
-    await context.close();
-  }, { scope: 'worker' }],
+  },
 });
 
 test('should re-add binding after reset', async ({ reusedContext }) => {

--- a/tests/library/browsercontext-reuse.spec.ts
+++ b/tests/library/browsercontext-reuse.spec.ts
@@ -17,17 +17,19 @@
 import { browserTest, expect } from '../config/browserTest';
 import type { BrowserContext, BrowserContextOptions } from '@playwright/test';
 
-const test = browserTest.extend<{ reusedContext: (options?: BrowserContextOptions) => Promise<BrowserContext> }>({
-  reusedContext: async ({ browserType, browser }, use) => {
+const test = browserTest.extend<{}, { reusedContext: (options?: BrowserContextOptions) => Promise<BrowserContext> }>({
+  reusedContext: [async ({ browserType, browser }, use) => {
+    let context;
     await use(async (options: BrowserContextOptions = {}) => {
       const defaultContextOptions = (browserType as any)._defaultContextOptions;
-      const context = await (browser as any)._newContextForReuse({
+      context = await (browser as any)._newContextForReuse({
         ...defaultContextOptions,
         ...options,
       });
       return context;
     });
-  },
+    await context.close();
+  }, { scope: 'worker' }],
 });
 
 test('should re-add binding after reset', async ({ reusedContext }) => {


### PR DESCRIPTION
The problem was the following:

1. [tests/library/browsercontext-reuse.spec.ts:270](https://github.com/microsoft/playwright/blob/32aecac55b67de801bbabf1b5ff4653b4de38139/tests/library/browsercontext-reuse.spec.ts#L270-L285) starts tracing but never stops it.
2. This means that [Connection._tracingCount](https://github.com/microsoft/playwright/blob/7ad255301f500c323030c2a67415a013e2cf0c35/packages/playwright-core/src/client/connection.ts#L76) is still 1 when starting to run other tests
3. In the affected test we start tracing again, and another chunk, so `tracingCount` is 2.
4. When stopping the last chunk, we add its record as an action to the trace, [if the count is > 0](https://github.com/microsoft/playwright/blob/7ad255301f500c323030c2a67415a013e2cf0c35/packages/playwright-core/src/client/connection.ts#L137) - in this case its 1, because there was a stale trace running. So `Tracing.stopChunk` gets added, which creates the resource.txt file and the test will fail.

This PR fixes it based on that in two places:

1. Actually close the re-used context when the reuse tests are done. This does not keep an unused context lying around.
2. Discard Tracing when a context gets closed. This will reset the connection trace counters and dispose all the used resources.

Fixes https://github.com/microsoft/playwright/issues/30247