### PR TITLE
devops: remove GHA todo in primary workflow for itest

### DIFF
--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -219,7 +219,6 @@ jobs:
       with:
         command: npm run itest
         bot-name: "package-installations-${{ matrix.os }}"
-        # TODO: figure out why itest fails with 'bash' on Windows.
         shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash' }}
         flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
         flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}


### PR DESCRIPTION
This TODO got added during our GHA refactoring a while ago, where I thought it might make sense to run our itests in `bash`. We didn't do it before the refactoring either. It seems good to keep them running in `pwsh` instead, so lets just remove the TODO.

Investigation notes: Running in `bash` on Windows via `Git Bash` seems like doing a lot of magic, especially with path handling. Things [like](https://github.com/microsoft/playwright/blob/a02ed38e604d6c8517dda148fcf63ee44f5c9ce4/tests/installation/registry.ts#L143) this break then, since `tar` even when using `Git Bash` [doesn't accept a Windows path](https://sourceforge.net/p/mingw/mailman/mingw-users/thread/54CE104A.7060108@hccnet.nl/).