### PR TITLE
fix(ct-vue): Upgrade plugin-vue to be compatible with Vite 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2171,14 +2171,15 @@
       }
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.6.2.tgz",
-      "integrity": "sha512-kqf7SGFoG+80aZG6Pf+gsZIVvGSCKE98JbiWqcCV9cThtg91Jav0yvYFC9Zb+jKetNGF6ZKeoaxgZfND21fWKw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.0.tgz",
+      "integrity": "sha512-7n7KdUEtx/7Yl7I/WVAMZ1bEb0eVvXF3ummWTeLcs/9gvo9pJhuLdouSXGjdZ/MKD1acf1I272+X0RMua4/R3g==",
+      "license": "MIT",
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.0.0 || ^5.0.0",
+        "vite": "^5.0.0",
         "vue": "^3.2.25"
       }
     },
@@ -7876,7 +7877,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@playwright/experimental-ct-core": "1.50.0-next",
-        "@vitejs/plugin-vue": "^4.2.1"
+        "@vitejs/plugin-vue": "^5.2.0"
       },
       "bin": {
         "playwright": "cli.js"

--- a/packages/playwright-ct-vue/package.json
+++ b/packages/playwright-ct-vue/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@playwright/experimental-ct-core": "1.50.0-next",
-    "@vitejs/plugin-vue": "^4.2.1"
+    "@vitejs/plugin-vue": "^5.2.0"
   },
   "bin": {
     "playwright": "cli.js"

--- a/tests/components/ct-vue-vite/package.json
+++ b/tests/components/ct-vue-vite/package.json
@@ -12,7 +12,7 @@
     "vue-router": "^4.1.5"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.1.0",
+    "@vitejs/plugin-vue": "^5.2.0",
     "@vue/tsconfig": "^0.5.1",
     "typescript": "5.6.2",
     "vite": "^5.2.8",


### PR DESCRIPTION
ct-core uses Vite 5, but ct-vue uses the Vue plugin for Vite 4.