### PR TITLE
chore(ui): hide attach _prompt action

### DIFF
--- a/packages/trace-viewer/src/ui/attachmentsTab.tsx
+++ b/packages/trace-viewer/src/ui/attachmentsTab.tsx
@@ -102,8 +102,12 @@ export const AttachmentsTab: React.FunctionComponent<{
 
     for (const action of model?.actions || []) {
       const traceUrl = action.context.traceUrl;
-      for (const attachment of action.attachments || [])
+      for (const attachment of action.attachments || []) {
+        if (attachment.name.startsWith("_prompt-"))
+          continue
         attachments.add({ ...attachment, traceUrl });
+      }
+        
     }
     const diffMap = new Map<string, { expected: Attachment | undefined, actual: Attachment | undefined, diff: Attachment | undefined }>();
 

--- a/packages/trace-viewer/src/ui/attachmentsTab.tsx
+++ b/packages/trace-viewer/src/ui/attachmentsTab.tsx
@@ -103,11 +103,11 @@ export const AttachmentsTab: React.FunctionComponent<{
     for (const action of model?.actions || []) {
       const traceUrl = action.context.traceUrl;
       for (const attachment of action.attachments || []) {
-        if (attachment.name.startsWith("_prompt-"))
-          continue
+        if (attachment.name.startsWith('_prompt-'))
+          continue;
         attachments.add({ ...attachment, traceUrl });
       }
-        
+
     }
     const diffMap = new Map<string, { expected: Attachment | undefined, actual: Attachment | undefined, diff: Attachment | undefined }>();
 

--- a/packages/trace-viewer/src/ui/modelUtil.ts
+++ b/packages/trace-viewer/src/ui/modelUtil.ts
@@ -338,6 +338,8 @@ export function buildActionTree(actions: ActionTraceEventInContext[]): { rootIte
 
   const rootItem: ActionTreeItem = { id: '', parent: undefined, children: [] };
   for (const item of itemMap.values()) {
+    if (item.action?.apiName.startsWith('attach "_prompt-'))
+      continue;
     const parent = item.action!.parentId ? itemMap.get(item.action!.parentId) || rootItem : rootItem;
     parent.children.push(item);
     item.parent = parent;

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -164,7 +164,8 @@ export const Workbench: React.FunctionComponent<{
   const networkModel = useNetworkTabModel(model, selectedTime);
   const errorsModel = useErrorsTabModel(model);
   const attachments = React.useMemo(() => {
-    return model?.actions.map(a => a.attachments || []).flat() || [];
+    const attachments = model?.actions.flatMap(a => a.attachments ?? []) ?? [];
+    return attachments.filter(a => !a.name.startsWith('_prompt-'));
   }, [model]);
 
   const sdkLanguage = model?.sdkLanguage || 'javascript';

--- a/tests/config/utils.ts
+++ b/tests/config/utils.ts
@@ -173,7 +173,7 @@ export async function parseTrace(file: string): Promise<{ resources: Map<string,
   };
   rootItem.children.forEach(a => visit(a, ''));
   return {
-    apiNames: model.actions.map(a => a.apiName),
+    apiNames: model.actions.map(a => a.apiName).filter(a => !a.startsWith('attach "_prompt-"')),
     resources: backend.entries,
     actions: model.actions,
     events: model.events,

--- a/tests/config/utils.ts
+++ b/tests/config/utils.ts
@@ -165,6 +165,8 @@ export async function parseTrace(file: string): Promise<{ resources: Map<string,
   const { rootItem } = buildActionTree(model.actions);
   const actionTree: string[] = [];
   const visit = (actionItem: ActionTreeItem, indent: string) => {
+    if (actionItem.action.apiName.startsWith('attach "_prompt-"'))
+      return;
     actionTree.push(`${indent}${actionItem.action?.apiName || actionItem.id}`);
     for (const child of actionItem.children)
       visit(child, indent + '  ');

--- a/tests/playwright-test/playwright.connect.spec.ts
+++ b/tests/playwright-test/playwright.connect.spec.ts
@@ -223,7 +223,6 @@ test('should record trace', async ({ runInlineTest }) => {
     'After Hooks',
     'fixture: page',
     'fixture: context',
-    'attach "_prompt-0"',
     'Worker Cleanup',
     'fixture: browser',
   ]);

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -129,7 +129,6 @@ test('should record api trace', async ({ runInlineTest, server }, testInfo) => {
     '  fixture: context',
     '  fixture: request',
     '    apiRequestContext.dispose',
-    '  attach "_prompt-0"',
     'Worker Cleanup',
     '  fixture: browser',
   ]);
@@ -328,7 +327,6 @@ test('should not override trace file in afterAll', async ({ runInlineTest, serve
     'After Hooks',
     '  fixture: page',
     '  fixture: context',
-    '  attach "_prompt-0"',
     '  afterAll hook',
     '    fixture: request',
     '      apiRequest.newContext',
@@ -671,7 +669,6 @@ test('should show non-expect error in trace', async ({ runInlineTest }, testInfo
     'After Hooks',
     '  fixture: page',
     '  fixture: context',
-    '  attach "_prompt-0"',
     'Worker Cleanup',
     '  fixture: browser',
   ]);
@@ -983,7 +980,6 @@ test('should record nested steps, even after timeout', async ({ runInlineTest },
     '      page.setContent',
     '  fixture: page',
     '  fixture: context',
-    '  attach "_prompt-0"',
     '  afterAll hook',
     '    fixture: barPage',
     '      barPage setup',
@@ -1043,7 +1039,6 @@ test('should attribute worker fixture teardown to the right test', async ({ runI
   expect(trace2.actionTree).toEqual([
     'Before Hooks',
     'After Hooks',
-    '  attach "_prompt-0"',
     'Worker Cleanup',
     '  fixture: foo',
     '    step in foo teardown',
@@ -1153,7 +1148,6 @@ test('should not corrupt actions when no library trace is present', async ({ run
     'After Hooks',
     '  fixture: foo',
     '    expect.toBe',
-    '  attach "_prompt-0"',
     'Worker Cleanup',
   ]);
 });
@@ -1184,7 +1178,6 @@ test('should record trace for manually created context in a failed test', async 
     'page.setContent',
     'expect.toBe',
     'After Hooks',
-    '  attach "_prompt-0"',
     'Worker Cleanup',
     '  fixture: browser',
   ]);
@@ -1272,7 +1265,6 @@ test('should record trace after fixture teardown timeout', {
     'page.evaluate',
     'After Hooks',
     '  fixture: fixture',
-    '  attach "_prompt-0"',
     'Worker Cleanup',
     '  fixture: browser',
   ]);


### PR DESCRIPTION
Hides the `_prompt` attachments, both from UI display and from test expectations.