### PR TITLE
chore: add page snapshot on test end

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -533,7 +533,7 @@ class SnapshotRecorder {
 
   constructor(
     private _artifactsRecorder: ArtifactsRecorder,
-    private _mode: ScreenshotMode,
+    private _mode: ScreenshotMode | PageSnapshotOption,
     private _name: string,
     private _contentType: string,
     private _extension: string,

--- a/packages/playwright/src/isomorphic/testServerInterface.ts
+++ b/packages/playwright/src/isomorphic/testServerInterface.ts
@@ -96,6 +96,7 @@ export interface TestServerInterface {
     workers?: number | string;
     updateSnapshots?: 'all' | 'changed' | 'missing' | 'none';
     updateSourceMethod?: 'overwrite' | 'patch' | '3way';
+    pageSnapshot?: 'off' | 'on' | 'only-on-failure';
     reporters?: string[],
     trace?: 'on' | 'off';
     video?: 'on' | 'off';

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -311,6 +311,7 @@ export class TestServerDispatcher implements TestServerInterface {
         ...(params.headed !== undefined ? { headless: !params.headed } : {}),
         _optionContextReuseMode: params.reuseContext ? 'when-possible' : undefined,
         _optionConnectOptions: params.connectWsEndpoint ? { wsEndpoint: params.connectWsEndpoint } : undefined,
+        _pageSnapshot: params.pageSnapshot,
       },
       ...(params.updateSnapshots ? { updateSnapshots: params.updateSnapshots } : {}),
       ...(params.updateSourceMethod ? { updateSourceMethod: params.updateSourceMethod } : {}),

--- a/tests/playwright-test/playwright.artifacts.spec.ts
+++ b/tests/playwright-test/playwright.artifacts.spec.ts
@@ -420,3 +420,71 @@ test('should take screenshot when page is closed in afterEach', async ({ runInli
   expect(result.failed).toBe(1);
   expect(fs.existsSync(testInfo.outputPath('test-results', 'a-fails', 'test-failed-1.png'))).toBeTruthy();
 });
+
+test('should work with _pageSnapshot: on', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...testFiles,
+    'playwright.config.ts': `
+      module.exports = { use: { _pageSnapshot: 'on' } };
+    `,
+  }, { workers: 1 });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(5);
+  expect(result.failed).toBe(5);
+  expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
+    '.last-run.json',
+    'artifacts-failing',
+    '  test-failed-1.ariasnapshot',
+    'artifacts-own-context-failing',
+    '  test-failed-1.ariasnapshot',
+    'artifacts-own-context-passing',
+    '  test-finished-1.ariasnapshot',
+    'artifacts-passing',
+    '  test-finished-1.ariasnapshot',
+    'artifacts-persistent-failing',
+    '  test-failed-1.ariasnapshot',
+    'artifacts-persistent-passing',
+    '  test-finished-1.ariasnapshot',
+    'artifacts-shared-shared-failing',
+    '  test-failed-1.ariasnapshot',
+    '  test-failed-2.ariasnapshot',
+    'artifacts-shared-shared-passing',
+    '  test-finished-1.ariasnapshot',
+    '  test-finished-2.ariasnapshot',
+    'artifacts-two-contexts',
+    '  test-finished-1.ariasnapshot',
+    '  test-finished-2.ariasnapshot',
+    'artifacts-two-contexts-failing',
+    '  test-failed-1.ariasnapshot',
+    '  test-failed-2.ariasnapshot',
+  ]);
+});
+
+test('should work with _pageSnapshot: only-on-failure', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...testFiles,
+    'playwright.config.ts': `
+      module.exports = { use: { _pageSnapshot: 'only-on-failure' } };
+    `,
+  }, { workers: 1 });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(5);
+  expect(result.failed).toBe(5);
+  expect(listFiles(testInfo.outputPath('test-results'))).toEqual([
+    '.last-run.json',
+    'artifacts-failing',
+    '  test-failed-1.ariasnapshot',
+    'artifacts-own-context-failing',
+    '  test-failed-1.ariasnapshot',
+    'artifacts-persistent-failing',
+    '  test-failed-1.ariasnapshot',
+    'artifacts-shared-shared-failing',
+    '  test-failed-1.ariasnapshot',
+    '  test-failed-2.ariasnapshot',
+    'artifacts-two-contexts-failing',
+    '  test-failed-1.ariasnapshot',
+    '  test-failed-2.ariasnapshot',
+  ]);
+});


### PR DESCRIPTION
Adds a pageSnapshot option that allows testserver clients to get an ARIA snapshot at the end of the test. It works just like the existing screenshot logic, so I extracted that to reuse it.