### PR TITLE
docs: update macOS version requirement to 14 Ventura

### DIFF
--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -233,7 +233,7 @@ See our doc on [Running and Debugging Tests](./running-tests.md) to learn more a
 
 - Playwright is distributed as a .NET Standard 2.0 library. We recommend .NET 8.
 - Windows 10+, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
-- macOS 13 Ventura, or later.
+- macOS 14 Ventura, or later.
 - Debian 12, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
 
 ## What's next

--- a/docs/src/intro-java.md
+++ b/docs/src/intro-java.md
@@ -130,7 +130,7 @@ By default browsers launched with Playwright run headless, meaning no browser UI
 
 - Java 8 or higher.
 - Windows 10+, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
-- macOS 13 Ventura, or later.
+- macOS 14 Ventura, or later.
 - Debian 12, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
 
 ## What's next

--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -288,7 +288,7 @@ pnpm exec playwright --version
 
 - Latest version of Node.js 18, 20 or 22.
 - Windows 10+, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
-- macOS 13 Ventura, or later.
+- macOS 14 Ventura, or later.
 - Debian 12, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
 
 ## What's next

--- a/docs/src/intro-python.md
+++ b/docs/src/intro-python.md
@@ -101,7 +101,7 @@ pip install pytest-playwright playwright -U
 
 - Python 3.8 or higher.
 - Windows 10+, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
-- macOS 13 Ventura, or later.
+- macOS 14 Ventura, or later.
 - Debian 12, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
 
 ## What's next


### PR DESCRIPTION
WebKit on macOS 13 is frozen. We don't recommend it anymore but keep testing it until it reaches sub 5%. Currently, it's at 8%.