### PR TITLE
feat: list installed browsers

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -50,8 +50,8 @@ runs:
         echo "::endgroup::"
       shell: bash
     - run: |
-        echo "::group::npx playwright install --with-deps"
-        npx playwright install --with-deps ${{ inputs.browsers-to-install }}
+        echo "::group::npx playwright install --with-deps --list"
+        npx playwright install --with-deps --list ${{ inputs.browsers-to-install }}
         echo "::endgroup::"
       shell: bash
     - name: Run tests

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -1,0 +1,64 @@
+# Playwright CLI
+
+## `playwright ls`
+
+List installed browsers.
+
+### Usage
+
+```sh
+npx playwright ls
+```
+
+### Description
+
+The `playwright ls` command lists all installed browsers along with their versions and installation locations.
+
+### Example
+
+```sh
+$ npx playwright ls
+Browser: chromium
+  Version: 91.0.4472.124
+  Install location: /path/to/chromium
+
+Browser: firefox
+  Version: 89.0
+  Install location: /path/to/firefox
+
+Browser: webkit
+  Version: 14.2
+  Install location: /path/to/webkit
+```
+
+## `npx playwright install --list`
+
+List installed browsers after installing them.
+
+### Usage
+
+```sh
+npx playwright install --list
+```
+
+### Description
+
+The `--list` option for the `npx playwright install` command lists all installed browsers along with their versions and installation locations after installing them.
+
+### Example
+
+```sh
+$ npx playwright install --list
+Installing browsers...
+Browser: chromium
+  Version: 91.0.4472.124
+  Install location: /path/to/chromium
+
+Browser: firefox
+  Version: 89.0
+  Install location: /path/to/firefox
+
+Browser: webkit
+  Version: 14.2
+  Install location: /path/to/webkit
+```

--- a/packages/playwright-core/src/cli/commands/install.ts
+++ b/packages/playwright-core/src/cli/commands/install.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { registry } from '../../server';
 import { gracefullyProcessExitDoNotHang } from '../../utils';
 
@@ -13,7 +29,7 @@ async function listInstalledBrowsers() {
       }
     }
   } catch (e) {
-    console.log(`Failed to list installed browsers\n${e}`);
+    console.error(`Failed to list installed browsers\n${e}`);
     gracefullyProcessExitDoNotHang(1);
   }
 }

--- a/packages/playwright-core/src/cli/commands/install.ts
+++ b/packages/playwright-core/src/cli/commands/install.ts
@@ -1,0 +1,21 @@
+import { registry } from '../../server';
+import { gracefullyProcessExitDoNotHang } from '../../utils';
+
+async function listInstalledBrowsers() {
+  try {
+    const executables = registry.executables();
+    for (const executable of executables) {
+      if (executable.installType !== 'none') {
+        console.log(`Browser: ${executable.name}`);
+        console.log(`  Version: ${executable.browserVersion}`);
+        console.log(`  Install location: ${executable.directory}`);
+        console.log('');
+      }
+    }
+  } catch (e) {
+    console.log(`Failed to list installed browsers\n${e}`);
+    gracefullyProcessExitDoNotHang(1);
+  }
+}
+
+export { listInstalledBrowsers };

--- a/packages/playwright-core/src/cli/commands/ls.test.ts
+++ b/packages/playwright-core/src/cli/commands/ls.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { execSync } from 'child_process';
 import { expect, test } from '@playwright/test';
 

--- a/packages/playwright-core/src/cli/commands/ls.test.ts
+++ b/packages/playwright-core/src/cli/commands/ls.test.ts
@@ -1,0 +1,9 @@
+import { execSync } from 'child_process';
+import { expect, test } from '@playwright/test';
+
+test('playwright ls command should list installed browsers', async () => {
+  const result = execSync('npx playwright ls').toString();
+  expect(result).toContain('Browser:');
+  expect(result).toContain('Version:');
+  expect(result).toContain('Install location:');
+});

--- a/packages/playwright-core/src/cli/commands/ls.ts
+++ b/packages/playwright-core/src/cli/commands/ls.ts
@@ -1,0 +1,21 @@
+import { registry } from '../../server';
+import { gracefullyProcessExitDoNotHang } from '../../utils';
+
+async function listInstalledBrowsers() {
+  try {
+    const executables = registry.executables();
+    for (const executable of executables) {
+      if (executable.installType !== 'none') {
+        console.log(`Browser: ${executable.name}`);
+        console.log(`  Version: ${executable.browserVersion}`);
+        console.log(`  Install location: ${executable.directory}`);
+        console.log('');
+      }
+    }
+  } catch (e) {
+    console.log(`Failed to list installed browsers\n${e}`);
+    gracefullyProcessExitDoNotHang(1);
+  }
+}
+
+export { listInstalledBrowsers };

--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -35,6 +35,7 @@ import { wrapInASCIIBox, isLikelyNpxGlobal, assert, gracefullyProcessExitDoNotHa
 import type { Executable } from '../server';
 import { registry, writeDockerVersion } from '../server';
 import { isTargetClosedError } from '../client/errors';
+import { listInstalledBrowsers } from './commands/ls';
 
 const packageJSON = require('../../package.json');
 
@@ -133,7 +134,8 @@ program
     .option('--force', 'force reinstall of stable browser channels')
     .option('--only-shell', 'only install headless shell when installing chromium')
     .option('--no-shell', 'do not install chromium headless shell')
-    .action(async function(args: string[], options: { withDeps?: boolean, force?: boolean, dryRun?: boolean, shell?: boolean, noShell?: boolean, onlyShell?: boolean }) {
+    .option('--list', 'list installed browsers')
+    .action(async function(args: string[], options: { withDeps?: boolean, force?: boolean, dryRun?: boolean, shell?: boolean, noShell?: boolean, onlyShell?: boolean, list?: boolean }) {
       // For '--no-shell' option, commander sets `shell: false` instead.
       if (options.shell === false)
         options.noShell = true;
@@ -182,6 +184,9 @@ program
             e.name = 'Playwright Host validation warning';
             console.error(e);
           });
+        }
+        if (options.list) {
+          await listInstalledBrowsers();
         }
       } catch (e) {
         console.log(`Failed to install browsers\n${e}`);
@@ -337,6 +342,13 @@ program
 Examples:
 
   $ show-trace https://example.com/trace.zip`);
+
+program
+    .command('ls')
+    .description('list installed browsers')
+    .action(async function() {
+      await listInstalledBrowsers();
+    });
 
 type Options = {
   browser: string;


### PR DESCRIPTION
List Installed Browser Command to Solve #34183

CoPilot Generated Summary:
* Add `playwright ls` command to list installed browsers in `packages/playwright-core/src/cli/commands/ls.ts`.
* Add `--list` option to `npx playwright install` command in `packages/playwright-core/src/cli/commands/install.ts`.
* Register the new `ls` command in the CLI program in `packages/playwright-core/src/cli/program.ts`.
* Write tests for the `playwright ls` command in `packages/playwright-core/src/cli/commands/ls.test.ts`.
* Add documentation for the new `playwright ls` command and `--list` option in `docs/src/cli.md`.
* Update `.github/actions/run-test/action.yml` to use `npx playwright install --with-deps --list` to list installed browsers.