### PR TITLE
fix(core): update maxRetries docs

### DIFF
--- a/docs/src/api/class-requestoptions.md
+++ b/docs/src/api/class-requestoptions.md
@@ -134,7 +134,7 @@ Defaults to `20`. Pass `0` to not follow redirects.
 * since: v1.46
 - `maxRetries` <[int]>
 
-Maximum number of times socket errors should be retried. Currently only `ECONNRESET` error is retried. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
+Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
 
 ## method: RequestOptions.setMethod
 * since: v1.18

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -469,7 +469,7 @@ Defaults to `20`. Pass `0` to not follow redirects.
 * langs: js, python, csharp
 - `maxRetries` <[int]>
 
-Maximum number of times socket errors should be retried. Currently only `ECONNRESET` error is retried. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
+Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
 
 ## evaluate-expression
 - `expression` <[string]>

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -15934,8 +15934,8 @@ export interface APIRequestContext {
     maxRedirects?: number;
 
     /**
-     * Maximum number of times socket errors should be retried. Currently only `ECONNRESET` error is retried. An error
-     * will be thrown if the limit is exceeded. Defaults to `0` - no retries.
+     * Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not
+     * retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
      */
     maxRetries?: number;
 
@@ -16040,8 +16040,8 @@ export interface APIRequestContext {
     maxRedirects?: number;
 
     /**
-     * Maximum number of times socket errors should be retried. Currently only `ECONNRESET` error is retried. An error
-     * will be thrown if the limit is exceeded. Defaults to `0` - no retries.
+     * Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not
+     * retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
      */
     maxRetries?: number;
 
@@ -16126,8 +16126,8 @@ export interface APIRequestContext {
     maxRedirects?: number;
 
     /**
-     * Maximum number of times socket errors should be retried. Currently only `ECONNRESET` error is retried. An error
-     * will be thrown if the limit is exceeded. Defaults to `0` - no retries.
+     * Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not
+     * retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
      */
     maxRetries?: number;
 
@@ -16212,8 +16212,8 @@ export interface APIRequestContext {
     maxRedirects?: number;
 
     /**
-     * Maximum number of times socket errors should be retried. Currently only `ECONNRESET` error is retried. An error
-     * will be thrown if the limit is exceeded. Defaults to `0` - no retries.
+     * Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not
+     * retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
      */
     maxRetries?: number;
 
@@ -16340,8 +16340,8 @@ export interface APIRequestContext {
     maxRedirects?: number;
 
     /**
-     * Maximum number of times socket errors should be retried. Currently only `ECONNRESET` error is retried. An error
-     * will be thrown if the limit is exceeded. Defaults to `0` - no retries.
+     * Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not
+     * retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
      */
     maxRetries?: number;
 
@@ -16426,8 +16426,8 @@ export interface APIRequestContext {
     maxRedirects?: number;
 
     /**
-     * Maximum number of times socket errors should be retried. Currently only `ECONNRESET` error is retried. An error
-     * will be thrown if the limit is exceeded. Defaults to `0` - no retries.
+     * Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not
+     * retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
      */
     maxRetries?: number;
 


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/playwright/pull/31386, updating some docs.

I've replaced `socket error` with `network error`, because I feel like it's more approachable for web developers. We also have precedent for calling this a "network error" in https://github.com/Skn0tt/playwright/blob/fbef5ff8493891dd304ffc3007b99406b6866192/docs/src/api/class-page.md?plain=1#L531, while there's no existing user-facing mention of "socket error".

Also, I could imagine beginner users being confused by the difference between a network-level error and an HTTP-level error. To help that, I added a note that "network error" does not include erroneous HTTP status codes. 