### PR TITLE
chore: step timeout improvements

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -1822,7 +1822,7 @@ Maximum time in milliseconds for the step to finish. Defaults to `0` (no timeout
 * since: v1.50
 - `timeout` <[float]>
 
-Maximum time in milliseconds for the step to finish. Defaults to `0` (no timeout).
+The maximum time, in milliseconds, allowed for the step to complete. If the step does not complete within the specified timeout, the [`method: Test.step`] method will throw a [TimeoutError]. Defaults to `0` (no timeout).
 
 ## method: Test.use
 * since: v1.10

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -369,7 +369,9 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
     });
 
     let counter = 0;
-    const closeReason = testInfo.status === 'timedOut' ? 'Test timeout of ' + testInfo.timeout + 'ms exceeded.' : 'Test ended.';
+    let closeReason = testInfo.status === 'timedOut' ? 'Test timeout of ' + testInfo.timeout + 'ms exceeded.' : 'Test ended.';
+    if (testInfo.status === 'failed' && testInfo.error?.message?.startsWith('TimeoutError: Step timeout of '))
+      closeReason = testInfo.error.message.substring('TimeoutError: '.length);
     await Promise.all([...contexts.keys()].map(async context => {
       await (context as any)._wrapApiCall(async () => {
         await context.close({ reason: closeReason });

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -369,9 +369,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
     });
 
     let counter = 0;
-    let closeReason = testInfo.status === 'timedOut' ? 'Test timeout of ' + testInfo.timeout + 'ms exceeded.' : 'Test ended.';
-    if (testInfo.status === 'failed' && testInfo.error?.message?.startsWith('TimeoutError: Step timeout of '))
-      closeReason = testInfo.error.message.substring('TimeoutError: '.length);
+    const closeReason = testInfo.status === 'timedOut' ? 'Test timeout of ' + testInfo.timeout + 'ms exceeded.' : 'Test ended.';
     await Promise.all([...contexts.keys()].map(async context => {
       await (context as any)._wrapApiCall(async () => {
         await context.close({ reason: closeReason });

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -399,7 +399,7 @@ test('step timeout option', async ({ runInlineTest }) => {
   }, { reporter: '', workers: 1 });
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.output).toContain('Error: Step timeout 100ms exceeded.');
+  expect(result.output).toContain('Error: Step timeout of 100ms exceeded.');
 });
 
 test('step timeout longer than test timeout', async ({ runInlineTest }) => {
@@ -420,6 +420,26 @@ test('step timeout longer than test timeout', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
   expect(result.output).toContain('Test timeout of 900ms exceeded.');
+});
+
+test('step timeout includes interrupted action errors', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('step with timeout', async ({ page }) => {
+        await test.step('my step', async () => {
+          await page.waitForTimeout(100_000);
+        }, { timeout: 1000 });
+      });
+    `
+  }, { reporter: '', workers: 1 });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  // Should include 2 errors, one for the step timeout and one for the aborted action.
+  expect.soft(result.output).toContain('TimeoutError: Step timeout of 1000ms exceeded.');
+  expect.soft(result.output).toContain(`> 4 |         await test.step('my step', async () => {`);
+  expect.soft(result.output).toContain('Error: page.waitForTimeout: Step timeout of 1000ms exceeded.');
+  expect.soft(result.output).toContain('> 5 |           await page.waitForTimeout(100_000);');
 });
 
 test('step timeout is errors.TimeoutError', async ({ runInlineTest }) => {

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -438,7 +438,8 @@ test('step timeout includes interrupted action errors', async ({ runInlineTest }
   // Should include 2 errors, one for the step timeout and one for the aborted action.
   expect.soft(result.output).toContain('TimeoutError: Step timeout of 1000ms exceeded.');
   expect.soft(result.output).toContain(`> 4 |         await test.step('my step', async () => {`);
-  expect.soft(result.output).toContain('Error: page.waitForTimeout: Step timeout of 1000ms exceeded.');
+  expect.soft(result.output).toContain('Error: page.waitForTimeout: Test ended.');
+  expect.soft(result.output.split('Error: page.waitForTimeout: Test ended.').length).toBe(2);
   expect.soft(result.output).toContain('> 5 |           await page.waitForTimeout(100_000);');
 });
 


### PR DESCRIPTION
* display errors for interrupted actions within step
* docs: clarify what happens when step times out
* align timeout message with test timeout

<img width="662" alt="image" src="https://github.com/user-attachments/assets/8e98e85c-ab62-4942-90e1-3b4bc7e9ca74" />

Reference https://github.com/microsoft/playwright/issues/33475