### PR TITLE
test: add test for color input click behavior

### DIFF
--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -429,6 +429,20 @@ it('should not crash when clicking a label with a <input type="file"/>', {
   expect(fileChooser.page()).toBe(page);
 });
 
+it('should not crash when clicking a color input', {
+  annotation: {
+    type: 'issue',
+    description: 'https://github.com/microsoft/playwright/issues/33864'
+  }
+}, async ({ page }) => {
+  await page.setContent('<input type="color">');
+  const input = page.locator('input');
+
+  await expect(input).toBeVisible();
+  await input.click();
+  await expect(input).toBeVisible();
+});
+
 it('should not auto play audio', {
   annotation: {
     type: 'issue',

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -434,7 +434,9 @@ it('should not crash when clicking a color input', {
     type: 'issue',
     description: 'https://github.com/microsoft/playwright/issues/33864'
   }
-}, async ({ page }) => {
+}, async ({ page, browserMajorVersion, browserName }) => {
+  it.skip(browserName === 'firefox' && browserMajorVersion < 135);
+
   await page.setContent('<input type="color">');
   const input = page.locator('input');
 


### PR DESCRIPTION
Note: This requires a new Firefox revision to land.

Test for https://github.com/microsoft/playwright/issues/33864.
