### PR TITLE
feat: implement fixmeinci modifier to conditionally skip tests in CI environments

### DIFF
--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -35,7 +35,7 @@ class Base {
 }
 
 export type Modifier = {
-  type: 'slow' | 'fixme' | 'skip' | 'fail',
+  type: 'slow' | 'fixme' | 'fixmeinci' | 'skip' | 'fail',
   fn: Function,
   location: Location,
   description: string | undefined

--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -172,9 +172,7 @@ export class TestTypeImpl {
       child._parallelMode = 'serial';
     if (type === 'parallel' || type === 'parallel.only')
       child._parallelMode = 'parallel';
-    if (type === 'skip' || type === 'fixme')
-      child._staticAnnotations.push({ type });
-    else if (type === 'fixmeinci') {
+    if (type === 'skip' || type === 'fixme') {child._staticAnnotations.push({ type });} else if (type === 'fixmeinci') {
       // Important: For fixmeinci suites, we only add an annotation in CI environments
       // When in CI, use 'fixme' type to ensure tests are skipped
       // When not in CI, don't add any annotation to ensure tests run normally
@@ -263,7 +261,7 @@ export class TestTypeImpl {
       throw new Error(`test.${type}() can only be called inside test, describe block or fixture`);
     if (typeof modifierArgs[0] === 'function')
       throw new Error(`test.${type}() with a function can only be called inside describe block`);
-    
+
     // Handle fixmeinci special case - use fixme method in CI, do nothing otherwise
     if (type === 'fixmeinci') {
       if (process.env.CI)

--- a/packages/playwright/src/worker/timeoutManager.ts
+++ b/packages/playwright/src/worker/timeoutManager.ts
@@ -26,7 +26,7 @@ export type TimeSlot = {
   elapsed: number;
 };
 
-type RunnableType = 'test' | 'beforeAll' | 'afterAll' | 'beforeEach' | 'afterEach' | 'slow' | 'skip' | 'fail' | 'fixme' | 'teardown';
+type RunnableType = 'test' | 'beforeAll' | 'afterAll' | 'beforeEach' | 'afterEach' | 'slow' | 'skip' | 'fail' | 'fixme' | 'fixmeinci' | 'teardown';
 
 export type RunnableDescription = {
   type: RunnableType;

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -270,7 +270,7 @@ export class WorkerMain extends ProcessRunner {
         // Don't add any annotation when not in CI
         return;
       }
-      
+
       testInfo.annotations.push(annotation);
       switch (annotation.type) {
         case 'fixme':
@@ -312,7 +312,7 @@ export class WorkerMain extends ProcessRunner {
       const extraAnnotations = this._activeSuites.get(suite) || [];
       for (const annotation of extraAnnotations)
         processAnnotation(annotation);
-      
+
       // Check for fixmeinci static annotations on parent suites
       if (!!process.env.CI) {
         // When in CI, check for static suite annotations of type fixmeinci

--- a/tests/playwright-test/test-fixmeinci.spec.ts
+++ b/tests/playwright-test/test-fixmeinci.spec.ts
@@ -19,13 +19,13 @@ import { test, expect, expectTestHelper } from './playwright-test-fixtures';
 test('fixmeinci should skip tests in CI environments only', async ({ runInlineTest }) => {
   // Save original CI value
   const originalCI = process.env.CI;
-  
+
   try {
     // Test with CI=1 (in CI environment)
     // Set parent process CI variable to '1' - this doesn't affect child processes directly
     process.env.CI = '1';
     console.log('Setting parent process CI environment variable to:', process.env.CI);
-    
+
     // Explicitly pass CI environment to child process
     // We must explicitly pass the CI environment variable to the child process
     const resultInCI = await runInlineTest({
@@ -74,7 +74,7 @@ test('fixmeinci should skip tests in CI environments only', async ({ runInlineTe
 
     // Verify tests are skipped when in CI
     expect(resultInCI.exitCode).toBe(0);
-    
+
     const expectTestInCI = expectTestHelper(resultInCI);
     expectTestInCI('should run normally', 'passed', 'expected', []);
     expectTestInCI('should be skipped in CI', 'skipped', 'skipped', ['fixme']);
@@ -82,11 +82,11 @@ test('fixmeinci should skip tests in CI environments only', async ({ runInlineTe
     expectTestInCI('should be skipped with reason in CI', 'skipped', 'skipped', ['fixme']);
     expectTestInCI('should be skipped in CI in suite', 'skipped', 'skipped', ['fixme']);
     expectTestInCI('should be skipped in CI in fixmeinci suite', 'skipped', 'skipped', ['fixme']);
-    
+
     // Now test without CI (local environment)
     // Set parent process CI variable to empty - this doesn't affect child processes directly
     process.env.CI = '';
-    
+
     const resultLocal = await runInlineTest({
       'helper.ts': `
         import { test as base, expect } from '@playwright/test';
@@ -130,7 +130,7 @@ test('fixmeinci should skip tests in CI environments only', async ({ runInlineTe
 
     // Verify tests run normally when not in CI
     expect(resultLocal.exitCode).toBe(0);
-    
+
     const expectTestLocal = expectTestHelper(resultLocal);
     expectTestLocal('should run normally', 'passed', 'expected', []);
     expectTestLocal('should run locally', 'passed', 'expected', []);
@@ -138,7 +138,7 @@ test('fixmeinci should skip tests in CI environments only', async ({ runInlineTe
     expectTestLocal('should run with fixmeinci reason locally', 'passed', 'expected', []);
     expectTestLocal('should run locally in suite', 'passed', 'expected', []);
     expectTestLocal('should run locally in fixmeinci suite', 'passed', 'expected', []);
-    
+
   } finally {
     // Restore original CI value
     process.env.CI = originalCI;
@@ -148,11 +148,11 @@ test('fixmeinci should skip tests in CI environments only', async ({ runInlineTe
 test('fixmeinci should work alongside other modifiers', async ({ runInlineTest }) => {
   // Save original CI value
   const originalCI = process.env.CI;
-  
+
   try {
     // Test with CI=1
     process.env.CI = '1';
-    
+
     const result = await runInlineTest({
       'a.test.ts': `
         import { test, expect } from '@playwright/test';
@@ -167,7 +167,7 @@ test('fixmeinci should work alongside other modifiers', async ({ runInlineTest }
         });
       `,
     }, { reporter: 'line' }, { CI: '1' });
-    
+
     const expectTest = expectTestHelper(result);
 
     expect(result.exitCode).toBe(0);
@@ -177,10 +177,10 @@ test('fixmeinci should work alongside other modifiers', async ({ runInlineTest }
     expectTest('fixmeinci inner', 'skipped', 'skipped', ['fixme']);
     expectTest('fixme wrap', 'skipped', 'skipped', ['fixme']);
     expectTest('fixmeinci and skip', 'skipped', 'skipped', ['skip']);
-    
+
     // Now test without CI
     process.env.CI = '';
-    
+
     const resultLocal = await runInlineTest({
       'a.test.ts': `
         import { test, expect } from '@playwright/test';
@@ -195,7 +195,7 @@ test('fixmeinci should work alongside other modifiers', async ({ runInlineTest }
         });
       `,
     }, { reporter: 'line' }, { CI: '' });
-    
+
     const expectTestLocal = expectTestHelper(resultLocal);
 
     expect(resultLocal.exitCode).toBe(0);
@@ -205,7 +205,7 @@ test('fixmeinci should work alongside other modifiers', async ({ runInlineTest }
     expectTestLocal('fixmeinci inner', 'passed', 'expected', []);
     expectTestLocal('fixme wrap', 'skipped', 'skipped', ['fixme']);
     expectTestLocal('fixmeinci and skip', 'skipped', 'skipped', ['skip']);
-    
+
   } finally {
     // Restore original CI value
     process.env.CI = originalCI;

--- a/tests/playwright-test/test-fixmeinci.spec.ts
+++ b/tests/playwright-test/test-fixmeinci.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, expectTestHelper } from './playwright-test-fixtures';
+
+test('fixmeinci should skip tests in CI environments only', async ({ runInlineTest }) => {
+  // Save original CI value
+  const originalCI = process.env.CI;
+  
+  try {
+    // Test with CI=1 (in CI environment)
+    // Set parent process CI variable to '1' - this doesn't affect child processes directly
+    process.env.CI = '1';
+    console.log('Setting parent process CI environment variable to:', process.env.CI);
+    
+    // Explicitly pass CI environment to child process
+    // We must explicitly pass the CI environment variable to the child process
+    const resultInCI = await runInlineTest({
+      'helper.ts': `
+        import { test as base, expect } from '@playwright/test';
+        export const test = base.extend({
+          foo: true,
+        });
+      `,
+      'a.test.ts': `
+        import { test } from './helper';
+
+        test('should run normally', async ({foo}) => {
+          // This test should run normally
+        });
+        
+        test.fixmeinci('should be skipped in CI', async ({foo}) => {
+          // This test should be skipped in CI but run locally
+        });
+        
+        test('should be skipped via method in CI', async ({foo}) => {
+          test.fixmeinci();
+        });
+        
+        test('should be skipped with reason in CI', async ({foo}) => {
+          test.fixmeinci('skipping in CI with reason');
+        });
+        
+        test.describe('suite with fixmeinci', () => {
+          test.fixmeinci();
+          // Add console output to debug the environment
+          test('should be skipped in CI in suite', () => {
+            console.log('Inside test: CI env variable is:', process.env.CI);
+            // This test should be skipped in CI but run locally
+          });
+        });
+        
+        test.describe.fixmeinci('suite declared with fixmeinci', () => {
+          test('should be skipped in CI in fixmeinci suite', () => {
+            console.log('Inside fixmeinci suite test: CI env variable is:', process.env.CI);
+            // This test should be skipped in CI but run locally
+          });
+        });
+      `,
+    }, { reporter: 'line' }, { CI: '1' });
+
+    // Verify tests are skipped when in CI
+    expect(resultInCI.exitCode).toBe(0);
+    
+    const expectTestInCI = expectTestHelper(resultInCI);
+    expectTestInCI('should run normally', 'passed', 'expected', []);
+    expectTestInCI('should be skipped in CI', 'skipped', 'skipped', ['fixme']);
+    expectTestInCI('should be skipped via method in CI', 'skipped', 'skipped', ['fixme']);
+    expectTestInCI('should be skipped with reason in CI', 'skipped', 'skipped', ['fixme']);
+    expectTestInCI('should be skipped in CI in suite', 'skipped', 'skipped', ['fixme']);
+    expectTestInCI('should be skipped in CI in fixmeinci suite', 'skipped', 'skipped', ['fixme']);
+    
+    // Now test without CI (local environment)
+    // Set parent process CI variable to empty - this doesn't affect child processes directly
+    process.env.CI = '';
+    
+    const resultLocal = await runInlineTest({
+      'helper.ts': `
+        import { test as base, expect } from '@playwright/test';
+        export const test = base.extend({
+          foo: true,
+        });
+      `,
+      'a.test.ts': `
+        import { test } from './helper';
+
+        test('should run normally', async ({foo}) => {
+          // This test should run normally
+        });
+        
+        test.fixmeinci('should run locally', async ({foo}) => {
+          // This test should be skipped in CI but run locally
+        });
+        
+        test('should run with fixmeinci method locally', async ({foo}) => {
+          test.fixmeinci();
+        });
+        
+        test('should run with fixmeinci reason locally', async ({foo}) => {
+          test.fixmeinci('would skip in CI with reason');
+        });
+        
+        test.describe('suite with fixmeinci', () => {
+          test.fixmeinci();
+          test('should run locally in suite', () => {
+            // This test should run locally
+          });
+        });
+        
+        test.describe.fixmeinci('suite declared with fixmeinci', () => {
+          test('should run locally in fixmeinci suite', () => {
+            // This test should run locally
+          });
+        });
+      `,
+    }, { reporter: 'line' }, { CI: '' });
+
+    // Verify tests run normally when not in CI
+    expect(resultLocal.exitCode).toBe(0);
+    
+    const expectTestLocal = expectTestHelper(resultLocal);
+    expectTestLocal('should run normally', 'passed', 'expected', []);
+    expectTestLocal('should run locally', 'passed', 'expected', []);
+    expectTestLocal('should run with fixmeinci method locally', 'passed', 'expected', []);
+    expectTestLocal('should run with fixmeinci reason locally', 'passed', 'expected', []);
+    expectTestLocal('should run locally in suite', 'passed', 'expected', []);
+    expectTestLocal('should run locally in fixmeinci suite', 'passed', 'expected', []);
+    
+  } finally {
+    // Restore original CI value
+    process.env.CI = originalCI;
+  }
+});
+
+test('fixmeinci should work alongside other modifiers', async ({ runInlineTest }) => {
+  // Save original CI value
+  const originalCI = process.env.CI;
+  
+  try {
+    // Test with CI=1
+    process.env.CI = '1';
+    
+    const result = await runInlineTest({
+      'a.test.ts': `
+        import { test, expect } from '@playwright/test';
+
+        test.describe('suite1', () => {
+          test('no marker', () => {});
+          test.skip('skip wrap', () => {});
+          test.fixmeinci('fixmeinci wrap', () => {});
+          test('fixmeinci inner', () => { test.fixmeinci(); });
+          test.fixme('fixme wrap', () => {});
+          test.fixmeinci.skip('fixmeinci and skip', () => {});
+        });
+      `,
+    }, { reporter: 'line' }, { CI: '1' });
+    
+    const expectTest = expectTestHelper(result);
+
+    expect(result.exitCode).toBe(0);
+    expectTest('no marker', 'passed', 'expected', []);
+    expectTest('skip wrap', 'skipped', 'skipped', ['skip']);
+    expectTest('fixmeinci wrap', 'skipped', 'skipped', ['fixme']);
+    expectTest('fixmeinci inner', 'skipped', 'skipped', ['fixme']);
+    expectTest('fixme wrap', 'skipped', 'skipped', ['fixme']);
+    expectTest('fixmeinci and skip', 'skipped', 'skipped', ['skip']);
+    
+    // Now test without CI
+    process.env.CI = '';
+    
+    const resultLocal = await runInlineTest({
+      'a.test.ts': `
+        import { test, expect } from '@playwright/test';
+
+        test.describe('suite1', () => {
+          test('no marker', () => {});
+          test.skip('skip wrap', () => {});
+          test.fixmeinci('fixmeinci wrap', () => {});
+          test('fixmeinci inner', () => { test.fixmeinci(); });
+          test.fixme('fixme wrap', () => {});
+          test.fixmeinci.skip('fixmeinci and skip', () => {});
+        });
+      `,
+    }, { reporter: 'line' }, { CI: '' });
+    
+    const expectTestLocal = expectTestHelper(resultLocal);
+
+    expect(resultLocal.exitCode).toBe(0);
+    expectTestLocal('no marker', 'passed', 'expected', []);
+    expectTestLocal('skip wrap', 'skipped', 'skipped', ['skip']);
+    expectTestLocal('fixmeinci wrap', 'passed', 'expected', []);
+    expectTestLocal('fixmeinci inner', 'passed', 'expected', []);
+    expectTestLocal('fixme wrap', 'skipped', 'skipped', ['fixme']);
+    expectTestLocal('fixmeinci and skip', 'skipped', 'skipped', ['skip']);
+    
+  } finally {
+    // Restore original CI value
+    process.env.CI = originalCI;
+  }
+});


### PR DESCRIPTION
## Overview

This PR introduces a new test modifier `.fixmeinci()` which allows tests to be conditionally skipped in CI environments while still running normally in local development environments. This feature helps address flaky or environment-specific tests that may not be reliable in CI pipelines but are still valuable for local testing.

## Features

- New `.fixmeinci()` modifier for test cases and test suites
- Conditional test skipping based on CI environment detection
- Support for test-level and suite-level annotations
- Chaining support for combining with other modifiers
- Comprehensive test coverage

## Implementation Details

### 1. Added Type Definitions and Interfaces

- Extended the `RunnableType` definition in `timeoutManager.ts` to include the new `fixmeinci` type
- Updated the `Modifier` type in `test.ts` to include `fixmeinci` as a valid modifier type

### 2. Test and Suite-Level Implementations

- Added `test.fixmeinci()` method with support for chaining (e.g., `test.fixmeinci.skip()`)
- Added `test.describe.fixmeinci()` for suite-level skipping
- Implemented proper handling of annotations based on environment

### 3. Runtime Logic

- Modified `processAnnotation` function in `workerMain.ts` to:
  - Skip processing annotations entirely when not in CI
  - Convert `fixmeinci` annotations to `fixme` annotations in CI environments
- Updated suite modifier processing to ensure consistent behavior

### 4. CI Environment Detection

- Implemented consistent checking of `process.env.CI` using `!!process.env.CI` to handle various truthy values
- Added safeguards against improper environment variable handling

### 5. Test Coverage

- Created comprehensive test file (`test-fixmeinci.spec.ts`) with scenarios for:
  - Individual test cases with `fixmeinci`
  - Test suites with `fixmeinci`
  - Mixing `fixmeinci` with other modifiers
  - Verifying local vs CI behavior

## Code Examples

### Test Case Usage

```typescript
// Skip individual test only in CI
test('flaky test', async ({ page }) => {
  test.fixmeinci('Flaky in CI pipeline');
  // Test will run locally but be skipped in CI
});

// With chaining
test.fixmeinci('skips in CI only', async ({ page }) => {
  // Test will be skipped in CI but run locally
});
```

### Suite Usage

```typescript
// Skip an entire suite in CI
test.describe.fixmeinci('suite of environment-sensitive tests', () => {
  test('test 1', async () => {
    // This test will be skipped in CI
  });
  
  test('test 2', async () => {
    // This test will also be skipped in CI
  });
});

// Or use within a suite
test.describe('suite with some CI-sensitive tests', () => {
  test.fixmeinci(); // All tests in this suite will be skipped in CI
  
  test('sensitive test', async () => {
    // Will be skipped in CI
  });
});
```

## Testing Strategy

Tests cover both positive and negative scenarios:
- Verification that tests are properly skipped in CI environments
- Verification that tests run normally in local environments
- Verification that test expectations match actual behavior
- Testing proper annotation handling for both environments

## Benefits

1. **Improved Test Reliability**: Allows flagging tests that are known to be environment-sensitive
2. **Better Developer Experience**: Tests still run locally where they can be fixed and verified
3. **Clean CI Pipelines**: Prevents flaky tests from causing false CI failures
4. **Discoverable Syntax**: Follows the pattern of existing modifiers like `test.skip()` and `test.fixme()`

## Future Considerations

- Further enhancements could include conditional testing based on other environment variables
- Consider adding this feature to the public documentation

## Documentation Update

Update to the internal documentation to reflect the new modifier:

```markdown
### test.fixmeinci([condition], [description])

Mark a test or suite as skipped when running in CI environments, but run it normally in local environments.

- When `process.env.CI` is truthy, the test behaves like `test.fixme()`
- When `process.env.CI` is falsy, the test runs normally

This is useful for tests that are unreliable in CI environments but still valuable in local development.
```

## Related Issues

This feature helps address common issues with flaky tests in CI pipelines without removing test coverage for local development.
