### PR TITLE
test: change ct-vite projects to type: module

### DIFF
--- a/tests/components/ct-react-vite/package.json
+++ b/tests/components/ct-react-vite/package.json
@@ -2,6 +2,7 @@
   "name": "ct-react-vite",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -9,16 +10,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.6.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.1.5"
   },
   "devDependencies": {
-    "@types/react": "^18.0.26",
-    "@types/react-dom": "^18.0.10",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.2.1",
     "msw": "^2.3.0",
     "typescript": "^5.2.2",
-    "vite": "^5.2.8"
+    "vite": "^6.1.0"
   }
 }

--- a/tests/components/ct-react-vite/playwright.config.ts
+++ b/tests/components/ct-react-vite/playwright.config.ts
@@ -15,7 +15,8 @@
  */
 
 import { defineConfig, devices } from '@playwright/experimental-ct-react';
-import { resolve } from 'path';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 export default defineConfig({
   testDir: 'tests',
@@ -30,7 +31,7 @@ export default defineConfig({
       },
       resolve: {
         alias: {
-          '@': resolve(__dirname, './src'),
+          '@': path.resolve(path.dirname(fileURLToPath(import.meta.url)), './src'),
         }
       }
     }

--- a/tests/components/ct-vue-vite/package.json
+++ b/tests/components/ct-vue-vite/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ct-vue-vite",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -12,10 +13,10 @@
     "vue-router": "^4.1.5"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.2.0",
-    "@vue/tsconfig": "^0.5.1",
-    "typescript": "5.6.2",
-    "vite": "^5.2.8",
-    "vue-tsc": "^2.0.21"
+    "@vitejs/plugin-vue": "^5.2.1",
+    "@vue/tsconfig": "^0.7.0",
+    "typescript": "~5.7.2",
+    "vite": "^6.1.0",
+    "vue-tsc": "^2.2.0"
   }
 }

--- a/tests/components/ct-vue-vite/playwright.config.ts
+++ b/tests/components/ct-vue-vite/playwright.config.ts
@@ -15,7 +15,8 @@
  */
 
 import { defineConfig, devices } from '@playwright/experimental-ct-vue';
-import { resolve } from 'path';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 export default defineConfig({
   testDir: 'tests',
@@ -27,7 +28,7 @@ export default defineConfig({
     ctViteConfig: {
       resolve: {
         alias: {
-          '@': resolve(__dirname, './src'),
+          '@': path.resolve(path.dirname(fileURLToPath(import.meta.url)), './src'),
         }
       }
     }


### PR DESCRIPTION
This aligns it with what `npm init vite` gives us as of today.