### PR TITLE
chore(bidi): use fractional coordinates for pointerAction

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiInput.ts
+++ b/packages/playwright-core/src/server/bidi/bidiInput.ts
@@ -78,9 +78,6 @@ export class RawMouseImpl implements input.RawMouse {
   }
 
   async move(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void> {
-    // Bidi throws when x/y are not integers.
-    x = Math.floor(x);
-    y = Math.floor(y);
     await this._performActions([{ type: 'pointerMove', x, y }]);
   }
 
@@ -93,9 +90,6 @@ export class RawMouseImpl implements input.RawMouse {
   }
 
   async wheel(x: number, y: number, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, deltaX: number, deltaY: number): Promise<void> {
-    // Bidi throws when x/y are not integers.
-    x = Math.round(x);
-    y = Math.round(y);
     await this._session.send('input.performActions', {
       context: this._session.sessionId,
       actions: [


### PR DESCRIPTION
See previous discussion in https://github.com/microsoft/playwright/pull/34665#issuecomment-2642566559. Chromium already supports fractional values and Firefox is going to address it via https://bugzilla.mozilla.org/show_bug.cgi?id=1946774.

The spec is going to be updated: https://github.com/w3c/webdriver-bidi/issues/873