### PR TITLE
Revert "chore(bidi): use fractional coordinates for pointerAction (#3…

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiInput.ts
+++ b/packages/playwright-core/src/server/bidi/bidiInput.ts
@@ -79,6 +79,9 @@ export class RawMouseImpl implements input.RawMouse {
   }
 
   async move(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void> {
+    // Bidi throws when x/y are not integers.
+    x = Math.floor(x);
+    y = Math.floor(y);
     await this._performActions([{ type: 'pointerMove', x, y }]);
   }
 
@@ -91,6 +94,9 @@ export class RawMouseImpl implements input.RawMouse {
   }
 
   async wheel(x: number, y: number, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, deltaX: number, deltaY: number): Promise<void> {
+    // Bidi throws when x/y are not integers.
+    x = Math.round(x);
+    y = Math.round(y);
     await this._session.send('input.performActions', {
       context: this._session.sessionId,
       actions: [

--- a/packages/playwright-core/src/server/bidi/bidiInput.ts
+++ b/packages/playwright-core/src/server/bidi/bidiInput.ts
@@ -95,8 +95,8 @@ export class RawMouseImpl implements input.RawMouse {
 
   async wheel(x: number, y: number, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, deltaX: number, deltaY: number): Promise<void> {
     // Bidi throws when x/y are not integers.
-    x = Math.round(x);
-    y = Math.round(y);
+    x = Math.floor(x);
+    y = Math.floor(y);
     await this._session.send('input.performActions', {
       context: this._session.sessionId,
       actions: [


### PR DESCRIPTION
…4675)"

Reverting this until Firefox implements support for fractional coordinates. Landing this now increases overall testing time on the bots and tips over the limit for Firefox Bidi tests.

This reverts commit 8e51be9069c775a199b4326af5751434bca59d9d.

Reference: https://github.com/microsoft/playwright/issues/34742