### PR TITLE
chore(ct): replace `find-related-test-files` hook with `populateDependencies`

### DIFF
--- a/packages/playwright-ct-core/index.js
+++ b/packages/playwright-ct-core/index.js
@@ -16,7 +16,7 @@
 
 const { test: baseTest, expect, devices, defineConfig: originalDefineConfig } = require('playwright/test');
 const { fixtures } = require('./lib/mount');
-const { clearCacheCommand, runDevServerCommand, findRelatedTestFilesCommand } = require('./lib/cliOverrides');
+const { runDevServerCommand } = require('./lib/cliOverrides');
 const { createPlugin } = require('./lib/vitePlugin');
 
 const defineConfig = (...configs) => {
@@ -30,7 +30,6 @@ const defineConfig = (...configs) => {
         [require.resolve('./lib/tsxTransform')]
       ],
       cli: {
-        'clear-cache': clearCacheCommand,
         'dev-server': runDevServerCommand,
       },
     }

--- a/packages/playwright-ct-core/index.js
+++ b/packages/playwright-ct-core/index.js
@@ -32,7 +32,6 @@ const defineConfig = (...configs) => {
       cli: {
         'clear-cache': clearCacheCommand,
         'dev-server': runDevServerCommand,
-        'find-related-test-files': findRelatedTestFilesCommand,
       },
     }
   };

--- a/packages/playwright-ct-core/index.js
+++ b/packages/playwright-ct-core/index.js
@@ -16,7 +16,6 @@
 
 const { test: baseTest, expect, devices, defineConfig: originalDefineConfig } = require('playwright/test');
 const { fixtures } = require('./lib/mount');
-const { runDevServerCommand } = require('./lib/cliOverrides');
 const { createPlugin } = require('./lib/vitePlugin');
 
 const defineConfig = (...configs) => {
@@ -29,9 +28,6 @@ const defineConfig = (...configs) => {
       babelPlugins: [
         [require.resolve('./lib/tsxTransform')]
       ],
-      cli: {
-        'dev-server': runDevServerCommand,
-      },
     }
   };
 };

--- a/packages/playwright-ct-core/src/cliOverrides.ts
+++ b/packages/playwright-ct-core/src/cliOverrides.ts
@@ -15,18 +15,8 @@
  * limitations under the License.
  */
 
-import { cacheDir } from 'playwright/lib/transform/compilationCache';
-import { resolveDirs } from './viteUtils';
 import { runDevServer } from './devServer';
 import type { FullConfigInternal } from 'playwright/lib/common/config';
-import { removeFolderAndLogToConsole } from 'playwright/lib/runner/testServer';
-
-export async function clearCacheCommand(config: FullConfigInternal) {
-  const dirs = await resolveDirs(config.configDir, config.config);
-  if (dirs)
-    await removeFolderAndLogToConsole(dirs.outDir);
-  await removeFolderAndLogToConsole(cacheDir);
-}
 
 export async function runDevServerCommand(config: FullConfigInternal) {
   return await runDevServer(config);

--- a/packages/playwright-ct-core/src/cliOverrides.ts
+++ b/packages/playwright-ct-core/src/cliOverrides.ts
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-import { affectedTestFiles, cacheDir } from 'playwright/lib/transform/compilationCache';
-import { buildBundle } from './vitePlugin';
+import { cacheDir } from 'playwright/lib/transform/compilationCache';
 import { resolveDirs } from './viteUtils';
 import { runDevServer } from './devServer';
 import type { FullConfigInternal } from 'playwright/lib/common/config';
@@ -27,11 +26,6 @@ export async function clearCacheCommand(config: FullConfigInternal) {
   if (dirs)
     await removeFolderAndLogToConsole(dirs.outDir);
   await removeFolderAndLogToConsole(cacheDir);
-}
-
-export async function findRelatedTestFilesCommand(files: string[],  config: FullConfigInternal) {
-  await buildBundle(config.config, config.configDir);
-  return { testFiles: affectedTestFiles(files) };
 }
 
 export async function runDevServerCommand(config: FullConfigInternal) {

--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -31,6 +31,7 @@ import type { ImportInfo } from './tsxTransform';
 import type { ComponentRegistry } from './viteUtils';
 import { createConfig, frameworkConfig, hasJSComponents, populateComponentsFromTests, resolveDirs, resolveEndpoint, transformIndexFile } from './viteUtils';
 import { resolveHook } from 'playwright/lib/transform/transform';
+import { removeFolderAndLogToConsole } from 'playwright/lib/runner/testServer';
 
 const log = debug('pw:vite');
 
@@ -73,6 +74,12 @@ export function createPlugin(): TestRunnerPlugin {
       if (stoppableServer)
         await new Promise(f => stoppableServer.stop(f));
     },
+
+    clearCache: async () => {
+      const dirs = await resolveDirs(configDir, config);
+      if (dirs)
+        await removeFolderAndLogToConsole(dirs.outDir);
+    }
   };
 }
 

--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -84,7 +84,7 @@ export function createPlugin(): TestRunnerPlugin {
     },
 
     runDevServer: async (config: FullConfigInternal) => {
-      await runDevServer(config);
+      return await runDevServer(config);
     }
   };
 }

--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -32,6 +32,8 @@ import type { ComponentRegistry } from './viteUtils';
 import { createConfig, frameworkConfig, hasJSComponents, populateComponentsFromTests, resolveDirs, resolveEndpoint, transformIndexFile } from './viteUtils';
 import { resolveHook } from 'playwright/lib/transform/transform';
 import { removeFolderAndLogToConsole } from 'playwright/lib/runner/testServer';
+import { runDevServer } from './devServer';
+import type { FullConfigInternal } from 'playwright/lib/common/config';
 
 const log = debug('pw:vite');
 
@@ -79,6 +81,10 @@ export function createPlugin(): TestRunnerPlugin {
       const dirs = await resolveDirs(configDir, config);
       if (dirs)
         await removeFolderAndLogToConsole(dirs.outDir);
+    },
+
+    runDevServer: async (config: FullConfigInternal) => {
+      await runDevServer(config);
     }
   };
 }

--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -48,7 +48,7 @@ export function createPlugin(): TestRunnerPlugin {
       configDir = configDirectory;
     },
 
-    populateDependencies: async (config: FullConfig, configDir: string) => {
+    populateDependencies: async () => {
       await buildBundle(config, configDir);
     },
 

--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -48,6 +48,10 @@ export function createPlugin(): TestRunnerPlugin {
       configDir = configDirectory;
     },
 
+    populateDependencies: async (config: FullConfig, configDir: string) => {
+      await buildBundle(config, configDir);
+    },
+
     begin: async (suite: Suite) => {
       const result = await buildBundle(config, configDir);
       if (!result)
@@ -68,10 +72,6 @@ export function createPlugin(): TestRunnerPlugin {
     end: async () => {
       if (stoppableServer)
         await new Promise(f => stoppableServer.stop(f));
-    },
-
-    populateDependencies: async () => {
-      await buildBundle(config, configDir);
     },
   };
 }

--- a/packages/playwright/src/plugins/index.ts
+++ b/packages/playwright/src/plugins/index.ts
@@ -20,7 +20,7 @@ import type { ReporterV2 } from '../reporters/reporterV2';
 export interface TestRunnerPlugin {
   name: string;
   setup?(config: FullConfig, configDir: string, reporter: ReporterV2): Promise<void>;
-  populateDependencies?(): Promise<void>;
+  populateDependencies?(config: FullConfig, configDir: string): Promise<void>;
   begin?(suite: Suite): Promise<void>;
   end?(): Promise<void>;
   teardown?(): Promise<void>;

--- a/packages/playwright/src/plugins/index.ts
+++ b/packages/playwright/src/plugins/index.ts
@@ -24,6 +24,9 @@ export interface TestRunnerPlugin {
   begin?(suite: Suite): Promise<void>;
   end?(): Promise<void>;
   teardown?(): Promise<void>;
+
+  clearCache?(): Promise<void>;
+  runDevServer?(): Promise<void>;
 }
 
 export type TestRunnerPluginRegistration = {

--- a/packages/playwright/src/plugins/index.ts
+++ b/packages/playwright/src/plugins/index.ts
@@ -20,7 +20,7 @@ import type { ReporterV2 } from '../reporters/reporterV2';
 export interface TestRunnerPlugin {
   name: string;
   setup?(config: FullConfig, configDir: string, reporter: ReporterV2): Promise<void>;
-  populateDependencies?(config: FullConfig, configDir: string): Promise<void>;
+  populateDependencies?(): Promise<void>;
   begin?(suite: Suite): Promise<void>;
   end?(): Promise<void>;
   teardown?(): Promise<void>;

--- a/packages/playwright/src/plugins/index.ts
+++ b/packages/playwright/src/plugins/index.ts
@@ -15,6 +15,7 @@
  */
 
 import type { FullConfig, Suite } from '../../types/testReporter';
+import type { FullConfigInternal } from '../common/config';
 import type { ReporterV2 } from '../reporters/reporterV2';
 
 export interface TestRunnerPlugin {
@@ -26,7 +27,7 @@ export interface TestRunnerPlugin {
   teardown?(): Promise<void>;
 
   clearCache?(): Promise<void>;
-  runDevServer?(): Promise<void>;
+  runDevServer?(config: FullConfigInternal): Promise<() => Promise<void>>;
 }
 
 export type TestRunnerPluginRegistration = {

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -97,8 +97,10 @@ function addDevServerCommand(program: Command) {
     const configInternal = await loadConfigFromFileRestartIfNeeded(options.config);
     if (!configInternal)
       return;
-    const { config } = configInternal;
-    const implementation = (config as any)['@playwright/test']?.['cli']?.['dev-server'];
+
+    await testServer.setupPlugins(configInternal);
+
+    const implementation = configInternal.plugins.map(p => p.instance!).find(p => p.runDevServer)?.runDevServer;
     if (implementation) {
       await implementation(configInternal);
     } else {

--- a/packages/playwright/src/runner/runner.ts
+++ b/packages/playwright/src/runner/runner.ts
@@ -108,7 +108,7 @@ export class Runner {
     return status;
   }
 
-  async loadAllTests(mode: 'in-process' | 'out-of-process' = 'in-process', options: { populatePluginDependencies?: boolean }): Promise<{ status: FullResult['status'], suite?: Suite, errors: TestError[] }> {
+  async loadAllTests(mode: 'in-process' | 'out-of-process' = 'in-process', options: { populatePluginDependencies?: boolean } = {}): Promise<{ status: FullResult['status'], suite?: Suite, errors: TestError[] }> {
     const config = this._config;
     const errors: TestError[] = [];
     const reporters = [wrapReporterAsV2({

--- a/packages/playwright/src/runner/runner.ts
+++ b/packages/playwright/src/runner/runner.ts
@@ -143,8 +143,13 @@ export class Runner {
       return { errors: result.errors, testFiles: [] };
 
     const resolvedFiles = (files as string[]).map(file => path.resolve(process.cwd(), file));
-    for (const plugin of this._config.plugins)
-      await plugin.instance?.populateDependencies?.();
+
+    for (const plugin of this._config.plugins) {
+      if (!plugin.instance)
+        plugin.instance = typeof plugin.factory === 'function' ? await plugin.factory() : plugin.factory;
+
+      await plugin.instance.populateDependencies?.(this._config.config, this._config.configDir);
+    }
     return { testFiles: affectedTestFiles(resolvedFiles) };
   }
 }

--- a/packages/playwright/src/runner/runner.ts
+++ b/packages/playwright/src/runner/runner.ts
@@ -120,14 +120,7 @@ export class Runner {
     const testRun = new TestRun(config);
     taskRunner.reporter.onConfigure(config.config);
 
-    const taskStatus = await taskRunner.run(testRun, 0);
-    let status: FullResult['status'] = testRun.failureTracker.result();
-    if (status === 'passed' && taskStatus !== 'passed')
-      status = taskStatus;
-    const modifiedResult = await taskRunner.reporter.onEnd({ status });
-    if (modifiedResult && modifiedResult.status)
-      status = modifiedResult.status;
-    await taskRunner.reporter.onExit();
+    const status = await taskRunner.run(testRun, 0);
     return { status, suite: testRun.rootSuite, errors };
   }
 

--- a/packages/playwright/src/runner/runner.ts
+++ b/packages/playwright/src/runner/runner.ts
@@ -143,9 +143,8 @@ export class Runner {
       return { errors: result.errors, testFiles: [] };
 
     const resolvedFiles = (files as string[]).map(file => path.resolve(process.cwd(), file));
-    const override = (this._config.config as any)['@playwright/test']?.['cli']?.['find-related-test-files'];
-    if (override)
-      return await override(resolvedFiles, this._config);
+    for (const plugin of this._config.plugins)
+      await plugin.instance?.populateDependencies?.();
     return { testFiles: affectedTestFiles(resolvedFiles) };
   }
 }

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -106,7 +106,7 @@ function addRunTasks(taskRunner: TaskRunner<TestRun>, config: FullConfigInternal
   return taskRunner;
 }
 
-export function createTaskRunnerForList(config: FullConfigInternal, reporters: ReporterV2[], mode: 'in-process' | 'out-of-process', options: { failOnLoadErrors: boolean, populatePluginDependencies?: boolean }): TaskRunner<TestRun> {
+export function createTaskRunnerForList(config: FullConfigInternal, reporters: ReporterV2[], mode: 'in-process' | 'out-of-process', options: { failOnLoadErrors: boolean }): TaskRunner<TestRun> {
   const taskRunner = TaskRunner.create<TestRun>(reporters, config.config.globalTimeout);
   taskRunner.addTask('load tests', createLoadTask(mode, { ...options, filterOnly: false }));
   taskRunner.addTask('report begin', createReportBeginTask());

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -118,7 +118,6 @@ export function createTaskRunnerForFindRelatedTests(config: FullConfigInternal, 
   for (const plugin of config.plugins)
     taskRunner.addTask('plugin setup', createPluginSetupTask(plugin));
   taskRunner.addTask('load tests', createLoadTask(mode, { filterOnly: false, populatePluginDependencies: true, failOnLoadErrors: false }));
-  taskRunner.addTask('report begin', createReportBeginTask());
   return taskRunner;
 }
 

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -106,6 +106,15 @@ function addRunTasks(taskRunner: TaskRunner<TestRun>, config: FullConfigInternal
   return taskRunner;
 }
 
+export function createTaskRunnerForPluginSetup(config: FullConfigInternal, reporters: ReporterV2[]): TaskRunner<TestRun> {
+  const taskRunner = TaskRunner.create<TestRun>(reporters, config.config.globalTimeout);
+
+  for (const plugin of config.plugins)
+    taskRunner.addTask('plugin setup', createPluginSetupTask(plugin));
+
+  return taskRunner;
+}
+
 export function createTaskRunnerForList(config: FullConfigInternal, reporters: ReporterV2[], mode: 'in-process' | 'out-of-process', options: { failOnLoadErrors: boolean, populatePluginDependencies?: boolean }): TaskRunner<TestRun> {
   const taskRunner = TaskRunner.create<TestRun>(reporters, config.config.globalTimeout);
 

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -231,7 +231,7 @@ function createLoadTask(mode: 'out-of-process' | 'in-process', options: { filter
       let cliOnlyChangedMatcher: Matcher | undefined = undefined;
       if (testRun.config.cliOnlyChanged && options.filterOnlyChanged) {
         for (const plugin of testRun.config.plugins)
-          await plugin.instance?.populateDependencies?.();
+          await plugin.instance?.populateDependencies?.(testRun.config.config, testRun.config.configDir);
         const changedFiles = await detectChangedTests(testRun.config.cliOnlyChanged, testRun.config.configDir);
         cliOnlyChangedMatcher = file => changedFiles.has(file);
       }


### PR DESCRIPTION
As discussed in the team sync, now that we have the `populateDependencies` plugin step, we don't need this CLI hook anymore.

I'm not sure if this refactor is worth it though, because it means we'll start calling the Plugin steps out of order (we call `populateDependencies` without calling `setup` first). Should we also run `setup`? If we do that, does that mean we should also run `teardown()`? Should we use a proper `TaskRunner` instance for managing that? Or should we just stick with the hook we have for simplicity over architectural conformance?

Lots of questions that i'm sure @dgozman has great answers to :D

This is a follow-up to https://github.com/microsoft/playwright/pull/31727.