### PR TITLE
fix(recorder): reattach toolbar if it was unmounted by framework hydration

### DIFF
--- a/packages/playwright-core/src/server/injected/highlight.ts
+++ b/packages/playwright-core/src/server/injected/highlight.ts
@@ -42,7 +42,6 @@ export type HighlightOptions = {
 export class Highlight {
   private _glassPaneElement: HTMLElement;
   private _glassPaneShadow: ShadowRoot;
-  private _glassPaneInterval?: NodeJS.Timeout;
   private _highlightEntries: HighlightEntry[] = [];
   private _highlightOptions: HighlightOptions = {};
   private _actionPointElement: HTMLElement;
@@ -91,12 +90,8 @@ export class Highlight {
   }
 
   install() {
-    this._injectedScript.document.documentElement.appendChild(this._glassPaneElement);
-
-    this._glassPaneInterval = setInterval(() => {
-      if (!this._injectedScript.document.documentElement.contains(this._glassPaneElement))
-        this._injectedScript.document.documentElement.appendChild(this._glassPaneElement);
-    }, 500);
+    if (!this._injectedScript.document.documentElement.contains(this._glassPaneElement))
+      this._injectedScript.document.documentElement.appendChild(this._glassPaneElement);
   }
 
   setLanguage(language: Language) {
@@ -113,7 +108,6 @@ export class Highlight {
   uninstall() {
     if (this._rafRequest)
       cancelAnimationFrame(this._rafRequest);
-    clearInterval(this._glassPaneInterval);
     this._glassPaneElement.remove();
   }
 

--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -1038,7 +1038,7 @@ export class Recorder {
     ];
 
     this.highlight.install();
-    // some frameworks erase the DOM on hydration, so periodically ensure that the highlighter is installed
+    // some frameworks erase the DOM on hydration, this ensures it's reattached
     const recreationInterval = setInterval(() => {
       this.highlight.install();
     }, 500);

--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -1038,6 +1038,7 @@ export class Recorder {
     ];
 
     this.highlight.install();
+    // some frameworks erase the DOM on hydration, so periodically ensure that the highlighter is installed
     const recreationInterval = setInterval(() => {
       this.highlight.install();
     }, 500);

--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -1036,7 +1036,13 @@ export class Recorder {
       addEventListener(this.document, 'focus', event => this._onFocus(event), true),
       addEventListener(this.document, 'scroll', event => this._onScroll(event), true),
     ];
+
     this.highlight.install();
+    const recreationInterval = setInterval(() => {
+      this.highlight.install();
+    }, 500);
+    this._listeners.push(() => clearInterval(recreationInterval));
+
     this.overlay?.install();
     this.document.adoptedStyleSheets.push(this._stylesheet);
   }

--- a/tests/library/inspector/cli-codegen-3.spec.ts
+++ b/tests/library/inspector/cli-codegen-3.spec.ts
@@ -739,4 +739,21 @@ await page.GetByLabel("Coun\\"try").ClickAsync();`);
     expect.soft(sources1.get('Java')!.text).toContain(`assertThat(page.getByRole(AriaRole.TEXTBOX)).isVisible()`);
     expect.soft(sources1.get('C#')!.text).toContain(`await Expect(page.GetByRole(AriaRole.Textbox)).ToBeVisibleAsync()`);
   });
+
+  test('should keep toolbar visible even if webpage erases content in hydration', async ({ openRecorder }) => {
+    const recorder = await openRecorder();
+
+    const hydrate = () => {
+      setTimeout(() => {
+        document.documentElement.innerHTML = '<p>Post-Hydration Content</p>';
+      }, 500);
+    };
+    await recorder.setContentAndWait(`
+      <p>Pre-Hydration Content</p>
+      <script>(${hydrate})()</script>
+    `);
+
+    await expect(recorder.page.getByText('Post-Hydration Content')).toBeVisible();
+    await expect(recorder.page.locator('x-pw-glass')).toBeVisible();
+  });
 });


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32632. A side effect of Remix's hydration implementation is that it throws away the entire DOM. This is broadly discussed in https://github.com/remix-run/remix/issues/4822 - there might be a fix in coming React versions, but who knows.
Besides breaking browser extensions, this also deletes our toolbar!
This PR fixes it by periodically checking in on `x-pw-glass`, and remounting it if it was unmounted. Hacky but effective!