### PR TITLE
chore(docs): clarify connection method via BrowserType.connect

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -87,15 +87,23 @@ class BrowserTypeExamples
 
 ## async method: BrowserType.connect
 * since: v1.8
+* langs: js
 - returns: <[Browser]>
 
-This method attaches Playwright to an existing browser instance. When connecting to another browser launched via `BrowserType.launchServer` in Node.js, the major and minor version needs to match the client version (1.2.3 → is compatible with 1.2.x).
+This method attaches Playwright to an existing browser instance created via [`method: BrowserType.launchServer`], which can only be run from Node.js. When connecting to another browser, the major and minor version of the Playwright instance you're calling from needs to match the client browser version (1.2.3 → is compatible with 1.2.x).
+
+## async method: BrowserType.connect
+* since: v1.8
+* langs: python, csharp, java
+- returns: <[Browser]>
+
+This method attaches Playwright to an existing browser instance created via `BrowserType.launchServer` in Node.js. When connecting to another browser, the major and minor version of the Playwright instance you're calling from needs to match the client browser version (1.2.3 → is compatible with 1.2.x).
 
 ### param: BrowserType.connect.wsEndpoint
 * since: v1.10
 - `wsEndpoint` <[string]>
 
-A browser websocket endpoint to connect to.
+A Playwright browser websocket endpoint to connect to. You obtain this endpoint via [`method: BrowserServer.wsEndpoint`]
 
 ### option: BrowserType.connect.headers
 * since: v1.11
@@ -150,6 +158,10 @@ The default browser context is accessible via [`method: Browser.contexts`].
 
 :::note
 Connecting over the Chrome DevTools Protocol is only supported for Chromium-based browsers.
+:::
+
+:::note
+This connection is significantly lower fidelity than the Playwright protocol connection via [`method: BrowserType.connect`]. If you are experiencing issues or attempting to use advanced functionality, you probably want to use [`method: BrowserType.connect`].
 :::
 
 **Usage**

--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -90,20 +90,28 @@ class BrowserTypeExamples
 * langs: js
 - returns: <[Browser]>
 
-This method attaches Playwright to an existing browser instance created via [`method: BrowserType.launchServer`], which can only be run from Node.js. When connecting to another browser, the major and minor version of the Playwright instance you're calling from needs to match the client browser version (1.2.3 → is compatible with 1.2.x).
+This method attaches Playwright to an existing browser instance created via [`method: BrowserType.launchServer`].
+
+:::note
+The major and minor version of the Playwright instance that connects needs to match the version of Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
+:::
 
 ## async method: BrowserType.connect
 * since: v1.8
 * langs: python, csharp, java
 - returns: <[Browser]>
 
-This method attaches Playwright to an existing browser instance created via `BrowserType.launchServer` in Node.js. When connecting to another browser, the major and minor version of the Playwright instance you're calling from needs to match the client browser version (1.2.3 → is compatible with 1.2.x).
+This method attaches Playwright to an existing browser instance created via `BrowserType.launchServer` in Node.js.
+
+:::note
+The major and minor version of the Playwright instance that connects needs to match the version of Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
+:::
 
 ### param: BrowserType.connect.wsEndpoint
 * since: v1.10
 - `wsEndpoint` <[string]>
 
-A Playwright browser websocket endpoint to connect to. You obtain this endpoint via [`method: BrowserServer.wsEndpoint`]
+A Playwright browser websocket endpoint to connect to. You obtain this endpoint via [`method: BrowserServer.wsEndpoint`].
 
 ### option: BrowserType.connect.headers
 * since: v1.11

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14554,6 +14554,11 @@ export interface BrowserType<Unused = {}> {
    *
    * **NOTE** Connecting over the Chrome DevTools Protocol is only supported for Chromium-based browsers.
    *
+   * **NOTE** This connection is significantly lower fidelity than the Playwright protocol connection via
+   * [browserType.connect(wsEndpoint[, options])](https://playwright.dev/docs/api/class-browsertype#browser-type-connect).
+   * If you are experiencing issues or attempting to use advanced functionality, you probably want to use
+   * [browserType.connect(wsEndpoint[, options])](https://playwright.dev/docs/api/class-browsertype#browser-type-connect).
+   *
    * **Usage**
    *
    * ```js
@@ -14579,6 +14584,11 @@ export interface BrowserType<Unused = {}> {
    *
    * **NOTE** Connecting over the Chrome DevTools Protocol is only supported for Chromium-based browsers.
    *
+   * **NOTE** This connection is significantly lower fidelity than the Playwright protocol connection via
+   * [browserType.connect(wsEndpoint[, options])](https://playwright.dev/docs/api/class-browsertype#browser-type-connect).
+   * If you are experiencing issues or attempting to use advanced functionality, you probably want to use
+   * [browserType.connect(wsEndpoint[, options])](https://playwright.dev/docs/api/class-browsertype#browser-type-connect).
+   *
    * **Usage**
    *
    * ```js
@@ -14593,10 +14603,13 @@ export interface BrowserType<Unused = {}> {
    */
   connectOverCDP(options: ConnectOverCDPOptions & { wsEndpoint?: string }): Promise<Browser>;
   /**
-   * This method attaches Playwright to an existing browser instance. When connecting to another browser launched via
-   * `BrowserType.launchServer` in Node.js, the major and minor version needs to match the client version (1.2.3 → is
-   * compatible with 1.2.x).
-   * @param wsEndpoint A browser websocket endpoint to connect to.
+   * This method attaches Playwright to an existing browser instance created via
+   * [browserType.launchServer([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server),
+   * which can only be run from Node.js. When connecting to another browser, the major and minor version of the
+   * Playwright instance you're calling from needs to match the client browser version (1.2.3 → is compatible with
+   * 1.2.x).
+   * @param wsEndpoint A Playwright browser websocket endpoint to connect to. You obtain this endpoint via
+   * [browserServer.wsEndpoint()](https://playwright.dev/docs/api/class-browserserver#browser-server-ws-endpoint)
    * @param options
    */
   connect(wsEndpoint: string, options?: ConnectOptions): Promise<Browser>;
@@ -14607,10 +14620,13 @@ export interface BrowserType<Unused = {}> {
    * @deprecated
    */
   /**
-   * This method attaches Playwright to an existing browser instance. When connecting to another browser launched via
-   * `BrowserType.launchServer` in Node.js, the major and minor version needs to match the client version (1.2.3 → is
-   * compatible with 1.2.x).
-   * @param wsEndpoint A browser websocket endpoint to connect to.
+   * This method attaches Playwright to an existing browser instance created via
+   * [browserType.launchServer([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server),
+   * which can only be run from Node.js. When connecting to another browser, the major and minor version of the
+   * Playwright instance you're calling from needs to match the client browser version (1.2.3 → is compatible with
+   * 1.2.x).
+   * @param wsEndpoint A Playwright browser websocket endpoint to connect to. You obtain this endpoint via
+   * [browserServer.wsEndpoint()](https://playwright.dev/docs/api/class-browserserver#browser-server-ws-endpoint)
    * @param options
    */
   connect(options: ConnectOptions & { wsEndpoint?: string }): Promise<Browser>;

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14604,12 +14604,13 @@ export interface BrowserType<Unused = {}> {
   connectOverCDP(options: ConnectOverCDPOptions & { wsEndpoint?: string }): Promise<Browser>;
   /**
    * This method attaches Playwright to an existing browser instance created via
-   * [browserType.launchServer([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server),
-   * which can only be run from Node.js. When connecting to another browser, the major and minor version of the
-   * Playwright instance you're calling from needs to match the client browser version (1.2.3 → is compatible with
-   * 1.2.x).
+   * [browserType.launchServer([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server).
+   *
+   * **NOTE** The major and minor version of the Playwright instance that connects needs to match the version of
+   * Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
+   *
    * @param wsEndpoint A Playwright browser websocket endpoint to connect to. You obtain this endpoint via
-   * [browserServer.wsEndpoint()](https://playwright.dev/docs/api/class-browserserver#browser-server-ws-endpoint)
+   * [browserServer.wsEndpoint()](https://playwright.dev/docs/api/class-browserserver#browser-server-ws-endpoint).
    * @param options
    */
   connect(wsEndpoint: string, options?: ConnectOptions): Promise<Browser>;
@@ -14621,12 +14622,13 @@ export interface BrowserType<Unused = {}> {
    */
   /**
    * This method attaches Playwright to an existing browser instance created via
-   * [browserType.launchServer([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server),
-   * which can only be run from Node.js. When connecting to another browser, the major and minor version of the
-   * Playwright instance you're calling from needs to match the client browser version (1.2.3 → is compatible with
-   * 1.2.x).
+   * [browserType.launchServer([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server).
+   *
+   * **NOTE** The major and minor version of the Playwright instance that connects needs to match the version of
+   * Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
+   *
    * @param wsEndpoint A Playwright browser websocket endpoint to connect to. You obtain this endpoint via
-   * [browserServer.wsEndpoint()](https://playwright.dev/docs/api/class-browserserver#browser-server-ws-endpoint)
+   * [browserServer.wsEndpoint()](https://playwright.dev/docs/api/class-browserserver#browser-server-ws-endpoint).
    * @param options
    */
   connect(options: ConnectOptions & { wsEndpoint?: string }): Promise<Browser>;


### PR DESCRIPTION
`BrowserType.connect` usage was very unclear on how to use. Clarify this.