### PR TITLE
chore(ui):  test that UI works behind proxy, take 2

### DIFF
--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -63,7 +63,7 @@ export class TestProxy {
     this._prependHandler('request', (req: IncomingMessage) => {
       this.requestUrls.push(req.url);
       const url = new URL(req.url, `http://${req.headers.host}`);
-      url.port = '' + port;
+      url.host = `localhost:${port}`;
       if (options?.prefix)
         url.pathname = url.pathname.replace(options.prefix, '');
       req.url = url.toString();
@@ -74,12 +74,12 @@ export class TestProxy {
       if (kConnectHostsToIgnore.has(req.url))
         return;
       this.connectHosts.push(req.url);
-      req.url = `127.0.0.1:${port}`;
+      req.url = `localhost:${port}`;
     });
     this._prependHandler('upgrade', (req: IncomingMessage) => {
       this.wsUrls.push(req.url);
       const url = new URL(req.url, `http://${req.headers.host}`);
-      url.port = '' + port;
+      url.host = `localhost:${port}`;
       if (options?.prefix)
         url.pathname = url.pathname.replace(options.prefix, '');
       req.url = url.toString();

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -63,7 +63,7 @@ export class TestProxy {
     this._prependHandler('request', (req: IncomingMessage) => {
       this.requestUrls.push(req.url);
       const url = new URL(req.url, `http://${req.headers.host}`);
-      url.host = `localhost:${port}`;
+      url.host = `127.0.0.1:${port}`;
       if (options?.prefix)
         url.pathname = url.pathname.replace(options.prefix, '');
       req.url = url.toString();
@@ -74,12 +74,12 @@ export class TestProxy {
       if (kConnectHostsToIgnore.has(req.url))
         return;
       this.connectHosts.push(req.url);
-      req.url = `localhost:${port}`;
+      req.url = `127.0.0.1:${port}`;
     });
     this._prependHandler('upgrade', (req: IncomingMessage) => {
       this.wsUrls.push(req.url);
       const url = new URL(req.url, `http://${req.headers.host}`);
-      url.host = `localhost:${port}`;
+      url.host = `127.0.0.1:${port}`;
       if (options?.prefix)
         url.pathname = url.pathname.replace(options.prefix, '');
       req.url = url.toString();

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -58,11 +58,13 @@ export class TestProxy {
     await new Promise(x => this._server.close(x));
   }
 
-  forwardTo(port: number, options?: { allowConnectRequests: boolean }) {
+  forwardTo(port: number, options?: { allowConnectRequests?: boolean, prefix?: string }) {
     this._prependHandler('request', (req: IncomingMessage) => {
       this.requestUrls.push(req.url);
-      const url = new URL(req.url);
-      url.host = `127.0.0.1:${port}`;
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      url.port = '' + port;
+      if (options.prefix)
+        url.pathname = url.pathname.replace(options.prefix, '');
       req.url = url.toString();
     });
     this._prependHandler('connect', (req: IncomingMessage) => {

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -59,11 +59,14 @@ export class TestProxy {
     await new Promise(x => this._server.close(x));
   }
 
-  forwardTo(port: number, options?: { allowConnectRequests?: boolean, prefix?: string }) {
+  forwardTo(port: number, options?: { allowConnectRequests?: boolean, prefix?: string, dontTouchHost?: boolean }) {
     this._prependHandler('request', (req: IncomingMessage) => {
       this.requestUrls.push(req.url);
       const url = new URL(req.url, `http://${req.headers.host}`);
-      url.host = `127.0.0.1:${port}`;
+      if (options?.dontTouchHost)
+        url.port = '' + port;
+      else
+        url.host = `127.0.0.1:${port}`;
       if (options?.prefix)
         url.pathname = url.pathname.replace(options.prefix, '');
       req.url = url.toString();
@@ -79,7 +82,10 @@ export class TestProxy {
     this._prependHandler('upgrade', (req: IncomingMessage) => {
       this.wsUrls.push(req.url);
       const url = new URL(req.url, `http://${req.headers.host}`);
-      url.host = `127.0.0.1:${port}`;
+      if (options?.dontTouchHost)
+        url.port = '' + port;
+      else
+        url.host = `127.0.0.1:${port}`;
       if (options?.prefix)
         url.pathname = url.pathname.replace(options.prefix, '');
       req.url = url.toString();

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -64,7 +64,7 @@ export class TestProxy {
       this.requestUrls.push(req.url);
       const url = new URL(req.url, `http://${req.headers.host}`);
       url.port = '' + port;
-      if (options.prefix)
+      if (options?.prefix)
         url.pathname = url.pathname.replace(options.prefix, '');
       req.url = url.toString();
     });
@@ -80,7 +80,7 @@ export class TestProxy {
       this.wsUrls.push(req.url);
       const url = new URL(req.url, `http://${req.headers.host}`);
       url.port = '' + port;
-      if (options.prefix)
+      if (options?.prefix)
         url.pathname = url.pathname.replace(options.prefix, '');
       req.url = url.toString();
     });

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -59,11 +59,11 @@ export class TestProxy {
     await new Promise(x => this._server.close(x));
   }
 
-  forwardTo(port: number, options?: { allowConnectRequests?: boolean, prefix?: string, dontTouchHost?: boolean }) {
+  forwardTo(port: number, options?: { allowConnectRequests?: boolean, prefix?: string, preserveHostname?: boolean }) {
     this._prependHandler('request', (req: IncomingMessage) => {
       this.requestUrls.push(req.url);
       const url = new URL(req.url, `http://${req.headers.host}`);
-      if (options?.dontTouchHost)
+      if (options?.preserveHostname)
         url.port = '' + port;
       else
         url.host = `127.0.0.1:${port}`;
@@ -82,7 +82,7 @@ export class TestProxy {
     this._prependHandler('upgrade', (req: IncomingMessage) => {
       this.wsUrls.push(req.url);
       const url = new URL(req.url, `http://${req.headers.host}`);
-      if (options?.dontTouchHost)
+      if (options?.preserveHostname)
         url.port = '' + port;
       else
         url.host = `127.0.0.1:${port}`;

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -32,6 +32,7 @@ export class TestProxy {
 
   connectHosts: string[] = [];
   requestUrls: string[] = [];
+  wsUrls: string[] = [];
 
   private readonly _server: ProxyServer;
   private readonly _sockets = new Set<net.Socket>();
@@ -74,6 +75,14 @@ export class TestProxy {
         return;
       this.connectHosts.push(req.url);
       req.url = `127.0.0.1:${port}`;
+    });
+    this._prependHandler('upgrade', (req: IncomingMessage) => {
+      this.wsUrls.push(req.url);
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      url.port = '' + port;
+      if (options.prefix)
+        url.pathname = url.pathname.replace(options.prefix, '');
+      req.url = url.toString();
     });
   }
 

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -353,7 +353,7 @@ test('should work behind proxy', { annotation: { type: 'issue', description: 'ht
   });
 
   const origin = new URL(page.url());
-  proxyServer.forwardTo(+origin.port, { prefix: '/subdir' });
+  proxyServer.forwardTo(+origin.port, { prefix: '/subdir', dontTouchHost: true });
   await page.goto(`${proxyServer.URL}/subdir${origin.pathname}?${origin.searchParams}`);
 
   await page.getByText('trace test').dblclick();

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -340,7 +340,7 @@ test('should show request source context id', async ({ runUITest, server }) => {
   await expect(page.getByText('api#1')).toBeVisible();
 });
 
-test('should work behind proxy', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33705' } }, async ({ runUITest, proxyServer }, testInfo) => {
+test('should work behind reverse proxy', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33705' } }, async ({ runUITest, proxyServer: reverseProxy }) => {
   const { page } = await runUITest({
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
@@ -352,9 +352,9 @@ test('should work behind proxy', { annotation: { type: 'issue', description: 'ht
     `,
   });
 
-  const origin = new URL(page.url());
-  proxyServer.forwardTo(+origin.port, { prefix: '/subdir', dontTouchHost: true });
-  await page.goto(`${proxyServer.URL}/subdir${origin.pathname}?${origin.searchParams}`);
+  const uiModeUrl = new URL(page.url());
+  reverseProxy.forwardTo(+uiModeUrl.port, { prefix: '/subdir', preserveHostname: true });
+  await page.goto(`${reverseProxy.URL}/subdir${uiModeUrl.pathname}?${uiModeUrl.searchParams}`);
 
   await page.getByText('trace test').dblclick();
 


### PR DESCRIPTION
This PR adds a test to ensure we support running UI behind a proxy. It adds websocket support to our vendored `proxy` library as part of that.

Closes https://github.com/microsoft/playwright/issues/33705.
Supercedes https://github.com/microsoft/playwright/pull/33767, which added the same test but used a separate WS proxy library.