### PR TITLE
feat(chromium-tip-of-tree): roll to r1211

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -9,9 +9,9 @@
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1210",
+      "revision": "1211",
       "installByDefault": false,
-      "browserVersion": "125.0.6408.0"
+      "browserVersion": "125.0.6412.0"
     },
     {
       "name": "firefox",


### PR DESCRIPTION
Bisect RANGE: https://chromium.googlesource.com/chromium/src/+log/d0df26553773add67138d8fbf1bfc9edb4f8d7d4..a0295f6b8caaffb87654f8fbf0b5feb5cc0872a9
Upstream CL: https://chromium-review.googlesource.com/c/chromium/src/+/5437174
Repro: `npx bisect-chrome --good 1284140 --bad 1285417 --shell "npm run ctest -- --timeout=5000 --reporter=list library/capabilities.spec.ts:133:3"`
Regression: Timeout on setContent

Looks like that we before returned `false` in `content::ContentRendererClient overrides` because we ended up [here](https://source.chromium.org/chromium/chromium/src/+/main:media/base/supported_types.cc;l=356;drc=2a5aaed0ff3a0895c8551495c2656ed49baf742c). And now on the bots we return `true` because we end up [here](https://source.chromium.org/chromium/chromium/src/+/main:headless/lib/renderer/headless_content_renderer_client.cc;l=44-51) and override the method.

Maybe fallback to [IsDefaultSupportedVideoType](https://source.chromium.org/chromium/chromium/src/+/main:media/base/supported_types.cc;drc=2a5aaed0ff3a0895c8551495c2656ed49baf742c;l=350) like it was before if the CLI arg wasn't specified?

Upstream bug: https://issues.chromium.org/issues/333858791