### PR TITLE
fix(trace): ensure har entry _monotonicTime is always start time

### DIFF
--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -434,12 +434,6 @@ export class HarTracer {
     const pageEntry = this._createPageEntryIfNeeded(page);
     const request = response.request();
 
-    // Prefer "response received" time over "request sent" time
-    // for the purpose of matching requests that were used in a particular snapshot.
-    // Note that both snapshot time and request time are taken here in the Node process.
-    if (this._options.includeTraceInfo)
-      harEntry._monotonicTime = monotonicTime();
-
     harEntry.response = {
       status: response.status(),
       statusText: response.statusText(),

--- a/packages/trace-viewer/src/ui/modelUtil.ts
+++ b/packages/trace-viewer/src/ui/modelUtil.ts
@@ -285,6 +285,10 @@ function adjustMonotonicTime(contexts: ContextEntry[], monotonicTimeDelta: numbe
       for (const frame of page.screencastFrames)
         frame.timestamp += monotonicTimeDelta;
     }
+    for (const resource of context.resources) {
+      if (resource._monotonicTime)
+        resource._monotonicTime += monotonicTimeDelta;
+    }
   }
 }
 


### PR DESCRIPTION
* Revert harTracer change from https://github.com/microsoft/playwright/commit/aeba083da0d8da9591e2a72c571477691a095d74 to make sure that har.Entry._monotonicTime always represents request start time. The issue from the corresponding report was due to HEAD and GET request sent for the same URL, that use case is still addressed as we match by url + method
* Adjust resources monotonic time as well when several contexts are shown in the trace viewer.

Fixes https://github.com/microsoft/playwright/issues/31133