### PR TITLE
chore(ct): vue update vue-component-type-helpers

### DIFF
--- a/packages/playwright-ct-vue/index.d.ts
+++ b/packages/playwright-ct-vue/index.d.ts
@@ -24,7 +24,7 @@ type ComponentEvents = Record<string, Function>;
 
 // Copied from: https://github.com/vuejs/language-tools/blob/master/packages/vue-component-type-helpers/index.d.ts#L10-L13
 type ComponentProps<T> =
-	T extends new () => { $props: infer P; } ? NonNullable<P> :
+	T extends new (...angs: any) => { $props: infer P; } ? NonNullable<P> :
 	T extends (props: infer P, ...args: any) => any ? P :
 	{};
 

--- a/packages/playwright-ct-vue2/index.d.ts
+++ b/packages/playwright-ct-vue2/index.d.ts
@@ -24,7 +24,7 @@ type ComponentEvents = Record<string, Function>;
 
 // Copied from: https://github.com/vuejs/language-tools/blob/master/packages/vue-component-type-helpers/index.d.ts#L10-L13
 type ComponentProps<T> =
-	T extends new () => { $props: infer P; } ? NonNullable<P> :
+	T extends new (...angs: any) => { $props: infer P; } ? NonNullable<P> :
 	T extends (props: infer P, ...args: any) => any ? P :
 	{};
 


### PR DESCRIPTION
The `ComponentProps` copied from [`vue-component-type-helpers`](https://github.com/vuejs/language-tools/blob/5c65f102d01ade46975001e8509f26a2d90774e9/packages/component-type-helpers/index.ts#L6-L9) was outdated and had an issue accurately inferring generic/functional Vue components.