### PR TITLE
chore(test runner): include projects in teleReceiver's config

### DIFF
--- a/packages/playwright/src/reporters/merge.ts
+++ b/packages/playwright/src/reporters/merge.ts
@@ -304,7 +304,7 @@ function mergeConfigs(to: JsonConfig, from: JsonConfig): JsonConfig {
       actualWorkers: (to.metadata.actualWorkers || 0) + (from.metadata.actualWorkers || 0),
     },
     workers: to.workers + from.workers,
-    projects: dedupByName(to.projects, from.projects),
+    projects: dedupByName(to?.projects ?? [], from?.projects ?? []),
   };
 }
 

--- a/packages/playwright/src/reporters/merge.ts
+++ b/packages/playwright/src/reporters/merge.ts
@@ -255,6 +255,7 @@ function mergeConfigureEvents(configureEvents: JsonEvent[], rootDirOverride: str
     rootDir: '',
     version: '',
     workers: 0,
+    projects: [],
   };
   for (const event of configureEvents)
     config = mergeConfigs(config, event.params.config);
@@ -288,6 +289,11 @@ function mergeConfigureEvents(configureEvents: JsonEvent[], rootDirOverride: str
   };
 }
 
+function dedupByName<T extends { name: string }>(a: T[], b: T[]) {
+  const aNames = new Set(a.map(v => v.name));
+  return a.concat(b.filter(b => !aNames.has(b.name)));
+}
+
 function mergeConfigs(to: JsonConfig, from: JsonConfig): JsonConfig {
   return {
     ...to,
@@ -298,6 +304,7 @@ function mergeConfigs(to: JsonConfig, from: JsonConfig): JsonConfig {
       actualWorkers: (to.metadata.actualWorkers || 0) + (from.metadata.actualWorkers || 0),
     },
     workers: to.workers + from.workers,
+    projects: dedupByName(to.projects, from.projects),
   };
 }
 

--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -161,12 +161,12 @@ export class TeleReporterEmitter implements ReporterV2 {
       rootDir: config.rootDir,
       version: config.version,
       workers: config.workers,
+      projects: config.projects.map(project => this._serializeConfigProject(project)),
     };
   }
 
-  private _serializeProject(suite: reporterTypes.Suite): teleReceiver.JsonProject {
-    const project = suite.project()!;
-    const report: teleReceiver.JsonProject = {
+  private _serializeConfigProject(project: reporterTypes.FullProject): teleReceiver.JsonConfigProject {
+    return {
       metadata: project.metadata,
       name: project.name,
       outputDir: this._relativePath(project.outputDir),
@@ -176,16 +176,20 @@ export class TeleReporterEmitter implements ReporterV2 {
       testIgnore: serializeRegexPatterns(project.testIgnore),
       testMatch: serializeRegexPatterns(project.testMatch),
       timeout: project.timeout,
-      suites: suite.suites.map(fileSuite => {
-        return this._serializeSuite(fileSuite);
-      }),
       grep: serializeRegexPatterns(project.grep),
       grepInvert: serializeRegexPatterns(project.grepInvert || []),
       dependencies: project.dependencies,
       snapshotDir: this._relativePath(project.snapshotDir),
       teardown: project.teardown,
     };
-    return report;
+  }
+
+  private _serializeProject(suite: reporterTypes.Suite): teleReceiver.JsonProject {
+    const project = suite.project()!;
+    return {
+      ...this._serializeConfigProject(project),
+      suites: suite.suites.map(fileSuite => this._serializeSuite(fileSuite)),
+    };
   }
 
   private _serializeSuite(suite: reporterTypes.Suite): teleReceiver.JsonSuite {

--- a/packages/playwright/src/runner/watchMode.ts
+++ b/packages/playwright/src/runner/watchMode.ts
@@ -167,7 +167,7 @@ export async function runWatchModeLoop(configLocation: ConfigLocation, initialOp
         type: 'multiselect',
         name: 'selectedProjects',
         message: 'Select projects',
-        choices: teleSuiteUpdater.rootSuite!.suites.map(s => s.title),
+        choices: teleSuiteUpdater.config!.projects.map(p => p.name),
       }).catch(() => ({ selectedProjects: null }));
       if (!selectedProjects)
         continue;


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/playwright/pull/32156#discussion_r1741628770. Transmits `config.projects` via the TeleEmitter, so it can be read from UI and watch mode.

Let me know where I should add more tests for this.