### PR TITLE
fix(ui): fix washed out dropdown colors in dark mode

### DIFF
--- a/packages/web/src/components/tabbedPane.css
+++ b/packages/web/src/components/tabbedPane.css
@@ -69,6 +69,14 @@
   justify-content: center;
 }
 
+@media (prefers-color-scheme: dark) {
+  .dropdown-content,
+  select,
+  option {
+    background-color: var(--vscode-tab-activeBackground);
+  }
+}
+
 .tabbed-pane-tab-counter.error {
   background: var(--vscode-list-errorForeground);
   color: var(--vscode-button-foreground);

--- a/packages/web/src/components/tabbedPane.css
+++ b/packages/web/src/components/tabbedPane.css
@@ -69,14 +69,6 @@
   justify-content: center;
 }
 
-@media (prefers-color-scheme: dark) {
-  .dropdown-content,
-  select,
-  option {
-    background-color: var(--vscode-tab-activeBackground);
-  }
-}
-
 .tabbed-pane-tab-counter.error {
   background: var(--vscode-list-errorForeground);
   color: var(--vscode-button-foreground);

--- a/packages/web/src/components/toolbar.css
+++ b/packages/web/src/components/toolbar.css
@@ -64,7 +64,7 @@
 }
 
 .toolbar option {
-  background-color: var(--vscode-tab-activeBackground) !important;
+  background-color: var(--vscode-tab-activeBackground)
 }
 
 .toolbar input, .toolbar select {

--- a/packages/web/src/components/toolbar.css
+++ b/packages/web/src/components/toolbar.css
@@ -63,7 +63,7 @@
   margin: 2px;
 }
 
-.toolbar select {
+.toolbar option {
   background-color: var(--vscode-tab-activeBackground) !important;
 }
 

--- a/packages/web/src/components/toolbar.css
+++ b/packages/web/src/components/toolbar.css
@@ -63,6 +63,10 @@
   margin: 2px;
 }
 
+.toolbar select {
+  background-color: var(--vscode-tab-activeBackground) !important;
+}
+
 .toolbar input, .toolbar select {
   border: none;
   color: var(--vscode-input-foreground);


### PR DESCRIPTION
This patch enforces a dark-mode-friendly background and text color on the dropdown elements.

previously 
![image](https://github.com/user-attachments/assets/3a5dcf4a-c8fa-4c71-a8b5-5b92e393754d)
with the fix 

![image](https://github.com/user-attachments/assets/8a86432d-58b0-4e82-94cb-ee89a0f1f46a)

![image](https://github.com/user-attachments/assets/e5448997-9e4d-4551-afe3-1aec2db83b86)


References #33931