### PR TITLE
feat(chromium-tip-of-tree): roll to r1307

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -15,15 +15,15 @@
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1306",
+      "revision": "1307",
       "installByDefault": false,
-      "browserVersion": "135.0.7035.0"
+      "browserVersion": "135.0.7039.0"
     },
     {
       "name": "chromium-tip-of-tree-headless-shell",
-      "revision": "1306",
+      "revision": "1307",
       "installByDefault": false,
-      "browserVersion": "135.0.7035.0"
+      "browserVersion": "135.0.7039.0"
     },
     {
       "name": "firefox",


### PR DESCRIPTION
Turns out there is a regression in `page-autowaiting-no-hang.spec.ts:34:3` which fails since this roll. I bisected it to this upstream range: https://chromium.googlesource.com/chromium/src/+log/ef844eb9c0fde675c0cb859d00e92922df71595c..fec3236b064abc551a90b062bc0d8f3b8743be56

Via `npx bisect-chrome --good 1424246 --bad 1425506 --shell "npm run ctest -- age-autowaiting-no-hang.spec.ts:34:3 --reporter=list"`