### PR TITLE
devops: simplify headed testing matrix

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -123,7 +123,13 @@ jobs:
       fail-fast: false
       matrix:
         browser: [chromium, firefox, webkit]
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-14-xlarge, windows-latest]
+        os: [ubuntu-24.04, macos-14-xlarge, windows-latest]
+        include:
+          # We have different binaries per Ubuntu version for WebKit.
+          - browser: webkit
+            os: ubuntu-20.04
+          - browser: webkit
+            os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
For Chromium and Firefox we have a single Linux binary which works across all the Ubuntu versions.

For WebKit this is not the case. We have a binary per Ubuntu version.

This allows us to stop spanning the matrix across all the ubuntu versions and only running the headed WebKit tests on older Ubuntu versions.

In other words, this stops testing:

- ubuntu20-chromium
- ubuntu20-firefox
- ubuntu22-chromium
- ubuntu22-firefox 