### PR TITLE
test: fix failing client-certificate tests

### DIFF
--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -187,7 +187,7 @@ test.describe('fetch', () => {
   });
 
   test('should throw a http error if the pfx passphrase is incorect', async ({ playwright, startCCServer, asset, browserName }) => {
-    const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && process.platform === 'darwin' });
+    const serverURL = await startCCServer();
     const request = await playwright.request.newContext({
       ignoreHTTPSErrors: true,
       clientCertificates: [{
@@ -201,7 +201,7 @@ test.describe('fetch', () => {
   });
 
   test('should fail with matching certificates in legacy pfx format', async ({ playwright, startCCServer, asset, browserName }) => {
-    const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && process.platform === 'darwin' });
+    const serverURL = await startCCServer();
     const request = await playwright.request.newContext({
       ignoreHTTPSErrors: true,
       clientCertificates: [{


### PR DESCRIPTION
We don't need the `local.playwright` path translation for `APIRequestContext`. This fixes the tests introduced in https://github.com/microsoft/playwright/pull/32008.