### PR TITLE
fix(drag-n-drop): send two mousemove events to target to make Angular CDK work

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1210,6 +1210,10 @@ export class Frame extends SdkObject {
       // Note: do not perform locator handlers checkpoint to avoid moving the mouse in the middle of a drag operation.
       dom.assertDone(await this._retryWithProgressIfNotConnected(progress, target, options.strict, false /* performActionPreChecks */, async handle => {
         return handle._retryPointerAction(progress, 'move and up', false, async point => {
+          // NOTE: Normal browsers emit usually a lot of dragover/mousemove events during drag'n
+          // drop operations. We want to emit minimal to make the ecosystem work. When using
+          // Native drag'n drop the browser does emit dropover events instead.
+          await this._page.mouse.move(point.x, point.y);
           await this._page.mouse.move(point.x, point.y);
           await this._page.mouse.up();
         }, {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1211,8 +1211,7 @@ export class Frame extends SdkObject {
       dom.assertDone(await this._retryWithProgressIfNotConnected(progress, target, options.strict, false /* performActionPreChecks */, async handle => {
         return handle._retryPointerAction(progress, 'move and up', false, async point => {
           // NOTE: Normal browsers emit usually a lot of dragover/mousemove events during drag'n
-          // drop operations. We want to emit minimal to make the ecosystem work. When using
-          // Native drag'n drop the browser does emit dropover events instead.
+          // drop operations. We want to emit minimal (2) to make Angular CDK work.
           await this._page.mouse.move(point.x, point.y);
           await this._page.mouse.move(point.x, point.y);
           await this._page.mouse.up();

--- a/tests/assets/drag-n-drop-manual.html
+++ b/tests/assets/drag-n-drop-manual.html
@@ -62,7 +62,6 @@ div:not(.mouse-helper) {
           sourceElement.style.border = 'dashed'
         });
         
-        // Mouse move handler - move the element
         document.addEventListener('mousemove', function(e) {
           if (!isDragging) return;
           
@@ -70,7 +69,6 @@ div:not(.mouse-helper) {
           sourceElement.style.top = (e.clientY - offsetY) + 'px';
         });
         
-        // Mouse up handler - stop dragging and check if dropped on target
         document.addEventListener('mouseup', function(e) {
           if (!isDragging) return;
           

--- a/tests/assets/drag-n-drop-manual.html
+++ b/tests/assets/drag-n-drop-manual.html
@@ -39,42 +39,33 @@ div:not(.mouse-helper) {
       <div id="target">Drop Zone</div>
     
       <script>
-        // Elements
         const sourceElement = document.getElementById('source');
         const targetElement = document.getElementById('target');
         
-        // State variables
         let isDragging = false;
         let offsetX, offsetY;
         let originalPosition = { left: 0, top: 0 };
         
-        // Mouse down handler - start dragging
         sourceElement.addEventListener('mousedown', function(e) {
           e.preventDefault();
           
-          // Store the original position
           const rect = sourceElement.getBoundingClientRect();
           originalPosition = {
             left: rect.left,
             top: rect.top
           };
           
-          // Calculate the mouse offset
           offsetX = e.clientX - rect.left;
           offsetY = e.clientY - rect.top;
           
-          // Start dragging
           isDragging = true;
           sourceElement.style.border = 'dashed'
-          
-          console.log('mousedown', e.clientX, e.clientY);
         });
         
         // Mouse move handler - move the element
         document.addEventListener('mousemove', function(e) {
           if (!isDragging) return;
           
-          // Set new position
           sourceElement.style.left = (e.clientX - offsetX) + 'px';
           sourceElement.style.top = (e.clientY - offsetY) + 'px';
         });
@@ -85,7 +76,6 @@ div:not(.mouse-helper) {
           
           isDragging = false;
           
-          // Check if dropped on target area
           const sourceRect = sourceElement.getBoundingClientRect();
           const targetRect = targetElement.getBoundingClientRect();
           
@@ -97,17 +87,14 @@ div:not(.mouse-helper) {
           );
           
           if (isOverlapping) {
-            // Successful drop - append to target
             targetElement.appendChild(sourceElement);
             
-            // Reset position relative to the new parent
             sourceElement.style.removeProperty('position')
             sourceElement.style.removeProperty('top')
             sourceElement.style.removeProperty('left')
             
             console.log('Drop successful');
           } else {
-            // Failed drop - return to original position
             sourceElement.style.left = originalPosition.left + 'px';
             sourceElement.style.top = originalPosition.top + 'px';
             
@@ -115,12 +102,10 @@ div:not(.mouse-helper) {
           }
         });
         
-        // Cancel dragging if mouse leaves the window
         document.addEventListener('mouseleave', function() {
           if (isDragging) {
             isDragging = false;
             
-            // Return to original position
             sourceElement.style.left = originalPosition.left + 'px';
             sourceElement.style.top = originalPosition.top + 'px';
           }

--- a/tests/assets/drag-n-drop-manual.html
+++ b/tests/assets/drag-n-drop-manual.html
@@ -1,0 +1,129 @@
+<style>
+* {
+  box-sizing: border-box;
+}
+body, html {
+  margin: 0;
+  padding: 0;
+}
+div:not(.mouse-helper) {
+  margin: 0;
+  padding: 0;
+}
+#source {
+  color: blue;
+  border: 1px solid black;
+  position: absolute;
+  left: 20px;
+  top: 20px;
+  width: 200px;
+  height: 100px;
+  cursor: move;
+  user-select: none;
+}
+#target {
+  border: 1px solid black;
+  position: absolute;
+  left: 40px;
+  top: 200px;
+  width: 400px;
+  height: 300px;
+}
+</style>
+    
+    <body>
+      <div>
+        <p id="source">
+          Select this element, drag it to the Drop Zone and then release the selection to move the element.</p>
+      </div>
+      <div id="target">Drop Zone</div>
+    
+      <script>
+        // Elements
+        const sourceElement = document.getElementById('source');
+        const targetElement = document.getElementById('target');
+        
+        // State variables
+        let isDragging = false;
+        let offsetX, offsetY;
+        let originalPosition = { left: 0, top: 0 };
+        
+        // Mouse down handler - start dragging
+        sourceElement.addEventListener('mousedown', function(e) {
+          e.preventDefault();
+          
+          // Store the original position
+          const rect = sourceElement.getBoundingClientRect();
+          originalPosition = {
+            left: rect.left,
+            top: rect.top
+          };
+          
+          // Calculate the mouse offset
+          offsetX = e.clientX - rect.left;
+          offsetY = e.clientY - rect.top;
+          
+          // Start dragging
+          isDragging = true;
+          sourceElement.style.border = 'dashed'
+          
+          console.log('mousedown', e.clientX, e.clientY);
+        });
+        
+        // Mouse move handler - move the element
+        document.addEventListener('mousemove', function(e) {
+          if (!isDragging) return;
+          
+          // Set new position
+          sourceElement.style.left = (e.clientX - offsetX) + 'px';
+          sourceElement.style.top = (e.clientY - offsetY) + 'px';
+        });
+        
+        // Mouse up handler - stop dragging and check if dropped on target
+        document.addEventListener('mouseup', function(e) {
+          if (!isDragging) return;
+          
+          isDragging = false;
+          
+          // Check if dropped on target area
+          const sourceRect = sourceElement.getBoundingClientRect();
+          const targetRect = targetElement.getBoundingClientRect();
+          
+          const isOverlapping = !(
+            sourceRect.right < targetRect.left || 
+            sourceRect.left > targetRect.right || 
+            sourceRect.bottom < targetRect.top || 
+            sourceRect.top > targetRect.bottom
+          );
+          
+          if (isOverlapping) {
+            // Successful drop - append to target
+            targetElement.appendChild(sourceElement);
+            
+            // Reset position relative to the new parent
+            sourceElement.style.removeProperty('position')
+            sourceElement.style.removeProperty('top')
+            sourceElement.style.removeProperty('left')
+            
+            console.log('Drop successful');
+          } else {
+            // Failed drop - return to original position
+            sourceElement.style.left = originalPosition.left + 'px';
+            sourceElement.style.top = originalPosition.top + 'px';
+            
+            console.log('Drop failed - returning to original position');
+          }
+        });
+        
+        // Cancel dragging if mouse leaves the window
+        document.addEventListener('mouseleave', function() {
+          if (isDragging) {
+            isDragging = false;
+            
+            // Return to original position
+            sourceElement.style.left = originalPosition.left + 'px';
+            sourceElement.style.top = originalPosition.top + 'px';
+          }
+        });
+      </script>
+    </body>

--- a/tests/page/page-drag.spec.ts
+++ b/tests/page/page-drag.spec.ts
@@ -64,7 +64,7 @@ it.describe('Drag and drop', () => {
       browserName === 'firefox' ? 'mousemove at 240;350' : 'dragstart at 120;86',
       'dragenter at 240;350',
       // NOTE: Normal browsers emit usually a lot of dragover events during drag'n
-      // drop operations. We want to emit minimal (2) to make the ecosystem work.
+      // drop operations. We want to emit minimal (2) to make Angular CDK work.
       'dragover at 240;350',
       'dragover at 240;350',
       'drop at 240;350',
@@ -334,7 +334,7 @@ it.describe('Drag and drop', () => {
     expect(await events.jsonValue()).toEqual([
       { type: 'mousemove', x: 120, y: 86 },
       // NOTE: Normal browsers emit usually a lot of mousemove events during drag'n
-      // drop operations. We want to emit minimal(2) to make the ecosystem work.
+      // drop operations. We want to emit minimal (2) to make Angular CDK work.
       { type: 'mousemove', x: 240, y: 350 },
       { type: 'mousemove', x: 240, y: 350 },
     ]);

--- a/tests/page/page-drag.spec.ts
+++ b/tests/page/page-drag.spec.ts
@@ -321,7 +321,7 @@ it.describe('Drag and drop', () => {
     await page.goto(server.PREFIX + '/drag-n-drop-manual.html');
     const events = await page.evaluateHandle(() => {
       const events = [];
-      document.addEventListener('drop', (event: MouseEvent) => {
+      document.addEventListener('mousemove', (event: MouseEvent) => {
         events.push({
           type: event.type,
           x: event.clientX,


### PR DESCRIPTION
Background:

There are two types of Drag & Drop in the web:

### Native HTML5 Drag and Drop (drag-n-drop.html)

- Uses `draggable="true"` attribute
- Relies on browser's drag events (`dragstart`, `dragover`, `drop`)
- Browser switches from `mousemove` to drag events during operation
- Used in most web applications
- See `drag-n-drop.html`

### Uses raw mouse events (mousedown, mousemove, mouseup)

- Complete control over the dragging behavior
- Continues to emit `mousemove` events throughout the operation
- Used in custom implementations (e.g., drawing tools, custom UI)
- Used by Angular CDK https://material.angular.io/cdk/drag-drop/examples
- The test expects two mousemove events because: https://github.com/microsoft/playwright/issues/34688#issuecomment-2654110029

In this PR I had to add the latter with an expectation that there should be two `mousemove` events emitted.

Fixes https://github.com/microsoft/playwright/issues/34688