### PR TITLE
fix:  throw error when workers option is not number or percentage

### DIFF
--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -107,7 +107,7 @@ export class FullConfigInternal {
         const cpus = os.cpus().length;
         this.config.workers = Math.max(1, Math.floor(cpus * (parseInt(workers, 10) / 100)));
       } else {
-        this.config.workers = resolveWorkes(workers);
+        this.config.workers = resolveWorkers(workers);
       }
     } else {
       this.config.workers = workers;
@@ -223,7 +223,7 @@ function resolveReporters(reporters: Config['reporter'], rootDir: string): Repor
   });
 }
 
-function resolveWorkes(workers: string) {
+function resolveWorkers(workers: string) {
   const parsedWorkers = parseInt(workers, 10);
   if (isNaN(parsedWorkers))
     throw new Error(`Workers ${workers} must be a number or percentage.`);

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -225,9 +225,8 @@ function resolveReporters(reporters: Config['reporter'], rootDir: string): Repor
 
 function resolveWorkes(workers: string) {
   const parsedWorkers = parseInt(workers, 10);
-  if (isNaN(parsedWorkers)) {
+  if (isNaN(parsedWorkers))
     throw new Error(`Workers ${workers} must be a number or percentage.`);
-  }
 
   return parsedWorkers;
 }

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -107,7 +107,7 @@ export class FullConfigInternal {
         const cpus = os.cpus().length;
         this.config.workers = Math.max(1, Math.floor(cpus * (parseInt(workers, 10) / 100)));
       } else {
-        this.config.workers = resolveWorkers(workers);
+        this.config.workers = parseWorkers(workers);
       }
     } else {
       this.config.workers = workers;
@@ -223,7 +223,7 @@ function resolveReporters(reporters: Config['reporter'], rootDir: string): Repor
   });
 }
 
-function resolveWorkers(workers: string) {
+function parseWorkers(workers: string) {
   const parsedWorkers = parseInt(workers, 10);
   if (isNaN(parsedWorkers))
     throw new Error(`Workers ${workers} must be a number or percentage.`);

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -107,7 +107,7 @@ export class FullConfigInternal {
         const cpus = os.cpus().length;
         this.config.workers = Math.max(1, Math.floor(cpus * (parseInt(workers, 10) / 100)));
       } else {
-        this.config.workers = parseInt(workers, 10);
+        this.config.workers = resolveWorkes(workers);
       }
     } else {
       this.config.workers = workers;
@@ -221,6 +221,15 @@ function resolveReporters(reporters: Config['reporter'], rootDir: string): Repor
       return [id, arg];
     return [require.resolve(id, { paths: [rootDir] }), arg];
   });
+}
+
+function resolveWorkes(workers: string) {
+  const parsedWorkers = parseInt(workers, 10);
+  if (isNaN(parsedWorkers)) {
+    throw new Error('Workers must be a number or percentage.');
+  }
+
+  return parsedWorkers;
 }
 
 function resolveProjectDependencies(projects: FullProjectInternal[]) {

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -226,7 +226,7 @@ function resolveReporters(reporters: Config['reporter'], rootDir: string): Repor
 function resolveWorkes(workers: string) {
   const parsedWorkers = parseInt(workers, 10);
   if (isNaN(parsedWorkers)) {
-    throw new Error('Workers must be a number or percentage.');
+    throw new Error(`Workers ${workers} must be a number or percentage.`);
   }
 
   return parsedWorkers;


### PR DESCRIPTION
fix: #31208 

Add checking of the workers option in CLI.

Current validation of the config file shows the error to the user, but the wrong input in CLI shows `NaN` instead of showing the error message. 

So I added the error message for the user to realize the wrong input.




