### PR TITLE
feat(playwright-html-report): added global checkbox for enabling/disabling html snippets to Playwright Report

### DIFF
--- a/packages/html-reporter/src/checkbox.css
+++ b/packages/html-reporter/src/checkbox.css
@@ -1,0 +1,21 @@
+/*
+  Copyright (c) Microsoft Corporation.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+.setting {
+    line-height: 38px;
+    padding-left: 9px;
+  }
+  
+  .default {
+    margin-right: 7px;
+  }
+  

--- a/packages/html-reporter/src/checkbox.tsx
+++ b/packages/html-reporter/src/checkbox.tsx
@@ -45,4 +45,3 @@ export const CheckBox: React.FunctionComponent<{
       </>
     );
   };
-  

--- a/packages/html-reporter/src/checkbox.tsx
+++ b/packages/html-reporter/src/checkbox.tsx
@@ -45,3 +45,4 @@ export const CheckBox: React.FunctionComponent<{
       </>
     );
   };
+  

--- a/packages/html-reporter/src/checkbox.tsx
+++ b/packages/html-reporter/src/checkbox.tsx
@@ -1,0 +1,47 @@
+/*
+  Copyright (c) Microsoft Corporation.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import * as React from 'react';
+import './checkbox.css';
+
+export type Check<T> = {
+    value: T;
+    set: (value: T) => void;
+    name: string;
+    title?: string;
+};
+
+export const CheckBox: React.FunctionComponent<{
+    checkBoxSettings: Check<boolean>[];
+  }> = ({ checkBoxSettings }) => {
+    return (
+      <>
+        {checkBoxSettings.map(({ value, set, name, title }) => {
+          const labelId = `checkBoxSetting-${name}`;
+
+          return (
+            <div key={name} className='setting' title={title}>
+              <input
+                className = 'default'
+                type='checkbox'
+                id={labelId}
+                checked={value}
+                onChange={() => set(!value)}
+              />
+              <label htmlFor={labelId}>{name}</label>
+            </div>
+          );
+        })}
+      </>
+    );
+  };

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2790,6 +2790,69 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await page.getByRole('link', { name: 'sample' }).click();
       await expect(page.getByRole('button', { name: 'Copy prompt' })).toHaveCount(1);
     });
+
+    test('should toggle code snippet visibility', async ({ runInlineTest, showReport, page }) => {
+      await runInlineTest({
+        'a.test.js': `
+            const { test, expect } = require('@playwright/test');
+
+            test('test with multiple steps and snippets', async ({ page }) => {
+              console.log('Test started'); // First snippet
+          
+              await test.step('Step 1: Navigate to example page', async () => {
+                await page.goto('https://example.com');
+                console.log('Navigated to example.com'); // Second snippet
+              });
+          
+              await test.step('Step 2: Check page title', async () => {
+                const title = await page.title();
+                console.log('Page title is:', title); // Third snippet
+                expect(title).toBe('Example Domain'); // Fourth snippet
+              });
+          
+              await test.step('Step 3: Find and click a link', async () => {
+                const link = page.locator('a');
+                await expect(link).toBeVisible();
+                console.log('Link is visible'); // Fifth snippet
+                await link.click();
+                console.log('Clicked the link'); // Sixth snippet
+              });
+          
+              console.log('Test finished'); // Seventh snippet
+            });
+          `,
+      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+
+
+      await showReport();
+
+      const testLink = page.locator('a[title*="test with multiple steps and snippets"]').nth(0);
+      await expect(testLink).toBeVisible();
+      await testLink.click();
+
+      await expect(page).toHaveURL(/#\?testId=/);
+      const toggleCheckbox = page.locator('#checkBoxSetting-Show\\ Snippets');
+      await expect(toggleCheckbox).toBeVisible();
+
+      const secondTreeItem = page.locator('.tree-item-title').nth(1);
+      await expect(secondTreeItem).toBeVisible();
+      await secondTreeItem.click();
+
+      const thirdTreeItem = page.locator('.tree-item-title').nth(2);
+      await expect(thirdTreeItem).toBeVisible();
+      await thirdTreeItem.click();
+
+      const codeSnippets = page.locator('[data-testid="test-snippet"]');
+      await expect(codeSnippets.first()).toBeVisible();
+
+      // click checkbox to hide snippets
+      await toggleCheckbox.click();
+      await expect(codeSnippets.first()).not.toBeVisible();
+
+      // click checkbox again to show code snippets
+      await toggleCheckbox.click();
+      await expect(codeSnippets.first()).toBeVisible();
+    });
   });
 }
 


### PR DESCRIPTION
fixes #34052 

**Before:**
<img width="1037" alt="before" src="https://github.com/user-attachments/assets/e610f7d0-e999-448b-a642-425fa0fbdb87" />

**After:**
Not Showing Snippets:
<img width="1020" alt="afterNotShowing" src="https://github.com/user-attachments/assets/a5b2f526-c3c4-41b5-94c5-31410ea6b622" />

Showing Snippets
<img width="1036" alt="afterShowing" src="https://github.com/user-attachments/assets/e4763ae0-d043-43bf-8472-7a4f7f1e69e4" />

