### PR TITLE
chore(recorder): support HMR

### DIFF
--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -88,7 +88,7 @@ export class RecorderApp extends EventEmitter implements IRecorderApp {
     });
 
     const mainFrame = this._page.mainFrame();
-    await mainFrame.goto(serverSideCallMetadata(), 'https://playwright/index.html');
+    await mainFrame.goto(serverSideCallMetadata(), process.env.PW_HMR ? 'http://localhost:44225' : 'https://playwright/index.html');
   }
 
   static factory(context: BrowserContext): IRecorderAppFactory {

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -323,6 +323,13 @@ if (watchMode) {
     cwd: path.join(__dirname, '..', '..', 'packages', 'html-reporter'),
     concurrent: true,
   });
+  steps.push({
+    command: 'npx',
+    args: ['vite', '--port', '44225'],
+    shell: true,
+    cwd: path.join(__dirname, '..', '..', 'packages', 'recorder'),
+    concurrent: true,
+  });
 }
 
 // Generate injected.


### PR DESCRIPTION
I think we should not run the vite dev servers twice. We do it now [here](https://github.com/microsoft/playwright/blob/66249d171df04554ec80fda208eb597d7cbe7d83/utils/build/build.js#L295-L308) and the one which I just added/above.