### PR TITLE
test: skip windows/CR client-certificates proxy tests

### DIFF
--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -174,6 +174,8 @@ test.describe('fetch', () => {
 
 
 test.describe('browser', () => {
+  test.skip(({ browserName, platform, browserMajorVersion }) => browserName === 'chromium' && platform === 'win32' && browserMajorVersion < 128, 'Depends on https://chromium-review.googlesource.com/c/chromium/src/+/5688851');
+
   test('validate input', async ({ browser }) => {
     for (const [contextOptions, expected] of kValidationSubTests)
       await expect(browser.newContext(contextOptions)).rejects.toThrow(expected);


### PR DESCRIPTION
Based on <img width="1643" alt="Screenshot 2024-07-12 at 14 23 53" src="https://github.com/user-attachments/assets/fc26a137-e5be-4960-9eb0-e1dadd852616">

I think skipping everything below 128 should fix it.