### PR TITLE
devops: fix stress tests on Windows

### DIFF
--- a/.github/workflows/tests_stress.yml
+++ b/.github/workflows/tests_stress.yml
@@ -34,7 +34,6 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: npx playwright install --with-deps
-      if: matrix.os != 'windows-latest'
     - run: npm run stest contexts -- --project=chromium
       if: ${{ !cancelled() }}
     - run: npm run stest browsers -- --project=chromium


### PR DESCRIPTION
We forgot to remove this line in https://github.com/microsoft/playwright/pull/30626.