### PR TITLE
chore: add android keys for channels switching

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/androidDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/androidDispatcher.ts
@@ -297,6 +297,8 @@ const keyMap = new Map<string, number>([
   ['Menu', 82],
   ['Notification', 83],
   ['Search', 84],
+  ['ChannelUp', 166],
+  ['ChannelDown', 167],
   ['AppSwitch', 187],
   ['Assist', 219],
   ['Cut', 277],

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14352,6 +14352,7 @@ export type AndroidKey =
   'Star' | 'Pound' | '*' | '#' |
   'DialUp' | 'DialDown' | 'DialLeft' | 'DialRight' | 'DialCenter' |
   'VolumeUp' | 'VolumeDown' |
+  'ChannelUp' | 'ChannelDown' |
   'Power' |
   'Camera' |
   'Clear' |

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -299,6 +299,7 @@ export type AndroidKey =
   'Star' | 'Pound' | '*' | '#' |
   'DialUp' | 'DialDown' | 'DialLeft' | 'DialRight' | 'DialCenter' |
   'VolumeUp' | 'VolumeDown' |
+  'ChannelUp' | 'ChannelDown' |
   'Power' |
   'Camera' |
   'Clear' |


### PR DESCRIPTION
"channel +" and  "channel -" are the most used keys, IMHO.