### PR TITLE
Revert "fix(test): do not allow mixing tests from different types (#29284)"

### DIFF
--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -56,12 +56,10 @@ export class Suite extends Base {
   _fullProject: FullProjectInternal | undefined;
   _fileId: string | undefined;
   readonly _type: 'root' | 'project' | 'file' | 'describe';
-  readonly _testTypeImpl: TestTypeImpl | undefined;
 
-  constructor(title: string, type: 'root' | 'project' | 'file' | 'describe', testTypeImpl?: TestTypeImpl) {
+  constructor(title: string, type: 'root' | 'project' | 'file' | 'describe') {
     super(title);
     this._type = type;
-    this._testTypeImpl = testTypeImpl;
   }
 
   get type(): 'root' | 'project' | 'file' | 'describe' {

--- a/tests/playwright-test/basic.spec.ts
+++ b/tests/playwright-test/basic.spec.ts
@@ -550,22 +550,3 @@ test('should support describe.fixme', async ({ runInlineTest }) => {
   expect(result.skipped).toBe(3);
   expect(result.output).toContain('heytest4');
 });
-
-test('should not allow mixing test types', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'mixed.spec.ts': `
-      import { test } from '@playwright/test';
-
-      export const test2 = test.extend({
-        value: 42,
-      });
-
-      test.describe("test1 suite", () => {
-        test2("test 2", async () => {});
-      });
-    `
-  });
-  expect(result.exitCode).toBe(1);
-  expect(result.output).toContain(`Can't call test() inside a describe() suite of a different test type.`);
-  expect(result.output).toContain('>  9 |         test2(');
-});


### PR DESCRIPTION
This reverts commit 4784139bb0bce071c0745c6c07f623c37d3c70ce.

Closes https://github.com/microsoft/playwright/issues/29734.

Reason for revert: this original change only covers cases where `test.describe()` is explicitly called in a file. However, most users have top-level definition of tests without a describe block, so it does not solve both problems it was introduced for:
- mixing hooks and tests, e.g. `test1.beforeEach()` and `test2()`;
- mixing `test1.use()` and `test2()`;
- forcing different workers inside a single file/suite because of different worker fixtures between `test1()` and `test2()`.
