### PR TITLE
chore: make sure error stack includes message as before #31691

### DIFF
--- a/packages/playwright-core/src/server/isomorphic/utilityScriptSerializers.ts
+++ b/packages/playwright-core/src/server/isomorphic/utilityScriptSerializers.ts
@@ -170,8 +170,16 @@ export function source() {
     if (typeof value === 'bigint')
       return { bi: value.toString() };
 
-    if (isError(value))
-      return { e: { n: value.name, m: value.message, s: value.stack || '' } };
+    if (isError(value)) {
+      let stack;
+      if (value.stack?.startsWith(value.name + ': ' + value.message)) {
+        // v8
+        stack = value.stack;
+      } else {
+        stack = `${value.name}: ${value.message}\n${value.stack}`;
+      }
+      return { e: { n: value.name, m: value.message, s: stack } };
+    }
     if (isDate(value))
       return { d: value.toJSON() };
     if (isURL(value))


### PR DESCRIPTION
This brings stack formatting to how it was prior to https://github.com/microsoft/playwright/commit/1686e5174db39599a0adac7c2001d93a21f2a0aa so that the ports can use it.