### PR TITLE
Export MakeMatchers type

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6548,7 +6548,7 @@ export type MatcherReturnType = {
   log?: string[];
 };
 
-type MakeMatchers<R, T, ExtendedMatchers> = {
+export type MakeMatchers<R, T, ExtendedMatchers> = {
   /**
    * If you know how to test something, `.not` lets you test its opposite.
    */

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6018,7 +6018,7 @@ interface AsymmetricMatchers {
  * ```
  *
  */
-interface GenericAssertions<R> {
+export interface GenericAssertions<R> {
   /**
    * Makes the assertion check for the opposite condition. For example, the following code passes:
    *
@@ -6650,7 +6650,7 @@ export { };
  * ```
  *
  */
-interface APIResponseAssertions {
+export interface APIResponseAssertions {
   /**
    * Ensures the response status code is within `200..299` range.
    *
@@ -6690,7 +6690,7 @@ interface APIResponseAssertions {
  * ```
  *
  */
-interface LocatorAssertions {
+export interface LocatorAssertions {
   /**
    * Ensures that {@link Locator} points to an element that is
    * [connected](https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected) to a Document or a ShadowRoot.
@@ -7562,7 +7562,7 @@ interface LocatorAssertions {
  * ```
  *
  */
-interface PageAssertions {
+export interface PageAssertions {
   /**
    * This function will wait until two consecutive page screenshots yield the same result, and then compare the last
    * screenshot with the expectation.
@@ -7658,7 +7658,7 @@ interface PageAssertions {
  * ```
  *
  */
-interface SnapshotAssertions {
+export interface SnapshotAssertions {
   /**
    * **NOTE** To compare screenshots, use
    * [expect(page).toHaveScreenshot(name[, options])](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1)


### PR DESCRIPTION
MakeMatchers is a useful type for library authors who which to provide fluent APIs for interacting with Playwright's expect assertions. Without this type, library authors can't publish type definitions, since the inferred return type of 'expect' becomes too large to serialize into a .d.ts file.

I'm not certain if this is the correct place to expose this type, if there are upstream symbols that need to be exported, please let me know and I'll make the changes!