### PR TITLE
feat(webserver): customize shutdown with new `kill` option

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -619,7 +619,7 @@ export default defineConfig({
   - `stdout` ?<["pipe"|"ignore"]> If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`.
   - `stderr` ?<["pipe"|"ignore"]> Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`.
   - `timeout` ?<[int]> How long to wait for the process to start up and be available in milliseconds. Defaults to 60000.
-  - `shutdownTimeout` ?<[int]> How long to wait for the process to gracefully shut down after it was sent `SIGINT`. If exceeded, process is killed with `SIGKILL`. Defaults to 500 milliseconds.
+  - `shutdownTimeout` ?<[int]> How long to wait for the process to gracefully shut down after it was sent `SIGINT`. If exceeded, process is killed with `SIGKILL`. Defaults to 500 milliseconds. Set to 0 to send `SIGKILL` immediately.
   - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is checked. Either `port` or `url` should be specified.
 
 Launch a development web server (or multiple) during the tests.

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -619,7 +619,7 @@ export default defineConfig({
   - `stdout` ?<["pipe"|"ignore"]> If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`.
   - `stderr` ?<["pipe"|"ignore"]> Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`.
   - `timeout` ?<[int]> How long to wait for the process to start up and be available in milliseconds. Defaults to 60000.
-  - `shutdownTimeout` ?<[int]> How long to wait for the process to gracefully shut down after it was sent `SIGINT`. If exceeded, process is killed with `SIGKILL`. Defaults to 500 milliseconds. Set to 0 to send `SIGKILL` immediately.
+  - `kill` ?<{ SIGINT: number } | { SIGTERM: number }> How to shut down the process gracefully. If unspecified, the process group is forcefully `SIGKILL`ed. If set to `{ SIGINT: 500 }`, the top process is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms. You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT` and `SIGTERM` signals, so this option is ignored.
   - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is checked. Either `port` or `url` should be specified.
 
 Launch a development web server (or multiple) during the tests.

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -620,8 +620,8 @@ export default defineConfig({
   - `stderr` ?<["pipe"|"ignore"]> Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`.
   - `timeout` ?<[int]> How long to wait for the process to start up and be available in milliseconds. Defaults to 60000.
   - `kill` ?<[Object]> How to shut down the process gracefully. If unspecified, the process group is forcefully `SIGKILL`ed. If set to `{ SIGINT: 500 }`, the top process is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms. You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT` and `SIGTERM` signals, so this option is ignored.
-    - `SIGINT` <[int]>
-    - `SIGTERM` <[int]> 
+    - `SIGINT` ?<[int]>
+    - `SIGTERM` ?<[int]> 
   - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is checked. Either `port` or `url` should be specified.
 
 Launch a development web server (or multiple) during the tests.

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -619,7 +619,7 @@ export default defineConfig({
   - `stdout` ?<["pipe"|"ignore"]> If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`.
   - `stderr` ?<["pipe"|"ignore"]> Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`.
   - `timeout` ?<[int]> How long to wait for the process to start up and be available in milliseconds. Defaults to 60000.
-  - `kill` ?<[Object]> How to shut down the process gracefully. If unspecified, the process group is forcefully `SIGKILL`ed. If set to `{ SIGINT: 500 }`, the top process is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms. You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT` and `SIGTERM` signals, so this option is ignored.
+  - `kill` ?<[Object]> How to shut down the process gracefully. If unspecified, the process group is forcefully `SIGKILL`ed. If set to `{ SIGINT: 500 }`, the process group is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms. You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT` and `SIGTERM` signals, so this option is ignored.
     - `SIGINT` ?<[int]>
     - `SIGTERM` ?<[int]> 
   - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is checked. Either `port` or `url` should be specified.

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -619,7 +619,9 @@ export default defineConfig({
   - `stdout` ?<["pipe"|"ignore"]> If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`.
   - `stderr` ?<["pipe"|"ignore"]> Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`.
   - `timeout` ?<[int]> How long to wait for the process to start up and be available in milliseconds. Defaults to 60000.
-  - `kill` ?<{ SIGINT: number } | { SIGTERM: number }> How to shut down the process gracefully. If unspecified, the process group is forcefully `SIGKILL`ed. If set to `{ SIGINT: 500 }`, the top process is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms. You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT` and `SIGTERM` signals, so this option is ignored.
+  - `kill` ?<[Object]> How to shut down the process gracefully. If unspecified, the process group is forcefully `SIGKILL`ed. If set to `{ SIGINT: 500 }`, the top process is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms. You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT` and `SIGTERM` signals, so this option is ignored.
+    - `SIGINT` <[int]>
+    - `SIGTERM` <[int]> 
   - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is checked. Either `port` or `url` should be specified.
 
 Launch a development web server (or multiple) during the tests.

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -619,6 +619,7 @@ export default defineConfig({
   - `stdout` ?<["pipe"|"ignore"]> If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`.
   - `stderr` ?<["pipe"|"ignore"]> Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`.
   - `timeout` ?<[int]> How long to wait for the process to start up and be available in milliseconds. Defaults to 60000.
+  - `shutdownTimeout` ?<[int]> How long to wait for the process to gracefully shut down after it was sent `SIGINT`. If exceeded, process is killed with `SIGKILL`. Defaults to 500 milliseconds.
   - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is checked. Either `port` or `url` should be specified.
 
 Launch a development web server (or multiple) during the tests.

--- a/docs/src/test-webserver-js.md
+++ b/docs/src/test-webserver-js.md
@@ -37,7 +37,7 @@ export default defineConfig({
 | `stdout` | If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`. |
 | `stderr` | Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`. |
 | `timeout` | How long to wait for the process to start up and be available in milliseconds. Defaults to 60000. |
-| `shutdownTimeout` | How long to wait for the process to gracefully shut down after it was sent `SIGINT`. If exceeded, process is killed with `SIGKILL`. Defaults to 500 milliseconds. Set to 0 to send `SIGKILL` immediately. |
+| `kill` | How to shut down the process gracefully. If unspecified, the process group is forcefully `SIGKILL`ed. If set to `{ SIGINT: 500 }`, the top process is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms. You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT` and `SIGTERM` signals, so this option is ignored. |
 
 ## Adding a server timeout
 

--- a/docs/src/test-webserver-js.md
+++ b/docs/src/test-webserver-js.md
@@ -37,7 +37,7 @@ export default defineConfig({
 | `stdout` | If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`. |
 | `stderr` | Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`. |
 | `timeout` | How long to wait for the process to start up and be available in milliseconds. Defaults to 60000. |
-| `kill` | How to shut down the process gracefully. If unspecified, the process group is forcefully `SIGKILL`ed. If set to `{ SIGINT: 500 }`, the top process is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms. You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT` and `SIGTERM` signals, so this option is ignored. |
+| `kill` | How to shut down the process gracefully. If unspecified, the process group is forcefully `SIGKILL`ed. If set to `{ SIGINT: 500 }`, the process group is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms. You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT` and `SIGTERM` signals, so this option is ignored. |
 
 ## Adding a server timeout
 

--- a/docs/src/test-webserver-js.md
+++ b/docs/src/test-webserver-js.md
@@ -37,7 +37,7 @@ export default defineConfig({
 | `stdout` | If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`. |
 | `stderr` | Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`. |
 | `timeout` | How long to wait for the process to start up and be available in milliseconds. Defaults to 60000. |
-| `shutdownTimeout` | How long to wait for the process to gracefully shut down after it was sent `SIGINT`. If exceeded, process is killed with `SIGKILL`. Defaults to 500 milliseconds. |
+| `shutdownTimeout` | How long to wait for the process to gracefully shut down after it was sent `SIGINT`. If exceeded, process is killed with `SIGKILL`. Defaults to 500 milliseconds. Set to 0 to send `SIGKILL` immediately. |
 
 ## Adding a server timeout
 

--- a/docs/src/test-webserver-js.md
+++ b/docs/src/test-webserver-js.md
@@ -36,7 +36,8 @@ export default defineConfig({
 | `cwd` | Current working directory of the spawned process, defaults to the directory of the configuration file. |
 | `stdout` | If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`. |
 | `stderr` | Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`. |
-| `timeout` | `How long to wait for the process to start up and be available in milliseconds. Defaults to 60000. |
+| `timeout` | How long to wait for the process to start up and be available in milliseconds. Defaults to 60000. |
+| `shutdownTimeout` | How long to wait for the process to gracefully shut down after it was sent `SIGINT`. If exceeded, process is killed with `SIGKILL`. Defaults to 500 milliseconds. |
 
 ## Adding a server timeout
 

--- a/packages/playwright-core/src/utils/processLauncher.ts
+++ b/packages/playwright-core/src/utils/processLauncher.ts
@@ -215,18 +215,18 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     }
     gracefullyClosing = true;
     options.log(`[pid=${spawnedProcess.pid}] <gracefully close start>`);
-    await options.attemptToGracefullyClose().catch(() => killProcess());
+    await options.attemptToGracefullyClose().catch(() => killProcess(true));
     await waitForCleanup;  // Ensure the process is dead and we have cleaned up.
     options.log(`[pid=${spawnedProcess.pid}] <gracefully close end>`);
   }
 
   // This method has to be sync to be used in the 'exit' event handler.
-  function killProcess() {
+  function killProcess(evenIfAlreadyKilled = false) {
     gracefullyCloseSet.delete(gracefullyClose);
     killSet.delete(killProcessAndCleanup);
     removeProcessHandlersIfNeeded();
     options.log(`[pid=${spawnedProcess.pid}] <kill>`);
-    if (spawnedProcess.pid && !spawnedProcess.killed && !processClosed) {
+    if (spawnedProcess.pid && (evenIfAlreadyKilled || !spawnedProcess.killed) && !processClosed) {
       options.log(`[pid=${spawnedProcess.pid}] <will force kill>`);
       // Force kill the browser.
       try {

--- a/packages/playwright-core/src/utils/processLauncher.ts
+++ b/packages/playwright-core/src/utils/processLauncher.ts
@@ -215,7 +215,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     }
     gracefullyClosing = true;
     options.log(`[pid=${spawnedProcess.pid}] <gracefully close start>`);
-    await options.attemptToGracefullyClose().catch((e) => killProcess());
+    await options.attemptToGracefullyClose().catch(() => killProcess());
     await waitForCleanup;  // Ensure the process is dead and we have cleaned up.
     options.log(`[pid=${spawnedProcess.pid}] <gracefully close end>`);
   }

--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -124,15 +124,13 @@ export class WebServerPlugin implements TestRunnerPlugin {
         if (!signal)
           throw new Error('skip graceful shutdown');
 
-        const success = launchedProcess.kill(signal);
-        if (!success)
-          throw new Error(`signal didn't succeed, fall back to non-graceful shutdown`);
-
+        process.kill(-launchedProcess.pid!, signal);
         return new Promise<void>((resolve, reject) => {
           const timer = timeout !== 0
             ? setTimeout(() => reject(new Error(`process didn't close gracefully within timeout, falling back to SIGKILL`)), timeout)
             : undefined;
-          launchedProcess.once('exit', () => {
+          launchedProcess.once('close', (...args) => {
+            console.log("closing", ...args)
             clearTimeout(timer);
             resolve();
           });

--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -108,6 +108,9 @@ export class WebServerPlugin implements TestRunnerPlugin {
         if (process.platform === 'win32')
           throw new Error('Graceful shutdown is not supported on Windows');
 
+        if (this._options.shutdownTimeout === 0)
+          throw new Error('skip graceful shutdown');
+
         const success = launchedProcess.kill('SIGINT');
         if (!success)
           throw new Error(`SIGINT didn't succeed, fall back to non-graceful shutdown`);

--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -104,6 +104,9 @@ export class WebServerPlugin implements TestRunnerPlugin {
       stdio: 'stdin',
       shell: true,
       attemptToGracefullyClose: async () => {
+        if (process.platform === 'win32')
+          throw new Error('Graceful shutdown is not supported on Windows');
+
         const success = launchedProcess.kill('SIGINT');
         if (!success)
           throw new Error(`SIGINT didn't succeed, fall back to non-graceful shutdown`);

--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -130,11 +130,7 @@ export class WebServerPlugin implements TestRunnerPlugin {
 
         return new Promise<void>((resolve, reject) => {
           const timer = timeout !== 0
-            ? setTimeout(() => {
-              // @ts-expect-error. SIGINT didn't kill the process, but `processLauncher` will only attempt killing it if this is false
-              launchedProcess.killed = false;
-              reject(new Error(`process didn't close gracefully within timeout, falling back to SIGKILL`));
-            }, timeout)
+            ? setTimeout(() => reject(new Error(`process didn't close gracefully within timeout, falling back to SIGKILL`)), timeout)
             : undefined;
           launchedProcess.once('exit', () => {
             clearTimeout(timer);

--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -101,6 +101,8 @@ export class WebServerPlugin implements TestRunnerPlugin {
         timeout = this._options.kill.SIGINT;
       }
       if ('SIGTERM' in this._options.kill && typeof this._options.kill.SIGTERM === 'number') {
+        if (signal)
+          throw new Error('Only one of SIGINT or SIGTERM can be specified in config.webServer.kill');
         signal = 'SIGTERM';
         timeout = this._options.kill.SIGTERM;
       }

--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -135,10 +135,10 @@ export class WebServerPlugin implements TestRunnerPlugin {
         } else {
           await Promise.race([
             processExit,
-            timers.setTimeout(timeout).then(() => {
+            timers.setTimeout(timeout, undefined, { ref: false }).then(() => {
               // @ts-expect-error. SIGINT didn't kill the process, but `processLauncher` will only attempt killing it if this is false
               launchedProcess.killed = false;
-              return Promise.reject(new Error(`process didn't close gracefully within timeout, falling back to SIGKILL`));
+              throw new Error(`process didn't close gracefully within timeout, falling back to SIGKILL`);
             }),
           ]);
         }

--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -30,7 +30,7 @@ export type WebServerPluginOptions = {
   url?: string;
   ignoreHTTPSErrors?: boolean;
   timeout?: number;
-  kill?: { SIGINT: number }|{ SIGTERM: number };
+  kill?: { SIGINT?: number, SIGTERM?: number };
   reuseExistingServer?: boolean;
   cwd?: string;
   env?: { [key: string]: string; };
@@ -95,11 +95,11 @@ export class WebServerPlugin implements TestRunnerPlugin {
     let signal: 'SIGINT' | 'SIGTERM' | undefined = undefined;
     let timeout = 0;
     if (this._options.kill) {
-      if ('SIGINT' in this._options.kill && typeof this._options.kill.SIGINT === 'number') {
+      if (typeof this._options.kill.SIGINT === 'number') {
         signal = 'SIGINT';
         timeout = this._options.kill.SIGINT;
       }
-      if ('SIGTERM' in this._options.kill && typeof this._options.kill.SIGTERM === 'number') {
+      if (typeof this._options.kill.SIGTERM === 'number') {
         if (signal)
           throw new Error('Only one of SIGINT or SIGTERM can be specified in config.webServer.kill');
         signal = 'SIGTERM';

--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -31,6 +31,7 @@ export type WebServerPluginOptions = {
   url?: string;
   ignoreHTTPSErrors?: boolean;
   timeout?: number;
+  shutdownTimeout?: number;
   reuseExistingServer?: boolean;
   cwd?: string;
   env?: { [key: string]: string; };
@@ -111,10 +112,10 @@ export class WebServerPlugin implements TestRunnerPlugin {
         if (!success)
           throw new Error(`SIGINT didn't succeed, fall back to non-graceful shutdown`);
         await Promise.race([
-          timers.setTimeout(1000).then(() => {
+          timers.setTimeout(this._options.shutdownTimeout ?? 500).then(() => {
             // @ts-expect-error. SIGINT didn't kill the process, but `processLauncher` will only attempt killing it if this is false
             launchedProcess.killed = false;
-            return Promise.reject(new Error(`server didn't close gracefully within a second, falling back to non-graceful shutdown`))
+            return Promise.reject(new Error(`server didn't close gracefully within a second, falling back to non-graceful shutdown`));
           }),
           new Promise(f => launchedProcess.once('exit', f)),
         ]);

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -9373,7 +9373,7 @@ interface TestConfigWebServer {
 
   /**
    * How to shut down the process gracefully. If unspecified, the process group is forcefully `SIGKILL`ed. If set to `{
-   * SIGINT: 500 }`, the top process is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms.
+   * SIGINT: 500 }`, the process group is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms.
    * You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT`
    * and `SIGTERM` signals, so this option is ignored.
    */

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -9378,9 +9378,9 @@ interface TestConfigWebServer {
    * and `SIGTERM` signals, so this option is ignored.
    */
   kill?: {
-    SIGINT: number;
+    SIGINT?: number;
 
-    SIGTERM: number;
+    SIGTERM?: number;
   };
 
   /**

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -9372,6 +9372,12 @@ interface TestConfigWebServer {
   timeout?: number;
 
   /**
+   * How long to wait for the process to gracefully shut down after it was sent `SIGINT`. If exceeded, process is killed
+   * with `SIGKILL`. Defaults to 500 milliseconds.
+   */
+  shutdownTimeout?: number;
+
+  /**
    * The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the
    * server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is
    * checked. Either `port` or `url` should be specified.

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -9377,7 +9377,11 @@ interface TestConfigWebServer {
    * You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT`
    * and `SIGTERM` signals, so this option is ignored.
    */
-  kill?: { SIGINT: number }|{ SIGTERM: number };
+  kill?: {
+    SIGINT: number;
+
+    SIGTERM: number;
+  };
 
   /**
    * The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -9372,10 +9372,12 @@ interface TestConfigWebServer {
   timeout?: number;
 
   /**
-   * How long to wait for the process to gracefully shut down after it was sent `SIGINT`. If exceeded, process is killed
-   * with `SIGKILL`. Defaults to 500 milliseconds.
+   * How to shut down the process gracefully. If unspecified, the process group is forcefully `SIGKILL`ed. If set to `{
+   * SIGINT: 500 }`, the top process is sent a `SIGINT` signal, followed by `SIGKILL` if it doesn't exit within 500ms.
+   * You can also use `SIGTERM` instead. A `0` timeout means no `SIGKILL` will be sent. Windows doesn't support `SIGINT`
+   * and `SIGTERM` signals, so this option is ignored.
    */
-  shutdownTimeout?: number;
+  kill?: { SIGINT: number }|{ SIGTERM: number };
 
   /**
    * The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the

--- a/tests/config/commonFixtures.ts
+++ b/tests/config/commonFixtures.ts
@@ -151,9 +151,17 @@ export class TestChildProcess {
     this.exitCode = this.exited.then(r => r.exitCode);
   }
 
-  outputLines(): string[] {
+  outputLines(options: { prefix?: string } = {}): string[] {
     const strippedOutput = stripAnsi(this.output);
-    return strippedOutput.split('\n').filter(line => line.startsWith('%%')).map(line => line.substring(2).trim());
+    return strippedOutput
+        .split('\n')
+        .map(line => {
+          if (options.prefix && line.startsWith(options.prefix))
+            return line.substring(options.prefix.length);
+          return line;
+        })
+        .filter(line => line.startsWith('%%'))
+        .map(line => line.substring(2).trim());
   }
 
   async kill(signal: 'SIGINT' | 'SIGKILL' = 'SIGKILL') {

--- a/tests/config/commonFixtures.ts
+++ b/tests/config/commonFixtures.ts
@@ -151,17 +151,9 @@ export class TestChildProcess {
     this.exitCode = this.exited.then(r => r.exitCode);
   }
 
-  outputLines(options: { prefix?: string } = {}): string[] {
+  outputLines(): string[] {
     const strippedOutput = stripAnsi(this.output);
-    return strippedOutput
-        .split('\n')
-        .map(line => {
-          if (options.prefix && line.startsWith(options.prefix))
-            return line.substring(options.prefix.length);
-          return line;
-        })
-        .filter(line => line.startsWith('%%'))
-        .map(line => line.substring(2).trim());
+    return strippedOutput.split('\n').filter(line => line.startsWith('%%')).map(line => line.substring(2).trim());
   }
 
   async kill(signal: 'SIGINT' | 'SIGKILL' = 'SIGKILL') {

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -745,36 +745,52 @@ test('should forward stdout when set to "pipe" before server is ready', async ({
   expect(result.output).not.toContain('Timed out waiting 3000ms');
 });
 
-test('should gracefully kill server', async ({ interactWithTestRunner }, { workerIndex }) => {
+test.describe('graceful shutdown', () => {
   test.skip(process.platform === 'win32', 'No sending SIGINT on Windows');
 
-  const port = workerIndex * 2 + 10510;
+  const files = (additionalOptions = {}) => {
+    const port = test.info().workerIndex * 2 + 10510;
+    return {
+      'web-server.js': `
+        process.on('SIGINT', () => { console.log('%%webserver received SIGINT but stubbornly refuses to wind down') })
+        const server = require('http').createServer((req, res) => { res.end("ok"); })
+        server.listen(process.argv[2], () => { console.log('webserver started'); });
+      `,
+      'test.spec.ts': `
+        import { test, expect } from '@playwright/test';
+        test('pass', async ({}) => {});
+      `,
+      'playwright.config.ts': `
+        module.exports = {
+          webServer: {
+            command: 'node web-server.js ${port}',
+            port: ${port},
+            stdout: 'pipe',
+            timeout: 3000,
+            ...${JSON.stringify(additionalOptions)}
+          },
+        };
+      `,
+    };
+  };
 
-  const testProcess = await interactWithTestRunner({
-    'web-server.js': `
-      process.on('SIGINT', () => { console.log('%%webserver received SIGINT but stubbornly refuses to wind down') })
-      const server = require('http').createServer((req, res) => { res.end("ok"); })
-      server.listen(process.argv[2], () => { console.log('webserver started'); });
-    `,
-    'test.spec.ts': `
-      import { test, expect } from '@playwright/test';
-      test('pass', async ({}) => {});
-    `,
-    'playwright.config.ts': `
-      module.exports = {
-        webServer: {
-          command: 'node web-server.js ${port}',
-          port: ${port},
-          stdout: 'pipe',
-          timeout: 3000,
-        },
-      };
-    `,
-  }, { workers: 1 });
+  test('sends SIGINT by default', async ({ interactWithTestRunner }) => {
+    const testProcess = await interactWithTestRunner(files(), { workers: 1 });
 
-  await testProcess.waitForOutput('webserver started');
-  process.kill(testProcess.process.pid!, 'SIGINT');
-  await testProcess.exited;
+    await testProcess.waitForOutput('webserver started');
+    process.kill(testProcess.process.pid!, 'SIGINT');
+    await testProcess.exited;
 
-  expect(testProcess.outputLines({ prefix: '[WebServer] ' })).toEqual(['webserver received SIGINT but stubbornly refuses to wind down']);
+    expect(testProcess.outputLines({ prefix: '[WebServer] ' })).toEqual(['webserver received SIGINT but stubbornly refuses to wind down']);
+  });
+
+  test('can be disabled', async ({ interactWithTestRunner }) => {
+    const testProcess = await interactWithTestRunner(files({ shutdownTimeout: 0 }), { workers: 1 });
+
+    await testProcess.waitForOutput('webserver started');
+    process.kill(testProcess.process.pid!, 'SIGINT');
+    await testProcess.exited;
+
+    expect(testProcess.outputLines({ prefix: '[WebServer] ' })).toEqual([]);
+  });
 });

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -773,7 +773,7 @@ test('should gracefully kill server', async ({ interactWithTestRunner }, { worke
   }, { workers: 1 });
 
   await testProcess.waitForOutput('webserver started');
-  process.kill(-testProcess.process.pid!, 'SIGINT');
+  process.kill(testProcess.process.pid!, 'SIGINT');
   await testProcess.exited;
 
   expect(testProcess.outputLines({ prefix: '[WebServer] ' })).toEqual(['webserver received SIGINT but stubbornly refuses to wind down']);

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -804,4 +804,11 @@ test.describe('kill option', () => {
 
     expect(testProcess.outputLines({ prefix: '[WebServer] ' })).toEqual(['webserver received SIGINT but stubbornly refuses to wind down']);
   });
+
+  test('throws when mixed', async ({ interactWithTestRunner }) => {
+    const testProcess = await interactWithTestRunner(files({ kill: { SIGINT: 500, SIGTERM: 500 } }), { workers: 1 });
+    await testProcess.exited;
+
+    expect(testProcess.output).toContain('Only one of SIGINT or SIGTERM can be specified in config.webServer.kill');
+  });
 });

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -756,7 +756,7 @@ test.describe('kill option', () => {
         process.on('SIGINT', () => { console.log('%%webserver received SIGINT but stubbornly refuses to wind down') })
         process.on('SIGTERM', () => { console.log('%%webserver received SIGTERM but stubbornly refuses to wind down') })
         const server = require('http').createServer((req, res) => { res.end("ok"); })
-        server.listen(process.argv[2], () => { console.log('webserver started'); });
+        server.listen(process.argv[2]);
       `,
       'test.spec.ts': `
         import { test, expect } from '@playwright/test';


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/33377, https://github.com/microsoft/playwright/issues/18209

There's quite some backstory on this that we should keep in mind:

We [tried this in the past](https://github.com/microsoft/playwright/pull/18220), then [reverted](https://github.com/microsoft/playwright/pull/18661) because we wanted to have it spawn a child process instead of a separate process group [PR](https://github.com/microsoft/playwright/pull/18564), which we also reverted because [it changed from SIGKILL to SIGTERM and that broke Svelte](https://github.com/microsoft/playwright/issues/18865).

This PR proposes a `kill` option that allows users customizing this shutdown behaviour.

---
> the below is for previous version of this PR. i'll still keep it here for future reference, so we don't lose this research.

This PR proposes to keep things mostly as they are. The addition is to try sending a `SIGINT` first, and if it didn't exit after half a second (configurable with `shutdownTimeout` setting), continue as usual with a `SIGKILL`.

Putting 500ms as a default timeout is based on two assumptions about common `webserver` usage:

1. it's mostly used to start web framework dev servers and `docker compose` setups, which we can expect to understand `SIGINT`
2. most local development environments can shut down in 500ms

Users that fulfil both assumptions will now get proper graceful shutdown. User that don't fulfil the second one won't see a benefit until they configure `shutdownTimeout`. Most other users will see a slowdown of 500ms, but no other breaking changes. Only folks that have a weird implementation of `SIGINT` will see a breaking change, which should be fine.

Let me know if you think we should use `SIGTERM` instead of `SIGINT`. I'm unsure which one is more idiomatic, since Playwright is a user-controlled tool, but we also initiate the signal programatically.

We could also solve some of the `docker compose` cleanup issues by killing only the top process, and not the entire process group (see [here](https://github.com/microsoft/playwright/issues/33377#issuecomment-2459549210)). This would help this specific `docker compose` thing, but not `docker run --rm` or any other processes that depend on `SIGINT` for cleanup.