### PR TITLE
fix(chromium): concat all post data entries for request.postData()

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -583,8 +583,9 @@ class InterceptableRequest {
     } = requestPausedEvent ? requestPausedEvent.request : requestWillBeSentEvent.request;
     const type = (requestWillBeSentEvent.type || '').toLowerCase();
     let postDataBuffer = null;
-    if (postDataEntries && postDataEntries.length && postDataEntries[0].bytes)
-      postDataBuffer = Buffer.from(postDataEntries[0].bytes, 'base64');
+    const entries = postDataEntries?.filter(entry => entry.bytes);
+    if (entries && entries.length)
+      postDataBuffer = Buffer.concat(entries.map(entry => Buffer.from(entry.bytes!, 'base64')));
 
     this.request = new network.Request(context, frame, serviceWorker, redirectedFrom?.request || null, documentId, url, type, method, postDataBuffer, headersObjectToArray(headers));
   }


### PR DESCRIPTION
This already works in Firefox, but does not work in WebKit.