### PR TITLE
devops: deduplicate redudant information in client side changes issue

### DIFF
--- a/.github/workflows/pr_check_client_side_changes.yml
+++ b/.github/workflows/pr_check_client_side_changes.yml
@@ -27,7 +27,11 @@ jobs:
               repo: context.repo.repo,
               commit_sha: context.sha,
             });
-            const commitHeader = data.message.split('\n')[0].replace(/#(\d+)/g, 'https://github.com/microsoft/playwright/pull/$1');
+            const commitHeader = data.message.split('\n')[0];
+            const prMatch = commitHeader.match(/#(\d+)/);
+            const formattedCommit = prMatch 
+              ? `https://github.com/microsoft/playwright/pull/${prMatch[1]}`
+              : `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha} (${commitHeader})`;
 
             const title = '[Ports]: Backport client side changes for ' + currentPlaywrightVersion;
             for (const repo of ['playwright-python', 'playwright-java', 'playwright-dotnet']) {
@@ -50,7 +54,7 @@ jobs:
                 issueBody = issueCreateData.body;
               }
               const newBody = issueBody.trimEnd() + `
-              - [ ] https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha} (${commitHeader})`;
+              - [ ] ${formattedCommit}`;
               const data = await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: repo,


### PR DESCRIPTION
Problem, it looked like this:

  - [ ] https://github.com/microsoft/playwright/commit/4817483ff2551e830ea10ffb3c9e3ef97b0742f9 (chore: allow highlighting aria template from extension (https://github.com/microsoft/playwright/pull/33594))
  - [ ] https://github.com/microsoft/playwright/commit/f5477d90512f3fb325bae773a5a2ad436b28ff04 (docs: add ariaSnapshot.timeout for language ports (https://github.com/microsoft/playwright/pull/33614))
  - [ ] https://github.com/microsoft/playwright/commit/2aa9e11a7ff274da7a4126b8e25ec8ee432ec85c (fix(aria): normalize whitespace in toMatchAccessible{Name,Description} (https://github.com/microsoft/playwright/pull/33619))
  - [ ] https://github.com/microsoft/playwright/commit/e61cea597a6a8b39599b271a05b3c780566b026d (docs(dotnet): fix assertion snippets (https://github.com/microsoft/playwright/pull/33622))
  - [ ] https://github.com/microsoft/playwright/commit/5e8b469c1c0b9fa1fb1c608215c2555a90d5db63 (fix(test): hide response.* calls from reports (https://github.com/microsoft/playwright/pull/33620))
  - [ ] https://github.com/microsoft/playwright/commit/7f054ef8c6d6c3dcbbf0ce4c766f704c140c49a0 (feat(aria): extend toHaveAccessibleName() to accept an array of expected accessible names (https://github.com/microsoft/playwright/pull/33277))

Now it looks like this:

- [ ] https://github.com/microsoft/playwright/pull/33594
- [ ] https://github.com/microsoft/playwright/pull/33614
- [ ] https://github.com/microsoft/playwright/pull/33619
- [ ] https://github.com/microsoft/playwright/pull/33622
- [ ] https://github.com/microsoft/playwright/pull/33620
- [ ] https://github.com/microsoft/playwright/pull/33277
