### PR TITLE
chore: cache normalized whitespaces in recorder

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -33,7 +33,7 @@ import { getChecked, getAriaDisabled, getAriaRole, getElementAccessibleName, get
 import { kLayoutSelectorNames, type LayoutSelectorName, layoutSelectorScore } from './layoutSelectorUtils';
 import { asLocator } from '../../utils/isomorphic/locatorGenerators';
 import type { Language } from '../../utils/isomorphic/locatorGenerators';
-import { normalizeWhiteSpace, trimStringWithEllipsis } from '../../utils/isomorphic/stringUtils';
+import { cacheNormalizedWhitespaces, normalizeWhiteSpace, trimStringWithEllipsis } from '../../utils/isomorphic/stringUtils';
 
 export type FrameExpectParams = Omit<channels.FrameExpectParams, 'expectedValue'> & { expectedValue?: any };
 
@@ -66,7 +66,7 @@ export class InjectedScript {
   // eslint-disable-next-line no-restricted-globals
   readonly window: Window & typeof globalThis;
   readonly document: Document;
-  readonly utils = { isInsideScope, elementText, asLocator, normalizeWhiteSpace };
+  readonly utils = { isInsideScope, elementText, asLocator, normalizeWhiteSpace, cacheNormalizedWhitespaces };
 
   // eslint-disable-next-line no-restricted-globals
   constructor(window: Window & typeof globalThis, isUnderTest: boolean, sdkLanguage: Language, testIdAttributeNameForStrictErrorAndConsoleCodegen: string, stableRafCount: number, browserName: string, customEngines: { name: string, engine: SelectorEngine }[]) {

--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -973,7 +973,7 @@ export class Recorder {
       body[data-pw-cursor=text] *, body[data-pw-cursor=text] *::after { cursor: text !important; }
     `);
     this.installListeners();
-
+    injectedScript.utils.cacheNormalizedWhitespaces();
     if (injectedScript.isUnderTest)
       console.error('Recorder script ready for test'); // eslint-disable-line no-console
   }

--- a/packages/playwright-core/src/utils/isomorphic/stringUtils.ts
+++ b/packages/playwright-core/src/utils/isomorphic/stringUtils.ts
@@ -75,7 +75,7 @@ export function cacheNormalizedWhitespaces() {
 
 export function normalizeWhiteSpace(text: string): string {
   let result = normalizedWhitespaceCache?.get(text);
-  if (!result) {
+  if (result === undefined) {
     result = text.replace(/\u200b/g, '').trim().replace(/\s+/g, ' ');
     normalizedWhitespaceCache?.set(text, result);
   }

--- a/packages/playwright-core/src/utils/isomorphic/stringUtils.ts
+++ b/packages/playwright-core/src/utils/isomorphic/stringUtils.ts
@@ -67,8 +67,19 @@ function cssEscapeOne(s: string, i: number): string {
   return '\\' + s.charAt(i);
 }
 
+let normalizedWhitespaceCache: Map<string, string> | undefined;
+
+export function cacheNormalizedWhitespaces() {
+  normalizedWhitespaceCache = new Map();
+}
+
 export function normalizeWhiteSpace(text: string): string {
-  return text.replace(/\u200b/g, '').trim().replace(/\s+/g, ' ');
+  let result = normalizedWhitespaceCache?.get(text);
+  if (!result) {
+    result = text.replace(/\u200b/g, '').trim().replace(/\s+/g, ' ');
+    normalizedWhitespaceCache?.set(text, result);
+  }
+  return result;
 }
 
 export function normalizeEscapedRegexQuotes(source: string) {


### PR DESCRIPTION
Reference: https://github.com/microsoft/playwright/issues/31254

On the web page from the bug it reduces time to compute selectors by 8x:

**Before:**
<img width="549" alt="before" src="https://github.com/microsoft/playwright/assets/9798949/f4482860-29d5-4643-92ab-b360a702f232">

**After:**
<img width="580" alt="after" src="https://github.com/microsoft/playwright/assets/9798949/b6aca6a1-9306-4041-9042-d504dce1c33a">
