### PR TITLE
feat(chromium): switch to headless=new by default

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -268,8 +268,8 @@ jobs:
     - run: npx playwright install-deps
     - run: utils/build/build-playwright-driver.sh
 
-  test_linux_chromium_headless_new:
-    name: Linux Chromium Headless New
+  test_linux_chromium_headless_old:
+    name: Linux Chromium Headless Old
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ubuntu-latest
     steps:
@@ -278,12 +278,12 @@ jobs:
       with:
         browsers-to-install: chromium
         command: npm run ctest
-        bot-name: "headless-new"
+        bot-name: "headless-old"
         flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
         flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
         flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
       env:
-        PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW: 1
+        PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD: 1
 
   test_linux_chromium_headless_shell:
     name: Chromium Headless Shell

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -268,23 +268,6 @@ jobs:
     - run: npx playwright install-deps
     - run: utils/build/build-playwright-driver.sh
 
-  test_linux_chromium_headless_old:
-    name: Linux Chromium Headless Old
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ./.github/actions/run-test
-      with:
-        browsers-to-install: chromium
-        command: npm run ctest
-        bot-name: "headless-old"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
-      env:
-        PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD: 1
-
   test_linux_chromium_headless_shell:
     name: Chromium Headless Shell
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}

--- a/packages/playwright-core/src/server/bidi/bidiChromium.ts
+++ b/packages/playwright-core/src/server/bidi/bidiChromium.ts
@@ -112,10 +112,10 @@ export class BidiChromium extends BrowserType {
     if (options.devtools)
       chromeArguments.push('--auto-open-devtools-for-tabs');
     if (options.headless) {
-      if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW)
-        chromeArguments.push('--headless=new');
-      else
+      if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD)
         chromeArguments.push('--headless=old');
+      else
+        chromeArguments.push('--headless=new');
 
       chromeArguments.push(
           '--hide-scrollbars',

--- a/packages/playwright-core/src/server/bidi/bidiChromium.ts
+++ b/packages/playwright-core/src/server/bidi/bidiChromium.ts
@@ -112,10 +112,7 @@ export class BidiChromium extends BrowserType {
     if (options.devtools)
       chromeArguments.push('--auto-open-devtools-for-tabs');
     if (options.headless) {
-      if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD)
-        chromeArguments.push('--headless=old');
-      else
-        chromeArguments.push('--headless=new');
+      chromeArguments.push('--headless=new');
 
       chromeArguments.push(
           '--hide-scrollbars',

--- a/packages/playwright-core/src/server/bidi/bidiChromium.ts
+++ b/packages/playwright-core/src/server/bidi/bidiChromium.ts
@@ -112,7 +112,7 @@ export class BidiChromium extends BrowserType {
     if (options.devtools)
       chromeArguments.push('--auto-open-devtools-for-tabs');
     if (options.headless) {
-      chromeArguments.push('--headless=new');
+      chromeArguments.push('--headless');
 
       chromeArguments.push(
           '--hide-scrollbars',

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -309,7 +309,7 @@ export class Chromium extends BrowserType {
     if (options.devtools)
       chromeArguments.push('--auto-open-devtools-for-tabs');
     if (options.headless) {
-      chromeArguments.push('--headless=new');
+      chromeArguments.push('--headless');
 
       chromeArguments.push(
           '--hide-scrollbars',

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -309,10 +309,7 @@ export class Chromium extends BrowserType {
     if (options.devtools)
       chromeArguments.push('--auto-open-devtools-for-tabs');
     if (options.headless) {
-      if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD || options.channel === 'chromium-headless-shell')
-        chromeArguments.push('--headless=old');
-      else
-        chromeArguments.push('--headless=new');
+      chromeArguments.push('--headless=new');
 
       chromeArguments.push(
           '--hide-scrollbars',

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -309,10 +309,10 @@ export class Chromium extends BrowserType {
     if (options.devtools)
       chromeArguments.push('--auto-open-devtools-for-tabs');
     if (options.headless) {
-      if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW)
-        chromeArguments.push('--headless=new');
-      else
+      if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD)
         chromeArguments.push('--headless=old');
+      else
+        chromeArguments.push('--headless=new');
 
       chromeArguments.push(
           '--hide-scrollbars',

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -309,7 +309,7 @@ export class Chromium extends BrowserType {
     if (options.devtools)
       chromeArguments.push('--auto-open-devtools-for-tabs');
     if (options.headless) {
-      if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD)
+      if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD || options.channel === 'chromium-headless-shell')
         chromeArguments.push('--headless=old');
       else
         chromeArguments.push('--headless=new');

--- a/tests/library/browsercontext-credentials.spec.ts
+++ b/tests/library/browsercontext-credentials.spec.ts
@@ -19,7 +19,7 @@ import { browserTest as base, expect } from '../config/browserTest';
 
 const it = base.extend<{ isChromiumHeadedLike: boolean }>({
   isChromiumHeadedLike: async ({ browserName, headless }, use) => {
-    const isChromiumHeadedLike = browserName === 'chromium' && (!headless || !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW);
+    const isChromiumHeadedLike = browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD);
     await use(isChromiumHeadedLike);
   },
 });

--- a/tests/library/browsercontext-credentials.spec.ts
+++ b/tests/library/browsercontext-credentials.spec.ts
@@ -19,9 +19,7 @@ import { browserTest as base, expect } from '../config/browserTest';
 
 const it = base.extend<{ isChromiumHeadedLike: boolean }>({
   isChromiumHeadedLike: async ({ browserName, headless, channel }, use) => {
-    const isChromiumHeadedLike = browserName === 'chromium'
-      && ((headless && !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD
-      && channel !== 'chromium-headless-shell') || !headless);
+    const isChromiumHeadedLike = browserName === 'chromium' && ((headless && channel !== 'chromium-headless-shell') || !headless);
     await use(isChromiumHeadedLike);
   },
 });

--- a/tests/library/browsercontext-credentials.spec.ts
+++ b/tests/library/browsercontext-credentials.spec.ts
@@ -19,7 +19,9 @@ import { browserTest as base, expect } from '../config/browserTest';
 
 const it = base.extend<{ isChromiumHeadedLike: boolean }>({
   isChromiumHeadedLike: async ({ browserName, headless, channel }, use) => {
-    const isChromiumHeadedLike = browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD) && channel !== 'chromium-headless-shell';
+    const isChromiumHeadedLike = browserName === 'chromium'
+      && ((headless && !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD
+      && channel !== 'chromium-headless-shell') || !headless);
     await use(isChromiumHeadedLike);
   },
 });

--- a/tests/library/browsercontext-credentials.spec.ts
+++ b/tests/library/browsercontext-credentials.spec.ts
@@ -15,33 +15,26 @@
  * limitations under the License.
  */
 
-import { browserTest as base, expect } from '../config/browserTest';
+import { browserTest as it, expect } from '../config/browserTest';
 
-const it = base.extend<{ isChromiumHeadedLike: boolean }>({
-  isChromiumHeadedLike: async ({ browserName, headless, channel }, use) => {
-    const isChromiumHeadedLike = browserName === 'chromium' && ((headless && channel !== 'chromium-headless-shell') || !headless);
-    await use(isChromiumHeadedLike);
-  },
-});
-
-it('should fail without credentials', async ({ browser, server, isChromiumHeadedLike }) => {
+it('should fail without credentials', async ({ browser, server, browserName, channel }) => {
   server.setAuth('/empty.html', 'user', 'pass');
   const context = await browser.newContext();
   const page = await context.newPage();
   const responseOrError = await page.goto(server.EMPTY_PAGE).catch(e => e);
-  if (isChromiumHeadedLike)
+  if (browserName === 'chromium' && channel !== 'chromium-headless-shell')
     expect(responseOrError.message).toContain('net::ERR_INVALID_AUTH_CREDENTIALS');
   else
     expect(responseOrError.status()).toBe(401);
 });
 
-it('should work with setHTTPCredentials', async ({ browser, server, isChromiumHeadedLike }) => {
+it('should work with setHTTPCredentials', async ({ browser, server, browserName, channel }) => {
   server.setAuth('/empty.html', 'user', 'pass');
   const context = await browser.newContext();
   const page = await context.newPage();
 
   let responseOrError = await page.goto(server.EMPTY_PAGE).catch(e => e);
-  if (isChromiumHeadedLike)
+  if (browserName === 'chromium' && channel !== 'chromium-headless-shell')
     expect(responseOrError.message).toContain('net::ERR_INVALID_AUTH_CREDENTIALS');
   else
     expect(responseOrError.status()).toBe(401);
@@ -109,21 +102,21 @@ it('should work with correct credentials and matching origin case insensitive', 
   await context.close();
 });
 
-it('should fail with correct credentials and mismatching scheme', async ({ browser, server, isChromiumHeadedLike }) => {
+it('should fail with correct credentials and mismatching scheme', async ({ browser, server, browserName, channel }) => {
   server.setAuth('/empty.html', 'user', 'pass');
   const context = await browser.newContext({
     httpCredentials: { username: 'user', password: 'pass', origin: server.PREFIX.replace('http://', 'https://') }
   });
   const page = await context.newPage();
   const responseOrError = await page.goto(server.EMPTY_PAGE).catch(e => e);
-  if (isChromiumHeadedLike)
+  if (browserName === 'chromium' && channel !== 'chromium-headless-shell')
     expect(responseOrError.message).toContain('net::ERR_INVALID_AUTH_CREDENTIALS');
   else
     expect(responseOrError.status()).toBe(401);
   await context.close();
 });
 
-it('should fail with correct credentials and mismatching hostname', async ({ browser, server, isChromiumHeadedLike }) => {
+it('should fail with correct credentials and mismatching hostname', async ({ browser, server, browserName, channel }) => {
   server.setAuth('/empty.html', 'user', 'pass');
   const hostname = new URL(server.PREFIX).hostname;
   const origin = server.PREFIX.replace(hostname, 'mismatching-hostname');
@@ -132,14 +125,14 @@ it('should fail with correct credentials and mismatching hostname', async ({ bro
   });
   const page = await context.newPage();
   const responseOrError = await page.goto(server.EMPTY_PAGE).catch(e => e);
-  if (isChromiumHeadedLike)
+  if (browserName === 'chromium' && channel !== 'chromium-headless-shell')
     expect(responseOrError.message).toContain('net::ERR_INVALID_AUTH_CREDENTIALS');
   else
     expect(responseOrError.status()).toBe(401);
   await context.close();
 });
 
-it('should fail with correct credentials and mismatching port', async ({ browser, server, isChromiumHeadedLike }) => {
+it('should fail with correct credentials and mismatching port', async ({ browser, server, browserName, channel }) => {
   server.setAuth('/empty.html', 'user', 'pass');
   const origin = server.PREFIX.replace(server.PORT.toString(), (server.PORT + 1).toString());
   const context = await browser.newContext({
@@ -147,7 +140,7 @@ it('should fail with correct credentials and mismatching port', async ({ browser
   });
   const page = await context.newPage();
   const responseOrError = await page.goto(server.EMPTY_PAGE).catch(e => e);
-  if (isChromiumHeadedLike)
+  if (browserName === 'chromium' && channel !== 'chromium-headless-shell')
     expect(responseOrError.message).toContain('net::ERR_INVALID_AUTH_CREDENTIALS');
   else
     expect(responseOrError.status()).toBe(401);

--- a/tests/library/browsercontext-credentials.spec.ts
+++ b/tests/library/browsercontext-credentials.spec.ts
@@ -18,8 +18,8 @@
 import { browserTest as base, expect } from '../config/browserTest';
 
 const it = base.extend<{ isChromiumHeadedLike: boolean }>({
-  isChromiumHeadedLike: async ({ browserName, headless }, use) => {
-    const isChromiumHeadedLike = browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD);
+  isChromiumHeadedLike: async ({ browserName, headless, channel }, use) => {
+    const isChromiumHeadedLike = browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD) && channel !== 'chromium-headless-shell';
     await use(isChromiumHeadedLike);
   },
 });

--- a/tests/library/download.spec.ts
+++ b/tests/library/download.spec.ts
@@ -637,7 +637,7 @@ it('should be able to download a inline PDF file via response interception', asy
 });
 
 it('should be able to download a inline PDF file via navigation', async ({ browser, server, asset, browserName, headless }) => {
-  it.fixme(((!headless || !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW) && browserName === 'chromium'));
+  it.fixme(((!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD) && browserName === 'chromium'));
   const page = await browser.newPage();
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`

--- a/tests/library/download.spec.ts
+++ b/tests/library/download.spec.ts
@@ -637,7 +637,7 @@ it('should be able to download a inline PDF file via response interception', asy
 });
 
 it('should be able to download a inline PDF file via navigation', async ({ browser, server, asset, browserName, channel }) => {
-  it.skip(browserName === 'chromium' && channel !== 'chromium-headless-shell');
+  it.skip(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'We expect PDF Viewer to open up in Chromium');
   const page = await browser.newPage();
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`

--- a/tests/library/download.spec.ts
+++ b/tests/library/download.spec.ts
@@ -637,7 +637,7 @@ it('should be able to download a inline PDF file via response interception', asy
 });
 
 it('should be able to download a inline PDF file via navigation', async ({ browser, server, asset, browserName, channel }) => {
-  it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell');
+  it.skip(browserName === 'chromium' && channel !== 'chromium-headless-shell');
   const page = await browser.newPage();
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`

--- a/tests/library/download.spec.ts
+++ b/tests/library/download.spec.ts
@@ -636,8 +636,8 @@ it('should be able to download a inline PDF file via response interception', asy
   await page.close();
 });
 
-it('should be able to download a inline PDF file via navigation', async ({ browser, server, asset, browserName, headless }) => {
-  it.fixme(((!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD) && browserName === 'chromium'));
+it('should be able to download a inline PDF file via navigation', async ({ browser, server, asset, browserName, channel }) => {
+  it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell');
   const page = await browser.newPage();
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`

--- a/tests/library/emulation-focus.spec.ts
+++ b/tests/library/emulation-focus.spec.ts
@@ -104,7 +104,8 @@ it('should change document.activeElement', async ({ page, server }) => {
 it('should not affect screenshots', async ({ page, server, browserName, headless, isWindows, channel }) => {
   it.skip(browserName === 'webkit' && isWindows && !headless, 'WebKit/Windows/headed has a larger minimal viewport. See https://github.com/microsoft/playwright/issues/22616');
   it.skip(browserName === 'firefox' && !headless, 'Firefox headed produces a different image');
-  it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'https://github.com/microsoft/playwright/issues/33330');
+  // TODO: We want to see test results
+  // it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'https://github.com/microsoft/playwright/issues/33330');
 
   const page2 = await page.context().newPage();
   await Promise.all([

--- a/tests/library/emulation-focus.spec.ts
+++ b/tests/library/emulation-focus.spec.ts
@@ -104,6 +104,7 @@ it('should change document.activeElement', async ({ page, server }) => {
 it('should not affect screenshots', async ({ page, server, browserName, headless, isWindows }) => {
   it.skip(browserName === 'webkit' && isWindows && !headless, 'WebKit/Windows/headed has a larger minimal viewport. See https://github.com/microsoft/playwright/issues/22616');
   it.skip(browserName === 'firefox' && !headless, 'Firefox headed produces a different image');
+  it.fixme(browserName === 'chromium' && !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD, 'https://github.com/microsoft/playwright/issues/33330');
 
   const page2 = await page.context().newPage();
   await Promise.all([

--- a/tests/library/emulation-focus.spec.ts
+++ b/tests/library/emulation-focus.spec.ts
@@ -101,10 +101,10 @@ it('should change document.activeElement', async ({ page, server }) => {
   expect(active).toEqual(['INPUT', 'TEXTAREA']);
 });
 
-it('should not affect screenshots', async ({ page, server, browserName, headless, isWindows }) => {
+it('should not affect screenshots', async ({ page, server, browserName, headless, isWindows, channel }) => {
   it.skip(browserName === 'webkit' && isWindows && !headless, 'WebKit/Windows/headed has a larger minimal viewport. See https://github.com/microsoft/playwright/issues/22616');
   it.skip(browserName === 'firefox' && !headless, 'Firefox headed produces a different image');
-  it.fixme(browserName === 'chromium' && !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD, 'https://github.com/microsoft/playwright/issues/33330');
+  it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'https://github.com/microsoft/playwright/issues/33330');
 
   const page2 = await page.context().newPage();
   await Promise.all([

--- a/tests/library/permissions.spec.ts
+++ b/tests/library/permissions.spec.ts
@@ -150,7 +150,7 @@ it('should support clipboard read', async ({ page, context, server, browserName,
   it.fail(browserName === 'firefox', 'No such permissions (requires flag) in Firefox');
   it.fixme(browserName === 'webkit' && isWindows, 'WebPasteboardProxy::allPasteboardItemInfo not implemented for Windows.');
   it.fixme(browserName === 'webkit' && isLinux && headless, 'WebPasteboardProxy::allPasteboardItemInfo not implemented for WPE.');
-  const isChromiumHeadedLike = browserName === 'chromium' && (!headless || !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW);
+  const isChromiumHeadedLike = browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD);
 
   await page.goto(server.EMPTY_PAGE);
   // There is no 'clipboard-read' permission in WebKit Web API.

--- a/tests/library/permissions.spec.ts
+++ b/tests/library/permissions.spec.ts
@@ -145,12 +145,12 @@ it.describe('permissions', () => {
   });
 });
 
-it('should support clipboard read', async ({ page, context, server, browserName, isWindows, isLinux, headless }) => {
+it('should support clipboard read', async ({ page, context, server, browserName, isWindows, isLinux, headless, channel }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27475' });
   it.fail(browserName === 'firefox', 'No such permissions (requires flag) in Firefox');
   it.fixme(browserName === 'webkit' && isWindows, 'WebPasteboardProxy::allPasteboardItemInfo not implemented for Windows.');
   it.fixme(browserName === 'webkit' && isLinux && headless, 'WebPasteboardProxy::allPasteboardItemInfo not implemented for WPE.');
-  const isChromiumHeadedLike = browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD);
+  const isChromiumHeadedLike = browserName === 'chromium' && channel !== 'chromium-headless-shell';
 
   await page.goto(server.EMPTY_PAGE);
   // There is no 'clipboard-read' permission in WebKit Web API.

--- a/tests/library/permissions.spec.ts
+++ b/tests/library/permissions.spec.ts
@@ -150,15 +150,14 @@ it('should support clipboard read', async ({ page, context, server, browserName,
   it.fail(browserName === 'firefox', 'No such permissions (requires flag) in Firefox');
   it.fixme(browserName === 'webkit' && isWindows, 'WebPasteboardProxy::allPasteboardItemInfo not implemented for Windows.');
   it.fixme(browserName === 'webkit' && isLinux && headless, 'WebPasteboardProxy::allPasteboardItemInfo not implemented for WPE.');
-  const isChromiumHeadedLike = browserName === 'chromium' && channel !== 'chromium-headless-shell';
 
   await page.goto(server.EMPTY_PAGE);
   // There is no 'clipboard-read' permission in WebKit Web API.
   if (browserName !== 'webkit')
     expect(await getPermission(page, 'clipboard-read')).toBe('prompt');
 
-  if (!isChromiumHeadedLike) {
-    // Headed Chromium shows a dialog and does not resolve the promise.
+  if (browserName === 'chromium' && channel !== 'chromium-headless-shell') {
+    // Chromium shows a dialog and does not resolve the promise.
     const error = await page.evaluate(() => navigator.clipboard.readText()).catch(e => e);
     expect(error.toString()).toContain('denied');
   }

--- a/tests/library/permissions.spec.ts
+++ b/tests/library/permissions.spec.ts
@@ -156,7 +156,7 @@ it('should support clipboard read', async ({ page, context, server, browserName,
   if (browserName !== 'webkit')
     expect(await getPermission(page, 'clipboard-read')).toBe('prompt');
 
-  if (browserName === 'chromium' && channel !== 'chromium-headless-shell') {
+  if (browserName === 'chromium' && channel === 'chromium-headless-shell') {
     // Chromium shows a dialog and does not resolve the promise.
     const error = await page.evaluate(() => navigator.clipboard.readText()).catch(e => e);
     expect(error.toString()).toContain('denied');

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -127,8 +127,8 @@ for (const browserName of browserNames) {
       platform: process.platform,
       docker: !!process.env.INSIDE_DOCKER,
       headless: (() => {
-        if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW)
-          return 'headless-new';
+        if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD)
+          return 'headless-old';
         if (headed)
           return 'headed';
         return 'headless';

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -127,8 +127,6 @@ for (const browserName of browserNames) {
       platform: process.platform,
       docker: !!process.env.INSIDE_DOCKER,
       headless: (() => {
-        if (process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD)
-          return 'headless-old';
         if (headed)
           return 'headed';
         return 'headless';

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -126,11 +126,7 @@ for (const browserName of browserNames) {
     metadata: {
       platform: process.platform,
       docker: !!process.env.INSIDE_DOCKER,
-      headless: (() => {
-        if (headed)
-          return 'headed';
-        return 'headless';
-      })(),
+      headless: headed ? 'headed' : 'headless',
       browserName,
       channel,
       mode,

--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -22,8 +22,8 @@ import { verifyViewport } from '../config/utils';
 browserTest.describe('page screenshot', () => {
   browserTest.skip(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
 
-  browserTest('should run in parallel in multiple pages', async ({ server, contextFactory, browserName }) => {
-    browserTest.fixme(browserName === 'chromium' && !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD, 'https://github.com/microsoft/playwright/issues/33330');
+  browserTest('should run in parallel in multiple pages', async ({ server, contextFactory, browserName, channel }) => {
+    browserTest.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'https://github.com/microsoft/playwright/issues/33330');
     const context = await contextFactory();
     const N = 5;
     const pages = await Promise.all(Array(N).fill(0).map(async () => {

--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -22,7 +22,8 @@ import { verifyViewport } from '../config/utils';
 browserTest.describe('page screenshot', () => {
   browserTest.skip(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
 
-  browserTest('should run in parallel in multiple pages', async ({ server, contextFactory }) => {
+  browserTest('should run in parallel in multiple pages', async ({ server, contextFactory, browserName }) => {
+    browserTest.fixme(browserName === 'chromium' && !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD, 'https://github.com/microsoft/playwright/issues/33330');
     const context = await contextFactory();
     const N = 5;
     const pages = await Promise.all(Array(N).fill(0).map(async () => {

--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -23,7 +23,8 @@ browserTest.describe('page screenshot', () => {
   browserTest.skip(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
 
   browserTest('should run in parallel in multiple pages', async ({ server, contextFactory, browserName, channel }) => {
-    browserTest.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'https://github.com/microsoft/playwright/issues/33330');
+    // TODO: We want to see test results
+    // browserTest.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'https://github.com/microsoft/playwright/issues/33330');
     const context = await contextFactory();
     const N = 5;
     const pages = await Promise.all(Array(N).fill(0).map(async () => {

--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -409,7 +409,7 @@ for (const params of [
 ]) {
   browserTest(`should produce screencast frames ${params.id}`, async ({ video, contextFactory, browserName, platform, headless }, testInfo) => {
     browserTest.skip(browserName === 'chromium' && video === 'on', 'Same screencast resolution conflicts');
-    browserTest.fixme(browserName === 'chromium' && (!headless || !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW), 'Chromium screencast on headed has a min width issue');
+    browserTest.fixme(browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD), 'Chromium screencast on headed has a min width issue');
     browserTest.fixme(params.id === 'fit' && browserName === 'chromium' && platform === 'darwin', 'High DPI maxes image at 600x600');
     browserTest.fixme(params.id === 'fit' && browserName === 'webkit' && platform === 'linux', 'Image size is flaky');
     browserTest.fixme(browserName === 'firefox' && !headless, 'Image size is different');

--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -407,9 +407,9 @@ for (const params of [
     height: 768,
   }
 ]) {
-  browserTest(`should produce screencast frames ${params.id}`, async ({ video, contextFactory, browserName, platform, headless }, testInfo) => {
+  browserTest(`should produce screencast frames ${params.id}`, async ({ video, contextFactory, browserName, platform, headless, channel }, testInfo) => {
     browserTest.skip(browserName === 'chromium' && video === 'on', 'Same screencast resolution conflicts');
-    browserTest.fixme(browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD), 'Chromium screencast on headed has a min width issue');
+    browserTest.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'Chromium screencast on headed has a min width issue');
     browserTest.fixme(params.id === 'fit' && browserName === 'chromium' && platform === 'darwin', 'High DPI maxes image at 600x600');
     browserTest.fixme(params.id === 'fit' && browserName === 'webkit' && platform === 'linux', 'Image size is flaky');
     browserTest.fixme(browserName === 'firefox' && !headless, 'Image size is different');

--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -409,7 +409,7 @@ for (const params of [
 ]) {
   browserTest(`should produce screencast frames ${params.id}`, async ({ video, contextFactory, browserName, platform, headless, channel }, testInfo) => {
     browserTest.skip(browserName === 'chromium' && video === 'on', 'Same screencast resolution conflicts');
-    browserTest.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'Chromium screencast on headed has a min width issue');
+    browserTest.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'Chromium screencast has a min width issue');
     browserTest.fixme(params.id === 'fit' && browserName === 'chromium' && platform === 'darwin', 'High DPI maxes image at 600x600');
     browserTest.fixme(params.id === 'fit' && browserName === 'webkit' && platform === 'linux', 'Image size is flaky');
     browserTest.fixme(browserName === 'firefox' && !headless, 'Image size is different');

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -474,7 +474,7 @@ it.describe('screencast', () => {
   });
 
   it('should scale frames down to the requested size ', async ({ browser, browserName, server, headless, trace }, testInfo) => {
-    const isChromiumHeadlessNew = browserName === 'chromium' && !!headless && !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW;
+    const isChromiumHeadlessNew = browserName === 'chromium' && !!headless && !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD;
     it.fixme(!headless || isChromiumHeadlessNew, 'Fails on headed');
 
     const context = await browser.newContext({
@@ -724,7 +724,7 @@ it.describe('screencast', () => {
 
   it('should capture full viewport', async ({ browserType, browserName, headless, isWindows }, testInfo) => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22411' });
-    it.fixme(browserName === 'chromium' && (!headless || !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW), 'The square is not on the video');
+    it.fixme(browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD), 'The square is not on the video');
     it.fixme(browserName === 'firefox' && isWindows, 'https://github.com/microsoft/playwright/issues/14405');
     const size = { width: 600, height: 400 };
     const browser = await browserType.launch();
@@ -759,7 +759,7 @@ it.describe('screencast', () => {
 
   it('should capture full viewport on hidpi', async ({ browserType, browserName, headless, isWindows, isLinux }, testInfo) => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22411' });
-    it.fixme(browserName === 'chromium' && (!headless || !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW), 'The square is not on the video');
+    it.fixme(browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD), 'The square is not on the video');
     it.fixme(browserName === 'firefox' && isWindows, 'https://github.com/microsoft/playwright/issues/14405');
     it.fixme(browserName === 'webkit' && isLinux && !headless, 'https://github.com/microsoft/playwright/issues/22617');
     const size = { width: 600, height: 400 };
@@ -796,7 +796,7 @@ it.describe('screencast', () => {
 
   it('should work with video+trace', async ({ browser, trace, headless }, testInfo) => {
     it.skip(trace === 'on');
-    it.fixme(!headless || !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW, 'different trace screencast image size on all browsers');
+    it.fixme(!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD, 'different trace screencast image size on all browsers');
 
     const size = { width: 500, height: 400 };
     const traceFile = testInfo.outputPath('trace.zip');

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -474,8 +474,8 @@ it.describe('screencast', () => {
   });
 
   it('should scale frames down to the requested size ', async ({ browser, browserName, server, headless, channel }, testInfo) => {
-    const isChromiumHeadlessNew = browserName === 'chromium' && channel !== 'chromium-headless-shell';
-    it.fixme(!headless || isChromiumHeadlessNew, 'Fails on headed');
+    it.fixme(!headless, 'Fails on headed');
+    it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'Fails on Chromiums');
 
     const context = await browser.newContext({
       recordVideo: {
@@ -796,8 +796,8 @@ it.describe('screencast', () => {
 
   it('should work with video+trace', async ({ browser, trace, headless, browserName, channel }, testInfo) => {
     it.skip(trace === 'on');
-    const isChromiumHeadlessNew = browserName === 'chromium' && channel !== 'chromium-headless-shell';
-    it.fixme(!headless || isChromiumHeadlessNew, 'different trace screencast image size on all browsers');
+    it.fixme(!headless, 'different trace screencast image size on all browsers');
+    it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'different trace screencast image size on Chromium');
 
     const size = { width: 500, height: 400 };
     const traceFile = testInfo.outputPath('trace.zip');

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -473,8 +473,8 @@ it.describe('screencast', () => {
     expect(videoFiles.length).toBe(2);
   });
 
-  it('should scale frames down to the requested size ', async ({ browser, browserName, server, headless, trace }, testInfo) => {
-    const isChromiumHeadlessNew = browserName === 'chromium' && !!headless && !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD;
+  it('should scale frames down to the requested size ', async ({ browser, browserName, server, headless, channel }, testInfo) => {
+    const isChromiumHeadlessNew = browserName === 'chromium' && channel !== 'chromium-headless-shell';
     it.fixme(!headless || isChromiumHeadlessNew, 'Fails on headed');
 
     const context = await browser.newContext({
@@ -722,9 +722,9 @@ it.describe('screencast', () => {
     expect(files.length).toBe(1);
   });
 
-  it('should capture full viewport', async ({ browserType, browserName, headless, isWindows }, testInfo) => {
+  it('should capture full viewport', async ({ browserType, browserName, isWindows, channel }, testInfo) => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22411' });
-    it.fixme(browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD), 'The square is not on the video');
+    it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'The square is not on the video');
     it.fixme(browserName === 'firefox' && isWindows, 'https://github.com/microsoft/playwright/issues/14405');
     const size = { width: 600, height: 400 };
     const browser = await browserType.launch();
@@ -757,9 +757,9 @@ it.describe('screencast', () => {
     expectAll(pixels, almostRed);
   });
 
-  it('should capture full viewport on hidpi', async ({ browserType, browserName, headless, isWindows, isLinux }, testInfo) => {
+  it('should capture full viewport on hidpi', async ({ browserType, browserName, headless, isWindows, isLinux, channel }, testInfo) => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22411' });
-    it.fixme(browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD), 'The square is not on the video');
+    it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'The square is not on the video');
     it.fixme(browserName === 'firefox' && isWindows, 'https://github.com/microsoft/playwright/issues/14405');
     it.fixme(browserName === 'webkit' && isLinux && !headless, 'https://github.com/microsoft/playwright/issues/22617');
     const size = { width: 600, height: 400 };
@@ -794,9 +794,10 @@ it.describe('screencast', () => {
     expectAll(pixels, almostRed);
   });
 
-  it('should work with video+trace', async ({ browser, trace, headless }, testInfo) => {
+  it('should work with video+trace', async ({ browser, trace, headless, browserName, channel }, testInfo) => {
     it.skip(trace === 'on');
-    it.fixme(!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD, 'different trace screencast image size on all browsers');
+    const isChromiumHeadlessNew = browserName === 'chromium' && channel !== 'chromium-headless-shell';
+    it.fixme(!headless || isChromiumHeadlessNew, 'different trace screencast image size on all browsers');
 
     const size = { width: 500, height: 400 };
     const traceFile = testInfo.outputPath('trace.zip');

--- a/tests/page/page-focus.spec.ts
+++ b/tests/page/page-focus.spec.ts
@@ -120,7 +120,7 @@ it('clicking checkbox should activate it', async ({ page, browserName, headless,
 it('tab should cycle between single input and browser', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32339' }
 }, async ({ page, browserName, headless }) => {
-  it.fixme(browserName === 'chromium' && (!headless || !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW),
+  it.fixme(browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD),
       'Chromium in headful mode keeps input focused.');
   it.fixme(browserName !== 'chromium');
   await page.setContent(`<label for="input1">input1</label>
@@ -148,7 +148,7 @@ it('tab should cycle between single input and browser', {
 it('tab should cycle between document elements and browser', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32339' }
 }, async ({ page, browserName, headless }) => {
-  it.fixme(browserName === 'chromium' && (!headless || !!process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_NEW),
+  it.fixme(browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD),
       'Chromium in headful mode keeps last input focused.');
   it.fixme(browserName !== 'chromium');
   await page.setContent(`

--- a/tests/page/page-focus.spec.ts
+++ b/tests/page/page-focus.spec.ts
@@ -120,8 +120,7 @@ it('clicking checkbox should activate it', async ({ page, browserName, headless,
 it('tab should cycle between single input and browser', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32339' }
 }, async ({ page, browserName, channel }) => {
-  it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell',
-      'Chromium in headful mode keeps input focused.');
+  it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'Chromium keeps input focused.');
   it.fixme(browserName !== 'chromium');
   await page.setContent(`<label for="input1">input1</label>
     <input id="input1">
@@ -148,8 +147,7 @@ it('tab should cycle between single input and browser', {
 it('tab should cycle between document elements and browser', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32339' }
 }, async ({ page, browserName, channel }) => {
-  it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell',
-      'Chromium in headful mode keeps last input focused.');
+  it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell', 'Chromium keeps last input focused.');
   it.fixme(browserName !== 'chromium');
   await page.setContent(`
     <input id="input1">

--- a/tests/page/page-focus.spec.ts
+++ b/tests/page/page-focus.spec.ts
@@ -119,8 +119,8 @@ it('clicking checkbox should activate it', async ({ page, browserName, headless,
 
 it('tab should cycle between single input and browser', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32339' }
-}, async ({ page, browserName, headless }) => {
-  it.fixme(browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD),
+}, async ({ page, browserName, channel }) => {
+  it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell',
       'Chromium in headful mode keeps input focused.');
   it.fixme(browserName !== 'chromium');
   await page.setContent(`<label for="input1">input1</label>
@@ -147,8 +147,8 @@ it('tab should cycle between single input and browser', {
 
 it('tab should cycle between document elements and browser', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32339' }
-}, async ({ page, browserName, headless }) => {
-  it.fixme(browserName === 'chromium' && (!headless || !process.env.PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD),
+}, async ({ page, browserName, channel }) => {
+  it.fixme(browserName === 'chromium' && channel !== 'chromium-headless-shell',
       'Chromium in headful mode keeps last input focused.');
   it.fixme(browserName !== 'chromium');
   await page.setContent(`


### PR DESCRIPTION
~~This PR switches to headless=new by default to assess the impact. `PLAYWRIGHT_CHROMIUM_USE_HEADLESS_OLD` environment variable reverses to the old behavior.~~

This PR switches to the `headless=new` by default to assess the impact. To reverse to the old behaviour we recommend `channel: 'chromium-headless-shell'`.

https://github.com/microsoft/playwright/issues/33144