### PR TITLE
feat(runner): enable gitCommitInfo by default on GH Actions

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -334,6 +334,8 @@ Whether to populate `'git.commit.info'` field of the [`property: TestConfig.meta
 
 This information will appear in the HTML and JSON reports and is available in the Reporter API.
 
+On Github Actions, this feature is enabled by default.
+
 **Usage**
 
 ```js title="playwright.config.ts"

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -78,7 +78,7 @@ export class FullConfigInternal {
     const privateConfiguration = (userConfig as any)['@playwright/test'];
     this.plugins = (privateConfiguration?.plugins || []).map((p: any) => ({ factory: p }));
     this.singleTSConfigPath = pathResolve(configDir, userConfig.tsconfig);
-    this.populateGitInfo = takeFirst(userConfig.populateGitInfo, false);
+    this.populateGitInfo = takeFirst(userConfig.populateGitInfo, defaultPopulateGitInfo);
 
     this.globalSetups = (Array.isArray(userConfig.globalSetup) ? userConfig.globalSetup : [userConfig.globalSetup]).map(s => resolveScript(s, configDir)).filter(script => script !== undefined);
     this.globalTeardowns = (Array.isArray(userConfig.globalTeardown) ? userConfig.globalTeardown : [userConfig.globalTeardown]).map(s => resolveScript(s, configDir)).filter(script => script !== undefined);
@@ -301,6 +301,7 @@ function resolveScript(id: string | undefined, rootDir: string): string | undefi
 
 export const defaultGrep = /.*/;
 export const defaultReporter = process.env.CI ? 'dot' : 'list';
+const defaultPopulateGitInfo = process.env.GITHUB_ACTIONS === 'true';
 
 const configInternalSymbol = Symbol('configInternalSymbol');
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1367,6 +1367,8 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    *
    * This information will appear in the HTML and JSON reports and is available in the Reporter API.
    *
+   * On Github Actions, this feature is enabled by default.
+   *
    * **Usage**
    *
    * ```js

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -222,6 +222,7 @@ export function cleanEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     CI_COMMIT_SHA: undefined,
     CI_JOB_URL: undefined,
     CI_PROJECT_URL: undefined,
+    GITHUB_ACTIONS: undefined,
     GITHUB_REPOSITORY: undefined,
     GITHUB_RUN_ID: undefined,
     GITHUB_SERVER_URL: undefined,

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1242,42 +1242,6 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       `);
     });
 
-    test('should include metadata on GH Actions', async ({ runInlineTest, writeFiles, showReport, page }) => {
-      const files = {
-        'example.spec.ts': `
-          import { test, expect } from '@playwright/test';
-          test('sample', async ({}) => { expect(2).toBe(2); });
-        `,
-      };
-      const baseDir = await writeFiles(files);
-
-      const execGit = async (args: string[]) => {
-        const { code, stdout, stderr } = await spawnAsync('git', args, { stdio: 'pipe', cwd: baseDir });
-        if (!!code)
-          throw new Error(`Non-zero exit of:\n$ git ${args.join(' ')}\nConsole:\nstdout:\n${stdout}\n\nstderr:\n${stderr}\n\n`);
-        return;
-      };
-
-      await execGit(['init']);
-      await execGit(['config', '--local', 'user.email', 'shakespeare@example.local']);
-      await execGit(['config', '--local', 'user.name', 'William']);
-      await execGit(['add', '*']);
-      await execGit(['commit', '-m', 'chore(html): make this test look nice']);
-
-      const result = await runInlineTest(files, { reporter: 'dot,html' }, {
-        GITHUB_ACTIONS: 'true',
-        PLAYWRIGHT_HTML_OPEN: 'never',
-      });
-
-      await showReport();
-
-      expect(result.exitCode).toBe(0);
-      await page.getByRole('button', { name: 'Metadata' }).click();
-      await expect(page.locator('.metadata-view')).toMatchAriaSnapshot(`
-        - text: /make this test look nice/
-      `);
-    });
-
     test('should not include git metadata with populateGitInfo = false', async ({ runInlineTest, showReport, page }) => {
       const result = await runInlineTest({
         'playwright.config.ts': `

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1242,6 +1242,42 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       `);
     });
 
+    test('should include metadata on GH Actions', async ({ runInlineTest, writeFiles, showReport, page }) => {
+      const files = {
+        'example.spec.ts': `
+          import { test, expect } from '@playwright/test';
+          test('sample', async ({}) => { expect(2).toBe(2); });
+        `,
+      };
+      const baseDir = await writeFiles(files);
+
+      const execGit = async (args: string[]) => {
+        const { code, stdout, stderr } = await spawnAsync('git', args, { stdio: 'pipe', cwd: baseDir });
+        if (!!code)
+          throw new Error(`Non-zero exit of:\n$ git ${args.join(' ')}\nConsole:\nstdout:\n${stdout}\n\nstderr:\n${stderr}\n\n`);
+        return;
+      };
+
+      await execGit(['init']);
+      await execGit(['config', '--local', 'user.email', 'shakespeare@example.local']);
+      await execGit(['config', '--local', 'user.name', 'William']);
+      await execGit(['add', '*']);
+      await execGit(['commit', '-m', 'chore(html): make this test look nice']);
+
+      const result = await runInlineTest(files, { reporter: 'dot,html' }, {
+        GITHUB_ACTIONS: 'true',
+        PLAYWRIGHT_HTML_OPEN: 'never',
+      });
+
+      await showReport();
+
+      expect(result.exitCode).toBe(0);
+      await page.getByRole('button', { name: 'Metadata' }).click();
+      await expect(page.locator('.metadata-view')).toMatchAriaSnapshot(`
+        - text: /make this test look nice/
+      `);
+    });
+
     test('should not include git metadata with populateGitInfo = false', async ({ runInlineTest, showReport, page }) => {
       const result = await runInlineTest({
         'playwright.config.ts': `


### PR DESCRIPTION
As discusses yesterday, this enables git commit info by default on GH Actions, where we're certain about the execution environment.