### PR TITLE
test: replace setTimeout with builtinSetTimeout in UI mode test

### DIFF
--- a/tests/playwright-test/ui-mode-test-output.spec.ts
+++ b/tests/playwright-test/ui-mode-test-output.spec.ts
@@ -130,7 +130,7 @@ test('should collapse repeated console messages for test', async ({ runUITest })
           await new Promise(resolve => {
             for (let i = 0; i < 10; ++i)
               console.log('page message')
-            setTimeout(() => {
+            builtinSetTimeout(() => {
               for (let i = 0; i < 10; ++i)
                 console.log('page message')
               resolve()


### PR DESCRIPTION
Fixes `PW_CLOCK=frozen npm run ttest -- tests/playwright-test/ui-mode-test-output.spec.ts:117:5`