### PR TITLE
chore: call out that that the vscode extension is for Node.js

### DIFF
--- a/docs/src/getting-started-vscode-js.md
+++ b/docs/src/getting-started-vscode-js.md
@@ -18,7 +18,7 @@ Get started by installing Playwright and generating a test to see it in action. 
 
 ## Installation
 
-Install the [VS Code extension from the marketplace](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) or from the extensions tab in VS Code.
+To use Playwright for Node.js from VS Code, install the [VS Code extension from the marketplace](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) or from the extensions tab in VS Code.
 
 ![VS Code extension for Playwright](https://github.com/microsoft/playwright/assets/13063165/cab54568-3168-4b3f-bf3d-854976594903)
 

--- a/docs/src/getting-started-vscode-js.md
+++ b/docs/src/getting-started-vscode-js.md
@@ -18,7 +18,7 @@ Get started by installing Playwright and generating a test to see it in action. 
 
 ## Installation
 
-To use Playwright for Node.js from VS Code, install the [VS Code extension from the marketplace](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) or from the extensions tab in VS Code.
+Playwright has a VS Code extension which is available when testing with Node.js. Install [it from the VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) or from the extensions tab in VS Code.
 
 ![VS Code extension for Playwright](https://github.com/microsoft/playwright/assets/13063165/cab54568-3168-4b3f-bf3d-854976594903)
 


### PR DESCRIPTION
In https://github.com/microsoft/playwright/issues/32861, an interested .NET user wanted to try Playwright and found the VS Code Getting Started guide. It didn't work for them because the VS Code Extension is for usage with Node.js, and they don't have NPM installed. We can reduce confusion by mentioning that VS Code Getting started is for Node.js.