### PR TITLE
chore: make NodeSnapshot type recursive and more

### DIFF
--- a/packages/playwright-core/src/server/deviceDescriptors.ts
+++ b/packages/playwright-core/src/server/deviceDescriptors.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-/**
- * @type {import('./types').Devices}
- */
-module.exports = require("./deviceDescriptorsSource.json")
+import type { Devices } from './types';
+
+import deviceDescriptorsSource from './deviceDescriptorsSource.json';
+
+export const deviceDescriptors = deviceDescriptorsSource as Devices;

--- a/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
@@ -26,7 +26,7 @@ import { Dispatcher } from './dispatcher';
 import { yazl, yauzl } from '../../zipBundle';
 import { ZipFile } from '../../utils/zipFile';
 import type * as har from '@trace/har';
-import type { HeadersArray, Devices } from '../types';
+import type { HeadersArray } from '../types';
 import { JsonPipeDispatcher } from '../dispatchers/jsonPipeDispatcher';
 import { WebSocketTransport } from '../transport';
 import { SocksInterceptor } from '../socksInterceptor';
@@ -40,6 +40,7 @@ import type http from 'http';
 import type { Playwright } from '../playwright';
 import { SdkObject } from '../../server/instrumentation';
 import { serializeClientSideCallMetadata } from '../../utils';
+import { deviceDescriptors as descriptors }  from '../deviceDescriptors';
 
 export class LocalUtilsDispatcher extends Dispatcher<{ guid: string }, channels.LocalUtilsChannel, RootDispatcher> implements channels.LocalUtilsChannel {
   _type_LocalUtils: boolean;
@@ -53,7 +54,6 @@ export class LocalUtilsDispatcher extends Dispatcher<{ guid: string }, channels.
 
   constructor(scope: RootDispatcher, playwright: Playwright) {
     const localUtils = new SdkObject(playwright, 'localUtils', 'localUtils');
-    const descriptors = require('../deviceDescriptors') as Devices;
     const deviceDescriptors = Object.entries(descriptors)
         .map(([name, descriptor]) => ({ name, descriptor }));
     super(scope, localUtils, 'LocalUtils', {

--- a/packages/playwright-core/src/server/recorder/csharp.ts
+++ b/packages/playwright-core/src/server/recorder/csharp.ts
@@ -22,7 +22,7 @@ import type { Action } from './recorderActions';
 import type { MouseClickOptions } from './utils';
 import { toModifiers } from './utils';
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
-const deviceDescriptors = require('../deviceDescriptorsSource.json');
+import { deviceDescriptors } from '../deviceDescriptors';
 import { asLocator } from '../../utils/isomorphic/locatorGenerators';
 
 type CSharpLanguageMode = 'library' | 'mstest' | 'nunit';

--- a/packages/playwright-core/src/server/recorder/java.ts
+++ b/packages/playwright-core/src/server/recorder/java.ts
@@ -21,7 +21,7 @@ import type { ActionInContext } from './codeGenerator';
 import type { Action } from './recorderActions';
 import type { MouseClickOptions } from './utils';
 import { toModifiers } from './utils';
-const deviceDescriptors = require('../deviceDescriptorsSource.json');
+import { deviceDescriptors } from '../deviceDescriptors';
 import { JavaScriptFormatter } from './javascript';
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
 import { asLocator } from '../../utils/isomorphic/locatorGenerators';

--- a/packages/playwright-core/src/server/recorder/javascript.ts
+++ b/packages/playwright-core/src/server/recorder/javascript.ts
@@ -21,7 +21,7 @@ import type { ActionInContext } from './codeGenerator';
 import type { Action } from './recorderActions';
 import type { MouseClickOptions } from './utils';
 import { toModifiers } from './utils';
-const deviceDescriptors = require('../deviceDescriptorsSource.json');
+import { deviceDescriptors } from '../deviceDescriptors';
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
 import { asLocator } from '../../utils/isomorphic/locatorGenerators';
 

--- a/packages/playwright-core/src/server/recorder/python.ts
+++ b/packages/playwright-core/src/server/recorder/python.ts
@@ -22,7 +22,7 @@ import type { Action } from './recorderActions';
 import type { MouseClickOptions } from './utils';
 import { toModifiers } from './utils';
 import { escapeWithQuotes, toSnakeCase } from '../../utils/isomorphic/stringUtils';
-const deviceDescriptors = require('../deviceDescriptorsSource.json');
+import { deviceDescriptors } from '../deviceDescriptors';
 import { asLocator } from '../../utils/isomorphic/locatorGenerators';
 
 export class PythonLanguageGenerator implements LanguageGenerator {

--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -540,7 +540,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
         return checkAndReturn(result);
       };
 
-      const visitStyleSheet = (sheet: CSSStyleSheet) => {
+      const visitStyleSheet = (sheet: CSSStyleSheet): { equals: boolean, n: NodeSnapshot } => {
         const data = ensureCachedData(sheet);
         const oldCSSText = data.cssText;
         const cssText = this._updateStyleElementStyleSheetTextIfNeeded(sheet, true /* forceText */)!;

--- a/packages/trace/src/snapshot.ts
+++ b/packages/trace/src/snapshot.ts
@@ -18,18 +18,18 @@ import type { Entry as HAREntry } from './har';
 
 export type ResourceSnapshot = HAREntry;
 
-export type NodeSnapshot =
-  // Text node.
-  string |
-  // Subtree reference, "x snapshots ago, node #y". Could point to a text node.
-  // Only nodes that are not references are counted, starting from zero, using post-order traversal.
-  [ [number, number] ] |
-  // Just node name.
-  [ string ] |
-  // Node name, attributes, child nodes.
-  // Unfortunately, we cannot make this type definition recursive, therefore "any".
-  [ string, { [attr: string]: string }, ...any ];
+// Text node.
+export type TextNodeSnapshot = string;
+// Subtree reference, "x snapshots ago, node #y". Could point to a text node.
+// Only nodes that are not references are counted, starting from zero, using post-order traversal.
+export type SubtreeReferenceSnapshot = [ [number, number] ];
+// Node name, and optional attributes and child nodes.
+export type NodeNameAttributesChildNodesSnapshot = [ string ] | [ string, Record<string, string>, ...NodeSnapshot[] ];
 
+export type NodeSnapshot =
+  TextNodeSnapshot |
+  SubtreeReferenceSnapshot |
+  NodeNameAttributesChildNodesSnapshot;
 
 export type ResourceOverride = {
   url: string,

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -16,7 +16,7 @@
 
 // @ts-check
 const path = require('path');
-const devices = require('../../packages/playwright-core/lib/server/deviceDescriptors');
+const devices = require('../../packages/playwright-core/lib/server/deviceDescriptorsSource.json');
 const md = require('../markdown');
 const docs = require('../doclint/documentation');
 const PROJECT_DIR = path.join(__dirname, '..', '..');


### PR DESCRIPTION
Also, deviceDescriptors are now imported with ESM import instead of require()