### PR TITLE
docs: add missing pytest-playwright installation command

### DIFF
--- a/docs/src/intro-python.md
+++ b/docs/src/intro-python.md
@@ -45,7 +45,7 @@ Install the [Pytest plugin](https://anaconda.org/Microsoft/pytest-playwright):
 ```bash
 conda config --add channels conda-forge
 conda config --add channels microsoft
-conda install playwright
+conda install pytest-playwright
 ```
 
 </TabItem>


### PR DESCRIPTION
Hello, 

It seems the explicit `conda install pytest-playwright` is missing, otherwise an error about `page fixtures` is thrown.

btw: I would also add explicit indications to install `pytest` as it's also required.

Thanks
