### PR TITLE
fix: do not hang in route.continue with unsafe header

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -660,6 +660,8 @@ async function catchDisallowedErrors(callback: () => Promise<void>) {
   } catch (e) {
     if (isProtocolError(e) && e.message.includes('Invalid http status code or phrase'))
       throw e;
+    if (isProtocolError(e) && e.message.includes('Unsafe header'))
+      throw e;
   }
 }
 


### PR DESCRIPTION
route.continue() should throw an error on attempt to set usafe header. Otherwise the request just gets aborted without any indication for the user.