### PR TITLE
feat(playwright-test): test.step supports passing step params to trace view

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -1715,6 +1715,11 @@ Whether to box the step in the report. Defaults to `false`. When the step is box
 - `location` <[Location]>
 Specifies a custom location for the step to be shown in test reports. By default, location of the [`method: Test.step`] call is shown.
 
+### option: Test.step.params
+* since: v1.48
+- `params` ?<[Object]>
+An optional key-value object where keys are step parameter names and values are their corresponding parameter values. This information is shown in the trace view.
+
 ## method: Test.use
 * since: v1.10
 

--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -259,11 +259,11 @@ export class TestTypeImpl {
     suite._use.push({ fixtures, location });
   }
 
-  async _step<T>(title: string, body: () => Promise<T>, options: {box?: boolean, location?: Location } = {}): Promise<T> {
+  async _step<T>(title: string, body: () => Promise<T>, options: { box?: boolean, location?: Location, params?: Record<string, any> } = {}): Promise<T> {
     const testInfo = currentTestInfo();
     if (!testInfo)
       throw new Error(`test.step() can only be called from a test`);
-    const step = testInfo._addStep({ category: 'test.step', title, location: options.location, box: options.box });
+    const step = testInfo._addStep({ category: 'test.step', title, location: options.location, params: options.params, box: options.box });
     return await zones.run('stepZone', step, async () => {
       try {
         const result = await body();

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -4703,7 +4703,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * @param body Step body.
    * @param options
    */
-  step<T>(title: string, body: () => T | Promise<T>, options?: { box?: boolean, location?: Location }): Promise<T>;
+  step<T>(title: string, body: () => T | Promise<T>, options?: { box?: boolean, location?: Location, params?: Record<string, any> }): Promise<T>;
   /**
    * `expect` function can be used to create test assertions. Read more about [test assertions](https://playwright.dev/docs/test-assertions).
    *

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -128,7 +128,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
   afterAll(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   afterAll(title: string, inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   use(fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs>): void;
-  step<T>(title: string, body: () => T | Promise<T>, options?: { box?: boolean, location?: Location }): Promise<T>;
+  step<T>(title: string, body: () => T | Promise<T>, options?: { box?: boolean, location?: Location, params?: Record<string, any> }): Promise<T>;
   expect: Expect<{}>;
   extend<T extends KeyValue, W extends KeyValue = {}>(fixtures: Fixtures<T, W, TestArgs, WorkerArgs>): TestType<TestArgs & T, WorkerArgs & W>;
   info(): TestInfo;


### PR DESCRIPTION
Extending the functionality requested in #30160 and #32680 and building on #32504 and #32687, this pull request enables the `test.step` API to accept an optional `params` object, to be included in the trace viewer.

This enables test automation frameworks that integrate with Playwright Test, such as [Serenity/JS](https://serenity-js.org), to add extra context to Playwright reports.

Example usage:

```ts
// helper.ts
import { test, TestType } from '@playwright/test';

export async function sayHello(name: string) {
  await test.step('says hello', () => {}, { params: { name } });
}
```
```ts
// playwright.config.ts
module.exports = {
  reporter: './reporter',
  use: {
    trace: 'on',
  }
};
```
```ts
// a.test.ts
import { test } from '@playwright/test';
import { sayHello } from './helper';

test('params', async () => {
  await sayHello('World');
});
```

Example result (using [Serenity/JS Playwright example](https://github.com/serenity-js/serenity-js/tree/main/examples/playwright-test-todomvc)):
<img width="870" alt="Screenshot 2024-09-19 at 11 27 51" src="https://github.com/user-attachments/assets/2e3929b3-c3ef-4261-ac31-d6f21fe21172">

CC: @dgozman, @mxschmitt, @vitalets, @osohyun0224, @WestonThayer
