### PR TITLE
test: fix android tests

### DIFF
--- a/tests/config/serverFixtures.ts
+++ b/tests/config/serverFixtures.ts
@@ -51,7 +51,7 @@ export const serverFixtures: Fixtures<ServerFixtures, ServerWorkerOptions> = {
 
     const socksServer = new MockSocksServer();
     const socksPort = port + 2;
-    await socksServer.listen(socksPort, loopback);
+    await socksServer.listen(socksPort);
 
     const proxyPort = port + 3;
     const proxyServer = await TestProxy.create(proxyPort);
@@ -124,7 +124,7 @@ export class MockSocksServer {
     });
   }
 
-  async listen(port: number, hostname: string) {
+  async listen(port: number, hostname?: string) {
     await this._socksProxy.listen(port, hostname);
   }
 


### PR DESCRIPTION
This regressed in 042161e1ce4040a3a03b00a214a7f010c41da995 and aligns it now how we do it with a [normal http(s) server](https://github.com/microsoft/playwright/blob/cdcaa7fab64e13ed08b3930074f06422793ec34d/tests/config/testserver/index.ts#L108).

For reference:

1. (Pre 042161e1ce4040a3a03b00a214a7f010c41da995) We used to have `127.0.0.1`.
1. (ToT) We changed it to `loopback` which is undefined for `!= Android`.
1. (this PR) And now its undefined for Android as well.