### PR TITLE
chore: make expect timeout field required in the protocol

### DIFF
--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -21,7 +21,7 @@ import * as util from 'util';
 import { asLocator, isString, monotonicTime } from '../utils';
 import { ElementHandle } from './elementHandle';
 import type { Frame } from './frame';
-import type { FilePayload, FrameExpectOptions, Rect, SelectOption, SelectOptionOptions, TimeoutOptions } from './types';
+import type { FilePayload, FrameExpectParams, Rect, SelectOption, SelectOptionOptions, TimeoutOptions } from './types';
 import { parseResult, serializeArgument } from './jsHandle';
 import { escapeForTextSelector } from '../utils/isomorphic/stringUtils';
 import type { ByRoleOptions } from '../utils/isomorphic/locatorUtils';
@@ -354,7 +354,7 @@ export class Locator implements api.Locator {
     await this._frame._channel.waitForSelector({ selector: this._selector, strict: true, omitReturnValue: true, ...options });
   }
 
-  async _expect(expression: string, options: Omit<FrameExpectOptions, 'expectedValue'> & { expectedValue?: any }): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean }> {
+  async _expect(expression: string, options: FrameExpectParams): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean }> {
     const params: channels.FrameExpectParams = { selector: this._selector, expression, ...options, isNot: !!options.isNot };
     params.expectedValue = serializeArgument(options.expectedValue);
     const result = (await this._frame._channel.expect(params));

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -154,4 +154,4 @@ export type SelectorEngine = {
 export type RemoteAddr = channels.RemoteAddr;
 export type SecurityDetails = channels.SecurityDetails;
 
-export type FrameExpectOptions = channels.FrameExpectOptions & { isNot?: boolean };
+export type FrameExpectParams = Omit<channels.FrameExpectParams, 'selector'|'expression'|'expectedValue'> & { expectedValue?: any };

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1770,7 +1770,7 @@ scheme.FrameExpectParams = tObject({
   expectedValue: tOptional(tType('SerializedArgument')),
   useInnerText: tOptional(tBoolean),
   isNot: tBoolean,
-  timeout: tOptional(tNumber),
+  timeout: tNumber,
 });
 scheme.FrameExpectResult = tObject({
   matches: tBoolean,

--- a/packages/playwright-core/src/utils/isomorphic/recorderUtils.ts
+++ b/packages/playwright-core/src/utils/isomorphic/recorderUtils.ts
@@ -22,6 +22,8 @@ export function buildFullSelector(framePath: string[], selector: string) {
   return [...framePath, selector].join(' >> internal:control=enter-frame >> ');
 }
 
+const kDefaultTimeout = 5_000;
+
 export function traceParamsForAction(actionInContext: recorderActions.ActionInContext): { method: string, params: any } {
   const { action } = actionInContext;
 
@@ -101,6 +103,7 @@ export function traceParamsForAction(actionInContext: recorderActions.ActionInCo
         selector: action.selector,
         expression: 'to.be.checked',
         isNot: !action.checked,
+        timeout: kDefaultTimeout,
       };
       return { method: 'expect', params };
     }
@@ -110,6 +113,7 @@ export function traceParamsForAction(actionInContext: recorderActions.ActionInCo
         expression: 'to.have.text',
         expectedText: [],
         isNot: false,
+        timeout: kDefaultTimeout,
       };
       return { method: 'expect', params };
     }
@@ -119,6 +123,7 @@ export function traceParamsForAction(actionInContext: recorderActions.ActionInCo
         expression: 'to.have.value',
         expectedValue: undefined,
         isNot: false,
+        timeout: kDefaultTimeout,
       };
       return { method: 'expect', params };
     }
@@ -127,6 +132,7 @@ export function traceParamsForAction(actionInContext: recorderActions.ActionInCo
         selector,
         expression: 'to.be.visible',
         isNot: false,
+        timeout: kDefaultTimeout,
       };
       return { method: 'expect', params };
     }
@@ -136,6 +142,7 @@ export function traceParamsForAction(actionInContext: recorderActions.ActionInCo
         expression: 'to.match.snapshot',
         expectedText: [],
         isNot: false,
+        timeout: kDefaultTimeout,
       };
       return { method: 'expect', params };
     }

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Locator, Page, APIResponse } from 'playwright-core';
-import type { FrameExpectOptions } from 'playwright-core/lib/client/types';
+import type { FrameExpectParams } from 'playwright-core/lib/client/types';
 import { colors } from 'playwright-core/lib/utilsBundle';
 import { expectTypes, callLogText } from '../util';
 import { toBeTruthy } from './toBeTruthy';
@@ -28,7 +28,7 @@ import type { ExpectMatcherState } from '../../types/test';
 import { takeFirst } from '../common/config';
 
 export interface LocatorEx extends Locator {
-  _expect(expression: string, options: Omit<FrameExpectOptions, 'expectedValue'> & { expectedValue?: any }): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean }>;
+  _expect(expression: string, options: FrameExpectParams): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean }>;
 }
 
 interface APIResponseEx extends APIResponse {

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -3162,7 +3162,7 @@ export type FrameExpectParams = {
   expectedValue?: SerializedArgument,
   useInnerText?: boolean,
   isNot: boolean,
-  timeout?: number,
+  timeout: number,
 };
 export type FrameExpectOptions = {
   expressionArg?: any,
@@ -3170,7 +3170,6 @@ export type FrameExpectOptions = {
   expectedNumber?: number,
   expectedValue?: SerializedArgument,
   useInnerText?: boolean,
-  timeout?: number,
 };
 export type FrameExpectResult = {
   matches: boolean,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -2388,7 +2388,7 @@ Frame:
         expectedValue: SerializedArgument?
         useInnerText: boolean?
         isNot: boolean
-        timeout: number?
+        timeout: number
       returns:
         matches: boolean
         received: SerializedValue?


### PR DESCRIPTION
Timeout is always passed explicitly by our matchers and its value is already printed as part of the error message. Make the types align with this behavior.