### PR TITLE
chore: throw when using headless-shell with headed mode

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -294,6 +294,8 @@ export class Chromium extends BrowserType {
       throw new Error('Playwright manages remote debugging connection itself.');
     if (args.find(arg => !arg.startsWith('-')))
       throw new Error('Arguments can not specify page to be opened');
+    if (!options.headless && options.channel === 'chromium-headless-shell')
+      throw new Error('Cannot launch headed Chromium via headless-shell. Consider using normal Chromium instead.');
     const chromeArguments = [...chromiumSwitches];
 
     if (os.platform() === 'darwin') {

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -295,7 +295,7 @@ export class Chromium extends BrowserType {
     if (args.find(arg => !arg.startsWith('-')))
       throw new Error('Arguments can not specify page to be opened');
     if (!options.headless && options.channel === 'chromium-headless-shell')
-      throw new Error('Cannot launch headed Chromium via headless-shell. Consider using normal Chromium instead.');
+      throw new Error('Cannot launch headed Chromium with `chromium-headless-shell` channel. Consider using regular Chromium instead.');
     const chromeArguments = [...chromiumSwitches];
 
     if (os.platform() === 'darwin') {

--- a/tests/library/chromium/launcher.spec.ts
+++ b/tests/library/chromium/launcher.spec.ts
@@ -184,3 +184,8 @@ it('should not create pages automatically', async ({ browserType }) => {
   await browser.close();
   expect(targets.length).toBe(0);
 });
+
+it('should throw helpful error when launching chromium-headless-shell channel as headed', async ({ browserType, channel }) => {
+  it.skip(channel !== 'chromium-headless-shell');
+  await expect(browserType.launch({ channel: 'chromium-headless-shell', headless: false })).rejects.toThrow('Cannot launch headed Chromium via headless-shell. Consider using normal Chromium instead.');
+});

--- a/tests/library/chromium/launcher.spec.ts
+++ b/tests/library/chromium/launcher.spec.ts
@@ -187,5 +187,7 @@ it('should not create pages automatically', async ({ browserType }) => {
 
 it('should throw helpful error when launching chromium-headless-shell channel as headed', async ({ browserType, channel }) => {
   it.skip(channel !== 'chromium-headless-shell');
-  await expect(browserType.launch({ channel: 'chromium-headless-shell', headless: false })).rejects.toThrow('Cannot launch headed Chromium via headless-shell. Consider using normal Chromium instead.');
+  await expect(browserType.launch({ channel: 'chromium-headless-shell', headless: false })).rejects.toThrow(
+      'Cannot launch headed Chromium with `chromium-headless-shell` channel. Consider using regular Chromium instead.'
+  );
 });


### PR DESCRIPTION
https://github.com/microsoft/playwright/issues/33144