### PR TITLE
chore: update pull request link pr_check_client_side_changes.yml

### DIFF
--- a/.github/workflows/pr_check_client_side_changes.yml
+++ b/.github/workflows/pr_check_client_side_changes.yml
@@ -27,7 +27,7 @@ jobs:
               repo: context.repo.repo,
               commit_sha: context.sha,
             });
-            const commitHeader = data.message.split('\n')[0].substring(1); // skip the `#` character
+            const commitHeader = data.message.split('\n')[0].replace(/#(\d+)/g, 'https://github.com/microsoft/playwright/pull/$1');
 
             const title = '[Ports]: Backport client side changes for ' + currentPlaywrightVersion;
             for (const repo of ['playwright-python', 'playwright-java', 'playwright-dotnet']) {

--- a/.github/workflows/pr_check_client_side_changes.yml
+++ b/.github/workflows/pr_check_client_side_changes.yml
@@ -50,7 +50,7 @@ jobs:
                 issueBody = issueCreateData.body;
               }
               const newBody = issueBody.trimEnd() + `
-              - [ ] https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha} (https://github.com/microsoft/playwright/pull/${commitHeader})`;
+              - [ ] https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha} (${commitHeader})`;
               const data = await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: repo,

--- a/.github/workflows/pr_check_client_side_changes.yml
+++ b/.github/workflows/pr_check_client_side_changes.yml
@@ -50,7 +50,7 @@ jobs:
                 issueBody = issueCreateData.body;
               }
               const newBody = issueBody.trimEnd() + `
-              - [ ] https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha} (${commitHeader})`;
+              - [ ] https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha} (https://github.com/microsoft/playwright/pull/${commitHeader})`;
               const data = await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: repo,

--- a/.github/workflows/pr_check_client_side_changes.yml
+++ b/.github/workflows/pr_check_client_side_changes.yml
@@ -27,7 +27,7 @@ jobs:
               repo: context.repo.repo,
               commit_sha: context.sha,
             });
-            const commitHeader = data.message.split('\n')[0];
+            const commitHeader = data.message.split('\n')[0].substring(1); // skip the `#` character
 
             const title = '[Ports]: Backport client side changes for ' + currentPlaywrightVersion;
             for (const repo of ['playwright-python', 'playwright-java', 'playwright-dotnet']) {


### PR DESCRIPTION
current issue description:

example of current:
```
Please backport client side changes:
  - [ ] https://github.com/microsoft/playwright/commit/6373fe703dbde7fc40e11a006e48476579664c1a (docs: fix Java/.NET types for docs rolling (#32924))
  - [ ] https://github.com/microsoft/playwright/commit/94321fef1c94f9851b6fcc4304d3844760e986cb (chore: implement locator.ariaSnapshot (#33125))
```

new rendered description:
```
Please backport client side changes:
  - [ ] https://github.com/microsoft/playwright/commit/6373fe703dbde7fc40e11a006e48476579664c1a (docs: fix Java/.NET types for docs rolling (https://github.com/microsoft/playwright/pull/32924))
  - [ ] https://github.com/microsoft/playwright/commit/94321fef1c94f9851b6fcc4304d3844760e986cb (chore: implement locator.ariaSnapshot (https://github.com/microsoft/playwright/pull/33125))
```

rendered as:
![image](https://github.com/user-attachments/assets/ba5e03eb-8fd0-4603-b424-4adecf7db330)

by modifying the pull request id to be an absolute URL to this repository the pull request link will appear in the brackets as well.

something like this:

Please backport client side changes:
  - [ ] https://github.com/microsoft/playwright/commit/6373fe703dbde7fc40e11a006e48476579664c1a (docs: fix Java/.NET types for docs rolling (https://github.com/microsoft/playwright/pull/32924))
  - [ ] https://github.com/microsoft/playwright/commit/94321fef1c94f9851b6fcc4304d3844760e986cb (chore: implement locator.ariaSnapshot (https://github.com/microsoft/playwright/pull/33125))

(works here due to these pull request ids being from this repo)