### PR TITLE
fix(client-certificates): error response body Content-Length calculation

### DIFF
--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -201,7 +201,7 @@ class SocksProxyConnection {
               'HTTP/1.1 503 Internal Server Error',
               'Content-Type: text/html; charset=utf-8',
               'Content-Length: ' + Buffer.byteLength(responseBody),
-              '\r\n',
+              '',
               responseBody,
             ].join('\r\n'));
             closeBothSockets();

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -274,7 +274,7 @@ test.describe('browser', () => {
       }],
     });
     await page.goto(browserName === 'webkit' && platform === 'darwin' ? httpsServer.EMPTY_PAGE.replace('localhost', 'local.playwright') : httpsServer.EMPTY_PAGE);
-    await expect(page.getByText('Playwright client-certificate error')).toBeVisible();
+    await expect(page.getByText('Playwright client-certificate error: self-signed certificate')).toBeVisible();
     await page.close();
   });
 


### PR DESCRIPTION
Motivation: Before the browser was truncating two characters, because the response body has `\r\n` as a prefix, which the browser thought was part of the response. So it didn't show the last two characters of `responseBody`.

We could also do it similar to how we do it with http2, like have an intermediate http.Server instance in order to let Node.js construct us a valid http response, but probably not worth it for just a simple error message.