### PR TITLE
chore(ui): handle trace not being available without exceptions

### DIFF
--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -54,6 +54,8 @@ async function loadTrace(traceUrl: string, traceFileName: string | null, clientI
     const backend = traceUrl.endsWith('json') ? new FetchTraceModelBackend(traceUrl) : new ZipTraceModelBackend(traceUrl, fetchProgress);
     await traceModel.load(backend, unzipProgress);
   } catch (error: any) {
+    if (error?.message === 'trace not found')
+      throw error;
     // eslint-disable-next-line no-console
     console.error(error);
     if (error?.message?.includes('Cannot find .trace file') && await traceModel.hasEntry('index.html'))
@@ -106,6 +108,8 @@ async function doFetch(event: FetchEvent): Promise<Response> {
           headers: { 'Content-Type': 'application/json' }
         });
       } catch (error: any) {
+        if (error?.message === 'trace not found')
+          return new Response(null, { status: 404 });
         return new Response(JSON.stringify({ error: error?.message }), {
           status: 500,
           headers: { 'Content-Type': 'application/json' }

--- a/packages/trace-viewer/src/sw/traceModelBackends.ts
+++ b/packages/trace-viewer/src/sw/traceModelBackends.ts
@@ -88,7 +88,10 @@ export class FetchTraceModelBackend implements TraceModelBackend {
   constructor(traceURL: string) {
     this._traceURL = traceURL;
     this._entriesPromise = fetch('/trace/file?path=' + encodeURIComponent(traceURL)).then(async response => {
-      const json = JSON.parse(await response.text());
+      if (response.status === 404)
+        throw new Error(`trace not found`);
+
+      const json = await response.json();
       const entries = new Map<string, string>();
       for (const entry of json.entries)
         entries.set(entry.name, entry.path);

--- a/packages/trace-viewer/src/ui/uiModeTraceView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeTraceView.tsx
@@ -33,6 +33,7 @@ export const TraceView: React.FC<{
   pathSeparator: string,
 }> = ({ item, rootDir, onOpenExternally, revealSource, pathSeparator }) => {
   const [model, setModel] = React.useState<{ model: MultiTraceModel, isLive: boolean } | undefined>();
+  const [rerender, setRerender] = React.useState(0);
   const pollTimer = React.useRef<NodeJS.Timeout | null>(null);
 
   const { outputDir } = React.useMemo(() => {
@@ -79,13 +80,15 @@ export const TraceView: React.FC<{
           setModel({ model, isLive: true });
       } catch {
         setModel(undefined);
+      } finally {
+        setRerender(rerender + 1);
       }
     }, 500);
     return () => {
       if (pollTimer.current)
         clearTimeout(pollTimer.current);
     };
-  }, [outputDir, item, setModel, pathSeparator]);
+  }, [outputDir, item, setModel, rerender, setRerender, pathSeparator]);
 
   return <Workbench
     key='workbench'


### PR DESCRIPTION
The control flow for loading live traces is currently based on exceptions, and it's hard to follow. It's expected that the live trace only becomes available after a couple retries, but the code doesn't reflect that.

This PR adds some handling for 404s so we represent the "trace not yet available" state with 404 responses instead of 
errors. It also renames the `counter` state to `rerender` to make the intent clearer.

Console before this change:

<img width="732" alt="Screenshot 2024-11-04 at 16 01 58" src="https://github.com/user-attachments/assets/4efc5b3a-693b-4d70-a93f-4a19b51455b7">

Console after this change:

<img width="807" alt="Screenshot 2024-11-04 at 16 02 46" src="https://github.com/user-attachments/assets/b720e446-d6d4-47fe-9cec-f3cc6750ac8c">


Closes https://github.com/microsoft/playwright/issues/33339.