### PR TITLE
chore: ignore noWaitAfter option in press()

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -710,7 +710,7 @@ Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
 
 Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 
-### option: ElementHandle.press.noWaitAfter = %%-input-no-wait-after-%%
+### option: ElementHandle.press.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.8
 
 ### option: ElementHandle.press.timeout = %%-input-timeout-%%

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -1417,7 +1417,7 @@ Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
 
 Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 
-### option: Frame.press.noWaitAfter = %%-input-no-wait-after-%%
+### option: Frame.press.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.8
 
 ### option: Frame.press.strict = %%-input-strict-%%

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -1782,7 +1782,7 @@ Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
 
 Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 
-### option: Locator.press.noWaitAfter = %%-input-no-wait-after-%%
+### option: Locator.press.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.14
 
 ### option: Locator.press.timeout = %%-input-timeout-%%

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3032,7 +3032,7 @@ Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
 
 Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 
-### option: Page.press.noWaitAfter = %%-input-no-wait-after-%%
+### option: Page.press.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.8
 
 ### option: Page.press.strict = %%-input-strict-%%

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1606,7 +1606,6 @@ scheme.FramePressParams = tObject({
   strict: tOptional(tBoolean),
   key: tString,
   delay: tOptional(tNumber),
-  noWaitAfter: tOptional(tBoolean),
   timeout: tOptional(tNumber),
 });
 scheme.FramePressResult = tOptional(tObject({}));
@@ -1956,7 +1955,6 @@ scheme.ElementHandlePressParams = tObject({
   key: tString,
   delay: tOptional(tNumber),
   timeout: tOptional(tNumber),
-  noWaitAfter: tOptional(tBoolean),
 });
 scheme.ElementHandlePressResult = tOptional(tObject({}));
 scheme.ElementHandleQuerySelectorParams = tObject({

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -711,7 +711,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return 'done';
   }
 
-  async press(metadata: CallMetadata, key: string, options: { delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions & types.StrictOptions): Promise<void> {
+  async press(metadata: CallMetadata, key: string, options: { delay?: number } & types.TimeoutOptions & types.StrictOptions): Promise<void> {
     const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       const result = await this._press(progress, key, options);
@@ -719,17 +719,15 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     }, this._page._timeoutSettings.timeout(options));
   }
 
-  async _press(progress: Progress, key: string, options: { delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions & types.StrictOptions): Promise<'error:notconnected' | 'done'> {
+  async _press(progress: Progress, key: string, options: { delay?: number } & types.TimeoutOptions & types.StrictOptions): Promise<'error:notconnected' | 'done'> {
     progress.log(`elementHandle.press("${key}")`);
     await progress.beforeInputAction(this);
-    return this._page._frameManager.waitForSignalsCreatedBy(progress, !options.noWaitAfter, async () => {
-      const result = await this._focus(progress, true /* resetSelectionIfNotFocused */);
-      if (result !== 'done')
-        return result;
-      progress.throwIfAborted();  // Avoid action that has side-effects.
-      await this._page.keyboard.press(key, options);
-      return 'done';
-    });
+    const result = await this._focus(progress, true /* resetSelectionIfNotFocused */);
+    if (result !== 'done')
+      return result;
+    progress.throwIfAborted();  // Avoid action that has side-effects.
+    await this._page.keyboard.press(key, options);
+    return 'done';
   }
 
   async check(metadata: CallMetadata, options: { position?: types.Point } & types.PointerActionWaitOptions) {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1365,7 +1365,7 @@ export class Frame extends SdkObject {
     }, this._page._timeoutSettings.timeout(options));
   }
 
-  async press(metadata: CallMetadata, selector: string, key: string, options: { delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions & types.StrictOptions = {}) {
+  async press(metadata: CallMetadata, selector: string, key: string, options: { delay?: number } & types.TimeoutOptions & types.StrictOptions = {}) {
     const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options.strict, true /* performLocatorHandlersCheckpoint */, handle => handle._press(progress, key, options)));

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -3647,10 +3647,8 @@ export interface Page {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
-     * @deprecated This option will default to `true` in the future.
+     * This option has no effect.
+     * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
 
@@ -6936,10 +6934,8 @@ export interface Frame {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
-     * @deprecated This option will default to `true` in the future.
+     * This option has no effect.
+     * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
 
@@ -10923,10 +10919,8 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
-     * @deprecated This option will default to `true` in the future.
+     * This option has no effect.
+     * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
 
@@ -13130,10 +13124,8 @@ export interface Locator {
     delay?: number;
 
     /**
-     * Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You
-     * can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as
-     * navigating to inaccessible pages. Defaults to `false`.
-     * @deprecated This option will default to `true` in the future.
+     * This option has no effect.
+     * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
 

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -2895,13 +2895,11 @@ export type FramePressParams = {
   strict?: boolean,
   key: string,
   delay?: number,
-  noWaitAfter?: boolean,
   timeout?: number,
 };
 export type FramePressOptions = {
   strict?: boolean,
   delay?: number,
-  noWaitAfter?: boolean,
   timeout?: number,
 };
 export type FramePressResult = void;
@@ -3482,12 +3480,10 @@ export type ElementHandlePressParams = {
   key: string,
   delay?: number,
   timeout?: number,
-  noWaitAfter?: boolean,
 };
 export type ElementHandlePressOptions = {
   delay?: number,
   timeout?: number,
-  noWaitAfter?: boolean,
 };
 export type ElementHandlePressResult = void;
 export type ElementHandleQuerySelectorParams = {

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -2143,7 +2143,6 @@ Frame:
         strict: boolean?
         key: string
         delay: number?
-        noWaitAfter: boolean?
         timeout: number?
       flags:
         slowMo: true
@@ -2685,7 +2684,6 @@ ElementHandle:
         key: string
         delay: number?
         timeout: number?
-        noWaitAfter: boolean?
       flags:
         slowMo: true
         snapshot: true


### PR DESCRIPTION
This continues `noWaitAfter` deprecation. Two releases did not bring any issues. After this change, the only action keeping `noWaitAfter` is `click()`.