### PR TITLE
chore(docs): Restore links removed in #34594, fixed in #34596

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -87,6 +87,18 @@ class BrowserTypeExamples
 
 ## async method: BrowserType.connect
 * since: v1.8
+* langs: js
+- returns: <[Browser]>
+
+This method attaches Playwright to an existing browser instance created via [`method: BrowserType.launchServer`].
+
+:::note
+The major and minor version of the Playwright instance that connects needs to match the version of Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
+:::
+
+## async method: BrowserType.connect
+* since: v1.8
+* langs: python, csharp, java
 - returns: <[Browser]>
 
 This method attaches Playwright to an existing browser instance created via `BrowserType.launchServer` in Node.js.
@@ -97,9 +109,17 @@ The major and minor version of the Playwright instance that connects needs to ma
 
 ### param: BrowserType.connect.wsEndpoint
 * since: v1.10
+* langs: js
 - `wsEndpoint` <[string]>
 
-A Playwright browser websocket endpoint to connect to. You obtain this endpoint via `BrowserServer.wsEndpoint`.
+A Playwright browser websocket endpoint to connect to. You obtain this endpoint via [`method: BrowserServer.wsEndpoint`].
+
+### param: BrowserType.connect.wsEndpoint
+* since: v1.10
+* langs: python, csharp, java
+- `wsEndpoint` <[string]>
+
+A Playwright browser websocket endpoint to connect to. You obtain this endpoint via `BrowserServer.wsEndpoint` in Node.js.
 
 ### option: BrowserType.connect.headers
 * since: v1.11

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14603,12 +14603,14 @@ export interface BrowserType<Unused = {}> {
    */
   connectOverCDP(options: ConnectOverCDPOptions & { wsEndpoint?: string }): Promise<Browser>;
   /**
-   * This method attaches Playwright to an existing browser instance created via `BrowserType.launchServer` in Node.js.
+   * This method attaches Playwright to an existing browser instance created via
+   * [browserType.launchServer([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server).
    *
    * **NOTE** The major and minor version of the Playwright instance that connects needs to match the version of
    * Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
    *
-   * @param wsEndpoint A Playwright browser websocket endpoint to connect to. You obtain this endpoint via `BrowserServer.wsEndpoint`.
+   * @param wsEndpoint A Playwright browser websocket endpoint to connect to. You obtain this endpoint via
+   * [browserServer.wsEndpoint()](https://playwright.dev/docs/api/class-browserserver#browser-server-ws-endpoint).
    * @param options
    */
   connect(wsEndpoint: string, options?: ConnectOptions): Promise<Browser>;
@@ -14619,12 +14621,14 @@ export interface BrowserType<Unused = {}> {
    * @deprecated
    */
   /**
-   * This method attaches Playwright to an existing browser instance created via `BrowserType.launchServer` in Node.js.
+   * This method attaches Playwright to an existing browser instance created via
+   * [browserType.launchServer([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server).
    *
    * **NOTE** The major and minor version of the Playwright instance that connects needs to match the version of
    * Playwright that launches the browser (1.2.3 → is compatible with 1.2.x).
    *
-   * @param wsEndpoint A Playwright browser websocket endpoint to connect to. You obtain this endpoint via `BrowserServer.wsEndpoint`.
+   * @param wsEndpoint A Playwright browser websocket endpoint to connect to. You obtain this endpoint via
+   * [browserServer.wsEndpoint()](https://playwright.dev/docs/api/class-browserserver#browser-server-ws-endpoint).
    * @param options
    */
   connect(options: ConnectOptions & { wsEndpoint?: string }): Promise<Browser>;


### PR DESCRIPTION
Restore docs functionality originally from #34560.

Requires #34596.