### PR TITLE
fix(role): explicitly hidden aria-labelledby should be recursively traversed

### DIFF
--- a/tests/assets/axe-core/accessible-text.js
+++ b/tests/assets/axe-core/accessible-text.js
@@ -73,10 +73,7 @@ module.exports = [
       '<label for="t1">HTML Label</label>' +
       '<input type="text" id="t1" aria-labelledby="t1label">',
     target: '#t1',
-    // accessibleText: 'This is a hidden secret',
-    // Note: axe-core insists on child nodes being used as visible, although
-    // spec 2A says "directly referenced by aria-labelledby".
-    accessibleText: 'This is a',
+    accessibleText: 'This is a hidden secret',
   },
 
   {

--- a/tests/library/role-utils.spec.ts
+++ b/tests/library/role-utils.spec.ts
@@ -306,6 +306,26 @@ test('display:contents should be visible when contents are visible', async ({ pa
   await expect(page.getByRole('button')).toHaveCount(1);
 });
 
+test('label/labelled-by aria-hidden with descendants', async ({ page }) => {
+  await page.setContent(`
+    <body>
+      <div id="case1">
+        <button aria-labelledby="label1" type="button"></button>
+        <tool-tip id="label1" for="button-preview" popover="manual" aria-hidden="true" role="tooltip">Label1</tool-tip>
+      </div>
+      <div id="case2">
+        <label for="button2" aria-hidden="true"><div id="label2">Label2</div></label>
+        <button id="button2" type="button"></button>
+      </div>
+    </body>
+  `);
+  await page.$$eval('#label1, #label2', els => {
+    els.forEach(el => el.attachShadow({ mode: 'open' }).appendChild(document.createElement('slot')));
+  });
+  expect.soft(await getNameAndRole(page, '#case1 button')).toEqual({ role: 'button', name: 'Label1' });
+  expect.soft(await getNameAndRole(page, '#case2 button')).toEqual({ role: 'button', name: 'Label2' });
+});
+
 function toArray(x: any): any[] {
   return Array.isArray(x) ? x : [x];
 }


### PR DESCRIPTION
The accessible name computation spec has changed to explicitly mention this case:

Step 2A. Hidden Not Referenced. If the current node is hidden and is:
- Not part of an aria-labelledby or aria-describedby traversal, where the node directly referenced by that relation was hidden.
- Nor part of a native host language text alternative element (e.g. label in HTML) or attribute traversal, where the root of that traversal was hidden.

See https://w3c.github.io/accname/#computation-steps. Chromium, Firefox and Safari all agree with the spec.

Fixes #29796.