### PR TITLE
fix: headless-shell follow-up

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -22,7 +22,7 @@
     {
       "name": "chromium-tip-of-tree-headless-shell",
       "revision": "1285",
-      "installByDefault": true,
+      "installByDefault": false,
       "browserVersion": "133.0.6887.0"
     },
     {


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/playwright/pull/33964 since installation test bots were not working.