### PR TITLE
feat(client-certificates): allow passing certificates from memory

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -531,9 +531,9 @@ Does not enforce fixed viewport, allows resizing window in the headed mode.
 - `clientCertificates` <[Array]<[Object]>>
   - `origin` <[string]> Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
   - `certPath` ?<[path]> Path to the file with the certificate in PEM format.
-  - `cert` ?<[string]> Direct value of the certificate in PEM format.
+  - `cert` ?<[Buffer]> Direct value of the certificate in PEM format.
   - `keyPath` ?<[path]> Path to the file with the private key in PEM format.
-  - `key` ?<[string]> Direct value of the private key in PEM format.
+  - `key` ?<[Buffer]> Direct value of the private key in PEM format.
   - `pfxPath` ?<[path]> Path to the PFX or PKCS12 encoded private key and certificate chain.
   - `pfx` ?<[Buffer]> Direct value of the PFX or PKCS12 encoded private key and certificate chain.
   - `passphrase` ?<[string]> Passphrase for the private key (PEM or PFX).

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -531,15 +531,18 @@ Does not enforce fixed viewport, allows resizing window in the headed mode.
 - `clientCertificates` <[Array]<[Object]>>
   - `origin` <[string]> Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
   - `certPath` ?<[path]> Path to the file with the certificate in PEM format.
+  - `cert` ?<[string]> Direct value of the certificate in PEM format.
   - `keyPath` ?<[path]> Path to the file with the private key in PEM format.
+  - `key` ?<[string]> Direct value of the private key in PEM format.
   - `pfxPath` ?<[path]> Path to the PFX or PKCS12 encoded private key and certificate chain.
+  - `pfx` ?<[Buffer]> Direct value of the PFX or PKCS12 encoded private key and certificate chain.
   - `passphrase` ?<[string]> Passphrase for the private key (PEM or PFX).
 
 TLS Client Authentication allows the server to request a client certificate and verify it.
 
 **Details**
 
-An array of client certificates to be used. Each certificate object must have both `certPath` and `keyPath` or a single `pfxPath` to load the client certificate. Optionally, `passphrase` property should be provided if the certficiate is encrypted. The `origin` property should be provided with an exact match to the request origin that the certificate is valid for.
+An array of client certificates to be used. Each certificate object must have either both `certPath` and `keyPath`, a single `pfxPath`, or their corresponding direct value equivalents (`cert` and `key`, or `pfx`). Optionally, `passphrase` property should be provided if the certificate is encrypted. The `origin` property should be provided with an exact match to the request origin that the certificate is valid for.
 
 :::note
 Using Client Certificates in combination with Proxy Servers is not supported.

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -553,9 +553,9 @@ export async function toClientCertificatesProtocol(certs?: BrowserContextOptions
   if (!certs)
     return undefined;
 
-  const bufferizeContent = async (value?: string | Buffer, path?: string): Promise<Buffer | undefined> => {
+  const bufferizeContent = async (value?: Buffer, path?: string): Promise<Buffer | undefined> => {
     if (value)
-      return Buffer.from(value);
+      return value;
     if (path)
       return await fs.promises.readFile(path);
   };

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -552,13 +552,19 @@ function toAcceptDownloadsProtocol(acceptDownloads?: boolean) {
 export async function toClientCertificatesProtocol(certs?: BrowserContextOptions['clientCertificates']): Promise<channels.PlaywrightNewRequestParams['clientCertificates']> {
   if (!certs)
     return undefined;
-  return await Promise.all(certs.map(async cert => {
-    return {
-      origin: cert.origin,
-      cert: cert.certPath ? await fs.promises.readFile(cert.certPath) : undefined,
-      key: cert.keyPath ? await fs.promises.readFile(cert.keyPath) : undefined,
-      pfx: cert.pfxPath ? await fs.promises.readFile(cert.pfxPath) : undefined,
-      passphrase: cert.passphrase,
-    };
-  }));
+
+  const bufferizeContent = async (value?: string | Buffer, path?: string): Promise<Buffer | undefined> => {
+    if (value)
+      return Buffer.from(value);
+    if (path)
+      return await fs.promises.readFile(path);
+  };
+
+  return await Promise.all(certs.map(async cert => ({
+    origin: cert.origin,
+    cert: await bufferizeContent(cert.cert, cert.certPath),
+    key: await bufferizeContent(cert.key, cert.keyPath),
+    pfx: await bufferizeContent(cert.pfx, cert.pfxPath),
+    passphrase: cert.passphrase,
+  })));
 }

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -49,8 +49,11 @@ export const kLifecycleEvents: Set<LifecycleEvent> = new Set(['load', 'domconten
 
 export type ClientCertificate = {
   origin: string;
+  cert?: string;
   certPath?: string;
+  key?: string;
   keyPath?: string;
+  pfx?: Buffer;
   pfxPath?: string;
   passphrase?: string;
 };

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -49,9 +49,9 @@ export const kLifecycleEvents: Set<LifecycleEvent> = new Set(['load', 'domconten
 
 export type ClientCertificate = {
   origin: string;
-  cert?: string;
+  cert?: Buffer;
   certPath?: string;
-  key?: string;
+  key?: Buffer;
   keyPath?: string;
   pfx?: Buffer;
   pfxPath?: string;

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9138,10 +9138,10 @@ export interface Browser {
      *
      * **Details**
      *
-     * An array of client certificates to be used. Each certificate object must have both `certPath` and `keyPath` or a
-     * single `pfxPath` to load the client certificate. Optionally, `passphrase` property should be provided if the
-     * certficiate is encrypted. The `origin` property should be provided with an exact match to the request origin that
-     * the certificate is valid for.
+     * An array of client certificates to be used. Each certificate object must have either both `certPath` and `keyPath`,
+     * a single `pfxPath`, or their corresponding direct value equivalents (`cert` and `key`, or `pfx`). Optionally,
+     * `passphrase` property should be provided if the certificate is encrypted. The `origin` property should be provided
+     * with an exact match to the request origin that the certificate is valid for.
      *
      * **NOTE** Using Client Certificates in combination with Proxy Servers is not supported.
      *
@@ -9160,14 +9160,29 @@ export interface Browser {
       certPath?: string;
 
       /**
+       * Direct value of the certificate in PEM format.
+       */
+      cert?: string;
+
+      /**
        * Path to the file with the private key in PEM format.
        */
       keyPath?: string;
 
       /**
+       * Direct value of the private key in PEM format.
+       */
+      key?: string;
+
+      /**
        * Path to the PFX or PKCS12 encoded private key and certificate chain.
        */
       pfxPath?: string;
+
+      /**
+       * Direct value of the PFX or PKCS12 encoded private key and certificate chain.
+       */
+      pfx?: Buffer;
 
       /**
        * Passphrase for the private key (PEM or PFX).
@@ -13850,10 +13865,10 @@ export interface BrowserType<Unused = {}> {
      *
      * **Details**
      *
-     * An array of client certificates to be used. Each certificate object must have both `certPath` and `keyPath` or a
-     * single `pfxPath` to load the client certificate. Optionally, `passphrase` property should be provided if the
-     * certficiate is encrypted. The `origin` property should be provided with an exact match to the request origin that
-     * the certificate is valid for.
+     * An array of client certificates to be used. Each certificate object must have either both `certPath` and `keyPath`,
+     * a single `pfxPath`, or their corresponding direct value equivalents (`cert` and `key`, or `pfx`). Optionally,
+     * `passphrase` property should be provided if the certificate is encrypted. The `origin` property should be provided
+     * with an exact match to the request origin that the certificate is valid for.
      *
      * **NOTE** Using Client Certificates in combination with Proxy Servers is not supported.
      *
@@ -13872,14 +13887,29 @@ export interface BrowserType<Unused = {}> {
       certPath?: string;
 
       /**
+       * Direct value of the certificate in PEM format.
+       */
+      cert?: string;
+
+      /**
        * Path to the file with the private key in PEM format.
        */
       keyPath?: string;
 
       /**
+       * Direct value of the private key in PEM format.
+       */
+      key?: string;
+
+      /**
        * Path to the PFX or PKCS12 encoded private key and certificate chain.
        */
       pfxPath?: string;
+
+      /**
+       * Direct value of the PFX or PKCS12 encoded private key and certificate chain.
+       */
+      pfx?: Buffer;
 
       /**
        * Passphrase for the private key (PEM or PFX).
@@ -16259,10 +16289,10 @@ export interface APIRequest {
      *
      * **Details**
      *
-     * An array of client certificates to be used. Each certificate object must have both `certPath` and `keyPath` or a
-     * single `pfxPath` to load the client certificate. Optionally, `passphrase` property should be provided if the
-     * certficiate is encrypted. The `origin` property should be provided with an exact match to the request origin that
-     * the certificate is valid for.
+     * An array of client certificates to be used. Each certificate object must have either both `certPath` and `keyPath`,
+     * a single `pfxPath`, or their corresponding direct value equivalents (`cert` and `key`, or `pfx`). Optionally,
+     * `passphrase` property should be provided if the certificate is encrypted. The `origin` property should be provided
+     * with an exact match to the request origin that the certificate is valid for.
      *
      * **NOTE** Using Client Certificates in combination with Proxy Servers is not supported.
      *
@@ -16281,14 +16311,29 @@ export interface APIRequest {
       certPath?: string;
 
       /**
+       * Direct value of the certificate in PEM format.
+       */
+      cert?: string;
+
+      /**
        * Path to the file with the private key in PEM format.
        */
       keyPath?: string;
 
       /**
+       * Direct value of the private key in PEM format.
+       */
+      key?: string;
+
+      /**
        * Path to the PFX or PKCS12 encoded private key and certificate chain.
        */
       pfxPath?: string;
+
+      /**
+       * Direct value of the PFX or PKCS12 encoded private key and certificate chain.
+       */
+      pfx?: Buffer;
 
       /**
        * Passphrase for the private key (PEM or PFX).
@@ -20600,10 +20645,10 @@ export interface BrowserContextOptions {
    *
    * **Details**
    *
-   * An array of client certificates to be used. Each certificate object must have both `certPath` and `keyPath` or a
-   * single `pfxPath` to load the client certificate. Optionally, `passphrase` property should be provided if the
-   * certficiate is encrypted. The `origin` property should be provided with an exact match to the request origin that
-   * the certificate is valid for.
+   * An array of client certificates to be used. Each certificate object must have either both `certPath` and `keyPath`,
+   * a single `pfxPath`, or their corresponding direct value equivalents (`cert` and `key`, or `pfx`). Optionally,
+   * `passphrase` property should be provided if the certificate is encrypted. The `origin` property should be provided
+   * with an exact match to the request origin that the certificate is valid for.
    *
    * **NOTE** Using Client Certificates in combination with Proxy Servers is not supported.
    *
@@ -20622,14 +20667,29 @@ export interface BrowserContextOptions {
     certPath?: string;
 
     /**
+     * Direct value of the certificate in PEM format.
+     */
+    cert?: string;
+
+    /**
      * Path to the file with the private key in PEM format.
      */
     keyPath?: string;
 
     /**
+     * Direct value of the private key in PEM format.
+     */
+    key?: string;
+
+    /**
      * Path to the PFX or PKCS12 encoded private key and certificate chain.
      */
     pfxPath?: string;
+
+    /**
+     * Direct value of the PFX or PKCS12 encoded private key and certificate chain.
+     */
+    pfx?: Buffer;
 
     /**
      * Passphrase for the private key (PEM or PFX).

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9162,7 +9162,7 @@ export interface Browser {
       /**
        * Direct value of the certificate in PEM format.
        */
-      cert?: string;
+      cert?: Buffer;
 
       /**
        * Path to the file with the private key in PEM format.
@@ -9172,7 +9172,7 @@ export interface Browser {
       /**
        * Direct value of the private key in PEM format.
        */
-      key?: string;
+      key?: Buffer;
 
       /**
        * Path to the PFX or PKCS12 encoded private key and certificate chain.
@@ -13889,7 +13889,7 @@ export interface BrowserType<Unused = {}> {
       /**
        * Direct value of the certificate in PEM format.
        */
-      cert?: string;
+      cert?: Buffer;
 
       /**
        * Path to the file with the private key in PEM format.
@@ -13899,7 +13899,7 @@ export interface BrowserType<Unused = {}> {
       /**
        * Direct value of the private key in PEM format.
        */
-      key?: string;
+      key?: Buffer;
 
       /**
        * Path to the PFX or PKCS12 encoded private key and certificate chain.
@@ -16313,7 +16313,7 @@ export interface APIRequest {
       /**
        * Direct value of the certificate in PEM format.
        */
-      cert?: string;
+      cert?: Buffer;
 
       /**
        * Path to the file with the private key in PEM format.
@@ -16323,7 +16323,7 @@ export interface APIRequest {
       /**
        * Direct value of the private key in PEM format.
        */
-      key?: string;
+      key?: Buffer;
 
       /**
        * Path to the PFX or PKCS12 encoded private key and certificate chain.
@@ -20669,7 +20669,7 @@ export interface BrowserContextOptions {
     /**
      * Direct value of the certificate in PEM format.
      */
-    cert?: string;
+    cert?: Buffer;
 
     /**
      * Path to the file with the private key in PEM format.
@@ -20679,7 +20679,7 @@ export interface BrowserContextOptions {
     /**
      * Direct value of the private key in PEM format.
      */
-    key?: string;
+    key?: Buffer;
 
     /**
      * Path to the PFX or PKCS12 encoded private key and certificate chain.

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5206,10 +5206,10 @@ export interface PlaywrightTestOptions {
    *
    * **Details**
    *
-   * An array of client certificates to be used. Each certificate object must have both `certPath` and `keyPath` or a
-   * single `pfxPath` to load the client certificate. Optionally, `passphrase` property should be provided if the
-   * certficiate is encrypted. The `origin` property should be provided with an exact match to the request origin that
-   * the certificate is valid for.
+   * An array of client certificates to be used. Each certificate object must have either both `certPath` and `keyPath`,
+   * a single `pfxPath`, or their corresponding direct value equivalents (`cert` and `key`, or `pfx`). Optionally,
+   * `passphrase` property should be provided if the certificate is encrypted. The `origin` property should be provided
+   * with an exact match to the request origin that the certificate is valid for.
    *
    * **NOTE** Using Client Certificates in combination with Proxy Servers is not supported.
    *

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -303,6 +303,21 @@ test.describe('browser', () => {
     await page.close();
   });
 
+  test('should pass with matching certificates when passing as content', async ({ browser, startCCServer, asset, browserName }) => {
+    const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && process.platform === 'darwin' });
+    const page = await browser.newPage({
+      ignoreHTTPSErrors: true,
+      clientCertificates: [{
+        origin: new URL(serverURL).origin,
+        cert: (await fs.promises.readFile(asset('client-certificates/client/trusted/cert.pem'))).toString(),
+        key: (await fs.promises.readFile(asset('client-certificates/client/trusted/key.pem'))).toString(),
+      }],
+    });
+    await page.goto(serverURL);
+    await expect(page.getByTestId('message')).toHaveText('Hello Alice, your certificate was issued by localhost!');
+    await page.close();
+  });
+
   test('should not hang on tls errors during TLS 1.2 handshake', async ({ browser, asset, platform, browserName }) => {
     for (const tlsVersion of ['TLSv1.3', 'TLSv1.2'] as const) {
       await test.step(`TLS version: ${tlsVersion}`, async () => {
@@ -352,6 +367,21 @@ test.describe('browser', () => {
       clientCertificates: [{
         origin: new URL(serverURL).origin,
         pfxPath: asset('client-certificates/client/trusted/cert.pfx'),
+        passphrase: 'secure'
+      }],
+    });
+    await page.goto(serverURL);
+    await expect(page.getByTestId('message')).toHaveText('Hello Alice, your certificate was issued by localhost!');
+    await page.close();
+  });
+
+  test('should pass with matching certificates in pfx format when passing as content', async ({ browser, startCCServer, asset, browserName }) => {
+    const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && process.platform === 'darwin' });
+    const page = await browser.newPage({
+      ignoreHTTPSErrors: true,
+      clientCertificates: [{
+        origin: new URL(serverURL).origin,
+        pfx: await fs.promises.readFile(asset('client-certificates/client/trusted/cert.pfx')),
         passphrase: 'secure'
       }],
     });

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -309,8 +309,8 @@ test.describe('browser', () => {
       ignoreHTTPSErrors: true,
       clientCertificates: [{
         origin: new URL(serverURL).origin,
-        cert: (await fs.promises.readFile(asset('client-certificates/client/trusted/cert.pem'))).toString(),
-        key: (await fs.promises.readFile(asset('client-certificates/client/trusted/key.pem'))).toString(),
+        cert: await fs.promises.readFile(asset('client-certificates/client/trusted/cert.pem')),
+        key: await fs.promises.readFile(asset('client-certificates/client/trusted/key.pem')),
       }],
     });
     await page.goto(serverURL);


### PR DESCRIPTION
Motivation: We received multiple feedback from users who want to add certificates from in-memory.

Fixes https://github.com/microsoft/playwright/issues/32200