### PR TITLE
Revert "chore(docs): clarify connection method via BrowserType.connect (#34560)"

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -87,31 +87,15 @@ class BrowserTypeExamples
 
 ## async method: BrowserType.connect
 * since: v1.8
-* langs: js
 - returns: <[Browser]>
 
-This method attaches Playwright to an existing browser instance created via [`method: BrowserType.launchServer`].
-
-:::note
-The major and minor version of the Playwright instance that connects needs to match the version of Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
-:::
-
-## async method: BrowserType.connect
-* since: v1.8
-* langs: python, csharp, java
-- returns: <[Browser]>
-
-This method attaches Playwright to an existing browser instance created via `BrowserType.launchServer` in Node.js.
-
-:::note
-The major and minor version of the Playwright instance that connects needs to match the version of Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
-:::
+This method attaches Playwright to an existing browser instance. When connecting to another browser launched via `BrowserType.launchServer` in Node.js, the major and minor version needs to match the client version (1.2.3 → is compatible with 1.2.x).
 
 ### param: BrowserType.connect.wsEndpoint
 * since: v1.10
 - `wsEndpoint` <[string]>
 
-A Playwright browser websocket endpoint to connect to. You obtain this endpoint via [`method: BrowserServer.wsEndpoint`].
+A browser websocket endpoint to connect to.
 
 ### option: BrowserType.connect.headers
 * since: v1.11
@@ -166,10 +150,6 @@ The default browser context is accessible via [`method: Browser.contexts`].
 
 :::note
 Connecting over the Chrome DevTools Protocol is only supported for Chromium-based browsers.
-:::
-
-:::note
-This connection is significantly lower fidelity than the Playwright protocol connection via [`method: BrowserType.connect`]. If you are experiencing issues or attempting to use advanced functionality, you probably want to use [`method: BrowserType.connect`].
 :::
 
 **Usage**

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14554,11 +14554,6 @@ export interface BrowserType<Unused = {}> {
    *
    * **NOTE** Connecting over the Chrome DevTools Protocol is only supported for Chromium-based browsers.
    *
-   * **NOTE** This connection is significantly lower fidelity than the Playwright protocol connection via
-   * [browserType.connect(wsEndpoint[, options])](https://playwright.dev/docs/api/class-browsertype#browser-type-connect).
-   * If you are experiencing issues or attempting to use advanced functionality, you probably want to use
-   * [browserType.connect(wsEndpoint[, options])](https://playwright.dev/docs/api/class-browsertype#browser-type-connect).
-   *
    * **Usage**
    *
    * ```js
@@ -14584,11 +14579,6 @@ export interface BrowserType<Unused = {}> {
    *
    * **NOTE** Connecting over the Chrome DevTools Protocol is only supported for Chromium-based browsers.
    *
-   * **NOTE** This connection is significantly lower fidelity than the Playwright protocol connection via
-   * [browserType.connect(wsEndpoint[, options])](https://playwright.dev/docs/api/class-browsertype#browser-type-connect).
-   * If you are experiencing issues or attempting to use advanced functionality, you probably want to use
-   * [browserType.connect(wsEndpoint[, options])](https://playwright.dev/docs/api/class-browsertype#browser-type-connect).
-   *
    * **Usage**
    *
    * ```js
@@ -14603,14 +14593,10 @@ export interface BrowserType<Unused = {}> {
    */
   connectOverCDP(options: ConnectOverCDPOptions & { wsEndpoint?: string }): Promise<Browser>;
   /**
-   * This method attaches Playwright to an existing browser instance created via
-   * [browserType.launchServer([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server).
-   *
-   * **NOTE** The major and minor version of the Playwright instance that connects needs to match the version of
-   * Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
-   *
-   * @param wsEndpoint A Playwright browser websocket endpoint to connect to. You obtain this endpoint via
-   * [browserServer.wsEndpoint()](https://playwright.dev/docs/api/class-browserserver#browser-server-ws-endpoint).
+   * This method attaches Playwright to an existing browser instance. When connecting to another browser launched via
+   * `BrowserType.launchServer` in Node.js, the major and minor version needs to match the client version (1.2.3 → is
+   * compatible with 1.2.x).
+   * @param wsEndpoint A browser websocket endpoint to connect to.
    * @param options
    */
   connect(wsEndpoint: string, options?: ConnectOptions): Promise<Browser>;
@@ -14621,14 +14607,10 @@ export interface BrowserType<Unused = {}> {
    * @deprecated
    */
   /**
-   * This method attaches Playwright to an existing browser instance created via
-   * [browserType.launchServer([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server).
-   *
-   * **NOTE** The major and minor version of the Playwright instance that connects needs to match the version of
-   * Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
-   *
-   * @param wsEndpoint A Playwright browser websocket endpoint to connect to. You obtain this endpoint via
-   * [browserServer.wsEndpoint()](https://playwright.dev/docs/api/class-browserserver#browser-server-ws-endpoint).
+   * This method attaches Playwright to an existing browser instance. When connecting to another browser launched via
+   * `BrowserType.launchServer` in Node.js, the major and minor version needs to match the client version (1.2.3 → is
+   * compatible with 1.2.x).
+   * @param wsEndpoint A browser websocket endpoint to connect to.
    * @param options
    */
   connect(options: ConnectOptions & { wsEndpoint?: string }): Promise<Browser>;


### PR DESCRIPTION
This reverts commit 1936cfa6c3f345c6e0a2b88039433bb045f3895f. It broke language ports (Python) which then saw the connect method without any other params on it.