### PR TITLE
fix(ui mode): do not render anonymous describe

### DIFF
--- a/packages/playwright/src/isomorphic/testTree.ts
+++ b/packages/playwright/src/isomorphic/testTree.ts
@@ -79,14 +79,19 @@ export class TestTree {
 
     const visitSuite = (project: reporterTypes.FullProject, parentSuite: reporterTypes.Suite, parentGroup: GroupItem) => {
       for (const suite of parentSuite.suites) {
-        const title = suite.title || '<anonymous>';
-        let group = parentGroup.children.find(item => item.kind === 'group' && item.title === title) as GroupItem | undefined;
+        if (!suite.title) {
+          // Flatten anonymous describes.
+          visitSuite(project, suite, parentGroup);
+          continue;
+        }
+
+        let group = parentGroup.children.find(item => item.kind === 'group' && item.title === suite.title) as GroupItem | undefined;
         if (!group) {
           group = {
             kind: 'group',
             subKind: 'describe',
-            id: 'suite:' + parentSuite.titlePath().join('\x1e') + '\x1e' + title,  // account for anonymous suites
-            title,
+            id: 'suite:' + parentSuite.titlePath().join('\x1e') + '\x1e' + suite.title,  // account for anonymous suites
+            title: suite.title,
             location: suite.location!,
             duration: 0,
             parent: parentGroup,

--- a/tests/playwright-test/ui-mode-test-tree.spec.ts
+++ b/tests/playwright-test/ui-mode-test-tree.spec.ts
@@ -315,28 +315,23 @@ test('should list parametrized tests', async ({ runUITest }) => {
 
   await page.getByText('cookies').click();
   await page.keyboard.press('ArrowRight');
-  await page.getByText('<anonymous>').click();
-  await page.keyboard.press('ArrowRight');
 
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ◯ a.test.ts
-      ▼ ◯ cookies
-        ▼ ◯ <anonymous> <=
-            ◯ test FR
-            ◯ test DE
-            ◯ test LT
+      ▼ ◯ cookies <=
+          ◯ test FR
+          ◯ test DE
+          ◯ test LT
   `);
   await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
-          - treeitem "[icon-circle-outline] cookies" [expanded]:
+          - treeitem "[icon-circle-outline] cookies" [expanded] [selected]:
             - group:
-              - treeitem "[icon-circle-outline] <anonymous>" [expanded] [selected]:
-                - group:
-                  - treeitem "[icon-circle-outline] test FR"
-                  - treeitem "[icon-circle-outline] test DE"
-                  - treeitem "[icon-circle-outline] test LT"
+              - treeitem "[icon-circle-outline] test FR"
+              - treeitem "[icon-circle-outline] test DE"
+              - treeitem "[icon-circle-outline] test LT"
   `);
 });
 
@@ -356,28 +351,23 @@ test('should update parametrized tests', async ({ runUITest, writeFiles }) => {
 
   await page.getByText('cookies').click();
   await page.keyboard.press('ArrowRight');
-  await page.getByText('<anonymous>').click();
-  await page.keyboard.press('ArrowRight');
 
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ◯ a.test.ts
-      ▼ ◯ cookies
-        ▼ ◯ <anonymous> <=
-            ◯ test FR
-            ◯ test DE
-            ◯ test LT
+      ▼ ◯ cookies <=
+          ◯ test FR
+          ◯ test DE
+          ◯ test LT
   `);
   await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
-          - treeitem "[icon-circle-outline] cookies" [expanded]:
+          - treeitem "[icon-circle-outline] cookies" [expanded] [selected]:
             - group:
-              - treeitem "[icon-circle-outline] <anonymous>" [expanded] [selected]:
-                - group:
-                  - treeitem "[icon-circle-outline] test FR"
-                  - treeitem "[icon-circle-outline] test DE"
-                  - treeitem "[icon-circle-outline] test LT"
+              - treeitem "[icon-circle-outline] test FR"
+              - treeitem "[icon-circle-outline] test DE"
+              - treeitem "[icon-circle-outline] test LT"
   `);
 
   await writeFiles({
@@ -396,21 +386,18 @@ test('should update parametrized tests', async ({ runUITest, writeFiles }) => {
 
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ◯ a.test.ts
-      ▼ ◯ cookies
-        ▼ ◯ <anonymous> <=
-            ◯ test FR
-            ◯ test LT
+      ▼ ◯ cookies <=
+          ◯ test FR
+          ◯ test LT
   `);
   await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
-          - treeitem "[icon-circle-outline] cookies" [expanded]:
+          - treeitem "[icon-circle-outline] cookies" [expanded] [selected]:
             - group:
-              - treeitem "[icon-circle-outline] <anonymous>" [expanded] [selected]:
-                - group:
-                  - treeitem "[icon-circle-outline] test FR"
-                  - treeitem "[icon-circle-outline] test LT"
+              - treeitem "[icon-circle-outline] test FR"
+              - treeitem "[icon-circle-outline] test LT"
   `);
 });
 


### PR DESCRIPTION
Tests inside the anonymous describe are flatten into the parent suite.

Fixes #30476.