### PR TITLE
feat(reporting): Add hyperlink rendering for `URL` fields in `HTML` reports

### DIFF
--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -182,7 +182,7 @@ You can also annotate all tests in a group or provide multiple annotations:
 import { test, expect } from '@playwright/test';
 
 test.describe('report tests', {
-  annotation: { type: 'category', description: 'report', url: 'https://github.com/microsoft/playwright/issues/23180' },
+  annotation: { type: 'category', description: 'report' },
 }, () => {
   test('test report header', async ({ page }) => {
     // ...
@@ -192,7 +192,7 @@ test.describe('report tests', {
     annotation: [
       { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23180' },
       { type: 'performance', description: 'very slow test!' },
-      { type: 'performance', description: 'very slow test!', url: 'https://github.com/microsoft/playwright/issues/23180' },
+      { type: 'performance', url: 'https://github.com/microsoft/playwright/issues/23180' },
     ],
   }, async ({ page }) => {
     // ...

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -182,7 +182,7 @@ You can also annotate all tests in a group or provide multiple annotations:
 import { test, expect } from '@playwright/test';
 
 test.describe('report tests', {
-  annotation: { type: 'category', description: 'report' },
+  annotation: { type: 'category', description: 'report', url: 'https://github.com/microsoft/playwright/issues/23180'},
 }, () => {
   test('test report header', async ({ page }) => {
     // ...
@@ -192,6 +192,7 @@ test.describe('report tests', {
     annotation: [
       { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23180' },
       { type: 'performance', description: 'very slow test!' },
+      { type: 'performance', description: 'very slow test!', url: 'https://github.com/microsoft/playwright/issues/23180'},
     ],
   }, async ({ page }) => {
     // ...

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -182,7 +182,7 @@ You can also annotate all tests in a group or provide multiple annotations:
 import { test, expect } from '@playwright/test';
 
 test.describe('report tests', {
-  annotation: { type: 'category', description: 'report', url: 'https://github.com/microsoft/playwright/issues/23180'},
+  annotation: { type: 'category', description: 'report', url: 'https://github.com/microsoft/playwright/issues/23180' },
 }, () => {
   test('test report header', async ({ page }) => {
     // ...
@@ -192,7 +192,7 @@ test.describe('report tests', {
     annotation: [
       { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23180' },
       { type: 'performance', description: 'very slow test!' },
-      { type: 'performance', description: 'very slow test!', url: 'https://github.com/microsoft/playwright/issues/23180'},
+      { type: 'performance', description: 'very slow test!', url: 'https://github.com/microsoft/playwright/issues/23180' },
     ],
   }, async ({ page }) => {
     // ...

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -176,7 +176,10 @@ function cacheSearchValues(test: TestCaseSummary): SearchValues {
     line: String(test.location.line),
     column: String(test.location.column),
     labels: test.tags.map(tag => tag.toLowerCase()),
-    annotations: test.annotations.map(a => a.type.toLowerCase() + '=' + a.description?.toLocaleLowerCase())
+    annotations: test.annotations.map(a => {
+      const value = a.description?.toLocaleLowerCase() || a.url?.toLocaleLowerCase() || '';
+      return a.type.toLowerCase() + '=' + value;
+    }),
   };
   (test as any)[searchValuesSymbol] = searchValues;
   return searchValues;

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -74,9 +74,8 @@ function renderAnnotationDescription(description: string) {
 
 function renderAnnotationLink(url: string) {
   try {
-    if (['http:', 'https:'].includes(new URL(url).protocol)) {
+    if (['http:', 'https:'].includes(new URL(url).protocol))
       return <a href={url} target='_blank' rel='noopener noreferrer'>{url}</a>;
-    }
   } catch {}
   return url;
 }

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -72,11 +72,21 @@ function renderAnnotationDescription(description: string) {
   return description;
 }
 
-function TestCaseAnnotationView({ annotation: { type, description } }: { annotation: TestCaseAnnotation }) {
+function renderAnnotationLink(url: string) {
+  try {
+    if (['http:', 'https:'].includes(new URL(url).protocol)) {
+      return <a href={url} target='_blank' rel='noopener noreferrer'>{url}</a>;
+    }
+  } catch {}
+  return url;
+}
+
+function TestCaseAnnotationView({ annotation: { type, description, url } }: { annotation: TestCaseAnnotation }) {
   return (
     <div className='test-case-annotation'>
       <span style={{ fontWeight: 'bold' }}>{type}</span>
       {description && <span>: {renderAnnotationDescription(description)}</span>}
+      {url && <span>: {renderAnnotationLink(url)}</span>}
     </div>
   );
 }

--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -80,7 +80,7 @@ export type TestEndPayload = {
   errors: TestInfoError[];
   hasNonRetriableError: boolean;
   expectedStatus: TestStatus;
-  annotations: { type: string, description?: string }[];
+  annotations: { type: string, description?: string, url?: string }[];
   timeout: number;
 };
 

--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -221,13 +221,12 @@ export class TestTypeImpl {
       }
 
       if (typeof modifierArgs[0] === 'function') {
-        suite._modifiers.push({ type, fn: modifierArgs[0], location, description: modifierArgs[1], url: modifierArgs[1] });
+        suite._modifiers.push({ type, fn: modifierArgs[0], location, description: modifierArgs[1] });
       } else {
         if (modifierArgs.length >= 1 && !modifierArgs[0])
           return;
         const description = modifierArgs[1];
-        const url = modifierArgs[1];
-        suite._staticAnnotations.push({ type, description, url });
+        suite._staticAnnotations.push({ type, description });
       }
       return;
     }

--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -221,12 +221,13 @@ export class TestTypeImpl {
       }
 
       if (typeof modifierArgs[0] === 'function') {
-        suite._modifiers.push({ type, fn: modifierArgs[0], location, description: modifierArgs[1] });
+        suite._modifiers.push({ type, fn: modifierArgs[0], location, description: modifierArgs[1], url: modifierArgs[1] });
       } else {
         if (modifierArgs.length >= 1 && !modifierArgs[0])
           return;
         const description = modifierArgs[1];
-        suite._staticAnnotations.push({ type, description });
+        const url = modifierArgs[1];
+        suite._staticAnnotations.push({ type, description, url });
       }
       return;
     }

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -69,14 +69,14 @@ export type JsonTestCase = {
   retries: number;
   tags?: string[];
   repeatEachIndex: number;
-  annotations?: { type: string, description?: string }[];
+  annotations?: { type: string, description?: string, url?: string }[];
 };
 
 export type JsonTestEnd = {
   testId: string;
   expectedStatus: reporterTypes.TestStatus;
   timeout: number;
-  annotations: { type: string, description?: string }[];
+  annotations: { type: string, description?: string, url?: string }[];
 };
 
 export type JsonTestResultStart = {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -380,7 +380,11 @@ class HtmlBuilder {
         location,
         duration,
         // Annotations can be pushed directly, with a wrong type.
-        annotations: test.annotations.map(a => ({ type: a.type, description: a.description ? String(a.description) : a.description })),
+        annotations: test.annotations.map(a => ({
+          type: a.type,
+          description: a.description ? String(a.description) : a.description,
+          url: a.url ? String(a.url) : a.url
+        })),
         tags: test.tags,
         outcome: test.outcome(),
         path,
@@ -394,7 +398,11 @@ class HtmlBuilder {
         location,
         duration,
         // Annotations can be pushed directly, with a wrong type.
-        annotations: test.annotations.map(a => ({ type: a.type, description: a.description ? String(a.description) : a.description })),
+        annotations: test.annotations.map(a => ({
+          type: a.type,
+          description: a.description ? String(a.description) : a.description,
+          url: a.url ? String(a.url) : a.url
+        })),
         tags: test.tags,
         outcome: test.outcome(),
         path,

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -382,8 +382,7 @@ class HtmlBuilder {
         // Annotations can be pushed directly, with a wrong type.
         annotations: test.annotations.map(a => ({
           type: a.type,
-          description: a.description ? String(a.description) : a.description,
-          url: a.url ? String(a.url) : a.url
+          description: a.description ? String(a.description) : a.description
         })),
         tags: test.tags,
         outcome: test.outcome(),
@@ -400,8 +399,7 @@ class HtmlBuilder {
         // Annotations can be pushed directly, with a wrong type.
         annotations: test.annotations.map(a => ({
           type: a.type,
-          description: a.description ? String(a.description) : a.description,
-          url: a.url ? String(a.url) : a.url
+          description: a.description ? String(a.description) : a.description
         })),
         tags: test.tags,
         outcome: test.outcome(),

--- a/packages/playwright/src/reporters/versions/blobV1.ts
+++ b/packages/playwright/src/reporters/versions/blobV1.ts
@@ -71,7 +71,7 @@ export type JsonTestEnd = {
   testId: string;
   expectedStatus: reporterTypes.TestStatus;
   timeout: number;
-  annotations: { type: string, description?: string }[];
+  annotations: { type: string, description?: string, url?: string }[];
 };
 
 export type JsonTestResultStart = {

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -198,7 +198,7 @@ export class TestInfoImpl implements TestInfo {
     this._tracing = new TestTracing(this, workerParams.artifactsDir);
   }
 
-  private _modifier(type: 'skip' | 'fail' | 'fixme' | 'slow', modifierArgs: [arg?: any, description?: string]) {
+  private _modifier(type: 'skip' | 'fail' | 'fixme' | 'slow', modifierArgs: [arg?: any, description?: string, url?: string]) {
     if (typeof modifierArgs[1] === 'function') {
       throw new Error([
         'It looks like you are calling test.skip() inside the test and pass a callback.',
@@ -473,19 +473,19 @@ export class TestInfoImpl implements TestInfo {
     return path.normalize(path.resolve(this._configInternal.configDir, snapshotPath));
   }
 
-  skip(...args: [arg?: any, description?: string]) {
+  skip(...args: [arg?: any, description?: string, url?: string]) {
     this._modifier('skip', args);
   }
 
-  fixme(...args: [arg?: any, description?: string]) {
+  fixme(...args: [arg?: any, description?: string, url?: string]) {
     this._modifier('fixme', args);
   }
 
-  fail(...args: [arg?: any, description?: string]) {
+  fail(...args: [arg?: any, description?: string, url?: string]) {
     this._modifier('fail', args);
   }
 
-  slow(...args: [arg?: any, description?: string]) {
+  slow(...args: [arg?: any, description?: string, url?: string]) {
     this._modifier('slow', args);
   }
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1845,6 +1845,7 @@ export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped' | 'interru
 type TestDetailsAnnotation = {
   type: string;
   description?: string;
+  url?: string;
 };
 
 export type TestDetails = {
@@ -8175,6 +8176,11 @@ export interface TestInfo {
      * Optional description.
      */
     description?: string;
+
+    /**
+     * Optional url.
+     */
+    url?: string;
   }>;
 
   /**

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -8176,11 +8176,6 @@ export interface TestInfo {
      * Optional description.
      */
     description?: string;
-
-    /**
-     * Optional url.
-     */
-    url?: string;
   }>;
 
   /**

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -481,11 +481,6 @@ export interface TestCase {
      * Optional description.
      */
     description?: string;
-    
-    /**
-     * Optional url.
-     */
-    url?: string;
   }>;
 
   /**

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -273,7 +273,7 @@ export interface JSONReportSpec {
 
 export interface JSONReportTest {
   timeout: number;
-  annotations: { type: string, description?: string }[],
+  annotations: { type: string, description?: string, url?: string }[],
   expectedStatus: TestStatus;
   projectName: string;
   projectId: string;
@@ -481,6 +481,11 @@ export interface TestCase {
      * Optional description.
      */
     description?: string;
+    
+    /**
+     * Optional url.
+     */
+    url?: string;
   }>;
 
   /**

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -724,7 +724,27 @@ for (const useIntermediateMergeReport of [false] as const) {
         'a.test.js': `
           import { test, expect } from '@playwright/test';
           test('annotated test', async ({ page }) => {
-            test.info().annotations.push({ type: 'issue', description: 'I am not interested in this test' });
+test.info().annotations.push({ type: 'issue', description: 'I am not interested in this test' });
+          });
+        `,
+      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+      expect(result.exitCode).toBe(0);
+      expect(result.passed).toBe(1);
+
+      await showReport();
+      await page.click('text=annotated test');
+      await expect(page.locator('.test-case-annotation')).toHaveText('issue: I am not interested in this test');
+    });
+
+    test('should render annotations with url', async ({ runInlineTest, page, showReport }) => {
+      const result = await runInlineTest({
+        'playwright.config.js': `
+          module.exports = { timeout: 1500 };
+        `,
+        'a.test.js': `
+          import { test, expect } from '@playwright/test';
+          test('annotated test', async ({ page }) => {
+            test.info().annotations.push({ type: 'issue', description: 'I add URL field to annotations for hyperlink display', url: 'https://github.com/microsoft/playwright/pull/31014' });
           });
         `,
       }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -744,16 +744,15 @@ test.info().annotations.push({ type: 'issue', description: 'I am not interested 
         'a.test.js': `
           import { test, expect } from '@playwright/test';
           test('annotated test', async ({ page }) => {
-            test.info().annotations.push({ type: 'issue', description: 'I add URL field to annotations for hyperlink display', url: 'https://github.com/microsoft/playwright/pull/31014' });
+            test.info().annotations.push({ type: 'url', url: 'https://github.com/microsoft/playwright/pull/31014' });
           });
         `,
       }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
       expect(result.exitCode).toBe(0);
       expect(result.passed).toBe(1);
-
       await showReport();
       await page.click('text=annotated test');
-      await expect(page.locator('.test-case-annotation')).toHaveText('issue: I am not interested in this test');
+      await expect(page.locator('.test-case-annotation')).toHaveText(`url: https://github.com/microsoft/playwright/pull/31014`);
     });
 
     test('should render annotations as link if needed', async ({ runInlineTest, page, showReport, server }) => {

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -68,6 +68,7 @@ export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped' | 'interru
 type TestDetailsAnnotation = {
   type: string;
   description?: string;
+  url?: string;
 };
 
 export type TestDetails = {

--- a/utils/generate_types/overrides-testReporter.d.ts
+++ b/utils/generate_types/overrides-testReporter.d.ts
@@ -94,7 +94,7 @@ export interface JSONReportSpec {
 
 export interface JSONReportTest {
   timeout: number;
-  annotations: { type: string, description?: string }[],
+  annotations: { type: string, description?: string, url?: string }[],
   expectedStatus: TestStatus;
   projectName: string;
   projectId: string;


### PR DESCRIPTION
Hello, I am the contributor of the recently merged #30665 pull request. Following the merge, @pavelfeldman , the maintainer, suggested further implementation of the "rendering it in the HTML report and other reports" feature, which I have now added. I am requesting a review!

**Description:**
This pull request enhances the functionality introduced in previous updates by rendering URLs as clickable hyperlinks in HTML and other reports within Playwright tests. It builds on the existing capability to include URL fields in annotations by ensuring these URLs are interactive, thereby improving the accessibility and user experience of test reports.

**Motivation:**
Previous updates allowed URLs to be treated as hyperlinks within the `description` field, but with the addition of the `url` field, we can now more clearly and effectively display URLs in annotations. This change significantly enhances the usability and navigability of the reports, allowing users to interact directly with and easily navigate to related resources.

**Changes:**
Implemented hyperlink rendering in the HTML reporter and other report generators.

**Expected Outcome:**
With this update, URLs included in test annotations are now rendered as clickable hyperlinks. This change not only improves the interactivity of reports but also makes it easier for users to access related online resources directly from within the reports. Enhancing user engagement and providing direct access to necessary resources aligns with our goals of making test reports more informative and functional.

References:
Continues to address #30665 - "feat(test): add URL field to annotations for hyperlink display"
