### PR TITLE
feat(chromium-tip-of-tree): roll to r1232

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -9,9 +9,9 @@
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1231",
+      "revision": "1232",
       "installByDefault": false,
-      "browserVersion": "128.0.6536.0"
+      "browserVersion": "128.0.6543.0"
     },
     {
       "name": "firefox",

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -319,7 +319,7 @@ export class Chromium extends BrowserType {
       if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW)
         chromeArguments.push('--headless=new');
       else
-        chromeArguments.push('--headless');
+        chromeArguments.push('--headless=old');
 
       chromeArguments.push(
           '--hide-scrollbars',


### PR DESCRIPTION
Good:

```
#      CURRENT_VERSION: 128.0.6536.0
# BRANCH_BASE_POSITION: 1314318
BRANCH_COMMIT="11d56f88594ff95c8e34acabd4893e9a1d431cf1"
```

Bad:

```
#      CURRENT_VERSION: 128.0.6543.0
# BRANCH_BASE_POSITION: 1316206
BRANCH_COMMIT="6c15c08c7ff32fc9bf8899b07f7f56789fb8f3bc"
```

Failing PR: https://github.com/microsoft/playwright/pull/31362

Failing tests:

```
    [chromium-library] › library/browsercontext-credentials.spec.ts:27:1 › should fail without credentials 
    [chromium-library] › library/browsercontext-credentials.spec.ts:41:1 › should work with setHTTPCredentials 
    [chromium-library] › library/browsercontext-credentials.spec.ts:112:1 › should fail with correct credentials and mismatching scheme 
    [chromium-library] › library/browsercontext-credentials.spec.ts:124:1 › should fail with correct credentials and mismatching hostname 
    [chromium-library] › library/browsercontext-credentials.spec.ts:138:1 › should fail with correct credentials and mismatching port 
    [chromium-library] › library/download.spec.ts:641:3 › should be able to download a inline PDF file via navigation 
    [chromium-library] › library/emulation-focus.spec.ts:104:3 › should not affect screenshots ─────
    [chromium-library] › library/permissions.spec.ts:153:3 › should support clipboard read ─────────
    [chromium-library] › library/tracing.spec.ts:412:14 › should produce screencast frames fit ─────
    [chromium-library] › library/tracing.spec.ts:412:14 › should produce screencast frames crop ────
    [chromium-library] › library/tracing.spec.ts:412:14 › should produce screencast frames scale ───
    [chromium-library] › library/video.spec.ts:446:5 › screencast › should scale frames down to the requested size  
    [chromium-library] › library/video.spec.ts:695:5 › screencast › should capture full viewport ───
    [chromium-library] › library/video.spec.ts:730:5 › screencast › should capture full viewport on hidpi 
    [chromium-library] › library/video.spec.ts:767:5 › screencast › should work with video+trace ───
```

Bisect 1 (`library/browsercontext-credentials.spec.ts:27:1`):

Command: `npx bisect-chrome --good 1314318 --bad 1316206 --shell "npm run ctest -- --reporter=list library/browsercontext-credentials.spec.ts:27:1"`

RANGE: https://chromium.googlesource.com/chromium/src/+log/fadb61567ce2a7f1bcc181ce65e000d56064fe8d..1f24a69d69b03bc83a26bed4c236e397d6ba44c2

Commit: https://chromium.googlesource.com/chromium/src/+/b9b39a430f71c710d16aafcc67278ef77440c18d

Resolution: --headless -> --headless=old

This causes crashes with:

```
  pw:browser [pid=101511][err] #3 0x60415dc99040 [0619/085814.809447:ERROR:render_process_host_impl.cc(5571)] Terminating render process for bad Mojo message: Received bad user message: No binder found for interface translate.mojom.ContentTranslateDriver for the frame/document scope +1ms
```

Minimal repro is:

```
 /ms-playwright/chromium_tip_of_tree-1232/chrome-linux/chrome --no-sandbox --headless=old --screenshot=foo.png https://github.com
```

Filed as https://issues.chromium.org/u/1/issues/348031037