### PR TITLE
fix: do not send favicon request to network when interception is on

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -296,7 +296,8 @@ export class FrameManager {
     if (request._documentId)
       frame.setPendingDocument({ documentId: request._documentId, request });
     if (request._isFavicon) {
-      route?.continue({ isFallback: true }).catch(() => {});
+      // Abort favicon requests to avoid network access in case of interception.
+      route?.abort('aborted').catch(() => {});
       return;
     }
     this._page.emitOnContext(BrowserContext.Events.Request, request);


### PR DESCRIPTION
Otherwise we hit the network in presumably hermetic tests:

```
Error: 6 [ERROR] com.microsoft.playwright.TestBrowserContextStorageState.shouldCaptureLocalStorage -- Time elapsed: 7.768 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <{"cookies":[],"origins":[{"origin":"https://www.domain.com/","localStorage":[{"name":"name2","value":"value2"}]},{"origin":"https://www.example.com/","localStorage":[{"name":"name1","value":"value1"}]}]}> but was: <{"cookies":[{"name":"__cf_bm","value":"swy7AlkQNfUppNapX0xrvlt.YyuGQW91vnBWHolxA0Q-1731700690-1.0.1.1-hs3s0FARyESNGlio6FS9qbG3pDn9jeZIk0IpGBRkgPDDb5HDF7d6Vizjtfo52QDEeE85uhjBVIJvNtjV3q4XpQ","domain":".domain.com","path":"/","expires":1731702490.484379,"httpOnly":true,"secure":true,"sameSite":"None"}],"origins":[{"origin":"https://www.domain.com/","localStorage":[{"name":"name2","value":"value2"}]},{"origin":"https://www.example.com/","localStorage":[{"name":"name1","value":"value1"}]}]}>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at com.microsoft.playwright.Utils.assertJsonEquals(Utils.java:66)
	at com.microsoft.playwright.TestBrowserContextStorageState.shouldCaptureLocalStorage(TestBrowserContextStorageState.java:46)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:175)
```