### PR TITLE
chore: remove bright counter from sidebar tab selector

### DIFF
--- a/packages/web/src/components/tabbedPane.tsx
+++ b/packages/web/src/components/tabbedPane.tsx
@@ -62,17 +62,8 @@ export const TabbedPane: React.FunctionComponent<{
             setSelectedTab(tabs[e.currentTarget.selectedIndex].id);
           }}>
             {tabs.map(tab => {
-              let suffix = '';
-              if (tab.count === 1)
-                suffix = ' 🔵';
-              else if (tab.count)
-                suffix = ` 🔵✖️${tab.count}`;
-              if (tab.errorCount === 1)
-                suffix = ` 🔴`;
-              else if (tab.errorCount)
-                suffix = ` 🔴✖️${tab.errorCount}`;
-              return <option value={tab.id} selected={tab.id === selectedTab}>{tab.title}{suffix}</option>;
-            })}
+              return <option value={tab.id} selected={tab.id === selectedTab}>{tab.title}</option>;
+          })}
           </select>
         </div>}
         {rightToolbar && <div style={{ flex: 'none', display: 'flex', alignItems: 'center' }}>

--- a/packages/web/src/components/tabbedPane.tsx
+++ b/packages/web/src/components/tabbedPane.tsx
@@ -62,8 +62,13 @@ export const TabbedPane: React.FunctionComponent<{
             setSelectedTab(tabs[e.currentTarget.selectedIndex].id);
           }}>
             {tabs.map(tab => {
-              return <option value={tab.id} selected={tab.id === selectedTab}>{tab.title}</option>;
-          })}
+              let suffix = '';
+              if (tab.count)
+                suffix = ` (${tab.count})`;
+              if (tab.errorCount)
+                suffix = ` (${tab.errorCount})`;
+              return <option value={tab.id} selected={tab.id === selectedTab}>{tab.title}{suffix}</option>;
+            })}
           </select>
         </div>}
         {rightToolbar && <div style={{ flex: 'none', display: 'flex', alignItems: 'center' }}>


### PR DESCRIPTION
Removing the following icon:
![image](https://github.com/user-attachments/assets/d2de2ed0-f66e-4452-8763-aad1b6e7bb79)

HTML `options` element cannot be styled, so just removing the counter in sidebar mode:

<img width="348" alt="image" src="https://github.com/user-attachments/assets/d636dca2-5007-41f7-866e-3a0f604d46fc">
