### PR TITLE
fix(merge): preserve static annotations on the tests that did not run

### DIFF
--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -69,6 +69,7 @@ export type JsonTestCase = {
   retries: number;
   tags?: string[];
   repeatEachIndex: number;
+  annotations?: { type: string, description?: string }[];
 };
 
 export type JsonTestEnd = {
@@ -366,6 +367,7 @@ export class TeleReporterReceiver {
     test.location = this._absoluteLocation(payload.location);
     test.retries = payload.retries;
     test.tags = payload.tags ?? [];
+    test.annotations = payload.annotations ?? [];
     return test;
   }
 

--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -208,6 +208,7 @@ export class TeleReporterEmitter implements ReporterV2 {
       retries: test.retries,
       tags: test.tags,
       repeatEachIndex: test.repeatEachIndex,
+      annotations: test.annotations,
     };
   }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/30260