### PR TITLE
fix(selector generator): properly escape re used in has-text

### DIFF
--- a/packages/playwright-core/src/server/injected/selectorGenerator.ts
+++ b/packages/playwright-core/src/server/injected/selectorGenerator.ts
@@ -325,8 +325,10 @@ function buildTextCandidates(injectedScript: InjectedScript, element: Element, i
     const cssToken: SelectorToken = { engine: 'css', selector: cssEscape(element.nodeName.toLowerCase()), score: kCSSTagNameScore };
     for (const alternative of alternatives)
       candidates.push([cssToken, { engine: 'internal:has-text', selector: escapeForTextSelector(alternative.text, false), score: kTextScore - alternative.scoreBouns }]);
-    if (text.length <= 80)
-      candidates.push([cssToken, { engine: 'internal:has-text', selector: '/^' + escapeRegExp(text) + '$/', score: kTextScoreRegex }]);
+    if (text.length <= 80) {
+      const re = new RegExp('^' + escapeRegExp(text) + '$');
+      candidates.push([cssToken, { engine: 'internal:has-text', selector: escapeForTextSelector(re, false), score: kTextScoreRegex }]);
+    }
   }
 
   const ariaRole = getAriaRole(element);

--- a/tests/library/selector-generator.spec.ts
+++ b/tests/library/selector-generator.spec.ts
@@ -203,6 +203,15 @@ it.describe('selector generator', () => {
     expect(await generate(page, 'div div')).toBe(`div >> internal:has-text=/^Hello world$/`);
   });
 
+  it('should use internal:has-text with regexp with a quote', async ({ page }) => {
+    await page.setContent(`
+      <span>Hello'world</span>
+      <div><div>Hello'<span>world</span></div>extra</div>
+      <a>Goodbye'<span>world</span></a>
+    `);
+    expect(await generate(page, 'div div')).toBe(`div >> internal:has-text=/^Hello\\'world$/`);
+  });
+
   it('should chain text after parent', async ({ page }) => {
     await page.setContent(`
       <div>Hello <span>world</span></div>


### PR DESCRIPTION
Fixes #30499.