### PR TITLE
feat(pwt): expose Error.cause from Worker and show in reporters

### DIFF
--- a/docs/src/test-api/class-testinfoerror.md
+++ b/docs/src/test-api/class-testinfoerror.md
@@ -8,7 +8,7 @@ Information about an error thrown during test execution.
 * since: v1.49
 - type: ?<[TestInfoError]>
 
-Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error]
+Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error].
 
 ## property: TestInfoError.message
 * since: v1.10

--- a/docs/src/test-api/class-testinfoerror.md
+++ b/docs/src/test-api/class-testinfoerror.md
@@ -8,7 +8,7 @@ Information about an error thrown during test execution.
 * since: v1.49
 - type: ?<[TestInfoError]>
 
-Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be null if there is no cause or if the cause is not an instance of [Error] (or its subclass).
+Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error]
 
 ## property: TestInfoError.message
 * since: v1.10

--- a/docs/src/test-api/class-testinfoerror.md
+++ b/docs/src/test-api/class-testinfoerror.md
@@ -4,6 +4,12 @@
 
 Information about an error thrown during test execution.
 
+## property: TestInfoError.cause
+* since: v1.49
+- type: ?<[TestInfoError]>
+
+Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be null if there is no cause or if the cause is not an instance of [Error] (or its subclass).
+
 ## property: TestInfoError.message
 * since: v1.10
 - type: ?<[string]>

--- a/docs/src/test-reporter-api/class-testerror.md
+++ b/docs/src/test-reporter-api/class-testerror.md
@@ -8,7 +8,7 @@ Information about an error thrown during test execution.
 * since: v1.49
 - type: ?<[TestError]>
 
-Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error]
+Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error].
 
 ## property: TestError.message
 * since: v1.10

--- a/docs/src/test-reporter-api/class-testerror.md
+++ b/docs/src/test-reporter-api/class-testerror.md
@@ -8,7 +8,7 @@ Information about an error thrown during test execution.
 * since: v1.49
 - type: ?<[TestError]>
 
-Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be null if there is no cause or if the cause is not an instance of [Error] (or its subclass).
+Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error]
 
 ## property: TestError.message
 * since: v1.10

--- a/docs/src/test-reporter-api/class-testerror.md
+++ b/docs/src/test-reporter-api/class-testerror.md
@@ -4,6 +4,12 @@
 
 Information about an error thrown during test execution.
 
+## property: TestError.cause
+* since: v1.49
+- type: ?<[TestError]>
+
+Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be null if there is no cause or if the cause is not an instance of [Error] (or its subclass).
+
 ## property: TestError.message
 * since: v1.10
 - type: ?<[string]>

--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -434,14 +434,17 @@ export function formatError(error: TestError, highlightCode: boolean): ErrorDeta
     tokens.push(snippet);
   }
 
-  if (parsedStack && parsedStack.stackLines.length) {
-    tokens.push('');
+  if (parsedStack && parsedStack.stackLines.length)
     tokens.push(colors.dim(parsedStack.stackLines.join('\n')));
-  }
 
   let location = error.location;
   if (parsedStack && !location)
     location = parsedStack.location;
+
+  if (error.cause) {
+    tokens.push();
+    tokens.push(indent(colors.dim('[cause]: ') + formatError(error.cause, highlightCode).message, '  '));
+  }
 
   return {
     location,

--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -441,10 +441,8 @@ export function formatError(error: TestError, highlightCode: boolean): ErrorDeta
   if (parsedStack && !location)
     location = parsedStack.location;
 
-  if (error.cause) {
-    tokens.push();
-    tokens.push(indent(colors.dim('[cause]: ') + formatError(error.cause, highlightCode).message, '  '));
-  }
+  if (error.cause)
+    tokens.push(colors.dim('[cause]: ') + formatError(error.cause, highlightCode).message);
 
   return {
     location,

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -29,15 +29,17 @@ import type { TestInfoErrorImpl } from './common/ipc';
 const PLAYWRIGHT_TEST_PATH = path.join(__dirname, '..');
 const PLAYWRIGHT_CORE_PATH = path.dirname(require.resolve('playwright-core/package.json'));
 
-export function filterStackTrace(e: Error): { message: string, stack: string } {
+export function filterStackTrace(e: Error): { message: string, stack: string, cause?: ReturnType<typeof filterStackTrace> } {
   const name = e.name ? e.name + ': ' : '';
+  const cause = e.cause instanceof Error ? filterStackTrace(e.cause) : undefined;
   if (process.env.PWDEBUGIMPL)
-    return { message: name + e.message, stack: e.stack || '' };
+    return { message: name + e.message, stack: e.stack || '', cause };
 
   const stackLines = stringifyStackFrames(filteredStackTrace(e.stack?.split('\n') || []));
   return {
     message: name + e.message,
-    stack: `${name}${e.message}${stackLines.map(line => '\n' + line).join('')}`
+    stack: `${name}${e.message}${stackLines.map(line => '\n' + line).join('')}`,
+    cause,
   };
 }
 

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -224,9 +224,16 @@ export class TestTracing {
     const stack = rawStack ? filteredStackTrace(rawStack) : [];
     this._appendTraceEvent({
       type: 'error',
-      message: error.message || String(error.value),
+      message: this._formatError(error),
       stack,
     });
+  }
+
+  _formatError(error: TestInfoErrorImpl) {
+    const parts: string[] = [error.message || String(error.value)];
+    if (error.cause)
+      parts.push('[cause]: ' + this._formatError(error.cause));
+    return parts.join('\n');
   }
 
   appendStdioToTrace(type: 'stdout' | 'stderr', chunk: string | Buffer) {

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -9155,7 +9155,7 @@ export interface TestInfoError {
   /**
    * Error cause. Set when there is a
    * [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the
-   * error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error]
+   * error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error].
    */
   cause?: TestInfoError;
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -9153,6 +9153,13 @@ export interface TestInfo {
  */
 export interface TestInfoError {
   /**
+   * Error cause. Set when there is a
+   * [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the
+   * error. Will be null if there is no cause or if the cause is not an instance of [Error] (or its subclass).
+   */
+  cause?: TestInfoError;
+
+  /**
    * Error message. Set when [Error] (or its subclass) has been thrown.
    */
   message?: string;

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -9155,7 +9155,7 @@ export interface TestInfoError {
   /**
    * Error cause. Set when there is a
    * [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the
-   * error. Will be null if there is no cause or if the cause is not an instance of [Error] (or its subclass).
+   * error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error]
    */
   cause?: TestInfoError;
 

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -557,7 +557,7 @@ export interface TestError {
   /**
    * Error cause. Set when there is a
    * [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the
-   * error. Will be null if there is no cause or if the cause is not an instance of [Error] (or its subclass).
+   * error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error]
    */
   cause?: TestError;
 

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -557,7 +557,7 @@ export interface TestError {
   /**
    * Error cause. Set when there is a
    * [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the
-   * error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error]
+   * error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error].
    */
   cause?: TestError;
 

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -555,6 +555,13 @@ export interface TestCase {
  */
 export interface TestError {
   /**
+   * Error cause. Set when there is a
+   * [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the
+   * error. Will be null if there is no cause or if the cause is not an instance of [Error] (or its subclass).
+   */
+  cause?: TestError;
+
+  /**
    * Error location in the source code.
    */
   location?: Location;

--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -118,6 +118,53 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(output).toContain(`a.spec.ts:5:13`);
     });
 
+    test('should print error with a nested cause', async ({ runInlineTest }) => {
+      const result = await runInlineTest({
+        'a.spec.ts': `
+          import { test, expect } from '@playwright/test';
+
+          test('foobar', async ({}) => {
+            try {
+              try {
+                const error = new Error('my-message');
+                error.name = 'SpecialError';
+                throw error;
+              } catch (e) {
+                try {
+                  throw new Error('inner-message', { cause: e });
+                } catch (e) {
+                  throw new Error('outer-message', { cause: e });
+                }
+              }
+            } catch (e) {
+              throw new Error('wrapper-message', { cause: e });
+            }
+          });
+          test.afterAll(() => {
+            expect(test.info().errors.length).toBe(1);
+            expect(test.info().errors[0]).toBe(test.info().error);
+            expect(test.info().error.message).toBe('Error: wrapper-message');
+            expect(test.info().error.cause.message).toBe('Error: outer-message');
+            expect(test.info().error.cause.cause.message).toBe('Error: inner-message');
+            expect(test.info().error.cause.cause.cause.message).toBe('SpecialError: my-message');
+            expect(test.info().error.cause.cause.cause.cause).toBe(undefined);
+            console.log('afterAll executed successfully');
+          })
+        `
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.failed).toBe(1);
+      const testFile = path.join(result.report.config.rootDir, result.report.suites[0].specs[0].file);
+      expect(result.output).toContain(`       at ${testFile}:18:21`);
+      expect(result.output).toContain(`      [cause]: Error: outer-message`);
+      expect(result.output).toContain(`          at ${testFile}:14:25`);
+      expect(result.output).toContain(`        [cause]: Error: inner-message`);
+      expect(result.output).toContain(`            at ${testFile}:12:25`);
+      expect(result.output).toContain(`          [cause]: SpecialError: my-message`);
+      expect(result.output).toContain(`              at ${testFile}:7:31`);
+      expect(result.output).toContain('afterAll executed successfully');
+    });
+
     test('should print codeframe from a helper', async ({ runInlineTest }) => {
       const result = await runInlineTest({
         'helper.ts': `

--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -155,13 +155,13 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(result.exitCode).toBe(1);
       expect(result.failed).toBe(1);
       const testFile = path.join(result.report.config.rootDir, result.report.suites[0].specs[0].file);
-      expect(result.output).toContain(`       at ${testFile}:18:21`);
-      expect(result.output).toContain(`    [cause]: Error: outer-message`);
-      expect(result.output).toContain(`       at ${testFile}:14:25`);
-      expect(result.output).toContain(`    [cause]: Error: inner-message`);
-      expect(result.output).toContain(`       at ${testFile}:12:25`);
-      expect(result.output).toContain(`    [cause]: SpecialError: my-message`);
-      expect(result.output).toContain(`       at ${testFile}:7:31`);
+      expect(result.output).toContain(`${testFile}:18:21`);
+      expect(result.output).toContain(`[cause]: Error: outer-message`);
+      expect(result.output).toContain(`${testFile}:14:25`);
+      expect(result.output).toContain(`[cause]: Error: inner-message`);
+      expect(result.output).toContain(`${testFile}:12:25`);
+      expect(result.output).toContain(`[cause]: SpecialError: my-message`);
+      expect(result.output).toContain(`${testFile}:7:31`);
       expect(result.output).toContain('afterAll executed successfully');
     });
 

--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -156,12 +156,12 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(result.failed).toBe(1);
       const testFile = path.join(result.report.config.rootDir, result.report.suites[0].specs[0].file);
       expect(result.output).toContain(`       at ${testFile}:18:21`);
-      expect(result.output).toContain(`      [cause]: Error: outer-message`);
-      expect(result.output).toContain(`          at ${testFile}:14:25`);
-      expect(result.output).toContain(`        [cause]: Error: inner-message`);
-      expect(result.output).toContain(`            at ${testFile}:12:25`);
-      expect(result.output).toContain(`          [cause]: SpecialError: my-message`);
-      expect(result.output).toContain(`              at ${testFile}:7:31`);
+      expect(result.output).toContain(`    [cause]: Error: outer-message`);
+      expect(result.output).toContain(`       at ${testFile}:14:25`);
+      expect(result.output).toContain(`    [cause]: Error: inner-message`);
+      expect(result.output).toContain(`       at ${testFile}:12:25`);
+      expect(result.output).toContain(`    [cause]: SpecialError: my-message`);
+      expect(result.output).toContain(`       at ${testFile}:7:31`);
       expect(result.output).toContain('afterAll executed successfully');
     });
 


### PR DESCRIPTION
While looking at solving https://github.com/microsoft/playwright/issues/26848 we investigated various ways.

1. We tried serialising error causes as multiple errors which didn't gave us a great DX. (https://github.com/microsoft/playwright/pull/32834)
1. We tried modifying the `.stack` property which we don't like since it might break our users. (https://github.com/microsoft/playwright/pull/28488)
1. Exposing a separate `.cause` property felt like the best solution since its not breaking any users. It requires customers now to look at this property and the serialise the error appropriately.

This PR implements option 3.

I tested the experience across the following consumers:

1. UI Mode, looks good.
2. JSON reporter: We use this for testing, so its covered.
3. PWT inside worker process (TestInfoError): Looks good, I test it inside the test.
4. VSCode extension: Requires us to serialise the error there, see https://github.com/microsoft/playwright-vscode/pull/547.

Relates https://github.com/microsoft/playwright/issues/26848