### PR TITLE
chore(trace-viewer): move call tab copy button next to the value

### DIFF
--- a/packages/trace-viewer/src/ui/callTab.css
+++ b/packages/trace-viewer/src/ui/callTab.css
@@ -59,7 +59,6 @@
 
 .copy-icon {
   display: none;
-  margin-right: 4px;
 }
 
 .call-line:hover .copy-icon {
@@ -71,7 +70,6 @@
   margin-left: 2px;
   text-overflow: ellipsis;
   overflow: hidden;
-  flex: 1;
 }
 
 .call-value::before {

--- a/packages/trace-viewer/src/ui/callTab.css
+++ b/packages/trace-viewer/src/ui/callTab.css
@@ -57,8 +57,9 @@
   white-space: nowrap;
 }
 
-.copy-icon {
+.call-line .copy-icon {
   display: none;
+  margin-left: 5px;
 }
 
 .call-line:hover .copy-icon {


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/31557

As per https://github.com/microsoft/playwright/issues/31557#issuecomment-2211250466

Before:

<img width="1728" alt="Screenshot 2024-07-08 at 10 02 24" src="https://github.com/microsoft/playwright/assets/17984549/b01d768a-7aa3-4f0f-a8f6-a0ac1884a7e7">

After:

<img width="1728" alt="Screenshot 2024-07-08 at 10 02 08" src="https://github.com/microsoft/playwright/assets/17984549/a308c87d-60bc-4b0d-8547-452d39fa8be3">

