### PR TITLE
fix(ci): Prevent workflows from automatically running on forks

### DIFF
--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   test_bidi:
     name: BiDi
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/tests_components.yml
+++ b/.github/workflows/tests_components.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   test_components:
     name: ${{ matrix.os }} - Node.js ${{ matrix.node-version }}
+    if: github.repository == 'microsoft/playwright'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests_others.yml
+++ b/.github/workflows/tests_others.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   test_stress:
     name: Stress - ${{ matrix.os }}
+    if: github.repository == 'microsoft/playwright'
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +58,7 @@ jobs:
 
   test_webview2:
     name: WebView2
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: windows-2022
     permissions:
@@ -87,6 +89,7 @@ jobs:
 
   test_clock_frozen_time_linux:
     name: time library - ${{ matrix.clock }}
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     permissions:
       id-token: write   # This is required for OIDC login (azure/login) to succeed
@@ -112,6 +115,7 @@ jobs:
 
   test_clock_frozen_time_test_runner:
     name: time test runner - ${{ matrix.clock }}
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ubuntu-22.04
     permissions:
@@ -136,6 +140,7 @@ jobs:
 
   test_electron:
     name: Electron - ${{ matrix.os }}
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -27,6 +27,7 @@ env:
 jobs:
   test_linux:
     name: ${{ matrix.os }} (${{ matrix.browser }} - Node.js ${{ matrix.node-version }})
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -59,6 +60,7 @@ jobs:
 
   test_linux_chromium_tot:
     name: ${{ matrix.os }} (chromium tip-of-tree)
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -83,6 +85,7 @@ jobs:
 
   test_test_runner:
     name: Test Runner
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -127,6 +130,7 @@ jobs:
 
   test_web_components:
     name: Web Components
+    if: github.repository == 'microsoft/playwright'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -162,6 +166,7 @@ jobs:
 
   test_vscode_extension:
     name: VSCode Extension
+    if: github.repository == 'microsoft/playwright'
     runs-on: ubuntu-latest
     env:
       PWTEST_BOT_NAME: "vscode-extension"
@@ -198,6 +203,7 @@ jobs:
 
   test_package_installations:
     name: "Installation Test ${{ matrix.os }}"
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   test_linux:
     name: ${{ matrix.os }} (${{ matrix.browser }})
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -46,6 +47,7 @@ jobs:
 
   test_mac:
     name: ${{ matrix.os }} (${{ matrix.browser }})
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -73,6 +75,7 @@ jobs:
 
   test_win:
     name: "Windows"
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -92,6 +95,7 @@ jobs:
 
   test-package-installations-other-node-versions:
     name: "Installation Test ${{ matrix.os }} (${{ matrix.node_version }})"
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.os  }}
     strategy:
@@ -125,6 +129,7 @@ jobs:
 
   headed_tests:
     name: "headed ${{ matrix.browser }} (${{ matrix.os }})"
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -151,6 +156,7 @@ jobs:
 
   transport_linux:
     name: "Transport"
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -172,6 +178,7 @@ jobs:
 
   tracing_linux:
     name: Tracing ${{ matrix.browser }} ${{ matrix.channel }}
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -199,6 +206,7 @@ jobs:
 
   test_chromium_channels:
     name: Test ${{ matrix.channel }} on ${{ matrix.runs-on }}
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
@@ -221,6 +229,7 @@ jobs:
 
   chromium_tot:
     name: Chromium tip-of-tree ${{ matrix.os }}${{ matrix.headed }}
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.os  }}
     strategy:
@@ -243,6 +252,7 @@ jobs:
 
   chromium_tot_headless_shell:
     name: Chromium tip-of-tree headless-shell-${{ matrix.os }}
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.os  }}
     strategy:
@@ -264,6 +274,7 @@ jobs:
 
   firefox_beta:
     name: Firefox Beta ${{ matrix.os }}
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.os  }}
     strategy:
@@ -285,6 +296,7 @@ jobs:
 
   build-playwright-driver:
     name: "build-playwright-driver"
+    if: github.repository == 'microsoft/playwright'
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
@@ -298,6 +310,7 @@ jobs:
 
   test_channel_chromium:
     name: Test channel=chromium
+    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests_service.yml
+++ b/.github/workflows/tests_service.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   test:
     name: "Service"
+    if: github.repository == 'microsoft/playwright'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests_video.yml
+++ b/.github/workflows/tests_video.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   video_linux:
     name: "Video Linux"
+    if: github.repository == 'microsoft/playwright'
     environment: allow-uploading-flakiness-results
     strategy:
       fail-fast: false

--- a/.github/workflows/trigger_tests.yml
+++ b/.github/workflows/trigger_tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   trigger:
     name: "trigger"
+    if: github.repository == 'microsoft/playwright'
     runs-on: ubuntu-24.04
     steps:
     - run: |


### PR DESCRIPTION
Our CI workflows are set to automatically trigger on certain conditions. These conditions currently hold even if we're operating on a fork. This means that a user with a fork making a change/branch that meets the workflow rules will end up running the CI against their personal account, which can have cost consequences.

Prevent the jobs from running on any repo besides `microsoft/playwright`.