### PR TITLE
docs: add third-party GitHub pull request reporter

### DIFF
--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -355,6 +355,7 @@ npx playwright test --reporter="./myreporter/my-awesome-reporter.ts"
 * [Argos Visual Testing](https://argos-ci.com/docs/playwright)
 * [Currents](https://www.npmjs.com/package/@currents/playwright)
 * [GitHub Actions Reporter](https://www.npmjs.com/package/@estruyf/github-actions-reporter)
+* [GitHub Pull Request Comment](https://github.com/marketplace/actions/playwright-report-comment)
 * [Monocart](https://github.com/cenfun/monocart-reporter)
 * [ReportPortal](https://github.com/reportportal/agent-js-playwright)
 * [Serenity/JS](https://serenity-js.org/handbook/test-runners/playwright-test)


### PR DESCRIPTION
Add a new third-party reporter: [Playwright Report Comment Action](https://github.com/marketplace/actions/playwright-report-comment).

A GitHub action that comments report summaries on pull requests.

Screenshots visible in the action readme and below.

![Screenshot](https://github.com/daun/playwright-report-summary/raw/main/assets/comment-passed.png)

![Screenshot](https://github.com/daun/playwright-report-summary/raw/main/assets/comment-failed.png)
