### PR TITLE
chore(roll): roll WebKit to r2121

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "webkit",
-      "revision": "2120",
+      "revision": "2121",
       "installByDefault": true,
       "revisionOverrides": {
         "debian11-x64": "2105",


### PR DESCRIPTION
Similar to the roll before - the automated PR roll logic seems to be broken - hence doing the roll manually. Probably because a race between two jobs finishing at the same time.

This should probably end up in page-event-crash tests failing - which would get 'fixed' with this PR: https://github.com/microsoft/playwright/pull/34178.