### PR TITLE
chore(test runner): make 'debug' an explicit option internally

### DIFF
--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -79,7 +79,7 @@ export class FullConfigInternal {
       globalTimeout: takeFirst(configCLIOverrides.globalTimeout, userConfig.globalTimeout, 0),
       grep: takeFirst(userConfig.grep, defaultGrep),
       grepInvert: takeFirst(userConfig.grepInvert, null),
-      maxFailures: takeFirst(configCLIOverrides.maxFailures, userConfig.maxFailures, 0),
+      maxFailures: takeFirst(configCLIOverrides.debug ? 1 : undefined, configCLIOverrides.maxFailures, userConfig.maxFailures, 0),
       metadata: takeFirst(userConfig.metadata, {}),
       preserveOutput: takeFirst(userConfig.preserveOutput, 'always'),
       reporter: takeFirst(configCLIOverrides.reporter, resolveReporters(userConfig.reporter, configDir), [[defaultReporter]]),
@@ -99,7 +99,7 @@ export class FullConfigInternal {
 
     (this.config as any)[configInternalSymbol] = this;
 
-    const workers = takeFirst(configCLIOverrides.workers, userConfig.workers, '50%');
+    const workers = takeFirst(configCLIOverrides.debug ? 1 : undefined, configCLIOverrides.workers, userConfig.workers, '50%');
     if (typeof workers === 'string') {
       if (workers.endsWith('%')) {
         const cpus = os.cpus().length;
@@ -179,7 +179,7 @@ export class FullProjectInternal {
       snapshotDir: takeFirst(pathResolve(configDir, projectConfig.snapshotDir), pathResolve(configDir, config.snapshotDir), testDir),
       testIgnore: takeFirst(projectConfig.testIgnore, config.testIgnore, []),
       testMatch: takeFirst(projectConfig.testMatch, config.testMatch, '**/*.@(spec|test).?(c|m)[jt]s?(x)'),
-      timeout: takeFirst(configCLIOverrides.timeout, projectConfig.timeout, config.timeout, defaultTimeout),
+      timeout: takeFirst(configCLIOverrides.debug ? 0 : undefined, configCLIOverrides.timeout, projectConfig.timeout, config.timeout, defaultTimeout),
       use: mergeObjects(config.use, projectConfig.use, configCLIOverrides.use),
       dependencies: projectConfig.dependencies || [],
       teardown: projectConfig.teardown,

--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -20,6 +20,7 @@ import type { ConfigLocation, FullConfigInternal } from './config';
 import type { ReporterDescription, TestInfoError, TestStatus } from '../../types/test';
 
 export type ConfigCLIOverrides = {
+  debug?: boolean;
   forbidOnly?: boolean;
   fullyParallel?: boolean;
   globalTimeout?: number;

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -229,7 +229,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
       playwrightLibrary.selectors.setTestIdAttribute(testIdAttribute);
     testInfo.snapshotSuffix = process.platform;
     if (debugMode())
-      testInfo.setTimeout(0);
+      (testInfo as TestInfoImpl)._setDebugMode();
     for (const browserType of [playwright.chromium, playwright.firefox, playwright.webkit]) {
       (browserType as any)._defaultContextOptions = _combinedContextOptions;
       (browserType as any)._defaultContextTimeout = actionTimeout || 0;
@@ -270,7 +270,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
         step?.complete({ error });
       },
       onWillPause: () => {
-        currentTestInfo()?.setTimeout(0);
+        currentTestInfo()?._setDebugMode();
       },
       runAfterCreateBrowserContext: async (context: BrowserContext) => {
         await artifactsRecorder?.didCreateBrowserContext(context);

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -308,9 +308,7 @@ function overridesFromOptions(options: { [key: string]: any }): ConfigCLIOverrid
   if (options.headed || options.debug)
     overrides.use = { headless: false };
   if (!options.ui && options.debug) {
-    overrides.maxFailures = 1;
-    overrides.timeout = 0;
-    overrides.workers = 1;
+    overrides.debug = true;
     process.env.PWDEBUG = '1';
   }
   if (!options.ui && options.trace) {

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -167,6 +167,8 @@ export class TestInfoImpl implements TestInfo {
     this.expectedStatus = test?.expectedStatus ?? 'skipped';
 
     this._timeoutManager = new TimeoutManager(this.project.timeout);
+    if (configInternal.configCLIOverrides.debug)
+      this._setDebugMode();
 
     this.outputDir = (() => {
       const relativeTestFilePath = path.relative(this.project.testDir, this._requireFile.replace(/\.(spec|test)\.(js|ts|jsx|tsx|mjs|mts|cjs|cts)$/, ''));
@@ -223,17 +225,6 @@ export class TestInfoImpl implements TestInfo {
       if (this.expectedStatus !== 'skipped')
         this.expectedStatus = 'failed';
     }
-  }
-
-  private _findLastNonFinishedStep(filter: (step: TestStepInternal) => boolean) {
-    let result: TestStepInternal | undefined;
-    const visit = (step: TestStepInternal) => {
-      if (!step.endWallTime && filter(step))
-        result = step;
-      step.steps.forEach(visit);
-    };
-    this._steps.forEach(visit);
-    return result;
   }
 
   private _findLastStageStep() {
@@ -402,6 +393,10 @@ export class TestInfoImpl implements TestInfo {
       if (type && ['beforeAll', 'afterAll', 'beforeEach', 'afterEach'].includes(type))
         return type;
     }
+  }
+
+  _setDebugMode() {
+    this._timeoutManager.setIgnoreTimeouts();
   }
 
   // ------------ TestInfo methods ------------

--- a/packages/playwright/src/worker/timeoutManager.ts
+++ b/packages/playwright/src/worker/timeoutManager.ts
@@ -52,9 +52,14 @@ export const kMaxDeadline = 2147483647; // 2^31-1
 export class TimeoutManager {
   private _defaultSlot: TimeSlot;
   private _running?: Running;
+  private _ignoreTimeouts = false;
 
   constructor(timeout: number) {
     this._defaultSlot = { timeout, elapsed: 0 };
+  }
+
+  setIgnoreTimeouts() {
+    this._ignoreTimeouts = true;
   }
 
   interrupt() {
@@ -94,7 +99,7 @@ export class TimeoutManager {
     if (running.timer)
       clearTimeout(running.timer);
     running.timer = undefined;
-    if (!running.slot.timeout) {
+    if (this._ignoreTimeouts || !running.slot.timeout) {
       running.deadline = kMaxDeadline;
       return;
     }
@@ -119,8 +124,6 @@ export class TimeoutManager {
 
   setTimeout(timeout: number) {
     const slot = this._running ? this._running.slot : this._defaultSlot;
-    if (!slot.timeout)
-      return; // Zero timeout means some debug mode - do not set a timeout.
     slot.timeout = timeout;
     if (this._running)
       this._updateTimeout(this._running);


### PR DESCRIPTION
This allows any time slot that has a legitimate timeout of zero to be updated later on. See test for an example.

Previously, setting timeout to zero at any moment was considered a "debug mode" and any subsequent timeouts were ignored.