### PR TITLE
docs: Update wrong tab-item value

### DIFF
--- a/docs/src/test-components-js.md
+++ b/docs/src/test-components-js.md
@@ -508,7 +508,7 @@ You can use `beforeMount` and `afterMount` hooks to configure your app. This let
 
   </TabItem>
 
-  <TabItem value="vue3">
+  <TabItem value="vue">
 
   ```js title="playwright/index.ts"
   import { beforeMount, afterMount } from '@playwright/experimental-ct-vue/hooks';


### PR DESCRIPTION
Noticed I forgot to update the value of a `TabItem` that I changed in #35182, this PR fixes that.