### PR TITLE
fix: increase global timeout for a test

### DIFF
--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -232,7 +232,7 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(result.passed).toBe(1);
       expect(result.interrupted).toBe(1);
       expect(result.didNotRun).toBe(1);
-      expect(result.output).toContain('Timed out waiting 1s for the test suite to run');
+      expect(result.output).toContain('Timed out waiting 3s for the test suite to run');
     });
 
     test('should not print slow parallel tests', async ({ runInlineTest }) => {

--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -214,7 +214,7 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       const result = await runInlineTest({
         'playwright.config.ts': `
           module.exports = {
-            globalTimeout: 1000,
+            globalTimeout: 3000,
           };
         `,
         'dir/a.test.js': `


### PR DESCRIPTION
1s is not enought on CI to start running the tests sometimes.

<img width="849" alt="image" src="https://github.com/microsoft/playwright/assets/9798949/73ee7337-0f07-4ba4-80c7-23a78526748e">
