### PR TITLE
chore(bidi): Disable some external services for Firefox

### DIFF
--- a/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
@@ -54,10 +54,23 @@ function defaultProfilePreferences(
     // console
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1543115
     'browser.dom.window.dump.enabled': true,
+
+    // Make sure newtab weather doesn't hit the network to retrieve weather data.
+    'browser.newtabpage.activity-stream.discoverystream.region-weather-config': '',
+
+    // Make sure newtab wallpapers don't hit the network to retrieve wallpaper data.
+    'browser.newtabpage.activity-stream.newtabWallpapers.enabled': false,
+    'browser.newtabpage.activity-stream.newtabWallpapers.v2.enabled': false,
+
+    // Make sure Topsites doesn't hit the network to retrieve sponsored tiles.
+    'browser.newtabpage.activity-stream.showSponsoredTopSites': false,
+
     // Disable topstories
     'browser.newtabpage.activity-stream.feeds.system.topstories': false,
+
     // Always display a blank page
     'browser.newtabpage.enabled': false,
+
     // Background thumbnails in particular cause grief: and disabling
     // thumbnails in general cannot hurt
     'browser.pagethumbnails.capturing_disabled': true,
@@ -193,6 +206,9 @@ function defaultProfilePreferences(
     // Disable the GFX sanity window
     'media.sanity-test.disabled': true,
 
+    // Disable connectivity service pings
+    'network.connectivity-service.enabled': false,
+
     // Disable experimental feature that is only available in Nightly
     'network.cookie.sameSite.laxByDefault': false,
 
@@ -227,9 +243,6 @@ function defaultProfilePreferences(
 
     // Do not wait for the notification button security delay
     'security.notification_enable_delay': 0,
-
-    // Ensure blocklist updates do not hit the network
-    'services.settings.server': `http://${server}/dummy/blocklist/`,
 
     // Do not automatically fill sign-in forms with known usernames and
     // passwords


### PR DESCRIPTION
Fixes some extra junk logging to the console to make it less verbose but also fixes some additional services for reaching the network - making it harder to investigate test failures.

