### PR TITLE
docs(test-parameterize): use absolute dotenv import

### DIFF
--- a/docs/src/test-parameterize-js.md
+++ b/docs/src/test-parameterize-js.md
@@ -216,8 +216,8 @@ import { defineConfig } from '@playwright/test';
 import dotenv from 'dotenv';
 import path from 'path';
 
-// Read from default ".env" file.
-dotenv.config();
+// Read from ".env" file.
+dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 // Alternatively, read from "../my.env" file.
 dotenv.config({ path: path.resolve(__dirname, '..', 'my.env') });


### PR DESCRIPTION
https://github.com/microsoft/playwright/issues/31145

The default is `Default: path.resolve(process.cwd(), '.env')` which is a problem for us in monorepo scenarios.