### PR TITLE
devops: update GitHub Actions via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*" 


### PR DESCRIPTION
It has proven to work quite well on playwright-browsers/playwright-dotnet/python repository e.g. https://github.com/microsoft/playwright-dotnet/pull/3059.