### PR TITLE
fix(har): account for reused sockets

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -329,6 +329,11 @@ export abstract class APIRequestContext extends SdkObject {
             blocked: -1,
           };
 
+          if (request.reusedSocket) {
+            timings.connect = -1;
+            timings.dns = -1;
+          }
+
           const requestFinishedEvent: APIRequestFinishedEvent = {
             requestEvent,
             httpVersion: response.httpVersion,
@@ -491,8 +496,13 @@ export abstract class APIRequestContext extends SdkObject {
       request.on('socket', socket => {
         // happy eyeballs don't emit lookup and connect events, so we use our custom ones
         const happyEyeBallsTimings = timingForSocket(socket);
-        dnsLookupAt = happyEyeBallsTimings.dnsLookupAt;
-        tcpConnectionAt ??= happyEyeBallsTimings.tcpConnectionAt;
+        if (request.reusedSocket) {
+          dnsLookupAt = startAt;
+          tcpConnectionAt = startAt;
+        } else {
+          dnsLookupAt = happyEyeBallsTimings.dnsLookupAt;
+          tcpConnectionAt ??= happyEyeBallsTimings.tcpConnectionAt;
+        }
 
         // non-happy-eyeballs sockets
         listeners.push(

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -302,6 +302,7 @@ export abstract class APIRequestContext extends SdkObject {
       const requestOptions = { ...options, agent };
 
       const startAt = monotonicTime();
+      let reusedSocketAt: number | undefined;
       let dnsLookupAt: number | undefined;
       let tcpConnectionAt: number | undefined;
       let tlsHandshakeAt: number | undefined;
@@ -330,6 +331,7 @@ export abstract class APIRequestContext extends SdkObject {
           };
 
           if (request.reusedSocket) {
+            timings.blocked = reusedSocketAt! - startAt;
             timings.connect = -1;
             timings.dns = -1;
           }
@@ -497,6 +499,7 @@ export abstract class APIRequestContext extends SdkObject {
         // happy eyeballs don't emit lookup and connect events, so we use our custom ones
         const happyEyeBallsTimings = timingForSocket(socket);
         if (request.reusedSocket) {
+          reusedSocketAt = monotonicTime();
           dnsLookupAt = startAt;
           tcpConnectionAt = startAt;
         } else {

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -877,6 +877,18 @@ it('should include timings when using socks proxy', async ({ contextFactory, ser
   expect(log.entries[0].timings.connect).toBeGreaterThan(0);
 });
 
+it('should not have connect and dns timings when socket is reused', async ({ contextFactory, server }, testInfo) => {
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo);
+  await page.request.get(server.EMPTY_PAGE);
+  await page.request.get(server.EMPTY_PAGE);
+
+  const log = await getLog();
+  expect(log.entries).toHaveLength(2);
+  const request2 = log.entries[1];
+  expect.soft(request2.timings.connect).toBe(-1);
+  expect.soft(request2.timings.dns).toBe(-1);
+});
+
 it('should include redirects from API request', async ({ contextFactory, server }, testInfo) => {
   server.setRedirect('/redirect-me', '/simple.json');
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -887,6 +887,7 @@ it('should not have connect and dns timings when socket is reused', async ({ con
   const request2 = log.entries[1];
   expect.soft(request2.timings.connect).toBe(-1);
   expect.soft(request2.timings.dns).toBe(-1);
+  expect.soft(request2.timings.blocked).toBeGreaterThan(0);
 });
 
 it('should include redirects from API request', async ({ contextFactory, server }, testInfo) => {


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32960

If the socket is reused, the connect and DNS timings are set to -1, because that timing doesn't apply to the current request. The time between request start and the socket being free is counted as `blocked`.