### PR TITLE
feat(cli): add command to list installed browsers

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -1121,3 +1121,41 @@ playwright uninstall --all
 ```bash csharp
 pwsh bin/Debug/netX/playwright.ps1 uninstall --all
 ```
+
+### List browsers
+
+This will list the browsers of the current Playwright installation:
+
+```bash js
+npx playwright list
+```
+
+```bash java
+mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="list"
+```
+
+```bash python
+playwright list
+```
+
+```bash csharp
+pwsh bin/Debug/netX/playwright.ps1 list
+```
+
+To list browsers of other Playwright installations as well, pass `--all` flag:
+
+```bash js
+npx playwright list --all
+```
+
+```bash java
+mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="list --all"
+```
+
+```bash python
+playwright list --all
+```
+
+```bash csharp
+pwsh bin/Debug/netX/playwright.ps1 list --all
+```

--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -65,6 +65,24 @@ playwright install --help
 pwsh bin/Debug/netX/playwright.ps1 install --help
 ```
 
+List all installed browsers:
+
+```bash js
+npx playwright install --list
+```
+
+```bash java
+mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --list"
+```
+
+```bash python
+playwright install --list
+```
+
+```bash csharp
+pwsh bin/Debug/netX/playwright.ps1 install --list
+```
+
 ### Install browsers via API
 * langs: csharp
 
@@ -1120,42 +1138,4 @@ playwright uninstall --all
 
 ```bash csharp
 pwsh bin/Debug/netX/playwright.ps1 uninstall --all
-```
-
-### List browsers
-
-This will list the browsers of the current Playwright installation:
-
-```bash js
-npx playwright list
-```
-
-```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="list"
-```
-
-```bash python
-playwright list
-```
-
-```bash csharp
-pwsh bin/Debug/netX/playwright.ps1 list
-```
-
-To list browsers of other Playwright installations as well, pass `--all` flag:
-
-```bash js
-npx playwright list --all
-```
-
-```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="list --all"
-```
-
-```bash python
-playwright list --all
-```
-
-```bash csharp
-pwsh bin/Debug/netX/playwright.ps1 list --all
 ```

--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -170,7 +170,6 @@ program
               console.log(`  Browser: ${browser.name}`);
               console.log(`    Version: ${browser.version}`);
               console.log(`    Location: ${browser.dir}`);
-              console.log(`    Installation completed: ${browser.installationCompleted}`);
             }
             console.log(``);
           }

--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -200,6 +200,29 @@ Examples:
     Install custom browsers, supports ${suggestedBrowsersToInstall()}.`);
 
 program
+    .command('list')
+    .description('List browsers used by this installation of Playwright')
+    .option('--all', 'List all browsers used by any Playwright installation.')
+    .action(async (options: { all?: boolean }) => {
+      await registry.list(!!options.all).then(browsersInfo => {
+        for (const info of browsersInfo) {
+          const whichInstanceLog = ` (${info.currentInstance ? 'CURRENT' : 'OTHER'})`;
+          console.log(`Playwright${options.all ? whichInstanceLog : ''}: ${info.target}`);
+
+          for (const browser of info.browsers) {
+            console.log(`  Browser: ${browser.name}`);
+            console.log(`    Version: ${browser.version}`);
+            console.log(`    Location: ${browser.dir}`);
+            console.log(`    Installation completed: ${browser.installationCompleted}`);
+            console.log(``);
+          }
+          console.log(``);
+          console.log(``);
+        }
+      }).catch(logErrorAndExit);
+    });
+
+program
     .command('uninstall')
     .description('Removes browsers used by this installation of Playwright from the system (chromium, firefox, webkit, ffmpeg). This does not include branded channels.')
     .option('--all', 'Removes all browsers used by any Playwright installation from the system.')

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -26,7 +26,7 @@ import { installDependenciesLinux, installDependenciesWindows, validateDependenc
 import { calculateSha1, getAsBooleanFromENV, getFromENV, getPackageManagerExecCommand } from '../../utils';
 import { wrapInASCIIBox } from '../utils/ascii';
 import { debugLogger } from '../utils/debugLogger';
-import {  hostPlatform, isOfficiallySupportedPlatform } from '../utils/hostPlatform';
+import { hostPlatform, isOfficiallySupportedPlatform } from '../utils/hostPlatform';
 import { fetchData } from '../utils/network';
 import { spawnAsync } from '../utils/spawnAsync';
 import { getEmbedderName } from '../utils/userAgent';
@@ -1024,15 +1024,14 @@ export class Registry {
       return await installDependenciesLinux(targets, dryRun);
   }
 
-  async list(all?: boolean) {
+  async list() {
     const linksDir = path.join(registryDirectory, '.links');
     const links = new Set<string>();
     links.add(calculateSha1(PACKAGE_PATH));
 
-    if (all)
-      (await fs.promises.readdir(linksDir)).forEach(link => links.add(link));
+    (await fs.promises.readdir(linksDir)).forEach(link => links.add(link));
 
-    const browsersInfo: { target: string;currentInstance: boolean; browsers: { name: string;  version: string; dir: string; installationCompleted: boolean}[] }[] = [];
+    const browsersInfo: { target: string; currentInstance: boolean; browsers: { name: string; version: string; dir: string; installationCompleted: boolean }[] }[] = [];
 
     for (const link of links) {
       try {
@@ -1041,7 +1040,7 @@ export class Registry {
         const descriptors = readDescriptors(browsersJSON);
         const currentTargetBrowsers = [];
 
-        for (const  descriptor of descriptors) {
+        for (const descriptor of descriptors) {
           const { name, browserVersion, dir } = descriptor;
           if (!isBrowserDirectory(dir))
             continue;
@@ -1063,7 +1062,7 @@ export class Registry {
           currentInstance: linkTarget === PACKAGE_PATH,
         });
 
-      } catch (e) {}
+      } catch (e) { }
     }
 
     return browsersInfo;
@@ -1203,7 +1202,7 @@ export class Registry {
       return [];
     const downloadPath = util.format(downloadPathTemplate, descriptor.revision);
 
-    let downloadURLs = PLAYWRIGHT_CDN_MIRRORS.map(mirror => `${mirror}/${downloadPath}`) ;
+    let downloadURLs = PLAYWRIGHT_CDN_MIRRORS.map(mirror => `${mirror}/${downloadPath}`);
     let downloadHostEnv;
     if (descriptor.name.startsWith('chromium'))
       downloadHostEnv = 'PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST';


### PR DESCRIPTION
Add a new CLI command to list all browser installations managed by Playwright. Fixes #34183

This command shows browsers installed by the _current_ Playwright instance
`npx playwright list`

![image](https://github.com/user-attachments/assets/97a9091c-1e5c-462e-8d5f-2ed7c1a7cadb)

To list browsers installed by _all_ Playwright instances, use the `--all` flag:

`npx playwright list --all`

![image](https://github.com/user-attachments/assets/5903ff34-5906-47dd-816f-6d4e5bfd1e94)
