### PR TITLE
fix: pass key attribute from jsx to component test

### DIFF
--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -40,7 +40,10 @@ function __pwRender(value) {
     if (isJsxComponent(v)) {
       const component = v;
       const props = component.props ? __pwRender(component.props) : {};
+      const key = component.key ? __pwRender(component.key) : undefined;
       const { children, ...propsWithoutChildren } = props;
+      if (key)
+        propsWithoutChildren.key = key;
       const createElementArguments = [propsWithoutChildren];
       if (children)
         createElementArguments.push(children);

--- a/packages/playwright-ct-react17/registerSource.mjs
+++ b/packages/playwright-ct-react17/registerSource.mjs
@@ -40,7 +40,10 @@ function __pwRender(value) {
     if (isJsxComponent(v)) {
       const component = v;
       const props = component.props ? __pwRender(component.props) : {};
+      const key = component.key ? __pwRender(component.key) : undefined;
       const { children, ...propsWithoutChildren } = props;
+      if (key)
+        propsWithoutChildren.key = key;
       const createElementArguments = [propsWithoutChildren];
       if (children)
         createElementArguments.push(children);

--- a/packages/playwright/jsx-runtime.js
+++ b/packages/playwright/jsx-runtime.js
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-function jsx(type, props) {
+function jsx(type, props, key) {
   return {
     __pw_type: 'jsx',
     type,
     props,
+    key,
   };
 }
 
-function jsxs(type, props) {
+function jsxs(type, props, key) {
   return {
     __pw_type: 'jsx',
     type,
     props,
+    key,
   };
 }
 


### PR DESCRIPTION
When using the `key` attribute in jsx inside the test modules, it is not serialised and passed to the browser in component test