### PR TITLE
fix(electron): allow downloads

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -654,8 +654,13 @@ export function validateBrowserContextOptions(options: channels.BrowserNewContex
     throw new Error(`"deviceScaleFactor" option is not supported with null "viewport"`);
   if (options.noDefaultViewport && !!options.isMobile)
     throw new Error(`"isMobile" option is not supported with null "viewport"`);
-  if (options.acceptDownloads === undefined)
+  if (options.acceptDownloads === undefined && browserOptions.name !== 'electron')
     options.acceptDownloads = 'accept';
+  // Electron requires explicit acceptDownloads: true since we wait for
+  // https://github.com/electron/electron/pull/41718 to be widely shipped.
+  // In 6-12 months, we can remove this check.
+  else if (options.acceptDownloads === undefined && browserOptions.name === 'electron')
+    options.acceptDownloads = 'internal-browser-default';
   if (!options.viewport && !options.noDefaultViewport)
     options.viewport = { width: 1280, height: 720 };
   if (options.recordVideo) {

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -348,7 +348,7 @@ export class CRBrowserContext extends BrowserContext {
   override async _initialize() {
     assert(!Array.from(this._browser._crPages.values()).some(page => page._browserContext === this));
     const promises: Promise<any>[] = [super._initialize()];
-    if (this._browser.options.name !== 'electron' && this._browser.options.name !== 'clank' && this._options.acceptDownloads !== 'internal-browser-default') {
+    if (this._browser.options.name !== 'clank' && this._options.acceptDownloads !== 'internal-browser-default') {
       promises.push(this._browser._session.send('Browser.setDownloadBehavior', {
         behavior: this._options.acceptDownloads === 'accept' ? 'allowAndName' : 'deny',
         browserContextId: this._browserContextId,


### PR DESCRIPTION
Maybe we should move https://github.com/microsoft/playwright/blob/main/tests/library/download.spec.ts into "page tests"? Except this single test which does `browser.newPage({ acceptDownloads: false });`.

This was fixed by https://github.com/electron/electron/pull/41718 - hence we didn't do it before. We should probably wait with this one until August 20th, when Electron v29 [reaches EOL](https://www.electronjs.org/docs/latest/tutorial/electron-timelines), or make this call either "not throw" / add a version check to it, since it throws in v29.

Fixes https://github.com/microsoft/playwright/issues/31389
Depends on https://github.com/microsoft/playwright/pull/30334

