### PR TITLE
chore: harden trace file regex

### DIFF
--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -335,7 +335,7 @@ async function mergeTraceFiles(fileName: string, temporaryTraceFiles: string[]) 
           // Keep the name for test traces so that the last test trace
           // that contains most of the information is kept in the trace.
           // Note the reverse order of the iteration (from new traces to old).
-        } else if (entry.fileName.match(/[\d-]*trace\./)) {
+        } else if (entry.fileName.match(/trace\.[a-z]*$/)) {
           entryName = i + '-' + entry.fileName;
         }
         if (entryNames.has(entryName)) {

--- a/packages/trace-viewer/src/sw/traceModel.ts
+++ b/packages/trace-viewer/src/sw/traceModel.ts
@@ -43,7 +43,7 @@ export class TraceModel {
     const ordinals: string[] = [];
     let hasSource = false;
     for (const entryName of await this._backend.entryNames()) {
-      const match = entryName.match(/(.+)\.trace/);
+      const match = entryName.match(/(.+)\.trace$/);
       if (match)
         ordinals.push(match[1] || '');
       if (entryName.includes('src@'))


### PR DESCRIPTION
Trace files are those ending with `.trace` and `trace.netwrork`, `trace.stacks`.