### PR TITLE
chore: use EventEmitter generics

### DIFF
--- a/packages/playwright-core/src/remote/playwrightConnection.ts
+++ b/packages/playwright-core/src/remote/playwrightConnection.ts
@@ -18,12 +18,12 @@ import type { WebSocket } from '../utilsBundle';
 import type { DispatcherScope, Playwright } from '../server';
 import type * as channels from '@protocol/channels';
 import { createPlaywright, DispatcherConnection, RootDispatcher, PlaywrightDispatcher } from '../server';
-import { Browser } from '../server/browser';
+import type { Browser } from '../server/browser';
 import { serverSideCallMetadata } from '../server/instrumentation';
 import { SocksProxy } from '../common/socksProxy';
 import { assert, isUnderTest } from '../utils';
 import type { LaunchOptions } from '../server/types';
-import { AndroidDevice } from '../server/android/android';
+import type { AndroidDevice } from '../server/android/android';
 import { DebugControllerDispatcher } from '../server/dispatchers/debugControllerDispatcher';
 import { startProfiling, stopProfiling } from '../utils';
 import { monotonicTime } from '../utils';
@@ -123,7 +123,7 @@ export class PlaywrightConnection {
       for (const browser of playwright.allBrowsers())
         await browser.close({ reason: 'Connection terminated' });
     });
-    browser.on(Browser.Events.Disconnected, () => {
+    browser.on('disconnected', () => {
       // Underlying browser did close for some reason - force disconnect the client.
       this.close({ code: 1001, reason: 'Browser closed' });
     });
@@ -139,7 +139,7 @@ export class PlaywrightConnection {
     this._preLaunched.socksProxy?.setPattern(this._options.socksProxyPattern);
 
     const browser = this._preLaunched.browser!;
-    browser.on(Browser.Events.Disconnected, () => {
+    browser.on('disconnected', () => {
       // Underlying browser did close for some reason - force disconnect the client.
       this.close({ code: 1001, reason: 'Browser closed' });
     });
@@ -158,7 +158,7 @@ export class PlaywrightConnection {
     debugLogger.log('server', `[${this._id}] engaged pre-launched (Android) mode`);
     const playwright = this._preLaunched.playwright!;
     const androidDevice = this._preLaunched.androidDevice!;
-    androidDevice.on(AndroidDevice.Events.Close, () => {
+    androidDevice.on('close', () => {
       // Underlying browser did close for some reason - force disconnect the client.
       this.close({ code: 1001, reason: 'Android device disconnected' });
     });
@@ -202,7 +202,7 @@ export class PlaywrightConnection {
         ...this._options.launchOptions,
         headless: !!process.env.PW_DEBUG_CONTROLLER_HEADLESS,
       });
-      browser.on(Browser.Events.Disconnected, () => {
+      browser.on('disconnected', () => {
         // Underlying browser did close for some reason - force disconnect the client.
         this.close({ code: 1001, reason: 'Browser closed' });
       });

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -15,7 +15,6 @@
  */
 
 import { debug } from '../../utilsBundle';
-import { EventEmitter } from 'events';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -451,7 +450,7 @@ export class AndroidDevice extends SdkObject<{
   }
 }
 
-class AndroidBrowser extends EventEmitter {
+class AndroidBrowser {
   readonly device: AndroidDevice;
   private _socket: SocketBackend;
   private _receiver: stream.Writable;
@@ -460,8 +459,6 @@ class AndroidBrowser extends EventEmitter {
   onclose?: () => void;
 
   constructor(device: AndroidDevice, socket: SocketBackend) {
-    super();
-    this.setMaxListeners(0);
     this.device = device;
     this._socket = socket;
     this._socket.on('close', () => {

--- a/packages/playwright-core/src/server/android/backendAdb.ts
+++ b/packages/playwright-core/src/server/android/backendAdb.ts
@@ -17,9 +17,8 @@
 import { debug } from '../../utilsBundle';
 import type * as channels from '@protocol/channels';
 import * as net from 'net';
-import { EventEmitter } from 'events';
-import type { Backend, DeviceBackend, SocketBackend } from './android';
-import { assert, createGuid } from '../../utils';
+import type { Backend, DeviceBackend, SocketBackend, SocketBackendEvents } from './android';
+import { assert, createGuid, ManagedEventEmitter } from '../../utils';
 
 export class AdbBackend implements Backend {
   async devices(options: channels.AndroidDevicesOptions = {}): Promise<DeviceBackend[]> {
@@ -112,7 +111,7 @@ function encodeMessage(message: string): Buffer {
   return Buffer.from(lenHex + message);
 }
 
-class BufferedSocketWrapper extends EventEmitter implements SocketBackend {
+class BufferedSocketWrapper extends ManagedEventEmitter<SocketBackendEvents> implements SocketBackend {
   readonly guid = createGuid();
   private _socket: net.Socket;
   private _buffer = Buffer.from([]);

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -52,13 +52,10 @@ export type BrowserOptions = {
   originalLaunchOptions: types.LaunchOptions;
 };
 
-export abstract class Browser extends SdkObject {
-
-  static Events = {
-    BeforeClose: 'beforeClose',
-    Disconnected: 'disconnected',
-  };
-
+export abstract class Browser extends SdkObject<{
+  beforeClose: []
+  disconnected: []
+}> {
   readonly options: BrowserOptions;
   private _downloads = new Map<string, Download>();
   _defaultContext: BrowserContext | null = null;
@@ -140,8 +137,8 @@ export abstract class Browser extends SdkObject {
     pageOrError.then(page => {
       if (page instanceof Page) {
         page._video = artifact;
-        page.emitOnContext(BrowserContext.Events.VideoStarted, artifact);
-        page.emit(Page.Events.Video, artifact);
+        page.emitOnContext('videostarted', artifact);
+        page.emit('video', artifact);
       }
     });
   }
@@ -158,7 +155,7 @@ export abstract class Browser extends SdkObject {
 
   _didClose() {
     if (this._needsBeforeCloseEvent)
-      this.emit(Browser.Events.BeforeClose);
+      this.emit('beforeClose');
     else
       this.beforeCloseFinished();
   }
@@ -168,7 +165,7 @@ export abstract class Browser extends SdkObject {
       context._browserClosed();
     if (this._defaultContext)
       this._defaultContext._browserClosed();
-    this.emit(Browser.Events.Disconnected);
+    this.emit('disconnected');
     this.instrumentation.onBrowserClose(this);
   }
 
@@ -180,7 +177,7 @@ export abstract class Browser extends SdkObject {
       await this.options.browserProcess.close();
     }
     if (this.isConnected())
-      await new Promise(x => this.once(Browser.Events.Disconnected, x));
+      await new Promise<void>(x => this.once('disconnected', x));
   }
 
   async killForTests() {

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -28,7 +28,6 @@ import type { ConnectionTransport, ProtocolRequest } from '../transport';
 import { WebSocketTransport } from '../transport';
 import { CRDevTools } from './crDevTools';
 import type { BrowserOptions, BrowserProcess } from '../browser';
-import { Browser } from '../browser';
 import type * as types from '../types';
 import type * as channels from '@protocol/channels';
 import type { HTTPRequestParams } from '../../utils/network';
@@ -121,7 +120,7 @@ export class Chromium extends BrowserType {
     progress.throwIfAborted();
     const browser = await CRBrowser.connect(this.attribution.playwright, chromeTransport, browserOptions);
     browser._isCollocatedWithServer = false;
-    browser.on(Browser.Events.Disconnected, doCleanup);
+    browser.on('disconnected', doCleanup);
     return browser;
   }
 

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -192,7 +192,7 @@ export class CRBrowser extends Browser {
     if (targetInfo.type === 'service_worker') {
       const serviceWorker = new CRServiceWorker(context, session, targetInfo.url);
       this._serviceWorkers.set(targetInfo.targetId, serviceWorker);
-      context.emit(CRBrowserContext.CREvents.ServiceWorker, serviceWorker);
+      context.emit('serviceworker', serviceWorker);
       return;
     }
 
@@ -333,11 +333,6 @@ export class CRBrowser extends Browser {
 }
 
 export class CRBrowserContext extends BrowserContext {
-  static CREvents = {
-    BackgroundPage: 'backgroundpage',
-    ServiceWorker: 'serviceworker',
-  };
-
   declare readonly _browser: CRBrowser;
 
   constructor(browser: CRBrowser, browserContextId: string | undefined, options: channels.BrowserNewContextParams) {

--- a/packages/playwright-core/src/server/chromium/crCoverage.ts
+++ b/packages/playwright-core/src/server/chromium/crCoverage.ts
@@ -78,9 +78,9 @@ class JSCoverage {
     this._scriptIds.clear();
     this._scriptSources.clear();
     this._eventListeners = [
-      eventsHelper.addEventListener(this._client, 'Debugger.scriptParsed', this._onScriptParsed.bind(this)),
-      eventsHelper.addEventListener(this._client, 'Runtime.executionContextsCleared', this._onExecutionContextsCleared.bind(this)),
-      eventsHelper.addEventListener(this._client, 'Debugger.paused', this._onDebuggerPaused.bind(this)),
+      this._client.addManagedListener('Debugger.scriptParsed', this._onScriptParsed.bind(this)),
+      this._client.addManagedListener('Runtime.executionContextsCleared', this._onExecutionContextsCleared.bind(this)),
+      this._client.addManagedListener('Debugger.paused', this._onDebuggerPaused.bind(this)),
     ];
     await Promise.all([
       this._client.send('Profiler.enable'),
@@ -164,8 +164,8 @@ class CSSCoverage {
     this._stylesheetURLs.clear();
     this._stylesheetSources.clear();
     this._eventListeners = [
-      eventsHelper.addEventListener(this._client, 'CSS.styleSheetAdded', this._onStyleSheet.bind(this)),
-      eventsHelper.addEventListener(this._client, 'Runtime.executionContextsCleared', this._onExecutionContextsCleared.bind(this)),
+      this._client.addManagedListener('CSS.styleSheetAdded', this._onStyleSheet.bind(this)),
+      this._client.addManagedListener('Runtime.executionContextsCleared', this._onExecutionContextsCleared.bind(this)),
     ];
     await Promise.all([
       this._client.send('DOM.enable'),

--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -60,25 +60,25 @@ export class CRNetworkManager {
   async addSession(session: CRSession, workerFrame?: frames.Frame, isMain?: boolean) {
     const sessionInfo: SessionInfo = { session, isMain, workerFrame, eventListeners: [] };
     sessionInfo.eventListeners = [
-      eventsHelper.addEventListener(session, 'Fetch.requestPaused', this._onRequestPaused.bind(this, sessionInfo)),
-      eventsHelper.addEventListener(session, 'Fetch.authRequired', this._onAuthRequired.bind(this, sessionInfo)),
-      eventsHelper.addEventListener(session, 'Network.requestWillBeSent', this._onRequestWillBeSent.bind(this, sessionInfo)),
-      eventsHelper.addEventListener(session, 'Network.requestWillBeSentExtraInfo', this._onRequestWillBeSentExtraInfo.bind(this)),
-      eventsHelper.addEventListener(session, 'Network.requestServedFromCache', this._onRequestServedFromCache.bind(this)),
-      eventsHelper.addEventListener(session, 'Network.responseReceived', this._onResponseReceived.bind(this, sessionInfo)),
-      eventsHelper.addEventListener(session, 'Network.responseReceivedExtraInfo', this._onResponseReceivedExtraInfo.bind(this)),
-      eventsHelper.addEventListener(session, 'Network.loadingFinished', this._onLoadingFinished.bind(this, sessionInfo)),
-      eventsHelper.addEventListener(session, 'Network.loadingFailed', this._onLoadingFailed.bind(this, sessionInfo)),
+      session.addManagedListener('Fetch.requestPaused', this._onRequestPaused.bind(this, sessionInfo)),
+      session.addManagedListener('Fetch.authRequired', this._onAuthRequired.bind(this, sessionInfo)),
+      session.addManagedListener('Network.requestWillBeSent', this._onRequestWillBeSent.bind(this, sessionInfo)),
+      session.addManagedListener('Network.requestWillBeSentExtraInfo', this._onRequestWillBeSentExtraInfo.bind(this)),
+      session.addManagedListener('Network.requestServedFromCache', this._onRequestServedFromCache.bind(this)),
+      session.addManagedListener('Network.responseReceived', this._onResponseReceived.bind(this, sessionInfo)),
+      session.addManagedListener('Network.responseReceivedExtraInfo', this._onResponseReceivedExtraInfo.bind(this)),
+      session.addManagedListener('Network.loadingFinished', this._onLoadingFinished.bind(this, sessionInfo)),
+      session.addManagedListener('Network.loadingFailed', this._onLoadingFailed.bind(this, sessionInfo)),
     ];
     if (this._page) {
       sessionInfo.eventListeners.push(...[
-        eventsHelper.addEventListener(session, 'Network.webSocketCreated', e => this._page!._frameManager.onWebSocketCreated(e.requestId, e.url)),
-        eventsHelper.addEventListener(session, 'Network.webSocketWillSendHandshakeRequest', e => this._page!._frameManager.onWebSocketRequest(e.requestId)),
-        eventsHelper.addEventListener(session, 'Network.webSocketHandshakeResponseReceived', e => this._page!._frameManager.onWebSocketResponse(e.requestId, e.response.status, e.response.statusText)),
-        eventsHelper.addEventListener(session, 'Network.webSocketFrameSent', e => e.response.payloadData && this._page!._frameManager.onWebSocketFrameSent(e.requestId, e.response.opcode, e.response.payloadData)),
-        eventsHelper.addEventListener(session, 'Network.webSocketFrameReceived', e => e.response.payloadData && this._page!._frameManager.webSocketFrameReceived(e.requestId, e.response.opcode, e.response.payloadData)),
-        eventsHelper.addEventListener(session, 'Network.webSocketClosed', e => this._page!._frameManager.webSocketClosed(e.requestId)),
-        eventsHelper.addEventListener(session, 'Network.webSocketFrameError', e => this._page!._frameManager.webSocketError(e.requestId, e.errorMessage)),
+        session.addManagedListener('Network.webSocketCreated', e => this._page!._frameManager.onWebSocketCreated(e.requestId, e.url)),
+        session.addManagedListener('Network.webSocketWillSendHandshakeRequest', e => this._page!._frameManager.onWebSocketRequest(e.requestId)),
+        session.addManagedListener('Network.webSocketHandshakeResponseReceived', e => this._page!._frameManager.onWebSocketResponse(e.requestId, e.response.status, e.response.statusText)),
+        session.addManagedListener('Network.webSocketFrameSent', e => e.response.payloadData && this._page!._frameManager.onWebSocketFrameSent(e.requestId, e.response.opcode, e.response.payloadData)),
+        session.addManagedListener('Network.webSocketFrameReceived', e => e.response.payloadData && this._page!._frameManager.webSocketFrameReceived(e.requestId, e.response.opcode, e.response.payloadData)),
+        session.addManagedListener('Network.webSocketClosed', e => this._page!._frameManager.webSocketClosed(e.requestId)),
+        session.addManagedListener('Network.webSocketFrameError', e => this._page!._frameManager.webSocketError(e.requestId, e.errorMessage)),
       ]);
     }
     this._sessions.set(session, sessionInfo);

--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -19,7 +19,6 @@ import type { CRSession } from './crConnection';
 import { CRExecutionContext } from './crExecutionContext';
 import { CRNetworkManager } from './crNetworkManager';
 import * as network from '../network';
-import { BrowserContext } from '../browserContext';
 
 export class CRServiceWorker extends Worker {
   readonly _browserContext: CRBrowserContext;
@@ -87,19 +86,19 @@ export class CRServiceWorker extends Worker {
   }
 
   reportRequestFinished(request: network.Request, response: network.Response | null) {
-    this._browserContext.emit(BrowserContext.Events.RequestFinished, { request, response });
+    this._browserContext.emit('requestfinished', { request, response });
   }
 
   requestFailed(request: network.Request, _canceled: boolean) {
-    this._browserContext.emit(BrowserContext.Events.RequestFailed, request);
+    this._browserContext.emit('requestfailed', request);
   }
 
   requestReceivedResponse(response: network.Response) {
-    this._browserContext.emit(BrowserContext.Events.Response, response);
+    this._browserContext.emit('response', response);
   }
 
   requestStarted(request: network.Request, route?: network.RouteDelegate) {
-    this._browserContext.emit(BrowserContext.Events.Request, request);
+    this._browserContext.emit('request', request);
     if (route) {
       const r = new network.Route(request, route);
       if (this._browserContext._requestInterceptor?.(r, request))

--- a/packages/playwright-core/src/server/chromium/videoRecorder.ts
+++ b/packages/playwright-core/src/server/chromium/videoRecorder.ts
@@ -16,7 +16,7 @@
 
 import type { ChildProcess } from 'child_process';
 import { assert, monotonicTime } from '../../utils';
-import { Page } from '../page';
+import type { Page } from '../page';
 import { launchProcess } from '../../utils/processLauncher';
 import type { Progress } from '../progress';
 import { ProgressController } from '../progress';
@@ -53,7 +53,7 @@ export class VideoRecorder {
   private constructor(page: Page, ffmpegPath: string, progress: Progress) {
     this._progress = progress;
     this._ffmpegPath = ffmpegPath;
-    page.on(Page.Events.ScreencastFrame, frame => this.writeFrame(frame.buffer, frame.timestamp));
+    page.on('screencastframe', frame => this.writeFrame(frame.buffer, frame.timestamp!));
   }
 
   private async _launch(options: types.PageScreencastOptions) {

--- a/packages/playwright-core/src/server/debugController.ts
+++ b/packages/playwright-core/src/server/debugController.ts
@@ -28,15 +28,13 @@ import type { Language } from '../utils/isomorphic/locatorGenerators';
 
 const internalMetadata = serverSideCallMetadata();
 
-export class DebugController extends SdkObject {
-  static Events = {
-    StateChanged: 'stateChanged',
-    InspectRequested: 'inspectRequested',
-    SourceChanged: 'sourceChanged',
-    Paused: 'paused',
-    SetModeRequested: 'setModeRequested',
-  };
-
+export class DebugController extends SdkObject<{
+  stateChanged: [{ pageCount: number }]
+  inspectRequested: [{ selector: string, locator: string }]
+  sourceChanged: [{ text: string, header: string | undefined, footer: string | undefined, actions: string[] | undefined }]
+  paused: [{ paused: boolean }]
+  setModeRequested: [{ mode: Mode }]
+}> {
   private _autoCloseTimer: NodeJS.Timeout | undefined;
   // TODO: remove in 1.27
   private _autoCloseAllowed = false;
@@ -193,7 +191,7 @@ export class DebugController extends SdkObject {
         pageCount += context.pages().length;
       }
     }
-    this.emit(DebugController.Events.StateChanged, { pageCount });
+    this.emit('stateChanged', { pageCount });
   }
 
   private async _allRecorders(): Promise<Recorder[]> {
@@ -226,20 +224,20 @@ class InspectingRecorderApp extends EmptyRecorderApp {
 
   override async setSelector(selector: string): Promise<void> {
     const locator: string = asLocator(this._debugController._sdkLanguage, selector);
-    this._debugController.emit(DebugController.Events.InspectRequested, { selector, locator });
+    this._debugController.emit('inspectRequested', { selector, locator });
   }
 
   override async setSources(sources: Source[]): Promise<void> {
     const source = sources.find(s => s.id === this._debugController._codegenId);
     const { text, header, footer, actions } = source || { text: '' };
-    this._debugController.emit(DebugController.Events.SourceChanged, { text, header, footer, actions });
+    this._debugController.emit('sourceChanged', { text, header, footer, actions });
   }
 
   override async setPaused(paused: boolean) {
-    this._debugController.emit(DebugController.Events.Paused, { paused });
+    this._debugController.emit('paused', { paused });
   }
 
   override async setMode(mode: Mode) {
-    this._debugController.emit(DebugController.Events.SetModeRequested, { mode });
+    this._debugController.emit('setModeRequested', { mode });
   }
 }

--- a/packages/playwright-core/src/server/dispatchers/androidDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/androidDispatcher.ts
@@ -17,7 +17,7 @@
 import type { RootDispatcher } from './dispatcher';
 import { Dispatcher, existingDispatcher } from './dispatcher';
 import type { Android, SocketBackend } from '../android/android';
-import { AndroidDevice } from '../android/android';
+import type { AndroidDevice } from '../android/android';
 import type * as channels from '@protocol/channels';
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 import type { CallMetadata } from '../instrumentation';
@@ -56,9 +56,9 @@ export class AndroidDeviceDispatcher extends Dispatcher<AndroidDevice, channels.
     });
     for (const webView of device.webViews())
       this._dispatchEvent('webViewAdded', { webView });
-    this.addObjectListener(AndroidDevice.Events.WebViewAdded, webView => this._dispatchEvent('webViewAdded', { webView }));
-    this.addObjectListener(AndroidDevice.Events.WebViewRemoved, socketName => this._dispatchEvent('webViewRemoved', { socketName }));
-    this.addObjectListener(AndroidDevice.Events.Close, socketName => this._dispatchEvent('close'));
+    this.addObjectListener('webViewAdded', webView => this._dispatchEvent('webViewAdded', { webView }));
+    this.addObjectListener('webViewRemoved', socketName => this._dispatchEvent('webViewRemoved', { socketName }));
+    this.addObjectListener('close', () => this._dispatchEvent('close'));
   }
 
   async wait(params: channels.AndroidDeviceWaitParams) {

--- a/packages/playwright-core/src/server/dispatchers/browserDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserDispatcher.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Browser } from '../browser';
+import type { Browser } from '../browser';
 import type * as channels from '@protocol/channels';
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 import { CDPSessionDispatcher } from './cdpSessionDispatcher';
@@ -24,7 +24,7 @@ import { Dispatcher } from './dispatcher';
 import type { CRBrowser } from '../chromium/crBrowser';
 import type { PageDispatcher } from './pageDispatcher';
 import type { CallMetadata } from '../instrumentation';
-import { BrowserContext } from '../browserContext';
+import type { BrowserContext } from '../browserContext';
 import { Selectors } from '../selectors';
 import type { BrowserTypeDispatcher } from './browserTypeDispatcher';
 import { ArtifactDispatcher } from './artifactDispatcher';
@@ -35,8 +35,8 @@ export class BrowserDispatcher extends Dispatcher<Browser, channels.BrowserChann
   constructor(scope: BrowserTypeDispatcher, browser: Browser) {
     super(scope, browser, 'Browser', { version: browser.version(), name: browser.options.name });
     browser.setNeedsBeforeCloseEvent(true);
-    this.addObjectListener(Browser.Events.BeforeClose, () => this._dispatchEvent('beforeClose'));
-    this.addObjectListener(Browser.Events.Disconnected, () => this._didClose());
+    this.addObjectListener('beforeClose', () => this._dispatchEvent('beforeClose'));
+    this.addObjectListener('disconnected', () => this._didClose());
   }
 
   override _onDispose() {
@@ -109,7 +109,7 @@ export class ConnectedBrowserDispatcher extends Dispatcher<Browser, channels.Bro
 
   constructor(scope: RootDispatcher, browser: Browser) {
     super(scope, browser, 'Browser', { version: browser.version(), name: browser.options.name });
-    this.addObjectListener(Browser.Events.BeforeClose, () => this.emit('beforeClose'));
+    this.addObjectListener('beforeClose', () => this.emit('beforeClose'));
     // When we have a remotely-connected browser, each client gets a fresh Selector instance,
     // so that two clients do not interfere between each other.
     this.selectors = new Selectors();
@@ -121,7 +121,7 @@ export class ConnectedBrowserDispatcher extends Dispatcher<Browser, channels.Bro
     const context = await this._object.newContext(metadata, params);
     this._contexts.add(context);
     context.setSelectors(this.selectors);
-    context.on(BrowserContext.Events.Close, () => this._contexts.delete(context));
+    context.on('close', () => this._contexts.delete(context));
     return { context: new BrowserContextDispatcher(this, context) };
   }
 

--- a/packages/playwright-core/src/server/dispatchers/cdpSessionDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/cdpSessionDispatcher.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { CDPSession } from '../chromium/crConnection';
+import type { CDPSession } from '../chromium/crConnection';
 import type * as channels from '@protocol/channels';
 import { Dispatcher } from './dispatcher';
 import type { BrowserDispatcher } from './browserDispatcher';
@@ -26,8 +26,8 @@ export class CDPSessionDispatcher extends Dispatcher<CDPSession, channels.CDPSes
 
   constructor(scope: BrowserDispatcher | BrowserContextDispatcher, cdpSession: CDPSession) {
     super(scope, cdpSession, 'CDPSession', {});
-    this.addObjectListener(CDPSession.Events.Event, ({ method, params }) => this._dispatchEvent('event', { method, params }));
-    this.addObjectListener(CDPSession.Events.Closed, () => this._dispose());
+    this.addObjectListener('event', ({ method, params }) => this._dispatchEvent('event', { method, params }));
+    this.addObjectListener('closed', () => this._dispose());
   }
 
   async send(params: channels.CDPSessionSendParams): Promise<channels.CDPSessionSendResult> {

--- a/packages/playwright-core/src/server/dispatchers/debugControllerDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/debugControllerDispatcher.ts
@@ -17,7 +17,7 @@
 import type * as channels from '@protocol/channels';
 import { eventsHelper } from '../../utils';
 import type { RegisteredListener } from '../../utils/eventsHelper';
-import { DebugController } from '../debugController';
+import type { DebugController } from '../debugController';
 import type { DispatcherConnection, RootDispatcher } from './dispatcher';
 import { Dispatcher } from './dispatcher';
 
@@ -29,19 +29,19 @@ export class DebugControllerDispatcher extends Dispatcher<DebugController, chann
     super(connection, debugController, 'DebugController', {});
     this._type_DebugController = true;
     this._listeners = [
-      eventsHelper.addEventListener(this._object, DebugController.Events.StateChanged, params => {
+      this._object.addManagedListener('stateChanged', params => {
         this._dispatchEvent('stateChanged', params);
       }),
-      eventsHelper.addEventListener(this._object, DebugController.Events.InspectRequested, ({ selector, locator }) => {
+      this._object.addManagedListener('inspectRequested', ({ selector, locator }) => {
         this._dispatchEvent('inspectRequested', { selector, locator });
       }),
-      eventsHelper.addEventListener(this._object, DebugController.Events.SourceChanged, ({ text, header, footer, actions }) => {
+      this._object.addManagedListener('sourceChanged', ({ text, header, footer, actions }) => {
         this._dispatchEvent('sourceChanged', ({ text, header, footer, actions }));
       }),
-      eventsHelper.addEventListener(this._object, DebugController.Events.Paused, ({ paused }) => {
+      this._object.addManagedListener('paused', ({ paused }) => {
         this._dispatchEvent('paused', ({ paused }));
       }),
-      eventsHelper.addEventListener(this._object, DebugController.Events.SetModeRequested, ({ mode }) => {
+      this._object.addManagedListener('setModeRequested', ({ mode }) => {
         this._dispatchEvent('setModeRequested', ({ mode }));
       }),
     ];

--- a/packages/playwright-core/src/server/dispatchers/electronDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/electronDispatcher.ts
@@ -17,7 +17,7 @@
 import type { RootDispatcher } from './dispatcher';
 import { Dispatcher } from './dispatcher';
 import type { Electron } from '../electron/electron';
-import { ElectronApplication } from '../electron/electron';
+import type { ElectronApplication } from '../electron/electron';
 import type * as channels from '@protocol/channels';
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 import type { PageDispatcher } from './pageDispatcher';
@@ -47,11 +47,11 @@ export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplicatio
     super(scope, electronApplication, 'ElectronApplication', {
       context: new BrowserContextDispatcher(scope, electronApplication.context())
     });
-    this.addObjectListener(ElectronApplication.Events.Close, () => {
+    this.addObjectListener('close', () => {
       this._dispatchEvent('close');
       this._dispose();
     });
-    this.addObjectListener(ElectronApplication.Events.Console, (message: ConsoleMessage) => {
+    this.addObjectListener('console', (message: ConsoleMessage) => {
       if (!this._subscriptions.has('console'))
         return;
       this._dispatchEvent('console', {

--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -15,7 +15,7 @@
  */
 
 import type { NavigationEvent } from '../frames';
-import { Frame } from '../frames';
+import type { Frame } from '../frames';
 import type * as channels from '@protocol/channels';
 import { Dispatcher, existingDispatcher } from './dispatcher';
 import { ElementHandleDispatcher } from './elementHandlerDispatcher';
@@ -58,13 +58,13 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
     }, gcBucket);
     this._browserContextDispatcher = scope;
     this._frame = frame;
-    this.addObjectListener(Frame.Events.AddLifecycle, lifecycleEvent => {
+    this.addObjectListener('addlifecycle', lifecycleEvent => {
       this._dispatchEvent('loadstate', { add: lifecycleEvent });
     });
-    this.addObjectListener(Frame.Events.RemoveLifecycle, lifecycleEvent => {
+    this.addObjectListener('removelifecycle', lifecycleEvent => {
       this._dispatchEvent('loadstate', { remove: lifecycleEvent });
     });
-    this.addObjectListener(Frame.Events.InternalNavigation, (event: NavigationEvent) => {
+    this.addObjectListener('internalnavigation', (event: NavigationEvent) => {
       if (!event.isPublic)
         return;
       const params = { url: event.url, name: event.name, error: event.error ? event.error.message : undefined };

--- a/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
+++ b/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
@@ -18,7 +18,7 @@ import type * as channels from '@protocol/channels';
 import type { APIRequestContext } from '../fetch';
 import type { CallMetadata } from '../instrumentation';
 import type { Request, Response, Route } from '../network';
-import { WebSocket } from '../network';
+import type { WebSocket } from '../network';
 import type { RootDispatcher } from './dispatcher';
 import { Dispatcher, existingDispatcher } from './dispatcher';
 import { TracingDispatcher } from './tracingDispatcher';
@@ -164,10 +164,10 @@ export class WebSocketDispatcher extends Dispatcher<WebSocket, channels.WebSocke
     super(scope, webSocket, 'WebSocket', {
       url: webSocket.url(),
     });
-    this.addObjectListener(WebSocket.Events.FrameSent, (event: { opcode: number, data: string }) => this._dispatchEvent('frameSent', event));
-    this.addObjectListener(WebSocket.Events.FrameReceived, (event: { opcode: number, data: string }) => this._dispatchEvent('frameReceived', event));
-    this.addObjectListener(WebSocket.Events.SocketError, (error: string) => this._dispatchEvent('socketError', { error }));
-    this.addObjectListener(WebSocket.Events.Close, () => this._dispatchEvent('close', {}));
+    this.addObjectListener('framesent', (event: { opcode: number, data: string }) => this._dispatchEvent('frameSent', event));
+    this.addObjectListener('framereceived', (event: { opcode: number, data: string }) => this._dispatchEvent('frameReceived', event));
+    this.addObjectListener('socketerror', (error: string) => this._dispatchEvent('socketError', { error }));
+    this.addObjectListener('close', () => this._dispatchEvent('close', {}));
   }
 }
 

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -16,7 +16,8 @@
 
 import type { BrowserContext } from '../browserContext';
 import type { Frame } from '../frames';
-import { Page, Worker } from '../page';
+import type { Worker } from '../page';
+import type { Page } from '../page';
 import type * as channels from '@protocol/channels';
 import { Dispatcher, existingDispatcher } from './dispatcher';
 import { parseError } from '../errors';
@@ -70,25 +71,25 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     this.adopt(mainFrame);
 
     this._page = page;
-    this.addObjectListener(Page.Events.Close, () => {
+    this.addObjectListener('close', () => {
       this._dispatchEvent('close');
       this._dispose();
     });
-    this.addObjectListener(Page.Events.Crash, () => this._dispatchEvent('crash'));
-    this.addObjectListener(Page.Events.Download, (download: Download) => {
+    this.addObjectListener('crash', () => this._dispatchEvent('crash'));
+    this.addObjectListener('download', (download: Download) => {
       // Artifact can outlive the page, so bind to the context scope.
       this._dispatchEvent('download', { url: download.url, suggestedFilename: download.suggestedFilename(), artifact: ArtifactDispatcher.from(parentScope, download.artifact) });
     });
-    this.addObjectListener(Page.Events.FileChooser, (fileChooser: FileChooser) => this._dispatchEvent('fileChooser', {
+    this.addObjectListener('filechooser', (fileChooser: FileChooser) => this._dispatchEvent('fileChooser', {
       element: ElementHandleDispatcher.from(mainFrame, fileChooser.element()),
       isMultiple: fileChooser.isMultiple()
     }));
-    this.addObjectListener(Page.Events.FrameAttached, frame => this._onFrameAttached(frame));
-    this.addObjectListener(Page.Events.FrameDetached, frame => this._onFrameDetached(frame));
-    this.addObjectListener(Page.Events.LocatorHandlerTriggered, (uid: number) => this._dispatchEvent('locatorHandlerTriggered', { uid }));
-    this.addObjectListener(Page.Events.WebSocket, webSocket => this._dispatchEvent('webSocket', { webSocket: new WebSocketDispatcher(this, webSocket) }));
-    this.addObjectListener(Page.Events.Worker, worker => this._dispatchEvent('worker', { worker: new WorkerDispatcher(this, worker) }));
-    this.addObjectListener(Page.Events.Video, (artifact: Artifact) => this._dispatchEvent('video', { artifact: ArtifactDispatcher.from(parentScope, artifact) }));
+    this.addObjectListener('frameattached', frame => this._onFrameAttached(frame));
+    this.addObjectListener('framedetached', frame => this._onFrameDetached(frame));
+    this.addObjectListener('locatorhandlertriggered', (uid: number) => this._dispatchEvent('locatorHandlerTriggered', { uid }));
+    this.addObjectListener('websocket', webSocket => this._dispatchEvent('webSocket', { webSocket: new WebSocketDispatcher(this, webSocket) }));
+    this.addObjectListener('worker', worker => this._dispatchEvent('worker', { worker: new WorkerDispatcher(this, worker) }));
+    this.addObjectListener('video', (artifact: Artifact) => this._dispatchEvent('video', { artifact: ArtifactDispatcher.from(parentScope, artifact) }));
     if (page._video)
       this._dispatchEvent('video', { artifact: ArtifactDispatcher.from(this.parentScope(), page._video) });
     // Ensure client knows about all frames.
@@ -338,7 +339,7 @@ export class WorkerDispatcher extends Dispatcher<Worker, channels.WorkerChannel,
     super(scope, worker, 'Worker', {
       url: worker.url()
     });
-    this.addObjectListener(Worker.Events.Close, () => this._dispatchEvent('close'));
+    this.addObjectListener('close', () => this._dispatchEvent('close'));
   }
 
   async evaluateExpression(params: channels.WorkerEvaluateExpressionParams, metadata: CallMetadata): Promise<channels.WorkerEvaluateExpressionResult> {

--- a/packages/playwright-core/src/server/dispatchers/playwrightDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/playwrightDispatcher.ts
@@ -19,7 +19,7 @@ import type { Browser } from '../browser';
 import { GlobalAPIRequestContext } from '../fetch';
 import type { Playwright } from '../playwright';
 import type { SocksSocketClosedPayload, SocksSocketDataPayload, SocksSocketRequestedPayload } from '../../common/socksProxy';
-import { SocksProxy } from '../../common/socksProxy';
+import type { SocksProxy } from '../../common/socksProxy';
 import { AndroidDispatcher } from './androidDispatcher';
 import { BrowserTypeDispatcher } from './browserTypeDispatcher';
 import type { RootDispatcher } from './dispatcher';
@@ -79,9 +79,9 @@ class SocksSupportDispatcher extends Dispatcher<{ guid: string }, channels.Socks
     this._type_SocksSupport = true;
     this._socksProxy = socksProxy;
     this._socksListeners = [
-      eventsHelper.addEventListener(socksProxy, SocksProxy.Events.SocksRequested, (payload: SocksSocketRequestedPayload) => this._dispatchEvent('socksRequested', payload)),
-      eventsHelper.addEventListener(socksProxy, SocksProxy.Events.SocksData, (payload: SocksSocketDataPayload) => this._dispatchEvent('socksData', payload)),
-      eventsHelper.addEventListener(socksProxy, SocksProxy.Events.SocksClosed, (payload: SocksSocketClosedPayload) => this._dispatchEvent('socksClosed', payload)),
+      socksProxy.addManagedListener('socksRequested', (payload: SocksSocketRequestedPayload) => this._dispatchEvent('socksRequested', payload)),
+      socksProxy.addManagedListener('socksData', (payload: SocksSocketDataPayload) => this._dispatchEvent('socksData', payload)),
+      socksProxy.addManagedListener('socksClosed', (payload: SocksSocketClosedPayload) => this._dispatchEvent('socksClosed', payload)),
     ];
   }
 

--- a/packages/playwright-core/src/server/download.ts
+++ b/packages/playwright-core/src/server/download.ts
@@ -15,7 +15,7 @@
  */
 
 import path from 'path';
-import { Page } from './page';
+import type { Page } from './page';
 import { assert } from '../utils';
 import { Artifact } from './artifact';
 
@@ -35,13 +35,13 @@ export class Download {
     this._suggestedFilename = suggestedFilename;
     page._browserContext._downloads.add(this);
     if (suggestedFilename !== undefined)
-      this._page.emit(Page.Events.Download, this);
+      this._page.emit('download', this);
   }
 
   _filenameSuggested(suggestedFilename: string) {
     assert(this._suggestedFilename === undefined);
     this._suggestedFilename = suggestedFilename;
-    this._page.emit(Page.Events.Download, this);
+    this._page.emit('download', this);
   }
 
   suggestedFilename(): string {

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -25,7 +25,7 @@ import type { InitScript, Page, PageBinding, PageDelegate } from '../page';
 import type { ConnectionTransport } from '../transport';
 import type * as types from '../types';
 import type * as channels from '@protocol/channels';
-import { ConnectionEvents, FFConnection, type FFSession } from './ffConnection';
+import { FFConnection, type FFSession } from './ffConnection';
 import { FFPage } from './ffPage';
 import type { Protocol } from './protocol';
 import type { SdkObject } from '../instrumentation';
@@ -69,7 +69,7 @@ export class FFBrowser extends Browser {
     this.session = connection.rootSession;
     this._ffPages = new Map();
     this._contexts = new Map();
-    this._connection.on(ConnectionEvents.Disconnected, () => this._onDisconnect());
+    this._connection.on('disconnected', () => this._onDisconnect());
     this.session.on('Browser.attachedToTarget', this._onAttachedToTarget.bind(this));
     this.session.on('Browser.detachedFromTarget', this._onDetachedFromTarget.bind(this));
     this.session.on('Browser.downloadCreated', this._onDownloadCreated.bind(this));

--- a/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
+++ b/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
@@ -38,10 +38,10 @@ export class FFNetworkManager {
     this._page = page;
 
     this._eventListeners = [
-      eventsHelper.addEventListener(session, 'Network.requestWillBeSent', this._onRequestWillBeSent.bind(this)),
-      eventsHelper.addEventListener(session, 'Network.responseReceived', this._onResponseReceived.bind(this)),
-      eventsHelper.addEventListener(session, 'Network.requestFinished', this._onRequestFinished.bind(this)),
-      eventsHelper.addEventListener(session, 'Network.requestFailed', this._onRequestFailed.bind(this)),
+      session.addManagedListener('Network.requestWillBeSent', this._onRequestWillBeSent.bind(this)),
+      session.addManagedListener('Network.responseReceived', this._onResponseReceived.bind(this)),
+      session.addManagedListener('Network.requestFinished', this._onRequestFinished.bind(this)),
+      session.addManagedListener('Network.requestFailed', this._onRequestFailed.bind(this)),
     ];
   }
 

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -35,7 +35,6 @@ import type { Progress } from '../progress';
 import { splitErrorMessage } from '../../utils/stackTrace';
 import { debugLogger } from '../../utils/debugLogger';
 import { ManualPromise } from '../../utils/manualPromise';
-import { BrowserContext } from '../browserContext';
 import { TargetClosedError } from '../errors';
 
 export const UTILITY_WORLD_NAME = '__playwright_utility_world__';
@@ -70,36 +69,36 @@ export class FFPage implements PageDelegate {
     this._page = new Page(this, browserContext);
     this.rawMouse.setPage(this._page);
     this._networkManager = new FFNetworkManager(session, this._page);
-    this._page.on(Page.Events.FrameDetached, frame => this._removeContextsForFrame(frame));
+    this._page.on('framedetached', frame => this._removeContextsForFrame(frame));
     // TODO: remove Page.willOpenNewWindowAsynchronously from the protocol.
     this._eventListeners = [
-      eventsHelper.addEventListener(this._session, 'Page.eventFired', this._onEventFired.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.frameAttached', this._onFrameAttached.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.frameDetached', this._onFrameDetached.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.navigationAborted', this._onNavigationAborted.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.navigationCommitted', this._onNavigationCommitted.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.navigationStarted', this._onNavigationStarted.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.sameDocumentNavigation', this._onSameDocumentNavigation.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Runtime.executionContextCreated', this._onExecutionContextCreated.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Runtime.executionContextDestroyed', this._onExecutionContextDestroyed.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Runtime.executionContextsCleared', this._onExecutionContextsCleared.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.linkClicked', event => this._onLinkClicked(event.phase)),
-      eventsHelper.addEventListener(this._session, 'Page.uncaughtError', this._onUncaughtError.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Runtime.console', this._onConsole.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.dialogOpened', this._onDialogOpened.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.bindingCalled', this._onBindingCalled.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.fileChooserOpened', this._onFileChooserOpened.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.workerCreated', this._onWorkerCreated.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.workerDestroyed', this._onWorkerDestroyed.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.dispatchMessageFromWorker', this._onDispatchMessageFromWorker.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.crashed', this._onCrashed.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.videoRecordingStarted', this._onVideoRecordingStarted.bind(this)),
+      this._session.addManagedListener('Page.eventFired', this._onEventFired.bind(this)),
+      this._session.addManagedListener('Page.frameAttached', this._onFrameAttached.bind(this)),
+      this._session.addManagedListener('Page.frameDetached', this._onFrameDetached.bind(this)),
+      this._session.addManagedListener('Page.navigationAborted', this._onNavigationAborted.bind(this)),
+      this._session.addManagedListener('Page.navigationCommitted', this._onNavigationCommitted.bind(this)),
+      this._session.addManagedListener('Page.navigationStarted', this._onNavigationStarted.bind(this)),
+      this._session.addManagedListener('Page.sameDocumentNavigation', this._onSameDocumentNavigation.bind(this)),
+      this._session.addManagedListener('Runtime.executionContextCreated', this._onExecutionContextCreated.bind(this)),
+      this._session.addManagedListener('Runtime.executionContextDestroyed', this._onExecutionContextDestroyed.bind(this)),
+      this._session.addManagedListener('Runtime.executionContextsCleared', this._onExecutionContextsCleared.bind(this)),
+      this._session.addManagedListener('Page.linkClicked', event => this._onLinkClicked(event.phase)),
+      this._session.addManagedListener('Page.uncaughtError', this._onUncaughtError.bind(this)),
+      this._session.addManagedListener('Runtime.console', this._onConsole.bind(this)),
+      this._session.addManagedListener('Page.dialogOpened', this._onDialogOpened.bind(this)),
+      this._session.addManagedListener('Page.bindingCalled', this._onBindingCalled.bind(this)),
+      this._session.addManagedListener('Page.fileChooserOpened', this._onFileChooserOpened.bind(this)),
+      this._session.addManagedListener('Page.workerCreated', this._onWorkerCreated.bind(this)),
+      this._session.addManagedListener('Page.workerDestroyed', this._onWorkerDestroyed.bind(this)),
+      this._session.addManagedListener('Page.dispatchMessageFromWorker', this._onDispatchMessageFromWorker.bind(this)),
+      this._session.addManagedListener('Page.crashed', this._onCrashed.bind(this)),
+      this._session.addManagedListener('Page.videoRecordingStarted', this._onVideoRecordingStarted.bind(this)),
 
-      eventsHelper.addEventListener(this._session, 'Page.webSocketCreated', this._onWebSocketCreated.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.webSocketClosed', this._onWebSocketClosed.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.webSocketFrameReceived', this._onWebSocketFrameReceived.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.webSocketFrameSent', this._onWebSocketFrameSent.bind(this)),
-      eventsHelper.addEventListener(this._session, 'Page.screencastFrame', this._onScreencastFrame.bind(this)),
+      this._session.addManagedListener('Page.webSocketCreated', this._onWebSocketCreated.bind(this)),
+      this._session.addManagedListener('Page.webSocketClosed', this._onWebSocketClosed.bind(this)),
+      this._session.addManagedListener('Page.webSocketFrameReceived', this._onWebSocketFrameReceived.bind(this)),
+      this._session.addManagedListener('Page.webSocketFrameSent', this._onWebSocketFrameSent.bind(this)),
+      this._session.addManagedListener('Page.screencastFrame', this._onScreencastFrame.bind(this)),
 
     ];
     this._session.once('Page.ready', async () => {
@@ -244,7 +243,7 @@ export class FFPage implements PageDelegate {
     const error = new Error(message);
     error.stack = params.message + '\n' + params.stack.split('\n').filter(Boolean).map(a => a.replace(/([^@]*)@(.*)/, '    at $1 ($2)')).join('\n');
     error.name = name;
-    this._page.emitOnContextOnceInitialized(BrowserContext.Events.PageError, error, this._page);
+    this._page.emitOnContextOnceInitialized('pageerror', error, this._page);
   }
 
   _onConsole(payload: Protocol.Runtime.consolePayload) {
@@ -257,7 +256,7 @@ export class FFPage implements PageDelegate {
   }
 
   _onDialogOpened(params: Protocol.Page.dialogOpenedPayload) {
-    this._page.emitOnContext(BrowserContext.Events.Dialog, new dialog.Dialog(
+    this._page.emitOnContext('dialog', new dialog.Dialog(
         this._page,
         params.type,
         params.message,
@@ -519,7 +518,7 @@ export class FFPage implements PageDelegate {
     });
 
     const buffer = Buffer.from(event.data, 'base64');
-    this._page.emit(Page.Events.ScreencastFrame, {
+    this._page.emit('screencastframe', {
       buffer,
       width: event.deviceWidth,
       height: event.deviceHeight,

--- a/packages/playwright-core/src/server/helper.ts
+++ b/packages/playwright-core/src/server/helper.ts
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 
-import type { EventEmitter } from 'events';
 import type * as types from './types';
 import type { Progress } from './progress';
 import { debugLogger } from '../utils/debugLogger';
-import type { RegisteredListener } from '../utils/eventsHelper';
+import type { ManagedEventEmitter, RegisteredListener } from '../utils/eventsHelper';
 import { eventsHelper } from '../utils/eventsHelper';
 
 const MAX_LOG_LENGTH = process.env.MAX_LOG_LENGTH ? +process.env.MAX_LOG_LENGTH : Infinity;
@@ -53,10 +52,10 @@ class Helper {
     return null;
   }
 
-  static waitForEvent(progress: Progress | null, emitter: EventEmitter, event: string | symbol, predicate?: Function): { promise: Promise<any>, dispose: () => void } {
+  static waitForEvent<T extends ManagedEventEmitter<any>, K extends keyof T['_events']>(progress: Progress | null, emitter: T, event: K, predicate?: Function): { promise: Promise<any>, dispose: () => void } {
     const listeners: RegisteredListener[] = [];
     const promise = new Promise((resolve, reject) => {
-      listeners.push(eventsHelper.addEventListener(emitter, event, eventArg => {
+      listeners.push(emitter.addManagedListener(event, eventArg => {
         try {
           if (predicate && !predicate(eventArg))
             return;

--- a/packages/playwright-core/src/server/instrumentation.ts
+++ b/packages/playwright-core/src/server/instrumentation.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
-import { createGuid } from '../utils';
+import { createGuid, ManagedEventEmitter } from '../utils';
 import type { APIRequestContext } from './fetch';
 import type { Browser } from './browser';
 import type { BrowserContext } from './browserContext';
@@ -37,7 +36,7 @@ export type Attribution = {
 import type { CallMetadata } from '@protocol/callMetadata';
 export type { CallMetadata } from '@protocol/callMetadata';
 
-export class SdkObject extends EventEmitter {
+export class SdkObject<Events extends Record<string, any[]> = any> extends ManagedEventEmitter<Events> {
   guid: string;
   attribution: Attribution;
   instrumentation: Instrumentation;

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -139,7 +139,7 @@ export class ClientCertificatesProxy {
   ) {
     this._socksProxy = new SocksProxy();
     this._socksProxy.setPattern('*');
-    this._socksProxy.addListener(SocksProxy.Events.SocksRequested, async (payload: SocksSocketRequestedPayload) => {
+    this._socksProxy.addListener('socksRequested', async (payload: SocksSocketRequestedPayload) => {
       try {
         const connection = new SocksProxyConnection(this, payload.uid, payload.host, payload.port);
         await connection.connect();
@@ -148,10 +148,10 @@ export class ClientCertificatesProxy {
         this._socksProxy.socketFailed({ uid: payload.uid, errorCode: error.code });
       }
     });
-    this._socksProxy.addListener(SocksProxy.Events.SocksData, async (payload: SocksSocketDataPayload) => {
+    this._socksProxy.addListener('socksData', async (payload: SocksSocketDataPayload) => {
       this._connections.get(payload.uid)?.onData(payload.data);
     });
-    this._socksProxy.addListener(SocksProxy.Events.SocksClosed, (payload: SocksSocketClosedPayload) => {
+    this._socksProxy.addListener('socksClosed', (payload: SocksSocketClosedPayload) => {
       this._connections.get(payload.uid)?.onClose();
       this._connections.delete(payload.uid);
     });

--- a/packages/playwright-core/src/server/socksInterceptor.ts
+++ b/packages/playwright-core/src/server/socksInterceptor.ts
@@ -47,11 +47,11 @@ export class SocksInterceptor {
         };
       },
     }) as channels.SocksSupportChannel & EventEmitter;
-    this._handler.on(socks.SocksProxyHandler.Events.SocksConnected, (payload: socks.SocksSocketConnectedPayload) => this._channel.socksConnected(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksData, (payload: socks.SocksSocketDataPayload) => this._channel.socksData(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksError, (payload: socks.SocksSocketErrorPayload) => this._channel.socksError(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksFailed, (payload: socks.SocksSocketFailedPayload) => this._channel.socksFailed(payload));
-    this._handler.on(socks.SocksProxyHandler.Events.SocksEnd, (payload: socks.SocksSocketEndPayload) => this._channel.socksEnd(payload));
+    this._handler.on('socksConnected', (payload: socks.SocksSocketConnectedPayload) => this._channel.socksConnected(payload));
+    this._handler.on('socksData', (payload: socks.SocksSocketDataPayload) => this._channel.socksData(payload));
+    this._handler.on('socksError', (payload: socks.SocksSocketErrorPayload) => this._channel.socksError(payload));
+    this._handler.on('socksFailed', (payload: socks.SocksSocketFailedPayload) => this._channel.socksFailed(payload));
+    this._handler.on('socksEnd', (payload: socks.SocksSocketEndPayload) => this._channel.socksEnd(payload));
     this._channel.on('socksRequested', payload => this._handler.socketRequested(payload));
     this._channel.on('socksClosed', payload => this._handler.socketClosed(payload));
     this._channel.on('socksData', payload => this._handler.sendSocketData(payload));

--- a/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { BrowserContext } from '../../browserContext';
-import { Page } from '../../page';
+import type { BrowserContext } from '../../browserContext';
+import type { Page } from '../../page';
 import type { RegisteredListener } from '../../../utils/eventsHelper';
 import { eventsHelper } from '../../../utils/eventsHelper';
 import { debugLogger } from '../../../utils/debugLogger';
@@ -83,7 +83,7 @@ export class Snapshotter {
     for (const page of this._context.pages())
       this._onPage(page);
     this._eventListeners = [
-      eventsHelper.addEventListener(this._context, BrowserContext.Events.Page, this._onPage.bind(this)),
+      this._context.addManagedListener('page', this._onPage.bind(this)),
     ];
 
     const { javaScriptEnabled } = this._context._options;
@@ -160,7 +160,7 @@ export class Snapshotter {
     // Annotate frame hierarchy so that snapshots could include frame ids.
     for (const frame of page.frames())
       this._annotateFrameHierarchy(frame);
-    this._eventListeners.push(eventsHelper.addEventListener(page, Page.Events.FrameAttached, frame => this._annotateFrameHierarchy(frame)));
+    this._eventListeners.push(page.addManagedListener('frameattached', frame => this._annotateFrameHierarchy(frame)));
   }
 
   private async _annotateFrameHierarchy(frame: Frame) {

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -20,7 +20,6 @@ import { Browser } from '../browser';
 import { assertBrowserContextIsNotOwned, BrowserContext, verifyGeolocation } from '../browserContext';
 import type { RegisteredListener } from '../../utils/eventsHelper';
 import { assert } from '../../utils';
-import { eventsHelper } from '../../utils/eventsHelper';
 import * as network from '../network';
 import type { InitScript, Page, PageBinding, PageDelegate } from '../page';
 import type { ConnectionTransport } from '../transport';
@@ -64,15 +63,15 @@ export class WKBrowser extends Browser {
     this._connection = new WKConnection(transport, this._onDisconnect.bind(this), options.protocolLogger, options.browserLogsCollector);
     this._browserSession = this._connection.browserSession;
     this._eventListeners = [
-      eventsHelper.addEventListener(this._browserSession, 'Playwright.pageProxyCreated', this._onPageProxyCreated.bind(this)),
-      eventsHelper.addEventListener(this._browserSession, 'Playwright.pageProxyDestroyed', this._onPageProxyDestroyed.bind(this)),
-      eventsHelper.addEventListener(this._browserSession, 'Playwright.provisionalLoadFailed', event => this._onProvisionalLoadFailed(event)),
-      eventsHelper.addEventListener(this._browserSession, 'Playwright.windowOpen', event => this._onWindowOpen(event)),
-      eventsHelper.addEventListener(this._browserSession, 'Playwright.downloadCreated', this._onDownloadCreated.bind(this)),
-      eventsHelper.addEventListener(this._browserSession, 'Playwright.downloadFilenameSuggested', this._onDownloadFilenameSuggested.bind(this)),
-      eventsHelper.addEventListener(this._browserSession, 'Playwright.downloadFinished', this._onDownloadFinished.bind(this)),
-      eventsHelper.addEventListener(this._browserSession, 'Playwright.screencastFinished', this._onScreencastFinished.bind(this)),
-      eventsHelper.addEventListener(this._browserSession, kPageProxyMessageReceived, this._onPageProxyMessageReceived.bind(this)),
+      this._browserSession.addManagedListener('Playwright.pageProxyCreated', this._onPageProxyCreated.bind(this)),
+      this._browserSession.addManagedListener('Playwright.pageProxyDestroyed', this._onPageProxyDestroyed.bind(this)),
+      this._browserSession.addManagedListener('Playwright.provisionalLoadFailed', event => this._onProvisionalLoadFailed(event)),
+      this._browserSession.addManagedListener('Playwright.windowOpen', event => this._onWindowOpen(event)),
+      this._browserSession.addManagedListener('Playwright.downloadCreated', this._onDownloadCreated.bind(this)),
+      this._browserSession.addManagedListener('Playwright.downloadFilenameSuggested', this._onDownloadFilenameSuggested.bind(this)),
+      this._browserSession.addManagedListener('Playwright.downloadFinished', this._onDownloadFinished.bind(this)),
+      this._browserSession.addManagedListener('Playwright.screencastFinished', this._onScreencastFinished.bind(this)),
+      this._browserSession.addManagedListener(kPageProxyMessageReceived, this._onPageProxyMessageReceived.bind(this)),
     ];
   }
 

--- a/packages/playwright-core/src/server/webkit/wkConnection.ts
+++ b/packages/playwright-core/src/server/webkit/wkConnection.ts
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
-import { assert } from '../../utils';
+import { assert, ManagedEventEmitter } from '../../utils';
 import type { ConnectionTransport, ProtocolRequest, ProtocolResponse } from '../transport';
 import type { Protocol } from './protocol';
 import type { RecentLogsCollector } from '../../utils/debugLogger';
@@ -97,7 +96,11 @@ export class WKConnection {
   }
 }
 
-export class WKSession extends EventEmitter {
+export class WKSession extends ManagedEventEmitter<{
+  [K in keyof Protocol.Events]: [Protocol.Events[K]]
+ } & {
+  [kPageProxyMessageReceived]: [PageProxyMessageReceivedPayload]
+ }> {
   connection: WKConnection;
   readonly sessionId: string;
 
@@ -105,12 +108,6 @@ export class WKSession extends EventEmitter {
   private readonly _rawSend: (message: any) => void;
   private readonly _callbacks = new Map<number, { resolve: (o: any) => void, reject: (e: ProtocolError) => void, error: ProtocolError }>();
   private _crashed: boolean = false;
-
-  override on: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  override addListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  override off: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  override removeListener: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
-  override once: <T extends keyof Protocol.Events | symbol>(event: T, listener: (payload: T extends symbol ? any : Protocol.Events[T extends keyof Protocol.Events ? T : never]) => void) => this;
 
   constructor(connection: WKConnection, sessionId: string, rawSend: (message: any) => void) {
     super();

--- a/packages/playwright-core/src/server/webkit/wkProvisionalPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkProvisionalPage.ts
@@ -43,11 +43,11 @@ export class WKProvisionalPage {
     const wkPage = this._wkPage;
 
     this._sessionListeners = [
-      eventsHelper.addEventListener(session, 'Network.requestWillBeSent', overrideFrameId(e => wkPage._onRequestWillBeSent(session, e))),
-      eventsHelper.addEventListener(session, 'Network.requestIntercepted', overrideFrameId(e => wkPage._onRequestIntercepted(session, e))),
-      eventsHelper.addEventListener(session, 'Network.responseReceived', overrideFrameId(e => wkPage._onResponseReceived(session, e))),
-      eventsHelper.addEventListener(session, 'Network.loadingFinished', overrideFrameId(e => wkPage._onLoadingFinished(e))),
-      eventsHelper.addEventListener(session, 'Network.loadingFailed', overrideFrameId(e => wkPage._onLoadingFailed(session, e))),
+      session.addManagedListener('Network.requestWillBeSent', overrideFrameId(e => wkPage._onRequestWillBeSent(session, e))),
+      session.addManagedListener('Network.requestIntercepted', overrideFrameId(e => wkPage._onRequestIntercepted(session, e))),
+      session.addManagedListener('Network.responseReceived', overrideFrameId(e => wkPage._onResponseReceived(session, e))),
+      session.addManagedListener('Network.loadingFinished', overrideFrameId(e => wkPage._onLoadingFinished(e))),
+      session.addManagedListener('Network.loadingFailed', overrideFrameId(e => wkPage._onLoadingFailed(session, e))),
     ];
 
     this.initializationPromise = this._wkPage._initializeSession(session, true, ({ frameTree }) => this._handleFrameTree(frameTree));
@@ -59,7 +59,7 @@ export class WKProvisionalPage {
 
   commit() {
     assert(this._mainFrameId);
-    this._wkPage._onFrameAttached(this._mainFrameId, null);
+    this._wkPage._onFrameAttached(this._mainFrameId, undefined);
   }
 
   private _handleFrameTree(frameTree: Protocol.Page.FrameResourceTree) {

--- a/packages/playwright-core/src/server/webkit/wkWorkers.ts
+++ b/packages/playwright-core/src/server/webkit/wkWorkers.ts
@@ -36,7 +36,7 @@ export class WKWorkers {
     eventsHelper.removeEventListeners(this._sessionListeners);
     this.clear();
     this._sessionListeners = [
-      eventsHelper.addEventListener(session, 'Worker.workerCreated', (event: Protocol.Worker.workerCreatedPayload) => {
+      session.addManagedListener('Worker.workerCreated', (event: Protocol.Worker.workerCreatedPayload) => {
         const worker = new Worker(this._page, event.url);
         const workerSession = new WKSession(session.connection, event.workerId, (message: any) => {
           session.send('Worker.sendMessageToWorker', {
@@ -59,13 +59,13 @@ export class WKWorkers {
           this._page._removeWorker(event.workerId);
         });
       }),
-      eventsHelper.addEventListener(session, 'Worker.dispatchMessageFromWorker', (event: Protocol.Worker.dispatchMessageFromWorkerPayload) => {
+      session.addManagedListener('Worker.dispatchMessageFromWorker', (event: Protocol.Worker.dispatchMessageFromWorkerPayload) => {
         const workerSession = this._workerSessions.get(event.workerId)!;
         if (!workerSession)
           return;
         workerSession.dispatchMessage(JSON.parse(event.message));
       }),
-      eventsHelper.addEventListener(session, 'Worker.workerTerminated', (event: Protocol.Worker.workerTerminatedPayload) => {
+      session.addManagedListener('Worker.workerTerminated', (event: Protocol.Worker.workerTerminatedPayload) => {
         const workerSession = this._workerSessions.get(event.workerId)!;
         if (!workerSession)
           return;

--- a/packages/playwright-core/src/utils/eventsHelper.ts
+++ b/packages/playwright-core/src/utils/eventsHelper.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import type { EventEmitter } from 'events';
+import { EventEmitter } from 'events';
 
 export type RegisteredListener = {
   emitter: EventEmitter;
@@ -24,6 +24,8 @@ export type RegisteredListener = {
 };
 
 class EventsHelper {
+  // Used for normal EventEmitter instances, in order to benefit from
+  // auto-completion, use ManagedEventEmitter.addManagedListener instead
   static addEventListener(
     emitter: EventEmitter,
     eventName: (string | symbol),
@@ -40,6 +42,30 @@ class EventsHelper {
     for (const listener of listeners)
       listener.emitter.removeListener(listener.eventName, listener.handler);
     listeners.splice(0, listeners.length);
+  }
+}
+
+// From node_modules/@types/node/events.d.ts
+type DefaultEventMap = [never];
+type Listener<K, T, F> = T extends DefaultEventMap ? F : (
+  K extends keyof T ? (
+          T[K] extends unknown[] ? (...args: T[K]) => void : never
+      )
+      : never
+);
+type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
+type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
+
+export class ManagedEventEmitter<T extends Record<keyof T, any[]>> extends EventEmitter<T> {
+  public _events!: T;
+
+  addManagedListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): RegisteredListener {
+    this.on(eventName, listener);
+    return {
+      emitter: this as EventEmitter, 
+      eventName: eventName as string,
+      handler: listener
+    };
   }
 }
 

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -504,13 +504,13 @@ class JobDispatcher {
     worker.runTestGroup(runPayload);
 
     this._listeners = [
-      eventsHelper.addEventListener(worker, 'testBegin', this._onTestBegin.bind(this)),
-      eventsHelper.addEventListener(worker, 'testEnd', this._onTestEnd.bind(this)),
-      eventsHelper.addEventListener(worker, 'stepBegin', this._onStepBegin.bind(this)),
-      eventsHelper.addEventListener(worker, 'stepEnd', this._onStepEnd.bind(this)),
-      eventsHelper.addEventListener(worker, 'attach', this._onAttach.bind(this)),
-      eventsHelper.addEventListener(worker, 'done', this._onDone.bind(this)),
-      eventsHelper.addEventListener(worker, 'exit', this.onExit.bind(this)),
+      worker.addManagedListener('testBegin', this._onTestBegin.bind(this)),
+      worker.addManagedListener('testEnd', this._onTestEnd.bind(this)),
+      worker.addManagedListener('stepBegin', this._onStepBegin.bind(this)),
+      worker.addManagedListener('stepEnd', this._onStepEnd.bind(this)),
+      worker.addManagedListener('attach', this._onAttach.bind(this)),
+      worker.addManagedListener('done', this._onDone.bind(this)),
+      worker.addManagedListener('exit', this.onExit.bind(this)),
     ];
   }
 

--- a/packages/playwright/src/runner/workerHost.ts
+++ b/packages/playwright/src/runner/workerHost.ts
@@ -18,12 +18,28 @@ import fs from 'fs';
 import path from 'path';
 import type { TestGroup } from './testGroups';
 import { stdioChunkToParams } from '../common/ipc';
-import type { RunPayload, SerializedConfig, WorkerInitParams } from '../common/ipc';
+import type { AttachmentPayload, DonePayload, RunPayload, SerializedConfig, StepBeginPayload, StepEndPayload, TeardownErrorsPayload, TestBeginPayload, TestEndPayload, TestOutputPayload, WorkerInitParams } from '../common/ipc';
+import type { ProcessExitData } from './processHost';
 import { ProcessHost } from './processHost';
 import { artifactsFolderName } from '../isomorphic/folders';
 import { removeFolders } from 'playwright-core/lib/utils';
 
 let lastWorkerIndex = 0;
+
+export type WorkerHostEvents = {
+  stdOut: [TestOutputPayload]
+  stdErr: [TestOutputPayload]
+  testBegin: [TestBeginPayload]
+  testEnd: [TestEndPayload]
+  stepBegin: [StepBeginPayload]
+  stepEnd: [StepEndPayload]
+  attach: [AttachmentPayload]
+  done: [DonePayload]
+  teardownErrors: [TeardownErrorsPayload]
+
+  exit: [ProcessExitData]
+  ready: []
+};
 
 export class WorkerHost extends ProcessHost {
   readonly parallelIndex: number;

--- a/tests/config/serverFixtures.ts
+++ b/tests/config/serverFixtures.ts
@@ -18,9 +18,9 @@ import type { Fixtures } from '@playwright/test';
 import path from 'path';
 import { TestServer } from './testserver';
 import { TestProxy } from './proxy';
-import type { SocksSocketRequestedPayload } from '../../packages/playwright-core/src/common/socksProxy';
 
-import { SocksProxy } from '../../packages/playwright-core/lib/common/socksProxy';
+import type { SocksProxy } from '../../packages/playwright-core/src/common/socksProxy';
+const SocksProxyImpl = require('../../packages/playwright-core/lib/common/socksProxy').SocksProxy as any as typeof SocksProxy;
 
 export type ServerWorkerOptions = {
   loopback?: string;
@@ -100,16 +100,16 @@ export class MockSocksServer {
   private _socksProxy: SocksProxy;
 
   constructor() {
-    this._socksProxy = new SocksProxy();
+    this._socksProxy = new SocksProxyImpl();
     this._socksProxy.setPattern('*');
-    this._socksProxy.addListener(SocksProxy.Events.SocksRequested, async (payload: SocksSocketRequestedPayload) => {
+    this._socksProxy.addListener('socksRequested', async payload => {
       this._socksProxy.socketConnected({
         uid: payload.uid,
         host: '127.0.0.1',
         port: 0,
       });
     });
-    this._socksProxy.addListener(SocksProxy.Events.SocksData, async (payload: SocksSocketRequestedPayload) => {
+    this._socksProxy.addListener('socksData', async payload => {
       const body = '<html><title>Served by the SOCKS proxy</title></html>';
       const data = Buffer.from([
         'HTTP/1.1 200 OK',


### PR DESCRIPTION
Motivation: Proposal for making our `\\server` side event listeners type-safe, since `@types/node` has since a couple of months type-safe EventEmitters.

Some thoughts:

- Win: Reduces imports across files
- Win: Checks the event payloads on send/receive
- ~We should probably get rid of all eventsHelper.addEventListener.~ Did that. Only `EventEmitter` from Node.js directly are left, maybe time to rename it to e.g. `toManagedFromUntypedEventEmitter` and use `ManagedEventListener::addManagedListener` wherever we can.
- Ideally we fix workerHost/CRBrowserContext events, so that they don't leak into e.g. `FFBrowserContext`. Right now I found no trivial way of making `CRBrowserContext` extend from `BrowserContext` events to add custom ones.
  - Filed as https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70046.
- This touches only the server side, maybe we can also do similar things on the client side as a follow-up.
- Maybe a better name for `ManagedEventListener`