### PR TITLE
WebDriver BiDi: "browsingContext.captureScreenshot" accepts quality from 0 to 1

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -399,7 +399,7 @@ export class BidiPage implements PageDelegate {
       context: this._session.sessionId,
       format: {
         type: `image/${format === 'png' ? 'png' : 'jpeg'}`,
-        quality: quality || 80,
+        quality: quality ? quality / 100 : 0.8,
       },
       origin: documentRect ? 'document' : 'viewport',
       clip: {


### PR DESCRIPTION
While Playwright accepts a range for the `quality` argument from `0` to `100`, the [WebDriver BiDi protocol defines it from `0` to `1`](https://w3c.github.io/webdriver-bidi/#command-browsingContext-captureScreenshot).

This PR fixes it by converting the Playwright range to `[0..1]`. With the patch applied not only 4 tests within `page-screenshot.spec.ts` are passing but 39.

@yury-s can you please take a look?

