### PR TITLE
fix(electron): tracing with @playwright/test

### DIFF
--- a/packages/playwright-core/src/client/electron.ts
+++ b/packages/playwright-core/src/client/electron.ts
@@ -116,8 +116,7 @@ export class ElectronApplication extends ChannelOwner<channels.ElectronApplicati
   }
 
   async close() {
-    // eslint-disable-next-line no-console
-    await this._context.close().catch(error => console.error(error));
+    await this._context.close().catch(() => {});
   }
 
   async waitForEvent(event: string, optionsOrPredicate: WaitForEventOptions = {}): Promise<any> {

--- a/packages/playwright-core/src/client/electron.ts
+++ b/packages/playwright-core/src/client/electron.ts
@@ -116,7 +116,8 @@ export class ElectronApplication extends ChannelOwner<channels.ElectronApplicati
   }
 
   async close() {
-    await this._context.close().catch(() => {});
+    // eslint-disable-next-line no-console
+    await this._context.close().catch(error => console.error(error));
   }
 
   async waitForEvent(event: string, optionsOrPredicate: WaitForEventOptions = {}): Promise<any> {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -597,7 +597,7 @@ class ArtifactsRecorder {
     if ((tracing as any)[this._startedCollectingArtifacts])
       return;
     (tracing as any)[this._startedCollectingArtifacts] = true;
-    if (this._testInfo._tracing.traceOptions())
+    if (this._testInfo._tracing.traceOptions() && (tracing as any)[kTracingStarted])
       await tracing.stopChunk({ path: this._testInfo._tracing.generateNextTraceRecordingPath() });
   }
 }

--- a/tests/installation/playwright-electron-should-work.spec.ts
+++ b/tests/installation/playwright-electron-should-work.spec.ts
@@ -15,6 +15,7 @@
  */
 import { test } from './npmTest';
 import fs from 'fs';
+import { expect } from 'packages/playwright-test';
 import path from 'path';
 
 test('electron should work', async ({ exec, tsc, writeFiles }) => {
@@ -38,4 +39,47 @@ test('electron should work with special characters in path', async ({ exec, tmpW
   await exec('node sanity-electron.js', {
     cwd: path.join(folderName)
   });
+});
+
+test('should work when wrapped inside @playwright/test and trace is enabled', async ({ exec, tmpWorkspace, writeFiles }) => {
+  await exec('npm i -D @playwright/test electron@31');
+  await writeFiles({
+    'electron-with-tracing.spec.ts': `
+      import { test, expect, _electron } from '@playwright/test';
+
+      test('should work', async ({ trace }) => {
+        const electronApp = await _electron.launch({ args: [${JSON.stringify(path.join(__dirname, '../electron/electron-window-app.js'))}] });
+
+        const window = await electronApp.firstWindow();
+        if (trace)
+          await window.context().tracing.start({ screenshots: true, snapshots: true });
+
+        await window.goto('data:text/html,<title>Playwright</title><h1>Playwright</h1>');
+        await expect(window).toHaveTitle(/Playwright/);
+        await expect(window.getByRole('heading')).toHaveText('Playwright');
+
+        const path = test.info().outputPath('electron-trace.zip');
+        if (trace) {
+          await window.context().tracing.stop({ path });
+          test.info().attachments.push({ name: 'trace', path, contentType: 'application/zip' });
+        }
+        await electronApp.close();
+      });
+    `,
+  });
+  const jsonOutputName = test.info().outputPath('report.json');
+  await exec('npx playwright test --trace=on --reporter=json electron-with-tracing.spec.ts', {
+    env: { PLAYWRIGHT_JSON_OUTPUT_NAME: jsonOutputName }
+  });
+  const traces = [
+    // our actual trace.
+    path.join(tmpWorkspace, 'test-results', 'electron-with-tracing-should-work', 'electron-trace.zip'),
+    // contains the expect() calls
+    path.join(tmpWorkspace, 'test-results', 'electron-with-tracing-should-work', 'trace.zip'),
+  ];
+  for (const trace of traces)
+    expect(fs.existsSync(trace)).toBe(true);
+  const report = JSON.parse(fs.readFileSync(jsonOutputName, 'utf-8'));
+  expect(new Set(['trace'])).toEqual(new Set(report.suites[0].specs[0].tests[0].results[0].attachments.map(a => a.name)));
+  expect(new Set(traces.map(p => fs.realpathSync(p)))).toEqual(new Set(report.suites[0].specs[0].tests[0].results[0].attachments.map(a => a.path)));
 });


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/31473

This regressed in https://github.com/microsoft/playwright/commit/e7a11c0ca22881623b073f2540c21b5d2da24085#diff-d7c041137e763edae5c4d18bc8ded9a1ac668078e310712341c444ef3aac423b - v1.45.0.

When Electron browser context gets closed, the request object gets disposed. But tracing was never started on the Electron request instance. This throws now:

```
➜  playwright git:(bugfix/electron-pwt) ✗ npm run ctest --  --trace=on wheel:18

> playwright-internal@1.46.0-next ctest
> playwright test --config=tests/library/playwright.config.ts --project=chromium-* --trace=on wheel:18


Running 1 test using 1 worker
  1) [chromium-page] › page/wheel.spec.ts:18:5 › should work ───────────────────────────────────────

    Error: ENOENT: no such file or directory, open '/Users/maxschmitt/Developer/playwright/test-results/.playwright-artifacts-0/fd9b718e68bb993159f60c54492d3af1.zip'

    attachment #1: trace (application/zip) ─────────────────────────────────────────────────────────
    test-results/wheel-should-work-chromium-page/electron-trace.zip
    Usage:

        npx playwright show-trace test-results/wheel-should-work-chromium-page/electron-trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────

  1 failed
    [chromium-page] › page/wheel.spec.ts:18:5 › should work ────────────────────────────────────────

To open last HTML report run:

  npx playwright show-report

➜  playwright git:(bugfix/electron-pwt) ✗ 
```

In normal PWT setup, this is not a problem, since we already start the tracing before. But since we don't check if the Tracing has been started, it throws now, that we didn't start it before.

I see two solutions:

a) We call didCreateContext in Electron, see footnote
  + Tracing support in Electron
  - Risk which we don't want right now.

b) just ignore the stop call, it wasn't marked with the start symbol.


---

```diff
diff --git a/packages/playwright-core/src/client/electron.ts b/packages/playwright-core/src/client/electron.ts
index a9e90b77f..bb92fdfa5 100644
--- a/packages/playwright-core/src/client/electron.ts
+++ b/packages/playwright-core/src/client/electron.ts
@@ -30,6 +30,7 @@ import { ConsoleMessage } from './consoleMessage';
 import type { Env, WaitForEventOptions, Headers, BrowserContextOptions } from './types';
 import { Waiter } from './waiter';
 import { TargetClosedError } from './errors';
+import { Playwright } from './playwright';
 
 type ElectronOptions = Omit<channels.ElectronLaunchOptions, 'env'|'extraHTTPHeaders'|'recordHar'|'colorScheme'|'acceptDownloads'> & {
   env?: Env,
@@ -42,6 +43,8 @@ type ElectronOptions = Omit<channels.ElectronLaunchOptions, 'env'|'extraHTTPHead
 type ElectronAppType = typeof import('electron');
 
 export class Electron extends ChannelOwner<channels.ElectronChannel> implements api.Electron {
+  _playwright!: Playwright;
+
   static from(electron: channels.ElectronChannel): Electron {
     return (electron as any)._object;
   }
@@ -57,6 +60,7 @@ export class Electron extends ChannelOwner<channels.ElectronChannel> implements
       tracesDir: options.tracesDir,
     };
     const app = ElectronApplication.from((await this._channel.launch(params)).electronApplication);
+    await this._playwright.chromium._didCreateContext(app.context(), params, options, this._logger);
     app._context._setOptions(params, options);
     return app;
   }
```