### PR TITLE
fix(docker): set default shell encoding

### DIFF
--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -4,6 +4,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=America/Los_Angeles
 ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright:v%version%-focal"
 
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
 # === INSTALL Node.js ===
 
 RUN apt-get update && \

--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -4,6 +4,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=America/Los_Angeles
 ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright:v%version%-jammy"
 
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
 # === INSTALL Node.js ===
 
 RUN apt-get update && \


### PR DESCRIPTION
This seems to be common practise, as per [here](https://github.com/search?q=org%3Amicrosoft%20%2FENV%20LANG%3DC.UTF-8%2F&type=code).

Fixes https://github.com/microsoft/playwright/issues/30245
Fixes https://github.com/microsoft/playwright/issues/28642