### PR TITLE
chore(bidi): Stop dividing BiDi network event timings by 1000

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
+++ b/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
@@ -96,10 +96,10 @@ export class BidiNetworkManager {
     function relativeToStart(time: number): number {
       if (!time)
         return -1;
-      return (time - startTime) / 1000;
+      return (time - startTime);
     }
     const timing: network.ResourceTiming = {
-      startTime: startTime / 1000,
+      startTime: startTime,
       requestStart: relativeToStart(timings.requestStart),
       responseStart: relativeToStart(timings.responseStart),
       domainLookupStart: relativeToStart(timings.dnsStart),
@@ -130,7 +130,7 @@ export class BidiNetworkManager {
 
     // Keep redirected requests in the map for future reference as redirectedFrom.
     const isRedirected = response.status() >= 300 && response.status() <= 399;
-    const responseEndTime = params.request.timings.responseEnd / 1000 - response.timing().startTime;
+    const responseEndTime = params.request.timings.responseEnd - response.timing().startTime;
     if (isRedirected) {
       response._requestFinished(responseEndTime);
     } else {


### PR DESCRIPTION
BiDi network event timings are already in milliseconds. They are computed from DOMHighResTimeStamp(s) https://www.w3.org/TR/hr-time-3/#dom-domhighrestimestamp

I assume the rest of the playwright codebase expects milliseconds. This makes at least one additional test pass: 
> library/har.spec.ts :: should return receive time