### PR TITLE
docs(ci.md): added Drone CI docs for NodeJs using the playwright Docker image

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -615,7 +615,7 @@ steps:
   - name: test
     image: mcr.microsoft.com/playwright:v%%VERSION%%-jammy
     commands:
-      - npx playwright test --project=$PROJECT
+      - npx playwright test
 ```
 
 ## Caching browsers

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -601,6 +601,23 @@ steps:
   - 'CI=true'
 ```
 
+### Drone
+* langs: js
+
+To run Playwright tests on Drone, use our public Docker image ([see Dockerfile](./docker.md)).
+
+```yml
+kind: pipeline
+name: default
+type: docker
+
+steps:
+  - name: test
+    image: mcr.microsoft.com/playwright:v%%VERSION%%-jammy
+    commands:
+      - npx playwright test --project=$PROJECT
+```
+
 ## Caching browsers
 
 Caching browser binaries is not recommended, since the amount of time it takes to restore the cache is comparable to the time it takes to download the binaries. Especially under Linux, [operating system dependencies](./browsers.md#install-system-dependencies) need to be installed, which are not cacheable.


### PR DESCRIPTION
## Why

To onboard the Drone CI users to run the Playwright in the CI.