### PR TITLE
chore: fix client side changes workflow

### DIFF
--- a/.github/workflows/pr_check_client_side_changes.yml
+++ b/.github/workflows/pr_check_client_side_changes.yml
@@ -30,7 +30,7 @@ jobs:
             const title = '[Ports]: Backport client side changes';
             for (const repo of ['playwright-python', 'playwright-java', 'playwright-dotnet']) {
               const { data: issuesData } = await github.rest.search.issuesAndPullRequests({
-                q: `is:issue is:open repo:microsoft/${repo} in:title "${title}"`
+                q: `is:issue is:open repo:microsoft/${repo} in:title "${title}" author:playwrightmachine"`
               })
               let issueNumber = null;
               let issueBody = '';


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/actions/runs/9004694741/job/24738285579#step:2:89

It happened when the "port client side changes" issue got manually created, our API user had to access to modify that issue. This caused a defect of updating this issue to the java/dotnet repository. Updating it manually for now there and using Python as a base.

