### PR TITLE
fix(ui-mode): fix issue when updating state while rendering

### DIFF
--- a/packages/trace-viewer/src/ui/uiModeTestListView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeTestListView.tsx
@@ -99,11 +99,17 @@ export const TestListView: React.FC<{
       setSelectedTreeItemId(selectedTreeItem.id);
   }, [runningState, setSelectedTreeItemId, testTree, collapseAllCount, setCollapseAllCount, requestedCollapseAllCount, expandAllCount, setExpandAllCount, requestedExpandAllCount, treeState, setTreeState]);
 
-  // Compute selected item.
-  const { selectedTreeItem } = React.useMemo(() => {
+  // Compute selected item
+  const selectedTreeItem = React.useMemo(() => {
+    if (!selectedTreeItemId)
+      return undefined;
+    return testTree.treeItemById(selectedTreeItemId);
+  }, [selectedTreeItemId, testTree]);
+
+  // Handle selection effects separately
+  React.useEffect(() => {
     if (!testModel)
-      return { selectedTreeItem: undefined };
-    const selectedTreeItem = selectedTreeItemId ? testTree.treeItemById(selectedTreeItemId) : undefined;
+      return;
     const testFile = itemLocation(selectedTreeItem, testModel);
     let selectedTest: reporterTypes.TestCase | undefined;
     if (selectedTreeItem?.kind === 'test')
@@ -111,8 +117,7 @@ export const TestListView: React.FC<{
     else if (selectedTreeItem?.kind === 'case' && selectedTreeItem.tests.length === 1)
       selectedTest = selectedTreeItem.tests[0];
     onItemSelected({ treeItem: selectedTreeItem, testCase: selectedTest, testFile });
-    return { selectedTreeItem };
-  }, [onItemSelected, selectedTreeItemId, testModel, testTree]);
+  }, [testModel, selectedTreeItem, onItemSelected]);
 
   // Update watch all.
   React.useEffect(() => {


### PR DESCRIPTION
Motivation: This fixes a React warning of updating component state on a render. It was caught by HMR of React Dev Server:

```
react-dom.development.js:86 Warning: Cannot update a component (`UIModeView`) while rendering a different component (`TestListView`). To locate the bad setState() call inside `TestListView`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
    at TestListView (http://localhost:44223/trace/src/ui/uiModeTestListView.tsx:38:5)
    at MillionProfilerRaw (http://localhost:44223/trace/node_modules/.vite/deps/@million_lint_runtime-dev.js?v=362ca7e4:7363:13)
    at div
    at div
    at div
    at SplitView (http://localhost:44223/trace/@fs/Users/maxschmitt/Developer/playwright/packages/web/src/components/splitView.tsx:31:5)
    at MillionProfilerRaw (http://localhost:44223/trace/node_modules/.vite/deps/@million_lint_runtime-dev.js?v=362ca7e4:7363:13)
    at div
    at UIModeView (http://localhost:44223/trace/src/ui/uiModeView.tsx:70:28)
printWarning	@	react-dom.development.js:86
```

See https://reactjs.org/link/setstate-in-render for more details.