### PR TITLE
refactor: remove redundant parameters from isElementStyleVisibilityVi…

### DIFF
--- a/packages/playwright-core/src/server/injected/domUtils.ts
+++ b/packages/playwright-core/src/server/injected/domUtils.ts
@@ -84,7 +84,7 @@ export function isElementStyleVisibilityVisible(element: Element, style?: CSSSty
   // https://bugs.webkit.org/show_bug.cgi?id=264733
   // @ts-ignore
   if (Element.prototype.checkVisibility && browserNameForWorkarounds !== 'webkit') {
-    if (!element.checkVisibility({ checkOpacity: false, checkVisibilityCSS: false }))
+    if (!element.checkVisibility())
       return false;
   } else {
     // Manual workaround for WebKit that does not have checkVisibility.


### PR DESCRIPTION
…sible

Remove the following unnecessary parameters from checkVisibility() in isElementStyleVisibilityVisible:

- checkOpacity (historic alias for opacityProperty, defaults to false)
- checkVisibilityCSS (historic alias for visibilityProperty, defaults to false)

Simplify the function call by removing these obsolete parameters.