### PR TITLE
fix(transform): allow import attributes always

### DIFF
--- a/packages/playwright/bundles/babel/src/babelBundleImpl.ts
+++ b/packages/playwright/bundles/babel/src/babelBundleImpl.ts
@@ -27,7 +27,9 @@ import traverseFunction from '@babel/traverse';
 export const traverse = traverseFunction;
 
 function babelTransformOptions(isTypeScript: boolean, isModule: boolean, pluginsPrologue: [string, any?][], pluginsEpilogue: [string, any?][]): TransformOptions {
-  const plugins = [];
+  const plugins = [
+    [require('@babel/plugin-syntax-import-attributes'), { deprecatedAssertSyntax: true }],
+  ];
 
   if (isTypeScript) {
     plugins.push(
@@ -45,7 +47,6 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
         [require('@babel/plugin-syntax-async-generators')],
         [require('@babel/plugin-syntax-object-rest-spread')],
         [require('@babel/plugin-transform-export-namespace-from')],
-        [require('@babel/plugin-syntax-import-attributes'), { deprecatedAssertSyntax: true }],
         [
           // From https://github.com/G-Rath/babel-plugin-replace-ts-export-assignment/blob/8dfdca32c8aa428574b0cae341444fc5822f2dc6/src/index.ts
           (

--- a/tests/playwright-test/esm.spec.ts
+++ b/tests/playwright-test/esm.spec.ts
@@ -45,9 +45,15 @@ test('should support import attributes', async ({ runInlineTest }) => {
     'package.json': JSON.stringify({ type: 'module', foo: 'bar' }),
     'a.test.ts': `
       import config from './package.json' with { type: 'json' };
+      import configFooFromUtils from './utils.js'
       console.log('imported value (test): ' + config.foo);
       import { test, expect } from '@playwright/test';
+      expect(configFooFromUtils.foo).toBe('bar');
       test('pass', async () => {});
+    `,
+    'utils.js': `
+      import config from './package.json' with { type: 'json' };
+      export default config;
     `
   });
   expect(result.exitCode).toBe(0);


### PR DESCRIPTION
This regressed in https://github.com/microsoft/playwright/pull/32713 but was not covered with a test before.

Before we added it `!isModule`. After my patch above it was always used when it was `TypeScript`.

This patch does what it should - enable it all the time, since Babel is not able to parse it otherwise and threw `SyntaxError`.