### PR TITLE
chore(chromium): remove DeferRendererTasksAfterInput from disabled features

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -38,10 +38,7 @@ export const chromiumSwitches = [
   // ThirdPartyStoragePartitioning - https://github.com/microsoft/playwright/issues/32230
   // LensOverlay - Hides the Lens feature in the URL address bar. Its not working in unofficial builds.
   // PlzDedicatedWorker - https://github.com/microsoft/playwright/issues/31747
-  // DeferRendererTasksAfterInput - this makes Page.frameScheduledNavigation arrive much later after a click,
-  //   making our navigation auto-wait after click not working. Can be removed once we deperecate noWaitAfter.
-  //   See https://github.com/microsoft/playwright/pull/34372.
-  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,HttpsUpgrades,PaintHolding,ThirdPartyStoragePartitioning,LensOverlay,PlzDedicatedWorker,DeferRendererTasksAfterInput',
+  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,HttpsUpgrades,PaintHolding,ThirdPartyStoragePartitioning,LensOverlay,PlzDedicatedWorker',
   '--allow-pre-commit-input',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',


### PR DESCRIPTION
This was supposedly fixed upstream, see https://issues.chromium.org/u/1/issues/350540984.

References #34377.