### PR TITLE
fix(test runner): apply `--last-failed` after sharding

### DIFF
--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -56,6 +56,7 @@ export class FullConfigInternal {
   cliFailOnFlakyTests?: boolean;
   cliLastFailed?: boolean;
   testIdMatcher?: Matcher;
+  lastFailedTestIdMatcher?: Matcher;
   defineConfigWasUsed = false;
 
   globalSetups: string[] = [];

--- a/packages/playwright/src/runner/lastRun.ts
+++ b/packages/playwright/src/runner/lastRun.ts
@@ -43,7 +43,7 @@ export class LastRunReporter implements ReporterV2 {
       return;
     try {
       const lastRunInfo = JSON.parse(await fs.promises.readFile(this._lastRunFile, 'utf8')) as LastRunInfo;
-      this._config.testIdMatcher = id => lastRunInfo.failedTests.includes(id);
+      this._config.lastFailedTestIdMatcher = id => lastRunInfo.failedTests.includes(id);
     } catch {
     }
   }

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -194,6 +194,10 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
     filterTestsRemoveEmptySuites(rootSuite, test => testsInThisShard.has(test));
   }
 
+  // Explicitly apply --last-failed filter after sharding.
+  if (config.lastFailedTestIdMatcher)
+    filterByTestIds(rootSuite, config.lastFailedTestIdMatcher);
+
   // Now prepend dependency projects without filtration.
   {
     // Filtering 'only' and sharding might have reduced the number of top-level projects.


### PR DESCRIPTION
Consider the following snippet:

```
npx playwright test --shard=2/3
npx playwright test --shard=2/3 --last-failed
```

The expectation is that the second invocation runs failed tests from the second shard. To achieve this, we must apply `--last-failed` filter after sharding.

References #33804.