### PR TITLE
Revert "fix: add 'window-management' to chromium browser (#31687)"

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -980,7 +980,6 @@ A permission or an array of permissions to grant. Permissions can be one of the 
 * `'notifications'`
 * `'payment-handler'`
 * `'storage-access'`
-* `'window-management'`
 
 ### option: BrowserContext.grantPermissions.origin
 * since: v1.8

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -434,7 +434,6 @@ export class CRBrowserContext extends BrowserContext {
       // chrome-specific permissions we have.
       ['midi-sysex', 'midiSysex'],
       ['storage-access', 'storageAccess'],
-      ['window-management', 'windowManagement']
     ]);
     const filtered = permissions.map(permission => {
       const protocolPermission = webPermissionToProtocol.get(permission);

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8445,7 +8445,6 @@ export interface BrowserContext {
    * - `'notifications'`
    * - `'payment-handler'`
    * - `'storage-access'`
-   * - `'window-management'`
    * @param options
    */
   grantPermissions(permissions: ReadonlyArray<string>, options?: {

--- a/tests/library/permissions.spec.ts
+++ b/tests/library/permissions.spec.ts
@@ -48,14 +48,6 @@ it.describe('permissions', () => {
     expect(await getPermission(page, 'geolocation')).toBe('granted');
   });
 
-  it('should grant window-management permission when origin is listed', async ({ page, context, server, browserName }) => {
-    it.skip(browserName !== 'chromium', 'Only Chromium supports window management API.');
-
-    await page.goto(server.EMPTY_PAGE);
-    await context.grantPermissions(['window-management'], { origin: server.EMPTY_PAGE });
-    expect(await getPermission(page, 'window-management')).toBe('granted');
-  });
-
   it('should prompt for geolocation permission when origin is not listed', async ({ page, context, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions(['geolocation'], { origin: server.EMPTY_PAGE });


### PR DESCRIPTION
This reverts commit 0aa2f06f68959e2515f62ea9bb570cf1815230b2.

Discussed the new permission in the API review and decided not to proceed with the feature as we are not ready to commit to supporting it yet:
* the API is Chromium specific
* the API is still experimental
* there is no clarity to what extend the screen manipulation APIs will work in old headless which is our main test environment

We'll keep an eye on the demand for the feature and may get back to implementing it in the future.

Reference: https://github.com/microsoft/playwright/issues/27198