### PR TITLE
fix(setInputFiles): throw when uploading file in directory upload

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ All API classes, methods, and events should have a description in [`docs/src`](h
 To run the documentation linter, use:
 
 ```bash
-npm run doclint
+npm run doc
 ```
 
 To build the documentation site locally and test how your changes will look in practice:

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -639,6 +639,8 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
         throw injected.createStacklessError('Non-multiple file input can only accept single file');
       if (directoryUpload && !inputElement.webkitdirectory)
         throw injected.createStacklessError('File input does not support directories, pass individual files instead');
+      if (!directoryUpload && inputElement.webkitdirectory)
+        throw injected.createStacklessError('[webkitdirectory] input requires passing a path to a directory');
       return inputElement;
     }, { multiple, directoryUpload: !!localDirectory });
     if (result === 'error:notconnected' || !result.asElement())

--- a/tests/page/page-set-input-files.spec.ts
+++ b/tests/page/page-set-input-files.spec.ts
@@ -350,8 +350,7 @@ it('should emit event via prepend', async ({ page, server }) => {
   expect(chooser).toBeTruthy();
 });
 
-it('should emit event for iframe', async ({ page, server, browserName }) => {
-  it.skip(browserName === 'firefox');
+it('should emit event for iframe', async ({ page, server }) => {
   const frame = await attachFrame(page, 'frame1', server.EMPTY_PAGE);
   await frame.setContent(`<input type=file>`);
   const [chooser] = await Promise.all([

--- a/tests/page/page-set-input-files.spec.ts
+++ b/tests/page/page-set-input-files.spec.ts
@@ -120,6 +120,15 @@ it('should throw when uploading a folder in a normal file upload input', async (
   await expect(input.setInputFiles(dir)).rejects.toThrow('File input does not support directories, pass individual files instead');
 });
 
+it('should throw when uploading a file in a directory upload input', async ({ page, server, isAndroid, asset }) => {
+  it.skip(isAndroid);
+  it.skip(os.platform() === 'darwin' && parseInt(os.release().split('.')[0], 10) <= 21, 'WebKit on macOS-12 is frozen');
+
+  await page.goto(server.PREFIX + '/input/folderupload.html');
+  const input = await page.$('input');
+  await expect(input.setInputFiles(asset('file to upload.txt'))).rejects.toThrow('[webkitdirectory] input requires passing a path to a directory');
+});
+
 it('should upload a file after popup', async ({ page, server, asset }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/29923' });
   await page.goto(server.PREFIX + '/input/fileupload.html');


### PR DESCRIPTION
As of today, v1.45, when uploading a file in a directory input, it:
- Skips the passed file in Chromium (see [here](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/file_select_helper.cc;l=239;drc=fa1e0cf5238e2600039f60af6909aefbd4cf003c;bpv=1;bpt=1))
- Throws in Firefox (Juggler)
- Works in WebKit

This is the same behaviour as in v1.44, so we didn't regress anything with our recent folder upload changes.

This change makes it more strict, so it throws to the user, that the user should create a directory first and specifying this when uploading the files to the browser.

Alternatives which were considered:

- Use the parent directory of the file when a file gets specified:
  - pro: no need for additional cleanups
  - con: uploads unwanted files
- Move all the files which are specified into a separate directory and send this one to the browser
  - pro: might be what the user wants
  - con: user is not able to control `webkitrelativepath` property.

I think throwing for now is the best, since its not a regression and it provides the most control to the user.

Fixes https://github.com/microsoft/playwright/issues/31661