### PR TITLE
chore: only provide a single console resource

### DIFF
--- a/packages/playwright-mcp/src/resources/console.ts
+++ b/packages/playwright-mcp/src/resources/console.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Resource, ResourceResult } from './resource';
+import type { Resource } from './resource';
 
 export const console: Resource = {
   schema: {
@@ -24,14 +24,14 @@ export const console: Resource = {
   },
 
   read: async (context, uri) => {
-    const result: ResourceResult[] = [];
-    for (const message of await context.ensureConsole()) {
-      result.push({
+    const messages = await context.ensureConsole();
+    const log = messages.map(message => `[${message.type().toUpperCase()}] ${message.text()}`).join(`\n`);
+    return [
+      {
         uri,
         mimeType: 'text/plain',
-        text: `[${message.type().toUpperCase()}] ${message.text()}`,
-      });
-    }
-    return result;
+        text: log,
+      }
+    ];
   },
 };


### PR DESCRIPTION
Returning one resource per log line is flooding the Claude UI:

<img width="1061" alt="Screenshot 2025-03-19 at 16 01 45" src="https://github.com/user-attachments/assets/1779374e-6b9d-44d7-b916-c521933e1085" />

Returning one big resource with all lines feels better.