### PR TITLE
chore: apply "injected" eslint rules to "isomorphic"

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -253,7 +253,11 @@ export default [{
     'no-console': 'off'
   }
 }, {
-  files: ['packages/playwright-core/src/server/injected/**/*.ts'],
+  files: [
+    'packages/playwright-core/src/server/injected/**/*.ts',
+    'packages/playwright-core/src/server/isomorphic/**/*.ts',
+    'packages/playwright-core/src/utils/isomorphic/**/*.ts',
+  ],
   languageOptions: languageOptionsWithTsConfig,
   rules: {
     ...noWebGlobalsRules,

--- a/packages/playwright-core/src/server/isomorphic/utilityScriptSerializers.ts
+++ b/packages/playwright-core/src/server/isomorphic/utilityScriptSerializers.ts
@@ -129,10 +129,13 @@ export function source() {
 
   function serialize(value: any, handleSerializer: (value: any) => HandleOrValue, visitorInfo: VisitorInfo): SerializedValue {
     if (value && typeof value === 'object') {
+      // eslint-disable-next-line no-restricted-globals
       if (typeof globalThis.Window === 'function' && value instanceof globalThis.Window)
         return 'ref: <Window>';
+      // eslint-disable-next-line no-restricted-globals
       if (typeof globalThis.Document === 'function' && value instanceof globalThis.Document)
         return 'ref: <Document>';
+      // eslint-disable-next-line no-restricted-globals
       if (typeof globalThis.Node === 'function' && value instanceof globalThis.Node)
         return 'ref: <Node>';
     }


### PR DESCRIPTION
"injected" code depends on "isomorphic", so it should enfore the same rules.