### PR TITLE
fix(pwt): custom fixture titles in UI Mode / HTML Reporter

### DIFF
--- a/packages/playwright/src/worker/fixtureRunner.ts
+++ b/packages/playwright/src/worker/fixtureRunner.ts
@@ -66,7 +66,7 @@ class Fixture {
     }
 
     await testInfo._runAsStage({
-      title: `fixture: ${this._setupDescription.title}`,
+      title: `fixture: ${this.registration.customTitle ?? this.registration.name}`,
       runnable: { ...runnable, fixture: this._setupDescription },
       stepInfo: this._stepInfo,
     }, async () => {
@@ -131,7 +131,7 @@ class Fixture {
       // time remaining in the time slot. This avoids cascading timeouts.
       if (!testInfo._timeoutManager.isTimeExhaustedFor(fixtureRunnable)) {
         await testInfo._runAsStage({
-          title: `fixture: ${this._setupDescription.title}`,
+          title: `fixture: ${this.registration.customTitle ?? this.registration.name}`,
           runnable: fixtureRunnable,
           stepInfo: this._stepInfo,
         }, async () => {

--- a/packages/playwright/src/worker/fixtureRunner.ts
+++ b/packages/playwright/src/worker/fixtureRunner.ts
@@ -66,7 +66,7 @@ class Fixture {
     }
 
     await testInfo._runAsStage({
-      title: `fixture: ${this.registration.name}`,
+      title: `fixture: ${this._setupDescription.title}`,
       runnable: { ...runnable, fixture: this._setupDescription },
       stepInfo: this._stepInfo,
     }, async () => {
@@ -131,7 +131,7 @@ class Fixture {
       // time remaining in the time slot. This avoids cascading timeouts.
       if (!testInfo._timeoutManager.isTimeExhaustedFor(fixtureRunnable)) {
         await testInfo._runAsStage({
-          title: `fixture: ${this.registration.name}`,
+          title: `fixture: ${this._setupDescription.title}`,
           runnable: fixtureRunnable,
           stepInfo: this._stepInfo,
         }, async () => {

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -363,3 +363,33 @@ test('should filter actions tab on double-click', async ({ runUITest, server }) 
     /page.goto/,
   ]);
 });
+
+test('should show custom fixture titles in actions tree', async ({ runUITest }) => {
+  const { page } = await runUITest({
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      
+      const test = base.extend({
+        fixture1: [async ({}, use) => {
+          await use();
+        }, { title: 'My Custom Fixture' }],
+        fixture2: async ({}, use) => {
+          await use();
+        },
+      });
+
+      test('fixture test', async ({ fixture1, fixture2 }) => {
+        // Empty test using both fixtures
+      });
+    `,
+  });
+
+  await page.getByText('fixture test').dblclick();
+  const listItem = page.getByTestId('actions-tree').getByRole('treeitem');
+  await expect(listItem, 'action list').toHaveText([
+    /Before Hooks[\d.]+m?s/,
+    /My Custom Fixture[\d.]+m?s/,
+    /fixture2[\d.]+m?s/,
+    /After Hooks[\d.]+m?s/,
+  ]);
+});


### PR DESCRIPTION
Looks like we have coverage for timeout exceeded already [here](https://github.com/microsoft/playwright/blob/e17d1c498b9dc365fdea47a58c4c35cbad952a5a/tests/playwright-test/timeout.spec.ts#L185).

Fixes https://github.com/microsoft/playwright/issues/33741