### PR TITLE
fix(core): websocket client when running in Bun

### DIFF
--- a/packages/playwright-core/src/utilsBundle.ts
+++ b/packages/playwright-core/src/utilsBundle.ts
@@ -34,7 +34,7 @@ export const progress: typeof import('../bundles/utils/node_modules/@types/progr
 export const SocksProxyAgent: typeof import('../bundles/utils/node_modules/socks-proxy-agent').SocksProxyAgent = require('./utilsBundleImpl').SocksProxyAgent;
 export const yaml: typeof import('../bundles/utils/node_modules/yaml') = require('./utilsBundleImpl').yaml;
 export type { Scalar as YAMLScalar, YAMLSeq, YAMLMap, YAMLError, Range as YAMLRange } from '../bundles/utils/node_modules/yaml';
-export const ws: typeof import('../bundles/utils/node_modules/@types/ws') = typeof globalThis.Bun !== 'undefined' ? require('ws') : require('./utilsBundleImpl').ws;
+export const ws: typeof import('../bundles/utils/node_modules/@types/ws') = 'Bun' in globalThis ? require('ws') : require('./utilsBundleImpl').ws;
 export const wsServer: typeof import('../bundles/utils/node_modules/@types/ws').WebSocketServer = require('./utilsBundleImpl').wsServer;
 export const wsReceiver = require('./utilsBundleImpl').wsReceiver;
 export const wsSender = require('./utilsBundleImpl').wsSender;

--- a/packages/playwright-core/src/utilsBundle.ts
+++ b/packages/playwright-core/src/utilsBundle.ts
@@ -34,7 +34,7 @@ export const progress: typeof import('../bundles/utils/node_modules/@types/progr
 export const SocksProxyAgent: typeof import('../bundles/utils/node_modules/socks-proxy-agent').SocksProxyAgent = require('./utilsBundleImpl').SocksProxyAgent;
 export const yaml: typeof import('../bundles/utils/node_modules/yaml') = require('./utilsBundleImpl').yaml;
 export type { Scalar as YAMLScalar, YAMLSeq, YAMLMap, YAMLError, Range as YAMLRange } from '../bundles/utils/node_modules/yaml';
-export const ws: typeof import('../bundles/utils/node_modules/@types/ws') = require('./utilsBundleImpl').ws;
+export const ws: typeof import('../bundles/utils/node_modules/@types/ws') = typeof globalThis.Bun !== 'undefined' ? require('ws') : require('./utilsBundleImpl').ws;
 export const wsServer: typeof import('../bundles/utils/node_modules/@types/ws').WebSocketServer = require('./utilsBundleImpl').wsServer;
 export const wsReceiver = require('./utilsBundleImpl').wsReceiver;
 export const wsSender = require('./utilsBundleImpl').wsSender;


### PR DESCRIPTION
## What This PR Does

Fixes a problem where `chromium.connectOverCDP` fails to connect when running Playwright in Bun. Related issue: https://github.com/oven-sh/bun/issues/9911

### The Problem

Bun's HTTP client does not currently support upgrading connections to other protocols, which breaks breaks [`ws`](https://github.com/websockets/ws/blob/b9ca55b0aa8c72b39a778542bd0fa9b6c455d4c4/lib/websocket.js#L742) (and other manual websocket implementations). To keep packages using it from breaking, Bun intercepts `ws` imports and provides a [polyfill](https://github.com/oven-sh/bun/blob/main/src/js/thirdparty/ws.js) that wraps a [WATWG `WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket).

This normally works fine, but Playwright bundles `ws` at build time, so the import is never made. This PR updates `utilsBundle.ts` to detect if Playwright is running in Bun and, if so, use Bun's built-in `ws` module.

### Notes
Notably, this PR does _not_ shim ws' `WebSocketServer`, `Recevier`, or `Sender` classes.
- Bun's HTTP server implementation supports upgrade requests, so no corrective actions is needed
- The latter two are only used by the android backend and operate directly on a socket. This problem is isolated to `node:http`, so anything built on top of `node:net` should be fine.
