### PR TITLE
[babel] [typescript] allow declare fields in typescript

### DIFF
--- a/packages/playwright/bundles/babel/src/babelBundleImpl.ts
+++ b/packages/playwright/bundles/babel/src/babelBundleImpl.ts
@@ -32,6 +32,7 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
 
   if (isTypeScript) {
     plugins.push(
+        [require('@babel/plugin-transform-typescript'), { allowDeclareFields: true }],
         [require('@babel/plugin-proposal-decorators'), { version: '2023-05' }],
         [require('@babel/plugin-proposal-explicit-resource-management')],
         [require('@babel/plugin-transform-class-properties')],


### PR DESCRIPTION
Playwright (1.44.0) runner will throw errors when class contains declare fields
```shell
SyntaxError: xxxxx.ts: TypeScript 'declare' fields must first be transformed by @babel/plugin-transform-typescript.
If you have already enabled that plugin (or '@babel/preset-typescript'), make sure that it runs before any plugin related to additional class features:
 - @babel/plugin-transform-class-properties
 - @babel/plugin-transform-private-methods
 - @babel/plugin-proposal-decorators
  33 | })
```
Declaring fields is inevitable in typescript when [useDefineForClassFields](https://www.typescriptlang.org/tsconfig#useDefineForClassFields) is on:
```ts
interface Animal {
  dateOfBirth: any;
}
 
interface Dog extends Animal {
  breed: any;
}
 
class AnimalHouse {
  resident: Animal;
  constructor(animal: Animal) {
    this.resident = animal;
  }
}
 
class DogHouse extends AnimalHouse {
  // Does not emit JavaScript code,
  // only ensures the types are correct
  declare resident: Dog;
  constructor(dog: Dog) {
    super(dog);
  }
}
```
> https://www.typescriptlang.org/docs/handbook/2/classes.html#type-only-field-declarations


