### PR TITLE
fix(runner): filter args should respect trailing slash

### DIFF
--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -159,7 +159,7 @@ export function mergeObjects<A extends object, B extends object, C extends objec
 }
 
 export function forceRegExp(pattern: string): RegExp {
-  const match = pattern.match(/^\/(.*)\/([gi]*)$/);
+  const match = pattern.match(/^\/(.*\/)([gi]*)$/);
   if (match)
     return new RegExp(match[1], match[2]);
   return new RegExp(pattern, 'gi');

--- a/tests/playwright-test/command-line-filter.spec.ts
+++ b/tests/playwright-test/command-line-filter.spec.ts
@@ -196,3 +196,28 @@ test('should focus a single test suite', async ({ runInlineTest }) => {
   expect(result.report.suites[0].suites[0].suites[0].specs[0].title).toEqual('pass2');
   expect(result.report.suites[0].suites[0].suites[0].specs[1].title).toEqual('pass3');
 });
+
+test('should filter by folder with absolute path', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/34813' } }, async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'foo/x.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('fails', () => { expect(1).toBe(2); });
+    `,
+    'foo/y.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('fails', () => { expect(1).toBe(2); });
+    `,
+    'foobar/x.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('fails', () => { expect(1).toBe(2); });
+    `,
+    'foobar/y.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('fails', () => { expect(1).toBe(2); });
+    `,
+  }, undefined, undefined, { additionalArgs: [test.info().outputPath('foo') + '/'] });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(2);
+  expect(result.output).toMatch(/foo[\\/]x.spec.ts/);
+  expect(result.output).toMatch(/foo[\\/]y.spec.ts/);
+});


### PR DESCRIPTION
Currently, `npx playwright test foo` has the same result as `npx playwright test foo/`, because we swallow the trailing slash while parsing the argument. This makes it impossible to specify that you want to run files in `foo/`, but not in `foobar/`.

Discovered as part of https://github.com/microsoft/playwright/issues/34813