### PR TITLE
chore(bidi): disable thottling of background tabs in Firefox

### DIFF
--- a/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
@@ -133,6 +133,12 @@ function defaultProfilePreferences(
     'dom.max_chrome_script_run_time': 0,
     'dom.max_script_run_time': 0,
 
+    // Disable background timer throttling to allow tests to run in parallel
+    // without a decrease in performance.
+    'dom.min_background_timeout_value': 0,
+    'dom.min_background_timeout_value_without_budget_throttling': 0,
+    'dom.timeout.enable_budget_timer_throttling': false,
+
     // Only load extensions from the application and user profile
     // AddonManager.SCOPE_PROFILE + AddonManager.SCOPE_APPLICATION
     'extensions.autoDisableScopes': 0,
@@ -174,6 +180,9 @@ function defaultProfilePreferences(
 
     // Show chrome errors and warnings in the error console
     'javascript.options.showInConsole': true,
+
+    // Do not throttle rendering (requestAnimationFrame) in background tabs
+    'layout.testing.top-level-always-active': true,
 
     // Disable download and usage of OpenH264: and Widevine plugins
     'media.gmp-manager.updateEnabled': false,

--- a/tests/bidi/expectations/bidi-firefox-nightly-library.txt
+++ b/tests/bidi/expectations/bidi-firefox-nightly-library.txt
@@ -101,7 +101,6 @@ library/inspector/cli-codegen-3.spec.ts › cli codegen › should generate fram
 library/page-clock.spec.ts › popup › should run time before popup [timeout]
 library/page-clock.spec.ts › popup › should tick after popup [timeout]
 library/page-clock.spec.ts › popup › should tick before popup [timeout]
-library/popup.spec.ts › should not throttle rAF in the opener page [timeout]
 library/popup.spec.ts › should not throw when click closes popup [timeout]
 library/popup.spec.ts › should use viewport size from window features [timeout]
 library/trace-viewer.spec.ts › should serve css without content-type [timeout]


### PR DESCRIPTION
With this patch throttling of background tabs will no longer happen. This PR changes the following:

* No throttling of the timer to 1s as minimum
* No throttling of rendering (requestAnimationFrame) by a [newly added preference in Firefox Nightly](https://bugzilla.mozilla.org/show_bug.cgi?id=1940688).

@yury-s at least one test is no longer timing out with Firefox. I'm not sure if others might benefit from that as well. Also depending on your usage of `setTimeout` in general you should see a big improvement.