### PR TITLE
devops: fix electron bots

### DIFF
--- a/.github/actions/upload-blob-report/action.yml
+++ b/.github/actions/upload-blob-report/action.yml
@@ -12,6 +12,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Warn if directory does not exist
+      shell: bash
+      run: |
+        if [[ ! -d "${{ inputs.report_dir }}" ]]; then
+          echo "Directory '${{ inputs.report_dir }}' does not exist";
+          exit 0;
+        fi
     - name: Integrity check
       shell: bash
       run: find "${{ inputs.report_dir }}" -name "*.zip" -exec unzip -t {} \;

--- a/.github/actions/upload-blob-report/action.yml
+++ b/.github/actions/upload-blob-report/action.yml
@@ -12,29 +12,34 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Warn if directory does not exist
+    - id: check_dir
+      name: Warn if directory does not exist
       shell: bash
       run: |
         if [[ ! -d "${{ inputs.report_dir }}" ]]; then
           echo "Directory '${{ inputs.report_dir }}' does not exist";
+          echo "dir_exists=false" >> $GITHUB_OUTPUT
           exit 0;
+        else
+          echo "dir_exists=true" >> $GITHUB_OUTPUT
         fi
     - name: Integrity check
+      if: ${{ steps.check_dir.outputs.dir_exists == 'true' }}
       shell: bash
       run: find "${{ inputs.report_dir }}" -name "*.zip" -exec unzip -t {} \;
     - name: Upload blob report to GitHub
-      if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+      if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.check_dir.outputs.dir_exists == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: blob-report-${{ inputs.job_name }}
         path: ${{ inputs.report_dir }}/**
         retention-days: 7
     - name: Write triggering pull request number in a file
-      if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+      if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.check_dir.outputs.dir_exists == 'true' }}
       shell: bash
       run: echo '${{ github.event.number }}' > pull_request_number.txt;
     - name: Upload artifact with the pull request number
-      if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+      if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.check_dir.outputs.dir_exists == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: pull-request-${{ inputs.job_name }}


### PR DESCRIPTION
Motivation: We don't produce blobs for the electron tests - this currently makes them red since we try to upload the blob-report directory.

See https://github.com/microsoft/playwright/actions/workflows/tests_electron.yml