### PR TITLE
fix(clock): amend setSystemTime docs

### DIFF
--- a/docs/src/api/class-clock.md
+++ b/docs/src/api/class-clock.md
@@ -251,7 +251,7 @@ Time to be set.
 
 Sets system time, but does not trigger any timers. Use this to test how the web page reacts to a time shift, for example switching from summer to winter time, or changing time zones.
 
-Don't use together with [`method: Clock.install`]. Read docs on [clock emulation](../clock.md) to learn more.
+Use this method for simple scenarios where you only need to test with a predefined time. For more advanced scenarios, use [`method: Clock.install`] instead. Read docs on [clock emulation](../clock.md) to learn more.
 
 **Usage**
 

--- a/docs/src/api/class-clock.md
+++ b/docs/src/api/class-clock.md
@@ -249,7 +249,9 @@ Time to be set.
 ## async method: Clock.setSystemTime
 * since: v1.45
 
-Sets current system time without pausing, but does not trigger any timers. You most likely don't need this.
+Sets system time, but does not trigger any timers. Use this to test how the web page reacts to a time shift, for example switching from summer to winter time, or changing time zones.
+
+Don't use together with [`method: Clock.install`]. Read docs on [clock emulation](../clock.md) to learn more.
 
 **Usage**
 

--- a/docs/src/api/class-clock.md
+++ b/docs/src/api/class-clock.md
@@ -249,7 +249,7 @@ Time to be set.
 ## async method: Clock.setSystemTime
 * since: v1.45
 
-Sets current system time but does not trigger any timers.
+Sets current system time without pausing, but does not trigger any timers. You most likely don't need this.
 
 **Usage**
 

--- a/docs/src/api/class-clock.md
+++ b/docs/src/api/class-clock.md
@@ -193,6 +193,8 @@ Resumes timers. Once this method is called, time resumes flowing, timers are fir
 Makes `Date.now` and `new Date()` return fixed fake time at all times,
 keeps all the timers running.
 
+Use this method for simple scenarios where you only need to test with a predefined time. For more advanced scenarios, use [`method: Clock.install`] instead. Read docs on [clock emulation](../clock.md) to learn more.
+
 **Usage**
 
 ```js
@@ -250,8 +252,6 @@ Time to be set.
 * since: v1.45
 
 Sets system time, but does not trigger any timers. Use this to test how the web page reacts to a time shift, for example switching from summer to winter time, or changing time zones.
-
-Use this method for simple scenarios where you only need to test with a predefined time. For more advanced scenarios, use [`method: Clock.install`] instead. Read docs on [clock emulation](../clock.md) to learn more.
 
 **Usage**
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -18555,7 +18555,11 @@ export interface Clock {
   setFixedTime(time: number|string|Date): Promise<void>;
 
   /**
-   * Sets current system time without pausing, but does not trigger any timers. You most likely don't need this.
+   * Sets system time, but does not trigger any timers. Use this to test how the web page reacts to a time shift, for
+   * example switching from summer to winter time, or changing time zones.
+   *
+   * Don't use together with [clock.install([options])](https://playwright.dev/docs/api/class-clock#clock-install). Read
+   * docs on [clock emulation](https://playwright.dev/docs/clock) to learn more.
    *
    * **Usage**
    *

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -18555,7 +18555,7 @@ export interface Clock {
   setFixedTime(time: number|string|Date): Promise<void>;
 
   /**
-   * Sets current system time but does not trigger any timers.
+   * Sets current system time without pausing, but does not trigger any timers. You most likely don't need this.
    *
    * **Usage**
    *

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -18542,6 +18542,10 @@ export interface Clock {
   /**
    * Makes `Date.now` and `new Date()` return fixed fake time at all times, keeps all the timers running.
    *
+   * Use this method for simple scenarios where you only need to test with a predefined time. For more advanced
+   * scenarios, use [clock.install([options])](https://playwright.dev/docs/api/class-clock#clock-install) instead. Read
+   * docs on [clock emulation](https://playwright.dev/docs/clock) to learn more.
+   *
    * **Usage**
    *
    * ```js
@@ -18557,9 +18561,6 @@ export interface Clock {
   /**
    * Sets system time, but does not trigger any timers. Use this to test how the web page reacts to a time shift, for
    * example switching from summer to winter time, or changing time zones.
-   *
-   * Don't use together with [clock.install([options])](https://playwright.dev/docs/api/class-clock#clock-install). Read
-   * docs on [clock emulation](https://playwright.dev/docs/clock) to learn more.
    *
    * **Usage**
    *


### PR DESCRIPTION
As discussed yesterday over https://github.com/microsoft/playwright/issues/32807. Adds some words to differentiate `setSystemTime` from `setFixedTime`.