### PR TITLE
chore: drop firefox-asan

### DIFF
--- a/.github/workflows/tests_stress.yml
+++ b/.github/workflows/tests_stress.yml
@@ -34,7 +34,6 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: npx playwright install --with-deps
-    - run: npx playwright install firefox-asan
       if: matrix.os != 'windows-latest'
     - run: npm run stest contexts -- --project=chromium
       if: ${{ !cancelled() }}

--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -20,12 +20,6 @@
       "browserVersion": "125.0.1"
     },
     {
-      "name": "firefox-asan",
-      "revision": "1449",
-      "installByDefault": false,
-      "browserVersion": "125.0.1"
-    },
-    {
       "name": "firefox-beta",
       "revision": "1449",
       "installByDefault": false,

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -175,31 +175,6 @@ const DOWNLOAD_PATHS: Record<BrowserName | InternalTool, DownloadPaths> = {
     'mac14-arm64': 'builds/firefox-beta/%s/firefox-beta-mac-13-arm64.zip',
     'win64': 'builds/firefox-beta/%s/firefox-beta-win64.zip',
   },
-  'firefox-asan': {
-    '<unknown>': undefined,
-    'ubuntu18.04-x64': undefined,
-    'ubuntu20.04-x64': undefined,
-    'ubuntu22.04-x64': 'builds/firefox/%s/firefox-asan-ubuntu-22.04.zip',
-    'ubuntu18.04-arm64': undefined,
-    'ubuntu20.04-arm64': undefined,
-    'ubuntu22.04-arm64': undefined,
-    'debian11-x64': undefined,
-    'debian11-arm64': undefined,
-    'debian12-x64': undefined,
-    'debian12-arm64': undefined,
-    'mac10.13': 'builds/firefox/%s/firefox-asan-mac-13.zip',
-    'mac10.14': 'builds/firefox/%s/firefox-asan-mac-13.zip',
-    'mac10.15': 'builds/firefox/%s/firefox-asan-mac-13.zip',
-    'mac11': 'builds/firefox/%s/firefox-asan-mac-13.zip',
-    'mac11-arm64': undefined,
-    'mac12': 'builds/firefox/%s/firefox-asan-mac-13.zip',
-    'mac12-arm64': undefined,
-    'mac13': 'builds/firefox/%s/firefox-asan-mac-13.zip',
-    'mac13-arm64': undefined,
-    'mac14': 'builds/firefox/%s/firefox-asan-mac-13.zip',
-    'mac14-arm64': undefined,
-    'win64': undefined,
-  },
   'webkit': {
     '<unknown>': undefined,
     'ubuntu18.04-x64': undefined,
@@ -361,7 +336,7 @@ function readDescriptors(browsersJSON: BrowsersJSON) {
 }
 
 export type BrowserName = 'chromium' | 'firefox' | 'webkit';
-type InternalTool = 'ffmpeg' | 'firefox-beta' | 'firefox-asan' | 'chromium-tip-of-tree' | 'android';
+type InternalTool = 'ffmpeg' | 'firefox-beta' | 'chromium-tip-of-tree' | 'android';
 type ChromiumChannel = 'chrome' | 'chrome-beta' | 'chrome-dev' | 'chrome-canary' | 'msedge' | 'msedge-beta' | 'msedge-dev' | 'msedge-canary';
 const allDownloadable = ['chromium', 'firefox', 'webkit', 'ffmpeg', 'firefox-beta', 'chromium-tip-of-tree'];
 
@@ -546,24 +521,6 @@ export class Registry {
       downloadURLs: this._downloadURLs(firefox),
       browserVersion: firefox.browserVersion,
       _install: () => this._downloadExecutable(firefox, firefoxExecutable),
-      _dependencyGroup: 'firefox',
-      _isHermeticInstallation: true,
-    });
-
-    const firefoxAsan = descriptors.find(d => d.name === 'firefox-asan')!;
-    const firefoxAsanExecutable = findExecutablePath(firefoxAsan.dir, 'firefox');
-    this._executables.push({
-      type: 'browser',
-      name: 'firefox-asan',
-      browserName: 'firefox',
-      directory: firefoxAsan.dir,
-      executablePath: () => firefoxAsanExecutable,
-      executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('firefox-asan', firefoxAsanExecutable, firefoxAsan.installByDefault, sdkLanguage),
-      installType: firefoxAsan.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, 'firefox', firefoxAsan.dir, ['firefox'], [], ['firefox']),
-      downloadURLs: this._downloadURLs(firefoxAsan),
-      browserVersion: firefoxAsan.browserVersion,
-      _install: () => this._downloadExecutable(firefoxAsan, firefoxAsanExecutable),
       _dependencyGroup: 'firefox',
       _isHermeticInstallation: true,
     });

--- a/tests/stress/playwright.config.ts
+++ b/tests/stress/playwright.config.ts
@@ -31,7 +31,6 @@ export default defineConfig({
       name: 'firefox',
       use: {
         browserName: 'firefox',
-        channel: process.platform !== 'win32' ? 'firefox-asan' : undefined,
       },
     },
 


### PR DESCRIPTION
Motivation: We did not use the asan build in the past and this fixes also the stress tests.