### PR TITLE
fix(ui-mode): use onChange instead of onClick for <input type='checkbox'

### DIFF
--- a/packages/trace-viewer/src/ui/settingsView.tsx
+++ b/packages/trace-viewer/src/ui/settingsView.tsx
@@ -30,7 +30,7 @@ export const SettingsView: React.FunctionComponent<{
     {settings.map(({ value, set, title }) => {
       return <div key={title} className='setting'>
         <label>
-          <input type='checkbox' checked={value} onClick={() => set(!value)}/>
+          <input type='checkbox' checked={value} onChange={() => set(!value)}/>
           {title}
         </label>
       </div>;

--- a/packages/trace-viewer/src/ui/uiModeFiltersView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeFiltersView.tsx
@@ -62,7 +62,7 @@ export const FiltersView: React.FC<{
         {[...statusFilters.entries()].map(([status, value]) => {
           return <div className='filter-entry' key={status} role='listitem'>
             <label>
-              <input type='checkbox' checked={value} onClick={() => {
+              <input type='checkbox' checked={value} onChange={() => {
                 const copy = new Map(statusFilters);
                 copy.set(status, !copy.get(status));
                 setStatusFilters(copy);
@@ -76,7 +76,7 @@ export const FiltersView: React.FC<{
         {[...projectFilters.entries()].map(([projectName, value]) => {
           return <div className='filter-entry' key={projectName}  role='listitem'>
             <label>
-              <input type='checkbox' checked={value} onClick={() => {
+              <input type='checkbox' checked={value} onChange={() => {
                 const copy = new Map(projectFilters);
                 copy.set(projectName, !copy.get(projectName));
                 setProjectFilters(copy);


### PR DESCRIPTION
This fixes:

```
react-dom.development.js:86 Warning: You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.
    at input
    at label
    at div
    at div
    at div
    at div
    at FiltersView (http://localhost:44223/trace/src/ui/uiModeFiltersView.tsx?t=1731709403821:33:5)
    at MillionProfilerRaw (http://localhost:44223/trace/node_modules/.vite/deps/@million_lint_runtime-dev.js?v=edb77da9:7363:13)
    at div
    at div
    at div
    at SplitView (http://localhost:44223/trace/@fs/Users/maxschmitt/Developer/playwright/packages/web/src/components/splitView.tsx:31:5)
    at MillionProfilerRaw (http://localhost:44223/trace/node_modules/.vite/deps/@million_lint_runtime-dev.js?v=edb77da9:7363:13)
    at div
    at UIModeView (http://localhost:44223/trace/src/ui/uiModeView.tsx?t=1731709403821:70:28)
```