### PR TITLE
chore: change expect.getState() return type to unknown

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6515,7 +6515,7 @@ export type Expect<ExtendedMatchers = {}> = {
     timeout?: number,
     soft?: boolean,
   }) => Expect<ExtendedMatchers>;
-  getState(): ExpectMatcherState;
+  getState(): unknown;
   not: Omit<AsymmetricMatchers, 'any' | 'anything'>;
 } & AsymmetricMatchers;
 

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -404,7 +404,7 @@ export type Expect<ExtendedMatchers = {}> = {
     timeout?: number,
     soft?: boolean,
   }) => Expect<ExtendedMatchers>;
-  getState(): ExpectMatcherState;
+  getState(): unknown;
   not: Omit<AsymmetricMatchers, 'any' | 'anything'>;
 } & AsymmetricMatchers;
 


### PR DESCRIPTION
Eventually we would like to remove this method altogether.