### PR TITLE
fix: added chain operator to avoid empty reports when an annotation i…

### DIFF
--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -176,7 +176,7 @@ function cacheSearchValues(test: TestCaseSummary & { [searchValuesSymbol]?: Sear
     line: String(test.location.line),
     column: String(test.location.column),
     labels: test.tags.map(tag => tag.toLowerCase()),
-    annotations: test.annotations.map(a => a.type.toLowerCase() + '=' + a.description?.toLocaleLowerCase())
+    annotations: test.annotations.map(a => a.type?.toLowerCase() + '=' + a.description?.toLocaleLowerCase())
   };
   test[searchValuesSymbol] = searchValues;
   return searchValues;


### PR DESCRIPTION
…s wrongly set e.g. test.info.annotations.push(' //')