### PR TITLE
chore: prefer executablePath for page.pause()

### DIFF
--- a/packages/playwright-core/src/server/launchApp.ts
+++ b/packages/playwright-core/src/server/launchApp.ts
@@ -43,7 +43,7 @@ export async function launchApp(browserType: BrowserType, options: {
   }
 
   const context = await browserType.launchPersistentContext(serverSideCallMetadata(), '', {
-    channel: findChromiumChannel(options.sdkLanguage),
+    channel: !options.persistentContextOptions?.executablePath ? findChromiumChannel(options.sdkLanguage) : undefined,
     noDefaultViewport: true,
     ignoreDefaultArgs: ['--enable-automation'],
     colorScheme: 'no-override',

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -127,6 +127,7 @@ export class RecorderApp extends EventEmitter implements IRecorderApp {
         useWebSocket: !!process.env.PWTEST_RECORDER_PORT,
         handleSIGINT,
         args: process.env.PWTEST_RECORDER_PORT ? [`--remote-debugging-port=${process.env.PWTEST_RECORDER_PORT}`] : [],
+        executablePath: inspectedContext._browser.options.isChromium ? inspectedContext._browser.options.customExecutablePath : undefined,
       }
     });
     const controller = new ProgressController(serverSideCallMetadata(), context._browser);


### PR DESCRIPTION
Motivation: For scenarios where [`findChromiumChannel`](https://github.com/microsoft/playwright/blob/f17de8222fe48e4627983d4f2386deabb00bded2/packages/playwright-core/src/server/registry/index.ts#L1016) throws (no branded browser and no normal browser is installed) we were [silently catching](https://github.com/microsoft/playwright/blob/f17de8222fe48e4627983d4f2386deabb00bded2/packages/playwright-core/src/server/recorder.ts#L79) when calling `page.pause()`.

This patch does not invoke `findChromiumChannel` when the inspectedContext is Chromium based and has an `executablePath` specified.

Note this was already fixed by #6214, but regressed since then.

Fixes https://github.com/microsoft/playwright/issues/31967