### PR TITLE
fix(test runner): when sharding with beforeAll, use shards total instead of workers

### DIFF
--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -176,8 +176,11 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
   if (config.config.shard) {
     // Create test groups for top-level projects.
     const testGroups: TestGroup[] = [];
-    for (const projectSuite of rootSuite.suites)
-      testGroups.push(...createTestGroups(projectSuite, config.config.workers));
+    for (const projectSuite of rootSuite.suites) {
+      // Split beforeAll-grouped tests into "config.shard.total" groups when needed.
+      // Later on, we'll re-split them between workers by using "config.workers" instead.
+      testGroups.push(...createTestGroups(projectSuite, config.config.shard.total));
+    }
 
     // Shard test groups.
     const testGroupsInThisShard = filterForShard(config.config.shard, testGroups);

--- a/packages/playwright/src/runner/testGroups.ts
+++ b/packages/playwright/src/runner/testGroups.ts
@@ -24,7 +24,7 @@ export type TestGroup = {
   tests: TestCase[];
 };
 
-export function createTestGroups(projectSuite: Suite, workers: number): TestGroup[] {
+export function createTestGroups(projectSuite: Suite, expectedParallelism: number): TestGroup[] {
   // This function groups tests that can be run together.
   // Tests cannot be run together when:
   // - They belong to different projects - requires different workers.
@@ -116,7 +116,7 @@ export function createTestGroups(projectSuite: Suite, workers: number): TestGrou
       result.push(...withRequireFile.parallel.values());
 
       // Tests with beforeAll/afterAll should try to share workers as much as possible.
-      const parallelWithHooksGroupSize = Math.ceil(withRequireFile.parallelWithHooks.tests.length / workers);
+      const parallelWithHooksGroupSize = Math.ceil(withRequireFile.parallelWithHooks.tests.length / expectedParallelism);
       let lastGroup: TestGroup | undefined;
       for (const test of withRequireFile.parallelWithHooks.tests) {
         if (!lastGroup || lastGroup.tests.length >= parallelWithHooksGroupSize) {


### PR DESCRIPTION
Otherwise, we might split the `beforeAll`-grouped test group into `workers` parts instead of `shard.total` parts as the user would expect.

Fixes #33077.