### PR TITLE
fix(firefox): disable fetch keep-alive for now before a proper fix

### DIFF
--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -435,4 +435,6 @@ function toJugglerProxyOptions(proxy: types.ProxySettings) {
 
 // Prefs for quick fixes that didn't make it to the build.
 // Should all be moved to `playwright.cfg`.
-const kBandaidFirefoxUserPrefs = {};
+const kBandaidFirefoxUserPrefs = {
+  'dom.fetchKeepalive.enabled': false,
+};

--- a/tests/page/page-event-request.spec.ts
+++ b/tests/page/page-event-request.spec.ts
@@ -47,7 +47,6 @@ it('should fire for fetches with keepalive: true', {
     description: 'https://github.com/microsoft/playwright/issues/34497'
   }
 }, async ({ page, server, browserName }) => {
-  it.fixme(browserName === 'firefox');
   const requests = [];
   page.on('request', request => requests.push(request));
   await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/34497