### PR TITLE
chore(docs): fix APIResponse.headersArray() desc

### DIFF
--- a/docs/src/api/class-apiresponse.md
+++ b/docs/src/api/class-apiresponse.md
@@ -60,7 +60,7 @@ An object with all the response HTTP headers associated with this response.
   - `name` <[string]> Name of the header.
   - `value` <[string]> Value of the header.
 
-An array with all the request HTTP headers associated with this response. Header names are not lower-cased.
+An array with all the response HTTP headers associated with this response. Header names are not lower-cased.
 Headers with multiple entries, such as `Set-Cookie`, appear in the array multiple times.
 
 ## async method: APIResponse.json

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -17320,8 +17320,8 @@ export interface APIResponse {
   headers(): { [key: string]: string; };
 
   /**
-   * An array with all the request HTTP headers associated with this response. Header names are not lower-cased. Headers
-   * with multiple entries, such as `Set-Cookie`, appear in the array multiple times.
+   * An array with all the response HTTP headers associated with this response. Header names are not lower-cased.
+   * Headers with multiple entries, such as `Set-Cookie`, appear in the array multiple times.
    */
   headersArray(): Array<{
     /**


### PR DESCRIPTION
Modify APIResponse.headersArray() description as it was mentioning request headers, while actually response headers are returned