### PR TITLE
fix(toHaveScreenshot): sanitize attachment names and paths

### DIFF
--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -145,7 +145,7 @@ test('should generate separate actual results for repeating names', async ({ run
     {
       'name': 'bar/baz-actual.txt',
       'contentType': 'text/plain',
-      'path': 'test-results/a-is-a-test/bar-baz-actual.txt'
+      'path': 'test-results/a-is-a-test/bar/baz-actual.txt'
     },
     {
       'name': 'bar/baz-1-expected.txt',
@@ -155,7 +155,7 @@ test('should generate separate actual results for repeating names', async ({ run
     {
       'name': 'bar/baz-1-actual.txt',
       'contentType': 'text/plain',
-      'path': 'test-results/a-is-a-test/bar-baz-1-actual.txt'
+      'path': 'test-results/a-is-a-test/bar/baz-1-actual.txt'
     }
   ]);
 });
@@ -977,12 +977,12 @@ test('should attach expected/actual/diff with snapshot path', async ({ runInline
     {
       name: 'test/path/snapshot-actual.png',
       contentType: 'image/png',
-      path: 'a-is-a-test/test-path-snapshot-actual.png'
+      path: 'a-is-a-test/test/path/snapshot-actual.png'
     },
     {
       name: 'test/path/snapshot-diff.png',
       contentType: 'image/png',
-      path: 'a-is-a-test/test-path-snapshot-diff.png'
+      path: 'a-is-a-test/test/path/snapshot-diff.png'
     }
   ]);
 });

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -1320,3 +1320,49 @@ function playwrightConfig(obj: any) {
     `,
   };
 }
+
+test('should trim+sanitize attachment names and paths', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...playwrightConfig({
+      snapshotPathTemplate: '__screenshots__/{testFilePath}/{arg}{ext}',
+    }),
+    'a.spec.js': `
+      const { test, expect } = require('@playwright/test');
+      test.afterEach(async ({}, testInfo) => {
+        console.log('## ' + JSON.stringify(testInfo.attachments));
+      });
+      const title = 'long '.repeat(30) + 'title';
+      test(title, async ({ page }) => {
+        await expect.soft(page).toHaveScreenshot();
+        const name = 'long '.repeat(30) + 'name.png';
+        await expect.soft(page).toHaveScreenshot(name);
+        await expect.soft(page).toHaveScreenshot(['dir', name]);
+      });
+    `
+  });
+
+  expect(result.exitCode).toBe(1);
+  const attachments = result.output.split('\n').filter(l => l.startsWith('## ')).map(l => l.substring(3)).map(l => JSON.parse(l))[0];
+  for (const attachment of attachments) {
+    attachment.path = attachment.path.replace(testInfo.outputDir, '').substring(1).replace(/\\/g, '/');
+    attachment.name = attachment.name.replace(/\\/g, '/');
+  }
+  expect(attachments).toEqual([
+    {
+      name: 'long-long-long-long-long-l-852e1-long-long-long-long-title-1-actual.png',
+      contentType: 'image/png',
+      path: 'test-results/a-long-long-long-long-long-abd51-g-long-long-long-long-title/long-long-long-long-long-l-852e1-long-long-long-long-title-1-actual.png',
+    },
+    {
+      name: 'long-long-long-long-long-l-6bf1e-ong-long-long-long-name-actual.png',
+      contentType: 'image/png',
+      path: 'test-results/a-long-long-long-long-long-abd51-g-long-long-long-long-title/long-long-long-long-long-l-6bf1e-ong-long-long-long-name-actual.png',
+    },
+    {
+      name: 'dir/long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long name-actual.png',
+      contentType: 'image/png',
+      path: 'test-results/a-long-long-long-long-long-abd51-g-long-long-long-long-title/dir/long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long name-actual.png',
+    },
+  ]);
+});
+


### PR DESCRIPTION
... unless an array of file-system-friendly parts is provided.

Motivation: attachment name is used as a file system path when downloading attachments, so we keep them fs-friendly.

References #30693.