### PR TITLE
devops: move macos runners to public infra

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -50,7 +50,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13, macos-14]
+        # From macos-14 onwards, GitHub is using Apple Silicon machines by default.
+        os: [macos-12, macos-13, macos-13-xlarge, macos-14-large, macos-14]
         browser: [chromium, firefox, webkit]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -50,7 +50,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # From macos-14 onwards, GitHub is using Apple Silicon machines by default.
+        # Intel: macos-12, macos-13, macos-14-large
+        # Arm64: macos-13-xlarge, macos-14
         os: [macos-12, macos-13, macos-13-xlarge, macos-14-large, macos-14]
         browser: [chromium, firefox, webkit]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
See https://github.com/microsoft/playwright-browsers/pull/1242.

Before we were running macos-13-arm64 tests twice but weren't running any macOS-14 Intel tests (all x3 for 3 browsers). Since we only use public infrastructure as of today, we can move it in the main repo and simplify the setup.

Only macos-12-arm64 which the public infra doesn't offer, we keep in the internal repo.