### PR TITLE
feat(routeFromHAR): add `shouldSave` option to control when to save HAR files

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1267,6 +1267,11 @@ When set to `minimal`, only record information necessary for routing from HAR. T
 
 Optional setting to control resource content management. If `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file.
 
+### option: BrowserContext.routeFromHAR.shouldSave
+* since: v1.49
+- `shouldSave` <[function]\(\):[boolean]>
+
+If specified, controls when the HAR file should be saved to disk. Defaults to always save the HAR file.
 
 ## async method: BrowserContext.routeWebSocket
 * since: v1.48

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3668,6 +3668,11 @@ When set to `minimal`, only record information necessary for routing from HAR. T
 
 Optional setting to control resource content management. If `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file.
 
+### option: Page.routeFromHAR.shouldSave
+* since: v1.49
+- `shouldSave` <[function]\(\):[boolean]>
+
+If specified, controls when the HAR file should be saved to disk. Defaults to always save the HAR file.
 
 ## async method: Page.routeWebSocket
 * since: v1.48

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -700,6 +700,7 @@ Logger sink for Playwright logging.
   - `path` <[path]> Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by default.
   - `mode` ?<[HarMode]<"full"|"minimal">> When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
   - `urlFilter` ?<[string]|[RegExp]> A glob or regex pattern to filter requests that are stored in the HAR. When a [`option: Browser.newContext.baseURL`] via the context options was provided and the passed URL is a path, it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor. Defaults to none.
+  - `shouldSave` ?<[function]\(\):[boolean]> If specified, controls when the HAR file should be saved to disk. Defaults to always save the HAR file.
 
 Enables [HAR](http://www.softwareishard.com/blog/har-12-spec) recording for all pages into `recordHar.path` file. If not
 specified, the HAR is not recorded. Make sure to await [`method: BrowserContext.close`] for the HAR to be

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -516,7 +516,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     await this._updateInterceptionPatterns();
   }
 
-  async routeFromHAR(har: string, options: { url?: string | RegExp, notFound?: 'abort' | 'fallback', update?: boolean, updateContent?: 'attach' | 'embed', updateMode?: 'minimal' | 'full'} = {}): Promise<void> {
+  async routeFromHAR(har: string, options: { url?: string | RegExp, notFound?: 'abort' | 'fallback', update?: boolean, updateContent?: 'attach' | 'embed', updateMode?: 'minimal' | 'full', shouldSave?: () => boolean } = {}): Promise<void> {
     if (options.update) {
       await this._browserContext._recordIntoHAR(har, this, options);
       return;

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -4008,6 +4008,11 @@ export interface Page {
     notFound?: "abort"|"fallback";
 
     /**
+     * If specified, controls when the HAR file should be saved to disk. Defaults to always save the HAR file.
+     */
+    shouldSave?: (() => boolean);
+
+    /**
      * If specified, updates the given HAR with the actual network information instead of serving from file. The file is
      * written to disk when
      * [browserContext.close([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) is
@@ -9098,6 +9103,11 @@ export interface BrowserContext {
     notFound?: "abort"|"fallback";
 
     /**
+     * If specified, controls when the HAR file should be saved to disk. Defaults to always save the HAR file.
+     */
+    shouldSave?: (() => boolean);
+
+    /**
      * If specified, updates the given HAR with the actual network information instead of serving from file. The file is
      * written to disk when
      * [browserContext.close([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) is
@@ -9941,6 +9951,11 @@ export interface Browser {
        * [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor. Defaults to none.
        */
       urlFilter?: string|RegExp;
+
+      /**
+       * If specified, controls when the HAR file should be saved to disk. Defaults to always save the HAR file.
+       */
+      shouldSave?: (() => boolean);
     };
 
     /**
@@ -15024,6 +15039,11 @@ export interface BrowserType<Unused = {}> {
        * [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor. Defaults to none.
        */
       urlFilter?: string|RegExp;
+
+      /**
+       * If specified, controls when the HAR file should be saved to disk. Defaults to always save the HAR file.
+       */
+      shouldSave?: (() => boolean);
     };
 
     /**
@@ -16772,6 +16792,11 @@ export interface AndroidDevice {
        * [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor. Defaults to none.
        */
       urlFilter?: string|RegExp;
+
+      /**
+       * If specified, controls when the HAR file should be saved to disk. Defaults to always save the HAR file.
+       */
+      shouldSave?: (() => boolean);
     };
 
     /**
@@ -19195,6 +19220,11 @@ export interface Electron {
        * [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor. Defaults to none.
        */
       urlFilter?: string|RegExp;
+
+      /**
+       * If specified, controls when the HAR file should be saved to disk. Defaults to always save the HAR file.
+       */
+      shouldSave?: (() => boolean);
     };
 
     /**
@@ -22075,6 +22105,11 @@ export interface BrowserContextOptions {
      * [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor. Defaults to none.
      */
     urlFilter?: string|RegExp;
+
+    /**
+     * If specified, controls when the HAR file should be saved to disk. Defaults to always save the HAR file.
+     */
+    shouldSave?: (() => boolean);
   };
 
   /**

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -557,3 +557,29 @@ it('should ignore aborted requests', async ({ contextFactory, server }) => {
     expect(result).toBe('timeout');
   }
 });
+
+it('should save HAR files by default', async ({ contextFactory, server }, testInfo) => {
+  const harPath = testInfo.outputPath('har.har');
+  const context = await contextFactory();
+  await context.routeFromHAR(harPath, { update: true });
+
+  const page = await context.newPage();
+  await page.goto(server.PREFIX + '/one-style.html');
+  await context.close();
+
+  expect(fs.existsSync(harPath)).toBe(true);
+  const har = fs.readFileSync(harPath, 'utf-8');
+  expect(har).not.toContain('background-color');
+});
+
+it('can disable saving HAR files', async ({ contextFactory, server }, testInfo) => {
+  const harPath = testInfo.outputPath('har.har');
+  const context = await contextFactory();
+  await context.routeFromHAR(harPath, { update: true, shouldSave: () => false });
+
+  const page = await context.newPage();
+  await page.goto(server.PREFIX + '/one-style.html');
+  await context.close();
+
+  expect(fs.existsSync(harPath)).toBe(false);
+});


### PR DESCRIPTION
This adds a function to allow conditionally saving HAR files. This can be combined with `testInfo` to save HAR files only if a test passes, etc.

**Example usage**

```js
it('welcome', async ({ page }, testInfo) => {
  const harPath = testInfo.outputPath('har.har');
  await page.routeFromHAR(harPath, {
    update: true,
    shouldSave: () => testInfo.status === 'passed'
  });

  await page.goto('/welcome');
  await expect(page.getByRole('heading')).toHaveText('Welcome');
});
```

Fixes #33559, inspired by #28796