### PR TITLE
chore(bidi): Handle headers properly in BiDi network.continueRequest

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
+++ b/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
@@ -67,9 +67,13 @@ export class BidiNetworkManager {
     if (param.intercepts) {
       // We do not support intercepting redirects.
       if (redirectedFrom) {
+        let params = {};
+        if (redirectedFrom._originalRequestRoute?._alreadyContinuedHeaders)
+          params = toBidiRequestHeaders(redirectedFrom._originalRequestRoute._alreadyContinuedHeaders ?? []);
+
         this._session.sendMayFail('network.continueRequest', {
           request: param.request.request,
-          ...(redirectedFrom._originalRequestRoute?._alreadyContinuedHeaders || {}),
+          ...params,
         });
       } else {
         route = new BidiRouteImpl(this._session, param.request.request);


### PR DESCRIPTION
Headers should be converted to valid bidi request headers.

Should fix the following tests with bidi:
page/page-request-continue.spec.ts :: continue should delete headers on redirects
page/page-request-continue.spec.ts :: continue should propagate headers to redirects
page/page-request-continue.spec.ts :: propagate headers cross origin redirect after interception

