### PR TITLE
chore(ui): ensure that --ignore-snapshots is respected

### DIFF
--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -503,3 +503,23 @@ test('should respect --tsconfig option', {
 
   await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
 });
+
+test('should respect --ignore-snapshots option', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32868' }
+}, async ({ runUITest }) => {
+  const { page } = await runUITest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('snapshot', () => {
+        expect('foo').toMatchSnapshot(); // fails because no snapshot is present
+      });
+    `,
+  }, undefined, { additionalArgs: ['--ignore-snapshots'] });
+
+  await page.getByTitle('Run all').click();
+
+  await expect.poll(dumpTestTree(page)).toBe(`
+    ▼ ✅ a.test.ts
+        ✅ snapshot
+  `);
+});


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32868.

The actual fix was already delivered in https://github.com/microsoft/playwright/pull/32798/files#diff-98ff2ff92b08ca7e8b274abb3ba6b2eec9bab332e340d062cc18ad1dfe505bf2R299, this PR adds a test to ensure we don't regress. 