### PR TITLE
Support Devuan in browser install scripts

### DIFF
--- a/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
@@ -13,6 +13,9 @@ if [[ ! -f "/etc/os-release" ]]; then
 fi
 
 ID=$(bash -c 'source /etc/os-release && echo $ID')
+if [[ "${ID}" == "devuan" ]]; then
+  ID="debian"
+fi
 if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" ]]; then
   echo "ERROR: cannot install on $ID distribution - only Ubuntu and Debian are supported"
   exit 1

--- a/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
@@ -13,6 +13,9 @@ if [[ ! -f "/etc/os-release" ]]; then
 fi
 
 ID=$(bash -c 'source /etc/os-release && echo $ID')
+if [[ "${ID}" == "devuan" ]]; then
+  ID="debian"
+fi
 if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" ]]; then
   echo "ERROR: cannot install on $ID distribution - only Ubuntu and Debian are supported"
   exit 1

--- a/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
@@ -14,6 +14,9 @@ if [[ ! -f "/etc/os-release" ]]; then
 fi
 
 ID=$(bash -c 'source /etc/os-release && echo $ID')
+if [[ "${ID}" == "devuan" ]]; then
+  ID="debian"
+fi
 if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" ]]; then
   echo "ERROR: cannot install on $ID distribution - only Ubuntu and Debian are supported"
   exit 1

--- a/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
@@ -14,6 +14,9 @@ if [[ ! -f "/etc/os-release" ]]; then
 fi
 
 ID=$(bash -c 'source /etc/os-release && echo $ID')
+if [[ "${ID}" == "devuan" ]]; then
+  ID="debian"
+fi
 if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" ]]; then
   echo "ERROR: cannot install on $ID distribution - only Ubuntu and Debian are supported"
   exit 1

--- a/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
@@ -14,6 +14,9 @@ if [[ ! -f "/etc/os-release" ]]; then
 fi
 
 ID=$(bash -c 'source /etc/os-release && echo $ID')
+if [[ "${ID}" == "devuan" ]]; then
+  ID="debian"
+fi
 if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" ]]; then
   echo "ERROR: cannot install on $ID distribution - only Ubuntu and Debian are supported"
   exit 1


### PR DESCRIPTION
Finishes the work of #32990 to be able to install the Chrome and MS Edge browsers on Devuan.

Please, check [my comment](https://github.com/microsoft/playwright/pull/32990#issuecomment-2445192994) in the linked PR. Looks like somehow #32990 hasn't made it into any release since it was merged.