### PR TITLE
chore: do not use |0 for rounding large numbers

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/time.ts
+++ b/packages/playwright-core/src/utils/isomorphic/time.ts
@@ -15,5 +15,5 @@
  */
 
 export function monotonicTime(): number {
-  return (performance.now() * 1000 | 0) / 1000;
+  return Math.floor(performance.now() * 1000) / 1000;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/35093