### PR TITLE
chore(ui): separate transport from `TestServerConnection`

### DIFF
--- a/packages/trace-viewer/src/ui/uiModeTestListView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeTestListView.tsx
@@ -29,7 +29,7 @@ import type { SourceLocation } from './modelUtil';
 import { testStatusIcon } from './testUtils';
 import type { TestModel } from './uiModeModel';
 import './uiModeTestListView.css';
-import type { TestServerConnection } from '@testIsomorphic/testServerConnection';
+import type { WSTestServerConnection } from '@testIsomorphic/testServerConnection';
 import { TagView } from './tag';
 
 const TestTreeView = TreeView<TreeItem>;
@@ -37,7 +37,7 @@ const TestTreeView = TreeView<TreeItem>;
 export const TestListView: React.FC<{
   filterText: string,
   testTree: TestTree,
-  testServerConnection: TestServerConnection | undefined,
+  testServerConnection: WSTestServerConnection | undefined,
   testModel?: TestModel,
   runTests: (mode: 'bounce-if-busy' | 'queue-if-busy', testIds: Set<string>) => void,
   runningState?: { testIds: Set<string>, itemSelectedByUser?: boolean, completed?: boolean },

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -33,7 +33,7 @@ import { useDarkModeSetting } from '@web/theme';
 import { clsx, settings, useSetting } from '@web/uiUtils';
 import { statusEx, TestTree } from '@testIsomorphic/testTree';
 import type { TreeItem  } from '@testIsomorphic/testTree';
-import { TestServerConnection } from '@testIsomorphic/testServerConnection';
+import { WSTestServerConnection } from '@testIsomorphic/testServerConnection';
 import { pathSeparator } from './uiModeModel';
 import type { TestModel } from './uiModeModel';
 import { FiltersView } from './uiModeFiltersView';
@@ -95,7 +95,7 @@ export const UIModeView: React.FC<{}> = ({
   const [collapseAllCount, setCollapseAllCount] = React.useState(0);
   const [isDisconnected, setIsDisconnected] = React.useState(false);
   const [hasBrowsers, setHasBrowsers] = React.useState(true);
-  const [testServerConnection, setTestServerConnection] = React.useState<TestServerConnection>();
+  const [testServerConnection, setTestServerConnection] = React.useState<WSTestServerConnection>();
   const [teleSuiteUpdater, setTeleSuiteUpdater] = React.useState<TeleSuiteUpdater>();
   const [settingsVisible, setSettingsVisible] = React.useState(false);
   const [testingOptionsVisible, setTestingOptionsVisible] = React.useState(false);
@@ -135,7 +135,7 @@ export const UIModeView: React.FC<{}> = ({
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const reloadTests = React.useCallback(() => {
-    setTestServerConnection(new TestServerConnection(wsURL.toString()));
+    setTestServerConnection(new WSTestServerConnection(wsURL.toString()));
   }, []);
 
   // Load tests on startup.

--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -21,7 +21,7 @@ import { MultiTraceModel } from './modelUtil';
 import './workbenchLoader.css';
 import { toggleTheme } from '@web/theme';
 import { Workbench } from './workbench';
-import { TestServerConnection } from '@testIsomorphic/testServerConnection';
+import { WSTestServerConnection } from '@testIsomorphic/testServerConnection';
 
 export const WorkbenchLoader: React.FunctionComponent<{
 }> = () => {
@@ -102,7 +102,7 @@ export const WorkbenchLoader: React.FunctionComponent<{
       const guid = new URLSearchParams(window.location.search).get('ws');
       const wsURL = new URL(`../${guid}`, window.location.toString());
       wsURL.protocol = (window.location.protocol === 'https:' ? 'wss:' : 'ws:');
-      const testServerConnection = new TestServerConnection(wsURL.toString());
+      const testServerConnection = new WSTestServerConnection(wsURL.toString());
       testServerConnection.onLoadTraceRequested(async params => {
         setTraceURLs(params.traceUrl ? [params.traceUrl] : []);
         setDragOver(false);

--- a/tests/playwright-test/test-server-connection.spec.ts
+++ b/tests/playwright-test/test-server-connection.spec.ts
@@ -15,9 +15,9 @@
  */
 import { test as baseTest, expect } from './ui-mode-fixtures';
 
-import { TestServerConnection } from '../../packages/playwright/lib/isomorphic/testServerConnection';
+import { WSTestServerConnection } from '../../packages/playwright/lib/isomorphic/testServerConnection';
 
-class TestServerConnectionUnderTest extends TestServerConnection {
+class TestServerConnectionUnderTest extends WSTestServerConnection {
   events: [string, any][] = [];
 
   constructor(wsUrl: string) {


### PR DESCRIPTION
Preparation for https://github.com/microsoft/playwright/issues/32076. We'd like to use `TestServer` for the implementation of `PWTEST_WATCH`, where there's no need for a full-blown WebSocket. By separating the transport from `TestServerConnection`, we can use an in-memory transport instead.