### PR TITLE
fix(ui): only populate settings once

### DIFF
--- a/packages/playwright-core/src/server/launchApp.ts
+++ b/packages/playwright-core/src/server/launchApp.ts
@@ -90,6 +90,8 @@ export async function syncLocalStorageWithSettings(page: Page, appName: string) 
         // iframes w/ snapshots, etc.
         if (location && location.protocol === 'data:')
           return;
+        if (window.top !== window)
+          return;
         Object.entries(settings).map(([k, v]) => localStorage[k] = v);
         (window as any).saveSettings = () => {
           (window as any)._saveSerializedSettings(JSON.stringify({ ...localStorage }));


### PR DESCRIPTION
We populate `localStorage` using an init script. Currently, this script isn't just run for the UI though, but also for all iframes. So we're resetting `localStorage` every time the UI loads an iframe.

This hasn't been a problem in the past, because the only consumer of `localStorage`, `Settings`, only read from `localStorage` once and kept most state in `useState` afterwards. With https://github.com/microsoft/playwright/pull/31911, this is no longer true, so the bug starts biting us!

The fix is to ensure the init script isn't run on iframes.