### PR TITLE
fix(tests): Downgrade all Ubuntu references in Actions

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -38,7 +38,7 @@ jobs:
       run: npm audit --omit dev
   lint-snippets:
     name: "Lint snippets"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/.github/workflows/tests_components.yml
+++ b/.github/workflows/tests_components.yml
@@ -23,12 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         node-version: [18]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node-version: 20
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node-version: 22
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests_others.yml
+++ b/.github/workflows/tests_others.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
     permissions:
       id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -87,24 +87,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
         node-version: [18]
         shardIndex: [1, 2]
         shardTotal: [2]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node-version: 20
             shardIndex: 1
             shardTotal: 2
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node-version: 20
             shardIndex: 2
             shardTotal: 2
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node-version: 22
             shardIndex: 1
             shardTotal: 2
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node-version: 22
             shardIndex: 2
             shardTotal: 2
@@ -127,7 +127,7 @@ jobs:
 
   test_web_components:
     name: Web Components
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -162,7 +162,7 @@ jobs:
 
   test_vscode_extension:
     name: VSCode Extension
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PWTEST_BOT_NAME: "vscode-extension"
     steps:
@@ -203,7 +203,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-latest
+        - ubuntu-22.04
         - macos-latest
         - windows-latest
     runs-on: ${{ matrix.os  }}

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -98,9 +98,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-22.04
           node_version: 20
-        - os: ubuntu-latest
+        - os: ubuntu-22.04
           node_version: 22
     timeout-minutes: 30
     steps:
@@ -295,7 +295,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, windows-latest, macos-latest]
+        runs-on: [ubuntu-22.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub Actions updated the `ubuntu-latest` tag to point to Ubuntu 24.04 without much of an announcement (see https://github.com/actions/runner-images/issues/10636). After looking into fixing the upgrade, we found various filesystem and networking issues with `npm` that may be more insidious, so this downgrades all of our actions so they continue to work.