### PR TITLE
feat: add ability to render base64-encoded trace recieved from window messages

### DIFF
--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -73,19 +73,13 @@ export const WorkbenchLoader: React.FunctionComponent<{
     return () => document.removeEventListener('paste', listener);
   });
   React.useEffect(() => {
-    const listener = async (e: MessageEvent) => {
-      if (!e.data.b64trace)
+    const listener = (e: MessageEvent) => {
+      const { method, params } = e.data;
+
+      if (method !== 'load' || !(params?.trace instanceof Blob))
         return;
 
-      const bytes = atob(e.data.b64trace);
-      const arrayBuffer = new ArrayBuffer(bytes.length);
-      const uint8Array = new Uint8Array(arrayBuffer);
-
-      for (let i = 0; i < bytes.length; i++)
-        uint8Array[i] = bytes.charCodeAt(i);
-
-      const traceBlob = new Blob([uint8Array], { type: 'application/zip' });
-      const traceFile = new File([traceBlob], 'trace.zip', { type: 'application/zip' });
+      const traceFile = new File([params.trace], 'trace.zip', { type: 'application/zip' });
       const dataTransfer = new DataTransfer();
 
       dataTransfer.items.add(traceFile);

--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -72,6 +72,29 @@ export const WorkbenchLoader: React.FunctionComponent<{
     document.addEventListener('paste', listener);
     return () => document.removeEventListener('paste', listener);
   });
+  React.useEffect(() => {
+    const listener = async (e: MessageEvent) => {
+      if (!e.data.b64trace)
+        return;
+
+      const bytes = atob(e.data.b64trace);
+      const arrayBuffer = new ArrayBuffer(bytes.length);
+      const uint8Array = new Uint8Array(arrayBuffer);
+
+      for (let i = 0; i < bytes.length; i++)
+        uint8Array[i] = bytes.charCodeAt(i);
+
+      const traceBlob = new Blob([uint8Array], { type: 'application/zip' });
+      const traceFile = new File([traceBlob], 'trace.zip', { type: 'application/zip' });
+      const dataTransfer = new DataTransfer();
+
+      dataTransfer.items.add(traceFile);
+
+      processTraceFiles(dataTransfer.files);
+    };
+    window.addEventListener('message', listener);
+    return () => window.removeEventListener('message', listener);
+  });
 
   const handleDropEvent = React.useCallback((event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();


### PR DESCRIPTION
Hello there,

We want to allow Allure Report users to work with Playwright Trace Viewer right in the report, but we can't implement the feature using the current approach because we can't guarantee the user access to the trace archive as is (for example, in the single-file mode, when the report is presented as a single HTML-file which actively uses in Azure DevOps integration). But if we had a way to pass trace content to the trace viewer application as a base64 string, it would work as we expected.

This PR provides an ability to render trace received from outside in a message:

1. The user opens Allure Report which contains Playwright Trace file
2. Then clicks "Open trace viewer" button
3. The application opens iframe with the Trace Viewer application
4. When the iframe appears, the application sends a trace file as a base64 string into it

This approach seems simple, straight-forward, and doesn't bring any breaking change.