### PR TITLE
chore: in PW_HMR mode, transfer cookies via params

### DIFF
--- a/packages/web/src/uiUtils.ts
+++ b/packages/web/src/uiUtils.ts
@@ -32,7 +32,7 @@ export function useAsyncMemo<T>(fn: () => Promise<T>, deps: React.DependencyList
     return () => {
       canceled = true;
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
   return value;
 }
@@ -252,7 +252,8 @@ export function useFlash(): [boolean, EffectCallback] {
 
 export function useCookies() {
   const cookies = React.useMemo(() => {
-    return document.cookie.split('; ').filter(v => v.includes('=')).map(kv => {
+    const cookie = new URLSearchParams(location.search).get('cookies') ?? document.cookie; // in PW_HMR mode, we pass cookies via params because we don't control the origin
+    return cookie.split('; ').filter(v => v.includes('=')).map(kv => {
       const separator = kv.indexOf('=');
       return [kv.substring(0, separator), kv.substring(separator + 1)];
     });


### PR DESCRIPTION
We decided to put sensitive tokens into cookies instead of params, so they're not visible in the URL bar of browsers. This breaks PW_HMR mode, because the cookie won't be accessible on the Vite dev server origin.

As a workaround, i'm adding the cookie values into a `param` in PW_HMR mode.