### PR TITLE
feat(ct): class and object components

### DIFF
--- a/tests/components/ct-vue-vite/src/components/Story.ts
+++ b/tests/components/ct-vue-vite/src/components/Story.ts
@@ -1,0 +1,10 @@
+import { defineComponent, h } from 'vue';
+
+export const Story = defineComponent(
+  (props) => {
+    return () => h('div', props.title);
+  },
+  {
+    props: ['title'],
+  }
+);

--- a/tests/components/ct-vue-vite/tests/render/render.spec.js
+++ b/tests/components/ct-vue-vite/tests/render/render.spec.js
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/experimental-ct-vue';
 import Button from '@/components/Button.vue';
 import EmptyTemplate from '@/components/EmptyTemplate.vue';
 import Component from '@/components/Component.vue';
+import { Story } from '@/components/Story';
 
 test('render props', async ({ mount }) => {
   const component = await mount(Button, {
@@ -22,4 +23,13 @@ test('get textContent of the empty template', async ({ mount }) => {
 test('render a component without options', async ({ mount }) => {
   const component = await mount(Component);
   await expect(component).toContainText('test');
+});
+
+test('render props with defineComponent syntax', async ({ mount }) => {
+  const component = await mount(Story, {
+    props: {
+      title: 'story/wrapper'
+    }
+  });
+  await expect(component).toContainText('story/wrapper');
 });

--- a/tests/components/ct-vue-vite/tests/render/render.spec.ts
+++ b/tests/components/ct-vue-vite/tests/render/render.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/experimental-ct-vue';
 import Button from '@/components/Button.vue';
 import EmptyTemplate from '@/components/EmptyTemplate.vue';
 import Component from '@/components/Component.vue';
+import { Story } from '@/components/Story';
 
 test('render props', async ({ mount }) => {
   const component = await mount(Button, {
@@ -22,4 +23,13 @@ test('get textContent of the empty template', async ({ mount }) => {
 test('render a component without options', async ({ mount }) => {
   const component = await mount(Component);
   await expect(component).toContainText('test');
+});
+
+test('render props with defineComponent syntax', async ({ mount }) => {
+  const component = await mount(Story, {
+    props: {
+      title: 'story/wrapper'
+    }
+  });
+  await expect(component).toContainText('story/wrapper');
 });

--- a/tests/components/ct-vue-vite/tests/render/render.spec.tsx
+++ b/tests/components/ct-vue-vite/tests/render/render.spec.tsx
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/experimental-ct-vue';
 import Button from '@/components/Button.vue';
 import EmptyTemplate from '@/components/EmptyTemplate.vue';
+import { Story } from '@/components/Story';
 
 test('render props', async ({ mount }) => {
   const component = await mount(<Button title='Submit' />);
@@ -18,4 +19,9 @@ test('render an empty component', async ({ page, mount }) => {
   expect(await component.allTextContents()).toEqual(['']);
   expect(await component.textContent()).toBe('');
   await expect(component).toHaveText('');
+});
+
+test('render props with defineComponent syntax', async ({ mount }) => {
+  const component = await mount(<Story title="story/wrapper" />);
+  await expect(component).toContainText('story/wrapper');
 });


### PR DESCRIPTION
closes https://github.com/microsoft/playwright/issues/29544, https://github.com/microsoft/playwright/issues/29928, partially https://github.com/microsoft/playwright/issues/31217 and introduces an improved approach for creating multiple wrapper/story components within a single file _(considering it's only possible to define one component in a `.vue` file)_. @yjaaidi made the change in [`tsxTransform.ts`](https://github.com/sand4rt/playwright/pull/5/files/3449eb8e120b8685bf394cf024ef83161ff21013#diff-8dd3534dc5013c3779edeaded71324b0dd1c1807668f3c6d9e9a1aab1c20ae91) 
