### PR TITLE
chore: duplicate type expression

### DIFF
--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -265,7 +265,7 @@ export function resolveReporterOutputPath(defaultValue: string, configDir: strin
   return path.resolve(basePath, defaultValue);
 }
 
-export async function normalizeAndSaveAttachment(outputPath: string, name: string, options: { path?: string, body?: string | Buffer, contentType?: string } = {}): Promise<{ name: string; path?: string | undefined; body?: Buffer | undefined; contentType: string; }> {
+export async function normalizeAndSaveAttachment(outputPath: string, name: string, options: { path?: string, body?: string | Buffer, contentType?: string } = {}): Promise<{ name: string; path?: string; body?: Buffer; contentType: string; }> {
   if (options.path === undefined && options.body === undefined)
     return { name, contentType: 'text/plain' };
   if ((options.path !== undefined ? 1 : 0) + (options.body !== undefined ? 1 : 0) !== 1)


### PR DESCRIPTION
`foo?: bar | undefined` is unnecessarily repetitive. In german we say it's "doppelt gemoppelt".