### PR TITLE
chore: override host platform with env variable

### DIFF
--- a/packages/playwright-core/src/utils/hostPlatform.ts
+++ b/packages/playwright-core/src/utils/hostPlatform.ts
@@ -35,6 +35,12 @@ export type HostPlatform = 'win64' |
                            '<unknown>';
 
 function calculatePlatform(): { hostPlatform: HostPlatform, isOfficiallySupportedPlatform: boolean } {
+  if (process.env.PLAYWRIGHT_HOST_PLATFORM_OVERRIDE) {
+    return {
+      hostPlatform: process.env.PLAYWRIGHT_HOST_PLATFORM_OVERRIDE as HostPlatform,
+      isOfficiallySupportedPlatform: false
+    };
+  }
   const platform = os.platform();
   if (platform === 'darwin') {
     const ver = os.release().split('.').map((a: string) => parseInt(a, 10));


### PR DESCRIPTION
Allow to override host platform with an environment variable. This is for adventurous users that
want to run Playwright on unsupported linux distributions. This way we do not need to hard code
the distro's name and version in Playwright deps installer. The clients can manually override the
platform.

Fixes https://github.com/microsoft/playwright/issues/33432