### PR TITLE
fix: Prepare CI to properly run Electron on ubuntu-latest (24.04)

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -36,6 +36,11 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
     - uses: ./.github/actions/enable-microphone-access
+    - name: Setup Ubuntu Electron
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+      shell: bash
     - run: |
         echo "::group::npm ci"
         npm ci
@@ -53,11 +58,6 @@ runs:
         echo "::group::npx playwright install --with-deps"
         npx playwright install --with-deps ${{ inputs.browsers-to-install }}
         echo "::endgroup::"
-      shell: bash
-    - name: Setup Ubuntu Electron
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       shell: bash
     - name: Run tests
       if: inputs.shell == 'bash'

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -36,13 +36,6 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
     - uses: ./.github/actions/enable-microphone-access
-    - name: Setup Ubuntu Binary Installation
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        if grep -q "Ubuntu 24" /etc/os-release; then
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-        fi
-      shell: bash
     - run: |
         echo "::group::npm ci"
         npm ci

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -58,6 +58,7 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       run: |
         sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+      shell: bash
     - name: Run tests
       if: inputs.shell == 'bash'
       run: |

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -65,6 +65,7 @@ runs:
       shell: bash
       env:
         PWTEST_BOT_NAME: ${{ inputs.bot-name }}
+        DEBUG: pw:browser
     - name: Run tests
       if: inputs.shell != 'bash'
       run: ${{ inputs.command }}

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -54,6 +54,10 @@ runs:
         npx playwright install --with-deps ${{ inputs.browsers-to-install }}
         echo "::endgroup::"
       shell: bash
+    - name: Setup Ubuntu Electron
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
     - name: Run tests
       if: inputs.shell == 'bash'
       run: |

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -39,7 +39,9 @@ runs:
     - name: Setup Ubuntu Electron
       if: ${{ runner.os == 'Linux' }}
       run: |
-        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        if grep -q "Ubuntu 24" /etc/os-release; then
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        fi
       shell: bash
     - run: |
         echo "::group::npm ci"

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -65,7 +65,6 @@ runs:
       shell: bash
       env:
         PWTEST_BOT_NAME: ${{ inputs.bot-name }}
-        DEBUG: pw:browser
     - name: Run tests
       if: inputs.shell != 'bash'
       run: ${{ inputs.command }}

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -36,7 +36,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
     - uses: ./.github/actions/enable-microphone-access
-    - name: Setup Ubuntu Electron
+    - name: Setup Ubuntu Binary Installation
       if: ${{ runner.os == 'Linux' }}
       run: |
         if grep -q "Ubuntu 24" /etc/os-release; then

--- a/.github/workflows/tests_others.yml
+++ b/.github/workflows/tests_others.yml
@@ -147,6 +147,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
+    - name: Setup Ubuntu Binary Installation # TODO: Remove when https://github.com/electron/electron/issues/42510 is fixed
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        if grep -q "Ubuntu 24" /etc/os-release; then
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        fi
+      shell: bash
     - uses: ./.github/actions/run-test
       with:
         browsers-to-install: chromium

--- a/.github/workflows/tests_others.yml
+++ b/.github/workflows/tests_others.yml
@@ -147,10 +147,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
-    - name: Setup Ubuntu
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
     - uses: ./.github/actions/run-test
       with:
         browsers-to-install: chromium

--- a/.github/workflows/tests_others.yml
+++ b/.github/workflows/tests_others.yml
@@ -147,6 +147,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
+    - name: Setup Ubuntu
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgbm-dev
+        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
     - uses: ./.github/actions/run-test
       with:
         browsers-to-install: chromium

--- a/.github/workflows/tests_others.yml
+++ b/.github/workflows/tests_others.yml
@@ -150,8 +150,6 @@ jobs:
     - name: Setup Ubuntu
       if: ${{ runner.os == 'Linux' }}
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libgbm-dev
         sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
     - uses: ./.github/actions/run-test
       with:

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -215,6 +215,13 @@ jobs:
     - uses: actions/checkout@v4
     - run: npm install -g yarn@1
     - run: npm install -g pnpm@8
+    - name: Setup Ubuntu Binary Installation # TODO: Remove when https://github.com/electron/electron/issues/42510 is fixed
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        if grep -q "Ubuntu 24" /etc/os-release; then
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        fi
+      shell: bash
     - uses: ./.github/actions/run-test
       with:
         command: npm run itest

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -213,6 +213,12 @@ jobs:
       contents: read    # This is required for actions/checkout to succeed
     steps:
     - uses: actions/checkout@v4
+    - name: Setup Ubuntu
+      if: ${{ runner.os == 'Linux' }}
+      # Install dependencies necessary for running Electron on newer Ubuntu images
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libatk1.0-0 libatk-bridge2.0-0 libcups2 libgtk-3-0 libgbm-dev libasound2t64
     - run: npm install -g yarn@1
     - run: npm install -g pnpm@8
     - uses: ./.github/actions/run-test

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -218,8 +218,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libgbm-dev
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
+        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
     - run: npm install -g yarn@1
     - run: npm install -g pnpm@8
     - uses: ./.github/actions/run-test

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -215,10 +215,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup Ubuntu
       if: ${{ runner.os == 'Linux' }}
-      # Install dependencies necessary for running Electron on newer Ubuntu images
       run: |
         sudo apt-get update
-        sudo apt-get install -y libatk1.0-0 libatk-bridge2.0-0 libcups2 libgtk-3-0 libgbm-dev libasound2t64
+        npx playwright install-deps chromium
     - run: npm install -g yarn@1
     - run: npm install -g pnpm@8
     - uses: ./.github/actions/run-test

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -216,8 +216,6 @@ jobs:
     - name: Setup Ubuntu
       if: ${{ runner.os == 'Linux' }}
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libgbm-dev
         sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
     - run: npm install -g yarn@1
     - run: npm install -g pnpm@8

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -218,6 +218,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libgbm-dev
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - run: npm install -g yarn@1
     - run: npm install -g pnpm@8
     - uses: ./.github/actions/run-test

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -213,10 +213,6 @@ jobs:
       contents: read    # This is required for actions/checkout to succeed
     steps:
     - uses: actions/checkout@v4
-    - name: Setup Ubuntu
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
     - run: npm install -g yarn@1
     - run: npm install -g pnpm@8
     - uses: ./.github/actions/run-test

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -217,7 +217,7 @@ jobs:
       if: ${{ runner.os == 'Linux' }}
       run: |
         sudo apt-get update
-        npx playwright install-deps chromium
+        sudo apt-get install -y libgbm-dev
     - run: npm install -g yarn@1
     - run: npm install -g pnpm@8
     - uses: ./.github/actions/run-test

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -170,13 +170,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 18
-    - name: Setup Ubuntu Binary Installation
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        if grep -q "Ubuntu 24" /etc/os-release; then
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-        fi
-      shell: bash
     - run: npm ci
       env:
         DEBUG: pw:install

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -170,6 +170,13 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 18
+    - name: Setup Ubuntu Binary Installation
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        if grep -q "Ubuntu 24" /etc/os-release; then
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        fi
+      shell: bash
     - run: npm ci
       env:
         DEBUG: pw:install

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -107,6 +107,13 @@ jobs:
     - uses: actions/checkout@v4
     - run: npm install -g yarn@1
     - run: npm install -g pnpm@8
+    - name: Setup Ubuntu Binary Installation # TODO: Remove when https://github.com/electron/electron/issues/42510 is fixed
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        if grep -q "Ubuntu 24" /etc/os-release; then
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        fi
+      shell: bash
     - uses: ./.github/actions/run-test
       with:
         node-version: ${{ matrix.node_version }}


### PR DESCRIPTION
GitHub Actions updated the `ubuntu-latest` tag to point to Ubuntu 24.04 without much of an announcement (see https://github.com/actions/runner-images/issues/10636). This included removing several required packages for running Electron, causing our Electron smoke tests to fail.