### PR TITLE
fix(recorder): allow clearing when recording is disabled

### DIFF
--- a/packages/playwright-core/src/server/recorder/recorderCollection.ts
+++ b/packages/playwright-core/src/server/recorder/recorderCollection.ts
@@ -38,7 +38,7 @@ export class RecorderCollection extends EventEmitter {
 
   restart() {
     this._actions = [];
-    this._fireChange();
+    this.emit('change', []);
   }
 
   setEnabled(enabled: boolean) {

--- a/packages/playwright-core/src/server/recorder/recorderCollection.ts
+++ b/packages/playwright-core/src/server/recorder/recorderCollection.ts
@@ -79,8 +79,7 @@ export class RecorderCollection extends EventEmitter {
     callMetadata.error = error ? serializeError(error) : undefined;
     // Do not wait for onAfterCall so that performAction returned immediately after the action.
     mainFrame.instrumentation.onAfterCall(mainFrame, callMetadata).then(() => {
-      if (this._enabled)
-        this._fireChange();
+      this._fireChange();
     }).catch(() => {});
   }
 
@@ -127,6 +126,9 @@ export class RecorderCollection extends EventEmitter {
   }
 
   private _fireChange() {
+    if (!this._enabled)
+      return;
+
     this.emit('change', collapseActions(this._actions));
   }
 }

--- a/packages/playwright-core/src/server/recorder/recorderCollection.ts
+++ b/packages/playwright-core/src/server/recorder/recorderCollection.ts
@@ -79,7 +79,8 @@ export class RecorderCollection extends EventEmitter {
     callMetadata.error = error ? serializeError(error) : undefined;
     // Do not wait for onAfterCall so that performAction returned immediately after the action.
     mainFrame.instrumentation.onAfterCall(mainFrame, callMetadata).then(() => {
-      this._fireChange();
+      if (this._enabled)
+        this._fireChange();
     }).catch(() => {});
   }
 
@@ -126,8 +127,6 @@ export class RecorderCollection extends EventEmitter {
   }
 
   private _fireChange() {
-    if (!this._enabled)
-      return;
     this.emit('change', collapseActions(this._actions));
   }
 }


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/33802. This regressed in https://github.com/microsoft/playwright/pull/32880, which aimed to unflake a specific test with a race condition around the `mainFrame.instrumentation.onAfterCall` callback. As a side effect, it broke clearing a disabled recorder. The fix is to move the `this._enabled` check up the call chain, so it only impacts the race condition.