### PR TITLE
devops: group run-test commands into groups

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -36,14 +36,23 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
     - uses: ./.github/actions/enable-microphone-access
-    - run: npm ci
+    - run: |
+        echo "::group::npm ci"
+        npm ci
+        echo "::endgroup::"
       shell: bash
       env:
         DEBUG: pw:install
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
-    - run: npm run build
+    - run: |
+        echo "::group::npm run build"
+        npm run build
+        echo "::endgroup::"
       shell: bash
-    - run: npx playwright install --with-deps ${{ inputs.browsers-to-install }}
+    - run: |
+        echo "::group::npx playwright install --with-deps"
+        npx playwright install --with-deps ${{ inputs.browsers-to-install }}
+        echo "::endgroup::"
       shell: bash
     - name: Run tests
       if: inputs.shell == 'bash'
@@ -69,7 +78,10 @@ runs:
         client-id: ${{ inputs.flakiness-client-id }}
         tenant-id: ${{ inputs.flakiness-tenant-id }}
         subscription-id: ${{ inputs.flakiness-subscription-id }}
-    - run: ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+    - run: |
+        echo "::group::./utils/upload_flakiness_dashboard.sh"
+        ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+        echo "::endgroup::"
       if: ${{ !cancelled() }}
       shell: bash
     - name: Upload blob report


### PR DESCRIPTION
Motivation: This should make job logs much easier to navigate than before. Intentionally not grouping `npx playwright test`, since this is the most important step to focus on.

Before: https://github.com/microsoft/playwright/actions/runs/9331374006/job/25685966022#step:3:458

After: https://github.com/microsoft/playwright/actions/runs/9330114962/job/25683358085?pr=31116#step:3:467