### PR TITLE
fix(ui): clear action selection when executing test

### DIFF
--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -86,9 +86,10 @@ export const Workbench: React.FunctionComponent<{
   const sources = React.useMemo(() => model?.sources || new Map<string, modelUtil.SourceModel>(), [model]);
 
   React.useEffect(() => {
+    setSelectedAction(undefined);
     setSelectedTime(undefined);
     setRevealedError(undefined);
-  }, [model]);
+  }, [model, setSelectedAction]);
 
   const selectedAction = React.useMemo(() => {
     if (selectedCallId) {


### PR DESCRIPTION
Fixes #34482. When executing a test with an existing selection in UI Mode, the action selection follows the test execution, up until completion or the first error, as it does on initial execution (without a selection).

This also fixes an issue where selections were preserved between tests, causing strange things to be highlighted.