### PR TITLE
chore: remove ffmpeg dependency from firefox nativeDeps in Ubuntu 22.04

### DIFF
--- a/packages/playwright-core/src/server/registry/nativeDeps.ts
+++ b/packages/playwright-core/src/server/registry/nativeDeps.ts
@@ -274,7 +274,6 @@ export const deps: any = {
       'libxrandr2'
     ],
     firefox: [
-      'ffmpeg',
       'libasound2',
       'libatk1.0-0',
       'libcairo-gobject2',

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -66,7 +66,6 @@ it('should respect CSP @smoke', async ({ page, server }) => {
 
 it('should play video @smoke', async ({ page, asset, browserName, isWindows, isLinux, mode }) => {
   it.skip(browserName === 'webkit' && isWindows, 'passes locally but fails on GitHub Action bot, apparently due to a Media Pack issue in the Windows Server');
-  it.fixme(browserName === 'firefox' && isLinux, 'https://github.com/microsoft/playwright/issues/5721');
   it.skip(mode.startsWith('service'));
 
   // Safari only plays mp4 so we test WebKit with an .mp4 clip.


### PR DESCRIPTION
- As of today we don't have `ffmpeg` included in our 24.04 builds
- As of today the tests seem to be passing in 24.04
- 22.04 tests are also passing without `ffmpeg`
- Since 24.04 already lives without it, I think we don't need any `docker.md` adjustments to optionally include it