### PR TITLE
Revert "fix: shut down workers before reporter.onEnd (#30329)"

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -148,7 +148,7 @@ export default defineConfig({
 * since: v1.10
 - type: ?<[int]>
 
-Maximum time in milliseconds the whole test suite can run. Zero timeout (default) disables this behavior. Useful on CI to prevent broken setup from running too long and wasting resources. Note that even if global timeout is reached, Playwright will still allow up to 30 extra seconds for teardown hooks to finish. Learn more about [various timeouts](../test-timeouts.md).
+Maximum time in milliseconds the whole test suite can run. Zero timeout (default) disables this behavior. Useful on CI to prevent broken setup from running too long and wasting resources. Learn more about [various timeouts](../test-timeouts.md).
 
 **Usage**
 

--- a/packages/playwright/src/runner/taskRunner.ts
+++ b/packages/playwright/src/runner/taskRunner.ts
@@ -105,14 +105,9 @@ export class TaskRunner<Context> {
       status = 'failed';
     }
     cancelPromise?.resolve();
-    const cleanup = async () => {
-      // Upon hitting deadline we add extra 30s to actually perform cleanup, otherwise
-      // the task exits immediately because of the same deadline and we may continue
-      // while the test workers are still running.
-      const extraTime = timeoutWatcher.timedOut() ? 30_000 : 0;
-      const { status } = await teardownRunner.runDeferCleanup(context, deadline + extraTime);
-      return status;
-    };
+    // Note that upon hitting deadline, we "run cleanup", but it exits immediately
+    // because of the same deadline. Essentially, we're not performing any cleanup.
+    const cleanup = () => teardownRunner.runDeferCleanup(context, deadline).then(r => r.status);
     return { status, cleanup };
   }
 }

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1101,8 +1101,7 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
 
   /**
    * Maximum time in milliseconds the whole test suite can run. Zero timeout (default) disables this behavior. Useful on
-   * CI to prevent broken setup from running too long and wasting resources. Note that even if global timeout is
-   * reached, Playwright will still allow up to 30 extra seconds for teardown hooks to finish. Learn more about
+   * CI to prevent broken setup from running too long and wasting resources. Learn more about
    * [various timeouts](https://playwright.dev/docs/test-timeouts).
    *
    * **Usage**

--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -230,7 +230,8 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       });
       expect(result.exitCode).toBe(1);
       expect(result.passed).toBe(1);
-      expect(result.interrupted).toBe(1);
+      // TODO: uncomment once https://github.com/microsoft/playwright/issues/30550 is fixed.
+      // expect(result.interrupted).toBe(1);
       expect(result.didNotRun).toBe(1);
       expect(result.output).toContain('Timed out waiting 3s for the test suite to run');
     });

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -776,6 +776,8 @@ test('unhandled exception in test.fail should restart worker and continue', asyn
 });
 
 test('wait for workers to finish before reporter.onEnd', async ({ runInlineTest }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/30550' });
+  test.fixme();
   const result = await runInlineTest({
     'playwright.config.ts': `
       export default {


### PR DESCRIPTION
This reverts commit 3cea17abb6c8d7371a6d4dd913f714c427ea0fa0.

Reference https://github.com/microsoft/playwright/issues/30550

The test is preserved but marked as fixme.