### PR TITLE
fix(inspector): do not start recording by default

### DIFF
--- a/packages/playwright-core/src/server/recorder/contextRecorder.ts
+++ b/packages/playwright-core/src/server/recorder/contextRecorder.ts
@@ -108,7 +108,7 @@ export class ContextRecorder extends EventEmitter {
     this._listeners.push(eventsHelper.addEventListener(process, 'exit', () => {
       this._throttledOutputFile?.flush();
     }));
-    this.setEnabled(true);
+    this.setEnabled(params.mode === 'recording');
   }
 
   setOutput(codegenId: string, outputFile?: string) {


### PR DESCRIPTION
Otherwise `RecorderCollection.signal` generates extra `navigate` action.

Fixes https://github.com/microsoft/playwright/issues/33785