### PR TITLE
chore(bidi): disambiguate report.csv artifact name

### DIFF
--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -48,6 +48,6 @@ jobs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
-        name: csv-report
+        name: csv-report-${{ matrix.channel }}
         path: test-results/report.csv
         retention-days: 7


### PR DESCRIPTION
Fixes the following error:
```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```