### PR TITLE
chore(bidi): implement setInputFiles

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -530,11 +530,21 @@ export class BidiPage implements PageDelegate {
   }
 
   async setInputFiles(handle: dom.ElementHandle<HTMLInputElement>, files: types.FilePayload[]): Promise<void> {
-    throw new Error('Method not implemented.');
+    throw new Error('Setting FilePayloads is not supported in Bidi.');
   }
 
   async setInputFilePaths(handle: dom.ElementHandle<HTMLInputElement>, paths: string[]): Promise<void> {
-    throw new Error('Method not implemented.');
+    const fromContext = toBidiExecutionContext(handle._context);
+    const shared = await fromContext.rawCallFunction('x => x',  { handle: handle._objectId });
+    // TODO: store sharedId in the handle.
+    if (!('sharedId' in shared))
+      throw new Error('Element is not a node');
+    const sharedId = shared.sharedId!;
+    await this._session.send('input.setFiles', {
+      context: this._session.sessionId,
+      element: { sharedId },
+      files: paths,
+    });
   }
 
   async adoptElementHandle<T extends Node>(handle: dom.ElementHandle<T>, to: dom.FrameExecutionContext): Promise<dom.ElementHandle<T>> {


### PR DESCRIPTION
This PR implements `setInputFiles` with file paths. The one that takes in-memory `FilePayloads` is not supported as Bidi protocol doesn't have corresponding command.