### PR TITLE
fix(recorder): address custom context menus

### DIFF
--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -259,6 +259,11 @@ class RecordActionTool implements RecorderTool {
     });
   }
 
+  onContextMenu(event: MouseEvent) {
+    // in case the web page has a custom context menu
+    this.onClick(event);
+  }
+
   onPointerDown(event: PointerEvent) {
     if (this._shouldIgnoreMouseEvent(event))
       return;

--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -260,8 +260,22 @@ class RecordActionTool implements RecorderTool {
   }
 
   onContextMenu(event: MouseEvent) {
-    // in case the web page has a custom context menu
-    this.onClick(event);
+    if (this._shouldIgnoreMouseEvent(event))
+      return;
+    if (this._actionInProgress(event))
+      return;
+    if (this._consumedDueToNoModel(event, this._hoveredModel))
+      return;
+
+    this._performAction({
+      name: 'click',
+      selector: this._hoveredModel!.selector,
+      position: positionForEvent(event),
+      signals: [],
+      button: 'right',
+      modifiers: 0,
+      clickCount: event.detail
+    });
   }
 
   onPointerDown(event: PointerEvent) {

--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -277,7 +277,7 @@ class RecordActionTool implements RecorderTool {
       signals: [],
       button: 'right',
       modifiers: 0,
-      clickCount: event.detail
+      clickCount: 0
     });
   }
 

--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -260,6 +260,9 @@ class RecordActionTool implements RecorderTool {
   }
 
   onContextMenu(event: MouseEvent) {
+    // the 'contextmenu' event is triggered by a right-click or equivalent action,
+    // and it prevents the click event from firing for that action, so we always
+    // convert 'contextmenu' into a right-click.
     if (this._shouldIgnoreMouseEvent(event))
       return;
     if (this._actionInProgress(event))

--- a/tests/library/inspector/inspectorTest.ts
+++ b/tests/library/inspector/inspectorTest.ts
@@ -186,9 +186,12 @@ class Recorder {
     await this.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
   }
 
-  async trustedClick() {
-    await this.page.mouse.down();
-    await this.page.mouse.up();
+  async trustedClick(options?: {
+    button?: 'left' | 'right' | 'middle';
+    clickCount?: number;
+  }) {
+    await this.page.mouse.down(options);
+    await this.page.mouse.up(options);
   }
 
   async focusElement(selector: string): Promise<string> {

--- a/tests/library/inspector/inspectorTest.ts
+++ b/tests/library/inspector/inspectorTest.ts
@@ -186,10 +186,7 @@ class Recorder {
     await this.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
   }
 
-  async trustedClick(options?: {
-    button?: 'left' | 'right' | 'middle';
-    clickCount?: number;
-  }) {
+  async trustedClick(options?: { button?: 'left' | 'right' | 'middle' }) {
     await this.page.mouse.down(options);
     await this.page.mouse.up(options);
   }


### PR DESCRIPTION
resolves https://github.com/microsoft/playwright/issues/31740

## Overview of problem

The following two issues happen when using the recorder (`npx playwright codegen`) on a web app that uses a custom context menu:
1. The recorder **_does not generate code for the right click_**. (Timestamps: 0:00 - 0:15)
2. The recorder change's the web app's behavior: **_It executes an extra right click_**. (Timestamps: 0:29 - 0:40)

They happen at different times, and I don't know why one happens instead of the other.

Video (it has sound):

https://github.com/microsoft/playwright/assets/8968171/9ef95cb7-6b60-4f8a-a0f2-b94a1fc4225f

## Steps to reproduce

1. Run `npx playwright codegen`
2. Within the recorder's browser, navigate to a local file with the following HTML (or navigate to https://custom-context-menu.netlify.app/):

<details>
  <summary>Click to expand HTML</summary>

```html
<html>
  <head>
    <title>Custom Context Menu</title>
    <style>
      .grid {
        display: grid;
        grid-template-columns: repeat(2, 100px);
        grid-template-rows: repeat(2, 100px);
        gap: 10px;
      }
      .box {
        background-color: lightgray;
        border: 1px solid black;
        display: flex;
        justify-content: center;
        align-items: center;
      }
      #menu {
        display: none;
        flex-direction: column;
        position: absolute;
        background-color: white;
        border: 1px solid black;
      }
    </style>
  </head>
  <body>
    <div>Right click on a box to show the custom context menu.</div>
    <div class="grid">
      <div class="box">1</div>
      <div class="box">2</div>
      <div class="box">3</div>
      <div class="box">4</div>
    </div>
    <div id="menu">
      <button>Menu option 1</button>
      <button>Menu option 2</button>
    </div>
    <script>
      document.addEventListener("contextmenu", function (event) {
        const menu = document.getElementById("menu");
        if (event.target.classList.contains("box")) {
          event.preventDefault();
          menu.style.display = "flex";
          menu.style.left = `${event.pageX}px`;
          menu.style.top = `${event.pageY}px`;
        } else {
          menu.style.display = "none";
        }
      });
      document.addEventListener("click", function () {
        document.getElementById("menu").style.display = "none";
      });
    </script>
  </body>
</html>
```

</details>

3. Right click a grid cell.
4. Notice that the recorder did not generate code for the right click.
5. Left click a menu option.
6. Notice that the menu appears again (because Playwright executes the right click redundantly).

You may have to repeat steps 3 through 6 until you experience both issues.

## Overview of solution

Interpret `contextmenu` events as click events:

```js
onContextMenu(event: MouseEvent) {
  // in case the web page has a custom context menu
  this.onClick(event);
}
```

This solves both issues, achieving:
1. The recorder generates code for the right click.
2. The recorder does not cause an extra right click.

Timestamps: 1:57 - 2:10

## Concerns

1. The coordinates of Playwright's performed right click are a little off.
2. My knowledge of Playwright is limited, so I might be missing important edge cases.