### PR TITLE
fix: don't throw error on about:blank when blocking ServiceWorker

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -142,7 +142,7 @@ export abstract class BrowserContext extends SdkObject {
     if (debugMode() === 'console')
       await this.extendInjectedScript(consoleApiSource.source);
     if (this._options.serviceWorkers === 'block')
-      await this.addInitScript(`\nnavigator.serviceWorker.register = async () => { console.warn('Service Worker registration blocked by Playwright'); };\n`);
+      await this.addInitScript(`\nif (navigator.serviceWorker) navigator.serviceWorker.register = async () => { console.warn('Service Worker registration blocked by Playwright'); };\n`);
 
     if (this._options.permissions)
       await this.grantPermissions(this._options.permissions);

--- a/tests/library/browsercontext-service-worker-policy.spec.ts
+++ b/tests/library/browsercontext-service-worker-policy.spec.ts
@@ -29,4 +29,12 @@ it.describe('block', () => {
       page.goto(server.PREFIX + '/serviceworkers/empty/sw.html'),
     ]);
   });
+
+  it('should not throw error on about:blank', async ({ page }) => {
+    it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32292' });
+    const errors = [];
+    page.on('pageerror', error => errors.push(error));
+    await page.goto('about:blank');
+    expect(errors).toEqual([]);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/32292