### PR TITLE
chore(ui): abstract useSetting/state combo into own hook

### DIFF
--- a/packages/web/src/components/splitView.tsx
+++ b/packages/web/src/components/splitView.tsx
@@ -43,8 +43,8 @@ export const SplitView: React.FC<SplitViewProps> = ({
   main,
 }) => {
   const defaultSize = Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio;
-  const [hSize, setHSize] = useSettingOrState(settingName + '.' + orientation + ':size', defaultSize, !!settingName);
-  const [vSize, setVSize] = useSettingOrState(settingName + '.' + orientation + ':size', defaultSize, !!settingName);
+  const [hSize, setHSize] = useSettingOrState(settingName ? `${settingName}.horizontal:size` : undefined, defaultSize);
+  const [vSize, setVSize] = useSettingOrState(settingName ? `${settingName}.vertical:size` : undefined, defaultSize);
 
   const [resizing, setResizing] = React.useState<{ offset: number, size: number } | null>(null);
   const [measure, ref] = useMeasure<HTMLDivElement>();

--- a/packages/web/src/components/splitView.tsx
+++ b/packages/web/src/components/splitView.tsx
@@ -43,8 +43,8 @@ export const SplitView: React.FC<SplitViewProps> = ({
   main,
 }) => {
   const defaultSize = Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio;
-  const [hSize, setHSize] = useSettingOrState(settingName ? `${settingName}.horizontal:size` : undefined, defaultSize);
-  const [vSize, setVSize] = useSettingOrState(settingName ? `${settingName}.vertical:size` : undefined, defaultSize);
+  const [hSize, setHSize] = useSettingOrState(settingName ? `${settingName}.${orientation}:size` : undefined, defaultSize);
+  const [vSize, setVSize] = useSettingOrState(settingName ? `${settingName}.${orientation}:size` : undefined, defaultSize);
 
   const [resizing, setResizing] = React.useState<{ offset: number, size: number } | null>(null);
   const [measure, ref] = useMeasure<HTMLDivElement>();

--- a/packages/web/src/components/splitView.tsx
+++ b/packages/web/src/components/splitView.tsx
@@ -43,8 +43,8 @@ export const SplitView: React.FC<SplitViewProps> = ({
   main,
 }) => {
   const defaultSize = Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio;
-  const [hSize, setHSize] = useSettingOrState(settingName + '.' + orientation + ':size', defaultSize, undefined, !!settingName);
-  const [vSize, setVSize] = useSettingOrState(settingName + '.' + orientation + ':size', defaultSize, undefined, !!settingName);
+  const [hSize, setHSize] = useSettingOrState(settingName + '.' + orientation + ':size', defaultSize, !!settingName);
+  const [vSize, setVSize] = useSettingOrState(settingName + '.' + orientation + ':size', defaultSize, !!settingName);
 
   const [resizing, setResizing] = React.useState<{ offset: number, size: number } | null>(null);
   const [measure, ref] = useMeasure<HTMLDivElement>();

--- a/packages/web/src/components/splitView.tsx
+++ b/packages/web/src/components/splitView.tsx
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import { clsx, useMeasure, useSetting } from '../uiUtils';
+import { clsx, useMeasure, useSettingOrState } from '../uiUtils';
 import './splitView.css';
 import * as React from 'react';
 
@@ -43,12 +43,8 @@ export const SplitView: React.FC<SplitViewProps> = ({
   main,
 }) => {
   const defaultSize = Math.max(minSidebarSize, sidebarSize) * window.devicePixelRatio;
-  const hSetting = useSetting<number>((settingName ?? 'unused') + '.' + orientation + ':size', defaultSize);
-  const vSetting = useSetting<number>((settingName ?? 'unused') + '.' + orientation + ':size', defaultSize);
-  const hState = React.useState(defaultSize);
-  const vState = React.useState(defaultSize);
-  const [hSize, setHSize] = settingName ? hSetting : hState;
-  const [vSize, setVSize] = settingName ? vSetting : vState;
+  const [hSize, setHSize] = useSettingOrState(settingName + '.' + orientation + ':size', defaultSize, undefined, !!settingName);
+  const [vSize, setVSize] = useSettingOrState(settingName + '.' + orientation + ':size', defaultSize, undefined, !!settingName);
 
   const [resizing, setResizing] = React.useState<{ offset: number, size: number } | null>(null);
   const [measure, ref] = useMeasure<HTMLDivElement>();

--- a/packages/web/src/uiUtils.ts
+++ b/packages/web/src/uiUtils.ts
@@ -157,6 +157,12 @@ export function useSetting<S>(name: string, defaultValue: S, title?: string): [S
   return [value, setValueWrapper, setting];
 }
 
+export function useSettingOrState<S>(name: string | undefined, defaultValue: S, title?: string, persist?: boolean): [S, (v: S) => void, Setting<S>] {
+  const setting = useSetting(name ?? 'unused', defaultValue, title);
+  const state = React.useState(defaultValue);
+  return persist ? setting : [...state, [...state, title ?? '']];
+}
+
 export class Settings {
   onChangeEmitter = new EventTarget();
 

--- a/packages/web/src/uiUtils.ts
+++ b/packages/web/src/uiUtils.ts
@@ -157,10 +157,10 @@ export function useSetting<S>(name: string, defaultValue: S, title?: string): [S
   return [value, setValueWrapper, setting];
 }
 
-export function useSettingOrState<S>(name: string | undefined, defaultValue: S, persist?: boolean): [S, (v: S) => void] {
+export function useSettingOrState<S>(name: string | undefined, defaultValue: S): [S, (v: S) => void] {
   const [settingValue, settingSet] = useSetting(name ?? 'unused', defaultValue);
   const state = React.useState(defaultValue);
-  return persist ? [settingValue, settingSet] : state;
+  return name ? [settingValue, settingSet] : state;
 }
 
 export class Settings {

--- a/packages/web/src/uiUtils.ts
+++ b/packages/web/src/uiUtils.ts
@@ -157,10 +157,10 @@ export function useSetting<S>(name: string, defaultValue: S, title?: string): [S
   return [value, setValueWrapper, setting];
 }
 
-export function useSettingOrState<S>(name: string | undefined, defaultValue: S, title?: string, persist?: boolean): [S, (v: S) => void, Setting<S>] {
-  const setting = useSetting(name ?? 'unused', defaultValue, title);
+export function useSettingOrState<S>(name: string | undefined, defaultValue: S, persist?: boolean): [S, (v: S) => void] {
+  const [settingValue, settingSet] = useSetting(name ?? 'unused', defaultValue);
   const state = React.useState(defaultValue);
-  return persist ? setting : [...state, [...state, title ?? '']];
+  return persist ? [settingValue, settingSet] : state;
 }
 
 export class Settings {


### PR DESCRIPTION
As discussed in the sync yesterday, here's a PR to abstract the useSetting/useState combo in `SplitView` into its own custom hook, moving the complexity from the callsite into the lib side of things.