### PR TITLE
cherry-pick(#31369): docs: use long for time in milliseconds

### DIFF
--- a/docs/src/api/class-clock.md
+++ b/docs/src/api/class-clock.md
@@ -41,7 +41,7 @@ await page.Clock.FastForwardAsync("30:00");
 
 ### param: Clock.fastForward.ticks
 * since: v1.45
-- `ticks` <[int]|[string]>
+- `ticks` <[long]|[string]>
 
 Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
 
@@ -65,7 +65,7 @@ Fake timers are used to manually control the flow of time in tests. They allow y
 
 ### option: Clock.install.time
 * since: v1.45
-- `time` <[int]|[string]|[Date]>
+- `time` <[long]|[string]|[Date]>
 
 Time to initialize with, current system time by default.
 
@@ -103,7 +103,7 @@ await page.Clock.RunForAsync("30:00");
 
 ### param: Clock.runFor.ticks
 * since: v1.45
-- `ticks` <[int]|[string]>
+- `ticks` <[long]|[string]>
 
 Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
 
@@ -147,7 +147,7 @@ await page.Clock.PauseAtAsync("2020-02-02");
 
 ### param: Clock.pauseAt.time
 * since: v1.45
-- `time` <[int]|[string]|[Date]>
+- `time` <[long]|[string]|[Date]>
 
 
 ## async method: Clock.resume
@@ -195,7 +195,7 @@ await page.Clock.SetFixedTimeAsync("2020-02-02");
 
 ### param: Clock.setFixedTime.time
 * since: v1.45
-- `time` <[int]|[string]|[Date]>
+- `time` <[long]|[string]|[Date]>
 
 Time to be set.
 
@@ -238,4 +238,4 @@ await page.Clock.SetSystemTimeAsync("2020-02-02");
 
 ### param: Clock.setSystemTime.time
 * since: v1.45
-- `time` <[int]|[string]|[Date]>
+- `time` <[long]|[string]|[Date]>

--- a/utils/doclint/documentation.js
+++ b/utils/doclint/documentation.js
@@ -866,6 +866,7 @@ function csharpOptionOverloadSuffix(option, type) {
     case 'Buffer': return 'Byte';
     case 'Serializable': return 'Object';
     case 'int': return 'Int';
+    case 'long': return 'Int64';
     case 'Date': return 'Date';
   }
   throw new Error(`CSharp option "${option}" has unsupported type overload "${type}"`);

--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -829,7 +829,7 @@ function translateType(type, parent, generateNameCallback = t => t.name, optiona
  * @param {Documentation.Type} type
  */
 function registerModelType(typeName, type) {
-  if (['object', 'string', 'int'].includes(typeName))
+  if (['object', 'string', 'int', 'long'].includes(typeName))
     return;
   if (typeName.endsWith('Option'))
     return;

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -427,7 +427,7 @@ class TypesGenerator {
       return `{ [key: ${keyType}]: ${valueType}; }`;
     }
     let out = type.name;
-    if (out === 'int' || out === 'float')
+    if (out === 'int' || out === 'long' || out === 'float')
       out = 'number';
     if (out === 'Array' && direction === 'in')
       out = 'ReadonlyArray';


### PR DESCRIPTION
In Java and .NET int is not enough to store millis since epoch.