### PR TITLE
fix: add validations to --shard cli parameter (#34463)

### DIFF
--- a/tests/playwright-test/shard.spec.ts
+++ b/tests/playwright-test/shard.spec.ts
@@ -139,6 +139,12 @@ test('should respect shard=3/4', async ({ runInlineTest }) => {
   ]);
 });
 
+test('should exit with shard=/3', async ({ runInlineTest }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/34463' });
+  const result = await runInlineTest(tests, { shard: '/3' });
+  expect(result.exitCode).toBe(1);
+});
+
 test('should not produce skipped tests for zero-sized shards', async ({ runInlineTest }) => {
   const result = await runInlineTest(tests, { shard: '10/10', workers: 1 });
   expect(result.exitCode).toBe(0);


### PR DESCRIPTION
#### Throw error and exit when --shard parameter is invalid
- shard is in format current/total
- The total should be a positive number
- current should be a positive number and less than the total

fixes: https://github.com/microsoft/playwright/issues/34463