### PR TITLE
fix(web): use currentTheme instead of settings in toggleTheme

### DIFF
--- a/packages/web/src/theme.ts
+++ b/packages/web/src/theme.ts
@@ -39,12 +39,8 @@ type Theme = 'dark-mode' | 'light-mode';
 
 const listeners = new Set<(theme: Theme) => void>();
 export function toggleTheme() {
-  const oldTheme = settings.getString('theme', 'light-mode');
-  let newTheme: Theme;
-  if (oldTheme === 'dark-mode')
-    newTheme = 'light-mode';
-  else
-    newTheme = 'dark-mode';
+  const oldTheme = currentTheme();
+  const newTheme = oldTheme === 'dark-mode' ? 'light-mode' : 'dark-mode';
 
   if (oldTheme)
     document.body.classList.remove(oldTheme);


### PR DESCRIPTION
Value stored in settings doesn't always match the `currentTheme` value. In `applyTheme`:

https://github.com/microsoft/playwright/blob/9b3e0e5667ab52b5b750b732a9ec6367602dc5df/packages/web/src/theme.ts#L32-L35

it can set theme to `dark-mode` even if the setting is set to `light-mode` when `prefersDarkScheme.matches` is true, and the setting value is not updated. So, when toggling theme, if it looks into the setting value, it will not change the theme.

This PR replaces the setting with `currentTheme` on `toggleTheme` to compute the right theme to toggle from.