### PR TITLE
chore: validate test cli args

### DIFF
--- a/packages/playwright-core/bundles/utils/src/utilsBundleImpl.ts
+++ b/packages/playwright-core/bundles/utils/src/utilsBundleImpl.ts
@@ -41,7 +41,7 @@ export const open = openLibrary;
 
 export { PNG } from 'pngjs';
 
-export { program } from 'commander';
+export { program, InvalidArgumentError } from 'commander';
 
 import progressLibrary from 'progress';
 export const progress = progressLibrary;

--- a/packages/playwright-core/src/utilsBundle.ts
+++ b/packages/playwright-core/src/utilsBundle.ts
@@ -28,6 +28,7 @@ export const minimatch: typeof import('../bundles/utils/node_modules/@types/mini
 export const open: typeof import('../bundles/utils/node_modules/open') = require('./utilsBundleImpl').open;
 export const PNG: typeof import('../bundles/utils/node_modules/@types/pngjs').PNG = require('./utilsBundleImpl').PNG;
 export const program: typeof import('../bundles/utils/node_modules/commander').program = require('./utilsBundleImpl').program;
+export const InvalidArgumentError: typeof import('../bundles/utils/node_modules/commander').InvalidArgumentError = require('./utilsBundleImpl').InvalidArgumentError;
 export const progress: typeof import('../bundles/utils/node_modules/@types/progress') = require('./utilsBundleImpl').progress;
 export const SocksProxyAgent: typeof import('../bundles/utils/node_modules/socks-proxy-agent').SocksProxyAgent = require('./utilsBundleImpl').SocksProxyAgent;
 export const ws: typeof import('../bundles/utils/node_modules/@types/ws') = require('./utilsBundleImpl').ws;

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -220,10 +220,9 @@ function parseWorkers(workers: string) {
     const cpus = os.cpus().length;
     return Math.max(1, Math.floor(cpus * (percentage / 100)));
   }
-  const parsedWorkers = parseInt(workers, 10);
-  if (isNaN(parsedWorkers))
+  if (/[^0-9]/.test(workers))
     throw new Error(`Workers ${workers} must be a number or percentage.`);
-  return parsedWorkers;
+  return parseInt(workers, 10);
 }
 
 function resolveProjectDependencies(projects: FullProjectInternal[]) {

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -340,7 +340,7 @@ class OptionValidators {
     if (isNaN(parsed))
       throw new InvalidArgumentError('Not a number.');
     if (options.min !== undefined && parsed < options.min)
-      throw new InvalidArgumentError(`Expected a number greater than ${options.min}.`);
+      throw new InvalidArgumentError(`Expected a number greater or equal than ${options.min}.`);
     if (options.max !== undefined && parsed > options.max)
       throw new InvalidArgumentError(`Expected a number less than ${options.max}.`);
     return value;
@@ -348,7 +348,7 @@ class OptionValidators {
 
   static validateWorkers(value: string): string {
     if (value[value.length - 1] === '%') {
-      OptionValidators.validateNumber(value, { min: 1, max: 100 });
+      OptionValidators.validateNumber(value.slice(0, -1), { min: 1, max: 100 });
       return value;
     }
     OptionValidators.validateNumber(value, { min: 1 });
@@ -384,7 +384,7 @@ const testOptions: [string, string, ((value: string) => string | number)?][] = [
   ['--pass-with-no-tests', `Makes test run succeed even if no tests were found`],
   ['--project <project-name...>', `Only run tests from the specified list of projects, supports '*' wildcard (default: run all projects)`],
   ['--quiet', `Suppress stdio`],
-  ['--repeat-each <N>', `Run each test N times (default: 1)`, value => OptionValidators.validateNumber(value, { min: 0 })],
+  ['--repeat-each <N>', `Run each test N times (default: 1)`, value => OptionValidators.validateNumber(value, { min: 1 })],
   ['--reporter <reporter>', `Reporter to use, comma-separated, can be ${builtInReporters.map(name => `"${name}"`).join(', ')} (default: "${defaultReporter}")`],
   ['--retries <retries>', `Maximum retry count for flaky tests, zero for no retries (default: no retries)`, value => OptionValidators.validateNumber(value, { min: 0 })],
   ['--shard <shard>', `Shard tests and execute only the selected shard, specify in the form "current/all", 1-based, for example "3/5"`, OptionValidators.validateShard],


### PR DESCRIPTION
Before:

```
> playwright-internal@1.46.0-next ctest
> playwright test --config=tests/library/playwright.config.ts --project=chromium-* --workers=abc

Error: Workers abc must be a number or percentage.
    at parseWorkers (/Users/maxschmitt/Developer/playwright/packages/playwright/src/common/config.ts:227:11)
    at new FullConfigInternal (/Users/maxschmitt/Developer/playwright/packages/playwright/src/common/config.ts:108:31)
    at loadConfig (/Users/maxschmitt/Developer/playwright/packages/playwright/src/common/configLoader.ts:106:22)
    at loadConfigFromFileRestartIfNeeded (/Users/maxschmitt/Developer/playwright/packages/playwright/src/common/configLoader.ts:330:10)
    at runTests (/Users/maxschmitt/Developer/playwright/packages/playwright/src/program.ts:183:18)
    at t.<anonymous> (/Users/maxschmitt/Developer/playwright/packages/playwright/src/program.ts:46:7)
```

After:

```
> playwright-internal@1.46.0-next ctest
> playwright test --config=tests/library/playwright.config.ts --project=chromium-* --workers=abc

error: option '-j, --workers <workers>' argument 'abc' is invalid. Not a number.
```

Follow-up to https://github.com/microsoft/playwright/pull/31210 so it validates on CLI (this PR) and config parsing side (already done in https://github.com/microsoft/playwright/pull/31210)