### PR TITLE
docs: document config executing multiple times

### DIFF
--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -183,6 +183,10 @@ Metadata that will be put directly to the test report serialized as JSON.
 
 Project name is visible in the report and during test execution.
 
+:::warning
+Playwright executes the configuration file multiple times. Do not dynamically produce non-stable values in your configuration.
+:::
+
 ## property: TestProject.snapshotDir
 * since: v1.10
 - type: ?<[string]>

--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -68,10 +68,6 @@ export default defineConfig({
 | [`property: TestConfig.webServer`] | To launch a server during the tests, use the `webServer` option |
 | [`property: TestConfig.workers`] | The maximum number of concurrent worker processes to use for parallelizing tests. Can also be set as percentage of logical CPU cores, e.g. `'50%'.`. See [Parallelism](./test-parallel) and [Sharding](./test-sharding) for more details. |
 
-:::warning
-Playwright executes the configuration file multiple times. Do not dynamically produce non-stable values in your configuration (for example, using the current datetime in [`property: TestProject.name`]).
-:::
-
 ## Filtering Tests
 
 Filter tests by glob patterns or regular expressions.

--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -68,6 +68,10 @@ export default defineConfig({
 | [`property: TestConfig.webServer`] | To launch a server during the tests, use the `webServer` option |
 | [`property: TestConfig.workers`] | The maximum number of concurrent worker processes to use for parallelizing tests. Can also be set as percentage of logical CPU cores, e.g. `'50%'.`. See [Parallelism](./test-parallel) and [Sharding](./test-sharding) for more details. |
 
+:::warning
+Playwright executes the configuration file multiple times. Do not dynamically produce non-stable values in your configuration (for example, using the current datetime in [`property: TestProject.name`]).
+:::
+
 ## Filtering Tests
 
 Filter tests by glob patterns or regular expressions.

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -349,6 +349,10 @@ interface TestProject<TestArgs = {}, WorkerArgs = {}> {
 
   /**
    * Project name is visible in the report and during test execution.
+   *
+   * **NOTE** Playwright executes the configuration file multiple times. Do not dynamically produce non-stable values in
+   * your configuration.
+   *
    */
   name?: string;
 


### PR DESCRIPTION
Begins to address #34559. The config file will execute multiple times; at least once for the CLI process, then once for each worker. This can produce obscure issues depending on what the user is doing.