### PR TITLE
docs(trace-viewer.md): link to trace object docs

### DIFF
--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -160,6 +160,8 @@ Available options to record a trace:
 
 You can also use `trace: 'retain-on-failure'` if you do not enable retries but still want traces for failed tests.
 
+There are more granular options available, see [`property: TestOptions.trace`].
+
 If you are not using Playwright as a Test Runner, use the [`property: BrowserContext.tracing`] API instead.
 
 ## Recording a trace


### PR DESCRIPTION
This doc changes makes it clear, that you can control what to record in CI. 

As suggested by [dgozman](https://github.com/dgozman) in https://github.com/microsoft/playwright/pull/27321 this pr only links to the doc instead of duplicate information.

