### PR TITLE
docs: remove redundant TOC usages

### DIFF
--- a/docs/src/accessibility-testing-java.md
+++ b/docs/src/accessibility-testing-java.md
@@ -14,8 +14,6 @@ A few examples of problems this can catch include:
 
 The following examples rely on the [`com.deque.html.axe-core/playwright`](https://mvnrepository.com/artifact/com.deque.html.axe-core/playwright) Maven package which adds support for running the [axe accessibility testing engine](https://www.deque.com/axe/) as part of your Playwright tests.
 
-<!-- TOC -->
-
 ## Disclaimer
 
 Automated accessibility tests can detect some common accessibility problems such as missing or invalid properties. But many accessibility problems can only be discovered through manual testing. We recommend using a combination of automated testing, manual accessibility assessments, and inclusive user testing.

--- a/docs/src/api-testing-csharp.md
+++ b/docs/src/api-testing-csharp.md
@@ -18,8 +18,6 @@ All of that could be achieved via [APIRequestContext] methods.
 
 The following examples rely on the [`Microsoft.Playwright.MSTest`](./test-runners.md) package which creates a Playwright and Page instance for each test.
 
-<!-- TOC -->
-
 ## Writing API Test
 
 [APIRequestContext] can send all kinds of HTTP(S) requests over network.

--- a/docs/src/api-testing-java.md
+++ b/docs/src/api-testing-java.md
@@ -16,8 +16,6 @@ A few examples where it may come in handy:
 
 All of that could be achieved via [APIRequestContext] methods.
 
-<!-- TOC -->
-
 ## Writing API Test
 
 [APIRequestContext] can send all kinds of HTTP(S) requests over network.

--- a/docs/src/api-testing-js.md
+++ b/docs/src/api-testing-js.md
@@ -16,8 +16,6 @@ A few examples where it may come in handy:
 
 All of that could be achieved via [APIRequestContext] methods.
 
-<!-- TOC3 -->
-
 ## Writing API Test
 
 [APIRequestContext] can send all kinds of HTTP(S) requests over network.

--- a/docs/src/api-testing-python.md
+++ b/docs/src/api-testing-python.md
@@ -18,8 +18,6 @@ All of that could be achieved via [APIRequestContext] methods.
 
 The following examples rely on the [`pytest-playwright`](./test-runners.md) package which add Playwright fixtures to the Pytest test-runner.
 
-<!-- TOC -->
-
 ## Writing API Test
 
 [APIRequestContext] can send all kinds of HTTP(S) requests over network.

--- a/docs/src/junit-java.md
+++ b/docs/src/junit-java.md
@@ -10,8 +10,6 @@ With a few lines of code, you can hook up Playwright to your favorite Java test 
 In [JUnit](https://junit.org/junit5/), you can use Playwright [fixtures](./junit.md#fixtures) to automatically initialize [Playwright], [Browser], [BrowserContext] or [Page]. In the example below, all three test methods use the same
 [Browser]. Each test uses its own [BrowserContext] and [Page].
 
-<!-- TOC -->
-
 ```java
 package org.example;
 

--- a/docs/src/screenshots.md
+++ b/docs/src/screenshots.md
@@ -33,8 +33,6 @@ await Page.ScreenshotAsync(new()
 
 [Screenshots API](./api/class-page#page-screenshot) accepts many parameters for image format, clip area, quality, etc. Make sure to check them out.
 
-<!-- TOC -->
-
 ## Full page screenshots
 
 Full page screenshot is a screenshot of a full scrollable page, as if you had a very

--- a/docs/src/test-runners-java.md
+++ b/docs/src/test-runners-java.md
@@ -11,8 +11,6 @@ Playwright and Browser instances can be reused between tests for better performa
 recommend running each test case in a new BrowserContext, this way browser state will be
 isolated between the tests.
 
-<!-- TOC -->
-
 ## JUnit
 
 In [JUnit](https://junit.org/junit5/) you can initialize [Playwright] and [Browser] in [@BeforeAll](https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/BeforeAll.html) method and


### PR DESCRIPTION
Motivation: They were broken (not shown aka. comment was put into the `.mdx` file) since a while. Since we used them only in non-popular / smaller guides, it seems reasonable to remove them instead of fixing them.