### PR TITLE
fix: add 'window-management' to chromium browser

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -980,6 +980,7 @@ A permission or an array of permissions to grant. Permissions can be one of the 
 * `'notifications'`
 * `'payment-handler'`
 * `'storage-access'`
+* `'window-management'`
 
 ### option: BrowserContext.grantPermissions.origin
 * since: v1.8

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -434,6 +434,7 @@ export class CRBrowserContext extends BrowserContext {
       // chrome-specific permissions we have.
       ['midi-sysex', 'midiSysex'],
       ['storage-access', 'storageAccess'],
+      ['window-management', 'windowManagement']
     ]);
     const filtered = permissions.map(permission => {
       const protocolPermission = webPermissionToProtocol.get(permission);

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8472,6 +8472,7 @@ export interface BrowserContext {
    * - `'notifications'`
    * - `'payment-handler'`
    * - `'storage-access'`
+   * - `'window-management'`
    * @param options
    */
   grantPermissions(permissions: ReadonlyArray<string>, options?: {

--- a/tests/library/permissions.spec.ts
+++ b/tests/library/permissions.spec.ts
@@ -48,6 +48,14 @@ it.describe('permissions', () => {
     expect(await getPermission(page, 'geolocation')).toBe('granted');
   });
 
+  it('should grant window-management permission when origin is listed', async ({ page, context, server, browserName }) => {
+    it.fail(browserName === 'firefox');
+
+    await page.goto(server.EMPTY_PAGE);
+    await context.grantPermissions(['window-management'], { origin: server.EMPTY_PAGE });
+    expect(await getPermission(page, 'window-management')).toBe('granted');
+  });
+
   it('should prompt for geolocation permission when origin is not listed', async ({ page, context, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions(['geolocation'], { origin: server.EMPTY_PAGE });


### PR DESCRIPTION
this fixes #27198 with testing and added documentation

adds the 'windowManagement' permission to the list of permissions that can be granted on Chromium.

https://chromedevtools.github.io/devtools-protocol/tot/Browser/#type-PermissionType