### PR TITLE
chore(build): empty out dir

### DIFF
--- a/packages/trace-viewer/vite.config.ts
+++ b/packages/trace-viewer/vite.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
   },
   build: {
     outDir: path.resolve(__dirname, '../playwright-core/lib/vite/traceViewer'),
+    emptyOutDir: true,
     rollupOptions: {
       input: {
         index: path.resolve(__dirname, 'index.html'),


### PR DESCRIPTION
We're seeing the following error:

```
(!) outDir playwright/packages/playwright-core/lib/vite/traceViewer is not inside project root and will not be emptied.
Use --emptyOutDir to override.
```

I've removed `emptyOutDir: false` in a previous PR to enable emptying. Wasn't aware they check for the project root. It looks like we need `emptyOutDir: true` to achieve what we want :D