### PR TITLE
docs: Fix dotnet IsMobile

### DIFF
--- a/docs/src/emulation.md
+++ b/docs/src/emulation.md
@@ -283,7 +283,7 @@ context = browser.new_context(
 ```csharp
 await using var context = await browser.NewContextAsync(new()
 {
-    IsMobile = new IsMoble() { false }
+    IsMobile = false
 });
 ```
 


### PR DESCRIPTION
IsMobile is just a simple `bool`:

![image](https://github.com/microsoft/playwright/assets/12619902/d033a30b-85b8-4415-8fdb-c800995bcba1)
