### PR TITLE
test(bidi): Update beforeunload tests to avoid hangs with bidi

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -390,10 +390,17 @@ export class BidiPage implements PageDelegate {
   }
 
   async closePage(runBeforeUnload: boolean): Promise<void> {
-    await this._session.send('browsingContext.close', {
+    const onClose = this._session.send('browsingContext.close', {
       context: this._session.sessionId,
       promptUnload: runBeforeUnload,
     });
+
+    // Only wait for the browsingContext to close if runBeforeUnload is false.
+    // Otherwise a before unload prompt might be displayed and should be handled
+    // by the caller.
+    // See NOTE on https://playwright.dev/docs/api/class-page#page-close
+    if (!runBeforeUnload)
+      await onClose;
   }
 
   async setBackgroundColor(color?: { r: number; g: number; b: number; a: number; }): Promise<void> {

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -180,6 +180,12 @@ export class BidiPage implements PageDelegate {
     const frameId = params.context;
     this._page._frameManager.frameRequestedNavigation(frameId, params.navigation!);
 
+    // url is missing from navigationStarted events on Firefox when the
+    // navigation is interrupted by a beforeunload prompt.
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1908952
+    if (!params.url)
+      return;
+
     const url = params.url.toLowerCase();
     if (url.startsWith('file:') || url.startsWith('data:') || url === 'about:blank') {
       // Navigation to file urls doesn't emit network events, so we fire 'commit' event right when navigation is started.

--- a/tests/bidi/expectations/bidi-chromium-library.txt
+++ b/tests/bidi/expectations/bidi-chromium-library.txt
@@ -1,5 +1,3 @@
-library/beforeunload.spec.ts › should access page after beforeunload [timeout]
-library/beforeunload.spec.ts › should run beforeunload if asked for @smoke [timeout]
 library/browsercontext-events.spec.ts › console event should work in immediately closed popup [timeout]
 library/browsercontext-events.spec.ts › console event should work in popup 2 [timeout]
 library/browsercontext-events.spec.ts › dialog event should work in immediately closed popup [timeout]


### PR DESCRIPTION
The WebDriver BiDi browsingContext.close command will only resolve when the context closes. 
Some beforeunload tests are awaiting on browsingContext.close before dismissing the beforeunload prompt and therefore will deadlock and timeout.
