### PR TITLE
fix(fetch): fallback to given URL if baseURL is invalid

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -25,7 +25,7 @@ import zlib from 'zlib';
 import type { HTTPCredentials } from '../../types/types';
 import { TimeoutSettings } from '../common/timeoutSettings';
 import { getUserAgent } from '../utils/userAgent';
-import { assert, createGuid, monotonicTime } from '../utils';
+import { assert, constructURLBasedOnBaseURL, createGuid, monotonicTime } from '../utils';
 import { HttpsProxyAgent, SocksProxyAgent } from '../utilsBundle';
 import { BrowserContext, verifyClientCertificates } from './browserContext';
 import { CookieStore, domainMatches, parseRawCookie } from './cookieStore';
@@ -159,7 +159,7 @@ export abstract class APIRequestContext extends SdkObject {
         setHeader(headers, name, value);
     }
 
-    const requestUrl = new URL(params.url, defaults.baseURL);
+    const requestUrl = new URL(constructURLBasedOnBaseURL(defaults.baseURL, params.url));
     if (params.encodedParams) {
       requestUrl.search = params.encodedParams;
     } else if (params.params) {

--- a/tests/library/global-fetch.spec.ts
+++ b/tests/library/global-fetch.spec.ts
@@ -220,6 +220,13 @@ it('should resolve url relative to global baseURL option', async ({ playwright, 
   await request.dispose();
 });
 
+it('should fallback to given URL if baseURL is bogus', async ({ playwright, server }) => {
+  const request = await playwright.request.newContext({ baseURL: 'bogus' });
+  const response = await request.get(server.PREFIX + '/empty.html');
+  expect(response.url()).toBe(server.EMPTY_PAGE);
+  await request.dispose();
+});
+
 it('should set playwright as user-agent', async ({ playwright, server, isWindows, isLinux, isMac }) => {
   const request = await playwright.request.newContext();
   const [serverRequest] = await Promise.all([


### PR DESCRIPTION
Fetch baseURL handling should be identical to what we do with `page.goto`. I saw a bug report on Discord which worked with `page.goto` but didn't with `request.get`.