### PR TITLE
Add 'window-management' to chromium browser

### DIFF
--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -434,6 +434,7 @@ export class CRBrowserContext extends BrowserContext {
       // chrome-specific permissions we have.
       ['midi-sysex', 'midiSysex'],
       ['storage-access', 'storageAccess'],
+      ['window-management', 'windowManagement']
     ]);
     const filtered = permissions.map(permission => {
       const protocolPermission = webPermissionToProtocol.get(permission);


### PR DESCRIPTION
Resolves #27198 

This adds the 'windowManagement' permission to the list of permissions that can be granted on Chromium.

https://chromedevtools.github.io/devtools-protocol/tot/Browser/#type-PermissionType