### PR TITLE
devops: speculative fix for flakiness dashboard data loss

### DIFF
--- a/utils/flakiness-dashboard/host.json
+++ b/utils/flakiness-dashboard/host.json
@@ -12,6 +12,9 @@
     "queues": {
       "batchSize": 1,
       "newBatchThreshold": 0
+    },
+    "blobs": {
+      "maxDegreeOfParallelism": 1
     }
   },
   "extensionBundle": {


### PR DESCRIPTION
We sometimes loose data, e.g. between edge-beta bots (3 platforms) only 1 platforms appears on the dashboard. For some runs others appear.

Our speculation is that there is a race here:

https://github.com/microsoft/playwright/blob/80ff7c396a596854e11d95e36fb2d66afae53c6c/utils/flakiness-dashboard/processing/dashboard_raw.js#L21

Lets see if thats the case and limit it to 1 which should be enough for our scale.

See here, that its by default [8 * the number of CPUs](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob?tabs=isolated-process%2Cextensionv5%2Cextensionv3&pivots=programming-language-javascript#hostjson-settings).