### PR TITLE
devops: remove macos-12 bots

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -50,9 +50,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Intel: macos-12, macos-13, macos-14-large
+        # Intel: macos-13, macos-14-large
         # Arm64: macos-13-xlarge, macos-14
-        os: [macos-12, macos-13, macos-13-xlarge, macos-14-large, macos-14]
+        os: [macos-13, macos-13-xlarge, macos-14-large, macos-14]
         browser: [chromium, firefox, webkit]
     runs-on: ${{ matrix.os }}
     steps:
@@ -237,7 +237,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-latest]
+        os: [ubuntu-20.04, macos-13, windows-latest]
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/run-test


### PR DESCRIPTION
We stopped supporting macos-12 in 1.45, see the release notes and https://github.com/microsoft/playwright/pull/31283.