### PR TITLE
fix(tracing): use page swap timestamp to find closest screenshot

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -898,7 +898,7 @@ class FrameSession {
     const buffer = Buffer.from(payload.data, 'base64');
     this._page.emit(Page.Events.ScreencastFrame, {
       buffer,
-      timestamp: payload.metadata.timestamp ? payload.metadata.timestamp * 1000 : undefined,
+      frameSwapWallTime: payload.metadata.timestamp ? payload.metadata.timestamp * 1000 : undefined,
       width: payload.metadata.deviceWidth,
       height: payload.metadata.deviceHeight,
     });

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -898,7 +898,7 @@ class FrameSession {
     const buffer = Buffer.from(payload.data, 'base64');
     this._page.emit(Page.Events.ScreencastFrame, {
       buffer,
-      timestamp: payload.metadata.timestamp,
+      timestamp: payload.metadata.timestamp ? payload.metadata.timestamp * 1000 : undefined,
       width: payload.metadata.deviceWidth,
       height: payload.metadata.deviceHeight,
     });

--- a/packages/playwright-core/src/server/chromium/videoRecorder.ts
+++ b/packages/playwright-core/src/server/chromium/videoRecorder.ts
@@ -53,7 +53,7 @@ export class VideoRecorder {
   private constructor(page: Page, ffmpegPath: string, progress: Progress) {
     this._progress = progress;
     this._ffmpegPath = ffmpegPath;
-    page.on(Page.Events.ScreencastFrame, frame => this.writeFrame(frame.buffer, frame.frameSwapWallTime));
+    page.on(Page.Events.ScreencastFrame, frame => this.writeFrame(frame.buffer, frame.frameSwapWallTime / 1000));
   }
 
   private async _launch(options: types.PageScreencastOptions) {

--- a/packages/playwright-core/src/server/chromium/videoRecorder.ts
+++ b/packages/playwright-core/src/server/chromium/videoRecorder.ts
@@ -53,7 +53,7 @@ export class VideoRecorder {
   private constructor(page: Page, ffmpegPath: string, progress: Progress) {
     this._progress = progress;
     this._ffmpegPath = ffmpegPath;
-    page.on(Page.Events.ScreencastFrame, frame => this.writeFrame(frame.buffer, frame.timestamp));
+    page.on(Page.Events.ScreencastFrame, frame => this.writeFrame(frame.buffer, frame.frameSwapWallTime));
   }
 
   private async _launch(options: types.PageScreencastOptions) {

--- a/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
@@ -137,7 +137,7 @@ export class Snapshotter {
         html: data.html,
         viewport: data.viewport,
         timestamp: monotonicTime(),
-        absoluteTimestamp: data.absoluteTimestamp,
+        wallTime: data.wallTime,
         collectionTime: data.collectionTime,
         resourceOverrides: [],
         isMainFrame: page.mainFrame() === frame

--- a/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
@@ -137,6 +137,7 @@ export class Snapshotter {
         html: data.html,
         viewport: data.viewport,
         timestamp: monotonicTime(),
+        absoluteTimestamp: data.absoluteTimestamp,
         collectionTime: data.collectionTime,
         resourceOverrides: [],
         isMainFrame: page.mainFrame() === frame

--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -27,7 +27,7 @@ export type SnapshotData = {
   }[],
   viewport: { width: number, height: number },
   url: string,
-  absoluteTimestamp: number, // milliseconds since epoch
+  wallTime: number,
   collectionTime: number,
 };
 
@@ -572,7 +572,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
           height: window.innerHeight,
         },
         url: location.href,
-        absoluteTimestamp: Date.now(),
+        wallTime: Date.now(),
         collectionTime: 0,
       };
 

--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -27,7 +27,6 @@ export type SnapshotData = {
   }[],
   viewport: { width: number, height: number },
   url: string,
-  timestamp: number,
   absoluteTimestamp: number, // milliseconds since epoch
   collectionTime: number,
 };
@@ -573,7 +572,6 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
           height: window.innerHeight,
         },
         url: location.href,
-        timestamp,
         absoluteTimestamp: Date.now(),
         collectionTime: 0,
       };
@@ -591,7 +589,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
         result.resourceOverrides.push({ url, content, contentType: 'text/css' },);
       }
 
-      result.collectionTime = performance.now() - result.timestamp;
+      result.collectionTime = performance.now() - timestamp;
       return result;
     }
   }

--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -28,6 +28,7 @@ export type SnapshotData = {
   viewport: { width: number, height: number },
   url: string,
   timestamp: number,
+  absoluteTimestamp: number, // milliseconds since epoch
   collectionTime: number,
 };
 
@@ -573,6 +574,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
         },
         url: location.href,
         timestamp,
+        absoluteTimestamp: Date.now(),
         collectionTime: 0,
       };
 

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -473,7 +473,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
             width: params.width,
             height: params.height,
             timestamp: monotonicTime(),
-            frameSwapTimestamp: params.timestamp,
+            frameSwapWallTime: params.timestamp,
           };
           // Make sure to write the screencast frame before adding a reference to it.
           this._appendResource(sha1, params.buffer);

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -473,7 +473,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
             width: params.width,
             height: params.height,
             timestamp: monotonicTime(),
-            frameSwapWallTime: params.timestamp,
+            frameSwapWallTime: params.frameSwapWallTime,
           };
           // Make sure to write the screencast frame before adding a reference to it.
           this._appendResource(sha1, params.buffer);

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -473,7 +473,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
             width: params.width,
             height: params.height,
             timestamp: monotonicTime(),
-            frameSwapTimestamp: params.timestamp ? params.timestamp * 1000 : undefined,
+            frameSwapTimestamp: params.timestamp,
           };
           // Make sure to write the screencast frame before adding a reference to it.
           this._appendResource(sha1, params.buffer);

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -472,7 +472,8 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
             sha1,
             width: params.width,
             height: params.height,
-            timestamp: monotonicTime()
+            timestamp: monotonicTime(),
+            frameSwapTimestamp: params.timestamp ? params.timestamp * 1000 : undefined,
           };
           // Make sure to write the screencast frame before adding a reference to it.
           this._appendResource(sha1, params.buffer);

--- a/packages/trace-viewer/src/entries.ts
+++ b/packages/trace-viewer/src/entries.ts
@@ -45,6 +45,7 @@ export type PageEntry = {
   screencastFrames: {
     sha1: string,
     timestamp: number,
+    frameSwapTimestamp?: number,
     width: number,
     height: number,
   }[];

--- a/packages/trace-viewer/src/entries.ts
+++ b/packages/trace-viewer/src/entries.ts
@@ -45,7 +45,7 @@ export type PageEntry = {
   screencastFrames: {
     sha1: string,
     timestamp: number,
-    frameSwapTimestamp?: number,
+    frameSwapWallTime?: number,
     width: number,
     height: number,
   }[];

--- a/packages/trace-viewer/src/snapshotServer.ts
+++ b/packages/trace-viewer/src/snapshotServer.ts
@@ -46,7 +46,7 @@ export class SnapshotServer {
       viewport: snapshot.viewport(),
       url: snapshot.snapshot().frameUrl,
       timestamp: snapshot.snapshot().timestamp,
-      absoluteTimestamp: snapshot.snapshot().absoluteTimestamp,
+      wallTime: snapshot.snapshot().wallTime,
     } : {
       error: 'No snapshot found'
     });

--- a/packages/trace-viewer/src/snapshotServer.ts
+++ b/packages/trace-viewer/src/snapshotServer.ts
@@ -46,6 +46,7 @@ export class SnapshotServer {
       viewport: snapshot.viewport(),
       url: snapshot.snapshot().frameUrl,
       timestamp: snapshot.snapshot().timestamp,
+      absoluteTimestamp: snapshot.snapshot().absoluteTimestamp,
     } : {
       error: 'No snapshot found'
     });

--- a/packages/trace-viewer/src/traceModernizer.ts
+++ b/packages/trace-viewer/src/traceModernizer.ts
@@ -395,10 +395,6 @@ export class TraceModernizer {
         result.push({ ...event, monotonicTime: 0, origin: 'library' });
         continue;
       }
-      if (event.type === 'frame-snapshot') {
-        result.push({ ...event, snapshot: { ...event.snapshot, wallTime: 0 } });
-        continue;
-      }
       // Take wall and monotonic time from the first event.
       if (!this._contextEntry.wallTime && event.type === 'before')
         this._contextEntry.wallTime = event.wallTime;

--- a/packages/trace-viewer/src/traceModernizer.ts
+++ b/packages/trace-viewer/src/traceModernizer.ts
@@ -395,6 +395,10 @@ export class TraceModernizer {
         result.push({ ...event, monotonicTime: 0, origin: 'library' });
         continue;
       }
+      if (event.type === 'frame-snapshot') {
+        result.push({ ...event, snapshot: { ...event.snapshot, wallTime: 0 } });
+        continue;
+      }
       // Take wall and monotonic time from the first event.
       if (!this._contextEntry.wallTime && event.type === 'before')
         this._contextEntry.wallTime = event.wallTime;

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -101,7 +101,7 @@ export const SnapshotTab: React.FunctionComponent<{
 
   const iframeRef0 = React.useRef<HTMLIFrameElement>(null);
   const iframeRef1 = React.useRef<HTMLIFrameElement>(null);
-  const [snapshotInfo, setSnapshotInfo] = React.useState<{ viewport: typeof kDefaultViewport, url: string, timestamp?: number, absoluteTimestamp?: undefined }>({ viewport: kDefaultViewport, url: '' });
+  const [snapshotInfo, setSnapshotInfo] = React.useState<{ viewport: typeof kDefaultViewport, url: string, timestamp?: number, wallTime?: undefined }>({ viewport: kDefaultViewport, url: '' });
   const loadingRef = React.useRef({ iteration: 0, visibleIframe: 0 });
 
   React.useEffect(() => {
@@ -110,7 +110,7 @@ export const SnapshotTab: React.FunctionComponent<{
       const newVisibleIframe = 1 - loadingRef.current.visibleIframe;
       loadingRef.current.iteration = thisIteration;
 
-      const newSnapshotInfo = { url: '', viewport: kDefaultViewport, timestamp: undefined, absoluteTimestamp: undefined };
+      const newSnapshotInfo = { url: '', viewport: kDefaultViewport, timestamp: undefined, wallTime: undefined };
       if (snapshotInfoUrl) {
         const response = await fetch(snapshotInfoUrl);
         const info = await response.json();
@@ -118,7 +118,7 @@ export const SnapshotTab: React.FunctionComponent<{
           newSnapshotInfo.url = info.url;
           newSnapshotInfo.viewport = info.viewport;
           newSnapshotInfo.timestamp = info.timestamp;
-          newSnapshotInfo.absoluteTimestamp = info.absoluteTimestamp;
+          newSnapshotInfo.wallTime = info.wallTime;
         }
       }
 
@@ -170,13 +170,13 @@ export const SnapshotTab: React.FunctionComponent<{
   const page = action ? pageForAction(action) : undefined;
   const screencastFrame = React.useMemo(
       () => {
-        if (snapshotInfo.absoluteTimestamp && page?.screencastFrames[0]?.frameSwapTimestamp)
-          return findClosest(page.screencastFrames, frame => frame.frameSwapTimestamp!, snapshotInfo.absoluteTimestamp);
+        if (snapshotInfo.wallTime && page?.screencastFrames[0]?.frameSwapTimestamp)
+          return findClosest(page.screencastFrames, frame => frame.frameSwapTimestamp!, snapshotInfo.wallTime);
 
         if (snapshotInfo.timestamp && page?.screencastFrames)
           return findClosest(page.screencastFrames, frame => frame.timestamp, snapshotInfo.timestamp);
       },
-      [page?.screencastFrames, snapshotInfo.timestamp, snapshotInfo.absoluteTimestamp]
+      [page?.screencastFrames, snapshotInfo.timestamp, snapshotInfo.wallTime]
   );
 
   return <div

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -170,8 +170,8 @@ export const SnapshotTab: React.FunctionComponent<{
   const page = action ? pageForAction(action) : undefined;
   const screencastFrame = React.useMemo(
       () => {
-        if (snapshotInfo.wallTime && page?.screencastFrames[0]?.frameSwapTimestamp)
-          return findClosest(page.screencastFrames, frame => frame.frameSwapTimestamp!, snapshotInfo.wallTime);
+        if (snapshotInfo.wallTime && page?.screencastFrames[0]?.frameSwapWallTime)
+          return findClosest(page.screencastFrames, frame => frame.frameSwapWallTime!, snapshotInfo.wallTime);
 
         if (snapshotInfo.timestamp && page?.screencastFrames)
           return findClosest(page.screencastFrames, frame => frame.timestamp, snapshotInfo.timestamp);

--- a/packages/trace/src/snapshot.ts
+++ b/packages/trace/src/snapshot.ts
@@ -44,7 +44,7 @@ export type FrameSnapshot = {
   frameId: string,
   frameUrl: string,
   timestamp: number,
-  absoluteTimestamp: number,
+  wallTime: number,
   collectionTime: number,
   doctype?: string,
   html: NodeSnapshot,

--- a/packages/trace/src/snapshot.ts
+++ b/packages/trace/src/snapshot.ts
@@ -44,7 +44,7 @@ export type FrameSnapshot = {
   frameId: string,
   frameUrl: string,
   timestamp: number,
-  wallTime: number,
+  wallTime?: number,
   collectionTime: number,
   doctype?: string,
   html: NodeSnapshot,

--- a/packages/trace/src/snapshot.ts
+++ b/packages/trace/src/snapshot.ts
@@ -44,6 +44,7 @@ export type FrameSnapshot = {
   frameId: string,
   frameUrl: string,
   timestamp: number,
+  absoluteTimestamp: number,
   collectionTime: number,
   doctype?: string,
   html: NodeSnapshot,

--- a/packages/trace/src/trace.ts
+++ b/packages/trace/src/trace.ts
@@ -53,6 +53,7 @@ export type ScreencastFrameTraceEvent = {
   width: number,
   height: number,
   timestamp: number,
+  frameSwapTimestamp?: number, // milliseconds since epoch
 };
 
 export type BeforeActionTraceEvent = {

--- a/packages/trace/src/trace.ts
+++ b/packages/trace/src/trace.ts
@@ -53,7 +53,7 @@ export type ScreencastFrameTraceEvent = {
   width: number,
   height: number,
   timestamp: number,
-  frameSwapTimestamp?: number, // milliseconds since epoch
+  frameSwapWallTime?: number,
 };
 
 export type BeforeActionTraceEvent = {


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/playwright/pull/32248. When we have it, we should use the page swap timestamp we get from Chromium to find the closest screenshot.