### PR TITLE
chore: update headless shell treatment

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -268,29 +268,8 @@ jobs:
     - run: npx playwright install-deps
     - run: utils/build/build-playwright-driver.sh
 
-  test_linux_chromium_headless_shell:
-    name: Chromium Headless Shell
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [ubuntu-latest]
-    runs-on: ${{ matrix.runs-on }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ./.github/actions/run-test
-      with:
-        browsers-to-install: chromium chromium-headless-shell
-        command: npm run ctest
-        bot-name: "headless-shell-${{ matrix.runs-on }}"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
-      env:
-        PWTEST_CHANNEL: chromium-headless-shell
-
-  test_chromium_next:
-    name: Test chromium-next channel
+  test_channel_chromium:
+    name: Test channel=chromium
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -301,11 +280,13 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/run-test
       with:
+        # TODO: this should pass --no-shell.
+        # However, codegen tests do not inherit the channel and try to launch headless shell.
         browsers-to-install: chromium
         command: npm run ctest
-        bot-name: "chromium-next-${{ matrix.runs-on }}"
+        bot-name: "channel-chromium-${{ matrix.runs-on }}"
         flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
         flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
         flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
       env:
-        PWTEST_CHANNEL: chromium-next
+        PWTEST_CHANNEL: chromium

--- a/packages/playwright-browser-chromium/install.js
+++ b/packages/playwright-browser-chromium/install.js
@@ -24,4 +24,4 @@ try {
 }
 
 if (install)
-  install(['chromium', 'ffmpeg']);
+  install(['chromium', 'chromium-headless-shell', 'ffmpeg']);

--- a/packages/playwright-chromium/install.js
+++ b/packages/playwright-chromium/install.js
@@ -24,4 +24,4 @@ try {
 }
 
 if (install)
-  install(['chromium', 'ffmpeg']);
+  install(['chromium', 'chromium-headless-shell', 'ffmpeg']);

--- a/packages/playwright-core/src/server/index.ts
+++ b/packages/playwright-core/src/server/index.ts
@@ -19,7 +19,6 @@ export {
   registry,
   registryDirectory,
   Registry,
-  installDefaultBrowsersForNpmInstall,
   installBrowsersForNpmInstall,
   writeDockerVersion } from './registry';
 

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -35,6 +35,7 @@ export type BrowserTestWorkerFixtures = PageWorkerFixtures & {
   browserType: BrowserType;
   isAndroid: boolean;
   isElectron: boolean;
+  isHeadlessShell: boolean;
   nodeVersion: { major: number, minor: number, patch: number };
   bidiTestSkipPredicate: (info: TestInfo) => boolean;
 };
@@ -96,6 +97,10 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
   isElectron: [false, { scope: 'worker' }],
   electronMajorVersion: [0, { scope: 'worker' }],
   isWebView2: [false, { scope: 'worker' }],
+
+  isHeadlessShell: [async ({ browserName, channel, headless }, use) => {
+    await use(browserName === 'chromium' && (channel === 'chromium-headless-shell' || (!channel && headless)));
+  }, { scope: 'worker' }],
 
   contextFactory: async ({ _contextFactory }: any, run) => {
     await run(_contextFactory);

--- a/tests/installation/playwright-packages-install-behavior.spec.ts
+++ b/tests/installation/playwright-packages-install-behavior.spec.ts
@@ -76,13 +76,22 @@ test(`playwright should work`, async ({ exec, installedSoftwareOnDisk }) => {
   await exec('node esm-playwright.mjs');
 });
 
-test(`playwright should work with chromium-next`, async ({ exec, installedSoftwareOnDisk }) => {
+test(`playwright should work with chromium --no-shell`, async ({ exec, installedSoftwareOnDisk }) => {
   const result1 = await exec('npm i --foreground-scripts playwright');
   expect(result1).toHaveLoggedSoftwareDownload([]);
   expect(await installedSoftwareOnDisk()).toEqual([]);
-  const result2 = await exec('npx playwright install chromium-next');
+  const result2 = await exec('npx playwright install chromium --no-shell');
   expect(result2).toHaveLoggedSoftwareDownload(['chromium', 'ffmpeg']);
   expect(await installedSoftwareOnDisk()).toEqual(['chromium', 'ffmpeg']);
+});
+
+test(`playwright should work with chromium --only-shell`, async ({ exec, installedSoftwareOnDisk }) => {
+  const result1 = await exec('npm i --foreground-scripts playwright');
+  expect(result1).toHaveLoggedSoftwareDownload([]);
+  expect(await installedSoftwareOnDisk()).toEqual([]);
+  const result2 = await exec('npx playwright install --only-shell');
+  expect(result2).toHaveLoggedSoftwareDownload(['chromium-headless-shell', 'ffmpeg', 'firefox', 'webkit']);
+  expect(await installedSoftwareOnDisk()).toEqual(['chromium-headless-shell', 'ffmpeg', 'firefox', 'webkit']);
 });
 
 test('@playwright/test should work', async ({ exec, installedSoftwareOnDisk }) => {

--- a/tests/library/browsercontext-credentials.spec.ts
+++ b/tests/library/browsercontext-credentials.spec.ts
@@ -18,8 +18,7 @@
 import { browserTest as base, expect } from '../config/browserTest';
 
 const it = base.extend<{ failsOn401: boolean }>({
-  failsOn401: async ({ browserName, headless, channel }, use) => {
-    const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
+  failsOn401: async ({ browserName, isHeadlessShell }, use) => {
     await use(browserName === 'chromium' && !isHeadlessShell);
   },
 });

--- a/tests/library/chromium/launcher.spec.ts
+++ b/tests/library/chromium/launcher.spec.ts
@@ -52,8 +52,7 @@ it('should open devtools when "devtools: true" option is given', async ({ browse
   await browser.close();
 });
 
-it('should return background pages', async ({ browserType, createUserDataDir, asset, headless, channel }) => {
-  const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
+it('should return background pages', async ({ browserType, createUserDataDir, asset, isHeadlessShell }) => {
   it.skip(isHeadlessShell, 'Headless Shell has no support for extensions');
 
   const userDataDir = await createUserDataDir();
@@ -78,8 +77,7 @@ it('should return background pages', async ({ browserType, createUserDataDir, as
   expect(context.backgroundPages().length).toBe(0);
 });
 
-it('should return background pages when recording video', async ({ browserType, createUserDataDir, asset, headless, channel }, testInfo) => {
-  const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
+it('should return background pages when recording video', async ({ browserType, createUserDataDir, asset, isHeadlessShell }, testInfo) => {
   it.skip(isHeadlessShell, 'Headless Shell has no support for extensions');
 
   const userDataDir = await createUserDataDir();
@@ -105,8 +103,7 @@ it('should return background pages when recording video', async ({ browserType, 
   await context.close();
 });
 
-it('should support request/response events when using backgroundPage()', async ({ browserType, createUserDataDir, asset, server, headless, channel }) => {
-  const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
+it('should support request/response events when using backgroundPage()', async ({ browserType, createUserDataDir, asset, server, isHeadlessShell }) => {
   it.skip(isHeadlessShell, 'Headless Shell has no support for extensions');
 
   server.setRoute('/empty.html', (req, res) => {
@@ -157,8 +154,7 @@ it('should support request/response events when using backgroundPage()', async (
 
 it('should report console messages from content script', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32762' }
-}, async ({ browserType, createUserDataDir, asset, server, headless, channel }) => {
-  const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
+}, async ({ browserType, createUserDataDir, asset, server, isHeadlessShell }) => {
   it.skip(isHeadlessShell, 'Headless Shell has no support for extensions');
 
   const userDataDir = await createUserDataDir();

--- a/tests/library/download.spec.ts
+++ b/tests/library/download.spec.ts
@@ -636,8 +636,7 @@ it('should be able to download a inline PDF file via response interception', asy
   await page.close();
 });
 
-it('should be able to download a inline PDF file via navigation', async ({ browser, server, asset, browserName, channel, headless }) => {
-  const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
+it('should be able to download a inline PDF file via navigation', async ({ browser, server, asset, browserName, isHeadlessShell }) => {
   it.skip(browserName === 'chromium' && !isHeadlessShell, 'We expect PDF Viewer to open up in headed Chromium');
 
   const page = await browser.newPage();

--- a/tests/library/emulation-focus.spec.ts
+++ b/tests/library/emulation-focus.spec.ts
@@ -101,10 +101,9 @@ it('should change document.activeElement', async ({ page, server }) => {
   expect(active).toEqual(['INPUT', 'TEXTAREA']);
 });
 
-it('should not affect screenshots', async ({ page, server, browserName, headless, isWindows, channel }) => {
+it('should not affect screenshots', async ({ page, server, browserName, headless, isWindows, isHeadlessShell }) => {
   it.skip(browserName === 'webkit' && isWindows && !headless, 'WebKit/Windows/headed has a larger minimal viewport. See https://github.com/microsoft/playwright/issues/22616');
   it.skip(browserName === 'firefox' && !headless, 'Firefox headed produces a different image');
-  const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
   it.fixme(browserName === 'chromium' && !isHeadlessShell, 'https://github.com/microsoft/playwright/issues/33330');
 
   const page2 = await page.context().newPage();

--- a/tests/library/permissions.spec.ts
+++ b/tests/library/permissions.spec.ts
@@ -145,7 +145,7 @@ it.describe('permissions', () => {
   });
 });
 
-it('should support clipboard read', async ({ page, context, server, browserName, isWindows, isLinux, headless, channel }) => {
+it('should support clipboard read', async ({ page, context, server, browserName, isWindows, isLinux, headless, isHeadlessShell }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27475' });
   it.fail(browserName === 'firefox', 'No such permissions (requires flag) in Firefox');
   it.fixme(browserName === 'webkit' && isWindows, 'WebPasteboardProxy::allPasteboardItemInfo not implemented for Windows.');
@@ -156,8 +156,7 @@ it('should support clipboard read', async ({ page, context, server, browserName,
   if (browserName !== 'webkit')
     expect(await getPermission(page, 'clipboard-read')).toBe('prompt');
 
-  const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
-  if (browserName === 'chromium' && isHeadlessShell) {
+  if (isHeadlessShell) {
     // Chromium (but not headless-shell) shows a dialog and does not resolve the promise.
     const error = await page.evaluate(() => navigator.clipboard.readText()).catch(e => e);
     expect(error.toString()).toContain('denied');

--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -22,8 +22,7 @@ import { verifyViewport } from '../config/utils';
 browserTest.describe('page screenshot', () => {
   browserTest.skip(({ browserName, headless }) => browserName === 'firefox' && !headless, 'Firefox headed produces a different image.');
 
-  browserTest('should run in parallel in multiple pages', async ({ server, contextFactory, browserName, headless, channel }) => {
-    const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
+  browserTest('should run in parallel in multiple pages', async ({ server, contextFactory, browserName, isHeadlessShell }) => {
     browserTest.fixme(browserName === 'chromium' && !isHeadlessShell, 'https://github.com/microsoft/playwright/issues/33330');
 
     const context = await contextFactory();

--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -429,8 +429,7 @@ for (const params of [
     height: 768,
   }
 ]) {
-  browserTest(`should produce screencast frames ${params.id}`, async ({ video, contextFactory, browserName, platform, headless, channel }, testInfo) => {
-    const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
+  browserTest(`should produce screencast frames ${params.id}`, async ({ video, contextFactory, browserName, platform, headless, isHeadlessShell }, testInfo) => {
     browserTest.skip(browserName === 'chromium' && video === 'on', 'Same screencast resolution conflicts');
     browserTest.fixme(browserName === 'chromium' && !isHeadlessShell, 'Chromium (but not headless-shell) screencast has a min width issue');
     browserTest.fixme(params.id === 'fit' && browserName === 'chromium' && platform === 'darwin', 'High DPI maxes image at 600x600');

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -473,9 +473,8 @@ it.describe('screencast', () => {
     expect(videoFiles.length).toBe(2);
   });
 
-  it('should scale frames down to the requested size ', async ({ browser, browserName, server, headless, channel }, testInfo) => {
+  it('should scale frames down to the requested size ', async ({ browser, browserName, server, headless, isHeadlessShell }, testInfo) => {
     it.fixme(!headless, 'Fails on headed');
-    const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
     it.fixme(browserName === 'chromium' && !isHeadlessShell, 'Chromium (but not headless shell) has a min width issue');
 
     const context = await browser.newContext({
@@ -723,9 +722,8 @@ it.describe('screencast', () => {
     expect(files.length).toBe(1);
   });
 
-  it('should capture full viewport', async ({ browserType, browserName, isWindows, headless, channel }, testInfo) => {
+  it('should capture full viewport', async ({ browserType, browserName, isWindows, headless, isHeadlessShell }, testInfo) => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22411' });
-    const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
     it.fixme(browserName === 'chromium' && !isHeadlessShell, 'The square is not on the video');
     it.fixme(browserName === 'firefox' && isWindows, 'https://github.com/microsoft/playwright/issues/14405');
     const size = { width: 600, height: 400 };
@@ -759,9 +757,8 @@ it.describe('screencast', () => {
     expectAll(pixels, almostRed);
   });
 
-  it('should capture full viewport on hidpi', async ({ browserType, browserName, headless, isWindows, isLinux, channel }, testInfo) => {
+  it('should capture full viewport on hidpi', async ({ browserType, browserName, headless, isWindows, isLinux, isHeadlessShell }, testInfo) => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/22411' });
-    const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
     it.fixme(browserName === 'chromium' && !isHeadlessShell, 'The square is not on the video');
     it.fixme(browserName === 'firefox' && isWindows, 'https://github.com/microsoft/playwright/issues/14405');
     it.fixme(browserName === 'webkit' && isLinux && !headless, 'https://github.com/microsoft/playwright/issues/22617');
@@ -797,10 +794,9 @@ it.describe('screencast', () => {
     expectAll(pixels, almostRed);
   });
 
-  it('should work with video+trace', async ({ browser, trace, headless, browserName, channel }, testInfo) => {
+  it('should work with video+trace', async ({ browser, trace, headless, browserName, isHeadlessShell }, testInfo) => {
     it.skip(trace === 'on');
     it.fixme(!headless, 'different trace screencast image size on all browsers');
-    const isHeadlessShell = channel === 'chromium-headless-shell' || (!channel && headless);
     it.fixme(browserName === 'chromium' && !isHeadlessShell, 'different trace screencast image size');
 
     const size = { width: 500, height: 400 };


### PR DESCRIPTION
- remove `chromium-headless-shell` from the list of channels;
- make `channel: 'chromium'` opt into new headless;
- support `--only-shell` and `--no-shell` installation options.