### PR TITLE
chore(trace viewer): decouple test server from web server

### DIFF
--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -125,6 +125,8 @@ export async function installRootRedirect(server: HttpServer, traceUrls: string[
   for (const reporter of options.reporter || [])
     params.append('reporter', reporter);
 
+  params.set('server', server.urlPrefix('precise'));
+
   const urlPath  = `./trace/${options.webApp || 'index.html'}?${params.toString()}`;
   server.routePath('/', (_, response) => {
     response.statusCode = 302;

--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -93,6 +93,14 @@ async function doFetch(event: FetchEvent): Promise<Response> {
       return new Response(null, { status: 200 });
     }
 
+    let traceViewerServerBaseUrl = self.registration.scope;
+    if (client?.url) {
+      const clientUrl = new URL(client.url);
+      if (clientUrl.searchParams.has('server'))
+        traceViewerServerBaseUrl = clientUrl.searchParams.get('server')!;
+    }
+    const traceViewerServer = new TraceViewerServerBackend(traceViewerServerBaseUrl);
+
     const traceUrl = url.searchParams.get('trace');
 
     if (relativePath === '/contexts') {

--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -148,7 +148,15 @@ async function doFetch(event: FetchEvent): Promise<Response> {
       return new Response(null, { status: 404 });
     }
 
-    // Fallback to network.
+    if (relativePath.startsWith('/file/')) {
+      const path = url.searchParams.get('path')!;
+      const response = await traceViewerServer.readFile(path);
+      if (!response)
+        return new Response(null, { status: 404 });
+      return response;
+    }
+
+    // Fallback for static assets.
     return fetch(event.request);
   }
 

--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -36,13 +36,21 @@ const scopePath = new URL(self.registration.scope).pathname;
 
 const loadedTraces = new Map<string, { traceModel: TraceModel, snapshotServer: SnapshotServer }>();
 
-const clientIdToTraceUrls = new Map<string, { limit: number | undefined, traceUrls: Set<string> }>();
+const clientIdToTraceUrls = new Map<string, { limit: number | undefined, traceUrls: Set<string>, traceViewerServer: TraceViewerServer }>();
 
-async function loadTrace(traceUrl: string, traceFileName: string | null, clientId: string, traceViewerServer: TraceViewerServer, limit: number | undefined, progress: (done: number, total: number) => undefined): Promise<TraceModel> {
+async function loadTrace(traceUrl: string, traceFileName: string | null, client: any | undefined, limit: number | undefined, progress: (done: number, total: number) => undefined): Promise<TraceModel> {
   await gc();
+  const clientId = client?.id ?? '';
   let data = clientIdToTraceUrls.get(clientId);
   if (!data) {
-    data = { limit, traceUrls: new Set() };
+    let traceViewerServerBaseUrl = self.registration.scope;
+    if (client?.url) {
+      const clientUrl = new URL(client.url);
+      if (clientUrl.searchParams.has('server'))
+        traceViewerServerBaseUrl = clientUrl.searchParams.get('server')!;
+    }
+
+    data = { limit, traceUrls: new Set(), traceViewerServer: new TraceViewerServer(traceViewerServerBaseUrl) };
     clientIdToTraceUrls.set(clientId, data);
   }
   data.traceUrls.add(traceUrl);
@@ -51,7 +59,7 @@ async function loadTrace(traceUrl: string, traceFileName: string | null, clientI
   try {
     // Allow 10% to hop from sw to page.
     const [fetchProgress, unzipProgress] = splitProgress(progress, [0.5, 0.4, 0.1]);
-    const backend = traceUrl.endsWith('json') ? new FetchTraceModelBackend(traceUrl, traceViewerServer) : new ZipTraceModelBackend(traceUrl, traceViewerServer, fetchProgress);
+    const backend = traceUrl.endsWith('json') ? new FetchTraceModelBackend(traceUrl, data.traceViewerServer) : new ZipTraceModelBackend(traceUrl, data.traceViewerServer, fetchProgress);
     await traceModel.load(backend, unzipProgress);
   } catch (error: any) {
     // eslint-disable-next-line no-console
@@ -69,22 +77,6 @@ async function loadTrace(traceUrl: string, traceFileName: string | null, clientI
   return traceModel;
 }
 
-const traceViewerServers = new Map<string, TraceViewerServer>();
-
-function getTraceViewerServer(client?: any): TraceViewerServer {
-  let traceViewerServerBaseUrl = self.registration.scope;
-  if (client?.url) {
-    const clientUrl = new URL(client.url);
-    if (clientUrl.searchParams.has('server'))
-      traceViewerServerBaseUrl = clientUrl.searchParams.get('server')!;
-  }
-
-  if (!traceViewerServers.has(traceViewerServerBaseUrl))
-    traceViewerServers.set(traceViewerServerBaseUrl, new TraceViewerServer(traceViewerServerBaseUrl));
-
-  return traceViewerServers.get(traceViewerServerBaseUrl)!;
-}
-
 // @ts-ignore
 async function doFetch(event: FetchEvent): Promise<Response> {
   // In order to make Accessibility Insights for Web work.
@@ -93,7 +85,6 @@ async function doFetch(event: FetchEvent): Promise<Response> {
 
   const request = event.request;
   const client = await self.clients.get(event.clientId);
-  const traceViewerServer = getTraceViewerServer(client);
 
   // When trace viewer is deployed over https, we will force upgrade
   // insecure http subresources to https. Otherwise, these will fail
@@ -115,7 +106,7 @@ async function doFetch(event: FetchEvent): Promise<Response> {
     if (relativePath === '/contexts') {
       try {
         const limit = url.searchParams.has('limit') ? +url.searchParams.get('limit')! : undefined;
-        const traceModel = await loadTrace(traceUrl!, url.searchParams.get('traceFileName'), event.clientId, traceViewerServer, limit, (done: number, total: number) => {
+        const traceModel = await loadTrace(traceUrl!, url.searchParams.get('traceFileName'), client, limit, (done: number, total: number) => {
           client.postMessage({ method: 'progress', params: { done, total } });
         });
         return new Response(JSON.stringify(traceModel!.contextEntries), {
@@ -167,6 +158,9 @@ async function doFetch(event: FetchEvent): Promise<Response> {
 
     if (relativePath.startsWith('/file/')) {
       const path = url.searchParams.get('path')!;
+      const traceViewerServer = clientIdToTraceUrls.get(event.clientId ?? '')?.traceViewerServer;
+      if (!traceViewerServer)
+        throw new Error('client is not initialized');
       const response = await traceViewerServer.readFile(path);
       if (!response)
         return new Response(null, { status: 404 });

--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -18,7 +18,7 @@ import { splitProgress } from './progress';
 import { unwrapPopoutUrl } from './snapshotRenderer';
 import { SnapshotServer } from './snapshotServer';
 import { TraceModel } from './traceModel';
-import { FetchTraceModelBackend, TraceViewerServerBackend, ZipTraceModelBackend } from './traceModelBackends';
+import { FetchTraceModelBackend, TraceViewerServer, ZipTraceModelBackend } from './traceModelBackends';
 import { TraceVersionError } from './traceModernizer';
 
 // @ts-ignore
@@ -38,7 +38,7 @@ const loadedTraces = new Map<string, { traceModel: TraceModel, snapshotServer: S
 
 const clientIdToTraceUrls = new Map<string, { limit: number | undefined, traceUrls: Set<string> }>();
 
-async function loadTrace(traceUrl: string, traceFileName: string | null, clientId: string, traceViewerServer: TraceViewerServerBackend, limit: number | undefined, progress: (done: number, total: number) => undefined): Promise<TraceModel> {
+async function loadTrace(traceUrl: string, traceFileName: string | null, clientId: string, traceViewerServer: TraceViewerServer, limit: number | undefined, progress: (done: number, total: number) => undefined): Promise<TraceModel> {
   await gc();
   let data = clientIdToTraceUrls.get(clientId);
   if (!data) {
@@ -69,9 +69,9 @@ async function loadTrace(traceUrl: string, traceFileName: string | null, clientI
   return traceModel;
 }
 
-const traceViewerServers = new Map<string, TraceViewerServerBackend>();
+const traceViewerServers = new Map<string, TraceViewerServer>();
 
-function getTraceViewerServer(client?: any): TraceViewerServerBackend {
+function getTraceViewerServer(client?: any): TraceViewerServer {
   let traceViewerServerBaseUrl = self.registration.scope;
   if (client?.url) {
     const clientUrl = new URL(client.url);
@@ -80,7 +80,7 @@ function getTraceViewerServer(client?: any): TraceViewerServerBackend {
   }
 
   if (!traceViewerServers.has(traceViewerServerBaseUrl))
-    traceViewerServers.set(traceViewerServerBaseUrl, new TraceViewerServerBackend(traceViewerServerBaseUrl));
+    traceViewerServers.set(traceViewerServerBaseUrl, new TraceViewerServer(traceViewerServerBaseUrl));
 
   return traceViewerServers.get(traceViewerServerBaseUrl)!;
 }

--- a/packages/trace-viewer/src/sw/traceModelBackends.ts
+++ b/packages/trace-viewer/src/sw/traceModelBackends.ts
@@ -28,7 +28,7 @@ export class ZipTraceModelBackend implements TraceModelBackend {
   private _entriesPromise: Promise<Map<string, zip.Entry>>;
   private _traceURL: string;
 
-  constructor(traceURL: string, server: TraceViewerServerBackend, progress: Progress) {
+  constructor(traceURL: string, server: TraceViewerServer, progress: Progress) {
     this._traceURL = traceURL;
     zipjs.configure({ baseURL: self.location.href } as any);
     this._zipReader = new zipjs.ZipReader(
@@ -84,9 +84,9 @@ export class ZipTraceModelBackend implements TraceModelBackend {
 export class FetchTraceModelBackend implements TraceModelBackend {
   private _entriesPromise: Promise<Map<string, string>>;
   private _path: string;
-  private _server: TraceViewerServerBackend;
+  private _server: TraceViewerServer;
 
-  constructor(path: string, server: TraceViewerServerBackend) {
+  constructor(path: string, server: TraceViewerServer) {
     this._path  = path;
     this._server = server;
     this._entriesPromise = server.readFile(path).then(async response => {
@@ -137,7 +137,7 @@ export class FetchTraceModelBackend implements TraceModelBackend {
   }
 }
 
-function formatUrl(trace: string, server: TraceViewerServerBackend) {
+function formatUrl(trace: string, server: TraceViewerServer) {
   let url = trace.startsWith('http') || trace.startsWith('blob') ? trace : server.getFileURL(trace).toString();
   // Dropbox does not support cors.
   if (url.startsWith('https://www.dropbox.com/'))
@@ -145,7 +145,7 @@ function formatUrl(trace: string, server: TraceViewerServerBackend) {
   return url;
 }
 
-export class TraceViewerServerBackend {
+export class TraceViewerServer {
   constructor(private readonly baseUrl: string) {}
 
   getFileURL(path: string): URL {

--- a/packages/trace-viewer/src/sw/traceModelBackends.ts
+++ b/packages/trace-viewer/src/sw/traceModelBackends.ts
@@ -147,11 +147,13 @@ function formatUrl(trace: string, server: TraceViewerServerBackend) {
 
 export class TraceViewerServerBackend {
   constructor(private readonly baseUrl: string) {}
+
   getFileURL(path: string): URL {
     const url = new URL('trace/file', this.baseUrl);
     url.searchParams.set('path', path);
     return url;
   }
+
   async readFile(path: string): Promise<Response | undefined> {
     const response = await fetch(this.getFileURL(path));
     if (response.status === 404)

--- a/packages/trace-viewer/src/sw/traceModelBackends.ts
+++ b/packages/trace-viewer/src/sw/traceModelBackends.ts
@@ -28,11 +28,11 @@ export class ZipTraceModelBackend implements TraceModelBackend {
   private _entriesPromise: Promise<Map<string, zip.Entry>>;
   private _traceURL: string;
 
-  constructor(traceURL: string, progress: Progress) {
+  constructor(traceURL: string, server: TraceViewerServerBackend, progress: Progress) {
     this._traceURL = traceURL;
     zipjs.configure({ baseURL: self.location.href } as any);
     this._zipReader = new zipjs.ZipReader(
-        new zipjs.HttpReader(formatUrl(traceURL), { mode: 'cors', preventHeadRequest: true } as any),
+        new zipjs.HttpReader(formatUrl(traceURL, server), { mode: 'cors', preventHeadRequest: true } as any),
         { useWebWorkers: false });
     this._entriesPromise = this._zipReader.getEntries({ onprogress: progress }).then(entries => {
       const map = new Map<string, zip.Entry>();
@@ -83,12 +83,16 @@ export class ZipTraceModelBackend implements TraceModelBackend {
 
 export class FetchTraceModelBackend implements TraceModelBackend {
   private _entriesPromise: Promise<Map<string, string>>;
-  private _traceURL: string;
+  private _path: string;
+  private _server: TraceViewerServerBackend;
 
-  constructor(traceURL: string) {
-    this._traceURL = traceURL;
-    this._entriesPromise = fetch('/trace/file?path=' + encodeURIComponent(traceURL)).then(async response => {
-      const json = JSON.parse(await response.text());
+  constructor(path: string, server: TraceViewerServerBackend) {
+    this._path  = path;
+    this._server = server;
+    this._entriesPromise = server.readFile(path).then(async response => {
+      if (!response)
+        throw new Error('File not found');
+      const json = await response.json();
       const entries = new Map<string, string>();
       for (const entry of json.entries)
         entries.set(entry.name, entry.path);
@@ -101,7 +105,7 @@ export class FetchTraceModelBackend implements TraceModelBackend {
   }
 
   traceURL(): string {
-    return this._traceURL;
+    return this._path;
   }
 
   async entryNames(): Promise<string[]> {
@@ -129,14 +133,29 @@ export class FetchTraceModelBackend implements TraceModelBackend {
     const fileName = entries.get(entryName);
     if (!fileName)
       return;
-    return fetch('/trace/file?path=' + encodeURIComponent(fileName));
+    return this._server.readFile(fileName);
   }
 }
 
-function formatUrl(trace: string) {
-  let url = trace.startsWith('http') || trace.startsWith('blob') ? trace : `file?path=${encodeURIComponent(trace)}`;
+function formatUrl(trace: string, server: TraceViewerServerBackend) {
+  let url = trace.startsWith('http') || trace.startsWith('blob') ? trace : server.getFileURL(trace).toString();
   // Dropbox does not support cors.
   if (url.startsWith('https://www.dropbox.com/'))
     url = 'https://dl.dropboxusercontent.com/' + url.substring('https://www.dropbox.com/'.length);
   return url;
+}
+
+export class TraceViewerServerBackend {
+  constructor(private readonly baseUrl: string) {}
+  getFileURL(path: string): URL {
+    const url = new URL('trace/file', this.baseUrl);
+    url.searchParams.set('path', path);
+    return url;
+  }
+  async readFile(path: string): Promise<Response | undefined> {
+    const response = await fetch(this.getFileURL(path));
+    if (response.status === 404)
+      return;
+    return response;
+  }
 }

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -328,6 +328,7 @@ export function collectSnapshots(action: ActionTraceEvent | undefined): Snapshot
 }
 
 const isUnderTest = new URLSearchParams(window.location.search).has('isUnderTest');
+const serverParam = new URLSearchParams(window.location.search).get('server');
 
 export function extendSnapshot(snapshot: Snapshot): SnapshotUrls {
   const params = new URLSearchParams();
@@ -346,6 +347,7 @@ export function extendSnapshot(snapshot: Snapshot): SnapshotUrls {
 
   const popoutParams = new URLSearchParams();
   popoutParams.set('r', snapshotUrl);
+  popoutParams.set('server', serverParam ?? '');
   popoutParams.set('trace', context(snapshot.action).traceUrl);
   if (snapshot.point) {
     popoutParams.set('pointX', String(snapshot.point.x));


### PR DESCRIPTION
The trace viewer server has three purposes:

1. serve static assets
2. provide websocket access to test server
3. provide file access

In preparation for hot module replacement, this PR allows specifying a separate backend for 2. and 3.. This could also be helpful in the future in a codespace-like setup.

It adds a `TraceViewerServerBackend` class that encapsulates file access, and propagates the baseURL via a search parameter. It also adds a `/file/` handler to the service worker, so all communication with the trace viewer server is explicitly handled through the service worker.