### PR TITLE
Revert "chore: tidy up headless-shell hacks (#33967)"

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -8,7 +8,19 @@
       "browserVersion": "133.0.6943.35"
     },
     {
+      "name": "chromium-headless-shell",
+      "revision": "1157",
+      "installByDefault": true,
+      "browserVersion": "133.0.6943.35"
+    },
+    {
       "name": "chromium-tip-of-tree",
+      "revision": "1300",
+      "installByDefault": false,
+      "browserVersion": "134.0.6998.0"
+    },
+    {
+      "name": "chromium-tip-of-tree-headless-shell",
       "revision": "1300",
       "installByDefault": false,
       "browserVersion": "134.0.6998.0"

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -445,14 +445,7 @@ type BrowsersJSONDescriptor = {
 };
 
 function readDescriptors(browsersJSON: BrowsersJSON): BrowsersJSONDescriptor[] {
-  const headlessShells: BrowsersJSON['browsers'] = [];
-  for (const browserName of ['chromium', 'chromium-tip-of-tree']) {
-    headlessShells.push({
-      ...browsersJSON.browsers.find(browser => browser.name === browserName)!,
-      name: `${browserName}-headless-shell`,
-    });
-  }
-  return [...browsersJSON.browsers, ...headlessShells].map(obj => {
+  return (browsersJSON['browsers']).map(obj => {
     const name = obj.name;
     const revisionOverride = (obj.revisionOverrides || {})[hostPlatform];
     const revision = revisionOverride || obj.revision;

--- a/utils/roll_browser.js
+++ b/utils/roll_browser.js
@@ -94,6 +94,18 @@ Example:
     console.log('\nUpdating browser version in browsers.json...');
     for (const descriptor of descriptors)
       descriptor.browserVersion = browserVersion;
+
+    // 4.1 chromium-headless-shell is equal to chromium version.
+    if (browserName === 'chromium') {
+      const headlessShellBrowser = await browsersJSON.browsers.find(b => b.name === 'chromium-headless-shell');
+      headlessShellBrowser.revision = revision;
+      headlessShellBrowser.browserVersion = browserVersion;
+    } else if (browserName === 'chromium-tip-of-tree') {
+      const tipOfTreeBrowser = await browsersJSON.browsers.find(b => b.name === 'chromium-tip-of-tree-headless-shell');
+      tipOfTreeBrowser.revision = revision;
+      tipOfTreeBrowser.browserVersion = browserVersion;
+    }
+
     fs.writeFileSync(path.join(CORE_PATH, 'browsers.json'), JSON.stringify(browsersJSON, null, 2) + '\n');
   }
 


### PR DESCRIPTION
This reverts commit 38758c0596c013335ec3e2bfadd7373cf121ee72.

https://github.com/microsoft/playwright/pull/34636
https://github.com/microsoft/playwright/issues/34508