### PR TITLE
fix(client-certificates): keep ignoreHTTPSErrors false by default

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -26,7 +26,7 @@ import zlib from 'zlib';
 import type { HTTPCredentials } from '../../types/types';
 import { TimeoutSettings } from '../common/timeoutSettings';
 import { getUserAgent } from '../utils/userAgent';
-import { assert, createGuid, monotonicTime } from '../utils';
+import { assert, createGuid, isUnderTest, monotonicTime } from '../utils';
 import { HttpsProxyAgent, SocksProxyAgent } from '../utilsBundle';
 import { BrowserContext, verifyClientCertificates } from './browserContext';
 import { CookieStore, domainMatches } from './cookieStore';
@@ -196,7 +196,7 @@ export abstract class APIRequestContext extends SdkObject {
       ...clientCertificatesToTLSOptions(this._defaultOptions().clientCertificates, requestUrl.toString()),
       __testHookLookup: (params as any).__testHookLookup,
     };
-    if (process.env.PWTEST_UNSUPPORTED_CUSTOM_CA)
+    if (process.env.PWTEST_UNSUPPORTED_CUSTOM_CA && isUnderTest())
       options.ca = [fs.readFileSync(process.env.PWTEST_UNSUPPORTED_CUSTOM_CA)];
     // rejectUnauthorized = undefined is treated as true in Node.js 12.
     if (params.ignoreHTTPSErrors || defaults.ignoreHTTPSErrors)

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -100,7 +100,7 @@ class SocksProxyConnection {
 
     const tlsOptions: tls.ConnectionOptions = {
       socket: this.target,
-      rejectUnauthorized: this.socksProxy.ignoreHTTPSErrors === true ? false : true,
+      rejectUnauthorized: !!this.socksProxy.ignoreHTTPSErrors,
       ...clientCertificatesToTLSOptions(this.socksProxy.clientCertificates, `https://${this.host}:${this.port}/`),
     };
     if (process.env.PWTEST_UNSUPPORTED_CUSTOM_CA && isUnderTest())
@@ -137,7 +137,7 @@ export class ClientCertificatesProxy {
   _socksProxy: SocksProxy;
   private _connections: Map<string, SocksProxyConnection> = new Map();
   ignoreHTTPSErrors: boolean | undefined;
-  clientCertificates: { url: string; certs: { cert?: channels.Binary; key?: channels.Binary; passphrase?: string; pfx?: channels.Binary; }[]; }[] | undefined;
+  clientCertificates: channels.BrowserNewContextOptions['clientCertificates'];
 
   constructor(
     contextOptions: Pick<channels.BrowserNewContextOptions, 'clientCertificates' | 'ignoreHTTPSErrors'>

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -100,7 +100,7 @@ class SocksProxyConnection {
 
     const tlsOptions: tls.ConnectionOptions = {
       socket: this.target,
-      rejectUnauthorized: !!this.socksProxy.ignoreHTTPSErrors,
+      rejectUnauthorized: !this.socksProxy.ignoreHTTPSErrors,
       ...clientCertificatesToTLSOptions(this.socksProxy.clientCertificates, `https://${this.host}:${this.port}/`),
     };
     if (process.env.PWTEST_UNSUPPORTED_CUSTOM_CA && isUnderTest())

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -121,13 +121,14 @@ class SocksProxyConnection {
 
     internalTLS.on('error', () => closeBothSockets());
     targetTLS.on('error', error => {
-      internalTLS.write('HTTP/1.1 503 Internal Server Error\r\n');
-      internalTLS.write('Content-Type: text/html; charset=utf-8\r\n');
       const responseBody = 'Playwright client-certificate error: ' + error.message;
-      internalTLS.write('Content-Length: ' + Buffer.byteLength(responseBody) + '\r\n');
-      internalTLS.write('\r\n');
-      internalTLS.write(responseBody);
-      internalTLS.end();
+      internalTLS.end([
+        'HTTP/1.1 503 Internal Server Error',
+        'Content-Type: text/html; charset=utf-8',
+        'Content-Length: ' + Buffer.byteLength(responseBody),
+        '\r\n',
+        responseBody,
+      ].join('\r\n'));
       closeBothSockets();
     });
   }

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -249,6 +249,21 @@ test.describe('browser', () => {
     await page.close();
   });
 
+  test('should not ignoreHTTPSErrors by default', async ({ browser, httpsServer, asset }) => {
+    const page = await browser.newPage({
+      clientCertificates: [{
+        url: 'https://just-there-that-the-client-certificates-proxy-server-is-getting-launched.com',
+        certs: [{
+          certPath: asset('client-certificates/client/trusted/cert.pem'),
+          keyPath: asset('client-certificates/client/trusted/key.pem'),
+        }],
+      }],
+    });
+    await page.goto(httpsServer.EMPTY_PAGE);
+    await expect(page.getByText('Playwright client-certificate error')).toBeVisible();
+    await page.close();
+  });
+
   test.describe('persistentContext', () => {
     test('validate input', async ({ launchPersistent }) => {
       test.slow();

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -249,7 +249,7 @@ test.describe('browser', () => {
     await page.close();
   });
 
-  test('should not ignoreHTTPSErrors by default', async ({ browser, httpsServer, asset }) => {
+  test('should have ignoreHTTPSErrors=false by default', async ({ browser, httpsServer, asset }) => {
     const page = await browser.newPage({
       clientCertificates: [{
         url: 'https://just-there-that-the-client-certificates-proxy-server-is-getting-launched.com',


### PR DESCRIPTION
The problem was that we were holding a copy inside `ClientCertificatesInteceptor` but then changing the options [afterwards](https://github.com/microsoft/playwright/blob/6dbc7b54e8ea62c1f31c43aa8dad7e079e136003/packages/playwright-core/src/server/browserContext.ts#L669). Instead of holding a copy, lets only hold the properties we need. 