### PR TITLE
cherry-pick(#32094): fix(test runner): run project dependencies of `--only-changed` test files

### DIFF
--- a/tests/playwright-test/only-changed.spec.ts
+++ b/tests/playwright-test/only-changed.spec.ts
@@ -365,3 +365,52 @@ test('UI mode is not supported', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('--only-changed is not supported in UI mode');
 });
+
+test('should run project dependencies of changed tests', {
+  annotation: {
+    type: 'issue',
+    description: 'https://github.com/microsoft/playwright/issues/32070',
+  },
+}, async ({ runInlineTest, git, writeFiles }) => {
+  await writeFiles({
+    'playwright.config.ts': `
+      module.exports = {
+        projects: [
+          { name: 'setup', testMatch: 'setup.spec.ts', },
+          { name: 'main', dependencies: ['setup'] },
+        ],
+      };
+    `,
+    'setup.spec.ts': `
+    import { test, expect } from '@playwright/test';
+
+    test('setup test', async ({ page }) => {
+      console.log('setup test is executed')
+    });
+    `,
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('fails', () => { expect(1).toBe(2); });
+    `,
+    'b.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('fails', () => { expect(1).toBe(2); });
+    `,
+  });
+
+  git(`add .`);
+  git(`commit -m init`);
+
+  const result = await runInlineTest({
+    'c.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('fails', () => { expect(1).toBe(2); });
+    `
+  }, { 'only-changed': true });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.passed).toBe(1);
+
+  expect(result.output).toContain('setup test is executed');
+});


### PR DESCRIPTION
 Closes https://github.com/microsoft/playwright/issues/32070. We were applying `additionalFileMatcher` not just to `filteredProjectSuites`, but also to `projectSuites`. `projectSuites` is where we take dependency projects from, though - so `--only-changed` led to empty dependency projects, resulting in the reported bug.
    
The fix is to only apply `additionalFileMatcher` on `filteredProjectSuites`.