### PR TITLE
feat(extend): custom asymmetric matchers (before expect.extend immutable)

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6573,6 +6573,11 @@ type PollMatchers<R, T, ExtendedMatchers> = {
   not: PollMatchers<R, T, ExtendedMatchers>;
 } & BaseMatchers<R, T> & ToUserMatcherObject<ExtendedMatchers, T>;
 
+type ExtendedAsymmetricMatchers<M = {}> = {
+  [K in keyof M]: M[K] extends (this: ExpectMatcherState, received: any, ...args: infer P) => any ? (...args: P) => AsymmetricMatcher
+    : never
+}
+
 export type Expect<ExtendedMatchers = {}> = {
   <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }): MakeMatchers<void, T, ExtendedMatchers>;
   soft: <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }) => MakeMatchers<void, T, ExtendedMatchers>;
@@ -6584,8 +6589,8 @@ export type Expect<ExtendedMatchers = {}> = {
     soft?: boolean,
   }) => Expect<ExtendedMatchers>;
   getState(): unknown;
-  not: Omit<AsymmetricMatchers, 'any' | 'anything'>;
-} & AsymmetricMatchers;
+  not: Omit<AsymmetricMatchers & ExtendedAsymmetricMatchers<ExtendedMatchers>, 'any' | 'anything'>;
+} & AsymmetricMatchers & ExtendedAsymmetricMatchers<ExtendedMatchers>;
 
 // --- BEGINGLOBAL ---
 declare global {

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -910,11 +910,20 @@ test('should support mergeExpects (TSC)', async ({ runTSC }) => {
       const expect1 = baseExpect.extend({
         async toBeAGoodPage(page: Page, x: number) {
           return { pass: true, message: () => '' };
+        },
+        matchFoo(received: unknown, expected: string) {
+          return { pass: true, message: () => '' };
+        },
+        toBeFoo(received: unknown) {
+          return { pass: true, message: () => '' };
         }
       });
 
       const expect2 = baseExpect.extend({
         async toBeABadPage(page: Page, y: string) {
+          return { pass: true, message: () => '' };
+        },
+        matchBar(received: unknown, expected: string) {
           return { pass: true, message: () => '' };
         }
       });
@@ -924,12 +933,19 @@ test('should support mergeExpects (TSC)', async ({ runTSC }) => {
       test('custom matchers', async ({ page }) => {
         await expect(page).toBeAGoodPage(123);
         await expect(page).toBeABadPage('123');
+        await expect('foo').toEqual(expect.matchFoo('123'));
+        await expect('bar').not.toEqual(expect.not.matchBar('123'));
+        await expect({ name: 'Foo' }).toMatchObject({ name: expect.toBeFoo() });
         // @ts-expect-error
         await expect(page).toBeAMediocrePage();
         // @ts-expect-error
         await expect(page).toBeABadPage(123);
         // @ts-expect-error
         await expect(page).toBeAGoodPage('123');
+        // @ts-expect-error
+        expect('foo').toEqual(expect.matchFoo(123));
+        // @ts-expect-error
+        expect('bar').not.toEqual(expect.not.matchBar(123));
       });
     `
   });
@@ -945,11 +961,20 @@ test('should support mergeExpects', async ({ runInlineTest }) => {
       const expect1 = baseExpect.extend({
         async toBeAGoodPage(page: Page, x: number) {
           return { pass: true, message: () => '' };
+        },
+        matchFoo(received: unknown, expected: string) {
+          return { pass: true, message: () => '' };
+        },
+        toBeFoo(received: unknown) {
+          return { pass: true, message: () => '' };
         }
       });
 
       const expect2 = baseExpect.extend({
         async toBeABadPage(page: Page, y: string) {
+          return { pass: true, message: () => '' };
+        },
+        matchBar(received: unknown, expected: string) {
           return { pass: true, message: () => '' };
         }
       });
@@ -959,6 +984,9 @@ test('should support mergeExpects', async ({ runInlineTest }) => {
       test('custom matchers', async ({ page }) => {
         await expect(page).toBeAGoodPage(123);
         await expect(page).toBeABadPage('123');
+        await expect('foo').toEqual(expect.matchFoo('123'));
+        await expect('bar').not.toEqual(expect.not.matchBar('123'));
+        await expect({ name: 'Foo' }).toMatchObject({ name: expect.toBeFoo() });
       });
     `
   }, { workers: 1 });

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -411,6 +411,11 @@ type PollMatchers<R, T, ExtendedMatchers> = {
   not: PollMatchers<R, T, ExtendedMatchers>;
 } & BaseMatchers<R, T> & ToUserMatcherObject<ExtendedMatchers, T>;
 
+type ExtendedAsymmetricMatchers<M = {}> = {
+  [K in keyof M]: M[K] extends (this: ExpectMatcherState, received: any, ...args: infer P) => any ? (...args: P) => AsymmetricMatcher
+    : never
+}
+
 export type Expect<ExtendedMatchers = {}> = {
   <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }): MakeMatchers<void, T, ExtendedMatchers>;
   soft: <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }) => MakeMatchers<void, T, ExtendedMatchers>;
@@ -422,8 +427,8 @@ export type Expect<ExtendedMatchers = {}> = {
     soft?: boolean,
   }) => Expect<ExtendedMatchers>;
   getState(): unknown;
-  not: Omit<AsymmetricMatchers, 'any' | 'anything'>;
-} & AsymmetricMatchers;
+  not: Omit<AsymmetricMatchers & ExtendedAsymmetricMatchers<ExtendedMatchers>, 'any' | 'anything'>;
+} & AsymmetricMatchers & ExtendedAsymmetricMatchers<ExtendedMatchers>;
 
 // --- BEGINGLOBAL ---
 declare global {


### PR DESCRIPTION
#32562
