### PR TITLE
fix(ct): export package.json

### DIFF
--- a/packages/playwright-ct-react/package.json
+++ b/packages/playwright-ct-react/package.json
@@ -26,7 +26,8 @@
     "./hooks": {
       "types": "./hooks.d.ts",
       "default": "./hooks.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "dependencies": {
     "@playwright/experimental-ct-core": "1.46.0-next",

--- a/packages/playwright-ct-react17/package.json
+++ b/packages/playwright-ct-react17/package.json
@@ -26,7 +26,8 @@
     "./hooks": {
       "types": "./hooks.d.ts",
       "default": "./hooks.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "dependencies": {
     "@playwright/experimental-ct-core": "1.46.0-next",

--- a/packages/playwright-ct-solid/package.json
+++ b/packages/playwright-ct-solid/package.json
@@ -26,7 +26,8 @@
     "./hooks": {
       "types": "./hooks.d.ts",
       "default": "./hooks.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "dependencies": {
     "@playwright/experimental-ct-core": "1.46.0-next",

--- a/packages/playwright-ct-svelte/package.json
+++ b/packages/playwright-ct-svelte/package.json
@@ -26,7 +26,8 @@
     "./hooks": {
       "types": "./hooks.d.ts",
       "default": "./hooks.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "dependencies": {
     "@playwright/experimental-ct-core": "1.46.0-next",

--- a/packages/playwright-ct-vue/package.json
+++ b/packages/playwright-ct-vue/package.json
@@ -26,7 +26,8 @@
     "./hooks": {
       "types": "./hooks.d.ts",
       "default": "./hooks.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "dependencies": {
     "@playwright/experimental-ct-core": "1.46.0-next",

--- a/packages/playwright-ct-vue2/package.json
+++ b/packages/playwright-ct-vue2/package.json
@@ -26,7 +26,8 @@
     "./hooks": {
       "types": "./hooks.d.ts",
       "default": "./hooks.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "dependencies": {
     "@playwright/experimental-ct-core": "1.46.0-next",


### PR DESCRIPTION
As per https://github.com/microsoft/playwright-vscode/blob/fc6d85877b9d5c1b40313febb336d240a7d201d5/src/playwrightFinder.ts#L33 we should export `package.json` for CT. This was not noticed before, because `NPM` does install the dependencies, aka. `playwright` in the root of the `node_modules` directory while PNPM does it nested / deep.

Fixes https://github.com/microsoft/playwright/issues/31491

Investigation credits go to https://github.com/microsoft/playwright/issues/31491.