### PR TITLE
chore(docs): fix docs API handling duped methods with different langs

### DIFF
--- a/docs/src/api/class-video.md
+++ b/docs/src/api/class-video.md
@@ -36,6 +36,7 @@ Returns the file system path this video will be recorded to. The video is guaran
 upon closing the browser context. This method throws when connected remotely.
 
 ## async method: Video.saveAs
+* langs: js, csharp
 * since: v1.11
 
 Saves the video to a user-specified path. It is safe to call this method while the video

--- a/docs/src/api/class-weberror.md
+++ b/docs/src/api/class-weberror.md
@@ -63,5 +63,3 @@ Unhandled error that was thrown.
 * since: v1.38
 * langs: java, csharp
 - returns: <[string]>
-
-Unhandled error that was thrown.

--- a/utils/doclint/api_parser.js
+++ b/utils/doclint/api_parser.js
@@ -173,11 +173,12 @@ class ApiParser {
     if (!name)
       throw new Error('Invalid member name ' + spec.text);
     if (match[1] === 'param') {
-      const arg = this.parseProperty(spec, match[2]);
-      if (!arg)
-        return;
-      arg.name = name;
       for (const method of methods) {
+        // Purposefully create separate instances of the same option for each method
+        const arg = this.parseProperty(spec, match[2]);
+        if (!arg)
+          continue;
+        arg.name = name;
         const existingArg = method.argsArray.find(m => m.name === arg.name);
         if (existingArg && isTypeOverride(existingArg, arg)) {
           if (!arg.langs || !arg.langs.only)
@@ -193,9 +194,10 @@ class ApiParser {
     } else {
       // match[1] === 'option'
       for (const method of methods) {
+        // Purposefully create separate instances of the same option for each method
         const p = this.parseProperty(spec, match[2]);
         if (!p)
-          return;
+          continue;
         let options = method.argsArray.find(o => o.name === 'options');
         if (!options) {
           const type = new docs.Type('Object', []);


### PR DESCRIPTION
This allows docs to specify multiple instances of the same top level method for different languages, allowing for differing docs or arguments.

This docs construction fails on the ports:

```md
## async method: BrowserType.connect
* since: v1.8
* langs: js
- returns: <[Browser]>

String A

## async method: BrowserType.connect
* since: v1.8
* langs: python, csharp, java
- returns: <[Browser]>

String B

### param: BrowserType.connect.wsEndpoint
* since: v1.10
- `wsEndpoint` <[string]>
```

The only difference here is we want to have different docs for JS and the other languages. Parts of the API parsing code handle overloads correctly, some parts do not. This PR fixes one of them to make this use casefunctional.

Additionally, existing docs (`Video.saveAs`) contained a method definition with no provided languages, and an override with certain languages specified. This didn't resolve properly, only showing the "all language" definition.

```md
## async method: Video.saveAs
* since: v1.11

String A

## method: Video.saveAs
* langs: java
* since: v1.11

String B

## async method: Video.saveAs
* langs: python
* since: v1.11

String C
```

This situation now throws an error. The correct solution is to list each language under the corresponding docs entry.