### PR TITLE
docs: Add pnpm as an install option for Playwright

### DIFF
--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -17,7 +17,7 @@ Playwright Test was created specifically to accommodate the needs of end-to-end 
 
 ## Installing Playwright
 
-Get started by installing Playwright using npm or yarn. Alternatively you can also get started and run your tests using the [VS Code Extension](./getting-started-vscode.md).
+Get started by installing Playwright using npm, yarn or pnpm. Alternatively you can also get started and run your tests using the [VS Code Extension](./getting-started-vscode.md).
 
 <Tabs
   defaultValue="npm"


### PR DESCRIPTION
This pull request adds pnpm as an install option for Playwright. Previously, only npm and yarn were listed as installation options.