### PR TITLE
chore(bidi): Fix handling of cookie headers in network.continueRequest

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
+++ b/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
@@ -302,11 +302,9 @@ function fromBidiHeaders(bidiHeaders: bidi.Network.Header[]): types.HeadersArray
   return result;
 }
 
-function toBidiRequestHeaders(allHeaders: types.HeadersArray): { cookies: bidi.Network.CookieHeader[], headers: bidi.Network.Header[] } {
+function toBidiRequestHeaders(allHeaders: types.HeadersArray): { headers: bidi.Network.Header[] } {
   const bidiHeaders = toBidiHeaders(allHeaders);
-  const cookies = bidiHeaders.filter(h => h.name.toLowerCase() === 'cookie');
-  const headers = bidiHeaders.filter(h => h.name.toLowerCase() !== 'cookie');
-  return { cookies, headers };
+  return { headers: bidiHeaders };
 }
 
 function toBidiResponseHeaders(headers: types.HeadersArray): { cookies: bidi.Network.SetCookieHeader[], headers: bidi.Network.Header[] } {

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -167,7 +167,7 @@ it('should properly return navigation response when URL has cookies', async ({ p
 
 it('should override cookie header', async ({ page, server, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16773' });
-  it.fail(browserName !== 'firefox');
+  it.fail(browserName !== 'firefox' && !browserName.includes('bidi'));
 
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => document.cookie = 'original=value');


### PR DESCRIPTION
For WebDriver BiDi network.continueRequest, the `cookies` parameter is only a more convenient way to set the `cookie` header. But using the `headers` parameter with `cookie` items is also a valid way to set cookies in a request. 

Since playwright only allows to set headers on route.continue, there is no need to extract `cookie` headers, they can simply be all translated to BiDi request headers and forwarded to the command. 