### PR TITLE
Fix issues with audio in macOS 14 on GitHub Actions

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -169,6 +169,10 @@ jobs:
     env:
       PWTEST_BOT_NAME: "${{ matrix.browser }}-headed-${{ matrix.os }}"
     steps:
+    # https://github.com/actions/runner-images/issues/9330
+    - name: Allow microphone access to all apps (macOS 14)
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -65,6 +65,10 @@ jobs:
     env:
       PWTEST_BOT_NAME: "${{ matrix.browser }}-${{ matrix.os }}"
     steps:
+    # https://github.com/actions/runner-images/issues/9330
+    - name: Allow microphone access to all apps (macOS 14)
+      if: ${{ matrix.os == 'macos-14' }}
+      run: sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
While investigating a similar issue in my own repository, I noticed that some tests that play audio are failing on `macos-14` (e.g. https://github.com/microsoft/playwright/actions/runs/8727564874/job/23945367541). This happens because a microphone permission dialog appears whenever sound is first played.

This PR adds the microphone permission for all apps to the [TCC database](https://www.rainforestqa.com/blog/macos-tcc-db-deep-dive), preventing the issue from happening.

More info: https://github.com/actions/runner-images/issues/9330

In particular it fixes the following tests which were failing on Firefox and Chromium on newer macOS versions.

- should not crash on page with mp4 @smoke
- [should play video @smoke](https://github.com/microsoft/playwright/blob/984182bd5304ceabc9b5b06e1a74430a62d7b6fe/tests/library/capabilities.spec.ts#L67)
- should play audio