### PR TITLE
fix(vscode): keep config order in vscode extension project dropdown

### DIFF
--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -67,14 +67,12 @@ export async function collectProjectsAndTestFiles(testRun: TestRun, doNotRunTest
   const projectClosure = buildProjectsClosure([...filesToRunByProject.keys()]);
   for (const [project, type] of projectClosure) {
     if (type === 'dependency') {
-      filesToRunByProject.delete(project);
       const treatProjectAsEmpty = doNotRunTestsOutsideProjectFilter && !filteredProjects.includes(project);
       const files = treatProjectAsEmpty ? [] : allFilesForProject.get(project) || await collectFilesForProject(project, fsCache);
       filesToRunByProject.set(project, files);
     }
   }
 
-  testRun.projects = [...filesToRunByProject.keys()];
   testRun.projectFiles = filesToRunByProject;
   testRun.projectSuites = new Map();
 }

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -51,7 +51,6 @@ export class TestRun {
   readonly failureTracker: FailureTracker;
   rootSuite: Suite | undefined = undefined;
   readonly phases: Phase[] = [];
-  projects: FullProjectInternal[] = [];
   projectFiles: Map<FullProjectInternal, string[]> = new Map();
   projectSuites: Map<FullProjectInternal, Suite[]> = new Map();
 


### PR DESCRIPTION
Relates https://github.com/microsoft/playwright/issues/30936

Test plan: Cover it on the VSCode extension side once this is released under @next.