### PR TITLE
chore(trace viewer): reorder service worker operations

### DIFF
--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -113,8 +113,10 @@ async function doFetch(event: FetchEvent): Promise<Response> {
     }
 
     if (!client) {
-      // expected client to be defined for all non-iframe requests. something went wrong
-      return fetch(event.request);
+      // vscode webview doesn't sent clientId under some circumstances
+      if (url.pathname.endsWith('embedded.html'))
+        return fetch(event.request);
+      throw new Error('expected client to be defined for all non-iframe requests. something went wrong');
     }
 
     if (relativePath === '/contexts') {

--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -112,8 +112,10 @@ async function doFetch(event: FetchEvent): Promise<Response> {
       return snapshotServer.serveClosestScreenshot(relativePath, url.searchParams);
     }
 
-    if (!client)
-      throw new Error('expected client to be defined for all non-iframe requests. soemthing went wrong');
+    if (!client) {
+      // expected client to be defined for all non-iframe requests. something went wrong
+      return fetch(event.request);
+    }
 
     if (relativePath === '/contexts') {
       try {


### PR DESCRIPTION
This PR reorders the service worker operations to reflect whether they have a `client` available. I'll be reading settings from the client's `client.URL` in a future change, so this makes that easier typewise.