### PR TITLE
feat(test info): Add possibility to use test file name without extenson in snapshotPathTemplate

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -1809,6 +1809,8 @@ The list of supported tokens:
   * Value: `page`
 * `{testFileName}` - Test file name with extension.
   * Value: `page-click.spec.ts`
+* `{testFileNameWithoutExtension}` - Test file name without extension.
+  * Value: `page-click`
 * `{testFilePath}` - Relative path from `testDir` to **test file**
   * Value: `page/page-click.spec.ts`
 * `{testName}` - File-system-sanitized test title, including parent describes but excluding file name.

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -454,6 +454,7 @@ export class TestInfoImpl implements TestInfo {
         .replace(/\{(.)?projectName\}/g, projectNamePathSegment ? '$1' + projectNamePathSegment : '')
         .replace(/\{(.)?testName\}/g, '$1' + this._fsSanitizedTestName())
         .replace(/\{(.)?testFileName\}/g, '$1' + parsedRelativeTestFilePath.base)
+        .replace(/\{(.)?testFileNameWithoutExtension\}/g, '$1' + parsedRelativeTestFilePath.base.replace('.spec', '').replace('.ts', ''))
         .replace(/\{(.)?testFilePath\}/g, '$1' + relativeTestFilePath)
         .replace(/\{(.)?arg\}/g, '$1' + path.join(parsedSubPath.dir, parsedSubPath.name))
         .replace(/\{(.)?ext\}/g, parsedSubPath.ext ? '$1' + parsedSubPath.ext : '');

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -467,6 +467,8 @@ interface TestProject<TestArgs = {}, WorkerArgs = {}> {
    *   - Value: `page`
    * - `{testFileName}` - Test file name with extension.
    *   - Value: `page-click.spec.ts`
+   * - `{testFileNameWithoutExtension}` - Test file name without extension.
+   *   - Value: `page-click`
    * - `{testFilePath}` - Relative path from `testDir` to **test file**
    *   - Value: `page/page-click.spec.ts`
    * - `{testName}` - File-system-sanitized test title, including parent describes but excluding file name.
@@ -1531,6 +1533,8 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    *   - Value: `page`
    * - `{testFileName}` - Test file name with extension.
    *   - Value: `page-click.spec.ts`
+   * - `{testFileNameWithoutExtension}` - Test file name without extension.
+   *   - Value: `page-click`
    * - `{testFilePath}` - Relative path from `testDir` to **test file**
    *   - Value: `page/page-click.spec.ts`
    * - `{testName}` - File-system-sanitized test title, including parent describes but excluding file name.

--- a/tests/playwright-test/snapshot-path-template.spec.ts
+++ b/tests/playwright-test/snapshot-path-template.spec.ts
@@ -80,6 +80,9 @@ test('tokens should expand property', async ({ runInlineTest }, testInfo) => {
       name: 'testFileName',
       snapshotPathTemplate: '{testFileName}',
     }, {
+      name: 'testFileNameWithoutExtension',
+      snapshotPathTemplate: '{testFileNameWithoutExtension}',
+    }, {
       name: 'snapshotDir',
       snapshotDir: './a-snapshot-dir',
       snapshotPathTemplate: '{snapshotDir}.png',


### PR DESCRIPTION
# Description

At the moment there is no possibility to get test file name without the extension for `snapshotPathTemplate`. Please refer to https://github.com/microsoft/playwright/issues/24171

Our stakeholders requested to have path to snapshots without test file extension because it is confusing for them. The best place to achieve that is PW framework repo rather than custom fixtures in the project.

## What was done

- [x] Add new token for the `snapshotPathTemplate` to cut out extension for the test file name
- [x] Add new token into the tests for the `snapshotPathTemplate`
- [x] Add information about the new token to the declarations
- [x] Add information about the new token into the public documentation

## Testing

![Screenshot - 11_4_2024 , 9_13_17 AM](https://github.com/user-attachments/assets/d2ed97b2-cda9-4573-ae51-6cae1972e97f)
 