### PR TITLE
test: keep testing React 18

### DIFF
--- a/tests/components/ct-react-vite/package.json
+++ b/tests/components/ct-react-vite/package.json
@@ -10,16 +10,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-router-dom": "^7.1.5"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.6.1"
   },
   "devDependencies": {
-    "@types/react": "^19.0.8",
-    "@types/react-dom": "^19.0.3",
+    "@types/react": "^18.0.26",
+    "@types/react-dom": "^18.0.10",
     "@vitejs/plugin-react": "^4.2.1",
     "msw": "^2.3.0",
     "typescript": "^5.2.2",
-    "vite": "^6.1.0"
+    "vite": "^5.2.8"
   }
 }

--- a/tests/components/ct-vue-vite/package.json
+++ b/tests/components/ct-vue-vite/package.json
@@ -13,10 +13,10 @@
     "vue-router": "^4.1.5"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.2.1",
-    "@vue/tsconfig": "^0.7.0",
-    "typescript": "~5.7.2",
-    "vite": "^6.1.0",
-    "vue-tsc": "^2.2.0"
+    "@vitejs/plugin-vue": "^5.2.0",
+    "@vue/tsconfig": "^0.5.1",
+    "typescript": "5.6.2",
+    "vite": "^5.2.8",
+    "vue-tsc": "^2.0.21"
   }
 }


### PR DESCRIPTION
This partially reverts commit 8accb0ad1bc125c19ca92da58de24f8d64408d82 which by accident changed the dependencies. We should instead keep testing React 18 and introduce if needed a separate React 19 project.