### PR TITLE
chore: more aria snapshot fixes

### DIFF
--- a/packages/playwright-core/src/server/injected/ariaSnapshot.ts
+++ b/packages/playwright-core/src/server/injected/ariaSnapshot.ts
@@ -300,7 +300,8 @@ export function renderAriaTree(ariaNode: AriaNode, options?: { mode?: 'raw' | 'r
     }
 
     let key = ariaNode.role;
-    if (ariaNode.name) {
+    // Yaml has a limit of 1024 characters per key, and we leave some space for role and attributes.
+    if (ariaNode.name && ariaNode.name.length <= 900) {
       const name = renderString(ariaNode.name);
       if (name) {
         const stringifiedName = name.startsWith('/') && name.endsWith('/') ? name : JSON.stringify(name);

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -79,7 +79,7 @@ export async function toMatchAriaSnapshot(
   if (notFound) {
     return {
       pass: this.isNot,
-      message: () => messagePrefix + `Expected: ${this.utils.printExpected(expected)}\nReceived: ${EXPECTED_COLOR('not found')}` + callLogText(log),
+      message: () => messagePrefix + `Expected: ${this.utils.printExpected(expected)}\nReceived: ${EXPECTED_COLOR('<element not found>')}` + callLogText(log),
       name: 'toMatchAriaSnapshot',
       expected,
     };

--- a/tests/page/page-aria-snapshot.spec.ts
+++ b/tests/page/page-aria-snapshot.spec.ts
@@ -479,16 +479,16 @@ it('should escape yaml text in text nodes', async ({ page }) => {
   `);
 });
 
-it.fixme('should handle long strings', async ({ page }) => {
+it('should handle long strings', async ({ page }) => {
+  const s = 'a'.repeat(10000);
   await page.setContent(`
     <a href='about:blank'>
-      <div role='region'>${'a'.repeat(100000)}</div>
+      <div role='region'>${s}</div>
     </a>
   `);
 
-  const trimmed = 'a'.repeat(1000);
   await checkAndMatchSnapshot(page.locator('body'), `
-    - link "${trimmed}":
-      - region: "${trimmed}"
+    - link:
+      - region: ${s}
   `);
 });

--- a/tests/page/to-match-aria-snapshot.spec.ts
+++ b/tests/page/to-match-aria-snapshot.spec.ts
@@ -640,17 +640,6 @@ test('call log should contain actual snapshot', async ({ page }) => {
   expect(stripAnsi(error.message)).toContain(`- unexpected value "- heading "todos" [level=1]"`);
 });
 
-test.fixme('should normalize whitespace when matching accessible name', async ({ page }) => {
-  await page.setContent(`
-    <button>hello world</button>
-  `);
-  await expect(page.locator('body')).toMatchAriaSnapshot(`
-    - |
-        button "hello
-          world"
-  `);
-});
-
 test('should parse attributes', async ({ page }) => {
   {
     await page.setContent(`


### PR DESCRIPTION
- Handle long strings.
- Standard `<element not found>` error message.
- Some tests.