### PR TITLE
fix: allow empty userDataDir

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -100,7 +100,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
       ignoreAllDefaultArgs: !!options.ignoreDefaultArgs && !Array.isArray(options.ignoreDefaultArgs),
       env: options.env ? envObjectToArray(options.env) : undefined,
       channel: options.channel,
-      userDataDir: path.isAbsolute(userDataDir) ? userDataDir : path.resolve(userDataDir),
+      userDataDir: (path.isAbsolute(userDataDir) || !userDataDir) ? userDataDir : path.resolve(userDataDir),
     };
     return await this._wrapApiCall(async () => {
       const result = await this._channel.launchPersistentContext(persistentParams);


### PR DESCRIPTION
https://github.com/microsoft/playwright/pull/34710 introduced a bug where it used `CWD` as a userDataDir if none was provided. This fixes it - whats the best way of covering this with a test?