### PR TITLE
chore: do not create a GitHub Status Check for merge results

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -22,6 +22,7 @@ jobs:
       env:
         DEBUG: pw:install
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+        ELECTRON_SKIP_BINARY_DOWNLOAD: 1
     - run: npm run build
 
     - name: Download blob report artifact
@@ -120,21 +121,3 @@ jobs:
             ]),
           });
           core.info('Posted comment: ' + response.html_url);
-
-          const check = await github.rest.checks.create({
-            ...context.repo,
-            name: 'Merge report (${{ github.event.workflow_run.name }})',
-            head_sha: '${{ github.event.workflow_run.head_sha }}',
-            status: 'completed',
-            conclusion: 'success',
-            details_url: reportUrl,
-            output: {
-              title: 'Test results for "${{ github.event.workflow_run.name }}"',
-              summary: [
-                reportMd,
-                '',
-                '---',
-                `Full [HTML report](${reportUrl}). Merge [workflow run](${mergeWorkflowUrl}).`
-              ].join('\n'),
-            }
-          });


### PR DESCRIPTION
This is in preparation for https://github.com/microsoft/playwright/issues/32920.

Instead of us clicking on the Status Check, which e.g. ended up [here](https://github.com/microsoft/playwright/pull/32914/checks?check_run_id=30948181828) we looked at the comments.