### PR TITLE
fix: allow opt out from `IndexedDB` in storagestate

### DIFF
--- a/docs/src/api/class-apirequestcontext.md
+++ b/docs/src/api/class-apirequestcontext.md
@@ -914,4 +914,4 @@ Returns storage state for this request context, contains current cookies and loc
 * since: v1.51
 - `indexedDB` ?<boolean>
 
-Set to `false` to omit IndexedDB from snapshot.
+Defaults to `true`. Set to `false` to omit IndexedDB from snapshot.

--- a/docs/src/api/class-apirequestcontext.md
+++ b/docs/src/api/class-apirequestcontext.md
@@ -909,3 +909,9 @@ Returns storage state for this request context, contains current cookies and loc
 
 ### option: APIRequestContext.storageState.path = %%-storagestate-option-path-%%
 * since: v1.16
+
+### option: APIRequestContext.storageState.indexedDB
+* since: v1.51
+- `indexedDB` ?<boolean>
+
+Set to `false` to omit IndexedDB from snapshot.

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1541,6 +1541,12 @@ Returns storage state for this browser context, contains current cookies, local 
 ### option: BrowserContext.storageState.path = %%-storagestate-option-path-%%
 * since: v1.8
 
+### option: BrowserContext.storageState.indexedDB
+* since: v1.51
+- `indexedDB` ?<boolean>
+
+Set to `false` to disable IndexedDB snapshot.
+
 ## property: BrowserContext.tracing
 * since: v1.12
 - type: <[Tracing]>

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1545,7 +1545,7 @@ Returns storage state for this browser context, contains current cookies, local 
 * since: v1.51
 - `indexedDB` ?<boolean>
 
-Set to `false` to omit IndexedDB from snapshot.
+Defaults to `true`. Set to `false` to omit IndexedDB from snapshot.
 
 ## property: BrowserContext.tracing
 * since: v1.12

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1545,7 +1545,7 @@ Returns storage state for this browser context, contains current cookies, local 
 * since: v1.51
 - `indexedDB` ?<boolean>
 
-Set to `false` to disable IndexedDB snapshot.
+Set to `false` to omit IndexedDB from snapshot.
 
 ## property: BrowserContext.tracing
 * since: v1.12

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -426,7 +426,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
   }
 
   async storageState(options: { path?: string, indexedDB?: boolean } = {}): Promise<StorageState> {
-    const state = await this._channel.storageState({ indexedDB: options.indexedDB ?? true });
+    const state = await this._channel.storageState({ indexedDB: options.indexedDB });
     if (options.path) {
       await mkdirIfNeeded(options.path);
       await fs.promises.writeFile(options.path, JSON.stringify(state, undefined, 2), 'utf8');

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -425,8 +425,8 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     });
   }
 
-  async storageState(options: { path?: string } = {}): Promise<StorageState> {
-    const state = await this._channel.storageState();
+  async storageState(options: { path?: string, indexedDB?: boolean } = {}): Promise<StorageState> {
+    const state = await this._channel.storageState({ indexedDB: options.indexedDB ?? true });
     if (options.path) {
       await mkdirIfNeeded(options.path);
       await fs.promises.writeFile(options.path, JSON.stringify(state, undefined, 2), 'utf8');

--- a/packages/playwright-core/src/client/fetch.ts
+++ b/packages/playwright-core/src/client/fetch.ts
@@ -260,8 +260,8 @@ export class APIRequestContext extends ChannelOwner<channels.APIRequestContextCh
     });
   }
 
-  async storageState(options: { path?: string } = {}): Promise<StorageState> {
-    const state = await this._channel.storageState();
+  async storageState(options: { path?: string, indexedDB?: boolean } = {}): Promise<StorageState> {
+    const state = await this._channel.storageState({ indexedDB: options.indexedDB ?? true });
     if (options.path) {
       await mkdirIfNeeded(options.path);
       await fs.promises.writeFile(options.path, JSON.stringify(state, undefined, 2), 'utf8');

--- a/packages/playwright-core/src/client/fetch.ts
+++ b/packages/playwright-core/src/client/fetch.ts
@@ -261,7 +261,7 @@ export class APIRequestContext extends ChannelOwner<channels.APIRequestContextCh
   }
 
   async storageState(options: { path?: string, indexedDB?: boolean } = {}): Promise<StorageState> {
-    const state = await this._channel.storageState({ indexedDB: options.indexedDB ?? true });
+    const state = await this._channel.storageState({ indexedDB: options.indexedDB });
     if (options.path) {
       await mkdirIfNeeded(options.path);
       await fs.promises.writeFile(options.path, JSON.stringify(state, undefined, 2), 'utf8');

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -992,7 +992,9 @@ scheme.BrowserContextSetOfflineParams = tObject({
   offline: tBoolean,
 });
 scheme.BrowserContextSetOfflineResult = tOptional(tObject({}));
-scheme.BrowserContextStorageStateParams = tOptional(tObject({}));
+scheme.BrowserContextStorageStateParams = tObject({
+  indexedDB: tBoolean,
+});
 scheme.BrowserContextStorageStateResult = tObject({
   cookies: tArray(tType('NetworkCookie')),
   origins: tArray(tType('OriginStorage')),

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -234,7 +234,9 @@ scheme.APIRequestContextFetchLogParams = tObject({
 scheme.APIRequestContextFetchLogResult = tObject({
   log: tArray(tString),
 });
-scheme.APIRequestContextStorageStateParams = tOptional(tObject({}));
+scheme.APIRequestContextStorageStateParams = tObject({
+  indexedDB: tBoolean,
+});
 scheme.APIRequestContextStorageStateResult = tObject({
   cookies: tArray(tType('NetworkCookie')),
   origins: tArray(tType('OriginStorage')),

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -235,7 +235,7 @@ scheme.APIRequestContextFetchLogResult = tObject({
   log: tArray(tString),
 });
 scheme.APIRequestContextStorageStateParams = tObject({
-  indexedDB: tBoolean,
+  indexedDB: tOptional(tBoolean),
 });
 scheme.APIRequestContextStorageStateResult = tObject({
   cookies: tArray(tType('NetworkCookie')),
@@ -995,7 +995,7 @@ scheme.BrowserContextSetOfflineParams = tObject({
 });
 scheme.BrowserContextSetOfflineResult = tOptional(tObject({}));
 scheme.BrowserContextStorageStateParams = tObject({
-  indexedDB: tBoolean,
+  indexedDB: tOptional(tBoolean),
 });
 scheme.BrowserContextStorageStateResult = tObject({
   cookies: tArray(tType('NetworkCookie')),

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -508,7 +508,7 @@ export abstract class BrowserContext extends SdkObject {
     this._origins.add(origin);
   }
 
-  async storageState(indexedDB: boolean): Promise<channels.BrowserContextStorageStateResult> {
+  async storageState(indexedDB = true): Promise<channels.BrowserContextStorageStateResult> {
     const result: channels.BrowserContextStorageStateResult = {
       cookies: await this.cookies(),
       origins: []

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -508,14 +508,14 @@ export abstract class BrowserContext extends SdkObject {
     this._origins.add(origin);
   }
 
-  async storageState(): Promise<channels.BrowserContextStorageStateResult> {
+  async storageState(indexedDB: boolean): Promise<channels.BrowserContextStorageStateResult> {
     const result: channels.BrowserContextStorageStateResult = {
       cookies: await this.cookies(),
       origins: []
     };
     const originsToSave = new Set(this._origins);
 
-    const collectScript = `(${storageScript.collect})((${utilityScriptSerializers.source})(), ${this._browser.options.name === 'firefox'}, ${Boolean(process.env.PLAYWRIGHT_SKIP_INDEXEDDB)})`;
+    const collectScript = `(${storageScript.collect})((${utilityScriptSerializers.source})(), ${this._browser.options.name === 'firefox'}, ${indexedDB})`;
 
     // First try collecting storage stage from existing pages.
     for (const page of this.pages()) {

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -515,7 +515,7 @@ export abstract class BrowserContext extends SdkObject {
     };
     const originsToSave = new Set(this._origins);
 
-    const collectScript = `(${storageScript.collect})((${utilityScriptSerializers.source})(), ${this._browser.options.name === 'firefox'})`;
+    const collectScript = `(${storageScript.collect})((${utilityScriptSerializers.source})(), ${this._browser.options.name === 'firefox'}, ${Boolean(process.env.PLAYWRIGHT_SKIP_INDEXEDDB)})`;
 
     // First try collecting storage stage from existing pages.
     for (const page of this.pages()) {

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -291,7 +291,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   }
 
   async storageState(params: channels.BrowserContextStorageStateParams, metadata: CallMetadata): Promise<channels.BrowserContextStorageStateResult> {
-    return await this._context.storageState();
+    return await this._context.storageState(params.indexedDB);
   }
 
   async close(params: channels.BrowserContextCloseParams, metadata: CallMetadata): Promise<void> {

--- a/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
+++ b/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
@@ -194,8 +194,8 @@ export class APIRequestContextDispatcher extends Dispatcher<APIRequestContext, c
     this.adopt(tracing);
   }
 
-  async storageState(): Promise<channels.APIRequestContextStorageStateResult> {
-    return this._object.storageState();
+  async storageState(params: channels.APIRequestContextStorageStateParams): Promise<channels.APIRequestContextStorageStateResult> {
+    return this._object.storageState(params.indexedDB);
   }
 
   async dispose(params: channels.APIRequestContextDisposeParams, metadata: CallMetadata): Promise<void> {

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -133,7 +133,7 @@ export abstract class APIRequestContext extends SdkObject {
   abstract _defaultOptions(): FetchRequestOptions;
   abstract _addCookies(cookies: channels.NetworkCookie[]): Promise<void>;
   abstract _cookies(url: URL): Promise<channels.NetworkCookie[]>;
-  abstract storageState(indexedDB: boolean): Promise<channels.APIRequestContextStorageStateResult>;
+  abstract storageState(indexedDB?: boolean): Promise<channels.APIRequestContextStorageStateResult>;
 
   private _storeResponseBody(body: Buffer): string {
     const uid = createGuid();
@@ -618,7 +618,7 @@ export class BrowserContextAPIRequestContext extends APIRequestContext {
     return await this._context.cookies(url.toString());
   }
 
-  override async storageState(indexedDB: boolean): Promise<channels.APIRequestContextStorageStateResult> {
+  override async storageState(indexedDB?: boolean): Promise<channels.APIRequestContextStorageStateResult> {
     return this._context.storageState(indexedDB);
   }
 }
@@ -684,7 +684,7 @@ export class GlobalAPIRequestContext extends APIRequestContext {
     return this._cookieStore.cookies(url);
   }
 
-  override async storageState(indexedDB: boolean): Promise<channels.APIRequestContextStorageStateResult> {
+  override async storageState(indexedDB = true): Promise<channels.APIRequestContextStorageStateResult> {
     return {
       cookies: this._cookieStore.allCookies(),
       origins: (this._origins || []).map(origin => ({ ...origin, indexedDB: indexedDB ? origin.indexedDB : [] })),

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -133,7 +133,7 @@ export abstract class APIRequestContext extends SdkObject {
   abstract _defaultOptions(): FetchRequestOptions;
   abstract _addCookies(cookies: channels.NetworkCookie[]): Promise<void>;
   abstract _cookies(url: URL): Promise<channels.NetworkCookie[]>;
-  abstract storageState(): Promise<channels.APIRequestContextStorageStateResult>;
+  abstract storageState(indexedDB: boolean): Promise<channels.APIRequestContextStorageStateResult>;
 
   private _storeResponseBody(body: Buffer): string {
     const uid = createGuid();
@@ -618,8 +618,8 @@ export class BrowserContextAPIRequestContext extends APIRequestContext {
     return await this._context.cookies(url.toString());
   }
 
-  override async storageState(): Promise<channels.APIRequestContextStorageStateResult> {
-    return this._context.storageState();
+  override async storageState(indexedDB: boolean): Promise<channels.APIRequestContextStorageStateResult> {
+    return this._context.storageState(indexedDB);
   }
 }
 
@@ -684,10 +684,10 @@ export class GlobalAPIRequestContext extends APIRequestContext {
     return this._cookieStore.cookies(url);
   }
 
-  override async storageState(): Promise<channels.APIRequestContextStorageStateResult> {
+  override async storageState(indexedDB: boolean): Promise<channels.APIRequestContextStorageStateResult> {
     return {
       cookies: this._cookieStore.allCookies(),
-      origins: this._origins || []
+      origins: (this._origins || []).map(origin => ({ ...origin, indexedDB: indexedDB ? origin.indexedDB : [] })),
     };
   }
 }

--- a/packages/playwright-core/src/server/storageScript.ts
+++ b/packages/playwright-core/src/server/storageScript.ts
@@ -19,8 +19,8 @@ import type { source } from './isomorphic/utilityScriptSerializers';
 
 export type Storage = Omit<channels.OriginStorage, 'origin'>;
 
-export async function collect(serializers: ReturnType<typeof source>, isFirefox: boolean): Promise<Storage> {
-  const idbResult = await Promise.all((await indexedDB.databases()).map(async dbInfo => {
+export async function collect(serializers: ReturnType<typeof source>, isFirefox: boolean, skipIndexedDB: boolean): Promise<Storage> {
+  async function collectDB(dbInfo: IDBDatabaseInfo) {
     if (!dbInfo.name)
       throw new Error('Database name is empty');
     if (!dbInfo.version)
@@ -119,13 +119,13 @@ export async function collect(serializers: ReturnType<typeof source>, isFirefox:
       version: dbInfo.version,
       stores,
     };
-  })).catch(e => {
-    throw new Error('Unable to serialize IndexedDB: ' + e.message);
-  });
+  }
 
   return {
     localStorage: Object.keys(localStorage).map(name => ({ name, value: localStorage.getItem(name)! })),
-    indexedDB: idbResult,
+    indexedDB: skipIndexedDB ? [] : await Promise.all((await indexedDB.databases()).map(collectDB)).catch(e => {
+      throw new Error('Unable to serialize IndexedDB: ' + e.message);
+    }),
   };
 }
 

--- a/packages/playwright-core/src/server/storageScript.ts
+++ b/packages/playwright-core/src/server/storageScript.ts
@@ -19,7 +19,7 @@ import type { source } from './isomorphic/utilityScriptSerializers';
 
 export type Storage = Omit<channels.OriginStorage, 'origin'>;
 
-export async function collect(serializers: ReturnType<typeof source>, isFirefox: boolean, skipIndexedDB: boolean): Promise<Storage> {
+export async function collect(serializers: ReturnType<typeof source>, isFirefox: boolean, recordIndexedDB: boolean): Promise<Storage> {
   async function collectDB(dbInfo: IDBDatabaseInfo) {
     if (!dbInfo.name)
       throw new Error('Database name is empty');
@@ -123,9 +123,9 @@ export async function collect(serializers: ReturnType<typeof source>, isFirefox:
 
   return {
     localStorage: Object.keys(localStorage).map(name => ({ name, value: localStorage.getItem(name)! })),
-    indexedDB: skipIndexedDB ? [] : await Promise.all((await indexedDB.databases()).map(collectDB)).catch(e => {
+    indexedDB: recordIndexedDB ? await Promise.all((await indexedDB.databases()).map(collectDB)).catch(e => {
       throw new Error('Unable to serialize IndexedDB: ' + e.message);
-    }),
+    }) : [],
   };
 }
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9272,7 +9272,7 @@ export interface BrowserContext {
    */
   storageState(options?: {
     /**
-     * Set to `false` to omit IndexedDB from snapshot.
+     * Defaults to `true`. Set to `false` to omit IndexedDB from snapshot.
      */
     indexedDB?: boolean;
 
@@ -18537,7 +18537,7 @@ export interface APIRequestContext {
    */
   storageState(options?: {
     /**
-     * Set to `false` to omit IndexedDB from snapshot.
+     * Defaults to `true`. Set to `false` to omit IndexedDB from snapshot.
      */
     indexedDB?: boolean;
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9272,7 +9272,7 @@ export interface BrowserContext {
    */
   storageState(options?: {
     /**
-     * Set to `false` to disable IndexedDB snapshot.
+     * Set to `false` to omit IndexedDB from snapshot.
      */
     indexedDB?: boolean;
 
@@ -18536,6 +18536,11 @@ export interface APIRequestContext {
    * @param options
    */
   storageState(options?: {
+    /**
+     * Set to `false` to omit IndexedDB from snapshot.
+     */
+    indexedDB?: boolean;
+
     /**
      * The file path to save the storage state to. If
      * [`path`](https://playwright.dev/docs/api/class-apirequestcontext#api-request-context-storage-state-option-path) is

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9272,6 +9272,11 @@ export interface BrowserContext {
    */
   storageState(options?: {
     /**
+     * Set to `false` to disable IndexedDB snapshot.
+     */
+    indexedDB?: boolean;
+
+    /**
      * The file path to save the storage state to. If
      * [`path`](https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state-option-path) is a
      * relative path, then it is resolved relative to current working directory. If no path is provided, storage state is

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -403,10 +403,10 @@ export type APIRequestContextFetchLogResult = {
   log: string[],
 };
 export type APIRequestContextStorageStateParams = {
-  indexedDB: boolean,
+  indexedDB?: boolean,
 };
 export type APIRequestContextStorageStateOptions = {
-
+  indexedDB?: boolean,
 };
 export type APIRequestContextStorageStateResult = {
   cookies: NetworkCookie[],
@@ -1802,10 +1802,10 @@ export type BrowserContextSetOfflineOptions = {
 };
 export type BrowserContextSetOfflineResult = void;
 export type BrowserContextStorageStateParams = {
-  indexedDB: boolean,
+  indexedDB?: boolean,
 };
 export type BrowserContextStorageStateOptions = {
-
+  indexedDB?: boolean,
 };
 export type BrowserContextStorageStateResult = {
   cookies: NetworkCookie[],

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -1564,7 +1564,7 @@ export interface BrowserContextChannel extends BrowserContextEventTarget, EventT
   setNetworkInterceptionPatterns(params: BrowserContextSetNetworkInterceptionPatternsParams, metadata?: CallMetadata): Promise<BrowserContextSetNetworkInterceptionPatternsResult>;
   setWebSocketInterceptionPatterns(params: BrowserContextSetWebSocketInterceptionPatternsParams, metadata?: CallMetadata): Promise<BrowserContextSetWebSocketInterceptionPatternsResult>;
   setOffline(params: BrowserContextSetOfflineParams, metadata?: CallMetadata): Promise<BrowserContextSetOfflineResult>;
-  storageState(params?: BrowserContextStorageStateParams, metadata?: CallMetadata): Promise<BrowserContextStorageStateResult>;
+  storageState(params: BrowserContextStorageStateParams, metadata?: CallMetadata): Promise<BrowserContextStorageStateResult>;
   pause(params?: BrowserContextPauseParams, metadata?: CallMetadata): Promise<BrowserContextPauseResult>;
   enableRecorder(params: BrowserContextEnableRecorderParams, metadata?: CallMetadata): Promise<BrowserContextEnableRecorderResult>;
   newCDPSession(params: BrowserContextNewCDPSessionParams, metadata?: CallMetadata): Promise<BrowserContextNewCDPSessionResult>;
@@ -1797,8 +1797,12 @@ export type BrowserContextSetOfflineOptions = {
 
 };
 export type BrowserContextSetOfflineResult = void;
-export type BrowserContextStorageStateParams = {};
-export type BrowserContextStorageStateOptions = {};
+export type BrowserContextStorageStateParams = {
+  indexedDB: boolean,
+};
+export type BrowserContextStorageStateOptions = {
+
+};
 export type BrowserContextStorageStateResult = {
   cookies: NetworkCookie[],
   origins: OriginStorage[],

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -346,7 +346,7 @@ export interface APIRequestContextChannel extends APIRequestContextEventTarget, 
   fetch(params: APIRequestContextFetchParams, metadata?: CallMetadata): Promise<APIRequestContextFetchResult>;
   fetchResponseBody(params: APIRequestContextFetchResponseBodyParams, metadata?: CallMetadata): Promise<APIRequestContextFetchResponseBodyResult>;
   fetchLog(params: APIRequestContextFetchLogParams, metadata?: CallMetadata): Promise<APIRequestContextFetchLogResult>;
-  storageState(params?: APIRequestContextStorageStateParams, metadata?: CallMetadata): Promise<APIRequestContextStorageStateResult>;
+  storageState(params: APIRequestContextStorageStateParams, metadata?: CallMetadata): Promise<APIRequestContextStorageStateResult>;
   disposeAPIResponse(params: APIRequestContextDisposeAPIResponseParams, metadata?: CallMetadata): Promise<APIRequestContextDisposeAPIResponseResult>;
   dispose(params: APIRequestContextDisposeParams, metadata?: CallMetadata): Promise<APIRequestContextDisposeResult>;
 }
@@ -402,8 +402,12 @@ export type APIRequestContextFetchLogOptions = {
 export type APIRequestContextFetchLogResult = {
   log: string[],
 };
-export type APIRequestContextStorageStateParams = {};
-export type APIRequestContextStorageStateOptions = {};
+export type APIRequestContextStorageStateParams = {
+  indexedDB: boolean,
+};
+export type APIRequestContextStorageStateOptions = {
+
+};
 export type APIRequestContextStorageStateResult = {
   cookies: NetworkCookie[],
   origins: OriginStorage[],

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -377,7 +377,7 @@ APIRequestContext:
 
     storageState:
       parameters:
-        indexedDB: boolean
+        indexedDB: boolean?
       returns:
         cookies:
           type: array
@@ -1237,7 +1237,7 @@ BrowserContext:
 
     storageState:
       parameters:
-        indexedDB: boolean
+        indexedDB: boolean?
       returns:
         cookies:
           type: array

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -376,6 +376,8 @@ APIRequestContext:
           items: string
 
     storageState:
+      parameters:
+        indexedDB: boolean
       returns:
         cookies:
           type: array

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1234,6 +1234,8 @@ BrowserContext:
         offline: boolean
 
     storageState:
+      parameters:
+        indexedDB: boolean
       returns:
         cookies:
           type: array

--- a/tests/library/browsercontext-storage-state.spec.ts
+++ b/tests/library/browsercontext-storage-state.spec.ts
@@ -437,6 +437,5 @@ it('should support IndexedDB', async ({ page, server, contextFactory }) => {
         - text: /Pet the cat/
   `);
 
-
   expect(await context.storageState({ indexedDB: false })).toEqual({ cookies: [], origins: [] });
 });

--- a/tests/library/browsercontext-storage-state.spec.ts
+++ b/tests/library/browsercontext-storage-state.spec.ts
@@ -436,4 +436,7 @@ it('should support IndexedDB', async ({ page, server, contextFactory }) => {
       - listitem:
         - text: /Pet the cat/
   `);
+
+
+  expect(await context.storageState({ indexedDB: false })).toEqual({ cookies: [], origins: [] });
 });


### PR DESCRIPTION
Allows opting out from `storageState` via ~~env var~~ option.