### PR TITLE
test: update cookie expectations for macOS 15

### DIFF
--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -69,12 +69,16 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
       await run(false);
   }, { scope: 'worker' }],
 
-  defaultSameSiteCookieValue: [async ({ browserName, isLinux }, run) => {
+  defaultSameSiteCookieValue: [async ({ browserName, platform }, run) => {
     if (browserName === 'chromium' || browserName as any === '_bidiChromium')
       await run('Lax');
-    else if (browserName === 'webkit' && isLinux)
+    else if (browserName === 'webkit' && platform === 'linux')
       await run('Lax');
-    else if (browserName === 'webkit' && !isLinux)
+    else if (browserName === 'webkit' && platform === 'darwin' && parseInt(os.release(), 10) >= 24)
+      // macOS 15 Sequoia onwards
+      await run('Lax');
+    else if (browserName === 'webkit')
+      // Windows + older macOS
       await run('None');
     else if (browserName === 'firefox' || browserName as any === '_bidiFirefox')
       await run('None');

--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import os from 'os';
 import { contextTest as it, expect } from '../config/browserTest';
 
 it('should return no cookies in pristine browser context', async ({ context, page, server }) => {
@@ -396,7 +397,7 @@ it('should support requestStorageAccess', async ({ page, server, channel, browse
         server.waitForRequest('/title.html'),
         frame.evaluate(() => fetch('/title.html'))
       ]);
-      if (isLinux && browserName === 'webkit')
+      if ((isLinux || (isMac && parseInt(os.release(), 10) >= 24)) && browserName === 'webkit')
         expect(serverRequest.headers.cookie).toBe(undefined);
       else
         expect(serverRequest.headers.cookie).toBe('name=value');


### PR DESCRIPTION
We don't have bots yet which run on macOS 15 but that were the required updates to the test expectations which were necessary to make them pass.

TL;DR: macOS 15 has now Lax cookies, like WebKit/Linux and Chromium.

Related upstream bug about this change: https://bugs.webkit.org/show_bug.cgi?id=278353
Related code upstream: https://github.com/charliewolfe/WebKit/blob/4659e88a8afd048b77069f7aca297ef4b50b1200/Source/WTF/wtf/PlatformHave.h#L1868-L1875