### PR TITLE
fix(trace viewer): limit the number of contexts loaded in sw

### DIFF
--- a/packages/trace-viewer/src/ui/embeddedWorkbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/embeddedWorkbenchLoader.tsx
@@ -65,6 +65,7 @@ export const EmbeddedWorkbenchLoader: React.FunctionComponent = () => {
           const url = traceURLs[i];
           const params = new URLSearchParams();
           params.set('trace', url);
+          params.set('limit', String(traceURLs.length));
           const response = await fetch(`contexts?${params.toString()}`);
           if (!response.ok) {
             setProcessingErrorMessage((await response.json()).error);

--- a/packages/trace-viewer/src/ui/recorder/modelContext.tsx
+++ b/packages/trace-viewer/src/ui/recorder/modelContext.tsx
@@ -58,6 +58,7 @@ export const ModelProvider: React.FunctionComponent<React.PropsWithChildren<{
 async function loadSingleTraceFile(url: string): Promise<{ model: MultiTraceModel, sha1: string }> {
   const params = new URLSearchParams();
   params.set('trace', url);
+  params.set('limit', '1');
   const response = await fetch(`contexts?${params.toString()}`);
   const contextEntries = await response.json() as ContextEntry[];
 

--- a/packages/trace-viewer/src/ui/uiModeTraceView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeTraceView.tsx
@@ -111,6 +111,7 @@ const outputDirForTestCase = (testCase: reporterTypes.TestCase): string | undefi
 async function loadSingleTraceFile(url: string): Promise<MultiTraceModel> {
   const params = new URLSearchParams();
   params.set('trace', url);
+  params.set('limit', '1');
   const response = await fetch(`contexts?${params.toString()}`);
   const contextEntries = await response.json() as ContextEntry[];
   return new MultiTraceModel(contextEntries);

--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -131,6 +131,7 @@ export const WorkbenchLoader: React.FunctionComponent<{
           params.set('trace', url);
           if (uploadedTraceNames.length)
             params.set('traceFileName', uploadedTraceNames[i]);
+          params.set('limit', String(traceURLs.length));
           const response = await fetch(`contexts?${params.toString()}`);
           if (!response.ok) {
             if (!isServer)


### PR DESCRIPTION
UI mode may load many traces, one for each test, in the same service worker. This change introduces an upper limit to the number of traces stored in sw.

References #33086, #33219, #33141.