### PR TITLE
test: unflake 'should properly synchronize local and remote time' test

### DIFF
--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -130,7 +130,9 @@ test('should complain about newer version of trace in old viewer', async ({ show
 test('should properly synchronize local and remote time', async ({ showTraceViewer, asset }, testInfo) => {
   const traceViewer = await showTraceViewer([asset('trace-remote-time-diff.zip')]);
   // The total duration should be sub 10s, rather than 16h.
-  await expect(traceViewer.page.locator('.timeline-time').last()).toHaveText('8.5s');
+  await expect.poll(async () =>
+    parseInt(await traceViewer.page.locator('.timeline-time').last().innerText(), 10)
+  ).toBeLessThan(10);
 });
 
 test('should contain action info', async ({ showTraceViewer }) => {


### PR DESCRIPTION
We run the Trace Viewer in the tests using `launchApp` which uses [`noDefaultViewport: true`](https://github.com/microsoft/playwright/blob/33890eb6c5298b239b42763e4652b3c7e40bf68f/packages/playwright-core/src/server/launchApp.ts#L47). Our Trace Viewer does not always render `8.5s`, it also renders just `8.0s`, based on the viewport which was given. The window size on CI is probably just 1024x720 or something like that (assumption).

We could also check for `toBeLessThan`.