### PR TITLE
chore: allow running manifest v2 extensions for a little longer

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -17,6 +17,43 @@
 
 // No dependencies as it is used from the Electron loader.
 
+const disabledFeatures = [
+  // See https://github.com/microsoft/playwright/pull/10380
+  'AcceptCHFrame',
+  // See https://github.com/microsoft/playwright/pull/10679
+  'AutoExpandDetailsElement',
+  // See https://github.com/microsoft/playwright/issues/14047
+  'AvoidUnnecessaryBeforeUnloadCheckSync',
+  // See https://github.com/microsoft/playwright/pull/12992
+  'CertificateTransparencyComponentUpdater',
+  // This makes Page.frameScheduledNavigation arrive much later after a click,
+  // making our navigation auto-wait after click not working.
+  // Can be removed once we deperecate noWaitAfter.
+  // See https://github.com/microsoft/playwright/pull/34372.
+  'DeferRendererTasksAfterInput',
+  'DestroyProfileOnBrowserClose',
+  // See https://github.com/microsoft/playwright/pull/13854
+  'DialMediaRouteProvider',
+  // Chromium is disabling manifest version 2. Allow testing it as long as Chromium can actually run it.
+  // Disabled in https://chromium-review.googlesource.com/c/chromium/src/+/6265903.
+  'ExtensionManifestV2Disabled',
+  'GlobalMediaControls',
+  // See https://github.com/microsoft/playwright/pull/27605
+  'HttpsUpgrades',
+  'ImprovedCookieControls',
+  'LazyFrameLoading',
+  // Hides the Lens feature in the URL address bar. Its not working in unofficial builds.
+  'LensOverlay',
+  // See https://github.com/microsoft/playwright/pull/8162
+  'MediaRouter',
+  // See https://github.com/microsoft/playwright/issues/28023
+  'PaintHolding',
+  // See https://github.com/microsoft/playwright/issues/32230
+  'ThirdPartyStoragePartitioning',
+  // See https://github.com/microsoft/playwright/issues/16126
+  'Translate',
+];
+
 export const chromiumSwitches = [
   '--disable-field-trial-config', // https://source.chromium.org/chromium/chromium/src/+/main:testing/variations/README.md
   '--disable-background-networking',
@@ -31,16 +68,7 @@ export const chromiumSwitches = [
   '--disable-default-apps',
   '--disable-dev-shm-usage',
   '--disable-extensions',
-  // AvoidUnnecessaryBeforeUnloadCheckSync - https://github.com/microsoft/playwright/issues/14047
-  // Translate - https://github.com/microsoft/playwright/issues/16126
-  // HttpsUpgrades - https://github.com/microsoft/playwright/pull/27605
-  // PaintHolding - https://github.com/microsoft/playwright/issues/28023
-  // ThirdPartyStoragePartitioning - https://github.com/microsoft/playwright/issues/32230
-  // LensOverlay - Hides the Lens feature in the URL address bar. Its not working in unofficial builds.
-  // DeferRendererTasksAfterInput - this makes Page.frameScheduledNavigation arrive much later after a click,
-  //   making our navigation auto-wait after click not working. Can be removed once we deperecate noWaitAfter.
-  //   See https://github.com/microsoft/playwright/pull/34372.
-  '--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,HttpsUpgrades,PaintHolding,ThirdPartyStoragePartitioning,LensOverlay,DeferRendererTasksAfterInput',
+  '--disable-features=' + disabledFeatures.join(','),
   '--allow-pre-commit-input',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',


### PR DESCRIPTION
See #34917, where it blocks the new Chromium roll.