### PR TITLE
bug(artifacts) Fix generic screenshot paths causing collisions in multi-sharded DevOps builds

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -627,9 +627,10 @@ class ArtifactsRecorder {
 
   private _createScreenshotAttachmentPath() {
     const testFailed = this._testInfo._isFailure();
+    const sanitizedTestName = this._testInfo._fsSanitizedTestName();
     const index = this._screenshotOrdinal + 1;
     ++this._screenshotOrdinal;
-    const screenshotPath = this._testInfo.outputPath(`test-${testFailed ? 'failed' : 'finished'}-${index}.png`);
+    const screenshotPath = this._testInfo.outputPath(`test-${testFailed ? 'failed' : 'finished'}-${sanitizedTestName}-${index}.png`);
     return screenshotPath;
   }
 

--- a/tests/playwright-test/playwright.artifacts.spec.ts
+++ b/tests/playwright-test/playwright.artifacts.spec.ts
@@ -138,29 +138,29 @@ test('should work with screenshot: on', async ({ runInlineTest }, testInfo) => {
   expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
     '.last-run.json',
     'artifacts-failing',
-    '  test-failed-1.png',
+    '  test-failed-failing-1.png',
     'artifacts-own-context-failing',
-    '  test-failed-1.png',
+    '  test-failed-own-context-failing-1.png',
     'artifacts-own-context-passing',
-    '  test-finished-1.png',
+    '  test-finished-own-context-passing-1.png',
     'artifacts-passing',
-    '  test-finished-1.png',
+    '  test-finished-passing-1.png',
     'artifacts-persistent-failing',
-    '  test-failed-1.png',
+    '  test-failed-persistent-failing-1.png',
     'artifacts-persistent-passing',
-    '  test-finished-1.png',
+    '  test-finished-persistent-passing-1.png',
     'artifacts-shared-shared-failing',
-    '  test-failed-1.png',
-    '  test-failed-2.png',
+    '  test-failed-shared-shared-failing-1.png',
+    '  test-failed-shared-shared-failing-2.png',
     'artifacts-shared-shared-passing',
-    '  test-finished-1.png',
-    '  test-finished-2.png',
+    '  test-finished-shared-shared-passing-1.png',
+    '  test-finished-shared-shared-passing-2.png',
     'artifacts-two-contexts',
-    '  test-finished-1.png',
-    '  test-finished-2.png',
+    '  test-finished-two-contexts-1.png',
+    '  test-finished-two-contexts-2.png',
     'artifacts-two-contexts-failing',
-    '  test-failed-1.png',
-    '  test-failed-2.png',
+    '  test-failed-two-contexts-failing-1.png',
+    '  test-failed-two-contexts-failing-2.png',
   ]);
 });
 
@@ -178,17 +178,17 @@ test('should work with screenshot: only-on-failure', async ({ runInlineTest }, t
   expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
     '.last-run.json',
     'artifacts-failing',
-    '  test-failed-1.png',
+    '  test-failed-failing-1.png',
     'artifacts-own-context-failing',
-    '  test-failed-1.png',
+    '  test-failed-own-context-failing-1.png',
     'artifacts-persistent-failing',
-    '  test-failed-1.png',
+    '  test-failed-persistent-failing-1.png',
     'artifacts-shared-shared-failing',
-    '  test-failed-1.png',
-    '  test-failed-2.png',
+    '  test-failed-shared-shared-failing-1.png',
+    '  test-failed-shared-shared-failing-2.png',
     'artifacts-two-contexts-failing',
-    '  test-failed-1.png',
-    '  test-failed-2.png',
+    '  test-failed-two-contexts-failing-1.png',
+    '  test-failed-two-contexts-failing-2.png',
   ]);
 });
 
@@ -213,10 +213,10 @@ test('should work with screenshot: only-on-failure & fullPage', async ({ runInli
   expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
     '.last-run.json',
     'artifacts-should-fail-and-take-fullPage-screenshots',
-    '  test-failed-1.png',
+    '  test-failed-should-fail-and-take-fullPage-screenshots-1.png',
   ]);
   const screenshotFailure = fs.readFileSync(
-      testInfo.outputPath('test-results', 'artifacts-should-fail-and-take-fullPage-screenshots', 'test-failed-1.png')
+      testInfo.outputPath('test-results', 'artifacts-should-fail-and-take-fullPage-screenshots', 'test-failed-should-fail-and-take-fullPage-screenshots-1.png')
   );
   expect.soft(screenshotFailure).toMatchSnapshot('screenshot-grid-fullpage.png');
 });
@@ -391,5 +391,12 @@ test('should take screenshot when page is closed in afterEach', async ({ runInli
 
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(fs.existsSync(testInfo.outputPath('test-results', 'a-fails', 'test-failed-1.png'))).toBeTruthy();
+
+  expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
+    '.last-run.json',
+    'a-fails',
+    '  test-failed-fails-1.png',
+  ]);
+
+  expect(fs.existsSync(testInfo.outputPath('test-results', 'a-fails', 'test-failed-fails-1.png'))).toBeTruthy();
 });


### PR DESCRIPTION
Append the sanitized test name to the automatic screenshot mechanism of Playwright.

Why?

Currently the names are very generic and cause conflicts in CI/CD Systems like Azure Devops when we have multiple jobs failing with the same generic name:

![image](https://github.com/user-attachments/assets/26178a77-8b29-46c5-8703-2a1c8acc73b5)


It's also not very clear which number responds to which testcase when we are able to upload:

![image](https://github.com/user-attachments/assets/b6d297fe-4717-4cc3-a3a4-00ef6d621c9e)



Fix!

Added the sanitized file name, a good example of how this looks like are the fixed unit tests : 

![image](https://github.com/user-attachments/assets/c0eece85-b4b0-458e-85ed-2451d1077c29)
