### PR TITLE
devops: bump actions/github-script@v6 to actions/github-script@v7

### DIFF
--- a/.github/workflows/cherry_pick_into_release_branch.yml
+++ b/.github/workflows/cherry_pick_into_release_branch.yml
@@ -60,7 +60,7 @@ jobs:
         git checkout -b "$BRANCH_NAME"
         git push origin $BRANCH_NAME
     - name: Create Pull Request
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.REPOSITORY_DISPATCH_PERSONAL_ACCESS_TOKEN }}
         script: |

--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -58,7 +58,7 @@ jobs:
         path: '.'
 
     - name: Comment on PR
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/pr_check_client_side_changes.yml
+++ b/.github/workflows/pr_check_client_side_changes.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'microsoft/playwright'
     steps:
       - name: Create GitHub issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.REPOSITORY_DISPATCH_PERSONAL_ACCESS_TOKEN }}
           script: |

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -38,7 +38,7 @@ jobs:
         git commit -m "feat(${{ github.event.client_payload.browser }}): roll to r${{ github.event.client_payload.revision }}"
         git push origin $BRANCH_NAME
     - name: Create Pull Request
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.REPOSITORY_DISPATCH_PERSONAL_ACCESS_TOKEN }}
         script: |

--- a/.github/workflows/roll_driver_nodejs.yml
+++ b/.github/workflows/roll_driver_nodejs.yml
@@ -35,7 +35,7 @@ jobs:
           git push origin $BRANCH_NAME
       - name: Create Pull Request
         if: ${{ steps.prepare-branch.outputs.HAS_CHANGES == '1' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.REPOSITORY_DISPATCH_PERSONAL_ACCESS_TOKEN }}
           script: |


### PR DESCRIPTION
This resolves this warning: https://github.com/microsoft/playwright/actions/runs/9226701285

There are no breaking changes which affect us as per [release-notes](https://github.com/actions/github-script/releases/tag/v7.0.0).