### PR TITLE
chore(har recorder): ensure we respect minimal mode

### DIFF
--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -845,6 +845,7 @@ it('should respect minimal mode for API Requests', async ({ contextFactory, serv
   const [entry] = entries;
   expect(entry.timings).toEqual({ receive: -1, send: -1, wait: -1 });
   expect(entry.request.cookies).toEqual([]);
+  expect(entry.request.bodySize).toBe(-1);
 });
 
 it('should include redirects from API request', async ({ contextFactory, server }, testInfo) => {

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -844,6 +844,7 @@ it('should respect minimal mode for API Requests', async ({ contextFactory, serv
   expect(entries).toHaveLength(1);
   const [entry] = entries;
   expect(entry.timings).toEqual({ receive: -1, send: -1, wait: -1 });
+  expect(entry.request.cookies).toEqual([]);
 });
 
 it('should include redirects from API request', async ({ contextFactory, server }, testInfo) => {


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32653.

Adds some test coverage to ensure we respect minimal mode for API Requests in HAR tracing.

| omit setting | result |
| - | - |
| `omitCookies` |  added test for it |
| `omitTiming` | already covered |
| `omitSecurityDetails` | not recorded yet |
| `omitServerIP` | we don't record it yet, so no action here. gonna open a separate issue |
| `omitPages` | not relevant to API requests |
| `omitSizes` | added test for it |
| `omitScripts` | not relevant to API requests |
