### PR TITLE
fix(expect): adjust normalization for regex values in toHaveText matcher

### DIFF
--- a/packages/playwright/src/matchers/toEqual.ts
+++ b/packages/playwright/src/matchers/toEqual.ts
@@ -19,6 +19,7 @@ import { matcherHint } from './matcherHint';
 import type { MatcherResult } from './matcherHint';
 import type { ExpectMatcherState } from '../../types/test';
 import type { Locator } from 'playwright-core';
+import { isRegExp } from 'playwright-core/lib/utils';
 
 // Omit colon and one or more spaces, so can call getLabelPrinter.
 const EXPECTED_LABEL = 'Expected';
@@ -62,7 +63,7 @@ export async function toEqual<T>(
   } else if (Array.isArray(expected) && Array.isArray(received)) {
     const normalizedExpected = expected.map((exp, index) => {
       const rec = received[index];
-      if (exp instanceof RegExp)
+      if (isRegExp(exp))
         return exp.test(rec) ? rec : exp;
 
       return exp;

--- a/packages/playwright/src/matchers/toEqual.ts
+++ b/packages/playwright/src/matchers/toEqual.ts
@@ -59,6 +59,21 @@ export async function toEqual<T>(
   if (pass) {
     printedExpected = `Expected: not ${this.utils.printExpected(expected)}`;
     printedReceived = `Received: ${this.utils.printReceived(received)}`;
+  } else if (Array.isArray(expected) && Array.isArray(received)) {
+    const normalizedExpected = expected.map((exp, index) => {
+      const rec = received[index];
+      if (exp instanceof RegExp)
+        return exp.test(rec) ? rec : exp;
+
+      return exp;
+    });
+    printedDiff = this.utils.printDiffOrStringify(
+        normalizedExpected,
+        received,
+        EXPECTED_LABEL,
+        RECEIVED_LABEL,
+        false,
+    );
   } else {
     printedDiff = this.utils.printDiffOrStringify(
         expected,

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -616,6 +616,33 @@ test('should print pending operations for toHaveText', async ({ runInlineTest })
   expect(output).toContain('waiting for locator(\'no-such-thing\')');
 });
 
+test('should only highlight unmatched regex in diff message for toHaveText with array', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+
+      test('toHaveText with mixed strings and regexes (array)', async ({ page }) => {
+        await page.setContent(\`
+          <ul>
+            <li>Coffee</li>
+            <li>Tea</li>
+            <li>Milk</li>
+          </ul>
+        \`);
+
+        const items = page.locator('li');
+        await expect(items).toHaveText(['Coffee', /\\d+/, /Milk/]);
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  const output = result.output;
+  expect(output).toContain('-   /\\d+/,');
+  expect(output).toContain('+   "Tea",');
+  expect(output).not.toContain('-   /Milk/,');
+  expect(output).not.toContain('-   "Coffee",');
+});
+
 test('should print expected/received on Ctrl+C', async ({ interactWithTestRunner }) => {
   test.skip(process.platform === 'win32', 'No sending SIGINT on Windows');
 


### PR DESCRIPTION
Fixes #29382

1. The current issue occurs in the `toEqual` call when the `expected` type in `toHaveText` is `(string | RegExp)[]`. Since we cannot modify the external dependency `this.utils.printDiffOrStringify`, normalization is performed before invoking it.
2. As a precaution, I checked the `toMatchText` method, which handles cases where the type is `string | RegExp`, to ensure that regex values are processed correctly. Regression tests confirmed that no issues are present.