### PR TITLE
replace full ASCII box w/ only top and bottom to allow copy

### DIFF
--- a/packages/playwright-core/src/utils/ascii.ts
+++ b/packages/playwright-core/src/utils/ascii.ts
@@ -18,9 +18,9 @@ export function wrapInASCIIBox(text: string, padding = 0): string {
   const lines = text.split('\n');
   const maxLength = Math.max(...lines.map(line => line.length));
   return [
-    '╔' + '═'.repeat(maxLength + padding * 2) + '╗',
-    ...lines.map(line => '║' + ' '.repeat(padding) + line + ' '.repeat(maxLength - line.length + padding) + '║'),
-    '╚' + '═'.repeat(maxLength + padding * 2) + '╝',
+    '═'.repeat(maxLength + padding * 2),
+    ...lines.map(line => ' '.repeat(padding) + line + ' '.repeat(maxLength - line.length + padding)),
+    '═'.repeat(maxLength + padding * 2),
   ].join('\n');
 }
 


### PR DESCRIPTION
Fixes #30126

Example with 0 padding :

```bash
═══════════════════════
Hello
World

echo "This is line 1" \
"This is line 2" \
"This is line 3"

multilines ?
═══════════════════════
```