### PR TITLE
feat: provide commit diff to HTML reporter

### DIFF
--- a/packages/html-reporter/src/metadataView.tsx
+++ b/packages/html-reporter/src/metadataView.tsx
@@ -98,13 +98,13 @@ const GitCommitInfoView: React.FC<{ info: GitCommitInfo }> = ({ info }) => {
         {info['ci.link'] && (
           <>
             <span className='mx-2'>·</span>
-            <a href={info['ci.link']} target='_blank' rel='noopener noreferrer' title='CI/CD logs'>logs</a>
+            <a href={info['ci.link']} target='_blank' rel='noopener noreferrer' title='CI/CD logs'>Logs</a>
           </>
         )}
         {info['pull.link'] && (
           <>
             <span className='mx-2'>·</span>
-            <a href={info['pull.link']} target='_blank' rel='noopener noreferrer'>pull request</a>
+            <a href={info['pull.link']} target='_blank' rel='noopener noreferrer'>Pull Request</a>
           </>
         )}
       </div>

--- a/packages/html-reporter/src/metadataView.tsx
+++ b/packages/html-reporter/src/metadataView.tsx
@@ -95,7 +95,18 @@ const GitCommitInfoView: React.FC<{ info: GitCommitInfo }> = ({ info }) => {
       <div className='hbox m-2 mt-1'>
         <div className='mr-1'>{author}</div>
         <div title={longTimestamp}> on {shortTimestamp}</div>
-        {info['ci.link'] && <><span className='mx-2'>·</span><a href={info['ci.link']} target='_blank' rel='noopener noreferrer' title='CI/CD logs'>logs</a></>}
+        {info['ci.link'] && (
+          <>
+            <span className='mx-2'>·</span>
+            <a href={info['ci.link']} target='_blank' rel='noopener noreferrer' title='CI/CD logs'>logs</a>
+          </>
+        )}
+        {info['pull.link'] && (
+          <>
+            <span className='mx-2'>·</span>
+            <a href={info['pull.link']} target='_blank' rel='noopener noreferrer'>pull request</a>
+          </>
+        )}
       </div>
     </div>
     {!!info['revision.link'] && <a href={info['revision.link']} target='_blank' rel='noopener noreferrer'>

--- a/packages/playwright/src/isomorphic/types.d.ts
+++ b/packages/playwright/src/isomorphic/types.d.ts
@@ -22,4 +22,5 @@ export interface GitCommitInfo {
   'revision.timestamp'?: number | Date;
   'revision.link'?: string;
   'ci.link'?: string;
+  'revision.diff'?: string;
 }

--- a/packages/playwright/src/isomorphic/types.d.ts
+++ b/packages/playwright/src/isomorphic/types.d.ts
@@ -22,5 +22,8 @@ export interface GitCommitInfo {
   'revision.timestamp'?: number | Date;
   'revision.link'?: string;
   'revision.diff'?: string;
+  'pull.link'?: string;
+  'pull.diff'?: string;
+  'pull.base'?: string;
   'ci.link'?: string;
 }

--- a/packages/playwright/src/isomorphic/types.d.ts
+++ b/packages/playwright/src/isomorphic/types.d.ts
@@ -22,7 +22,6 @@ export interface GitCommitInfo {
   'revision.timestamp'?: number | Date;
   'revision.link'?: string;
   'revision.diff'?: string;
-  'pull.id'?: string;
   'pull.link'?: string;
   'pull.diff'?: string;
   'pull.base'?: string;

--- a/packages/playwright/src/isomorphic/types.d.ts
+++ b/packages/playwright/src/isomorphic/types.d.ts
@@ -22,6 +22,7 @@ export interface GitCommitInfo {
   'revision.timestamp'?: number | Date;
   'revision.link'?: string;
   'revision.diff'?: string;
+  'pull.id'?: string;
   'pull.link'?: string;
   'pull.diff'?: string;
   'pull.base'?: string;

--- a/packages/playwright/src/isomorphic/types.d.ts
+++ b/packages/playwright/src/isomorphic/types.d.ts
@@ -21,6 +21,6 @@ export interface GitCommitInfo {
   'revision.subject'?: string;
   'revision.timestamp'?: number | Date;
   'revision.link'?: string;
-  'ci.link'?: string;
   'revision.diff'?: string;
+  'ci.link'?: string;
 }

--- a/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
+++ b/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
@@ -89,14 +89,6 @@ async function gitStatusFromCLI(gitDir: string, envInfo: Pick<GitCommitInfo, 'pu
     'revision.timestamp': timestamp,
   };
 
-  const diffResult = await spawnAsync(
-      'git',
-      ['diff', 'HEAD~1'],
-      { stdio: 'pipe', cwd: gitDir, timeout: GIT_OPERATIONS_TIMEOUT_MS }
-  );
-  if (!diffResult.code)
-    result['revision.diff'] = diffResult.stdout;
-
   if (envInfo['pull.base']) {
     const pullDiffResult = await spawnAsync(
         'git',
@@ -105,6 +97,14 @@ async function gitStatusFromCLI(gitDir: string, envInfo: Pick<GitCommitInfo, 'pu
     );
     if (!pullDiffResult.code)
       result['pull.diff'] = pullDiffResult.stdout;
+  } else {
+    const diffResult = await spawnAsync(
+        'git',
+        ['diff', 'HEAD~1'],
+        { stdio: 'pipe', cwd: gitDir, timeout: GIT_OPERATIONS_TIMEOUT_MS }
+    );
+    if (!diffResult.code)
+      result['revision.diff'] = diffResult.stdout;
   }
 
   return result;

--- a/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
+++ b/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
@@ -60,8 +60,8 @@ function linksFromEnv() {
   if (process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID)
     out['ci.link'] = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
   if (process.env.GITHUB_REF_NAME && process.env.GITHUB_REF_NAME.endsWith('/merge')) {
-    out['pull.id'] = process.env.GITHUB_REF_NAME.substring(0, process.env.GITHUB_REF_NAME.indexOf('/merge'));
-    out['pull.link'] = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${out['pull.id']}`;
+    const pullId = process.env.GITHUB_REF_NAME.substring(0, process.env.GITHUB_REF_NAME.indexOf('/merge'));
+    out['pull.link'] = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${pullId}`;
     out['pull.base'] = process.env.GITHUB_BASE_REF;
   }
   return out;

--- a/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
+++ b/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
@@ -44,8 +44,8 @@ interface GitCommitInfoPluginOptions {
   directory?: string;
 }
 
-function linksFromEnv(): Pick<GitCommitInfo, 'revision.link' | 'ci.link' | 'pull.link' | 'pull.base'> {
-  const out: { 'revision.link'?: string; 'ci.link'?: string; 'pull.link'?: string; 'pull.base'?: string; } = {};
+function linksFromEnv() {
+  const out: Partial<GitCommitInfo> = {};
   // Jenkins: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
   if (process.env.BUILD_URL)
     out['ci.link'] = process.env.BUILD_URL;
@@ -60,8 +60,8 @@ function linksFromEnv(): Pick<GitCommitInfo, 'revision.link' | 'ci.link' | 'pull
   if (process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID)
     out['ci.link'] = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
   if (process.env.GITHUB_REF_NAME && process.env.GITHUB_REF_NAME.endsWith('/merge')) {
-    const pullId = process.env.GITHUB_REF_NAME.substring(0, process.env.GITHUB_REF_NAME.indexOf('/merge'));
-    out['pull.link'] = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${pullId}`;
+    out['pull.id'] = process.env.GITHUB_REF_NAME.substring(0, process.env.GITHUB_REF_NAME.indexOf('/merge'));
+    out['pull.link'] = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${out['pull.id']}`;
     out['pull.base'] = process.env.GITHUB_BASE_REF;
   }
   return out;

--- a/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
+++ b/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
@@ -89,6 +89,7 @@ async function gitStatusFromCLI(gitDir: string, envInfo: Pick<GitCommitInfo, 'pu
     'revision.timestamp': timestamp,
   };
 
+  const diffLimit = 1_000_000; // 1MB
   if (envInfo['pull.base']) {
     const pullDiffResult = await spawnAsync(
         'git',
@@ -96,7 +97,7 @@ async function gitStatusFromCLI(gitDir: string, envInfo: Pick<GitCommitInfo, 'pu
         { stdio: 'pipe', cwd: gitDir, timeout: GIT_OPERATIONS_TIMEOUT_MS }
     );
     if (!pullDiffResult.code)
-      result['pull.diff'] = pullDiffResult.stdout;
+      result['pull.diff'] = pullDiffResult.stdout.substring(0, diffLimit);
   } else {
     const diffResult = await spawnAsync(
         'git',
@@ -104,7 +105,7 @@ async function gitStatusFromCLI(gitDir: string, envInfo: Pick<GitCommitInfo, 'pu
         { stdio: 'pipe', cwd: gitDir, timeout: GIT_OPERATIONS_TIMEOUT_MS }
     );
     if (!diffResult.code)
-      result['revision.diff'] = diffResult.stdout;
+      result['revision.diff'] = diffResult.stdout.substring(0, diffLimit);
   }
 
   return result;

--- a/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
+++ b/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
@@ -33,7 +33,7 @@ export const gitCommitInfo = (options?: GitCommitInfoPluginOptions): TestRunnerP
 
     setup: async (config: FullConfig, configDir: string) => {
       const fromEnv = linksFromEnv();
-      const fromCLI = await gitStatusFromCLI(options?.directory || configDir);
+      const fromCLI = await gitStatusFromCLI(options?.directory || configDir, fromEnv);
       config.metadata = config.metadata || {};
       config.metadata['git.commit.info'] = { ...fromEnv, ...fromCLI };
     },
@@ -44,8 +44,8 @@ interface GitCommitInfoPluginOptions {
   directory?: string;
 }
 
-function linksFromEnv(): Pick<GitCommitInfo, 'revision.link' | 'ci.link'> {
-  const out: { 'revision.link'?: string; 'ci.link'?: string; } = {};
+function linksFromEnv(): Pick<GitCommitInfo, 'revision.link' | 'ci.link' | 'pull.link' | 'pull.base'> {
+  const out: { 'revision.link'?: string; 'ci.link'?: string; 'pull.link'?: string; 'pull.base'?: string; } = {};
   // Jenkins: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
   if (process.env.BUILD_URL)
     out['ci.link'] = process.env.BUILD_URL;
@@ -59,10 +59,15 @@ function linksFromEnv(): Pick<GitCommitInfo, 'revision.link' | 'ci.link'> {
     out['revision.link'] = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/commit/${process.env.GITHUB_SHA}`;
   if (process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID)
     out['ci.link'] = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+  if (process.env.GITHUB_REF_NAME && process.env.GITHUB_REF_NAME.endsWith('/merge')) {
+    const pullId = process.env.GITHUB_REF_NAME.substring(0, process.env.GITHUB_REF_NAME.indexOf('/merge'));
+    out['pull.link'] = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${pullId}`;
+    out['pull.base'] = process.env.GITHUB_BASE_REF;
+  }
   return out;
 }
 
-async function gitStatusFromCLI(gitDir: string): Promise<GitCommitInfo | undefined> {
+async function gitStatusFromCLI(gitDir: string, envInfo: Pick<GitCommitInfo, 'pull.base'>): Promise<GitCommitInfo | undefined> {
   const separator = `:${createGuid().slice(0, 4)}:`;
   const commitInfoResult = await spawnAsync(
       'git',
@@ -91,6 +96,16 @@ async function gitStatusFromCLI(gitDir: string): Promise<GitCommitInfo | undefin
   );
   if (!diffResult.code)
     result['revision.diff'] = diffResult.stdout;
+
+  if (envInfo['pull.base']) {
+    const pullDiffResult = await spawnAsync(
+        'git',
+        ['diff', envInfo['pull.base']],
+        { stdio: 'pipe', cwd: gitDir, timeout: GIT_OPERATIONS_TIMEOUT_MS }
+    );
+    if (!pullDiffResult.code)
+      result['pull.diff'] = pullDiffResult.stdout;
+  }
 
   return result;
 }

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1213,6 +1213,8 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await execGit(['init']);
       await execGit(['config', '--local', 'user.email', 'shakespeare@example.local']);
       await execGit(['config', '--local', 'user.name', 'William']);
+      await execGit(['add', 'playwright.config.ts']);
+      await execGit(['commit', '-m', 'init']);
       await execGit(['add', '*.ts']);
       await execGit(['commit', '-m', 'chore(html): make this test look nice']);
 
@@ -1222,6 +1224,8 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         GITHUB_RUN_ID: 'example-run-id',
         GITHUB_SERVER_URL: 'https://playwright.dev',
         GITHUB_SHA: 'example-sha',
+        GITHUB_REF_NAME: '42/merge',
+        GITHUB_BASE_REF: 'HEAD~1',
       });
 
       await showReport();
@@ -1232,6 +1236,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         - 'link "chore(html): make this test look nice"'
         - text: /^William <shakespeare@example.local> on/
         - link "logs"
+        - link "pull request"
         - link /^[a-f0-9]{7}$/
         - text: 'foo: value1 bar: {"prop":"value2"} baz: ["value3",123]'
       `);

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1235,8 +1235,8 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.locator('.metadata-view')).toMatchAriaSnapshot(`
         - 'link "chore(html): make this test look nice"'
         - text: /^William <shakespeare@example.local> on/
-        - link "logs"
-        - link "pull request"
+        - link "Logs"
+        - link "Pull Request"
         - link /^[a-f0-9]{7}$/
         - text: 'foo: value1 bar: {"prop":"value2"} baz: ["value3",123]'
       `);


### PR DESCRIPTION
Works towards https://github.com/microsoft/playwright/issues/34476. This PR makes our git plugin record the commit diff, or if it's in a pull request, the pull request diff. This will be useful to the HTML reporter.

Also adds a "pull request" link to the HTML reporter UI:

![Screenshot 2025-02-06 at 11 33 59](https://github.com/user-attachments/assets/2f288873-890e-4134-b884-90d13a757190)
