### PR TITLE
devops: increase heap size to 8 GB for merge report workflow

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         npx playwright merge-reports --config .github/workflows/merge.config.ts ./all-blob-reports
       env:
-        NODE_OPTIONS: --max-old-space-size=4096
+        NODE_OPTIONS: --max-old-space-size=8192
 
     - name: Azure Login
       uses: azure/login@v2


### PR DESCRIPTION
Note: The machine which we are using has 16 GB of memory, so this should just work.