### PR TITLE
test: add test for 'should parse cookie with large Max-Age correctly'

### DIFF
--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -403,7 +403,7 @@ it('should support requestStorageAccess', async ({ page, server, channel, browse
 
 it('should parse cookie with large Max-Age correctly', async ({ server, page, defaultSameSiteCookieValue, browserName, platform }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/30305' });
-  it.skip(browserName === 'webkit' && platform === 'linux', 'https://github.com/microsoft/playwright/issues/30305');
+  it.fixme(browserName === 'webkit' && platform === 'linux', 'https://github.com/microsoft/playwright/issues/30305');
 
   server.setRoute('/foobar', (req, res) => {
     res.setHeader('set-cookie', [

--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -400,3 +400,30 @@ it('should support requestStorageAccess', async ({ page, server, channel, browse
     }
   }
 });
+
+it('should parse cookie with large Max-Age correctly', async ({ server, page, defaultSameSiteCookieValue, browserName, platform }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/30305' });
+  it.skip(browserName === 'webkit' && platform === 'linux', 'https://github.com/microsoft/playwright/issues/30305');
+
+  server.setRoute('/foobar', (req, res) => {
+    res.setHeader('set-cookie', [
+      'cookie1=value1; Path=/; Expires=Thu, 08 Sep 2270 15:06:12 GMT; Max-Age=7776000000'
+    ]);
+    res.statusCode = 200;
+    res.end();
+  });
+  await page.goto(server.PREFIX + '/foobar');
+  expect(await page.evaluate(() => document.cookie)).toBe('cookie1=value1');
+  expect(await page.context().cookies()).toEqual([
+    {
+      name: 'cookie1',
+      value: 'value1',
+      domain: 'localhost',
+      path: '/',
+      expires: expect.any(Number),
+      httpOnly: false,
+      secure: false,
+      sameSite: defaultSameSiteCookieValue,
+    },
+  ]);
+});


### PR DESCRIPTION
Test for https://github.com/microsoft/playwright/issues/30305.

It passes across the board on macOS. Also it passes in Firefox + Chromium on Linux. So we should make WebKit on Linux work.

