### PR TITLE
chore: remove dead code

### DIFF
--- a/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
+++ b/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
@@ -35,9 +35,6 @@ export const gitCommitInfo = (options?: GitCommitInfoPluginOptions): TestRunnerP
       const fromEnv = linksFromEnv();
       const fromCLI = await gitStatusFromCLI(options?.directory || configDir);
       const info = { ...fromEnv, ...fromCLI };
-      if (info['revision.timestamp'] instanceof Date)
-        info['revision.timestamp'] = info['revision.timestamp'].getTime();
-
       config.metadata = config.metadata || {};
       config.metadata['git.commit.info'] = info;
     },

--- a/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
+++ b/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
@@ -34,9 +34,8 @@ export const gitCommitInfo = (options?: GitCommitInfoPluginOptions): TestRunnerP
     setup: async (config: FullConfig, configDir: string) => {
       const fromEnv = linksFromEnv();
       const fromCLI = await gitStatusFromCLI(options?.directory || configDir);
-      const info = { ...fromEnv, ...fromCLI };
       config.metadata = config.metadata || {};
-      config.metadata['git.commit.info'] = info;
+      config.metadata['git.commit.info'] = { ...fromEnv, ...fromCLI };
     },
   };
 };


### PR DESCRIPTION
Going by the code, there's no way that `revision.timestamp` is ever a Date. Let's remove the branch.