### PR TITLE
fix: running electron tests on windows for node 20.12.2

### DIFF
--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -208,6 +208,7 @@ export class Electron extends SdkObject {
           progress.log(message);
           browserLogsCollector.log(message);
         },
+        shell: true,
         stdio: 'pipe',
         cwd: options.cwd,
         tempDirectories: [artifactsDir],


### PR DESCRIPTION
When running electron tests on Windows with Node 20.12.2, there will be a "spawn EINVAL" error on `electron.launch`.
Found a fix to a similar issue in https://github.com/node-red/node-red/pull/4652.

> Following the 18.20.2/20.12.2 node.js releases, it is no longer valid to call child_process.spawn with a .cmd or .bat file without using the shell: true option.