### PR TITLE
test(bidi): Update browserName used for har file tests when using bidi

### DIFF
--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -60,7 +60,10 @@ it('should have browser', async ({ browserName, browser, contextFactory, server 
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
   await page.goto(server.EMPTY_PAGE);
   const log = await getLog();
-  expect(log.browser!.name.toLowerCase()).toBe(browserName);
+
+  // _bidiFirefox and _bidiChromium are initialized with 'bidi' as browser name.
+  const harBrowserName = browserName.startsWith('_bidi') ? 'bidi' : browserName;
+  expect(log.browser!.name.toLowerCase()).toBe(harBrowserName);
   expect(log.browser!.version).toBe(browser.version());
 });
 
@@ -957,6 +960,9 @@ it('should not hang on slow chunked response', async ({ browserName, browser, co
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => (window as any).receivedFirstData);
   const log = await getLog();
-  expect(log.browser!.name.toLowerCase()).toBe(browserName);
+
+  // _bidiFirefox and _bidiChromium are initialized with 'bidi' as browser name.
+  const harBrowserName = browserName.startsWith('_bidi') ? 'bidi' : browserName;
+  expect(log.browser!.name.toLowerCase()).toBe(harBrowserName);
   expect(log.browser!.version).toBe(browser.version());
 });


### PR DESCRIPTION
bidiChromium and bidiFirefox are both initialized with a name set to "bidi", which is what ends up being used when creating the HAR files. 

When creating HAR files this name is set here https://github.com/microsoft/playwright/blob/a33659f2a89bf5fead26217518831c873aa9d2aa/packages/playwright-core/src/server/har/harTracer.ts#L541

And the browser classes can be found at https://github.com/microsoft/playwright/blob/a33659f2a89bf5fead26217518831c873aa9d2aa/packages/playwright-core/src/server/bidi/bidiFirefox.ts#L31-L33 and https://github.com/microsoft/playwright/blob/a33659f2a89bf5fead26217518831c873aa9d2aa/packages/playwright-core/src/server/bidi/bidiFirefox.ts#L31-L33

In this PR, I am just updating two tests asserting the browser property in har files to expect "bidi" in case of BiDi tests, but a better fix might be to expose the proper browser name ("firefox" or "chromium") on another getter on the BrowserContext object and use that when building HAR files? From the perspective of a HAR consumer, it is more important to know that the HAR was generated from Firefox or Chrome rather than from BiDi or not?