### PR TITLE
fix(trace viewer): fix memory leak

### DIFF
--- a/packages/trace-viewer/src/snapshotRenderer.ts
+++ b/packages/trace-viewer/src/snapshotRenderer.ts
@@ -41,7 +41,7 @@ function cacheAndReturn(key: SnapshotRenderer, compute: () => string): string {
 
   const result = compute();
 
-  while (cacheSize + result.length > CACHE_SIZE) {
+  while (cache.size && cacheSize + result.length > CACHE_SIZE) {
     const first = cache.keys().next().value;
     cacheSize -= cache.get(first)!.length;
     cache.delete(first);

--- a/packages/trace-viewer/src/snapshotRenderer.ts
+++ b/packages/trace-viewer/src/snapshotRenderer.ts
@@ -30,8 +30,14 @@ const cache = new Map<SnapshotRenderer, string>();
 const CACHE_SIZE = 300000000; // 300mb
 
 function cacheAndReturn(key: SnapshotRenderer, compute: () => string): string {
-  if (cache.has(key))
-    return cache.get(key)!;
+  if (cache.has(key)) {
+    const value = cache.get(key)!;
+    // reinserting makes this the least recently used entry
+    cache.delete(key);
+    cache.set(key, value);
+    return value;
+  }
+
 
   const result = compute();
 

--- a/packages/trace-viewer/src/snapshotRenderer.ts
+++ b/packages/trace-viewer/src/snapshotRenderer.ts
@@ -27,7 +27,7 @@ function isSubtreeReferenceSnapshot(n: NodeSnapshot): n is SubtreeReferenceSnaps
 
 let cacheSize = 0;
 const cache = new Map<SnapshotRenderer, string>();
-const CACHE_SIZE = 300000000; // 300mb
+const CACHE_SIZE = 300_000_000; // 300mb
 
 function lruCache(key: SnapshotRenderer, compute: () => string): string {
   if (cache.has(key)) {


### PR DESCRIPTION
In the `visit` method, we currently cache the rendered HTML for every walked node. This re-use works well for traces that consist mostly of references to earlier snapshots.
But for traces that don't share much, this is a large memory overhead and leads to the memory crash documented in https://github.com/microsoft/playwright/issues/32336. For the algocracks amongst you, the current memory usage for an html tree $h$ is $\mathcal{O}(|h| * \text{height}(h))$.

This PR removes that cache from the nodes and replaces it with a snapshot-level cache, fixing the memory crash.
Traces *without* reference should not see a performance impact from this.
Traces *with* references will have slower initial rendering, but re-rendering maintains speed because of the snapshot-level cache.

Closes https://github.com/microsoft/playwright/issues/32336