### PR TITLE
chore(bidi): use fractional coordinates for pointerAction

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiInput.ts
+++ b/packages/playwright-core/src/server/bidi/bidiInput.ts
@@ -79,9 +79,6 @@ export class RawMouseImpl implements input.RawMouse {
   }
 
   async move(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void> {
-    // Bidi throws when x/y are not integers.
-    x = Math.floor(x);
-    y = Math.floor(y);
     await this._performActions([{ type: 'pointerMove', x, y }]);
   }
 


### PR DESCRIPTION
Lets remove those lines again after it got backed out on https://github.com/microsoft/playwright/pull/34753.

Note that for now we can only remove the call to `floor()` for pointer actions but not for wheel because the situation there is still unclear.