### PR TITLE
chore: run server with headless shell for connect tests

### DIFF
--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -92,7 +92,7 @@ export class RemoteServer implements PlaywrightServer {
       handleSIGINT: true,
       handleSIGTERM: true,
       handleSIGHUP: true,
-      executablePath: browserOptions.channel ? undefined : browserOptions.executablePath || browserType.executablePath(),
+      executablePath: browserOptions.channel ? undefined : browserOptions.executablePath,
       logger: undefined,
     };
     const options = {


### PR DESCRIPTION
I was looking at the performance number for local vs. remote browser (prompted by https://github.com/microsoft/playwright/issues/33810) and noticed that a benchmark made of 'should record trace with sources' in browsertype-connect.spec.ts was twice slower locally than with websocket connection. Turned out that the difference was because we used headless shell for local execution and headless new for the remote and headless shell was noticeably (~16ms per action) slower on mac.