### PR TITLE
chore: fix flaky screenshot test

### DIFF
--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -1469,6 +1469,7 @@ test('should serve css without content-type', async ({ page, runAndTrace, server
 test('should allow showing screenshots instead of snapshots', async ({ runAndTrace, page, server }) => {
   const traceViewer = await runAndTrace(async () => {
     await page.goto(server.PREFIX + '/one-style.html');
+    await page.waitForTimeout(1000); // ensure we could take a screenshot
   });
 
   const screenshot = traceViewer.page.getByAltText(`Screenshot of page.goto > Action`);


### PR DESCRIPTION
In this test, the trace recording goes super fast. Sometimes, this means that the recording is finished before the screen recorder got a chance to take a screenshot. If that happens, the tests fail because we never show a screenshot. 
This PR fixes the flakiness by delaying the trace recording so that there's always a screenshot taken.