### PR TITLE
fix(trace viewer): make LRUCache per-trace

### DIFF
--- a/packages/trace-viewer/src/sw/lruCache.ts
+++ b/packages/trace-viewer/src/sw/lruCache.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class LRUCache<K, V> {
+  private _maxSize: number;
+  private _map: Map<K, { value: V, size: number }>;
+  private _size: number;
+
+  constructor(maxSize: number) {
+    this._maxSize = maxSize;
+    this._map = new Map();
+    this._size = 0;
+  }
+
+  getOrCompute(key: K, compute: () => { value: V, size: number }): V {
+    if (this._map.has(key)) {
+      const result = this._map.get(key)!;
+      // reinserting makes this the least recently used entry
+      this._map.delete(key);
+      this._map.set(key, result);
+      return result.value;
+    }
+
+    const result = compute();
+
+    while (this._map.size && this._size + result.size > this._maxSize) {
+      const [firstKey, firstValue] = this._map.entries().next().value;
+      this._size -= firstValue.size;
+      this._map.delete(firstKey);
+    }
+
+    this._map.set(key, result);
+    this._size += result.size;
+    return result.value;
+  }
+}

--- a/packages/trace-viewer/src/sw/snapshotStorage.ts
+++ b/packages/trace-viewer/src/sw/snapshotStorage.ts
@@ -17,6 +17,7 @@
 import type { FrameSnapshot, ResourceSnapshot } from '@trace/snapshot';
 import { rewriteURLForCustomProtocol, SnapshotRenderer } from './snapshotRenderer';
 import type { PageEntry } from '../types/entries';
+import { LRUCache } from './lruCache';
 
 export class SnapshotStorage {
   private _resources: ResourceSnapshot[] = [];
@@ -24,6 +25,7 @@ export class SnapshotStorage {
     raw: FrameSnapshot[],
     renderers: SnapshotRenderer[]
   }>();
+  private _cache = new LRUCache<SnapshotRenderer, string>(100_000_000);  // 100MB per each trace
 
   addResource(resource: ResourceSnapshot): void {
     resource.request.url = rewriteURLForCustomProtocol(resource.request.url);
@@ -44,7 +46,7 @@ export class SnapshotStorage {
         this._frameSnapshots.set(snapshot.pageId, frameSnapshots);
     }
     frameSnapshots.raw.push(snapshot);
-    const renderer = new SnapshotRenderer(this._resources, frameSnapshots.raw, screencastFrames, frameSnapshots.raw.length - 1);
+    const renderer = new SnapshotRenderer(this._cache, this._resources, frameSnapshots.raw, screencastFrames, frameSnapshots.raw.length - 1);
     frameSnapshots.renderers.push(renderer);
     return renderer;
   }


### PR DESCRIPTION
Instead of a single global one. This makes the cache collectable when a trace is unloaded. Otherwise, old cache entries stick around and hold traces in memory.

References #33086, #33219, #33141.