### PR TITLE
docs: clarify use of comments in contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Coding style is fully defined in [.eslintrc](https://github.com/microsoft/playwr
   npm run lint
   ```
 
-Comments should be generally avoided. If the code would not be understood without comments, consider re-writing the code to make it self-explanatory.
+Comments should have an explicit purpose and should improve readability rather than hinder it. If the code would not be understood without comments, consider re-writing the code to make it self-explanatory.
 
 ### Write documentation
 


### PR DESCRIPTION
As discussed during our summit, clarified the "comments should generally be avoided" comment in `CONTRIBUTING.md`.