### PR TITLE
docs(test-projects): add missing `devices` import in "Dependencies" snippet

### DIFF
--- a/docs/src/test-projects-js.md
+++ b/docs/src/test-projects-js.md
@@ -159,7 +159,7 @@ Dependencies are a list of projects that need to run before the tests in another
 In this example the chromium, firefox and webkit projects depend on the setup project.
 
 ```js title="playwright.config.ts"
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   projects: [


### PR DESCRIPTION
The "Dependencies" section on the "Projects" page is missing the `devices` import in the code snippet.

https://playwright.dev/docs/test-projects#dependencies

<details><summary>Screenshot</summary>
<p>

<img width="536" alt="Screenshot 2025-03-09 at 14 33 25" src="https://github.com/user-attachments/assets/55d6a709-5a83-426d-8ef1-4de9eeae779b" />

</p>
</details> 