### PR TITLE
fix(codegen): do not reset current tool upon clearing highlight

### DIFF
--- a/packages/playwright-core/src/server/injected/recorder/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder/recorder.ts
@@ -1157,7 +1157,6 @@ export class Recorder {
   }
 
   clearHighlight() {
-    this._currentTool.cleanup?.();
     this.updateHighlight(null, false);
   }
 


### PR DESCRIPTION
This breaks when VSCode updates the highlight during recording. The problem was exposed by #33632.

I wasn't able to write a test as a part of `codegen.spec`, `debug-controller.spec` or in the `playwright-vscode` repository. It seems like timing is very important to reproduce the issue.

Fixes #33787.