### PR TITLE
docs: link to input page instead of locators in testing-library migration guide

### DIFF
--- a/docs/src/testing-library-js.md
+++ b/docs/src/testing-library-js.md
@@ -18,7 +18,7 @@ If you use DOM Testing Library in the browser (for example, you bundle end-to-en
 | [screen](https://testing-library.com/docs/queries/about#screen) | [page](./api/class-page) and [component](./api/class-locator) |
 | [queries](https://testing-library.com/docs/queries/about) | [locators](./locators) |
 | [async helpers](https://testing-library.com/docs/dom-testing-library/api-async) | [assertions](./test-assertions) |
-| [user events](https://testing-library.com/docs/user-event/intro) | [actions](./api/class-locator) |
+| [user events](https://testing-library.com/docs/user-event/intro) | [actions](./input) |
 | `await user.click(screen.getByText('Click me'))`        | `await component.getByText('Click me').click()` |
 | `await user.click(await screen.findByText('Click me'))` | `await component.getByText('Click me').click()` |
 | `await user.type(screen.getByLabel('Password'), 'secret')` | `await component.getByLabel('Password').fill('secret')` |


### PR DESCRIPTION
This PR changes the actions link from the [locators](https://playwright.dev/docs/api/class-locator) page to the [actions](https://playwright.dev/docs/input) page which seems better to me logically.