### PR TITLE
test: fix Windows Socks tests

### DIFF
--- a/tests/config/serverFixtures.ts
+++ b/tests/config/serverFixtures.ts
@@ -108,6 +108,8 @@ export class MockSocksServer {
         host: '127.0.0.1',
         port: 0,
       });
+    });
+    this._socksProxy.addListener(SocksProxy.Events.SocksData, async (payload: SocksSocketRequestedPayload) => {
       const body = '<html><title>Served by the SOCKS proxy</title></html>';
       const data = Buffer.from([
         'HTTP/1.1 200 OK',
@@ -118,6 +120,7 @@ export class MockSocksServer {
         body
       ].join('\r\n'));
       this._socksProxy.sendSocketData({ uid: payload.uid, data });
+      this._socksProxy.sendSocketEnd({ uid: payload.uid });
     });
   }
 

--- a/tests/config/serverFixtures.ts
+++ b/tests/config/serverFixtures.ts
@@ -118,7 +118,6 @@ export class MockSocksServer {
         body
       ].join('\r\n'));
       this._socksProxy.sendSocketData({ uid: payload.uid, data });
-      this._socksProxy.sendSocketEnd({ uid: payload.uid });
     });
   }
 


### PR DESCRIPTION
The problem was that we were sending data before we received the 'client hello' from the HTTP request


Fixes https://github.com/microsoft/playwright/actions/runs/9895972260/job/27337087654?pr=31649#step:3:401

---

This aligns it back how it was before:

Looking at https://github.com/microsoft/playwright/pull/31639/files#diff-1ab09439f10a0e85e2003befe8bca94284577084e1a2e2bbbd8b2a90de5a6edbL50.

That regressed in https://github.com/microsoft/playwright/pull/31639.