### PR TITLE
devops: properly print group boundaries in GitHub actions

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -37,22 +37,28 @@ runs:
         node-version: ${{ inputs.node-version }}
     - uses: ./.github/actions/enable-microphone-access
     - run: |
-        echo "::group::npm ci"
-        npm ci
-        echo "::endgroup::"
+        {
+          echo "::group::npm ci"
+          npm ci
+          echo "::endgroup::"
+        }
       shell: bash
       env:
         DEBUG: pw:install
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
     - run: |
-        echo "::group::npm run build"
-        npm run build
-        echo "::endgroup::"
+        {
+          echo "::group::npm run build"
+          npm run build
+          echo "::endgroup::"
+        }
       shell: bash
     - run: |
-        echo "::group::npx playwright install --with-deps"
-        npx playwright install --with-deps ${{ inputs.browsers-to-install }}
-        echo "::endgroup::"
+        {
+          echo "::group::npx playwright install --with-deps"
+          npx playwright install --with-deps ${{ inputs.browsers-to-install }}
+          echo "::endgroup::"
+        }
       shell: bash
     - name: Run tests
       if: inputs.shell == 'bash'
@@ -79,9 +85,11 @@ runs:
         tenant-id: ${{ inputs.flakiness-tenant-id }}
         subscription-id: ${{ inputs.flakiness-subscription-id }}
     - run: |
-        echo "::group::./utils/upload_flakiness_dashboard.sh"
-        ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-        echo "::endgroup::"
+        {
+          echo "::group::./utils/upload_flakiness_dashboard.sh"
+          ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
+          echo "::endgroup::"
+        }
       if: ${{ !cancelled() }}
       shell: bash
     - name: Upload blob report

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -36,29 +36,23 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
     - uses: ./.github/actions/enable-microphone-access
-    - run: |
-        {
-          echo "::group::npm ci"
-          npm ci
-          echo "::endgroup::"
-        }
+    - run:
+        echo "::group::npm ci";
+        npm ci;
+        echo "::endgroup::";
       shell: bash
       env:
         DEBUG: pw:install
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
-    - run: |
-        {
-          echo "::group::npm run build"
-          npm run build
-          echo "::endgroup::"
-        }
+    - run:
+        echo "::group::npm run build";
+        npm run build;
+        echo "::endgroup::";
       shell: bash
-    - run: |
-        {
-          echo "::group::npx playwright install --with-deps"
-          npx playwright install --with-deps ${{ inputs.browsers-to-install }}
-          echo "::endgroup::"
-        }
+    - run:
+        echo "::group::npx playwright install --with-deps";
+        npx playwright install --with-deps ${{ inputs.browsers-to-install }};
+        echo "::endgroup::";
       shell: bash
     - name: Run tests
       if: inputs.shell == 'bash'
@@ -84,12 +78,10 @@ runs:
         client-id: ${{ inputs.flakiness-client-id }}
         tenant-id: ${{ inputs.flakiness-tenant-id }}
         subscription-id: ${{ inputs.flakiness-subscription-id }}
-    - run: |
-        {
-          echo "::group::./utils/upload_flakiness_dashboard.sh"
-          ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-          echo "::endgroup::"
-        }
+    - run:
+        echo "::group::./utils/upload_flakiness_dashboard.sh";
+        ./utils/upload_flakiness_dashboard.sh ./test-results/report.json;
+        echo "::endgroup::";
       if: ${{ !cancelled() }}
       shell: bash
     - name: Upload blob report

--- a/tests/page/page-leaks.spec.ts
+++ b/tests/page/page-leaks.spec.ts
@@ -80,7 +80,6 @@ test.afterEach(() => {
 });
 
 test('click should not leak', async ({ page, toImpl }) => {
-  const start = Date.now();
   await page.setContent(`
     <button>static button 1</button>
     <button>static button 2</button>
@@ -103,7 +102,6 @@ test('click should not leak', async ({ page, toImpl }) => {
 
   expect(leakedJSHandles()).toBeFalsy();
   await checkWeakRefs(toImpl(page), 2, 25);
-  console.log('click should not leak', Date.now() - start);
 });
 
 test('fill should not leak', async ({ page, mode, toImpl }) => {

--- a/tests/page/page-leaks.spec.ts
+++ b/tests/page/page-leaks.spec.ts
@@ -80,6 +80,7 @@ test.afterEach(() => {
 });
 
 test('click should not leak', async ({ page, toImpl }) => {
+  const start = Date.now();
   await page.setContent(`
     <button>static button 1</button>
     <button>static button 2</button>
@@ -102,6 +103,7 @@ test('click should not leak', async ({ page, toImpl }) => {
 
   expect(leakedJSHandles()).toBeFalsy();
   await checkWeakRefs(toImpl(page), 2, 25);
+  console.log('click should not leak', Date.now() - start);
 });
 
 test('fill should not leak', async ({ page, mode, toImpl }) => {


### PR DESCRIPTION
Wrapping the commands in `{ ... }` groups them as a single command in the GitHub Actions log. This will remove `echo` commands themselves from the logs below:

<img width="465" alt="image" src="https://github.com/user-attachments/assets/7b243ac4-e5ce-4702-8a96-85ce72a17ec3" />
