### PR TITLE
chore(bidi): suppress crash reporter in firefox

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiFirefox.ts
+++ b/packages/playwright-core/src/server/bidi/bidiFirefox.ts
@@ -51,6 +51,14 @@ export class BidiFirefox extends BrowserType {
   override amendEnvironment(env: Env, userDataDir: string, executable: string, browserArguments: string[]): Env {
     if (!path.isAbsolute(os.homedir()))
       throw new Error(`Cannot launch Firefox with relative home directory. Did you set ${os.platform() === 'win32' ? 'USERPROFILE' : 'HOME'} to a relative path?`);
+
+    env = {
+      ...env,
+      'MOZ_CRASHREPORTER': '1',
+      'MOZ_CRASHREPORTER_NO_REPORT': '1',
+      'MOZ_CRASHREPORTER_SHUTDOWN': '1',
+    };
+
     if (os.platform() === 'linux') {
       // Always remove SNAP_NAME and SNAP_INSTANCE_NAME env variables since they
       // confuse Firefox: in our case, builds never come from SNAP.


### PR DESCRIPTION
Same settings as geckodriver uses upstream: https://searchfox.org/mozilla-central/rev/c414b4538dd3c7e1dc674f7b66176e7c309afa95/testing/geckodriver/src/browser.rs#130-132