### PR TITLE
chore: throw if protocol can't get generated when rolling

### DIFF
--- a/utils/roll_browser.js
+++ b/utils/roll_browser.js
@@ -109,7 +109,7 @@ Example:
     // 5. Generate types.
     console.log('\nGenerating protocol types...');
     const executablePath = registry.findExecutable(browserName).executablePathOrDie();
-    await protocolGenerator.generateProtocol(browserName, executablePath).catch(console.warn);
+    await protocolGenerator.generateProtocol(browserName, executablePath);
 
     // 6. Update docs.
     console.log('\nUpdating documentation...');


### PR DESCRIPTION
This would have prevented a [broken roll](https://github.com/microsoft/playwright/pull/33606) from [here](https://github.com/microsoft/playwright/actions/runs/11837874864/job/32985772813#step:7:85) due to the lack of headless-shell on the CDN. (roll PR was created too early).