### PR TITLE
chore: roll chromium-headless-shell to r1147

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -9,7 +9,7 @@
     },
     {
       "name": "chromium-headless-shell",
-      "revision": "1146",
+      "revision": "1147",
       "installByDefault": false,
       "browserVersion": "131.0.6778.24"
     },


### PR DESCRIPTION
This regressed in https://github.com/microsoft/playwright/pull/33429.