### PR TITLE
chore: better error message when CSS selector fails to parse

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/cssParser.ts
+++ b/packages/playwright-core/src/utils/isomorphic/cssParser.ts
@@ -43,7 +43,7 @@ export function parseCSS(selector: string, customNames: Set<string>): { selector
     if (!(tokens[tokens.length - 1] instanceof css.EOFToken))
       tokens.push(new css.EOFToken());
   } catch (e) {
-    const newMessage = e.message + ` while parsing selector "${selector}"`;
+    const newMessage = e.message + ` while parsing css selector "${selector}". Did you mean to CSS.escape it?`;
     const index = (e.stack || '').indexOf(e.message);
     if (index !== -1)
       e.stack = e.stack.substring(0, index) + newMessage + e.stack.substring(index + e.message.length);
@@ -68,13 +68,13 @@ export function parseCSS(selector: string, customNames: Set<string>): { selector
       (token instanceof css.PercentageToken);
   });
   if (unsupportedToken)
-    throw new InvalidSelectorError(`Unsupported token "${unsupportedToken.toSource()}" while parsing selector "${selector}"`);
+    throw new InvalidSelectorError(`Unsupported token "${unsupportedToken.toSource()}" while parsing css selector "${selector}". Did you mean to CSS.escape it?`);
 
   let pos = 0;
   const names = new Set<string>();
 
   function unexpected() {
-    return new InvalidSelectorError(`Unexpected token "${tokens[pos].toSource()}" while parsing selector "${selector}"`);
+    return new InvalidSelectorError(`Unexpected token "${tokens[pos].toSource()}" while parsing css selector "${selector}". Did you mean to CSS.escape it?`);
   }
 
   function skipWhitespace() {
@@ -246,7 +246,7 @@ export function parseCSS(selector: string, customNames: Set<string>): { selector
   if (!isEOF())
     throw unexpected();
   if (result.some(arg => typeof arg !== 'object' || !('simples' in arg)))
-    throw new InvalidSelectorError(`Error while parsing selector "${selector}"`);
+    throw new InvalidSelectorError(`Error while parsing css selector "${selector}". Did you mean to CSS.escape it?`);
   return { selector: result as CSSComplexSelector[], names: Array.from(names) };
 }
 

--- a/tests/library/css-parser.spec.ts
+++ b/tests/library/css-parser.spec.ts
@@ -77,7 +77,8 @@ it('should throw on malformed css', async () => {
     } catch (e) {
       error = e;
     }
-    expect(error.message).toContain(`while parsing selector "${selector}"`);
+    expect(error.message).toContain(`while parsing css selector "${selector}"`);
+    expect(error.message).toContain(`Did you mean to CSS.escape it?`);
   }
 
   expectError('');

--- a/tests/page/expect-boolean.spec.ts
+++ b/tests/page/expect-boolean.spec.ts
@@ -479,7 +479,7 @@ test('should print unknown engine error', async ({ page }) => {
 
 test('should print selector syntax error', async ({ page }) => {
   const error = await expect(page.locator('row]')).toBeVisible().catch(e => e);
-  expect(error.message).toContain(`Unexpected token "]" while parsing selector "row]"`);
+  expect(error.message).toContain(`Unexpected token "]" while parsing css selector "row]"`);
 });
 
 test.describe(() => {

--- a/tests/page/selectors-misc.spec.ts
+++ b/tests/page/selectors-misc.spec.ts
@@ -415,7 +415,7 @@ it('should work with internal:has=', async ({ page, server }) => {
   const error3 = await page.$(`div >> internal:has=33`).catch(e => e);
   expect(error3.message).toContain('Malformed selector: internal:has=33');
   const error4 = await page.$(`div >> internal:has="span!"`).catch(e => e);
-  expect(error4.message).toContain('Unexpected token "!" while parsing selector "span!"');
+  expect(error4.message).toContain('Unexpected token "!" while parsing css selector "span!"');
 });
 
 it('should work with internal:has-not=', async ({ page }) => {


### PR DESCRIPTION
This updates error messages to:
- always mention "css selector";
- suggest using `CSS.escape` to fix it.

Unfortunately, we cannot suggest a fixed selector by applying `CSS.escape(brokenToken)` without updating third-party tokenizer, because things like `.8abc` are recognized as `DimensionToken` instead of `DelimToken` + something.

References #34320.