### PR TITLE
fix(runner): hide `APIResponse.*` calls from results

### DIFF
--- a/packages/playwright-core/src/client/fetch.ts
+++ b/packages/playwright-core/src/client/fetch.ts
@@ -338,16 +338,18 @@ export class APIResponse implements api.APIResponse {
   }
 
   async body(): Promise<Buffer> {
-    try {
-      const result = await this._request._channel.fetchResponseBody({ fetchUid: this._fetchUid() });
-      if (result.binary === undefined)
-        throw new Error('Response has been disposed');
-      return result.binary;
-    } catch (e) {
-      if (isTargetClosedError(e))
-        throw new Error('Response has been disposed');
-      throw e;
-    }
+    return await this._request._wrapApiCall(async () => {
+      try {
+        const result = await this._request._channel.fetchResponseBody({ fetchUid: this._fetchUid() });
+        if (result.binary === undefined)
+          throw new Error('Response has been disposed');
+        return result.binary;
+      } catch (e) {
+        if (isTargetClosedError(e))
+          throw new Error('Response has been disposed');
+        throw e;
+      }
+    }, true);
   }
 
   async text(): Promise<string> {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -258,7 +258,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
       onApiCallBegin: (data: ApiCallData) => {
         const testInfo = currentTestInfo();
         // Some special calls do not get into steps.
-        if (!testInfo || data.apiName.includes('setTestIdAttribute') || data.apiName === 'tracing.groupEnd' || data.apiName.startsWith('apiResponse.'))
+        if (!testInfo || data.apiName.includes('setTestIdAttribute') || data.apiName === 'tracing.groupEnd')
           return;
         const zone = currentZone().data<TestStepInternal>('stepZone');
         if (zone && zone.category === 'expect') {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -258,7 +258,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
       onApiCallBegin: (data: ApiCallData) => {
         const testInfo = currentTestInfo();
         // Some special calls do not get into steps.
-        if (!testInfo || data.apiName.includes('setTestIdAttribute') || data.apiName === 'tracing.groupEnd')
+        if (!testInfo || data.apiName.includes('setTestIdAttribute') || data.apiName === 'tracing.groupEnd' || data.apiName.startsWith('apiResponse.'))
           return;
         const zone = currentZone().data<TestStepInternal>('stepZone');
         if (zone && zone.category === 'expect') {

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -1448,10 +1448,7 @@ fixture   |  fixture: context
 });
 
 test('reading network request / response should not be listed as step', {
-  annotation: [
-    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33558' },
-    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/34840' },
-  ]
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33558' }
 }, async ({ runInlineTest, server }) => {
   const result = await runInlineTest({
     'reporter.ts': stepIndentReporter,
@@ -1464,11 +1461,6 @@ test('reading network request / response should not be listed as step', {
         });
         page.on('response', async response => {
           await response.text();
-        });
-        await page.route('**/*', async route => {
-          const response = await route.fetch();
-          await response.text();
-          await route.fallback();
         });
         await page.goto('${server.EMPTY_PAGE}');
       });
@@ -1484,8 +1476,7 @@ fixture   |  fixture: context
 pw:api    |    browser.newContext
 fixture   |  fixture: page
 pw:api    |    browserContext.newPage
-pw:api    |page.route @ a.test.ts:10
-pw:api    |page.goto(${server.EMPTY_PAGE}) @ a.test.ts:15
+pw:api    |page.goto(${server.EMPTY_PAGE}) @ a.test.ts:10
 hook      |After Hooks
 fixture   |  fixture: page
 fixture   |  fixture: context

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -1448,7 +1448,10 @@ fixture   |  fixture: context
 });
 
 test('reading network request / response should not be listed as step', {
-  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33558' }
+  annotation: [
+    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33558' },
+    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/34840' },
+  ]
 }, async ({ runInlineTest, server }) => {
   const result = await runInlineTest({
     'reporter.ts': stepIndentReporter,
@@ -1461,6 +1464,11 @@ test('reading network request / response should not be listed as step', {
         });
         page.on('response', async response => {
           await response.text();
+        });
+        await page.route('**/*', async route => {
+          const response = await route.fetch();
+          await response.text();
+          await route.fallback();
         });
         await page.goto('${server.EMPTY_PAGE}');
       });
@@ -1476,7 +1484,8 @@ fixture   |  fixture: context
 pw:api    |    browser.newContext
 fixture   |  fixture: page
 pw:api    |    browserContext.newPage
-pw:api    |page.goto(${server.EMPTY_PAGE}) @ a.test.ts:10
+pw:api    |page.route @ a.test.ts:10
+pw:api    |page.goto(${server.EMPTY_PAGE}) @ a.test.ts:15
 hook      |After Hooks
 fixture   |  fixture: page
 fixture   |  fixture: context

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -1529,9 +1529,7 @@ pw:api    |    browserContext.newPage
 test.step |custom step @ a.test.ts:4
 pw:api    |  page.route @ a.test.ts:5
 pw:api    |  page.goto(${server.EMPTY_PAGE}) @ a.test.ts:12
-pw:api    |  apiResponse.text @ a.test.ts:7
 expect    |  expect.toBe @ a.test.ts:8
-pw:api    |  apiResponse.text @ a.test.ts:9
 hook      |After Hooks
 fixture   |  fixture: page
 fixture   |  fixture: context


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/34840. We weren't hiding `APIResponse` calls, but they're all read-only so they shouldn't be visible in the test report.

`markAsInternalType` wasn't available in `APIResponse` because it's not a channel owner, so I had to add an explicit exclusion.