### PR TITLE
feat(firefox): roll to r1477

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎭 Playwright
 
-[![npm version](https://img.shields.io/npm/v/playwright.svg)](https://www.npmjs.com/package/playwright) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-134.0.6998.35-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-135.0-blue.svg?logo=firefoxbrowser)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-18.4-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop --> [![Join Discord](https://img.shields.io/badge/join-discord-infomational)](https://aka.ms/playwright/discord)
+[![npm version](https://img.shields.io/npm/v/playwright.svg)](https://www.npmjs.com/package/playwright) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-134.0.6998.35-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-136.0-blue.svg?logo=firefoxbrowser)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-18.4-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop --> [![Join Discord](https://img.shields.io/badge/join-discord-infomational)](https://aka.ms/playwright/discord)
 
 ## [Documentation](https://playwright.dev) | [API reference](https://playwright.dev/docs/api/class-playwright)
 
@@ -10,7 +10,7 @@ Playwright is a framework for Web Testing and Automation. It allows testing [Chr
 |   :---   | :---: | :---: | :---:   |
 | Chromium <!-- GEN:chromium-version -->134.0.6998.35<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | WebKit <!-- GEN:webkit-version -->18.4<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Firefox <!-- GEN:firefox-version -->135.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Firefox <!-- GEN:firefox-version -->136.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 Headless execution is supported for all browsers on all platforms. Check out [system requirements](https://playwright.dev/docs/intro#system-requirements) for details.
 

--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -27,9 +27,9 @@
     },
     {
       "name": "firefox",
-      "revision": "1476",
+      "revision": "1477",
       "installByDefault": true,
-      "browserVersion": "135.0"
+      "browserVersion": "136.0"
     },
     {
       "name": "firefox-beta",

--- a/packages/playwright-core/src/server/deviceDescriptorsSource.json
+++ b/packages/playwright-core/src/server/deviceDescriptorsSource.json
@@ -1592,7 +1592,7 @@
     "defaultBrowserType": "chromium"
   },
   "Desktop Firefox HiDPI": {
-    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:136.0) Gecko/20100101 Firefox/136.0",
     "screen": {
       "width": 1792,
       "height": 1120
@@ -1652,7 +1652,7 @@
     "defaultBrowserType": "chromium"
   },
   "Desktop Firefox": {
-    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:136.0) Gecko/20100101 Firefox/136.0",
     "screen": {
       "width": 1920,
       "height": 1080

--- a/utils/protocol-types-generator/index.js
+++ b/utils/protocol-types-generator/index.js
@@ -134,10 +134,11 @@ async function generateFirefoxProtocol(executablePath) {
   const data = zip.entryDataSync(zip.entry('chrome/juggler/content/protocol/Protocol.js'))
 
   const ctx = vm.createContext();
-  const protocolJSCode = data.toString('utf8');
+  const protocolJSCode = data.toString('utf8').replace('export const protocol', 'const protocol')
   function inject() {
     this.ChromeUtils = {
-      import: () => ({t})
+      import: () => ({t}),
+      importESModule: () => ({t}),
     }
     const t = {};
     t.String = {"$type": "string"};
@@ -166,7 +167,7 @@ async function generateFirefoxProtocol(executablePath) {
       return {"$type": "ref", "$ref": schemeName };
     }
   }
-  const json = vm.runInContext(`(${inject})();${protocolJSCode}; this.protocol;`, ctx);
+  const json = vm.runInContext(`(${inject})();${protocolJSCode}; protocol;`, ctx);
   await fs.promises.writeFile(outputPath, firefoxJSONToTS(json));
   console.log(`Wrote protocol.d.ts for Firefox to ${path.relative(process.cwd(), outputPath)}`);
 }


### PR DESCRIPTION
Since recent Firefox uses ESM Syntax internally, so does our Protocol.js. Instead of importing it as ESM, which seems to be _harder_ since it needs SourceTextModule (available as experimental in Node.js) we rewrite the `export const` to a normal `const` instead.

Fixes https://github.com/microsoft/playwright/actions/runs/13694619536/job/38294146210