### PR TITLE
test: update Modernizir expectations

### DIFF
--- a/tests/assets/modernizr/safari-18.json
+++ b/tests/assets/modernizr/safari-18.json
@@ -230,7 +230,7 @@
   "fullscreen": true,
   "gamepads": true,
   "geolocation": true,
-  "hiddenscroll": false,
+  "hiddenscroll": true,
   "history": true,
   "htmlimports": false,
   "ie8compat": false,

--- a/tests/library/modernizr.spec.ts
+++ b/tests/library/modernizr.spec.ts
@@ -39,7 +39,6 @@ it('Safari Desktop', async ({ browser, browserName, platform, server, headless, 
   const { actual, expected } = await checkFeatures('safari-18', context, server);
 
   expected.pushmanager = false;
-  expected.hiddenscroll = true;
   expected.devicemotion2 = false;
   expected.devicemotion = false;
   expected.deviceorientation = false;


### PR DESCRIPTION
Looks like `hiddenscroll` was different when an external monitor was connected.