### PR TITLE
feat: specify junit test properties by env variable

### DIFF
--- a/packages/playwright-core/src/utils/env.ts
+++ b/packages/playwright-core/src/utils/env.ts
@@ -17,7 +17,7 @@
 export function getFromENV(name: string): string | undefined {
   let value = process.env[name];
   value = value === undefined ? process.env[`npm_config_${name.toLowerCase()}`] : value;
-  value = value === undefined ?  process.env[`npm_package_config_${name.toLowerCase()}`] : value;
+  value = value === undefined ? process.env[`npm_package_config_${name.toLowerCase()}`] : value;
   return value;
 }
 
@@ -47,3 +47,27 @@ export function getPackageManagerExecCommand() {
     return 'pnpm exec';
   return 'npx';
 }
+
+export function getParsedFromEnv(key: string): Array<{name: string, value: string}> {
+  const envValue = getFromENV(key);
+  if (envValue) {
+    const commaSplittedValuesInEnv = [...new Set(envValue.split(','))].map(prop => {
+      let property = prop.split('=');
+      if (property.length === 2 && property[0] && property[1])
+        return {name: property[0].trim(), value: property[1].trim()};
+    }).filter(item => !!item)
+    const uniqueItems = [];
+    const mapWithUniqueName = new Map();
+    for (const value of commaSplittedValuesInEnv) {
+      const key = Object.values(value)[0];
+      if (!mapWithUniqueName.has(key)) {
+        mapWithUniqueName.set(key, true);
+        uniqueItems.push(value);
+      }
+    }
+    return uniqueItems;
+  }
+  return [];
+}
+
+


### PR DESCRIPTION
add PLAYWRIGHT_JUNIT_PROPERTIES variable with that properties can be specified like 

process.env.PLAYWRIGHT_JUNIT_PROPERTIES  = "dd_tags[arh]=x64,platfrom=beta"

then in junit xml it'll be added as usual to each run's test cases additionally to have been set in test annotation

<properties>
   <property name="dd_tags[arh]" value="x64">
   <property name="platform" value="beta">
</properties>