### PR TITLE
fix(runner): Properly attribute error messages to locator handlers

### DIFF
--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -151,6 +151,7 @@ scheme.SerializedError = tObject({
     message: tString,
     name: tString,
     stack: tOptional(tString),
+    apiNameOverride: tOptional(tString),
   })),
   value: tOptional(tType('SerializedValue')),
 });

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -281,6 +281,7 @@ export type SerializedError = {
     message: string,
     name: string,
     stack?: string,
+    apiNameOverride?: string,
   },
   value?: SerializedValue,
 };

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -241,6 +241,7 @@ SerializedError:
         message: string
         name: string
         stack: string?
+        apiNameOverride: string?
     value: SerializedValue?
 
 

--- a/tests/page/page-add-locator-handler.spec.ts
+++ b/tests/page/page-add-locator-handler.spec.ts
@@ -371,3 +371,19 @@ test('should removeLocatorHandler', async ({ page, server }) => {
   await expect(page.locator('#interstitial')).toBeVisible();
   expect(error.message).toContain('Timeout 3000ms exceeded');
 });
+
+test('should attribute errors to the locator handler', async ({ page }) => {
+  await page.setContent(`<html><body><script>setTimeout(() => {document.body.innerHTML = '<div><ul><li>Foo</li></ul><ul><li>Bar</li></ul></div>'}, 100)</script></body></html>`);
+
+  await page.addLocatorHandler(page.locator('ul'), async locator => Promise.resolve());
+
+  try {
+    // Perform an operation that will trigger the locator handler
+    await page.locator('ul > li').first().boundingBox();
+
+    // Unreachable
+    expect(false).toBeTruthy();
+  } catch (e) {
+    expect(e.message).toContain(`page.addLocatorHandler: Error: strict mode violation: locator('ul') resolved to 2 elements:`);
+  }
+});


### PR DESCRIPTION
Fix #34070. Provide a mechanism for overriding `apiName` in situations where the stack trace doesn't indicate the actual source of the test error.