### PR TITLE
chore: generate globalTimeout and maxFailures errors in runner

### DIFF
--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -194,8 +194,6 @@ export class BaseReporter implements ReporterV2 {
       tokens.push(colors.yellow(`  ${didNotRun} did not run`));
     if (expected)
       tokens.push(colors.green(`  ${expected} passed`) + colors.dim(` (${milliseconds(this.result.duration)})`));
-    if (this.result.status === 'timedout')
-      tokens.push(colors.red(`  Timed out waiting ${this.config.globalTimeout / 1000}s for the entire test run`));
     if (fatalErrors.length && expected + unexpected.length + interrupted.length + flaky.length > 0)
       tokens.push(colors.red(`  ${fatalErrors.length === 1 ? '1 error was not a part of any test' : fatalErrors.length + ' errors were not a part of any test'}, see above for details`));
 
@@ -250,7 +248,6 @@ export class BaseReporter implements ReporterV2 {
     if (full && summary.failuresToPrint.length && !this._omitFailures)
       this._printFailures(summary.failuresToPrint);
     this._printSlowTests();
-    this._printMaxFailuresReached();
     this._printSummary(summaryMessage);
   }
 
@@ -270,14 +267,6 @@ export class BaseReporter implements ReporterV2 {
     });
     if (slowTests.length)
       console.log(colors.yellow('  Consider splitting slow test files to speed up parallel execution'));
-  }
-
-  private _printMaxFailuresReached() {
-    if (!this.config.maxFailures)
-      return;
-    if (this._failureCount < this.config.maxFailures)
-      return;
-    console.log(colors.yellow(`Testing stopped early after ${this.config.maxFailures} maximum allowed failures.`));
   }
 
   private _printSummary(summary: string) {

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -26,6 +26,7 @@ import type { TestGroup } from './testGroups';
 import type { FullConfigInternal } from '../common/config';
 import type { ReporterV2 } from '../reporters/reporterV2';
 import type { FailureTracker } from './failureTracker';
+import { colors } from 'playwright-core/lib/utilsBundle';
 
 export type EnvByProjectId = Map<string, Record<string, string | undefined>>;
 
@@ -542,9 +543,13 @@ class JobDispatcher {
 
   private _reportTestEnd(test: TestCase, result: TestResult) {
     this._reporter.onTestEnd(test, result);
+    const hadMaxFailures = this._failureTracker.hasReachedMaxFailures()
     this._failureTracker.onTestEnd(test, result);
-    if (this._failureTracker.hasReachedMaxFailures())
+    if (this._failureTracker.hasReachedMaxFailures()) {
       this._stopCallback();
+      if (!hadMaxFailures)
+        this._reporter.onError({ message: colors.red(`Testing stopped early after ${this._failureTracker.maxFailures()} maximum allowed failures.`) });
+    }
   }
 }
 

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -543,7 +543,7 @@ class JobDispatcher {
 
   private _reportTestEnd(test: TestCase, result: TestResult) {
     this._reporter.onTestEnd(test, result);
-    const hadMaxFailures = this._failureTracker.hasReachedMaxFailures()
+    const hadMaxFailures = this._failureTracker.hasReachedMaxFailures();
     this._failureTracker.onTestEnd(test, result);
     if (this._failureTracker.hasReachedMaxFailures()) {
       this._stopCallback();

--- a/packages/playwright/src/runner/failureTracker.ts
+++ b/packages/playwright/src/runner/failureTracker.ts
@@ -40,8 +40,7 @@ export class FailureTracker {
   }
 
   hasReachedMaxFailures() {
-    const maxFailures = this._config.config.maxFailures;
-    return maxFailures > 0 && this._failureCount >= maxFailures;
+    return this.maxFailures() > 0 && this._failureCount >= this.maxFailures();
   }
 
   hasWorkerErrors() {
@@ -50,5 +49,9 @@ export class FailureTracker {
 
   result(): 'failed' | 'passed' {
     return this._hasWorkerErrors || this.hasReachedMaxFailures() || this._rootSuite?.allTests().some(test => !test.ok()) ? 'failed' : 'passed';
+  }
+
+  maxFailures() {
+    return this._config.config.maxFailures;
   }
 }

--- a/packages/playwright/src/runner/taskRunner.ts
+++ b/packages/playwright/src/runner/taskRunner.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { debug } from 'playwright-core/lib/utilsBundle';
+import { colors, debug } from 'playwright-core/lib/utilsBundle';
 import { ManualPromise, monotonicTime } from 'playwright-core/lib/utils';
 import type { FullResult, TestError } from '../../types/testReporter';
 import { SigIntWatcher } from './sigIntWatcher';
@@ -99,7 +99,7 @@ export class TaskRunner<Context> {
     if (sigintWatcher.hadSignal() || cancelPromise?.isDone()) {
       status = 'interrupted';
     } else if (timeoutWatcher.timedOut()) {
-      this._reporter.onError?.({ message: `Timed out waiting ${this._globalTimeoutForError / 1000}s for the ${currentTaskName} to run` });
+      this._reporter.onError?.({ message: colors.red(`Timed out waiting ${this._globalTimeoutForError / 1000}s for the ${currentTaskName} to run`) });
       status = 'timedout';
     } else if (this._hasErrors) {
       status = 'failed';


### PR DESCRIPTION
Generate 'global timeout' and 'max failures' errors in the runner. Avoid reading `config.globalTimeout` and `config.maxFailures` in the base reporters.

Reference https://github.com/microsoft/playwright/issues/29768