### PR TITLE
test: skip 'should work with error after successful open' on WebKit Windows

### DIFF
--- a/tests/library/route-web-socket.spec.ts
+++ b/tests/library/route-web-socket.spec.ts
@@ -144,9 +144,10 @@ for (const mock of ['no-mock', 'no-match', 'pass-through']) {
       ]);
     });
 
-    test('should work with error after successful open', async ({ page, server, browserName, isLinux }) => {
+    test('should work with error after successful open', async ({ page, server, browserName, isLinux, isWindows }) => {
       test.skip(browserName === 'firefox', 'Firefox does not close the websocket upon a bad frame');
       test.skip(browserName === 'webkit' && isLinux, 'WebKit linux does not close the websocket upon a bad frame');
+      test.skip(browserName === 'webkit' && isWindows, 'WebKit Windows does not close the websocket upon a bad frame');
 
       const upgradePromise = server.waitForUpgrade();
       await setupWS(page, server.PORT, 'blob');


### PR DESCRIPTION
This fixes 

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/fd37f15b-766d-4020-a2b3-1c0ef4e67647">
