### PR TITLE
fix(ct): vue jsx component.update type

### DIFF
--- a/packages/playwright-ct-vue/index.d.ts
+++ b/packages/playwright-ct-vue/index.d.ts
@@ -55,7 +55,7 @@ export interface MountResultJsx extends Locator {
 export const test: TestType<{
   mount<HooksConfig>(
     component: JSX.Element,
-    options: MountOptionsJsx<HooksConfig>
+    options?: MountOptionsJsx<HooksConfig>
   ): Promise<MountResultJsx>;
   mount<HooksConfig, Component = unknown>(
     component: Component,


### PR DESCRIPTION
partial fix for: https://github.com/microsoft/playwright/issues/31927#issuecomment-2267065378

The options object wasn't treated as partial, unlike in other frameworks, which led to the `component.update({ props: {} })` type being selected instead the `component.update(<Component prop={} />)` during jsx usage.