### PR TITLE
refactor(ui): synchronize settings via useSyncExternalStore instead of prop drilling

### DIFF
--- a/packages/trace-viewer/src/ui/embeddedWorkbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/embeddedWorkbenchLoader.tsx
@@ -86,7 +86,7 @@ export const EmbeddedWorkbenchLoader: React.FunctionComponent = () => {
     <div className='progress'>
       <div className='inner-progress' style={{ width: progress.total ? (100 * progress.done / progress.total) + '%' : 0 }}></div>
     </div>
-    <Workbench model={model} openPage={openPage} />
+    <Workbench model={model} openPage={openPage} showSettings />
     {!traceURLs.length && <div className='empty-state'>
       <div className='title'>Select test to see the trace</div>
     </div>}

--- a/packages/trace-viewer/src/ui/uiModeTraceView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeTraceView.tsx
@@ -25,15 +25,13 @@ import type { ContextEntry } from '../entries';
 import type { SourceLocation } from './modelUtil';
 import { idForAction, MultiTraceModel } from './modelUtil';
 import { Workbench } from './workbench';
-import { type Setting } from '@web/uiUtils';
 
 export const TraceView: React.FC<{
-  showRouteActionsSetting: Setting<boolean>,
   item: { treeItem?: TreeItem, testFile?: SourceLocation, testCase?: reporterTypes.TestCase },
   rootDir?: string,
   onOpenExternally?: (location: SourceLocation) => void,
   revealSource?: boolean,
-}> = ({ showRouteActionsSetting, item, rootDir, onOpenExternally, revealSource }) => {
+}> = ({ item, rootDir, onOpenExternally, revealSource }) => {
   const [model, setModel] = React.useState<{ model: MultiTraceModel, isLive: boolean } | undefined>();
   const [counter, setCounter] = React.useState(0);
   const pollTimer = React.useRef<NodeJS.Timeout | null>(null);
@@ -91,7 +89,6 @@ export const TraceView: React.FC<{
 
   return <Workbench
     key='workbench'
-    showRouteActionsSetting={showRouteActionsSetting}
     model={model?.model}
     showSourcesFirst={true}
     rootDir={rootDir}

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -438,7 +438,6 @@ export const UIModeView: React.FC<{}> = ({
         </div>
         <div className={'vbox' + (isShowingOutput ? ' hidden' : '')}>
           <TraceView
-            showRouteActionsSetting={showRouteActionsSetting}
             item={selectedItem}
             rootDir={testModel?.config?.rootDir}
             revealSource={revealSource}

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -56,7 +56,8 @@ export const Workbench: React.FunctionComponent<{
   openPage?: (url: string, target?: string) => Window | any,
   onOpenExternally?: (location: modelUtil.SourceLocation) => void,
   revealSource?: boolean,
-}> = ({ model, showSourcesFirst, rootDir, fallbackLocation, initialSelection, onSelectionChanged, isLive, status, inert, openPage, onOpenExternally, revealSource }) => {
+  showSettings?: boolean,
+}> = ({ model, showSourcesFirst, rootDir, fallbackLocation, initialSelection, onSelectionChanged, isLive, status, inert, openPage, onOpenExternally, revealSource, showSettings }) => {
   const [selectedAction, setSelectedActionImpl] = React.useState<ActionTraceEventInContext | undefined>(undefined);
   const [revealedStack, setRevealedStack] = React.useState<StackFrame[] | undefined>(undefined);
   const [highlightedAction, setHighlightedAction] = React.useState<ActionTraceEventInContext | undefined>();

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -36,7 +36,7 @@ import { AttachmentsTab } from './attachmentsTab';
 import type { Boundaries } from '../geometry';
 import { InspectorTab } from './inspectorTab';
 import { ToolbarButton } from '@web/components/toolbarButton';
-import { useSetting, msToString, type Setting } from '@web/uiUtils';
+import { useSetting, msToString } from '@web/uiUtils';
 import type { Entry } from '@trace/har';
 import './workbench.css';
 import { testStatusIcon, testStatusText } from './testUtils';
@@ -53,11 +53,10 @@ export const Workbench: React.FunctionComponent<{
   isLive?: boolean,
   status?: UITestStatus,
   inert?: boolean,
-  showRouteActionsSetting?: Setting<boolean>,
   openPage?: (url: string, target?: string) => Window | any,
   onOpenExternally?: (location: modelUtil.SourceLocation) => void,
   revealSource?: boolean,
-}> = ({ showRouteActionsSetting, model, showSourcesFirst, rootDir, fallbackLocation, initialSelection, onSelectionChanged, isLive, status, inert, openPage, onOpenExternally, revealSource }) => {
+}> = ({ model, showSourcesFirst, rootDir, fallbackLocation, initialSelection, onSelectionChanged, isLive, status, inert, openPage, onOpenExternally, revealSource }) => {
   const [selectedAction, setSelectedActionImpl] = React.useState<ActionTraceEventInContext | undefined>(undefined);
   const [revealedStack, setRevealedStack] = React.useState<StackFrame[] | undefined>(undefined);
   const [highlightedAction, setHighlightedAction] = React.useState<ActionTraceEventInContext | undefined>();
@@ -70,11 +69,7 @@ export const Workbench: React.FunctionComponent<{
   const activeAction = model ? highlightedAction || selectedAction : undefined;
   const [selectedTime, setSelectedTime] = React.useState<Boundaries | undefined>();
   const [sidebarLocation, setSidebarLocation] = useSetting<'bottom' | 'right'>('propertiesSidebarLocation', 'bottom');
-  const [, , showRouteActionsSettingInternal] = useSetting(showRouteActionsSetting ? undefined : 'show-route-actions', true, 'Show route actions');
-
-  const showSettings = !showRouteActionsSetting;
-  showRouteActionsSetting ||= showRouteActionsSettingInternal;
-  const showRouteActions = showRouteActionsSetting[0];
+  const [showRouteActions, , showRouteActionsSetting] = useSetting('show-route-actions', true, 'Show route actions');
 
   const filteredActions = React.useMemo(() => {
     return (model?.actions || []).filter(action => showRouteActions || action.class !== 'Route');

--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -165,7 +165,7 @@ export const WorkbenchLoader: React.FunctionComponent<{
     <div className='progress'>
       <div className='inner-progress' style={{ width: progress.total ? (100 * progress.done / progress.total) + '%' : 0 }}></div>
     </div>
-    <Workbench model={model} inert={showFileUploadDropArea} />
+    <Workbench model={model} inert={showFileUploadDropArea} showSettings />
     {fileForLocalModeError && <div className='drop-target'>
       <div>Trace Viewer uses Service Workers to show traces. To view trace:</div>
       <div style={{ paddingTop: 20 }}>

--- a/packages/web/src/components/splitView.tsx
+++ b/packages/web/src/components/splitView.tsx
@@ -38,8 +38,14 @@ export const SplitView: React.FC<React.PropsWithChildren<SplitViewProps>> = ({
   settingName,
   children
 }) => {
-  const [hSize, setHSize] = useSetting<number>((settingName ?? 'dont-persist') + '.' + orientation + ':size', Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio, undefined, !settingName);
-  const [vSize, setVSize] = useSetting<number>((settingName ?? 'dont-persist') + '.' + orientation + ':size', Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio, undefined, !settingName);
+  const defaultSize = Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio;
+  const hSetting = useSetting<number>((settingName ?? 'unused') + '.' + orientation + ':size', defaultSize);
+  const vSetting = useSetting<number>((settingName ?? 'unused') + '.' + orientation + ':size', defaultSize);
+  const hState = React.useState(defaultSize);
+  const vState = React.useState(defaultSize);
+  const [hSize, setHSize] = settingName ? hSetting : hState;
+  const [vSize, setVSize] = settingName ? vSetting : vState;
+
   const [resizing, setResizing] = React.useState<{ offset: number, size: number } | null>(null);
   const [measure, ref] = useMeasure<HTMLDivElement>();
 

--- a/packages/web/src/components/splitView.tsx
+++ b/packages/web/src/components/splitView.tsx
@@ -38,8 +38,8 @@ export const SplitView: React.FC<React.PropsWithChildren<SplitViewProps>> = ({
   settingName,
   children
 }) => {
-  const [hSize, setHSize] = useSetting<number>(settingName ? settingName + '.' + orientation + ':size' : undefined, Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio);
-  const [vSize, setVSize] = useSetting<number>(settingName ? settingName + '.' + orientation + ':size' : undefined, Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio);
+  const [hSize, setHSize] = useSetting<number>((settingName ?? 'dont-persist') + '.' + orientation + ':size', Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio, undefined, !settingName);
+  const [vSize, setVSize] = useSetting<number>((settingName ?? 'dont-persist') + '.' + orientation + ':size', Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio, undefined, !settingName);
   const [resizing, setResizing] = React.useState<{ offset: number, size: number } | null>(null);
   const [measure, ref] = useMeasure<HTMLDivElement>();
 

--- a/packages/web/src/uiUtils.ts
+++ b/packages/web/src/uiUtils.ts
@@ -163,7 +163,7 @@ export function useSetting<S>(name: string, defaultValue: S, title?: string, don
 export class Settings {
   onChangeEmitter = new EventTarget();
 
-  sessionSettings: Record<string, any> = {};
+  sessionSettings = new Map<string, any>();
 
   getString(name: string, defaultValue: string): string {
     return localStorage[name] || defaultValue;
@@ -178,7 +178,7 @@ export class Settings {
 
   getObject<T>(name: string, defaultValue: T): T {
     if (!localStorage[name])
-      return this.sessionSettings[name] ?? defaultValue;
+      return this.sessionSettings.has(name) ? this.sessionSettings.get(name) : defaultValue;
     try {
       return JSON.parse(localStorage[name]);
     } catch {
@@ -188,7 +188,7 @@ export class Settings {
 
   setObject<T>(name: string, value: T, dontPersist = false) {
     if (dontPersist) {
-      this.sessionSettings[name] = value;
+      this.sessionSettings.set(name, value);
       this.onChangeEmitter.dispatchEvent(new Event(name));
       return;
     }


### PR DESCRIPTION
Broken out from https://github.com/microsoft/playwright/pull/31900, part of https://github.com/microsoft/playwright/issues/31863.

Synchronizes different `useSettings` calls via `useSyncExternalStore`. This saves us from having to drill down settings props everywhere, without the big refactoring that a `Context` would be.