### PR TITLE
fix: prompt button should not be hidden by error

### DIFF
--- a/packages/html-reporter/src/testErrorView.css
+++ b/packages/html-reporter/src/testErrorView.css
@@ -17,8 +17,8 @@
 @import '@web/third_party/vscode/colors.css';
 
 .test-error-container {
+  position: relative;
   white-space: pre;
-  overflow: auto;
   flex: none;
   padding: 0;
   background-color: var(--color-canvas-subtle);
@@ -28,6 +28,7 @@
 }
 
 .test-error-view {
+  overflow: auto;
   padding: 16px;
 }
 

--- a/packages/html-reporter/src/testErrorView.tsx
+++ b/packages/html-reporter/src/testErrorView.tsx
@@ -28,7 +28,7 @@ export const TestErrorView: React.FC<{
   return (
     <CodeSnippet code={error} testId={testId}>
       {prompt && (
-        <div style={{ float: 'right', margin: 10 }}>
+        <div style={{ position: 'absolute', right: 0, padding: '10px' }}>
           <PromptButton prompt={prompt} />
         </div>
       )}


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/35251

Old:
<img width="868" alt="Screenshot 2025-03-19 at 11 36 31" src="https://github.com/user-attachments/assets/4399d82b-6414-419a-98b2-19cd909fe692" />

New:


https://github.com/user-attachments/assets/b53ad5ef-4e0e-41aa-8f65-186d5bc788d6

