### PR TITLE
chore: use a single binding for all Playwright needs

### DIFF
--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -21,7 +21,7 @@ import { Browser } from '../browser';
 import { assertBrowserContextIsNotOwned, BrowserContext, verifyGeolocation } from '../browserContext';
 import { assert, createGuid } from '../../utils';
 import * as network from '../network';
-import type { InitScript, PageBinding, PageDelegate, Worker } from '../page';
+import type { InitScript, PageDelegate, Worker } from '../page';
 import { Page } from '../page';
 import { Frame } from '../frames';
 import type { Dialog } from '../dialog';
@@ -491,19 +491,9 @@ export class CRBrowserContext extends BrowserContext {
       await (page._delegate as CRPage).addInitScript(initScript);
   }
 
-  async doRemoveInitScripts() {
+  async doRemoveNonInternalInitScripts() {
     for (const page of this.pages())
-      await (page._delegate as CRPage).removeInitScripts();
-  }
-
-  async doExposeBinding(binding: PageBinding) {
-    for (const page of this.pages())
-      await (page._delegate as CRPage).exposeBinding(binding);
-  }
-
-  async doRemoveExposedBindings() {
-    for (const page of this.pages())
-      await (page._delegate as CRPage).removeExposedBindings();
+      await (page._delegate as CRPage).removeNonInternalInitScripts();
   }
 
   async doUpdateRequestInterception(): Promise<void> {

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -20,7 +20,7 @@ import * as dom from '../dom';
 import type * as frames from '../frames';
 import type { RegisteredListener } from '../../utils/eventsHelper';
 import { eventsHelper } from '../../utils/eventsHelper';
-import type { PageBinding, PageDelegate } from '../page';
+import type { PageDelegate } from '../page';
 import { InitScript } from '../page';
 import { Page, Worker } from '../page';
 import type * as types from '../types';
@@ -114,7 +114,7 @@ export class FFPage implements PageDelegate {
     });
     // Ideally, we somehow ensure that utility world is created before Page.ready arrives, but currently it is racy.
     // Therefore, we can end up with an initialized page without utility world, although very unlikely.
-    this.addInitScript(new InitScript(''), UTILITY_WORLD_NAME).catch(e => this._markAsError(e));
+    this.addInitScript(new InitScript('', true), UTILITY_WORLD_NAME).catch(e => this._markAsError(e));
   }
 
   potentiallyUninitializedPage(): Page {
@@ -336,14 +336,6 @@ export class FFPage implements PageDelegate {
     this._browserContext._browser._videoStarted(this._browserContext, event.screencastId, event.file, this.pageOrError());
   }
 
-  async exposeBinding(binding: PageBinding) {
-    await this._session.send('Page.addBinding', { name: binding.name, script: binding.source });
-  }
-
-  async removeExposedBindings() {
-    // TODO: implement me.
-  }
-
   didClose() {
     this._markAsError(new TargetClosedError());
     this._session.dispose();
@@ -412,9 +404,9 @@ export class FFPage implements PageDelegate {
     await this._session.send('Page.setInitScripts', { scripts: this._initScripts.map(s => ({ script: s.initScript.source, worldName: s.worldName })) });
   }
 
-  async removeInitScripts() {
-    this._initScripts = [];
-    await this._session.send('Page.setInitScripts', { scripts: [] });
+  async removeNonInternalInitScripts() {
+    this._initScripts = this._initScripts.filter(s => s.initScript.internal);
+    await this._session.send('Page.setInitScripts', { scripts: this._initScripts.map(s => ({ script: s.initScript.source, worldName: s.worldName })) });
   }
 
   async closePage(runBeforeUnload: boolean): Promise<void> {

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -22,7 +22,7 @@ import type { RegisteredListener } from '../../utils/eventsHelper';
 import { assert } from '../../utils';
 import { eventsHelper } from '../../utils/eventsHelper';
 import * as network from '../network';
-import type { InitScript, Page, PageBinding, PageDelegate } from '../page';
+import type { InitScript, Page, PageDelegate } from '../page';
 import type { ConnectionTransport } from '../transport';
 import type * as types from '../types';
 import type * as channels from '@protocol/channels';
@@ -320,19 +320,9 @@ export class WKBrowserContext extends BrowserContext {
       await (page._delegate as WKPage)._updateBootstrapScript();
   }
 
-  async doRemoveInitScripts() {
+  async doRemoveNonInternalInitScripts() {
     for (const page of this.pages())
       await (page._delegate as WKPage)._updateBootstrapScript();
-  }
-
-  async doExposeBinding(binding: PageBinding) {
-    for (const page of this.pages())
-      await (page._delegate as WKPage).exposeBinding(binding);
-  }
-
-  async doRemoveExposedBindings() {
-    for (const page of this.pages())
-      await (page._delegate as WKPage).removeExposedBindings();
   }
 
   async doUpdateRequestInterception(): Promise<void> {

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -30,7 +30,7 @@ import { eventsHelper } from '../../utils/eventsHelper';
 import { helper } from '../helper';
 import type { JSHandle } from '../javascript';
 import * as network from '../network';
-import type { InitScript, PageBinding, PageDelegate } from '../page';
+import { type InitScript, PageBinding, type PageDelegate } from '../page';
 import { Page } from '../page';
 import type { Progress } from '../progress';
 import type * as types from '../types';
@@ -179,6 +179,7 @@ export class WKPage implements PageDelegate {
     const promises: Promise<any>[] = [
       // Resource tree should be received before first execution context.
       session.send('Runtime.enable'),
+      session.send('Runtime.addBinding', { name: PageBinding.kPlaywrightBinding }),
       session.send('Page.createUserWorld', { name: UTILITY_WORLD_NAME }).catch(_ => {}),  // Worlds are per-process
       session.send('Console.enable'),
       session.send('Network.enable'),
@@ -200,8 +201,6 @@ export class WKPage implements PageDelegate {
     const emulatedMedia = this._page.emulatedMedia();
     if (emulatedMedia.media || emulatedMedia.colorScheme || emulatedMedia.reducedMotion || emulatedMedia.forcedColors)
       promises.push(WKPage._setEmulateMedia(session, emulatedMedia.media, emulatedMedia.colorScheme, emulatedMedia.reducedMotion, emulatedMedia.forcedColors));
-    for (const binding of this._page.allBindings())
-      promises.push(session.send('Runtime.addBinding', { name: binding.name }));
     const bootstrapScript = this._calculateBootstrapScript();
     if (bootstrapScript.length)
       promises.push(session.send('Page.setBootstrapScript', { source: bootstrapScript }));
@@ -768,21 +767,11 @@ export class WKPage implements PageDelegate {
     });
   }
 
-  async exposeBinding(binding: PageBinding): Promise<void> {
-    this._session.send('Runtime.addBinding', { name: binding.name });
-    await this._updateBootstrapScript();
-    await Promise.all(this._page.frames().map(frame => frame.evaluateExpression(binding.source).catch(e => {})));
-  }
-
-  async removeExposedBindings(): Promise<void> {
-    await this._updateBootstrapScript();
-  }
-
   async addInitScript(initScript: InitScript): Promise<void> {
     await this._updateBootstrapScript();
   }
 
-  async removeInitScripts() {
+  async removeNonInternalInitScripts() {
     await this._updateBootstrapScript();
   }
 
@@ -795,11 +784,7 @@ export class WKPage implements PageDelegate {
     }
     scripts.push('if (!window.safari) window.safari = { pushNotification: { toString() { return "[object SafariRemoteNotification]"; } } };');
     scripts.push('if (!window.GestureEvent) window.GestureEvent = function GestureEvent() {};');
-
-    for (const binding of this._page.allBindings())
-      scripts.push(binding.source);
-    scripts.push(...this._browserContext.initScripts.map(s => s.source));
-    scripts.push(...this._page.initScripts.map(s => s.source));
+    scripts.push(...this._page.allInitScripts().map(script => script.source));
     return scripts.join(';\n');
   }
 

--- a/tests/assets/cached/bfcached.html
+++ b/tests/assets/cached/bfcached.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel='stylesheet' href='./one-style.css'>
+<div>BFCached</div>
+<script>
+  window.didShow = new Promise(f => window.addEventListener('pageshow', event => {
+    console.log(event);
+    window._persisted = !!event.persisted;
+    window._event = event;
+    f({ persisted: !!event.persisted });
+  }));
+</script>

--- a/tests/library/chromium/bfcache.spec.ts
+++ b/tests/library/chromium/bfcache.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { contextTest as test, expect } from '../../config/browserTest';
+
+test.use({
+  launchOptions: async ({ launchOptions }, use) => {
+    await use({ ...launchOptions, ignoreDefaultArgs: ['--disable-back-forward-cache'] });
+  }
+});
+
+test('bindings should work after restoring from bfcache', async ({ page, server }) => {
+  await page.exposeFunction('add', (a, b) => a + b);
+
+  await page.goto(server.PREFIX + '/cached/bfcached.html');
+  expect(await page.evaluate('window.add(1, 2)')).toBe(3);
+
+  await page.setContent(`<a href='about:blank'}>click me</a>`);
+  await page.click('a');
+
+  await page.goBack({ waitUntil: 'commit' });
+  await page.evaluate('window.didShow');
+  expect(await page.evaluate('window.add(2, 3)')).toBe(5);
+});

--- a/tests/page/page-history.spec.ts
+++ b/tests/page/page-history.spec.ts
@@ -92,15 +92,17 @@ it('page.goBack should work for file urls', async ({ page, server, asset, browse
 });
 
 it('goBack/goForward should work with bfcache-able pages', async ({ page, server }) => {
-  await page.goto(server.PREFIX + '/cached/one-style.html');
-  await page.setContent(`<a href=${JSON.stringify(server.PREFIX + '/cached/one-style.html?foo')}>click me</a>`);
+  await page.goto(server.PREFIX + '/cached/bfcached.html');
+  await page.setContent(`<a href=${JSON.stringify(server.PREFIX + '/cached/bfcached.html?foo')}>click me</a>`);
   await page.click('a');
 
   let response = await page.goBack();
-  expect(response.url()).toBe(server.PREFIX + '/cached/one-style.html');
+  expect(response.url()).toBe(server.PREFIX + '/cached/bfcached.html');
+  // BFCache should be disabled.
+  expect(await page.evaluate('window.didShow')).toEqual({ persisted: false });
 
   response = await page.goForward();
-  expect(response.url()).toBe(server.PREFIX + '/cached/one-style.html?foo');
+  expect(response.url()).toBe(server.PREFIX + '/cached/bfcached.html?foo');
 });
 
 it('page.reload should work', async ({ page, server }) => {


### PR DESCRIPTION
This makes it easier to manage bindings, being just init scripts.
Fixes the BFCache binding problem.
Makes bindings removable in Firefox.

Fixes #31515.