### PR TITLE
fix(ui): don't display "Timed Out" when executing action

### DIFF
--- a/packages/trace-viewer/src/ui/callTab.tsx
+++ b/packages/trace-viewer/src/ui/callTab.tsx
@@ -40,18 +40,12 @@ export const CallTab: React.FunctionComponent<{
   const startTimeMillis = action.startTime - startTimeOffset;
   const startTime = msToString(startTimeMillis);
 
-  const duration = action.endTime ? msToString(action.endTime - action.startTime) : 'Timed Out';
-
   return (
     <div className='call-tab'>
       <div className='call-line'>{action.apiName}</div>
-      {
-        <>
-          <div className='call-section'>Time</div>
-          <DateTimeCallLine name='start:' value={startTime} />
-          <DateTimeCallLine name='duration:' value={duration} />
-        </>
-      }
+      <div className='call-section'>Time</div>
+      <DateTimeCallLine name='start:' value={startTime} />
+      <DateTimeCallLine name='duration:' value={renderDuration(action)} />
       {
         !!paramKeys.length && <>
           <div className='call-section'>Parameters</div>
@@ -77,6 +71,15 @@ type Property = {
   type: 'string' | 'number' | 'object' | 'locator' | 'handle' | 'bigint' | 'boolean' | 'symbol' | 'undefined' | 'function';
   text: string;
 };
+
+function renderDuration(action: ActionTraceEventInContext): string {
+  if (action.endTime)
+    return msToString(action.endTime - action.startTime);
+  else if (!!action.error)
+    return 'Timed Out';
+  else
+    return 'Running';
+}
 
 function renderProperty(property: Property) {
   let text = property.text.replace(/\n/g, '↵');


### PR DESCRIPTION
UI View displays "Timed Out" when executing an action under the current duration.

Add a running message instead.

<img width="257" alt="Screenshot 2025-01-29 at 11 17 13 AM" src="https://github.com/user-attachments/assets/f5622379-dee6-432e-93aa-32d38bbc0804" />
