### PR TITLE
chore(reporter): add another surrogate pair test case

### DIFF
--- a/tests/playwright-test/fit-to-width.spec.ts
+++ b/tests/playwright-test/fit-to-width.spec.ts
@@ -29,4 +29,5 @@ test('surrogate pairs', () => {
   expect(fitToWidth('🚄🚄', 2)).toBe('…');
   expect(fitToWidth('🚄🚄', 3)).toBe('…🚄');
   expect(fitToWidth('🚄🚄', 4)).toBe('🚄🚄');
+  expect(fitToWidth('🧑‍🧑‍🧒🧑‍🧑‍🧒🧑‍🧑‍🧒', 4)).toBe('…🧑‍🧑‍🧒');
 });


### PR DESCRIPTION
Pavel asked for more surrogate pair test cases. I noticed we already had some, but I've added another test case that's special, in that not even VS Code handles it correctly. If you hit backspace on the character, it gets split up into its components:

https://github.com/user-attachments/assets/4de48b2c-9f38-4de9-b603-d03999eba982

The VS Code bug is tracked in https://github.com/microsoft/vscode/issues/99629 and it's purportedly closed completed - not sure if i'm seeing a regression. At least Playwright knows how to handle it :D

@pavelfeldman let me know in case you meant a different kind of character and I remembered wrong.
