### PR TITLE
experiment: special tracing view for API testing

### DIFF
--- a/examples/github-api/tests/example.spec.ts
+++ b/examples/github-api/tests/example.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('should get post #1', async ({ request }) => {
+  const post = await request.get(`https://jsonplaceholder.typicode.com/posts/1`);
+  expect(post.ok()).toBeTruthy();
+
+  await request.post(`https://jsonplaceholder.typicode.com/posts/1`);
+});

--- a/packages/trace-viewer/src/ui/actionList.css
+++ b/packages/trace-viewer/src/ui/actionList.css
@@ -84,6 +84,20 @@
   color: var(--vscode-charts-blue);
 }
 
+.action-green {
+  display: inline;
+  flex: none;
+  padding-left: 5px;
+  color: var(--vscode-charts-green);
+}
+
+.action-red {
+  display: inline;
+  flex: none;
+  padding-left: 5px;
+  color: var(--vscode-charts-red);
+}
+
 .action-list-show-all {
   display: flex;
   cursor: pointer;

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -99,7 +99,8 @@ export const renderAction = (
     time = '-';
   return <>
     <div className='action-title' title={action.apiName}>
-      <span>{action.apiName}</span>
+      {action.class !== 'APIRequestContext' && <span>{action.apiName}</span>}
+      {action.class === 'APIRequestContext' && <span className='action-selector'>{action.params.method}</span>}
       {locator && <div className='action-selector' title={locator}>{locator}</div>}
       {action.method === 'goto' && action.params.url && <div className='action-url' title={action.params.url}>{action.params.url}</div>}
       {action.class === 'APIRequestContext' && action.params.url && <div className='action-url' title={action.params.url}>{excludeOrigin(action.params.url)}</div>}

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -97,12 +97,14 @@ export const renderAction = (
     time = 'Timed out';
   else if (!isLive)
     time = '-';
+
   return <>
     <div className='action-title' title={action.apiName}>
-      {action.class !== 'APIRequestContext' && <span>{action.apiName}</span>}
-      {action.class === 'APIRequestContext' && <span className='action-selector'>{action.params.method}</span>}
+      <span>{action.apiName}</span>
       {locator && <div className='action-selector' title={locator}>{locator}</div>}
       {action.method === 'goto' && action.params.url && <div className='action-url' title={action.params.url}>{action.params.url}</div>}
+      {action.class === 'APIRequestContext' && action.params.method && <span className='action-selector'>{action.params.method}</span>}
+      {action.class === 'APIRequestContext' && action.result?.response?.status && <span className={action.result.response.status < 201 ? 'action-green' : action.result.response.status < 500 ? 'action-url' : 'action-red'}>{action.result.response.status}</span>}
       {action.class === 'APIRequestContext' && action.params.url && <div className='action-url' title={action.params.url}>{excludeOrigin(action.params.url)}</div>}
     </div>
     {(showDuration || showBadges) && <div className='spacer'></div>}

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -24,29 +24,29 @@ import { generateCurlCommand, generateFetchCall } from '../third_party/devtools'
 import { CopyToClipboard } from './copyToClipboard';
 
 export const NetworkResourceDetails: React.FunctionComponent<{
-  resource: ResourceSnapshot;
-  onClose: () => void;
+  resource?: ResourceSnapshot;
+  onClose?: () => void;
 }> = ({ resource, onClose }) => {
   const [selectedTab, setSelectedTab] = React.useState('request');
 
   return <TabbedPane
     dataTestId='network-request-details'
-    leftToolbar={[<ToolbarButton key='close' icon='close' title='Close' onClick={onClose}></ToolbarButton>]}
+    leftToolbar={onClose ? [<ToolbarButton key='close' icon='close' title='Close' onClick={onClose}></ToolbarButton>] : undefined}
     tabs={[
       {
         id: 'request',
         title: 'Request',
-        render: () => <RequestTab resource={resource}/>,
+        render: () => resource ? <RequestTab resource={resource}/> : <div/>,
       },
       {
         id: 'response',
         title: 'Response',
-        render: () => <ResponseTab resource={resource}/>,
+        render: () => resource ? <ResponseTab resource={resource}/> : <div/>,
       },
       {
         id: 'body',
         title: 'Body',
-        render: () => <BodyTab resource={resource}/>,
+        render: () => resource ? <BodyTab resource={resource}/> : <div/>,
       },
     ]}
     selectedTab={selectedTab}

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -108,6 +108,7 @@ export const UIModeView: React.FC<{}> = ({
   const [showRouteActions, setShowRouteActions] = useSetting('show-route-actions', true);
   const [darkMode, setDarkMode] = useDarkModeSetting();
   const [showScreenshot, setShowScreenshot] = useSetting('screenshot-instead-of-snapshot', false);
+  const [apiTestingView, setApiTestingView] = useSetting('api-testing-view', false);
 
 
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -528,6 +529,7 @@ export const UIModeView: React.FC<{}> = ({
           { value: darkMode, set: setDarkMode, title: 'Dark mode' },
           { value: showRouteActions, set: setShowRouteActions, title: 'Show route actions' },
           { value: showScreenshot, set: setShowScreenshot, title: 'Show screenshot instead of snapshot' },
+          { value: apiTestingView, set: setApiTestingView, title: 'API Testing view' },
         ]} />}
       </div>
       }


### PR DESCRIPTION
In https://github.com/microsoft/playwright/issues/19177, lots of folks are asking for improvements to debugging API Tests. We show pretty much all they ask for in the UI, but a lot of the screen space is taken up by browser-specific UI that's simply irrelevant to API testing. This PR demonstrates what a special-purpose "API Testing View" could look like. Instead of the snapshot viewer, it shows request details front-and-center, and it hides the inspector and console tabs.