### PR TITLE
fix(codegen): fallback to `iframe[name/src]` when failed to generate selector

### DIFF
--- a/packages/playwright-core/src/server/recorder/contextRecorder.ts
+++ b/packages/playwright-core/src/server/recorder/contextRecorder.ts
@@ -300,7 +300,6 @@ async function generateFrameSelectorInParent(parent: Frame, frame: Frame): Promi
       }, frameElement);
       return selector;
     } catch (e) {
-      return e.toString();
     }
   }, monotonicTime() + 2000);
   if (!result.timedOut && result.result)


### PR DESCRIPTION
This could happen, for example, when iframe element is inside a closed shadow root. Instead of using `error.toString()` as a selector (!), fallback to `iframe[name]` or `iframe[src]`.

Fixes #33922.