### PR TITLE
fix(test runner): cleanup DEBUG_COLORS usage

### DIFF
--- a/packages/playwright/src/runner/workerHost.ts
+++ b/packages/playwright/src/runner/workerHost.ts
@@ -37,7 +37,7 @@ export class WorkerHost extends ProcessHost {
     super(require.resolve('../worker/workerMain.js'), `worker-${workerIndex}`, {
       ...extraEnv,
       FORCE_COLOR: '1',
-      DEBUG_COLORS: '1',
+      DEBUG_COLORS: process.env.DEBUG_COLORS === undefined ? '1' : process.env.DEBUG_COLORS,
     });
     this.workerIndex = workerIndex;
     this.parallelIndex = parallelIndex;

--- a/tests/playwright-test/stdio.spec.ts
+++ b/tests/playwright-test/stdio.spec.ts
@@ -117,3 +117,23 @@ test('should not throw type error when using assert', async ({ runInlineTest }) 
   expect(result.output).not.toContain(`TypeError: process.stderr.hasColors is not a function`);
   expect(result.output).toContain(`AssertionError`);
 });
+
+test('should have debug colors by default, but respect DEBUG_COLORS=0', async ({ runInlineTest }) => {
+  const files = {
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      import debug from 'debug';
+      test('passes', () => {
+        const dbg = debug('example');
+        dbg.color = 34;  // red
+        dbg('some text');
+      });
+    `
+  };
+
+  const result1 = await runInlineTest(files, {}, { DEBUG: 'example', DEBUG_COLORS: undefined });
+  expect(result1.rawOutput).toContain('\x1b[38;5;34;1mexample \x1b[0msome text');
+
+  const result2 = await runInlineTest(files, {}, { DEBUG: 'example', DEBUG_COLORS: '0' });
+  expect(result2.rawOutput).not.toContain('\x1b[38;5;34;1mexample \x1b[0msome text');
+});


### PR DESCRIPTION
`DEBUG_COLORS` we default to `1`, but we should not do that when it is already defined to some value supplied by the user.

Closes #32543.