### PR TITLE
Added css assertion support

### DIFF
--- a/packages/playwright-core/src/server/codegen/csharp.ts
+++ b/packages/playwright-core/src/server/codegen/csharp.ts
@@ -147,6 +147,12 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
         const assertion = action.value ? `ToHaveValueAsync(${quote(action.value)})` : `ToBeEmptyAsync()`;
         return `await Expect(${subject}.${this._asLocator(action.selector)}).${assertion};`;
       }
+      case 'assertCss': {
+        const cssAssertions = Object.entries(action.css)
+        .map(([property, value]) => `await expect(${subject}.${this._asLocator(action.selector)}).ToHaveCssAsync(${quote(property)}, ${quote(value)});`)
+        .join('\n');
+        return `await Expect(${subject}.${this._asLocator(action.selector)}).${cssAssertions};`;
+      }
       case 'assertSnapshot':
         return `await Expect(${subject}.${this._asLocator(action.selector)}).ToMatchAriaSnapshotAsync(${quote(action.snapshot)});`;
     }

--- a/packages/playwright-core/src/server/codegen/java.ts
+++ b/packages/playwright-core/src/server/codegen/java.ts
@@ -134,6 +134,12 @@ export class JavaLanguageGenerator implements LanguageGenerator {
         const assertion = action.value ? `hasValue(${quote(action.value)})` : `isEmpty()`;
         return `assertThat(${subject}.${this._asLocator(action.selector, inFrameLocator)}).${assertion};`;
       }
+      case 'assertCss': {
+        const cssAssertions = Object.entries(action.css)
+          .map(([property, value]) => `(${subject}.${this._asLocator(action.selector, inFrameLocator)}).toHaveCSS(${quote(property)}, ${quote(value)});`)
+          .join('\n');
+        return `assertThat(${subject}.${this._asLocator(action.selector, inFrameLocator)}).${cssAssertions};`;
+      }
       case 'assertSnapshot':
         return `assertThat(${subject}.${this._asLocator(action.selector, inFrameLocator)}).matchesAriaSnapshot(${quote(action.snapshot)});`;
     }

--- a/packages/playwright-core/src/server/codegen/javascript.ts
+++ b/packages/playwright-core/src/server/codegen/javascript.ts
@@ -118,6 +118,12 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
         const assertion = action.value ? `toHaveValue(${quote(action.value)})` : `toBeEmpty()`;
         return `${this._isTest ? '' : '// '}await expect(${subject}.${this._asLocator(action.selector)}).${assertion};`;
       }
+      case 'assertCss': {
+        const cssAssertions = Object.entries(action.css)
+          .map(([property, value]) => `await expect(${subject}.${this._asLocator(action.selector)}).toHaveCSS(${quote(property)}, ${quote(value)});`)
+          .join('\n');
+        return `${this._isTest ? '' : '// '}${cssAssertions}`;
+      }
       case 'assertSnapshot': {
         const commentIfNeeded = this._isTest ? '' : '// ';
         return `${commentIfNeeded}await expect(${subject}.${this._asLocator(action.selector)}).toMatchAriaSnapshot(${quoteMultiline(action.snapshot, `${commentIfNeeded}  `)});`;

--- a/packages/playwright-core/src/server/codegen/python.ts
+++ b/packages/playwright-core/src/server/codegen/python.ts
@@ -127,6 +127,12 @@ export class PythonLanguageGenerator implements LanguageGenerator {
         const assertion = action.value ? `to_have_value(${quote(action.value)})` : `to_be_empty()`;
         return `expect(${subject}.${this._asLocator(action.selector)}).${assertion};`;
       }
+      case 'assertCss': {
+        const assertion = Object.entries(action.css)
+          .map(([property, value]) => `expect(${subject}.${this._asLocator(action.selector)}).to_have_css(${quote(property)}, ${quote(value)});`)
+          .join('\n');
+        return `${assertion};`;
+      }
       case 'assertSnapshot':
         return `expect(${subject}.${this._asLocator(action.selector)}).to_match_aria_snapshot(${quote(action.snapshot)})`;
     }

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -379,7 +379,7 @@ export class Recorder implements InstrumentationListener, IRecorder {
   }
 
   private _isRecording() {
-    return ['recording', 'assertingText', 'assertingVisibility', 'assertingValue', 'assertingSnapshot'].includes(this._mode);
+    return ['recording', 'assertingText', 'assertingVisibility', 'assertingValue', 'assertingSnapshot', 'assertingCss'].includes(this._mode);
   }
 
   private _readSource(fileName: string): string {

--- a/packages/playwright-core/src/server/recorder/recorderRunner.ts
+++ b/packages/playwright-core/src/server/recorder/recorderRunner.ts
@@ -117,6 +117,17 @@ export async function performAction(pageAliases: Map<Page, string>, actionInCont
     return;
   }
 
+  if (action.name === 'assertCss') {
+    await mainFrame.expect(callMetadata, selector, {
+      selector,
+      expression: 'to.have.css',
+      expectedValue: action.css,
+      isNot: false,
+      timeout: kActionTimeout,
+    });
+    return;
+  }
+
   if (action.name === 'assertVisible') {
     await mainFrame.expect(callMetadata, selector, {
       selector,

--- a/packages/recorder/src/actions.d.ts
+++ b/packages/recorder/src/actions.d.ts
@@ -31,6 +31,7 @@ export type ActionName =
   'assertValue' |
   'assertChecked' |
   'assertVisible' |
+  'assertCss' |
   'assertSnapshot';
 
 export type ActionBase = {
@@ -114,14 +115,24 @@ export type AssertVisibleAction = ActionWithSelector & {
   name: 'assertVisible',
 };
 
+export type AssertCssAction = ActionWithSelector & {
+  name: 'assertCss',
+  substring: boolean,
+  css: {
+    'background-color': string,
+    'font-style': string,
+    'font-size': string,
+  },
+};
+
 export type AssertSnapshotAction = ActionWithSelector & {
   name: 'assertSnapshot',
   snapshot: string,
 };
 
-export type Action = ClickAction | CheckAction | ClosesPageAction | OpenPageAction | UncheckAction | FillAction | NavigateAction | PressAction | SelectAction | SetInputFilesAction | AssertTextAction | AssertValueAction | AssertCheckedAction | AssertVisibleAction | AssertSnapshotAction;
-export type AssertAction = AssertCheckedAction | AssertValueAction | AssertTextAction | AssertVisibleAction | AssertSnapshotAction;
-export type PerformOnRecordAction = ClickAction | CheckAction | UncheckAction | PressAction | SelectAction;
+export type Action = ClickAction | CheckAction | ClosesPageAction | OpenPageAction | UncheckAction | FillAction | NavigateAction | PressAction | SelectAction | SetInputFilesAction | AssertTextAction | AssertValueAction | AssertCheckedAction | AssertVisibleAction | AssertCssAction | AssertSnapshotAction;
+export type AssertAction = AssertCheckedAction | AssertValueAction | AssertTextAction | AssertVisibleAction | AssertCssAction | AssertSnapshotAction;
+export type PerformOnRecordAction = ClickAction | CheckAction | UncheckAction | PressAction | SelectAction | AssertCssAction ;
 
 // Signals.
 

--- a/packages/recorder/src/recorderTypes.d.ts
+++ b/packages/recorder/src/recorderTypes.d.ts
@@ -28,6 +28,7 @@ export type Mode =
   | 'standby'
   | 'assertingVisibility'
   | 'assertingValue'
+  | 'assertingCss'
   | 'assertingSnapshot';
 
 export type ElementInfo = {


### PR DESCRIPTION
feat: Added support for css assertion for any element

### Overview
This PR implements the feature to add assertion for css properties for any UI element using codegen recorder. Below the feature request issue handled in this PR - [Feature](https://github.com/microsoft/playwright/issues/35113)

### Feature
1. Record the css property assertion using codegen. Recorder will show the following css properties with value by default in dialog box
`{
"background-color":"rgb(172, 227, 230)",
"font-style":"600 18px / 24px OpenSans, \"Segoe UI\", SegoeUI, \"Helvetica Neue\", Helvetica, Arial, sans-serif",
"font-size":"18px"
}`

2. User can update the default properties value expected and also add additional properties in same format as below
`{
"background-color":"rgb(172, 227, 230)",
"font-style":"600 18px / 24px OpenSans, \"Segoe UI\", SegoeUI, \"Helvetica Neue\", Helvetica, Arial, sans-serif",
"font-size":"18px",
"text-align":"left"
}`

### Benefits
This will help in recording css property assertions for UI elements using codegen.