### PR TITLE
chore(ui): add test expectation that doesn't immediately pass on blank tree

### DIFF
--- a/tests/playwright-test/ui-mode-test-filters.spec.ts
+++ b/tests/playwright-test/ui-mode-test-filters.spec.ts
@@ -234,6 +234,7 @@ test('should only show tests selected with --grep', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree, undefined, {
     additionalArgs: ['--grep', 'fails'],
   });
+  await expect.poll(dumpTestTree(page)).toContain('fails');
   await expect.poll(dumpTestTree(page)).not.toContain('passes');
 });
 


### PR DESCRIPTION
Followup to #31815 