### PR TITLE
feat(trace-viewer): allow pasting traces

### DIFF
--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -62,6 +62,10 @@ export const WorkbenchLoader: React.FunctionComponent<{
     const listener = async (e: ClipboardEvent) => {
       if (!e.clipboardData?.files.length)
         return;
+      for (const file of e.clipboardData.files) {
+        if (file.type !== 'application/zip')
+          return;
+      }
       e.preventDefault();
       processTraceFiles(e.clipboardData.files);
     };

--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -58,6 +58,17 @@ export const WorkbenchLoader: React.FunctionComponent<{
     setProcessingErrorMessage(null);
   }, []);
 
+  React.useEffect(() => {
+    const listener = async (e: ClipboardEvent) => {
+      if (!e.clipboardData?.files.length)
+        return;
+      e.preventDefault();
+      processTraceFiles(e.clipboardData.files);
+    };
+    document.addEventListener('paste', listener);
+    return () => document.removeEventListener('paste', listener);
+  });
+
   const handleDropEvent = React.useCallback((event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     processTraceFiles(event.dataTransfer.files);


### PR DESCRIPTION
Motivation: on macOS with multiple Desktops its hard to drag a file into it. Its simpler to just copy/paste it often using keyboard shortcuts.