### PR TITLE
fix(webkit): do not dipatch request event for about:blank

### DIFF
--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -1014,6 +1014,9 @@ export class WKPage implements PageDelegate {
   _onRequestWillBeSent(session: WKSession, event: Protocol.Network.requestWillBeSentPayload) {
     if (event.request.url.startsWith('data:'))
       return;
+    // WebKit started dispatching network events for about:blank after https://commits.webkit.org/292206@main.
+    if (event.request.url.startsWith('about:'))
+      return;
 
     // We do not support intercepting redirects.
     if (this._page.needsRequestInterception() && !event.redirectResponse)


### PR DESCRIPTION
Starting with https://github.com/WebKit/WebKit/pull/42408,  WebKit started dispatching `requestWillBeSent` event for `about:blank` URL. Similar to `data:` URLs we don't want to expose such event to the users as it doesn't hit the network.

This PR is a preparation to the roll https://github.com/microsoft/playwright-browsers/pull/1560.