### PR TITLE
chore: disable popover test on Darwin 13.7 WebKit

### DIFF
--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -1677,8 +1677,7 @@ test('should show only one pointer with multilevel iframes', async ({ page, runA
 });
 
 test('should show a popover', async ({ runAndTrace, page, server, platform, browserName, macVersion }) => {
-  // WebKit on macOS 13.7 reliably fails on this test for some reason
-  test.skip(platform === 'darwin' && macVersion === 13 && browserName === 'webkit');
+  test.skip(platform === 'darwin' && macVersion === 13 && browserName === 'webkit', 'WebKit on macOS 13.7 reliably fails on this test for some reason');
   const traceViewer = await runAndTrace(async () => {
     await page.setContent(`
       <button popovertarget="pop">Click me</button>

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -1676,7 +1676,9 @@ test('should show only one pointer with multilevel iframes', async ({ page, runA
   await expect.soft(snapshotFrame.frameLocator('iframe').frameLocator('iframe').locator('x-pw-pointer')).toBeVisible();
 });
 
-test('should show a popover', async ({ runAndTrace, page, server }) => {
+test('should show a popover', async ({ runAndTrace, page, server, platform, browserName, macVersion }) => {
+  // WebKit on macOS 13.7 reliably fails on this test for some reason
+  test.skip(platform === 'darwin' && macVersion === 13 && browserName === 'webkit');
   const traceViewer = await runAndTrace(async () => {
     await page.setContent(`
       <button popovertarget="pop">Click me</button>


### PR DESCRIPTION
`trace-viewer.spec.ts` `should show a popover` reliably fails on Darwin 13.7 on WebKit 18.2. There is no apparent reason for this to be failing, and Ventura is nearly out of support, so disable the test.

Addresses #34456