### PR TITLE
feat(watch mode): buffer mode

### DIFF
--- a/packages/playwright/src/runner/watchMode.ts
+++ b/packages/playwright/src/runner/watchMode.ts
@@ -152,8 +152,8 @@ export async function runWatchModeLoop(configLocation: ConfigLocation, initialOp
     if (bufferMode && command === 'changed')
       continue;
 
-    const commandToTriggerTestRun = (bufferMode ? 'run' : 'changed');
-    if (command === commandToTriggerTestRun) {
+    const shouldRunChangedFiles = bufferMode ? command === 'run' : command === 'changed';
+    if (shouldRunChangedFiles) {
       if (dirtyTestIds.size === 0)
         continue;
 

--- a/packages/playwright/src/runner/watchMode.ts
+++ b/packages/playwright/src/runner/watchMode.ts
@@ -119,7 +119,7 @@ export async function runWatchModeLoop(configLocation: ConfigLocation, initialOp
       }
       changedFiles.clear();
 
-      if (dirtyTestIds.size > 0) {
+      if (dirtyTestIds.size > 0) {
         onDirtyTests.resolve('changed');
         onDirtyTests = new ManualPromise();
       }
@@ -144,10 +144,9 @@ export async function runWatchModeLoop(configLocation: ConfigLocation, initialOp
     else
       printPrompt();
 
-    const readCommandPromise = readCommand();
     const command = await Promise.race([
       onDirtyTests,
-      readCommandPromise,
+      readCommand(),
     ]);
 
     if (bufferMode && command === 'changed')

--- a/packages/playwright/src/runner/watchMode.ts
+++ b/packages/playwright/src/runner/watchMode.ts
@@ -140,7 +140,7 @@ export async function runWatchModeLoop(configLocation: ConfigLocation, initialOp
 
   while (true) {
     if (bufferMode)
-      printBufferPrompt(dirtyTestFiles);
+      printBufferPrompt(dirtyTestFiles, teleSuiteUpdater.config!.rootDir);
     else
       printPrompt();
 
@@ -369,7 +369,7 @@ function printConfiguration(options: WatchModeOptions, title?: string) {
   process.stdout.write(lines.join('\n'));
 }
 
-function printBufferPrompt(dirtyTestFiles: Set<string>) {
+function printBufferPrompt(dirtyTestFiles: Set<string>, rootDir: string) {
   const sep = separator();
   process.stdout.write('\x1Bc');
   process.stdout.write(`${sep}\n`);
@@ -381,7 +381,7 @@ function printBufferPrompt(dirtyTestFiles: Set<string>) {
 
   process.stdout.write(`${colors.dim(`${dirtyTestFiles.size} test ${dirtyTestFiles.size === 1 ? 'file' : 'files'} changed:`)}\n\n`);
   for (const file of dirtyTestFiles)
-    process.stdout.write(` · ${file}\n`);
+    process.stdout.write(` · ${path.relative(rootDir, file)}\n`);
   process.stdout.write(`\n${colors.dim(`Press`)} ${colors.bold('enter')} ${colors.dim('to run')}, ${colors.bold('q')} ${colors.dim('to quit or')} ${colors.bold('h')} ${colors.dim('for more options.')}\n\n`);
 }
 

--- a/tests/playwright-test/watch.spec.ts
+++ b/tests/playwright-test/watch.spec.ts
@@ -313,12 +313,17 @@ test('should respect project filter C', async ({ runWatchTest, writeFiles }) => 
   await testProcess.waitForOutput('[foo] › a.test.ts:3:11 › passes');
   expect(testProcess.output).not.toContain('[bar] › a.test.ts:3:11 › passes');
 
+  await testProcess.waitForOutput('Waiting for file changes.');
   testProcess.clearOutput();
 
   await writeFiles(files); // file change triggers listTests with project filter
   await testProcess.waitForOutput('[foo] › a.test.ts:3:11 › passes');
 
+  testProcess.clearOutput();
+  await testProcess.waitForOutput('Waiting for file changes.');
+
   testProcess.write('c');
+  testProcess.clearOutput();
   await testProcess.waitForOutput('Select projects');
   await testProcess.waitForOutput('foo');
   await testProcess.waitForOutput('bar'); // second selection should still show all


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32578.

Adds a buffer mode that can be toggled by pressing <kbd>b</kbd>. When engaged, changed test files are collected and shown on screen. The test run is then kicked off by pressing <kbd>Enter</kbd>.

This changes the signal to start a test run from <kbd>Cmd+s</kbd> to a <kbd>Enter</kbd> press in the test terminal. It should help users with auto-save and make it easier to run on long-running tests. It feels very similar to running `npx playwright test`, but without having to write a filter.


https://github.com/user-attachments/assets/71e16139-9427-4e90-b523-8d218f09ed9d

