### PR TITLE
fix(types): Global JSX namespace is deprecated

### DIFF
--- a/packages/playwright-ct-react/hooks.d.ts
+++ b/packages/playwright-ct-react/hooks.d.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+import type React from 'react';
+
 export declare function beforeMount<HooksConfig>(
-  callback: (params: { hooksConfig?: HooksConfig; App: () => JSX.Element }) => Promise<void | JSX.Element>
+  callback: (params: { hooksConfig?: HooksConfig; App: () => React.JSX.Element }) => Promise<void | React.JSX.Element>
 ): void;
 export declare function afterMount<HooksConfig>(
   callback: (params: { hooksConfig?: HooksConfig }) => Promise<void>

--- a/packages/playwright-ct-react/index.d.ts
+++ b/packages/playwright-ct-react/index.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type React from 'react';
+
 import type { TestType, Locator } from '@playwright/experimental-ct-core';
 
 export interface MountOptions<HooksConfig> {
@@ -22,12 +24,12 @@ export interface MountOptions<HooksConfig> {
 
 export interface MountResult extends Locator {
   unmount(): Promise<void>;
-  update(component: JSX.Element): Promise<void>;
+  update(component: React.JSX.Element): Promise<void>;
 }
 
 export const test: TestType<{
   mount<HooksConfig>(
-    component: JSX.Element,
+    component: React.JSX.Element,
     options?: MountOptions<HooksConfig>
   ): Promise<MountResult>;
 }>;


### PR DESCRIPTION
The JSX Global namespace has been deprecated for a while, and removed in React 19: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript