### PR TITLE
chore: revert exposed expect error details on TestError

### DIFF
--- a/docs/src/test-reporter-api/class-testerror.md
+++ b/docs/src/test-reporter-api/class-testerror.md
@@ -4,53 +4,17 @@
 
 Information about an error thrown during test execution.
 
-## property: TestError.expected
-* since: v1.49
-- type: ?<[string]>
-
-Expected value formatted as a human-readable string.
-
-## property: TestError.locator
-* since: v1.49
-- type: ?<[string]>
-
-Receiver's locator.
-
-## property: TestError.log
-* since: v1.49
-- type: ?<[Array]<[string]>>
-
-Call log.
-
-## property: TestError.matcherName
-* since: v1.49
-- type: ?<[string]>
-
-Expect matcher name.
-
 ## property: TestError.message
 * since: v1.10
 - type: ?<[string]>
 
 Error message. Set when [Error] (or its subclass) has been thrown.
 
-## property: TestError.received
-* since: v1.49
-- type: ?<[string]>
-
-Received value formatted as a human-readable string.
-
 ## property: TestError.stack
 * since: v1.10
 - type: ?<[string]>
 
 Error stack. Set when [Error] (or its subclass) has been thrown.
-
-## property: TestError.timeout
-* since: v1.49
-- type: ?<[int]>
-
-Timeout in milliseconds, if the error was caused by a timeout.
 
 ## property: TestError.value
 * since: v1.10

--- a/packages/playwright/src/matchers/matcherHint.ts
+++ b/packages/playwright/src/matchers/matcherHint.ts
@@ -39,10 +39,6 @@ export type MatcherResult<E, A> = {
   actual?: A;
   log?: string[];
   timeout?: number;
-  locator?: string;
-  printedReceived?: string;
-  printedExpected?: string;
-  printedDiff?: string;
   suggestedRebaseline?: string;
 };
 

--- a/packages/playwright/src/matchers/toBeTruthy.ts
+++ b/packages/playwright/src/matchers/toBeTruthy.ts
@@ -73,7 +73,5 @@ export async function toBeTruthy(
     expected,
     log,
     timeout: timedOut ? timeout : undefined,
-    ...(printedReceived ? { printedReceived } : {}),
-    ...(printedExpected ? { printedExpected } : {}),
   };
 }

--- a/packages/playwright/src/matchers/toEqual.ts
+++ b/packages/playwright/src/matchers/toEqual.ts
@@ -83,8 +83,5 @@ export async function toEqual<T>(
     pass,
     log,
     timeout: timedOut ? timeout : undefined,
-    ...(printedReceived ? { printedReceived } : {}),
-    ...(printedExpected ? { printedExpected } : {}),
-    ...(printedDiff ? { printedDiff } : {}),
   };
 }

--- a/packages/playwright/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchSnapshot.ts
@@ -194,10 +194,6 @@ class SnapshotHelper {
       pass,
       message: () => message,
       log,
-      // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      ...(this.locator ? { locator: this.locator.toString() } : {}),
-      printedExpected: this.expectedPath,
-      printedReceived: this.actualPath,
     };
     return Object.fromEntries(Object.entries(unfiltered).filter(([_, v]) => v !== undefined)) as ImageMatcherResult;
   }

--- a/packages/playwright/src/matchers/toMatchText.ts
+++ b/packages/playwright/src/matchers/toMatchText.ts
@@ -118,10 +118,5 @@ export async function toMatchText(
     actual: received,
     log,
     timeout: timedOut ? timeout : undefined,
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    locator: receiver.toString(),
-    ...(printedReceived ? { printedReceived } : {}),
-    ...(printedExpected ? { printedExpected } : {}),
-    ...(printedDiff ? { printedDiff } : {}),
   };
 }

--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -26,13 +26,6 @@ export const kOutputSymbol = Symbol('output');
 type ErrorDetails = {
   message: string;
   location?: Location;
-  timeout?: number;
-  matcherName?: string;
-  locator?: string;
-  expected?: string;
-  received?: string;
-  log?: string[];
-  snippet?: string;
 };
 
 type TestSummary = {
@@ -362,13 +355,6 @@ export function formatResultFailure(test: TestCase, result: TestResult, initialI
     errorDetails.push({
       message: indent(formattedError.message, initialIndent),
       location: formattedError.location,
-      timeout: error.timeout,
-      matcherName: error.matcherName,
-      locator: error.locator,
-      expected: error.expected,
-      received: error.received,
-      log: error.log,
-      snippet: error.snippet,
     });
   }
   return errorDetails;

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -555,39 +555,14 @@ export interface TestCase {
  */
 export interface TestError {
   /**
-   * Expected value formatted as a human-readable string.
-   */
-  expected?: string;
-
-  /**
    * Error location in the source code.
    */
   location?: Location;
 
   /**
-   * Receiver's locator.
-   */
-  locator?: string;
-
-  /**
-   * Call log.
-   */
-  log?: Array<string>;
-
-  /**
-   * Expect matcher name.
-   */
-  matcherName?: string;
-
-  /**
    * Error message. Set when [Error] (or its subclass) has been thrown.
    */
   message?: string;
-
-  /**
-   * Received value formatted as a human-readable string.
-   */
-  received?: string;
 
   /**
    * Source code snippet with highlighted error.
@@ -598,11 +573,6 @@ export interface TestError {
    * Error stack. Set when [Error] (or its subclass) has been thrown.
    */
   stack?: string;
-
-  /**
-   * Timeout in milliseconds, if the error was caused by a timeout.
-   */
-  timeout?: number;
 
   /**
    * The value that was thrown. Set when anything except the [Error] (or its subclass) has been thrown.

--- a/tests/page/expect-matcher-result.spec.ts
+++ b/tests/page/expect-matcher-result.spec.ts
@@ -24,16 +24,12 @@ test('toMatchText-based assertions should have matcher result', async ({ page })
   {
     const e = await expect(locator).toHaveText(/Text2/, { timeout: 1 }).catch(e => e);
     e.matcherResult.message = stripAnsi(e.matcherResult.message);
-    e.matcherResult.printedDiff = stripAnsi(e.matcherResult.printedDiff);
     expect.soft(e.matcherResult).toEqual({
       actual: 'Text content',
       expected: /Text2/,
       message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).toHaveText(expected)`),
       name: 'toHaveText',
       pass: false,
-      locator: `locator('#node')`,
-      printedDiff: `Expected pattern: /Text2/
-Received string:  \"Text content\"`,
       log: expect.any(Array),
       timeout: 1,
     });
@@ -50,17 +46,12 @@ Call log`);
   {
     const e = await expect(locator).not.toHaveText(/Text/, { timeout: 1 }).catch(e => e);
     e.matcherResult.message = stripAnsi(e.matcherResult.message);
-    e.matcherResult.printedExpected = stripAnsi(e.matcherResult.printedExpected);
-    e.matcherResult.printedReceived = stripAnsi(e.matcherResult.printedReceived);
     expect.soft(e.matcherResult).toEqual({
       actual: 'Text content',
       expected: /Text/,
       message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).not.toHaveText(expected)`),
       name: 'toHaveText',
       pass: true,
-      locator: `locator('#node')`,
-      printedExpected: 'Expected pattern: not /Text/',
-      printedReceived: `Received string: \"Text content\"`,
       log: expect.any(Array),
       timeout: 1,
     });
@@ -88,8 +79,6 @@ test('toBeTruthy-based assertions should have matcher result', async ({ page }) 
       name: 'toBeVisible',
       pass: false,
       log: expect.any(Array),
-      printedExpected: 'Expected: visible',
-      printedReceived: 'Received: <element(s) not found>',
       timeout: 1,
     });
 
@@ -112,8 +101,6 @@ Call log`);
       name: 'toBeVisible',
       pass: true,
       log: expect.any(Array),
-      printedExpected: 'Expected: not visible',
-      printedReceived: 'Received: visible',
       timeout: 1,
     });
 
@@ -133,7 +120,6 @@ test('toEqual-based assertions should have matcher result', async ({ page }) => 
   {
     const e = await expect(page.locator('#node2')).toHaveCount(1, { timeout: 1 }).catch(e => e);
     e.matcherResult.message = stripAnsi(e.matcherResult.message);
-    e.matcherResult.printedDiff = stripAnsi(e.matcherResult.printedDiff);
     expect.soft(e.matcherResult).toEqual({
       actual: 0,
       expected: 1,
@@ -141,8 +127,6 @@ test('toEqual-based assertions should have matcher result', async ({ page }) => 
       name: 'toHaveCount',
       pass: false,
       log: expect.any(Array),
-      printedDiff: `Expected: 1
-Received: 0`,
       timeout: 1,
     });
 
@@ -157,8 +141,6 @@ Call log`);
   {
     const e = await expect(page.locator('#node')).not.toHaveCount(1, { timeout: 1 }).catch(e => e);
     e.matcherResult.message = stripAnsi(e.matcherResult.message);
-    e.matcherResult.printedExpected = stripAnsi(e.matcherResult.printedExpected);
-    e.matcherResult.printedReceived = stripAnsi(e.matcherResult.printedReceived);
     expect.soft(e.matcherResult).toEqual({
       actual: 1,
       expected: 1,
@@ -166,8 +148,6 @@ Call log`);
       name: 'toHaveCount',
       pass: true,
       log: expect.any(Array),
-      printedExpected: `Expected: not 1`,
-      printedReceived: `Received: 1`,
       timeout: 1,
     });
 
@@ -197,8 +177,6 @@ test('toBeChecked({ checked: false }) should have expected: false', async ({ pag
       name: 'toBeChecked',
       pass: false,
       log: expect.any(Array),
-      printedExpected: 'Expected: checked',
-      printedReceived: 'Received: unchecked',
       timeout: 1,
     });
 
@@ -221,8 +199,6 @@ Call log`);
       name: 'toBeChecked',
       pass: true,
       log: expect.any(Array),
-      printedExpected: 'Expected: not checked',
-      printedReceived: 'Received: checked',
       timeout: 1,
     });
 
@@ -245,8 +221,6 @@ Call log`);
       name: 'toBeChecked',
       pass: false,
       log: expect.any(Array),
-      printedExpected: 'Expected: unchecked',
-      printedReceived: 'Received: checked',
       timeout: 1,
     });
 
@@ -269,8 +243,6 @@ Call log`);
       name: 'toBeChecked',
       pass: true,
       log: expect.any(Array),
-      printedExpected: 'Expected: not unchecked',
-      printedReceived: 'Received: unchecked',
       timeout: 1,
     });
 
@@ -299,8 +271,6 @@ test('toHaveScreenshot should populate matcherResult', async ({ page, server, is
     name: 'toHaveScreenshot',
     pass: false,
     log: expect.any(Array),
-    printedExpected: expect.stringContaining('screenshot-sanity-'),
-    printedReceived: expect.stringContaining('screenshot-sanity-actual'),
   });
 
   expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(page).toHaveScreenshot(expected)


### PR DESCRIPTION
This is a partial revert of commit aebceb345e7849804752842c57ce02af130e202f. Removes structured error details exposed on `matcherResult`.