### PR TITLE
Fix select issue in Windows

### DIFF
--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -356,7 +356,7 @@ class RecordActionTool implements RecorderTool {
         return;
       this._performAction({
         name: 'select',
-        selector: this._hoveredModel!.selector,
+        selector: this._activeModel!.selector,
         options: [...selectElement.selectedOptions].map(option => option.value),
         signals: []
       });

--- a/tests/library/inspector/cli-codegen-1.spec.ts
+++ b/tests/library/inspector/cli-codegen-1.spec.ts
@@ -557,6 +557,7 @@ await page.Locator("#checkbox").UncheckAsync();`);
 
     const locator = await recorder.hoverOverElement('select');
     expect(locator).toBe(`locator('#age')`);
+    await page.locator('select').click();
 
     const [message, sources] = await Promise.all([
       page.waitForEvent('console', msg => msg.type() !== 'error'),


### PR DESCRIPTION
Fix https://github.com/microsoft/playwright/issues/31248

On Windows, it seems `mousemove` event is emitted even while select menu is open.

I think we need to use `_activeModel` here.

I confirmed this fixes the issue for both Edge and Chrome.

Edge

https://github.com/microsoft/playwright/assets/1796864/33f49d7d-b898-429e-a3d5-fc1f356d6088

Chrome

https://github.com/microsoft/playwright/assets/1796864/a002ffc8-2cfb-4452-80df-1f2b0a644c17

