### PR TITLE
chore(expect): clarify message() for custom matchers

### DIFF
--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -254,7 +254,7 @@ Note that by default `toPass` has timeout 0 and does not respect custom [expect 
 
 You can extend Playwright assertions by providing custom matchers. These matchers will be available on the `expect` object.
 
-In this example we add a custom `toHaveAmount` function. Custom matcher should return a `message` callback and a `pass` flag indicating whether the assertion passed.
+In this example we add a custom `toHaveAmount` function. Custom matcher should return a `pass` flag indicating whether the assertion passed, and a `message` callback that's used when the assertion fails.
 
 ```js title="fixtures.ts"
 import { expect as baseExpect } from '@playwright/test';

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -276,12 +276,12 @@ export const expect = baseExpect.extend({
     }
 
     const message = pass
-      ? () => this.utils.matcherHint(assertionName, undefined, undefined, { isNot: this.isNot }) +
+      ? () => this.utils.matcherHint(assertionName, undefined, undefined, { isNot: true }) +
           '\n\n' +
           `Locator: ${locator}\n` +
-          `Expected: ${this.isNot ? 'not' : ''}${this.utils.printExpected(expected)}\n` +
+          `Expected: not ${this.utils.printExpected(expected)}\n` +
           (matcherResult ? `Received: ${this.utils.printReceived(matcherResult.actual)}` : '')
-      : () =>  this.utils.matcherHint(assertionName, undefined, undefined, { isNot: this.isNot }) +
+      : () =>  this.utils.matcherHint(assertionName, undefined, undefined, { isNot: false }) +
           '\n\n' +
           `Locator: ${locator}\n` +
           `Expected: ${this.utils.printExpected(expected)}\n` +

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -276,12 +276,12 @@ export const expect = baseExpect.extend({
     }
 
     const message = pass
-      ? () => this.utils.matcherHint(assertionName, undefined, undefined, { isNot: true }) +
+      ? () => this.utils.matcherHint(assertionName, undefined, undefined, { isNot: this.isNot }) +
           '\n\n' +
           `Locator: ${locator}\n` +
           `Expected: not ${this.utils.printExpected(expected)}\n` +
           (matcherResult ? `Received: ${this.utils.printReceived(matcherResult.actual)}` : '')
-      : () =>  this.utils.matcherHint(assertionName, undefined, undefined, { isNot: false }) +
+      : () =>  this.utils.matcherHint(assertionName, undefined, undefined, { isNot: this.isNot }) +
           '\n\n' +
           `Locator: ${locator}\n` +
           `Expected: ${this.utils.printExpected(expected)}\n` +


### PR DESCRIPTION
This PR clarifies our docs for custom matchers. If `pass` is true, we know that `message` is only used for negated matches. From Jest's `expect` docs:

> `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, message should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, message should return the error message for when `expect(x).not.yourMatcher()` fails.

Closes https://github.com/microsoft/playwright/issues/33293