### PR TITLE
feat(trace-viewer) add request urls for actions initiated via APIRequestContext 

### DIFF
--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -102,7 +102,7 @@ export const renderAction = (
       <span>{action.apiName}</span>
       {locator && <div className='action-selector' title={locator}>{locator}</div>}
       {action.method === 'goto' && action.params.url && <div className='action-url' title={action.params.url}>{action.params.url}</div>}
-      {action.class === 'APIRequestContext' && action.params.url && <div className='action-url' title={action.params.url}>{excludeBaseUrl(action.params.url)}</div>}
+      {action.class === 'APIRequestContext' && action.params.url && <div className='action-url' title={action.params.url}>{excludeOrigin(action.params.url)}</div>}
     </div>
     {(showDuration || showBadges) && <div className='spacer'></div>}
     {showDuration && <div className='action-duration'>{time || <span className='codicon codicon-loading'></span>}</div>}
@@ -113,7 +113,11 @@ export const renderAction = (
   </>;
 };
 
-function excludeBaseUrl(url: string): string {
-  const match = url.match(/^(https?:\/\/[^/]+)(.*)$/);
-  return match ? match[2] : url;
+function excludeOrigin(url: string): string {
+  try {
+    const urlObject = new URL(url);
+    return urlObject.pathname + urlObject.search;
+  } catch (error) {
+    return url;
+  }
 }

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -102,6 +102,7 @@ export const renderAction = (
       <span>{action.apiName}</span>
       {locator && <div className='action-selector' title={locator}>{locator}</div>}
       {action.method === 'goto' && action.params.url && <div className='action-url' title={action.params.url}>{action.params.url}</div>}
+      {action.class === 'APIRequestContext' && action.params.url && <div className='action-url' title={action.params.url}>{excludeBaseUrl(action.params.url)}</div>}
     </div>
     {(showDuration || showBadges) && <div className='spacer'></div>}
     {showDuration && <div className='action-duration'>{time || <span className='codicon codicon-loading'></span>}</div>}
@@ -111,3 +112,8 @@ export const renderAction = (
     </div>}
   </>;
 };
+
+function excludeBaseUrl(url: string): string {
+  const match = url.match(/^(https?:\/\/[^/]+)(.*)$/);
+  return match ? match[2] : url;
+}

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -812,12 +812,12 @@ test('should open two trace files', async ({ context, page, request, server, sho
   await traceViewer.selectAction('apiRequestContext.get');
   await traceViewer.selectAction('apiRequestContext.post');
   await expect(traceViewer.actionTitles).toHaveText([
-    `apiRequestContext.get`,
+    `apiRequestContext.get/simple.json`,
     `page.gotohttp://localhost:${server.PORT}/input/button.html`,
-    `apiRequestContext.head`,
+    `apiRequestContext.head/simplezip.json`,
     `locator.clicklocator('button')`,
     `locator.clicklocator('button')`,
-    `apiRequestContext.post`,
+    `apiRequestContext.post/one-style.css`,
   ]);
 
   await traceViewer.page.locator('text=Metadata').click();


### PR DESCRIPTION
Improve action list UX by adding request urls for `APIRequestContext` actions


Currently the action list does not provide any information about the request urls for APIRequestContext actions. This makes it difficult to understand what the action is doing and would require the user to double click on the action to see the request url in the action details.

It would be advantageous to include the request url in the action list so that the user can quickly understand what the action is doing without having to double click on the action.

Note that this information is already exposed in the HTML report, so this change would only be for the action list in the Trace Viewer.

<img width="1130" alt="Snag_149cc729" src="https://github.com/microsoft/playwright/assets/50574915/32a7f1cf-cace-475b-82e3-1127a1e79da5">


### Changes made

Add the request url to the action list for APIRequestContext actions (without the baseURL).  When user hovers over the url, they can see the full url.

<img width="1459" alt="2024-07-02_21-12-50" src="https://github.com/microsoft/playwright/assets/50574915/841272a4-82ea-4d9a-881d-fc8ce2ce3dd6">

