### PR TITLE
fix(sw): fix UI mode on codespaces by not passing `server`

### DIFF
--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -125,7 +125,7 @@ export async function installRootRedirect(server: HttpServer, traceUrls: string[
   for (const reporter of options.reporter || [])
     params.append('reporter', reporter);
 
-  params.set('server', server.urlPrefix('precise'));
+  params.set('server', '..');
 
   const urlPath  = `./trace/${options.webApp || 'index.html'}?${params.toString()}`;
   server.routePath('/', (_, response) => {

--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -125,8 +125,6 @@ export async function installRootRedirect(server: HttpServer, traceUrls: string[
   for (const reporter of options.reporter || [])
     params.append('reporter', reporter);
 
-  params.set('server', '..');
-
   const urlPath  = `./trace/${options.webApp || 'index.html'}?${params.toString()}`;
   server.routePath('/', (_, response) => {
     response.statusCode = 302;

--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -45,7 +45,7 @@ async function loadTrace(traceUrl: string, traceFileName: string | null, client:
   if (!data) {
     let traceViewerServerBaseUrl = new URL(client?.url ?? self.registration.scope);
     if (traceViewerServerBaseUrl.searchParams.has('server'))
-      traceViewerServerBaseUrl = new URL(traceViewerServerBaseUrl.searchParams.get('server')!, traceViewerServerBaseUrl)
+      traceViewerServerBaseUrl = new URL(traceViewerServerBaseUrl.searchParams.get('server')!, traceViewerServerBaseUrl);
 
     data = { limit, traceUrls: new Set(), traceViewerServer: new TraceViewerServer(traceViewerServerBaseUrl) };
     clientIdToTraceUrls.set(clientId, data);

--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -43,7 +43,7 @@ async function loadTrace(traceUrl: string, traceFileName: string | null, client:
   const clientId = client?.id ?? '';
   let data = clientIdToTraceUrls.get(clientId);
   if (!data) {
-    let traceViewerServerBaseUrl = new URL(client?.url ?? self.registration.scope);
+    let traceViewerServerBaseUrl = new URL('../', client?.url ?? self.registration.scope);
     if (traceViewerServerBaseUrl.searchParams.has('server'))
       traceViewerServerBaseUrl = new URL(traceViewerServerBaseUrl.searchParams.get('server')!, traceViewerServerBaseUrl);
 

--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -43,12 +43,9 @@ async function loadTrace(traceUrl: string, traceFileName: string | null, client:
   const clientId = client?.id ?? '';
   let data = clientIdToTraceUrls.get(clientId);
   if (!data) {
-    let traceViewerServerBaseUrl = self.registration.scope;
-    if (client?.url) {
-      const clientUrl = new URL(client.url);
-      if (clientUrl.searchParams.has('server'))
-        traceViewerServerBaseUrl = clientUrl.searchParams.get('server')!;
-    }
+    let traceViewerServerBaseUrl = new URL(client?.url ?? self.registration.scope);
+    if (traceViewerServerBaseUrl.searchParams.has('server'))
+      traceViewerServerBaseUrl = new URL(traceViewerServerBaseUrl.searchParams.get('server')!, traceViewerServerBaseUrl)
 
     data = { limit, traceUrls: new Set(), traceViewerServer: new TraceViewerServer(traceViewerServerBaseUrl) };
     clientIdToTraceUrls.set(clientId, data);

--- a/packages/trace-viewer/src/sw/traceModelBackends.ts
+++ b/packages/trace-viewer/src/sw/traceModelBackends.ts
@@ -146,7 +146,7 @@ function formatUrl(trace: string, server: TraceViewerServer) {
 }
 
 export class TraceViewerServer {
-  constructor(private readonly baseUrl: string) {}
+  constructor(private readonly baseUrl: URL) {}
 
   getFileURL(path: string): URL {
     const url = new URL('trace/file', this.baseUrl);

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -47,11 +47,10 @@ const xtermDataSource: XtermDataSource = {
 };
 
 const searchParams = new URLSearchParams(window.location.search);
-const guid = searchParams.get('ws');
-let testServerBaseUrl = new URL(window.location.href);
+let testServerBaseUrl = new URL('../', window.location.href);
 if (testServerBaseUrl.searchParams.has('server'))
   testServerBaseUrl = new URL(testServerBaseUrl.searchParams.get('server')!, testServerBaseUrl);
-const wsURL = new URL(`../${guid}`, testServerBaseUrl);
+const wsURL = new URL(searchParams.get('ws')!, testServerBaseUrl);
 wsURL.protocol = (wsURL.protocol === 'https:' ? 'wss:' : 'ws:');
 const queryParams = {
   args: searchParams.getAll('arg'),

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -48,8 +48,11 @@ const xtermDataSource: XtermDataSource = {
 
 const searchParams = new URLSearchParams(window.location.search);
 const guid = searchParams.get('ws');
-const wsURL = new URL(`../${guid}`, window.location.toString());
-wsURL.protocol = (window.location.protocol === 'https:' ? 'wss:' : 'ws:');
+let testServerBaseUrl = new URL(window.location.href);
+if (testServerBaseUrl.searchParams.has('server'))
+  testServerBaseUrl = new URL(testServerBaseUrl.searchParams.get('server')!, testServerBaseUrl);
+const wsURL = new URL(`../${guid}`, testServerBaseUrl);
+wsURL.protocol = (wsURL.protocol === 'https:' ? 'wss:' : 'ws:');
 const queryParams = {
   args: searchParams.getAll('arg'),
   grep: searchParams.get('grep') || undefined,


### PR DESCRIPTION
Yesterday we found that UI mode is broken on codespaces b/c the new `server` parameter points to `localhost`, which isn't available when the UI is accessed over Codespace's port forwarding host.

This PR fixes that by making the `server` parameter only used in HMR mode. I'm also making the web server connection respect the `server` param in this PR.

I've developed this on a Codespace and verified that it works.