### PR TITLE
devops: fix for Canary Trace Viewer deployment

### DIFF
--- a/utils/build/deploy-trace-viewer.sh
+++ b/utils/build/deploy-trace-viewer.sh
@@ -29,7 +29,7 @@ npm run build
 # 2. Configure Git and clone the Trace Viewer repository
 git config --global user.name github-actions
 git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
-git clone "https://${GH_SERVICE_ACCOUNT_TOKEN}@github.com/microsoft/trace.playwright.dev.git" trace.playwright.dev
+git clone "https://x-access-token:${GH_SERVICE_ACCOUNT_TOKEN}@github.com/microsoft/trace.playwright.dev.git" trace.playwright.dev
 
 # 3. Copy the built Trace Viewer to the repository
 if [[ "${RELEASE_CHANNEL}" == "--stable" ]]; then


### PR DESCRIPTION
Switched from a PAT to a GitHub App token, which requires an explicit username in the clone URL. Previously, using a PAT worked by embedding the token directly. Now, updating the clone command to:

```bash
git clone "https://x-access-token:${GH_SERVICE_ACCOUNT_TOKEN}@github.com/microsoft/trace.playwright.dev.git" trace.playwright.dev
```

resolves the authentication error.

Fixes https://github.com/microsoft/playwright/actions/runs/13952785577/job/39056393493

Relates https://github.com/microsoft/playwright-internal/issues/231