### PR TITLE
chore: remove 'as *' imports because of `esModuleInterop: true`

### DIFF
--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -47,7 +47,7 @@ Create `tests/auth.setup.ts` that will prepare authenticated browser state for a
 
 ```js title="tests/auth.setup.ts"
 import { test as setup, expect } from '@playwright/test';
-import * as path from 'path';
+import path from 'path';
 
 const authFile = path.join(__dirname, '../playwright/.auth/user.json');
 
@@ -143,8 +143,8 @@ Create `playwright/fixtures.ts` file that will [override `storageState` fixture]
 
 ```js title="playwright/fixtures.ts"
 import { test as baseTest, expect } from '@playwright/test';
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 export * from '@playwright/test';
 export const test = baseTest.extend<{}, { workerStorageState: string }>({
@@ -348,8 +348,8 @@ Alternatively, in a [worker fixture](#moderate-one-account-per-parallel-worker):
 
 ```js title="playwright/fixtures.ts"
 import { test as baseTest, request } from '@playwright/test';
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 export * from '@playwright/test';
 export const test = baseTest.extend<{}, { workerStorageState: string }>({

--- a/docs/src/chrome-extensions-js-python.md
+++ b/docs/src/chrome-extensions-js-python.md
@@ -109,7 +109,7 @@ First, add fixtures that will load the extension:
 
 ```js title="fixtures.ts"
 import { test as base, chromium, type BrowserContext } from '@playwright/test';
-import * as path from 'path';
+import path from 'path';
 
 export const test = base.extend<{
   context: BrowserContext;

--- a/docs/src/evaluating.md
+++ b/docs/src/evaluating.md
@@ -389,7 +389,7 @@ Next, add init script to the page.
 
 ```js
 import { test, expect } from '@playwright/test';
-import * as path from 'path';
+import path from 'path';
 
 test.beforeEach(async ({ page }) => {
   // Add script for every test in the beforeEach hook.

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -291,7 +291,7 @@ Here is an example that uses [`method: TestInfo.outputPath`] to create a tempora
 
 ```js
 import { test, expect } from '@playwright/test';
-import * as fs from 'fs';
+import fs from 'fs';
 
 test('example test', async ({}, testInfo) => {
   const file = testInfo.outputPath('temporary-file.txt');

--- a/docs/src/test-api/class-testinfo.md
+++ b/docs/src/test-api/class-testinfo.md
@@ -254,7 +254,7 @@ Returns a path inside the [`property: TestInfo.outputDir`] where the test can sa
 
 ```js
 import { test, expect } from '@playwright/test';
-import * as fs from 'fs';
+import fs from 'fs';
 
 test('example test', async ({}, testInfo) => {
   const file = testInfo.outputPath('dir', 'temporary-file.txt');

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -212,7 +212,7 @@ Here is an example that uses [`method: TestInfo.outputPath`] to create a tempora
 
 ```js
 import { test, expect } from '@playwright/test';
-import * as fs from 'fs';
+import fs from 'fs';
 
 test('example test', async ({}, testInfo) => {
   const file = testInfo.outputPath('temporary-file.txt');

--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -408,7 +408,7 @@ Here is an example fixture that automatically attaches debug logs when the test 
 
 ```js title="my-test.ts"
 import debug from 'debug';
-import * as fs from 'fs';
+import fs from 'fs';
 import { test as base } from '@playwright/test';
 
 export const test = base.extend<{ saveLogs: void }>({

--- a/docs/src/test-parameterize-js.md
+++ b/docs/src/test-parameterize-js.md
@@ -262,7 +262,7 @@ To make environment variables easier to manage, consider something like `.env` f
 ```js title="playwright.config.ts"
 import { defineConfig } from '@playwright/test';
 import dotenv from 'dotenv';
-import * as path from 'path';
+import path from 'path';
 
 // Read from ".env" file.
 dotenv.config({ path: path.resolve(__dirname, '.env') });
@@ -309,8 +309,8 @@ See for example this CSV file, in our example `input.csv`:
 Based on this we'll generate some tests by using the [csv-parse](https://www.npmjs.com/package/csv-parse) library from NPM:
 
 ```js title="test.spec.ts"
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { test } from '@playwright/test';
 import { parse } from 'csv-parse/sync';
 

--- a/docs/src/webview2.md
+++ b/docs/src/webview2.md
@@ -72,9 +72,9 @@ Using the following, Playwright will run your WebView2 application as a sub-proc
 
 ```js title="webView2Test.ts"
 import { test as base } from '@playwright/test';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import childProcess from 'child_process';
 
 const EXECUTABLE_PATH = path.join(

--- a/packages/html-reporter/bundle.ts
+++ b/packages/html-reporter/bundle.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import type { Plugin, UserConfig } from 'vite';
 
 export function bundle(): Plugin {

--- a/packages/html-reporter/playwright.config.ts
+++ b/packages/html-reporter/playwright.config.ts
@@ -15,8 +15,8 @@
  */
 
 import { devices, defineConfig } from '@playwright/experimental-ct-react';
-import * as path from 'path';
-import * as url from 'url';
+import path from 'path';
+import url from 'url';
 
 export default defineConfig({
   testDir: 'src',

--- a/packages/html-reporter/vite.config.ts
+++ b/packages/html-reporter/vite.config.ts
@@ -17,7 +17,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { bundle } from './bundle';
-import * as path from 'path';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/packages/playwright-core/src/cli/driver.ts
+++ b/packages/playwright-core/src/cli/driver.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable no-console */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 import * as playwright from '../..';
 import { PipeTransport } from '../server/utils/pipeTransport';

--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -16,9 +16,9 @@
 
 /* eslint-disable no-console */
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import * as playwright from '../..';
 import { launchBrowserServer, printApiJson, runDriver, runServer } from './driver';

--- a/packages/playwright-core/src/outofprocess.ts
+++ b/packages/playwright-core/src/outofprocess.ts
@@ -15,7 +15,7 @@
  */
 
 import * as childProcess from 'child_process';
-import * as path from 'path';
+import path from 'path';
 
 import { createConnectionFactory } from './client/clientBundle';
 import { PipeTransport } from './server/utils/pipeTransport';

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -15,9 +15,9 @@
  */
 
 import { EventEmitter } from 'events';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { TimeoutSettings } from '../timeoutSettings';
 import { PipeTransport } from '../utils/pipeTransport';

--- a/packages/playwright-core/src/server/android/backendAdb.ts
+++ b/packages/playwright-core/src/server/android/backendAdb.ts
@@ -15,7 +15,7 @@
  */
 
 import { EventEmitter } from 'events';
-import * as net from 'net';
+import net from 'net';
 
 import { assert } from '../../utils/isomorphic/assert';
 import { createGuid } from '../utils/crypto';

--- a/packages/playwright-core/src/server/artifact.ts
+++ b/packages/playwright-core/src/server/artifact.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 import { assert } from '../utils';
 import { TargetClosedError } from './errors';

--- a/packages/playwright-core/src/server/bidi/bidiChromium.ts
+++ b/packages/playwright-core/src/server/bidi/bidiChromium.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as os from 'os';
+import os from 'os';
 
 import { assert } from '../../utils';
 import { wrapInASCIIBox } from '../utils/ascii';

--- a/packages/playwright-core/src/server/bidi/bidiFirefox.ts
+++ b/packages/playwright-core/src/server/bidi/bidiFirefox.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as os from 'os';
-import * as path from 'path';
+import os from 'os';
+import path from 'path';
 
 import { assert } from '../../utils';
 import { wrapInASCIIBox } from '../utils/ascii';

--- a/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 /* eslint-disable curly, indent */
 

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { TimeoutSettings } from './timeoutSettings';
 import { createGuid } from './utils/crypto';

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { normalizeProxySettings, validateBrowserContextOptions } from './browserContext';
 import { DEFAULT_TIMEOUT, TimeoutSettings } from './timeoutSettings';

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { chromiumSwitches } from './chromiumSwitches';
 import { CRBrowser } from './crBrowser';

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { assert } from '../../utils/isomorphic/assert';
 import { createGuid } from '../utils/crypto';

--- a/packages/playwright-core/src/server/chromium/crDevTools.ts
+++ b/packages/playwright-core/src/server/chromium/crDevTools.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 import type { CRSession } from './crConnection';
 

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { assert } from '../../utils/isomorphic/assert';
 import { createGuid } from '../utils/crypto';

--- a/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
+++ b/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 import { splitErrorMessage } from '../../utils/isomorphic/stackTrace';
 import { mkdirIfNeeded } from '../utils/fileUtils';

--- a/packages/playwright-core/src/server/dispatchers/artifactDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/artifactDispatcher.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 import { Dispatcher, existingDispatcher } from './dispatcher';
 import { StreamDispatcher } from './streamDispatcher';

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { BrowserContext } from '../browserContext';
 import { ArtifactDispatcher } from './artifactDispatcher';

--- a/packages/playwright-core/src/server/dispatchers/writableStreamDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/writableStreamDispatcher.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 import { Dispatcher } from './dispatcher';
 import { createGuid } from '../utils/crypto';

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 import * as js from './javascript';
 import { ProgressController } from './progress';

--- a/packages/playwright-core/src/server/download.ts
+++ b/packages/playwright-core/src/server/download.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { Page } from './page';
 import { assert } from '../utils';

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import * as readline from 'readline';
 
 import { TimeoutSettings } from '../timeoutSettings';

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import * as http from 'http';
-import * as https from 'https';
+import http from 'http';
+import https from 'https';
 import { Transform, pipeline } from 'stream';
 import { TLSSocket } from 'tls';
-import * as url from 'url';
+import url from 'url';
 import * as zlib from 'zlib';
 
 import { TimeoutSettings } from './timeoutSettings';

--- a/packages/playwright-core/src/server/fileUploadUtils.ts
+++ b/packages/playwright-core/src/server/fileUploadUtils.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { assert } from '../utils/isomorphic/assert';
 import { mime } from '../utilsBundle';

--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import * as os from 'os';
-import * as path from 'path';
+import os from 'os';
+import path from 'path';
 
 import { FFBrowser } from './ffBrowser';
 import { kBrowserCloseMessageId } from './ffConnection';

--- a/packages/playwright-core/src/server/har/harRecorder.ts
+++ b/packages/playwright-core/src/server/har/harRecorder.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { Artifact } from '../artifact';
 import { HarTracer } from './harTracer';

--- a/packages/playwright-core/src/server/harBackend.ts
+++ b/packages/playwright-core/src/server/harBackend.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { createGuid } from './utils/crypto';
 import { ZipFile } from './utils/zipFile';

--- a/packages/playwright-core/src/server/launchApp.ts
+++ b/packages/playwright-core/src/server/launchApp.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { isUnderTest } from '../utils';
 import { serverSideCallMetadata } from './instrumentation';

--- a/packages/playwright-core/src/server/localUtils.ts
+++ b/packages/playwright-core/src/server/localUtils.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { calculateSha1 } from './utils/crypto';
 import { HarBackend } from './harBackend';

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 import * as consoleApiSource from '../generated/consoleApiSource';
 import { isUnderTest } from '../utils';

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -15,8 +15,8 @@
  */
 
 import { EventEmitter } from 'events';
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { isUnderTest } from '../utils/debug';
 import { mime } from '../../utilsBundle';

--- a/packages/playwright-core/src/server/recorder/throttledFile.ts
+++ b/packages/playwright-core/src/server/recorder/throttledFile.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 export class ThrottledFile {
   private _file: string;

--- a/packages/playwright-core/src/server/registry/browserFetcher.ts
+++ b/packages/playwright-core/src/server/registry/browserFetcher.ts
@@ -16,9 +16,9 @@
  */
 
 import * as childProcess from 'child_process';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { debugLogger } from '../utils/debugLogger';
 import { ManualPromise } from '../../utils/isomorphic/manualPromise';

--- a/packages/playwright-core/src/server/registry/dependencies.ts
+++ b/packages/playwright-core/src/server/registry/dependencies.ts
@@ -15,9 +15,9 @@
  */
 
 import * as childProcess from 'child_process';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { deps } from './nativeDeps';
 import { wrapInASCIIBox } from '../utils/ascii';

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import * as util from 'util';
 
 import { downloadBrowserWithProgressBar, logPolitely } from './browserFetcher';

--- a/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
+++ b/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { ManualPromise } from '../../utils/isomorphic/manualPromise';
 import { httpRequest } from '../utils/network';

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -15,10 +15,10 @@
  */
 
 import { EventEmitter } from 'events';
-import * as http2 from 'http2';
-import * as net from 'net';
-import * as stream from 'stream';
-import * as tls from 'tls';
+import http2 from 'http2';
+import net from 'net';
+import stream from 'stream';
+import tls from 'tls';
 
 import { SocksProxy } from './utils/socksProxy';
 import { ManualPromise, escapeHTML, generateSelfSignedCertificate, rewriteErrorMessage } from '../utils';

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { Snapshotter } from './snapshotter';
 import { commandsWithTracingSnapshots } from '../../../protocol/debug';

--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { gracefullyProcessExitDoNotHang } from '../../../utils';
 import { isUnderTest } from '../../../utils';

--- a/packages/playwright-core/src/server/utils/crypto.ts
+++ b/packages/playwright-core/src/server/utils/crypto.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as crypto from 'crypto';
+import crypto from 'crypto';
 
 import { assert } from '../../utils/isomorphic/assert';
 

--- a/packages/playwright-core/src/server/utils/debugLogger.ts
+++ b/packages/playwright-core/src/server/utils/debugLogger.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 import { debug } from '../../utilsBundle';
 

--- a/packages/playwright-core/src/server/utils/fileUtils.ts
+++ b/packages/playwright-core/src/server/utils/fileUtils.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { ManualPromise } from '../../utils/isomorphic/manualPromise';
 import { yazl } from '../../zipBundle';

--- a/packages/playwright-core/src/server/utils/happyEyeballs.ts
+++ b/packages/playwright-core/src/server/utils/happyEyeballs.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import * as dns from 'dns';
-import * as http from 'http';
-import * as https from 'https';
-import * as net from 'net';
-import * as tls from 'tls';
+import dns from 'dns';
+import http from 'http';
+import https from 'https';
+import net from 'net';
+import tls from 'tls';
 
 import { assert } from '../../utils/isomorphic/assert';
 import { ManualPromise } from '../../utils/isomorphic/manualPromise';

--- a/packages/playwright-core/src/server/utils/hostPlatform.ts
+++ b/packages/playwright-core/src/server/utils/hostPlatform.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as os from 'os';
+import os from 'os';
 
 import { getLinuxDistributionInfoSync } from './linuxUtils';
 

--- a/packages/playwright-core/src/server/utils/httpServer.ts
+++ b/packages/playwright-core/src/server/utils/httpServer.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { mime, wsServer } from '../../utilsBundle';
 import { createGuid } from './crypto';

--- a/packages/playwright-core/src/server/utils/linuxUtils.ts
+++ b/packages/playwright-core/src/server/utils/linuxUtils.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 let didFailToReadOSRelease = false;
 let osRelease: {

--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -15,10 +15,10 @@
  */
 
 
-import * as http from 'http';
-import * as http2 from 'http2';
-import * as https from 'https';
-import * as url from 'url';
+import http from 'http';
+import http2 from 'http2';
+import https from 'https';
+import url from 'url';
 
 import { HttpsProxyAgent, getProxyForUrl } from '../../utilsBundle';
 import { httpHappyEyeballsAgent, httpsHappyEyeballsAgent } from './happyEyeballs';

--- a/packages/playwright-core/src/server/utils/nodePlatform.ts
+++ b/packages/playwright-core/src/server/utils/nodePlatform.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as crypto from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
 import * as util from 'util';
 import { Readable, Writable, pipeline } from 'stream';
 import { EventEmitter } from 'events';

--- a/packages/playwright-core/src/server/utils/processLauncher.ts
+++ b/packages/playwright-core/src/server/utils/processLauncher.ts
@@ -16,7 +16,7 @@
  */
 
 import * as childProcess from 'child_process';
-import * as fs from 'fs';
+import fs from 'fs';
 import * as readline from 'readline';
 
 import { removeFolders } from './fileUtils';

--- a/packages/playwright-core/src/server/utils/profiler.ts
+++ b/packages/playwright-core/src/server/utils/profiler.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 const profileDir = process.env.PWTEST_PROFILE_DIR || '';
 

--- a/packages/playwright-core/src/server/utils/socksProxy.ts
+++ b/packages/playwright-core/src/server/utils/socksProxy.ts
@@ -15,7 +15,7 @@
  */
 
 import EventEmitter from 'events';
-import * as net from 'net';
+import net from 'net';
 
 import { assert } from '../../utils/isomorphic/assert';
 import { createGuid } from './crypto';

--- a/packages/playwright-core/src/server/utils/userAgent.ts
+++ b/packages/playwright-core/src/server/utils/userAgent.ts
@@ -15,7 +15,7 @@
  */
 
 import { execSync } from 'child_process';
-import * as os from 'os';
+import os from 'os';
 
 import { getLinuxDistributionInfoSync } from '../utils/linuxUtils';
 

--- a/packages/playwright-core/src/server/webkit/webkit.ts
+++ b/packages/playwright-core/src/server/webkit/webkit.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { kBrowserCloseMessageId } from './wkConnection';
 import { wrapInASCIIBox } from '../utils/ascii';

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { assert } from '../../utils';
 import { headersArrayToObject } from '../../utils/isomorphic/headers';

--- a/packages/playwright-ct-core/src/devServer.ts
+++ b/packages/playwright-ct-core/src/devServer.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { Watcher } from 'playwright/lib/fsWatcher';
 

--- a/packages/playwright-ct-core/src/tsxTransform.ts
+++ b/packages/playwright-ct-core/src/tsxTransform.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { declare, traverse, types } from 'playwright/lib/transform/babelBundle';
 import { setTransformData } from 'playwright/lib/transform/transform';

--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { setExternalDependencies } from 'playwright/lib/transform/compilationCache';
 import { resolveHook } from 'playwright/lib/transform/transform';

--- a/packages/playwright-ct-core/src/viteUtils.ts
+++ b/packages/playwright-ct-core/src/viteUtils.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { getUserData } from 'playwright/lib/transform/compilationCache';
 import { resolveHook } from 'playwright/lib/transform/transform';

--- a/packages/playwright/bundles/babel/src/babelBundleImpl.ts
+++ b/packages/playwright/bundles/babel/src/babelBundleImpl.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import * as babel from '@babel/core';
 import traverseFunction from '@babel/traverse';

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { getPackageJsonPath, mergeObjects } from '../util';
 

--- a/packages/playwright/src/common/configLoader.ts
+++ b/packages/playwright/src/common/configLoader.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { gracefullyProcessExitDoNotHang } from 'playwright-core/lib/utils';
 import { isRegExp } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/common/esmLoaderHost.ts
+++ b/packages/playwright/src/common/esmLoaderHost.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as url from 'url';
+import url from 'url';
 
 import { addToCompilationCache, serializeCompilationCache } from '../transform/compilationCache';
 import { PortTransport } from '../transform/portTransport';

--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as crypto from 'crypto';
+import crypto from 'crypto';
 
 import { filterStackFile, formatLocation } from '../util';
 

--- a/packages/playwright/src/common/suiteUtils.ts
+++ b/packages/playwright/src/common/suiteUtils.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import * as path from 'path';
+import path from 'path';
 
 import { calculateSha1, toPosixPath } from 'playwright-core/lib/utils';
 

--- a/packages/playwright/src/common/testLoader.ts
+++ b/packages/playwright/src/common/testLoader.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 import util from 'util';
 
 import * as esmLoaderHost from './esmLoaderHost';

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import * as playwrightLibrary from 'playwright-core';
 import { setBoxedStackPrefixes, asLocator, createGuid, currentZone, debugMode, isString, jsonStringifyForceASCII } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/internalsForTest.ts
+++ b/packages/playwright/src/internalsForTest.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { fileDependenciesForTest } from './transform/compilationCache';
 

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -15,8 +15,8 @@
  */
 
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { escapeTemplateString, isString, sanitizeForFilePath } from 'playwright-core/lib/utils';
 

--- a/packages/playwright/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchSnapshot.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { compareBuffersOrStrings, getComparator, isString, sanitizeForFilePath } from 'playwright-core/lib/utils';
 import { colors } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as net from 'net';
-import * as path from 'path';
+import net from 'net';
+import path from 'path';
 
 import { launchProcess, isURLAvailable, monotonicTime, raceAgainstDeadline } from 'playwright-core/lib/utils';
 import { colors } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -16,8 +16,8 @@
 
 /* eslint-disable no-console */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { program } from 'playwright-core/lib/cli/program';
 import { gracefullyProcessExitDoNotHang, startProfiling, stopProfiling } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { getPackageManagerExecCommand } from 'playwright-core/lib/utils';
 import { parseStackFrame } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/reporters/blob.ts
+++ b/packages/playwright/src/reporters/blob.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { Readable } from 'stream';
 
 import { removeFolders, sanitizeForFilePath } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/reporters/github.ts
+++ b/packages/playwright/src/reporters/github.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { noColors } from 'playwright-core/lib/utils';
 import { ms as milliseconds } from 'playwright-core/lib/utilsBundle';

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { Transform } from 'stream';
 
 import { HttpServer, MultiMap, assert, calculateSha1, getPackageManagerExecCommand, copyFileAndMakeWritable, gracefullyProcessExitDoNotHang, removeFolders, sanitizeForFilePath, toPosixPath } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/reporters/internalReporter.ts
+++ b/packages/playwright/src/reporters/internalReporter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 
 import { monotonicTime } from 'playwright-core/lib/utils';
 

--- a/packages/playwright/src/reporters/json.ts
+++ b/packages/playwright/src/reporters/json.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { toPosixPath, MultiMap } from 'playwright-core/lib/utils';
 

--- a/packages/playwright/src/reporters/junit.ts
+++ b/packages/playwright/src/reporters/junit.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { getAsBooleanFromENV } from 'playwright-core/lib/utils';
 

--- a/packages/playwright/src/reporters/markdown.ts
+++ b/packages/playwright/src/reporters/markdown.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { resolveReporterOutputPath } from '../util';
 import { TerminalReporter } from './base';

--- a/packages/playwright/src/reporters/merge.ts
+++ b/packages/playwright/src/reporters/merge.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { ZipFile } from 'playwright-core/lib/utils';
 

--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { createGuid } from 'playwright-core/lib/utils';
 

--- a/packages/playwright/src/runner/lastRun.ts
+++ b/packages/playwright/src/runner/lastRun.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { filterProjects } from './projectUtils';
 

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { InProcessLoaderHost, OutOfProcessLoaderHost } from './loaderHost';
 import { createFileFiltersFromArguments, createFileMatcherFromArguments, createTitleMatcher, errorWithFile, forceRegExp } from '../util';

--- a/packages/playwright/src/runner/projectUtils.ts
+++ b/packages/playwright/src/runner/projectUtils.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { promisify } from 'util';
 
 import { escapeRegExp } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/runner/rebase.ts
+++ b/packages/playwright/src/runner/rebase.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 
 import { MultiMap } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/runner/reporters.ts
+++ b/packages/playwright/src/runner/reporters.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 
 import { calculateSha1 } from 'playwright-core/lib/utils';
 

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { promisify } from 'util';
 
 import { monotonicTime, removeFolders } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { installRootRedirect, openTraceInBrowser, openTraceViewerApp, registry, startTraceViewerServer } from 'playwright-core/lib/server';
 import { ManualPromise, isUnderTest, gracefullyProcessExitDoNotHang } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/runner/vcs.ts
+++ b/packages/playwright/src/runner/vcs.ts
@@ -15,7 +15,7 @@
  */
 
 import childProcess from 'child_process';
-import * as path from 'path';
+import path from 'path';
 
 import { affectedTestFiles } from '../transform/compilationCache';
 

--- a/packages/playwright/src/runner/watchMode.ts
+++ b/packages/playwright/src/runner/watchMode.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import path from 'path';
 import readline from 'readline';
 import { EventEmitter } from 'stream';
 

--- a/packages/playwright/src/runner/workerHost.ts
+++ b/packages/playwright/src/runner/workerHost.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { removeFolders } from 'playwright-core/lib/utils';
 

--- a/packages/playwright/src/third_party/tsconfig-loader.ts
+++ b/packages/playwright/src/third_party/tsconfig-loader.ts
@@ -24,8 +24,8 @@
 
 /* eslint-disable */
 
-import * as path from 'path';
-import * as fs from 'fs';
+import path from 'path';
+import fs from 'fs';
 import { json5 } from '../utilsBundle';
 
 /**

--- a/packages/playwright/src/transform/compilationCache.ts
+++ b/packages/playwright/src/transform/compilationCache.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { isWorkerProcess } from '../common/globals';
 import { sourceMapSupport } from '../utilsBundle';

--- a/packages/playwright/src/transform/esmLoader.ts
+++ b/packages/playwright/src/transform/esmLoader.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as url from 'url';
+import fs from 'fs';
+import url from 'url';
 
 import { addToCompilationCache, currentFileDepsCollector, serializeCompilationCache, startCollectingFileDeps, stopCollectingFileDeps } from './compilationCache';
 import { PortTransport } from './portTransport';

--- a/packages/playwright/src/transform/esmUtils.ts
+++ b/packages/playwright/src/transform/esmUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as url from 'url';
+import url from 'url';
 
 const kExperimentalLoaderOptions = [
   '--no-warnings',

--- a/packages/playwright/src/transform/transform.ts
+++ b/packages/playwright/src/transform/transform.ts
@@ -15,10 +15,10 @@
  */
 
 import crypto from 'crypto';
-import * as fs from 'fs';
+import fs from 'fs';
 import Module from 'module';
-import * as path from 'path';
-import * as url from 'url';
+import path from 'path';
+import url from 'url';
 
 import { loadTsConfig } from '../third_party/tsconfig-loader';
 import { createFileMatcher, fileIsModule, resolveImportSpecifierAfterMapping } from '../util';

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import * as url from 'url';
+import fs from 'fs';
+import path from 'path';
+import url from 'url';
 import util from 'util';
 
 import { parseStackFrame, sanitizeForFilePath, calculateSha1, isRegExp, isString, stringifyStackFrames } from 'playwright-core/lib/utils';

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { captureRawStack, monotonicTime, sanitizeForFilePath, stringifyStackFrames, currentZone } from 'playwright-core/lib/utils';
 

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { ManualPromise, SerializedFS, calculateSha1, createGuid, monotonicTime } from 'playwright-core/lib/utils';
 import { yauzl, yazl } from 'playwright-core/lib/zipBundle';

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -371,7 +371,7 @@ interface TestProject<TestArgs = {}, WorkerArgs = {}> {
    *
    * ```js
    * import { test, expect } from '@playwright/test';
-   * import * as fs from 'fs';
+   * import fs from 'fs';
    *
    * test('example test', async ({}, testInfo) => {
    *   const file = testInfo.outputPath('temporary-file.txt');
@@ -1349,7 +1349,7 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    *
    * ```js
    * import { test, expect } from '@playwright/test';
-   * import * as fs from 'fs';
+   * import fs from 'fs';
    *
    * test('example test', async ({}, testInfo) => {
    *   const file = testInfo.outputPath('temporary-file.txt');
@@ -9215,7 +9215,7 @@ export interface TestInfo {
    *
    * ```js
    * import { test, expect } from '@playwright/test';
-   * import * as fs from 'fs';
+   * import fs from 'fs';
    *
    * test('example test', async ({}, testInfo) => {
    *   const file = testInfo.outputPath('dir', 'temporary-file.txt');

--- a/packages/recorder/tsconfig.json
+++ b/packages/recorder/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": true,
     "skipLibCheck": false,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "module": "ESNext",

--- a/packages/recorder/vite.config.ts
+++ b/packages/recorder/vite.config.ts
@@ -16,7 +16,7 @@
 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import * as path from 'path';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/packages/trace-viewer/vite.config.ts
+++ b/packages/trace-viewer/vite.config.ts
@@ -17,7 +17,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { bundle } from './bundle';
-import * as path from 'path';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/packages/trace-viewer/vite.sw.config.ts
+++ b/packages/trace-viewer/vite.sw.config.ts
@@ -17,7 +17,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { bundle } from './bundle';
-import * as path from 'path';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
Turns out neither `as *` nor `without` is an import without any hacks. Its either wrapped in `_interopRequireWildcard` or in the  `_interopRequireDefault` function. See:

```ts
function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != typeof e && "function" != typeof e) return { default: e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n.default = e, t && t.set(e, n), n; }
```

This PR changes it back to how it was with the simpler wrapping function which makes the code in the docs and `//packages` more readable.