### PR TITLE
test: isolate Electron userDataDir per-test

### DIFF
--- a/tests/electron/electron-app.js
+++ b/tests/electron/electron-app.js
@@ -1,5 +1,9 @@
+const assert = require('node:assert/strict');
 const { app, protocol } = require('electron');
 const path = require('path');
+
+assert(process.argv.length > 0, 'No arguments provided. First argument needs to be a userDataDir.');
+app.setPath('appData', process.argv[2]);
 
 app.on('window-all-closed', e => e.preventDefault());
 

--- a/tests/electron/electron-app.js
+++ b/tests/electron/electron-app.js
@@ -2,8 +2,8 @@ const assert = require('node:assert/strict');
 const { app, protocol } = require('electron');
 const path = require('path');
 
-assert(process.argv.length > 0, 'No arguments provided. First argument needs to be a userDataDir.');
-app.setPath('appData', process.argv[2]);
+assert(process.env.PWTEST_ELECTRON_USER_DATA_DIR, 'PWTEST_ELECTRON_USER_DATA_DIR env var is not set');
+app.setPath('appData', process.env.PWTEST_ELECTRON_USER_DATA_DIR);
 
 app.on('window-all-closed', e => e.preventDefault());
 

--- a/tests/electron/electronTest.ts
+++ b/tests/electron/electronTest.ts
@@ -15,17 +15,21 @@
  */
 
 import { baseTest } from '../config/baseTest';
-import * as path from 'path';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
 import type { ElectronApplication, Page, Electron } from '@playwright/test';
 import type { PageTestFixtures, PageWorkerFixtures } from '../page/pageTestApi';
 import type { TraceViewerFixtures } from '../config/traceViewerFixtures';
 import { traceViewerFixtures } from '../config/traceViewerFixtures';
+import { removeFolders } from '../../packages/playwright-core/lib/server/utils/fileUtils';
 export { expect } from '@playwright/test';
 
 type ElectronTestFixtures = PageTestFixtures & {
   electronApp: ElectronApplication;
   launchElectronApp: (appFile: string, args?: string[], options?: Parameters<Electron['launch']>[0]) => Promise<ElectronApplication>;
   newWindow: () => Promise<Page>;
+  createUserDataDir: () => Promise<string>;
 };
 
 export const electronTest = baseTest.extend<TraceViewerFixtures>(traceViewerFixtures).extend<ElectronTestFixtures, PageWorkerFixtures>({
@@ -37,12 +41,25 @@ export const electronTest = baseTest.extend<TraceViewerFixtures>(traceViewerFixt
   isWebView2: [false, { scope: 'worker' }],
   isHeadlessShell: [false, { scope: 'worker' }],
 
-  launchElectronApp: async ({ playwright }, use) => {
+  createUserDataDir: async ({ mode }, run) => {
+    const dirs: string[] = [];
+    // We do not put user data dir in testOutputPath,
+    // because we do not want to upload them as test result artifacts.
+    await run(async () => {
+      const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'playwright-test-'));
+      dirs.push(dir);
+      return dir;
+    });
+    await removeFolders(dirs);
+  },
+
+  launchElectronApp: async ({ playwright, createUserDataDir }, use) => {
     // This env prevents 'Electron Security Policy' console message.
     process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = 'true';
     const apps: ElectronApplication[] = [];
     await use(async (appFile: string, args: string[] = [], options?: Parameters<Electron['launch']>[0]) => {
-      const app = await playwright._electron.launch({ ...options, args: [path.join(__dirname, appFile), ...args] });
+      const userDataDir = await createUserDataDir();
+      const app = await playwright._electron.launch({ ...options, args: [path.join(__dirname, appFile), userDataDir, ...args] });
       apps.push(app);
       return app;
     });

--- a/tests/electron/electronTest.ts
+++ b/tests/electron/electronTest.ts
@@ -59,7 +59,14 @@ export const electronTest = baseTest.extend<TraceViewerFixtures>(traceViewerFixt
     const apps: ElectronApplication[] = [];
     await use(async (appFile: string, args: string[] = [], options?: Parameters<Electron['launch']>[0]) => {
       const userDataDir = await createUserDataDir();
-      const app = await playwright._electron.launch({ ...options, args: [path.join(__dirname, appFile), userDataDir, ...args] });
+      const app = await playwright._electron.launch({
+        ...options,
+        args: [path.join(__dirname, appFile), ...args],
+        env: {
+          ...process.env,
+          PWTEST_ELECTRON_USER_DATA_DIR: userDataDir,
+        }
+      });
       apps.push(app);
       return app;
     });


### PR DESCRIPTION
Taken from [here](https://github.com/microsoft/playwright/blob/195fe11e1bd33466f8b7aa325e00634f93f24eab/tests/config/browserTest.ts#L111). Before this patch Electron has shared the cookies across different test-runs.