### PR TITLE
refactor(ui): in splitview component, move sidebar and main from children into named properties

### DIFF
--- a/packages/recorder/src/recorder.tsx
+++ b/packages/recorder/src/recorder.tsx
@@ -167,25 +167,27 @@ export const Recorder: React.FC<RecorderProps> = ({
       }}></ToolbarButton>
       <ToolbarButton icon='color-mode' title='Toggle color mode' toggled={false} onClick={() => toggleTheme()}></ToolbarButton>
     </Toolbar>
-    <SplitView sidebarSize={200}>
-      <CodeMirrorWrapper text={source.text} language={source.language} highlight={source.highlight} revealLine={source.revealLine} readOnly={true} lineNumbers={true}/>
-      <TabbedPane
+    <SplitView
+      sidebarSize={200}
+      sidebar={<TabbedPane
         rightToolbar={selectedTab === 'locator' ? [<ToolbarButton icon='files' title='Copy' onClick={() => copy(locator)} />] : []}
         tabs={[
           {
             id: 'locator',
             title: 'Locator',
-            render: () => <CodeMirrorWrapper text={locator} language={source.language} readOnly={false} focusOnChange={true} onChange={onEditorChange} wrapLines={true}/>
+            render: () => <CodeMirrorWrapper text={locator} language={source.language} readOnly={false} focusOnChange={true} onChange={onEditorChange} wrapLines={true} />
           },
           {
             id: 'log',
             title: 'Log',
-            render: () => <CallLogView language={source.language} log={Array.from(log.values())}/>
+            render: () => <CallLogView language={source.language} log={Array.from(log.values())} />
           },
         ]}
         selectedTab={selectedTab}
         setSelectedTab={setSelectedTab}
-      />
+      />}
+    >
+      <CodeMirrorWrapper text={source.text} language={source.language} highlight={source.highlight} revealLine={source.revealLine} readOnly={true} lineNumbers={true} />
     </SplitView>
   </div>;
 };

--- a/packages/recorder/src/recorder.tsx
+++ b/packages/recorder/src/recorder.tsx
@@ -169,6 +169,7 @@ export const Recorder: React.FC<RecorderProps> = ({
     </Toolbar>
     <SplitView
       sidebarSize={200}
+      main={<CodeMirrorWrapper text={source.text} language={source.language} highlight={source.highlight} revealLine={source.revealLine} readOnly={true} lineNumbers={true} />}
       sidebar={<TabbedPane
         rightToolbar={selectedTab === 'locator' ? [<ToolbarButton icon='files' title='Copy' onClick={() => copy(locator)} />] : []}
         tabs={[
@@ -186,9 +187,7 @@ export const Recorder: React.FC<RecorderProps> = ({
         selectedTab={selectedTab}
         setSelectedTab={setSelectedTab}
       />}
-    >
-      <CodeMirrorWrapper text={source.text} language={source.language} highlight={source.highlight} revealLine={source.revealLine} readOnly={true} lineNumbers={true} />
-    </SplitView>
+    />
   </div>;
 };
 

--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -101,10 +101,16 @@ export const NetworkTab: React.FunctionComponent<{
   />;
   return <>
     {!selectedEntry && grid}
-    {selectedEntry && <SplitView sidebarSize={columnWidths.get('name')!} sidebarIsFirst={true} orientation='horizontal' settingName='networkResourceDetails'>
-      <NetworkResourceDetails resource={selectedEntry.resource} onClose={() => setSelectedEntry(undefined)} />
-      {grid}
-    </SplitView>}
+    {selectedEntry &&
+      <SplitView
+        sidebarSize={columnWidths.get('name')!}
+        sidebarIsFirst={true}
+        orientation='horizontal'
+        settingName='networkResourceDetails'
+        sidebar={grid}
+      >
+        <NetworkResourceDetails resource={selectedEntry.resource} onClose={() => setSelectedEntry(undefined)} />
+      </SplitView>}
   </>;
 };
 

--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -107,10 +107,9 @@ export const NetworkTab: React.FunctionComponent<{
         sidebarIsFirst={true}
         orientation='horizontal'
         settingName='networkResourceDetails'
+        main={<NetworkResourceDetails resource={selectedEntry.resource} onClose={() => setSelectedEntry(undefined)} />}
         sidebar={grid}
-      >
-        <NetworkResourceDetails resource={selectedEntry.resource} onClose={() => setSelectedEntry(undefined)} />
-      </SplitView>}
+      />}
   </>;
 };
 

--- a/packages/trace-viewer/src/ui/sourceTab.tsx
+++ b/packages/trace-viewer/src/ui/sourceTab.tsx
@@ -100,17 +100,16 @@ export const SourceTab: React.FunctionComponent<{
     sidebarSize={200}
     orientation={stackFrameLocation === 'bottom' ? 'vertical' : 'horizontal'}
     sidebarHidden={!showStackFrames}
-    sidebar={<StackTraceView stack={stack} selectedFrame={selectedFrame} setSelectedFrame={setSelectedFrame} />}
-  >
-    <div className='vbox' data-testid='source-code'>
+    main={<div className='vbox' data-testid='source-code'>
       { fileName && <Toolbar>
         <span className='source-tab-file-name'>{fileName}</span>
         <CopyToClipboard description='Copy filename' value={getFileName(fileName, targetLine)}/>
         {location && <ToolbarButton icon='link-external' title='Open in VS Code' onClick={openExternally}></ToolbarButton>}
       </Toolbar> }
       <CodeMirrorWrapper text={source.content || ''} language='javascript' highlight={highlight} revealLine={targetLine} readOnly={true} lineNumbers={true} />
-    </div>
-  </SplitView>;
+    </div>}
+    sidebar={<StackTraceView stack={stack} selectedFrame={selectedFrame} setSelectedFrame={setSelectedFrame} />}
+  />;
 };
 
 export async function calculateSha1(text: string): Promise<string> {

--- a/packages/trace-viewer/src/ui/sourceTab.tsx
+++ b/packages/trace-viewer/src/ui/sourceTab.tsx
@@ -96,7 +96,12 @@ export const SourceTab: React.FunctionComponent<{
 
   const showStackFrames = (stack?.length ?? 0) > 1;
 
-  return <SplitView sidebarSize={200} orientation={stackFrameLocation === 'bottom' ? 'vertical' : 'horizontal'} sidebarHidden={!showStackFrames}>
+  return <SplitView
+    sidebarSize={200}
+    orientation={stackFrameLocation === 'bottom' ? 'vertical' : 'horizontal'}
+    sidebarHidden={!showStackFrames}
+    sidebar={<StackTraceView stack={stack} selectedFrame={selectedFrame} setSelectedFrame={setSelectedFrame} />}
+  >
     <div className='vbox' data-testid='source-code'>
       { fileName && <Toolbar>
         <span className='source-tab-file-name'>{fileName}</span>
@@ -105,7 +110,6 @@ export const SourceTab: React.FunctionComponent<{
       </Toolbar> }
       <CodeMirrorWrapper text={source.content || ''} language='javascript' highlight={highlight} revealLine={targetLine} readOnly={true} lineNumbers={true} />
     </div>
-    <StackTraceView stack={stack} selectedFrame={selectedFrame} setSelectedFrame={setSelectedFrame} />
   </SplitView>;
 };
 

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -458,84 +458,83 @@ export const UIModeView: React.FC<{}> = ({
           />
         </div>
       </div>}
-      sidebar={
-        <div className='vbox ui-mode-sidebar'>
-          <Toolbar noShadow={true} noMinHeight={true}>
-            <img src='playwright-logo.svg' alt='Playwright logo' />
-            <div className='section-title'>Playwright</div>
-            <ToolbarButton icon='refresh' title='Reload' onClick={() => reloadTests()} disabled={isRunningTest || isLoading}></ToolbarButton>
-            <ToolbarButton icon='terminal' title={'Toggle output — ' + (isMac ? '⌃`' : 'Ctrl + `')} toggled={isShowingOutput} onClick={() => { setIsShowingOutput(!isShowingOutput); }} />
-            {!hasBrowsers && <ToolbarButton icon='lightbulb-autofix' style={{ color: 'var(--vscode-list-warningForeground)' }} title='Playwright browsers are missing' onClick={openInstallDialog} />}
-          </Toolbar>
-          <FiltersView
-            filterText={filterText}
-            setFilterText={setFilterText}
-            statusFilters={statusFilters}
-            setStatusFilters={setStatusFilters}
-            projectFilters={projectFilters}
-            setProjectFilters={setProjectFilters}
-            testModel={testModel}
-            runTests={() => runTests('bounce-if-busy', visibleTestIds)} />
-          <Toolbar noMinHeight={true}>
-            {!isRunningTest && !progress && <div className='section-title'>Tests</div>}
-            {!isRunningTest && progress && <div data-testid='status-line' className='status-line'>
-              <div>{progress.passed}/{progress.total} passed ({(progress.passed / progress.total) * 100 | 0}%)</div>
-            </div>}
-            {isRunningTest && progress && <div data-testid='status-line' className='status-line'>
-              <div>Running {progress.passed}/{runningState.testIds.size} passed ({(progress.passed / runningState.testIds.size) * 100 | 0}%)</div>
-            </div>}
-            <ToolbarButton icon='play' title='Run all — F5' onClick={() => runTests('bounce-if-busy', visibleTestIds)} disabled={isRunningTest || isLoading}></ToolbarButton>
-            <ToolbarButton icon='debug-stop' title={'Stop — ' + (isMac ? '⇧F5' : 'Shift + F5')} onClick={() => testServerConnection?.stopTests({})} disabled={!isRunningTest || isLoading}></ToolbarButton>
-            <ToolbarButton icon='eye' title='Watch all' toggled={watchAll} onClick={() => {
-              setWatchedTreeIds({ value: new Set() });
-              setWatchAll(!watchAll);
-            }}></ToolbarButton>
-            <ToolbarButton icon='collapse-all' title='Collapse all' onClick={() => {
-              setCollapseAllCount(collapseAllCount + 1);
-            }} />
-          </Toolbar>
-          <TestListView
-            filterText={filterText}
-            testModel={testModel}
-            testTree={testTree}
-            testServerConnection={testServerConnection}
-            runningState={runningState}
-            runTests={runTests}
-            onItemSelected={setSelectedItem}
-            watchAll={watchAll}
-            watchedTreeIds={watchedTreeIds}
-            setWatchedTreeIds={setWatchedTreeIds}
-            isLoading={isLoading}
-            requestedCollapseAllCount={collapseAllCount}
-            setFilterText={setFilterText}
-            onRevealSource={onRevealSource}
+      sidebar={<div className='vbox ui-mode-sidebar'>
+        <Toolbar noShadow={true} noMinHeight={true}>
+          <img src='playwright-logo.svg' alt='Playwright logo' />
+          <div className='section-title'>Playwright</div>
+          <ToolbarButton icon='refresh' title='Reload' onClick={() => reloadTests()} disabled={isRunningTest || isLoading}></ToolbarButton>
+          <ToolbarButton icon='terminal' title={'Toggle output — ' + (isMac ? '⌃`' : 'Ctrl + `')} toggled={isShowingOutput} onClick={() => { setIsShowingOutput(!isShowingOutput); }} />
+          {!hasBrowsers && <ToolbarButton icon='lightbulb-autofix' style={{ color: 'var(--vscode-list-warningForeground)' }} title='Playwright browsers are missing' onClick={openInstallDialog} />}
+        </Toolbar>
+        <FiltersView
+          filterText={filterText}
+          setFilterText={setFilterText}
+          statusFilters={statusFilters}
+          setStatusFilters={setStatusFilters}
+          projectFilters={projectFilters}
+          setProjectFilters={setProjectFilters}
+          testModel={testModel}
+          runTests={() => runTests('bounce-if-busy', visibleTestIds)} />
+        <Toolbar noMinHeight={true}>
+          {!isRunningTest && !progress && <div className='section-title'>Tests</div>}
+          {!isRunningTest && progress && <div data-testid='status-line' className='status-line'>
+            <div>{progress.passed}/{progress.total} passed ({(progress.passed / progress.total) * 100 | 0}%)</div>
+          </div>}
+          {isRunningTest && progress && <div data-testid='status-line' className='status-line'>
+            <div>Running {progress.passed}/{runningState.testIds.size} passed ({(progress.passed / runningState.testIds.size) * 100 | 0}%)</div>
+          </div>}
+          <ToolbarButton icon='play' title='Run all — F5' onClick={() => runTests('bounce-if-busy', visibleTestIds)} disabled={isRunningTest || isLoading}></ToolbarButton>
+          <ToolbarButton icon='debug-stop' title={'Stop — ' + (isMac ? '⇧F5' : 'Shift + F5')} onClick={() => testServerConnection?.stopTests({})} disabled={!isRunningTest || isLoading}></ToolbarButton>
+          <ToolbarButton icon='eye' title='Watch all' toggled={watchAll} onClick={() => {
+            setWatchedTreeIds({ value: new Set() });
+            setWatchAll(!watchAll);
+          }}></ToolbarButton>
+          <ToolbarButton icon='collapse-all' title='Collapse all' onClick={() => {
+            setCollapseAllCount(collapseAllCount + 1);
+          }} />
+        </Toolbar>
+        <TestListView
+          filterText={filterText}
+          testModel={testModel}
+          testTree={testTree}
+          testServerConnection={testServerConnection}
+          runningState={runningState}
+          runTests={runTests}
+          onItemSelected={setSelectedItem}
+          watchAll={watchAll}
+          watchedTreeIds={watchedTreeIds}
+          setWatchedTreeIds={setWatchedTreeIds}
+          isLoading={isLoading}
+          requestedCollapseAllCount={collapseAllCount}
+          setFilterText={setFilterText}
+          onRevealSource={onRevealSource}
+        />
+        <Toolbar noShadow={true} noMinHeight={true} className='settings-toolbar' onClick={() => setTestingOptionsVisible(!testingOptionsVisible)}>
+          <span
+            className={`codicon codicon-${testingOptionsVisible ? 'chevron-down' : 'chevron-right'}`}
+            style={{ marginLeft: 5 }}
+            title={testingOptionsVisible ? 'Hide Testing Options' : 'Show Testing Options'}
           />
-          <Toolbar noShadow={true} noMinHeight={true} className='settings-toolbar' onClick={() => setTestingOptionsVisible(!testingOptionsVisible)}>
-            <span
-              className={`codicon codicon-${testingOptionsVisible ? 'chevron-down' : 'chevron-right'}`}
-              style={{ marginLeft: 5 }}
-              title={testingOptionsVisible ? 'Hide Testing Options' : 'Show Testing Options'}
-            />
-            <div className='section-title'>Testing Options</div>
-          </Toolbar>
-          {testingOptionsVisible && <SettingsView settings={[
-            singleWorkerSetting,
-            showBrowserSetting,
-            updateSnapshotsSetting,
-          ]} />}
-          <Toolbar noShadow={true} noMinHeight={true} className='settings-toolbar' onClick={() => setSettingsVisible(!settingsVisible)}>
-            <span
-              className={`codicon codicon-${settingsVisible ? 'chevron-down' : 'chevron-right'}`}
-              style={{ marginLeft: 5 }}
-              title={settingsVisible ? 'Hide Settings' : 'Show Settings'}
-            />
-            <div className='section-title'>Settings</div>
-          </Toolbar>
-          {settingsVisible && <SettingsView settings={[
-            darkModeSetting,
-            showRouteActionsSetting,
-          ]} />}
-        </div>
+          <div className='section-title'>Testing Options</div>
+        </Toolbar>
+        {testingOptionsVisible && <SettingsView settings={[
+          singleWorkerSetting,
+          showBrowserSetting,
+          updateSnapshotsSetting,
+        ]} />}
+        <Toolbar noShadow={true} noMinHeight={true} className='settings-toolbar' onClick={() => setSettingsVisible(!settingsVisible)}>
+          <span
+            className={`codicon codicon-${settingsVisible ? 'chevron-down' : 'chevron-right'}`}
+            style={{ marginLeft: 5 }}
+            title={settingsVisible ? 'Hide Settings' : 'Show Settings'}
+          />
+          <div className='section-title'>Settings</div>
+        </Toolbar>
+        {settingsVisible && <SettingsView settings={[
+          darkModeSetting,
+          showRouteActionsSetting,
+        ]} />}
+      </div>
       }
     />
   </div>;

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -433,7 +433,92 @@ export const UIModeView: React.FC<{}> = ({
       <div className='title'>UI Mode disconnected</div>
       <div><a href='#' onClick={() => window.location.href = '/'}>Reload the page</a> to reconnect</div>
     </div>}
-    <SplitView sidebarSize={250} minSidebarSize={150} orientation='horizontal' sidebarIsFirst={true} settingName='testListSidebar'>
+    <SplitView
+      sidebarSize={250}
+      minSidebarSize={150}
+      orientation='horizontal'
+      sidebarIsFirst={true}
+      settingName='testListSidebar'
+      sidebar={
+        <div className='vbox ui-mode-sidebar'>
+          <Toolbar noShadow={true} noMinHeight={true}>
+            <img src='playwright-logo.svg' alt='Playwright logo' />
+            <div className='section-title'>Playwright</div>
+            <ToolbarButton icon='refresh' title='Reload' onClick={() => reloadTests()} disabled={isRunningTest || isLoading}></ToolbarButton>
+            <ToolbarButton icon='terminal' title={'Toggle output — ' + (isMac ? '⌃`' : 'Ctrl + `')} toggled={isShowingOutput} onClick={() => { setIsShowingOutput(!isShowingOutput); }} />
+            {!hasBrowsers && <ToolbarButton icon='lightbulb-autofix' style={{ color: 'var(--vscode-list-warningForeground)' }} title='Playwright browsers are missing' onClick={openInstallDialog} />}
+          </Toolbar>
+          <FiltersView
+            filterText={filterText}
+            setFilterText={setFilterText}
+            statusFilters={statusFilters}
+            setStatusFilters={setStatusFilters}
+            projectFilters={projectFilters}
+            setProjectFilters={setProjectFilters}
+            testModel={testModel}
+            runTests={() => runTests('bounce-if-busy', visibleTestIds)} />
+          <Toolbar noMinHeight={true}>
+            {!isRunningTest && !progress && <div className='section-title'>Tests</div>}
+            {!isRunningTest && progress && <div data-testid='status-line' className='status-line'>
+              <div>{progress.passed}/{progress.total} passed ({(progress.passed / progress.total) * 100 | 0}%)</div>
+            </div>}
+            {isRunningTest && progress && <div data-testid='status-line' className='status-line'>
+              <div>Running {progress.passed}/{runningState.testIds.size} passed ({(progress.passed / runningState.testIds.size) * 100 | 0}%)</div>
+            </div>}
+            <ToolbarButton icon='play' title='Run all — F5' onClick={() => runTests('bounce-if-busy', visibleTestIds)} disabled={isRunningTest || isLoading}></ToolbarButton>
+            <ToolbarButton icon='debug-stop' title={'Stop — ' + (isMac ? '⇧F5' : 'Shift + F5')} onClick={() => testServerConnection?.stopTests({})} disabled={!isRunningTest || isLoading}></ToolbarButton>
+            <ToolbarButton icon='eye' title='Watch all' toggled={watchAll} onClick={() => {
+              setWatchedTreeIds({ value: new Set() });
+              setWatchAll(!watchAll);
+            }}></ToolbarButton>
+            <ToolbarButton icon='collapse-all' title='Collapse all' onClick={() => {
+              setCollapseAllCount(collapseAllCount + 1);
+            }} />
+          </Toolbar>
+          <TestListView
+            filterText={filterText}
+            testModel={testModel}
+            testTree={testTree}
+            testServerConnection={testServerConnection}
+            runningState={runningState}
+            runTests={runTests}
+            onItemSelected={setSelectedItem}
+            watchAll={watchAll}
+            watchedTreeIds={watchedTreeIds}
+            setWatchedTreeIds={setWatchedTreeIds}
+            isLoading={isLoading}
+            requestedCollapseAllCount={collapseAllCount}
+            setFilterText={setFilterText}
+            onRevealSource={onRevealSource}
+          />
+          <Toolbar noShadow={true} noMinHeight={true} className='settings-toolbar' onClick={() => setTestingOptionsVisible(!testingOptionsVisible)}>
+            <span
+              className={`codicon codicon-${testingOptionsVisible ? 'chevron-down' : 'chevron-right'}`}
+              style={{ marginLeft: 5 }}
+              title={testingOptionsVisible ? 'Hide Testing Options' : 'Show Testing Options'}
+            />
+            <div className='section-title'>Testing Options</div>
+          </Toolbar>
+          {testingOptionsVisible && <SettingsView settings={[
+            singleWorkerSetting,
+            showBrowserSetting,
+            updateSnapshotsSetting,
+          ]} />}
+          <Toolbar noShadow={true} noMinHeight={true} className='settings-toolbar' onClick={() => setSettingsVisible(!settingsVisible)}>
+            <span
+              className={`codicon codicon-${settingsVisible ? 'chevron-down' : 'chevron-right'}`}
+              style={{ marginLeft: 5 }}
+              title={settingsVisible ? 'Hide Settings' : 'Show Settings'}
+            />
+            <div className='section-title'>Settings</div>
+          </Toolbar>
+          {settingsVisible && <SettingsView settings={[
+            darkModeSetting,
+            showRouteActionsSetting,
+          ]} />}
+        </div>
+      }
+    >
       <div className='vbox'>
         <div className={'vbox' + (isShowingOutput ? '' : ' hidden')}>
           <Toolbar>
@@ -452,83 +537,6 @@ export const UIModeView: React.FC<{}> = ({
             onOpenExternally={location => testServerConnection?.openNoReply({ location: { file: location.file, line: location.line, column: location.column } })}
           />
         </div>
-      </div>
-      <div className='vbox ui-mode-sidebar'>
-        <Toolbar noShadow={true} noMinHeight={true}>
-          <img src='playwright-logo.svg' alt='Playwright logo' />
-          <div className='section-title'>Playwright</div>
-          <ToolbarButton icon='refresh' title='Reload' onClick={() => reloadTests()} disabled={isRunningTest || isLoading}></ToolbarButton>
-          <ToolbarButton icon='terminal' title={'Toggle output — ' + (isMac ? '⌃`' : 'Ctrl + `')} toggled={isShowingOutput} onClick={() => { setIsShowingOutput(!isShowingOutput); }} />
-          {!hasBrowsers && <ToolbarButton icon='lightbulb-autofix' style={{ color: 'var(--vscode-list-warningForeground)' }} title='Playwright browsers are missing' onClick={openInstallDialog} />}
-        </Toolbar>
-        <FiltersView
-          filterText={filterText}
-          setFilterText={setFilterText}
-          statusFilters={statusFilters}
-          setStatusFilters={setStatusFilters}
-          projectFilters={projectFilters}
-          setProjectFilters={setProjectFilters}
-          testModel={testModel}
-          runTests={() => runTests('bounce-if-busy', visibleTestIds)} />
-        <Toolbar noMinHeight={true}>
-          {!isRunningTest && !progress && <div className='section-title'>Tests</div>}
-          {!isRunningTest && progress && <div data-testid='status-line' className='status-line'>
-            <div>{progress.passed}/{progress.total} passed ({(progress.passed / progress.total) * 100 | 0}%)</div>
-          </div>}
-          {isRunningTest && progress && <div data-testid='status-line' className='status-line'>
-            <div>Running {progress.passed}/{runningState.testIds.size} passed ({(progress.passed / runningState.testIds.size) * 100 | 0}%)</div>
-          </div>}
-          <ToolbarButton icon='play' title='Run all — F5' onClick={() => runTests('bounce-if-busy', visibleTestIds)} disabled={isRunningTest || isLoading}></ToolbarButton>
-          <ToolbarButton icon='debug-stop' title={'Stop — ' + (isMac ? '⇧F5' : 'Shift + F5')} onClick={() => testServerConnection?.stopTests({})} disabled={!isRunningTest || isLoading}></ToolbarButton>
-          <ToolbarButton icon='eye' title='Watch all' toggled={watchAll} onClick={() => {
-            setWatchedTreeIds({ value: new Set() });
-            setWatchAll(!watchAll);
-          }}></ToolbarButton>
-          <ToolbarButton icon='collapse-all' title='Collapse all' onClick={() => {
-            setCollapseAllCount(collapseAllCount + 1);
-          }} />
-        </Toolbar>
-        <TestListView
-          filterText={filterText}
-          testModel={testModel}
-          testTree={testTree}
-          testServerConnection={testServerConnection}
-          runningState={runningState}
-          runTests={runTests}
-          onItemSelected={setSelectedItem}
-          watchAll={watchAll}
-          watchedTreeIds={watchedTreeIds}
-          setWatchedTreeIds={setWatchedTreeIds}
-          isLoading={isLoading}
-          requestedCollapseAllCount={collapseAllCount}
-          setFilterText={setFilterText}
-          onRevealSource={onRevealSource}
-        />
-        <Toolbar noShadow={true} noMinHeight={true} className='settings-toolbar' onClick={() => setTestingOptionsVisible(!testingOptionsVisible)}>
-          <span
-            className={`codicon codicon-${testingOptionsVisible ? 'chevron-down' : 'chevron-right'}`}
-            style={{ marginLeft: 5 }}
-            title={testingOptionsVisible ? 'Hide Testing Options' : 'Show Testing Options'}
-          />
-          <div className='section-title'>Testing Options</div>
-        </Toolbar>
-        {testingOptionsVisible && <SettingsView settings={[
-          singleWorkerSetting,
-          showBrowserSetting,
-          updateSnapshotsSetting,
-        ]} />}
-        <Toolbar noShadow={true} noMinHeight={true} className='settings-toolbar' onClick={() => setSettingsVisible(!settingsVisible)}>
-          <span
-            className={`codicon codicon-${settingsVisible ? 'chevron-down' : 'chevron-right'}`}
-            style={{ marginLeft: 5 }}
-            title={settingsVisible ? 'Hide Settings' : 'Show Settings'}
-          />
-          <div className='section-title'>Settings</div>
-        </Toolbar>
-        {settingsVisible && <SettingsView settings={[
-          darkModeSetting,
-          showRouteActionsSetting,
-        ]} />}
       </div>
     </SplitView>
   </div>;

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -439,6 +439,25 @@ export const UIModeView: React.FC<{}> = ({
       orientation='horizontal'
       sidebarIsFirst={true}
       settingName='testListSidebar'
+      main={<div className='vbox'>
+        <div className={'vbox' + (isShowingOutput ? '' : ' hidden')}>
+          <Toolbar>
+            <div className='section-title' style={{ flex: 'none' }}>Output</div>
+            <ToolbarButton icon='circle-slash' title='Clear output' onClick={() => xtermDataSource.clear()}></ToolbarButton>
+            <div className='spacer'></div>
+            <ToolbarButton icon='close' title='Close' onClick={() => setIsShowingOutput(false)}></ToolbarButton>
+          </Toolbar>
+          <XtermWrapper source={xtermDataSource}></XtermWrapper>
+        </div>
+        <div className={'vbox' + (isShowingOutput ? ' hidden' : '')}>
+          <TraceView
+            item={selectedItem}
+            rootDir={testModel?.config?.rootDir}
+            revealSource={revealSource}
+            onOpenExternally={location => testServerConnection?.openNoReply({ location: { file: location.file, line: location.line, column: location.column } })}
+          />
+        </div>
+      </div>}
       sidebar={
         <div className='vbox ui-mode-sidebar'>
           <Toolbar noShadow={true} noMinHeight={true}>
@@ -518,26 +537,6 @@ export const UIModeView: React.FC<{}> = ({
           ]} />}
         </div>
       }
-    >
-      <div className='vbox'>
-        <div className={'vbox' + (isShowingOutput ? '' : ' hidden')}>
-          <Toolbar>
-            <div className='section-title' style={{ flex: 'none' }}>Output</div>
-            <ToolbarButton icon='circle-slash' title='Clear output' onClick={() => xtermDataSource.clear()}></ToolbarButton>
-            <div className='spacer'></div>
-            <ToolbarButton icon='close' title='Close' onClick={() => setIsShowingOutput(false)}></ToolbarButton>
-          </Toolbar>
-          <XtermWrapper source={xtermDataSource}></XtermWrapper>
-        </div>
-        <div className={'vbox' + (isShowingOutput ? ' hidden' : '')}>
-          <TraceView
-            item={selectedItem}
-            rootDir={testModel?.config?.rootDir}
-            revealSource={revealSource}
-            onOpenExternally={location => testServerConnection?.openNoReply({ location: { file: location.file, line: location.line, column: location.column } })}
-          />
-        </div>
-      </div>
-    </SplitView>
+    />
   </div>;
 };

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -296,6 +296,28 @@ export const Workbench: React.FunctionComponent<{
     <SplitView
       sidebarSize={250}
       orientation={sidebarLocation === 'bottom' ? 'vertical' : 'horizontal'} settingName='propertiesSidebar'
+      main={<SplitView
+        sidebarSize={250}
+        orientation='horizontal'
+        sidebarIsFirst
+        settingName='actionListSidebar'
+        main={<SnapshotTab
+          action={activeAction}
+          sdkLanguage={sdkLanguage}
+          testIdAttributeName={model?.testIdAttributeName || 'data-testid'}
+          isInspecting={isInspecting}
+          setIsInspecting={setIsInspecting}
+          highlightedLocator={highlightedLocator}
+          setHighlightedLocator={locatorPicked}
+          openPage={openPage} />}
+        sidebar={
+          <TabbedPane
+            tabs={showSettings ? [actionsTab, metadataTab, settingsTab] : [actionsTab, metadataTab]}
+            selectedTab={selectedNavigatorTab}
+            setSelectedTab={setSelectedNavigatorTab}
+          />
+        }
+      />}
       sidebar={<TabbedPane
         tabs={tabs}
         selectedTab={selectedPropertiesTab}
@@ -311,30 +333,6 @@ export const Workbench: React.FunctionComponent<{
         ]}
         mode={sidebarLocation === 'bottom' ? 'default' : 'select'}
       />}
-    >
-      <SplitView
-        sidebarSize={250}
-        orientation='horizontal'
-        sidebarIsFirst={true}
-        settingName='actionListSidebar'
-        sidebar={
-          <TabbedPane
-            tabs={showSettings ? [actionsTab, metadataTab, settingsTab] : [actionsTab, metadataTab]}
-            selectedTab={selectedNavigatorTab}
-            setSelectedTab={setSelectedNavigatorTab}
-          />
-        }
-      >
-        <SnapshotTab
-          action={activeAction}
-          sdkLanguage={sdkLanguage}
-          testIdAttributeName={model?.testIdAttributeName || 'data-testid'}
-          isInspecting={isInspecting}
-          setIsInspecting={setIsInspecting}
-          highlightedLocator={highlightedLocator}
-          setHighlightedLocator={locatorPicked}
-          openPage={openPage} />
-      </SplitView>
-    </SplitView>
+    />
   </div>;
 };

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -293,24 +293,10 @@ export const Workbench: React.FunctionComponent<{
       selectedTime={selectedTime}
       setSelectedTime={setSelectedTime}
     />
-    <SplitView sidebarSize={250} orientation={sidebarLocation === 'bottom' ? 'vertical' : 'horizontal'} settingName='propertiesSidebar'>
-      <SplitView sidebarSize={250} orientation='horizontal' sidebarIsFirst={true} settingName='actionListSidebar'>
-        <SnapshotTab
-          action={activeAction}
-          sdkLanguage={sdkLanguage}
-          testIdAttributeName={model?.testIdAttributeName || 'data-testid'}
-          isInspecting={isInspecting}
-          setIsInspecting={setIsInspecting}
-          highlightedLocator={highlightedLocator}
-          setHighlightedLocator={locatorPicked}
-          openPage={openPage} />
-        <TabbedPane
-          tabs={showSettings ? [actionsTab, metadataTab, settingsTab] : [actionsTab, metadataTab]}
-          selectedTab={selectedNavigatorTab}
-          setSelectedTab={setSelectedNavigatorTab}
-        />
-      </SplitView>
-      <TabbedPane
+    <SplitView
+      sidebarSize={250}
+      orientation={sidebarLocation === 'bottom' ? 'vertical' : 'horizontal'} settingName='propertiesSidebar'
+      sidebar={<TabbedPane
         tabs={tabs}
         selectedTab={selectedPropertiesTab}
         setSelectedTab={selectPropertiesTab}
@@ -324,7 +310,31 @@ export const Workbench: React.FunctionComponent<{
             }} />
         ]}
         mode={sidebarLocation === 'bottom' ? 'default' : 'select'}
-      />
+      />}
+    >
+      <SplitView
+        sidebarSize={250}
+        orientation='horizontal'
+        sidebarIsFirst={true}
+        settingName='actionListSidebar'
+        sidebar={
+          <TabbedPane
+            tabs={showSettings ? [actionsTab, metadataTab, settingsTab] : [actionsTab, metadataTab]}
+            selectedTab={selectedNavigatorTab}
+            setSelectedTab={setSelectedNavigatorTab}
+          />
+        }
+      >
+        <SnapshotTab
+          action={activeAction}
+          sdkLanguage={sdkLanguage}
+          testIdAttributeName={model?.testIdAttributeName || 'data-testid'}
+          isInspecting={isInspecting}
+          setIsInspecting={setIsInspecting}
+          highlightedLocator={highlightedLocator}
+          setHighlightedLocator={locatorPicked}
+          openPage={openPage} />
+      </SplitView>
     </SplitView>
   </div>;
 };

--- a/packages/web/src/components/splitView.spec.tsx
+++ b/packages/web/src/components/splitView.spec.tsx
@@ -24,10 +24,9 @@ test('should render', async ({ mount }) => {
   const component = await mount(
       <SplitView
         sidebarSize={100}
+        main={<div id='main' style={{ border: '1px solid red', flex: 'auto' }}>main</div>}
         sidebar={<div id='sidebar' style={{ border: '1px solid blue', flex: 'auto' }}>sidebar</div>}
-      >
-        <div id='main' style={{ border: '1px solid red', flex: 'auto' }}>main</div>
-      </SplitView>);
+      />);
   const mainBox = await component.locator('#main').boundingBox();
   const sidebarBox = await component.locator('#sidebar').boundingBox();
   expect.soft(mainBox).toEqual({ x: 0, y: 0, width: 500, height: 400 });
@@ -38,11 +37,10 @@ test('should render sidebar first', async ({ mount }) => {
   const component = await mount(
       <SplitView
         sidebarSize={100}
-        sidebarIsFirst={true}
+        sidebarIsFirst
+        main={<div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>}
         sidebar={<div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>}
-      >
-        <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
-      </SplitView>);
+      />);
   const mainBox = await component.locator('#main').boundingBox();
   const sidebarBox = await component.locator('#sidebar').boundingBox();
   expect.soft(mainBox).toEqual({ x: 0, y: 100, width: 500, height: 400 });
@@ -53,12 +51,11 @@ test('should render horizontal split', async ({ mount }) => {
   const component = await mount(
       <SplitView
         sidebarSize={100}
-        sidebarIsFirst={true}
-        orientation={'horizontal'}
+        sidebarIsFirst
+        orientation='horizontal'
+        main={<div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>}
         sidebar={<div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>}
-      >
-        <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
-      </SplitView>);
+      />);
   const mainBox = await component.locator('#main').boundingBox();
   const sidebarBox = await component.locator('#sidebar').boundingBox();
   expect.soft(mainBox).toEqual({ x: 100, y: 0, width: 400, height: 500 });
@@ -70,11 +67,10 @@ test('should hide sidebar', async ({ mount }) => {
       <SplitView
         sidebarSize={100}
         orientation={'horizontal'}
-        sidebarHidden={true}
+        sidebarHidden
+        main={<div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>}
         sidebar={<div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>}
-      >
-        <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
-      </SplitView>);
+      />);
   const mainBox = await component.locator('#main').boundingBox();
   expect.soft(mainBox).toEqual({ x: 0, y: 0, width: 500, height: 500 });
 });
@@ -83,10 +79,9 @@ test('drag resize', async ({ page, mount }) => {
   const component = await mount(
       <SplitView
         sidebarSize={100}
+        main={<div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>}
         sidebar={<div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>}
-      >
-        <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
-      </SplitView>);
+      />);
   await page.mouse.move(25, 400);
   await page.mouse.down();
   await page.mouse.move(25, 100);

--- a/packages/web/src/components/splitView.spec.tsx
+++ b/packages/web/src/components/splitView.spec.tsx
@@ -21,10 +21,13 @@ import { SplitView } from './splitView';
 test.use({ viewport: { width: 500, height: 500 } });
 
 test('should render', async ({ mount }) => {
-  const component = await mount(<SplitView sidebarSize={100}>
-    <div id='main' style={{ border: '1px solid red', flex: 'auto' }}>main</div>
-    <div id='sidebar' style={{ border: '1px solid blue', flex: 'auto' }}>sidebar</div>
-  </SplitView>);
+  const component = await mount(
+      <SplitView
+        sidebarSize={100}
+        sidebar={<div id='sidebar' style={{ border: '1px solid blue', flex: 'auto' }}>sidebar</div>}
+      >
+        <div id='main' style={{ border: '1px solid red', flex: 'auto' }}>main</div>
+      </SplitView>);
   const mainBox = await component.locator('#main').boundingBox();
   const sidebarBox = await component.locator('#sidebar').boundingBox();
   expect.soft(mainBox).toEqual({ x: 0, y: 0, width: 500, height: 400 });
@@ -32,10 +35,14 @@ test('should render', async ({ mount }) => {
 });
 
 test('should render sidebar first', async ({ mount }) => {
-  const component = await mount(<SplitView sidebarSize={100} sidebarIsFirst={true}>
-    <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
-    <div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>
-  </SplitView>);
+  const component = await mount(
+      <SplitView
+        sidebarSize={100}
+        sidebarIsFirst={true}
+        sidebar={<div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>}
+      >
+        <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
+      </SplitView>);
   const mainBox = await component.locator('#main').boundingBox();
   const sidebarBox = await component.locator('#sidebar').boundingBox();
   expect.soft(mainBox).toEqual({ x: 0, y: 100, width: 500, height: 400 });
@@ -43,10 +50,15 @@ test('should render sidebar first', async ({ mount }) => {
 });
 
 test('should render horizontal split', async ({ mount }) => {
-  const component = await mount(<SplitView sidebarSize={100} sidebarIsFirst={true} orientation={'horizontal'}>
-    <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
-    <div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>
-  </SplitView>);
+  const component = await mount(
+      <SplitView
+        sidebarSize={100}
+        sidebarIsFirst={true}
+        orientation={'horizontal'}
+        sidebar={<div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>}
+      >
+        <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
+      </SplitView>);
   const mainBox = await component.locator('#main').boundingBox();
   const sidebarBox = await component.locator('#sidebar').boundingBox();
   expect.soft(mainBox).toEqual({ x: 100, y: 0, width: 400, height: 500 });
@@ -54,19 +66,27 @@ test('should render horizontal split', async ({ mount }) => {
 });
 
 test('should hide sidebar', async ({ mount }) => {
-  const component = await mount(<SplitView sidebarSize={100} orientation={'horizontal'} sidebarHidden={true}>
-    <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
-    <div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>
-  </SplitView>);
+  const component = await mount(
+      <SplitView
+        sidebarSize={100}
+        orientation={'horizontal'}
+        sidebarHidden={true}
+        sidebar={<div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>}
+      >
+        <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
+      </SplitView>);
   const mainBox = await component.locator('#main').boundingBox();
   expect.soft(mainBox).toEqual({ x: 0, y: 0, width: 500, height: 500 });
 });
 
 test('drag resize', async ({ page, mount }) => {
-  const component = await mount(<SplitView sidebarSize={100}>
-    <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
-    <div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>
-  </SplitView>);
+  const component = await mount(
+      <SplitView
+        sidebarSize={100}
+        sidebar={<div id='sidebar' style={{ border: '1px solid red', flex: 'auto' }}>sidebar</div>}
+      >
+        <div id='main' style={{ border: '1px solid blue', flex: 'auto' }}>main</div>
+      </SplitView>);
   await page.mouse.move(25, 400);
   await page.mouse.down();
   await page.mouse.move(25, 100);

--- a/packages/web/src/components/splitView.tsx
+++ b/packages/web/src/components/splitView.tsx
@@ -27,19 +27,20 @@ export type SplitViewProps = {
   settingName?: string;
 
   sidebar: React.ReactNode;
+  main: React.ReactNode;
 };
 
 const kMinSize = 50;
 
-export const SplitView: React.FC<React.PropsWithChildren<SplitViewProps>> = ({
+export const SplitView: React.FC<SplitViewProps> = ({
   sidebarSize,
   sidebarHidden = false,
   sidebarIsFirst = false,
   orientation = 'vertical',
   minSidebarSize = kMinSize,
   settingName,
-  children,
-  sidebar
+  sidebar,
+  main,
 }) => {
   const defaultSize = Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio;
   const hSetting = useSetting<number>((settingName ?? 'unused') + '.' + orientation + ':size', defaultSize);
@@ -78,7 +79,7 @@ export const SplitView: React.FC<React.PropsWithChildren<SplitViewProps>> = ({
   }
 
   return <div className={'split-view ' + orientation + (sidebarIsFirst ? ' sidebar-first' : '') } ref={ref}>
-    <div className='split-view-main'>{children}</div>
+    <div className='split-view-main'>{main}</div>
     { !sidebarHidden && <div style={{ flexBasis: size }} className='split-view-sidebar'>{sidebar}</div> }
     { !sidebarHidden && <div
       style={resizerStyle}

--- a/packages/web/src/components/splitView.tsx
+++ b/packages/web/src/components/splitView.tsx
@@ -25,6 +25,8 @@ export type SplitViewProps = {
   orientation?: 'vertical' | 'horizontal';
   minSidebarSize?: number;
   settingName?: string;
+
+  sidebar: React.ReactNode;
 };
 
 const kMinSize = 50;
@@ -36,7 +38,8 @@ export const SplitView: React.FC<React.PropsWithChildren<SplitViewProps>> = ({
   orientation = 'vertical',
   minSidebarSize = kMinSize,
   settingName,
-  children
+  children,
+  sidebar
 }) => {
   const defaultSize = Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio;
   const hSetting = useSetting<number>((settingName ?? 'unused') + '.' + orientation + ':size', defaultSize);
@@ -60,7 +63,6 @@ export const SplitView: React.FC<React.PropsWithChildren<SplitViewProps>> = ({
       size = measure.width - 10;
   }
 
-  const childrenArray = React.Children.toArray(children);
   document.body.style.userSelect = resizing ? 'none' : 'inherit';
   let resizerStyle: any = {};
   if (orientation === 'vertical') {
@@ -76,8 +78,8 @@ export const SplitView: React.FC<React.PropsWithChildren<SplitViewProps>> = ({
   }
 
   return <div className={'split-view ' + orientation + (sidebarIsFirst ? ' sidebar-first' : '') } ref={ref}>
-    <div className='split-view-main'>{childrenArray[0]}</div>
-    { !sidebarHidden && <div style={{ flexBasis: size }} className='split-view-sidebar'>{childrenArray[1]}</div> }
+    <div className='split-view-main'>{children}</div>
+    { !sidebarHidden && <div style={{ flexBasis: size }} className='split-view-sidebar'>{sidebar}</div> }
     { !sidebarHidden && <div
       style={resizerStyle}
       className='split-view-resizer'


### PR DESCRIPTION
Pulled out from https://github.com/microsoft/playwright/pull/31900

I stumbled over `React.Children`, because it's the first time I saw that used. https://react.dev/reference/react/Children lists `React.Children` it as "Legacy" and mentions it's uncommon. Also, the fact that SplitView only displays its first two children, and all others are silently discarded, can be a surprise to some.

By separating things out into `sidebar` and `main`, not only do we give the two elements names (otherwise one needs to remember that sidebar is always the first child), but we also prevent any "third children" from being dropped.