### PR TITLE
chore: ignore third-party execution contexts

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -690,15 +690,16 @@ class FrameSession {
     if (!frame || this._eventBelongsToStaleFrame(frame._id))
       return;
     const delegate = new CRExecutionContext(this._client, contextPayload);
-    let worldName: types.World|null = null;
+    let worldName: types.World;
     if (contextPayload.auxData && !!contextPayload.auxData.isDefault)
       worldName = 'main';
     else if (contextPayload.name === UTILITY_WORLD_NAME)
       worldName = 'utility';
+    else
+      return;
     const context = new dom.FrameExecutionContext(delegate, frame, worldName);
     (context as any)[contextDelegateSymbol] = delegate;
-    if (worldName)
-      frame._contextCreated(worldName, context);
+    frame._contextCreated(worldName, context);
     this._contextIdToContext.set(contextPayload.id, context);
   }
 

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -50,9 +50,9 @@ export function isNonRecoverableDOMError(error: Error) {
 export class FrameExecutionContext extends js.ExecutionContext {
   readonly frame: frames.Frame;
   private _injectedScriptPromise?: Promise<js.JSHandle>;
-  readonly world: types.World | null;
+  readonly world: types.World;
 
-  constructor(delegate: js.ExecutionContextDelegate, frame: frames.Frame, world: types.World|null) {
+  constructor(delegate: js.ExecutionContextDelegate, frame: frames.Frame, world: types.World) {
     super(frame, delegate, world || 'content-script');
     this.frame = frame;
     this.world = world;

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -163,15 +163,16 @@ export class FFPage implements PageDelegate {
     if (!frame)
       return;
     const delegate = new FFExecutionContext(this._session, executionContextId);
-    let worldName: types.World|null = null;
+    let worldName: types.World;
     if (auxData.name === UTILITY_WORLD_NAME)
       worldName = 'utility';
     else if (!auxData.name)
       worldName = 'main';
+    else
+      return;
     const context = new dom.FrameExecutionContext(delegate, frame, worldName);
     (context as any)[contextDelegateSymbol] = delegate;
-    if (worldName)
-      frame._contextCreated(worldName, context);
+    frame._contextCreated(worldName, context);
     this._contextIdToContext.set(executionContextId, context);
   }
 

--- a/packages/playwright-core/src/server/input.ts
+++ b/packages/playwright-core/src/server/input.ts
@@ -215,7 +215,7 @@ export class Mouse {
 
   async click(x: number, y: number, options: { delay?: number, button?: types.MouseButton, clickCount?: number } = {}, metadata?: CallMetadata) {
     if (metadata)
-      metadata.point = { x: this._x, y: this._y };
+      metadata.point = { x, y };
     const { delay = null, clickCount = 1 } = options;
     if (delay) {
       this.move(x, y, { forClick: true });

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -502,15 +502,16 @@ export class WKPage implements PageDelegate {
     if (!frame)
       return;
     const delegate = new WKExecutionContext(this._session, contextPayload.id);
-    let worldName: types.World|null = null;
+    let worldName: types.World;
     if (contextPayload.type === 'normal')
       worldName = 'main';
     else if (contextPayload.type === 'user' && contextPayload.name === UTILITY_WORLD_NAME)
       worldName = 'utility';
+    else
+      return;
     const context = new dom.FrameExecutionContext(delegate, frame, worldName);
     (context as any)[contextDelegateSymbol] = delegate;
-    if (worldName)
-      frame._contextCreated(worldName, context);
+    frame._contextCreated(worldName, context);
     this._contextIdToContext.set(contextPayload.id, context);
   }
 


### PR DESCRIPTION
* Only track main and utility world contexts
* Properly update click metadata