### PR TITLE
chore: Add new method testIdAttributeName

### DIFF
--- a/docs/src/api/class-selectors.md
+++ b/docs/src/api/class-selectors.md
@@ -248,3 +248,8 @@ Defines custom attribute name to be used in [`method: Page.getByTestId`]. `data-
 - `attributeName` <[string]>
 
 Test id attribute name.
+
+## method: Selectors.testIdAttributeName
+* since: v1.48
+
+Return the current Test id attribute name.

--- a/docs/src/api/class-selectors.md
+++ b/docs/src/api/class-selectors.md
@@ -251,5 +251,6 @@ Test id attribute name.
 
 ## method: Selectors.testIdAttributeName
 * since: v1.48
+- returns: <[string]>
 
 Return the current Test id attribute name.

--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -607,6 +607,26 @@ page.get_by_test_id("directions").click()
 await page.GetByTestId("directions").ClickAsync();
 ```
 
+#### Get the current test id attribute name
+
+Return the current test id attribute name, this will default to `data-testid`, if not updated using your test config or set using [`method: Selectors.setTestIdAttribute`].
+
+```java
+playwright.selectors().testIdAttributeName();
+```
+
+```python async
+playwright.selectors.test_id_attribute_name()
+```
+
+```python sync
+playwright.selectors.test_id_attribute_name()
+```
+
+```csharp
+playwright.Selectors.TestIdAttributeName();
+```
+
 ### Locate by CSS or XPath
 
 If you absolutely must use CSS or XPath locators, you can use [`method: Page.locator`] to create a locator that takes a selector describing how to find an element in the page. Playwright supports CSS and XPath selectors, and auto-detects them if you omit `css=` or `xpath=` prefix.

--- a/packages/playwright-core/src/client/selectors.ts
+++ b/packages/playwright-core/src/client/selectors.ts
@@ -39,6 +39,8 @@ export class Selectors implements api.Selectors {
       channel._channel.setTestIdAttributeName({ testIdAttributeName: attributeName }).catch(() => {});
   }
 
+  testIdAttributeName = () => testIdAttributeName();
+
   _addChannel(channel: SelectorsOwner) {
     this._channels.add(channel);
     for (const params of this._registrations) {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -19899,7 +19899,7 @@ export interface Selectors {
   /**
    * Return the current Test id attribute name.
    */
-  testIdAttributeName(): void;
+  testIdAttributeName(): string;
 }
 
 /**

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -19895,6 +19895,11 @@ export interface Selectors {
    * @param attributeName Test id attribute name.
    */
   setTestIdAttribute(attributeName: string): void;
+
+  /**
+   * Return the current Test id attribute name.
+   */
+  testIdAttributeName(): void;
 }
 
 /**

--- a/tests/library/selector-generator.spec.ts
+++ b/tests/library/selector-generator.spec.ts
@@ -596,4 +596,9 @@ it.describe('selector generator', () => {
       `span >> nth=1`,
     ]);
   });
+
+  it('should return the current testIdAttributeName', async ({ playwright }) => {
+    playwright.selectors.setTestIdAttribute('data-custom-id');
+    expect(playwright.selectors.testIdAttributeName()).toEqual('data-custom-id');
+  });
 });


### PR DESCRIPTION
### Description:

This pull request introduces a new method, `testIdAttributeName`; this method will get the current TestIdAttributeName either set using `Selectors.setTestIdAttribute` or initially with the user config. Therefore this will introduce `Selectors.testIdAttributeName`

### Motivation:

Knowing the most up-to date set `testIdAttributeName`. If the testAttributeName has been modified at runtime, this new method would allow the user to get this value. In my own use-case I want to get the value because across and within my projects, shared libraries need to know what the current testid is and a simple export via `playwright.config.ts` of the `testIdAttribute` value is not sufficient enough.

### Changes:

Added functionality and a test to confirm the current `testIdAttributeName`