### PR TITLE
fix: don't rely on requestAnimationFrame

### DIFF
--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -143,7 +143,7 @@ export function useIsAnchored(id: AnchorID) {
 export function Anchor({ id, children }: React.PropsWithChildren<{ id: AnchorID }>) {
   const ref = React.useRef<HTMLDivElement>(null);
   const onAnchorReveal = React.useCallback(() => {
-    requestAnimationFrame(() => ref.current?.scrollIntoView({ block: 'start', inline: 'start' }));
+    ref.current?.scrollIntoView({ block: 'start', inline: 'start' });
   }, []);
   useAnchor(id, onAnchorReveal);
 

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -936,6 +936,9 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(attachment).not.toBeInViewport();
       await page.getByLabel('attach "foo-2"').getByTitle('link to attachment').click();
       await expect(attachment).toBeInViewport();
+
+      await page.reload();
+      await expect(attachment).toBeInViewport();
     });
 
     test('should highlight textual diff', async ({ runInlineTest, showReport, page }) => {


### PR DESCRIPTION
One of the tests introduced in https://github.com/microsoft/playwright/pull/33267 failed with `PW_CLOCK=frozen` because the underlying code used `requestAnimationFrame`, which is made unusable by `PW_CLOCK=frozen`. `requestAnimationFrame` is in the code because at some point, it was necessary to make anchoring work on reload.

Turns out, in the latest iteration of the code, `requestAnimationFrame` isn't needed to make anchoring on reload work, as is evidenced by the test extension added in this PR!

This PR fixes the test under `PW_CLOCK=frozen`.