### PR TITLE
fix(ct-react): support shorthand fragment notation

### DIFF
--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -40,7 +40,7 @@ function __pwRender(value) {
     if (isJsxComponent(v)) {
       const component = v;
       let type = component.type;
-      if (type && type.__pw_type === 'fragment')
+      if (type && type.__pw_jsx_fragment) // detects the playwright mock Fragment (see jsx-runtime.js), used in <></> notation
         type = __pwReact.Fragment;
       const props = component.props ? __pwRender(component.props) : {};
       const key = component.key ? __pwRender(component.key) : undefined;

--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -34,7 +34,7 @@ function isJsxComponent(component) {
 
 /**
  * @param {any} type
- * @returns type is Playwright's mock JSX.Fragment
+ * @returns {boolean} type is Playwright's mock JSX.Fragment
  */
 function isJsxFragment(type) {
   return typeof type === 'object' && type?.__pw_jsx_fragment;

--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -40,7 +40,7 @@ function __pwRender(value) {
     if (isJsxComponent(v)) {
       const component = v;
       let type = component.type;
-      if ('__pw_type' in type && type.__pw_type === 'fragment')
+      if (type && type.__pw_type === 'fragment')
         type = __pwReact.Fragment;
       const props = component.props ? __pwRender(component.props) : {};
       const key = component.key ? __pwRender(component.key) : undefined;

--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -33,6 +33,7 @@ function isJsxComponent(component) {
 }
 
 /**
+ * Turns the Playwright representation of JSX (see jsx-runtime.js) into React.createElement calls.
  * @param {any} value
  */
 function __pwRender(value) {
@@ -40,7 +41,7 @@ function __pwRender(value) {
     if (isJsxComponent(v)) {
       const component = v;
       let type = component.type;
-      if (type && type.__pw_jsx_fragment) // detects the playwright mock Fragment (see jsx-runtime.js), used in <></> notation
+      if (type && type.__pw_jsx_fragment)
         type = __pwReact.Fragment;
       const props = component.props ? __pwRender(component.props) : {};
       const key = component.key ? __pwRender(component.key) : undefined;

--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -33,6 +33,14 @@ function isJsxComponent(component) {
 }
 
 /**
+ * @param {any} type
+ * @returns type is Playwright's mock JSX.Fragment
+ */
+function isJsxFragment(type) {
+  return typeof type === 'object' && type?.__pw_jsx_fragment;
+}
+
+/**
  * Turns the Playwright representation of JSX (see jsx-runtime.js) into React.createElement calls.
  * @param {any} value
  */
@@ -41,7 +49,7 @@ function __pwRender(value) {
     if (isJsxComponent(v)) {
       const component = v;
       let type = component.type;
-      if (type && type.__pw_jsx_fragment)
+      if (isJsxFragment(type))
         type = __pwReact.Fragment;
       const props = component.props ? __pwRender(component.props) : {};
       const key = component.key ? __pwRender(component.key) : undefined;

--- a/packages/playwright-ct-react/registerSource.mjs
+++ b/packages/playwright-ct-react/registerSource.mjs
@@ -39,6 +39,9 @@ function __pwRender(value) {
   return window.__pwTransformObject(value, v => {
     if (isJsxComponent(v)) {
       const component = v;
+      let type = component.type;
+      if ('__pw_type' in type && type.__pw_type === 'fragment')
+        type = __pwReact.Fragment;
       const props = component.props ? __pwRender(component.props) : {};
       const key = component.key ? __pwRender(component.key) : undefined;
       const { children, ...propsWithoutChildren } = props;
@@ -47,7 +50,7 @@ function __pwRender(value) {
       const createElementArguments = [propsWithoutChildren];
       if (children)
         createElementArguments.push(children);
-      return { result: __pwReact.createElement(component.type, ...createElementArguments) };
+      return { result: __pwReact.createElement(type, ...createElementArguments) };
     }
   });
 }

--- a/packages/playwright/jsx-runtime.js
+++ b/packages/playwright/jsx-runtime.js
@@ -32,7 +32,7 @@ function jsxs(type, props, key) {
   };
 }
 
-const Fragment = { __pw_type: 'fragment' };
+const Fragment = { __pw_jsx_fragment: true };
 
 module.exports = {
   Fragment,

--- a/packages/playwright/jsx-runtime.js
+++ b/packages/playwright/jsx-runtime.js
@@ -32,6 +32,7 @@ function jsxs(type, props, key) {
   };
 }
 
+// this is used in <></> notation
 const Fragment = { __pw_jsx_fragment: true };
 
 module.exports = {

--- a/packages/playwright/jsx-runtime.js
+++ b/packages/playwright/jsx-runtime.js
@@ -32,7 +32,7 @@ function jsxs(type, props, key) {
   };
 }
 
-const Fragment = {};
+const Fragment = { __pw_type: 'fragment' };
 
 module.exports = {
   Fragment,

--- a/tests/components/ct-react-vite/tests/render.spec.tsx
+++ b/tests/components/ct-react-vite/tests/render.spec.tsx
@@ -46,3 +46,8 @@ test('render inline component with an error if its nested', async ({ mount }) =>
     <MyInlineComponent value="Max" />
   </DefaultChildren>)).rejects.toThrow('Component "MyInlineComponent" cannot be mounted.');
 });
+
+test('render Fragment shorthand notation', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32853' } }, async ({ mount }) => {
+  const component = await mount(<>Learn React</>);
+  await expect(component).toContainText('Learn React');
+});

--- a/tests/playwright-test/playwright.ct-react.spec.ts
+++ b/tests/playwright-test/playwright.ct-react.spec.ts
@@ -596,3 +596,22 @@ test('should allow import from shared file', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
 });
+
+
+test('should render fragment at root', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': playwrightCtConfigText,
+    'playwright/index.html': `<script type="module" src="./index.ts"></script>`,
+    'playwright/index.ts': ``,
+    'src/component.spec.tsx': `
+      import { test, expect } from '@playwright/experimental-ct-react';
+
+      test('should work', async ({ mount, page }) => {
+        const component = await mount(<>Learn React</>);
+        await expect(component).toContainText('Learn React');
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});

--- a/tests/playwright-test/playwright.ct-react.spec.ts
+++ b/tests/playwright-test/playwright.ct-react.spec.ts
@@ -596,22 +596,3 @@ test('should allow import from shared file', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
 });
-
-
-test('should render fragment at root', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'playwright.config.ts': playwrightCtConfigText,
-    'playwright/index.html': `<script type="module" src="./index.ts"></script>`,
-    'playwright/index.ts': ``,
-    'src/component.spec.tsx': `
-      import { test, expect } from '@playwright/experimental-ct-react';
-
-      test('should work', async ({ mount, page }) => {
-        const component = await mount(<>Learn React</>);
-        await expect(component).toContainText('Learn React');
-      });
-    `
-  });
-  expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(1);
-});


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32853

Vite turns the shorthand fragment notation `<></>` into `import { Fragment } from "react"; <Fragment></Fragment>`. On the Node.js side of things, this `react` import resolves to our mock version of React, which currently mocks `Fragment` as `{}`. Currently, we pass that straight to `React.createElement`, which throws an error.

The fix is to make our `Fragment` mock detectable with a tag, and when we render it replace it with the real `__pwReact.Fragment`.