### PR TITLE
feat(trace): special UI for API tests

### DIFF
--- a/examples/todomvc/tests/api.spec.ts
+++ b/examples/todomvc/tests/api.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.use({
+  baseURL: 'https://jsonplaceholder.typicode.com',
+});
+
+test('posts', async ({ request }) => {
+  const get = await request.get('/posts');
+  expect(get.ok()).toBeTruthy();
+  expect(await get.json()).toBeInstanceOf(Array);
+
+  const post = await request.post('/posts');
+  expect(post.ok()).toBeTruthy();
+  expect(await post.json()).toEqual({
+    id: expect.any(Number),
+  });
+
+  const del = await request.delete('/posts/1');
+  expect(del.ok()).toBeTruthy();
+  expect(await del.json()).toEqual({});
+});

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -118,6 +118,16 @@ export const renderAction = (
   const { errors, warnings } = modelUtil.stats(action);
   const showAttachments = !!action.attachments?.length && !!revealAttachment;
 
+  let apiName = action.apiName;
+  if (apiName === 'apiRequestContext.get')
+    apiName = 'GET';
+  else if (apiName === 'apiRequestContext.post')
+    apiName = 'POST';
+  else if (apiName === 'apiRequestContext.put')
+    apiName = 'PUT';
+  else if (apiName === 'apiRequestContext.delete')
+    apiName = 'DELETE';
+
   const parameterString = actionParameterDisplayString(action, sdkLanguage || 'javascript');
 
   const isSkipped = action.class === 'Test' && action.method === 'step' && action.annotations?.some(a => a.type === 'skip');
@@ -129,8 +139,8 @@ export const renderAction = (
   else if (!isLive)
     time = '-';
   return <>
-    <div className='action-title' title={action.apiName}>
-      <span>{action.apiName}</span>
+    <div className='action-title' title={apiName}>
+      <span>{apiName}</span>
       {parameterString &&
           (parameterString.type === 'locator' ? (
             <>

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -118,15 +118,12 @@ export const renderAction = (
   const { errors, warnings } = modelUtil.stats(action);
   const showAttachments = !!action.attachments?.length && !!revealAttachment;
 
-  let apiName = action.apiName;
-  if (apiName === 'apiRequestContext.get')
-    apiName = 'GET';
-  else if (apiName === 'apiRequestContext.post')
-    apiName = 'POST';
-  else if (apiName === 'apiRequestContext.put')
-    apiName = 'PUT';
-  else if (apiName === 'apiRequestContext.delete')
-    apiName = 'DELETE';
+  const apiName = {
+    'apiRequestContext.get': 'GET',
+    'apiRequestContext.post': 'POST',
+    'apiRequestContext.put': 'PUT',
+    'apiRequestContext.delete': 'DELETE',
+  }[action.apiName] ?? action.apiName;
 
   const parameterString = actionParameterDisplayString(action, sdkLanguage || 'javascript');
 

--- a/packages/trace-viewer/src/ui/modelUtil.ts
+++ b/packages/trace-viewer/src/ui/modelUtil.ts
@@ -113,6 +113,22 @@ export class MultiTraceModel {
     return this.actions.findLast(a => a.error);
   }
 
+  /**
+   * Heuristic to toggle API testing UI. 
+   */
+  isAPITrace(): boolean | undefined {
+    if (this.browserName)
+      return false;
+
+    if (this.hasStepData) {
+      const setupDone = this.actions.some(a => a.apiName === 'Before Hooks' && a.endTime > 0);
+      if (!setupDone) // until the setup is done, we can't tell if it's an API test.
+        return undefined;
+    }
+
+    return true;
+  }
+
   private _errorDescriptorsFromActions(): ErrorDescription[] {
     const errors: ErrorDescription[] = [];
     for (const action of this.actions || []) {

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -30,13 +30,13 @@ export const NetworkResourceDetails: React.FunctionComponent<{
   resource: ResourceSnapshot;
   sdkLanguage: Language;
   startTimeOffset: number;
-  onClose: () => void;
+  onClose?: () => void;
 }> = ({ resource, sdkLanguage, startTimeOffset, onClose }) => {
   const [selectedTab, setSelectedTab] = React.useState('request');
 
   return <TabbedPane
     dataTestId='network-request-details'
-    leftToolbar={[<ToolbarButton key='close' icon='close' title='Close' onClick={onClose}></ToolbarButton>]}
+    leftToolbar={onClose ? [<ToolbarButton key='close' icon='close' title='Close' onClick={onClose}></ToolbarButton>] : undefined}
     tabs={[
       {
         id: 'request',

--- a/packages/web/src/uiUtils.ts
+++ b/packages/web/src/uiUtils.ts
@@ -258,3 +258,16 @@ export function useCookies() {
   }, []);
   return cookies;
 }
+
+/**
+ * Returns result of `fn()`. If `fn` returns undefined, returns last non-undefined value.
+ */
+export function useMemoWithMemory<T>(fn: () => T | undefined, initialValue: T, deps: React.DependencyList) {
+  const [value, setValue] = React.useState<T>(initialValue);
+  React.useEffect(() => {
+    const value = fn();
+    if (value !== undefined)
+      setValue(value);
+  }, deps);
+  return value;
+}


### PR DESCRIPTION
For tests that don't use Playwright's browser features, but exclusively [API testing](https://playwright.dev/docs/api-testing), our UI currently looks just like the UI for browser tests:

<img width="1392" alt="Screenshot 2025-02-26 at 15 20 56" src="https://github.com/user-attachments/assets/bcec3031-faa4-4e43-a5f5-52122b365dff" />

Most of the screen is taken up by the blank browser snapshot, the network requests are tucked away in a tab below, and they show exactly the same entries as the action panel already does. We also show a `Locator` tab that doesn't do anything inside an API test.

This PR is a draft for a special UI for API tests. It replaces the browser snapshot with the request details of the currently selected action, hides the `Locator` tab and removes the `Network` tab because the same list exists inside the actions panel:

<img width="1392" alt="Screenshot 2025-02-26 at 15 20 23" src="https://github.com/user-attachments/assets/7a24f6d7-f0e5-4723-b91b-977107e93ddc" />

Opening this here as a draft to gather feedback from our community. If you use Playwright extensively in your API testing, do you make use of the Playwright UI? Would these changes help you? What other UI changes would you like to see?
