### PR TITLE
chore(html): hmr report should survive reload

### DIFF
--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -50,6 +50,8 @@ window.onload = () => {
   ReactDOM.createRoot(document.querySelector('#root')!).render(<ReportLoader />);
 };
 
+const kPlaywrightReportStorageForHMR = 'playwrightReportStorageForHMR';
+
 class ZipReport implements LoadedReport {
   private _entries = new Map<string, zip.Entry>();
   private _json!: HTMLReport;
@@ -61,13 +63,13 @@ class ZipReport implements LoadedReport {
       if (window.opener) {
         window.addEventListener('message', event => {
           if (event.source === window.opener) {
-            localStorage.setItem('playwrightReportBase64', event.data);
+            localStorage.setItem(kPlaywrightReportStorageForHMR, event.data);
             resolve(event.data);
           }
         }, { once: true });
         window.opener.postMessage('ready', '*');
       } else {
-        const oldReport = localStorage.getItem('playwrightReportBase64');
+        const oldReport = localStorage.getItem(kPlaywrightReportStorageForHMR);
         if (oldReport)
           return resolve(oldReport);
         alert('couldnt find report, something with HMR is broken');


### PR DESCRIPTION
In HMR mode, the opening window transfers the report by sending a message. If the opened window is reloaded, it can't access that message anymore. We're fixing it by storing the report in localstorage between reports. This works for reports <10mb.