### PR TITLE
fix(reporters): improve detection of output folder clashes

### DIFF
--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -87,7 +87,11 @@ class HtmlReporter extends EmptyReporter {
     this._attachmentsBaseURL = attachmentsBaseURL;
     const reportedWarnings = new Set<string>();
     for (const project of this.config.projects) {
-      if (outputFolder.startsWith(project.outputDir) || project.outputDir.startsWith(outputFolder)) {
+      if (
+        outputFolder.startsWith(project.outputDir.replace(/\/?$/, '/')) ||
+        project.outputDir.startsWith(outputFolder.replace(/\/?$/, '/')) ||
+        outputFolder === project.outputDir
+      ) {
         const key = outputFolder + '|' + project.outputDir;
         if (reportedWarnings.has(key))
           continue;

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -86,12 +86,11 @@ class HtmlReporter extends EmptyReporter {
     this._open = open;
     this._attachmentsBaseURL = attachmentsBaseURL;
     const reportedWarnings = new Set<string>();
+    const normalizePath = (path: string) => path.replace(/\\/g, '/').replace(/([^/])$/, '$1/');
+    const reportOutputFolderNormalized = normalizePath(outputFolder);
     for (const project of this.config.projects) {
-      if (
-        outputFolder.startsWith(project.outputDir.replace(/\/?$/, '/')) ||
-        project.outputDir.startsWith(outputFolder.replace(/\/?$/, '/')) ||
-        outputFolder === project.outputDir
-      ) {
+      const outputDirNormalized = normalizePath(project.outputDir);
+      if (outputDirNormalized.startsWith(reportOutputFolderNormalized) || reportOutputFolderNormalized.startsWith(outputDirNormalized)) {
         const key = outputFolder + '|' + project.outputDir;
         if (reportedWarnings.has(key))
           continue;

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -86,11 +86,8 @@ class HtmlReporter extends EmptyReporter {
     this._open = open;
     this._attachmentsBaseURL = attachmentsBaseURL;
     const reportedWarnings = new Set<string>();
-    const normalizePath = (path: string) => path.replace(/\\/g, '/').replace(/([^/])$/, '$1/');
-    const reportOutputFolderNormalized = normalizePath(outputFolder);
     for (const project of this.config.projects) {
-      const outputDirNormalized = normalizePath(project.outputDir);
-      if (outputDirNormalized.startsWith(reportOutputFolderNormalized) || reportOutputFolderNormalized.startsWith(outputDirNormalized)) {
+      if (this._isSubdirectory(outputFolder, project.outputDir) || this._isSubdirectory(project.outputDir, outputFolder)) {
         const key = outputFolder + '|' + project.outputDir;
         if (reportedWarnings.has(key))
           continue;
@@ -114,6 +111,11 @@ class HtmlReporter extends EmptyReporter {
       open: getHtmlReportOptionProcessEnv() || this._options.open || 'on-failure',
       attachmentsBaseURL: this._options.attachmentsBaseURL || 'data/'
     };
+  }
+
+  _isSubdirectory(parentDir: string, dir: string): boolean {
+    const relativePath = path.relative(parentDir, dir);
+    return !!relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
   }
 
   override onError(error: TestError): void {

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1094,6 +1094,26 @@ for (const useIntermediateMergeReport of [false] as const) {
       expect(output).toContain('html-report');
     });
 
+    test('it should only identify exact matches as clashing folders', async ({ runInlineTest, useIntermediateMergeReport }) => {
+      test.skip(useIntermediateMergeReport);
+      const result = await runInlineTest({
+        'playwright.config.ts': `
+          module.exports = {
+            reporter: [['html', { outputFolder: 'test-results-html' }]]
+          }
+        `,
+        'a.test.js': `
+          import { test, expect } from '@playwright/test';
+          test('passes', async ({}) => {
+          });
+        `,
+      });
+      expect(result.exitCode).toBe(0);
+      const output = result.output;
+      expect(output).not.toContain('Configuration Error');
+      expect(output).toContain('test-results-html');
+    });
+
     test.describe('report location', () => {
       test('with config should create report relative to config', async ({ runInlineTest, useIntermediateMergeReport }, testInfo) => {
         test.skip(useIntermediateMergeReport);


### PR DESCRIPTION
When comparing `outputDir` and html-reporter `outputFolder`, we now make sure that both paths end with a forward-slash.

Fixes #28677