### PR TITLE
fix(webkit): make cookie SameSite=Lax by default

### DIFF
--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -267,7 +267,11 @@ export class WKBrowserContext extends BrowserContext {
     const cc = network.rewriteCookies(cookies).map(c => ({
       ...c,
       session: c.expires === -1 || c.expires === undefined,
-      expires: c.expires && c.expires !== -1 ? c.expires * 1000 : c.expires
+      expires: c.expires && c.expires !== -1 ? c.expires * 1000 : c.expires,
+      // Cookies without SameSite attribute are treated as Lax by the spec,
+      // so we provide the value explicitly to not depend on the underlying
+      // network library defaults.
+      sameSite: c.sameSite ?? 'Lax',
     })) as Protocol.Playwright.SetCookieParam[];
     await this._browser._browserSession.send('Playwright.setCookies', { cookies: cc, browserContextId: this._browserContextId });
   }

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -256,11 +256,7 @@ export class WKBrowserContext extends BrowserContext {
   async doGetCookies(urls: string[]): Promise<channels.NetworkCookie[]> {
     const { cookies } = await this._browser._browserSession.send('Playwright.getAllCookies', { browserContextId: this._browserContextId });
     return network.filterCookies(cookies.map((c: channels.NetworkCookie) => {
-      const copy: any = { ...c };
-      // "Prevent cross-site tracking." is on by default in Safary, which essentially
-      // disables SameSite=None and such cookies become Lax.
-      if (copy.sameSite === 'None')
-        copy.sameSite = 'Lax';
+      const copy: any = { ... c };
       copy.expires = c.expires === -1 ? -1 : c.expires / 1000;
       delete copy.session;
       return copy as channels.NetworkCookie;
@@ -271,10 +267,7 @@ export class WKBrowserContext extends BrowserContext {
     const cc = network.rewriteCookies(cookies).map(c => ({
       ...c,
       session: c.expires === -1 || c.expires === undefined,
-      expires: c.expires && c.expires !== -1 ? c.expires * 1000 : c.expires,
-      // With "Prevent cross-site tracking." on by default in Safary, SameSite=None cookies
-      // behave as Lax.
-      sameSite: (!c.sameSite || c.sameSite === 'None') ? 'Lax' : c.sameSite,
+      expires: c.expires && c.expires !== -1 ? c.expires * 1000 : c.expires
     })) as Protocol.Playwright.SetCookieParam[];
     await this._browser._browserSession.send('Playwright.setCookies', { cookies: cc, browserContextId: this._browserContextId });
   }

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -71,7 +71,7 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
     if (browserName === 'chromium')
       await run('Lax');
     else if (browserName === 'webkit')
-      await run('None');
+      await run('Lax');
     else if (browserName === 'firefox' && channel === 'firefox-beta')
       await run(browserMajorVersion >= 103 && browserMajorVersion < 110 ? 'Lax' : 'None');
     else if (browserName === 'firefox' && channel !== 'firefox-beta')

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -67,11 +67,11 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
       await run(false);
   }, { scope: 'worker' }],
 
-  defaultSameSiteCookieValue: [async ({ browserName, browserMajorVersion, channel, platform }, run) => {
+  defaultSameSiteCookieValue: [async ({ browserName, browserMajorVersion, channel }, run) => {
     if (browserName === 'chromium')
       await run('Lax');
     else if (browserName === 'webkit')
-      await run('Lax');
+      await run('None');
     else if (browserName === 'firefox' && channel === 'firefox-beta')
       await run(browserMajorVersion >= 103 && browserMajorVersion < 110 ? 'Lax' : 'None');
     else if (browserName === 'firefox' && channel !== 'firefox-beta')

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -67,11 +67,11 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
       await run(false);
   }, { scope: 'worker' }],
 
-  defaultSameSiteCookieValue: [async ({ browserName, browserMajorVersion, channel }, run) => {
+  defaultSameSiteCookieValue: [async ({ browserName, browserMajorVersion, channel, platform }, run) => {
     if (browserName === 'chromium')
       await run('Lax');
     else if (browserName === 'webkit')
-      await run('None');
+      await run('Lax');
     else if (browserName === 'firefox' && channel === 'firefox-beta')
       await run(browserMajorVersion >= 103 && browserMajorVersion < 110 ? 'Lax' : 'None');
     else if (browserName === 'firefox' && channel !== 'firefox-beta')

--- a/tests/library/browsercontext-add-cookies.spec.ts
+++ b/tests/library/browsercontext-add-cookies.spec.ts
@@ -224,7 +224,7 @@ it('should have |expires| set to |-1| for session cookies', async ({ context, se
   expect(cookies[0].expires).toBe(-1);
 });
 
-it('should set cookie with reasonable defaults', async ({ context, server, browserName }) => {
+it('should set cookie with reasonable defaults', async ({ context, server, browserName, defaultSameSiteCookieValue }) => {
   await context.addCookies([{
     url: server.EMPTY_PAGE,
     name: 'defaults',
@@ -239,7 +239,7 @@ it('should set cookie with reasonable defaults', async ({ context, server, brows
     expires: -1,
     httpOnly: false,
     secure: false,
-    sameSite: browserName === 'chromium' ? 'Lax' : 'None',
+    sameSite: defaultSameSiteCookieValue,
   }]);
 });
 

--- a/tests/library/browsercontext-add-cookies.spec.ts
+++ b/tests/library/browsercontext-add-cookies.spec.ts
@@ -224,7 +224,7 @@ it('should have |expires| set to |-1| for session cookies', async ({ context, se
   expect(cookies[0].expires).toBe(-1);
 });
 
-it('should set cookie with reasonable defaults', async ({ context, server, browserName, defaultSameSiteCookieValue }) => {
+it('should set cookie with reasonable defaults', async ({ context, server, browserName }) => {
   await context.addCookies([{
     url: server.EMPTY_PAGE,
     name: 'defaults',
@@ -239,7 +239,7 @@ it('should set cookie with reasonable defaults', async ({ context, server, brows
     expires: -1,
     httpOnly: false,
     secure: false,
-    sameSite: defaultSameSiteCookieValue,
+    sameSite: browserName === 'chromium' ? 'Lax' : 'None',
   }]);
 });
 

--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -384,7 +384,7 @@ it('should support requestStorageAccess', async ({ page, server, channel, browse
         server.waitForRequest('/title.html'),
         frame.evaluate(() => fetch('/title.html'))
       ]);
-      if (!isMac && browserName === 'webkit')
+      if (isWindows && browserName === 'webkit')
         expect(serverRequest.headers.cookie).toBe('name=value');
       else
         expect(serverRequest.headers.cookie).toBeFalsy();
@@ -396,7 +396,7 @@ it('should support requestStorageAccess', async ({ page, server, channel, browse
         server.waitForRequest('/title.html'),
         frame.evaluate(() => fetch('/title.html'))
       ]);
-      expect(serverRequest.headers.cookie).toBe('name=value');
+      expect(serverRequest.headers.cookie).toBe(browserName === 'webkit' ? undefined : 'name=value');
     }
   }
 });

--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -147,7 +147,7 @@ it('should get cookies from multiple urls', async ({ context, browserName, isWin
     url: 'https://foo.com',
     name: 'doggo',
     value: 'woofs',
-    sameSite: 'None',
+    sameSite: 'Lax',
   }, {
     url: 'https://bar.com',
     name: 'catto',
@@ -168,7 +168,7 @@ it('should get cookies from multiple urls', async ({ context, browserName, isWin
     expires: -1,
     httpOnly: false,
     secure: true,
-    sameSite: (browserName === 'webkit' && isWindows) ? 'None' : 'Lax',
+    sameSite: 'Lax',
   }, {
     name: 'doggo',
     value: 'woofs',
@@ -177,7 +177,7 @@ it('should get cookies from multiple urls', async ({ context, browserName, isWin
     expires: -1,
     httpOnly: false,
     secure: true,
-    sameSite: 'None',
+    sameSite: 'Lax',
   }]));
 });
 
@@ -279,7 +279,7 @@ it('should add cookies with an expiration', async ({ context }) => {
     url: 'https://foo.com',
     name: 'doggo',
     value: 'woofs',
-    sameSite: 'None',
+    sameSite: 'Lax',
     expires,
   }]);
   const cookies = await context.cookies(['https://foo.com']);
@@ -292,7 +292,7 @@ it('should add cookies with an expiration', async ({ context }) => {
     expires,
     httpOnly: false,
     secure: true,
-    sameSite: 'None',
+    sameSite: 'Lax',
   }]);
   {
     // Rollover to 5-digit year
@@ -300,14 +300,14 @@ it('should add cookies with an expiration', async ({ context }) => {
       url: 'https://foo.com',
       name: 'doggo',
       value: 'woofs',
-      sameSite: 'None',
+      sameSite: 'Lax',
       expires: 253402300799, // Fri, 31 Dec 9999 23:59:59 +0000 (UTC)
     }]);
     await expect(context.addCookies([{
       url: 'https://foo.com',
       name: 'doggo',
       value: 'woofs',
-      sameSite: 'None',
+      sameSite: 'Lax',
       expires: 253402300800, // Sat,  1 Jan 1000 00:00:00 +0000 (UTC)
     }])).rejects.toThrow(/Cookie should have a valid expires/);
   }
@@ -316,7 +316,7 @@ it('should add cookies with an expiration', async ({ context }) => {
     url: 'https://foo.com',
     name: 'doggo',
     value: 'woofs',
-    sameSite: 'None',
+    sameSite: 'Lax',
     expires: -42,
   }])).rejects.toThrow(/Cookie should have a valid expires/);
 });
@@ -350,26 +350,26 @@ it('should be able to send third party cookies via an iframe', async ({ browser,
   }
 });
 
-it('should support requestStorageAccess', async ({ page, server, channel, browserName, isMac, isLinux, isWindows }) => {
+it('should support requestStorageAccess', async ({ browser, httpsServer, channel, browserName, isLinux, isMac }) => {
+  const page = await browser.newPage({ ignoreHTTPSErrors: true });
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/17285' });
   it.skip(browserName === 'chromium', 'requestStorageAccess API is not available in Chromium');
   it.skip(channel === 'firefox-beta', 'hasStorageAccess returns true, but no cookie is sent');
-
-  server.setRoute('/set-cookie.html', (req, res) => {
-    res.setHeader('Set-Cookie', 'name=value; Path=/');
+  httpsServer.setRoute('/set-cookie.html', (req, res) => {
+    res.setHeader('Set-Cookie', 'name=value; Path=/; SameSite=None; Secure');
     res.end();
   });
   // Navigate once to the domain as top level.
-  await page.goto(server.CROSS_PROCESS_PREFIX + '/set-cookie.html');
-  await page.goto(server.EMPTY_PAGE);
-  await page.setContent(`<iframe src="${server.CROSS_PROCESS_PREFIX + '/empty.html'}"></iframe>`);
+  await page.goto(httpsServer.CROSS_PROCESS_PREFIX + '/set-cookie.html');
+  await page.goto(httpsServer.EMPTY_PAGE);
+  await page.setContent(`<iframe src="${httpsServer.CROSS_PROCESS_PREFIX + '/empty.html'}"></iframe>`);
 
   const frame = page.frames()[1];
   if (browserName === 'firefox') {
     expect(await frame.evaluate(() => document.hasStorageAccess())).toBeTruthy();
     {
       const [serverRequest] = await Promise.all([
-        server.waitForRequest('/title.html'),
+        httpsServer.waitForRequest('/title.html'),
         frame.evaluate(() => fetch('/title.html'))
       ]);
       expect(serverRequest.headers.cookie).toBe('name=value');
@@ -381,7 +381,7 @@ it('should support requestStorageAccess', async ({ page, server, channel, browse
       expect(await frame.evaluate(() => document.hasStorageAccess())).toBeFalsy();
     {
       const [serverRequest] = await Promise.all([
-        server.waitForRequest('/title.html'),
+        httpsServer.waitForRequest('/title.html'),
         frame.evaluate(() => fetch('/title.html'))
       ]);
       if (!isMac && browserName === 'webkit')
@@ -393,12 +393,13 @@ it('should support requestStorageAccess', async ({ page, server, channel, browse
     expect(await frame.evaluate(() => document.hasStorageAccess())).toBeTruthy();
     {
       const [serverRequest] = await Promise.all([
-        server.waitForRequest('/title.html'),
+        httpsServer.waitForRequest('/title.html'),
         frame.evaluate(() => fetch('/title.html'))
       ]);
       expect(serverRequest.headers.cookie).toBe('name=value');
     }
   }
+  await page.close();
 });
 
 it('should parse cookie with large Max-Age correctly', async ({ server, page, defaultSameSiteCookieValue, browserName, platform }) => {

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1202,7 +1202,7 @@ it('fetch should not throw on long set-cookie value', async ({ context, server }
   expect(cookies.map(c => c.name)).toContain('bar');
 });
 
-it('should support set-cookie with SameSite and without Secure attribute over HTTP', async ({ page, server, browserName, isWindows }) => {
+it('should support set-cookie with SameSite and without Secure attribute over HTTP', async ({ page, server, browserName, isWindows, isLinux }) => {
   for (const value of ['None', 'Lax', 'Strict']) {
     await it.step(`SameSite=${value}`, async () => {
       server.setRoute('/empty.html', (req, res) => {
@@ -1212,6 +1212,8 @@ it('should support set-cookie with SameSite and without Secure attribute over HT
       await page.request.get(server.EMPTY_PAGE);
       const [cookie] = await page.context().cookies();
       if (browserName === 'chromium' && value === 'None')
+        expect(cookie).toBeFalsy();
+      else if (browserName === 'webkit' && isLinux && value === 'None')
         expect(cookie).toBeFalsy();
       else if (browserName === 'webkit' && isWindows)
         expect(cookie.sameSite).toBe('None');

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1211,7 +1211,7 @@ it('should support set-cookie with SameSite and without Secure attribute over HT
       });
       await page.request.get(server.EMPTY_PAGE);
       const [cookie] = await page.context().cookies();
-      if (browserName === 'chromium' && value === 'None')
+      if (['chromium', 'webkit'].includes(browserName) && value === 'None')
         expect(cookie).toBeFalsy();
       else if (browserName === 'webkit' && isWindows)
         expect(cookie.sameSite).toBe('None');

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1211,7 +1211,7 @@ it('should support set-cookie with SameSite and without Secure attribute over HT
       });
       await page.request.get(server.EMPTY_PAGE);
       const [cookie] = await page.context().cookies();
-      if (['chromium', 'webkit'].includes(browserName) && value === 'None')
+      if (browserName === 'chromium' && value === 'None')
         expect(cookie).toBeFalsy();
       else if (browserName === 'webkit' && isWindows)
         expect(cookie.sameSite).toBe('None');


### PR DESCRIPTION
“Prevent cross-site tracking” [feature is on](https://support.apple.com/guide/safari/prevent-cross-site-tracking-sfri40732/mac) by default in Safari. It prevents SameSite=None cookie behavior, making such cookies Lax. With this PR the following behavior changes:

* The following cookies become SameSite=Lax when added via addCookies call:
  - `SameSite` is not specified
  - `SameSite=None` is specified

* Cookies added via `document.cookies='foo=bar'` are now reported as `Lax`.

Reference https://github.com/microsoft/playwright/issues/30305
Reference https://github.com/microsoft/playwright-browsers/issues/795