### PR TITLE
feat(trace-viewer): add copy to clipboard button for traceviewer snapshot url on hover (#35213)

### DIFF
--- a/packages/trace-viewer/src/ui/browserFrame.css
+++ b/packages/trace-viewer/src/ui/browserFrame.css
@@ -34,6 +34,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 
 .browser-frame-address-bar > button {

--- a/packages/trace-viewer/src/ui/browserFrame.css
+++ b/packages/trace-viewer/src/ui/browserFrame.css
@@ -57,10 +57,3 @@
 body.dark-mode .browser-frame-header {
   background: #444950;
 }
-
-.copy-button {
-  margin-left: 10px;
-  padding: 2px 5px;
-  font-size: 12px;
-  cursor: pointer;
-}

--- a/packages/trace-viewer/src/ui/browserFrame.css
+++ b/packages/trace-viewer/src/ui/browserFrame.css
@@ -57,3 +57,10 @@
 body.dark-mode .browser-frame-header {
   background: #444950;
 }
+
+.copy-button {
+  margin-left: 10px;
+  padding: 2px 5px;
+  font-size: 12px;
+  cursor: pointer;
+}

--- a/packages/trace-viewer/src/ui/browserFrame.css
+++ b/packages/trace-viewer/src/ui/browserFrame.css
@@ -37,11 +37,11 @@
 }
 
 .browser-frame-address-bar > button {
-  display: none;
+  visibility: hidden;
 }
 
 .browser-frame-address-bar:hover > button {
-  display: inline-block;
+  visibility: visible;
 }
 
 .browser-frame-menu-bar {

--- a/packages/trace-viewer/src/ui/browserFrame.css
+++ b/packages/trace-viewer/src/ui/browserFrame.css
@@ -36,6 +36,14 @@
   white-space: nowrap;
 }
 
+.browser-frame-address-bar > button {
+  display: none;
+}
+
+.browser-frame-address-bar:hover > button {
+  display: inline-block;
+}
+
 .browser-frame-menu-bar {
   background-color: #aaa;
   display: block;

--- a/packages/trace-viewer/src/ui/browserFrame.tsx
+++ b/packages/trace-viewer/src/ui/browserFrame.tsx
@@ -17,6 +17,7 @@
 import './browserFrame.css';
 import * as React from 'react';
 import { useState } from 'react';
+import { CopyToClipboard } from './copyToClipboard';
 
 export const BrowserFrame: React.FunctionComponent<{
   url?: string,
@@ -33,15 +34,15 @@ export const BrowserFrame: React.FunctionComponent<{
       <span className='browser-frame-dot' style={{ backgroundColor: 'rgb(251, 190, 60)' }}></span>
       <span className='browser-frame-dot' style={{ backgroundColor: 'rgb(88, 203, 66)' }}></span>
     </div>
-    <div 
-      className='browser-frame-address-bar' 
+    <div
+      className='browser-frame-address-bar'
       title={url || 'about:blank'}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
       {url || 'about:blank'}
       {isHovered && url && (
-        <button onClick={copyToClipboard} className='copy-button'>Copy</button>
+        <CopyToClipboard value={url} />
       )}
     </div>
     <div style={{ marginLeft: 'auto' }}>

--- a/packages/trace-viewer/src/ui/browserFrame.tsx
+++ b/packages/trace-viewer/src/ui/browserFrame.tsx
@@ -16,14 +16,11 @@
 
 import './browserFrame.css';
 import * as React from 'react';
-import { useState } from 'react';
 import { CopyToClipboard } from './copyToClipboard';
 
 export const BrowserFrame: React.FunctionComponent<{
   url?: string,
 }> = ({ url }): React.ReactElement => {
-  const [isHovered, setIsHovered] = useState(false);
-
   return <div className='browser-frame-header'>
     <div style={{ whiteSpace: 'nowrap' }}>
       <span className='browser-frame-dot' style={{ backgroundColor: 'rgb(242, 95, 88)' }}></span>
@@ -33,11 +30,9 @@ export const BrowserFrame: React.FunctionComponent<{
     <div
       className='browser-frame-address-bar'
       title={url || 'about:blank'}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       {url || 'about:blank'}
-      {isHovered && url && (
+      {url && (
         <CopyToClipboard value={url} />
       )}
     </div>

--- a/packages/trace-viewer/src/ui/browserFrame.tsx
+++ b/packages/trace-viewer/src/ui/browserFrame.tsx
@@ -24,10 +24,6 @@ export const BrowserFrame: React.FunctionComponent<{
 }> = ({ url }): React.ReactElement => {
   const [isHovered, setIsHovered] = useState(false);
 
-  const copyToClipboard = () => {
-    if (url) navigator.clipboard.writeText(url);
-  };
-
   return <div className='browser-frame-header'>
     <div style={{ whiteSpace: 'nowrap' }}>
       <span className='browser-frame-dot' style={{ backgroundColor: 'rgb(242, 95, 88)' }}></span>

--- a/packages/trace-viewer/src/ui/browserFrame.tsx
+++ b/packages/trace-viewer/src/ui/browserFrame.tsx
@@ -16,17 +16,34 @@
 
 import './browserFrame.css';
 import * as React from 'react';
+import { useState } from 'react';
 
 export const BrowserFrame: React.FunctionComponent<{
   url?: string,
-}> = ({ url }) => {
+}> = ({ url }): React.ReactElement => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const copyToClipboard = () => {
+    if (url) navigator.clipboard.writeText(url);
+  };
+
   return <div className='browser-frame-header'>
     <div style={{ whiteSpace: 'nowrap' }}>
       <span className='browser-frame-dot' style={{ backgroundColor: 'rgb(242, 95, 88)' }}></span>
       <span className='browser-frame-dot' style={{ backgroundColor: 'rgb(251, 190, 60)' }}></span>
       <span className='browser-frame-dot' style={{ backgroundColor: 'rgb(88, 203, 66)' }}></span>
     </div>
-    <div className='browser-frame-address-bar' title={url || 'about:blank'}>{url || 'about:blank'}</div>
+    <div 
+      className='browser-frame-address-bar' 
+      title={url || 'about:blank'}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {url || 'about:blank'}
+      {isHovered && url && (
+        <button onClick={copyToClipboard} className='copy-button'>Copy</button>
+      )}
+    </div>
     <div style={{ marginLeft: 'auto' }}>
       <div>
         <span className='browser-frame-menu-bar'></span>

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -469,7 +469,7 @@ test('should show snapshot URL', async ({ page, runAndTrace, server }) => {
   await traceViewer.snapshotFrame('page.evaluate');
   const browserFrameAddressBarLocator = traceViewer.page.locator('.browser-frame-address-bar');
   await expect(browserFrameAddressBarLocator).toHaveText(server.EMPTY_PAGE);
-  const copySelectorLocator = browserFrameAddressBarLocator.getByRole('button', { name: 'Copy'})
+  const copySelectorLocator = browserFrameAddressBarLocator.getByRole('button', { name: 'Copy' });
   await expect(copySelectorLocator).toBeHidden();
   await browserFrameAddressBarLocator.hover();
   await expect(copySelectorLocator).toBeVisible();

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -469,12 +469,11 @@ test('should show snapshot URL', async ({ page, runAndTrace, server }) => {
   await traceViewer.snapshotFrame('page.evaluate');
   const browserFrameAddressBarLocator = traceViewer.page.locator('.browser-frame-address-bar');
   await expect(browserFrameAddressBarLocator).toHaveText(server.EMPTY_PAGE);
-  await traceViewer.page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
-  await expect(browserFrameAddressBarLocator).toHaveText(server.EMPTY_PAGE);
-  const copySelectorLocator = traceViewer.page.locator('.browser-frame-address-bar > button[title="Copy"]');
+  const copySelectorLocator = browserFrameAddressBarLocator.getByRole('button', { name: 'Copy'})
   await expect(copySelectorLocator).toBeHidden();
-  await traceViewer.page.hover('.browser-frame-address-bar');
+  await browserFrameAddressBarLocator.hover();
   await expect(copySelectorLocator).toBeVisible();
+  await traceViewer.page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
   await copySelectorLocator.click();
   expect(await traceViewer.page.evaluate(() => navigator.clipboard.readText())).toBe(server.EMPTY_PAGE);
 });

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -467,22 +467,15 @@ test('should show snapshot URL', async ({ page, runAndTrace, server }) => {
     await page.evaluate('2+2');
   });
   await traceViewer.snapshotFrame('page.evaluate');
-  await expect(traceViewer.page.locator('.browser-frame-address-bar')).toHaveText(server.EMPTY_PAGE);
-});
-
-test('should show copy button on snapshot url hover and copy to clipboard on click', async ({ page, runAndTrace, server }) => {
-  const traceViewer = await runAndTrace(async () => {
-    await page.goto(server.EMPTY_PAGE);
-    await page.evaluate('2+2');
-  });
+  let browserFrameAddressBarLocator = traceViewer.page.locator('.browser-frame-address-bar');
+  await expect(browserFrameAddressBarLocator).toHaveText(server.EMPTY_PAGE);
   await traceViewer.page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
-  await traceViewer.snapshotFrame('page.evaluate');
-  await expect(traceViewer.page.locator('.browser-frame-address-bar')).toHaveText(server.EMPTY_PAGE);
-  const copySelector = '.browser-frame-address-bar > button[title="Copy"]';
-  await expect(traceViewer.page.locator(copySelector)).toBeHidden();
+  await expect(browserFrameAddressBarLocator).toHaveText(server.EMPTY_PAGE);
+  let copySelectorLocator = traceViewer.page.locator('.browser-frame-address-bar > button[title="Copy"]');
+  await expect(copySelectorLocator).toBeHidden();
   await traceViewer.page.hover('.browser-frame-address-bar');
-  await expect(traceViewer.page.locator(copySelector)).toBeVisible();
-  await traceViewer.page.locator(copySelector).click();
+  await expect(copySelectorLocator).toBeVisible();
+  await copySelectorLocator.click();
   expect(await traceViewer.page.evaluate(() => navigator.clipboard.readText())).toBe(server.EMPTY_PAGE);
 });
 

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -470,6 +470,22 @@ test('should show snapshot URL', async ({ page, runAndTrace, server }) => {
   await expect(traceViewer.page.locator('.browser-frame-address-bar')).toHaveText(server.EMPTY_PAGE);
 });
 
+test('should show copy button on snapshot url hover and copy to clipboard on click', async ({ page, runAndTrace, server }) => {
+  const traceViewer = await runAndTrace(async () => {
+    await page.goto(server.EMPTY_PAGE);
+    await page.evaluate('2+2');
+  });
+  await traceViewer.page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+  await traceViewer.snapshotFrame('page.evaluate');
+  await expect(traceViewer.page.locator('.browser-frame-address-bar')).toHaveText(server.EMPTY_PAGE);
+  const copySelector = '.browser-frame-address-bar > button[title="Copy"]'
+  await expect(traceViewer.page.locator(copySelector)).toBeHidden();
+  await traceViewer.page.hover('.browser-frame-address-bar')
+  await expect(traceViewer.page.locator(copySelector)).toBeVisible();
+  await traceViewer.page.locator(copySelector).click();
+  expect(await traceViewer.page.evaluate(() => navigator.clipboard.readText())).toBe(server.EMPTY_PAGE);
+});
+
 test('should popup snapshot', async ({ page, runAndTrace, server }) => {
   const traceViewer = await runAndTrace(async () => {
     await page.goto(server.EMPTY_PAGE);

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -478,9 +478,9 @@ test('should show copy button on snapshot url hover and copy to clipboard on cli
   await traceViewer.page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
   await traceViewer.snapshotFrame('page.evaluate');
   await expect(traceViewer.page.locator('.browser-frame-address-bar')).toHaveText(server.EMPTY_PAGE);
-  const copySelector = '.browser-frame-address-bar > button[title="Copy"]'
+  const copySelector = '.browser-frame-address-bar > button[title="Copy"]';
   await expect(traceViewer.page.locator(copySelector)).toBeHidden();
-  await traceViewer.page.hover('.browser-frame-address-bar')
+  await traceViewer.page.hover('.browser-frame-address-bar');
   await expect(traceViewer.page.locator(copySelector)).toBeVisible();
   await traceViewer.page.locator(copySelector).click();
   expect(await traceViewer.page.evaluate(() => navigator.clipboard.readText())).toBe(server.EMPTY_PAGE);

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -467,11 +467,11 @@ test('should show snapshot URL', async ({ page, runAndTrace, server }) => {
     await page.evaluate('2+2');
   });
   await traceViewer.snapshotFrame('page.evaluate');
-  let browserFrameAddressBarLocator = traceViewer.page.locator('.browser-frame-address-bar');
+  const browserFrameAddressBarLocator = traceViewer.page.locator('.browser-frame-address-bar');
   await expect(browserFrameAddressBarLocator).toHaveText(server.EMPTY_PAGE);
   await traceViewer.page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
   await expect(browserFrameAddressBarLocator).toHaveText(server.EMPTY_PAGE);
-  let copySelectorLocator = traceViewer.page.locator('.browser-frame-address-bar > button[title="Copy"]');
+  const copySelectorLocator = traceViewer.page.locator('.browser-frame-address-bar > button[title="Copy"]');
   await expect(copySelectorLocator).toBeHidden();
   await traceViewer.page.hover('.browser-frame-address-bar');
   await expect(copySelectorLocator).toBeVisible();


### PR DESCRIPTION
Closes #35213

Adds a new button on hover that copies snapshot url to clipboard
(https://github.com/microsoft/playwright/issues/35213)
And adds a test for the same
![Screen Shot 2025-03-18 at 10 48 40 AM](https://github.com/user-attachments/assets/e1acffba-cbf2-4645-ab50-df9f4284eb32)
