### PR TITLE
fix: improve compatibility of using ESM/TS with Deno

### DIFF
--- a/packages/playwright/src/common/configLoader.ts
+++ b/packages/playwright/src/common/configLoader.ts
@@ -347,8 +347,8 @@ export async function loadEmptyConfigForMergeReports() {
 }
 
 export function restartWithExperimentalTsEsm(configFile: string | undefined, force: boolean = false): boolean {
-  // Opt-out switch.
-  if (process.env.PW_DISABLE_TS_ESM)
+  // Opt-out switch. Default to disabled if running in Deno, which supports TS and ESM natively.
+  if (process.env.PW_DISABLE_TS_ESM || typeof process.versions.deno === 'string')
     return false;
 
   // There are two esm loader APIs:

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -293,6 +293,7 @@ function folderIsModule(folder: string): boolean {
   const isDeno = typeof process.versions.deno === 'string';
   if (!packageJsonPath)
     return isDeno;
+  // Rely on `require` internal caching logic.
   const type = require(packageJsonPath).type;
   if (type === 'module')
     return true;

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -289,10 +289,16 @@ export function fileIsModule(file: string): boolean {
 
 function folderIsModule(folder: string): boolean {
   const packageJsonPath = getPackageJsonPath(folder);
+  // deno is ESM unless package.json specifies otherwise
+  const isDeno = typeof process.versions.deno === 'string';
   if (!packageJsonPath)
+    return isDeno;
+  const type = require(packageJsonPath).type;
+  if (type === 'module')
+    return true;
+  if (type === 'commonjs')
     return false;
-  // Rely on `require` internal caching logic.
-  return require(packageJsonPath).type === 'module';
+  return isDeno;
 }
 
 const packageJsonMainFieldCache = new Map<string, string | undefined>();


### PR DESCRIPTION
### 
Deno does not support custom ESM loaders, which playwright uses to provide TS/ESM support. This currently means that deno users cannot use playwright with ESM. However, deno supports running typescript and ESM natively, so disabling the loader allows this to work.

A second small issue is that deno doesn't require a `package.json` file, and defaults to ESM (as opposed to node, which defaults to CommonJS). This means that currently if you don't have a `package.json` file, when running in deno playwright would incorrectly assume the project is commonjs.

Two small changes here:
- Disable the ESM loader when running in deno (as detected by looking for `process.versions.deno`)
- Consider files to be ESM, even without a package.json present, when running in deno

---

Overall this greatly improves the experience when using playwright with deno, and I hope the changes are minimal enough to be acceptable. Thanks for your time!