### PR TITLE
tests: delete flaky COOP test

### DIFF
--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -179,27 +179,6 @@ it('should work with Cross-Origin-Opener-Policy after redirect', async ({ page, 
   expect(firstRequest.url()).toBe(server.PREFIX + '/redirect');
 });
 
-it('should properly cancel Cross-Origin-Opener-Policy navigation', {
-  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32107' },
-}, async ({ page, server, browserName, isLinux, headless }) => {
-  it.fixme(browserName === 'webkit' && isLinux, 'Started failing after https://commits.webkit.org/281488@main');
-  it.fixme(browserName === 'chromium' && headless, 'COOP navigation cancels the one that starts later');
-  server.setRoute('/empty.html', (req, res) => {
-    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-    res.end();
-  });
-  const requestPromise = page.waitForRequest(server.EMPTY_PAGE);
-  page.goto(server.EMPTY_PAGE).catch(() => {});
-  await new Promise(f => setTimeout(f, 50));
-  // Non COOP response.
-  await page.goto(server.CROSS_PROCESS_PREFIX + '/error.html');
-  const req = await requestPromise;
-  const response = await Promise.race([req.response(), new Promise(f => setTimeout(() => f('timeout'), 5_000))]);
-  // First navigation request should either receive response or be canceled by the second
-  // navigation, but never hang unresolved.
-  expect(response).not.toBe('timeout');
-});
-
 it('should capture iframe navigation request', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   expect(page.url()).toBe(server.EMPTY_PAGE);


### PR DESCRIPTION
The scenario that the test covers is inherently racy and has been flaky in all browsers.

Fixes https://github.com/microsoft/playwright/issues/32107