### PR TITLE
chore(bidi): create parent dir for report.csv

### DIFF
--- a/tests/bidi/csvReporter.ts
+++ b/tests/bidi/csvReporter.ts
@@ -66,7 +66,10 @@ class CsvReporter implements Reporter {
     }
     const csv = rows.map(r => r.join(',')).join('\n');
     const reportFile = path.resolve(this._options.configDir, this._options.outputFile || 'test-results.csv');
-    this._pendingWrite = fs.promises.writeFile(reportFile, csv);
+    this._pendingWrite = (async () => {
+      await fs.mkdirSync(path.dirname(reportFile), { recursive: true });
+      await fs.promises.writeFile(reportFile, csv);
+    })();
   }
 
   async onExit() {


### PR DESCRIPTION
Fixes the following error when running single failing test:

```
node:internal/fs/promises:638
  return new FileHandle(await PromisePrototypeThen(
                        ^

Error: ENOENT: no such file or directory, open '/Users/yurys/playwright/test-results/report.csv'
    at open (node:internal/fs/promises:638:25)
    at Object.writeFile (node:internal/fs/promises:1208:14) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/yurys/playwright/test-results/report.csv'
}

```