### PR TITLE
chore(trace): add context create event for test runner

### DIFF
--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -179,7 +179,12 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       this._allocateNewTraceFile(this._state);
 
     this._fs.mkdir(path.dirname(this._state.traceFile));
-    const event: trace.TraceEvent = { ...this._contextCreatedEvent, title: options.title, wallTime: Date.now() };
+    const event: trace.TraceEvent = {
+      ...this._contextCreatedEvent,
+      title: options.title,
+      wallTime: Date.now(),
+      monotonicTime: monotonicTime()
+    };
     this._fs.appendFile(this._state.traceFile, JSON.stringify(event) + '\n');
 
     this._context.instrumentation.addListener(this, this._context);

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -45,7 +45,7 @@ import type { ConsoleMessage } from '../../console';
 import { Dispatcher } from '../../dispatchers/dispatcher';
 import { serializeError } from '../../errors';
 
-const version: trace.VERSION = 6;
+const version: trace.VERSION = 7;
 
 export type TracerOptions = {
   name?: string;
@@ -100,10 +100,12 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     this._contextCreatedEvent = {
       version,
       type: 'context-options',
+      origin: 'library',
       browserName: '',
       options: {},
       platform: process.platform,
       wallTime: 0,
+      monotonicTimeOffset: 0,
       sdkLanguage: context.attribution.playwright.options.sdkLanguage,
       testIdAttributeName
     };

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -105,7 +105,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       options: {},
       platform: process.platform,
       wallTime: 0,
-      monotonicTimeOffset: 0,
+      monotonicTime: 0,
       sdkLanguage: context.attribution.playwright.options.sdkLanguage,
       testIdAttributeName
     };

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -28,6 +28,7 @@ import type { TestInfoImpl } from './testInfo';
 
 export type Attachment = TestInfo['attachments'][0];
 export const testTraceEntryName = 'test.trace';
+const version: trace.VERSION = 7;
 let traceOrdinal = 0;
 
 type TraceFixtureValue =  PlaywrightWorkerOptions['trace'] | undefined;
@@ -41,11 +42,24 @@ export class TestTracing {
   private _temporaryTraceFiles: string[] = [];
   private _artifactsDir: string;
   private _tracesDir: string;
+  private _contextCreatedEvent: trace.ContextCreatedTraceEvent;
 
   constructor(testInfo: TestInfoImpl, artifactsDir: string) {
     this._testInfo = testInfo;
     this._artifactsDir = artifactsDir;
     this._tracesDir = path.join(this._artifactsDir, 'traces');
+    this._contextCreatedEvent = {
+      version,
+      type: 'context-options',
+      origin: 'testRunner',
+      browserName: '',
+      options: {},
+      platform: process.platform,
+      wallTime: Date.now(),
+      monotonicTimeOffset: Date.now() - monotonicTime(),
+      sdkLanguage: 'javascript',
+    };
+    this._appendTraceEvent(this._contextCreatedEvent);
   }
 
   private _shouldCaptureTrace() {

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -56,7 +56,7 @@ export class TestTracing {
       options: {},
       platform: process.platform,
       wallTime: Date.now(),
-      monotonicTimeOffset: Date.now() - monotonicTime(),
+      monotonicTime: monotonicTime(),
       sdkLanguage: 'javascript',
     };
     this._appendTraceEvent(this._contextCreatedEvent);

--- a/packages/trace-viewer/src/entries.ts
+++ b/packages/trace-viewer/src/entries.ts
@@ -27,6 +27,7 @@ export type ContextEntry = {
   channel?: string;
   platform?: string;
   wallTime?: number;
+  monotonicTimeOffset: number;
   sdkLanguage?: Language;
   testIdAttributeName?: string;
   title?: string;
@@ -58,6 +59,7 @@ export function createEmptyContext(): ContextEntry {
     origin: 'testRunner',
     traceUrl: '',
     startTime: Number.MAX_SAFE_INTEGER,
+    monotonicTimeOffset: 0,
     endTime: 0,
     browserName: '',
     options: {

--- a/packages/trace-viewer/src/entries.ts
+++ b/packages/trace-viewer/src/entries.ts
@@ -26,8 +26,7 @@ export type ContextEntry = {
   browserName: string;
   channel?: string;
   platform?: string;
-  wallTime?: number;
-  monotonicTimeOffset: number;
+  wallTime: number;
   sdkLanguage?: Language;
   testIdAttributeName?: string;
   title?: string;
@@ -59,7 +58,7 @@ export function createEmptyContext(): ContextEntry {
     origin: 'testRunner',
     traceUrl: '',
     startTime: Number.MAX_SAFE_INTEGER,
-    monotonicTimeOffset: 0,
+    wallTime: Number.MAX_SAFE_INTEGER,
     endTime: 0,
     browserName: '',
     options: {

--- a/packages/trace-viewer/src/traceModernizer.ts
+++ b/packages/trace-viewer/src/traceModernizer.ts
@@ -388,9 +388,11 @@ export class TraceModernizer {
         result.push({ ...event, monotonicTime: 0, origin: 'library' });
         continue;
       }
-      // Take wall time from the first event.
+      // Take wall and monotonic time from the first event.
       if (!this._contextEntry.wallTime && event.type === 'before')
         this._contextEntry.wallTime = event.wallTime;
+      if (!this._contextEntry.startTime && event.type === 'before')
+        this._contextEntry.startTime = event.startTime;
       result.push(event);
     }
     return result;

--- a/packages/trace-viewer/src/traceModernizer.ts
+++ b/packages/trace-viewer/src/traceModernizer.ts
@@ -18,6 +18,7 @@ import type * as trace from '@trace/trace';
 import type * as traceV3 from './versions/traceV3';
 import type * as traceV4 from './versions/traceV4';
 import type * as traceV5 from './versions/traceV5';
+import type * as traceV6 from './versions/traceV6';
 import type { ActionEntry, ContextEntry, PageEntry } from './entries';
 import type { SnapshotStorage } from './snapshotStorage';
 
@@ -71,7 +72,7 @@ export class TraceModernizer {
     switch (event.type) {
       case 'context-options': {
         this._version = event.version;
-        contextEntry.origin = 'library';
+        contextEntry.origin = event.origin;
         contextEntry.browserName = event.browserName;
         contextEntry.channel = event.channel;
         contextEntry.title = event.title;
@@ -145,11 +146,11 @@ export class TraceModernizer {
         break;
       }
       case 'resource-snapshot':
-        this._snapshotStorage!.addResource(event.snapshot);
+        this._snapshotStorage.addResource(event.snapshot);
         contextEntry.resources.push(event.snapshot);
         break;
       case 'frame-snapshot':
-        this._snapshotStorage!.addFrameSnapshot(event.snapshot);
+        this._snapshotStorage.addFrameSnapshot(event.snapshot);
         break;
     }
     // Make sure there is a page entry for each page, even without screencast frames,
@@ -170,10 +171,14 @@ export class TraceModernizer {
     }
   }
 
+  private _processedContextCreatedEvent() {
+    return this._version !== undefined;
+  }
+
   private _modernize(event: any): trace.TraceEvent[] {
     if (this._version === undefined)
       return [event];
-    const lastVersion: trace.VERSION = 6;
+    const lastVersion: trace.VERSION = 7;
     let events = [event];
     for (let version = this._version; version < lastVersion; ++version)
       events = (this as any)[`_modernize_${version}_to_${version + 1}`].call(this, events);
@@ -341,8 +346,8 @@ export class TraceModernizer {
     return event;
   }
 
-  _modernize_5_to_6(events: traceV5.TraceEvent[]): trace.TraceEvent[] {
-    const result: trace.TraceEvent[] = [];
+  _modernize_5_to_6(events: traceV5.TraceEvent[]): traceV6.TraceEvent[] {
+    const result: traceV6.TraceEvent[] = [];
     for (const event of events) {
       result.push(event);
       if (event.type !== 'after' || !event.log.length)
@@ -355,6 +360,34 @@ export class TraceModernizer {
           time: -1,
         });
       }
+    }
+    return result;
+  }
+
+  _modernize_6_to_7(events: traceV6.TraceEvent[]): trace.TraceEvent[] {
+    const result: trace.TraceEvent[] = [];
+    if (!this._processedContextCreatedEvent() && events[0].type !== 'context-options') {
+      const event: trace.ContextCreatedTraceEvent = {
+        type: 'context-options',
+        origin: 'testRunner',
+        version: 7,
+        browserName: '',
+        options: {},
+        platform: process.platform,
+        wallTime: 0,
+        monotonicTimeOffset: 0,
+        sdkLanguage: 'javascript',
+      };
+      result.push(event);
+    }
+    for (const event of events) {
+      if (event.type === 'context-options') {
+        result.push({ ...event, monotonicTimeOffset: 0, origin: 'library' });
+        continue;
+      }
+      if (!this._contextEntry.monotonicTimeOffset && event.type === 'before')
+        this._contextEntry.monotonicTimeOffset = event.wallTime - event.startTime;
+      result.push(event);
     }
     return result;
   }

--- a/packages/trace-viewer/src/versions/traceV6.ts
+++ b/packages/trace-viewer/src/versions/traceV6.ts
@@ -14,14 +14,85 @@
  * limitations under the License.
  */
 
-import type { Point, SerializedError, StackFrame } from '@protocol/channels';
-import type { Language } from '../../playwright-core/src/utils/isomorphic/locatorGenerators';
-import type { FrameSnapshot, ResourceSnapshot } from './snapshot';
+import type { Entry as ResourceSnapshot } from '../../../trace/src/har';
 
-export type Size = { width: number, height: number };
+type Language = 'javascript' | 'python' | 'java' | 'csharp' | 'jsonl';
+type Point = { x: number, y: number };
+type Size = { width: number, height: number };
 
-// Make sure you add _modernize_N_to_N1(event: any) to traceModel.ts.
-export type VERSION = 7;
+type StackFrame = {
+  file: string,
+  line: number,
+  column: number,
+  function?: string,
+};
+
+type SerializedValue = {
+  n?: number,
+  b?: boolean,
+  s?: string,
+  v?: 'null' | 'undefined' | 'NaN' | 'Infinity' | '-Infinity' | '-0',
+  d?: string,
+  u?: string,
+  bi?: string,
+  m?: SerializedValue,
+  se?: SerializedValue,
+  r?: {
+    p: string,
+    f: string,
+  },
+  a?: SerializedValue[],
+  o?: {
+    k: string,
+    v: SerializedValue,
+  }[],
+  h?: number,
+  id?: number,
+  ref?: number,
+};
+
+type SerializedError = {
+  error?: {
+    message: string,
+    name: string,
+    stack?: string,
+  },
+  value?: SerializedValue,
+};
+
+type NodeSnapshot =
+  // Text node.
+  string |
+  // Subtree reference, "x snapshots ago, node #y". Could point to a text node.
+  // Only nodes that are not references are counted, starting from zero, using post-order traversal.
+  [ [number, number] ] |
+  // Just node name.
+  [ string ] |
+  // Node name, attributes, child nodes.
+  // Unfortunately, we cannot make this type definition recursive, therefore "any".
+  [ string, { [attr: string]: string }, ...any ];
+
+
+type ResourceOverride = {
+  url: string,
+  sha1?: string,
+  ref?: number
+};
+
+type FrameSnapshot = {
+  snapshotName?: string,
+  callId: string,
+  pageId: string,
+  frameId: string,
+  frameUrl: string,
+  timestamp: number,
+  collectionTime: number,
+  doctype?: string,
+  html: NodeSnapshot,
+  resourceOverrides: ResourceOverride[],
+  viewport: { width: number, height: number },
+  isMainFrame: boolean,
+};
 
 export type BrowserContextEventOptions = {
   viewport?: Size,
@@ -33,12 +104,10 @@ export type BrowserContextEventOptions = {
 export type ContextCreatedTraceEvent = {
   version: number,
   type: 'context-options',
-  origin: 'testRunner' | 'library',
   browserName: string,
   channel?: string,
   platform: string,
   wallTime: number,
-  monotonicTimeOffset: number,
   title?: string,
   options: BrowserContextEventOptions,
   sdkLanguage?: Language,

--- a/packages/trace/src/trace.ts
+++ b/packages/trace/src/trace.ts
@@ -38,7 +38,7 @@ export type ContextCreatedTraceEvent = {
   channel?: string,
   platform: string,
   wallTime: number,
-  monotonicTimeOffset: number,
+  monotonicTime: number,
   title?: string,
   options: BrowserContextEventOptions,
   sdkLanguage?: Language,


### PR DESCRIPTION
Adding metadata event to the test.trace to simplify time computation logic.