### PR TITLE
feat(test results) Add timestamp to the errors

### DIFF
--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -132,6 +132,7 @@ export function formatCallLog(log: string[] | undefined): string {
   if (!log || !log.some(l => !!l))
     return '';
   return `
+Timestamp: ${new Date().toISOString()}
 Call log:
 ${colors.dim(log.join('\n'))}
 `;

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -71,6 +71,18 @@ test('should include custom expect message with web-first assertions', async ({ 
   expect(result.output).toContain('Call log:');
 });
 
+test('should include a timestamp of when expectation failed', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'expect-test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('custom expect message', async ({page}) => {
+        await expect(page.locator('x-foo'), { message: 'x-foo must be visible' }).toBeVisible({timeout: 1});
+      });
+    `
+  });
+  expect(result.output).toMatch(/Timestamp: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+});
+
 test('should work with generic matchers', async ({ runTSC }) => {
   const result = await runTSC({
     'a.spec.ts': `


### PR DESCRIPTION
Implementation for https://github.com/microsoft/playwright/issues/33412

Let me know if this is acceptable.  Note that the timestamp is using just plain ISO date string.