### PR TITLE
chore(service worker): 404 if there's no client

### DIFF
--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -77,6 +77,8 @@ async function doFetch(event: FetchEvent): Promise<Response> {
 
   const request = event.request;
   const client = await self.clients.get(event.clientId);
+  if (!client)
+    return new Response(null, { status: 404 });
 
   // When trace viewer is deployed over https, we will force upgrade
   // insecure http subresources to https. Otherwise, these will fail

--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -154,7 +154,7 @@ async function doFetch(event: FetchEvent): Promise<Response> {
     return fetch(event.request);
   }
 
-  const snapshotUrl = unwrapPopoutUrl(client!.url);
+  const snapshotUrl = unwrapPopoutUrl(client.url);
   const traceUrl = new URL(snapshotUrl).searchParams.get('trace')!;
   const { snapshotServer } = loadedTraces.get(traceUrl) || {};
   if (!snapshotServer)


### PR DESCRIPTION
Supercedes https://github.com/microsoft/playwright/pull/33497. Adds a check for `client` to be defined, so we can depend on that in the code below.

There's some cases where `event.clientId` is undefined, but it seems that it's fine to return a 404 in those. At least tests are passing.

As discussed, I also experimented with moving `kBlankSnapshotUrl` into the service worker, but that didn't change anything about `clientId` being defined.