### PR TITLE
chore: make find-related-test-files work through plugins

### DIFF
--- a/packages/playwright-ct-core/index.js
+++ b/packages/playwright-ct-core/index.js
@@ -16,7 +16,7 @@
 
 const { test: baseTest, expect, devices, defineConfig: originalDefineConfig } = require('playwright/test');
 const { fixtures } = require('./lib/mount');
-const { clearCacheCommand, findRelatedTestFilesCommand } = require('./lib/cliOverrides');
+const { clearCacheCommand } = require('./lib/cliOverrides');
 const { createPlugin } = require('./lib/vitePlugin');
 
 const defineConfig = (...configs) => {
@@ -31,7 +31,6 @@ const defineConfig = (...configs) => {
       ],
       cli: {
         'clear-cache': clearCacheCommand,
-        'find-related-test-files': findRelatedTestFilesCommand,
       },
     }
   };

--- a/packages/playwright-ct-core/src/cliOverrides.ts
+++ b/packages/playwright-ct-core/src/cliOverrides.ts
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-import { affectedTestFiles, cacheDir } from 'playwright/lib/transform/compilationCache';
-import { buildBundle } from './vitePlugin';
+import { cacheDir } from 'playwright/lib/transform/compilationCache';
 import { resolveDirs } from './viteUtils';
 import type { FullConfigInternal } from 'playwright/lib/common/config';
 import { removeFolderAndLogToConsole } from 'playwright/lib/runner/testServer';
@@ -26,9 +25,4 @@ export async function clearCacheCommand(config: FullConfigInternal) {
   if (dirs)
     await removeFolderAndLogToConsole(dirs.outDir);
   await removeFolderAndLogToConsole(cacheDir);
-}
-
-export async function findRelatedTestFilesCommand(files: string[],  config: FullConfigInternal) {
-  await buildBundle(config.config, config.configDir);
-  return { testFiles: affectedTestFiles(files) };
 }

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -86,7 +86,8 @@ function addFindRelatedTestFilesCommand(program: Command) {
   command.description('Returns the list of related tests to the given files');
   command.option('-c, --config <file>', `Configuration file, or a test directory with optional "playwright.config.{m,c}?{js,ts}"`);
   command.action(async (files, options) => {
-    await withRunnerAndMutedWrite(options.config, runner => runner.findRelatedTestFiles('in-process', files));
+    const resolvedFiles = (files as string[]).map(file => path.resolve(process.cwd(), file));
+    await withRunnerAndMutedWrite(options.config, runner => runner.findRelatedTestFiles(resolvedFiles));
   });
 }
 

--- a/packages/playwright/src/runner/runner.ts
+++ b/packages/playwright/src/runner/runner.ts
@@ -21,11 +21,9 @@ import { monotonicTime } from 'playwright-core/lib/utils';
 import type { FullResult, TestError } from '../../types/testReporter';
 import { webServerPluginsForConfig } from '../plugins/webServerPlugin';
 import { collectFilesForProject, filterProjects } from './projectUtils';
-import { createConsoleReporter, createReporters } from './reporters';
-import { TestRun, createTaskRunner, createTaskRunnerForDevServer, createTaskRunnerForList } from './tasks';
+import { createErrorCollectingReporter, createReporters } from './reporters';
+import { TestRun, createTaskRunner, createTaskRunnerForDevServer, createTaskRunnerForList, createTaskRunnerForRelatedTestFiles } from './tasks';
 import type { FullConfigInternal } from '../common/config';
-import type { Suite } from '../common/test';
-import { wrapReporterAsV2 } from '../reporters/reporterV2';
 import { affectedTestFiles } from '../transform/compilationCache';
 import { InternalReporter } from '../reporters/internalReporter';
 
@@ -109,43 +107,22 @@ export class Runner {
     return status;
   }
 
-  async loadAllTests(mode: 'in-process' | 'out-of-process' = 'in-process'): Promise<{ status: FullResult['status'], suite?: Suite, errors: TestError[] }> {
-    const config = this._config;
-    const errors: TestError[] = [];
-    const reporter = new InternalReporter([wrapReporterAsV2({
-      onError(error: TestError) {
-        errors.push(error);
-      }
-    })]);
-    const taskRunner = createTaskRunnerForList(config, reporter, mode, { failOnLoadErrors: true });
-    const testRun = new TestRun(config);
-    reporter.onConfigure(config.config);
-
-    const taskStatus = await taskRunner.run(testRun, 0);
-    let status: FullResult['status'] = testRun.failureTracker.result();
-    if (status === 'passed' && taskStatus !== 'passed')
-      status = taskStatus;
-    const modifiedResult = await reporter.onEnd({ status });
-    if (modifiedResult && modifiedResult.status)
-      status = modifiedResult.status;
+  async findRelatedTestFiles(files: string[]): Promise<FindRelatedTestFilesReport>  {
+    const errorReporter = createErrorCollectingReporter();
+    const reporter = new InternalReporter([errorReporter]);
+    const taskRunner = createTaskRunnerForRelatedTestFiles(this._config, reporter, 'in-process', true);
+    const testRun = new TestRun(this._config);
+    reporter.onConfigure(this._config.config);
+    const status = await taskRunner.run(testRun, 0);
+    await reporter.onEnd({ status });
     await reporter.onExit();
-    return { status, suite: testRun.rootSuite, errors };
-  }
-
-  async findRelatedTestFiles(mode: 'in-process' | 'out-of-process', files: string[]): Promise<FindRelatedTestFilesReport>  {
-    const result = await this.loadAllTests(mode);
-    if (result.status !== 'passed' || !result.suite)
-      return { errors: result.errors, testFiles: [] };
-
-    const resolvedFiles = (files as string[]).map(file => path.resolve(process.cwd(), file));
-    const override = (this._config.config as any)['@playwright/test']?.['cli']?.['find-related-test-files'];
-    if (override)
-      return await override(resolvedFiles, this._config);
-    return { testFiles: affectedTestFiles(resolvedFiles) };
+    if (status !== 'passed')
+      return { errors: errorReporter.errors(), testFiles: [] };
+    return { testFiles: affectedTestFiles(files) };
   }
 
   async runDevServer() {
-    const reporter = new InternalReporter([createConsoleReporter()]);
+    const reporter = new InternalReporter([createErrorCollectingReporter(true)]);
     const taskRunner = createTaskRunnerForDevServer(this._config, reporter, 'in-process', true);
     const testRun = new TestRun(this._config);
     reporter.onConfigure(this._config.config);

--- a/tests/playwright-test/find-related-tests.spec.ts
+++ b/tests/playwright-test/find-related-tests.spec.ts
@@ -15,9 +15,6 @@
  */
 
 import { test, expect } from './playwright-test-fixtures';
-import path from 'path';
-
-export const ctReactCliEntrypoint = path.join(__dirname, '../../packages/playwright-ct-react/cli.js');
 
 test('should list related tests', async ({ runCLICommand }) => {
   const result = await runCLICommand({
@@ -77,7 +74,7 @@ test('should list related tests for ct', async ({ runCLICommand }) => {
         await mount(<Button />);
       });
     `,
-  }, 'find-related-test-files', ['helper.tsx'], ctReactCliEntrypoint);
+  }, 'find-related-test-files', ['helper.tsx']);
   expect(result.exitCode).toBe(0);
   const data = JSON.parse(result.stdout);
   expect(data).toEqual({
@@ -85,4 +82,19 @@ test('should list related tests for ct', async ({ runCLICommand }) => {
       expect.stringContaining('button.spec.tsx'),
     ]
   });
+});
+
+test('should return errors', async ({ runCLICommand }) => {
+  const result = await runCLICommand({
+    'a.spec.ts': `
+      const a = 1;
+      const a = 2;
+    `,
+  }, 'find-related-test-files', ['a.spec.ts']);
+  expect(result.exitCode).toBe(0);
+  const data = JSON.parse(result.stdout);
+  expect(data).toEqual({ testFiles: [], errors: [
+    expect.objectContaining({ message: expect.stringContaining(`Identifier 'a' has already been declared`) }),
+    expect.objectContaining({ message: expect.stringContaining(`No tests found`) }),
+  ] });
 });


### PR DESCRIPTION
Also switches it to the task runner.