### PR TITLE
chore(build): fix bug where sw changes aren't copied in watch mode

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -291,6 +291,24 @@ steps.push({
   concurrent: watchMode, // feeds into trace-viewer's `public` directory, so it needs to be finished before trace-viewer build starts
 });
 
+if (watchMode) {
+  // the build above outputs into `packages/trace-viewer/public`, where the `vite build` for `packages/trace-viewer` is supposed to pick it up.
+  // there's a bug in `vite build --watch` though where the public dir is only copied over initially, but its not watched.
+  // to work around this, we run a second watch build of the service worker into the final output.
+  steps.push({
+    command: 'npx',
+    args: [
+      'vite', '--config', 'vite.sw.config.ts',
+      'build', '--watch', '--minify=false',
+      '--outDir', path.join(__dirname, '..', '..', 'packages', 'playwright-core', 'lib', 'vite', 'trace-viewer'),
+      '--emptyOutDir=false'
+    ],
+    shell: true,
+    cwd: path.join(__dirname, '..', '..', 'packages', 'trace-viewer'),
+    concurrent: true
+  });
+}
+
 // Build/watch web packages.
 for (const webPackage of ['html-reporter', 'recorder', 'trace-viewer']) {
   steps.push({

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -295,6 +295,7 @@ if (watchMode) {
   // the build above outputs into `packages/trace-viewer/public`, where the `vite build` for `packages/trace-viewer` is supposed to pick it up.
   // there's a bug in `vite build --watch` though where the public dir is only copied over initially, but its not watched.
   // to work around this, we run a second watch build of the service worker into the final output.
+  // bug: https://github.com/vitejs/vite/issues/18655
   steps.push({
     command: 'npx',
     args: [


### PR DESCRIPTION
#33511 introduced a bug where watch mode doesn't work correctly for the service worker anymore. This PR fixes that. Explanation of the bug is in the comments.

See https://github.com/vitejs/vite/issues/18655