### PR TITLE
feat(trace-viewer): display query string in network tab

### DIFF
--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -268,6 +268,8 @@ const renderEntry = (resource: Entry, boundaries: Boundaries, contextIdGenerator
     resourceName = url.pathname.substring(url.pathname.lastIndexOf('/') + 1);
     if (!resourceName)
       resourceName = url.host;
+    if (url.search)
+      resourceName += url.search;
   } catch {
     resourceName = resource.request.url;
   }


### PR DESCRIPTION
Addresses #34481.

Display query strings in addition to the final part of the URL path in the Trace Viewer Network tab.

<img width="414" alt="Screenshot 2025-01-27 at 12 29 24 PM" src="https://github.com/user-attachments/assets/514d3cc8-11a6-495f-8b88-30b7212d30ec" />
