### PR TITLE
fix(npx install): Preserve environment so HTTP_PROXY and HTTPS_PROXY go to root apt install commands.

### DIFF
--- a/packages/playwright-core/src/server/registry/dependencies.ts
+++ b/packages/playwright-core/src/server/registry/dependencies.ts
@@ -371,6 +371,6 @@ export async function transformCommandsForRoot(commands: string[]): Promise<{ co
     return { command: 'sh', args: ['-c', `${commands.join('&& ')}`], elevatedPermissions: false };
   const sudoExists = await spawnAsync('which', ['sudo']);
   if (sudoExists.code === 0)
-    return { command: 'sudo', args: ['--', 'sh', '-c', `${commands.join('&& ')}`], elevatedPermissions: true };
+    return { command: 'sudo', args: ['--preserve-env', '--', 'sh', '-c', `${commands.join('&& ')}`], elevatedPermissions: true };
   return { command: 'su', args: ['root', '-c', `${commands.join('&& ')}`], elevatedPermissions: true };
 }


### PR DESCRIPTION
I was following these instructions
https://playwright.dev/docs/browsers#install-behind-a-firewall-or-a-proxy
 and it appears that root does not get the HTTP_PROXY, HTTPS_PROXY, NO_PROXY, NODE_EXTRA_CA_CERTS, etc. environment variables.
 
# Expected behavior
When running `npx playwright install` as a non-root user with a proxy (or any other environment-dependent situation), when the installer elevates to root, preserve the environment variables.

 # The problem
 Apt no longer has the environment variables so it doesn't use the proxy.
 
 Here's a Dockerfile that demonstrates the problem:
 ```Dockerfile
 FROM mcr.microsoft.com/devcontainers/javascript-node:20-bookworm

RUN env | sort                                         # Has HTTP_PROXY and HTTPS_PROXY
RUN sh -c 'env | sort'                                 # Has HTTP_PROXY and HTTPS_PROXY
RUN sudo env | sort                                    # Does not have HTTP_PROXY and HTTPS_PROXY
RUN sudo --preserve-env env | sort             # Has HTTP_PROXY and HTTPS_PROXY
RUN sudo --preserve-env -- sh -c 'env | sort'  # Has HTTP_PROXY and HTTPS_PROXY

# Disable password for su for all users
RUN echo 'auth sufficient pam_permit.so' > /etc/pam.d/su
USER node

RUN env | sort                                         # Has HTTP_PROXY and HTTPS_PROXY
RUN sh -c 'env | sort'                                 # Has HTTP_PROXY and HTTPS_PROXY
RUN sudo env | sort                                    # Does not have HTTP_PROXY and HTTPS_PROXY
RUN sudo --preserve-env env | sort             # Has HTTP_PROXY and HTTPS_PROXY
RUN sudo --preserve-env -- sh -c 'env | sort'  # Has HTTP_PROXY and HTTPS_PROXY

RUN su root -c 'env | sort'                            # Has HTTP_PROXY and HTTPS_PROXY
RUN su root  --preserve-environment -c 'env | sort'    # Has HTTP_PROXY and HTTPS_PROXY

 ```
 Invoke: `docker build . --progress=plain --no-cache --build-arg HTTP_PROXY=foo --build-arg HTTPS_PROXY=bar`
 

## To Reproduce
Setup/use a machine that needs a proxy and won't connect to the internet without it.
(OR skip this step and trust me. 🤷 )

Setup your ~/.docker/config.json
```json
{
  "proxies": {
    "default": {
      "httpProxy": "http://example.proxy:1234",
      "httpsProxy": "https://example.proxy:1234"
    }
  }
}
```

Setup a Dockerfile.
```Dockerfile
FROM bitnami/node:latest

RUN HTTP_PROXY=${HTTP_PROXY}
# Should be your httpProxy from earlier
RUN whoami
# Should be root
RUN apt-get update
# Should work / Should use HTTP_PROXY

RUN useradd vscode
USER vscode
RUN npx playwright install --with-deps
# When sudo -- sh -c apt-get install ... gets called, HTTP_PROXY is unset
```

Invoke  `docker build .` or `docker build . --no-cache`

If your machine is setup such that only the proxy can access the internet, this will fail with a bunch of cannot connect / request timed out errors.

### See also:
https://man7.org/linux/man-pages/man1/su.1.html
https://man7.org/linux/man-pages/man8/sudo.8.html
https://linux.die.net/man/1/sh