### PR TITLE
Combine file name and test name to a single identifier for CSV export of BiDi results

### DIFF
--- a/tests/bidi/csvReporter.ts
+++ b/tests/bidi/csvReporter.ts
@@ -41,15 +41,14 @@ class CsvReporter implements Reporter {
   }
 
   onEnd(result: FullResult) {
-    const rows = [['File Name', 'Test Name', 'Expected Status', 'Status', 'Error Message']];
+    const rows = [['Test Name', 'Expected Status', 'Status', 'Error Message']];
     for (const project of this._suite.suites) {
       for (const file of project.suites) {
         for (const test of file.allTests()) {
           if (test.ok())
             continue;
           const row = [];
-          row.push(file.title);
-          row.push(csvEscape(test.title));
+          row.push(csvEscape(`${file.title} :: ${test.title}`));
           row.push(test.expectedStatus);
           row.push(test.outcome());
           const result = test.results.find(r => r.error);


### PR DESCRIPTION
It's going to be easier when only entries from a single column have to be compared across two sheets for addition or removal.

@yury-s I hope that ` :: ` is ok for a separator of file and test name and to construct the id.