### PR TITLE
feat: client certificates fixes (#34873) and URL pattern support

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -549,7 +549,7 @@ Does not enforce fixed viewport, allows resizing window in the headed mode.
 
 ## context-option-clientCertificates
 - `clientCertificates` <[Array]<[Object]>>
-  - `origin` <[string]> Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
+  - `origin` <[string]> Exact origin or chromium enterprise policy style URL pattern that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
   - `certPath` ?<[path]> Path to the file with the certificate in PEM format.
   - `cert` ?<[Buffer]> Direct value of the certificate in PEM format.
   - `keyPath` ?<[path]> Path to the file with the private key in PEM format.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -9740,7 +9740,8 @@ export interface Browser {
      */
     clientCertificates?: Array<{
       /**
-       * Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
+       * Exact origin or chromium enterprise policy style URL pattern that the certificate is valid for. Origin includes
+       * `https` protocol, a hostname and optionally a port.
        */
       origin: string;
 
@@ -14786,7 +14787,8 @@ export interface BrowserType<Unused = {}> {
      */
     clientCertificates?: Array<{
       /**
-       * Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
+       * Exact origin or chromium enterprise policy style URL pattern that the certificate is valid for. Origin includes
+       * `https` protocol, a hostname and optionally a port.
        */
       origin: string;
 
@@ -17490,7 +17492,8 @@ export interface APIRequest {
      */
     clientCertificates?: Array<{
       /**
-       * Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
+       * Exact origin or chromium enterprise policy style URL pattern that the certificate is valid for. Origin includes
+       * `https` protocol, a hostname and optionally a port.
        */
       origin: string;
 
@@ -21994,7 +21997,8 @@ export interface BrowserContextOptions {
    */
   clientCertificates?: Array<{
     /**
-     * Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
+     * Exact origin or chromium enterprise policy style URL pattern that the certificate is valid for. Origin includes
+     * `https` protocol, a hostname and optionally a port.
      */
     origin: string;
 

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -432,6 +432,16 @@ export function rewriteOpenSSLErrorIfNeeded(error: Error): Error {
   ].join('\n'));
 }
 
+/*
+  Pattern is a pattern that matches a URL. Based on the Chromium
+  implementation, used in content policies:
+  https://source.chromium.org/chromium/chromium/src/+/main:components/content_settings/core/common/content_settings_pattern.h;l=248;drc=20799f4c32d950ce93d495f44eec648400f38a19
+
+  Example: "https://[*.].hello.com/path"
+
+  The only difference is that we don't support the precedence rules and
+  paths patterns are not implemented.
+*/
 export class Pattern {
   private readonly _scheme: string;
   private readonly _isSchemeWildcard: boolean;

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -378,14 +378,6 @@ export class ClientCertificatesProxy {
   }
 }
 
-function normalizeOrigin(origin: string): string {
-  try {
-    return new URL(origin).origin;
-  } catch (error) {
-    return origin;
-  }
-}
-
 function convertClientCertificatesToTLSOptions(
   clientCertificates: types.BrowserContextOptions['clientCertificates']
 ): Pick<https.RequestOptions, 'pfx' | 'key' | 'cert'> | undefined {

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -139,10 +139,14 @@ class SocksProxyConnection {
   }
 
   async connect() {
+    const fixtures = {
+      __testHookLookup: (this._options as any).__testHookLookup
+    };
+
     if (this.socksProxy.proxyAgentFromOptions)
       this.target = await this.socksProxy.proxyAgentFromOptions.callback(new EventEmitter() as any, { host: rewriteToLocalhostIfNeeded(this.host), port: this.port, secureEndpoint: false });
     else
-      this.target = await createSocket(rewriteToLocalhostIfNeeded(this.host), this.port);
+      this.target = await createSocket({ host: rewriteToLocalhostIfNeeded(this.host), port: this.port, ...fixtures });
 
     this.target.once('close', this._targetCloseEventListener);
     this.target.once('error', error => this.socksProxy._socksProxy.sendSocketError({ uid: this.uid, error: error.message }));

--- a/packages/playwright-core/src/server/utils/happyEyeballs.ts
+++ b/packages/playwright-core/src/server/utils/happyEyeballs.ts
@@ -55,14 +55,14 @@ class HttpsHappyEyeballsAgent extends https.Agent {
 export const httpsHappyEyeballsAgent = new HttpsHappyEyeballsAgent({ keepAlive: true });
 export const httpHappyEyeballsAgent = new HttpHappyEyeballsAgent({ keepAlive: true });
 
-export async function createSocket(host: string, port: number): Promise<net.Socket> {
+export async function createSocket(options: { host: string, port: number }): Promise<net.Socket> {
   return new Promise((resolve, reject) => {
-    if (net.isIP(host)) {
-      const socket = net.createConnection({ host, port });
+    if (net.isIP(options.host)) {
+      const socket = net.createConnection(options);
       socket.on('connect', () => resolve(socket));
       socket.on('error', error => reject(error));
     } else {
-      createConnectionAsync({ host, port }, (err, socket) => {
+      createConnectionAsync(options, (err, socket) => {
         if (err)
           reject(err);
         if (socket)

--- a/packages/playwright-core/src/server/utils/socksProxy.ts
+++ b/packages/playwright-core/src/server/utils/socksProxy.ts
@@ -411,7 +411,7 @@ export class SocksProxy extends EventEmitter implements SocksConnectionClient {
 
   private async _handleDirect(request: SocksSocketRequestedPayload) {
     try {
-      const socket = await createSocket(request.host, request.port);
+      const socket = await createSocket({ host: request.host, port: request.port });
       socket.on('data', data => this._connections.get(request.uid)?.sendData(data));
       socket.on('error', error => {
         this._connections.get(request.uid)?.error(error.message);
@@ -540,7 +540,7 @@ export class SocksProxyHandler extends EventEmitter {
     try {
       if (this._redirectPortForTest)
         port = this._redirectPortForTest;
-      const socket = await createSocket(host, port);
+      const socket = await createSocket({ host, port });
       socket.on('data', data => {
         const payload: SocksSocketDataPayload = { uid, data };
         this.emit(SocksProxyHandler.Events.SocksData, payload);

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9740,7 +9740,8 @@ export interface Browser {
      */
     clientCertificates?: Array<{
       /**
-       * Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
+       * Exact origin or chromium enterprise policy style URL pattern that the certificate is valid for. Origin includes
+       * `https` protocol, a hostname and optionally a port.
        */
       origin: string;
 
@@ -14786,7 +14787,8 @@ export interface BrowserType<Unused = {}> {
      */
     clientCertificates?: Array<{
       /**
-       * Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
+       * Exact origin or chromium enterprise policy style URL pattern that the certificate is valid for. Origin includes
+       * `https` protocol, a hostname and optionally a port.
        */
       origin: string;
 
@@ -17490,7 +17492,8 @@ export interface APIRequest {
      */
     clientCertificates?: Array<{
       /**
-       * Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
+       * Exact origin or chromium enterprise policy style URL pattern that the certificate is valid for. Origin includes
+       * `https` protocol, a hostname and optionally a port.
        */
       origin: string;
 
@@ -21994,7 +21997,8 @@ export interface BrowserContextOptions {
    */
   clientCertificates?: Array<{
     /**
-     * Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
+     * Exact origin or chromium enterprise policy style URL pattern that the certificate is valid for. Origin includes
+     * `https` protocol, a hostname and optionally a port.
      */
     origin: string;
 

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -129,16 +129,16 @@ export class TestProxy {
 }
 
 export async function setupSocksForwardingServer({
-  port, forwardPort, allowedTargetPort
+  port, forwardPort, allowedTargetPort, additionalAllowedHosts = []
 }: {
-  port: number, forwardPort: number, allowedTargetPort: number
+  port: number, forwardPort: number, allowedTargetPort: number, additionalAllowedHosts?: string[]
 }) {
   const connectHosts = [];
   const connections = new Map<string, net.Socket>();
   const socksProxy = new SocksProxy();
   socksProxy.setPattern('*');
   socksProxy.addListener(SocksProxy.Events.SocksRequested, async (payload: SocksSocketRequestedPayload) => {
-    if (!['127.0.0.1', 'fake-localhost-127-0-0-1.nip.io', 'localhost'].includes(payload.host) || payload.port !== allowedTargetPort) {
+    if (!['127.0.0.1', 'fake-localhost-127-0-0-1.nip.io', 'localhost', ...additionalAllowedHosts].includes(payload.host) || payload.port !== allowedTargetPort) {
       socksProxy.sendSocketError({ uid: payload.uid, error: 'ECONNREFUSED' });
       return;
     }

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -955,6 +955,8 @@ test.describe('browser', () => {
           matches: [
             'https://www.hello.com:443/path',
             'https://www.sub.hello.com/path',
+            'https://10.0.0.1/path',
+            'https://[::1]/path',
           ],
           nonMatches: [
             'https://www.any.com:8443/path',

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -193,7 +193,7 @@ test.describe('fetch', () => {
         keyPath: asset('client-certificates/client/trusted/key.pem'),
       }],
     });
-    const response = await request.get(`https://www.hello.local:${new URL(serverURL).port}`, { __testHookLookup });
+    const response = await request.get(`https://www.hello.local:${new URL(serverURL).port}`, { __testHookLookup } as any);
     expect(response.url()).toBe(`https://www.hello.local:${new URL(serverURL).port}/`);
     expect(response.status()).toBe(200);
     expect(await response.text()).toContain('Hello Alice, your certificate was issued by localhost!');

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -24,6 +24,7 @@ import { expect, playwrightTest as base } from '../config/browserTest';
 import type net from 'net';
 import type { BrowserContextOptions } from 'packages/playwright-test';
 import { setupSocksForwardingServer } from '../config/proxy';
+import { LookupAddress } from 'dns';
 const { createHttpsServer, createHttp2Server } = require('../../packages/playwright-core/lib/utils');
 
 type TestOptions = {
@@ -371,6 +372,50 @@ test.describe('browser', () => {
     await page.close();
   });
 
+  test('should pass with matching certificates and when a http proxy is used on an otherwise unreachable server', async ({ browser, startCCServer, asset, browserName, proxyServer, isMac }) => {
+    const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && isMac });
+    const serverPort = parseInt(new URL(serverURL).port, 10);
+    const privateDomain = `private.playwright.test`;
+    proxyServer.forwardTo(parseInt(new URL(serverURL).port, 10), { allowConnectRequests: true });
+
+    // make private domain resolve to unreachable server 192.0.2.0
+    // any attempt to connect there will timeout
+    let interceptedHostnameLookup: string | undefined;
+    const __testHookLookup = (hostname: string): LookupAddress[] => {
+      if (hostname === privateDomain) {
+        interceptedHostnameLookup = hostname;
+        return [
+          { address: '192.0.2.0', family: 4 },
+        ];
+      }
+      return [];
+    };
+
+    const context = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      clientCertificates: [{
+        origin: new URL(serverURL).origin.replace('127.0.0.1', privateDomain),
+        certPath: asset('client-certificates/client/trusted/cert.pem'),
+        keyPath: asset('client-certificates/client/trusted/key.pem'),
+      }],
+      proxy: { server: `localhost:${proxyServer.PORT}` },
+      ...
+      {  __testHookLookup } as any
+    });
+
+    const page = await context.newPage();
+    const requestURL = serverURL.replace('127.0.0.1', privateDomain);
+    expect(proxyServer.connectHosts).toEqual([]);
+    await page.goto(requestURL);
+
+    // only the proxy server should have tried to resolve the private domain
+    // and the test proxy server does not resolve domains
+    expect(interceptedHostnameLookup).toBe(undefined);
+    expect([...new Set(proxyServer.connectHosts)]).toEqual([`${privateDomain}:${serverPort}`]);
+    await expect(page.getByTestId('message')).toHaveText('Hello Alice, your certificate was issued by localhost!');
+    await page.close();
+  });
+
   test('should pass with matching certificates and when a socks proxy is used', async ({ browser, startCCServer, asset, browserName, isMac }) => {
     const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && isMac });
     const serverPort = parseInt(new URL(serverURL).port, 10);
@@ -392,6 +437,55 @@ test.describe('browser', () => {
     await page.goto(serverURL);
     const host = browserName === 'webkit' && isMac ? 'localhost' : '127.0.0.1';
     expect(connectHosts).toEqual([`${host}:${serverPort}`]);
+    await expect(page.getByTestId('message')).toHaveText('Hello Alice, your certificate was issued by localhost!');
+    await page.close();
+    await closeProxyServer();
+  });
+
+  test('should pass with matching certificates and when a socks proxy is used on an otherwise unreachable server', async ({ browser, startCCServer, asset, browserName, isMac }) => {
+    const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && isMac });
+    const serverPort = parseInt(new URL(serverURL).port, 10);
+    const privateDomain = `private.playwright.test`;
+    const { proxyServerAddr, closeProxyServer, connectHosts } = await setupSocksForwardingServer({
+      port: test.info().workerIndex + 2048 + 2,
+      forwardPort: serverPort,
+      allowedTargetPort: serverPort,
+      additionalAllowedHosts: [privateDomain],
+    });
+
+    // make private domain resolve to unreachable server 192.0.2.0
+    // any attempt to connect will timeout
+    let interceptedHostnameLookup: string | undefined;
+    const __testHookLookup = (hostname: string): LookupAddress[] => {
+      if (hostname === privateDomain) {
+        interceptedHostnameLookup = hostname;
+        return [
+          { address: '192.0.2.0', family: 4 },
+        ];
+      }
+      return [];
+    };
+
+    const context = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      clientCertificates: [{
+        origin: new URL(serverURL).origin.replace('127.0.0.1', privateDomain),
+        certPath: asset('client-certificates/client/trusted/cert.pem'),
+        keyPath: asset('client-certificates/client/trusted/key.pem'),
+      }],
+      proxy: { server: proxyServerAddr },
+      ...
+      {  __testHookLookup } as any
+    });
+    const page = await context.newPage();
+    expect(connectHosts).toEqual([]);
+    const requestURL = serverURL.replace('127.0.0.1', privateDomain);
+    await page.goto(requestURL);
+
+    // only the proxy server should have tried to resolve the private domain
+    // and the test proxy server does not resolve domains
+    expect(interceptedHostnameLookup).toBe(undefined);
+    expect(connectHosts).toEqual([`${privateDomain}:${serverPort}`]);
     await expect(page.getByTestId('message')).toHaveText('Hello Alice, your certificate was issued by localhost!');
     await page.close();
     await closeProxyServer();


### PR DESCRIPTION
### Bug Fixes 
Fix for https://github.com/microsoft/playwright/issues/34873
- Makes ALPN use a proxy if available and the secureContext for the origin.
- Enable lookup fixtures in places that were missing, like the client certificates socks proxy.
- Private domains now work if available thorugh a proxy and using client certificates.

### Support for patterns in clientCertificates

- Backward compatible, current origin with schema are valid patterns.
- Follows chromium enterprise policy URL patterns, also known as content settings patterns
https://chromeenterprise.google/policies/url-patterns/
https://source.chromium.org/chromium/chromium/src/+/main:components/content_settings/core/common/content_settings_pattern.h;l=248;drc=20799f4c32d950ce93d495f44eec648400f38a19

For example:
- https://[*.]domain.com
- https://*/
- https://*.*.domain.com/
- https://www.domain.com:*/

