### PR TITLE
feat(test runner): make `expect.extend` immutable

### DIFF
--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -16,6 +16,7 @@
 
 import {
   captureRawStack,
+  createGuid,
   isString,
   pollAgainstDeadline } from 'playwright-core/lib/utils';
 import type { ExpectZone } from 'playwright-core/lib/utils';
@@ -61,7 +62,6 @@ import {
 import { zones } from 'playwright-core/lib/utils';
 import { TestInfoImpl } from '../worker/testInfo';
 import { ExpectError, isExpectError } from './matcherHint';
-import { randomUUID } from 'node:crypto';
 
 // #region
 // Mirrored from https://github.com/facebook/jest/blob/f13abff8df9a0e1148baf3584bcde6d1b479edc7/packages/expect/src/print.ts
@@ -131,7 +131,7 @@ function createExpect(info: ExpectMetaInfo, prefix: string[] = [], parentPrefixe
 
       if (property === 'extend') {
         return (matchers: any) => {
-          const qualifier = [...prefix, randomUUID()];
+          const qualifier = [...prefix, createGuid()];
 
           const wrappedMatchers: any = {};
           for (const [name, matcher] of Object.entries(matchers)) {

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -189,7 +189,7 @@ function createExpect(info: ExpectMetaInfo, prefix: string[] = [], parentPrefixe
         newInfo.pollIntervals = configuration._poll.intervals;
       }
     }
-    return createExpect(newInfo);
+    return createExpect(newInfo, prefix, parentPrefixes);
   };
 
   return expectInstance;

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -320,7 +320,6 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
       const step = testInfo._addStep(stepInfo);
 
       const reportStepError = (jestError: Error | unknown) => {
-        console.error(jestError);
         const error = isExpectError(jestError) ? new ExpectError(jestError, customMessage, stackFrames) : jestError;
         step.complete({ error });
         if (this._info.isSoft)

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -109,7 +109,7 @@ function createMatchers(actual: unknown, info: ExpectMetaInfo, prefix: string[])
   return new Proxy(expectLibrary(actual), new ExpectMetaInfoProxyHandler(info, prefix));
 }
 
-const getCustomMatchersSymbol = Symbol('get prefix');
+const getCustomMatchersSymbol = Symbol('get custom matchers');
 
 function qualifiedMatcherName(qualifier: string[], matcherName: string) {
   return qualifier.join(':') + '$' + matcherName;

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -111,6 +111,10 @@ function createMatchers(actual: unknown, info: ExpectMetaInfo, prefix: string[],
 
 const getPrefixSymbol = Symbol('get prefix');
 
+function qualifiedMatcherName(qualifier: string[], matcherName: string) {
+  return qualifier.join(':') + '$' + matcherName;
+}
+
 function createExpect(info: ExpectMetaInfo, prefix: string[] = [], parentPrefixes: string[][] = []) {
   const expectInstance: Expect<{}> = new Proxy(expectLibrary, {
     apply: function(target: any, thisArg: any, argumentsList: [unknown, ExpectMessage?]) {
@@ -135,7 +139,7 @@ function createExpect(info: ExpectMetaInfo, prefix: string[] = [], parentPrefixe
 
           const wrappedMatchers: any = {};
           for (const [name, matcher] of Object.entries(matchers)) {
-            const key = qualifier.join(':') + '$' + name;
+            const key = qualifiedMatcherName(qualifier, name);
             wrappedMatchers[key] = function(...args: any[]) {
               const { isNot, promise, utils } = this;
               const newThis: ExpectMatcherState = {
@@ -265,7 +269,7 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
     if (typeof matcherName === 'string') {
       for (const prefix of this._prefixes) {
         for (let i = prefix.length; i > 0; i--) {
-          const qualifiedName = `${prefix.slice(0, i).join(':')}$${matcherName}`;
+          const qualifiedName = qualifiedMatcherName(prefix.slice(0, i), matcherName);
           if (Reflect.has(target, qualifiedName)) {
             matcher = Reflect.get(target, qualifiedName, receiver);
             break;

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -265,21 +265,19 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
 
   get(target: Object, matcherName: string | symbol, receiver: any): any {
     let matcher = Reflect.get(target, matcherName, receiver);
+    if (typeof matcherName !== 'string')
+      return matcher;
 
-    if (typeof matcherName === 'string') {
-      for (const prefix of this._prefixes) {
-        for (let i = prefix.length; i > 0; i--) {
-          const qualifiedName = qualifiedMatcherName(prefix.slice(0, i), matcherName);
-          if (Reflect.has(target, qualifiedName)) {
-            matcher = Reflect.get(target, qualifiedName, receiver);
-            break;
-          }
+    for (const prefix of this._prefixes) {
+      for (let i = prefix.length; i > 0; i--) {
+        const qualifiedName = qualifiedMatcherName(prefix.slice(0, i), matcherName);
+        if (Reflect.has(target, qualifiedName)) {
+          matcher = Reflect.get(target, qualifiedName, receiver);
+          break;
         }
       }
     }
 
-    if (typeof matcherName !== 'string')
-      return matcher;
     if (matcher === undefined)
       throw new Error(`expect: Property '${matcherName}' not found.`);
     if (typeof matcher !== 'function') {

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6577,7 +6577,7 @@ type PollMatchers<R, T, ExtendedMatchers> = {
 export type Expect<ExtendedMatchers = {}> = {
   <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }): MakeMatchers<void, T, ExtendedMatchers>;
   soft: <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }) => MakeMatchers<void, T, ExtendedMatchers>;
-  poll: <T = unknown>(actual: () => T | Promise<T>, messageOrOptions?: string | { message?: string, timeout?: number, intervals?: number[] }) => PollMatchers<Promise<void>,T, ExtendedMatchers>
+  poll: <T = unknown>(actual: () => T | Promise<T>, messageOrOptions?: string | { message?: string, timeout?: number, intervals?: number[] }) => PollMatchers<Promise<void>, T, ExtendedMatchers>;
   extend<MoreMatchers extends Record<string, (this: ExpectMatcherState, receiver: any, ...args: any[]) => MatcherReturnType | Promise<MatcherReturnType>>>(matchers: MoreMatchers): Expect<ExtendedMatchers & MoreMatchers>;
   configure: (configuration: {
     message?: string,

--- a/tests/playwright-test/expect-poll.spec.ts
+++ b/tests/playwright-test/expect-poll.spec.ts
@@ -172,7 +172,9 @@ test('should support .not predicate', async ({ runInlineTest }) => {
 test('should support custom matchers', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.ts': `
-      expect.extend({
+      import { test, expect as baseExpect } from '@playwright/test';
+
+      const expect = baseExpect.extend({
         toBeWithinRange(received, floor, ceiling) {
           const pass = received >= floor && received <= ceiling;
           if (pass) {
@@ -191,10 +193,9 @@ test('should support custom matchers', async ({ runInlineTest }) => {
         },
       });
 
-      import { test, expect } from '@playwright/test';
       test('should poll', async () => {
         let i = 0;
-        await test.expect.poll(() => ++i).toBeWithinRange(3, Number.MAX_VALUE);
+        await expect.poll(() => ++i).toBeWithinRange(3, Number.MAX_VALUE);
       });
     `
   });

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -1063,3 +1063,44 @@ test('should throw error when using .equals()', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
 });
+
+test('expect.extendImmutable should work', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'expect-test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      const expectFoo = expect.extendImmutable({
+        toFoo() {
+          console.log('%%foo');
+          return { pass: true };
+        }
+      });
+      const expectFoo2 = expect.extendImmutable({
+        toFoo() {
+          console.log('%%foo2');
+          return { pass: true };
+        }
+      });
+      const expectBar = expectFoo.extendImmutable({
+        toBar() {
+          console.log('%%bar');
+          return { pass: true };
+        }
+      });
+      test('logs', () => {
+        expect(expectFoo).not.toBe(expectFoo2);
+        expect(expectFoo).not.toBe(expectBar);
+
+        expectFoo().toFoo();
+        expectFoo2().toFoo();
+        expectBar().toFoo();
+        expectBar().toBar();
+      });
+    `
+  });
+  expect(result.outputLines).toEqual([
+    'foo',
+    'foo2',
+    'foo',
+    'bar',
+  ]);
+});

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -18,41 +18,6 @@ import path from 'path';
 import { test, expect, parseTestRunnerOutput, stripAnsi } from './playwright-test-fixtures';
 const { spawnAsync } = require('../../packages/playwright-core/lib/utils');
 
-test('should be able to call expect.extend in config', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'helper.ts': `
-      import { test as base, expect } from '@playwright/test';
-      expect.extend({
-        toBeWithinRange(received, floor, ceiling) {
-          const pass = received >= floor && received <= ceiling;
-          if (pass) {
-            return {
-              message: () =>
-                'passed',
-              pass: true,
-            };
-          } else {
-            return {
-              message: () => 'failed',
-              pass: false,
-            };
-          }
-        },
-      });
-      export const test = base;
-    `,
-    'expect-test.spec.ts': `
-      import { test } from './helper';
-      test('numeric ranges', () => {
-        test.expect(100).toBeWithinRange(90, 110);
-        test.expect(101).not.toBeWithinRange(0, 100);
-      });
-    `
-  });
-  expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(1);
-});
-
 test('should not expand huge arrays', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'expect-test.spec.ts': `

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -1008,8 +1008,8 @@ test('should expose timeout to custom matchers', async ({ runInlineTest, runTSC 
 test('should throw error when using .equals()', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'helper.ts': `
-      import { test as base, expect } from '@playwright/test';
-      expect.extend({
+      import { test as base, expect as baseExpect } from '@playwright/test';
+      export const expect = baseExpect.extend({
         toBeWithinRange(received, floor, ceiling) {
           this.equals(1, 2);
         },
@@ -1017,10 +1017,10 @@ test('should throw error when using .equals()', async ({ runInlineTest }) => {
       export const test = base;
     `,
     'expect-test.spec.ts': `
-      import { test } from './helper';
+      import { test, expect } from './helper';
       test('numeric ranges', () => {
-        test.expect(() => {
-          test.expect(100).toBeWithinRange(90, 110);
+        expect(() => {
+          expect(100).toBeWithinRange(90, 110);
         }).toThrowError('It looks like you are using custom expect matchers that are not compatible with Playwright. See https://aka.ms/playwright/expect-compatibility');
       });
     `
@@ -1029,23 +1029,23 @@ test('should throw error when using .equals()', async ({ runInlineTest }) => {
   expect(result.passed).toBe(1);
 });
 
-test('expect.extendImmutable should work', async ({ runInlineTest }) => {
+test('expect.extend should be immutable', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'expect-test.spec.ts': `
       import { test, expect } from '@playwright/test';
-      const expectFoo = expect.extendImmutable({
+      const expectFoo = expect.extend({
         toFoo() {
           console.log('%%foo');
           return { pass: true };
         }
       });
-      const expectFoo2 = expect.extendImmutable({
+      const expectFoo2 = expect.extend({
         toFoo() {
           console.log('%%foo2');
           return { pass: true };
         }
       });
-      const expectBar = expectFoo.extendImmutable({
+      const expectBar = expectFoo.extend({
         toBar() {
           console.log('%%bar');
           return { pass: true };

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -311,7 +311,9 @@ test('should report custom expect steps', async ({ runInlineTest }) => {
       };
     `,
     'a.test.ts': `
-      expect.extend({
+      import { test, expect as baseExpect } from '@playwright/test';
+
+      const expect = baseExpect.extend({
         toBeWithinRange(received, floor, ceiling) {
           const pass = received >= floor && received <= ceiling;
           if (pass) {
@@ -338,7 +340,6 @@ test('should report custom expect steps', async ({ runInlineTest }) => {
         },
       });
 
-      import { test, expect } from '@playwright/test';
       test('fail', async ({}) => {
         expect(15).toBeWithinRange(10, 20);
         await expect(1).toBeFailingAsync(22);
@@ -349,8 +350,8 @@ test('should report custom expect steps', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.output).toBe(`
 hook      |Before Hooks
-expect    |expect.toBeWithinRange @ a.test.ts:31
-expect    |expect.toBeFailingAsync @ a.test.ts:32
+expect    |expect.toBeWithinRange @ a.test.ts:32
+expect    |expect.toBeFailingAsync @ a.test.ts:33
 expect    |↪ error: Error: It fails!
 hook      |After Hooks
 hook      |Worker Cleanup


### PR DESCRIPTION
Changes `expect.extend` behaviour so that it doesn't mutate the global instance and behaves closer to what users expect. This is formally a breaking change, and I had to remove a test that asserts the breaking behaviour.

TODO:
- [x] decide wether this is a separate method or a flag for `expect.extend`
- [x] figure out if we need to change docs