### PR TITLE
fix(client-certificates): stall on tls handshake errors

### DIFF
--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -60,11 +60,9 @@ class ALPNCache {
       ALPNProtocols: ['h2', 'http/1.1'],
       rejectUnauthorized: false,
     }).then(socket => {
-      socket.once('secureConnect', () => {
-        // The server may not respond with ALPN, in which case we default to http/1.1.
-        result.resolve(socket.alpnProtocol || 'http/1.1');
-        socket.end();
-      });
+      // The server may not respond with ALPN, in which case we default to http/1.1.
+      result.resolve(socket.alpnProtocol || 'http/1.1');
+      socket.end();
     }).catch(error => {
       debugLogger.log('client-certificates', `ALPN error: ${error.message}`);
       result.resolve('http/1.1');
@@ -213,8 +211,7 @@ class SocksProxyConnection {
           targetTLS.pipe(internalTLS);
         });
 
-        internalTLS.once('end', () => closeBothSockets());
-        targetTLS.once('end', () => closeBothSockets());
+        internalTLS.once('close', () => closeBothSockets());
 
         internalTLS.once('error', () => closeBothSockets());
         targetTLS.once('error', handleError);

--- a/packages/playwright-core/src/utils/happy-eyeballs.ts
+++ b/packages/playwright-core/src/utils/happy-eyeballs.ts
@@ -72,14 +72,16 @@ export async function createTLSSocket(options: tls.ConnectionOptions): Promise<t
     assert(options.host, 'host is required');
     if (net.isIP(options.host)) {
       const socket = tls.connect(options)
-      socket.on('connect', () => resolve(socket));
+      socket.on('secureConnect', () => resolve(socket));
       socket.on('error', error => reject(error));
     } else {
       createConnectionAsync(options, (err, socket) => {
         if (err)
           reject(err);
-        if (socket)
-          resolve(socket);
+        if (socket) {
+          socket.on('secureConnect', () => resolve(socket));
+          socket.on('error', error => reject(error));
+        }
       }, true).catch(err => reject(err));
     }
   });


### PR DESCRIPTION
Extracted from https://github.com/microsoft/playwright/pull/32158.