### PR TITLE
feat(fetch/network): add generic to json method

### DIFF
--- a/packages/playwright-core/src/client/fetch.ts
+++ b/packages/playwright-core/src/client/fetch.ts
@@ -350,9 +350,9 @@ export class APIResponse implements api.APIResponse {
     return content.toString('utf8');
   }
 
-  async json(): Promise<object> {
+  async json<T = object>(): Promise<T> {
     const content = await this.text();
-    return JSON.parse(content);
+    return JSON.parse(content) as T;
   }
 
   async [Symbol.asyncDispose]() {

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -718,9 +718,9 @@ export class Response extends ChannelOwner<channels.ResponseChannel> implements 
     return content.toString('utf8');
   }
 
-  async json(): Promise<object> {
+  async json<T = object>(): Promise<T> {
     const content = await this.text();
-    return JSON.parse(content);
+    return JSON.parse(content) as T;
   }
 
   request(): Request {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -18433,7 +18433,7 @@ export interface APIResponse {
    *
    * This method will throw if the response body is not parsable via `JSON.parse`.
    */
-  json(): Promise<Serializable>;
+  json<T = Serializable>(): Promise<T>;
 
   /**
    * Contains a boolean stating whether the response was successful (status in the range 200-299) or not.
@@ -20571,7 +20571,7 @@ export interface Response {
    *
    * This method will throw if the response body is not parsable via `JSON.parse`.
    */
-  json(): Promise<Serializable>;
+  json<T = Serializable>(): Promise<T>;
 
   /**
    * Contains a boolean stating whether the response was successful (status in the range 200-299) or not.

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -18433,7 +18433,7 @@ export interface APIResponse {
    *
    * This method will throw if the response body is not parsable via `JSON.parse`.
    */
-  json<T = Serializable>(): Promise<T>;
+  json(): Promise<Serializable>;
 
   /**
    * Contains a boolean stating whether the response was successful (status in the range 200-299) or not.
@@ -20571,7 +20571,7 @@ export interface Response {
    *
    * This method will throw if the response body is not parsable via `JSON.parse`.
    */
-  json<T = Serializable>(): Promise<T>;
+  json(): Promise<Serializable>;
 
   /**
    * Contains a boolean stating whether the response was successful (status in the range 200-299) or not.


### PR DESCRIPTION
Added the ability to specify the JSON type as Generic during parsing to improve Development Expirience 
If type is not specified, keep the original type (object)

Impact:
- APIResponse 
- Response
