### PR TITLE
chore: unflake 'should record'

### DIFF
--- a/packages/playwright-core/src/server/recorder/recorderCollection.ts
+++ b/packages/playwright-core/src/server/recorder/recorderCollection.ts
@@ -126,6 +126,8 @@ export class RecorderCollection extends EventEmitter {
   }
 
   private _fireChange() {
+    if (!this._enabled)
+      return;
     this.emit('change', collapseActions(this._actions));
   }
 }

--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -188,9 +188,9 @@ test('test', async ({ page }) => {
   await page.getByRole('button', { name: 'Submit' }).click();
 });`
   });
-  const length = events.length;
   // No events after mode disabled
   await backend.setRecorderMode({ mode: 'none' });
+  const length = events.length;
   await page.getByRole('button').click();
   expect(events).toHaveLength(length);
 });


### PR DESCRIPTION
Its caused by a change made [here](https://github.com/microsoft/playwright/commit/11014145ce37a8d44b6083fcf2c5f71453f018c7#diff-10d158206c9e19b9603a57206aa089d4b827dc541b86495a9ce5ca921b8d2f28R82). With that we call `this._fireChange()` twice for the same set of actions. This ends up in two `sourceChanged` events in the debug controller. We should not fire the same 'change' event if its not enabled.

Why was it racy? Because its fired in a microtask, depending on the load, it might or might not happen - turns out it only happened on busy systems.