### PR TITLE
chore: add playwright-client to the list of packages

### DIFF
--- a/utils/workspace.js
+++ b/utils/workspace.js
@@ -125,7 +125,7 @@ class Workspace {
       }
       await maybeWriteJSON(pkg.packageJSONPath, pkg.packageJSON);
     }
-  
+
     // Re-run npm i to make package-lock dirty.
     child_process.execSync('npm i');
     return hasChanges;
@@ -165,6 +165,11 @@ const workspace = new Workspace(ROOT_PATH, [
   new PWPackage({
     name: 'playwright-chromium',
     path: path.join(ROOT_PATH, 'packages', 'playwright-chromium'),
+    files: LICENCE_FILES,
+  }),
+  new PWPackage({
+    name: '@playwright/client',
+    path: path.join(ROOT_PATH, 'packages', 'playwright-client'),
     files: LICENCE_FILES,
   }),
   new PWPackage({


### PR DESCRIPTION
This fixes canary publishing, for an example error see https://github.com/microsoft/playwright/actions/runs/13510866477/job/37750689208.