### PR TITLE
Increase click target for test report

### DIFF
--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -14,16 +14,28 @@
   limitations under the License.
 */
 
+.hbox.static {
+  position: static;
+}
+
 .test-file-test {
   line-height: 32px;
-  align-items: center;
   padding: 2px 10px;
   overflow: hidden;
   text-overflow: ellipsis;
+  position: relative;
 }
 
 .test-file-test:hover {
   background-color: var(--color-canvas-subtle);
+}
+
+.test-file-link::before {
+  content: '';
+  display: block;
+  inset: 0;
+  position: absolute;
+  z-index: 0;
 }
 
 .test-file-title {
@@ -45,14 +57,12 @@
   text-overflow: ellipsis;
   overflow: hidden;
   color: var(--color-fg-subtle);
-}
-
-.test-file-path-link {
   margin-right: 10px;
 }
 
 .test-file-badge {
   flex: none;
+  position: relative;
 }
 
 .test-file-badge svg {
@@ -69,4 +79,10 @@
 
 .test-file-test-status-icon {
   flex: none;
+}
+
+.label {
+  cursor: pointer;
+  margin: 6px 0 0 6px;
+  position: relative;
 }

--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -41,13 +41,13 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
     </span>}>
     {file.tests.filter(t => filter.matches(t)).map(test =>
       <div key={`test-${test.testId}`} className={clsx('test-file-test', 'test-file-test-outcome-' + test.outcome)}>
-        <div className='hbox' style={{ alignItems: 'flex-start' }}>
-          <div className='hbox'>
+        <div className='hbox static' style={{ alignItems: 'flex-start' }}>
+          <div className='hbox static'>
             <span className='test-file-test-status-icon'>
               {statusIcon(test.outcome)}
             </span>
             <span>
-              <Link href={`#?testId=${test.testId}`} title={[...test.path, test.title].join(' › ')}>
+              <Link className='test-file-link' href={`#?testId=${test.testId}`} title={[...test.path, test.title].join(' › ')}>
                 <span className='test-file-title'>{[...test.path, test.title].join(' › ')}</span>
               </Link>
               {report.projectNames.length > 1 && !!test.projectName &&
@@ -58,9 +58,7 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
           <span data-testid='test-duration' style={{ minWidth: '50px', textAlign: 'right' }}>{msToString(test.duration)}</span>
         </div>
         <div className='test-file-details-row'>
-          <Link href={`#?testId=${test.testId}`} title={[...test.path, test.title].join(' › ')} className='test-file-path-link'>
-            <span className='test-file-path'>{test.location.file}:{test.location.line}</span>
-          </Link>
+          <span className='test-file-path'>{test.location.file}:{test.location.line}</span>
           {imageDiffBadge(test)}
           {videoBadge(test)}
           {traceBadge(test)}
@@ -102,7 +100,7 @@ const LabelsClickView: React.FC<React.PropsWithChildren<{
   return labels.length > 0 ? (
     <>
       {labels.map(label => (
-        <span key={label} style={{ margin: '6px 0 0 6px', cursor: 'pointer' }} className={clsx('label', 'label-color-' + hashStringToInt(label))} onClick={e => onClickHandle(e, label)}>
+        <span key={label} className={clsx('label', 'label-color-' + hashStringToInt(label))} onClick={e => onClickHandle(e, label)}>
           {label.slice(1)}
         </span>
       ))}

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2457,10 +2457,8 @@ for (const useIntermediateMergeReport of [false] as const) {
 
       await expect(page.locator('.test-file-test').locator('a').first()).toHaveAttribute('title', 'Root describe › Test passed');
       await expect(page.locator('.test-file-title')).toHaveText('Root describe › Test passed');
-      const testFilePathLink = page.locator('.test-file-path-link');
-      await expect(testFilePathLink).toHaveAttribute('title', 'Root describe › Test passed');
 
-      await testFilePathLink.click();
+      await page.locator('.test-file-title').click();
       await expect(page.locator('.test-case-path')).toHaveText('Root describe');
     });
   });


### PR DESCRIPTION
Fixes #32995 

Increases the click target in the HTML report to fill the entire card.  Embedded links or badges with `position: relative` will bubble up and still allow clicking.

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/28955ebe-f752-4bc5-906b-c8b6ead07cd0">
