### PR TITLE
devops: fix headed macOS-14 bots

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -200,14 +200,14 @@ jobs:
       fail-fast: false
       matrix:
         browser: [chromium, firefox, webkit]
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
       PWTEST_BOT_NAME: "${{ matrix.browser }}-headed-${{ matrix.os }}"
     steps:
     # https://github.com/actions/runner-images/issues/9330
     - name: Allow microphone access to all apps (macOS 14)
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ matrix.os == 'macos-14' }}
       run: sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/playwright/pull/30410 - they gradually roll out the new -latest version. Lets stick with 14 for now.

Fixes https://github.com/microsoft/playwright/actions/runs/8758947170/job/24040933743