### PR TITLE
chore(bidi): simplify launcher tests for Firefox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ test-results
 .cache/
 .eslintcache
 playwright.env
-firefox

--- a/tests/library/firefox/launcher.spec.ts
+++ b/tests/library/firefox/launcher.spec.ts
@@ -21,12 +21,12 @@ it('should pass firefox user preferences', async ({ browserType, mode }) => {
   const browser = await browserType.launch({
     firefoxUserPrefs: {
       'network.proxy.type': 1,
-      'network.proxy.http': '127.0.0.1',
-      'network.proxy.http_port': 3333,
+      'network.proxy.ssl': '127.0.0.1',
+      'network.proxy.ssl_port': 3333,
     }
   });
   const page = await browser.newPage();
-  const error = await page.goto('http://example.com').catch(e => e);
+  const error = await page.goto('https://example.com').catch(e => e);
   expect(error.message).toContain('NS_ERROR_PROXY_CONNECTION_REFUSED');
   await browser.close();
 });
@@ -36,10 +36,10 @@ it('should pass firefox user preferences in persistent', async ({ mode, launchPe
   const { page } = await launchPersistent({
     firefoxUserPrefs: {
       'network.proxy.type': 1,
-      'network.proxy.http': '127.0.0.1',
-      'network.proxy.http_port': 3333,
+      'network.proxy.ssl': '127.0.0.1',
+      'network.proxy.ssl_port': 3333,
     }
   });
-  const error = await page.goto('http://example.com').catch(e => e);
+  const error = await page.goto('https://example.com').catch(e => e);
   expect(error.message).toContain('NS_ERROR_PROXY_CONNECTION_REFUSED');
 });


### PR DESCRIPTION
With the automatic HTTP to HTTPS upgrade the HTTP
proxy as defined via "firefoxUserPrefs" will not
be used. Lets make that test simple enough and
check the availablity of Javascript instead.

@yury-s can you please review? Thanks!