### PR TITLE
Added Theatron to third-party reporter showcase in test-reporters-js.md

### DIFF
--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -437,3 +437,4 @@ npx playwright test --reporter="./myreporter/my-awesome-reporter.ts"
 * [Testmo](https://github.com/jonasclaes/playwright-testmo-reporter)
 * [Testomat.io](https://github.com/testomatio/reporter/blob/master/docs/frameworks.md#playwright)
 * [Tesults](https://www.tesults.com/docs/playwright)
+* [Theatron](https://www.theatron.dev)


### PR DESCRIPTION
Addresses issue #32866 raised by myself to add a reporter package that I maintain to the third party showcase, with a link to my website. Added to the end of the list on the hopefully sensible assumption that the list is alphabetical.