### PR TITLE
fix(html): encode all stdio attachments

### DIFF
--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -602,17 +602,10 @@ type JsonAttachment = {
 };
 
 function stdioAttachment(chunk: Buffer | string, type: 'stdout' | 'stderr'): JsonAttachment {
-  if (typeof chunk === 'string') {
-    return {
-      name: type,
-      contentType: 'text/plain',
-      body: chunk
-    };
-  }
   return {
     name: type,
-    contentType: 'application/octet-stream',
-    body: chunk
+    contentType: 'text/plain',
+    body: typeof chunk === 'string' ? chunk : chunk.toString('utf-8')
   };
 }
 

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2562,6 +2562,24 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         - button "tests/b/test.spec.ts"
       `);
     });
+
+    test('execSync doesnt produce a second stdout attachment', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33886' } }, async ({ runInlineTest, showReport, page }) => {
+      await runInlineTest({
+        'a.test.js': `
+          const { test, expect } = require('@playwright/test');
+          const { execSync } = require('node:child_process');
+          test('my test', async ({}) => {
+            console.log('foo');
+            execSync('echo bar', { stdio: 'inherit' });
+            console.log('baz');
+          });
+        `,
+      }, { reporter: 'dot,html' });
+
+      await showReport();
+      await page.getByText('my test').click();
+      await expect(page.locator('.tree-item', { hasText: 'stdout' })).toHaveCount(1);
+    });
   });
 }
 


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/33886. We're concatenating all stdio chunks that are `string`, but we don't concatenate `Buffer` chunks. The addition of `Buffer` attachments seems to go back to https://github.com/microsoft/playwright/pull/26391, but it's not sure if that was a necessary thing.

This PR fixes the issue by encoding all `Buffer` chunks, so they're concatenated together with the rest.