### PR TITLE
fix(test runner): do not use `@babel/plugin-transform-dynamic-import`

### DIFF
--- a/docs/src/test-typescript-js.md
+++ b/docs/src/test-typescript-js.md
@@ -108,16 +108,3 @@ In `package.json`, add two scripts:
 The `pretest` script runs typescript on the tests. `test` will run the tests that have been generated to the `tests-out` directory. The `-c` argument configures the test runner to look for tests inside the `tests-out` directory.
 
 Then `npm run test` will build the tests and run them.
-
-## Using `import` inside `evaluate()`
-
-Using dynamic imports inside a function passed to various `evaluate()` methods is not supported. This is because Playwright uses `Function.prototype.toString()` to serialize functions, and transpiler will sometimes replace dynamic imports with `require()` calls, which are not valid inside the web page.
-
-To work around this issue, use a string template instead of a function:
-
-```js
-await page.evaluate(`(async () => {
-  const { value } = await import('some-module');
-  console.log(value);
-})()`);
-```

--- a/packages/playwright/ThirdPartyNotices.txt
+++ b/packages/playwright/ThirdPartyNotices.txt
@@ -38,7 +38,6 @@ This project incorporates components from the projects listed below. The origina
 -	@babel/plugin-syntax-async-generators@7.8.4 (https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators)
 -	@babel/plugin-syntax-class-static-block@7.14.5 (https://github.com/babel/babel)
 -	@babel/plugin-syntax-decorators@7.24.1 (https://github.com/babel/babel)
--	@babel/plugin-syntax-dynamic-import@7.8.3 (https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import)
 -	@babel/plugin-syntax-explicit-resource-management@7.24.1 (https://github.com/babel/babel)
 -	@babel/plugin-syntax-export-namespace-from@7.8.3 (https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from)
 -	@babel/plugin-syntax-import-attributes@7.24.1 (https://github.com/babel/babel)
@@ -54,7 +53,6 @@ This project incorporates components from the projects listed below. The origina
 -	@babel/plugin-syntax-typescript@7.24.1 (https://github.com/babel/babel)
 -	@babel/plugin-transform-class-properties@7.24.1 (https://github.com/babel/babel)
 -	@babel/plugin-transform-class-static-block@7.24.4 (https://github.com/babel/babel)
--	@babel/plugin-transform-dynamic-import@7.24.1 (https://github.com/babel/babel)
 -	@babel/plugin-transform-export-namespace-from@7.24.1 (https://github.com/babel/babel)
 -	@babel/plugin-transform-logical-assignment-operators@7.24.1 (https://github.com/babel/babel)
 -	@babel/plugin-transform-modules-commonjs@7.24.1 (https://github.com/babel/babel)
@@ -1252,33 +1250,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF @babel/plugin-syntax-decorators@7.24.1 AND INFORMATION
 
-%% @babel/plugin-syntax-dynamic-import@7.8.3 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-MIT License
-
-Copyright (c) 2014-present Sebastian McKenzie and other contributors
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=========================================
-END OF @babel/plugin-syntax-dynamic-import@7.8.3 AND INFORMATION
-
 %% @babel/plugin-syntax-explicit-resource-management@7.24.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 MIT License
@@ -1683,33 +1654,6 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF @babel/plugin-transform-class-static-block@7.24.4 AND INFORMATION
-
-%% @babel/plugin-transform-dynamic-import@7.24.1 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-MIT License
-
-Copyright (c) 2014-present Sebastian McKenzie and other contributors
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=========================================
-END OF @babel/plugin-transform-dynamic-import@7.24.1 AND INFORMATION
 
 %% @babel/plugin-transform-export-namespace-from@7.24.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -4461,6 +4405,6 @@ END OF yallist@3.1.1 AND INFORMATION
 
 SUMMARY BEGIN HERE
 =========================================
-Total Packages: 153
+Total Packages: 151
 =========================================
 END OF SUMMARY

--- a/packages/playwright/bundles/babel/package-lock.json
+++ b/packages/playwright/bundles/babel/package-lock.json
@@ -21,7 +21,6 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-transform-class-properties": "^7.24.1",
         "@babel/plugin-transform-class-static-block": "^7.24.4",
-        "@babel/plugin-transform-dynamic-import": "^7.24.1",
         "@babel/plugin-transform-export-namespace-from": "^7.24.1",
         "@babel/plugin-transform-logical-assignment-operators": "^7.24.1",
         "@babel/plugin-transform-modules-commonjs": "^7.24.1",
@@ -434,17 +433,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-dynamic-import": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-explicit-resource-management": {
       "version": "7.24.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-explicit-resource-management/-/plugin-syntax-explicit-resource-management-7.24.1.tgz",
@@ -632,21 +620,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.12.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.24.1.tgz",
-      "integrity": "sha512-av2gdSTyXcJVdI+8aFZsCAtR29xJt0S5tas+Ef8NvBNmD1a+N/3ecMLeMBgfcK+xzsjdLDT6oHt+DFPyeqUbDA==",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {

--- a/packages/playwright/bundles/babel/package.json
+++ b/packages/playwright/bundles/babel/package.json
@@ -22,7 +22,6 @@
     "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
     "@babel/plugin-transform-class-properties": "^7.24.1",
     "@babel/plugin-transform-class-static-block": "^7.24.4",
-    "@babel/plugin-transform-dynamic-import": "^7.24.1",
     "@babel/plugin-transform-export-namespace-from": "^7.24.1",
     "@babel/plugin-transform-logical-assignment-operators": "^7.24.1",
     "@babel/plugin-transform-modules-commonjs": "^7.24.1",

--- a/packages/playwright/bundles/babel/src/babelBundleImpl.ts
+++ b/packages/playwright/bundles/babel/src/babelBundleImpl.ts
@@ -73,8 +73,9 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
 
   if (!isModule) {
     plugins.push([require('@babel/plugin-transform-modules-commonjs')]);
-    // This converts async imports to require() calls so that we can intercept them with pirates.
-    plugins.push([require('@babel/plugin-transform-dynamic-import')]);
+    // Note: we used to include '@babel/plugin-transform-dynamic-import' to convert async imports
+    // into require(), so that pirates can intercept them. With the ESM loader enabled by default,
+    // there is no need for this.
     plugins.push([
       (): PluginObj => ({
         name: 'css-to-identity-obj-proxy',


### PR DESCRIPTION
Historically, this plugin was important to translate dynamic imports into require calls so that we can intercept them and transpile.

This is not needed anymore with ESM loader enabled by default, so we can avoid this transformation and support dynamic imports of ESM-only packages/files.

Fixes #17075, fixes #23255, fixes #31140, references #23662.