### PR TITLE
Revert "docs: deprecate: Request.serviceWorker() (#32136)"

### DIFF
--- a/docs/src/api/class-request.md
+++ b/docs/src/api/class-request.md
@@ -288,10 +288,15 @@ Returns the matching [Response] object, or `null` if the response was not receiv
 ## method: Request.serviceWorker
 * since: v1.24
 * langs: js
-* deprecated: Requests made by a Service Worker are not reported in Playwright.
 - returns: <[null]|[Worker]>
 
-This method will always return `null`.
+The Service [Worker] that is performing the request.
+
+**Details**
+
+This method is Chromium only. It's safe to call when using other browsers, but it will always be `null`.
+
+Requests originated in a Service Worker do not have a [`method: Request.frame`] available.
 
 ## async method: Request.sizes
 * since: v1.15

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -19237,8 +19237,14 @@ export interface Request {
   response(): Promise<null|Response>;
 
   /**
-   * This method will always return `null`.
-   * @deprecated Requests made by a Service Worker are not reported in Playwright.
+   * The Service {@link Worker} that is performing the request.
+   *
+   * **Details**
+   *
+   * This method is Chromium only. It's safe to call when using other browsers, but it will always be `null`.
+   *
+   * Requests originated in a Service Worker do not have a
+   * [request.frame()](https://playwright.dev/docs/api/class-request#request-frame) available.
    */
   serviceWorker(): null|Worker;
 


### PR DESCRIPTION
This reverts commit b7ed4d7b9e433f1be414c6e580a0ddc39de71618.