### PR TITLE
test(bidi): create inspected page before initializing recorder

### DIFF
--- a/tests/library/selector-generator.spec.ts
+++ b/tests/library/selector-generator.spec.ts
@@ -28,7 +28,11 @@ async function generateMultiple(pageOrFrame: Page | Frame, target: string): Prom
 it.describe('selector generator', () => {
   it.skip(({ mode }) => mode !== 'default');
 
-  it.beforeEach(async ({ context }) => {
+  it.beforeEach(async ({ context, page }) => {
+    // Make sure `page`(fixture) is created before enabling recorder, so that
+    // we properly wait for `extendInjectedScript` call to finish. Otherwise
+    // if the page is created later, there is a race between ConsoleAPI
+    // initialization and playwright.selector(e) call in `generate()` function above.
     await (context as any)._enableRecorder({ language: 'javascript' });
   });
 


### PR DESCRIPTION
`_enableRecorder` calls [`extendInjectedScript`](https://github.com/microsoft/playwright/blob/b0f0a2951a1df24164d577d2f2e99e678e4c1468/packages/playwright-core/src/server/recorder.ts#L204) to inject ConsoleAPI into the inspected page. `extendInjectedScript` does wait for the script to be actually injected for existing pages, but for newly created it is done [asynchronously](https://github.com/microsoft/playwright/blob/b0f0a2951a1df24164d577d2f2e99e678e4c1468/packages/playwright-core/src/server/browserContext.ts#L632) when Page event is received. The latter creates a race condition in the `page-selector.spec.ts` tests where we may access `(window as any).playwright.selector(e)` before the API was initialized. This caused failures only in bidi tests, as the initialization is probably slower there.

Fixes failures in the following bidi tests in firefox:
```
library/selector-generator.spec.ts :: should prefer button over inner span
library/selector-generator.spec.ts :: should prefer role=button over inner span
library/selector-generator.spec.ts :: should use readable id
library/selector-generator.spec.ts :: should generate exact role when necessary
```