### PR TITLE
fix: rebuild project tree from scratch when listing tests

### DIFF
--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -521,6 +521,11 @@ export class TeleTestCase implements reporterTypes.TestCase {
     this._resultsMap.clear();
   }
 
+  _restoreResults(snapshot: Map<string, TeleTestResult>) {
+    this.results = [...snapshot.values()];
+    this._resultsMap = snapshot;
+  }
+
   _createTestResult(id: string): TeleTestResult {
     const result = new TeleTestResult(this.results.length);
     this.results.push(result);

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -146,6 +146,11 @@ export class TeleReporterReceiver {
     this._reporter = reporter;
   }
 
+  reset() {
+    this._rootSuite._entries = [];
+    this._tests.clear();
+  }
+
   dispatch(message: JsonEvent): Promise<void> | void {
     const { method, params } = message;
     if (method === 'onConfigure') {
@@ -206,35 +211,6 @@ export class TeleReporterReceiver {
     projectSuite._project = this._parseProject(project);
     for (const suite of project.suites)
       this._mergeSuiteInto(suite, projectSuite);
-
-    // Remove deleted tests when listing. Empty suites will be auto-filtered
-    // in the UI layer.
-    if (this.isListing) {
-      const testIds = new Set<string>();
-      const collectIds = (suite: JsonSuite) => {
-        suite.entries.forEach(entry => {
-          if ('testId' in entry)
-            testIds.add(entry.testId);
-          else
-            collectIds(entry);
-        });
-      };
-      project.suites.forEach(collectIds);
-
-      const filterTests = (suite: TeleSuite) => {
-        suite._entries = suite._entries.filter(entry => {
-          if (entry.type === 'test') {
-            if (testIds.has(entry.id))
-              return true;
-            this._tests.delete(entry.id);
-            return false;
-          }
-          filterTests(entry);
-          return true;
-        });
-      };
-      filterTests(projectSuite);
-    }
   }
 
   private _onBegin() {
@@ -585,7 +561,7 @@ class TeleTestStep implements reporterTypes.TestStep {
   }
 }
 
-class TeleTestResult implements reporterTypes.TestResult {
+export class TeleTestResult implements reporterTypes.TestResult {
   retry: reporterTypes.TestResult['retry'];
   parallelIndex: reporterTypes.TestResult['parallelIndex'] = -1;
   workerIndex: reporterTypes.TestResult['workerIndex'] = -1;

--- a/packages/trace-viewer/src/ui/teleSuiteUpdater.ts
+++ b/packages/trace-viewer/src/ui/teleSuiteUpdater.ts
@@ -82,11 +82,11 @@ export class TeleSuiteUpdater {
         this.progress.passed = 0;
         this.progress.failed = 0;
         this.progress.skipped = 0;
-        this._options.onUpdate(true);
+        // Do not call this._options.onUpdate(); here, as we want to wait
+        // for the test results to be restored in list mode.
       },
 
       onEnd: () => {
-        this._options.onUpdate(true);
       },
 
       onTestBegin: (test: reporterTypes.TestCase, testResult: reporterTypes.TestResult) => {
@@ -131,6 +131,7 @@ export class TeleSuiteUpdater {
       this._receiver.dispatch(message);
     // After recreating all projects restore previous results.
     results?.restore(this.rootSuite!);
+    this._options.onUpdate(true);
   }
 
   processTestReportEvent(message: any) {

--- a/packages/trace-viewer/src/ui/teleSuiteUpdater.ts
+++ b/packages/trace-viewer/src/ui/teleSuiteUpdater.ts
@@ -130,7 +130,7 @@ export class TeleSuiteUpdater {
     for (const message of report)
       this._receiver.dispatch(message);
     // After recreating all projects restore previous results.
-    results?.restore(this.rootSuite!)
+    results?.restore(this.rootSuite!);
   }
 
   processTestReportEvent(message: any) {


### PR DESCRIPTION
Instead of filtering tests assuming there are no two projects with same name we always rebuild test tree from scratch and restore previos test results in the list mode.

Fixes https://github.com/microsoft/playwright/issues/30396