### PR TITLE
docs(test-fixtures-js.md): Fix minor grammar mistake

### DIFF
--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -926,9 +926,9 @@ export default defineConfig<MyOptions>({
 Each fixture has a setup and teardown phase separated by the `await use()` call in the fixture. Setup is executed before the fixture is used by the test/hook, and teardown is executed when the fixture will not be used by the test/hook anymore.
 
 Fixtures follow these rules to determine the execution order:
-* When fixture A depends on fixture B: B is always set up before A and teared down after A.
+* When fixture A depends on fixture B: B is always set up before A and torn down after A.
 * Non-automatic fixtures are executed lazily, only when the test/hook needs them.
-* Test-scoped fixtures are teared down after each test, while worker-scoped fixtures are only teared down when the worker process executing tests is shutdown.
+* Test-scoped fixtures are torn down after each test, while worker-scoped fixtures are only torn down when the worker process executing tests is shutdown.
 
 Consider the following example:
 
@@ -1036,8 +1036,8 @@ Normally, if all tests pass and no errors are thrown, the order of execution is 
   * `beforeEach` runs.
   * `first test` runs.
   * `afterEach` runs.
-  * `page` teardown because it is a test-scoped fixture and should be teared down after the test finishes.
-  * `autoTestFixture` teardown because it is a test-scoped fixture and should be teared down after the test finishes.
+  * `page` teardown because it is a test-scoped fixture and should be torn down after the test finishes.
+  * `autoTestFixture` teardown because it is a test-scoped fixture and should be torn down after the test finishes.
 * `second test` section:
   * `autoTestFixture` setup because automatic test fixtures are always set up before test and `beforeEach` hooks.
   * `page` setup because it is required in `beforeEach` hook.
@@ -1046,20 +1046,20 @@ Normally, if all tests pass and no errors are thrown, the order of execution is 
   * `testFixture` setup because it is required by the `second test`.
   * `second test` runs.
   * `afterEach` runs.
-  * `testFixture` teardown because it is a test-scoped fixture and should be teared down after the test finishes.
-  * `page` teardown because it is a test-scoped fixture and should be teared down after the test finishes.
-  * `autoTestFixture` teardown because it is a test-scoped fixture and should be teared down after the test finishes.
+  * `testFixture` teardown because it is a test-scoped fixture and should be torn down after the test finishes.
+  * `page` teardown because it is a test-scoped fixture and should be torn down after the test finishes.
+  * `autoTestFixture` teardown because it is a test-scoped fixture and should be torn down after the test finishes.
 * `afterAll` and worker teardown section:
   * `afterAll` runs.
-  * `workerFixture` teardown because it is a workers-scoped fixture and should be teared down once at the end.
-  * `autoWorkerFixture` teardown because it is a workers-scoped fixture and should be teared down once at the end.
-  * `browser` teardown because it is a workers-scoped fixture and should be teared down once at the end.
+  * `workerFixture` teardown because it is a workers-scoped fixture and should be torn down once at the end.
+  * `autoWorkerFixture` teardown because it is a workers-scoped fixture and should be torn down once at the end.
+  * `browser` teardown because it is a workers-scoped fixture and should be torn down once at the end.
 
 A few observations:
-* `page` and `autoTestFixture` are set up and teared down for each test, as test-scoped fixtures.
+* `page` and `autoTestFixture` are set up and torn down for each test, as test-scoped fixtures.
 * `unusedFixture` is never set up because it is not used by any tests/hooks.
 * `testFixture` depends on `workerFixture` and triggers its setup.
-* `workerFixture` is lazily set up before the second test, but teared down once during worker shutdown, as a worker-scoped fixture.
+* `workerFixture` is lazily set up before the second test, but torn down once during worker shutdown, as a worker-scoped fixture.
 * `autoWorkerFixture` is set up for `beforeAll` hook, but `autoTestFixture` is not.
 
 ## Combine custom fixtures from multiple modules


### PR DESCRIPTION
Replaced "teared" with "torn" in 13 instances.