### PR TITLE
fix(client-certificates): errors during http2 TLS handshake

### DIFF
--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -169,7 +169,10 @@ class SocksProxyConnection {
               this.target.removeListener('close', this._targetCloseEventListener);
               // @ts-expect-error
               const session: http2.ServerHttp2Session = http2.performServerHandshake(internalTLS);
-              session.on('error', () => this._targetCloseEventListener());
+              session.on('error', () => {
+                this.target.destroy();
+                this._targetCloseEventListener();
+              });
               session.once('stream', (stream: http2.ServerHttp2Stream) => {
                 stream.respond({
                   'content-type': 'text/html',

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -169,6 +169,7 @@ class SocksProxyConnection {
               this.target.removeListener('close', this._targetCloseEventListener);
               // @ts-expect-error
               const session: http2.ServerHttp2Session = http2.performServerHandshake(internalTLS);
+              session.on('error', () => this._targetCloseEventListener());
               session.once('stream', (stream: http2.ServerHttp2Stream) => {
                 stream.respond({
                   'content-type': 'text/html',

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -461,7 +461,7 @@ test.describe('browser', () => {
     });
 
     await new Promise<void>(resolve => server.listen(0, 'localhost', resolve));
-    const port = (server.address() as import('net').AddressInfo).port;
+    const port = (server.address() as net.AddressInfo).port;
     const origin = 'https://' + (browserName === 'webkit' && platform === 'darwin' ? 'local.playwright' : 'localhost');
     const serverUrl = `${origin}:${port}`;
 
@@ -669,6 +669,39 @@ test.describe('browser', () => {
     await page.goto(serverURL);
     await expect(page.getByText('Playwright client-certificate error: self-signed certificate')).toBeVisible();
     await page.close();
+  });
+
+  test('should handle rejected certificate in handshake with HTTP/2', async ({ browser, asset, browserName, platform }) => {
+    const server: http2.Http2SecureServer = createHttp2Server({
+      key: fs.readFileSync(asset('client-certificates/server/server_key.pem')),
+      cert: fs.readFileSync(asset('client-certificates/server/server_cert.pem')),
+      ca: [fs.readFileSync(asset('client-certificates/server/server_cert.pem'))],
+      requestCert: true,
+    }, async (req: http2.Http2ServerRequest, res: http2.Http2ServerResponse) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('Hello world');
+    });
+
+    await new Promise<void>(resolve => server.listen(0, 'localhost', resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    const serverUrl = 'https://' + (browserName === 'webkit' && platform === 'darwin' ? 'local.playwright' : 'localhost') + ':' + port;
+
+    const context = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      clientCertificates: [{
+        origin: 'https://just-there-that-the-client-certificates-proxy-server-is-getting-launched.com',
+        certPath: asset('client-certificates/client/trusted/cert.pem'),
+        keyPath: asset('client-certificates/client/trusted/key.pem'),
+      }],
+    });
+
+    const page = await context.newPage();
+
+    // This was triggering an unhandled error before.
+    await page.goto(serverUrl).catch(e => e);
+
+    await context.close();
+    await new Promise<void>(resolve => server.close(() => resolve()));
   });
 
   test.describe('persistentContext', () => {

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -698,7 +698,7 @@ test.describe('browser', () => {
     const page = await context.newPage();
 
     // This was triggering an unhandled error before.
-    await page.goto(serverUrl).catch(e => e);
+    await page.goto(serverUrl).catch(() => {});
 
     await context.close();
     await new Promise<void>(resolve => server.close(() => resolve()));


### PR DESCRIPTION
Investigation: Currently when a TLS handshake error happens on a http2 connection, the response gets corrupted. This is because:

1. The client (browser, internalTLS) sends a http2 handshake to our proxy
1. The target connection emits a `secureConnect` event
1. We attach listeners since we received secureConnect event and send the buffered "client hello" data over
1. The target connection emits an `error` event
1. We try to send a http2 response over but the client (browser) already received some parts of the handshake and is confused. This ends up in `Error: Received bad client magic byte string` and `net::ERR_HTTP2_PROTOCOL_ERROR`.

This brought up that using the [`session` event](https://nodejs.org/api/tls.html#event-session) seems to be the right one for our use-case.

Relates https://github.com/playwright-community/playwright-go/pull/480
Example error: https://github.com/playwright-community/playwright-go/actions/runs/10465991368/job/28982096640?pr=480#step:6:166