### PR TITLE
fix(codgen): assertValue works with disabled select

### DIFF
--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -578,8 +578,8 @@ class TextAssertionTool implements RecorderTool {
 
   onPointerUp(event: PointerEvent) {
     const target = this._hoverHighlight?.elements[0];
-    if (this._kind === 'value' && target && target.nodeName === 'INPUT' && (target as HTMLInputElement).disabled) {
-      // Click on a disabled input does not produce a "click" event, but we still want
+    if (this._kind === 'value' && target && (target.nodeName === 'INPUT' || target.nodeName === 'SELECT') && (target as HTMLInputElement).disabled) {
+      // Click on a disabled input (or select) does not produce a "click" event, but we still want
       // to assert the value.
       this._commitAssertValue();
     }

--- a/tests/library/inspector/cli-codegen-3.spec.ts
+++ b/tests/library/inspector/cli-codegen-3.spec.ts
@@ -631,6 +631,27 @@ await page.GetByLabel("Coun\\"try").ClickAsync();`);
     expect.soft(sources2.get('C#')!.text).toContain(`await Expect(page.Locator("#second")).ToHaveValueAsync("bar")`);
   });
 
+  test('should assert value on disabled select', async ({ openRecorder, browserName }) => {
+    const recorder = await openRecorder();
+
+    await recorder.setContentAndWait(`
+      <select id=first><option value=foo1>Foo1</option><option value=bar1>Bar1</option></select>
+      <select id=second disabled><option value=foo2>Foo2</option><option value=bar2 selected>Bar2</option></select>
+    `);
+
+    await recorder.page.click('x-pw-tool-item.value');
+    await recorder.hoverOverElement('#second');
+    const [sources2] = await Promise.all([
+      recorder.waitForOutput('JavaScript', '#second'),
+      recorder.trustedClick(),
+    ]);
+    expect.soft(sources2.get('JavaScript')!.text).toContain(`await expect(page.locator('#second')).toHaveValue('bar2')`);
+    expect.soft(sources2.get('Python')!.text).toContain(`expect(page.locator("#second")).to_have_value("bar2")`);
+    expect.soft(sources2.get('Python Async')!.text).toContain(`await expect(page.locator("#second")).to_have_value("bar2")`);
+    expect.soft(sources2.get('Java')!.text).toContain(`assertThat(page.locator("#second")).hasValue("bar2")`);
+    expect.soft(sources2.get('C#')!.text).toContain(`await Expect(page.Locator("#second")).ToHaveValueAsync("bar2")`);
+  });
+
   test('should assert visibility', async ({ openRecorder }) => {
     const recorder = await openRecorder();
 


### PR DESCRIPTION
Manually tested against `https://4ydx.github.io/disabled-select/`

```
npm install
npm run build
node packages/playwright-core/cli.js codegen
```

Producing:

```
import { test, expect } from '@playwright/test';

test('test', async ({ page }) => {
  await page.goto('https://4ydx.github.io/disabled-select/');
  await expect(page.getByRole('combobox')).toHaveValue('option1'); // <--- HERE
});
```

Html:
```
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Simple HTML Page</title>
  </head>
  <body>
    <h1>Welcome to My Simple HTML Page</h1>

    <!-- Our disabled select -->
    <select disabled>
      <option value="option1">Option 1</option>
      <option value="option2">Option 2</option>
      <option value="option3">Option 3</option>
    </select>

  </body>
</html>
```