### PR TITLE
chore: Remove obsolete Chromium enabled features

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -20,7 +20,6 @@
 export const chromiumSwitches = [
   '--disable-field-trial-config', // https://source.chromium.org/chromium/chromium/src/+/main:testing/variations/README.md
   '--disable-background-networking',
-  '--enable-features=NetworkService,NetworkServiceInProcess',
   '--disable-background-timer-throttling',
   '--disable-backgrounding-occluded-windows',
   '--disable-back-forward-cache', // Avoids surprises like main request not being intercepted during page.goBack().


### PR DESCRIPTION
The "NetworkService" chromium feature has been removed since Jan 2022, see https://crrev.com/c/3417192.
The "NetworkServiceInProcess" chromium feature has been renamed since May 2022, see https://crrev.com/c/3647768.

And the new NetworkServiceInProcess2 flag might lead to crashes in latest versions of desktop Chrome according to https://github.com/puppeteer/puppeteer/pull/12261