### PR TITLE
fix: ubuntu version detection for linux mint 22

### DIFF
--- a/packages/playwright-core/src/utils/hostPlatform.ts
+++ b/packages/playwright-core/src/utils/hostPlatform.ts
@@ -78,9 +78,12 @@ function calculatePlatform(): { hostPlatform: HostPlatform, isOfficiallySupporte
     }
     // Linux Mint is ubuntu-based but does not have the same versions
     if (distroInfo?.id === 'linuxmint') {
-      if (parseInt(distroInfo.version, 10) <= 20)
+      const mintMajor = parseInt(distroInfo.version, 10);
+      if (mintMajor <= 20)
         return { hostPlatform: ('ubuntu20.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
-      return { hostPlatform: ('ubuntu22.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
+      if (mintMajor === 21)
+        return { hostPlatform: ('ubuntu22.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
+      return { hostPlatform: ('ubuntu24.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
     }
     if (distroInfo?.id === 'debian' || distroInfo?.id === 'raspbian') {
       const isOfficiallySupportedPlatform = distroInfo?.id === 'debian';


### PR DESCRIPTION
Add Linux Mint 22 (Ubuntu based distro) version detection for dependency installation
Linux Mint 22.x -> Ubuntu 24.04

(also see original Linux Mint support PR #28085)
