### PR TITLE
fix(playwright): test unexpected result if failed and skipped

### DIFF
--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -290,7 +290,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
       return 'skipped';
 
     const failures = results.filter(result => result.status !== 'skipped' && result.status !== 'interrupted' && result.status !== this.expectedStatus);
-    const skipped = results.filter(result => result.status === 'skipped');
+    const skipped = results.filter(result => result.status === 'skipped' && result.status !== this.expectedStatus);
     const passed = results.filter(result => result.status === 'passed');
     if (!failures.length) // all passed
       return 'expected';

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -296,7 +296,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
       return 'expected';
     if (failures.length === results.length) // all failed
       return 'unexpected';
-    if (failures.length && skipped.length && !passed.length) // some failed, none succedded and the rest where skipped
+    if (failures.length && skipped.length && !passed.length) // some failed, none succeeded and the rest were skipped
       return 'unexpected';
     return 'flaky'; // mixed bag
   }

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -290,9 +290,13 @@ export class TestCase extends Base implements reporterTypes.TestCase {
       return 'skipped';
 
     const failures = results.filter(result => result.status !== 'skipped' && result.status !== 'interrupted' && result.status !== this.expectedStatus);
+    const skipped = results.filter(result => result.status === 'skipped');
+    const passed = results.filter(result => result.status === 'passed');
     if (!failures.length) // all passed
       return 'expected';
     if (failures.length === results.length) // all failed
+      return 'unexpected';
+    if (failures.length && skipped.length && !passed.length) // some failed, none succedded and the rest where skipped
       return 'unexpected';
     return 'flaky'; // mixed bag
   }

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -290,8 +290,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
       return 'skipped';
 
     const failures = results.filter(result => result.status !== 'skipped' && result.status !== 'interrupted' && result.status !== this.expectedStatus);
-    const skipped = results.filter(result => result.status === 'skipped' && result.status !== this.expectedStatus);
-    const passed = results.filter(result => result.status === 'passed');
+    const passed = results.filter(result => result.status === this.expectedStatus);
     if (!failures.length) // all passed
       return 'expected';
     if (failures.length === results.length) // all failed

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -296,7 +296,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
       return 'expected';
     if (failures.length === results.length) // all failed
       return 'unexpected';
-    if (failures.length && skipped.length && !passed.length) // some failed, none succeeded and the rest were skipped
+    if (failures.length && !passed.length) // some failed, none succeeded
       return 'unexpected';
     return 'flaky'; // mixed bag
   }


### PR DESCRIPTION
Fixes #28322

**Changes**:
A test result should be unexpected if it fails (and is not expected) and skips the rest of the runs.
This MR implements this logic, so that runs in serial mode in specific cases (see added unit test) don't cause false positives.

