### PR TITLE
docs: update Docker configuration recommendations

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -454,15 +454,7 @@ jobs:
 
 ### Docker
 
-We have a [pre-built Docker image](./docker.md) which can either be used directly or as a reference to update your existing Docker definitions.
-
-Suggested configuration
-1. Using `--ipc=host` is also recommended when using Chromium. Without it Chromium can run out of memory
-   and crash. Learn more about this option in [Docker docs](https://docs.docker.com/reference/cli/docker/container/run/#ipc).
-1. Seeing other weird errors when launching Chromium? Try running your container
-   with `docker run --cap-add=SYS_ADMIN` when developing locally.
-1. Using `--init` Docker flag or [dumb-init](https://github.com/Yelp/dumb-init) is recommended to avoid special
-   treatment for processes with PID=1. This is a common reason for zombie processes.
+We have a [pre-built Docker image](./docker.md) which can either be used directly or as a reference to update your existing Docker definitions. Make sure to follow the [Recommended Docker Configuration](./docker.md#recommended-docker-configuration) to ensure the best performance.
 
 ### Azure Pipelines
 

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -94,10 +94,15 @@ docker run -it --rm --ipc=host --user pwuser --security-opt seccomp=seccomp_prof
 }
 ```
 
-:::note
-Using `--ipc=host` is recommended when using Chrome ([Docker docs](https://docs.docker.com/engine/reference/run/#ipc-settings---ipc)). Chrome can run out of memory without this flag.
-:::
+### Recommended Docker Configuration
 
+When running Playwright in Docker, the following configuration is recommended:
+
+1. **Using [`--init`](https://docs.docker.com/reference/cli/docker/container/run/#init)** Docker flag is recommended to avoid special treatment for processes with PID=1. This is a common reason for zombie processes.
+
+1. **Using `--ipc=host`** is recommended when using Chromium. Without it, Chromium can run out of memory and crash. Learn more about this option in [Docker docs](https://docs.docker.com/reference/cli/docker/container/run/#ipc).
+
+1. **If seeing weird errors when launching Chromium**, try running your container with `docker run --cap-add=SYS_ADMIN` when developing locally.
 
 ### Using on CI
 


### PR DESCRIPTION
Motivation: We've seen multiple reports like this in the past and the issue is mostly that `--init` is missing. We have a note about `--init` in the `ci.md` but its hard to spot hence moving it to the `docker.md`.

https://github.com/microsoft/playwright/issues/34983