### PR TITLE
fix(webkit): 204 response is not a failure

### DIFF
--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -1116,7 +1116,7 @@ export class WKPage implements PageDelegate {
     const response = request.createResponse(event.response);
     this._page._frameManager.requestReceivedResponse(response);
 
-    if (response.status() === 204) {
+    if (response.status() === 204 && request.request.isNavigationRequest()) {
       this._onLoadingFailed(session, {
         requestId: event.requestId,
         errorText: 'Aborted: 204 No Content',


### PR DESCRIPTION
The login being changed was added in https://github.com/microsoft/playwright/pull/1260 and is supposed to only work for navigation requests.

Reference: https://github.com/microsoft/playwright/issues/32752