### PR TITLE
chore(bidi): drop non standard permissions.setPermission

### DIFF
--- a/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
@@ -113,11 +113,6 @@ export interface Commands {
     returnType: Bidi.EmptyResult;
   };
 
-  'permissions.setPermission': {
-    params: Bidi.Permissions.SetPermissionParameters;
-    returnType: Bidi.EmptyResult;
-  };
-
   'session.end': {
     params: Bidi.EmptyParams;
     returnType: Bidi.EmptyResult;


### PR DESCRIPTION
This PR fixes the following error introduced by 017596dfd91161fc2f48e232f31ea7760896e58f:

```
packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts:117:18 - error TS2694: Namespace '"/home/yurys/playwright/packages/playwright-core/src/server/bidi/third_party/bidiProtocol"' has no exported member 'Permissions'.

117     params: Bidi.Permissions.SetPermissionParameters;
                     ~~~~~~~~~~~

```

Permissions domain is not a part of the official bidi spec.