### PR TITLE
chore: remove browser-specific bidi hacks

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiInput.ts
+++ b/packages/playwright-core/src/server/bidi/bidiInput.ts
@@ -90,24 +90,6 @@ export class RawMouseImpl implements input.RawMouse {
     await this._performActions([{ type: 'pointerUp', button: toBidiButton(button) }]);
   }
 
-  async click(x: number, y: number, options: { delay?: number, button?: types.MouseButton, clickCount?: number } = {}) {
-    x = Math.round(x);
-    y = Math.round(y);
-    const button = toBidiButton(options.button || 'left');
-    const { delay = null, clickCount = 1 } = options;
-    const actions: bidi.Input.PointerSourceAction[] = [];
-    actions.push({ type: 'pointerMove', x, y });
-    for (let cc = 1; cc <= clickCount; ++cc) {
-      actions.push({ type: 'pointerDown', button });
-      if (delay)
-        actions.push({ type: 'pause', duration: delay });
-      actions.push({ type: 'pointerUp', button });
-      if (delay && cc < clickCount)
-        actions.push({ type: 'pause', duration: delay });
-    }
-    await this._performActions(actions);
-  }
-
   async wheel(x: number, y: number, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, deltaX: number, deltaY: number): Promise<void> {
   }
 

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -91,7 +91,7 @@ export class BidiPage implements PageDelegate {
     await Promise.all([
       this.updateHttpCredentials(),
       this.updateRequestInterception(),
-      // this._updateViewport(),
+      this._updateViewport(),
     ]);
   }
 

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -91,7 +91,7 @@ export class BidiPage implements PageDelegate {
     await Promise.all([
       this.updateHttpCredentials(),
       this.updateRequestInterception(),
-      this._updateViewport(),
+      // this._updateViewport(),
     ]);
   }
 
@@ -503,10 +503,6 @@ export class BidiPage implements PageDelegate {
   }
 
   shouldToggleStyleSheetToSyncAnimations(): boolean {
-    return true;
-  }
-
-  useMainWorldForSetContent(): boolean {
     return true;
   }
 }

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -900,7 +900,7 @@ export class Frame extends SdkObject {
         const waitUntil = options.waitUntil === undefined ? 'load' : options.waitUntil;
         progress.log(`setting frame content, waiting until "${waitUntil}"`);
         const tag = `--playwright--set--content--${this._id}--${++this._setContentCounter}--`;
-        const context = this._page._delegate.useMainWorldForSetContent?.() ? await this._mainContext() : await this._utilityContext();
+        const context = await this._utilityContext();
         const lifecyclePromise = new Promise((resolve, reject) => {
           this._page._frameManager._consoleMessageTags.set(tag, () => {
             // Clear lifecycle right after document.open() - see 'tag' below.

--- a/packages/playwright-core/src/server/input.ts
+++ b/packages/playwright-core/src/server/input.ts
@@ -162,7 +162,6 @@ export interface RawMouse {
   move(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void>;
   down(x: number, y: number, button: types.MouseButton, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, clickCount: number): Promise<void>;
   up(x: number, y: number, button: types.MouseButton, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, clickCount: number): Promise<void>;
-  click?(x: number, y: number, options: { delay?: number, button?: types.MouseButton, clickCount?: number }): Promise<void>;
   wheel(x: number, y: number, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, deltaX: number, deltaY: number): Promise<void>;
 }
 
@@ -217,8 +216,6 @@ export class Mouse {
   async click(x: number, y: number, options: { delay?: number, button?: types.MouseButton, clickCount?: number } = {}, metadata?: CallMetadata) {
     if (metadata)
       metadata.point = { x, y };
-    if (this._raw.click)
-      return await this._raw.click(x, y, options);
     const { delay = null, clickCount = 1 } = options;
     if (delay) {
       this.move(x, y, { forClick: true });

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -98,8 +98,6 @@ export interface PageDelegate {
   resetForReuse(): Promise<void>;
   // WebKit hack.
   shouldToggleStyleSheetToSyncAnimations(): boolean;
-  // Bidi throws on attempt to document.open() in utility context.
-  useMainWorldForSetContent?(): boolean;
 }
 
 type EmulatedSize = { screen: types.Size, viewport: types.Size };


### PR DESCRIPTION
Those were just workarounds for browser-specific bugs, they should be fixed upstream.
* individual mouse down/up/down/up events don't trigger dblclick event in Firefox
* setContent throws when document.open/write is called in the utility context in Firefox