### PR TITLE
fix(test runner): run project dependencies of `--only-changed` test files

### DIFF
--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -123,6 +123,7 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
   const config = testRun.config;
   // Create root suite, where each child will be a project suite with cloned file suites inside it.
   const rootSuite = new Suite('', 'root');
+  const unfilteredProjectSuites = new Map<FullProjectInternal, Suite>();
   const projectSuites = new Map<FullProjectInternal, Suite>();
   const filteredProjectSuites = new Map<FullProjectInternal, Suite>();
 
@@ -136,6 +137,7 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
 
     // Filter file suites for all projects.
     for (const [project, fileSuites] of testRun.projectSuites) {
+      unfilteredProjectSuites.set(project, createProjectSuite(project, fileSuites));
       const filteredFileSuites = additionalFileMatcher ? fileSuites.filter(fileSuite => additionalFileMatcher(fileSuite.location!.file)) : fileSuites;
       const projectSuite = createProjectSuite(project, filteredFileSuites);
       projectSuites.set(project, projectSuite);
@@ -202,7 +204,7 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
     // Clone file suites for dependency projects.
     for (const project of projectClosure.keys()) {
       if (projectClosure.get(project) === 'dependency')
-        rootSuite._prependSuite(buildProjectSuite(project, projectSuites.get(project)!));
+        rootSuite._prependSuite(buildProjectSuite(project, unfilteredProjectSuites.get(project)!));
     }
   }
 

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -202,8 +202,8 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
     const projectClosure = new Map(buildProjectsClosure(rootSuite.suites.map(suite => suite._fullProject!)));
 
     // Clone file suites for dependency projects.
-    for (const project of projectClosure.keys()) {
-      if (projectClosure.get(project) === 'dependency')
+    for (const [project, level] of projectClosure.entries()) {
+      if (level === 'dependency')
         rootSuite._prependSuite(buildProjectSuite(project, unfilteredProjectSuites.get(project)!));
     }
   }

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -123,7 +123,6 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
   const config = testRun.config;
   // Create root suite, where each child will be a project suite with cloned file suites inside it.
   const rootSuite = new Suite('', 'root');
-  const unfilteredProjectSuites = new Map<FullProjectInternal, Suite>();
   const projectSuites = new Map<FullProjectInternal, Suite>();
   const filteredProjectSuites = new Map<FullProjectInternal, Suite>();
 
@@ -137,11 +136,10 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
 
     // Filter file suites for all projects.
     for (const [project, fileSuites] of testRun.projectSuites) {
-      unfilteredProjectSuites.set(project, createProjectSuite(project, fileSuites));
+      projectSuites.set(project, createProjectSuite(project, fileSuites));
+
       const filteredFileSuites = additionalFileMatcher ? fileSuites.filter(fileSuite => additionalFileMatcher(fileSuite.location!.file)) : fileSuites;
-      const projectSuite = createProjectSuite(project, filteredFileSuites);
-      projectSuites.set(project, projectSuite);
-      const filteredProjectSuite = filterProjectSuite(projectSuite, { cliFileFilters, cliTitleMatcher, testIdMatcher: config.testIdMatcher });
+      const filteredProjectSuite = filterProjectSuite(createProjectSuite(project, filteredFileSuites), { cliFileFilters, cliTitleMatcher, testIdMatcher: config.testIdMatcher });
       filteredProjectSuites.set(project, filteredProjectSuite);
     }
   }
@@ -204,7 +202,7 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
     // Clone file suites for dependency projects.
     for (const [project, level] of projectClosure.entries()) {
       if (level === 'dependency')
-        rootSuite._prependSuite(buildProjectSuite(project, unfilteredProjectSuites.get(project)!));
+        rootSuite._prependSuite(buildProjectSuite(project, projectSuites.get(project)!));
     }
   }
 

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -26,7 +26,7 @@ import type { Matcher, TestFileFilter } from '../util';
 import { buildProjectsClosure, collectFilesForProject, filterProjects } from './projectUtils';
 import type { TestRun } from './tasks';
 import { requireOrImport } from '../transform/transform';
-import { applyRepeatEachIndex, bindFileSuiteToProject, filterByFile, filterByFocusedLine, filterByTestIds, filterOnly, filterTestsRemoveEmptySuites } from '../common/suiteUtils';
+import { applyRepeatEachIndex, bindFileSuiteToProject, filterByFocusedLine, filterByTestIds, filterOnly, filterTestsRemoveEmptySuites } from '../common/suiteUtils';
 import { createTestGroups, filterForShard, type TestGroup } from './testGroups';
 import { dependenciesForTestFile } from '../transform/compilationCache';
 import { sourceMapSupport } from '../utilsBundle';

--- a/tests/playwright-test/only-changed.spec.ts
+++ b/tests/playwright-test/only-changed.spec.ts
@@ -371,13 +371,17 @@ test('should run project dependencies of changed tests', async ({ runInlineTest,
     'playwright.config.ts': `
       module.exports = {
         projects: [
-          { name: 'setup', testMatch: 'setup.ts', },
+          { name: 'setup', testMatch: 'setup.spec.ts', },
           { name: 'main', dependencies: ['setup'] },
         ],
       };
     `,
-    'setup.ts': `
-      console.log("setup is run")
+    'setup.spec.ts': `
+    import { test, expect } from '@playwright/test';
+
+    test('setup test', async ({ page }) => {
+      console.log('setup test is executed')
+    });
     `,
     'a.spec.ts': `
       import { test, expect } from '@playwright/test';
@@ -401,9 +405,7 @@ test('should run project dependencies of changed tests', async ({ runInlineTest,
 
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.passed).toBe(0);
+  expect(result.passed).toBe(1);
 
-  console.log(result.output);
-  expect(result.output).toContain('setup is run');
-  expect(result.output).toContain('c.spec.ts');
+  expect(result.output).toContain('setup test is executed');
 });

--- a/tests/playwright-test/only-changed.spec.ts
+++ b/tests/playwright-test/only-changed.spec.ts
@@ -366,7 +366,12 @@ test('UI mode is not supported', async ({ runInlineTest }) => {
   expect(result.output).toContain('--only-changed is not supported in UI mode');
 });
 
-test('should run project dependencies of changed tests', async ({ runInlineTest, git, writeFiles }) => {
+test('should run project dependencies of changed tests', {
+  annotation: {
+    type: 'issue',
+    description: 'https://github.com/microsoft/playwright/issues/32070',
+  },
+}, async ({ runInlineTest, git, writeFiles }) => {
   await writeFiles({
     'playwright.config.ts': `
       module.exports = {


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32070. We were applying `additionalFileMatcher` not just to `filteredProjectSuites`, but also to `projectSuites`.  `projectSuites` is where we take dependency projects from, though - so `--only-changed` led to empty dependency projects, resulting in the reported bug.

The fix is to only apply `additionalFileMatcher` on `filteredProjectSuites`.