### PR TITLE
feat(chromium): add missing grantable permissions

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -971,8 +971,11 @@ A permission or an array of permissions to grant. Permissions can be one of the 
 * `'camera'`
 * `'clipboard-read'`
 * `'clipboard-write'`
+* `'display-capture'`
 * `'geolocation'`
 * `'gyroscope'`
+* `'idle-detection'`
+* `'local-fonts'`
 * `'magnetometer'`
 * `'microphone'`
 * `'midi-sysex'` (system-exclusive midi)
@@ -980,6 +983,8 @@ A permission or an array of permissions to grant. Permissions can be one of the 
 * `'notifications'`
 * `'payment-handler'`
 * `'storage-access'`
+* `'usb'`
+* `'window-management'`
 
 ### option: BrowserContext.grantPermissions.origin
 * since: v1.8

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -983,7 +983,6 @@ A permission or an array of permissions to grant. Permissions can be one of the 
 * `'notifications'`
 * `'payment-handler'`
 * `'storage-access'`
-* `'usb'`
 * `'window-management'`
 
 ### option: BrowserContext.grantPermissions.origin

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -440,7 +440,6 @@ export class CRBrowserContext extends BrowserContext {
       ['local-fonts', 'localFonts'],
       ['midi-sysex', 'midiSysex'],
       ['storage-access', 'storageAccess'],
-      ['usb', 'usb'],
       ['window-management', 'windowManagement'],
     ]);
     const filtered = permissions.map(permission => {

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -418,23 +418,30 @@ export class CRBrowserContext extends BrowserContext {
 
   async doGrantPermissions(origin: string, permissions: string[]) {
     const webPermissionToProtocol = new Map<string, Protocol.Browser.PermissionType>([
-      ['geolocation', 'geolocation'],
-      ['midi', 'midi'],
-      ['notifications', 'notifications'],
-      ['camera', 'videoCapture'],
-      ['microphone', 'audioCapture'],
-      ['background-sync', 'backgroundSync'],
-      ['ambient-light-sensor', 'sensors'],
+      // General permissions
       ['accelerometer', 'sensors'],
-      ['gyroscope', 'sensors'],
-      ['magnetometer', 'sensors'],
       ['accessibility-events', 'accessibilityEvents'],
+      ['ambient-light-sensor', 'sensors'],
+      ['background-sync', 'backgroundSync'],
+      ['camera', 'videoCapture'],
       ['clipboard-read', 'clipboardReadWrite'],
       ['clipboard-write', 'clipboardSanitizedWrite'],
+      ['display-capture', 'displayCapture'],
+      ['geolocation', 'geolocation'],
+      ['gyroscope', 'sensors'],
+      ['magnetometer', 'sensors'],
+      ['microphone', 'audioCapture'],
+      ['midi', 'midi'],
+      ['notifications', 'notifications'],
       ['payment-handler', 'paymentHandler'],
-      // chrome-specific permissions we have.
+
+      // Chrome-specific permissions we have.
+      ['idle-detection', 'idleDetection'],
+      ['local-fonts', 'localFonts'],
       ['midi-sysex', 'midiSysex'],
       ['storage-access', 'storageAccess'],
+      ['usb', 'usb'],
+      ['window-management', 'windowManagement'],
     ]);
     const filtered = permissions.map(permission => {
       const protocolPermission = webPermissionToProtocol.get(permission);

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8981,7 +8981,6 @@ export interface BrowserContext {
    * - `'notifications'`
    * - `'payment-handler'`
    * - `'storage-access'`
-   * - `'usb'`
    * - `'window-management'`
    * @param options
    */

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8969,8 +8969,11 @@ export interface BrowserContext {
    * - `'camera'`
    * - `'clipboard-read'`
    * - `'clipboard-write'`
+   * - `'display-capture'`
    * - `'geolocation'`
    * - `'gyroscope'`
+   * - `'idle-detection'`
+   * - `'local-fonts'`
    * - `'magnetometer'`
    * - `'microphone'`
    * - `'midi-sysex'` (system-exclusive midi)
@@ -8978,6 +8981,8 @@ export interface BrowserContext {
    * - `'notifications'`
    * - `'payment-handler'`
    * - `'storage-access'`
+   * - `'usb'`
+   * - `'window-management'`
    * @param options
    */
   grantPermissions(permissions: ReadonlyArray<string>, options?: {


### PR DESCRIPTION
Extends the list of grantable Chromium permissions.

I hit `'Unknown permission: local-fonts'` while attempting to grant the permission in a test, which this change resolves. While there, I noticed a few more permissions that should be supported, which were already typed in `PermissionType`.