### PR TITLE
chore: make WKInterceptableRequest._requestId private

### DIFF
--- a/packages/playwright-core/src/server/webkit/wkInterceptableRequest.ts
+++ b/packages/playwright-core/src/server/webkit/wkInterceptableRequest.ts
@@ -42,7 +42,7 @@ const errorReasons: { [reason: string]: Protocol.Network.ResourceErrorType } = {
 export class WKInterceptableRequest {
   private readonly _session: WKSession;
   readonly request: network.Request;
-  readonly _requestId: string;
+  private readonly _requestId: string;
   _timestamp: number;
   _wallTime: number;
 


### PR DESCRIPTION
With COOP navigation we may need to take over request in the new provisional page where it will have different id. This is preparation to that.