### PR TITLE
chore(html): support HMR for local dev

### DIFF
--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -55,7 +55,14 @@ class ZipReport implements LoadedReport {
   private _json!: HTMLReport;
 
   async load() {
-    const zipReader = new zipjs.ZipReader(new zipjs.Data64URIReader(window.playwrightReportBase64!), { useWebWorkers: false });
+    const zipURI = await new Promise<string>(resolve => {
+      if (window.playwrightReportBase64)
+        return resolve(window.playwrightReportBase64);
+      window.addEventListener('message', event => event.source === window.opener && resolve(event.data), { once: true });
+      window.opener.postMessage('ready', '*');
+    });
+
+    const zipReader = new zipjs.ZipReader(new zipjs.Data64URIReader(zipURI), { useWebWorkers: false });
     for (const entry of await zipReader.getEntries())
       this._entries.set(entry.filename, entry);
     this._json = await this.entry('report.json') as HTMLReport;

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -357,20 +357,22 @@ class HtmlBuilder {
       }
     }
 
-    // Inline report data.
-    const indexFile = path.join(this._reportFolder, 'index.html');
-    fs.appendFileSync(indexFile, '<script>\nwindow.playwrightReportBase64 = "data:application/zip;base64,');
+    await this._writeReportData(path.join(this._reportFolder, 'index.html'));
+
+
+    return { ok, singleTestId };
+  }
+
+  private async _writeReportData(path: string) {
+    fs.appendFileSync(path, '<script>\nwindow.playwrightReportBase64 = "data:application/zip;base64,');
     await new Promise(f => {
       this._dataZipFile!.end(undefined, () => {
         this._dataZipFile!.outputStream
             .pipe(new Base64Encoder())
-            .pipe(fs.createWriteStream(indexFile, { flags: 'a' })).on('close', f);
+            .pipe(fs.createWriteStream(path, { flags: 'a' })).on('close', f);
       });
     });
-    fs.appendFileSync(indexFile, '";</script>');
-
-
-    return { ok, singleTestId };
+    fs.appendFileSync(path, '";</script>');
   }
 
   private _addDataFile(fileName: string, data: any) {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -365,16 +365,16 @@ class HtmlBuilder {
     return { ok, singleTestId };
   }
 
-  private async _writeReportData(path: string) {
-    fs.appendFileSync(path, '<script>\nwindow.playwrightReportBase64 = "data:application/zip;base64,');
+  private async _writeReportData(filePath: string) {
+    fs.appendFileSync(filePath, '<script>\nwindow.playwrightReportBase64 = "data:application/zip;base64,');
     await new Promise(f => {
       this._dataZipFile!.end(undefined, () => {
         this._dataZipFile!.outputStream
             .pipe(new Base64Encoder())
-            .pipe(fs.createWriteStream(path, { flags: 'a' })).on('close', f);
+            .pipe(fs.createWriteStream(filePath, { flags: 'a' })).on('close', f);
       });
     });
-    fs.appendFileSync(path, '";</script>');
+    fs.appendFileSync(filePath, '";</script>');
   }
 
   private _addDataFile(fileName: string, data: any) {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -325,8 +325,10 @@ class HtmlBuilder {
         const hmrURL = new URL('http://localhost:44224'); // dev server, port is harcoded in build.js
         const popup = window.open(hmrURL);
         window.addEventListener('message', evt => {
-          if (evt.source === popup && evt.data === 'ready')
+          if (evt.source === popup && evt.data === 'ready') {
             popup!.postMessage((window as any).playwrightReportBase64, hmrURL.origin);
+            window.close();
+          }
         }, { once: true });
       }
 

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -316,6 +316,13 @@ if (watchMode) {
     cwd: path.join(__dirname, '..', '..', 'packages', 'trace-viewer'),
     concurrent: true,
   });
+  steps.push({
+    command: 'npx',
+    args: ['vite', '--port', '44224'],
+    shell: true,
+    cwd: path.join(__dirname, '..', '..', 'packages', 'html-reporter'),
+    concurrent: true,
+  });
 }
 
 // Generate injected.


### PR DESCRIPTION
This PR gives us hot module replacement for the html report. Enable it with `PW_HMR=1`.

In HMR mode, the HTML report becomes a redirect file to the dev server. We can't pass the ZIP contents via URL, so it's transferred via `postMessage` instead.

https://github.com/user-attachments/assets/d981fd2e-609f-49be-abaa-718f84152a54


