### PR TITLE
feat(test runner): Use timing file to balance shards

### DIFF
--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -57,6 +57,7 @@ export class FullConfigInternal {
   cliPassWithNoTests?: boolean;
   testIdMatcher?: Matcher;
   defineConfigWasUsed = false;
+  cliTimingFile?: string;
 
   constructor(location: ConfigLocation, userConfig: Config, configCLIOverrides: ConfigCLIOverrides) {
     if (configCLIOverrides.projects && userConfig.projects)

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -189,6 +189,7 @@ async function runTests(args: string[], opts: { [key: string]: any }) {
   config.cliListOnly = !!opts.list;
   config.cliProjectFilter = opts.project || undefined;
   config.cliPassWithNoTests = !!opts.passWithNoTests;
+  config.cliTimingFile = opts.timingFile || undefined;
 
   const runner = new Runner(config);
   let status: FullResult['status'];
@@ -336,6 +337,7 @@ const testOptions: [string, string][] = [
   ['--global-timeout <timeout>', `Maximum time this test suite can run in milliseconds (default: unlimited)`],
   ['-g, --grep <grep>', `Only run tests matching this regular expression (default: ".*")`],
   ['-gv, --grep-invert <grep>', `Only run tests that do not match this regular expression`],
+  ['--timing-file <file>', `Load JSON report to use as timing file for shard balancing`],
   ['--headed', `Run tests in headed browsers (default: headless)`],
   ['--ignore-snapshots', `Ignore screenshot and snapshot expectations`],
   ['--list', `Collect all the tests and report them, but do not run`],

--- a/packages/playwright/src/runner/testGroups.ts
+++ b/packages/playwright/src/runner/testGroups.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JSONReport, JSONReportSuite, JSONReportTestResult } from 'packages/playwright-test/reporter';
+import type { JSONReport, JSONReportSuite } from 'packages/playwright-test/reporter';
 import type { Suite, TestCase } from '../common/test';
 
 export type TestGroup = {
@@ -29,7 +29,7 @@ type testDetails = {
   id: string,
   name: string,
   duration: number
-}
+};
 
 export function createTestGroups(projectSuite: Suite, workers: number): TestGroup[] {
   // This function groups tests that can be run together.
@@ -180,23 +180,23 @@ export function filterForShardFromTimingFile(timingFile: JSONReport, shard: { to
   recordedTests.forEach(group => result.add(group));
 
   // If not all test groups have recorded timing information, filter the remaining groups based on shard distribution
-  if (testDetails.length != testGroups.length) {
+  if (testDetails.length !== testGroups.length) {
     const allTestIds = testDetails.map(shardDetails => shardDetails.id);
     const UnrecordedTests = testGroups.filter(group => !allTestIds.includes(group.tests[0].id));
 
     let shardableTotal = 0;
     for (const group of UnrecordedTests)
       shardableTotal += group.tests.length;
-  
+
     // Each shard gets some tests.
     const shardSize = Math.floor(shardableTotal / shard.total);
     // First few shards get one more test each.
     const extraOne = shardableTotal - shardSize * shard.total;
-  
+
     const currentShard = shard.current - 1; // Make it zero-based for calculations.
     const from = shardSize * currentShard + Math.min(extraOne, currentShard);
     const to = from + shardSize + (currentShard < extraOne ? 1 : 0);
-  
+
     let current = 0;
     for (const group of UnrecordedTests) {
       // Any test group goes to the shard that contains the first test of this group.
@@ -211,7 +211,7 @@ export function filterForShardFromTimingFile(timingFile: JSONReport, shard: { to
 
 // Extracts test details from a JSON report and returns an array of test details objects.
 function getAllTestDetails(report: JSONReport) {
-  const allTestDetails:testDetails[] = [];
+  const allTestDetails: testDetails[] = [];
   report.suites.forEach((suite: JSONReportSuite) => {
     getTestDetails(suite, allTestDetails);
   });
@@ -222,9 +222,9 @@ function getAllTestDetails(report: JSONReport) {
 // Recursively traverses through test suites in a JSON report and extracts test details.
 function getTestDetails(suite: JSONReportSuite, allTestDetails: testDetails[]) {
   if (suite.specs) {
-    suite.specs.forEach((spec) => {
-      spec.tests.forEach((test) => {
-        test.results.forEach((result) => {
+    suite.specs.forEach(spec => {
+      spec.tests.forEach(test => {
+        test.results.forEach(result => {
           allTestDetails.push({
             id: spec.id,
             name: spec.title,
@@ -236,7 +236,7 @@ function getTestDetails(suite: JSONReportSuite, allTestDetails: testDetails[]) {
   }
 
   if (suite.suites) {
-    suite.suites.forEach((subSuite) => {
+    suite.suites.forEach(subSuite => {
       getTestDetails(subSuite, allTestDetails);
     });
   }
@@ -245,13 +245,13 @@ function getTestDetails(suite: JSONReportSuite, allTestDetails: testDetails[]) {
 function mapTestDetailsToShards(testDetails: testDetails[], shard: {total: number, current: number}) {
   testDetails.sort((a, b) => b.duration - a.duration);
 
-  const result:testDetails[][] = Array.from({ length: shard.total }, () => []);
+  const result: testDetails[][] = Array.from({ length: shard.total }, () => []);
   const sums = Array(shard.total).fill(0);
 
   // Distribute tests to shards based on their durations
-  for (let testDetailsObj of testDetails) {
+  for (const testDetailsObj of testDetails) {
     // Find the shard with the smallest total duration and assign the test to that shard
-    let minIndex = sums.indexOf(Math.min(...sums));
+    const minIndex = sums.indexOf(Math.min(...sums));
     result[minIndex].push(testDetailsObj);
     sums[minIndex] += testDetailsObj.duration;
   }

--- a/packages/playwright/src/runner/testGroups.ts
+++ b/packages/playwright/src/runner/testGroups.ts
@@ -175,8 +175,6 @@ export function filterForShardFromTimingFile(timingFile: JSONReport, shard: { to
   const shardsMapping = mapTestDetailsToShards(testDetails, shard);
   const testIds = shardsMapping[shard.current - 1].map(shardDetails => shardDetails.id);
   const recordedTests = testGroups.filter(group => testIds.includes(group.tests[0].id));
-  // console.log(shardsMapping);
-  // console.log(testDetails.length);
   const result = new Set<TestGroup>();
 
   recordedTests.forEach(group => result.add(group));
@@ -256,10 +254,6 @@ function mapTestDetailsToShards(testDetails: testDetails[], shard: {total: numbe
     let minIndex = sums.indexOf(Math.min(...sums));
     result[minIndex].push(testDetailsObj);
     sums[minIndex] += testDetailsObj.duration;
-  }
-
-  for (let i = 0; i < shard.total; i++) {
-    console.log(`Total duration for array ${i + 1}: ${sums[i]}`);
   }
 
   return result;


### PR DESCRIPTION
This feature came from this issue: https://github.com/microsoft/playwright/issues/17969

The idea is to use the JSON reporter and extract the duration of each test, then map the test groups based on the duration so the shards are all as equal as possible, the amount of tests per shard is not relevant here, only the duration of the tests.
If there are tests that are not recorded in the JSON report they will be distributed like they currently do based on the amount.

This is still in a POC state to get some feedback, but the functionality works well.

Some open questions:
- Not sure about the behavior of non-parallel tests/files
- Optionally adding a config flag as well, currently it's only available from CI
- Do we want to use the JSON report, or create a custom 'TestDetails' report which only includes the necessary data

At the end of the day unless you come up with some cloud solution, the 'infra' for this feature would need to be done mostly manually, a static JSON report is optional but might get irrelevant very fast.
On my project I've managed it by averaging the durations of the last 10 successful runs, which is being updated to a CDN from CI.

Some more details on current POC can be seen here:
https://github.com/microsoft/playwright/issues/17969#issuecomment-2037376375
https://github.com/microsoft/playwright/issues/17969#issuecomment-2042791382