### PR TITLE
docs: note that permissions list may change

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -963,9 +963,14 @@ specified.
 * since: v1.8
 - `permissions` <[Array]<[string]>>
 
-A permission or an array of permissions to grant. Permissions can be one of the following values:
+A list of permissions to grant.
+
+:::danger
+Supported permissions differ between browsers, and even between different versions of the same browser. Any permission may stop working after an update.
+:::
+
+Here are some permissions that may be supported by some browsers:
 * `'accelerometer'`
-* `'accessibility-events'`
 * `'ambient-light-sensor'`
 * `'background-sync'`
 * `'camera'`

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -428,7 +428,6 @@ export class CRBrowserContext extends BrowserContext {
       ['accelerometer', 'sensors'],
       ['gyroscope', 'sensors'],
       ['magnetometer', 'sensors'],
-      ['accessibility-events', 'accessibilityEvents'],
       ['clipboard-read', 'clipboardReadWrite'],
       ['clipboard-write', 'clipboardSanitizedWrite'],
       ['payment-handler', 'paymentHandler'],

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8961,9 +8961,13 @@ export interface BrowserContext {
   /**
    * Grants specified permissions to the browser context. Only grants corresponding permissions to the given origin if
    * specified.
-   * @param permissions A permission or an array of permissions to grant. Permissions can be one of the following values:
+   * @param permissions A list of permissions to grant.
+   *
+   * **NOTE** Supported permissions differ between browsers, and even between different versions of the same browser.
+   * Any permission may stop working after an update.
+   *
+   * Here are some permissions that may be supported by some browsers:
    * - `'accelerometer'`
-   * - `'accessibility-events'`
    * - `'ambient-light-sensor'`
    * - `'background-sync'`
    * - `'camera'`


### PR DESCRIPTION
Also remove 'accessibility-events' from the list as it is not supported by any browser anymore.

References #33678.