### PR TITLE
devops: add Node.js 22 bots

### DIFF
--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -41,6 +41,9 @@ jobs:
           - os: ubuntu-22.04
             node-version: 20
             browser: chromium
+          - os: ubuntu-22.04
+            node-version: 22
+            browser: chromium
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write   # This is required for OIDC login (azure/login) to succeed
@@ -106,6 +109,14 @@ jobs:
             shardTotal: 2
           - os: ubuntu-latest
             node-version: 20
+            shardIndex: 2
+            shardTotal: 2
+          - os: ubuntu-latest
+            node-version: 22
+            shardIndex: 1
+            shardTotal: 2
+          - os: ubuntu-latest
+            node-version: 22
             shardIndex: 2
             shardTotal: 2
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -95,6 +95,8 @@ jobs:
           node_version: 16
         - os: ubuntu-latest
           node_version: 20
+        - os: ubuntu-latno est
+          node_version: 22
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -95,7 +95,7 @@ jobs:
           node_version: 16
         - os: ubuntu-latest
           node_version: 20
-        - os: ubuntu-latno est
+        - os: ubuntu-latest
           node_version: 22
     timeout-minutes: 30
     steps:

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -829,7 +829,7 @@ it('should not hang on a brotli encoded Range request', async ({ context, server
     headers: {
       range: 'bytes=0-2',
     },
-  })).rejects.toThrow(`failed to decompress 'br' encoding: Error: unexpected end of file`);
+  })).rejects.toThrow(/(failed to decompress 'br' encoding: Error: unexpected end of file|Parse Error: Data after \`Connection: close\`)/);
 });
 
 it('should dispose', async function({ context, server }) {


### PR DESCRIPTION
Motivation: Node.js 22 is the new current and will be LTS in October. We expect users to already use Node.js 22.

---

Bisect results from the brotli breakage:

v21.0.0-nightly20230916 db8217b1bf /                 16-Sep-2023 08:30                   - good
v21.0.0-nightly20230917 56ecf29283 /                 17-Sep-2023 08:30                   - bad

https://github.com/nodejs/node/compare/db8217b1bf...56ecf29283

Downstream llhttp range: https://github.com/nodejs/llhttp/compare/v8.1.1...v9.1.2