### PR TITLE
chore: document indexeddb type as "unknown"

### DIFF
--- a/docs/src/api/class-apirequest.md
+++ b/docs/src/api/class-apirequest.md
@@ -71,25 +71,7 @@ Methods like [`method: APIRequestContext.get`] take the base URL into considerat
     - `localStorage` <[Array]<[Object]>>
       - `name` <[string]>
       - `value` <[string]>
-    - `indexedDB` ?<[Array]<[Object]>> indexedDB to set for context
-      - `name` <[string]> database name
-      - `version` <[int]> database version
-      - `stores` <[Array]<[Object]>>
-        - `name` <[string]>
-        - `keyPath` ?<[string]>
-        - `keyPathArray` ?<[Array]<[string]>>
-        - `autoIncrement` <[boolean]>
-        - `indexes` <[Array]<[Object]>>
-          - `name` <[string]>
-          - `keyPath` ?<[string]>
-          - `keyPathArray` ?<[Array]<[string]>>
-          - `unique` <[boolean]>
-          - `multiEntry` <[boolean]>
-        - `records` <[Array]<[Object]>>
-          - `key` ?<[Object]>
-          - `keyEncoded` ?<[Object]> if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-          - `value` ?<[Object]>
-          - `valueEncoded` ?<[Object]> if `value` is not JSON-serializable, this contains an encoded version that preserves types.
+    - `indexedDB` ?<[Array]<[unknown]>> indexedDB to set for context
 
 Populates context with given storage state. This option can be used to initialize context with logged-in information
 obtained via [`method: BrowserContext.storageState`] or [`method: APIRequestContext.storageState`]. Either a path to the

--- a/docs/src/api/class-apirequestcontext.md
+++ b/docs/src/api/class-apirequestcontext.md
@@ -880,25 +880,7 @@ context cookies from the response. The method will automatically follow redirect
     - `localStorage` <[Array]<[Object]>>
       - `name` <[string]>
       - `value` <[string]>
-    - `indexedDB` <[Array]<[Object]>>
-        - `name` <[string]>
-        - `version` <[int]>
-        - `stores` <[Array]<[Object]>>
-          - `name` <[string]>
-          - `keyPath` ?<[string]>
-          - `keyPathArray` ?<[Array]<[string]>>
-          - `autoIncrement` <[boolean]>
-          - `indexes` <[Array]<[Object]>>
-            - `name` <[string]>
-            - `keyPath` ?<[string]>
-            - `keyPathArray` ?<[Array]<[string]>>
-            - `unique` <[boolean]>
-            - `multiEntry` <[boolean]>
-          - `records` <[Array]<[Object]>>
-            - `key` ?<[Object]>
-            - `keyEncoded` ?<[Object]> if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-            - `value` ?<[Object]>
-            - `valueEncoded` ?<[Object]> if `value` is not JSON-serializable, this contains an encoded version that preserves types.
+    - `indexedDB` <[Array]<[unknown]>>
 
 Returns storage state for this request context, contains current cookies and local storage snapshot if it was passed to the constructor.
 

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1511,25 +1511,7 @@ Whether to emulate network being offline for the browser context.
     - `localStorage` <[Array]<[Object]>>
       - `name` <[string]>
       - `value` <[string]>
-    - `indexedDB` <[Array]<[Object]>>
-      - `name` <[string]>
-      - `version` <[int]>
-      - `stores` <[Array]<[Object]>>
-        - `name` <[string]>
-        - `keyPath` ?<[string]>
-        - `keyPathArray` ?<[Array]<[string]>>
-        - `autoIncrement` <[boolean]>
-        - `indexes` <[Array]<[Object]>>
-          - `name` <[string]>
-          - `keyPath` ?<[string]>
-          - `keyPathArray` ?<[Array]<[string]>>
-          - `unique` <[boolean]>
-          - `multiEntry` <[boolean]>
-        - `records` <[Array]<[Object]>>
-          - `key` ?<[Object]>
-          - `keyEncoded` ?<[Object]> if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-          - `value` ?<[Object]>
-          - `valueEncoded` ?<[Object]> if `value` is not JSON-serializable, this contains an encoded version that preserves types.
+    - `indexedDB` <[Array]<[unknown]>>
 
 Returns storage state for this browser context, contains current cookies, local storage snapshot and IndexedDB snapshot.
 

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -264,25 +264,7 @@ Specify environment variables that will be visible to the browser. Defaults to `
     - `localStorage` <[Array]<[Object]>> localStorage to set for context
       - `name` <[string]>
       - `value` <[string]>
-    - `indexedDB` ?<[Array]<[Object]>> indexedDB to set for context
-      - `name` <[string]> database name
-      - `version` <[int]> database version
-      - `stores` <[Array]<[Object]>>
-        - `name` <[string]>
-        - `keyPath` ?<[string]>
-        - `keyPathArray` ?<[Array]<[string]>>
-        - `autoIncrement` <[boolean]>
-        - `indexes` <[Array]<[Object]>>
-          - `name` <[string]>
-          - `keyPath` ?<[string]>
-          - `keyPathArray` ?<[Array]<[string]>>
-          - `unique` <[boolean]>
-          - `multiEntry` <[boolean]>
-        - `records` <[Array]<[Object]>>
-          - `key` ?<[Object]>
-          - `keyEncoded` ?<[Object]> if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-          - `value` ?<[Object]>
-          - `valueEncoded` ?<[Object]> if `value` is not JSON-serializable, this contains an encoded version that preserves types.
+    - `indexedDB` ?<[Array]<[unknown]>> indexedDB to set for context
 
 Learn more about [storage state and auth](../auth.md).
 

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -9316,49 +9316,7 @@ export interface BrowserContext {
         value: string;
       }>;
 
-      indexedDB: Array<{
-        name: string;
-
-        version: number;
-
-        stores: Array<{
-          name: string;
-
-          keyPath?: string;
-
-          keyPathArray?: Array<string>;
-
-          autoIncrement: boolean;
-
-          indexes: Array<{
-            name: string;
-
-            keyPath?: string;
-
-            keyPathArray?: Array<string>;
-
-            unique: boolean;
-
-            multiEntry: boolean;
-          }>;
-
-          records: Array<{
-            key?: Object;
-
-            /**
-             * if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            keyEncoded?: Object;
-
-            value?: Object;
-
-            /**
-             * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            valueEncoded?: Object;
-          }>;
-        }>;
-      }>;
+      indexedDB: Array<unknown>;
     }>;
   }>;
 
@@ -10129,55 +10087,7 @@ export interface Browser {
         /**
          * indexedDB to set for context
          */
-        indexedDB?: Array<{
-          /**
-           * database name
-           */
-          name: string;
-
-          /**
-           * database version
-           */
-          version: number;
-
-          stores: Array<{
-            name: string;
-
-            keyPath?: string;
-
-            keyPathArray?: Array<string>;
-
-            autoIncrement: boolean;
-
-            indexes: Array<{
-              name: string;
-
-              keyPath?: string;
-
-              keyPathArray?: Array<string>;
-
-              unique: boolean;
-
-              multiEntry: boolean;
-            }>;
-
-            records: Array<{
-              key?: Object;
-
-              /**
-               * if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-               */
-              keyEncoded?: Object;
-
-              value?: Object;
-
-              /**
-               * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
-               */
-              valueEncoded?: Object;
-            }>;
-          }>;
-        }>;
+        indexedDB?: Array<unknown>;
       }>;
     };
 
@@ -17736,55 +17646,7 @@ export interface APIRequest {
         /**
          * indexedDB to set for context
          */
-        indexedDB?: Array<{
-          /**
-           * database name
-           */
-          name: string;
-
-          /**
-           * database version
-           */
-          version: number;
-
-          stores: Array<{
-            name: string;
-
-            keyPath?: string;
-
-            keyPathArray?: Array<string>;
-
-            autoIncrement: boolean;
-
-            indexes: Array<{
-              name: string;
-
-              keyPath?: string;
-
-              keyPathArray?: Array<string>;
-
-              unique: boolean;
-
-              multiEntry: boolean;
-            }>;
-
-            records: Array<{
-              key?: Object;
-
-              /**
-               * if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-               */
-              keyEncoded?: Object;
-
-              value?: Object;
-
-              /**
-               * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
-               */
-              valueEncoded?: Object;
-            }>;
-          }>;
-        }>;
+        indexedDB?: Array<unknown>;
       }>;
     };
 
@@ -18600,49 +18462,7 @@ export interface APIRequestContext {
         value: string;
       }>;
 
-      indexedDB: Array<{
-        name: string;
-
-        version: number;
-
-        stores: Array<{
-          name: string;
-
-          keyPath?: string;
-
-          keyPathArray?: Array<string>;
-
-          autoIncrement: boolean;
-
-          indexes: Array<{
-            name: string;
-
-            keyPath?: string;
-
-            keyPathArray?: Array<string>;
-
-            unique: boolean;
-
-            multiEntry: boolean;
-          }>;
-
-          records: Array<{
-            key?: Object;
-
-            /**
-             * if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            keyEncoded?: Object;
-
-            value?: Object;
-
-            /**
-             * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            valueEncoded?: Object;
-          }>;
-        }>;
-      }>;
+      indexedDB: Array<unknown>;
     }>;
   }>;
 
@@ -22494,55 +22314,7 @@ export interface BrowserContextOptions {
       /**
        * indexedDB to set for context
        */
-      indexedDB?: Array<{
-        /**
-         * database name
-         */
-        name: string;
-
-        /**
-         * database version
-         */
-        version: number;
-
-        stores: Array<{
-          name: string;
-
-          keyPath?: string;
-
-          keyPathArray?: Array<string>;
-
-          autoIncrement: boolean;
-
-          indexes: Array<{
-            name: string;
-
-            keyPath?: string;
-
-            keyPathArray?: Array<string>;
-
-            unique: boolean;
-
-            multiEntry: boolean;
-          }>;
-
-          records: Array<{
-            key?: Object;
-
-            /**
-             * if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            keyEncoded?: Object;
-
-            value?: Object;
-
-            /**
-             * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            valueEncoded?: Object;
-          }>;
-        }>;
-      }>;
+      indexedDB?: Array<unknown>;
     }>;
   };
 

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -510,7 +510,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
 
 async function prepareStorageState(platform: Platform, options: BrowserContextOptions): Promise<channels.BrowserNewContextParams['storageState']> {
   if (typeof options.storageState !== 'string')
-    return options.storageState;
+    return options.storageState as any;
   try {
     return JSON.parse(await platform.fs().promises.readFile(options.storageState, 'utf8'));
   } catch (e) {

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -37,11 +37,11 @@ export type SelectOptionOptions = { force?: boolean, timeout?: number };
 export type FilePayload = { name: string, mimeType: string, buffer: Buffer };
 export type StorageState = {
   cookies: channels.NetworkCookie[],
-  origins: channels.OriginStorage[],
+  origins: (Omit<channels.OriginStorage, 'indexedDB'> & { indexedDB: unknown[] })[],
 };
 export type SetStorageState = {
   cookies?: channels.SetNetworkCookie[],
-  origins?: channels.SetOriginStorage[]
+  origins?: (Omit<channels.SetOriginStorage, 'indexedDB'> & { indexedDB?: unknown[] })[]
 };
 
 export type LifecycleEvent = channels.LifecycleEvent;

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9316,49 +9316,7 @@ export interface BrowserContext {
         value: string;
       }>;
 
-      indexedDB: Array<{
-        name: string;
-
-        version: number;
-
-        stores: Array<{
-          name: string;
-
-          keyPath?: string;
-
-          keyPathArray?: Array<string>;
-
-          autoIncrement: boolean;
-
-          indexes: Array<{
-            name: string;
-
-            keyPath?: string;
-
-            keyPathArray?: Array<string>;
-
-            unique: boolean;
-
-            multiEntry: boolean;
-          }>;
-
-          records: Array<{
-            key?: Object;
-
-            /**
-             * if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            keyEncoded?: Object;
-
-            value?: Object;
-
-            /**
-             * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            valueEncoded?: Object;
-          }>;
-        }>;
-      }>;
+      indexedDB: Array<unknown>;
     }>;
   }>;
 
@@ -10129,55 +10087,7 @@ export interface Browser {
         /**
          * indexedDB to set for context
          */
-        indexedDB?: Array<{
-          /**
-           * database name
-           */
-          name: string;
-
-          /**
-           * database version
-           */
-          version: number;
-
-          stores: Array<{
-            name: string;
-
-            keyPath?: string;
-
-            keyPathArray?: Array<string>;
-
-            autoIncrement: boolean;
-
-            indexes: Array<{
-              name: string;
-
-              keyPath?: string;
-
-              keyPathArray?: Array<string>;
-
-              unique: boolean;
-
-              multiEntry: boolean;
-            }>;
-
-            records: Array<{
-              key?: Object;
-
-              /**
-               * if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-               */
-              keyEncoded?: Object;
-
-              value?: Object;
-
-              /**
-               * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
-               */
-              valueEncoded?: Object;
-            }>;
-          }>;
-        }>;
+        indexedDB?: Array<unknown>;
       }>;
     };
 
@@ -17736,55 +17646,7 @@ export interface APIRequest {
         /**
          * indexedDB to set for context
          */
-        indexedDB?: Array<{
-          /**
-           * database name
-           */
-          name: string;
-
-          /**
-           * database version
-           */
-          version: number;
-
-          stores: Array<{
-            name: string;
-
-            keyPath?: string;
-
-            keyPathArray?: Array<string>;
-
-            autoIncrement: boolean;
-
-            indexes: Array<{
-              name: string;
-
-              keyPath?: string;
-
-              keyPathArray?: Array<string>;
-
-              unique: boolean;
-
-              multiEntry: boolean;
-            }>;
-
-            records: Array<{
-              key?: Object;
-
-              /**
-               * if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-               */
-              keyEncoded?: Object;
-
-              value?: Object;
-
-              /**
-               * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
-               */
-              valueEncoded?: Object;
-            }>;
-          }>;
-        }>;
+        indexedDB?: Array<unknown>;
       }>;
     };
 
@@ -18600,49 +18462,7 @@ export interface APIRequestContext {
         value: string;
       }>;
 
-      indexedDB: Array<{
-        name: string;
-
-        version: number;
-
-        stores: Array<{
-          name: string;
-
-          keyPath?: string;
-
-          keyPathArray?: Array<string>;
-
-          autoIncrement: boolean;
-
-          indexes: Array<{
-            name: string;
-
-            keyPath?: string;
-
-            keyPathArray?: Array<string>;
-
-            unique: boolean;
-
-            multiEntry: boolean;
-          }>;
-
-          records: Array<{
-            key?: Object;
-
-            /**
-             * if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            keyEncoded?: Object;
-
-            value?: Object;
-
-            /**
-             * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            valueEncoded?: Object;
-          }>;
-        }>;
-      }>;
+      indexedDB: Array<unknown>;
     }>;
   }>;
 
@@ -22494,55 +22314,7 @@ export interface BrowserContextOptions {
       /**
        * indexedDB to set for context
        */
-      indexedDB?: Array<{
-        /**
-         * database name
-         */
-        name: string;
-
-        /**
-         * database version
-         */
-        version: number;
-
-        stores: Array<{
-          name: string;
-
-          keyPath?: string;
-
-          keyPathArray?: Array<string>;
-
-          autoIncrement: boolean;
-
-          indexes: Array<{
-            name: string;
-
-            keyPath?: string;
-
-            keyPathArray?: Array<string>;
-
-            unique: boolean;
-
-            multiEntry: boolean;
-          }>;
-
-          records: Array<{
-            key?: Object;
-
-            /**
-             * if `key` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            keyEncoded?: Object;
-
-            value?: Object;
-
-            /**
-             * if `value` is not JSON-serializable, this contains an encoded version that preserves types.
-             */
-            valueEncoded?: Object;
-          }>;
-        }>;
-      }>;
+      indexedDB?: Array<unknown>;
     }>;
   };
 


### PR DESCRIPTION
The proper types for Java and Dotnet are `Object`, for Python it's `Any`.