### PR TITLE
devops: stop testing ubuntu-20.04

### DIFF
--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write   # This is required for OIDC login (azure/login) to succeed

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -134,8 +134,6 @@ jobs:
         include:
           # We have different binaries per Ubuntu version for WebKit.
           - browser: webkit
-            os: ubuntu-20.04
-          - browser: webkit
             os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
@@ -156,7 +154,7 @@ jobs:
       fail-fast: false
       matrix:
         mode: [driver, service]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/run-test
@@ -182,7 +180,7 @@ jobs:
           - browser: webkit
           - browser: chromium
             channel: chromium-tip-of-tree
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/run-test
@@ -205,7 +203,7 @@ jobs:
       fail-fast: false
       matrix:
         channel: [chrome, chrome-beta, msedge, msedge-beta, msedge-dev]
-        runs-on: [ubuntu-20.04, macos-latest, windows-latest]
+        runs-on: [ubuntu-22.04, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/run-test
@@ -226,7 +224,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13, windows-latest]
+        os: [ubuntu-22.04, macos-13, windows-latest]
         headed: ['--headed', '']
     steps:
     - uses: actions/checkout@v4
@@ -248,7 +246,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/run-test
@@ -269,7 +267,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/run-test

--- a/.github/workflows/tests_video.yml
+++ b/.github/workflows/tests_video.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         browser: [chromium, firefox, webkit]
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     permissions:
       id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed


### PR DESCRIPTION
GitHub Actions removes support for ubuntu-20.04 image:

> This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01. For more details, see https://github.com/actions/runner-images/issues/11101

This makes some of our bots not run anymore. Playwright started freezing / not supporting it anymore [in v1.49](https://playwright.dev/docs/release-notes#version-149) aka Nov 18, 2024.