### PR TITLE
chore: remove unused kTestSdkObjects

### DIFF
--- a/packages/playwright-core/src/server/instrumentation.ts
+++ b/packages/playwright-core/src/server/instrumentation.ts
@@ -37,8 +37,6 @@ export type Attribution = {
 import type { CallMetadata } from '@protocol/callMetadata';
 export type { CallMetadata } from '@protocol/callMetadata';
 
-export const kTestSdkObjects = new WeakSet<SdkObject>();
-
 export class SdkObject extends EventEmitter {
   guid: string;
   attribution: Attribution;
@@ -50,8 +48,6 @@ export class SdkObject extends EventEmitter {
     this.setMaxListeners(0);
     this.attribution = { ...parent.attribution };
     this.instrumentation = parent.instrumentation;
-    if (process.env._PW_INTERNAL_COUNT_SDK_OBJECTS)
-      kTestSdkObjects.add(this);
   }
 }
 


### PR DESCRIPTION
Looks like it was added in https://github.com/microsoft/playwright/commit/04fafcabd89d40c5139e35820c6e8c4a67a58bc4 and the usage removed in https://github.com/microsoft/playwright/commit/71a55c74daf4117a1501f65242bc0d66333980e6.