### PR TITLE
fix(docs): API types do not extend EventEmitter

### DIFF
--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -1,6 +1,5 @@
 # class: Browser
 * since: v1.8
-* extends: [EventEmitter]
 
 A Browser is created via [`method: BrowserType.launch`]. An example of using a [Browser] to create a [Page]:
 

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1,6 +1,5 @@
 # class: BrowserContext
 * since: v1.8
-* extends: [EventEmitter]
 
 BrowserContexts provide a way to operate multiple independent browser sessions.
 

--- a/docs/src/api/class-cdpsession.md
+++ b/docs/src/api/class-cdpsession.md
@@ -1,6 +1,5 @@
 # class: CDPSession
 * since: v1.8
-* extends: [EventEmitter]
 
 The `CDPSession` instances are used to talk raw Chrome Devtools Protocol:
 * protocol methods can be called with `session.send` method.

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1,6 +1,5 @@
 # class: Page
 * since: v1.8
-* extends: [EventEmitter]
 
 Page provides methods to interact with a single tab in a [Browser], or an
 [extension background page](https://developer.chrome.com/extensions/background_pages) in Chromium. One [Browser]

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -29,8 +29,6 @@ type ElementHandleWaitForSelectorOptionsNotHidden = ElementHandleWaitForSelector
 };
 
 /**
- * - extends: [EventEmitter]
- *
  * Page provides methods to interact with a single tab in a {@link Browser}, or an
  * [extension background page](https://developer.chrome.com/extensions/background_pages) in Chromium. One {@link
  * Browser} instance might have multiple {@link Page} instances.
@@ -7535,8 +7533,6 @@ export interface Frame {
 }
 
 /**
- * - extends: [EventEmitter]
- *
  * BrowserContexts provide a way to operate multiple independent browser sessions.
  *
  * If a page opens another page, e.g. with a `window.open` call, the popup will belong to the parent page's browser
@@ -8942,8 +8938,6 @@ export interface BrowserContext {
 }
 
 /**
- * - extends: [EventEmitter]
- *
  * A Browser is created via
  * [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch). An example
  * of using a {@link Browser} to create a {@link Page}:
@@ -14450,8 +14444,6 @@ export interface BrowserType<Unused = {}> {
 }
 
 /**
- * - extends: [EventEmitter]
- *
  * The `CDPSession` instances are used to talk raw Chrome Devtools Protocol:
  * - protocol methods can be called with `session.send` method.
  * - protocol events can be subscribed to with `session.on` method.

--- a/utils/doclint/documentation.js
+++ b/utils/doclint/documentation.js
@@ -98,7 +98,7 @@ class Documentation {
     for (const [name, clazz] of this.classes.entries()) {
       clazz.sortMembers();
 
-      if (!clazz.extends || ['EventEmitter', 'Error', 'Exception', 'RuntimeException'].includes(clazz.extends))
+      if (!clazz.extends || ['Error', 'Exception', 'RuntimeException'].includes(clazz.extends))
         continue;
       const superClass = this.classes.get(clazz.extends);
       if (!superClass) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/32097