### PR TITLE
Copy annotation text in HTML report 

### DIFF
--- a/packages/html-reporter/src/copyToClipboard.tsx
+++ b/packages/html-reporter/src/copyToClipboard.tsx
@@ -34,5 +34,5 @@ export const CopyToClipboard: React.FunctionComponent<{
     });
   }, [value]);
   const iconElement = icon === 'check' ? icons.check() : icon === 'cross' ? icons.cross() : icons.copy();
-  return <button className='copy-icon' onClick={handleCopy}>{iconElement}</button>;
+  return <button className='copy-icon' onClick={handleCopy} aria-label="copy to clipboard">{iconElement}</button>;
 };

--- a/packages/html-reporter/src/testCaseView.css
+++ b/packages/html-reporter/src/testCaseView.css
@@ -74,3 +74,13 @@
   flex-direction: row;
   flex-wrap: wrap;
 }
+
+.annotation-copy-button{
+  padding-left: 3px;
+  display: none;
+}
+
+.test-case-annotation:hover .annotation-copy-button{
+  padding-left: 3px;
+  display: inline;
+}

--- a/packages/html-reporter/src/testCaseView.spec.tsx
+++ b/packages/html-reporter/src/testCaseView.spec.tsx
@@ -64,7 +64,13 @@ const testCase: TestCase = {
 
 test('should render test case', async ({ mount }) => {
   const component = await mount(<TestCaseView projectNames={['chromium', 'webkit']} test={testCase} run={0} anchor=''></TestCaseView>);
-  await expect(component.getByText('Annotation text', { exact: false }).first()).toBeVisible();
+  const firstAnnotationElement = component.getByText('Annotation text', { exact: false }).first();
+  await expect(firstAnnotationElement).toBeVisible();
+  await expect(component.getByRole('button', { name: 'copy to clipboard' }).first()).not.toBeVisible();
+  await expect(component.getByRole('button', { name: 'copy to clipboard' }).nth(1)).not.toBeVisible();
+  await firstAnnotationElement.hover();
+  await expect(component.getByRole('button', { name: 'copy to clipboard' }).first()).toBeVisible();
+  await expect(component.getByRole('button', { name: 'copy to clipboard' }).nth(1)).not.toBeVisible();
   await component.getByText('Annotations').click();
   await expect(component.getByText('Annotation text')).not.toBeVisible();
   await expect(component.getByText('Outer step')).toBeVisible();

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -25,6 +25,7 @@ import './testCaseView.css';
 import { TestResultView } from './testResultView';
 import { hashStringToInt } from './labelUtils';
 import { msToString } from './uiUtils';
+import { CopyToClipboard } from './copyToClipboard';
 
 export const TestCaseView: React.FC<{
   projectNames: string[],
@@ -68,15 +69,16 @@ function renderAnnotationDescription(description: string) {
   try {
     if (['http:', 'https:'].includes(new URL(description).protocol))
       return <a href={description} target='_blank' rel='noopener noreferrer'>{description}</a>;
-  } catch {}
+  } catch { }
   return description;
 }
 
 function TestCaseAnnotationView({ annotation: { type, description } }: { annotation: TestCaseAnnotation }) {
   return (
     <div className='test-case-annotation'>
-      <span style={{ fontWeight: 'bold' }}>{type}</span>
+      <span style={{ fontWeight: 'bold', display: 'inline-block', marginBlock: '3px' }}>{type}</span>
       {description && <span>: {renderAnnotationDescription(description)}</span>}
+      <span className='annotation-copy-button'>{description && <CopyToClipboard value={description} />}</span>
     </div>
   );
 }


### PR DESCRIPTION
Feature Request : https://github.com/microsoft/playwright/issues/30141

In this PR I have added changes required to make annotation text be copied in one click . 


Annotation
<img width="327" alt="Screenshot 2024-05-11 at 1 12 14 PM" src="https://github.com/microsoft/playwright/assets/150931175/d8290070-723f-4263-b51c-a03961476805">

On hover

<img width="297" alt="Screenshot 2024-05-11 at 1 12 21 PM" src="https://github.com/microsoft/playwright/assets/150931175/3ab38454-cf56-4a52-8f21-dbde7cb69d80">

On copy 
<img width="227" alt="Screenshot 2024-05-11 at 1 12 34 PM" src="https://github.com/microsoft/playwright/assets/150931175/d3966d0b-7a54-44af-9f13-a89e2af023ba">

