### PR TITLE
fix: add libicu74 dependency to webkit Ubuntu 24.04

### DIFF
--- a/packages/playwright-core/src/server/registry/nativeDeps.ts
+++ b/packages/playwright-core/src/server/registry/nativeDeps.ts
@@ -520,6 +520,7 @@ export const deps: any = {
       'gstreamer1.0-plugins-bad',
       'gstreamer1.0-plugins-base',
       'gstreamer1.0-plugins-good',
+      'libicu74',
       'libatomic1',
       'libatk-bridge2.0-0t64',
       'libatk1.0-0t64',


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-browsers/actions/runs/9351520636/job/25804186240?pr=1084#step:11:3733