### PR TITLE
fix(fetch): allow UTF-8 in Location header

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -336,12 +336,15 @@ export abstract class APIRequestContext extends SdkObject {
             redirectOptions.rejectUnauthorized = false;
 
           // HTTP-redirect fetch step 4: If locationURL is null, then return response.
-          if (response.headers.location) {
+          // Best-effort UTF-8 decoding, per spec it's US-ASCII only, but browsers are more lenient.
+          // Node.js parses it as Latin1, so we convert it to UTF-8.
+          const locationHeaderValue = Buffer.from(response.headers.location ?? '', 'latin1').toString('utf8');
+          if (locationHeaderValue) {
             let locationURL;
             try {
-              locationURL = new URL(response.headers.location, url);
+              locationURL = new URL(locationHeaderValue, url);
             } catch (error) {
-              reject(new Error(`uri requested responds with an invalid redirect URL: ${response.headers.location}`));
+              reject(new Error(`uri requested responds with an invalid redirect URL: ${locationHeaderValue}`));
               request.destroy();
               return;
             }

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -337,7 +337,7 @@ export abstract class APIRequestContext extends SdkObject {
 
           // HTTP-redirect fetch step 4: If locationURL is null, then return response.
           // Best-effort UTF-8 decoding, per spec it's US-ASCII only, but browsers are more lenient.
-          // Node.js parses it as Latin1, so we convert it to UTF-8.
+          // Node.js parses it as Latin1 via std::v8::String, so we convert it to UTF-8.
           const locationHeaderValue = Buffer.from(response.headers.location ?? '', 'latin1').toString('utf8');
           if (locationHeaderValue) {
             let locationURL;


### PR DESCRIPTION
This brings up the discussion if we want to post-process all the headers as UTF-8 as well.

Fixes https://github.com/microsoft/playwright/issues/30903#issuecomment-2119959937