### PR TITLE
added NON_ISOLATED_TESTS env for getting round test isolation if needed

### DIFF
--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -401,7 +401,7 @@ class JobDispatcher {
     // - there are no remaining
     // - we are here not because something failed
     // - no unrecoverable worker error
-    if (!this._remainingByTestId.size && !this._failedTests.size && !params.fatalErrors.length && !params.skipTestsDueToSetupFailure.length && !params.fatalUnknownTestIds && !params.unexpectedExitError) {
+    if (!this._remainingByTestId.size && !this._failedTests.size && !params.fatalErrors.length && !params.skipTestsDueToSetupFailure.length && !params.fatalUnknownTestIds && !params.unexpectedExitError && !process.env.NON_ISOLATED_TESTS) {
       this._finished({ didFail: false });
       return;
     }

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -396,7 +396,7 @@ export class WorkerMain extends ProcessRunner {
       // In case of failure the worker will be stopped and we have to make sure that afterAll
       // hooks run before worker fixtures teardown.
       for (const suite of reversedSuites) {
-        if (!nextSuites.has(suite) || testInfo._isFailure()) {
+        if (!nextSuites.has(suite) || (testInfo._isFailure() && !process.env.NOT_ISOLATED)) {
           try {
             await this._runAfterAllHooksForSuite(suite, testInfo);
           } catch (error) {
@@ -534,8 +534,11 @@ export class WorkerMain extends ProcessRunner {
         }
       }
     }
-    if (firstError)
+    if (firstError) {
+      if (process.env.NONE_ISOLATED)
+        this._didRunFullCleanup = true;
       throw firstError;
+    }
   }
 
   private async _runAfterAllHooksForSuite(suite: Suite, testInfo: TestInfoImpl) {

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -266,7 +266,7 @@ export class WorkerMain extends ProcessRunner {
       }
     };
 
-    if (!(this._isStopped && !process.env.NONE_ISOLATED))
+    if (!(this._isStopped && !process.env.NON_ISOLATED_TESTS))
       this._fixtureRunner.setPool(test._pool!);
 
     const suites = getSuites(test);
@@ -320,7 +320,7 @@ export class WorkerMain extends ProcessRunner {
         await testInfo._tracing.startIfNeeded(traceFixtureRegistration.fn);
       });
 
-      if ((this._isStopped && !process.env.NONE_ISOLATED) || isSkipped) {
+      if ((this._isStopped && !process.env.NON_ISOLATED_TESTS) || isSkipped) {
         // Two reasons to get here:
         // - Last test is skipped, so we should not run the test, but run the cleanup.
         // - Worker is requested to stop, but was not able to run full cleanup yet.
@@ -396,7 +396,7 @@ export class WorkerMain extends ProcessRunner {
       // In case of failure the worker will be stopped and we have to make sure that afterAll
       // hooks run before worker fixtures teardown.
       for (const suite of reversedSuites) {
-        if (!nextSuites.has(suite) || (testInfo._isFailure() && !process.env.NOT_ISOLATED)) {
+        if (!nextSuites.has(suite) || (testInfo._isFailure() && !process.env.NON_ISOLATED_TESTS)) {
           try {
             await this._runAfterAllHooksForSuite(suite, testInfo);
           } catch (error) {
@@ -412,7 +412,7 @@ export class WorkerMain extends ProcessRunner {
     if (testInfo._isFailure())
       this._isStopped = true;
 
-    if (this._isStopped && !process.env.NONE_ISOLATED) {
+    if (this._isStopped && !process.env.NON_ISOLATED_TESTS) {
       // Run all remaining "afterAll" hooks and teardown all fixtures when worker is shutting down.
       // Mark as "cleaned up" early to avoid running cleanup twice.
       this._didRunFullCleanup = true;
@@ -535,7 +535,7 @@ export class WorkerMain extends ProcessRunner {
       }
     }
     if (firstError) {
-      if (process.env.NONE_ISOLATED)
+      if (process.env.NON_ISOLATED_TESTS)
         this._didRunFullCleanup = true;
       throw firstError;
     }
@@ -544,7 +544,7 @@ export class WorkerMain extends ProcessRunner {
   private async _runAfterAllHooksForSuite(suite: Suite, testInfo: TestInfoImpl) {
     if (!this._activeSuites.has(suite))
       return;
-    if (!process.env.NONE_ISOLATED)
+    if (!process.env.NON_ISOLATED_TESTS)
       this._activeSuites.delete(suite);
     await this._runAllHooksForSuite(suite, testInfo, 'afterAll');
   }

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -541,9 +541,8 @@ export class WorkerMain extends ProcessRunner {
   private async _runAfterAllHooksForSuite(suite: Suite, testInfo: TestInfoImpl) {
     if (!this._activeSuites.has(suite))
       return;
-    if (!process.env.NONE_ISOLATED) {
+    if (!process.env.NONE_ISOLATED)
       this._activeSuites.delete(suite);
-    }
     await this._runAllHooksForSuite(suite, testInfo, 'afterAll');
   }
 


### PR DESCRIPTION
I was inspired the requests and also i'd like to use that for my needs
https://github.com/microsoft/playwright/issues/14584
https://github.com/microsoft/playwright/issues/14508

In the PR was added NON_ISOLATED_TESTS env variable it's preventing creation new worker after failed test cases. All test cases within a suite will be executed in the same worker. That mean 

For test.describe/test file

- test.beforeAll, test.afterAll - will be executed only once even if any of test was failed
- workerFixture - will be executed only once even if any of test was failed
- error in test.beforeAll/workerFixture  will fail all tests
- error in test.afterAll/workerTeardown will fail the latest test case
- worker - will be the same for all tests in a test.describe/test file, but different in other test.describe/test files

For some reason especially for heavy conditions it's really helpful.

Hope playwright's team will support the feature as community is interested in the flexibility 