### PR TITLE
[Feature] IDE mode trace viewer

### DIFF
--- a/packages/playwright/src/isomorphic/testServerConnection.ts
+++ b/packages/playwright/src/isomorphic/testServerConnection.ts
@@ -67,12 +67,14 @@ export class TestServerConnection implements TestServerInterface, TestServerInte
   readonly onStdio: events.Event<{ type: 'stderr' | 'stdout'; text?: string | undefined; buffer?: string | undefined; }>;
   readonly onTestFilesChanged: events.Event<{ testFiles: string[] }>;
   readonly onLoadTraceRequested: events.Event<{ traceUrl: string }>;
+  readonly onTraceViewerEvent: events.Event<{ method: string; params: any; }>;
 
   private _onCloseEmitter = new events.EventEmitter<void>();
   private _onReportEmitter = new events.EventEmitter<any>();
   private _onStdioEmitter = new events.EventEmitter<{ type: 'stderr' | 'stdout'; text?: string | undefined; buffer?: string | undefined; }>();
   private _onTestFilesChangedEmitter = new events.EventEmitter<{ testFiles: string[] }>();
   private _onLoadTraceRequestedEmitter = new events.EventEmitter<{ traceUrl: string }>();
+  private _onTraceViewerEventEmitter = new events.EventEmitter<{ method: string; params: any }>();
 
   private _lastId = 0;
   private _transport: TestServerTransport;
@@ -86,6 +88,7 @@ export class TestServerConnection implements TestServerInterface, TestServerInte
     this.onStdio = this._onStdioEmitter.event;
     this.onTestFilesChanged = this._onTestFilesChangedEmitter.event;
     this.onLoadTraceRequested = this._onLoadTraceRequestedEmitter.event;
+    this.onTraceViewerEvent = this._onTraceViewerEventEmitter.event;
 
     this._transport = transport;
     this._transport.onmessage(data => {
@@ -146,6 +149,8 @@ export class TestServerConnection implements TestServerInterface, TestServerInte
       this._onTestFilesChangedEmitter.fire(params);
     else if (method === 'loadTraceRequested')
       this._onLoadTraceRequestedEmitter.fire(params);
+    else if (method === 'traceViewerEvent')
+      this._onTraceViewerEventEmitter.fire(params);
   }
 
   async initialize(params: Parameters<TestServerInterface['initialize']>[0]): ReturnType<TestServerInterface['initialize']> {
@@ -234,6 +239,22 @@ export class TestServerConnection implements TestServerInterface, TestServerInte
 
   stopTestsNoReply(params: Parameters<TestServerInterface['stopTests']>[0]) {
     this._sendMessageNoReply('stopTests', params);
+  }
+
+  async openTraceViewer(params: Parameters<TestServerInterface['openTraceViewer']>[0]): ReturnType<TestServerInterface['openTraceViewer']>  {
+    await this._sendMessage('openTraceViewer', params);
+  }
+
+  async closeTraceViewer(params: Parameters<TestServerInterface['closeTraceViewer']>[0]): ReturnType<TestServerInterface['closeTraceViewer']> {
+    await this._sendMessage('closeTraceViewer', params);
+  }
+
+  async dispatchTraceViewerEvent(params: Parameters<TestServerInterface['dispatchTraceViewerEvent']>[0]): ReturnType<TestServerInterface['dispatchTraceViewerEvent']> {
+    await this._sendMessage('dispatchTraceViewerEvent', params);
+  }
+
+  dispatchTraceViewerEventNoReply(params: Parameters<TestServerInterface['dispatchTraceViewerEvent']>[0]) {
+    this._sendMessageNoReply('dispatchTraceViewerEvent', params);
   }
 
   async closeGracefully(params: Parameters<TestServerInterface['closeGracefully']>[0]): ReturnType<TestServerInterface['closeGracefully']> {

--- a/packages/playwright/src/isomorphic/testServerInterface.ts
+++ b/packages/playwright/src/isomorphic/testServerInterface.ts
@@ -21,6 +21,7 @@ import type { JsonEvent } from './teleReceiver';
 // -- Reuse boundary -- Everything below this line is reused in the vscode extension.
 
 export type ReportEntry = JsonEvent;
+export type TraceViewerEvent = JsonEvent;
 
 export interface TestServerInterface {
   initialize(params: {
@@ -114,6 +115,12 @@ export interface TestServerInterface {
 
   stopTests(params: {}): Promise<void>;
 
+  openTraceViewer(params: { traceViewerURL: string; openInBrowser?: boolean }): Promise<void>;
+
+  closeTraceViewer(params: {}): Promise<void>;
+
+  dispatchTraceViewerEvent(params: { method: string; params: any; }): Promise<void>;
+
   closeGracefully(params: {}): Promise<void>;
 }
 
@@ -122,6 +129,7 @@ export interface TestServerInterfaceEvents {
   onStdio: Event<{ type: 'stdout' | 'stderr', text?: string, buffer?: string }>;
   onTestFilesChanged: Event<{ testFiles: string[] }>;
   onLoadTraceRequested: Event<{ traceUrl: string }>;
+  onTraceViewerEvent: Event<{ method: string; params: any; }>;
 }
 
 export interface TestServerInterfaceEventEmitters {
@@ -129,4 +137,5 @@ export interface TestServerInterfaceEventEmitters {
   dispatchEvent(event: 'stdio', params: { type: 'stdout' | 'stderr', text?: string, buffer?: string }): void;
   dispatchEvent(event: 'testFilesChanged', params: { testFiles: string[] }): void;
   dispatchEvent(event: 'loadTraceRequested', params: { traceUrl: string }): void;
+  dispatchEvent(event: 'traceViewerEvent', params: { method: string; params: any; }): void;
 }

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -114,6 +114,7 @@ function addTestServerCommand(program: Command) {
   command.option('-c, --config <file>', `Configuration file, or a test directory with optional "playwright.config.{m,c}?{js,ts}"`);
   command.option('--host <host>', 'Host to start the server on', 'localhost');
   command.option('--port <port>', 'Port to start the server on', '0');
+  command.option('--ide-mode', 'IDE node');
   command.action(opts => runTestServer(opts));
 }
 
@@ -227,7 +228,8 @@ async function runTests(args: string[], opts: { [key: string]: any }) {
 async function runTestServer(opts: { [key: string]: any }) {
   const host = opts.host || 'localhost';
   const port = opts.port ? +opts.port : 0;
-  const status = await testServer.runTestServer(opts.config, { host, port });
+  const ideMode = !!opts.ideMode;
+  const status = await testServer.runTestServer(opts.config, { host, port, ideMode });
   if (status === 'restarted')
     return;
   const exitCode = status === 'interrupted' ? 130 : (status === 'passed' ? 0 : 1);

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -479,15 +479,17 @@ export async function runUIMode(configFile: string | undefined, options: TraceVi
   });
 }
 
-export async function runTestServer(configFile: string | undefined, options: { host?: string, port?: number }): Promise<reporterTypes.FullResult['status'] | 'restarted'> {
+export async function runTestServer(configFile: string | undefined, options: { host?: string, port?: number, ideMode?: boolean }): Promise<reporterTypes.FullResult['status'] | 'restarted'> {
   const configLocation = resolveConfigLocation(configFile);
   return await innerRunTestServer(configLocation, options, async server => {
+    if (options.ideMode)
+      await installRootRedirect(server, [], { ...options, webApp: 'ideMode.html' });
     // eslint-disable-next-line no-console
     console.log('Listening on ' + server.urlPrefix('precise').replace('http:', 'ws:') + '/' + server.wsGuid());
   });
 }
 
-async function innerRunTestServer(configLocation: ConfigLocation, options: { host?: string, port?: number }, openUI: (server: HttpServer, cancelPromise: ManualPromise<void>, configLocation: ConfigLocation) => Promise<void>): Promise<reporterTypes.FullResult['status'] | 'restarted'> {
+async function innerRunTestServer(configLocation: ConfigLocation, options: { host?: string, port?: number, ideMode?: boolean }, openUI: (server: HttpServer, cancelPromise: ManualPromise<void>, configLocation: ConfigLocation) => Promise<void>): Promise<reporterTypes.FullResult['status'] | 'restarted'> {
   if (restartWithExperimentalTsEsm(undefined, true))
     return 'restarted';
   const testServer = new TestServer(configLocation);

--- a/packages/trace-viewer/ideMode.html
+++ b/packages/trace-viewer/ideMode.html
@@ -18,10 +18,11 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Playwright Trace Viewer for VS Code</title>
+    <link rel="icon" href="/playwright-logo.svg" type="image/svg+xml">
+    <title>Playwright Trace Viewer</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/embedded.tsx"></script>
+    <script type="module" src="/src/ideMode.tsx"></script>
   </body>
 </html>

--- a/packages/trace-viewer/src/ideMode.tsx
+++ b/packages/trace-viewer/src/ideMode.tsx
@@ -18,30 +18,10 @@ import '@web/common.css';
 import { applyTheme } from '@web/theme';
 import '@web/third_party/vscode/codicon.css';
 import * as ReactDOM from 'react-dom/client';
-import { EmbeddedWorkbenchLoader } from './ui/embeddedWorkbenchLoader';
+import { IDEModeView } from './ui/ideModeView';
 
 (async () => {
   applyTheme();
-
-  // workaround to send keystrokes back to vscode webview to keep triggering key bindings there
-  const handleKeyEvent = (e: KeyboardEvent) => {
-    if (!e.isTrusted)
-      return;
-    window.parent?.postMessage({
-      type: e.type,
-      key: e.key,
-      keyCode: e.keyCode,
-      code: e.code,
-      shiftKey: e.shiftKey,
-      altKey: e.altKey,
-      ctrlKey: e.ctrlKey,
-      metaKey: e.metaKey,
-      repeat: e.repeat,
-    }, '*');
-  };
-  window.addEventListener('keydown', handleKeyEvent);
-  window.addEventListener('keyup', handleKeyEvent);
-
   if (window.location.protocol !== 'file:') {
     if (!navigator.serviceWorker)
       throw new Error(`Service workers are not supported.\nMake sure to serve the Trace Viewer (${window.location}) via HTTPS or localhost.`);
@@ -56,5 +36,5 @@ import { EmbeddedWorkbenchLoader } from './ui/embeddedWorkbenchLoader';
     setInterval(function() { fetch('ping'); }, 10000);
   }
 
-  ReactDOM.createRoot(document.querySelector('#root')!).render(<EmbeddedWorkbenchLoader />);
+  ReactDOM.createRoot(document.querySelector('#root')!).render(<IDEModeView />);
 })();

--- a/packages/trace-viewer/src/ui/ideModeView.css
+++ b/packages/trace-viewer/src/ui/ideModeView.css
@@ -48,6 +48,7 @@ body.dark-mode .empty-state {
   flex: none;
   width: 100%;
   height: 3px;
+  margin-top: -3px;
   z-index: 10;
 }
 
@@ -56,8 +57,49 @@ body.dark-mode .empty-state {
   height: 100%;
 }
 
-.workbench-loader {
+.header {
+  display: flex;
+  background-color: #000;
+  flex: none;
+  flex-basis: 48px;
+  line-height: 48px;
+  font-size: 16px;
+  color: #cccccc;
+}
+
+.ide-mode {
   contain: size;
+}
+
+.ide-mode .header .toolbar-button {
+  margin: 12px;
+  padding: 8px 4px;
+}
+
+.ide-mode .logo {
+  margin-left: 16px;
+  display: flex;
+  align-items: center;
+}
+
+.ide-mode .logo img {
+  height: 32px;
+  width: 32px;
+  pointer-events: none;
+  flex: none;
+}
+
+.ide-mode .product {
+  font-weight: 600;
+  margin-left: 16px;
+  flex: none;
+}
+
+.ide-mode .header .title {
+  margin-left: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-wrap: nowrap;
 }
 
 /* Limit to a reasonable minimum viewport */

--- a/packages/trace-viewer/src/ui/ideModeView.tsx
+++ b/packages/trace-viewer/src/ui/ideModeView.tsx
@@ -91,7 +91,7 @@ export const IDEModeView: React.FunctionComponent = () => {
     <div className='progress'>
       <div className='inner-progress' style={{ width: progress.total ? (100 * progress.done / progress.total) + '%' : 0 }}></div>
     </div>
-    <Workbench model={model} onSelectionChanged={selectionChanged} showSettings />
+    <Workbench model={model} onSelectionChanged={selectionChanged} showSettings excludeSidebarTabs={['source']} />
     {!traceURLs.length && <div className='empty-state'>
       <div className='title'>Select test to see the trace</div>
     </div>}

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -59,7 +59,8 @@ export const Workbench: React.FunctionComponent<{
   onOpenExternally?: (location: modelUtil.SourceLocation) => void,
   revealSource?: boolean,
   showSettings?: boolean,
-}> = ({ model, showSourcesFirst, rootDir, fallbackLocation, initialSelection, onSelectionChanged, isLive, status, annotations, inert, openPage, onOpenExternally, revealSource, showSettings }) => {
+  excludeSidebarTabs?: string[]
+}> = ({ model, showSourcesFirst, rootDir, fallbackLocation, initialSelection, onSelectionChanged, isLive, status, annotations, inert, openPage, onOpenExternally, revealSource, showSettings, excludeSidebarTabs }) => {
   const [selectedAction, setSelectedActionImpl] = React.useState<modelUtil.ActionTraceEventInContext | undefined>(undefined);
   const [revealedStack, setRevealedStack] = React.useState<StackFrame[] | undefined>(undefined);
   const [highlightedAction, setHighlightedAction] = React.useState<modelUtil.ActionTraceEventInContext | undefined>();
@@ -347,7 +348,7 @@ export const Workbench: React.FunctionComponent<{
         }
       />}
       sidebar={<TabbedPane
-        tabs={tabs}
+        tabs={excludeSidebarTabs ? tabs.filter(t => !excludeSidebarTabs.includes(t.id)) : tabs}
         selectedTab={selectedPropertiesTab}
         setSelectedTab={selectPropertiesTab}
         rightToolbar={[

--- a/packages/trace-viewer/vite.config.ts
+++ b/packages/trace-viewer/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
       input: {
         index: path.resolve(__dirname, 'index.html'),
         uiMode: path.resolve(__dirname, 'uiMode.html'),
-        embedded: path.resolve(__dirname, 'embedded.html'),
+        ideMode: path.resolve(__dirname, 'ideMode.html'),
         recorder: path.resolve(__dirname, 'recorder.html'),
         snapshot: path.resolve(__dirname, 'snapshot.html'),
       },


### PR DESCRIPTION
Companion PR of https://github.com/microsoft/playwright-vscode/pull/531.

For VS code and trace viewer to communicate using events, this PR adds support to multiple websockets connections and event broadcasting.

It also extends testServer to provide trace viewer support, as well as converting embedded trace viewer page into IDE mode, which uses `testServerConnection` to dispatch events to VS code.