### PR TITLE
docs(webkit): supprot for non-core features may differ between OSes

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -461,7 +461,7 @@ Playwright's Firefox version matches the recent [Firefox Stable](https://www.moz
 
 ### WebKit
 
-Playwright's WebKit version matches the recent WebKit trunk build, before it is used in Apple Safari and other WebKit-based browsers. This gives a lot of lead time to react on the potential browser update issues. Playwright doesn't work with the branded version of Safari since it relies on patches. Instead you can test against the recent WebKit build.
+Playwright's WebKit is derived from the latest WebKit main branch sources, often before these updates are incorporated into Apple Safari and other WebKit-based browsers. This gives a lot of lead time to react on the potential browser update issues. Playwright doesn't work with the branded version of Safari since it relies on patches. Instead, you can test using the most recent WebKit build. Note that avialability of certain features, which depend heavily on the underlying platform, may vary between operating systems.
 
 ## Install behind a firewall or a proxy
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/playwright/issues/31017