### PR TITLE
test: move page-clock tests into library/ tests folder

### DIFF
--- a/tests/library/page-clock.frozen.spec.ts
+++ b/tests/library/page-clock.frozen.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test as it, expect } from './pageTest';
+import { browserTest as it, expect } from '../config/browserTest';
 
 it('clock should be frozen', async ({ page }) => {
   it.skip(process.env.PW_CLOCK !== 'frozen');

--- a/tests/library/page-clock.spec.ts
+++ b/tests/library/page-clock.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect } from './pageTest';
+import { browserTest as test, expect } from '../config/browserTest';
 
 test.skip(!!process.env.PW_CLOCK);
 


### PR DESCRIPTION
Before, especially the clock tests, have had the clock installed before, which caused failing tests. This resets the context (including addInitScripts) which this is mostly about.

Edit: Decided to move the tests into library tests folder instead.

