### PR TITLE
test: fix CR/LF warning on only-changed tests

### DIFF
--- a/tests/playwright-test/only-changed.spec.ts
+++ b/tests/playwright-test/only-changed.spec.ts
@@ -26,6 +26,7 @@ const test = baseTest.extend<{ git(command: string): void }>({
     git(`init --initial-branch=main`);
     git(`config --local user.name "Robert Botman"`);
     git(`config --local user.email "botty@mcbotface.com"`);
+    git(`config --local core.autocrlf false`);
 
     await use((command: string) => git(command));
   },


### PR DESCRIPTION
We don't need it in our repository, because we have a [`.gitattributes`](https://github.com/microsoft/playwright/blob/0ee9a8292647947912594705c5c6198b12f54064/.gitattributes#L2) file. Inside the test it falls back to the global setting, which is `true` for default installations.

Fixes https://github.com/microsoft/playwright/actions/runs/11002734638/job/30550364245#step:3:348