### PR TITLE
chore(docs): fix documentation url

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ test('Intercept network requests', async ({ page }) => {
 
 ## Resources
 
-* [Documentation](https://playwright.dev/docs/intro)
+* [Documentation](https://playwright.dev)
 * [API reference](https://playwright.dev/docs/api/class-playwright/)
 * [Contribution guide](CONTRIBUTING.md)
 * [Changelog](https://github.com/microsoft/playwright/releases)


### PR DESCRIPTION
fix link to home page, consistent with

https://github.com/microsoft/playwright/blob/2d150eec25958f28e0b0ba7ae214572f1df7546b/README.md?plain=1#L5

instead of linking to: Docs > Getting Started > Installation