### PR TITLE
chore(test runner): document that --only-changed on CI needs history

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -433,6 +433,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        # Force a non-shallow checkout, so that we can reference $GITHUB_BASE_REF.
+        # See https://github.com/actions/checkout for more details.
         fetch-depth: 0
     - uses: actions/setup-node@v4
       with:

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -432,6 +432,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: actions/setup-node@v4
       with:
         node-version: 18


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32452

`--only-changed=$GITHUB_BASE_REF` needs the base ref available locally to work properly. `fetch-depth: 0` does that, see https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches.