### PR TITLE
test: unflake signals temp dir removal test

### DIFF
--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -302,6 +302,7 @@ function generatePreview(value: any, visited = new Set<any>()): string {
 }
 
 async function mergeTraceFiles(fileName: string, temporaryTraceFiles: string[]) {
+  temporaryTraceFiles = temporaryTraceFiles.filter(file => fs.existsSync(file));
   if (temporaryTraceFiles.length === 1) {
     await fs.promises.rename(temporaryTraceFiles[0], fileName);
     return;


### PR DESCRIPTION
Repro: `PWTEST_TRACE=on npm run ctest library/signals.spec.ts:45:5`

Issue was that `await tracing.stopChunk({ path: file });` was throwing that the target is getting closed, so the file was never written to disk and https://github.com/microsoft/playwright/blob/97e2aa07a55c0a3e4a00712a9393723b2e73fc5b/packages/playwright/src/worker/testTracing.ts#L318 was throwing because the file does not exist.

Another way of solving this would be to filter the non-existing files out.

Happens since https://github.com/microsoft/playwright/commit/bc27ca225e69995f238192426df4ccb3f940a50d