### PR TITLE
chore: fix tsc linting error

### DIFF
--- a/packages/trace-viewer/src/types/entries.ts
+++ b/packages/trace-viewer/src/types/entries.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Language } from 'playwright-core/src/utils/isomorphic/locatorGenerators';
+import type { Language } from '../../../playwright-core/src/utils/isomorphic/locatorGenerators';
 import type { ResourceSnapshot } from '@trace/snapshot';
 import type * as trace from '@trace/trace';
 

--- a/packages/trace-viewer/tsconfig.json
+++ b/packages/trace-viewer/tsconfig.json
@@ -9,7 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
This fixes that when using `npm run watch`:

```
env➜  playwright git:(main) ✗ npx tsc -p packages/trace-viewer      
node_modules/vite/dist/node/index.d.ts:5:41 - error TS2307: Cannot find module 'rollup/parseAst' or its corresponding type declarations.
  There are types at '/Users/maxschmitt/Developer/playwright/node_modules/rollup/dist/parseAst.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.

5 export { parseAst, parseAstAsync } from 'rollup/parseAst';
                                          ~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/vite/dist/node/index.d.ts:5
```

similar to what we did in https://github.com/microsoft/playwright/pull/34704.