### PR TITLE
chore: manually add exception for esbuild vulnerability

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -35,7 +35,7 @@ jobs:
           exit 1
         fi
     - name: Audit prod NPM dependencies
-      run: npm audit --omit dev
+      run: node utils/check_audit.js
   lint-snippets:
     name: "Lint snippets"
     runs-on: ubuntu-latest

--- a/packages/trace-viewer/src/ui/consoleTab.tsx
+++ b/packages/trace-viewer/src/ui/consoleTab.tsx
@@ -72,7 +72,7 @@ export function useConsoleTabModel(model: modelUtil.MultiTraceModel | undefined,
       const aTimestamp = 'time' in a ? a.time : a.timestamp;
       const bTimestamp = 'time' in b ? b.time : b.timestamp;
       return aTimestamp - bTimestamp;
-    })
+    });
     for (const event of logEvents) {
       if (event.type === 'console') {
         const body = event.args && event.args.length ? format(event.args) : formatAnsi(event.text);

--- a/utils/check_audit.js
+++ b/utils/check_audit.js
@@ -1,0 +1,54 @@
+const { exec } = require('child_process');
+
+const URL_LIST = [
+  // Not encountered by Vite, thus we cannot hit it
+  'https://github.com/advisories/GHSA-67mh-4wv8-2f99'
+];
+
+const runNpmAudit = () => new Promise((resolve, reject) => {
+  exec('npm audit --omit dev --json', (error, stdout, stderr) => {
+    if (error && stderr) {
+      // npm audit returns a non-zero exit code if there are vulnerabilities
+      reject(`Audit error: ${error}\n${stdout}\n${stderr}`);
+      return;
+    }
+    resolve(stdout);
+  });
+});
+
+// interface Audit {
+//   [name: string]: AuditEntry;
+// }
+
+// interface AuditEntry {
+//   severity: string;
+//   range: string;
+//   via: Array<{
+//     url: string;
+//   } | string>;
+// }
+
+const checkAudit = async () => {
+  const audit = JSON.parse(await runNpmAudit());
+
+  const validVulnerabilities = Object.entries(audit.vulnerabilities).filter(([_name, entry]) => {
+    const originalVulnerabilities = entry.via.filter(viaEntry => typeof viaEntry === 'object' && !URL_LIST.includes(viaEntry.url));
+    return originalVulnerabilities.length > 0;
+  });
+
+  for (const [name, entry] of validVulnerabilities) {
+    console.error(`Vulnerability (${entry.severity}): ${name} ${entry.range}`);
+  }
+
+  if (validVulnerabilities.length > 0) {
+    process.exit(1);
+  }
+
+  console.log('No vulnerabilities found');
+};
+
+// You can manually run `npm audit --omit dev` to see the vulnerabilities in a human-friendly
+checkAudit().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
`esbuild` has a [recent minor vulnerability](https://github.com/advisories/GHSA-67mh-4wv8-2f99) that is flagging our CI process. `esbuild` is only included into the Playwright monorepo via Vite. [Vite has confirmed that the vulnerability does not apply](https://github.com/vitejs/vite/issues/19412).

`npm audit` doesn't provide many tools for filtering. To prevent this problem in the future, add a small script to check for the matched vulnerability URLs, allowing us to filter.