### PR TITLE
feat(api): add method to force garbage collection

### DIFF
--- a/browser_patches/firefox/juggler/protocol/PageHandler.js
+++ b/browser_patches/firefox/juggler/protocol/PageHandler.js
@@ -256,6 +256,14 @@ class PageHandler {
     return await this._contentPage.send('disposeObject', options);
   }
 
+  async ['Heap.collectGarbage']() {
+    await new Promise((resolve) => {
+      Cu.schedulePreciseGC(() => {
+        resolve();
+      });
+    });
+  }
+
   async ['Network.getResponseBody']({requestId}) {
     return this._pageNetwork.getResponseBody(requestId);
   }

--- a/browser_patches/firefox/juggler/protocol/PageHandler.js
+++ b/browser_patches/firefox/juggler/protocol/PageHandler.js
@@ -257,11 +257,10 @@ class PageHandler {
   }
 
   async ['Heap.collectGarbage']() {
-    await new Promise((resolve) => {
-      Cu.schedulePreciseGC(() => {
-        resolve();
-      });
-    });
+    Services.obs.notifyObservers(null, "child-gc-request");
+    Cu.forceGC();
+    Services.obs.notifyObservers(null, "child-cc-request");
+    Cu.forceCC();
   }
 
   async ['Network.getResponseBody']({requestId}) {

--- a/browser_patches/firefox/juggler/protocol/Protocol.js
+++ b/browser_patches/firefox/juggler/protocol/Protocol.js
@@ -487,6 +487,17 @@ const Browser = {
   },
 };
 
+const Heap = {
+  targets: ['page'],
+  types: {},
+  events: {},
+  methods: {
+    'collectGarbage': {
+      params: {},
+    },
+  },
+};
+
 const Network = {
   targets: ['page'],
   types: networkTypes,
@@ -1002,7 +1013,7 @@ const Accessibility = {
 }
 
 this.protocol = {
-  domains: {Browser, Page, Runtime, Network, Accessibility},
+  domains: {Browser, Heap, Page, Runtime, Network, Accessibility},
 };
 this.checkScheme = checkScheme;
 this.EXPORTED_SYMBOLS = ['protocol', 'checkScheme'];

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2333,6 +2333,15 @@ last redirect. If cannot go forward, returns `null`.
 
 Navigate to the next page in history.
 
+## async method: Page.forceGarbageCollection
+* since: v1.47
+
+Force the browser to perform garbage collection.
+
+:::note
+Forcing garbage collection is only supported in Chromium and WebKit.
+:::
+
 ### option: Page.goForward.waitUntil = %%-navigation-wait-until-%%
 * since: v1.8
 

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2338,10 +2338,6 @@ Navigate to the next page in history.
 
 Force the browser to perform garbage collection.
 
-:::note
-Forcing garbage collection is only supported in Chromium and WebKit.
-:::
-
 ### option: Page.goForward.waitUntil = %%-navigation-wait-until-%%
 * since: v1.8
 

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -468,6 +468,10 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     return Response.fromNullable((await this._channel.goForward({ ...options, waitUntil })).response);
   }
 
+  async forceGarbageCollection() {
+    await this._channel.forceGarbageCollection();
+  }
+
   async emulateMedia(options: { media?: 'screen' | 'print' | null, colorScheme?: 'dark' | 'light' | 'no-preference' | null, reducedMotion?: 'reduce' | 'no-preference' | null, forcedColors?: 'active' | 'none' | null } = {}) {
     await this._channel.emulateMedia({
       media: options.media === null ? 'no-override' : options.media,

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1122,6 +1122,8 @@ scheme.PageGoForwardParams = tObject({
 scheme.PageGoForwardResult = tObject({
   response: tOptional(tChannel(['Response'])),
 });
+scheme.PageForceGarbageCollectionParams = tOptional(tObject({}));
+scheme.PageForceGarbageCollectionResult = tOptional(tObject({}));
 scheme.PageRegisterLocatorHandlerParams = tObject({
   selector: tString,
   noWaitAfter: tOptional(tBoolean),

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -323,6 +323,10 @@ export class BidiPage implements PageDelegate {
     throw new Error('Method not implemented.');
   }
 
+  async forceGarbageCollection(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+
   async addInitScript(initScript: InitScript): Promise<void> {
     const { script } = await this._session.send('script.addPreloadScript', {
       // TODO: remove function call from the source.

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -247,6 +247,10 @@ export class CRPage implements PageDelegate {
     return this._go(+1);
   }
 
+  async forceGarbageCollection(): Promise<void> {
+    await this._mainFrameSession._client.send('HeapProfiler.collectGarbage');
+  }
+
   async addInitScript(initScript: InitScript, world: types.World = 'main'): Promise<void> {
     await this._forAllFrameSessions(frame => frame._evaluateOnNewDocument(initScript, world));
   }

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -137,6 +137,10 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     return { response: ResponseDispatcher.fromNullable(this.parentScope(), await this._page.goForward(metadata, params)) };
   }
 
+  async forceGarbageCollection(params: channels.PageForceGarbageCollectionParams, metadata: CallMetadata): Promise<channels.PageForceGarbageCollectionResult> {
+    await this._page.forceGarbageCollection();
+  }
+
   async registerLocatorHandler(params: channels.PageRegisterLocatorHandlerParams, metadata: CallMetadata): Promise<channels.PageRegisterLocatorHandlerResult> {
     const uid = this._page.registerLocatorHandler(params.selector, params.noWaitAfter);
     return { uid };

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -401,7 +401,7 @@ export class FFPage implements PageDelegate {
   }
 
   async forceGarbageCollection(): Promise<void> {
-    // Not supported in Firefox.
+    await this._session.send('Heap.collectGarbage');
   }
 
   async addInitScript(initScript: InitScript, worldName?: string): Promise<void> {

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -400,6 +400,10 @@ export class FFPage implements PageDelegate {
     return success;
   }
 
+  async forceGarbageCollection(): Promise<void> {
+    // Not supported in Firefox.
+  }
+
   async addInitScript(initScript: InitScript, worldName?: string): Promise<void> {
     this._initScripts.push({ initScript, worldName });
     await this._session.send('Page.setInitScripts', { scripts: this._initScripts.map(s => ({ script: s.initScript.source, worldName: s.worldName })) });

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -54,6 +54,7 @@ export interface PageDelegate {
   reload(): Promise<void>;
   goBack(): Promise<boolean>;
   goForward(): Promise<boolean>;
+  forceGarbageCollection(): Promise<void>;
   addInitScript(initScript: InitScript): Promise<void>;
   removeNonInternalInitScripts(): Promise<void>;
   closePage(runBeforeUnload: boolean): Promise<void>;
@@ -428,6 +429,10 @@ export class Page extends SdkObject {
         throw error;
       return response;
     }), this._timeoutSettings.navigationTimeout(options));
+  }
+
+  forceGarbageCollection(): Promise<void> {
+    return this._delegate.forceGarbageCollection();
   }
 
   registerLocatorHandler(selector: string, noWaitAfter: boolean | undefined) {

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -768,6 +768,10 @@ export class WKPage implements PageDelegate {
     });
   }
 
+  async forceGarbageCollection(): Promise<void> {
+    await this._session.send('Heap.gc');
+  }
+
   async addInitScript(initScript: InitScript): Promise<void> {
     await this._updateBootstrapScript();
   }

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2555,6 +2555,13 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * Force the browser to perform garbage collection.
+   *
+   * **NOTE** Forcing garbage collection is only supported in Chromium and WebKit.
+   */
+  forceGarbageCollection(): Promise<void>;
+
+  /**
    * Returns frame matching the specified criteria. Either `name` or `url` must be specified.
    *
    * **Usage**

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2556,8 +2556,6 @@ export interface Page {
 
   /**
    * Force the browser to perform garbage collection.
-   *
-   * **NOTE** Forcing garbage collection is only supported in Chromium and WebKit.
    */
   forceGarbageCollection(): Promise<void>;
 

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1933,6 +1933,7 @@ export interface PageChannel extends PageEventTarget, EventTargetChannel {
   exposeBinding(params: PageExposeBindingParams, metadata?: CallMetadata): Promise<PageExposeBindingResult>;
   goBack(params: PageGoBackParams, metadata?: CallMetadata): Promise<PageGoBackResult>;
   goForward(params: PageGoForwardParams, metadata?: CallMetadata): Promise<PageGoForwardResult>;
+  forceGarbageCollection(params?: PageForceGarbageCollectionParams, metadata?: CallMetadata): Promise<PageForceGarbageCollectionResult>;
   registerLocatorHandler(params: PageRegisterLocatorHandlerParams, metadata?: CallMetadata): Promise<PageRegisterLocatorHandlerResult>;
   resolveLocatorHandlerNoReply(params: PageResolveLocatorHandlerNoReplyParams, metadata?: CallMetadata): Promise<PageResolveLocatorHandlerNoReplyResult>;
   unregisterLocatorHandler(params: PageUnregisterLocatorHandlerParams, metadata?: CallMetadata): Promise<PageUnregisterLocatorHandlerResult>;
@@ -2070,6 +2071,9 @@ export type PageGoForwardOptions = {
 export type PageGoForwardResult = {
   response?: ResponseChannel,
 };
+export type PageForceGarbageCollectionParams = {};
+export type PageForceGarbageCollectionOptions = {};
+export type PageForceGarbageCollectionResult = void;
 export type PageRegisterLocatorHandlerParams = {
   selector: string,
   noWaitAfter?: boolean,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1430,7 +1430,7 @@ Page:
         slowMo: true
         snapshot: true
 
-    forceGarbageCollection: {}
+    forceGarbageCollection:
 
     registerLocatorHandler:
       parameters:

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1430,6 +1430,8 @@ Page:
         slowMo: true
         snapshot: true
 
+    forceGarbageCollection: {}
+
     registerLocatorHandler:
       parameters:
         selector: string

--- a/tests/page/page-force-gc.spec.ts
+++ b/tests/page/page-force-gc.spec.ts
@@ -16,12 +16,12 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should work', async function({ page, browserName }) {
+it.only('should work', async function({ page, browserName }) {
   await page.evaluate(() => {
-    globalThis.thing = {};
-    globalThis.something = new WeakRef(globalThis.thing);
+    globalThis.objectToDestroy = {};
+    globalThis.weakRef = new WeakRef(globalThis.objectToDestroy);
   });
-  await page.evaluate(() => globalThis.thing = null);
+  await page.evaluate(() => globalThis.objectToDestroy = null);
   await page.forceGarbageCollection();
-  expect(await page.evaluate(() => globalThis.something.deref())).toBe(undefined);
+  expect(await page.evaluate(() => globalThis.weakRef.deref())).toBe(undefined);
 });

--- a/tests/page/page-force-gc.spec.ts
+++ b/tests/page/page-force-gc.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2024 Adobe Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test as it, expect } from './pageTest';
+
+it('should work', async function({ page, browserName }) {
+  it.skip(browserName === 'firefox', 'forceGarbageCollection is supported only in Chromium and WebKit');
+
+  await page.evaluate(() => {
+    globalThis.thing = {};
+    globalThis.something = new WeakRef(globalThis.thing);
+  });
+  await page.evaluate(() => globalThis.thing = null);
+  await page.forceGarbageCollection();
+  expect(await page.evaluate(() => globalThis.something.deref())).toBe(undefined);
+});

--- a/tests/page/page-force-gc.spec.ts
+++ b/tests/page/page-force-gc.spec.ts
@@ -17,8 +17,6 @@
 import { test as it, expect } from './pageTest';
 
 it('should work', async function({ page, browserName }) {
-  it.skip(browserName === 'firefox', 'forceGarbageCollection is supported only in Chromium and WebKit');
-
   await page.evaluate(() => {
     globalThis.thing = {};
     globalThis.something = new WeakRef(globalThis.thing);

--- a/tests/page/page-force-gc.spec.ts
+++ b/tests/page/page-force-gc.spec.ts
@@ -16,7 +16,7 @@
 
 import { test as it, expect } from './pageTest';
 
-it.only('should work', async function({ page, browserName }) {
+it('should work', async function({ page, browserName }) {
   await page.evaluate(() => {
     globalThis.objectToDestroy = {};
     globalThis.weakRef = new WeakRef(globalThis.objectToDestroy);

--- a/tests/page/page-force-gc.spec.ts
+++ b/tests/page/page-force-gc.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { test as it, expect } from './pageTest';
+import { test, expect } from './pageTest';
 
-it('should work', async function({ page, browserName }) {
+test('should work', async ({ page }) => {
   await page.evaluate(() => {
     globalThis.objectToDestroy = {};
     globalThis.weakRef = new WeakRef(globalThis.objectToDestroy);


### PR DESCRIPTION
Add a method to Page that forces garbage collection. For now this method is supported only in Chromium and WebKit.

~I made several attempts to get this to work in Firefox, using both [Components.utils.schedulePreciseGC](https://udn.realityripple.com/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.utils.schedulePreciseGC) and [Components.utils.forceGC](https://udn.realityripple.com/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.utils.forceGC), but was unsuccessful. See https://github.com/marmphco/playwright/commit/42bd3ef906b43faacf329432600f3131203b8d1a for those changes. Either garbage collection isn't running or its effects aren't visible immediately to the test code like they are for WebKit and Chromium. I don't have a good enough understanding of Firefox's internals to figure this out so I left it as unsupported for now. If this is unacceptable I can try to implement via a different route. Suggestions for better approaches would be appreciated 🙂~

7c826ee includes support for Firefox.

Closes #32278