### PR TITLE
test(esm): fix import attribute tests

### DIFF
--- a/tests/playwright-test/esm.spec.ts
+++ b/tests/playwright-test/esm.spec.ts
@@ -39,9 +39,10 @@ test('should support import assertions', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
       import packageJSON from './package.json' assert { type: 'json' };
+      console.log('imported value: ' + packageJSON.foo);
       export default { };
     `,
-    'package.json': JSON.stringify({ type: 'module' }),
+    'package.json': JSON.stringify({ type: 'module', foo: 'bar' }),
     'a.esm.test.ts': `
       import { test, expect } from '@playwright/test';
 
@@ -53,23 +54,28 @@ test('should support import assertions', async ({ runInlineTest }) => {
 
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
+  expect(result.stdout).toContain('imported value: bar');
 });
 
 test('should support import attributes', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
       import packageJSON from './package.json' with { type: 'json' };
+      console.log('imported value (config): ' + packageJSON.foo);
       export default { };
     `,
-    'package.json': JSON.stringify({ type: 'module' }),
+    'package.json': JSON.stringify({ type: 'module', foo: 'bar' }),
     'a.test.ts': `
-      import config from './config.json' with { type: 'json' };
+      import config from './package.json' with { type: 'json' };
+      console.log('imported value (test): ' + config.foo);
       import { test, expect } from '@playwright/test';
       test('pass', async () => {});
     `
   });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
+  expect(result.stdout).toContain('imported value (config): bar');
+  expect(result.stdout).toContain('imported value (test): bar');
 });
 
 test('should import esm from ts when package.json has type module in experimental mode', async ({ runInlineTest }) => {


### PR DESCRIPTION
Pre Node.js `18.20.0`:

- `assert` is supported

Post Node.js `18.20.0`

- `assert` and `with` is supported.

Before https://github.com/microsoft/playwright/pull/30482 we kept `asserts` in the JS code, Node.js was interpreting them. The `with` keyword was not supported, this was what the PR was fixing.

After https://github.com/microsoft/playwright/pull/30482 Babel is converting `assert` (deprecated) into `with` (successor) since we use the `deprecatedAssertSyntax` option.

This means, that the minimum Node.js version we support in order to use import attributes is now `18.20.0` where they added the `with` support. This follows our principle of supporting only the latest minor release for Node.js versions. 

See here for the 18.20 changelog:

> #### Added support for import attributes
>
> Support has been added for import attributes, to replace the old import
> assertions syntax. This will aid migration by making the new syntax available
> across all currently supported Node.js release lines.
>
> This adds the `with` keyword which should be used in place of the previous
> `assert` keyword, which will be removed in a future semver-major Node.js
> release.
>
> For example,
>
> ```console
> import "foo" assert { ... }
> ```
>
> should be replaced with
>
> ```console
> import "foo" with { ... }
> ```

Fixes https://github.com/microsoft/playwright/pull/30482 - the tests were a noop before, since they were tree-shaked by Babel.