### PR TITLE
fix(toHaveScreenshot): attach "expected" when writing a missing expectation

### DIFF
--- a/packages/playwright/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchSnapshot.ts
@@ -222,11 +222,11 @@ class SnapshotHelper {
 
   handleMissing(actual: Buffer | string): ImageMatcherResult {
     const isWriteMissingMode = this.updateSnapshots === 'all' || this.updateSnapshots === 'missing';
-    if (isWriteMissingMode) {
+    if (isWriteMissingMode)
       writeFileSync(this.expectedPath, actual);
-      writeFileSync(this.actualPath, actual);
-      this.testInfo.attachments.push({ name: addSuffixToFilePath(this.attachmentBaseName, '-actual'), contentType: this.mimeType, path: this.actualPath });
-    }
+    this.testInfo.attachments.push({ name: addSuffixToFilePath(this.attachmentBaseName, '-expected'), contentType: this.mimeType, path: this.expectedPath });
+    writeFileSync(this.actualPath, actual);
+    this.testInfo.attachments.push({ name: addSuffixToFilePath(this.attachmentBaseName, '-actual'), contentType: this.mimeType, path: this.actualPath });
     const message = `A snapshot doesn't exist at ${this.expectedPath}${isWriteMissingMode ? ', writing actual.' : '.'}`;
     if (this.updateSnapshots === 'all') {
       /* eslint-disable no-console */

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -263,8 +263,10 @@ test('should report toHaveScreenshot step with expectation name in title', async
     `end browserContext.newPage`,
     `end fixture: page`,
     `end Before Hooks`,
+    `end attach "foo-expected.png"`,
     `end attach "foo-actual.png"`,
     `end expect.toHaveScreenshot(foo.png)`,
+    `end attach "is-a-test-1-expected.png"`,
     `end attach "is-a-test-1-actual.png"`,
     `end expect.toHaveScreenshot(is-a-test-1.png)`,
     `end fixture: page`,
@@ -654,12 +656,22 @@ test('should write missing expectations locally twice and attach them', async ({
 
   const attachments = result.outputLines.map(l => JSON.parse(l))[0];
   for (const attachment of attachments)
-    attachment.path = attachment.path.replace(/\\/g, '/').replace(/.*test-results\//, '');
+    attachment.path = attachment.path.replace(/\\/g, '/').replace(/.*test-results\//, '').replace(/.*__screenshots__/, '__screenshots__');
   expect(attachments).toEqual([
+    {
+      name: 'snapshot-expected.png',
+      contentType: 'image/png',
+      path: '__screenshots__/a.spec.js/snapshot.png'
+    },
     {
       name: 'snapshot-actual.png',
       contentType: 'image/png',
       path: 'a-is-a-test/snapshot-actual.png'
+    },
+    {
+      name: 'snapshot2-expected.png',
+      contentType: 'image/png',
+      path: '__screenshots__/a.spec.js/snapshot2.png'
     },
     {
       name: 'snapshot2-actual.png',
@@ -1349,14 +1361,29 @@ test('should trim+sanitize attachment names and paths', async ({ runInlineTest }
   }
   expect(attachments).toEqual([
     {
+      name: 'long-long-long-long-long-l-852e1-long-long-long-long-title-1-expected.png',
+      contentType: 'image/png',
+      path: '__screenshots__/a.spec.js/long-long-long-long-long-long-long-long-long-l-852e1-long-long-long-long-long-long-long-long-title-1.png',
+    },
+    {
       name: 'long-long-long-long-long-l-852e1-long-long-long-long-title-1-actual.png',
       contentType: 'image/png',
       path: 'test-results/a-long-long-long-long-long-abd51-g-long-long-long-long-title/long-long-long-long-long-l-852e1-long-long-long-long-title-1-actual.png',
     },
     {
+      name: 'long-long-long-long-long-l-6bf1e-ong-long-long-long-name-expected.png',
+      contentType: 'image/png',
+      path: '__screenshots__/a.spec.js/long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-name.png',
+    },
+    {
       name: 'long-long-long-long-long-l-6bf1e-ong-long-long-long-name-actual.png',
       contentType: 'image/png',
       path: 'test-results/a-long-long-long-long-long-abd51-g-long-long-long-long-title/long-long-long-long-long-l-6bf1e-ong-long-long-long-name-actual.png',
+    },
+    {
+      name: 'dir/long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long name-expected.png',
+      contentType: 'image/png',
+      path: '__screenshots__/a.spec.js/dir/long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long name.png',
     },
     {
       name: 'dir/long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long name-actual.png',

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -94,6 +94,7 @@ test('should merge screenshot assertions', async ({  runUITest }, testInfo) => {
     /Before Hooks[\d.]+m?s/,
     /page.setContent[\d.]+m?s/,
     /expect.toHaveScreenshot[\d.]+m?s/,
+    /attach "trace-test-1-expected.png/,
     /attach "trace-test-1-actual.png/,
     /After Hooks[\d.]+m?s/,
     /Worker Cleanup[\d.]+m?s/,


### PR DESCRIPTION
Previously, only the "actual" attachment was created, pointing to the file in `test-results`. Now, the "expected" attachment pointing to the file in `__screenshots__` is also created. This will help any reporters that would like to know the "expected" path, for example to do a manual accept/decline of the baseline.

Fixes #30693.