### PR TITLE
docs(test-runners): restructure .NET test-runners doc

### DIFF
--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -7,7 +7,7 @@ title: "Installation"
 
 Playwright was created specifically to accommodate the needs of end-to-end testing. Playwright supports all modern rendering engines including Chromium, WebKit, and Firefox. Test on Windows, Linux, and macOS, locally or on CI, headless or headed with native mobile emulation.
 
-You can choose to use [MSTest base classes](./test-runners.md#mstest) or [NUnit base classes](./test-runners.md#nunit) that Playwright provides to write end-to-end tests. These classes support running tests on multiple browser engines, parallelizing tests, adjusting launch/context options and getting a [Page]/[BrowserContext] instance per test out of the box. Alternatively you can use the [library](./library.md) to manually write the testing infrastructure.
+You can choose to use [MSTest base classes](./test-runners.md) or [NUnit base classes](./test-runners.md) that Playwright provides to write end-to-end tests. These classes support running tests on multiple browser engines, parallelizing tests, adjusting launch/context options and getting a [Page]/[BrowserContext] instance per test out of the box. Alternatively you can use the [library](./library.md) to manually write the testing infrastructure.
 
 1. Start by creating a new project with `dotnet new`. This will create the `PlaywrightTests` directory which includes a `UnitTest1.cs` file:
 

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -30,7 +30,7 @@ You can choose any testing framework such as JUnit or TestNG based on your proje
 
 ## .NET
 
-Playwright for .NET comes with [MSTest base classes](https://playwright.dev/dotnet/docs/test-runners#mstest) and [NUnit base classes](https://playwright.dev/dotnet/docs/test-runners#nunit) for writing end-to-end tests.
+Playwright for .NET comes with [MSTest base classes](https://playwright.dev/dotnet/docs/test-runners) and [NUnit base classes](https://playwright.dev/dotnet/docs/test-runners) for writing end-to-end tests.
 
 * [Documentation](https://playwright.dev/dotnet/docs/intro)
 * [GitHub repo](https://github.com/microsoft/playwright-dotnet)

--- a/docs/src/library-csharp.md
+++ b/docs/src/library-csharp.md
@@ -5,7 +5,7 @@ title: "Getting started - Library"
 
 ## Introduction
 
-Playwright can either be used with the [MSTest](./test-runners.md#mstest) or [NUnit](./test-runners.md#nunit), or as a Playwright Library (this guide). If you are working on an application that utilizes Playwright capabilities or you are using Playwright with another test runner, read on.
+Playwright can either be used with the [MSTest](./test-runners.md) or [NUnit](./test-runners.md), or as a Playwright Library (this guide). If you are working on an application that utilizes Playwright capabilities or you are using Playwright with another test runner, read on.
 
 ## Usage
 

--- a/docs/src/test-runners-csharp.md
+++ b/docs/src/test-runners-csharp.md
@@ -5,19 +5,57 @@ title: "Test Runners"
 
 ## Introduction
 
-While Playwright for .NET isn't tied to a particular test runner or testing framework, in our experience the easiest way of getting started is by using the base classes we provide for [MSTest](#mstest) and [NUnit](#nunit). These classes support running tests on multiple browser engines, adjusting launch/context options and getting a [Page]/[BrowserContext] instance per test out of the box. 
+While Playwright for .NET isn't tied to a particular test runner or testing framework, in our experience the easiest way of getting started is by using the base classes we provide for MSTest and NUnit. These classes support running tests on multiple browser engines, adjusting launch/context options and getting a [Page]/[BrowserContext] instance per test out of the box. 
 
 Playwright and Browser instances will be reused between tests for better performance. We
 recommend running each test case in a new BrowserContext, this way browser state will be
 isolated between the tests.
 
-## MSTest
+<Tabs
+  groupId="test-runners"
+  defaultValue="mstest"
+  values={[
+    {label: 'MSTest', value: 'mstest'},
+    {label: 'NUnit', value: 'nunit'},
+  ]
+}>
+<TabItem value="nunit">
+
+Playwright provides base classes to write tests with NUnit via the [`Microsoft.Playwright.NUnit`](https://www.nuget.org/packages/Microsoft.Playwright.NUnit) package.
+
+</TabItem>
+<TabItem value="mstest">
 
 Playwright provides base classes to write tests with MSTest via the [`Microsoft.Playwright.MSTest`](https://www.nuget.org/packages/Microsoft.Playwright.MSTest) package.
 
+</TabItem>
+</Tabs>
+
 Check out the [installation guide](./intro.md) to get started.
 
-### Running MSTest tests in Parallel
+## Running tests in Parallel
+
+<Tabs
+  groupId="test-runners"
+  defaultValue="mstest"
+  values={[
+    {label: 'MSTest', value: 'mstest'},
+    {label: 'NUnit', value: 'nunit'},
+  ]
+}>
+<TabItem value="nunit">
+
+By default NUnit will run all test files in parallel, while running tests inside each file sequentially (`ParallelScope.Self`). It will create as many processes as there are cores on the host system. You can adjust this behavior using the NUnit.NumberOfTestWorkers parameter.
+Only `ParallelScope.Self` is supported.
+
+For CPU-bound tests, we recommend using as many workers as there are cores on your system, divided by 2. For IO-bound tests you can use as many workers as you have cores.
+
+```bash
+dotnet test -- NUnit.NumberOfTestWorkers=5
+```
+
+</TabItem>
+<TabItem value="mstest">
 
 By default MSTest will run all classes in parallel, while running tests inside each class sequentially (`ExecutionScope.ClassLevel`). It will create as many processes as there are cores on the host system. You can adjust this behavior by using the following CLI parameter or using a `.runsettings` file, see below.
 Running tests in parallel at the method level (`ExecutionScope.MethodLevel`) is not supported.
@@ -26,7 +64,58 @@ Running tests in parallel at the method level (`ExecutionScope.MethodLevel`) is 
 dotnet test --settings:.runsettings -- MSTest.Parallelize.Workers=4
 ```
 
-### Customizing [BrowserContext] options
+</TabItem>
+</Tabs>
+
+
+## Customizing [BrowserContext] options
+
+<Tabs
+  groupId="test-runners"
+  defaultValue="mstest"
+  values={[
+    {label: 'MSTest', value: 'mstest'},
+    {label: 'NUnit', value: 'nunit'},
+  ]
+}>
+<TabItem value="nunit">
+
+To customize context options, you can override the `ContextOptions` method of your test class derived from `Microsoft.Playwright.MSTest.PageTest` or `Microsoft.Playwright.MSTest.ContextTest`. See the following example:
+
+```csharp
+using Microsoft.Playwright.NUnit;
+
+namespace PlaywrightTests;
+
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+public class MyTest : PageTest
+{
+    [Test]
+    public async Task TestWithCustomContextOptions()
+    {
+        // The following Page (and BrowserContext) instance has the custom colorScheme, viewport and baseURL set:
+        await Page.GotoAsync("/login");
+    }
+
+    public override BrowserNewContextOptions ContextOptions()
+    {
+        return new BrowserNewContextOptions()
+        {
+            ColorScheme = ColorScheme.Light,
+            ViewportSize = new()
+            {
+                Width = 1920,
+                Height = 1080
+            },
+            BaseURL = "https://github.com",
+        };
+    }
+}
+```
+
+</TabItem>
+<TabItem value="mstest">
 
 To customize context options, you can override the `ContextOptions` method of your test class derived from `Microsoft.Playwright.MSTest.PageTest` or `Microsoft.Playwright.MSTest.ContextTest`. See the following example:
 
@@ -65,7 +154,11 @@ public class ExampleTest : PageTest
 
 ```
 
-### Customizing [Browser]/launch options
+</TabItem>
+</Tabs>
+
+
+## Customizing [Browser]/launch options
 
 [Browser]/launch options can be overridden either using a run settings file or by setting the run settings options directly via the
 CLI. See the following example:
@@ -87,13 +180,54 @@ CLI. See the following example:
 dotnet test -- Playwright.BrowserName=chromium Playwright.LaunchOptions.Headless=false Playwright.LaunchOptions.Channel=msedge
 ```
 
-### Using Verbose API Logs
+## Using Verbose API Logs
 
-When you have enabled the [verbose API log](./debug.md#verbose-api-logs), via the `DEBUG` environment variable, you will see the messages in the standard error stream. In MSTest, within Visual Studio, that will be the `Tests` pane of the `Output` window. It will also be displayed in the `Test Log` for each test.
+When you have enabled the [verbose API log](./debug.md#verbose-api-logs), via the `DEBUG` environment variable, you will see the messages in the standard error stream. Within Visual Studio, that will be the `Tests` pane of the `Output` window. It will also be displayed in the `Test Log` for each test.
 
-### Using the .runsettings file
+## Using the .runsettings file
 
 When running tests from Visual Studio, you can take advantage of the `.runsettings` file. The following shows a reference of the supported values.
+
+<Tabs
+  groupId="test-runners"
+  defaultValue="mstest"
+  values={[
+    {label: 'MSTest', value: 'mstest'},
+    {label: 'NUnit', value: 'nunit'},
+  ]
+}>
+<TabItem value="nunit">
+
+For example, to specify the number of workers you can use `NUnit.NumberOfTestWorkers` or to enable `DEBUG` logs `RunConfiguration.EnvironmentVariables`.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <!-- NUnit adapter -->  
+  <NUnit>
+    <NumberOfTestWorkers>24</NumberOfTestWorkers>
+  </NUnit>
+  <!-- General run configuration -->
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <!-- For debugging selectors, it's recommend to set the following environment variable -->
+      <DEBUG>pw:api</DEBUG>
+    </EnvironmentVariables>
+  </RunConfiguration>
+  <!-- Playwright -->  
+  <Playwright>
+    <BrowserName>chromium</BrowserName>
+    <ExpectTimeout>5000</ExpectTimeout>
+    <LaunchOptions>
+      <Headless>false</Headless>
+      <Channel>msedge</Channel>
+    </LaunchOptions>
+  </Playwright>
+</RunSettings>
+```
+
+</TabItem>
+<TabItem value="mstest">
 
 For example, to specify the number of workers, you can use `MSTest.Parallelize.Workers`. You can also enable `DEBUG` logs using `RunConfiguration.EnvironmentVariables`.
 
@@ -125,131 +259,30 @@ For example, to specify the number of workers, you can use `MSTest.Parallelize.W
 </RunSettings>
 ```
 
-### Base MSTest classes for Playwright
+</TabItem>
+</Tabs>
+
+## Base classes for Playwright
+
+<Tabs
+  groupId="test-runners"
+  defaultValue="mstest"
+  values={[
+    {label: 'MSTest', value: 'mstest'},
+    {label: 'NUnit', value: 'nunit'},
+  ]
+}>
+<TabItem value="nunit">
+
+There are a few base classes available to you in `Microsoft.Playwright.NUnit` namespace:
+
+</TabItem>
+<TabItem value="mstest">
 
 There are a few base classes available to you in `Microsoft.Playwright.MSTest` namespace:
 
-|Test          |Description|
-|--------------|-----------|
-|PageTest      |Each test gets a fresh copy of a web [Page] created in its own unique [BrowserContext]. Extending this class is the simplest way of writing a fully-functional Playwright test.<br></br><br></br>Note: You can override the `ContextOptions` method in each test file to control context options, the ones typically passed into the [`method: Browser.newContext`] method. That way you can specify all kinds of emulation options for your test file individually.|
-|ContextTest   |Each test will get a fresh copy of a [BrowserContext]. You can create as many pages in this context as you'd like. Using this test is the easiest way to test multi-page scenarios where you need more than one tab.<br></br><br></br>Note: You can override the `ContextOptions` method in each test file to control context options, the ones typically passed into the [`method: Browser.newContext`] method. That way you can specify all kinds of emulation options for your test file individually.|
-|BrowserTest   |Each test will get a browser and can create as many contexts as it likes. Each test is responsible for cleaning up all the contexts it created.|
-|PlaywrightTest|This gives each test a Playwright object so that the test could start and stop as many browsers as it likes.|
-
-## NUnit
-
-Playwright provides base classes to write tests with NUnit via the [`Microsoft.Playwright.NUnit`](https://www.nuget.org/packages/Microsoft.Playwright.NUnit) package.
-
-Check out the [installation guide](./intro.md) to get started.
-
-### Running NUnit tests in Parallel
-
-By default NUnit will run all test files in parallel, while running tests inside each file sequentially (`ParallelScope.Self`). It will create as many processes as there are cores on the host system. You can adjust this behavior using the NUnit.NumberOfTestWorkers parameter.
-Only `ParallelScope.Self` is supported.
-
-For CPU-bound tests, we recommend using as many workers as there are cores on your system, divided by 2. For IO-bound tests you can use as many workers as you have cores.
-
-```bash
-dotnet test -- NUnit.NumberOfTestWorkers=5
-```
-
-### Customizing [BrowserContext] options
-
-To customize context options, you can override the `ContextOptions` method of your test class derived from `Microsoft.Playwright.MSTest.PageTest` or `Microsoft.Playwright.MSTest.ContextTest`. See the following example:
-
-```csharp
-using Microsoft.Playwright.NUnit;
-
-namespace PlaywrightTests;
-
-[Parallelizable(ParallelScope.Self)]
-[TestFixture]
-public class MyTest : PageTest
-{
-    [Test]
-    public async Task TestWithCustomContextOptions()
-    {
-        // The following Page (and BrowserContext) instance has the custom colorScheme, viewport and baseURL set:
-        await Page.GotoAsync("/login");
-    }
-
-    public override BrowserNewContextOptions ContextOptions()
-    {
-        return new BrowserNewContextOptions()
-        {
-            ColorScheme = ColorScheme.Light,
-            ViewportSize = new()
-            {
-                Width = 1920,
-                Height = 1080
-            },
-            BaseURL = "https://github.com",
-        };
-    }
-}
-```
-
-### Customizing [Browser]/launch options
-
-[Browser]/launch options can be overridden either using a run settings file or by setting the run settings options directly via the
-CLI. See the following example:
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<RunSettings>
-  <Playwright>
-    <BrowserName>chromium</BrowserName>
-    <LaunchOptions>
-      <Headless>false</Headless>
-      <Channel>msedge</Channel>
-    </LaunchOptions>
-  </Playwright>
-</RunSettings>
-```
-
-```bash
-dotnet test -- Playwright.BrowserName=chromium Playwright.LaunchOptions.Headless=false Playwright.LaunchOptions.Channel=msedge
-```
-
-### Using Verbose API Logs
-
-When you have enabled the [verbose API log](./debug.md#verbose-api-logs), via the `DEBUG` environment variable, you will see the messages in the standard error stream. In NUnit, within Visual Studio, that will be the `Tests` pane of the `Output` window. It will also be displayed in the `Test Log` for each test.
-
-### Using the .runsettings file
-
-When running tests from Visual Studio, you can take advantage of the `.runsettings` file. The following shows a reference of the supported values.
-
-For example, to specify the amount of workers you can use `NUnit.NumberOfTestWorkers` or to enable `DEBUG` logs `RunConfiguration.EnvironmentVariables`.
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<RunSettings>
-  <!-- NUnit adapter -->  
-  <NUnit>
-    <NumberOfTestWorkers>24</NumberOfTestWorkers>
-  </NUnit>
-  <!-- General run configuration -->
-  <RunConfiguration>
-    <EnvironmentVariables>
-      <!-- For debugging selectors, it's recommend to set the following environment variable -->
-      <DEBUG>pw:api</DEBUG>
-    </EnvironmentVariables>
-  </RunConfiguration>
-  <!-- Playwright -->  
-  <Playwright>
-    <BrowserName>chromium</BrowserName>
-    <ExpectTimeout>5000</ExpectTimeout>
-    <LaunchOptions>
-      <Headless>false</Headless>
-      <Channel>msedge</Channel>
-    </LaunchOptions>
-  </Playwright>
-</RunSettings>
-```
-
-### Base NUnit classes for Playwright
-
-There are a few base classes available to you in `Microsoft.Playwright.NUnit` namespace:
+</TabItem>
+</Tabs>
 
 |Test          |Description|
 |--------------|-----------|


### PR DESCRIPTION
No text changes, just move / de-duplicate like we usually do via tabs in .NET.