### PR TITLE
feat(tracing) Adding groups to trace via pw-api

### DIFF
--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -302,7 +302,7 @@ Group name shown in the trace viewer.
 ## async method: Tracing.groupEnd
 * since: v1.49
 
-Closes the last opened inline group in the trace log.
+Closes the last opened inline group in the trace.
 
 ## async method: Tracing.stop
 * since: v1.12

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -284,7 +284,7 @@ To specify the final trace zip file name, you need to pass `path` option to
 ## async method: Tracing.group
 * since: v1.49
 
-Creates a new inline group in the trace, causing any subsequent calls to belong to this group, until [`method: Tracing.groupEnd`] is called.
+Creates a new inline group within the trace, assigning any subsequent calls to this group until [method: Tracing.groupEnd] is invoked.
 
 Groups can be nested and are similar to `test.step` in trace.
 However, groups are only visualized in the trace viewer and, unlike test.step, have no effect on the test reports.

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -286,11 +286,35 @@ To specify the final trace zip file name, you need to pass `path` option to
 
 Creates a new inline group in the trace, causing any subsequent calls to belong to this group, until [`method: Tracing.groupEnd`] is called.
 
+Groups can be nested and are similar to `test.step` in trace.
+However, groups are only visualized in the trace viewer and, unlike test.step, have no effect on the test reports.
+
+:::note Groups should not be used with Playwright Test!
+
+This API is intended for Playwright API users that can not use `test.step`.
+:::
+
+**Usage**
+
+```js
+await context.tracing.start({ screenshots: true, snapshots: true });
+await context.tracing.group('Open Playwright.dev');
+// All actions between group and groupEnd will be shown in the trace viewer as a group.
+const page = await context.newPage();
+await page.goto('https://playwright.dev/');
+await context.tracing.groupEnd();
+await context.tracing.group('Open API Docs of Tracing');
+await page.getByRole('link', { name: 'API' }).click();
+await page.getByRole('link', { name: 'Tracing' }).click();
+await context.tracing.groupEnd();
+// This Trace will have two groups: 'Open Playwright.dev' and 'Open API Docs of Tracing'.
+```
+
 ### param: Tracing.group.name
 * since: v1.49
 - `name` <[string]>
 
-Group name shown in the trace viewer.
+Group name shown in the actions tree in trace viewer.
 
 ### option: Tracing.group.location
 * since: v1.49
@@ -299,10 +323,13 @@ Group name shown in the trace viewer.
   - `line` ?<[int]> Line number in the source file.
   - `column` ?<[int]> Column number in the source file
 
+Specifies a custom location for the group start to be shown in source tab in trace viewer.
+By default, location of the tracing.group() call is shown.
+
 ## async method: Tracing.groupEnd
 * since: v1.49
 
-Closes the last opened inline group in the trace.
+Closes the currently open inline group in the trace.
 
 ## async method: Tracing.stop
 * since: v1.12

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -281,6 +281,29 @@ given name prefix inside the [`option: BrowserType.launch.tracesDir`] directory 
 To specify the final trace zip file name, you need to pass `path` option to
 [`method: Tracing.stopChunk`] instead.
 
+## async method: Tracing.group
+* since: v1.49
+
+Creates a new inline group in the trace log, causing any subsequent calls to be indented by an additional level, until [`method: Tracing.groupEnd`] is called.
+
+### param: Tracing.group.name
+* since: v1.49
+- `name` <[string]>
+
+Group name shown in the trace viewer.
+
+### option: Tracing.group.location
+* since: v1.49
+- `location` ?<[Object]>
+  - `file` <[string]> Source file path to be shown in the trace viewer source tab.
+  - `line` ?<[int]> Line number in the source file.
+  - `column` ?<[int]> Column number in the source file
+
+## async method: Tracing.groupEnd
+* since: v1.49
+
+Closes the last opened inline group in the trace log.
+
 ## async method: Tracing.stop
 * since: v1.12
 

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -284,7 +284,7 @@ To specify the final trace zip file name, you need to pass `path` option to
 ## async method: Tracing.group
 * since: v1.49
 
-Creates a new inline group in the trace log, causing any subsequent calls to be indented by an additional level, until [`method: Tracing.groupEnd`] is called.
+Creates a new inline group in the trace, causing any subsequent calls to belong to this group, until [`method: Tracing.groupEnd`] is called.
 
 ### param: Tracing.group.name
 * since: v1.49

--- a/packages/playwright-core/src/client/channelOwner.ts
+++ b/packages/playwright-core/src/client/channelOwner.ts
@@ -168,7 +168,7 @@ export abstract class ChannelOwner<T extends channels.Channel = channels.Channel
     return channel;
   }
 
-  async _wrapApiCall<R>(func: (apiZone: ApiZone) => Promise<R>, isInternal = false): Promise<R> {
+  async _wrapApiCall<R>(func: (apiZone: ApiZone) => Promise<R>, isInternal?: boolean): Promise<R> {
     const logger = this._logger;
     const apiZone = zones.zoneData<ApiZone>('apiZone');
     if (apiZone)
@@ -178,7 +178,8 @@ export abstract class ChannelOwner<T extends channels.Channel = channels.Channel
     let apiName: string | undefined = stackTrace.apiName;
     const frames: channels.StackFrame[] = stackTrace.frames;
 
-    isInternal = isInternal || this._isInternalType;
+    if (isInternal === undefined)
+      isInternal = this._isInternalType;
     if (isInternal)
       apiName = undefined;
 

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -18,8 +18,7 @@ import type * as api from '../../types/types';
 import type * as channels from '@protocol/channels';
 import { Artifact } from './artifact';
 import { ChannelOwner } from './channelOwner';
-import { captureRawStack } from '../utils';
-import { filteredStackTrace } from 'playwright/lib/util';
+import { captureRawStack, filteredStackTrace } from '../utils';
 
 export class Tracing extends ChannelOwner<channels.TracingChannel> implements api.Tracing {
   private _includeSources = false;

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -18,6 +18,8 @@ import type * as api from '../../types/types';
 import type * as channels from '@protocol/channels';
 import { Artifact } from './artifact';
 import { ChannelOwner } from './channelOwner';
+import { captureRawStack } from '../utils';
+import { filteredStackTrace } from 'playwright/lib/util';
 
 export class Tracing extends ChannelOwner<channels.TracingChannel> implements api.Tracing {
   private _includeSources = false;
@@ -52,6 +54,10 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
   }
 
   async group(name: string, options: { location?: { file: string, line?: number, column?: number } } = {}) {
+    if (!options.location) {
+      const filteredStack = filteredStackTrace(captureRawStack());
+      options.location = filteredStack[0];
+    }
     await this._channel.tracingGroup({ name, options });
   }
 

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -52,11 +52,15 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
   }
 
   async group(name: string, options: { location?: { file: string, line?: number, column?: number } } = {}) {
-    await this._channel.tracingGroup({ name, location: options.location });
+    await this._wrapApiCall(async () => {
+      await this._channel.tracingGroup({ name, location: options.location });
+    }, false);
   }
 
   async groupEnd() {
-    await this._channel.tracingGroupEnd();
+    await this._wrapApiCall(async () => {
+      await this._channel.tracingGroupEnd();
+    }, false);
   }
 
   private async _startCollectingStacks(traceName: string) {

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -51,7 +51,7 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
     await this._startCollectingStacks(traceName);
   }
 
-  async group(name: string, options: { location?: string } = {}) {
+  async group(name: string, options: { location?: { file: string, line?: number, column?: number } } = {}) {
     await this._channel.tracingGroup({ name, options });
   }
 

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -52,7 +52,7 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
   }
 
   async group(name: string, options: { location?: { file: string, line?: number, column?: number } } = {}) {
-    await this._channel.tracingGroup({ name, options });
+    await this._channel.tracingGroup({ name, location: options.location });
   }
 
   async groupEnd() {

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -18,7 +18,6 @@ import type * as api from '../../types/types';
 import type * as channels from '@protocol/channels';
 import { Artifact } from './artifact';
 import { ChannelOwner } from './channelOwner';
-import { captureRawStack, filteredStackTrace } from '../utils';
 
 export class Tracing extends ChannelOwner<channels.TracingChannel> implements api.Tracing {
   private _includeSources = false;
@@ -53,10 +52,6 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
   }
 
   async group(name: string, options: { location?: { file: string, line?: number, column?: number } } = {}) {
-    if (!options.location) {
-      const filteredStack = filteredStackTrace(captureRawStack());
-      options.location = filteredStack[0];
-    }
     await this._channel.tracingGroup({ name, options });
   }
 

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -51,6 +51,14 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
     await this._startCollectingStacks(traceName);
   }
 
+  async group(name: string, options: { location?: string } = {}) {
+    await this._channel.tracingGroup({ name, options });
+  }
+
+  async groupEnd() {
+    await this._channel.tracingGroupEnd();
+  }
+
   private async _startCollectingStacks(traceName: string) {
     if (!this._isTracing) {
       this._isTracing = true;

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -2280,6 +2280,9 @@ scheme.DialogAcceptParams = tObject({
 scheme.DialogAcceptResult = tOptional(tObject({}));
 scheme.DialogDismissParams = tOptional(tObject({}));
 scheme.DialogDismissResult = tOptional(tObject({}));
+scheme.TracingGroupOptions = tObject({
+  location: tString,
+});
 scheme.TracingInitializer = tOptional(tObject({}));
 scheme.TracingTracingStartParams = tObject({
   name: tOptional(tString),
@@ -2295,6 +2298,13 @@ scheme.TracingTracingStartChunkParams = tObject({
 scheme.TracingTracingStartChunkResult = tObject({
   traceName: tString,
 });
+scheme.TracingTracingGroupParams = tObject({
+  name: tString,
+  options: tType('TracingGroupOptions'),
+});
+scheme.TracingTracingGroupResult = tOptional(tObject({}));
+scheme.TracingTracingGroupEndParams = tOptional(tObject({}));
+scheme.TracingTracingGroupEndResult = tOptional(tObject({}));
 scheme.TracingTracingStopChunkParams = tObject({
   mode: tEnum(['archive', 'discard', 'entries']),
 });

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -26,12 +26,13 @@ scheme.StackFrame = tObject({
   column: tNumber,
   function: tOptional(tString),
 });
+scheme.Location = tObject({
+  file: tString,
+  line: tOptional(tNumber),
+  column: tOptional(tNumber),
+});
 scheme.Metadata = tObject({
-  location: tOptional(tObject({
-    file: tString,
-    line: tOptional(tNumber),
-    column: tOptional(tNumber),
-  })),
+  location: tOptional(tType('Location')),
   apiName: tOptional(tString),
   internal: tOptional(tBoolean),
   stepId: tOptional(tString),
@@ -2281,7 +2282,7 @@ scheme.DialogAcceptResult = tOptional(tObject({}));
 scheme.DialogDismissParams = tOptional(tObject({}));
 scheme.DialogDismissResult = tOptional(tObject({}));
 scheme.TracingGroupOptions = tObject({
-  location: tString,
+  location: tOptional(tType('Location')),
 });
 scheme.TracingInitializer = tOptional(tObject({}));
 scheme.TracingTracingStartParams = tObject({

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -26,13 +26,12 @@ scheme.StackFrame = tObject({
   column: tNumber,
   function: tOptional(tString),
 });
-scheme.Location = tObject({
-  file: tString,
-  line: tOptional(tNumber),
-  column: tOptional(tNumber),
-});
 scheme.Metadata = tObject({
-  location: tOptional(tType('Location')),
+  location: tOptional(tObject({
+    file: tString,
+    line: tOptional(tNumber),
+    column: tOptional(tNumber),
+  })),
   apiName: tOptional(tString),
   internal: tOptional(tBoolean),
   stepId: tOptional(tString),
@@ -2281,9 +2280,6 @@ scheme.DialogAcceptParams = tObject({
 scheme.DialogAcceptResult = tOptional(tObject({}));
 scheme.DialogDismissParams = tOptional(tObject({}));
 scheme.DialogDismissResult = tOptional(tObject({}));
-scheme.TracingGroupOptions = tObject({
-  location: tOptional(tType('Location')),
-});
 scheme.TracingInitializer = tOptional(tObject({}));
 scheme.TracingTracingStartParams = tObject({
   name: tOptional(tString),
@@ -2301,7 +2297,11 @@ scheme.TracingTracingStartChunkResult = tObject({
 });
 scheme.TracingTracingGroupParams = tObject({
   name: tString,
-  options: tType('TracingGroupOptions'),
+  location: tOptional(tObject({
+    file: tString,
+    line: tOptional(tNumber),
+    column: tOptional(tNumber),
+  })),
 });
 scheme.TracingTracingGroupResult = tOptional(tObject({}));
 scheme.TracingTracingGroupEndParams = tOptional(tObject({}));

--- a/packages/playwright-core/src/server/dispatchers/tracingDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/tracingDispatcher.ts
@@ -15,6 +15,7 @@
  */
 
 import type * as channels from '@protocol/channels';
+import type { CallMetadata } from '@protocol/callMetadata';
 import type { Tracing } from '../trace/recorder/tracing';
 import { ArtifactDispatcher } from './artifactDispatcher';
 import { Dispatcher, existingDispatcher } from './dispatcher';
@@ -41,9 +42,9 @@ export class TracingDispatcher extends Dispatcher<Tracing, channels.TracingChann
     return await this._object.startChunk(params);
   }
 
-  async tracingGroup(params: channels.TracingTracingGroupParams): Promise<channels.TracingTracingGroupResult> {
+  async tracingGroup(params: channels.TracingTracingGroupParams, metadata: CallMetadata): Promise<channels.TracingTracingGroupResult> {
     const { name, options } = params;
-    await this._object.group(name, options);
+    await this._object.group(name, options, metadata);
   }
 
   async tracingGroupEnd(params: channels.TracingTracingGroupEndParams): Promise<channels.TracingTracingGroupEndResult> {

--- a/packages/playwright-core/src/server/dispatchers/tracingDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/tracingDispatcher.ts
@@ -43,8 +43,8 @@ export class TracingDispatcher extends Dispatcher<Tracing, channels.TracingChann
   }
 
   async tracingGroup(params: channels.TracingTracingGroupParams, metadata: CallMetadata): Promise<channels.TracingTracingGroupResult> {
-    const { name, options } = params;
-    await this._object.group(name, options, metadata);
+    const { name, location } = params;
+    await this._object.group(name, location, metadata);
   }
 
   async tracingGroupEnd(params: channels.TracingTracingGroupEndParams): Promise<channels.TracingTracingGroupEndResult> {

--- a/packages/playwright-core/src/server/dispatchers/tracingDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/tracingDispatcher.ts
@@ -33,12 +33,26 @@ export class TracingDispatcher extends Dispatcher<Tracing, channels.TracingChann
     super(scope, tracing, 'Tracing', {});
   }
 
+  // async start(options: TracerOptions) {
   async tracingStart(params: channels.TracingTracingStartParams): Promise<channels.TracingTracingStartResult> {
     await this._object.start(params);
   }
 
+  // async startChunk(options: { name?: string, title?: string } = {}): Promise<{ traceName: string }> {
   async tracingStartChunk(params: channels.TracingTracingStartChunkParams): Promise<channels.TracingTracingStartChunkResult> {
     return await this._object.startChunk(params);
+  }
+
+
+  // async group(name: string, options: { location?: string } = {}): Promise<void> {
+  async tracingGroup(params: channels.TracingTracingGroupParams): Promise<channels.TracingTracingGroupResult> {
+    const { name, options } = params;
+    await this._object.group(name, options);
+  }
+
+  // async groupEnd(): Promise<void> {
+  async tracingGroupEnd(params: channels.TracingTracingGroupEndParams): Promise<channels.TracingTracingGroupEndResult> {
+    await this._object.groupEnd();
   }
 
   async tracingStopChunk(params: channels.TracingTracingStopChunkParams): Promise<channels.TracingTracingStopChunkResult> {

--- a/packages/playwright-core/src/server/dispatchers/tracingDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/tracingDispatcher.ts
@@ -33,24 +33,19 @@ export class TracingDispatcher extends Dispatcher<Tracing, channels.TracingChann
     super(scope, tracing, 'Tracing', {});
   }
 
-  // async start(options: TracerOptions) {
   async tracingStart(params: channels.TracingTracingStartParams): Promise<channels.TracingTracingStartResult> {
     await this._object.start(params);
   }
 
-  // async startChunk(options: { name?: string, title?: string } = {}): Promise<{ traceName: string }> {
   async tracingStartChunk(params: channels.TracingTracingStartChunkParams): Promise<channels.TracingTracingStartChunkResult> {
     return await this._object.startChunk(params);
   }
 
-
-  // async group(name: string, options: { location?: string } = {}): Promise<void> {
   async tracingGroup(params: channels.TracingTracingGroupParams): Promise<channels.TracingTracingGroupResult> {
     const { name, options } = params;
     await this._object.group(name, options);
   }
 
-  // async groupEnd(): Promise<void> {
   async tracingGroupEnd(params: channels.TracingTracingGroupEndParams): Promise<channels.TracingTracingGroupEndResult> {
     await this._object.groupEnd();
   }

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -196,11 +196,11 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     return { traceName: this._state.traceName };
   }
 
-  async group(name: string, options: { location?: { file: string, line?: number, column?: number } } = {}, metadata: CallMetadata): Promise<void> {
+  async group(name: string, location: { file: string, line?: number, column?: number } | undefined, metadata: CallMetadata): Promise<void> {
     if (!this._state)
       return;
     const stackFrames: StackFrame[] = [];
-    const { file, line, column } = options.location ?? metadata.location ?? {};
+    const { file, line, column } = location ?? metadata.location ?? {};
     if (file) {
       stackFrames.push({
         file,

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -280,6 +280,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       throw new Error(`Tracing is already stopping`);
     if (this._state.recording)
       throw new Error(`Must stop trace file before stopping tracing`);
+    await this._closeAllGroups();
     this._harTracer.stop();
     this.flushHarEntries();
     await this._fs.syncAndGetError();

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -214,8 +214,9 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       startTime: metadata.startTime,
       apiName: name,
       class: 'Tracing',
-      method: 'group',
+      method: 'tracingGroup',
       params: { },
+      stepId: metadata.stepId,
       stack: stackFrames,
     };
     if (this._state.groupStack.length)

--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -47,6 +47,25 @@ export function captureRawStack(): RawStack {
   return stack.split('\n');
 }
 
+export function filterStackFile(file: string) {
+  if (!process.env.PWDEBUGIMPL && file.startsWith(CORE_DIR))
+    return false;
+  return true;
+}
+
+export function filteredStackTrace(rawStack: RawStack): StackFrame[] {
+  const frames: StackFrame[] = [];
+  for (const line of rawStack) {
+    const frame = parseStackTraceLine(line);
+    if (!frame || !frame.file)
+      continue;
+    if (!filterStackFile(frame.file))
+      continue;
+    frames.push(frame);
+  }
+  return frames;
+}
+
 export function captureLibraryStackTrace(): { frames: StackFrame[], apiName: string } {
   const stack = captureRawStack();
 

--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -47,25 +47,6 @@ export function captureRawStack(): RawStack {
   return stack.split('\n');
 }
 
-export function filterStackFile(file: string) {
-  if (!process.env.PWDEBUGIMPL && file.startsWith(CORE_DIR))
-    return false;
-  return true;
-}
-
-export function filteredStackTrace(rawStack: RawStack): StackFrame[] {
-  const frames: StackFrame[] = [];
-  for (const line of rawStack) {
-    const frame = parseStackTraceLine(line);
-    if (!frame || !frame.file)
-      continue;
-    if (!filterStackFile(frame.file))
-      continue;
-    frames.push(frame);
-  }
-  return frames;
-}
-
 export function captureLibraryStackTrace(): { frames: StackFrame[], apiName: string } {
   const stack = captureRawStack();
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21062,16 +21062,17 @@ export interface Tracing {
    * Creates a new inline group in the trace, causing any subsequent calls to belong to this group, until
    * [tracing.groupEnd()](https://playwright.dev/docs/api/class-tracing#tracing-group-end) is called.
    *
-   * Groups can be nested and are similar to [test.step()](https://playwright.dev/docs/api/class-test#test-step) in trace.
-   * However, groups are only visualized in the trace viewer and, unlike test.step, have no effect on the test reports.
+   * Groups can be nested and are similar to `test.step` in trace. However, groups are only visualized in the trace
+   * viewer and, unlike test.step, have no effect on the test reports.
    *
-   * **NOTE** Groups should not be used with Playwright Test! This API is intended for Playwright API users that can not use [test.step()](https://playwright.dev/docs/api/class-test#test-step).
-   *
+   * **NOTE** This API is intended for Playwright API users that can not use `test.step`.
    *
    * **Usage**
+   *
    * ```js
    * await context.tracing.start({ screenshots: true, snapshots: true });
    * await context.tracing.group('Open Playwright.dev');
+   * // All actions between group and groupEnd will be shown in the trace viewer as a group.
    * const page = await context.newPage();
    * await page.goto('https://playwright.dev/');
    * await context.tracing.groupEnd();
@@ -21079,6 +21080,7 @@ export interface Tracing {
    * await page.getByRole('link', { name: 'API' }).click();
    * await page.getByRole('link', { name: 'Tracing' }).click();
    * await context.tracing.groupEnd();
+   * // This Trace will have two groups: 'Open Playwright.dev' and 'Open API Docs of Tracing'.
    * ```
    *
    * @param name Group name shown in the actions tree in trace viewer.
@@ -21086,8 +21088,8 @@ export interface Tracing {
    */
   group(name: string, options?: {
     /**
-     * Specifies a custom location for the group start to be shown in source tab in trace viewer.
-     * By default, location of the tracing.group() call is shown.
+     * Specifies a custom location for the group start to be shown in source tab in trace viewer. By default, location of
+     * the tracing.group() call is shown.
      */
     location?: {
       /**
@@ -21109,7 +21111,6 @@ export interface Tracing {
 
   /**
    * Closes the currently open inline group in the trace.
-   *
    */
   groupEnd(): Promise<void>;
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21059,6 +21059,36 @@ export interface Touchscreen {
  */
 export interface Tracing {
   /**
+   * Creates a new inline group in the trace log, causing any subsequent calls to be indented by an additional level,
+   * until [tracing.groupEnd()](https://playwright.dev/docs/api/class-tracing#tracing-group-end) is called.
+   * @param name Group name shown in the trace viewer.
+   * @param options
+   */
+  group(name: string, options?: {
+    location?: {
+      /**
+       * Source file path to be shown in the trace viewer source tab.
+       */
+      file: string;
+
+      /**
+       * Line number in the source file.
+       */
+      line?: number;
+
+      /**
+       * Column number in the source file
+       */
+      column?: number;
+    };
+  }): Promise<void>;
+
+  /**
+   * Closes the last opened inline group in the trace log.
+   */
+  groupEnd(): Promise<void>;
+
+  /**
    * Start tracing.
    *
    * **Usage**

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21059,8 +21059,8 @@ export interface Touchscreen {
  */
 export interface Tracing {
   /**
-   * Creates a new inline group in the trace log, causing any subsequent calls to be indented by an additional level,
-   * until [tracing.groupEnd()](https://playwright.dev/docs/api/class-tracing#tracing-group-end) is called.
+   * Creates a new inline group in the trace, causing any subsequent calls to belong to this group, until
+   * [tracing.groupEnd()](https://playwright.dev/docs/api/class-tracing#tracing-group-end) is called.
    * @param name Group name shown in the trace viewer.
    * @param options
    */
@@ -21084,7 +21084,7 @@ export interface Tracing {
   }): Promise<void>;
 
   /**
-   * Closes the last opened inline group in the trace log.
+   * Closes the last opened inline group in the trace.
    */
   groupEnd(): Promise<void>;
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21061,10 +21061,34 @@ export interface Tracing {
   /**
    * Creates a new inline group in the trace, causing any subsequent calls to belong to this group, until
    * [tracing.groupEnd()](https://playwright.dev/docs/api/class-tracing#tracing-group-end) is called.
-   * @param name Group name shown in the trace viewer.
+   *
+   * Groups can be nested and are similar to [test.step()](https://playwright.dev/docs/api/class-test#test-step) in trace.
+   * However, groups are only visualized in the trace viewer and, unlike test.step, have no effect on the test reports.
+   *
+   * **NOTE** Groups should not be used with Playwright Test! This API is intended for Playwright API users that can not use [test.step()](https://playwright.dev/docs/api/class-test#test-step).
+   *
+   *
+   * **Usage**
+   * ```js
+   * await context.tracing.start({ screenshots: true, snapshots: true });
+   * await context.tracing.group('Open Playwright.dev');
+   * const page = await context.newPage();
+   * await page.goto('https://playwright.dev/');
+   * await context.tracing.groupEnd();
+   * await context.tracing.group('Open API Docs of Tracing');
+   * await page.getByRole('link', { name: 'API' }).click();
+   * await page.getByRole('link', { name: 'Tracing' }).click();
+   * await context.tracing.groupEnd();
+   * ```
+   *
+   * @param name Group name shown in the actions tree in trace viewer.
    * @param options
    */
   group(name: string, options?: {
+    /**
+     * Specifies a custom location for the group start to be shown in source tab in trace viewer.
+     * By default, location of the tracing.group() call is shown.
+     */
     location?: {
       /**
        * Source file path to be shown in the trace viewer source tab.
@@ -21084,7 +21108,8 @@ export interface Tracing {
   }): Promise<void>;
 
   /**
-   * Closes the last opened inline group in the trace.
+   * Closes the currently open inline group in the trace.
+   *
    */
   groupEnd(): Promise<void>;
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21059,8 +21059,8 @@ export interface Touchscreen {
  */
 export interface Tracing {
   /**
-   * Creates a new inline group in the trace, causing any subsequent calls to belong to this group, until
-   * [tracing.groupEnd()](https://playwright.dev/docs/api/class-tracing#tracing-group-end) is called.
+   * Creates a new inline group within the trace, assigning any subsequent calls to this group until
+   * [method: Tracing.groupEnd] is invoked.
    *
    * Groups can be nested and are similar to `test.step` in trace. However, groups are only visualized in the trace
    * viewer and, unlike test.step, have no effect on the test reports.

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -256,7 +256,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
     const artifactsRecorder = new ArtifactsRecorder(playwright, tracing().artifactsDir(), screenshot);
     await artifactsRecorder.willStartTest(testInfo as TestInfoImpl);
 
-    let tracingGroupSteps: TestStepInternal[] = [];
+    const tracingGroupSteps: TestStepInternal[] = [];
     const csiListener: ClientInstrumentationListener = {
       onApiCallBegin: (apiName: string, params: Record<string, any>, frames: StackFrame[], userData: any, out: { stepId?: string }) => {
         const testInfo = currentTestInfo();

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -20,7 +20,7 @@ import type { APIRequestContext, BrowserContext, Browser, BrowserContextOptions,
 import * as playwrightLibrary from 'playwright-core';
 import { createGuid, debugMode, addInternalStackPrefix, isString, asLocator, jsonStringifyForceASCII } from 'playwright-core/lib/utils';
 import type { Fixtures, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, ScreenshotMode, TestInfo, TestType, VideoMode } from '../types/test';
-import type { TestInfoImpl } from './worker/testInfo';
+import type { TestInfoImpl, TestStepInternal } from './worker/testInfo';
 import { rootTestType } from './common/testType';
 import type { ContextReuseMode } from './common/config';
 import type { ClientInstrumentation, ClientInstrumentationListener } from '../../playwright-core/src/client/clientInstrumentation';
@@ -255,20 +255,28 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
 
     const artifactsRecorder = new ArtifactsRecorder(playwright, tracing().artifactsDir(), screenshot);
     await artifactsRecorder.willStartTest(testInfo as TestInfoImpl);
+
+    let tracingGroupSteps: TestStepInternal[] = [];
     const csiListener: ClientInstrumentationListener = {
       onApiCallBegin: (apiName: string, params: Record<string, any>, frames: StackFrame[], userData: any, out: { stepId?: string }) => {
         const testInfo = currentTestInfo();
         if (!testInfo || apiName.includes('setTestIdAttribute'))
           return { userObject: null };
+        if (apiName === 'tracing.groupEnd') {
+          tracingGroupSteps.pop();
+          return { userObject: null };
+        }
         const step = testInfo._addStep({
           location: frames[0] as any,
           category: 'pw:api',
           title: renderApiCall(apiName, params),
           apiName,
           params,
-        });
+        }, tracingGroupSteps[tracingGroupSteps.length - 1]);
         userData.userObject = step;
         out.stepId = step.stepId;
+        if (apiName === 'tracing.group')
+          tracingGroupSteps.push(step);
       },
       onApiCallEnd: (userData: any, error?: Error) => {
         const step = userData.userObject;

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -237,15 +237,15 @@ export class TestInfoImpl implements TestInfo {
     }
   }
 
-  _addStep(data: Omit<TestStepInternal, 'complete' | 'stepId' | 'steps'>): TestStepInternal {
+  _addStep(data: Omit<TestStepInternal, 'complete' | 'stepId' | 'steps'>, parentStep?: TestStepInternal): TestStepInternal {
     const stepId = `${data.category}@${++this._lastStepId}`;
 
-    let parentStep: TestStepInternal | undefined;
     if (data.isStage) {
       // Predefined stages form a fixed hierarchy - use the current one as parent.
       parentStep = this._findLastStageStep(this._steps);
     } else {
-      parentStep = zones.zoneData<TestStepInternal>('stepZone');
+      if (!parentStep)
+        parentStep = zones.zoneData<TestStepInternal>('stepZone');
       if (!parentStep) {
         // If no parent step on stack, assume the current stage as parent.
         parentStep = this._findLastStageStep(this._steps);

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -144,14 +144,12 @@ export type StackFrame = {
   function?: string,
 };
 
-export type Location = {
-  file: string,
-  line?: number,
-  column?: number,
-};
-
 export type Metadata = {
-  location?: Location,
+  location?: {
+    file: string,
+    line?: number,
+    column?: number,
+  },
   apiName?: string,
   internal?: boolean,
   stepId?: string,
@@ -4079,10 +4077,6 @@ export type DialogDismissResult = void;
 export interface DialogEvents {
 }
 
-export type TracingGroupOptions = {
-  location?: Location,
-};
-
 // ----------- Tracing -----------
 export type TracingInitializer = {};
 export interface TracingEventTarget {
@@ -4122,10 +4116,18 @@ export type TracingTracingStartChunkResult = {
 };
 export type TracingTracingGroupParams = {
   name: string,
-  options: TracingGroupOptions,
+  location?: {
+    file: string,
+    line?: number,
+    column?: number,
+  },
 };
 export type TracingTracingGroupOptions = {
-
+  location?: {
+    file: string,
+    line?: number,
+    column?: number,
+  },
 };
 export type TracingTracingGroupResult = void;
 export type TracingTracingGroupEndParams = {};

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -4077,6 +4077,10 @@ export type DialogDismissResult = void;
 export interface DialogEvents {
 }
 
+export type TracingGroupOptions = {
+  location: string,
+};
+
 // ----------- Tracing -----------
 export type TracingInitializer = {};
 export interface TracingEventTarget {
@@ -4085,6 +4089,8 @@ export interface TracingChannel extends TracingEventTarget, Channel {
   _type_Tracing: boolean;
   tracingStart(params: TracingTracingStartParams, metadata?: CallMetadata): Promise<TracingTracingStartResult>;
   tracingStartChunk(params: TracingTracingStartChunkParams, metadata?: CallMetadata): Promise<TracingTracingStartChunkResult>;
+  tracingGroup(params: TracingTracingGroupParams, metadata?: CallMetadata): Promise<TracingTracingGroupResult>;
+  tracingGroupEnd(params?: TracingTracingGroupEndParams, metadata?: CallMetadata): Promise<TracingTracingGroupEndResult>;
   tracingStopChunk(params: TracingTracingStopChunkParams, metadata?: CallMetadata): Promise<TracingTracingStopChunkResult>;
   tracingStop(params?: TracingTracingStopParams, metadata?: CallMetadata): Promise<TracingTracingStopResult>;
 }
@@ -4112,6 +4118,17 @@ export type TracingTracingStartChunkOptions = {
 export type TracingTracingStartChunkResult = {
   traceName: string,
 };
+export type TracingTracingGroupParams = {
+  name: string,
+  options: TracingGroupOptions,
+};
+export type TracingTracingGroupOptions = {
+
+};
+export type TracingTracingGroupResult = void;
+export type TracingTracingGroupEndParams = {};
+export type TracingTracingGroupEndOptions = {};
+export type TracingTracingGroupEndResult = void;
 export type TracingTracingStopChunkParams = {
   mode: 'archive' | 'discard' | 'entries',
 };

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -144,12 +144,14 @@ export type StackFrame = {
   function?: string,
 };
 
+export type Location = {
+  file: string,
+  line?: number,
+  column?: number,
+};
+
 export type Metadata = {
-  location?: {
-    file: string,
-    line?: number,
-    column?: number,
-  },
+  location?: Location,
   apiName?: string,
   internal?: boolean,
   stepId?: string,
@@ -4078,7 +4080,7 @@ export interface DialogEvents {
 }
 
 export type TracingGroupOptions = {
-  location: string,
+  location?: Location,
 };
 
 // ----------- Tracing -----------

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -3176,6 +3176,7 @@ Dialog:
 
     dismiss:
 
+
 Tracing:
   type: interface
 

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -3177,6 +3177,11 @@ Dialog:
     dismiss:
 
 
+TracingGroupOptions:
+  type: object
+  properties:
+    location: string
+
 Tracing:
   type: interface
 
@@ -3195,6 +3200,13 @@ Tracing:
         title: string?
       returns:
         traceName: string
+
+    tracingGroup:
+      parameters:
+        name: string
+        options: TracingGroupOptions
+
+    tracingGroupEnd:
 
     tracingStopChunk:
       parameters:

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -20,19 +20,17 @@ StackFrame:
     column: number
     function: string?
 
-Location:
-  type: object
-  properties:
-    file: string
-    line: number?
-    column: number?
-
 # This object can be send with any rpc call in the "metadata" field.
 
 Metadata:
   type: object
   properties:
-    location: Location?
+    location:
+      type: object?
+      properties:
+        file: string
+        line: number?
+        column: number?
     apiName: string?
     internal: boolean?
     # Test runner step id.
@@ -3178,12 +3176,6 @@ Dialog:
 
     dismiss:
 
-
-TracingGroupOptions:
-  type: object
-  properties:
-    location: Location?
-
 Tracing:
   type: interface
 
@@ -3206,7 +3198,12 @@ Tracing:
     tracingGroup:
       parameters:
         name: string
-        options: TracingGroupOptions
+        location:
+          type: object?
+          properties:
+            file: string
+            line: number?
+            column: number?
 
     tracingGroupEnd:
 

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -20,17 +20,19 @@ StackFrame:
     column: number
     function: string?
 
+Location:
+  type: object
+  properties:
+    file: string
+    line: number?
+    column: number?
+
 # This object can be send with any rpc call in the "metadata" field.
 
 Metadata:
   type: object
   properties:
-    location:
-      type: object?
-      properties:
-        file: string
-        line: number?
-        column: number?
+    location: Location?
     apiName: string?
     internal: boolean?
     # Test runner step id.
@@ -3180,7 +3182,7 @@ Dialog:
 TracingGroupOptions:
   type: object
   properties:
-    location: string
+    location: Location?
 
 Tracing:
   type: interface

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -36,6 +36,7 @@ export type TraceViewerFixtures = {
 
 class TraceViewerPage {
   actionTitles: Locator;
+  actionsTree: Locator;
   callLines: Locator;
   consoleLines: Locator;
   logLines: Locator;
@@ -46,9 +47,11 @@ class TraceViewerPage {
   networkRequests: Locator;
   metadataTab: Locator;
   snapshotContainer: Locator;
+  sourceCodeTab: Locator;
 
   constructor(public page: Page) {
     this.actionTitles = page.locator('.action-title');
+    this.actionsTree = page.getByTestId('actions-tree');
     this.callLines = page.locator('.call-tab .call-line');
     this.logLines = page.getByTestId('log-list').locator('.list-view-entry');
     this.consoleLines = page.locator('.console-line');
@@ -59,6 +62,7 @@ class TraceViewerPage {
     this.networkRequests = page.getByTestId('network-list').locator('.list-view-entry');
     this.snapshotContainer = page.locator('.snapshot-container iframe.snapshot-visible[name=snapshot]');
     this.metadataTab = page.getByTestId('metadata-view');
+    this.sourceCodeTab = page.getByTestId('source-code');
   }
 
   async actionIconsText(action: string) {

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -62,15 +62,6 @@ test.beforeAll(async function recordTrace({ browser, browserName, browserType, s
   }
   await doClick();
 
-  await context.tracing.group('High-level Group');
-  await context.tracing.group('First Mid-level Group', { location: { file: `${__dirname}/tracing.spec.ts`, line: 100, column: 10 } });
-  await page.locator('button >> nth=0').click();
-  await context.tracing.groupEnd();
-  await context.tracing.group('Second Mid-level Group', { location: { file: __filename } });
-  await expect(page.getByText('Click')).toBeVisible();
-  await context.tracing.groupEnd();
-  await context.tracing.groupEnd();
-
   await Promise.all([
     page.waitForNavigation(),
     page.waitForResponse(server.PREFIX + '/frames/frame.html'),
@@ -111,64 +102,103 @@ test('should open trace viewer on specific host', async ({ showTraceViewer }, te
   await expect(traceViewer.page).toHaveURL(/127.0.0.1/);
 });
 
-test('should show groups as tree in trace viewer', async ({ showTraceViewer }) => {
-  const traceViewer = await showTraceViewer([traceFile]);
-  await expect(traceViewer.actionTitles).toHaveText([
-    /browserContext.newPage/,
-    /page.gotodata:text\/html,<!DOCTYPE html><html>Hello world<\/html>/,
-    /page.setContent/,
-    /expect.toHaveTextlocator\('button'\)/,
-    /expect.toBeHiddengetByTestId\('amazing-btn'\)/,
-    /expect.toBeHiddengetByTestId\(\/amazing-btn-regex\/\)/,
-    /page.evaluate/,
-    /page.evaluate/,
-    /locator.clickgetByText\('Click'\)/,
-    /High-level Group/,
-    /page.waitForNavigation/,
-    /page.waitForResponse/,
-    /page.waitForTimeout/,
-    /page.gotohttp:\/\/localhost:\d+\/frames\/frame.html/,
-    /page.setViewportSize/,
-  ]);
-  await traceViewer.actionsTree.locator('.tree-view-entry:has-text("High-level Group") .codicon-chevron-right').click();
-  await traceViewer.actionsTree.locator('.tree-view-entry:has-text("First Mid-level Group") .codicon-chevron-right').click();
-  await traceViewer.actionsTree.locator('.tree-view-entry:has-text("Second Mid-level Group") .codicon-chevron-right').click();
-  await expect(traceViewer.actionTitles).toHaveText([
-    /browserContext.newPage/,
-    /page.gotodata:text\/html,<!DOCTYPE html><html>Hello world<\/html>/,
-    /page.setContent/,
-    /expect.toHaveTextlocator\('button'\)/,
-    /expect.toBeHiddengetByTestId\('amazing-btn'\)/,
-    /expect.toBeHiddengetByTestId\(\/amazing-btn-regex\/\)/,
-    /page.evaluate/,
-    /page.evaluate/,
-    /locator.clickgetByText\('Click'\)/,
-    /High-level Group/,
-    /First Mid-level Group/,
-    /locator\.clicklocator\('button'\)\.first\(\)/,
-    /Second Mid-level Group/,
-    /expect\.toBeVisiblegetByText\('Click'\)/,
-    /page.waitForNavigation/,
-    /page.waitForResponse/,
-    /page.waitForTimeout/,
-    /page.gotohttp:\/\/localhost:\d+\/frames\/frame.html/,
-    /page.setViewportSize/,
-  ]);
-  await expect(traceViewer.actionsTree.locator('.tree-view-entry:has-text("First Mid-level Group") > .tree-view-indent')).toHaveCount(1);
-  await expect(traceViewer.actionsTree.locator('.tree-view-entry:has-text("Second Mid-level Group") > .tree-view-indent')).toHaveCount(1);
-  await expect(traceViewer.actionsTree.locator('.tree-view-entry:has-text("locator.clicklocator(\'button\').first()") > .tree-view-indent')).toHaveCount(2);
-  await expect(traceViewer.actionsTree.locator('.tree-view-entry:has-text("expect.toBeVisiblegetByText(\'Click\')") > .tree-view-indent')).toHaveCount(2);
+test('should show groups as tree in trace viewer', async ({ runAndTrace, page, context }) => {
+  const outerGroup = 'Outer Group';
+  const outerGroupContent = 'locator.clickgetByText(\'Click\')';
+  const firstInnerGroup = 'First Inner Group';
+  const firstInnerGroupContent = 'locator.clicklocator(\'button\').first()';
+  const secondInnerGroup = 'Second Inner Group';
+  const secondInnerGroupContent = 'expect.toBeVisiblegetByText(\'Click\')';
+  const expandedFailure = 'Expanded Failure';
 
-  await traceViewer.showSourceTab();
-  await traceViewer.selectAction('High-level Group');
-  await expect(traceViewer.sourceCodeTab.locator('.source-tab-file-name')).toHaveAttribute('title', __filename);
-  await expect(traceViewer.sourceCodeTab.locator('.source-line-running')).toHaveText(/\d+\s+await context.tracing.group\('High-level Group'\);/);
+  const traceViewer = await test.step('create trace with groups', async () => {
+    return await runAndTrace(async () => {
+      try {
+        await page.goto(`data:text/html,<!DOCTYPE html><html>Hello world</html>`);
+        await page.setContent('<!DOCTYPE html><button>Click</button>');
+        async function doClick() {
+          await page.getByText('Click').click();
+        }
+        await context.tracing.group(outerGroup);  // Outer group
+        await doClick();
+        await context.tracing.group(firstInnerGroup, { location: { file: `${__dirname}/tracing.spec.ts`, line: 100, column: 10 } });
+        await page.locator('button >> nth=0').click();
+        await context.tracing.groupEnd();
+        await context.tracing.group(secondInnerGroup, { location: { file: __filename } });
+        await expect(page.getByText('Click')).toBeVisible();
+        await context.tracing.groupEnd();
+        await context.tracing.groupEnd();
+        await context.tracing.group(expandedFailure);
+        try {
+          await expect(page.getByText('Click')).toBeHidden({ timeout: 1 });
+        } catch (e) {}
+        await context.tracing.groupEnd();
+        await page.evaluate(() => console.log('ungrouped'), null);
+      } catch (e) {}
+    });
+  }, { box: true });
+  const treeViewEntries = traceViewer.actionsTree.locator('.tree-view-entry');
 
-  await traceViewer.selectAction('First Mid-level Group');
-  await expect(traceViewer.sourceCodeTab.locator('.source-tab-file-name')).toHaveAttribute('title', `${__dirname}/tracing.spec.ts`);
-
-  await traceViewer.selectAction('Second Mid-level Group');
-  await expect(traceViewer.sourceCodeTab.getByText(/Licensed under the Apache License/)).toBeVisible();
+  await test.step('check automatic expansion of groups on failure', async () => {
+    await expect(traceViewer.actionTitles).toHaveText([
+      /page.gotodata:text\/html,<!DOCTYPE html><html>Hello world<\/html>/,
+      /page.setContent/,
+      outerGroup,
+      expandedFailure,
+      /expect.toBeHiddengetByText\('Click'\)/,
+      /page.evaluate/,
+    ]);
+    await expect(traceViewer.actionsTree.locator('.tree-view-entry.selected > .tree-view-indent')).toHaveCount(1);
+    await expect(traceViewer.actionsTree.locator('.tree-view-entry.selected')).toHaveText(/expect.toBeHiddengetByText\('Click'\)/);
+    await treeViewEntries.filter({ hasText: expandedFailure }).locator('.codicon-chevron-down').click();
+  });
+  await test.step('check outer group', async () => {
+    await treeViewEntries.filter({ hasText: outerGroup }).locator('.codicon-chevron-right').click();
+    await expect(traceViewer.actionTitles).toHaveText([
+      /page.gotodata:text\/html,<!DOCTYPE html><html>Hello world<\/html>/,
+      /page.setContent/,
+      outerGroup,
+      outerGroupContent,
+      firstInnerGroup,
+      secondInnerGroup,
+      expandedFailure,
+      /page.evaluate/,
+    ]);
+    await expect(treeViewEntries.filter({ hasText: firstInnerGroup }).locator(' > .tree-view-indent')).toHaveCount(1);
+    await expect(treeViewEntries.filter({ hasText: secondInnerGroup }).locator(' > .tree-view-indent')).toHaveCount(1);
+    await test.step('check automatic location of groups', async () => {
+      await traceViewer.showSourceTab();
+      await traceViewer.selectAction(outerGroup);
+      await expect(traceViewer.sourceCodeTab.locator('.source-tab-file-name')).toHaveAttribute('title', __filename);
+      await expect(traceViewer.sourceCodeTab.locator('.source-line-running')).toHaveText(/\d+\s+await context.tracing.group\(outerGroup\);  \/\/ Outer group/);
+    });
+  });
+  await test.step('check inner groups', async () => {
+    await treeViewEntries.filter({ hasText: firstInnerGroup }).locator('.codicon-chevron-right').click();
+    await treeViewEntries.filter({ hasText: secondInnerGroup }).locator('.codicon-chevron-right').click();
+    await expect(traceViewer.actionTitles).toHaveText([
+      /page.gotodata:text\/html,<!DOCTYPE html><html>Hello world<\/html>/,
+      /page.setContent/,
+      outerGroup,
+      outerGroupContent,
+      firstInnerGroup,
+      firstInnerGroupContent,
+      secondInnerGroup,
+      secondInnerGroupContent,
+      expandedFailure,
+      /page.evaluate/,
+    ]);
+    await expect(treeViewEntries.filter({ hasText: firstInnerGroupContent }).locator(' > .tree-view-indent')).toHaveCount(2);
+    await expect(treeViewEntries.filter({ hasText: secondInnerGroupContent }).locator(' > .tree-view-indent')).toHaveCount(2);
+    await test.step('check location with file, line, column', async () => {
+      await traceViewer.selectAction(firstInnerGroup);
+      await expect(traceViewer.sourceCodeTab.locator('.source-tab-file-name')).toHaveAttribute('title', `${__dirname}/tracing.spec.ts`);
+    });
+    await test.step('check location with file', async () => {
+      await traceViewer.selectAction(secondInnerGroup);
+      await expect(traceViewer.sourceCodeTab.getByText(/Licensed under the Apache License/)).toBeVisible();
+    });
+  });
 });
 
 
@@ -184,7 +214,6 @@ test('should open simple trace viewer', async ({ showTraceViewer }) => {
     /page.evaluate/,
     /page.evaluate/,
     /locator.clickgetByText\('Click'\)/,
-    /High-level Group/,
     /page.waitForNavigation/,
     /page.waitForResponse/,
     /page.waitForTimeout/,

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -130,9 +130,9 @@ test('should show groups as tree in trace viewer', async ({ showTraceViewer }) =
     /page.gotohttp:\/\/localhost:\d+\/frames\/frame.html/,
     /page.setViewportSize/,
   ]);
-  await traceViewer.actionsTree.locator('.list-view-entry:has-text("High-level Group") .codicon-chevron-right').click();
-  await traceViewer.actionsTree.locator('.list-view-entry:has-text("First Mid-level Group") .codicon-chevron-right').click();
-  await traceViewer.actionsTree.locator('.list-view-entry:has-text("Second Mid-level Group") .codicon-chevron-right').click();
+  await traceViewer.actionsTree.locator('.tree-view-entry:has-text("High-level Group") .codicon-chevron-right').click();
+  await traceViewer.actionsTree.locator('.tree-view-entry:has-text("First Mid-level Group") .codicon-chevron-right').click();
+  await traceViewer.actionsTree.locator('.tree-view-entry:has-text("Second Mid-level Group") .codicon-chevron-right').click();
   await expect(traceViewer.actionTitles).toHaveText([
     /browserContext.newPage/,
     /page.gotodata:text\/html,<!DOCTYPE html><html>Hello world<\/html>/,
@@ -154,10 +154,10 @@ test('should show groups as tree in trace viewer', async ({ showTraceViewer }) =
     /page.gotohttp:\/\/localhost:\d+\/frames\/frame.html/,
     /page.setViewportSize/,
   ]);
-  await expect(traceViewer.actionsTree.locator('.list-view-entry:has-text("First Mid-level Group") > .list-view-indent')).toHaveCount(1);
-  await expect(traceViewer.actionsTree.locator('.list-view-entry:has-text("Second Mid-level Group") > .list-view-indent')).toHaveCount(1);
-  await expect(traceViewer.actionsTree.locator('.list-view-entry:has-text("locator.clicklocator(\'button\').first()") > .list-view-indent')).toHaveCount(2);
-  await expect(traceViewer.actionsTree.locator('.list-view-entry:has-text("expect.toBeVisiblegetByText(\'Click\')") > .list-view-indent')).toHaveCount(2);
+  await expect(traceViewer.actionsTree.locator('.tree-view-entry:has-text("First Mid-level Group") > .tree-view-indent')).toHaveCount(1);
+  await expect(traceViewer.actionsTree.locator('.tree-view-entry:has-text("Second Mid-level Group") > .tree-view-indent')).toHaveCount(1);
+  await expect(traceViewer.actionsTree.locator('.tree-view-entry:has-text("locator.clicklocator(\'button\').first()") > .tree-view-indent')).toHaveCount(2);
+  await expect(traceViewer.actionsTree.locator('.tree-view-entry:has-text("expect.toBeVisiblegetByText(\'Click\')") > .tree-view-indent')).toHaveCount(2);
 
   await traceViewer.showSourceTab();
   await traceViewer.selectAction('High-level Group');


### PR DESCRIPTION
This PR implements #33047 .

It shall be possible to add groups to trace logs so that also users that do not use Playwright-Test, like Playwright Python, Robot Framework, Cucumber etc., can also group their traces.
Similar to test.step visually.