### PR TITLE
fix(trace): do not save trace on failure after success in test+hooks

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -726,7 +726,7 @@ class ArtifactsRecorder {
       return;
     (tracing as any)[this._startedCollectingArtifacts] = true;
     if (this._testInfo._tracing.traceOptions() && (tracing as any)[kTracingStarted])
-      await tracing.stopChunk({ path: this._testInfo._tracing.generateNextTraceRecordingPath() });
+      await tracing.stopChunk({ path: this._testInfo._tracing.maybeGenerateNextTraceRecordingPath() });
   }
 }
 

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -399,6 +399,8 @@ export class WorkerMain extends ProcessRunner {
         firstAfterHooksError = firstAfterHooksError ?? error;
       }
 
+      testInfo._tracing.didFinishTestFunctionAndAfterEachHooks();
+
       try {
         // Teardown test-scoped fixtures. Attribute to 'test' so that users understand
         // they should probably increase the test timeout to fix this issue.


### PR DESCRIPTION
Previously, we always saved the trace for each context until the very end of the test, and then either repacked them or abandoned depending on the `trace` mode.

However, this could result in downloading large traces from the remote server when the tests succeeded but trace was set to `retain-on-failure`. This slows down remote operations quite a lot.

The fix is to carefully consider whether the trace should be saved or abandoned, based on whether the test and afterEach hooks have finished successfully.

This could be a minor regression, where the trace will not be saved if one of the fixture teardowns fails after the context has been already closed, and trace mode was `retain-on-failure` or `retain-on-first-failure`.

Fixes #34416.