### PR TITLE
fix(tracing): speed up trace recording

### DIFF
--- a/packages/playwright-core/src/utils/fileUtils.ts
+++ b/packages/playwright-core/src/utils/fileUtils.ts
@@ -16,6 +16,9 @@
 
 import fs from 'fs';
 import path from 'path';
+import { ManualPromise } from './manualPromise';
+import type { EventEmitter } from 'events';
+import { yazl } from '../zipBundle';
 
 export const fileUploadSizeLimit = 50 * 1024 * 1024;
 
@@ -55,4 +58,148 @@ export function sanitizeForFilePath(s: string) {
 
 export function toPosixPath(aPath: string): string {
   return aPath.split(path.sep).join(path.posix.sep);
+}
+
+type NameValue = { name: string, value: string };
+type SerializedFSOperation = {
+  op: 'mkdir', dir: string,
+} | {
+  op: 'writeFile', file: string, content: string | Buffer, skipIfExists?: boolean,
+} | {
+  op: 'appendFile', file: string, content: string,
+} | {
+  op: 'copyFile', from: string, to: string,
+} | {
+  op: 'zip', entries: NameValue[], zipFileName: string,
+};
+
+export class SerializedFS {
+  private _buffers = new Map<string, string[]>(); // Should never be accessed from within appendOperation.
+  private _error: Error | undefined;
+  private _operations: SerializedFSOperation[] = [];
+  private _operationsDone: ManualPromise<void>;
+
+  constructor() {
+    this._operationsDone = new ManualPromise();
+    this._operationsDone.resolve();  // No operations scheduled yet.
+  }
+
+  mkdir(dir: string) {
+    this._appendOperation({ op: 'mkdir', dir });
+  }
+
+  writeFile(file: string, content: string | Buffer, skipIfExists?: boolean) {
+    this._buffers.delete(file); // No need to flush the buffer since we'll overwrite anyway.
+    this._appendOperation({ op: 'writeFile', file, content, skipIfExists });
+  }
+
+  appendFile(file: string, text: string, flush?: boolean) {
+    if (!this._buffers.has(file))
+      this._buffers.set(file, []);
+    this._buffers.get(file)!.push(text);
+    if (flush)
+      this._flushFile(file);
+  }
+
+  private _flushFile(file: string) {
+    const buffer = this._buffers.get(file);
+    if (buffer === undefined)
+      return;
+    const content = buffer.join('');
+    this._buffers.delete(file);
+    this._appendOperation({ op: 'appendFile', file, content });
+  }
+
+  copyFile(from: string, to: string) {
+    this._flushFile(from);
+    this._buffers.delete(to); // No need to flush the buffer since we'll overwrite anyway.
+    this._appendOperation({ op: 'copyFile', from, to });
+  }
+
+  async syncAndGetError() {
+    for (const file of this._buffers.keys())
+      this._flushFile(file);
+    await this._operationsDone;
+    return this._error;
+  }
+
+  zip(entries: NameValue[], zipFileName: string) {
+    for (const file of this._buffers.keys())
+      this._flushFile(file);
+
+    // Chain the export operation against write operations,
+    // so that files do not change during the export.
+    this._appendOperation({ op: 'zip', entries, zipFileName });
+  }
+
+  // This method serializes all writes to the trace.
+  private _appendOperation(op: SerializedFSOperation): void {
+    const last = this._operations[this._operations.length - 1];
+    if (last?.op === 'appendFile' && op.op === 'appendFile' && last.file === op.file) {
+      // Merge pending appendFile operations for performance.
+      last.content += op.content;
+      return;
+    }
+
+    this._operations.push(op);
+    if (this._operationsDone.isDone())
+      this._performOperations();
+  }
+
+  private async _performOperations() {
+    this._operationsDone = new ManualPromise();
+    while (this._operations.length) {
+      const op = this._operations.shift()!;
+      // Ignore all operations after the first error.
+      if (this._error)
+        continue;
+      try {
+        await this._performOperation(op);
+      } catch (e) {
+        this._error = e;
+      }
+    }
+    this._operationsDone.resolve();
+  }
+
+  private async _performOperation(op: SerializedFSOperation) {
+    switch (op.op) {
+      case 'mkdir': {
+        await fs.promises.mkdir(op.dir, { recursive: true });
+        return;
+      }
+      case 'writeFile': {
+        // Note: 'wx' flag only writes when the file does not exist.
+        // See https://nodejs.org/api/fs.html#file-system-flags.
+        // This way tracing never have to write the same resource twice.
+        if (op.skipIfExists)
+          await fs.promises.writeFile(op.file, op.content, { flag: 'wx' }).catch(() => {});
+        else
+          await fs.promises.writeFile(op.file, op.content);
+        return;
+      }
+      case 'copyFile': {
+        await fs.promises.copyFile(op.from, op.to);
+        return;
+      }
+      case 'appendFile': {
+        await fs.promises.appendFile(op.file, op.content);
+        return;
+      }
+      case 'zip': {
+        const zipFile = new yazl.ZipFile();
+        const result = new ManualPromise<void>();
+        (zipFile as any as EventEmitter).on('error', error => result.reject(error));
+        for (const entry of op.entries)
+          zipFile.addFile(entry.value, entry.name);
+        zipFile.end();
+        zipFile.outputStream
+            .pipe(fs.createWriteStream(op.zipFileName))
+            .on('close', () => result.resolve())
+            .on('error', error => result.reject(error));
+        await result;
+        return;
+      }
+    }
+  }
 }

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -19,7 +19,6 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { PNG } from 'playwright-core/lib/utilsBundle';
-import { removeFolders } from '../../packages/playwright-core/src/utils/fileUtils';
 import type { CommonFixtures, CommonWorkerFixtures, TestChildProcess } from '../config/commonFixtures';
 import { commonFixtures } from '../config/commonFixtures';
 import type { ServerFixtures, ServerWorkerOptions } from '../config/serverFixtures';
@@ -457,3 +456,9 @@ export default defineConfig({
   projects: [{name: 'default'}],
 });
 `;
+
+export async function removeFolders(dirs: string[]): Promise<Error[]> {
+  return await Promise.all(dirs.map((dir: string) =>
+    fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 10 }).catch(e => e)
+  ));
+}

--- a/tests/playwright-test/ui-mode-fixtures.ts
+++ b/tests/playwright-test/ui-mode-fixtures.ts
@@ -18,11 +18,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { TestChildProcess } from '../config/commonFixtures';
-import { cleanEnv, cliEntrypoint, test as base, writeFiles } from './playwright-test-fixtures';
+import { cleanEnv, cliEntrypoint, test as base, writeFiles, removeFolders } from './playwright-test-fixtures';
 import type { Files, RunOptions } from './playwright-test-fixtures';
 import type { Browser, BrowserType, Page, TestInfo } from './stable-test-runner';
 import { createGuid } from '../../packages/playwright-core/src/utils/crypto';
-import { removeFolders } from '../../packages/playwright-core/src/utils/fileUtils';
 
 type Latch = {
   blockingCode: string;


### PR DESCRIPTION
This includes two major changes:
- reuse `SerializedFS` for live test runner tracing;
- merge scheduled `appendFile` operations into a single `fs` call.

In some cases, this improves performance of UI mode by 61% and performance of `trace: on` mode by 38%. Note that performance improvement on the average test will not be as noticeable.

References #30875, #30635.