### PR TITLE
fix(websocket): pass through underlying WebSocket protocol

### DIFF
--- a/packages/playwright-core/src/server/injected/webSocketMock.ts
+++ b/packages/playwright-core/src/server/injected/webSocketMock.ts
@@ -331,6 +331,13 @@ export function inject(globalThis: GlobalThis) {
     _ensureOpened() {
       if (this.readyState !== WebSocketMock.CONNECTING)
         return;
+      this.extensions = this._ws?.extensions || '';
+      if (this._ws)
+        this.protocol = this._ws.protocol;
+      else if (Array.isArray(this._protocols))
+        this.protocol = this._protocols[0] || '';
+      else
+        this.protocol = this._protocols || '';
       this.readyState = WebSocketMock.OPEN;
       this.dispatchEvent(new Event('open', { cancelable: true }));
     }


### PR DESCRIPTION
3 modes:

- **pass-through:** We call `ensureOpened` after the server negotiated and set the actual underlying `ws.protocol` setting.
- **mock via protocol as a string:**: There we select the given one.
- **mock via protocol as a string array:**: There we select the first one and pretend this one was negotiated.

Its getting set right before we emit the `open` event. Before its an empty string as per [here](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/protocol).

Fixes https://github.com/microsoft/playwright/issues/33425.