### PR TITLE
chore(ui): move chat to the right

### DIFF
--- a/packages/trace-viewer/src/ui/aiConversation.css
+++ b/packages/trace-viewer/src/ui/aiConversation.css
@@ -20,12 +20,14 @@
   flex-direction: column;
   justify-content: space-between;
   color: #e0e0e0;
+  height: 100%;
 }
 
 .chat-disclaimer {
+  flex: 1;
   text-align: center;
   color: var(--vscode-editorBracketMatch-border);
-  margin: 0px;
+  margin: 8px;
 }
 
 .chat-container hr {
@@ -34,25 +36,28 @@
   border-top: 1px solid var(--vscode-titleBar-inactiveBackground);
 }
 
-.messages-container {
-  flex: 1;
-  overflow-y: auto;
-  padding: 16px;
-
+.chat-scroll {
   display: flex;
   flex-direction: column;
+  height: 100%;
+  overflow-y: scroll;
+}
+
+.messages-container {
+  padding: 32px 16px;
   gap: 16px;
 }
 
 .message {
   gap: 12px;
-  max-width: 85%;
+  padding-bottom: 16px;
 }
 
 .user-message {
   flex-direction: row-reverse;
   margin-left: auto;
-  width: fit-content
+  width: fit-content;
+  max-width: 85%;
 }
 
 .message-icon {
@@ -82,8 +87,6 @@
 
 /* Input form styles */
 .input-form {
-  position: sticky;
-  bottom: 0;
   display: flex;
   height: 64px;
   gap: 8px;
@@ -125,4 +128,8 @@
 .send-button:disabled {
   background-color: var(--vscode-disabledForeground);
   cursor: not-allowed;
+}
+
+.chat-view {
+  width: 100%;
 }

--- a/packages/trace-viewer/src/ui/aiConversation.tsx
+++ b/packages/trace-viewer/src/ui/aiConversation.tsx
@@ -41,12 +41,13 @@ export function AIConversation({ conversationId, setConversationId }: { conversa
       history={history}
       apiName={chat.api.name}
       onSend={content => conversation.send(content)}
-      onCancel={conversation.isSending() ? () => conversation.abortSending() : undefined}
+      sending={conversation.isSending()}
+      onCancel={() => conversation.abortSending()}
     />
   );
 }
 
-export function AIConversationView({ history, onSend, onCancel, apiName }: { history: LLMMessage[], onSend(message: string): void, onCancel?(): void; apiName: string; }) {
+export function AIConversationView({ history, onSend, sending, onCancel, apiName }: { history: LLMMessage[], onSend(message: string): void, sending?: boolean, onCancel?(): void; apiName: string; }) {
   const [input, setInput] = useState('');
   const onSubmit = useCallback(() => {
     setInput(content => {
@@ -93,7 +94,7 @@ export function AIConversationView({ history, onSend, onCancel, apiName }: { his
           placeholder='Ask a question...'
           className='message-input'
         />
-        {onCancel ? (
+        {sending ? (
           <button type='button' className='send-button' onClick={evt => {
             evt.preventDefault();
             onCancel();

--- a/packages/trace-viewer/src/ui/aiConversation.tsx
+++ b/packages/trace-viewer/src/ui/aiConversation.tsx
@@ -97,7 +97,7 @@ export function AIConversationView({ history, onSend, sending, onCancel, apiName
         {sending ? (
           <button type='button' className='send-button' onClick={evt => {
             evt.preventDefault();
-            onCancel();
+            onCancel?.();
           }}>
             Cancel
           </button>

--- a/packages/trace-viewer/src/ui/aiConversation.tsx
+++ b/packages/trace-viewer/src/ui/aiConversation.tsx
@@ -56,7 +56,7 @@ export function AIConversationView({ history, onSend, onCancel, apiName }: { his
   }, [onSend]);
 
   return (
-    <div className='chat-container'>
+    <div className='chat-container' role='region' aria-label='Chat'>
       <div className='chat-scroll'>
         <p className='chat-disclaimer'>Chat based on {apiName}. Check for mistakes.<hr/></p>
 

--- a/packages/trace-viewer/src/ui/aiConversation.tsx
+++ b/packages/trace-viewer/src/ui/aiConversation.tsx
@@ -17,15 +17,15 @@ import { useCallback, useState } from 'react';
 import Markdown from 'markdown-to-jsx';
 import './aiConversation.css';
 import { clsx } from '@web/uiUtils';
-import { LLMMessage, useLLMChat } from './llm';
+import { LLMMessage, useLLMChat, useLLMConversation } from './llm';
 
 export function AIConversation({ conversationId, setConversationId }: { conversationId?: string, setConversationId(id: string): void; }) {
   const chat = useLLMChat();
-  const conversation = conversationId ? chat.getConversation(conversationId) : undefined;
+  const [history, conversation] = useLLMConversation(conversationId);
 
   if (!conversation) {
     return <AIConversationView
-      history={[]}
+      history={history}
       apiName={chat.api.name}
       onSend={content => () => {
         const id = crypto.randomUUID();
@@ -38,7 +38,7 @@ export function AIConversation({ conversationId, setConversationId }: { conversa
 
   return (
     <AIConversationView
-      history={conversation.history}
+      history={history}
       apiName={chat.api.name}
       onSend={content => conversation.send(content)}
       onCancel={conversation.isSending() ? () => conversation.abortSending() : undefined}

--- a/packages/trace-viewer/src/ui/aiConversation.tsx
+++ b/packages/trace-viewer/src/ui/aiConversation.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import Markdown from 'markdown-to-jsx';
 import './aiConversation.css';
 import { clsx } from '@web/uiUtils';

--- a/packages/trace-viewer/src/ui/aiConversation.tsx
+++ b/packages/trace-viewer/src/ui/aiConversation.tsx
@@ -27,7 +27,7 @@ export function AIConversation({ conversationId, setConversationId }: { conversa
     return <AIConversationView
       history={history}
       apiName={chat.api.name}
-      onSend={content => () => {
+      onSend={content => {
         const id = crypto.randomUUID();
         const conversation = chat.startConversation(id, '');
         conversation.send(content);

--- a/packages/trace-viewer/src/ui/aiConversation.tsx
+++ b/packages/trace-viewer/src/ui/aiConversation.tsx
@@ -49,12 +49,12 @@ export function AIConversation({ conversationId, setConversationId }: { conversa
 
 export function AIConversationView({ history, onSend, sending, onCancel, apiName }: { history: LLMMessage[], onSend(message: string): void, sending?: boolean, onCancel?(): void; apiName: string; }) {
   const [input, setInput] = useState('');
-  const onSubmit = useCallback(() => {
+  const onSubmit = () => {
     setInput(content => {
       onSend(content);
       return '';
     });
-  }, [onSend]);
+  };
 
   return (
     <div className='chat-container' role='region' aria-label='Chat'>

--- a/packages/trace-viewer/src/ui/errorsTab.tsx
+++ b/packages/trace-viewer/src/ui/errorsTab.tsx
@@ -21,7 +21,6 @@ import { PlaceholderPanel } from './placeholderPanel';
 import { renderAction } from './actionList';
 import type { Language } from '@isomorphic/locatorGenerators';
 import { CopyToClipboardTextButton } from './copyToClipboard';
-import { AIConversation } from './aiConversation';
 import { ToolbarButton } from '@web/components/toolbarButton';
 import { useIsLLMAvailable, useLLMChat } from './llm';
 import { useAsyncMemo } from '@web/uiUtils';

--- a/packages/trace-viewer/src/ui/errorsTab.tsx
+++ b/packages/trace-viewer/src/ui/errorsTab.tsx
@@ -63,7 +63,7 @@ function Error({
   error: modelUtil.ErrorDescription,
   sdkLanguage: Language,
   revealInSource: (error: modelUtil.ErrorDescription) => void,
-  revealConversation(id: string): void,
+  revealConversation: (id: string) => void,
 }) {
   const llmAvailable = useIsLLMAvailable();
 
@@ -109,7 +109,7 @@ function Error({
   </div>;
 }
 
-function FixWithAIButton({ revealConversation, prompt }: { revealConversation(id: string): void, prompt: string }) {
+function FixWithAIButton({ revealConversation, prompt }: { revealConversation: (id: string) => void, prompt: string }) {
   const chat = useLLMChat();
 
   return <ToolbarButton
@@ -145,7 +145,7 @@ export const ErrorsTab: React.FunctionComponent<{
   wallTime: number,
   sdkLanguage: Language,
   revealInSource: (error: modelUtil.ErrorDescription) => void,
-  revealConversation(id: string): void;
+  revealConversation: (id: string) => void;
 }> = ({ errorsModel, sdkLanguage, revealInSource, revealConversation, wallTime }) => {
   if (!errorsModel.errors.size)
     return <PlaceholderPanel text='No errors' />;

--- a/packages/trace-viewer/src/ui/llm.tsx
+++ b/packages/trace-viewer/src/ui/llm.tsx
@@ -249,12 +249,13 @@ export function useIsLLMAvailable() {
   return !!React.useContext(llmContext);
 }
 
-export function useLLMConversation(id: string) {
-  const conversation = useLLMChat().getConversation(id);
-  if (!conversation)
-    throw new Error('No conversation found for id: ' + id);
-  const [history, setHistory] = React.useState(conversation.history);
+export function useLLMConversation(id?: string): readonly [LLMMessage[], Conversation | undefined] {
+  const chat = useLLMChat();
+  const conversation = id ? chat.getConversation(id) : undefined;
+  const [history, setHistory] = React.useState(conversation?.history ?? []);
   React.useEffect(() => {
+    if (!conversation)
+      return;
     function update() {
       setHistory([...conversation!.history]);
     }

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -42,6 +42,8 @@ import { testStatusIcon, testStatusText } from './testUtils';
 import type { UITestStatus } from './testUtils';
 import type { AfterActionTraceEventAttachment } from '@trace/trace';
 import type { HighlightedElement } from './snapshotTab';
+import { useIsLLMAvailable } from './llm';
+import { ChatView } from './aiConversation';
 
 export const Workbench: React.FunctionComponent<{
   model?: modelUtil.MultiTraceModel,
@@ -68,6 +70,7 @@ export const Workbench: React.FunctionComponent<{
   const [highlightedElement, setHighlightedElement] = React.useState<HighlightedElement>({ lastEdited: 'none' });
   const [selectedTime, setSelectedTime] = React.useState<Boundaries | undefined>();
   const [sidebarLocation, setSidebarLocation] = useSetting<'bottom' | 'right'>('propertiesSidebarLocation', 'bottom');
+  const llmAvailable = useIsLLMAvailable();
 
   const setSelectedAction = React.useCallback((action: modelUtil.ActionTraceEventInContext | undefined) => {
     setSelectedCallId(action?.callId);
@@ -316,59 +319,67 @@ export const Workbench: React.FunctionComponent<{
     component: <MetadataView model={model}/>
   };
 
-  return <div className='vbox workbench' {...(inert ? { inert: 'true' } : {})}>
-    {!hideTimeline && <Timeline
-      model={model}
-      consoleEntries={consoleModel.entries}
-      boundaries={boundaries}
-      highlightedAction={highlightedAction}
-      highlightedEntry={highlightedEntry}
-      highlightedConsoleEntry={highlightedConsoleMessage}
-      onSelected={onActionSelected}
-      sdkLanguage={sdkLanguage}
-      selectedTime={selectedTime}
-      setSelectedTime={setSelectedTime}
-    />}
-    <SplitView
-      sidebarSize={250}
-      orientation={sidebarLocation === 'bottom' ? 'vertical' : 'horizontal'} settingName='propertiesSidebar'
-      main={<SplitView
-        sidebarSize={250}
-        orientation='horizontal'
-        sidebarIsFirst
-        settingName='actionListSidebar'
-        main={<SnapshotTabsView
-          action={activeAction}
+  return <SplitView
+    main={
+      <div className='vbox workbench' {...(inert ? { inert: 'true' } : {})}>
+        {!hideTimeline && <Timeline
           model={model}
+          consoleEntries={consoleModel.entries}
+          boundaries={boundaries}
+          highlightedAction={highlightedAction}
+          highlightedEntry={highlightedEntry}
+          highlightedConsoleEntry={highlightedConsoleMessage}
+          onSelected={onActionSelected}
           sdkLanguage={sdkLanguage}
-          testIdAttributeName={model?.testIdAttributeName || 'data-testid'}
-          isInspecting={isInspecting}
-          setIsInspecting={setIsInspecting}
-          highlightedElement={highlightedElement}
-          setHighlightedElement={elementPicked} />}
-        sidebar={
-          <TabbedPane
-            tabs={[actionsTab, metadataTab]}
-            selectedTab={selectedNavigatorTab}
-            setSelectedTab={setSelectedNavigatorTab}
-          />
-        }
-      />}
-      sidebar={<TabbedPane
-        tabs={tabs}
-        selectedTab={selectedPropertiesTab}
-        setSelectedTab={selectPropertiesTab}
-        rightToolbar={[
-          sidebarLocation === 'bottom' ?
-            <ToolbarButton title='Dock to right' icon='layout-sidebar-right-off' onClick={() => {
-              setSidebarLocation('right');
-            }} /> :
-            <ToolbarButton title='Dock to bottom' icon='layout-panel-off' onClick={() => {
-              setSidebarLocation('bottom');
-            }} />
-        ]}
-        mode={sidebarLocation === 'bottom' ? 'default' : 'select'}
-      />}
-    />
-  </div>;
+          selectedTime={selectedTime}
+          setSelectedTime={setSelectedTime}
+        />}
+        <SplitView
+          sidebarSize={250}
+          orientation={sidebarLocation === 'bottom' ? 'vertical' : 'horizontal'} settingName='propertiesSidebar'
+          main={<SplitView
+            sidebarSize={250}
+            orientation='horizontal'
+            sidebarIsFirst
+            settingName='actionListSidebar'
+            main={<SnapshotTabsView
+              action={activeAction}
+              model={model}
+              sdkLanguage={sdkLanguage}
+              testIdAttributeName={model?.testIdAttributeName || 'data-testid'}
+              isInspecting={isInspecting}
+              setIsInspecting={setIsInspecting}
+              highlightedElement={highlightedElement}
+              setHighlightedElement={elementPicked} />}
+            sidebar={
+              <TabbedPane
+                tabs={[actionsTab, metadataTab]}
+                selectedTab={selectedNavigatorTab}
+                setSelectedTab={setSelectedNavigatorTab}
+              />
+            }
+          />}
+          sidebar={<TabbedPane
+            tabs={tabs}
+            selectedTab={selectedPropertiesTab}
+            setSelectedTab={selectPropertiesTab}
+            rightToolbar={[
+              sidebarLocation === 'bottom' ?
+                <ToolbarButton title='Dock to right' icon='layout-sidebar-right-off' onClick={() => {
+                  setSidebarLocation('right');
+                }} /> :
+                <ToolbarButton title='Dock to bottom' icon='layout-panel-off' onClick={() => {
+                  setSidebarLocation('bottom');
+                }} />
+            ]}
+            mode={sidebarLocation === 'bottom' ? 'default' : 'select'}
+          />}
+        />
+      </div>
+    }
+    sidebarSize={250}
+    orientation='horizontal'
+    sidebarHidden={!llmAvailable}
+    sidebar={llmAvailable && <ChatView />}
+  />;
 };

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -320,63 +320,61 @@ export const Workbench: React.FunctionComponent<{
     component: <MetadataView model={model}/>
   };
 
-  const workbench = (
-    <div className='vbox workbench' {...(inert ? { inert: 'true' } : {})}>
-      {!hideTimeline && <Timeline
-        model={model}
-        consoleEntries={consoleModel.entries}
-        boundaries={boundaries}
-        highlightedAction={highlightedAction}
-        highlightedEntry={highlightedEntry}
-        highlightedConsoleEntry={highlightedConsoleMessage}
-        onSelected={onActionSelected}
-        sdkLanguage={sdkLanguage}
-        selectedTime={selectedTime}
-        setSelectedTime={setSelectedTime}
-      />}
-      <SplitView
+  const workbench = <div className='vbox workbench' {...(inert ? { inert: 'true' } : {})}>
+    {!hideTimeline && <Timeline
+      model={model}
+      consoleEntries={consoleModel.entries}
+      boundaries={boundaries}
+      highlightedAction={highlightedAction}
+      highlightedEntry={highlightedEntry}
+      highlightedConsoleEntry={highlightedConsoleMessage}
+      onSelected={onActionSelected}
+      sdkLanguage={sdkLanguage}
+      selectedTime={selectedTime}
+      setSelectedTime={setSelectedTime}
+    />}
+    <SplitView
+      sidebarSize={250}
+      orientation={sidebarLocation === 'bottom' ? 'vertical' : 'horizontal'} settingName='propertiesSidebar'
+      main={<SplitView
         sidebarSize={250}
-        orientation={sidebarLocation === 'bottom' ? 'vertical' : 'horizontal'} settingName='propertiesSidebar'
-        main={<SplitView
-          sidebarSize={250}
-          orientation='horizontal'
-          sidebarIsFirst
-          settingName='actionListSidebar'
-          main={<SnapshotTabsView
-            action={activeAction}
-            model={model}
-            sdkLanguage={sdkLanguage}
-            testIdAttributeName={model?.testIdAttributeName || 'data-testid'}
-            isInspecting={isInspecting}
-            setIsInspecting={setIsInspecting}
-            highlightedElement={highlightedElement}
-            setHighlightedElement={elementPicked} />}
-          sidebar={
-            <TabbedPane
-              tabs={[actionsTab, metadataTab]}
-              selectedTab={selectedNavigatorTab}
-              setSelectedTab={setSelectedNavigatorTab}
-            />
-          }
-        />}
-        sidebar={<TabbedPane
-          tabs={tabs}
-          selectedTab={selectedPropertiesTab}
-          setSelectedTab={selectPropertiesTab}
-          rightToolbar={[
-            sidebarLocation === 'bottom' ?
-              <ToolbarButton title='Dock to right' icon='layout-sidebar-right-off' onClick={() => {
-                setSidebarLocation('right');
-              }} /> :
-              <ToolbarButton title='Dock to bottom' icon='layout-panel-off' onClick={() => {
-                setSidebarLocation('bottom');
-              }} />
-          ]}
-          mode={sidebarLocation === 'bottom' ? 'default' : 'select'}
-        />}
-      />
-    </div>
-  );
+        orientation='horizontal'
+        sidebarIsFirst
+        settingName='actionListSidebar'
+        main={<SnapshotTabsView
+          action={activeAction}
+          model={model}
+          sdkLanguage={sdkLanguage}
+          testIdAttributeName={model?.testIdAttributeName || 'data-testid'}
+          isInspecting={isInspecting}
+          setIsInspecting={setIsInspecting}
+          highlightedElement={highlightedElement}
+          setHighlightedElement={elementPicked} />}
+        sidebar={
+          <TabbedPane
+            tabs={[actionsTab, metadataTab]}
+            selectedTab={selectedNavigatorTab}
+            setSelectedTab={setSelectedNavigatorTab}
+          />
+        }
+      />}
+      sidebar={<TabbedPane
+        tabs={tabs}
+        selectedTab={selectedPropertiesTab}
+        setSelectedTab={selectPropertiesTab}
+        rightToolbar={[
+          sidebarLocation === 'bottom' ?
+            <ToolbarButton title='Dock to right' icon='layout-sidebar-right-off' onClick={() => {
+              setSidebarLocation('right');
+            }} /> :
+            <ToolbarButton title='Dock to bottom' icon='layout-panel-off' onClick={() => {
+              setSidebarLocation('bottom');
+            }} />
+        ]}
+        mode={sidebarLocation === 'bottom' ? 'default' : 'select'}
+      />}
+    />
+  </div>;
 
   return <SplitView
     main={workbench}

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -43,7 +43,7 @@ import type { UITestStatus } from './testUtils';
 import type { AfterActionTraceEventAttachment } from '@trace/trace';
 import type { HighlightedElement } from './snapshotTab';
 import { useIsLLMAvailable } from './llm';
-import { ChatView } from './aiConversation';
+import { AIConversation } from './aiConversation';
 
 export const Workbench: React.FunctionComponent<{
   model?: modelUtil.MultiTraceModel,
@@ -70,6 +70,7 @@ export const Workbench: React.FunctionComponent<{
   const [highlightedElement, setHighlightedElement] = React.useState<HighlightedElement>({ lastEdited: 'none' });
   const [selectedTime, setSelectedTime] = React.useState<Boundaries | undefined>();
   const [sidebarLocation, setSidebarLocation] = useSetting<'bottom' | 'right'>('propertiesSidebarLocation', 'bottom');
+  const [conversationId, setConversationId] = React.useState<string>();
   const llmAvailable = useIsLLMAvailable();
 
   const setSelectedAction = React.useCallback((action: modelUtil.ActionTraceEventInContext | undefined) => {
@@ -198,7 +199,7 @@ export const Workbench: React.FunctionComponent<{
       else
         setRevealedError(error);
       selectPropertiesTab('source');
-    }} wallTime={model?.wallTime ?? 0} />
+    }} wallTime={model?.wallTime ?? 0} revealConversation={setConversationId} />
   };
 
   // Fallback location w/o action stands for file / test.
@@ -380,6 +381,6 @@ export const Workbench: React.FunctionComponent<{
     sidebarSize={250}
     orientation='horizontal'
     sidebarHidden={!llmAvailable}
-    sidebar={llmAvailable && <ChatView />}
+    sidebar={llmAvailable && <AIConversation conversationId={conversationId} setConversationId={setConversationId} />}
   />;
 };

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -320,64 +320,66 @@ export const Workbench: React.FunctionComponent<{
     component: <MetadataView model={model}/>
   };
 
-  return <SplitView
-    main={
-      <div className='vbox workbench' {...(inert ? { inert: 'true' } : {})}>
-        {!hideTimeline && <Timeline
-          model={model}
-          consoleEntries={consoleModel.entries}
-          boundaries={boundaries}
-          highlightedAction={highlightedAction}
-          highlightedEntry={highlightedEntry}
-          highlightedConsoleEntry={highlightedConsoleMessage}
-          onSelected={onActionSelected}
-          sdkLanguage={sdkLanguage}
-          selectedTime={selectedTime}
-          setSelectedTime={setSelectedTime}
-        />}
-        <SplitView
+  const workbench = (
+    <div className='vbox workbench' {...(inert ? { inert: 'true' } : {})}>
+      {!hideTimeline && <Timeline
+        model={model}
+        consoleEntries={consoleModel.entries}
+        boundaries={boundaries}
+        highlightedAction={highlightedAction}
+        highlightedEntry={highlightedEntry}
+        highlightedConsoleEntry={highlightedConsoleMessage}
+        onSelected={onActionSelected}
+        sdkLanguage={sdkLanguage}
+        selectedTime={selectedTime}
+        setSelectedTime={setSelectedTime}
+      />}
+      <SplitView
+        sidebarSize={250}
+        orientation={sidebarLocation === 'bottom' ? 'vertical' : 'horizontal'} settingName='propertiesSidebar'
+        main={<SplitView
           sidebarSize={250}
-          orientation={sidebarLocation === 'bottom' ? 'vertical' : 'horizontal'} settingName='propertiesSidebar'
-          main={<SplitView
-            sidebarSize={250}
-            orientation='horizontal'
-            sidebarIsFirst
-            settingName='actionListSidebar'
-            main={<SnapshotTabsView
-              action={activeAction}
-              model={model}
-              sdkLanguage={sdkLanguage}
-              testIdAttributeName={model?.testIdAttributeName || 'data-testid'}
-              isInspecting={isInspecting}
-              setIsInspecting={setIsInspecting}
-              highlightedElement={highlightedElement}
-              setHighlightedElement={elementPicked} />}
-            sidebar={
-              <TabbedPane
-                tabs={[actionsTab, metadataTab]}
-                selectedTab={selectedNavigatorTab}
-                setSelectedTab={setSelectedNavigatorTab}
-              />
-            }
-          />}
-          sidebar={<TabbedPane
-            tabs={tabs}
-            selectedTab={selectedPropertiesTab}
-            setSelectedTab={selectPropertiesTab}
-            rightToolbar={[
-              sidebarLocation === 'bottom' ?
-                <ToolbarButton title='Dock to right' icon='layout-sidebar-right-off' onClick={() => {
-                  setSidebarLocation('right');
-                }} /> :
-                <ToolbarButton title='Dock to bottom' icon='layout-panel-off' onClick={() => {
-                  setSidebarLocation('bottom');
-                }} />
-            ]}
-            mode={sidebarLocation === 'bottom' ? 'default' : 'select'}
-          />}
-        />
-      </div>
-    }
+          orientation='horizontal'
+          sidebarIsFirst
+          settingName='actionListSidebar'
+          main={<SnapshotTabsView
+            action={activeAction}
+            model={model}
+            sdkLanguage={sdkLanguage}
+            testIdAttributeName={model?.testIdAttributeName || 'data-testid'}
+            isInspecting={isInspecting}
+            setIsInspecting={setIsInspecting}
+            highlightedElement={highlightedElement}
+            setHighlightedElement={elementPicked} />}
+          sidebar={
+            <TabbedPane
+              tabs={[actionsTab, metadataTab]}
+              selectedTab={selectedNavigatorTab}
+              setSelectedTab={setSelectedNavigatorTab}
+            />
+          }
+        />}
+        sidebar={<TabbedPane
+          tabs={tabs}
+          selectedTab={selectedPropertiesTab}
+          setSelectedTab={selectPropertiesTab}
+          rightToolbar={[
+            sidebarLocation === 'bottom' ?
+              <ToolbarButton title='Dock to right' icon='layout-sidebar-right-off' onClick={() => {
+                setSidebarLocation('right');
+              }} /> :
+              <ToolbarButton title='Dock to bottom' icon='layout-panel-off' onClick={() => {
+                setSidebarLocation('bottom');
+              }} />
+          ]}
+          mode={sidebarLocation === 'bottom' ? 'default' : 'select'}
+        />}
+      />
+    </div>
+  );
+
+  return <SplitView
+    main={workbench}
     sidebarSize={250}
     orientation='horizontal'
     sidebarHidden={!llmAvailable}

--- a/tests/playwright-test/ui-mode-llm.spec.ts
+++ b/tests/playwright-test/ui-mode-llm.spec.ts
@@ -18,7 +18,7 @@ import { test, expect, retries } from './ui-mode-fixtures';
 
 test.describe.configure({ mode: 'parallel', retries });
 
-test.fixme('openai', async ({ runUITest, server }) => {
+test('openai', async ({ runUITest, server }) => {
   server.setRoute('/v1/chat/completions', async (req, res) => {
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Allow-Headers', '*');
@@ -51,14 +51,14 @@ test.fixme('openai', async ({ runUITest, server }) => {
   await page.getByTitle('Run all').click();
   await page.getByText('Errors', { exact: true }).click();
   await page.getByRole('button', { name: 'Fix with AI' }).click();
-  await expect(page.getByRole('tabpanel', { name: 'Errors' })).toMatchAriaSnapshot(`
-    - tabpanel "Errors":
-      - text: Help me with the error above. Take the page snapshot into account.
+  await expect(page.getByRole('region', { name: 'Chat' })).toMatchAriaSnapshot(`
+    - region "Chat":
+      - text: Help me with the error. What's going wrong?
       - text: This is a mock response
   `);
 });
 
-test.fixme('anthropic', async ({ runUITest, server }) => {
+test('anthropic', async ({ runUITest, server }) => {
   server.setRoute('/v1/messages', async (req, res) => {
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Allow-Headers', '*');
@@ -91,9 +91,9 @@ test.fixme('anthropic', async ({ runUITest, server }) => {
   await page.getByTitle('Run all').click();
   await page.getByText('Errors', { exact: true }).click();
   await page.getByRole('button', { name: 'Fix with AI' }).click();
-  await expect(page.getByRole('tabpanel', { name: 'Errors' })).toMatchAriaSnapshot(`
-    - tabpanel "Errors":
-      - text: Help me with the error above. Take the page snapshot into account.
+  await expect(page.getByRole('region', { name: 'Chat' })).toMatchAriaSnapshot(`
+    - region "Chat":
+      - text: Help me with the error. What's going wrong?
       - text: This is a mock response
   `);
 });


### PR DESCRIPTION
<img width="1392" alt="Screenshot 2025-03-06 at 11 11 50" src="https://github.com/user-attachments/assets/13336560-e63d-4046-ab42-729ef125cfd5" />

Moving the chat to the right gives more vertical chat space and allows using it as a general-purpose chat, outside of fixing errors.

It makes the screen a little crowded, but the collapsible sidebar in https://github.com/microsoft/playwright/pull/35018 should help with that.