### PR TITLE
chore: simplify toBeChecked for language ports

### DIFF
--- a/packages/playwright-core/src/server/injected/injectedScript.ts
+++ b/packages/playwright-core/src/server/injected/injectedScript.ts
@@ -1291,7 +1291,7 @@ export class InjectedScript {
       } else if (expression === 'to.be.checked') {
         const { checked, indeterminate } = options.expectedValue;
         if (indeterminate) {
-          if (checked !== undefined)
+          if (typeof checked === 'boolean')
             throw this.createStacklessError('Can\'t assert indeterminate and checked at the same time');
           result = this.elementState(element, 'indeterminate');
         } else {


### PR DESCRIPTION
Playwright Language bindings don't have `undefined` e.g. in Python or .NET. Adjusting this check like that makes it easier for the ports instead of having to pass the value or omit it they are allowed to pass `null` which is the default for options. Before ports like Node.js passed `undefined` so the check was working for Node.js while Python passed `null` which was throwing then.