### PR TITLE
test: listen always on 127.0.0.1 for client certificate tests

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -261,6 +261,7 @@ export abstract class APIRequestContext extends SdkObject {
       try {
         return await this._sendRequest(progress, url, options, postData);
       } catch (e) {
+        e = rewriteOpenSSLErrorIfNeeded(e);
         if (maxRetries === 0)
           throw e;
         if (i === maxRetries || (options.deadline && monotonicTime() + backoff > options.deadline))
@@ -469,7 +470,7 @@ export abstract class APIRequestContext extends SdkObject {
         body.on('data', chunk => chunks.push(chunk));
         body.on('end', notifyBodyFinished);
       });
-      request.on('error', error => reject(rewriteOpenSSLErrorIfNeeded(error)));
+      request.on('error', reject);
 
       const disposeListener = () => {
         reject(new Error('Request context disposed.'));

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -57,14 +57,14 @@ export class TestProxy {
     this._prependHandler('request', (req: IncomingMessage) => {
       this.requestUrls.push(req.url);
       const url = new URL(req.url);
-      url.host = `localhost:${port}`;
+      url.host = `127.0.0.1:${port}`;
       req.url = url.toString();
     });
     this._prependHandler('connect', (req: IncomingMessage) => {
       if (!options?.allowConnectRequests)
         return;
       this.connectHosts.push(req.url);
-      req.url = `localhost:${port}`;
+      req.url = `127.0.0.1:${port}`;
     });
   }
 
@@ -141,7 +141,7 @@ export async function setupSocksForwardingServer({
   await socksProxy.listen(port, '127.0.0.1');
   return {
     closeProxyServer: () => socksProxy.close(),
-    proxyServerAddr: `socks5://localhost:${port}`,
+    proxyServerAddr: `socks5://127.0.0.1:${port}`,
     connectHosts,
   };
 }

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -138,7 +138,7 @@ export async function setupSocksForwardingServer({
     connections.get(payload.uid)?.destroy();
     connections.delete(payload.uid);
   });
-  await socksProxy.listen(port, 'localhost');
+  await socksProxy.listen(port, '127.0.0.1');
   return {
     closeProxyServer: () => socksProxy.close(),
     proxyServerAddr: `socks5://localhost:${port}`,

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -68,7 +68,7 @@ const test = base.extend<TestOptions>({
         res.end(parts.map(({ key, value }) => `<div data-testid="${key}">${value}</div>`).join(''));
       });
       await new Promise<void>(f => server.listen(0, '127.0.0.1', () => f()));
-      const host = options?.useFakeLocalhost ? 'local.playwright' : 'localhost';
+      const host = options?.useFakeLocalhost ? 'local.playwright' : '127.0.0.1';
       return `https://${host}:${(server.address() as net.AddressInfo).port}/`;
     });
     if (server)
@@ -365,7 +365,7 @@ test.describe('browser', () => {
     });
     expect(proxyServer.connectHosts).toEqual([]);
     await page.goto(serverURL);
-    expect([...new Set(proxyServer.connectHosts)]).toEqual([`localhost:${new URL(serverURL).port}`]);
+    expect([...new Set(proxyServer.connectHosts)]).toEqual([`127.0.0.1:${new URL(serverURL).port}`]);
     await expect(page.getByTestId('message')).toHaveText('Hello Alice, your certificate was issued by localhost!');
     await page.close();
   });
@@ -389,7 +389,7 @@ test.describe('browser', () => {
     });
     expect(connectHosts).toEqual([]);
     await page.goto(serverURL);
-    expect(connectHosts).toEqual([`localhost:${serverPort}`]);
+    expect(connectHosts).toEqual([`127.0.0.1:${serverPort}`]);
     await expect(page.getByTestId('message')).toHaveText('Hello Alice, your certificate was issued by localhost!');
     await page.close();
     await closeProxyServer();
@@ -687,7 +687,7 @@ test.describe('browser', () => {
       }],
     });
     {
-      await page.goto(serverURL.replace('localhost', 'local.playwright'));
+      await page.goto(serverURL.replace('127.0.0.1', 'local.playwright'));
       await expect(page.getByTestId('message')).toHaveText('Sorry, but you need to provide a client certificate to continue.');
       await expect(page.getByTestId('alpn-protocol')).toHaveText('h2');
       await expect(page.getByTestId('servername')).toHaveText('local.playwright');
@@ -713,7 +713,7 @@ test.describe('browser', () => {
       }],
     });
     {
-      await page.goto(serverURL.replace('localhost', 'local.playwright'));
+      await page.goto(serverURL.replace('127.0.0.1', 'local.playwright'));
       await expect(page.getByTestId('message')).toHaveText('Sorry, but you need to provide a client certificate to continue.');
       await expect(page.getByTestId('alpn-protocol')).toHaveText('http/1.1');
     }

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -28,7 +28,6 @@ const { createHttpsServer, createHttp2Server } = require('../../packages/playwri
 
 type TestOptions = {
   startCCServer(options?: {
-    host?: string;
     http2?: boolean;
     enableHTTP1FallbackWhenUsingHttp2?: boolean;
     useFakeLocalhost?: boolean;
@@ -68,7 +67,7 @@ const test = base.extend<TestOptions>({
         }
         res.end(parts.map(({ key, value }) => `<div data-testid="${key}">${value}</div>`).join(''));
       });
-      await new Promise<void>(f => server.listen(0, options?.host ?? 'localhost', () => f()));
+      await new Promise<void>(f => server.listen(0, '127.0.0.1', () => f()));
       const host = options?.useFakeLocalhost ? 'local.playwright' : 'localhost';
       return `https://${host}:${(server.address() as net.AddressInfo).port}/`;
     });
@@ -195,7 +194,7 @@ test.describe('fetch', () => {
   });
 
   test('pass with trusted client certificates and when a socks proxy is used', async ({ playwright, startCCServer, asset }) => {
-    const serverURL = await startCCServer({ host: '127.0.0.1' });
+    const serverURL = await startCCServer();
     const serverPort = parseInt(new URL(serverURL).port, 10);
     const { proxyServerAddr, closeProxyServer, connectHosts } = await setupSocksForwardingServer({
       port: test.info().workerIndex + 2048 + 2,
@@ -372,7 +371,7 @@ test.describe('browser', () => {
   });
 
   test('should pass with matching certificates and when a socks proxy is used', async ({ browser, startCCServer, asset, browserName }) => {
-    const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && process.platform === 'darwin', host: '127.0.0.1' });
+    const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && process.platform === 'darwin' });
     const serverPort = parseInt(new URL(serverURL).port, 10);
     const { proxyServerAddr, closeProxyServer, connectHosts } = await setupSocksForwardingServer({
       port: test.info().workerIndex + 2048 + 2,
@@ -625,7 +624,7 @@ test.describe('browser', () => {
   });
 
   test('should pass with matching certificates on context APIRequestContext instance', async ({ browser, startCCServer, asset, browserName }) => {
-    const serverURL = await startCCServer({ host: '127.0.0.1' });
+    const serverURL = await startCCServer();
     const baseOptions = {
       certPath: asset('client-certificates/client/trusted/cert.pem'),
       keyPath: asset('client-certificates/client/trusted/key.pem'),


### PR DESCRIPTION
They were red in environments with Docker:

<img width="1638" alt="image" src="https://github.com/user-attachments/assets/ad4d9459-46ee-4190-b38f-080a6669724c">

We don't control how the `{https,socks}-proxy-agent` connects in terms of happy-eyeballs and we don't have happy-eyeballs for `setupSocksForwardingServer` (used only inside tests) so it seems reasonable to listen always on 127.0.0.1.