### PR TITLE
fix(trace-viewer): Fix network log flicker #33929

### DIFF
--- a/packages/web/src/uiUtils.ts
+++ b/packages/web/src/uiUtils.ts
@@ -43,6 +43,11 @@ export function useMeasure<T extends Element>() {
     const target = ref.current;
     if (!target)
       return;
+
+    const bounds = target.getBoundingClientRect();
+
+    setMeasure(new DOMRect(0, 0, bounds.width, bounds.height));
+
     const resizeObserver = new ResizeObserver((entries: any) => {
       const entry = entries[entries.length - 1];
       if (entry && entry.contentRect)


### PR DESCRIPTION
Properly calculate starting bounds in `useMeasure`. This fixes flicker (#33929) when opening/closing the details in the Trace Viewer network log.