### PR TITLE
Revert "feat(aria): extend toHaveAccessibleName() to accept an array …

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -1313,7 +1313,7 @@ await Expect(locator).ToHaveAccessibleNameAsync("Save to disk");
 
 ### param: LocatorAssertions.toHaveAccessibleName.name
 * since: v1.44
-- `name` <[string]|[RegExp]|[Array]<[string]|[RegExp]>>
+- `name` <[string]|[RegExp]>
 
 Expected accessible name.
 

--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -1437,8 +1437,6 @@ export class InjectedScript {
       received = elements.map(e => options.useInnerText ? (e as HTMLElement).innerText : elementText(new Map(), e).full);
     else if (expression === 'to.have.class.array')
       received = elements.map(e => e.classList.toString());
-    else if (expression === 'to.have.accessible.name.array')
-      received = elements.map(e => getElementAccessibleName(e, false));
 
     if (received && options.expectedText) {
       // "To match an array" is "to contain an array" + "equal length"

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -196,20 +196,13 @@ export function toHaveAccessibleDescription(
 export function toHaveAccessibleName(
   this: ExpectMatcherState,
   locator: LocatorEx,
-  expected: string | RegExp | (string | RegExp)[],
-  options: { timeout?: number, ignoreCase?: boolean, normalizeWhiteSpace?: boolean } = {}
+  expected: string | RegExp,
+  options?: { timeout?: number, ignoreCase?: boolean },
 ) {
-  if (Array.isArray(expected)) {
-    return toEqual.call(this, 'toHaveAccessibleName', locator, 'Locator', async (isNot, timeout) => {
-      const expectedText = serializeExpectedTextValues(expected, { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-      return await locator._expect('to.have.accessible.name.array', { expectedText, isNot, timeout });
-    }, expected, options);
-  } else {
-    return toMatchText.call(this, 'toHaveAccessibleName', locator, 'Locator', async (isNot, timeout) => {
-      const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-      return await locator._expect('to.have.accessible.name', { expectedText, isNot, timeout });
-    }, expected, options);
-  }
+  return toMatchText.call(this, 'toHaveAccessibleName', locator, 'Locator', async (isNot, timeout) => {
+    const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
+    return await locator._expect('to.have.accessible.name', { expectedText, isNot, timeout });
+  }, expected, options);
 }
 
 export function toHaveAccessibleErrorMessage(

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -8142,7 +8142,7 @@ interface LocatorAssertions {
    * @param name Expected accessible name.
    * @param options
    */
-  toHaveAccessibleName(name: string|RegExp|ReadonlyArray<string|RegExp>, options?: {
+  toHaveAccessibleName(name: string|RegExp, options?: {
     /**
      * Whether to perform case-insensitive match.
      * [`ignoreCase`](https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-have-accessible-name-option-ignore-case)

--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -436,43 +436,6 @@ test('toHaveAccessibleName', async ({ page }) => {
   await expect(page.locator('button')).toHaveAccessibleName('foo bar baz');
 });
 
-test('toHaveAccessibleName should accept array of names for multiple elements', async ({ page }) => {
-  await page.setContent(`
-    <table>
-      <tr role="row">
-        <td role="cell">Cell A1</td>
-        <td role="cell">Cell B1</td>
-        <td role="cell">Cell C1</td>
-      </tr>
-      <tr role="row">
-        <td role="cell">Cell A2</td>
-        <td role="cell">Cell B2</td>
-        <td role="cell">Cell C2</td>
-      </tr>
-      <tr role="row">
-        <td role="cell">Cell A3</td>
-        <td role="cell">Cell B3</td>
-        <td role="cell">Cell C3</td>
-      </tr>
-    </table>
-  `);
-  await expect(page.getByRole('row')).toHaveAccessibleName([
-    'Cell A1 Cell B1 Cell C1',
-    'Cell A2 Cell B2 Cell C2',
-    'Cell A3 Cell B3 Cell C3',
-  ]);
-  await expect(page.getByRole('row')).toHaveAccessibleName(['cell a1 cell b1 cell C1',
-    'cell A2 Cell b2 Cell c2',
-    'Cell a3 Cell b3 cell C3',], { ignoreCase: true });
-
-  await expect(page.getByRole('row')).not.toHaveAccessibleName([
-    'Cel A4 Cell B4 Cell C4',
-    'Cell A5 Cell B5 Cell C5',
-    'Cell A6 Cell B6 Cell C6',
-  ]);
-});
-
-
 test('toHaveAccessibleDescription', async ({ page }) => {
   await page.setContent(`
     <div role="button" aria-description="Hello"></div>


### PR DESCRIPTION
…of expected accessible names (#33277)"

In our team meeting today we decided to revert this change from 1.50 based on [this comment](https://github.com/microsoft/playwright/issues/32593#issuecomment-2591864357) and explore more if `toMatchAriaSnapshot` already provides better API for the use case.

This reverts commit 7f054ef8c6d6c3dcbbf0ce4c766f704c140c49a0.

Reference https://github.com/microsoft/playwright/issues/32593.