### PR TITLE
fix(html-reporter): add filter for anonymous describe

### DIFF
--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -359,7 +359,7 @@ class HtmlBuilder {
   private _createTestEntry(test: TestCasePublic, projectName: string, path: string[]): TestEntry {
     const duration = test.results.reduce((a, r) => a + r.duration, 0);
     const location = this._relativeLocation(test.location)!;
-    path = path.slice(1);
+    path = path.slice(1).filter(path => path.length > 0);
     const results = test.results.map(r => this._createTestResult(test, r));
 
     return {

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2330,6 +2330,36 @@ for (const useIntermediateMergeReport of [false] as const) {
       await showReport();
       await expect(page.getByTestId('report-errors')).toHaveText(/Error: From teardown.*at globalTeardown.ts:3.*export default async function globalTeardown/s);
     });
+
+    test('should not render anonymous describe', async ({ runInlineTest, showReport, page }) => {
+      const result = await runInlineTest({
+        'a.test.js': `
+            const { expect, test } = require('@playwright/test');
+            test.describe('Root describe', () => {
+              test.describe(() => {
+                test('Test passed', async ({}) => {
+                  expect(1).toBe(1);
+                });
+              });
+            });
+          `,
+      }, { reporter: 'dot,html' }, { PW_TEST_HTML_REPORT_OPEN: 'never' });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.passed).toBe(1);
+
+      await showReport();
+
+      await expect(page.locator('.test-file-test')).toHaveCount(1);
+
+      await expect(page.locator('.test-file-test').locator('a').first()).toHaveAttribute('title', 'Root describe › Test passed');
+      await expect(page.locator('.test-file-title')).toHaveText('Root describe › Test passed');
+      const testFilePathLink = page.locator('.test-file-path-link');
+      await expect(testFilePathLink).toHaveAttribute('title', 'Root describe › Test passed');
+
+      await testFilePathLink.click();
+      await expect(page.locator('.test-case-path')).toHaveText('Root describe');
+    });
   });
 }
 


### PR DESCRIPTION
related issue: https://github.com/microsoft/playwright/issues/30475

## Motivation:
On https://github.com/microsoft/playwright/issues/30475, we found that anonymous describe is rendered in html report

## Modification:
Make filter for anonymous describe

## Result:
anonymous describe will be filtered out.
Not render empty describe
Close https://github.com/microsoft/playwright/issues/30475 issue