### PR TITLE
fix(test runner): esm loader in old Node versions

### DIFF
--- a/packages/playwright/src/common/esmLoaderHost.ts
+++ b/packages/playwright/src/common/esmLoaderHost.ts
@@ -30,7 +30,6 @@ export function registerESMLoader() {
   const { port1, port2 } = new MessageChannel();
   // register will wait until the loader is initialized.
   require('node:module').register(url.pathToFileURL(require.resolve('../transform/esmLoader')), {
-    parentURL: url.pathToFileURL(__filename),
     data: { port: port2 },
     transferList: [port2],
   });


### PR DESCRIPTION
Arguments of the `register()` call have changed over time, in particular the `parentURL` was not a part of options. We do not need to pass it, because the first argument `specifier` is already an absolute file url, so we do not need a base url.

Verified this fix works on Node versions 20.11, 20.6, 18.17 and 22.13.