### PR TITLE
fix(client-certificates): use matching origin for connections on :443

### DIFF
--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -148,7 +148,7 @@ class SocksProxyConnection {
           port: this.port,
           rejectUnauthorized: !this.socksProxy.ignoreHTTPSErrors,
           ALPNProtocols: [internalTLS.alpnProtocol || 'http/1.1'],
-          ...clientCertificatesToTLSOptions(this.socksProxy.clientCertificates, `https://${this.host}:${this.port}`),
+          ...clientCertificatesToTLSOptions(this.socksProxy.clientCertificates, new URL(`https://${this.host}:${this.port}`).origin),
         };
         if (!net.isIP(this.host))
           tlsOptions.servername = this.host;


### PR DESCRIPTION
Motivation: When using client-certificates on a website on port `443`, we would normalise the user input with `new URL` but still generate a "bad" representation of the "origin" internally, since the just do concatenated "host:port".

(The origin doesn't contain the port in case of :443)

We use `clientCertificatesToTLSOptions` in two places:

a) for APIRequestContext, there we pass one from the URL constructor over and
b) from the socks proxy, there we **now** also pass a "good one" over.

Test plan: We don't want to run the tests on port :443, so only manually validated the fix.

Relates https://github.com/microsoft/playwright/issues/31906