### PR TITLE
fix(trace-viewer): fix snapshot.html

### DIFF
--- a/packages/trace-viewer/snapshot.html
+++ b/packages/trace-viewer/snapshot.html
@@ -26,7 +26,7 @@
         const traceUrl = new URL(location.href).searchParams.get('trace');
         const params = new URLSearchParams();
         params.set('trace', traceUrl);
-        await fetch('context?' + params.toString()).then(r => r.json());
+        await fetch('contexts?' + params.toString()).then(r => r.json());
         await location.reload();
       })();
     </script>


### PR DESCRIPTION
Actual path to get trace contexts is /contexts, not /context