### PR TITLE
fix(trace): in `indexTree` check `isVisible` before adding to result

### DIFF
--- a/packages/web/src/components/treeView.tsx
+++ b/packages/web/src/components/treeView.tsx
@@ -319,8 +319,8 @@ function indexTree<T extends TreeItem>(
   selectedItem: T | undefined,
   expandedItems: Map<string, boolean | undefined>,
   autoExpandDepth: number,
-  isVisible?: (item: T) => boolean): Map<T, TreeItemData> {
-  if (isVisible && !isVisible(rootItem))
+  isVisible: (item: T) => boolean = () => true): Map<T, TreeItemData> {
+  if (!isVisible(rootItem))
     return new Map();
 
   const result = new Map<T, TreeItemData>();
@@ -331,7 +331,7 @@ function indexTree<T extends TreeItem>(
 
   const appendChildren = (parent: T, depth: number) => {
     for (const item of parent.children as T[]) {
-      if (isVisible && !isVisible(item))
+      if (!isVisible(item))
         continue;
       const expandState = temporaryExpanded.has(item.id) || expandedItems.get(item.id);
       const autoExpandMatches = autoExpandDepth > depth && result.size < 25 && expandState !== false;

--- a/packages/web/src/components/treeView.tsx
+++ b/packages/web/src/components/treeView.tsx
@@ -328,8 +328,6 @@ function indexTree<T extends TreeItem>(
   let lastItem: T | null = null;
 
   const appendChildren = (parent: T, depth: number) => {
-    if (isVisible && !isVisible(parent))
-      return;
     for (const item of parent.children as T[]) {
       if (isVisible && !isVisible(item))
         continue;

--- a/packages/web/src/components/treeView.tsx
+++ b/packages/web/src/components/treeView.tsx
@@ -320,6 +320,8 @@ function indexTree<T extends TreeItem>(
   expandedItems: Map<string, boolean | undefined>,
   autoExpandDepth: number,
   isVisible?: (item: T) => boolean): Map<T, TreeItemData> {
+  if (isVisible && !isVisible(rootItem))
+    return new Map();
 
   const result = new Map<T, TreeItemData>();
   const temporaryExpanded = new Set<string>();

--- a/packages/web/src/components/treeView.tsx
+++ b/packages/web/src/components/treeView.tsx
@@ -331,6 +331,8 @@ function indexTree<T extends TreeItem>(
     if (isVisible && !isVisible(parent))
       return;
     for (const item of parent.children as T[]) {
+      if (isVisible && !isVisible(item))
+        continue;
       const expandState = temporaryExpanded.has(item.id) || expandedItems.get(item.id);
       const autoExpandMatches = autoExpandDepth > depth && result.size < 25 && expandState !== false;
       const expanded = item.children.length ? expandState ?? autoExpandMatches : undefined;

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -339,3 +339,27 @@ test('should show request source context id', async ({ runUITest, server }) => {
   await expect(page.getByText('page#2')).toBeVisible();
   await expect(page.getByText('api#1')).toBeVisible();
 });
+
+test('should filter actions tab on double-click', async ({ runUITest, server }) => {
+  const { page } = await runUITest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async ({ page }) => {
+        await page.goto('${server.EMPTY_PAGE}');
+      });
+    `,
+  });
+
+  await page.getByText('pass').dblclick();
+
+  const actionsTree = page.getByTestId('actions-tree');
+  await expect(actionsTree.getByRole('treeitem')).toHaveText([
+    /Before Hooks/,
+    /page.goto/,
+    /After Hooks/,
+  ]);
+  await actionsTree.getByRole('treeitem', { name: 'page.goto' }).dblclick();
+  await expect(actionsTree.getByRole('treeitem')).toHaveText([
+    /page.goto/,
+  ]);
+});


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/33788.

https://github.com/microsoft/playwright/commit/2e8e7a66cd9d6dae8f4a9d2a60331bcc4c7d24f0 rewrote how the tree is composed. The bug is that it appends onto `result` without checking if the node is visible.