### PR TITLE
test: unskip "should preserve cookie order from Set-Cookie header"

### DIFF
--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -281,7 +281,6 @@ it('should add cookies from Set-Cookie header', async ({ context, page, server }
 });
 
 it('should preserve cookie order from Set-Cookie header', async ({ context, page, server, browserName, isLinux }) => {
-  it.fixme(browserName === 'webkit' && isLinux, 'https://github.com/microsoft/playwright-browsers/issues/1512');
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23390' });
   server.setRoute('/setcookie.html', (req, res) => {
     res.setHeader('Set-Cookie', ['cookie.0=foo', 'cookie.1=bar']);


### PR DESCRIPTION
The ordering issue was fixed by https://github.com/microsoft/playwright-browsers/pull/1513.

Fixes https://github.com/microsoft/playwright-browsers/issues/1512