### PR TITLE
test: unflake contextmenu recorder test

### DIFF
--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -230,6 +230,9 @@ class RecordActionTool implements RecorderTool {
     // So we check the hovered element instead, and if it is a range input, we skip click handling
     if (isRangeInput(this._hoveredElement))
       return;
+    // Right clicks are handled by 'contextmenu' event if its auxclick
+    if (event.button === 2 && event.type === 'auxclick')
+      return;
     if (this._shouldIgnoreMouseEvent(event))
       return;
     if (this._actionInProgress(event))

--- a/tests/library/inspector/cli-codegen-3.spec.ts
+++ b/tests/library/inspector/cli-codegen-3.spec.ts
@@ -559,7 +559,7 @@ await page.GetByLabel("Coun\\"try").ClickAsync();`);
     ]);
   });
 
-  test('should consume contextmenu events, despite a custom context menu', async ({ page, openRecorder }) => {
+  test('should consume contextmenu events, despite a custom context menu', async ({ page, openRecorder, browserName, platform }) => {
     const recorder = await openRecorder();
 
     await recorder.setContentAndWait(`
@@ -597,20 +597,36 @@ await page.GetByLabel("Coun\\"try").ClickAsync();`);
       recorder.trustedClick({ button: 'right' }),
     ]);
     expect(message.text()).toBe('right-clicked');
-    expect(await page.evaluate('log')).toEqual([
-      // hover
-      'button: pointermove',
-      'button: mousemove',
-      // trusted right click
-      'button: pointerup',
-      'button: pointermove',
-      'button: mousemove',
-      'button: pointerdown',
-      'button: mousedown',
-      'button: contextmenu',
-      'menu: pointerup',
-      'menu: mouseup'
-    ]);
+    if (browserName === 'chromium' && platform === 'win32') {
+      expect(await page.evaluate('log')).toEqual([
+        // hover
+        'button: pointermove',
+        'button: mousemove',
+        // trusted right click
+        'button: pointermove',
+        'button: mousemove',
+        'button: pointerdown',
+        'button: mousedown',
+        'button: pointerup',
+        'button: mouseup',
+        'button: contextmenu',
+      ]);
+    } else {
+      expect(await page.evaluate('log')).toEqual([
+        // hover
+        'button: pointermove',
+        'button: mousemove',
+        // trusted right click
+        'button: pointerup',
+        'button: pointermove',
+        'button: mousemove',
+        'button: pointerdown',
+        'button: mousedown',
+        'button: contextmenu',
+        'menu: pointerup',
+        'menu: mouseup',
+      ]);
+    }
   });
 
   test('should assert value', async ({ openRecorder }) => {


### PR DESCRIPTION
Looking at the last 5 runs on the flakiness dashboard, it shows that Chromium based browsers on Windows are red on this test. This is because on windows 'auxclick' fires before 'contextmenu' (this was also reproduced on a minimal example) which causes an action to be in progress, so when the actual 'contextmenu' fires, it does not emit any actions.

In order to fix it, we ignore right click 'auxclick' events, which sound reasonable, since they are handled via 'contextmenu' event.