### PR TITLE
fix(recorder): do not ignore signals except for navigation

### DIFF
--- a/packages/playwright-core/src/server/recorder/codeGenerator.ts
+++ b/packages/playwright-core/src/server/recorder/codeGenerator.ts
@@ -130,7 +130,8 @@ export class CodeGenerator extends EventEmitter {
       this._currentAction.action.signals.push(signal);
       return;
     }
-    if (this._lastAction && !this._lastAction.committed) {
+
+    if (this._lastAction && (!this._lastAction.committed || signal.name !== 'navigation')) {
       const signals = this._lastAction.action.signals;
       if (signal.name === 'navigation' && signals.length && signals[signals.length - 1].name === 'download')
         return;


### PR DESCRIPTION
When a signal arrives late enough, after the last action was committed in 5 seconds, we should still account for it. This includes downloads, popups and dialogs, but not navigations.

Exposed by a flaky test "should record open in a new tab with url".