### PR TITLE
chore: start listening for navigation events before navigation starts

### DIFF
--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -181,8 +181,9 @@ it('should work with Cross-Origin-Opener-Policy after redirect', async ({ page, 
 
 it('should properly cancel Cross-Origin-Opener-Policy navigation', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32107' },
-}, async ({ page, server, browserName, isLinux }) => {
+}, async ({ page, server, browserName, isLinux, headless }) => {
   it.fixme(browserName === 'webkit' && isLinux, 'Started failing after https://commits.webkit.org/281488@main');
+  it.fixme(browserName === 'chromium' && headless, 'COOP navigation cancels the one that starts later');
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
     res.end();


### PR DESCRIPTION
There is a chance in case of cross-process navigation that the navigation event comes before `navigateFrame` finishes.