### PR TITLE
Docs: improve docs and tests for URL glob pattern

### DIFF
--- a/docs/src/network.md
+++ b/docs/src/network.md
@@ -708,9 +708,13 @@ Playwright uses simplified glob patterns for URL matching in network interceptio
   - A double `**` matches any characters including `/`
 1. Question mark `?` matches any single character except `/`
 1. Curly braces `{}` can be used to match a list of options separated by commas `,`
+1. Square brackets `[]` can be used to match a set of characters
+1. Backslash `\` can be used to escape any of special characters (note to escape backslash itself as `\\`)
 
 Examples:
 - `https://example.com/*.js` matches `https://example.com/file.js` but not `https://example.com/path/file.js`
+- `https://example.com/\\?page=1` matches `https://example.com/?page=1` but not `https://example.com`
+- `**/v[0-9]*` matches `https://example.com/v1/` but not `https://example.com/vote/`
 - `**/*.js` matches both `https://example.com/file.js` and `https://example.com/path/file.js`
 - `**/*.{png,jpg,jpeg}` matches all image requests
 

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -90,7 +90,14 @@ it('should work with glob', async () => {
   expect(globToRegex('http://localhost:3000/signin-oidc*').test('http://localhost:3000/signin-oidc/foo')).toBeFalsy();
   expect(globToRegex('http://localhost:3000/signin-oidc*').test('http://localhost:3000/signin-oidcnice')).toBeTruthy();
 
-  expect(globToRegex('**/three-columns/settings.html?**id=[a-z]**').test('http://mydomain:8080/blah/blah/three-columns/settings.html?id=settings-e3c58efe-02e9-44b0-97ac-dd138100cf7c&blah')).toBeTruthy();
+  // range []
+  expect(globToRegex('**/api/v[0-9]').test('http://example.com/api/v1')).toBeTruthy();
+  expect(globToRegex('**/api/v[0-9]').test('http://example.com/api/version')).toBeFalsy();
+
+  // query params
+  expect(globToRegex('**/api\\?param').test('http://example.com/api?param')).toBeTruthy();
+  expect(globToRegex('**/api\\?param').test('http://example.com/api-param')).toBeFalsy();
+  expect(globToRegex('**/three-columns/settings.html\\?**id=[a-z]**').test('http://mydomain:8080/blah/blah/three-columns/settings.html?id=settings-e3c58efe-02e9-44b0-97ac-dd138100cf7c&blah')).toBeTruthy();
 
   expect(globToRegex('\\?')).toEqual(/^\?$/);
   expect(globToRegex('\\')).toEqual(/^\\$/);


### PR DESCRIPTION
- added note about square brackets (they are supported but not documented)
- added note about escaping with `\` 
- added examples with query params and range match
- improved tests for globs
