### PR TITLE
fix(fs-watcher) ignore node_modules on windows

### DIFF
--- a/packages/playwright/src/fsWatcher.ts
+++ b/packages/playwright/src/fsWatcher.ts
@@ -16,7 +16,6 @@
 
 import { chokidar } from './utilsBundle';
 import type { FSWatcher } from 'chokidar';
-import path from 'path';
 
 export type FSEvent = { event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir', file: string };
 
@@ -52,7 +51,7 @@ export class Watcher {
     if (!this._watchedFiles.length)
       return;
 
-    const ignored = [...this._ignoredFolders, (name: string) => name.includes(path.sep + 'node_modules' + path.sep)];
+    const ignored = [...this._ignoredFolders, '**/node_modules/**'];
     this._fsWatcher = chokidar.watch(watchedFiles, { ignoreInitial: true, ignored }).on('all', async (event, file) => {
       if (this._throttleTimer)
         clearTimeout(this._throttleTimer);


### PR DESCRIPTION
Partially fixes https://github.com/microsoft/playwright/issues/31337 by supporting ignoring node_modules on windows.

When I debug the function it gets a unix style path filename on windows, so the function never ignores node_modules. The ignore path globs are expected to use the unix path seperator and I've tested this fix works on windows and I assume that since mac uses unix style, it also works there (this is a pretty standard glob construct (chokidar points at any match https://github.com/micromatch/anymatch and anymatch has this exact example in their readme.md)