### PR TITLE
feat: allow `URLSearchParams` and `string` as params in `APIRequestContext`

### DIFF
--- a/docs/src/api/class-apirequestcontext.md
+++ b/docs/src/api/class-apirequestcontext.md
@@ -138,10 +138,13 @@ context cookies from the response. The method will automatically follow redirect
 ### param: APIRequestContext.delete.url = %%-fetch-param-url-%%
 * since: v1.16
 
+### option: APIRequestContext.delete.params = %%-js-fetch-option-params-%%
+* since: v1.16
+
 ### param: APIRequestContext.delete.params = %%-java-csharp-fetch-params-%%
 * since: v1.18
 
-### option: APIRequestContext.delete.params = %%-js-python-fetch-option-params-%%
+### option: APIRequestContext.delete.params = %%-python-fetch-option-params-%%
 * since: v1.16
 
 ### option: APIRequestContext.delete.params = %%-csharp-fetch-option-params-%%
@@ -297,10 +300,13 @@ await Request.FetchAsync("https://example.com/api/uploadScript", new() { Method 
 
 Target URL or Request to get all parameters from.
 
+### option: APIRequestContext.fetch.params = %%-js-fetch-option-params-%%
+* since: v1.16
+
 ### param: APIRequestContext.fetch.params = %%-java-csharp-fetch-params-%%
 * since: v1.18
 
-### option: APIRequestContext.fetch.params = %%-js-python-fetch-option-params-%%
+### option: APIRequestContext.fetch.params = %%-python-fetch-option-params-%%
 * since: v1.16
 
 ### option: APIRequestContext.fetch.params = %%-csharp-fetch-option-params-%%
@@ -397,10 +403,13 @@ await request.GetAsync("https://example.com/api/getText", new() { Params = query
 ### param: APIRequestContext.get.url = %%-fetch-param-url-%%
 * since: v1.16
 
+### option: APIRequestContext.get.params = %%-js-fetch-option-params-%%
+* since: v1.16
+
 ### param: APIRequestContext.get.params = %%-java-csharp-fetch-params-%%
 * since: v1.18
 
-### option: APIRequestContext.get.params = %%-js-python-fetch-option-params-%%
+### option: APIRequestContext.get.params = %%-python-fetch-option-params-%%
 * since: v1.16
 
 ### option: APIRequestContext.get.params = %%-csharp-fetch-option-params-%%
@@ -453,10 +462,13 @@ context cookies from the response. The method will automatically follow redirect
 ### param: APIRequestContext.head.url = %%-fetch-param-url-%%
 * since: v1.16
 
+### option: APIRequestContext.head.params = %%-js-fetch-option-params-%%
+* since: v1.16
+
 ### param: APIRequestContext.head.params = %%-java-csharp-fetch-params-%%
 * since: v1.18
 
-### option: APIRequestContext.head.params = %%-js-python-fetch-option-params-%%
+### option: APIRequestContext.head.params = %%-python-fetch-option-params-%%
 * since: v1.16
 
 ### option: APIRequestContext.head.params = %%-csharp-fetch-option-params-%%
@@ -509,10 +521,13 @@ context cookies from the response. The method will automatically follow redirect
 ### param: APIRequestContext.patch.url = %%-fetch-param-url-%%
 * since: v1.16
 
+### option: APIRequestContext.patch.params = %%-js-fetch-option-params-%%
+* since: v1.16
+
 ### param: APIRequestContext.patch.params = %%-java-csharp-fetch-params-%%
 * since: v1.18
 
-### option: APIRequestContext.patch.params = %%-js-python-fetch-option-params-%%
+### option: APIRequestContext.patch.params = %%-python-fetch-option-params-%%
 * since: v1.16
 
 ### option: APIRequestContext.patch.params = %%-csharp-fetch-option-params-%%
@@ -686,10 +701,13 @@ await request.PostAsync("https://example.com/api/uploadScript", new() { Multipar
 ### param: APIRequestContext.post.url = %%-fetch-param-url-%%
 * since: v1.16
 
+### option: APIRequestContext.post.params = %%-js-fetch-option-params-%%
+* since: v1.16
+
 ### param: APIRequestContext.post.params = %%-java-csharp-fetch-params-%%
 * since: v1.18
 
-### option: APIRequestContext.post.params = %%-js-python-fetch-option-params-%%
+### option: APIRequestContext.post.params = %%-python-fetch-option-params-%%
 * since: v1.16
 
 ### option: APIRequestContext.post.params = %%-csharp-fetch-option-params-%%
@@ -742,10 +760,13 @@ context cookies from the response. The method will automatically follow redirect
 ### param: APIRequestContext.put.url = %%-fetch-param-url-%%
 * since: v1.16
 
+### option: APIRequestContext.put.params = %%-js-fetch-option-params-%%
+* since: v1.16
+
 ### param: APIRequestContext.put.params = %%-java-csharp-fetch-params-%%
 * since: v1.18
 
-### option: APIRequestContext.put.params = %%-js-python-fetch-option-params-%%
+### option: APIRequestContext.put.params = %%-python-fetch-option-params-%%
 * since: v1.16
 
 ### option: APIRequestContext.put.params = %%-csharp-fetch-option-params-%%

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -356,8 +356,14 @@ Emulates consistent window screen size available inside web page via `window.scr
 
 Target URL.
 
-## js-python-fetch-option-params
-* langs: js, python
+## js-fetch-option-params
+* langs: js
+- `params` <[Object]<[string], [string]|[number]|[boolean]>|[URLSearchParams]|[string]>
+
+Query parameters to be sent with the URL.
+
+## python-fetch-option-params
+* langs: python
 - `params` <[Object]<[string], [string]|[float]|[boolean]>>
 
 Query parameters to be sent with the URL.

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -157,7 +157,7 @@ export abstract class APIRequestContext extends SdkObject {
     const requestUrl = new URL(params.url, defaults.baseURL);
     if (params.params) {
       for (const { name, value } of params.params)
-        requestUrl.searchParams.set(name, value);
+        requestUrl.searchParams.append(name, value);
     }
 
     const credentials = this._getHttpCredentials(requestUrl);

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -16526,7 +16526,7 @@ export interface APIRequestContext {
     /**
      * Query parameters to be sent with the URL.
      */
-    params?: { [key: string]: string|number|boolean; };
+    params?: { [key: string]: string|number|boolean; }|URLSearchParams|string;
 
     /**
      * Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
@@ -16662,7 +16662,7 @@ export interface APIRequestContext {
     /**
      * Query parameters to be sent with the URL.
      */
-    params?: { [key: string]: string|number|boolean; };
+    params?: { [key: string]: string|number|boolean; }|URLSearchParams|string;
 
     /**
      * Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
@@ -16762,7 +16762,7 @@ export interface APIRequestContext {
     /**
      * Query parameters to be sent with the URL.
      */
-    params?: { [key: string]: string|number|boolean; };
+    params?: { [key: string]: string|number|boolean; }|URLSearchParams|string;
 
     /**
      * Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
@@ -16848,7 +16848,7 @@ export interface APIRequestContext {
     /**
      * Query parameters to be sent with the URL.
      */
-    params?: { [key: string]: string|number|boolean; };
+    params?: { [key: string]: string|number|boolean; }|URLSearchParams|string;
 
     /**
      * Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
@@ -16934,7 +16934,7 @@ export interface APIRequestContext {
     /**
      * Query parameters to be sent with the URL.
      */
-    params?: { [key: string]: string|number|boolean; };
+    params?: { [key: string]: string|number|boolean; }|URLSearchParams|string;
 
     /**
      * Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
@@ -17062,7 +17062,7 @@ export interface APIRequestContext {
     /**
      * Query parameters to be sent with the URL.
      */
-    params?: { [key: string]: string|number|boolean; };
+    params?: { [key: string]: string|number|boolean; }|URLSearchParams|string;
 
     /**
      * Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
@@ -17148,7 +17148,7 @@ export interface APIRequestContext {
     /**
      * Query parameters to be sent with the URL.
      */
-    params?: { [key: string]: string|number|boolean; };
+    params?: { [key: string]: string|number|boolean; }|URLSearchParams|string;
 
     /**
      * Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.


### PR DESCRIPTION
Resolves https://github.com/microsoft/playwright/issues/28863

I allowed passing `URLSearchParams` and `string` as query params to `APIRequestContext` methods.

Currently, it is impossible to pass duplicated params (which is quite common) using an object because keys cannot be duplicated - e.g. `{ status:  'available', status: 'pending' }`.
Support for `URLSearchParams` and `string` should offer more flexibility in more complex situations.

Let me know what you think.