### PR TITLE
chore: fix recorder tsconfig linting

### DIFF
--- a/packages/recorder/tsconfig.json
+++ b/packages/recorder/tsconfig.json
@@ -9,7 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
We were hitting it only during `npm run watch` because it inside runs `npx tsc -w -p packages/recorder` which we don't do for `npm run build` aka CI mode:

```
[1:00:21 PM] Starting compilation in watch mode...

node_modules/vite/dist/node/index.d.ts:5:41 - error TS2307: Cannot find module 'rollup/parseAst' or its corresponding type declarations.
  There are types at '/Users/maxschmitt/Developer/playwright/node_modules/rollup/dist/parseAst.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.

5 export { parseAst, parseAstAsync } from 'rollup/parseAst';
                                          ~~~~~~~~~~~~~~~~~

[1:00:31 PM] Found 1 error. Watching for file changes.

```

Relates https://github.com/rollup/rollup/issues/5199#issuecomment-1782231154