### PR TITLE
fix(client-certificates): pass TLS servername for SNI

### DIFF
--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type net from 'net';
+import net from 'net';
 import path from 'path';
 import type https from 'https';
 import fs from 'fs';
@@ -100,10 +100,13 @@ class SocksProxyConnection {
 
     const tlsOptions: tls.ConnectionOptions = {
       socket: this.target,
+      host: this.host,
+      port: this.port,
       rejectUnauthorized: !this.socksProxy.ignoreHTTPSErrors,
-      servername: this.host,
       ...clientCertificatesToTLSOptions(this.socksProxy.clientCertificates, `https://${this.host}:${this.port}/`),
     };
+    if (!net.isIP(this.host))
+      tlsOptions.servername = this.host;
     if (process.env.PWTEST_UNSUPPORTED_CUSTOM_CA && isUnderTest())
       tlsOptions.ca = [fs.readFileSync(process.env.PWTEST_UNSUPPORTED_CUSTOM_CA)];
     const targetTLS = tls.connect(tlsOptions);

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -101,6 +101,7 @@ class SocksProxyConnection {
     const tlsOptions: tls.ConnectionOptions = {
       socket: this.target,
       rejectUnauthorized: !this.socksProxy.ignoreHTTPSErrors,
+      servername: this.host,
       ...clientCertificatesToTLSOptions(this.socksProxy.clientCertificates, `https://${this.host}:${this.port}/`),
     };
     if (process.env.PWTEST_UNSUPPORTED_CUSTOM_CA && isUnderTest())

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -32,7 +32,8 @@ const test = base.extend<{ serverURL: string, serverURLRewrittenToLocalhost: str
       rejectUnauthorized: false,
     }, (req, res) => {
       const tlsSocket = req.socket as import('tls').TLSSocket;
-      expect((tlsSocket as any).servername).toBe('localhost');
+      // @ts-expect-error
+      expect(['localhost', 'local.playwright'].includes((tlsSocket).servername)).toBe(true);
       const cert = tlsSocket.getPeerCertificate();
       if ((req as any).client.authorized) {
         res.writeHead(200, { 'Content-Type': 'text/html' });

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -31,7 +31,9 @@ const test = base.extend<{ serverURL: string, serverURLRewrittenToLocalhost: str
       requestCert: true,
       rejectUnauthorized: false,
     }, (req, res) => {
-      const cert = (req.socket as import('tls').TLSSocket).getPeerCertificate();
+      const tlsSocket = req.socket as import('tls').TLSSocket;
+      expect((tlsSocket as any).servername).toBe('localhost');
+      const cert = tlsSocket.getPeerCertificate();
       if ((req as any).client.authorized) {
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(`Hello ${cert.subject.CN}, your certificate was issued by ${cert.issuer.CN}!`);


### PR DESCRIPTION
Quoting from the Node.js docs:

> servername: [<string>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type) Server name for the SNI (Server Name Indication) TLS extension. It is the name of the host being connected to, and must be a host name, and not an IP address. It can be used by a multi-homed server to choose the correct certificate to present to the client, see the SNICallback option to [tls.createServer()](https://nodejs.org/api/tls.html#tlscreateserveroptions-secureconnectionlistener).

Without that, it doesn't work at most of the sites in the internet.