### PR TITLE
chore: remove expectZone

### DIFF
--- a/packages/playwright-core/src/utils/stackTrace.ts
+++ b/packages/playwright-core/src/utils/stackTrace.ts
@@ -156,8 +156,3 @@ export function compressCallLog(log: string[]): string[] {
   }
   return lines;
 }
-
-export type ExpectZone = {
-  title: string;
-  stepId: string;
-};

--- a/packages/playwright-core/src/utils/zones.ts
+++ b/packages/playwright-core/src/utils/zones.ts
@@ -16,7 +16,7 @@
 
 import { AsyncLocalStorage } from 'async_hooks';
 
-export type ZoneType = 'apiZone' | 'expectZone' | 'stepZone';
+export type ZoneType = 'apiZone' | 'stepZone';
 
 class ZoneManager {
   private readonly _asyncLocalStorage = new AsyncLocalStorage<Zone | undefined>();

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -19,7 +19,6 @@ import * as path from 'path';
 import type { APIRequestContext, BrowserContext, Browser, BrowserContextOptions, LaunchOptions, Page, Tracing, Video } from 'playwright-core';
 import * as playwrightLibrary from 'playwright-core';
 import { createGuid, debugMode, addInternalStackPrefix, isString, asLocator, jsonStringifyForceASCII, zones } from 'playwright-core/lib/utils';
-import type { ExpectZone } from 'playwright-core/lib/utils';
 import type { Fixtures, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, ScreenshotMode, TestInfo, TestType, VideoMode } from '../types/test';
 import type { TestInfoImpl, TestStepInternal } from './worker/testInfo';
 import { rootTestType } from './common/testType';
@@ -264,12 +263,12 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
         // Some special calls do not get into steps.
         if (!testInfo || data.apiName.includes('setTestIdAttribute') || data.apiName === 'tracing.groupEnd')
           return;
-        const expectZone = zones.zoneData<ExpectZone>('expectZone');
-        if (expectZone) {
+        const zone = zones.zoneData<TestStepInternal>('stepZone');
+        if (zone && zone.category === 'expect') {
           // Display the internal locator._expect call under the name of the enclosing expect call,
           // and connect it to the existing expect step.
-          data.apiName = expectZone.title;
-          data.stepId = expectZone.stepId;
+          data.apiName = zone.title;
+          data.stepId = zone.stepId;
           return;
         }
         // In the general case, create a step for each api call and connect them through the stepId.

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -17,7 +17,6 @@
 import fs from 'fs';
 import path from 'path';
 import { captureRawStack, monotonicTime, zones, sanitizeForFilePath, stringifyStackFrames } from 'playwright-core/lib/utils';
-import type { ExpectZone } from 'playwright-core/lib/utils';
 import type { TestInfo, TestStatus, FullProject } from '../../types/test';
 import type { AttachmentPayload, StepBeginPayload, StepEndPayload, TestInfoErrorImpl, WorkerInitParams } from '../common/ipc';
 import type { TestCase } from '../common/test';
@@ -35,7 +34,7 @@ export interface TestStepInternal {
   attachmentIndices: number[];
   stepId: string;
   title: string;
-  category: 'hook' | 'fixture' | 'test.step' | 'test.step.skip' | 'expect' | 'attach' | string;
+  category: string;
   location?: Location;
   boxedStack?: StackFrame[];
   steps: TestStepInternal[];
@@ -195,7 +194,7 @@ export class TestInfoImpl implements TestInfo {
     this._attachmentsPush = this.attachments.push.bind(this.attachments);
     this.attachments.push = (...attachments: TestInfo['attachments']) => {
       for (const a of attachments)
-        this._attach(a, this._expectStepId() ?? this._parentStep()?.stepId);
+        this._attach(a, this._parentStep()?.stepId);
       return this.attachments.length;
     };
 
@@ -243,10 +242,6 @@ export class TestInfoImpl implements TestInfo {
   private _parentStep() {
     return zones.zoneData<TestStepInternal>('stepZone')
       ?? this._findLastStageStep(this._steps); // If no parent step on stack, assume the current stage as parent.
-  }
-
-  private _expectStepId() {
-    return zones.zoneData<ExpectZone>('expectZone')?.stepId;
   }
 
   _addStep(data: Omit<TestStepInternal, 'complete' | 'stepId' | 'steps' | 'attachmentIndices'>, parentStep?: TestStepInternal): TestStepInternal {


### PR DESCRIPTION
This turns expect zones into step zones to avoid handling them specially.

The only observable difference is that `expect.toPass()` and `expect.poll()` are now reported as a step with `category: 'step'` instead of `category: 'expect'`. This actually better reflects reality, because these expects are retriable steps that execute other expects inside, as seen from the tests.

This also makes API calls made by expect matcher to be nested instead of being invisible.