### PR TITLE
fix(download): fix second browser download of channels

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -8,6 +8,12 @@
       "browserVersion": "131.0.6778.24"
     },
     {
+      "name": "chromium-headless-shell",
+      "revision": "1146",
+      "installByDefault": false,
+      "browserVersion": "131.0.6778.24"
+    },
+    {
       "name": "chromium-tip-of-tree",
       "revision": "1271",
       "installByDefault": false,

--- a/utils/roll_browser.js
+++ b/utils/roll_browser.js
@@ -94,6 +94,14 @@ Example:
     console.log('\nUpdating browser version in browsers.json...');
     for (const descriptor of descriptors)
       descriptor.browserVersion = browserVersion;
+
+    // 4.1 chromium-headless-shell is equal to chromium version.
+    if (browserName === 'chromium') {
+      const headlessShellBrowser = await browsersJSON.browsers.find(b => b.name === 'chromium-headless-shell');
+      headlessShellBrowser.revision = revision;
+      headlessShellBrowser.browserVersion = browserVersion;
+    }
+
     fs.writeFileSync(path.join(CORE_PATH, 'browsers.json'), JSON.stringify(browsersJSON, null, 2) + '\n');
   }
 


### PR DESCRIPTION
**What does it fix?**

This fixes when `npx playwright install chromium-headless-shell` was executed twice in a row. This also applied to `firefox-beta` or `chromium-tip-of-tree`.

Expected: Second time the browser does get get downloaded again.

Actual: The browser gets downloaded again and the browser GC kicks in before that.

**What happened?**

Before we normalised the browser names when writing the binaries into the directories here:

https://github.com/microsoft/playwright/blob/edf1eb154dfc1f2f6080438a3af3cc5ecccd37bb/packages/playwright-core/src/server/registry/index.ts#L399

We checked it here tho without the normalisation applied:

https://github.com/microsoft/playwright/blob/edf1eb154dfc1f2f6080438a3af3cc5ecccd37bb/packages/playwright-core/src/server/registry/index.ts#L355

Since the unused browser logic is based on `browser.json` I moved the chromium-headless-shell descriptor into the `readDescriptor` function:

https://github.com/microsoft/playwright/blob/edf1eb154dfc1f2f6080438a3af3cc5ecccd37bb/packages/playwright-core/src/server/registry/index.ts#L1156