### PR TITLE
fix(test runner): perform shallow clone check in config directory

### DIFF
--- a/packages/playwright/src/runner/vcs.ts
+++ b/packages/playwright/src/runner/vcs.ts
@@ -30,7 +30,7 @@ export async function detectChangedTestFiles(baseCommit: string, configDir: stri
 
       const unknownRevision = error.output.some(line => line?.includes('unknown revision'));
       if (unknownRevision) {
-        const isShallowClone = childProcess.execSync('git rev-parse --is-shallow-repository', { encoding: 'utf-8',  stdio: 'pipe' }).trim() === 'true';
+        const isShallowClone = childProcess.execSync('git rev-parse --is-shallow-repository', { encoding: 'utf-8',  stdio: 'pipe', cwd: configDir }).trim() === 'true';
         if (isShallowClone) {
           throw new Error([
             `The repository is a shallow clone and does not have '${baseCommit}' available locally.`,


### PR DESCRIPTION
Our CI operates on shallow clones. In vcs.ts, we perform a check for shallow clones in `process.cwd()` instead of the test directory. This makes the test in https://github.com/Skn0tt/playwright/blob/3c208aeeff255fd9ccf0528863e6b4b790d0f1b8/tests/playwright-test/only-changed.spec.ts#L201 failing in CI, but only for PRs. The fix is to perform the check on. the test directory.