### PR TITLE
chore: enforce tags format via typescript types

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1825,8 +1825,10 @@ type TestDetailsAnnotation = {
   description?: string;
 };
 
+type TestDetailsTag = `@${string}`;
+
 export type TestDetails = {
-  tag?: string | string[];
+  tag?: TestDetailsTag | TestDetailsTag[];
   annotation?: TestDetailsAnnotation | TestDetailsAnnotation[];
 }
 

--- a/tests/playwright-test/test-tag.spec.ts
+++ b/tests/playwright-test/test-tag.spec.ts
@@ -147,6 +147,18 @@ test('should enforce @ symbol', async ({ runInlineTest }) => {
   expect(result.output).toContain(`Error: Tag must start with "@" symbol, got "foo" instead.`);
 });
 
+test('types should enforce @ symbol', async ({ runTSC }) => {
+  const result = await runTSC({
+    'stdio.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('test1', { tag: 'foo' }, () => {
+      });
+    `
+  });
+  expect(result.exitCode).toBe(2);
+  expect(result.output).toContain('error TS2322: Type \'"foo"\' is not assignable to type \'`@${string}` | `@${string}`[] | undefined');
+});
+
 test('should be included in testInfo', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'a.test.ts': `

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -70,8 +70,10 @@ type TestDetailsAnnotation = {
   description?: string;
 };
 
+type TestDetailsTag = `@${string}`;
+
 export type TestDetails = {
-  tag?: string | string[];
+  tag?: TestDetailsTag | TestDetailsTag[];
   annotation?: TestDetailsAnnotation | TestDetailsAnnotation[];
 }
 


### PR DESCRIPTION
Leverage [template literal types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html).

Fixes https://github.com/microsoft/playwright/issues/32382