### PR TITLE
test: retry installation tests up to 3 times

### DIFF
--- a/tests/installation/playwright.config.ts
+++ b/tests/installation/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
   outputDir,
   testIgnore: '**\/fixture-scripts/**',
   timeout: 5 * 60 * 1000,
-  retries: 0,
+  retries: process.env.CI ? 3 : 0,
   reporter: reporters(),
   forbidOnly: !!process.env.CI,
   workers: 1,


### PR DESCRIPTION
Installation tests can fail due to e.g. network issues. Lets align with library tests and retry up to 3 times.