### PR TITLE
fix(connect): annotate internal api calls correctly

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -155,7 +155,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
         connection.close(reason || closeError);
       };
       pipe.on('closed', params => onPipeClosed(params.reason));
-      connection.onmessage = message => this._wrapApiCall(() => pipe.send({ message }).catch(() => onPipeClosed()), true);
+      connection.onmessage = message => this._wrapApiCall(() => pipe.send({ message }).catch(() => onPipeClosed()), /* isInternal */ true);
 
       pipe.on('message', ({ message }) => {
         try {
@@ -181,7 +181,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
         this._didLaunchBrowser(browser, {}, logger);
         browser._shouldCloseConnectionOnClose = true;
         browser._connectHeaders = connectHeaders;
-        browser.on(Events.Browser.Disconnected, () => this._wrapApiCall(() => closePipe(), true));
+        browser.on(Events.Browser.Disconnected, () => this._wrapApiCall(() => closePipe(), /* isInternal */ true));
         return browser;
       }, deadline);
       if (!result.timedOut) {

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -155,7 +155,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
         connection.close(reason || closeError);
       };
       pipe.on('closed', params => onPipeClosed(params.reason));
-      connection.onmessage = message => pipe.send({ message }).catch(() => onPipeClosed());
+      connection.onmessage = message => this._wrapApiCall(() => pipe.send({ message }).catch(() => onPipeClosed()), true);
 
       pipe.on('message', ({ message }) => {
         try {
@@ -181,7 +181,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
         this._didLaunchBrowser(browser, {}, logger);
         browser._shouldCloseConnectionOnClose = true;
         browser._connectHeaders = connectHeaders;
-        browser.on(Events.Browser.Disconnected, closePipe);
+        browser.on(Events.Browser.Disconnected, () => this._wrapApiCall(() => closePipe(), true));
         return browser;
       }, deadline);
       if (!result.timedOut) {

--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -194,6 +194,8 @@ export class Connection extends EventEmitter {
   }
 
   close(cause?: string) {
+    if (this._closedError)
+      return;
     this._closedError = new TargetClosedError(cause);
     for (const callback of this._callbacks.values())
       callback.reject(this._closedError);


### PR DESCRIPTION
Motivation: Durations were shown in VSCode extension twice. This was because every method was reported twice as test steps. This also includes `DEBUG=pw:api` log lines. This patches cleans them up. Now a connect looks the following:

```
➜  playwright git:(connect-pw-api-cleanups) ✗ DEBUG=pw:api node test.js 
  pw:api => browserType.connect started +0ms
  pw:api <= browserType.connect succeeded +33ms
  pw:api => browser.newPage started +1ms
  pw:api <= browser.newPage succeeded +145ms
  pw:api => page.goto started +0ms
  pw:api <= page.goto succeeded +7s
  pw:api => browser.close started +0ms
  pw:api <= browser.close succeeded +2ms
➜  playwright git:(connect-pw-api-cleanups) ✗ 
```

Before there were multiple entries for close and empty lines (without apiName - since they had no stack to get the apiName inside the browser disconnect/json pipe close handlers), see the following:

```
➜  playwright git:(connect-pw-api-cleanups) ✗ DEBUG=pw:api node test.js
  pw:api => browserType.connect started +0ms
  pw:api =>  started +26ms
  pw:api <=  succeeded +2ms
  pw:api <= browserType.connect succeeded +4ms
  pw:api => browser.newPage started +0ms
  pw:api => browser.newContext started +1ms
  pw:api <= browser.newContext succeeded +0ms
  pw:api =>  started +6ms
  pw:api <=  succeeded +0ms
  pw:api <= browser.newPage succeeded +67ms
  pw:api => page.goto started +1ms
  pw:api => page.goto started +0ms
  pw:api <= page.goto succeeded +0ms
  pw:api <= page.goto succeeded +767ms
  pw:api => browser.close started +0ms
  pw:api =>  started +1ms
  pw:api =>  started +1ms
  pw:api <= browser.close succeeded +0ms
  pw:api <=  failed +0ms
  pw:api <=  failed +0ms
➜  playwright git:(main) ✗ 
```