### PR TITLE
feat(recorder): display primary page URL in recorder title

### DIFF
--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -37,9 +37,8 @@ export class EmptyRecorderApp extends EventEmitter implements IRecorderApp {
   async setRunningFile(file: string | undefined): Promise<void> {}
   async elementPicked(elementInfo: ElementInfo, userGesture?: boolean): Promise<void> {}
   async updateCallLogs(callLogs: CallLog[]): Promise<void> {}
-  async setSources(sources: Source[]): Promise<void> {}
+  async setSources(sources: Source[], primaryPageURL: string | undefined): Promise<void> {}
   async setActions(actions: actions.ActionInContext[], sources: Source[]): Promise<void> {}
-  async setBasePageURL(url: string): Promise<void> {}
 }
 
 export class RecorderApp extends EventEmitter implements IRecorderApp {
@@ -144,10 +143,10 @@ export class RecorderApp extends EventEmitter implements IRecorderApp {
     }).toString(), { isFunction: true }, paused).catch(() => {});
   }
 
-  async setSources(sources: Source[]): Promise<void> {
-    await this._page.mainFrame().evaluateExpression(((sources: Source[]) => {
-      window.playwrightSetSources(sources);
-    }).toString(), { isFunction: true }, sources).catch(() => {});
+  async setSources(sources: Source[], primaryPageURL: string | undefined): Promise<void> {
+    await this._page.mainFrame().evaluateExpression((({ sources, primaryPageURL }: { sources: Source[], primaryPageURL: string | undefined }) => {
+      window.playwrightSetSources(sources, primaryPageURL);
+    }).toString(), { isFunction: true }, { sources, primaryPageURL }).catch(() => {});
 
     // Testing harness for runCLI mode.
     if (process.env.PWTEST_CLI_IS_UNDER_TEST && sources.length) {
@@ -157,12 +156,6 @@ export class RecorderApp extends EventEmitter implements IRecorderApp {
   }
 
   async setActions(actions: actions.ActionInContext[], sources: Source[]): Promise<void> {
-  }
-
-  async setBasePageURL(url: string): Promise<void> {
-    await this._page.mainFrame().evaluateExpression(((url: string) => {
-      window.playwrightSetBasePageURL(url);
-    }).toString(), { isFunction: true }, url).catch(() => {});
   }
 
   async elementPicked(elementInfo: ElementInfo, userGesture?: boolean): Promise<void> {

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -39,6 +39,7 @@ export class EmptyRecorderApp extends EventEmitter implements IRecorderApp {
   async updateCallLogs(callLogs: CallLog[]): Promise<void> {}
   async setSources(sources: Source[]): Promise<void> {}
   async setActions(actions: actions.ActionInContext[], sources: Source[]): Promise<void> {}
+  async setBasePageURL(url: string): Promise<void> {}
 }
 
 export class RecorderApp extends EventEmitter implements IRecorderApp {
@@ -156,6 +157,12 @@ export class RecorderApp extends EventEmitter implements IRecorderApp {
   }
 
   async setActions(actions: actions.ActionInContext[], sources: Source[]): Promise<void> {
+  }
+
+  async setBasePageURL(url: string): Promise<void> {
+    await this._page.mainFrame().evaluateExpression(((url: string) => {
+      window.playwrightSetBasePageURL(url);
+    }).toString(), { isFunction: true }, url).catch(() => {});
   }
 
   async elementPicked(elementInfo: ElementInfo, userGesture?: boolean): Promise<void> {

--- a/packages/playwright-core/src/server/recorder/recorderFrontend.ts
+++ b/packages/playwright-core/src/server/recorder/recorderFrontend.ts
@@ -32,9 +32,8 @@ export interface IRecorderApp extends EventEmitter {
   setRunningFile(file: string | undefined): Promise<void>;
   elementPicked(elementInfo: ElementInfo, userGesture?: boolean): Promise<void>;
   updateCallLogs(callLogs: CallLog[]): Promise<void>;
-  setSources(sources: Source[]): Promise<void>;
+  setSources(sources: Source[], primaryPageURL: string | undefined): Promise<void>;
   setActions(actions: actions.ActionInContext[], sources: Source[]): Promise<void>;
-  setBasePageURL(url: string): Promise<void>;
 }
 
 export type IRecorderAppFactory = (recorder: IRecorder) => Promise<IRecorderApp>;

--- a/packages/playwright-core/src/server/recorder/recorderFrontend.ts
+++ b/packages/playwright-core/src/server/recorder/recorderFrontend.ts
@@ -34,6 +34,7 @@ export interface IRecorderApp extends EventEmitter {
   updateCallLogs(callLogs: CallLog[]): Promise<void>;
   setSources(sources: Source[]): Promise<void>;
   setActions(actions: actions.ActionInContext[], sources: Source[]): Promise<void>;
+  setBasePageURL(url: string): Promise<void>;
 }
 
 export type IRecorderAppFactory = (recorder: IRecorder) => Promise<IRecorderApp>;

--- a/packages/recorder/src/main.tsx
+++ b/packages/recorder/src/main.tsx
@@ -26,22 +26,31 @@ export const Main: React.FC = ({
   const [log, setLog] = React.useState(new Map<string, CallLog>());
   const [mode, setMode] = React.useState<Mode>('none');
 
-  window.playwrightSetMode = setMode;
-  window.playwrightSetSources = React.useCallback((sources: Source[]) => {
-    setSources(sources);
-    window.playwrightSourcesEchoForTest = sources;
+  React.useLayoutEffect(() => {
+    window.playwrightSetMode = setMode;
+    window.playwrightSetSources = (sources: Source[]) => {
+      setSources(sources);
+      window.playwrightSourcesEchoForTest = sources;
+    };
+    window.playwrightSetPaused = setPaused;
+    window.playwrightUpdateLogs = callLogs => {
+      setLog(log => {
+        const newLog = new Map<string, CallLog>(log);
+        for (const callLog of callLogs) {
+          callLog.reveal = !log.has(callLog.id);
+          newLog.set(callLog.id, callLog);
+        }
+        return newLog;
+      });
+    };
+    window.playwrightSetBasePageURL = (url: string) => {
+      if (url)
+        document.title = `Playwright Inspector - ${url}`;
+      else
+        document.title = `Playwright Inspector`;
+    };
   }, []);
-  window.playwrightSetPaused = setPaused;
-  window.playwrightUpdateLogs = callLogs => {
-    setLog(log => {
-      const newLog = new Map<string, CallLog>(log);
-      for (const callLog of callLogs) {
-        callLog.reveal = !log.has(callLog.id);
-        newLog.set(callLog.id, callLog);
-      }
-      return newLog;
-    });
-  };
+
 
   return <Recorder sources={sources} paused={paused} log={log} mode={mode} />;
 };

--- a/packages/recorder/src/main.tsx
+++ b/packages/recorder/src/main.tsx
@@ -19,8 +19,7 @@ import * as React from 'react';
 import { Recorder } from './recorder';
 import './recorder.css';
 
-export const Main: React.FC = ({
-}) => {
+export const Main: React.FC = ({}) => {
   const [sources, setSources] = React.useState<Source[]>([]);
   const [paused, setPaused] = React.useState(false);
   const [log, setLog] = React.useState(new Map<string, CallLog>());
@@ -28,9 +27,12 @@ export const Main: React.FC = ({
 
   React.useLayoutEffect(() => {
     window.playwrightSetMode = setMode;
-    window.playwrightSetSources = (sources: Source[]) => {
+    window.playwrightSetSources = (sources, primaryPageURL) => {
       setSources(sources);
       window.playwrightSourcesEchoForTest = sources;
+      document.title = primaryPageURL
+        ? `Playwright Inspector - ${primaryPageURL}`
+        : `Playwright Inspector`;
     };
     window.playwrightSetPaused = setPaused;
     window.playwrightUpdateLogs = callLogs => {
@@ -43,14 +45,7 @@ export const Main: React.FC = ({
         return newLog;
       });
     };
-    window.playwrightSetBasePageURL = (url: string) => {
-      if (url)
-        document.title = `Playwright Inspector - ${url}`;
-      else
-        document.title = `Playwright Inspector`;
-    };
   }, []);
-
 
   return <Recorder sources={sources} paused={paused} log={log} mode={mode} />;
 };

--- a/packages/recorder/src/recorderTypes.d.ts
+++ b/packages/recorder/src/recorderTypes.d.ts
@@ -103,6 +103,7 @@ declare global {
     playwrightSetPaused: (paused: boolean) => void;
     playwrightSetSources: (sources: Source[]) => void;
     playwrightSetOverlayVisible: (visible: boolean) => void;
+    playwrightSetBasePageURL: (url: string) => void;
     playwrightUpdateLogs: (callLogs: CallLog[]) => void;
     playwrightSetRunningFile: (file: string | undefined) => void;
     playwrightElementPicked: (elementInfo: ElementInfo, userGesture?: boolean) => void;

--- a/packages/recorder/src/recorderTypes.d.ts
+++ b/packages/recorder/src/recorderTypes.d.ts
@@ -101,9 +101,8 @@ declare global {
   interface Window {
     playwrightSetMode: (mode: Mode) => void;
     playwrightSetPaused: (paused: boolean) => void;
-    playwrightSetSources: (sources: Source[]) => void;
+    playwrightSetSources: (sources: Source[], primaryPageURL: string | undefined) => void;
     playwrightSetOverlayVisible: (visible: boolean) => void;
-    playwrightSetBasePageURL: (url: string) => void;
     playwrightUpdateLogs: (callLogs: CallLog[]) => void;
     playwrightSetRunningFile: (file: string | undefined) => void;
     playwrightElementPicked: (elementInfo: ElementInfo, userGesture?: boolean) => void;

--- a/tests/library/inspector/title.spec.ts
+++ b/tests/library/inspector/title.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './inspectorTest';
+
+test('should reflect formatted URL of the page', async ({ openRecorder, server }) => {
+  const { recorder } = await openRecorder();
+  await recorder.setContentAndWait('');
+  await expect(await recorder.recorderPage.title()).toBe('Playwright Inspector - about:blank');
+
+  await recorder.setContentAndWait('', server.EMPTY_PAGE);
+  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.EMPTY_PAGE}`);
+});
+
+test('should update primary page URL when original primary closes', async ({ context, openRecorder, server }) => {
+  const { recorder } = await openRecorder();
+  await recorder.setContentAndWait('', `${server.PREFIX}/background-color.html`);
+  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/background-color.html`);
+
+  const page2 = await context.newPage();
+  await page2.goto(`${server.PREFIX}/empty.html`);
+  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/background-color.html`);
+
+  const page3 = await context.newPage();
+  await page3.goto(`${server.PREFIX}/dom.html`);
+  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/background-color.html`);
+
+  const page4 = await context.newPage();
+  await page4.goto(`${server.PREFIX}/grid.html`);
+  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/background-color.html`);
+
+  await page2.close();
+  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/background-color.html`);
+
+  await recorder.page.close();
+  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/dom.html`);
+
+  await page3.close();
+  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/grid.html`);
+});

--- a/tests/library/inspector/title.spec.ts
+++ b/tests/library/inspector/title.spec.ts
@@ -16,38 +16,68 @@
 
 import { test, expect } from './inspectorTest';
 
-test('should reflect formatted URL of the page', async ({ openRecorder, server }) => {
+test('should reflect formatted URL of the page', async ({
+  openRecorder,
+  server,
+}) => {
   const { recorder } = await openRecorder();
   await recorder.setContentAndWait('');
-  await expect(await recorder.recorderPage.title()).toBe('Playwright Inspector - about:blank');
+  await expect(recorder.recorderPage).toHaveTitle(
+      'Playwright Inspector - about:blank',
+  );
 
   await recorder.setContentAndWait('', server.EMPTY_PAGE);
-  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.EMPTY_PAGE}`);
+  await expect(recorder.recorderPage).toHaveTitle(
+      `Playwright Inspector - ${server.EMPTY_PAGE}`,
+  );
 });
 
-test('should update primary page URL when original primary closes', async ({ context, openRecorder, server }) => {
+test('should update primary page URL when original primary closes', async ({
+  context,
+  openRecorder,
+  server,
+}) => {
   const { recorder } = await openRecorder();
-  await recorder.setContentAndWait('', `${server.PREFIX}/background-color.html`);
-  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/background-color.html`);
+  await recorder.setContentAndWait(
+      '',
+      `${server.PREFIX}/background-color.html`,
+  );
+  await expect(recorder.recorderPage).toHaveTitle(
+      `Playwright Inspector - ${server.PREFIX}/background-color.html`,
+  );
 
   const page2 = await context.newPage();
   await page2.goto(`${server.PREFIX}/empty.html`);
-  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/background-color.html`);
+  await expect(recorder.recorderPage).toHaveTitle(
+      `Playwright Inspector - ${server.PREFIX}/background-color.html`,
+  );
 
   const page3 = await context.newPage();
   await page3.goto(`${server.PREFIX}/dom.html`);
-  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/background-color.html`);
+  await expect(recorder.recorderPage).toHaveTitle(
+      `Playwright Inspector - ${server.PREFIX}/background-color.html`,
+  );
 
   const page4 = await context.newPage();
   await page4.goto(`${server.PREFIX}/grid.html`);
-  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/background-color.html`);
+  await expect(recorder.recorderPage).toHaveTitle(
+      `Playwright Inspector - ${server.PREFIX}/background-color.html`,
+  );
 
   await page2.close();
-  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/background-color.html`);
+  await expect(recorder.recorderPage).toHaveTitle(
+      `Playwright Inspector - ${server.PREFIX}/background-color.html`,
+  );
 
   await recorder.page.close();
-  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/dom.html`);
+  // URL will not update without performing some action
+  await page3.getByRole('checkbox').click();
+  await expect(recorder.recorderPage).toHaveTitle(
+      `Playwright Inspector - ${server.PREFIX}/dom.html`,
+  );
 
   await page3.close();
-  await expect(await recorder.recorderPage.title()).toBe(`Playwright Inspector - ${server.PREFIX}/grid.html`);
+  await expect(recorder.recorderPage).toHaveTitle(
+      `Playwright Inspector - ${server.PREFIX}/grid.html`,
+  );
 });


### PR DESCRIPTION
<img width="712" alt="Screenshot 2025-02-05 at 10 39 42 AM" src="https://github.com/user-attachments/assets/b1d38188-e490-4135-90d5-c6d148ebd387" />

Closes #34549. It is difficult to identify what recorder instance corresponds to a given browser session. This updates our title to roughly match how Chrome DevTools displays in the same scenario.

Note a given `BrowserContext` can have multiple pages, and thus multiple URLs. We take and maintain the first one (so your first tab) as the source of this URL.