### PR TITLE
chore: fix codegen SIGINT test

### DIFF
--- a/tests/library/inspector/cli-codegen-2.spec.ts
+++ b/tests/library/inspector/cli-codegen-2.spec.ts
@@ -459,8 +459,13 @@ await page1.GotoAsync("about:blank?foo");`);
     const cli = runCLI([`--save-storage=${storageFileName}`, `--save-har=${harFileName}`]);
     await cli.waitFor(`import { test, expect } from '@playwright/test'`);
     await cli.process.kill('SIGINT');
-    const { exitCode } = await cli.process.exited;
-    expect(exitCode).toBe(130);
+    const { exitCode, signal } = await cli.process.exited;
+    if (exitCode !== null) {
+      expect(exitCode).toBe(130);
+    } else {
+      // If the runner is slow enough, the process will be forcibly terminated by the signal
+      expect(signal).toBe('SIGINT');
+    }
     expect(fs.existsSync(storageFileName)).toBeTruthy();
     expect(fs.existsSync(harFileName)).toBeTruthy();
   });


### PR DESCRIPTION
On slow CI machines (typically macOS), the OS can end up forcibly killing the process because it didn't respond to the signal gracefully. Check for this scenario.