### PR TITLE
cherry-pick(#31666): Revert "fix(chromium): pass --enable-gpu when running headless (#30937)"

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -305,12 +305,9 @@ export class Chromium extends BrowserType {
     if (os.platform() === 'darwin') {
       // See https://github.com/microsoft/playwright/issues/7362
       chromeArguments.push('--enable-use-zoom-for-dsf=false');
-    }
-    if (options.headless) {
       // See https://bugs.chromium.org/p/chromium/issues/detail?id=1407025.
-      // See also https://github.com/microsoft/playwright/issues/30585
-      // and chromium fix at https://issues.chromium.org/issues/338414704.
-      chromeArguments.push('--enable-gpu');
+      if (options.headless)
+        chromeArguments.push('--use-angle');
     }
 
     if (options.devtools)

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -110,6 +110,7 @@ it('should play audio @smoke', async ({ page, server, browserName, platform }) =
 });
 
 it('should support webgl @smoke', async ({ page, browserName, platform }) => {
+  it.fixme(browserName === 'chromium' && platform === 'darwin' && os.arch() === 'arm64', 'SwiftShader is not available on macOS-arm64 - https://github.com/microsoft/playwright/issues/28216');
   const hasWebGL = await page.evaluate(() => {
     const canvas = document.createElement('canvas');
     return !!canvas.getContext('webgl');
@@ -118,7 +119,10 @@ it('should support webgl @smoke', async ({ page, browserName, platform }) => {
 });
 
 it('should support webgl 2 @smoke', async ({ page, browserName, headless, isWindows, platform }) => {
+  it.skip(browserName === 'webkit', 'WebKit doesn\'t have webgl2 enabled yet upstream.');
   it.fixme(browserName === 'firefox' && isWindows);
+  it.fixme(browserName === 'chromium' && !headless, 'chromium doesn\'t like webgl2 when running under xvfb');
+  it.fixme(browserName === 'chromium' && platform === 'darwin' && os.arch() === 'arm64', 'SwiftShader is not available on macOS-arm64 - https://github.com/microsoft/playwright/issues/28216');
 
   const hasWebGL2 = await page.evaluate(() => {
     const canvas = document.createElement('canvas');


### PR DESCRIPTION
This reverts commit d0b052e1e0599499bc3431fb53292d612c397511.