### PR TITLE
feat(fetch): record timings

### DIFF
--- a/examples/github-api/tests/demo.spec.ts
+++ b/examples/github-api/tests/demo.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test";
+
+test('should get posts', async ({ request }) => {
+    const posts = await request.get(`https://jsonplaceholder.typicode.com/posts/1`);
+    expect(posts.ok()).toBeTruthy();
+    expect(await posts.text()).toHaveLength(10)
+});

--- a/examples/github-api/tests/demo.spec.ts
+++ b/examples/github-api/tests/demo.spec.ts
@@ -1,7 +1,0 @@
-import { test, expect } from "@playwright/test";
-
-test('should get posts', async ({ request }) => {
-    const posts = await request.get(`https://jsonplaceholder.typicode.com/posts/1`);
-    expect(posts.ok()).toBeTruthy();
-    expect(await posts.text()).toHaveLength(10)
-});

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -30,7 +30,7 @@ import { HttpsProxyAgent, SocksProxyAgent } from '../utilsBundle';
 import { BrowserContext, verifyClientCertificates } from './browserContext';
 import { CookieStore, domainMatches } from './cookieStore';
 import { MultipartFormData } from './formData';
-import { httpHappyEyeballsAgent, httpsHappyEyeballsAgent } from '../utils/happy-eyeballs';
+import { httpHappyEyeballsAgent, httpsHappyEyeballsAgent, timingForSocket } from '../utils/happy-eyeballs';
 import type { CallMetadata } from './instrumentation';
 import { SdkObject } from './instrumentation';
 import type { Playwright } from './playwright';
@@ -488,8 +488,9 @@ export abstract class APIRequestContext extends SdkObject {
 
       request.on('socket', socket => {
         // happy eyeballs don't emit lookup and connect events, so we use our custom ones
-        dnsLookupAt = (socket as any).dnsLookupAt;
-        tcpConnectionAt = (socket as any).tcpConnectionAt;
+        const happyEyeBallsTimings = timingForSocket(socket);
+        dnsLookupAt = happyEyeBallsTimings.dnsLookupAt;
+        tcpConnectionAt = happyEyeBallsTimings.tcpConnectionAt;
 
         // non-happy-eyeballs sockets
         socket.on('lookup', () => { dnsLookupAt = monotonicTime(); });

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -315,11 +315,11 @@ export abstract class APIRequestContext extends SdkObject {
       let tcpConnectionAt: number | undefined;
       let tlsHandshakeAt: number | undefined;
       let requestFinishAt: number | undefined;
-      let endAt: number | undefined;
 
       const request = requestConstructor(url, requestOptions as any, async response => {
         const responseAt = monotonicTime();
         const notifyRequestFinished = (body?: Buffer) => {
+          const endAt = monotonicTime();
           // spec: http://www.softwareishard.com/blog/har-12-spec/#timings
           const timings: har.Timings = {
             send: requestFinishAt! - startAt,
@@ -435,7 +435,6 @@ export abstract class APIRequestContext extends SdkObject {
 
         const chunks: Buffer[] = [];
         const notifyBodyFinished = () => {
-          endAt = monotonicTime();
           const body = Buffer.concat(chunks);
           notifyRequestFinished(body);
           fulfill({

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -319,8 +319,6 @@ export abstract class APIRequestContext extends SdkObject {
       let endAt: number | undefined;
 
       const request = requestConstructor(url, requestOptions as any, async response => {
-        response.once('readable', () => { firstByteAt = monotonicTime(); });
-
         const notifyRequestFinished = (body?: Buffer) => {
           const timings: har.Timings = {
             send: requestFinishAt! - startAt,
@@ -476,7 +474,10 @@ export abstract class APIRequestContext extends SdkObject {
           body.on('error', reject);
         }
 
-        body.on('data', chunk => chunks.push(chunk));
+        body.on('data', chunk => {
+          firstByteAt ??= monotonicTime();
+          chunks.push(chunk);
+        });
         body.on('end', notifyBodyFinished);
       });
       request.on('error', error => reject(rewriteOpenSSLErrorIfNeeded(error)));

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -324,7 +324,7 @@ export abstract class APIRequestContext extends SdkObject {
           const timings: har.Timings = {
             send: requestFinishAt! - startAt,
             wait: responseAt - requestFinishAt!,
-            receive: endAt! - responseAt,
+            receive: endAt - responseAt,
             dns: dnsLookupAt ? dnsLookupAt - startAt : -1,
             connect: (tlsHandshakeAt ?? tcpConnectionAt!) - startAt, // "If [ssl] is defined then the time is also included in the connect field "
             ssl: tlsHandshakeAt ? tlsHandshakeAt - tcpConnectionAt! : -1,

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -320,7 +320,6 @@ export abstract class APIRequestContext extends SdkObject {
 
       const request = requestConstructor(url, requestOptions as any, async response => {
         response.once('readable', () => { firstByteAt = monotonicTime(); });
-        response.once('end', () => { endAt = monotonicTime(); });
 
         const notifyRequestFinished = (body?: Buffer) => {
           const timings: har.Timings = {
@@ -437,6 +436,7 @@ export abstract class APIRequestContext extends SdkObject {
 
         const chunks: Buffer[] = [];
         const notifyBodyFinished = () => {
+          endAt = monotonicTime();
           const body = Buffer.concat(chunks);
           notifyRequestFinished(body);
           fulfill({

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -494,7 +494,7 @@ export abstract class APIRequestContext extends SdkObject {
         dnsLookupAt = (socket as any).dnsLookupAt;
         tcpConnectionAt = (socket as any).tcpConnectionAt;
 
-        // standard case
+        // non-happy-eyeballs sockets
         socket.on('lookup', () => { dnsLookupAt = monotonicTime(); });
         socket.on('connect', () => { tcpConnectionAt = monotonicTime(); });
         socket.on('secureConnect', () => { tlsHandshakeAt = monotonicTime(); });

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -320,12 +320,13 @@ export abstract class APIRequestContext extends SdkObject {
 
       const request = requestConstructor(url, requestOptions as any, async response => {
         const notifyRequestFinished = (body?: Buffer) => {
+          // spec: http://www.softwareishard.com/blog/har-12-spec/#timings
           const timings: har.Timings = {
             send: requestFinishAt! - startAt,
             wait: firstByteAt! - requestFinishAt!,
             receive: endAt! - firstByteAt!,
             dns: dnsLookupAt ? dnsLookupAt - startAt : -1,
-            connect: (tlsHandshakeAt ?? tcpConnectionAt!) - startAt,
+            connect: (tlsHandshakeAt ?? tcpConnectionAt!) - startAt, // "If [ssl] is defined then the time is also included in the connect field "
             ssl: tlsHandshakeAt ? tlsHandshakeAt - tcpConnectionAt! : -1,
             blocked: -1,
           };

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -212,6 +212,10 @@ export class HarTracer {
     harEntry.response.statusText = event.statusMessage;
     harEntry.response.httpVersion = event.httpVersion;
     harEntry.response.redirectURL = event.headers.location || '';
+
+    harEntry.timings = event.timings;
+    this._computeHarEntryTotalTime(harEntry);
+
     for (let i = 0; i < event.rawHeaders.length; i += 2) {
       harEntry.response.headers.push({
         name: event.rawHeaders[i],

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -213,8 +213,10 @@ export class HarTracer {
     harEntry.response.httpVersion = event.httpVersion;
     harEntry.response.redirectURL = event.headers.location || '';
 
-    harEntry.timings = event.timings;
-    this._computeHarEntryTotalTime(harEntry);
+    if (!this._options.omitTiming) {
+      harEntry.timings = event.timings;
+      this._computeHarEntryTotalTime(harEntry);
+    }
 
     for (let i = 0; i < event.rawHeaders.length; i += 2) {
       harEntry.response.headers.push({

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -820,6 +820,17 @@ it('should include API request', async ({ contextFactory, server }, testInfo) =>
   expect(entry.response.headers.find(h => h.name.toLowerCase() === 'content-type')?.value).toContain('application/json');
   expect(entry.response.content.size).toBe(15);
   expect(entry.response.content.text).toBe(responseBody.toString());
+
+  expect(entry.time).toBeGreaterThan(0);
+  expect(entry.timings).toEqual(expect.objectContaining({
+    blocked: -1,
+    connect: expect.any(Number),
+    dns: expect.any(Number),
+    receive: expect.any(Number),
+    send: expect.any(Number),
+    ssl: expect.any(Number),
+    wait: expect.any(Number),
+  }));
 });
 
 it('should not hang on resources served from cache', async ({ contextFactory, server, browserName }, testInfo) => {


### PR DESCRIPTION
Related to https://github.com/microsoft/playwright/issues/19621

Adds some instrumentation to collect timings for `APIRequestContext` requests and adds them to the HAR trace. Doesn't yet expose them via an API, but makes our `Duration` field in the trace viewer show a nice duration:

<img width="1392" alt="Screenshot 2024-09-14 at 11 46 04" src="https://github.com/user-attachments/assets/8020382d-9494-4634-9cfd-22b6f4a1d770">


I'm gonna add it to our API in a separate PR.