### PR TITLE
docs(aria-snapshot): fix markdown rendering / langs

### DIFF
--- a/docs/src/aria-snapshot.md
+++ b/docs/src/aria-snapshot.md
@@ -112,7 +112,7 @@ attributes.
 In this example, the button role is matched, but the accessible name ("Submit") is not specified, allowing the test to
 pass regardless of the button’s label.
 
----
+<hr/>
 
 For elements with ARIA attributes like `checked` or `disabled`, omitting these attributes allows partial matching,
 focusing solely on role and hierarchy.
@@ -130,7 +130,7 @@ focusing solely on role and hierarchy.
 
 In this partial match, the `checked` attribute is ignored, so the test will pass regardless of the checkbox state.
 
----
+<hr/>
 
 Similarly, you can partially match children in lists or groups by omitting specific list items or nested elements.
 
@@ -222,6 +222,7 @@ accessibility tree for a selected locator, letting you explore, inspect, and ver
 accessible names to aid snapshot creation and review.
 
 ### 3. Updating Snapshots with `@playwright/test` and the `--update-snapshots` Flag
+* langs: js
 
 When using the Playwright test runner (`@playwright/test`), you can automatically update snapshots by running tests with
 the `--update-snapshots` flag:


### PR DESCRIPTION
Out markdown parser doesn't treat `---` correctly, it removes the line before it which leads to having the text before rendered as a h2.

We never use `---` so lets just stick with html tags here.

See here for [the bug](https://playwright.dev/docs/next/aria-snapshot#in-this-example-the-button-role-is-matched-but-the-accessible-name-submit-is-not-specified-allowing-the-test-to-pass-regardless-of-the-buttons-label).