### PR TITLE
docs: Improve clock doc

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you believe you have found a security vulnerability in any Microsoft-owned re
 
 Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you believe you have found a security vulnerability in any Microsoft-owned re
 
 Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 

--- a/docs/src/api/class-clock.md
+++ b/docs/src/api/class-clock.md
@@ -106,7 +106,7 @@ Returns fake milliseconds since the unix epoch.
 * since: v1.45
 - returns: <[int]>
 
-Advances the clock to the the moment of the first scheduled timer, firing it.
+Advances the clock to the moment of the first scheduled timer, firing it.
 Fake timers must be installed.
 Returns fake milliseconds since the unix epoch.
 

--- a/docs/src/api/class-clock.md
+++ b/docs/src/api/class-clock.md
@@ -130,7 +130,7 @@ Time may be the number of milliseconds to advance the clock by or a human-readab
 * since: v1.45
 - returns: <[int]>
 
-Advances the clock to the the moment of the first scheduled timer, firing it.
+Advances the clock to the moment of the first scheduled timer, firing it.
 Returns fake milliseconds since the unix epoch.
 
 **Usage**

--- a/docs/src/clock.md
+++ b/docs/src/clock.md
@@ -202,7 +202,7 @@ await page.goto('http://localhost:3333');
 // Tick through time manually, firing all timers in the process.
 // In this case, time will be updated in the screen 2 times.
 await page.clock.runFor(2000);
-await expect(locator).to_have_text('2/2/2024, 10:00:02 AM')
+await expect(locator).to_have_text('2/2/2024, 10:00:02 AM');
 ```
 
 ```python async

--- a/packages/playwright-core/src/utils/isomorphic/cssTokenizer.ts
+++ b/packages/playwright-core/src/utils/isomorphic/cssTokenizer.ts
@@ -392,16 +392,11 @@ export function tokenize(str1: string): CSSTokenInterface[] {
           break;
         }
       }
-      if (whitespace(next())) consume();
-      let value = parseInt(
-        digits
-          .map(function (x) {
-            return String.fromCharCode(x);
-          })
-          .join(""),
-        16
-      );
-      if (value > maximumallowedcodepoint) value = 0xfffd;
+      if (whitespace(next()))
+        consume();
+      let value = parseInt(digits.map(function(x) { return String.fromCharCode(x); }).join(''), 16);
+      if (value > maximumallowedcodepoint)
+        value = 0xfffd;
       return value;
     } else if (eof()) {
       return 0xfffd;

--- a/packages/playwright-core/src/utils/isomorphic/cssTokenizer.ts
+++ b/packages/playwright-core/src/utils/isomorphic/cssTokenizer.ts
@@ -378,7 +378,7 @@ export function tokenize(str1: string): CSSTokenInterface[] {
   };
 
   const consumeEscape = function() {
-    // Assume the the current character is the \
+    // Assume the current character is the \
     // and the next code point is not a newline.
     consume();
     if (hexdigit(code)) {
@@ -392,11 +392,16 @@ export function tokenize(str1: string): CSSTokenInterface[] {
           break;
         }
       }
-      if (whitespace(next()))
-        consume();
-      let value = parseInt(digits.map(function(x) { return String.fromCharCode(x); }).join(''), 16);
-      if (value > maximumallowedcodepoint)
-        value = 0xfffd;
+      if (whitespace(next())) consume();
+      let value = parseInt(
+        digits
+          .map(function (x) {
+            return String.fromCharCode(x);
+          })
+          .join(""),
+        16
+      );
+      if (value > maximumallowedcodepoint) value = 0xfffd;
       return value;
     } else if (eof()) {
       return 0xfffd;

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -17311,8 +17311,8 @@ export interface Clock {
   runToLastTimer(): Promise<number>;
 
   /**
-   * Advances the clock to the the moment of the first scheduled timer, firing it. Fake timers must be installed.
-   * Returns fake milliseconds since the unix epoch.
+   * Advances the clock to the moment of the first scheduled timer, firing it. Fake timers must be installed. Returns
+   * fake milliseconds since the unix epoch.
    */
   runToNextTimer(): Promise<number>;
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -17307,8 +17307,8 @@ export interface Clock {
   jump(time: number|string): Promise<void>;
 
   /**
-   * Advances the clock to the the moment of the first scheduled timer, firing it. Returns fake milliseconds since the
-   * unix epoch.
+   * Advances the clock to the moment of the first scheduled timer, firing it. Returns fake milliseconds since the unix
+   * epoch.
    *
    * **Usage**
    *


### PR DESCRIPTION
# Description

I found a minor `the the` in the new clock docs. While looking where that file was I found another instance of this typo.