### PR TITLE
fix(connect): disable context takeover in websocket transport

### DIFF
--- a/packages/playwright-core/src/server/transport.ts
+++ b/packages/playwright-core/src/server/transport.ts
@@ -24,6 +24,7 @@ import { httpHappyEyeballsAgent, httpsHappyEyeballsAgent } from '../utils/happy-
 import type { HeadersArray } from './types';
 
 export const perMessageDeflate = {
+  clientNoContextTakeover: true,
   zlibDeflateOptions: {
     level: 3,
   },

--- a/packages/playwright-core/src/utils/wsServer.ts
+++ b/packages/playwright-core/src/utils/wsServer.ts
@@ -25,6 +25,7 @@ let lastConnectionId = 0;
 const kConnectionSymbol = Symbol('kConnection');
 
 export const perMessageDeflate = {
+  serverNoContextTakeover: true,
   zlibDeflateOptions: {
     level: 3,
   },


### PR DESCRIPTION
The `threshold` option in `perMessageDeflate` is ignored due to context takeover being enabled. This leads to WebSocket RPC messages being unconditionally compressed.

Most RPC channel messages are small, and unconditionally performing message compression has measurable performance impact.

Disable context takeover (for both server and client) to let compression threshold option to take effect.

Fixes #33810