### PR TITLE
devops: retry download of upstream Node.js for drivers

### DIFF
--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   publish-canary:
     name: "publish canary NPM"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'microsoft/playwright'
     permissions:
       id-token: write  # This is required for OIDC login (azure/login) to succeed

--- a/.github/workflows/publish_release_driver.yml
+++ b/.github/workflows/publish_release_driver.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   publish-driver-release:
     name: "publish playwright driver to CDN"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'microsoft/playwright'
     permissions:
       id-token: write  # This is required for OIDC login (azure/login) to succeed

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -529,7 +529,7 @@ jobs:
 
   build-playwright-driver:
     name: "build-playwright-driver"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/utils/build/build-playwright-driver.sh
+++ b/utils/build/build-playwright-driver.sh
@@ -31,7 +31,7 @@ function build {
   mkdir -p ./output/playwright-${SUFFIX}
   tar -xzf ./output/playwright-core.tgz -C ./output/playwright-${SUFFIX}/
 
-  curl ${NODE_URL} -o ./output/${NODE_DIR}.${ARCHIVE}
+  curl --retry 10 --retry-all-errors ${NODE_URL} -o ./output/${NODE_DIR}.${ARCHIVE}
   NPM_PATH=""
   if [[ "${ARCHIVE}" == "zip" ]]; then
     cd ./output


### PR DESCRIPTION
Motivation: Driver publishing fails sometimes, see [here](https://github.com/microsoft/playwright/actions/runs/10198384446/job/28213175609#step:12:43).

[This flag](https://everything.curl.dev/usingcurl/downloads/retry.html#retry-on-any-and-all-errors) is only available in `ubuntu-24.04`. I thought about bumping the rest of the `publish*.yml` but I'd leave them for now until we have to?