### PR TITLE
feat(chromium-tip-of-tree): roll to r1257

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -9,9 +9,9 @@
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1256",
+      "revision": "1257",
       "installByDefault": false,
-      "browserVersion": "130.0.6695.0"
+      "browserVersion": "130.0.6699.0"
     },
     {
       "name": "firefox",


### PR DESCRIPTION
`page/selectors-text.spec.ts:20:3 › should work @smoke` is a real regression. Filed upstream issue https://issues.chromium.org/u/1/issues/364904763.

---

Update: upstream issue has been resolved, so the next roll should be ok. Skipping this one.
