### PR TITLE
chore: freeze ffmpeg on macOS-12

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -42,7 +42,13 @@
     {
       "name": "ffmpeg",
       "revision": "1010",
-      "installByDefault": true
+      "installByDefault": true,
+      "revisionOverrides": {
+        "mac11": "1010",
+        "mac11-arm64": "1010",
+        "mac12": "1010",
+        "mac12-arm64": "1010"
+      }
     },
     {
       "name": "android",

--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -44,8 +44,6 @@
       "revision": "1010",
       "installByDefault": true,
       "revisionOverrides": {
-        "mac11": "1010",
-        "mac11-arm64": "1010",
         "mac12": "1010",
         "mac12-arm64": "1010"
       }


### PR DESCRIPTION
ffmpeg 1010 is the last version supporting macOS-12 as per https://github.com/microsoft/playwright-browsers/pull/1249#discussion_r1757371311.
