### PR TITLE
chore: delete unused source-map-support code

### DIFF
--- a/packages/playwright/bundles/utils/build.js
+++ b/packages/playwright/bundles/utils/build.js
@@ -16,27 +16,7 @@
 
 // @ts-check
 const path = require('path');
-const fs = require('fs');
 const esbuild = require('esbuild');
-
-// Can be removed once source-map-support was is fixed.
-/** @type{import('esbuild').Plugin} */
-let patchSource = {
-  name: 'patch-source-map-support-deprecation',
-  setup(build) {
-    build.onResolve({ filter: /^source-map-support$/ }, () => {
-      const originalPath = require.resolve('source-map-support');
-      const patchedPath = path.join(path.dirname(originalPath), path.basename(originalPath, '.js') + '.pw-patched.js');
-      let sourceFileContent = fs.readFileSync(originalPath, 'utf8');
-      // source-map-support is overwriting __PW_ZONE__ with func in core if source maps are present.
-      const original = `return state.nextPosition.name || originalFunctionName();`;
-      const insertedLine = `if (state.nextPosition.name === 'func') return originalFunctionName() || 'func';`;
-      sourceFileContent = sourceFileContent.replace(original, insertedLine + original);
-      fs.writeFileSync(patchedPath, sourceFileContent);
-      return { path: patchedPath }
-    });
-  },
-};
 
 (async () => {
   const ctx = await esbuild.context({
@@ -44,7 +24,6 @@ let patchSource = {
     external: ['fsevents'],
     bundle: true,
     outdir: path.join(__dirname, '../../lib'),
-    plugins: [patchSource],
     format: 'cjs',
     platform: 'node',
     target: 'ES2019',


### PR DESCRIPTION
We no longer use __PW_ZONE__ after switching to node native zones. The original warning was fixed in source maps code upstream (by https://github.com/evanw/node-source-map-support/pull/212) and rolled into Playwright in this change: https://github.com/microsoft/playwright/commit/28f382bea62f5ff2346f9c35ce7129a5041f34ab, which also updated the previous code to address zone issue only.
