### PR TITLE
cherry-pick(#31970): fix(trace): do not place expect into unfinished …

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -261,6 +261,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
           title: renderApiCall(apiName, params),
           apiName,
           params,
+          canNestByTime: true,
         });
         userData.userObject = step;
         out.stepId = step.stepId;

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -33,7 +33,7 @@ export interface TestStepInternal {
   complete(result: { error?: Error, attachments?: Attachment[] }): void;
   stepId: string;
   title: string;
-  category: 'hook' | 'fixture' | 'test.step' | 'expect' | string;
+  category: 'hook' | 'fixture' | 'test.step' | 'expect' | 'attach' | string;
   location?: Location;
   boxedStack?: StackFrame[];
   steps: TestStepInternal[];
@@ -44,6 +44,9 @@ export interface TestStepInternal {
   infectParentStepsWithError?: boolean;
   box?: boolean;
   isStage?: boolean;
+  // TODO: this сould be decided based on the category, but pw:api
+  // is from a different abstraction layer.
+  canNestByTime?: boolean;
 }
 
 export type TestStage = {
@@ -252,7 +255,7 @@ export class TestInfoImpl implements TestInfo {
       parentStep = this._findLastStageStep();
     } else {
       parentStep = zones.zoneData<TestStepInternal>('stepZone');
-      if (!parentStep && data.category !== 'test.step') {
+      if (!parentStep && data.canNestByTime) {
         // API steps (but not test.step calls) can be nested by time, instead of by stack.
         // However, do not nest chains of route.continue by checking the title.
         parentStep = this._findLastNonFinishedStep(step => step.title !== data.title);


### PR DESCRIPTION
…api calls based on time

Fixes https://github.com/microsoft/playwright/issues/31959