### PR TITLE
chore(trace-viewer): hide status code field for failed request

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -78,10 +78,10 @@ const RequestTab: React.FunctionComponent<{
     <div className='network-request-details-header'>General</div>
     <div className='network-request-details-url'>{`URL: ${resource.request.url}`}</div>
     <div className='network-request-details-general'>{`Method: ${resource.request.method}`}</div>
-    <div className='network-request-details-general' style={{ display: 'flex' }}>
+    {resource.response.status !== -1 && <div className='network-request-details-general' style={{ display: 'flex' }}>
       Status Code: <span className={statusClass(resource.response.status)} style={{ display: 'inline-flex' }}>
         {`${resource.response.status} ${resource.response.statusText}`}
-      </span></div>
+      </span></div>}
     <div className='network-request-details-header'>Request Headers</div>
     <div className='network-request-details-headers'>{resource.request.headers.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
     {requestBody && <div className='network-request-details-header'>Request Body</div>}
@@ -118,6 +118,8 @@ const BodyTab: React.FunctionComponent<{
           const formattedBody = formatBody(await response.text(), resource.response.content.mimeType);
           setResponseBody({ text: formattedBody, mimeType: resource.response.content.mimeType });
         }
+      } else {
+        setResponseBody(null);
       }
     };
 

--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -93,7 +93,7 @@ export const NetworkTab: React.FunctionComponent<{
     columnTitle={columnTitle}
     columnWidths={columnWidths}
     setColumnWidths={setColumnWidths}
-    isError={item => item.status.code >= 400}
+    isError={item => item.status.code >= 400 || item.status.code === -1}
     isInfo={item => !!item.route}
     render={(item, column) => renderCell(item, column)}
     sorting={sorting}


### PR DESCRIPTION
* Hide 'Status Code:' field for interrupted requests that don't have it.
* Clear up previously selected body when showing aborted requests.
* Highlight interrupted requests in red.