### PR TITLE
feat(test): allow fixtures to be specified for single tests

### DIFF
--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -104,7 +104,17 @@ export class TestTypeImpl {
     test._requireFile = suite._requireFile;
     test._staticAnnotations.push(...validatedDetails.annotations);
     test._tags.push(...validatedDetails.tags);
-    suite._addTest(test);
+
+    if (typeof details.fixtures === 'object') {
+      const containingSubSuite = new Suite(title, 'describe');
+      containingSubSuite._requireFile = suite._requireFile;
+      containingSubSuite.location = location;
+      containingSubSuite._use.push({ fixtures: details.fixtures, location });
+      containingSubSuite._addTest(test);
+      suite._addSuite(containingSubSuite);
+    } else {
+      suite._addTest(test);
+    }
 
     if (type === 'only' || type === 'fail.only')
       test._only = true;

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1857,6 +1857,7 @@ type TestDetailsAnnotation = {
 export type TestDetails = {
   tag?: string | string[];
   annotation?: TestDetailsAnnotation | TestDetailsAnnotation[];
+  fixtures?: Fixtures;
 }
 
 type TestBody<TestArgs> = (args: TestArgs, testInfo: TestInfo) => Promise<void> | void;

--- a/tests/playwright-test/test-fixtures.spec.ts
+++ b/tests/playwright-test/test-fixtures.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './playwright-test-fixtures';
+
+test('test() should support fixture in test details', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        input: 'input',
+        foo: async ({ input }, use) => {
+          await use(input);
+        }
+      });
+
+      test('test', { fixtures: { input: 'asd' } }, ({ foo }) => {
+        expect(foo).toBe('asd');
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
+test('fixtures from the first test should not leak into the second test', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        input: 'defaultInput',
+        foo: async ({ input }, use) => {
+          await use(input);
+        }
+      });
+
+      test('test1', { fixtures: { input: 'asd' } }, ({ foo }) => {
+        expect(foo).toBe('asd');
+      });
+
+      test('test2', ({ foo }) => {
+        expect(foo).toBe('defaultInput');
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+});

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -73,6 +73,7 @@ type TestDetailsAnnotation = {
 export type TestDetails = {
   tag?: string | string[];
   annotation?: TestDetailsAnnotation | TestDetailsAnnotation[];
+  fixtures?: Fixtures;
 }
 
 type TestBody<TestArgs> = (args: TestArgs, testInfo: TestInfo) => Promise<void> | void;


### PR DESCRIPTION
The current way to specify fixture inputs for a single test is to do the following:

```js
import { test as base, expect } from '@playwright/test';

const test = base.extend({
  input: 'defaultInput',
  foo: async ({ input }, use) => {
    await use(input);
  }
});


test.describe(() => {
  test.use({ input: 'asd' });
  
  test('test1', ({ foo }) => {
    expect(foo).toBe('asd');
  });
});
```

This PR is an attempt to address #27138 by adding `fixtures` to the `TestDetails` for a test, enabling the following:

```js
// ...

test('test2', { fixtures: { input: 'asd' } }, ({ foo }) => {
  expect(foo).toBe('asd');
});

test('test3', ({ foo }) => {
  expect(foo).toBe('defaultInput');
});
```

This appeared to be the most straightforward way to specify fixtures for a single test. However, it has the downside of creating an implicit anonymous `test.describe` suite around each test that specifies fixtures, which may be confusing in Playwright UIs - also this is related to #30476.

If this approach is acceptable, I will update the documentation accordingly. Otherwise, I am happy to try a different approach or close this PR entirely if it's not desired.
