### PR TITLE
feat(pageSnapshot): add header comment with info

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -630,7 +630,8 @@ class ArtifactsRecorder {
 
     this._pageSnapshotRecorder = new SnapshotRecorder(this, pageSnapshot, 'pageSnapshot', 'text/plain', '.snapshot.yml', async (page, path) => {
       const ariaSnapshot = await page.locator('body').ariaSnapshot({ timeout: 5000 });
-      await fs.promises.writeFile(path, ariaSnapshot);
+      const header = `# ${this._testInfo.titlePath.join(' >> ')}\n# ARIA snapshot of the page contents after test ${this._testInfo._isFailure() ? 'failed' : 'finished'}\n`;
+      await fs.promises.writeFile(path, header + ariaSnapshot);
     });
   }
 

--- a/tests/playwright-test/playwright.artifacts.spec.ts
+++ b/tests/playwright-test/playwright.artifacts.spec.ts
@@ -459,6 +459,12 @@ test('should work with pageSnapshot: on', async ({ runInlineTest }, testInfo) =>
     '  test-failed-1.snapshot.yml',
     '  test-failed-2.snapshot.yml',
   ]);
+
+  expect(fs.readFileSync(testInfo.outputPath('test-results', 'artifacts-failing', 'test-failed-1.snapshot.yml'), { encoding: 'utf-8' })).toEqual(`
+# artifacts.spec.ts >> failing
+# ARIA snapshot of the page contents after test failed
+- text: I am the page
+  `.trim());
 });
 
 test('should work with pageSnapshot: only-on-failure', async ({ runInlineTest }, testInfo) => {


### PR DESCRIPTION
Adds a header comment to the `pageSnapshot` file that should help LLMs understand its contents better.