### PR TITLE
fix: throw an error when object reference chain is to long to serialize

### DIFF
--- a/packages/playwright-core/src/server/chromium/crExecutionContext.ts
+++ b/packages/playwright-core/src/server/chromium/crExecutionContext.ts
@@ -96,7 +96,7 @@ export class CRExecutionContext implements js.ExecutionContextDelegate {
 
 function rewriteError(error: Error): Protocol.Runtime.evaluateReturnValue {
   if (error.message.includes('Object reference chain is too long'))
-    return { result: { type: 'undefined' } };
+    throw new Error('Cannot serialize result: object reference chain is too long.');
   if (error.message.includes('Object couldn\'t be returned by value'))
     return { result: { type: 'undefined' } };
 

--- a/packages/playwright-core/src/server/webkit/wkExecutionContext.ts
+++ b/packages/playwright-core/src/server/webkit/wkExecutionContext.ts
@@ -115,6 +115,8 @@ function potentiallyUnserializableValue(remoteObject: Protocol.Runtime.RemoteObj
 }
 
 function rewriteError(error: Error): Error {
+  if (error.message.includes('Object has too long reference chain'))
+    throw new Error('Cannot serialize result: object reference chain is too long.');
   if (!js.isJavaScriptErrorInEvaluate(error) && !isSessionClosedError(error))
     return new Error('Execution context was destroyed, most likely because of a navigation.');
   return error;

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -400,6 +400,21 @@ it('should return undefined for non-serializable objects', async ({ page }) => {
   expect(await page.evaluate(() => function() {})).toBe(undefined);
 });
 
+it('should throw for too deep reference chain', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33997' }
+}, async ({ page, browserName }) => {
+  it.fixme(browserName === 'firefox', 'Firefox does not throw on long chain yet.');
+  await expect(page.evaluate((depth) => {
+    const obj = {};
+    let temp = obj;
+    for (let i = 0; i < depth; i++) {
+      temp[i] = {};
+      temp = temp[i];
+    }
+    return obj
+  }, 1000)).rejects.toThrow('Cannot serialize result: object reference chain is too long.');
+});
+
 it('should alias Window, Document and Node', async ({ page }) => {
   const object = await page.evaluate('[window, document, document.body]');
   expect(object).toEqual(['ref: <Window>', 'ref: <Document>', 'ref: <Node>']);

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -403,16 +403,17 @@ it('should return undefined for non-serializable objects', async ({ page }) => {
 it('should throw for too deep reference chain', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33997' }
 }, async ({ page, browserName }) => {
-  it.fixme(browserName === 'firefox', 'Firefox does not throw on long chain yet.');
-  await expect(page.evaluate((depth) => {
+  await expect(page.evaluate(depth => {
     const obj = {};
     let temp = obj;
     for (let i = 0; i < depth; i++) {
       temp[i] = {};
       temp = temp[i];
     }
-    return obj
-  }, 1000)).rejects.toThrow('Cannot serialize result: object reference chain is too long.');
+    return obj;
+  }, 1000)).rejects.toThrow(browserName === 'firefox'
+    ? 'Maximum call stack size exceeded'
+    : 'Cannot serialize result: object reference chain is too long.');
 });
 
 it('should alias Window, Document and Node', async ({ page }) => {


### PR DESCRIPTION
Firefox uses native JSON.stringify which doesn't set the 1000 depth limit currently.

Fixes https://github.com/microsoft/playwright/issues/33997