### PR TITLE
fix : Synchronize read and writes to avoid race condition reading babel transpiled files from local disk cache

### DIFF
--- a/packages/playwright/src/transform/compilationCache.ts
+++ b/packages/playwright/src/transform/compilationCache.ts
@@ -148,11 +148,10 @@ export function getFromCompilationCache(filename: string, hash: string, moduleUr
           fs.writeFileSync(dataPath, JSON.stringify(Object.fromEntries(data.entries()), undefined, 2), { encoding: 'utf8', flag: 'wx' });
         fs.writeFileSync(codePath, code, 'utf8');
         fs.closeSync(fs.openSync(markerFile, 'wx'));
-      }
-      catch (error) {
+      } catch (error) {
         if (error.code === 'EEXIST') {
         } else {
-            throw error;
+          throw error;
         }
       }
       const serializedCache = _innerAddToCompilationCacheAndSerialize(filename, { codePath, sourceMapPath, dataPath, moduleUrl });

--- a/packages/playwright/src/transform/compilationCache.ts
+++ b/packages/playwright/src/transform/compilationCache.ts
@@ -146,7 +146,7 @@ export function getFromCompilationCache(filename: string, hash: string, moduleUr
           fs.writeFileSync(sourceMapPath, JSON.stringify(map), { encoding: 'utf8', flag: 'wx' });
         if (data.size)
           fs.writeFileSync(dataPath, JSON.stringify(Object.fromEntries(data.entries()), undefined, 2), { encoding: 'utf8', flag: 'wx' });
-        fs.writeFileSync(codePath, code, 'utf8');
+        fs.writeFileSync(codePath, code, { encoding: 'utf8', flag: 'wx' });
         fs.closeSync(fs.openSync(markerFile, 'wx'));
       } catch (error) {
         if (error.code === 'EEXIST') {


### PR DESCRIPTION
1. Add a maker file to check if the previous write was fully completed.
2. In writefilesync section change the write mode to wx which uses exclusive lock 
3. If two writes happen same time and we get EEXIST error then ignore that 
FIX for #30577