### PR TITLE
docs: #33837 Clarify that clock.install must precede clock operations

### DIFF
--- a/docs/src/clock.md
+++ b/docs/src/clock.md
@@ -34,6 +34,10 @@ The recommended approach is to use `setFixedTime` to set the time to a specific 
   - `Event.timeStamp`
 :::
 
+:::warning
+If you call `install` at any point in your test, the call _MUST_ occur before any other clock related calls (see note above for list). For example, you cannot call `setInterval`, followed by `install`, then `clearInterval`, as `install` overrides the native definition of the clock functions.
+:::
+
 ## Test with predefined time
 
 Often you only need to fake `Date.now` while keeping the timers going.

--- a/docs/src/clock.md
+++ b/docs/src/clock.md
@@ -35,7 +35,7 @@ The recommended approach is to use `setFixedTime` to set the time to a specific 
 :::
 
 :::warning
-If you call `install` at any point in your test, the call _MUST_ occur before any other clock related calls (see note above for list). For example, you cannot call `setInterval`, followed by `install`, then `clearInterval`, as `install` overrides the native definition of the clock functions.
+If you call `install` at any point in your test, the call _MUST_ occur before any other clock related calls (see note above for list). Calling these methods out of order will result in undefined behavior. For example, you cannot call `setInterval`, followed by `install`, then `clearInterval`, as `install` overrides the native definition of the clock functions.
 :::
 
 ## Test with predefined time


### PR DESCRIPTION
Since `clock.install` overwrites native clock method implementations, it must precede any clock call, otherwise undefined behavior will occur. Document this limitation, preventing further issues like #33837.