### PR TITLE
docs(clock): Fix C# version of clock documentation

### DIFF
--- a/docs/src/clock.md
+++ b/docs/src/clock.md
@@ -152,7 +152,7 @@ assertThat(locator).hasText("2/2/2024, 10:30:00 AM");
 ```csharp
 // Initialize clock with some time before the test time and let the page load naturally.
 // `Date.now` will progress as the timers fire.
-await Page.Clock.InstallAsync(new
+await Page.Clock.InstallAsync(new()
 {
   Time = new DateTime(2024, 2, 2, 8, 0, 0)
 });
@@ -350,7 +350,7 @@ assertThat(locator).hasText("2/2/2024, 10:00:02 AM");
 
 ```csharp
 // Initialize clock with a specific time, let the page load naturally.
-await Page.Clock.InstallAsync(new
+await Page.Clock.InstallAsync(new()
 {
   Time = new DateTime(2024, 2, 2, 8, 0, 0, DateTimeKind.Pst)
 });

--- a/docs/src/clock.md
+++ b/docs/src/clock.md
@@ -154,7 +154,7 @@ assertThat(locator).hasText("2/2/2024, 10:30:00 AM");
 // `Date.now` will progress as the timers fire.
 await Page.Clock.InstallAsync(new()
 {
-  Time = new DateTime(2024, 2, 2, 8, 0, 0)
+  TimeDate = new DateTime(2024, 2, 2, 8, 0, 0)
 });
 await Page.GotoAsync("http://localhost:3333");
 
@@ -352,7 +352,7 @@ assertThat(locator).hasText("2/2/2024, 10:00:02 AM");
 // Initialize clock with a specific time, let the page load naturally.
 await Page.Clock.InstallAsync(new()
 {
-  Time = new DateTime(2024, 2, 2, 8, 0, 0, DateTimeKind.Pst)
+  TimeDate = new DateTime(2024, 2, 2, 8, 0, 0, DateTimeKind.Pst)
 });
 await page.GotoAsync("http://localhost:3333");
 var locator = page.GetByTestId("current-time");


### PR DESCRIPTION
Honestly I'm a little confused by the options on `InstallAsync`. There's a `Time` and a `TimeString` which do the exact same thing, and then a `TimeDate` as well?

If Playwright isn't too strict about API compatibility, even with a release that just came out a day ago, I suggest changing it to a single `DateTime? InitialTime`, and if people want a string they can `DateTime.Parse()` it.

Either way, the docs currently are out of line with the actual API exposed and should be fixed.