### PR TITLE
test: enable header overrides on redirect in firefox

### DIFF
--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -393,9 +393,12 @@ it('should continue preload link requests', async ({ page, server, browserName }
   expect(color).toBe('rgb(255, 192, 203)');
 });
 
-it('continue should propagate headers to redirects', async ({ page, server, browserName }) => {
-  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/28758' });
-  it.fixme(browserName === 'firefox');
+it('continue should propagate headers to redirects', {
+  annotation: [
+    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/28758' },
+    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32045' },
+  ]
+}, async ({ page, server }) => {
   await server.setRedirect('/redirect', '/empty.html');
   await page.route('**/redirect', route => {
     void route.continue({
@@ -413,9 +416,11 @@ it('continue should propagate headers to redirects', async ({ page, server, brow
 });
 
 it('redirected requests should report overridden headers', {
-  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/31351' }
-}, async ({ page, server, browserName }) => {
-  it.fixme(browserName === 'firefox');
+  annotation: [
+    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/31351' },
+    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32045' },
+  ]
+}, async ({ page, server }) => {
   await server.setRedirect('/redirect', '/empty.html');
   await page.route('**/redirect', route => {
     const headers = route.request().headers();
@@ -433,9 +438,12 @@ it('redirected requests should report overridden headers', {
   expect((await response.request().allHeaders())['custom']).toBe('value');
 });
 
-it('continue should delete headers on redirects', async ({ page, server, browserName }) => {
-  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/13106' });
-  it.fixme(browserName === 'firefox');
+it('continue should delete headers on redirects', {
+  annotation: [
+    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/13106' },
+    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32045' },
+  ]
+}, async ({ page, server }) => {
   await page.goto(server.PREFIX + '/empty.html');
   server.setRoute('/something', (request, response) => {
     response.writeHead(200, { 'Access-Control-Allow-Origin': '*' });


### PR DESCRIPTION
Fixes: https://github.com/microsoft/playwright/issues/32045