### PR TITLE
Remove special handling for getSelection() with Firefox from tests

### DIFF
--- a/tests/page/elementhandle-select-text.spec.ts
+++ b/tests/page/elementhandle-select-text.spec.ts
@@ -22,12 +22,7 @@ it('should select textarea', async ({ page, server, browserName }) => {
   const textarea = await page.$('textarea');
   await textarea.evaluate(textarea => textarea.value = 'some value');
   await textarea.selectText();
-  if (browserName === 'firefox') {
-    expect(await textarea.evaluate(el => el.selectionStart)).toBe(0);
-    expect(await textarea.evaluate(el => el.selectionEnd)).toBe(10);
-  } else {
-    expect(await page.evaluate(() => window.getSelection().toString())).toBe('some value');
-  }
+  expect(await page.evaluate(() => window.getSelection().toString())).toBe('some value');
 });
 
 it('should select input', async ({ page, server, browserName }) => {
@@ -35,12 +30,7 @@ it('should select input', async ({ page, server, browserName }) => {
   const input = await page.$('input');
   await input.evaluate(input => input.value = 'some value');
   await input.selectText();
-  if (browserName === 'firefox') {
-    expect(await input.evaluate(el => el.selectionStart)).toBe(0);
-    expect(await input.evaluate(el => el.selectionEnd)).toBe(10);
-  } else {
-    expect(await page.evaluate(() => window.getSelection().toString())).toBe('some value');
-  }
+  expect(await page.evaluate(() => window.getSelection().toString())).toBe('some value');
 });
 
 it('should select plain div', async ({ page, server }) => {

--- a/tests/page/locator-misc-2.spec.ts
+++ b/tests/page/locator-misc-2.spec.ts
@@ -78,12 +78,7 @@ it('should select textarea', async ({ page, server, browserName }) => {
   const textarea = page.locator('textarea');
   await textarea.evaluate(textarea => (textarea as HTMLTextAreaElement).value = 'some value');
   await textarea.selectText();
-  if (browserName === 'firefox') {
-    expect(await textarea.evaluate(el => (el as HTMLTextAreaElement).selectionStart)).toBe(0);
-    expect(await textarea.evaluate(el => (el as HTMLTextAreaElement).selectionEnd)).toBe(10);
-  } else {
-    expect(await page.evaluate(() => window.getSelection().toString())).toBe('some value');
-  }
+  expect(await page.evaluate(() => window.getSelection().toString())).toBe('some value');
 });
 
 it('should type', async ({ page }) => {

--- a/tests/page/retarget.spec.ts
+++ b/tests/page/retarget.spec.ts
@@ -239,12 +239,7 @@ it('input value retargeting', async ({ page, browserName }) => {
       await expect(target).toHaveValue('bar');
 
       await target.selectText();
-      if (browserName === 'firefox') {
-        expect(await page.locator('#target').evaluate((el: HTMLInputElement) => el.selectionStart)).toBe(0);
-        expect(await page.locator('#target').evaluate((el: HTMLInputElement) => el.selectionEnd)).toBe(3);
-      } else {
-        expect(await page.evaluate(() => window.getSelection()!.toString())).toBe('bar');
-      }
+      expect(await page.evaluate(() => window.getSelection()!.toString())).toBe('bar');
     });
   }
 });
@@ -270,14 +265,7 @@ it('selection retargeting', async ({ page, browserName }) => {
       await expect(page.locator('#target')).toHaveText('foo');
 
       await target.selectText();
-      if (browserName === 'firefox') {
-        expect(await page.$eval('#target', target => {
-          const selection = window.getSelection()!;
-          return selection.anchorNode === target && selection.focusNode === target;
-        })).toBe(true);
-      } else {
-        expect(await page.evaluate(() => window.getSelection()!.toString())).toBe('foo');
-      }
+      expect(await page.evaluate(() => window.getSelection()!.toString())).toBe('foo');
     });
   }
 });


### PR DESCRIPTION
We got https://bugzilla.mozilla.org/show_bug.cgi?id=85686 in Firefox fixed for version 138 which is currently in Nightly. That means that we no longer need to special-case the handling for `getSelection()` with Firefox. 

I assume this PR needs to wait with getting merged until Firefox 138 is going to be released?