### PR TITLE
cherry-pick(#32066): fix(types): revert type changes made to support TS 5.5

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -4815,9 +4815,9 @@ export type Fixtures<T extends KeyValue = {}, W extends KeyValue = {}, PT extend
 } & {
   [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean }];
 } & {
-  [K in Exclude<keyof W, keyof PW>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
 } & {
-  [K in Exclude<keyof T, keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof T]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';

--- a/tests/library/global-fetch.spec.ts
+++ b/tests/library/global-fetch.spec.ts
@@ -21,7 +21,7 @@ import { expect, playwrightTest as base } from '../config/browserTest';
 import { kTargetClosedErrorMessage } from 'tests/config/errors';
 
 const it = base.extend({
-  context: async () => {
+  context: async ({}, use) => {
     throw new Error('global fetch tests should not use context');
   }
 });

--- a/tests/playwright-test/types.spec.ts
+++ b/tests/playwright-test/types.spec.ts
@@ -19,7 +19,7 @@ import { test, expect } from './playwright-test-fixtures';
 test('should check types of fixtures', async ({ runTSC }) => {
   const result = await runTSC({
     'helper.ts': `
-      import { test as base, expect } from '@playwright/test';
+      import { test as base, expect, Page } from '@playwright/test';
       export type MyOptions = { foo: string, bar: number };
       export const test = base.extend<{ foo: string }, { bar: number }>({
         foo: 'foo',
@@ -71,7 +71,7 @@ test('should check types of fixtures', async ({ runTSC }) => {
         // @ts-expect-error
         baz: true,
       });
-      const fail9 = test.extend<{ foo: string }>({
+      const fail9 = test.extend({
         foo: [ async ({}, use) => {
           await use('foo');
           // @ts-expect-error
@@ -100,7 +100,21 @@ test('should check types of fixtures', async ({ runTSC }) => {
             return y;
           });
         },
-      })
+      });
+
+      const chain1 = base.extend({
+        page: async ({ page }, use) => {
+          await use(page);
+        },
+      });
+      const chain2 = chain1.extend<{ pageAsUser: Page }>({
+        pageAsUser: async ({ page }, use) => {
+          // @ts-expect-error
+          const x: number = page;
+          // @ts-expect-error
+          await use(x);
+        },
+      });
     `,
     'playwright.config.ts': `
       import { MyOptions } from './helper';

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -144,9 +144,9 @@ export type Fixtures<T extends KeyValue = {}, W extends KeyValue = {}, PT extend
 } & {
   [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean }];
 } & {
-  [K in Exclude<keyof W, keyof PW>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
 } & {
-  [K in Exclude<keyof T, keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof T]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';


### PR DESCRIPTION
Regressed in #31532. The TS5.5 changes broke chaining of `extend`s where the first `extend` did not specify any type arguments.

Fixes #32056.