### PR TITLE
docs: remove unnecessary hyphens in CircleCI's sharding example

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -804,7 +804,7 @@ Sharding in CircleCI is indexed with 0 which means that you will need to overrid
       executor: pw-noble-development
       parallelism: 4
       steps:
-        - run: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npx playwright test -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
+        - run: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npx playwright test --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
   ```
 
 ### Jenkins


### PR DESCRIPTION
## Context
I wasn’t sure if these hyphens were necessary for the command to work. If they were intentional, I’d appreciate it if you could close this PR. Thanks!

## Page
- https://playwright.dev/docs/ci#sharding-in-circleci

## Screenshot
![image](https://github.com/user-attachments/assets/ebade549-0a13-4a2a-94ff-af8bb85dc8af)
