### PR TITLE
fix(ui-mode): display no projects error if bad config provided

### DIFF
--- a/packages/trace-viewer/src/ui/shared/fullscreenModal.tsx
+++ b/packages/trace-viewer/src/ui/shared/fullscreenModal.tsx
@@ -1,0 +1,38 @@
+/*
+  Copyright (c) Microsoft Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import * as React from 'react';
+import './fullscreenModel.css';
+
+export interface FullscreenModalProps {
+  onClose?: () => void;
+}
+
+export const FullscreenModal: React.FC<
+  React.PropsWithChildren<FullscreenModalProps>
+> = ({ onClose, children }) => {
+  const ref = React.useRef<HTMLDialogElement>(null);
+
+  React.useEffect(() => {
+    ref.current?.showModal();
+  }, []);
+
+  return (
+    <dialog ref={ref} className='fullscreen-modal'>
+      <div className='fullscreen-modal-content'>{children}</div>
+    </dialog>
+  );
+};

--- a/packages/trace-viewer/src/ui/shared/fullscreenModel.css
+++ b/packages/trace-viewer/src/ui/shared/fullscreenModel.css
@@ -1,0 +1,29 @@
+/*
+  Copyright (c) Microsoft Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+.fullscreen-modal {
+  padding: 8px;
+
+  outline: none;
+}
+
+.fullscreen-modal-content {
+  margin: 8px;
+}
+
+.fullscreen-modal::backdrop {
+  background-color: rgba(0, 0, 0, 0.8);
+}


### PR DESCRIPTION
<img width="1392" alt="Screenshot 2025-02-06 at 6 02 00 AM" src="https://github.com/user-attachments/assets/5ebbcdbb-4599-4e9c-88ce-60191e8e3ee9" />

Fixes #34500. If the user launches UI Mode by specifying a `--project` filter that doesn't match anything, the UI would silently fail. Instead, block access to the entire UI and display an error indicating what happened.