### PR TITLE
fix(ui): respect --output param

### DIFF
--- a/packages/playwright/src/isomorphic/testServerInterface.ts
+++ b/packages/playwright/src/isomorphic/testServerInterface.ts
@@ -44,7 +44,7 @@ export interface TestServerInterface {
 
   installBrowsers(params: {}): Promise<void>;
 
-  runGlobalSetup(params: {}): Promise<{
+  runGlobalSetup(params: { outputDir?: string }): Promise<{
     report: ReportEntry[],
     status: reporterTypes.FullResult['status']
   }>;
@@ -81,6 +81,7 @@ export interface TestServerInterface {
     locations?: string[];
     grep?: string;
     grepInvert?: string;
+    outputDir?: string;
   }): Promise<{
     report: ReportEntry[],
     status: reporterTypes.FullResult['status']

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -148,7 +148,10 @@ class TestServerDispatcher implements TestServerInterface {
   async runGlobalSetup(params: Parameters<TestServerInterface['runGlobalSetup']>[0]): ReturnType<TestServerInterface['runGlobalSetup']> {
     await this.runGlobalTeardown();
 
-    const { config, error } = await this._loadConfig();
+    const overrides: ConfigCLIOverrides = {
+      outputDir: params.outputDir,
+    };
+    const { config, error } = await this._loadConfig(overrides);
     if (!config) {
       const { reporter, report } = await this._collectingInternalReporter();
       // Produce dummy config when it has an error.
@@ -256,6 +259,7 @@ class TestServerDispatcher implements TestServerInterface {
     const overrides: ConfigCLIOverrides = {
       repeatEach: 1,
       retries: 0,
+      outputDir: params.outputDir,
     };
     const { config, error } = await this._loadConfig(overrides);
     if (!config) {

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -205,12 +205,14 @@ export const UIModeView: React.FC<{}> = ({
           interceptStdio: true,
           watchTestDirs: true
         });
-        const { status, report } = await testServerConnection.runGlobalSetup({});
+        const { status, report } = await testServerConnection.runGlobalSetup({
+          outputDir: queryParams.outputDir,
+        });
         teleSuiteUpdater.processGlobalReport(report);
         if (status !== 'passed')
           return;
 
-        const result = await testServerConnection.listTests({ projects: queryParams.projects, locations: queryParams.args, grep: queryParams.grep, grepInvert: queryParams.grepInvert });
+        const result = await testServerConnection.listTests({ projects: queryParams.projects, locations: queryParams.args, grep: queryParams.grep, grepInvert: queryParams.grepInvert, outputDir: queryParams.outputDir });
         teleSuiteUpdater.processListReport(result.report);
 
         testServerConnection.onReport(params => {
@@ -333,7 +335,7 @@ export const UIModeView: React.FC<{}> = ({
       commandQueue.current = commandQueue.current.then(async () => {
         setIsLoading(true);
         try {
-          const result = await testServerConnection.listTests({ projects: queryParams.projects, locations: queryParams.args, grep: queryParams.grep, grepInvert: queryParams.grepInvert });
+          const result = await testServerConnection.listTests({ projects: queryParams.projects, locations: queryParams.args, grep: queryParams.grep, grepInvert: queryParams.grepInvert, outputDir: queryParams.outputDir });
           teleSuiteUpdater.processListReport(result.report);
         } catch (e) {
           // eslint-disable-next-line no-console

--- a/tests/playwright-test/ui-mode-test-setup.spec.ts
+++ b/tests/playwright-test/ui-mode-test-setup.spec.ts
@@ -29,9 +29,10 @@ test('should run global setup and teardown', async ({ runUITest }, testInfo) => 
       });
     `,
     'globalSetup.ts': `
+      import { basename } from "node:path";
       export default (config) => {
         console.log('\\n%%from-global-setup');
-        console.log('%%' + JSON.stringify(config));
+        console.log("setupOutputDir: " + basename(config.projects[0].outputDir));
       };
     `,
     'globalTeardown.ts': `
@@ -51,7 +52,7 @@ test('should run global setup and teardown', async ({ runUITest }, testInfo) => 
   await page.getByTitle('Toggle output').click();
   const output = page.getByTestId('output');
   await expect(output).toContainText('from-global-setup');
-  await expect(output).toContainText(`"outputDir":"${testInfo.outputPath('foo')}"`);
+  await expect(output).toContainText('setupOutputDir: foo');
   await page.close();
 
   await expect.poll(() => testProcess.outputLines()).toContain('from-global-teardown');


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32331

We're already passing the `outputDir` param to the UI, but the UI isn't passing it back to the TestServer. This PR fixes that. I've added it to `listTests`, which is requires to that `TestServerDispatcher#_ignoredProjectOutputs` is populated with the correct output dir. And i've added it to `runGlobalSetup`, which is what the bug report was about.