### PR TITLE
chore: no @web imports from @web package

### DIFF
--- a/packages/web/src/components/errorMessage.tsx
+++ b/packages/web/src/components/errorMessage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ansi2html } from '@web/ansi2html';
+import { ansi2html } from '../ansi2html';
 import * as React from 'react';
 import './errorMessage.css';
 

--- a/packages/web/src/components/gridView.tsx
+++ b/packages/web/src/components/gridView.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { ListView } from './listView';
 import type { ListViewProps } from './listView';
 import './gridView.css';
-import { ResizeView } from '@web/shared/resizeView';
+import { ResizeView } from '../shared/resizeView';
 
 export type Sorting<T> = { by: keyof T, negate: boolean };
 

--- a/packages/web/src/components/listView.tsx
+++ b/packages/web/src/components/listView.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import './listView.css';
-import { clsx, scrollIntoViewIfNeeded } from '@web/uiUtils';
+import { clsx, scrollIntoViewIfNeeded } from '../uiUtils';
 
 export type ListViewProps<T> = {
   name: string,

--- a/packages/web/src/components/tabbedPane.tsx
+++ b/packages/web/src/components/tabbedPane.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { clsx } from '@web/uiUtils';
+import { clsx } from '../uiUtils';
 import './tabbedPane.css';
 import { Toolbar } from './toolbar';
 import * as React from 'react';

--- a/packages/web/src/components/toolbar.tsx
+++ b/packages/web/src/components/toolbar.tsx
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import { clsx } from '@web/uiUtils';
+import { clsx } from '../uiUtils';
 import './toolbar.css';
 import * as React from 'react';
 

--- a/packages/web/src/components/toolbarButton.tsx
+++ b/packages/web/src/components/toolbarButton.tsx
@@ -17,7 +17,7 @@
 import './toolbarButton.css';
 import '../third_party/vscode/codicon.css';
 import * as React from 'react';
-import { clsx } from '@web/uiUtils';
+import { clsx } from '../uiUtils';
 
 export interface ToolbarButtonProps {
   title: string,

--- a/packages/web/src/components/treeView.tsx
+++ b/packages/web/src/components/treeView.tsx
@@ -15,7 +15,7 @@
 */
 
 import * as React from 'react';
-import { clsx, scrollIntoViewIfNeeded } from '@web/uiUtils';
+import { clsx, scrollIntoViewIfNeeded } from '../uiUtils';
 import './treeView.css';
 
 export type TreeItem = {

--- a/packages/web/src/components/xtermWrapper.tsx
+++ b/packages/web/src/components/xtermWrapper.tsx
@@ -19,8 +19,8 @@ import './xtermWrapper.css';
 import type { ITheme, Terminal } from 'xterm';
 import type { FitAddon } from 'xterm-addon-fit';
 import type { XtermModule } from './xtermModule';
-import { currentTheme, addThemeListener, removeThemeListener } from '@web/theme';
-import { useMeasure } from '@web/uiUtils';
+import { currentTheme, addThemeListener, removeThemeListener } from '../theme';
+import { useMeasure } from '../uiUtils';
 
 export type XtermDataSource = {
   pending: (string | Uint8Array)[];


### PR DESCRIPTION
Our `web` package should import from relative all the time internally and not use the `@web` alias.