### PR TITLE
fix(runner): don't write last run info when listing tests

### DIFF
--- a/packages/playwright/src/runner/runner.ts
+++ b/packages/playwright/src/runner/runner.ts
@@ -94,7 +94,8 @@ export class Runner {
     if (modifiedResult && modifiedResult.status)
       status = modifiedResult.status;
 
-    await writeLastRunInfo(testRun, status);
+    if (!listOnly)
+      await writeLastRunInfo(testRun, status);
 
     await reporter.onExit();
 


### PR DESCRIPTION
don't write last run info when listing tests.

----

This change is also part of https://github.com/microsoft/playwright/pull/30962