### PR TITLE
docs(ci.md): typo

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -650,7 +650,7 @@ By default, Playwright launches browsers in headless mode. See in our [Running t
 On Linux agents, headed execution requires [Xvfb](https://en.wikipedia.org/wiki/Xvfb) to be installed. Our [Docker image](./docker.md) and GitHub Action have Xvfb pre-installed. To run browsers in headed mode with Xvfb, add `xvfb-run` before the actual command.
 
 ```bash js
-xvfb-run npx playwrght test
+xvfb-run npx playwright test
 ```
 ```bash python
 xvfb-run pytest


### PR DESCRIPTION
Fixes a typo where one of the example commands used `playwrght` instead of  `playwright`

Stumbled upon this while copying the command from the documentation. 