### PR TITLE
feat(test runner): run tests with different worker fixtures in a single worker

### DIFF
--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -116,6 +116,7 @@ export type DonePayload = {
   fatalErrors: TestInfoError[];
   skipTestsDueToSetupFailure: string[];  // test ids
   fatalUnknownTestIds?: string[];
+  lastTestPoolDigest?: string;
 };
 
 export type TestOutputPayload = {

--- a/packages/playwright/src/common/suiteUtils.ts
+++ b/packages/playwright/src/common/suiteUtils.ts
@@ -77,10 +77,7 @@ export function bindFileSuiteToProject(project: FullProjectInternal, suite: Suit
     // Skip annotations imply skipped expectedStatus.
     if (test.annotations.some(a => a.type === 'skip' || a.type === 'fixme'))
       test.expectedStatus = 'skipped';
-
-    // We only compute / set digest in the runner.
-    if (test._poolDigest)
-      test._workerHash = `${project.id}-${test._poolDigest}-0`;
+    test._workerHash = `${project.id}-0`;
   });
 
   return result;
@@ -95,9 +92,7 @@ export function applyRepeatEachIndex(project: FullProjectInternal, fileSuite: Su
       const testId = suite._fileId + '-' + calculateSha1(testIdExpression).slice(0, 20);
       test.id = testId;
       test.repeatEachIndex = repeatEachIndex;
-
-      if (test._poolDigest)
-        test._workerHash = `${project.id}-${test._poolDigest}-${repeatEachIndex}`;
+      test._workerHash = `${project.id}-${repeatEachIndex}`;
     }
   });
 }

--- a/packages/playwright/src/runner/workerHost.ts
+++ b/packages/playwright/src/runner/workerHost.ts
@@ -29,6 +29,7 @@ export class WorkerHost extends ProcessHost {
   readonly parallelIndex: number;
   readonly workerIndex: number;
   private _hash: string;
+  poolDigest: string;
   private _params: WorkerInitParams;
   private _didFail = false;
 
@@ -42,6 +43,7 @@ export class WorkerHost extends ProcessHost {
     this.workerIndex = workerIndex;
     this.parallelIndex = parallelIndex;
     this._hash = testGroup.workerHash;
+    this.poolDigest = testGroup.firstPoolDigest;
 
     this._params = {
       workerIndex: this.workerIndex,

--- a/tests/playwright-test/fixture-errors.spec.ts
+++ b/tests/playwright-test/fixture-errors.spec.ts
@@ -676,44 +676,6 @@ test('should not run user fn when require fixture has failed', async ({ runInlin
   ]);
 });
 
-test('should provide helpful error message when digests do not match', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'helper.ts': `
-      import { test as base } from '@playwright/test';
-      export * from '@playwright/test';
-      export const test = base.extend({
-        foo: [ async ({}, use) => use(), { scope: 'worker' } ],
-      });
-
-      test.use({ foo: 'foo' });
-    `,
-    'a.spec.ts': `
-      import { test, expect } from './helper';
-
-      test('test-a', ({ foo }) => {
-        expect(foo).toBe('foo');
-      });
-    `,
-    'b.spec.ts': `
-      import { test, expect } from './helper';
-
-      test('test-b', ({ foo }) => {
-        expect(foo).toBe('foo');
-      });
-    `,
-    'c.spec.ts': `
-      import { test, expect } from './helper';
-
-      test('test-c', ({ foo }) => {
-        expect(foo).toBe('foo');
-      });
-    `,
-  }, { workers: 1 });
-  expect(result.exitCode).toBe(1);
-  expect(result.failed).toBe(1);
-  expect(result.output).toContain('Playwright detected inconsistent test.use() options.');
-});
-
 test('tear down base fixture after error in derived', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `

--- a/tests/playwright-test/test-extend.spec.ts
+++ b/tests/playwright-test/test-extend.spec.ts
@@ -46,8 +46,11 @@ test('test.extend should work', async ({ runInlineTest }) => {
           global.logs.push('beforeAll-' + suffix);
           await run();
           global.logs.push('afterAll-' + suffix);
-          if (suffix.includes('base'))
+          if (suffix.includes('base')) {
+            global.logs.push('end of worker');
             console.log(global.logs.join('\\n'));
+            global.logs = [];
+          }
         }, { scope: 'worker' }],
 
         baseTest: async ({ suffix, derivedWorker }, run) => {
@@ -85,10 +88,6 @@ test('test.extend should work', async ({ runInlineTest }) => {
     'afterEach-e1',
     'afterEach-base1',
     'afterAll-e1',
-    'afterAll-base1',
-  ].join('\n'));
-  expect(output).toContain([
-    'beforeAll-base1',
     'beforeAll-e2',
     'beforeEach-base1',
     'beforeEach-e2',
@@ -97,6 +96,7 @@ test('test.extend should work', async ({ runInlineTest }) => {
     'afterEach-base1',
     'afterAll-e2',
     'afterAll-base1',
+    'end of worker',
   ].join('\n'));
   expect(output).toContain([
     'beforeAll-base2',
@@ -107,10 +107,6 @@ test('test.extend should work', async ({ runInlineTest }) => {
     'afterEach-e1',
     'afterEach-base2',
     'afterAll-e1',
-    'afterAll-base2',
-  ].join('\n'));
-  expect(output).toContain([
-    'beforeAll-base2',
     'beforeAll-e2',
     'beforeEach-base2',
     'beforeEach-e2',
@@ -119,6 +115,7 @@ test('test.extend should work', async ({ runInlineTest }) => {
     'afterEach-base2',
     'afterAll-e2',
     'afterAll-base2',
+    'end of worker',
   ].join('\n'));
 });
 

--- a/tests/playwright-test/test-use.spec.ts
+++ b/tests/playwright-test/test-use.spec.ts
@@ -119,12 +119,12 @@ test('should run tests with different worker options', async ({ runInlineTest })
 
       test('test1', ({ foo }, testInfo) => {
         expect(foo).toBe('bar');
-        expect(testInfo.workerIndex).toBe(1);
+        expect(testInfo.workerIndex).toBe(0);
       });
 
       test('test2', ({ foo }, testInfo) => {
         expect(foo).toBe('bar');
-        expect(testInfo.workerIndex).toBe(1);
+        expect(testInfo.workerIndex).toBe(0);
       });
     `,
     'c.test.ts': `
@@ -132,7 +132,7 @@ test('should run tests with different worker options', async ({ runInlineTest })
       test.use({ foo: 'baz' });
       test('test2', ({ foo }, testInfo) => {
         expect(foo).toBe('baz');
-        expect(testInfo.workerIndex).toBe(2);
+        expect(testInfo.workerIndex).toBe(0);
       });
     `
   }, { workers: 1 });


### PR DESCRIPTION
Previously, we forced a new worker for a new set of worker fixtures. Now, we can reuse the worker by tearing down mismatching worker fixtures between tests.

The new behavior allows all tests from a single file run in-order, even when mixing various test types with different worker fixtures. This is less efficient, but more predictable for the user. Switching between worker fixtures is reported under "Reset Fixtures" step inside "Before Hooks" and has a separate timeout.

We still force a new worker for each project and repeatEach index.

----

After some discussions, we decided to not proceed with this:
- Very likely performance regressions for cases that mix various test types in a single file.
- Once this is shipped, we cannot undo because someone will rely on the fact that all tests from a file are executed in the same worker.
- The benefit is small, because we already run test types, that only differ in test-scoped fixtures, in the same worker. Two test types with different worker-scoped fixtures in the same file are much less likely.

For scheduling APIs, we'll have to keep test groups working.

