### PR TITLE
fix(clock): under reused context

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -216,6 +216,7 @@ export abstract class BrowserContext extends SdkObject {
     await this._resetStorage();
     await this._removeExposedBindings();
     await this._removeInitScripts();
+    this.clock.markAsUninstalled();
     // TODO: following can be optimized to not perform noops.
     if (this._options.permissions)
       await this.grantPermissions(this._options.permissions);

--- a/packages/playwright-core/src/server/clock.ts
+++ b/packages/playwright-core/src/server/clock.ts
@@ -26,6 +26,10 @@ export class Clock {
     this._browserContext = browserContext;
   }
 
+  markAsUninstalled() {
+    this._scriptInstalled = false;
+  }
+
   async fastForward(ticks: number | string) {
     await this._installIfNeeded();
     const ticksMillis = parseTicks(ticks);

--- a/tests/library/browsercontext-reuse.spec.ts
+++ b/tests/library/browsercontext-reuse.spec.ts
@@ -252,6 +252,19 @@ test('should reset tracing', async ({ reusedContext, trace }, testInfo) => {
   expect(error.message).toContain('Must start tracing before stopping');
 });
 
+test('should work with clock emulation', async ({ reusedContext, trace }, testInfo) => {
+  let context = await reusedContext();
+
+  let page = await context.newPage();
+  await page.clock.setFixedTime(new Date('2020-01-01T00:00:00.000Z'));
+  expect(await page.evaluate('new Date().toISOString()')).toBe('2020-01-01T00:00:00.000Z');
+
+  context = await reusedContext();
+  page = context.pages()[0];
+  await page.clock.setFixedTime(new Date('2020-01-01T00:00:00Z'));
+  expect(await page.evaluate('new Date().toISOString()')).toBe('2020-01-01T00:00:00.000Z');
+});
+
 test('should continue issuing events after closing the reused page', async ({ reusedContext, server }) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/24574' });
 


### PR DESCRIPTION
We uninstall all the setInitScript but forgot to mark `installed` as `false`.

Fixes https://github.com/microsoft/playwright/issues/31353