### PR TITLE
chore(build): typo in trace-viewer output dir

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -301,7 +301,7 @@ if (watchMode) {
     args: [
       'vite', '--config', 'vite.sw.config.ts',
       'build', '--watch', '--minify=false',
-      '--outDir', path.join(__dirname, '..', '..', 'packages', 'playwright-core', 'lib', 'vite', 'trace-viewer'),
+      '--outDir', path.join(__dirname, '..', '..', 'packages', 'playwright-core', 'lib', 'vite', 'traceViewer'),
       '--emptyOutDir=false'
     ],
     shell: true,


### PR DESCRIPTION
Tiny follow-up on https://github.com/microsoft/playwright/pull/33579. Looks like there was a typo in the output path 😅