### PR TITLE
fix(codegen): document.documentElement is null on early navigation

### DIFF
--- a/packages/playwright-core/src/server/injected/highlight.ts
+++ b/packages/playwright-core/src/server/injected/highlight.ts
@@ -90,7 +90,8 @@ export class Highlight {
   }
 
   install() {
-    if (!this._injectedScript.document.documentElement.contains(this._glassPaneElement))
+    // NOTE: document.documentElement can be null: https://github.com/microsoft/TypeScript/issues/50078
+    if (this._injectedScript.document.documentElement && !this._injectedScript.document.documentElement.contains(this._glassPaneElement))
       this._injectedScript.document.documentElement.appendChild(this._glassPaneElement);
   }
 

--- a/packages/playwright-core/src/server/injected/highlight.ts
+++ b/packages/playwright-core/src/server/injected/highlight.ts
@@ -91,7 +91,7 @@ export class Highlight {
 
   install() {
     // NOTE: document.documentElement can be null: https://github.com/microsoft/TypeScript/issues/50078
-    if (this._injectedScript.document.documentElement && !this._injectedScript.document.documentElement.contains(this._glassPaneElement))
+    if (!this._injectedScript.document.documentElement?.contains(this._glassPaneElement))
       this._injectedScript.document.documentElement.appendChild(this._glassPaneElement);
   }
 

--- a/packages/playwright-core/src/server/injected/highlight.ts
+++ b/packages/playwright-core/src/server/injected/highlight.ts
@@ -91,7 +91,7 @@ export class Highlight {
 
   install() {
     // NOTE: document.documentElement can be null: https://github.com/microsoft/TypeScript/issues/50078
-    if (!this._injectedScript.document.documentElement?.contains(this._glassPaneElement))
+    if (this._injectedScript.document.documentElement && !this._injectedScript.document.documentElement.contains(this._glassPaneElement))
       this._injectedScript.document.documentElement.appendChild(this._glassPaneElement);
   }
 


### PR DESCRIPTION
This PR fixes the following when opening Codegen on https://primevue.org/inputnumber/:

```
VM26:921 Recorder::installListners install error TypeError: Cannot read properties of null (reading 'contains')
    at Highlight.install (<anonymous>:4742:56)
    at Recorder.installListeners (eval at extend (inputnumber/:5876:40), <anonymous>:919:22)
    at new Recorder (eval at extend (inputnumber/:5876:40), <anonymous>:890:10)
    at new PollingRecorder (eval at extend (inputnumber/:5876:40), <anonymous>:1322:22)
    at InjectedScript.extend (<anonymous>:5882:12)
    at eval (eval at evaluate (inputnumber/:234:30), <anonymous>:5:29)
    at UtilityScript.evaluate (<anonymous>:236:17)
    at UtilityScript.<anonymous> (<anonymous>:1:44)
```

In TypeScript this type is not nullable. This is working as intended from their side: https://github.com/microsoft/TypeScript/issues/50078

Minimal Playwright repro script. This sometimes returns `true` and sometimes `false`.

```ts
import { chromium } from 'playwright';

(async () => {
  const check = async () => {
    const browser = await chromium.launch({ headless: false });
    const context = await browser.newContext();
    const page = await context.newPage();
    await page.goto('https://primevue.org/inputnumber/', {waitUntil: 'commit'});
    console.log(await page.evaluate(() => !!document.documentElement));

    await context.close();
    await browser.close();
  };
  while (true)
    await check();
})();
```

Contract-wise we have three users of `Highlight::install`:

1. Recorder.installListeners
1. Locator.highlight
1. Locator.maskSelectors

The first one retries every couple of seconds. The other two we expect to be called after the navigation has happened IIUC. 

I went over the rest of the code-base, there we usually check for null when interacting with `document.documentElement`.