### PR TITLE
chore(bidi): mouse coordinates must be interger

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiInput.ts
+++ b/packages/playwright-core/src/server/bidi/bidiInput.ts
@@ -94,8 +94,8 @@ export class RawMouseImpl implements input.RawMouse {
 
   async wheel(x: number, y: number, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, deltaX: number, deltaY: number): Promise<void> {
     // Bidi throws when x/y are not integers.
-    x = Math.round(x);
-    y = Math.round(y);
+    x = Math.floor(x);
+    y = Math.floor(y);
     await this._session.send('input.performActions', {
       context: this._session.sessionId,
       actions: [

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -576,6 +576,13 @@ export class BidiPage implements PageDelegate {
   shouldToggleStyleSheetToSyncAnimations(): boolean {
     return true;
   }
+
+  shouldClickAtIntegerCoordinates(): boolean {
+    // TODO: bidi spec requires integer coordinates, but Chromium actually supports
+    // fractional coordinates, perhaps the spec should be updated and we wouldn't need
+    // this hack.
+    return true;
+  }
 }
 
 function addMainBinding(callback: (arg: any) => void) {

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -370,6 +370,10 @@ export class CRPage implements PageDelegate {
   shouldToggleStyleSheetToSyncAnimations(): boolean {
     return false;
   }
+
+  shouldClickAtIntegerCoordinates(): boolean {
+    return false;
+  }
 }
 
 class FrameSession {

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -275,7 +275,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const filtered = quads.map(quad => intersectQuadWithViewport(quad)).filter(quad => computeQuadArea(quad) > 0.99);
     if (!filtered.length)
       return 'error:notinviewport';
-    if (this._page._browserContext._browser.options.name === 'firefox') {
+    if (this._page._delegate.shouldClickAtIntegerCoordinates()) {
       // Firefox internally uses integer coordinates, so 8.x is converted to 8 or 9 when clicking.
       //
       // This does not work nicely for small elements. For example, 1x1 square with corners

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -574,6 +574,10 @@ export class FFPage implements PageDelegate {
   shouldToggleStyleSheetToSyncAnimations(): boolean {
     return false;
   }
+
+  shouldClickAtIntegerCoordinates(): boolean {
+    return true;
+  }
 }
 
 function webSocketId(frameId: string, wsid: string): string {

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -96,6 +96,8 @@ export interface PageDelegate {
   readonly cspErrorsAsynchronousForInlineScripts?: boolean;
   // Work around for mouse position in Firefox.
   resetForReuse(): Promise<void>;
+  // Firefox can only click at integer coordinates.
+  shouldClickAtIntegerCoordinates(): boolean;
   // WebKit hack.
   shouldToggleStyleSheetToSyncAnimations(): boolean;
 }

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -1202,6 +1202,10 @@ export class WKPage implements PageDelegate {
   shouldToggleStyleSheetToSyncAnimations(): boolean {
     return true;
   }
+
+  shouldClickAtIntegerCoordinates(): boolean {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
This is a follow-up to the discussion in https://github.com/microsoft/playwright/pull/34191.

According to [the spec](https://www.w3.org/TR/webdriver-bidi/#command-input-performActions) mouse coordinates must be integers. Although Chromium does support fractional values, we have to have single implementation for all bidi browsers and we have to comply with the spec, as currently Firefox throws on fractional values.
