### PR TITLE
chore: fix Locator type issues

### DIFF
--- a/docs/src/api/class-apirequest.md
+++ b/docs/src/api/class-apirequest.md
@@ -81,7 +81,7 @@ Methods like [`method: APIRequestContext.get`] take the base URL into considerat
         - `records` <[Array]<[Object]>>
           - `key` ?<[Object]>
           - `keyEncoded` ?<[Object]> if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-          - `value` <[Object]>
+          - `value` ?<[Object]>
           - `valueEncoded` ?<[Object]> if `value` is not JSON-serializable, this contains an encoded version that preserves types.
 
 Populates context with given storage state. This option can be used to initialize context with logged-in information

--- a/docs/src/api/class-apirequestcontext.md
+++ b/docs/src/api/class-apirequestcontext.md
@@ -897,7 +897,7 @@ context cookies from the response. The method will automatically follow redirect
           - `records` <[Array]<[Object]>>
             - `key` ?<[Object]>
             - `keyEncoded` ?<[Object]> if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-            - `value` <[Object]>
+            - `value` ?<[Object]>
             - `valueEncoded` ?<[Object]> if `value` is not JSON-serializable, this contains an encoded version that preserves types.
 
 Returns storage state for this request context, contains current cookies and local storage snapshot if it was passed to the constructor.

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1528,7 +1528,7 @@ Whether to emulate network being offline for the browser context.
         - `records` <[Array]<[Object]>>
           - `key` ?<[Object]>
           - `keyEncoded` ?<[Object]> if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-          - `value` <[Object]>
+          - `value` ?<[Object]>
           - `valueEncoded` ?<[Object]> if `value` is not JSON-serializable, this contains an encoded version that preserves types.
 
 Returns storage state for this browser context, contains current cookies, local storage snapshot and IndexedDB snapshot.

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -281,7 +281,7 @@ Specify environment variables that will be visible to the browser. Defaults to `
         - `records` <[Array]<[Object]>>
           - `key` ?<[Object]>
           - `keyEncoded` ?<[Object]> if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-          - `value` <[Object]>
+          - `value` ?<[Object]>
           - `valueEncoded` ?<[Object]> if `value` is not JSON-serializable, this contains an encoded version that preserves types.
 
 Learn more about [storage state and auth](../auth.md).

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -37,7 +37,7 @@ export type SelectOptionOptions = { force?: boolean, timeout?: number };
 export type FilePayload = { name: string, mimeType: string, buffer: Buffer };
 export type StorageState = {
   cookies: channels.NetworkCookie[],
-  origins: channels.OriginStorage[]
+  origins: channels.OriginStorage[],
 };
 export type SetStorageState = {
   cookies?: channels.SetNetworkCookie[],

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9351,7 +9351,7 @@ export interface BrowserContext {
              */
             keyEncoded?: Object;
 
-            value: Object;
+            value?: Object;
 
             /**
              * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
@@ -10170,7 +10170,7 @@ export interface Browser {
                */
               keyEncoded?: Object;
 
-              value: Object;
+              value?: Object;
 
               /**
                * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
@@ -17758,7 +17758,7 @@ export interface APIRequest {
                */
               keyEncoded?: Object;
 
-              value: Object;
+              value?: Object;
 
               /**
                * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
@@ -18616,7 +18616,7 @@ export interface APIRequestContext {
              */
             keyEncoded?: Object;
 
-            value: Object;
+            value?: Object;
 
             /**
              * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
@@ -22512,7 +22512,7 @@ export interface BrowserContextOptions {
              */
             keyEncoded?: Object;
 
-            value: Object;
+            value?: Object;
 
             /**
              * if `value` is not JSON-serializable, this contains an encoded version that preserves types.


### PR DESCRIPTION
This fixes

    Type 'Locator' is missing the following properties from type 'Locator': _frame, _selector, _withElement, _equals, and 4 more.

Broken since https://github.com/microsoft/playwright/commit/7aac96d780152e297bd420d3eaf29a9395a37bb6

This issue was that protocol types and api types diverged. Once accepted value to be nullable (protocol) the other one didn't accept it. Why the linting error doesn't get surfaced in our normal CI status checks is a mystery. We could now also revert https://github.com/microsoft/playwright/pull/34682.