### PR TITLE
docs: fix android launchBrowser.pkg option

### DIFF
--- a/docs/src/api/class-androiddevice.md
+++ b/docs/src/api/class-androiddevice.md
@@ -136,7 +136,7 @@ Launches Chrome browser on the device, and returns its persistent context.
 
 ### option: AndroidDevice.launchBrowser.pkg
 * since: v1.9
-- `command` <[string]>
+- `pkg` <[string]>
 
 Optional package name to launch instead of default Chrome for Android.
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -16608,11 +16608,6 @@ export interface AndroidDevice {
     colorScheme?: null|"light"|"dark"|"no-preference";
 
     /**
-     * Optional package name to launch instead of default Chrome for Android.
-     */
-    command?: string;
-
-    /**
      * Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about
      * [emulating devices with device scale factor](https://playwright.dev/docs/emulation#devices).
      */
@@ -16719,6 +16714,11 @@ export interface AndroidDevice {
      * for more details. Defaults to none.
      */
     permissions?: Array<string>;
+
+    /**
+     * Optional package name to launch instead of default Chrome for Android.
+     */
+    pkg?: string;
 
     /**
      * Network proxy settings.


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/34259

Looks like there was a copy&paste error when documenting the `pkg` paramter. The title says `pkg`, but the body says `command`.