### PR TITLE
Try running audio/video tests on more browsers and platforms

### DIFF
--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -64,13 +64,7 @@ it('should respect CSP @smoke', async ({ page, server }) => {
   expect(await page.evaluate(() => window['testStatus'])).toBe('SUCCESS');
 });
 
-it('should play video @smoke', async ({ page, asset, browserName, platform, mode }) => {
-  // TODO: the test passes on Windows locally but fails on GitHub Action bot,
-  // apparently due to a Media Pack issue in the Windows Server.
-  // Also the test is very flaky on Linux WebKit.
-  it.fixme(browserName === 'webkit' && platform !== 'darwin');
-  it.fixme(browserName === 'firefox', 'https://github.com/microsoft/playwright/issues/5721');
-  it.fixme(browserName === 'webkit' && platform === 'darwin' && parseInt(os.release(), 10) === 20, 'Does not work on BigSur');
+it('should play video @smoke', async ({ page, asset, browserName, mode }) => {
   it.skip(mode.startsWith('service'));
 
   // Safari only plays mp4 so we test WebKit with an .mp4 clip.
@@ -83,9 +77,7 @@ it('should play video @smoke', async ({ page, asset, browserName, platform, mode
   await page.$eval('video', v => v.pause());
 });
 
-it('should play webm video @smoke', async ({ page, asset, browserName, platform, mode }) => {
-  it.fixme(browserName === 'webkit' && platform === 'darwin' && parseInt(os.release(), 10) === 20, 'Does not work on BigSur');
-  it.fixme(browserName === 'webkit' && platform === 'win32');
+it('should play webm video @smoke', async ({ page, asset, mode }) => {
   it.skip(mode.startsWith('service'));
 
   const absolutePath = asset('video_webm.html');
@@ -96,10 +88,7 @@ it('should play webm video @smoke', async ({ page, asset, browserName, platform,
   await page.$eval('video', v => v.pause());
 });
 
-it('should play audio @smoke', async ({ page, server, browserName, platform }) => {
-  it.fixme(browserName === 'firefox' && platform === 'win32', 'https://github.com/microsoft/playwright/issues/10887');
-  it.fixme(browserName === 'firefox' && platform === 'linux', 'https://github.com/microsoft/playwright/issues/10887');
-  it.fixme(browserName === 'webkit' && platform === 'win32', 'https://github.com/microsoft/playwright/issues/10892');
+it('should play audio @smoke', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<audio src="${server.PREFIX}/example.mp3"></audio>`);
   await page.$eval('audio', e => e.play());
@@ -130,9 +119,7 @@ it('should support webgl 2 @smoke', async ({ page, browserName, headless, isWind
   expect(hasWebGL2).toBe(true);
 });
 
-it('should not crash on page with mp4 @smoke', async ({ page, server, platform, browserName }) => {
-  it.fixme(browserName === 'webkit' && platform === 'win32', 'https://github.com/microsoft/playwright/issues/11009, times out in setContent');
-  it.fixme(browserName === 'firefox', 'https://bugzilla.mozilla.org/show_bug.cgi?id=1697004');
+it('should not crash on page with mp4 @smoke', async ({ page, server }) => {
   await page.setContent(`<video><source src="${server.PREFIX}/movie.mp4"/></video>`);
   await page.waitForTimeout(1000);
 });

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -69,6 +69,7 @@ it('should play video @smoke', async ({ page, asset, browserName, platform, mode
   // apparently due to a Media Pack issue in the Windows Server.
   // Also the test is very flaky on Linux WebKit.
   it.fixme(browserName === 'webkit' && platform !== 'darwin');
+  it.fixme(browserName === 'webkit' && platform === 'darwin' && parseInt(os.release(), 10) === 21, 'Flaky on macOS 12');
   it.skip(mode.startsWith('service'));
 
   // Safari only plays mp4 so we test WebKit with an .mp4 clip.
@@ -95,6 +96,7 @@ it('should play webm video @smoke', async ({ page, asset, browserName, platform,
 
 it('should play audio @smoke', async ({ page, server, browserName, platform }) => {
   it.fixme(browserName === 'webkit' && platform !== 'darwin');
+  it.fixme(browserName === 'webkit' && platform === 'darwin' && parseInt(os.release(), 10) === 21, 'Flaky on macOS 12');
 
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<audio src="${server.PREFIX}/example.mp3"></audio>`);

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -64,7 +64,11 @@ it('should respect CSP @smoke', async ({ page, server }) => {
   expect(await page.evaluate(() => window['testStatus'])).toBe('SUCCESS');
 });
 
-it('should play video @smoke', async ({ page, asset, browserName, mode }) => {
+it('should play video @smoke', async ({ page, asset, browserName, platform, mode }) => {
+  // TODO: the test passes on Windows locally but fails on GitHub Action bot,
+  // apparently due to a Media Pack issue in the Windows Server.
+  // Also the test is very flaky on Linux WebKit.
+  it.fixme(browserName === 'webkit' && platform !== 'darwin');
   it.skip(mode.startsWith('service'));
 
   // Safari only plays mp4 so we test WebKit with an .mp4 clip.
@@ -77,7 +81,8 @@ it('should play video @smoke', async ({ page, asset, browserName, mode }) => {
   await page.$eval('video', v => v.pause());
 });
 
-it('should play webm video @smoke', async ({ page, asset, mode }) => {
+it('should play webm video @smoke', async ({ page, asset, browserName, platform, mode }) => {
+  it.fixme(browserName === 'webkit' && platform !== 'darwin');
   it.skip(mode.startsWith('service'));
 
   const absolutePath = asset('video_webm.html');
@@ -88,7 +93,9 @@ it('should play webm video @smoke', async ({ page, asset, mode }) => {
   await page.$eval('video', v => v.pause());
 });
 
-it('should play audio @smoke', async ({ page, server }) => {
+it('should play audio @smoke', async ({ page, server, browserName, platform }) => {
+  it.fixme(browserName === 'webkit' && platform !== 'darwin');
+
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<audio src="${server.PREFIX}/example.mp3"></audio>`);
   await page.$eval('audio', e => e.play());

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -126,7 +126,9 @@ it('should support webgl 2 @smoke', async ({ page, browserName, headless, isWind
   expect(hasWebGL2).toBe(true);
 });
 
-it('should not crash on page with mp4 @smoke', async ({ page, server }) => {
+it('should not crash on page with mp4 @smoke', async ({ page, server, platform, browserName }) => {
+  it.fixme(browserName === 'webkit' && platform === 'win32', 'times out in setContent');
+
   await page.setContent(`<video><source src="${server.PREFIX}/movie.mp4"/></video>`);
   await page.waitForTimeout(1000);
 });


### PR DESCRIPTION
I'm trying to debug a Playwright issue with `AudioContext` on Windows runners (will file a separate issue if I can't figure it out), and I'm interested to see if Playwright's audio/video tests now work on all platforms and browsers.

This PR removes some `it.fixme` annotations from the audio/video tests in `capabilities.spec.ts`. All the `it.fixme` lines I removed were added more than a year ago, and all the linked issues look like they are resolved.

Related: https://github.com/microsoft/playwright/pull/30410