### PR TITLE
fix(client-certificates): improve close handling from target and proxy

### DIFF
--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -210,8 +210,10 @@ class SocksProxyConnection {
           return;
         }
 
-        if (this._closed)
+        if (this._closed) {
+          internalTLS.destroy();
           return;
+        }
         targetTLS = tls.connect({
           socket: this.target,
           host: this.host,


### PR DESCRIPTION
Motivation: TLS handshake errors were not reported correctly to the client. Before e.g. during ALPNCache.get neither catch/then was called which lead to stalling connections. This fixes it by adding the appropriate listeners and reporting it back to the client. 

https://github.com/microsoft/playwright/issues/32004