### PR TITLE
test: increase page-event-crash timeout

### DIFF
--- a/tests/library/page-event-crash.spec.ts
+++ b/tests/library/page-event-crash.spec.ts
@@ -32,6 +32,10 @@ const test = testBase.extend<{ crash: () => void }, { dummy: string }>({
   dummy: ['', { scope: 'worker' }],
 });
 
+test.beforeEach(({ platform, browserName }) => {
+  test.slow(platform === 'linux' && browserName === 'webkit', 'WebKit/Linux tests are consistently slower on some Linux environments. Most likely WebContent process is not getting terminated properly and is causing the slowdown.');
+});
+
 test('should emit crash event when page crashes', async ({ page, crash }) => {
   await page.setContent(`<div>This page should crash</div>`);
   crash();


### PR DESCRIPTION
As per [this](https://playwright.slack.com/archives/G013Z9QND41/p1735580163300289?thread_ts=1735303482.367269&cid=G013Z9QND41) discussion. It was slow before and some external changes, e.g. Ubuntu updates cause the test to be >30s now. Before it was ~23s so close to the timeout.