### PR TITLE
Revert "feat(test): add `URL` field to annotations for hyperlink disp…

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -71,8 +71,7 @@ import { test, expect } from '@playwright/test';
 test('basic test', {
   annotation: {
     type: 'issue',
-    description: 'feature tags API',
-    url: 'https://github.com/microsoft/playwright/issues/23180'
+    description: 'https://github.com/microsoft/playwright/issues/23180',
   },
 }, async ({ page }) => {
   await page.goto('https://playwright.dev/');
@@ -98,8 +97,7 @@ Test title.
   - `tag` ?<[string]|[Array]<[string]>>
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]> Annotation type, for example `'issue'`.
-    - `description` ?<[string]> Optional annotation description.
-    - `url` ?<[string]> Optional for example an issue url.
+    - `description` ?<[string]> Optional annotation description, for example an issue url.
 
 Additional test details.
 
@@ -442,7 +440,6 @@ Group title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 Additional details for all tests in the group.
 
@@ -571,7 +568,6 @@ Group title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 See [`method: Test.describe`] for details description.
 
@@ -627,7 +623,6 @@ Group title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 See [`method: Test.describe`] for details description.
 
@@ -681,7 +676,6 @@ Group title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 See [`method: Test.describe`] for details description.
 
@@ -733,7 +727,6 @@ Group title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 See [`method: Test.describe`] for details description.
 
@@ -789,7 +782,6 @@ Group title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 See [`method: Test.describe`] for details description.
 
@@ -847,7 +839,6 @@ Group title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 See [`method: Test.describe`] for details description.
 
@@ -900,7 +891,6 @@ Group title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 See [`method: Test.describe`] for details description.
 
@@ -1119,7 +1109,6 @@ Test title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 See [`method: Test.(call)`] for test details description.
 
@@ -1225,7 +1214,6 @@ Test title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 See [`method: Test.(call)`] for test details description.
 
@@ -1303,7 +1291,6 @@ Test title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 See [`method: Test.(call)`] for test details description.
 
@@ -1449,7 +1436,6 @@ Test title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-    - `url` ?<[string]>
 
 See [`method: Test.(call)`] for test details description.
 

--- a/packages/html-reporter/src/testCaseView.spec.tsx
+++ b/packages/html-reporter/src/testCaseView.spec.tsx
@@ -52,8 +52,8 @@ const testCase: TestCase = {
   projectName: 'chromium',
   location: { file: 'test.spec.ts', line: 42, column: 0 },
   annotations: [
-    { type: 'annotation', description: 'Annotation text', url: 'example url' },
-    { type: 'annotation', description: 'Another annotation text', url: 'Another example url' },
+    { type: 'annotation', description: 'Annotation text' },
+    { type: 'annotation', description: 'Another annotation text' },
   ],
   tags: [],
   outcome: 'expected',

--- a/packages/html-reporter/src/types.ts
+++ b/packages/html-reporter/src/types.ts
@@ -59,7 +59,7 @@ export type TestFileSummary = {
   stats: Stats;
 };
 
-export type TestCaseAnnotation = { type: string, description?: string, url?: string};
+export type TestCaseAnnotation = { type: string, description?: string };
 
 export type TestCaseSummary = {
   testId: string,

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -35,7 +35,7 @@ export type FixturesWithLocation = {
   fixtures: Fixtures;
   location: Location;
 };
-export type Annotation = { type: string, description?: string, url?: string };
+export type Annotation = { type: string, description?: string };
 
 export const defaultTimeout = 30000;
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -2198,8 +2198,7 @@ interface TestFunction<TestArgs> {
    * test('basic test', {
    *   annotation: {
    *     type: 'issue',
-   *     description: 'feature tags API',
-   *     url: 'https://github.com/microsoft/playwright/issues/23180'
+   *     description: 'https://github.com/microsoft/playwright/issues/23180',
    *   },
    * }, async ({ page }) => {
    *   await page.goto('https://playwright.dev/');
@@ -2275,8 +2274,7 @@ interface TestFunction<TestArgs> {
    * test('basic test', {
    *   annotation: {
    *     type: 'issue',
-   *     description: 'feature tags API',
-   *     url: 'https://github.com/microsoft/playwright/issues/23180'
+   *     description: 'https://github.com/microsoft/playwright/issues/23180',
    *   },
    * }, async ({ page }) => {
    *   await page.goto('https://playwright.dev/');


### PR DESCRIPTION
…lay (#30665)"

This reverts commit 165ecac5df9bf4472b3c37d5b3b6e4093b7d1f2b. Third party did not follow up with changes to trace viewer, reporters, etc. before the 1.45 cutoff date.