### PR TITLE
test: unflake two tests

### DIFF
--- a/tests/library/fetch-proxy.spec.ts
+++ b/tests/library/fetch-proxy.spec.ts
@@ -20,14 +20,15 @@ it.skip(({ mode }) => mode !== 'default');
 
 it('context request should pick up proxy credentials', async ({ browserType, server, proxyServer }) => {
   proxyServer.forwardTo(server.PORT, { allowConnectRequests: true });
-  let auth;
-  proxyServer.setAuthHandler(req => {
-    const header = req.headers['proxy-authorization'];
-    // Browser can issue various unrelated requests over the proxy,
-    // but we are only interested in our own request.
-    if (proxyServer.connectHosts.includes('non-existent.com:80'))
-      auth = header;
-    return !!header;
+  const authPromise = new Promise<string>(resolve => {
+    proxyServer.setAuthHandler(req => {
+      const header = req.headers['proxy-authorization'];
+      // Browser can issue various unrelated requests over the proxy,
+      // but we are only interested in our own request.
+      if (proxyServer.connectHosts.includes('non-existent.com:80'))
+        resolve(header);
+      return !!header;
+    });
   });
   const browser = await browserType.launch({
     proxy: { server: `localhost:${proxyServer.PORT}`, username: 'user', password: 'secret' }
@@ -35,6 +36,7 @@ it('context request should pick up proxy credentials', async ({ browserType, ser
   const context = await browser.newContext();
   const response = await context.request.get('http://non-existent.com/simple.json');
   expect(proxyServer.connectHosts).toContain('non-existent.com:80');
+  const auth = await authPromise;
   expect(auth).toBe('Basic ' + Buffer.from('user:secret').toString('base64'));
   expect(await response.json()).toEqual({ foo: 'bar' });
   await browser.close();

--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -129,26 +129,6 @@ it('should reject response.finished if page closes', async ({ page, server }) =>
   expect(error.message).toContain('closed');
 });
 
-it('should reject response.finished if context closes', async ({ page, server }) => {
-  await page.goto(server.EMPTY_PAGE);
-  server.setRoute('/get', (req, res) => {
-    // In Firefox, |fetch| will be hanging until it receives |Content-Type| header
-    // from server.
-    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
-    res.write('hello ');
-  });
-  // send request and wait for server response
-  const [pageResponse] = await Promise.all([
-    page.waitForEvent('response'),
-    page.evaluate(() => fetch('./get', { method: 'GET' })),
-  ]);
-
-  const finishPromise = pageResponse.finished().catch(e => e);
-  await page.context().close();
-  const error = await finishPromise;
-  expect(error.message).toContain('closed');
-});
-
 it('should return json', async ({ page, server }) => {
   const response = await page.goto(server.PREFIX + '/simple.json');
   expect(await response.json()).toEqual({ foo: 'bar' });


### PR DESCRIPTION
- the test that closes a context must not be a "page test";
- account for stray browser requests in the proxy test.