### PR TITLE
feat(matcher): add new GenericAssertions(toBeOneOf)

### DIFF
--- a/docs/src/api/class-genericassertions.md
+++ b/docs/src/api/class-genericassertions.md
@@ -227,6 +227,30 @@ expect(value).toBeNull();
 ```
 
 
+## method: GenericAssertions.toBeOneOf
+* since: v1.49.1
+
+Ensures that value is deeply equal to one of the elements in the expected array.
+
+**Usage**
+
+```js
+const value = 2;
+expect(value).toBeOneOf([1, 2, 3]);
+expect(value).not.toBeOneOf([4, 5, 6]);
+
+const obj = { a: 1 };
+expect(obj).toBeOneOf([{ a: 1 }, { b: 2 }]);
+expect(obj).not.toBeOneOf([{ a: 2 }, { b: 3 }]);
+```
+
+### param: GenericAssertions.toBeOneOf.expected
+* since: v1.49.1
+- `expected` <[Array]<[any]>>
+
+Expected array to match against.
+
+
 
 ## method: GenericAssertions.toBeTruthy
 * since: v1.9

--- a/packages/playwright/bundles/expect/third_party/matchers.ts
+++ b/packages/playwright/bundles/expect/third_party/matchers.ts
@@ -420,6 +420,37 @@ const matchers: MatchersObject = {
     return { message, pass };
   },
 
+  toBeOneOf(received: unknown, expected: Array<unknown>) {
+    const matcherName = 'toBeOneOf';
+    const isNot = this.isNot;
+    const options: MatcherHintOptions = {
+      isNot,
+      promise: this.promise,
+    };
+
+    if (!Array.isArray(expected)) {
+      throw new Error(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, undefined, options),
+              `${EXPECTED_COLOR('expected')} value must be an array`,
+              printWithType('Expected', expected, printExpected),
+          ),
+      );
+    }
+
+    const pass = expected.some(item =>
+      equals(received, item, [...this.customTesters, iterableEquality]),
+    );
+
+    const message = () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      `Expected: ${isNot ? 'not ' : ''}to be one of ${printExpected(expected)}\n` +
+      `Received: ${printReceived(received)}`;
+
+    return { actual: received, expected, message, name: matcherName, pass };
+  },
+
   toBeTruthy(received: unknown, expected: void) {
     const matcherName = 'toBeTruthy';
     const options: MatcherHintOptions = {

--- a/packages/playwright/bundles/expect/third_party/types.ts
+++ b/packages/playwright/bundles/expect/third_party/types.ts
@@ -224,6 +224,11 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
   toBeNull(): R;
   /**
    * Use when you don't care what a value is, you just want to ensure a value
+   * is not null. You will often see it in tests for checking that a callback
+   */
+  toBeOneOf(expected: Array<unknown>): R;
+  /**
+   * Use when you don't care what a value is, you just want to ensure a value
    * is true in a boolean context. In JavaScript, there are six falsy values:
    * `false`, `0`, `''`, `null`, `undefined`, and `NaN`. Everything else is truthy.
    */

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -7041,6 +7041,24 @@ interface GenericAssertions<R> {
    */
   toBeNull(): R;
   /**
+   * Ensures that value is deeply equal to one of the elements in the expected array.
+   *
+   * **Usage**
+   *
+   * ```js
+   * const value = 2;
+   * expect(value).toBeOneOf([1, 2, 3]);
+   * expect(value).not.toBeOneOf([4, 5, 6]);
+   *
+   * const obj = { a: 1 };
+   * expect(obj).toBeOneOf([{ a: 1 }, { b: 2 }]);
+   * expect(obj).not.toBeOneOf([{ a: 2 }, { b: 3 }]);
+   * ```
+   *
+   * @param expected Expected array to match against.
+   */
+  toBeOneOf(expected: unknown[]): R;
+  /**
    * Ensures that value is true in a boolean context, **anything but** `false`, `0`, `''`, `null`, `undefined` or `NaN`.
    * Use this method when you don't care about the specific value.
    *

--- a/tests/expect/matchers.snapshots.js
+++ b/tests/expect/matchers.snapshots.js
@@ -3612,3 +3612,108 @@ module.exports["toMatchObject() does not match properties up in the prototype ch
 <g>-   "ref": [Circular],</>
 <d>  }</>`;
 
+module.exports[".toBeOneOf() fails when the value is not in the expected array: expect(4).toBeOneOf([1, 2, 3])"] = `<d>expect(</><r>received</><d>).</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: to be one of <g>[1, 2, 3]</>
+Received: <r>4</>`;
+
+module.exports[".toBeOneOf() fails when the value is not in the expected array: expect(\"d\").toBeOneOf([\"a\", \"b\", \"c\"])"] = `<d>expect(</><r>received</><d>).</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: to be one of <g>["a", "b", "c"]</>
+Received: <r>"d"</>`;
+
+module.exports[".toBeOneOf() fails when the value is not in the expected array: expect(false).toBeOneOf([true])"] = `<d>expect(</><r>received</><d>).</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: to be one of <g>[true]</>
+Received: <r>false</>`;
+
+module.exports[".toBeOneOf() fails when the value is not in the expected array: expect(null).toBeOneOf([undefined])"] = `<d>expect(</><r>received</><d>).</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: to be one of <g>[undefined]</>
+Received: <r>null</>`;
+
+module.exports[".toBeOneOf() fails when the value is not in the expected array: expect(undefined).toBeOneOf([null])"] = `<d>expect(</><r>received</><d>).</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: to be one of <g>[null]</>
+Received: <r>undefined</>`;
+
+module.exports[".toBeOneOf() fails when the value is not in the expected array: expect(NaN).toBeOneOf([1, 2])"] = `<d>expect(</><r>received</><d>).</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: to be one of <g>[1, 2]</>
+Received: <r>NaN</>`;
+
+module.exports[".toBeOneOf() fails when the value is not in the expected array: expect(3n).toBeOneOf([1n, 2n])"] = `<d>expect(</><r>received</><d>).</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: to be one of <g>[1n, 2n]</>
+Received: <r>3n</>`;
+
+module.exports[".toBeOneOf() fails when the value is not in the expected array: expect([1, 2]).toBeOneOf([[3, 4], [5, 6]])"] = `<d>expect(</><r>received</><d>).</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: to be one of <g>[[3, 4], [5, 6]]</>
+Received: <r>[1, 2]</>`;
+
+module.exports[".toBeOneOf() fails when the value is not in the expected array: expect({\"a\": 1}).toBeOneOf([{\"b\": 2}, {\"c\": 3}])"] = `<d>expect(</><r>received</><d>).</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: to be one of <g>[{"b": 2}, {"c": 3}]</>
+Received: <r>{"a": 1}</>`;
+
+module.exports[".toBeOneOf() fails when the value is not in the expected array: expect({\"a\": {\"b\": {\"c\": 1}}}).toBeOneOf([{\"a\": {\"b\": {\"c\": 2}}}])"] = `<d>expect(</><r>received</><d>).</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: to be one of <g>[{"a": {"b": {"c": 2}}}]</>
+Received: <r>{"a": {"b": {"c": 1}}}</>`;
+
+module.exports[".toBeOneOf() fails when using .not and value is in the expected array: expect(2).not.toBeOneOf([1, 2, 3])"] = `<d>expect(</><r>received</><d>).</>not<d>.</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: not to be one of <g>[1, 2, 3]</>
+Received: <r>2</>`;
+
+module.exports[".toBeOneOf() fails when using .not and value is in the expected array: expect(\"b\").not.toBeOneOf([\"a\", \"b\", \"c\"])"] = `<d>expect(</><r>received</><d>).</>not<d>.</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: not to be one of <g>["a", "b", "c"]</>
+Received: <r>"b"</>`;
+
+module.exports[".toBeOneOf() fails when using .not and value is in the expected array: expect(true).not.toBeOneOf([false, true])"] = `<d>expect(</><r>received</><d>).</>not<d>.</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: not to be one of <g>[false, true]</>
+Received: <r>true</>`;
+
+module.exports[".toBeOneOf() fails when using .not and value is in the expected array: expect(null).not.toBeOneOf([undefined, null])"] = `<d>expect(</><r>received</><d>).</>not<d>.</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: not to be one of <g>[undefined, null]</>
+Received: <r>null</>`;
+
+module.exports[".toBeOneOf() fails when using .not and value is in the expected array: expect(undefined).not.toBeOneOf([undefined, null])"] = `<d>expect(</><r>received</><d>).</>not<d>.</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: not to be one of <g>[undefined, null]</>
+Received: <r>undefined</>`;
+
+module.exports[".toBeOneOf() fails when using .not and value is in the expected array: expect(NaN).not.toBeOneOf([NaN, 1, 2])"] = `<d>expect(</><r>received</><d>).</>not<d>.</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: not to be one of <g>[NaN, 1, 2]</>
+Received: <r>NaN</>`;
+
+module.exports[".toBeOneOf() fails when using .not and value is in the expected array: expect(1n).not.toBeOneOf([1n, 2n])"] = `<d>expect(</><r>received</><d>).</>not<d>.</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: not to be one of <g>[1n, 2n]</>
+Received: <r>1n</>`;
+
+module.exports[".toBeOneOf() fails when using .not and value is in the expected array: expect([1, 2]).not.toBeOneOf([[1, 2], [3, 4]])"] = `<d>expect(</><r>received</><d>).</>not<d>.</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: not to be one of <g>[[1, 2], [3, 4]]</>
+Received: <r>[1, 2]</>`;
+
+module.exports[".toBeOneOf() fails when using .not and value is in the expected array: expect({\"a\": 1}).not.toBeOneOf([{\"a\": 1}, {\"b\": 2}])"] = `<d>expect(</><r>received</><d>).</>not<d>.</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: not to be one of <g>[{"a": 1}, {"b": 2}]</>
+Received: <r>{"a": 1}</>`;
+
+module.exports[".toBeOneOf() fails when using .not and value is in the expected array: expect({\"a\": {\"b\": {\"c\": 1}}}).not.toBeOneOf([{\"a\": {\"b\": {\"c\": 1}}}, {\"a\": {\"b\": {\"c\": 2}}}])"] = `<d>expect(</><r>received</><d>).</>not<d>.</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: not to be one of <g>[{"a": {"b": {"c": 1}}}, {"a": {"b": {"c": 2}}}]</>
+Received: <r>{"a": {"b": {"c": 1}}}</>`;
+
+module.exports[".toBeOneOf() fails when value does not match any asymmetric matchers in expected array"] = `<d>expect(</><r>received</><d>).</>toBeOneOf<d>(</><g>expected</><d>)</>
+
+Expected: to be one of <g>[{"a": 2}, ObjectContaining {"c": 3}]</>
+Received: <r>{"a": 1, "b": 2}</>`;
+

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -141,6 +141,7 @@ test('should compile generic matchers', async ({ runTSC }) => {
       expect(42).toBeLessThanOrEqual(1);
       expect(42n).toBeLessThanOrEqual(1n);
       expect(42).toBeNull();
+      expect(42).toBeOneOf([1, 2, 42]);
       expect(42).toBeTruthy();
       expect(42).toBeUndefined();
       expect(42).toBeNaN();

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -314,6 +314,7 @@ interface GenericAssertions<R> {
   toBeLessThanOrEqual(expected: number | bigint): R;
   toBeNaN(): R;
   toBeNull(): R;
+  toBeOneOf(expected: unknown[]): R;
   toBeTruthy(): R;
   toBeUndefined(): R;
   toContain(expected: string): R;


### PR DESCRIPTION
Follow #24232  
- Add new `toBeOneOf` matcher as part of `GenericAssertions`.  
- I’ll create a follow-up PR with `toContainOneOf` soon.  

Looking forward to teams feedback. Thanks! :)