### PR TITLE
fix(trace): do not corrupt test runner actions when no library trace is present

### DIFF
--- a/packages/trace-viewer/src/ui/modelUtil.ts
+++ b/packages/trace-viewer/src/ui/modelUtil.ts
@@ -223,7 +223,7 @@ function mergeActionsAndUpdateTimingSameTrace(contexts: ContextEntry[]) {
   //   library context actions.
   // - In the older versions the step id is not stored and the match is perfomed based on
   //   action name and wallTime.
-  const matchByStepId = libraryContexts.some(c => c.actions.some(a => !!a.stepId));
+  const matchByStepId = !libraryContexts.length || libraryContexts.some(c => c.actions.some(a => !!a.stepId));
 
   for (const context of libraryContexts) {
     for (const action of context.actions) {

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -1118,6 +1118,39 @@ test('trace:retain-on-first-failure should create trace if request context is di
   expect(result.failed).toBe(1);
 });
 
+test('should not corrupt actions when no library trace is present', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        foo: async ({}, use) => {
+          expect(1).toBe(1);
+          await use();
+          expect(2).toBe(2);
+        },
+      });
+      test('fail', async ({ foo }) => {
+        expect(1).toBe(2);
+      });
+    `,
+  }, { trace: 'on' });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+
+  const tracePath = test.info().outputPath('test-results', 'a-fail', 'trace.zip');
+  const trace = await parseTrace(tracePath);
+  expect(trace.actionTree).toEqual([
+    'Before Hooks',
+    '  fixture: foo',
+    '    expect.toBe',
+    'expect.toBe',
+    'After Hooks',
+    '  fixture: foo',
+    '    expect.toBe',
+    'Worker Cleanup',
+  ]);
+});
+
 test('should record trace in workerStorageState', async ({ runInlineTest }) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/30287' });
 


### PR DESCRIPTION
Recent logic that matches either by `stepId` or by `apiName`+`wallTime` did not account for "no library trace" scenario.