### PR TITLE
fix(ct): import ct* flavour types from ct-core and then from pwt

### DIFF
--- a/packages/playwright-ct-core/index.d.ts
+++ b/packages/playwright-ct-core/index.d.ts
@@ -56,4 +56,4 @@ export function defineConfig(config: PlaywrightTestConfig, ...configs: Playwrigh
 export function defineConfig<T>(config: PlaywrightTestConfig<T>, ...configs: PlaywrightTestConfig[]): PlaywrightTestConfig<T>;
 export function defineConfig<T, W>(config: PlaywrightTestConfig<T, W>, ...configs: PlaywrightTestConfig[]): PlaywrightTestConfig<T, W>;
 
-export { expect, devices } from 'playwright/test';
+export { expect, devices, Locator } from 'playwright/test';

--- a/packages/playwright-ct-react/index.d.ts
+++ b/packages/playwright-ct-react/index.d.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import type { Locator } from 'playwright/test';
-import type { TestType } from '@playwright/experimental-ct-core';
+import type { TestType, Locator } from '@playwright/experimental-ct-core';
 
 export interface MountOptions<HooksConfig> {
   hooksConfig?: HooksConfig;
@@ -33,5 +32,4 @@ export const test: TestType<{
   ): Promise<MountResult>;
 }>;
 
-export { defineConfig, PlaywrightTestConfig } from '@playwright/experimental-ct-core';
-export { expect, devices } from 'playwright/test';
+export { defineConfig, PlaywrightTestConfig, expect, devices } from '@playwright/experimental-ct-core';

--- a/packages/playwright-ct-react17/index.d.ts
+++ b/packages/playwright-ct-react17/index.d.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import type { Locator } from 'playwright/test';
-import type { TestType } from '@playwright/experimental-ct-core';
+import type { TestType, Locator} from '@playwright/experimental-ct-core';
 
 export interface MountOptions<HooksConfig> {
   hooksConfig?: HooksConfig;
@@ -33,5 +32,4 @@ export const test: TestType<{
   ): Promise<MountResult>;
 }>;
 
-export { defineConfig, PlaywrightTestConfig } from '@playwright/experimental-ct-core';
-export { expect, devices } from 'playwright/test';
+export { defineConfig, PlaywrightTestConfig, expect, devices } from '@playwright/experimental-ct-core';

--- a/packages/playwright-ct-solid/index.d.ts
+++ b/packages/playwright-ct-solid/index.d.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import type { Locator } from 'playwright/test';
-import type { TestType } from '@playwright/experimental-ct-core';
+import type { TestType, Locator } from '@playwright/experimental-ct-core';
 
 export interface MountOptions<HooksConfig> {
   hooksConfig?: HooksConfig;
@@ -33,5 +32,4 @@ export const test: TestType<{
   ): Promise<MountResult>;
 }>;
 
-export { defineConfig, PlaywrightTestConfig } from '@playwright/experimental-ct-core';
-export { expect, devices } from 'playwright/test';
+export { defineConfig, PlaywrightTestConfig, expect, devices } from '@playwright/experimental-ct-core';

--- a/packages/playwright-ct-svelte/index.d.ts
+++ b/packages/playwright-ct-svelte/index.d.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import type { Locator } from 'playwright/test';
 import type { SvelteComponent, ComponentProps } from 'svelte/types/runtime';
-import type { TestType } from '@playwright/experimental-ct-core';
+import type { TestType, Locator } from '@playwright/experimental-ct-core';
 
 type ComponentSlot = string | string[];
 type ComponentSlots = Record<string, ComponentSlot> & { default?: ComponentSlot };
@@ -44,5 +43,4 @@ export const test: TestType<{
   ): Promise<MountResult<Component>>;
 }>;
 
-export { defineConfig, PlaywrightTestConfig } from '@playwright/experimental-ct-core';
-export { expect, devices } from 'playwright/test';
+export { defineConfig, PlaywrightTestConfig, expect, devices } from '@playwright/experimental-ct-core';

--- a/packages/playwright-ct-vue/index.d.ts
+++ b/packages/playwright-ct-vue/index.d.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import type { Locator } from 'playwright/test';
-import type { TestType } from '@playwright/experimental-ct-core';
+import type { TestType, Locator } from '@playwright/experimental-ct-core';
 
 type ComponentSlot = string | string[];
 type ComponentSlots = Record<string, ComponentSlot> & { default?: ComponentSlot };
@@ -64,5 +63,4 @@ export const test: TestType<{
   ): Promise<MountResult<Component>>;
 }>;
 
-export { defineConfig, PlaywrightTestConfig } from '@playwright/experimental-ct-core';
-export { expect, devices } from 'playwright/test';
+export { defineConfig, PlaywrightTestConfig, expect, devices } from '@playwright/experimental-ct-core';

--- a/packages/playwright-ct-vue2/index.d.ts
+++ b/packages/playwright-ct-vue2/index.d.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import type { Locator } from 'playwright/test';
-import type { TestType } from '@playwright/experimental-ct-core';
+import type { TestType, Locator } from '@playwright/experimental-ct-core';
 
 type Slot = string | string[];
 type ComponentSlots = Record<string, Slot> & { default?: Slot };
@@ -64,5 +63,4 @@ export const test: TestType<{
   ): Promise<MountResult<Component>>;
 }>;
 
-export { defineConfig, PlaywrightTestConfig } from '@playwright/experimental-ct-core';
-export { expect, devices } from 'playwright/test';
+export { defineConfig, PlaywrightTestConfig, expect, devices } from '@playwright/experimental-ct-core';


### PR DESCRIPTION
Motivation: ct* packages were importing from `playwright` while `playwright` was not declared as a dependency. This changes the imports to `ct-core` which internally re-exports the needed imports from `playwright`.

Fixes https://github.com/microsoft/playwright/issues/31626