### PR TITLE
fix(types): fixed `Fixtures` type to disambiguite between intersected mapped types

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5632,7 +5632,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
    * Learn more about [fixtures](https://playwright.dev/docs/test-fixtures) and [parametrizing tests](https://playwright.dev/docs/test-parameterize).
    * @param fixtures An object containing fixtures and/or options. Learn more about [fixtures format](https://playwright.dev/docs/test-fixtures).
    */
-  extend<T extends KeyValue, W extends KeyValue = {}>(fixtures: Fixtures<T, W, TestArgs, WorkerArgs>): TestType<TestArgs & T, WorkerArgs & W>;
+  extend<T extends {}, W extends {} = {}>(fixtures: Fixtures<T, W, TestArgs, WorkerArgs>): TestType<TestArgs & T, WorkerArgs & W>;
   /**
    * Returns information about the currently running test. This method can only be called during the test execution,
    * otherwise it throws.

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -5663,9 +5663,9 @@ export type Fixtures<T extends KeyValue = {}, W extends KeyValue = {}, PT extend
 } & {
   [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean }];
 } & {
-  [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof W as Exclude<K, keyof PW | keyof PT>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
 } & {
-  [K in keyof T]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof T as Exclude<K, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';

--- a/tests/installation/fixture-scripts/playwright-test-plugin-types.ts
+++ b/tests/installation/fixture-scripts/playwright-test-plugin-types.ts
@@ -17,3 +17,66 @@ test('sample test', async ({ page, plugin }) => {
   // @ts-expect-error
   await expect(page).toContainText(123);
 });
+
+test1.extend({
+  page: async ({ page }) => {
+    type IsPage = (typeof page) extends Page ? true : never;
+    const isPage: IsPage = true;
+  },
+});
+
+test1.extend<{ myFixture: (arg: number) => void }>({
+  page: async ({ page }) => {
+    type IsPage = (typeof page) extends Page ? true : never;
+    const isPage: IsPage = true;
+  },
+});
+
+test1.extend({
+  myFixture: async ({ page }) => {
+    type IsPage = (typeof page) extends Page ? true : never;
+    const isPage: IsPage = true;
+  }
+});
+
+test1.extend<{ myFixture: (arg: number) => void }>({
+  myFixture: async ({ page }) => {
+    type IsPage = (typeof page) extends Page ? true : never;
+    const isPage: IsPage = true;
+  }
+});
+
+test1.extend({
+  page: async ({ page }) => {
+    type IsPage = (typeof page) extends Page ? true : never;
+    const isPage: IsPage = true;
+  },
+  myFixture: async ({ page }) => {
+    type IsPage = (typeof page) extends Page ? true : never;
+    const isPage: IsPage = true;
+  }
+});
+
+test1.extend<{ myFixture: (arg: number) => void }>({
+  page: async ({ page }) => {
+    type IsPage = (typeof page) extends Page ? true : never;
+    const isPage: IsPage = true;
+  },
+  myFixture: async ({ page }) => {
+    type IsPage = (typeof page) extends Page ? true : never;
+    const isPage: IsPage = true;
+  }
+});
+
+test1.extend<{ myFixture: (arg: number) => void }>({
+  // @ts-expect-error
+  myFixture: (arg: number) => {},
+});
+
+test1.extend<{ myFixture: (arg: number) => void }>({
+  myFixture: async (_, use) => {
+    use((arg: number) => {});
+    // @ts-expect-error
+    use((arg: string) => {});
+  }
+});

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -164,7 +164,7 @@ export interface TestType<TestArgs extends KeyValue, WorkerArgs extends KeyValue
   use(fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs>): void;
   step<T>(title: string, body: () => T | Promise<T>, options?: { box?: boolean, location?: Location, timeout?: number }): Promise<T>;
   expect: Expect<{}>;
-  extend<T extends KeyValue, W extends KeyValue = {}>(fixtures: Fixtures<T, W, TestArgs, WorkerArgs>): TestType<TestArgs & T, WorkerArgs & W>;
+  extend<T extends {}, W extends {} = {}>(fixtures: Fixtures<T, W, TestArgs, WorkerArgs>): TestType<TestArgs & T, WorkerArgs & W>;
   info(): TestInfo;
 }
 

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -178,9 +178,9 @@ export type Fixtures<T extends KeyValue = {}, W extends KeyValue = {}, PT extend
 } & {
   [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean }];
 } & {
-  [K in keyof W]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof W as Exclude<K, keyof PW | keyof PT>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
 } & {
-  [K in keyof T]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof T as Exclude<K, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';


### PR DESCRIPTION
fixes https://github.com/microsoft/playwright/issues/33763
context behind the change can be found here: https://github.com/microsoft/TypeScript/issues/60619#issuecomment-2503967944
cc @dgozman 