### PR TITLE
docs(releaseNotes): Fixed typo in 1.44 js notes

### DIFF
--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -59,7 +59,7 @@ await page.removeLocatorHandler(locator);
   });
   ```
 
-- `expect(callback).toPass({ intervals })` can now be configured by `expect.toPass.inervals` option globally in [`property: TestConfig.expect`] or per project in [`property: TestProject.expect`].
+- `expect(callback).toPass({ intervals })` can now be configured by `expect.toPass.intervals` option globally in [`property: TestConfig.expect`] or per project in [`property: TestProject.expect`].
 - `expect(page).toHaveURL(url)` now supports `ignoreCase` [option](./api/class-pageassertions#page-assertions-to-have-url-option-ignore-case).
 - [`property: TestProject.ignoreSnapshots`](./api/class-testproject#test-project-ignore-snapshots) allows to configure  per project whether to skip screenshot expectations.
 


### PR DESCRIPTION
Hello,

I spotted a typo in the release notes of the incomming 1.44 update.
Thanks for the awesome work btw.

Best regards,
Chris.