### PR TITLE
chore: do not fall back to previous LTS release deps for new Ubuntu LTS

### DIFF
--- a/packages/playwright-core/src/server/registry/dependencies.ts
+++ b/packages/playwright-core/src/server/registry/dependencies.ts
@@ -95,7 +95,7 @@ export async function installDependenciesLinux(targets: Set<DependencyGroup>, dr
   for (const target of targets) {
     const info = deps[platform];
     if (!info) {
-      console.warn(`Cannot install dependencies for ${platform}!`);  // eslint-disable-line no-console
+      console.warn(`Cannot install dependencies for ${platform} with Playwright ${getPlaywrightVersion()}!`);  // eslint-disable-line no-console
       return;
     }
     libraries.push(...info[target]);

--- a/packages/playwright-core/src/utils/hostPlatform.ts
+++ b/packages/playwright-core/src/utils/hostPlatform.ts
@@ -74,14 +74,18 @@ function calculatePlatform(): { hostPlatform: HostPlatform, isOfficiallySupporte
     // KDE Neon is ubuntu-based and has the same versions.
     // TUXEDO OS is ubuntu-based and has the same versions.
     if (distroInfo?.id === 'ubuntu' || distroInfo?.id === 'pop' || distroInfo?.id === 'neon' || distroInfo?.id === 'tuxedo') {
-      const isOfficiallySupportedPlatform = distroInfo?.id === 'ubuntu';
-      if (parseInt(distroInfo.version, 10) <= 19)
+      const isUbuntu = distroInfo?.id === 'ubuntu';
+      const version = distroInfo?.version;
+      const major = parseInt(distroInfo.version, 10);
+      if (major < 20)
         return { hostPlatform: ('ubuntu18.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
-      if (parseInt(distroInfo.version, 10) <= 21)
-        return { hostPlatform: ('ubuntu20.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform };
-      if (parseInt(distroInfo.version, 10) <= 22)
-        return { hostPlatform: ('ubuntu22.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform };
-      return { hostPlatform: ('ubuntu24.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform };
+      if (major < 22)
+        return { hostPlatform: ('ubuntu20.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: isUbuntu && version === '20.04' };
+      if (major < 24)
+        return { hostPlatform: ('ubuntu22.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: isUbuntu && version === '22.04' };
+      if (major < 26)
+        return { hostPlatform: ('ubuntu24.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: isUbuntu && version === '24.04' };
+      return { hostPlatform: ('ubuntu' + distroInfo.version + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
     }
     // Linux Mint is ubuntu-based but does not have the same versions
     if (distroInfo?.id === 'linuxmint') {


### PR DESCRIPTION
Using Ubuntu 22.04 deps on Ubuntu 24.04 host resulted in references to unknown packages as described in the linked issue. It came as a surprise to the users the change of `ubuntu-latest` label from 22.04 to 24.04 broke their CI jobs. With this PR the users will get the following messages:

```
BEWARE: your OS is not officially supported by Playwright; installing dependencies for ubuntu24.04-x64 as a fallback.

Cannot install dependencies for ubuntu24.04-x64!
```

Fixes https://github.com/microsoft/playwright/issues/34342