### PR TITLE
chore: run all tests with bidi by default

### DIFF
--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -42,3 +42,5 @@ jobs:
       if: matrix.channel == 'bidi-firefox-beta'
     - name: Run tests
       run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run biditest -- --project=${{ matrix.channel }}*
+      env:
+        PWTEST_USE_BIDI_EXPECTATIONS: '1'

--- a/tests/bidi/expectationUtil.ts
+++ b/tests/bidi/expectationUtil.ts
@@ -23,6 +23,8 @@ export type TestExpectation = 'unknown' | 'flaky' | 'pass' | 'fail' | 'timeout';
 type ShouldSkipPredicate = (info: TestInfo) => boolean;
 
 export async function createSkipTestPredicate(projectName: string): Promise<ShouldSkipPredicate> {
+  if (!process.env.PWTEST_USE_BIDI_EXPECTATIONS)
+    return () => false;
   const expectationsMap = await parseBidiExpectations(projectName);
   return (info: TestInfo) => {
     const key = [info.project.name, ...info.titlePath].join(' › ');


### PR DESCRIPTION
Only use expectation files on CI to save resources