### PR TITLE
fix: truncated filters on network tab

### DIFF
--- a/packages/trace-viewer/src/ui/networkFilters.css
+++ b/packages/trace-viewer/src/ui/networkFilters.css
@@ -30,15 +30,18 @@
   display: flex;
   gap: 8px;
   align-items: center;
+  overflow: auto;
+  width: 100%;
 }
 
 .network-filters-resource-type {
   cursor: pointer;
   border-radius: 2px;
-  padding: 3px 8px;
+  padding: 3px 5px;
   text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 50px;
 }
 
 .network-filters-resource-type.selected {

--- a/packages/trace-viewer/src/ui/networkFilters.css
+++ b/packages/trace-viewer/src/ui/networkFilters.css
@@ -26,6 +26,10 @@
   padding: 0 5px;
 }
 
+.network-filters input[type="search"][placeholder] {
+  text-overflow: ellipsis;
+}
+
 .network-filters-resource-types {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
- make network category filters scrollable
- add ellipsis to filter input placeholder

fixes: #33930 

**Before:**
<img width="319" alt="image" src="https://github.com/user-attachments/assets/07558363-ad50-4148-a0a8-5801da5d07af" />

**After:**
<img width="272" alt="image" src="https://github.com/user-attachments/assets/e7f04004-76a5-456d-a46a-a4c22f5516a5" />

