### PR TITLE
fix(chromium): reset mouse position upon page reuse

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -364,6 +364,8 @@ export class CRPage implements PageDelegate {
   }
 
   async resetForReuse(): Promise<void> {
+    // See https://github.com/microsoft/playwright/issues/22432.
+    await this.rawMouse.move(-1, -1, 'none', new Set(), new Set(), true);
   }
 
   async pdf(options: channels.PagePdfParams): Promise<Buffer> {

--- a/tests/library/browsercontext-reuse.spec.ts
+++ b/tests/library/browsercontext-reuse.spec.ts
@@ -203,10 +203,10 @@ test('should ignore binding from beforeunload', async ({ reusedContext }) => {
   expect(called).toBe(false);
 });
 
-test('should reset mouse position', async ({ reusedContext, browserName, platform }) => {
+test('should reset mouse position', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22432' },
+}, async ({ reusedContext, browserName, platform }) => {
   // Note: this test only reproduces the issue locally when run with --repeat-each=20.
-  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22432' });
-  test.fixme(browserName === 'chromium' && platform !== 'darwin', 'chromium keeps hover on linux/win');
 
   const pageContent = `
     <style>
@@ -214,6 +214,7 @@ test('should reset mouse position', async ({ reusedContext, browserName, platfor
       div:hover { background: red; }
       html, body { margin: 0; padding: 0; }
     </style>
+    <div id=filler>one</div>
     <div id=one>one</div>
     <div id=two>two</div>
   `;
@@ -224,7 +225,7 @@ test('should reset mouse position', async ({ reusedContext, browserName, platfor
   await expect(page.locator('#one')).toHaveCSS('background-color', 'rgb(0, 0, 255)');
   await expect(page.locator('#two')).toHaveCSS('background-color', 'rgb(0, 0, 255)');
 
-  await page.mouse.move(10, 45);
+  await page.mouse.move(10, 75);
   await expect(page.locator('#one')).toHaveCSS('background-color', 'rgb(0, 0, 255)');
   await expect(page.locator('#two')).toHaveCSS('background-color', 'rgb(255, 0, 0)');
 


### PR DESCRIPTION
Similarly to Firefox, move the mouse to (-1, -1) upon page reuse. This fixes the corresponding test on all platforms.