### PR TITLE
fix(chromium): race between oopif attach and context clear

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -731,6 +731,10 @@ class FrameSession {
       if (!frame)
         return; // Subtree may be already gone due to renderer/browser race.
       this._page._frameManager.removeChildFramesRecursively(frame);
+      for (const [contextId, context] of this._contextIdToContext) {
+        if (context.frame === frame)
+          this._onExecutionContextDestroyed(contextId);
+      }
       const frameSession = new FrameSession(this._crPage, session, targetId, this);
       this._crPage._sessions.set(targetId, frameSession);
       frameSession._initialize(false).catch(e => e);


### PR DESCRIPTION
There is a race between:
- `Runtime.executionContextsCleared` coming in the OOPIF.
- `Page.frameNavigated`/`Target.attachedToTarget` when frame goes local->remote.

As a result, we can have stale execution contexts from the previous non-OOPIF frame that does not exist anymore, instead of new contexts in the OOPIF.

This causes things like recorder trying to initialize in the wrong context and fail.

Now that we clear contexts upon local->remote switch, recorder waits for the new context to be created an successfully initializes.