### PR TITLE
chore: enable @babel/plugin-syntax-import-attributes all the time

### DIFF
--- a/packages/playwright/bundles/babel/src/babelBundleImpl.ts
+++ b/packages/playwright/bundles/babel/src/babelBundleImpl.ts
@@ -45,6 +45,7 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
         [require('@babel/plugin-syntax-async-generators')],
         [require('@babel/plugin-syntax-object-rest-spread')],
         [require('@babel/plugin-transform-export-namespace-from')],
+        [require('@babel/plugin-syntax-import-attributes'), { deprecatedAssertSyntax: true }],
         [
           // From https://github.com/G-Rath/babel-plugin-replace-ts-export-assignment/blob/8dfdca32c8aa428574b0cae341444fc5822f2dc6/src/index.ts
           (
@@ -86,8 +87,6 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
         }
       })
     ]);
-  } else {
-    plugins.push([require('@babel/plugin-syntax-import-attributes'), { deprecatedAssertSyntax: true }]);
   }
 
   return {

--- a/tests/playwright-test/babel.spec.ts
+++ b/tests/playwright-test/babel.spec.ts
@@ -151,29 +151,31 @@ test('should not transform external', async ({ runInlineTest }) => {
   expect(result.output).toMatch(/(Cannot use import statement outside a module|require\(\) of ES Module .* not supported.)/);
 });
 
-test('should support import assertions', {
-  annotation: {
-    type: 'issue',
-    description: 'https://github.com/microsoft/playwright/issues/32659'
-  }
-}, async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'playwright.config.ts': `
+for (const type of ['module', undefined]) {
+  test(`should support import assertions with type=${type} in the package.json`, {
+    annotation: {
+      type: 'issue',
+      description: 'https://github.com/microsoft/playwright/issues/32659'
+    }
+  }, async ({ runInlineTest }) => {
+    const result = await runInlineTest({
+      'playwright.config.ts': `
       import packageJSON from './package.json' assert { type: 'json' };
       console.log('imported value: ' + packageJSON.foo);
       export default { };
     `,
-    'package.json': JSON.stringify({ foo: 'bar' }),
-    'a.esm.test.ts': `
+      'package.json': JSON.stringify({ foo: 'bar', type }),
+      'a.test.ts': `
       import { test, expect } from '@playwright/test';
 
       test('check project name', ({}, testInfo) => {
         expect(1).toBe(1);
       });
     `
-  });
+    });
 
-  expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(1);
-  expect(result.stdout).toContain('imported value: bar');
-});
+    expect(result.exitCode).toBe(0);
+    expect(result.passed).toBe(1);
+    expect(result.stdout).toContain('imported value: bar');
+  });
+}

--- a/tests/playwright-test/babel.spec.ts
+++ b/tests/playwright-test/babel.spec.ts
@@ -150,3 +150,30 @@ test('should not transform external', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.output).toMatch(/(Cannot use import statement outside a module|require\(\) of ES Module .* not supported.)/);
 });
+
+test('should support import assertions', {
+  annotation: {
+    type: 'issue',
+    description: 'https://github.com/microsoft/playwright/issues/32659'
+  }
+}, async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      import packageJSON from './package.json' assert { type: 'json' };
+      console.log('imported value: ' + packageJSON.foo);
+      export default { };
+    `,
+    'package.json': JSON.stringify({ foo: 'bar' }),
+    'a.esm.test.ts': `
+      import { test, expect } from '@playwright/test';
+
+      test('check project name', ({}, testInfo) => {
+        expect(1).toBe(1);
+      });
+    `
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.stdout).toContain('imported value: bar');
+});

--- a/tests/playwright-test/esm.spec.ts
+++ b/tests/playwright-test/esm.spec.ts
@@ -35,28 +35,6 @@ test('should load nested as esm when package.json has type module', async ({ run
   expect(result.passed).toBe(1);
 });
 
-test('should support import assertions', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'playwright.config.ts': `
-      import packageJSON from './package.json' assert { type: 'json' };
-      console.log('imported value: ' + packageJSON.foo);
-      export default { };
-    `,
-    'package.json': JSON.stringify({ type: 'module', foo: 'bar' }),
-    'a.esm.test.ts': `
-      import { test, expect } from '@playwright/test';
-
-      test('check project name', ({}, testInfo) => {
-        expect(1).toBe(1);
-      });
-    `
-  });
-
-  expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(1);
-  expect(result.stdout).toContain('imported value: bar');
-});
-
 test('should support import attributes', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/32659

Test is a copy of https://github.com/microsoft/playwright/blob/cc302fa5150734d712d6e1c02bd8c5a42a308633/tests/playwright-test/esm.spec.ts#L38 - maybe we should remove the test in esm.spec.ts and run it twice, once with type module and once without?