### PR TITLE
fix(trace viewer): preserve dialog.showModal() elements

### DIFF
--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -49,6 +49,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
   const kCurrentSrcAttribute = '__playwright_current_src__';
   const kBoundingRectAttribute = '__playwright_bounding_rect__';
   const kPopoverOpenAttribute = '__playwright_popover_open_';
+  const kDialogOpenAttribute = '__playwright_dialog_open_';
 
   // Symbols for our own info on Nodes/StyleSheets.
   const kSnapshotFrameId = Symbol('__playwright_snapshot_frameid_');
@@ -456,6 +457,12 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
             expectValue(value);
             attrs[kPopoverOpenAttribute] = value;
           }
+          if (nodeName === 'DIALOG' && (element as HTMLDialogElement).open) {
+            const value = (element as HTMLDialogElement).matches(':modal') ? 'modal' : 'true';
+            expectValue(kDialogOpenAttribute);
+            expectValue(value);
+            attrs[kDialogOpenAttribute] = value;
+          }
           if (element.scrollTop) {
             expectValue(kScrollTopAttribute);
             expectValue(element.scrollTop);
@@ -541,6 +548,8 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
             if (nodeName === 'IFRAME' && (name === 'src' || name === 'srcdoc' || name === 'sandbox'))
               continue;
             if (nodeName === 'FRAME' && name === 'src')
+              continue;
+            if (nodeName === 'DIALOG' && name === 'open')
               continue;
             let value = element.attributes[i].value;
             if (nodeName === 'META')

--- a/packages/trace-viewer/src/sw/snapshotRenderer.ts
+++ b/packages/trace-viewer/src/sw/snapshotRenderer.ts
@@ -313,6 +313,16 @@ function snapshotScript(viewport: ViewportSize, ...targetIds: (string | undefine
         }
         element.removeAttribute('__playwright_popover_open_');
       }
+      for (const element of root.querySelectorAll(`[__playwright_dialog_open_]`)) {
+        try {
+          if (element.getAttribute('__playwright_dialog_open_') === 'modal')
+            (element as HTMLDialogElement).showModal();
+          else
+            (element as HTMLDialogElement).show();
+        } catch {
+        }
+        element.removeAttribute('__playwright_dialog_open_');
+      }
 
       for (const targetId of targetIds) {
         for (const target of root.querySelectorAll(`[__playwright_target__="${targetId}"]`)) {


### PR DESCRIPTION
Previously, every `<dialog>` element was opened based on the `open` attribute, automatically by the web platform.

However, the information on `show()` vs `showModal()` was lost, which affected `:modal` selector matching, and did not apply quite a few user agent styles, not to mention web author's styles.

Fixes #35139.