### PR TITLE
refactor(test runner): send back `closeReason` from server

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -148,8 +148,8 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
         // Emulate all pages, contexts and the browser closing upon disconnect.
         for (const context of browser?.contexts() || []) {
           for (const page of context.pages())
-            page._onClose();
-          context._onClose();
+            page._onClose(reason);
+          context._onClose(reason);
         }
         connection.close(reason || closeError);
         // Give a chance to any API call promises to reject upon page/context closure.

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -608,7 +608,9 @@ scheme.BrowserInitializer = tObject({
   version: tString,
   name: tString,
 });
-scheme.BrowserCloseEvent = tOptional(tObject({}));
+scheme.BrowserCloseEvent = tObject({
+  reason: tOptional(tString),
+});
 scheme.BrowserCloseParams = tObject({
   reason: tOptional(tString),
 });

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -815,7 +815,9 @@ scheme.BrowserContextConsoleEvent = tObject({
   }),
   page: tChannel(['Page']),
 });
-scheme.BrowserContextCloseEvent = tOptional(tObject({}));
+scheme.BrowserContextCloseEvent = tObject({
+  reason: tOptional(tString),
+});
 scheme.BrowserContextDialogEvent = tObject({
   dialog: tChannel(['Dialog']),
 });
@@ -1045,7 +1047,9 @@ scheme.PageInitializer = tObject({
 scheme.PageBindingCallEvent = tObject({
   binding: tChannel(['BindingCall']),
 });
-scheme.PageCloseEvent = tOptional(tObject({}));
+scheme.PageCloseEvent = tObject({
+  reason: tOptional(tString),
+});
 scheme.PageCrashEvent = tOptional(tObject({}));
 scheme.PageDownloadEvent = tObject({
   url: tString,

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -155,7 +155,7 @@ export abstract class Browser extends SdkObject {
       context._browserClosed();
     if (this._defaultContext)
       this._defaultContext._browserClosed();
-    this.emit(Browser.Events.Disconnected);
+    this.emit(Browser.Events.Disconnected, { reason: this._closeReason });
     this.instrumentation.onBrowserClose(this);
   }
 

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -252,7 +252,7 @@ export abstract class BrowserContext extends SdkObject {
     if (this._isPersistentContext)
       this.onClosePersistent();
     this._closePromiseFulfill!(new Error('Context closed'));
-    this.emit(BrowserContext.Events.Close);
+    this.emit(BrowserContext.Events.Close, { reason: this._closeReason });
   }
 
   // BrowserContext methods.

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -82,8 +82,8 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     this.addObjectListener(BrowserContext.Events.Page, page => {
       this._dispatchEvent('page', { page: PageDispatcher.from(this, page) });
     });
-    this.addObjectListener(BrowserContext.Events.Close, () => {
-      this._dispatchEvent('close');
+    this.addObjectListener(BrowserContext.Events.Close, params => {
+      this._dispatchEvent('close', params);
       this._dispose();
     });
     this.addObjectListener(BrowserContext.Events.PageError, (error: Error, page: Page) => {

--- a/packages/playwright-core/src/server/dispatchers/browserDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserDispatcher.ts
@@ -34,11 +34,11 @@ export class BrowserDispatcher extends Dispatcher<Browser, channels.BrowserChann
 
   constructor(scope: BrowserTypeDispatcher, browser: Browser) {
     super(scope, browser, 'Browser', { version: browser.version(), name: browser.options.name });
-    this.addObjectListener(Browser.Events.Disconnected, () => this._didClose());
+    this.addObjectListener(Browser.Events.Disconnected, ({ reason }) => this._didClose(reason));
   }
 
-  _didClose() {
-    this._dispatchEvent('close');
+  _didClose(reason?: string) {
+    this._dispatchEvent('close', { reason });
     this._dispose();
   }
 

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -70,8 +70,8 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     this.adopt(mainFrame);
 
     this._page = page;
-    this.addObjectListener(Page.Events.Close, () => {
-      this._dispatchEvent('close');
+    this.addObjectListener(Page.Events.Close, params => {
+      this._dispatchEvent('close', params);
       this._dispose();
     });
     this.addObjectListener(Page.Events.Crash, () => this._dispatchEvent('crash'));

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -221,7 +221,7 @@ export class Page extends SdkObject {
     // in that case we fire another Close event to ensure that each reported Page will have
     // corresponding Close event after it is reported on the context.
     if (this.isClosed())
-      this.emit(Page.Events.Close);
+      this.emit(Page.Events.Close, { reason: this._closeReason });
     else
       this.instrumentation.onPageOpen(this);
   }
@@ -280,7 +280,7 @@ export class Page extends SdkObject {
     this._frameThrottler.dispose();
     assert(this._closedState !== 'closed', 'Page closed twice');
     this._closedState = 'closed';
-    this.emit(Page.Events.Close);
+    this.emit(Page.Events.Close, { reason: this._closeReason });
     this._closedPromise.resolve();
     this.instrumentation.onPageClose(this);
     this.openScope.close(new TargetClosedError());

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1545,7 +1545,9 @@ export type BrowserContextConsoleEvent = {
   },
   page: PageChannel,
 };
-export type BrowserContextCloseEvent = {};
+export type BrowserContextCloseEvent = {
+  reason?: string,
+};
 export type BrowserContextDialogEvent = {
   dialog: DialogChannel,
 };
@@ -1963,7 +1965,9 @@ export interface PageChannel extends PageEventTarget, EventTargetChannel {
 export type PageBindingCallEvent = {
   binding: BindingCallChannel,
 };
-export type PageCloseEvent = {};
+export type PageCloseEvent = {
+  reason?: string,
+};
 export type PageCrashEvent = {};
 export type PageDownloadEvent = {
   url: string,

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1131,7 +1131,9 @@ export interface BrowserChannel extends BrowserEventTarget, Channel {
   startTracing(params: BrowserStartTracingParams, metadata?: CallMetadata): Promise<BrowserStartTracingResult>;
   stopTracing(params?: BrowserStopTracingParams, metadata?: CallMetadata): Promise<BrowserStopTracingResult>;
 }
-export type BrowserCloseEvent = {};
+export type BrowserCloseEvent = {
+  reason?: string,
+};
 export type BrowserCloseParams = {
   reason?: string,
 };

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1285,6 +1285,8 @@ BrowserContext:
         page: Page
 
     close:
+      parameters:
+        reason: string?
 
     dialog:
       parameters:
@@ -1737,6 +1739,8 @@ Page:
         binding: BindingCall
 
     close:
+      parameters:
+        reason: string?
 
     crash:
 

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1009,6 +1009,8 @@ Browser:
   events:
 
     close:
+      parameters:
+        reason: string?
 
 ConsoleMessage:
   type: mixin

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -392,7 +392,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       expect(pageClosed).toBeTruthy();
     });
 
-    test('should terminate network waiters', async ({ connect, startRemoteServer, server }) => {
+    test('should terminate network waiters', async ({ connect, startRemoteServer, server, browserName }) => {
       const remoteServer = await startRemoteServer(kind);
       const browser = await connect(remoteServer.wsEndpoint());
       const newPage = await browser.newPage();
@@ -403,7 +403,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       ]);
       for (let i = 0; i < 2; i++) {
         const message = results[i].message;
-        expect(message).toContain(kTargetClosedErrorMessage);
+        expect(message).toContain(browserName === 'firefox' ? 'Browser closed' : kTargetClosedErrorMessage);
         expect(message).not.toContain('Timeout');
       }
     });

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -348,7 +348,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       ]);
       expect(browser.isConnected()).toBe(false);
       const error = await page.waitForNavigation().catch(e => e);
-      expect(error.message).toContain(kTargetClosedErrorMessage);
+      expect(error.message).toContain('page.waitForNavigation: Browser closed');
     });
 
     test('should reject navigation when browser closes', async ({ connect, startRemoteServer, server }) => {


### PR DESCRIPTION
Currently, when the server closes a BrowerContext/Page (e.g. because the page crashed), there's no way for the server to pass back a `_closeReason`. Because of that, server-originating closes will always show the fallback reason `'Target page, context or browser has been closed'`.

This PR makes the server send back the close reason as part of a new `reason` parameter on the `close` event, allowing both client- and server-originating closes to have a specific reason.