### PR TITLE
chore: remove references to jest expand

### DIFF
--- a/packages/playwright/src/matchers/toEqual.ts
+++ b/packages/playwright/src/matchers/toEqual.ts
@@ -25,9 +25,6 @@ import type { Locator } from 'playwright-core';
 const EXPECTED_LABEL = 'Expected';
 const RECEIVED_LABEL = 'Received';
 
-// The optional property of matcher context is true if undefined.
-const isExpand = (expand?: boolean): boolean => expand !== false;
-
 export async function toEqual<T>(
   this: ExpectMatcherContext,
   matcherName: string,
@@ -61,7 +58,7 @@ export async function toEqual<T>(
           received,
           EXPECTED_LABEL,
           RECEIVED_LABEL,
-          isExpand(this.expand),
+          false,
       ) + callLogText(log);
 
   // Passing the actual and expected objects so that a custom reporter

--- a/packages/playwright/src/matchers/toMatchText.ts
+++ b/packages/playwright/src/matchers/toMatchText.ts
@@ -83,7 +83,7 @@ export async function toMatchText(
       const labelExpected = `Expected ${typeof expected === 'string' ? stringSubstring : 'pattern'}`;
       if (notFound)
         return messagePrefix + `${labelExpected}: ${this.utils.printExpected(expected)}\nReceived: ${received}` + callLogText(log);
-      return messagePrefix + this.utils.printDiffOrStringify(expected, receivedString, labelExpected, 'Received string', this.expand !== false) + callLogText(log);
+      return messagePrefix + this.utils.printDiffOrStringify(expected, receivedString, labelExpected, 'Received string', false) + callLogText(log);
     }
   };
 


### PR DESCRIPTION
Since https://github.com/microsoft/playwright/pull/7722 we always set expand to false [here](https://github.com/microsoft/playwright/blob/a106428114a7948f4c51e85a67fd4ce930a466f1/packages/playwright/src/matchers/expect.ts#L176) and don't expose any means to change that (in jest it's expect.setState).