### PR TITLE
chore(firefox): Don't upgrade HTTP requests to HTTPS

### DIFF
--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -7,7 +7,7 @@ on:
       - main
     paths:
       - .github/workflows/tests_bidi.yml
-      - packages/playwright-core/src/server/bidi/*
+      - packages/playwright-core/src/server/bidi/**
   schedule:
     # Run every day at midnight
     - cron: '0 0 * * *'

--- a/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
@@ -139,6 +139,9 @@ function defaultProfilePreferences(
     'dom.min_background_timeout_value_without_budget_throttling': 0,
     'dom.timeout.enable_budget_timer_throttling': false,
 
+    // Disable HTTPS-First upgrades
+    'dom.security.https_first': false,
+
     // Only load extensions from the application and user profile
     // AddonManager.SCOPE_PROFILE + AddonManager.SCOPE_APPLICATION
     'extensions.autoDisableScopes': 0,


### PR DESCRIPTION
This is similar to [Chrome where it is disabled as well](https://github.com/microsoft/playwright/blob/f11768436ae0888fa2cc0803eb7a79e0dedb7d5b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts#L44).