### PR TITLE
Filter test cases by annotation text in HTML report

### DIFF
--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -15,12 +15,12 @@
 */
 
 import type { TestCaseSummary } from './types';
-
 export class Filter {
   project: string[] = [];
   status: string[] = [];
   text: string[] = [];
   labels: string[] = [];
+  annotations: string[] = [];
 
   empty(): boolean {
     return this.project.length + this.status.length + this.text.length === 0;
@@ -32,6 +32,7 @@ export class Filter {
     const status = new Set<string>();
     const text: string[] = [];
     const labels = new Set<string>();
+    const annotations = new Set<string>();
     for (const token of tokens) {
       if (token.startsWith('p:')) {
         project.add(token.slice(2));
@@ -45,6 +46,10 @@ export class Filter {
         labels.add(token);
         continue;
       }
+      if (token.startsWith('a:')) {
+        annotations.add(token.slice(2));
+        continue;
+      }
       text.push(token.toLowerCase());
     }
 
@@ -53,6 +58,7 @@ export class Filter {
     filter.project = [...project];
     filter.status = [...status];
     filter.labels = [...labels];
+    filter.annotations = [...annotations];
     return filter;
   }
 
@@ -127,7 +133,14 @@ export class Filter {
       if (!matches)
         return false;
     }
-
+    if (this.annotations.length) {
+      const matches = this.annotations.every(annotation =>
+        searchValues.annotations.some(_annotation => (
+          _annotation.includes(annotation)
+        )));
+      if (!matches)
+        return false;
+    }
     return true;
   }
 }
@@ -140,6 +153,7 @@ type SearchValues = {
   line: string;
   column: string;
   labels: string[];
+  annotations: string[];
 };
 
 const searchValuesSymbol = Symbol('searchValues');

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -176,6 +176,7 @@ function cacheSearchValues(test: TestCaseSummary): SearchValues {
     line: String(test.location.line),
     column: String(test.location.column),
     labels: test.tags.map(tag => tag.toLowerCase()),
+    annotations: test.annotations.map(a => a.type.toLowerCase() + '=' + a.description?.toLocaleLowerCase())
   };
   (test as any)[searchValuesSymbol] = searchValues;
   return searchValues;

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -46,8 +46,8 @@ export class Filter {
         labels.add(token);
         continue;
       }
-      if (token.startsWith('a:')) {
-        annotations.add(token.slice(2));
+      if (token.startsWith('annot:')) {
+        annotations.add(token.slice('annot:'.length));
         continue;
       }
       text.push(token.toLowerCase());
@@ -135,7 +135,7 @@ export class Filter {
     }
     if (this.annotations.length) {
       const matches = this.annotations.every(annotation =>
-        searchValues.annotations.some(_annotation => _annotation.includes(annotation)));
+        searchValues.annotations.some(a => a.includes(annotation)));
       if (!matches)
         return false;
     }

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -135,9 +135,7 @@ export class Filter {
     }
     if (this.annotations.length) {
       const matches = this.annotations.every(annotation =>
-        searchValues.annotations.some(_annotation => (
-          _annotation.includes(annotation)
-        )));
+        searchValues.annotations.some(_annotation => _annotation.includes(annotation)));
       if (!matches)
         return false;
     }

--- a/packages/html-reporter/src/headerView.spec.tsx
+++ b/packages/html-reporter/src/headerView.spec.tsx
@@ -27,7 +27,7 @@ test('should render counters', async ({ mount }) => {
     flaky: 17,
     skipped: 10,
     ok: false,
-  }} filterText='' setFilterText={() => {}}></HeaderView>);
+  }} filterText='' setFilterText={() => { }}></HeaderView>);
   await expect(component.locator('a', { hasText: 'All' }).locator('.counter')).toHaveText('90');
   await expect(component.locator('a', { hasText: 'Passed' }).locator('.counter')).toHaveText('42');
   await expect(component.locator('a', { hasText: 'Failed' }).locator('.counter')).toHaveText('31');
@@ -59,5 +59,6 @@ test('should toggle filters', async ({ page, mount }) => {
   await expect(page).toHaveURL(/#\?q=s:flaky/);
   await component.locator('a', { hasText: 'Skipped' }).click();
   await expect(page).toHaveURL(/#\?q=s:skipped/);
-  expect(filters).toEqual(['', 's:passed', 's:failed', 's:flaky', 's:skipped']);
+  await component.getByRole('searchbox').fill('a:annotation type=annotation description');
+  expect(filters).toEqual(['', 's:passed', 's:failed', 's:flaky', 's:skipped', 'a:annotation type=annotation description']);
 });

--- a/packages/html-reporter/src/headerView.spec.tsx
+++ b/packages/html-reporter/src/headerView.spec.tsx
@@ -59,6 +59,6 @@ test('should toggle filters', async ({ page, mount }) => {
   await expect(page).toHaveURL(/#\?q=s:flaky/);
   await component.locator('a', { hasText: 'Skipped' }).click();
   await expect(page).toHaveURL(/#\?q=s:skipped/);
-  await component.getByRole('searchbox').fill('a:annotation type=annotation description');
-  expect(filters).toEqual(['', 's:passed', 's:failed', 's:flaky', 's:skipped', 'a:annotation type=annotation description']);
+  await component.getByRole('searchbox').fill('annot:annotation type=annotation description');
+  expect(filters).toEqual(['', 's:passed', 's:failed', 's:flaky', 's:skipped', 'annot:annotation type=annotation description']);
 });

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1455,7 +1455,7 @@ for (const useIntermediateMergeReport of [false] as const) {
         await showReport();
 
         const searchInput = page.locator('.subnav-search-input');
-        const smokeLabelButton =  page.locator('.test-file-test', { has: page.getByText('Error Pages › @smoke fails', { exact: true }) }).locator('.label', { hasText: 'smoke' });
+        const smokeLabelButton = page.locator('.test-file-test', { has: page.getByText('Error Pages › @smoke fails', { exact: true }) }).locator('.label', { hasText: 'smoke' });
 
         await expect(smokeLabelButton).toBeVisible();
         await smokeLabelButton.click();
@@ -1465,7 +1465,7 @@ for (const useIntermediateMergeReport of [false] as const) {
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
         await expect(page.locator('.test-file-test .test-file-title')).toHaveText('Error Pages › @smoke fails');
 
-        const regressionLabelButton =  page.locator('.test-file-test', { has: page.getByText('Error Pages › @regression passes', { exact: true }) }).locator('.label', { hasText: 'regression' });
+        const regressionLabelButton = page.locator('.test-file-test', { has: page.getByText('Error Pages › @regression passes', { exact: true }) }).locator('.label', { hasText: 'regression' });
 
         await expect(regressionLabelButton).not.toBeVisible();
 
@@ -1577,7 +1577,7 @@ for (const useIntermediateMergeReport of [false] as const) {
 
         const searchInput = page.locator('.subnav-search-input');
 
-        const smokeLabelButton =  page.locator('.test-file-test', { has: page.getByText('@smoke fails', { exact: true }) }).locator('.label', { hasText: 'smoke' });
+        const smokeLabelButton = page.locator('.test-file-test', { has: page.getByText('@smoke fails', { exact: true }) }).locator('.label', { hasText: 'smoke' });
         await smokeLabelButton.click();
         await expect(page).toHaveURL(/@smoke/);
         await searchInput.clear();
@@ -1585,7 +1585,7 @@ for (const useIntermediateMergeReport of [false] as const) {
         await expect(searchInput).toHaveValue('');
         await expect(page).not.toHaveURL(/@smoke/);
 
-        const regressionLabelButton =  page.locator('.test-file-test', { has: page.getByText('@regression passes', { exact: true }) }).locator('.label', { hasText: 'regression' });
+        const regressionLabelButton = page.locator('.test-file-test', { has: page.getByText('@regression passes', { exact: true }) }).locator('.label', { hasText: 'regression' });
         await regressionLabelButton.click();
         await expect(page).toHaveURL(/@regression/);
         await searchInput.clear();
@@ -1702,8 +1702,8 @@ for (const useIntermediateMergeReport of [false] as const) {
         const passedNavMenu = page.locator('.subnav-item:has-text("Passed")');
         const failedNavMenu = page.locator('.subnav-item:has-text("Failed")');
         const allNavMenu = page.locator('.subnav-item:has-text("All")');
-        const smokeLabelButton =  page.locator('.label', { hasText: 'smoke' }).first();
-        const regressionLabelButton =  page.locator('.label', { hasText: 'regression' }).first();
+        const smokeLabelButton =  page.locator('.test-file-test', { has: page.getByText('@smoke fails', { exact: true }) }).locator('.label', { hasText: 'smoke' });
+        const regressionLabelButton =  page.locator('.test-file-test', { has: page.getByText('@regression passes', { exact: true }) }).locator('.label', { hasText: 'regression' });
 
         await failedNavMenu.click();
         await smokeLabelButton.click();
@@ -1863,7 +1863,7 @@ for (const useIntermediateMergeReport of [false] as const) {
         await expect(page.locator('.test-file-test .test-file-title', { hasText: '@company_information_widget fails' })).toHaveCount(1);
       });
 
-      test('handling of meta or ctrl key', async ({ runInlineTest, showReport, page,  }) => {
+      test('handling of meta or ctrl key', async ({ runInlineTest, showReport, page, }) => {
         const result = await runInlineTest({
           'a.test.js': `
             const { expect, test } = require('@playwright/test');
@@ -2212,6 +2212,29 @@ for (const useIntermediateMergeReport of [false] as const) {
       await expect(page.getByText('a.test.js', { exact: true })).toBeVisible();
       await expect(page.getByText('failed title')).not.toBeVisible();
       await expect(page.getByText('passes title')).toBeVisible();
+    });
+
+    test('tests should filter by annotation texts', async ({ runInlineTest, showReport, page }) => {
+      const result = await runInlineTest({
+        'a.test.js': `
+          const { test, expect } = require('@playwright/test');
+          test('annotated test',{ annotation :[{type:'key',description:'value'}]}, async ({}) => {expect(1).toBe(1);});
+          test('non-annotated test', async ({}) => {expect(1).toBe(2);});
+        `,
+      }, { reporter: 'dot,html' }, { PW_TEST_HTML_REPORT_OPEN: 'never' });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.passed).toBe(1);
+      expect(result.failed).toBe(1);
+
+      await showReport();
+
+      const searchInput = page.locator('.subnav-search-input');
+
+      await searchInput.fill('a:key=value');
+      await expect(page.getByText('a.test.js', { exact: true })).toBeVisible();
+      await expect(page.getByText('non-annotated test')).not.toBeVisible();
+      await expect(page.getByText('annotated test')).toBeVisible();
     });
 
     test('tests should filter by fileName:line/column', async ({ runInlineTest, showReport, page }) => {

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1702,8 +1702,8 @@ for (const useIntermediateMergeReport of [false] as const) {
         const passedNavMenu = page.locator('.subnav-item:has-text("Passed")');
         const failedNavMenu = page.locator('.subnav-item:has-text("Failed")');
         const allNavMenu = page.locator('.subnav-item:has-text("All")');
-        const smokeLabelButton =  page.locator('.test-file-test', { has: page.getByText('@smoke fails', { exact: true }) }).locator('.label', { hasText: 'smoke' });
-        const regressionLabelButton =  page.locator('.test-file-test', { has: page.getByText('@regression passes', { exact: true }) }).locator('.label', { hasText: 'regression' });
+        const smokeLabelButton =  page.locator('.label', { hasText: 'smoke' }).first();
+        const regressionLabelButton =  page.locator('.label', { hasText: 'regression' }).first();
 
         await failedNavMenu.click();
         await smokeLabelButton.click();
@@ -2231,7 +2231,7 @@ for (const useIntermediateMergeReport of [false] as const) {
 
       const searchInput = page.locator('.subnav-search-input');
 
-      await searchInput.fill('a:key=value');
+      await searchInput.fill('annot:key=value');
       await expect(page.getByText('a.test.js', { exact: true })).toBeVisible();
       await expect(page.getByText('non-annotated test')).not.toBeVisible();
       await expect(page.getByText('annotated test')).toBeVisible();


### PR DESCRIPTION
Feature request : https://github.com/microsoft/playwright/issues/30141
At Atlassian , we add team name , component name to annotations . If we want to search test case by teams on the HTML report we don't have any way . 

In this PR , I had added the functionality to search by annotation . 

Out of all tests there are two test cases with annotations . 
<img width="1063" alt="Screenshot 2024-05-11 at 5 06 47 PM" src="https://github.com/microsoft/playwright/assets/150931175/3390d3c8-4395-4633-b37f-9ff92b039da5">
<img width="1045" alt="Screenshot 2024-05-22 at 2 30 01 PM" src="https://github.com/microsoft/playwright/assets/150931175/a3e9a4d2-bf1d-42fa-8d0a-49bf6e05453e">
<img width="1106" alt="Screenshot 2024-05-22 at 2 30 11 PM" src="https://github.com/microsoft/playwright/assets/150931175/a1662185-d839-40fb-81e4-4e3efc0ac691">

If we just add to `author` in annotation search , both the test case appears . 
<img width="1051" alt="Screenshot 2024-05-22 at 2 27 46 PM" src="https://github.com/microsoft/playwright/assets/150931175/37b8a672-42a0-4445-b968-2f3b1b504fdd">

If we add `author=aman` only one test case appears . Same with `author=alex`
<img width="1019" alt="Screenshot 2024-05-22 at 2 29 47 PM" src="https://github.com/microsoft/playwright/assets/150931175/29bb3368-9df3-4b46-9a35-86a28647ce91">
<img width="1045" alt="Screenshot 2024-05-22 at 2 29 55 PM" src="https://github.com/microsoft/playwright/assets/150931175/dbb45718-c2b8-4beb-a5c9-9f4f52ac693a">


