### PR TITLE
fix(ui): reset higlighted action on keyboard navigation

### DIFF
--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -113,8 +113,9 @@ export const Workbench: React.FunctionComponent<{
 
   const onActionSelected = React.useCallback((action: modelUtil.ActionTraceEventInContext) => {
     setSelectedAction(action);
+    setHighlightedAction(undefined);
     onSelectionChanged?.(action);
-  }, [setSelectedAction, onSelectionChanged]);
+  }, [setSelectedAction, onSelectionChanged, setHighlightedAction]);
 
   const selectPropertiesTab = React.useCallback((tab: string) => {
     setSelectedPropertiesTab(tab);

--- a/packages/web/src/components/listView.tsx
+++ b/packages/web/src/components/listView.tsx
@@ -128,6 +128,7 @@ export function ListView<T>({
         scrollIntoViewIfNeeded(element || undefined);
         onHighlighted?.(undefined);
         onSelected?.(items[newIndex], newIndex);
+        setHighlightedItem(undefined);
       }}
       ref={itemListRef}
     >


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32050

When keyboarding through the action view, the UI continues showing the hovered action. This makes keyboard nav hard to use.

The fix is to reset the higlighted action on keyboard navigation. This is what we do when the mouse pointer leaves an action, and what I think is reasonable.