### PR TITLE
chore(bidi): pointerMove action needs to floor fractional values for x and y position

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiInput.ts
+++ b/packages/playwright-core/src/server/bidi/bidiInput.ts
@@ -79,8 +79,8 @@ export class RawMouseImpl implements input.RawMouse {
 
   async move(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void> {
     // Bidi throws when x/y are not integers.
-    x = Math.round(x);
-    y = Math.round(y);
+    x = Math.floor(x);
+    y = Math.floor(y);
     await this._performActions([{ type: 'pointerMove', x, y }]);
   }
 


### PR DESCRIPTION
For elements that are only 1 pixel in size, rounding can cause the click to occur outside the element’s rect.

For example, a 1px div at (8,8) would not be reached if the click is rounded to (9,9).

This will fix the test `page/page-click.spec.ts :: should click the aligned 1x1 div`.

@yury-s can you please review? Thanks.