### PR TITLE
chore(bidi): no retries on CI

### DIFF
--- a/tests/bidi/playwright.config.ts
+++ b/tests/bidi/playwright.config.ts
@@ -58,7 +58,7 @@ const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeW
   workers: process.env.CI ? 2 : undefined,
   fullyParallel: !process.env.CI,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 3 : 0,
+  retries: 0, // No retries even on CI for now.
   reporter: reporters(),
   projects: [],
 };


### PR DESCRIPTION
This will help to save time that is spent on retries, otherwise we run out of 1h budget on CI when running failing tests.