### PR TITLE
Docs/remove screenshot duplication

### DIFF
--- a/docs/src/api/class-pageassertions.md
+++ b/docs/src/api/class-pageassertions.md
@@ -185,59 +185,6 @@ Snapshot name.
 ### option: PageAssertions.toHaveScreenshot#1.threshold = %%-assertions-threshold-%%
 * since: v1.23
 
-## async method: PageAssertions.toHaveScreenshot#2
-* since: v1.23
-* langs: js
-
-This function will wait until two consecutive page screenshots
-yield the same result, and then compare the last screenshot with the expectation.
-
-**Usage**
-
-```js
-await expect(page).toHaveScreenshot();
-```
-
-Note that screenshot assertions only work with Playwright test runner.
-
-### option: PageAssertions.toHaveScreenshot#2.timeout = %%-js-assertions-timeout-%%
-* since: v1.23
-
-### option: PageAssertions.toHaveScreenshot#2.animations = %%-screenshot-option-animations-default-disabled-%%
-* since: v1.23
-
-### option: PageAssertions.toHaveScreenshot#2.caret = %%-screenshot-option-caret-%%
-* since: v1.23
-
-### option: PageAssertions.toHaveScreenshot#2.clip = %%-screenshot-option-clip-%%
-* since: v1.23
-
-### option: PageAssertions.toHaveScreenshot#2.fullPage = %%-screenshot-option-full-page-%%
-* since: v1.23
-
-### option: PageAssertions.toHaveScreenshot#2.mask = %%-screenshot-option-mask-%%
-* since: v1.23
-
-### option: PageAssertions.toHaveScreenshot#2.maskColor = %%-screenshot-option-mask-color-%%
-* since: v1.35
-
-### option: PageAssertions.toHaveScreenshot#2.stylePath = %%-screenshot-option-style-path-%%
-* since: v1.41
-
-### option: PageAssertions.toHaveScreenshot#2.omitBackground = %%-screenshot-option-omit-background-%%
-* since: v1.23
-
-### option: PageAssertions.toHaveScreenshot#2.scale = %%-screenshot-option-scale-default-css-%%
-* since: v1.23
-
-### option: PageAssertions.toHaveScreenshot#2.maxDiffPixels = %%-assertions-max-diff-pixels-%%
-* since: v1.23
-
-### option: PageAssertions.toHaveScreenshot#2.maxDiffPixelRatio = %%-assertions-max-diff-pixel-ratio-%%
-* since: v1.23
-
-### option: PageAssertions.toHaveScreenshot#2.threshold = %%-assertions-threshold-%%
-* since: v1.23
 
 ## async method: PageAssertions.toHaveTitle
 * since: v1.20

--- a/docs/src/test-sharding-js.md
+++ b/docs/src/test-sharding-js.md
@@ -5,7 +5,11 @@ title: "Sharding"
 
 ## Introduction
 
-By default, Playwright runs test files in [parallel](./test-parallel.md) and strives for optimal utilization of CPU cores on your machine. In order to achieve even greater parallelisation, you can further scale Playwright test execution by running tests on multiple machines simultaneously. We call this mode of operation "sharding".
+By default, Playwright runs test files in [parallel](./test-parallel.md) and strives for optimal utilization of CPU cores on your machine. In order to achieve even greater parallelisation, you can further scale Playwright test execution by running tests on multiple machines simultaneously. We call this mode of operation "sharding". Sharding in Playwright means splitting your tests into smaller parts called "shards". Each shard is like a separate job that can run independently. The whole purpose is to divide your tests to speed up test runtime.
+
+When you shard your tests, each shard can run on its own, utilizing the available CPU cores. This helps speed up the testing process by doing tasks simultaneously.
+
+In a CI pipeline, each shard can run as a separate job, making use of the hardware resources available in your CI pipeline, like CPU cores, to run tests faster.
 
 ## Sharding tests between multiple machines
 
@@ -18,7 +22,7 @@ npx playwright test --shard=3/4
 npx playwright test --shard=4/4
 ```
 
-Now, if you run these shards in parallel on different computers, your test suite completes four times faster.
+Now, if you run these shards in parallel on different jobs, your test suite completes four times faster.
 
 Note that Playwright can only shard tests that can be run in parallel. By default, this means Playwright will shard test files. Learn about other options in the [parallelism guide](./test-parallel.md).
 


### PR DESCRIPTION
I noticed that the section that documents the toHaveScreenshot part is duplicated and written twice 1:1.
removed the duplicated section.