### PR TITLE
fix: Enable sourcemaps on debug Vite Trace Viewer service worker build

### DIFF
--- a/packages/trace-viewer/.gitignore
+++ b/packages/trace-viewer/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 public/sw.bundle.js
+public/sw.bundle.js.map

--- a/packages/trace-viewer/vite.sw.config.ts
+++ b/packages/trace-viewer/vite.sw.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
     // outputs into the public dir, where the build of vite.config.ts will pick it up
     outDir: path.resolve(__dirname, 'public'),
     emptyOutDir: false,
+    sourcemap: true,
     rollupOptions: {
       input: {
         sw: path.resolve(__dirname, 'src/sw-main.ts'),


### PR DESCRIPTION
When developing the service worker via the Vite build step, it doesn't build sourcemaps automatically. Enable them.