### PR TITLE
Revert "fix(ci): Prevent workflows from automatically running on forks (#34408)"

### DIFF
--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -18,7 +18,6 @@ env:
 jobs:
   test_bidi:
     name: BiDi
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/tests_components.yml
+++ b/.github/workflows/tests_components.yml
@@ -20,7 +20,6 @@ env:
 jobs:
   test_components:
     name: ${{ matrix.os }} - Node.js ${{ matrix.node-version }}
-    if: github.repository == 'microsoft/playwright'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests_others.yml
+++ b/.github/workflows/tests_others.yml
@@ -21,7 +21,6 @@ env:
 jobs:
   test_stress:
     name: Stress - ${{ matrix.os }}
-    if: github.repository == 'microsoft/playwright'
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +57,6 @@ jobs:
 
   test_webview2:
     name: WebView2
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: windows-2022
     permissions:
@@ -89,7 +87,6 @@ jobs:
 
   test_clock_frozen_time_linux:
     name: time library - ${{ matrix.clock }}
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     permissions:
       id-token: write   # This is required for OIDC login (azure/login) to succeed
@@ -115,7 +112,6 @@ jobs:
 
   test_clock_frozen_time_test_runner:
     name: time test runner - ${{ matrix.clock }}
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ubuntu-22.04
     permissions:
@@ -140,7 +136,6 @@ jobs:
 
   test_electron:
     name: Electron - ${{ matrix.os }}
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -27,7 +27,6 @@ env:
 jobs:
   test_linux:
     name: ${{ matrix.os }} (${{ matrix.browser }} - Node.js ${{ matrix.node-version }})
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -60,7 +59,6 @@ jobs:
 
   test_linux_chromium_tot:
     name: ${{ matrix.os }} (chromium tip-of-tree)
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -85,7 +83,6 @@ jobs:
 
   test_test_runner:
     name: Test Runner
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -130,7 +127,6 @@ jobs:
 
   test_web_components:
     name: Web Components
-    if: github.repository == 'microsoft/playwright'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -166,7 +162,6 @@ jobs:
 
   test_vscode_extension:
     name: VSCode Extension
-    if: github.repository == 'microsoft/playwright'
     runs-on: ubuntu-latest
     env:
       PWTEST_BOT_NAME: "vscode-extension"
@@ -203,7 +198,6 @@ jobs:
 
   test_package_installations:
     name: "Installation Test ${{ matrix.os }}"
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -26,7 +26,6 @@ permissions:
 jobs:
   test_linux:
     name: ${{ matrix.os }} (${{ matrix.browser }})
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -47,7 +46,6 @@ jobs:
 
   test_mac:
     name: ${{ matrix.os }} (${{ matrix.browser }})
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -75,7 +73,6 @@ jobs:
 
   test_win:
     name: "Windows"
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -95,7 +92,6 @@ jobs:
 
   test-package-installations-other-node-versions:
     name: "Installation Test ${{ matrix.os }} (${{ matrix.node_version }})"
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.os  }}
     strategy:
@@ -129,7 +125,6 @@ jobs:
 
   headed_tests:
     name: "headed ${{ matrix.browser }} (${{ matrix.os }})"
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -156,7 +151,6 @@ jobs:
 
   transport_linux:
     name: "Transport"
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -178,7 +172,6 @@ jobs:
 
   tracing_linux:
     name: Tracing ${{ matrix.browser }} ${{ matrix.channel }}
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
@@ -206,7 +199,6 @@ jobs:
 
   test_chromium_channels:
     name: Test ${{ matrix.channel }} on ${{ matrix.runs-on }}
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
@@ -229,7 +221,6 @@ jobs:
 
   chromium_tot:
     name: Chromium tip-of-tree ${{ matrix.os }}${{ matrix.headed }}
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.os  }}
     strategy:
@@ -252,7 +243,6 @@ jobs:
 
   chromium_tot_headless_shell:
     name: Chromium tip-of-tree headless-shell-${{ matrix.os }}
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.os  }}
     strategy:
@@ -274,7 +264,6 @@ jobs:
 
   firefox_beta:
     name: Firefox Beta ${{ matrix.os }}
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.os  }}
     strategy:
@@ -296,7 +285,6 @@ jobs:
 
   build-playwright-driver:
     name: "build-playwright-driver"
-    if: github.repository == 'microsoft/playwright'
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
@@ -310,7 +298,6 @@ jobs:
 
   test_channel_chromium:
     name: Test channel=chromium
-    if: github.repository == 'microsoft/playwright'
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests_service.yml
+++ b/.github/workflows/tests_service.yml
@@ -10,7 +10,6 @@ env:
 jobs:
   test:
     name: "Service"
-    if: github.repository == 'microsoft/playwright'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests_video.yml
+++ b/.github/workflows/tests_video.yml
@@ -14,7 +14,6 @@ env:
 jobs:
   video_linux:
     name: "Video Linux"
-    if: github.repository == 'microsoft/playwright'
     environment: allow-uploading-flakiness-results
     strategy:
       fail-fast: false

--- a/.github/workflows/trigger_tests.yml
+++ b/.github/workflows/trigger_tests.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   trigger:
     name: "trigger"
-    if: github.repository == 'microsoft/playwright'
     runs-on: ubuntu-24.04
     steps:
     - run: |


### PR DESCRIPTION
This reverts commit b75fc4c547e2832b037e971199710b2648a0ffe1.

As per offline discussion, this breaks the scenario of us debugging the tests on forks while fixing a very niche use-case case of when the branch was prefixed with `release-` to avoid costs. Lets revert for now to not create unnecessary churn when debugging.