### PR TITLE
Revert "chore: enforce tags format via typescript types (#32384)"

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1825,10 +1825,8 @@ type TestDetailsAnnotation = {
   description?: string;
 };
 
-type TestDetailsTag = `@${string}`;
-
 export type TestDetails = {
-  tag?: TestDetailsTag | TestDetailsTag[];
+  tag?: string | string[];
   annotation?: TestDetailsAnnotation | TestDetailsAnnotation[];
 }
 

--- a/tests/playwright-test/test-tag.spec.ts
+++ b/tests/playwright-test/test-tag.spec.ts
@@ -147,18 +147,6 @@ test('should enforce @ symbol', async ({ runInlineTest }) => {
   expect(result.output).toContain(`Error: Tag must start with "@" symbol, got "foo" instead.`);
 });
 
-test('types should enforce @ symbol', async ({ runTSC }) => {
-  const result = await runTSC({
-    'stdio.spec.ts': `
-      import { test, expect } from '@playwright/test';
-      test('test1', { tag: 'foo' }, () => {
-      });
-    `
-  });
-  expect(result.exitCode).toBe(2);
-  expect(result.output).toContain('error TS2322: Type \'"foo"\' is not assignable to type \'`@${string}` | `@${string}`[] | undefined');
-});
-
 test('should be included in testInfo', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'a.test.ts': `

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -70,10 +70,8 @@ type TestDetailsAnnotation = {
   description?: string;
 };
 
-type TestDetailsTag = `@${string}`;
-
 export type TestDetails = {
-  tag?: TestDetailsTag | TestDetailsTag[];
+  tag?: string | string[];
   annotation?: TestDetailsAnnotation | TestDetailsAnnotation[];
 }
 


### PR DESCRIPTION
After API review we decided to revert it:
* VSCode extension and UI mode users already get the (runtime) error if the tag is not prefixed
* The typescript error message is not very nice
* The type change would break those clients that generate tests with tags passed as string

This reverts commit 90e7b9ebacbd597b7380522001eb6d17ee9c3d86.