### PR TITLE
feat(chromium-tip-of-tree): roll to r1295

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -9,9 +9,9 @@
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1293",
+      "revision": "1295",
       "installByDefault": false,
-      "browserVersion": "133.0.6943.0"
+      "browserVersion": "134.0.6960.0"
     },
     {
       "name": "firefox",

--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -38,7 +38,10 @@ export const chromiumSwitches = [
   // ThirdPartyStoragePartitioning - https://github.com/microsoft/playwright/issues/32230
   // LensOverlay - Hides the Lens feature in the URL address bar. Its not working in unofficial builds.
   // PlzDedicatedWorker - https://github.com/microsoft/playwright/issues/31747
-  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,HttpsUpgrades,PaintHolding,ThirdPartyStoragePartitioning,LensOverlay,PlzDedicatedWorker',
+  // DeferRendererTasksAfterInput - this makes Page.frameScheduledNavigation arrive much later after a click,
+  //   making our navigation auto-wait after click not working. Can be removed once we deperecate noWaitAfter.
+  //   See https://github.com/microsoft/playwright/pull/34372.
+  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,HttpsUpgrades,PaintHolding,ThirdPartyStoragePartitioning,LensOverlay,PlzDedicatedWorker,DeferRendererTasksAfterInput',
   '--allow-pre-commit-input',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',


### PR DESCRIPTION
The following tests are failing due to https://chromium-review.googlesource.com/c/chromium/src/+/6175333, which made Page.frameScheduledNavigation arrive much later after a click, breaking our navigation autowaiting after click.

```
❌ [chromium-library] › tests/library/har.spec.ts:179:3 › should include form params @ubuntu-20.04-chromium-tip-of-tree
❌ [chromium-page] › tests/page/page-autowaiting-basic.spec.ts:58:3 › should await form-get on click @ubuntu-20.04-chromium-tip-of-tree
❌ [chromium-page] › tests/page/page-autowaiting-basic.spec.ts:79:3 › should await form-post on click @ubuntu-20.04-chromium-tip-of-tree
❌ [chromium-page] › tests/page/page-network-request.spec.ts:288:3 › should parse the data if content-type is application/x-www-form-urlencoded @ubuntu-20.04-chromium-tip-of-tree
❌ [chromium-page] › tests/page/page-set-input-files.spec.ts:521:3 › should detect mime type @ubuntu-20.04-chromium-tip-of-tree
```

Decided to disable `DeferRendererTasksAfterInput` feature for now. Filed #34377.