### PR TITLE
chore(docs): remove dead link to install config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ npx playwright install
 You can optionally install only selected browsers, see [install browsers](https://playwright.dev/docs/cli#install-browsers) for more details. Or you can install no browsers at all and use existing [browser channels](https://playwright.dev/docs/browsers).
 
 * [Getting started](https://playwright.dev/docs/intro)
-* [Installation configuration](https://playwright.dev/docs/installation)
 * [API reference](https://playwright.dev/docs/api/class-playwright)
 
 ## Capabilities


### PR DESCRIPTION
it's redirecting by mistake to `/docs/library` (Guides > Library)