### PR TITLE
chore(trace viewer): make service worker types available

### DIFF
--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -68,7 +68,6 @@ async function loadTrace(traceUrl: string, traceFileName: string | null, clientI
   return traceModel;
 }
 
-// @ts-ignore
 async function doFetch(event: FetchEvent): Promise<Response> {
   // In order to make Accessibility Insights for Web work.
   if (event.request.url.startsWith('chrome-extension://'))
@@ -180,7 +179,6 @@ async function gc() {
   const usedTraces = new Set<string>();
 
   for (const [clientId, data] of clientIdToTraceUrls) {
-    // @ts-ignore
     if (!clients.find(c => c.id === clientId)) {
       clientIdToTraceUrls.delete(clientId);
       continue;
@@ -199,7 +197,6 @@ async function gc() {
   }
 }
 
-// @ts-ignore
 self.addEventListener('fetch', function(event: FetchEvent) {
   event.respondWith(doFetch(event));
 });

--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -21,7 +21,6 @@ import { TraceModel } from './traceModel';
 import { FetchTraceModelBackend, ZipTraceModelBackend } from './traceModelBackends';
 import { TraceVersionError } from './traceModernizer';
 
-// @ts-ignore
 declare const self: ServiceWorkerGlobalScope;
 
 self.addEventListener('install', function(event: any) {
@@ -99,7 +98,7 @@ async function doFetch(event: FetchEvent): Promise<Response> {
       try {
         const limit = url.searchParams.has('limit') ? +url.searchParams.get('limit')! : undefined;
         const traceModel = await loadTrace(traceUrl!, url.searchParams.get('traceFileName'), event.clientId, limit, (done: number, total: number) => {
-          client.postMessage({ method: 'progress', params: { done, total } });
+          client?.postMessage({ method: 'progress', params: { done, total } });
         });
         return new Response(JSON.stringify(traceModel!.contextEntries), {
           status: 200,

--- a/packages/trace-viewer/tsconfig.json
+++ b/packages/trace-viewer/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext", "WebWorker"],
     "allowJs": true,
     "skipLibCheck": false,
     "esModuleInterop": false,

--- a/packages/trace-viewer/tsconfig.json
+++ b/packages/trace-viewer/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext", "WebWorker"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": true,
     "skipLibCheck": false,
     "esModuleInterop": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2019",
     "module": "commonjs",
-    "lib": ["esnext", "dom", "DOM.Iterable"],
+    "lib": ["esnext", "dom", "DOM.Iterable", "WebWorker"],
     "baseUrl": ".",
     "paths": {
       /*


### PR DESCRIPTION
`self` is currently `any`. We can fix the types by adding the `WebWorkers` lib to our tsconfig.