### PR TITLE
docs: update to "Matching one of the two alternative locators" section

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -1218,7 +1218,7 @@ var button = page.GetByRole(AriaRole.Button).And(page.GetByTitle("Subscribe"));
 
 ### Matching one of the two alternative locators
 
-If you'd like to target one of the two or more elements, and you don't know which one it will be, use [`method: Locator.or`] to create a locator that matches any one of the alternatives.
+If you'd like to target one of the two or more elements, and you don't know which one it will be, use [`method: Locator.or`] to create a locator that matches any one or both of the alternatives.
 
 For example, consider a scenario where you'd like to click on a "New email" button, but sometimes a security settings dialog shows up instead. In this case, you can wait for either a "New email" button, or a dialog and act accordingly.
 

--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -1218,7 +1218,7 @@ var button = page.GetByRole(AriaRole.Button).And(page.GetByTitle("Subscribe"));
 
 ### Matching one of the two alternative locators
 
-If you'd like to target one of the two or more elements, and you don't know which one it will be, use [`method: Locator.or`] to create a locator that matches all of the alternatives.
+If you'd like to target one of the two or more elements, and you don't know which one it will be, use [`method: Locator.or`] to create a locator that matches any one of the alternatives.
 
 For example, consider a scenario where you'd like to click on a "New email" button, but sometimes a security settings dialog shows up instead. In this case, you can wait for either a "New email" button, or a dialog and act accordingly.
 


### PR DESCRIPTION
The section for "Matching one of the two alternative locators" mentioned "matching all of the alternatives". However, since we are using or() operator, it should match "any one of the alternatives" to locate the element.

![update_locators md_file](https://github.com/user-attachments/assets/721a4b54-4e60-429b-bc92-48547b770f4f)

@playwrightmachine If my understanding is wrong, kindly correct me.
