### PR TITLE
chore(bidi): remove assertion from response dispatch

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiConnection.ts
+++ b/packages/playwright-core/src/server/bidi/bidiConnection.ts
@@ -224,7 +224,6 @@ export class BidiSession extends EventEmitter {
       }
     } else if (object.id) {
       // Response might come after session has been disposed and rejected all callbacks.
-      assert(this.isDisposed());
     } else {
       Promise.resolve().then(() => this.emit(object.method, object.params));
     }

--- a/packages/playwright-core/src/server/bidi/bidiConnection.ts
+++ b/packages/playwright-core/src/server/bidi/bidiConnection.ts
@@ -15,7 +15,6 @@
  */
 
 import { EventEmitter } from 'events';
-import { assert } from '../../utils';
 import type { ConnectionTransport, ProtocolRequest, ProtocolResponse } from '../transport';
 import type { RecentLogsCollector } from '../../utils/debugLogger';
 import { debugLogger } from '../../utils/debugLogger';


### PR DESCRIPTION
After the context has been disposed we can't route any callbacks to it because
it is not in the map, so the assertion doesn't make sense as it always ends up in
the top level session.

Fixes the following error:
```
  pw:browser <closing ws> Closing websocket due to failed onmessage callback. eventData={"type":"success","id":32,"result":{}} e=Assertion error Error: Assertion error
  pw:browser     at assert (/home/yurys/playwright/packages/playwright-core/src/utils/debug.ts:21:11)
  pw:browser     at BidiSession.dispatchMessage (/home/yurys/playwright/packages/playwright-core/src/server/bidi/bidiConnection.ts:229:13)
  pw:browser     at BidiConnection.call [as _dispatchMessage] (/home/yurys/playwright/packages/playwright-core/src/server/bidi/bidiConnection.ts:93:25)
```
