### PR TITLE
test: update macOS-15 WebKit cookie tests expectations

### DIFF
--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -30,7 +30,6 @@ import type { TestInfo } from '@playwright/test';
 export type BrowserTestWorkerFixtures = PageWorkerFixtures & {
   browserVersion: string;
   defaultSameSiteCookieValue: string;
-  sameSiteStoredValueForNone: string;
   allowsThirdParty: boolean;
   browserMajorVersion: number;
   browserType: BrowserType;
@@ -76,21 +75,12 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
       await run('Lax');
     else if (browserName === 'webkit' && platform === 'linux')
       await run('Lax');
-    else if (browserName === 'webkit' && platform === 'darwin' && macVersion >= 15)
-      await run('Lax');
     else if (browserName === 'webkit')
       await run('None'); // Windows + older macOS
     else if (browserName === 'firefox' || browserName as any === '_bidiFirefox')
       await run('None');
     else
       throw new Error('unknown browser - ' + browserName);
-  }, { scope: 'worker' }],
-
-  sameSiteStoredValueForNone: [async ({ browserName, isMac, macVersion }, run) => {
-    if (browserName === 'webkit' && isMac && macVersion >= 15)
-      await run('Lax');
-    else
-      await run('None');
   }, { scope: 'worker' }],
 
   browserMajorVersion: [async ({ browserVersion }, run) => {

--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -142,7 +142,7 @@ it('should get multiple cookies', async ({ context, page, server, defaultSameSit
   ]));
 });
 
-it('should get cookies from multiple urls', async ({ context, browserName, isWindows, sameSiteStoredValueForNone }) => {
+it('should get cookies from multiple urls', async ({ context, browserName, isWindows }) => {
   await context.addCookies([{
     url: 'https://foo.com',
     name: 'doggo',
@@ -177,7 +177,7 @@ it('should get cookies from multiple urls', async ({ context, browserName, isWin
     expires: -1,
     httpOnly: false,
     secure: true,
-    sameSite: sameSiteStoredValueForNone,
+    sameSite: 'None',
   }]));
 });
 
@@ -273,7 +273,7 @@ it('should return secure cookies based on HTTP(S) protocol', async ({ context, b
   }]);
 });
 
-it('should add cookies with an expiration', async ({ context, sameSiteStoredValueForNone }) => {
+it('should add cookies with an expiration', async ({ context }) => {
   const expires = Math.floor((Date.now() / 1000)) + 3600;
   await context.addCookies([{
     url: 'https://foo.com',
@@ -292,7 +292,7 @@ it('should add cookies with an expiration', async ({ context, sameSiteStoredValu
     expires,
     httpOnly: false,
     secure: true,
-    sameSite: sameSiteStoredValueForNone,
+    sameSite: 'None',
   }]);
   {
     // Rollover to 5-digit year
@@ -396,7 +396,7 @@ it('should support requestStorageAccess', async ({ page, server, channel, browse
         server.waitForRequest('/title.html'),
         frame.evaluate(() => fetch('/title.html'))
       ]);
-      if ((isLinux || (isMac && macVersion >= 15)) && browserName === 'webkit')
+      if (isLinux && browserName === 'webkit')
         expect(serverRequest.headers.cookie).toBe(undefined);
       else
         expect(serverRequest.headers.cookie).toBe('name=value');

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1244,7 +1244,7 @@ it('should work with connectOverCDP', async ({ browserName, browserType, server 
   }
 });
 
-it('should support SameSite cookie attribute over https', async ({ contextFactory, httpsServer, browserName, isWindows, sameSiteStoredValueForNone }) => {
+it('should support SameSite cookie attribute over https', async ({ contextFactory, httpsServer, browserName, isWindows }) => {
   // Cookies with SameSite=None must also specify the Secure attribute. WebKit navigation
   // to HTTP url will fail if the response contains a cookie with Secure attribute, so
   // we do HTTPS navigation.
@@ -1260,8 +1260,6 @@ it('should support SameSite cookie attribute over https', async ({ contextFactor
       const [cookie] = await page.context().cookies();
       if (browserName === 'webkit' && isWindows)
         expect(cookie.sameSite).toBe('None');
-      else if (value === 'None')
-        expect(cookie.sameSite).toBe(sameSiteStoredValueForNone);
       else
         expect(cookie.sameSite).toBe(value);
     });
@@ -1291,7 +1289,7 @@ it('fetch should not throw on long set-cookie value', async ({ context, server }
   expect(cookies.map(c => c.name)).toContain('bar');
 });
 
-it('should support set-cookie with SameSite and without Secure attribute over HTTP', async ({ page, server, browserName, isWindows, isLinux, sameSiteStoredValueForNone }) => {
+it('should support set-cookie with SameSite and without Secure attribute over HTTP', async ({ page, server, browserName, isWindows, isLinux }) => {
   for (const value of ['None', 'Lax', 'Strict']) {
     await it.step(`SameSite=${value}`, async () => {
       server.setRoute('/empty.html', (req, res) => {
@@ -1306,8 +1304,6 @@ it('should support set-cookie with SameSite and without Secure attribute over HT
         expect(cookie).toBeFalsy();
       else if (browserName === 'webkit' && isWindows)
         expect(cookie.sameSite).toBe('None');
-      else if (value === 'None')
-        expect(cookie.sameSite).toBe(sameSiteStoredValueForNone);
       else
         expect(cookie.sameSite).toBe(value);
     });


### PR DESCRIPTION
This reverts the test expectation changes we did in https://github.com/microsoft/playwright/commit/463bd55cf02da37e15874fb7f0acf9cd1a7950e1 back to how they were before. WebKit test expectations are back aligned across macOS versions.

This got fixed from macOS 15.0.0 to 15.0.1 when GitHub Actions updated their runners see [here](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20241022.250).