### PR TITLE
fix(test runner): align with typescript behaviour for resolving `index.js` and `package.json` through path mapping

### DIFF
--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -249,7 +249,7 @@ function vitePlugin(registerSource: string, templateDir: string, buildInfo: Buil
 
     async writeBundle(this: PluginContext) {
       for (const importInfo of importInfos.values()) {
-        const importPath = resolveHook(importInfo.filename, importInfo.importSource);
+        const importPath = resolveHook(importInfo.filename, importInfo.importSource, true);
         if (!importPath)
           continue;
         const deps = new Set<string>();

--- a/packages/playwright-ct-core/src/viteUtils.ts
+++ b/packages/playwright-ct-core/src/viteUtils.ts
@@ -147,13 +147,13 @@ export async function populateComponentsFromTests(componentRegistry: ComponentRe
     for (const importInfo of importList)
       componentRegistry.set(importInfo.id, importInfo);
     if (componentsByImportingFile)
-      componentsByImportingFile.set(file, importList.map(i => resolveHook(i.filename, i.importSource)).filter(Boolean) as string[]);
+      componentsByImportingFile.set(file, importList.map(i => resolveHook(i.filename, i.importSource, true)).filter(Boolean) as string[]);
   }
 }
 
 export function hasJSComponents(components: ImportInfo[]): boolean {
   for (const component of components) {
-    const importPath = resolveHook(component.filename, component.importSource);
+    const importPath = resolveHook(component.filename, component.importSource, true);
     const extname = importPath ? path.extname(importPath) : '';
     if (extname === '.js' || (importPath && !extname && fs.existsSync(importPath + '.js')))
       return true;
@@ -183,7 +183,7 @@ export function transformIndexFile(id: string, content: string, templateDir: str
   lines.push(registerSource);
 
   for (const value of importInfos.values()) {
-    const importPath = resolveHook(value.filename, value.importSource) || value.importSource;
+    const importPath = resolveHook(value.filename, value.importSource, true) || value.importSource;
     lines.push(`const ${value.id} = () => import('${importPath?.replaceAll(path.sep, '/')}').then((mod) => mod.${value.remoteName || 'default'});`);
   }
 

--- a/packages/playwright/src/transform/esmLoader.ts
+++ b/packages/playwright/src/transform/esmLoader.ts
@@ -26,7 +26,7 @@ import { fileIsModule } from '../util';
 async function resolve(specifier: string, context: { parentURL?: string }, defaultResolve: Function) {
   if (context.parentURL && context.parentURL.startsWith('file://')) {
     const filename = url.fileURLToPath(context.parentURL);
-    const resolved = resolveHook(filename, specifier);
+    const resolved = resolveHook(filename, specifier, true);
     if (resolved !== undefined)
       specifier = url.pathToFileURL(resolved).toString();
   }

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -319,18 +319,17 @@ export function resolveImportSpecifierExtension(resolved: string, isPathMapping:
     break;  // Do not try '' when a more specific extension like '.jsx' matched.
   }
 
-  if (dirExists(resolved)) {
+  // Following TypeScript's path mapping logic, index files and package.json are not resolved in ESM.
+  // TypeScript does not interpret package.json for path mappings: https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths-should-not-point-to-monorepo-packages-or-node_modules-packages
+  const shouldNotResolveDirectory = isPathMapping && isESM;
+
+  if (!shouldNotResolveDirectory && dirExists(resolved)) {
     // If we import a package, let Node.js figure out the correct import based on package.json.
-    // TypeScript does not interpret package.json for path mappings: https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths-should-not-point-to-monorepo-packages-or-node_modules-packages
-    if (!isPathMapping && fileExists(path.join(resolved, 'package.json')))
+    if (fileExists(path.join(resolved, 'package.json')))
       return resolved;
 
-    // Following TypeScript's path mapping logic, index files are still resolved in CommonJS.
-    const shouldNotResolveIndex = isPathMapping && isESM;
-    if (!shouldNotResolveIndex) {
-      const dirImport = path.join(resolved, 'index');
-      return resolveImportSpecifierExtension(dirImport, isPathMapping, isESM);
-    }
+    const dirImport = path.join(resolved, 'index');
+    return resolveImportSpecifierExtension(dirImport, isPathMapping, isESM);
   }
 }
 

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -319,8 +319,16 @@ export function resolveImportSpecifierExtension(resolved: string, isPathMapping:
     break;  // Do not try '' when a more specific extension like '.jsx' matched.
   }
 
-  // Following TypeScript's path mapping logic, index files and package.json are not resolved in ESM.
-  // TypeScript does not interpret package.json for path mappings: https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths-should-not-point-to-monorepo-packages-or-node_modules-packages
+  // After TypeScript path mapping, here's how directories with a `package.json` are resolved:
+  //  - `package.json#exports` is not respected
+  //  - `package.json#main` is respected only in CJS mode
+  //  - `index.js` default is respected only in CJS mode
+  //
+  // More info:
+  //  - https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths-should-not-point-to-monorepo-packages-or-node_modules-packages
+  //  - https://www.typescriptlang.org/docs/handbook/modules/reference.html#directory-modules-index-file-resolution
+  //  - https://nodejs.org/dist/latest-v20.x/docs/api/modules.html#folders-as-modules
+
   const shouldNotResolveDirectory = isPathMapping && isESM;
 
   if (!shouldNotResolveDirectory && dirExists(resolved)) {

--- a/tests/playwright-test/resolver.spec.ts
+++ b/tests/playwright-test/resolver.spec.ts
@@ -606,6 +606,43 @@ test('should import packages with non-index main script through path resolver', 
   expect(result.output).toContain(`foo=42`);
 });
 
+test('does not honor `exports` field after type mapping', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'app/pkg/main.ts': `
+      export const filename = 'main.ts';
+    `,
+    'app/pkg/index.js': `
+      export const filename = 'index.js';
+    `,
+    'app/pkg/package.json': JSON.stringify({
+      exports: { '.': { require: './main.ts' } }
+    }),
+    'package.json': JSON.stringify({
+      name: 'example-project'
+    }),
+    'playwright.config.ts': `
+      export default {};
+    `,
+    'tsconfig.json': JSON.stringify({
+      compilerOptions: {
+        baseUrl: '.',
+        paths: {
+          'app/*': ['app/*'],
+        },
+      }
+    }),
+    'example.spec.ts': `
+      import { filename } from 'app/pkg';
+      import { test, expect } from '@playwright/test';
+      test('test', ({}) => {
+        console.log('filename=' + filename);
+      });
+    `,
+  });
+
+  expect(result.output).toContain('filename=index.js');
+});
+
 test('should respect tsconfig project references', async ({ runInlineTest }) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/29256' });
 


### PR DESCRIPTION
Supercedes https://github.com/microsoft/playwright/pull/31915, closes https://github.com/microsoft/playwright/issues/31811.

When TypeScript resolves a specifier via path mapping, it does not interpret `package.json`. If path mapping resolves to a directory, it only looks at the `index.js` file in that directory if it's in CommonJS mode.

We need to mirror this in our `esmLoader.ts`.