### PR TITLE
fix(test-runner): don't add slow annotation twice

### DIFF
--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -261,7 +261,7 @@ export class WorkerMain extends ProcessRunner {
             testInfo.expectedStatus = 'failed';
           break;
         case 'slow':
-          testInfo.slow();
+          testInfo._timeoutManager.slow();
           break;
       }
     };

--- a/tests/playwright-test/test-modifiers.spec.ts
+++ b/tests/playwright-test/test-modifiers.spec.ts
@@ -690,3 +690,28 @@ test('static modifiers should be added in serial mode', async ({ runInlineTest }
   expect(result.report.suites[0].specs[2].tests[0].annotations).toEqual([{ type: 'skip' }]);
   expect(result.report.suites[0].specs[3].tests[0].annotations).toEqual([]);
 });
+
+test('should contain only one slow modifier', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'slow.test.ts': `
+      import { test } from '@playwright/test';
+      test.slow();
+      test('pass', { annotation: { type: 'issue', description: 'my-value' } }, () => {});
+    `,
+    'skip.test.ts': `
+      import { test } from '@playwright/test';
+      test.skip();
+      test('pass', { annotation: { type: 'issue', description: 'my-value' } }, () => {});
+  `,
+    'fixme.test.ts': `
+      import { test } from '@playwright/test';
+      test.fixme();
+      test('pass', { annotation: { type: 'issue', description: 'my-value' } }, () => {});
+`,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fixme' }, { type: 'issue', description: 'my-value' }]);
+  expect(result.report.suites[1].specs[0].tests[0].annotations).toEqual([{ type: 'skip' }, { type: 'issue', description: 'my-value' }]);
+  expect(result.report.suites[2].specs[0].tests[0].annotations).toEqual([{ type: 'slow' }, { type: 'issue', description: 'my-value' }]);
+});


### PR DESCRIPTION
Discovered here: https://github.com/microsoft/devops.playwright.dev/pull/10#issue-2369497287