### PR TITLE
fix(expect): throw unsupported error when using this.equals() in expect

### DIFF
--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -308,6 +308,8 @@ test('amount', async () => {
 });
 ```
 
+### Compatibility with expect from Jest
+
 :::note
 Do not confuse Playwright's `expect` with the [`expect` library](https://jestjs.io/docs/expect). The latter is not fully integrated with Playwright test runner, so make sure to use Playwright's own `expect`.
 :::

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -308,7 +308,7 @@ test('amount', async () => {
 });
 ```
 
-### Compatibility with expect from Jest
+### Compatibility with expect library
 
 :::note
 Do not confuse Playwright's `expect` with the [`expect` library](https://jestjs.io/docs/expect). The latter is not fully integrated with Playwright test runner, so make sure to use Playwright's own `expect`.

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -185,7 +185,7 @@ function createExpect(info: ExpectMetaInfo) {
 }
 
 function throwUnsupportedExpectMatcherError() {
-  throw new Error('Playwright Expect matchers are not fully compatible with Jest matchers. See https://aka.ms/playwright/expect-compatibility');
+  throw new Error('It looks like you are using custom expect matchers that are not compatible with Playwright. See https://aka.ms/playwright/expect-compatibility');
 }
 
 expectLibrary.setState({ expand: false });

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -138,6 +138,7 @@ function createExpect(info: ExpectMetaInfo) {
                 utils,
                 timeout: currentExpectTimeout()
               };
+              (newThis as any).equals = throwUnsupportedExpectMatcherError;
               return (matcher as any).call(newThis, ...args);
             };
           }
@@ -181,6 +182,10 @@ function createExpect(info: ExpectMetaInfo) {
   };
 
   return expectInstance;
+}
+
+function throwUnsupportedExpectMatcherError() {
+  throw new Error('Playwright Expect matchers are not fully compatible with Jest matchers. See https://aka.ms/playwright/expect-compatibility');
 }
 
 expectLibrary.setState({ expand: false });

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -1039,3 +1039,27 @@ test('should expose timeout to custom matchers', async ({ runInlineTest, runTSC 
   expect(result.failed).toBe(0);
   expect(result.passed).toBe(2);
 });
+
+test('should throw error when using .equals()', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'helper.ts': `
+      import { test as base, expect } from '@playwright/test';
+      expect.extend({
+        toBeWithinRange(received, floor, ceiling) {
+          this.equals(1, 2);
+        },
+      });
+      export const test = base;
+    `,
+    'expect-test.spec.ts': `
+      import { test } from './helper';
+      test('numeric ranges', () => {
+        test.expect(() => {
+          test.expect(100).toBeWithinRange(90, 110);
+        }).toThrowError('Playwright Expect matchers are not fully compatible with Jest matchers. See https://aka.ms/playwright/expect-compatibility');
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -1056,7 +1056,7 @@ test('should throw error when using .equals()', async ({ runInlineTest }) => {
       test('numeric ranges', () => {
         test.expect(() => {
           test.expect(100).toBeWithinRange(90, 110);
-        }).toThrowError('Playwright Expect matchers are not fully compatible with Jest matchers. See https://aka.ms/playwright/expect-compatibility');
+        }).toThrowError('It looks like you are using custom expect matchers that are not compatible with Playwright. See https://aka.ms/playwright/expect-compatibility');
       });
     `
   });


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/31595