### PR TITLE
feat: Improve network tabs trace viewer

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -14,53 +14,78 @@
   limitations under the License.
 */
 
+.tab-network {
+  .toolbar {
+    min-height: 30px !important;
+    background-color: initial !important;
+    border-bottom: 1px solid var(--vscode-panel-border);
+
+    &&:after {
+      box-shadow: none !important;
+    }
+  }
+
+  .tabbed-pane-tab.selected {
+    font-weight: bold;
+  }
+}
+
+.copy-request-dropdown {
+  .copy-request-dropdown-toggle {
+    margin-right: 14px;
+    width: 135px;
+  }
+
+  .copy-request-dropdown-menu {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    width: 135px;
+
+    button {
+      padding: 8px;
+      text-align: left;
+      z-index: 10;
+    }
+  }
+}
+
 .network-request-details-tab {
   width: 100%;
   height: 100%;
   user-select: text;
   line-height: 24px;
-  margin-left: 10px;
   overflow: auto;
-}
 
-.network-request-details-url {
-  white-space: normal;
-  word-wrap: break-word;
-  margin-left: 10px;
-}
+  em {
+    margin: 10px
+  }
 
-.network-request-details-headers {
-  white-space: pre;
-  overflow: hidden;
-  margin-left: 10px;
-}
+  .network-details {
+    margin-bottom: 8px;
 
-.network-request-details-header {
-  margin: 3px 0;
-  font-weight: bold;
-}
+    summary {
+      font-weight: bold;
+      cursor: pointer;
+      background-color: var(--vscode-sideBar-background);
+      padding: 4px;
+    }
 
-.network-request-details-general {
-  white-space: pre;
-  margin-left: 10px;
-}
-
-.network-request-details-tab .cm-wrapper {
-  overflow: hidden;
-}
-
-.network-request-details-copy {
-  display: flex;
-  margin: 8px 10px;
-  gap: 8px;
+    .network-details-content {
+      display: grid;
+      grid-template-columns: 200px auto;
+      column-gap: 16px;
+      white-space: pre-wrap;
+      margin: 0 16px;
+    }
+  }
 }
 
 .network-font-preview {
   font-family: font-preview;
   font-size: 30px;
   line-height: 40px;
-  padding: 16px;
-  padding-left: 6px;
+  padding: 16px 16px 16px 6px;
   overflow: hidden;
   text-overflow: ellipsis;
   text-align: center;
@@ -69,20 +94,6 @@
 .network-font-preview-error {
   margin-top: 8px;
   text-align: center;
-}
-
-.tab-network .toolbar {
-  min-height: 30px !important;
-  background-color: initial !important;
-  border-bottom: 1px solid var(--vscode-panel-border);
-}
-
-.tab-network .toolbar::after {
-  box-shadow: none !important;
-}
-
-.tab-network .tabbed-pane-tab.selected {
-  font-weight: bold;
 }
 
 .green-circle::before,

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -71,12 +71,14 @@
       padding: 4px;
     }
 
-    .network-details-content {
-      display: grid;
-      grid-template-columns: 200px auto;
-      column-gap: 16px;
+    table {
       white-space: pre-wrap;
-      margin: 0 16px;
+      margin-left: 16px;
+      word-break: break-word;
+
+      td:first-of-type {
+        width: 200px;
+      }
     }
   }
 }

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -110,8 +110,8 @@ const DetailsSection: React.FC<{
 
       <table>
         <tbody>
-          {data.map(({ name, value }) => (
-            <tr key={name + value}>
+          {data.map(({ name, value }, index) => (
+            <tr key={index}>
               <td>{name}:</td>
               <td>{value}</td>
             </tr>

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -24,146 +24,141 @@ import { generateCurlCommand, generateFetchCall } from '../third_party/devtools'
 import { CopyToClipboardTextButton } from './copyToClipboard';
 import { getAPIRequestCodeGen } from './codegen';
 import type { Language } from '@isomorphic/locatorGenerators';
-import { msToString } from '@web/uiUtils';
+import { msToString, useSetting } from '@web/uiUtils';
+import type { Entry, QueryParameter } from '@trace/har';
 
-export const NetworkResourceDetails: React.FunctionComponent<{
-  resource: ResourceSnapshot;
-  sdkLanguage: Language;
-  startTimeOffset: number;
-  onClose: () => void;
-}> = ({ resource, sdkLanguage, startTimeOffset, onClose }) => {
-  const [selectedTab, setSelectedTab] = React.useState('request');
 
-  return <TabbedPane
-    dataTestId='network-request-details'
-    leftToolbar={[<ToolbarButton key='close' icon='close' title='Close' onClick={onClose}></ToolbarButton>]}
-    tabs={[
-      {
-        id: 'request',
-        title: 'Request',
-        render: () => <RequestTab resource={resource} sdkLanguage={sdkLanguage} startTimeOffset={startTimeOffset} />,
-      },
-      {
-        id: 'response',
-        title: 'Response',
-        render: () => <ResponseTab resource={resource}/>,
-      },
-      {
-        id: 'body',
-        title: 'Body',
-        render: () => <BodyTab resource={resource}/>,
-      },
-    ]}
-    selectedTab={selectedTab}
-    setSelectedTab={setSelectedTab} />;
-};
+type RequestBody = { text: string, mimeType?: string } | null;
+type ResponseBody = {  dataUrl?: string,  text?: string,  mimeType?: string,  font?: BufferSource} | null;
 
-const RequestTab: React.FunctionComponent<{
-  resource: ResourceSnapshot;
-  sdkLanguage: Language;
-  startTimeOffset: number;
-}> = ({ resource, sdkLanguage, startTimeOffset }) => {
-  const [requestBody, setRequestBody] = React.useState<{ text: string, mimeType?: string } | null>(null);
+function statusClass(statusCode: number): string {
+  if ((statusCode >= 100 && statusCode < 300) || statusCode === 304)
+    return 'green-circle';
+  if (statusCode >= 300 && statusCode < 400)
+    return 'yellow-circle';
+  return 'red-circle';
+}
 
-  React.useEffect(() => {
-    const readResources = async  () => {
-      if (resource.request.postData) {
-        const requestContentTypeHeader = resource.request.headers.find(q => q.name.toLowerCase() === 'content-type');
-        const requestContentType = requestContentTypeHeader ? requestContentTypeHeader.value : '';
-        if (resource.request.postData._sha1) {
-          const response = await fetch(`sha1/${resource.request.postData._sha1}`);
-          setRequestBody({ text: formatBody(await response.text(), requestContentType), mimeType: requestContentType });
-        } else {
-          setRequestBody({ text: formatBody(resource.request.postData.text, requestContentType), mimeType: requestContentType });
-        }
-      } else {
-        setRequestBody(null);
-      }
-    };
-    readResources();
-  }, [resource]);
+function formatBody(body: string | null, contentType: string): string {
+  if (body === null)
+    return 'Loading...';
 
-  return <div className='network-request-details-tab'>
-    <div className='network-request-details-header'>General</div>
-    <div className='network-request-details-url'>{`URL: ${resource.request.url}`}</div>
-    <div className='network-request-details-general'>{`Method: ${resource.request.method}`}</div>
-    {resource.response.status !== -1 && <div className='network-request-details-general' style={{ display: 'flex' }}>
-      Status Code: <span className={statusClass(resource.response.status)} style={{ display: 'inline-flex' }}>
-        {`${resource.response.status} ${resource.response.statusText}`}
-      </span></div>}
-    {resource.request.queryString.length ? <>
-      <div className='network-request-details-header'>Query String Parameters</div>
-      <div className='network-request-details-headers'>
-        {resource.request.queryString.map(param => `${param.name}: ${param.value}`).join('\n')}
-      </div>
-    </> : null}
-    <div className='network-request-details-header'>Request Headers</div>
-    <div className='network-request-details-headers'>{resource.request.headers.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
-    <div className='network-request-details-header'>Time</div>
-    <div className='network-request-details-general'>{`Start: ${msToString(startTimeOffset)}`}</div>
-    <div className='network-request-details-general'>{`Duration: ${msToString(resource.time)}`}</div>
+  if (body === '')
+    return '<Empty>';
 
-    <div className='network-request-details-copy'>
-      <CopyToClipboardTextButton description='Copy as cURL' value={() => generateCurlCommand(resource)} />
-      <CopyToClipboardTextButton description='Copy as Fetch' value={() => generateFetchCall(resource)} />
-      <CopyToClipboardTextButton description='Copy as Playwright' value={async () => getAPIRequestCodeGen(sdkLanguage).generatePlaywrightRequestCall(resource.request, requestBody?.text)} />
+  if (contentType.includes('application/json')) {
+    try {
+      return JSON.stringify(JSON.parse(body), null, 2);
+    } catch (err) {
+      return body;
+    }
+  }
+
+  if (contentType.includes('application/x-www-form-urlencoded'))
+    return decodeURIComponent(body);
+
+  return body;
+}
+
+const CopyDropdown: React.FC<{
+  resource: Entry,
+  sdkLanguage: Language,
+  requestBody: RequestBody,
+}> = ({ resource, sdkLanguage, requestBody }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const copiedDescription = <><span className='codicon codicon-check' style={{ marginRight: '5px' }}/> Copied </>;
+
+  return (
+    <div className='copy-request-dropdown' onMouseLeave={() => setIsOpen(false)} onMouseEnter={() => setIsOpen(true)}>
+      <ToolbarButton className='copy-request-dropdown-toggle'>
+        <span className='codicon codicon-copy' style={{ marginRight: '5px' }}/>
+        Copy request
+        <span className='codicon codicon-chevron-down' style={{ marginLeft: '5px' }}/>
+      </ToolbarButton>
+
+      {isOpen && (
+        <div className='copy-request-dropdown-menu'>
+          <CopyToClipboardTextButton description='Copy as cURL' copiedDescription={copiedDescription}
+            value={() => generateCurlCommand(resource)}/>
+          <CopyToClipboardTextButton description='Copy as Fetch' copiedDescription={copiedDescription}
+            value={() => generateFetchCall(resource)}/>
+          <CopyToClipboardTextButton description='Copy as Playwright' copiedDescription={copiedDescription}
+            value={async () => getAPIRequestCodeGen(sdkLanguage).generatePlaywrightRequestCall(resource.request, requestBody?.text)}/>
+        </div>
+      )}
     </div>
-
-    {requestBody && <div className='network-request-details-header'>Request Body</div>}
-    {requestBody && <CodeMirrorWrapper text={requestBody.text} mimeType={requestBody.mimeType} readOnly lineNumbers={true}/>}
-  </div>;
+  );
 };
 
-const ResponseTab: React.FunctionComponent<{
+const DetailsSection: React.FC<{
+  title: string;
+  data?: Record<string, React.ReactNode>,
+  showCountWhenCollapsed?: boolean,
+  children?: React.ReactElement
+}> = ({ title, data = {}, showCountWhenCollapsed, children }) => {
+  const [isOpen, setIsOpen] = useSetting(`trace-viewer-network-details-${title.replaceAll(' ', '-')}`, true);
+
+  return (
+    <details className='network-details' open={isOpen}>
+      <summary onClick={event => {
+        event.preventDefault();
+        setIsOpen(!isOpen);
+      }}>
+        {title} {!isOpen && showCountWhenCollapsed && `(${Object.keys(data).length})`}
+      </summary>
+      <div className='network-details-content'>
+        {Object.entries(data).map(([key, value]) => (
+          <React.Fragment key={key}>
+            <div>{key}:</div>
+            <div>{value}</div>
+          </React.Fragment>
+        ))}
+        {children}
+      </div>
+    </details>
+  );
+};
+
+const HeadersTab: React.FC<{
   resource: ResourceSnapshot;
-}> = ({ resource }) => {
+  startTimeOffset: number;
+}> = ({ resource, startTimeOffset }) => {
   return <div className='network-request-details-tab'>
-    <div className='network-request-details-header'>Response Headers</div>
-    <div className='network-request-details-headers'>{resource.response.headers.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
+    <DetailsSection title='General' data={{
+      'URL': resource.request.url,
+      'Method': resource.request.method,
+      'Status Code': resource.response.status !== -1 ? <span className={statusClass(resource.response.status)}> {resource.response.status} {resource.response.statusText} </span> : null,
+      'Start': msToString(startTimeOffset),
+      'Duration': msToString(resource.time)
+    }}/>
+
+    <DetailsSection title='Request Headers' showCountWhenCollapsed
+      data={Object.fromEntries(resource.request.headers.map(({ name, value }) => [name, value]))}/>
+
+    <DetailsSection title='Response Headers' showCountWhenCollapsed
+      data={Object.fromEntries(resource.response.headers.map(({ name, value }) => [name, value]))}/>
   </div>;
 };
 
-const BodyTab: React.FunctionComponent<{
-  resource: ResourceSnapshot;
-}> = ({ resource }) => {
-  const [responseBody, setResponseBody] = React.useState<{ dataUrl?: string, text?: string, mimeType?: string, font?: BufferSource } | null>(null);
-
-  React.useEffect(() => {
-    const readResources = async  () => {
-      if (resource.response.content._sha1) {
-        const useBase64 = resource.response.content.mimeType.includes('image');
-        const isFont = resource.response.content.mimeType.includes('font');
-        const response = await fetch(`sha1/${resource.response.content._sha1}`);
-        if (useBase64) {
-          const blob = await response.blob();
-          const reader = new FileReader();
-          const eventPromise = new Promise<any>(f => reader.onload = f);
-          reader.readAsDataURL(blob);
-          setResponseBody({ dataUrl: (await eventPromise).target.result });
-        } else if (isFont) {
-          const font = await response.arrayBuffer();
-          setResponseBody({ font });
-        } else {
-          const formattedBody = formatBody(await response.text(), resource.response.content.mimeType);
-          setResponseBody({ text: formattedBody, mimeType: resource.response.content.mimeType });
-        }
-      } else {
-        setResponseBody(null);
-      }
-    };
-
-    readResources();
-  }, [resource]);
+const PayloadTab: React.FC<{
+  queryString: QueryParameter[];
+  requestBody: RequestBody,
+}> = ({ queryString, requestBody }) => {
+  const queryData = Object.fromEntries(queryString.map(({ name, value }) => [name, value]));
 
   return <div className='network-request-details-tab'>
-    {!resource.response.content._sha1 && <div>Response body is not available for this request.</div>}
-    {responseBody && responseBody.font && <FontPreview font={responseBody.font} />}
-    {responseBody && responseBody.dataUrl && <img draggable='false' src={responseBody.dataUrl} />}
-    {responseBody && responseBody.text && <CodeMirrorWrapper text={responseBody.text} mimeType={responseBody.mimeType} readOnly lineNumbers={true}/>}
+    {!queryData.length && !requestBody && <em>No payload for this request</em>}
+
+    {queryData.length && <DetailsSection title='Query String Parameters' data={queryData}/>}
+
+    {requestBody && <DetailsSection title='Request Body'>
+      <CodeMirrorWrapper text={requestBody.text} mimeType={requestBody.mimeType} readOnly lineNumbers={true}/>
+    </DetailsSection>}
   </div>;
 };
 
-const FontPreview: React.FunctionComponent<{
+const FontPreview: React.FC<{
   font: BufferSource;
 }> = ({ font }) => {
   const [isError, setIsError] = React.useState(false);
@@ -199,32 +194,104 @@ const FontPreview: React.FunctionComponent<{
   </div>;
 };
 
-function statusClass(statusCode: number): string {
-  if (statusCode < 300 || statusCode === 304)
-    return 'green-circle';
-  if (statusCode < 400)
-    return 'yellow-circle';
-  return 'red-circle';
-}
+const ResponseTab: React.FC<{
+  resource: ResourceSnapshot;
+  responseBody: ResponseBody
+}> = ({ resource, responseBody }) => {
+  return <div className='network-request-details-tab'>
+    {!responseBody && <em>Response body is not available for this request</em>}
+    {responseBody?.font && <FontPreview font={responseBody.font}/>}
+    {responseBody?.dataUrl && <img draggable='false' src={responseBody.dataUrl}/>}
+    {responseBody?.text &&
+      <CodeMirrorWrapper text={responseBody.text} mimeType={responseBody.mimeType} readOnly lineNumbers={true}/>}
+  </div>;
+};
 
-function formatBody(body: string | null, contentType: string): string {
-  if (body === null)
-    return 'Loading...';
 
-  const bodyStr = body;
-  if (bodyStr === '')
-    return '<Empty>';
+export const NetworkResourceDetails: React.FC<{
+  resource: ResourceSnapshot;
+  sdkLanguage: Language;
+  startTimeOffset: number;
+  onClose: () => void;
+}> = ({ resource, sdkLanguage, startTimeOffset, onClose }) => {
+  const [selectedTab, setSelectedTab] = React.useState('headers');
 
-  if (contentType.includes('application/json')) {
-    try {
-      return JSON.stringify(JSON.parse(bodyStr), null, 2);
-    } catch (err) {
-      return bodyStr;
-    }
-  }
+  const [requestBody, setRequestBody] = React.useState<RequestBody>(null);
+  const [responseBody, setResponseBody] = React.useState<ResponseBody>(null);
 
-  if (contentType.includes('application/x-www-form-urlencoded'))
-    return decodeURIComponent(bodyStr);
+  React.useEffect(() => {
+    const readRequest = async () => {
+      if (!resource.request.postData) {
+        setRequestBody(null);
+        return;
+      }
 
-  return bodyStr;
-}
+      const requestContentTypeHeader = resource.request.headers.find(({ name }) => name.toLowerCase() === 'content-type');
+      const requestContentType = requestContentTypeHeader ? requestContentTypeHeader.value : '';
+      if (resource.request.postData._sha1) {
+        const response = await fetch(`sha1/${resource.request.postData._sha1}`);
+        setRequestBody({ text: formatBody(await response.text(), requestContentType), mimeType: requestContentType });
+      } else {
+        setRequestBody({
+          text: formatBody(resource.request.postData.text, requestContentType),
+          mimeType: requestContentType
+        });
+      }
+    };
+
+    const readResponse = async () => {
+      if (!resource.response.content._sha1) {
+        setResponseBody(null);
+        return;
+      }
+
+      const mimeType = resource.response.content.mimeType;
+      const useBase64 = mimeType.includes('image');
+      const response = await fetch(`sha1/${resource.response.content._sha1}`);
+      if (useBase64) {
+        const blob = await response.blob();
+        const reader = new FileReader();
+        const eventPromise = new Promise<any>(f => reader.onload = f);
+        reader.readAsDataURL(blob);
+        setResponseBody({ dataUrl: (await eventPromise).target.result });
+        return;
+      }
+
+      const isFont = mimeType.includes('font');
+      if (isFont) {
+        const font = await response.arrayBuffer();
+        setResponseBody({ font });
+      } else {
+        const formattedBody = formatBody(await response.text(), mimeType);
+        setResponseBody({ text: formattedBody, mimeType: mimeType });
+      }
+    };
+
+    readRequest();
+    readResponse();
+  }, [resource]);
+
+  return <TabbedPane
+    dataTestId='network-request-details'
+    leftToolbar={[<ToolbarButton key='close' icon='close' title='Close' onClick={onClose}/>]}
+    rightToolbar={[<CopyDropdown key='dropdown' requestBody={requestBody} resource={resource} sdkLanguage={sdkLanguage}/>]}
+    tabs={[
+      {
+        id: 'headers',
+        title: 'Headers',
+        render: () => <HeadersTab resource={resource} startTimeOffset={startTimeOffset}/>,
+      },
+      {
+        id: 'payload',
+        title: 'Payload',
+        render: () => <PayloadTab queryString={resource.request.queryString} requestBody={requestBody}/>,
+      },
+      {
+        id: 'response',
+        title: 'Response',
+        render: () => <ResponseTab resource={resource} responseBody={responseBody} />,
+      },
+    ]}
+    selectedTab={selectedTab}
+    setSelectedTab={setSelectedTab}/>;
+};

--- a/packages/web/src/components/tabbedPane.tsx
+++ b/packages/web/src/components/tabbedPane.tsx
@@ -106,7 +106,9 @@ export const TabbedPaneTab: React.FunctionComponent<{
     onClick={() => onSelect?.(id)}
     role='tab'
     title={title}
-    aria-controls={ariaControls}>
+    aria-controls={ariaControls}
+    aria-selected={selected}
+  >
     <div className='tabbed-pane-tab-label'>{title}</div>
     {!!count && <div className='tabbed-pane-tab-counter'>{count}</div>}
     {!!errorCount && <div className='tabbed-pane-tab-counter error'>{errorCount}</div>}

--- a/packages/web/src/components/toolbarButton.tsx
+++ b/packages/web/src/components/toolbarButton.tsx
@@ -20,11 +20,11 @@ import * as React from 'react';
 import { clsx } from '../uiUtils';
 
 export interface ToolbarButtonProps {
-  title: string,
+  title?: string,
   icon?: string,
   disabled?: boolean,
   toggled?: boolean,
-  onClick: (e: React.MouseEvent) => void,
+  onClick?: (e: React.MouseEvent) => void,
   style?: React.CSSProperties,
   testId?: string,
   className?: string,

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -406,7 +406,7 @@ test('should show font preview', async ({ page, runAndTrace, server }) => {
   await traceViewer.page.getByText('Font', { exact: true }).click();
   await expect(traceViewer.networkRequests).toHaveCount(1);
   await traceViewer.networkRequests.getByText('font.woff2').click();
-  await traceViewer.page.getByTestId('network-request-details').getByTitle('Body').click();
+  await traceViewer.page.getByTestId('network-request-details').getByTitle('Response').click();
   await expect(traceViewer.page.locator('.network-request-details-tab')).toContainText('ABCDEF');
 });
 

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -406,8 +406,8 @@ test('should show font preview', async ({ page, runAndTrace, server }) => {
   await traceViewer.page.getByText('Font', { exact: true }).click();
   await expect(traceViewer.networkRequests).toHaveCount(1);
   await traceViewer.networkRequests.getByText('font.woff2').click();
-  await traceViewer.page.getByTestId('network-request-details').getByTitle('Response').click();
-  await expect(traceViewer.page.locator('.network-request-details-tab')).toContainText('ABCDEF');
+  await traceViewer.page.getByTestId('network-request-details').getByRole('tab', { name: 'Response' }).click();
+  await expect(traceViewer.page.getByRole('tabpanel', { name: 'Response' })).toContainText('ABCDEF');
 });
 
 test('should filter network requests by url', async ({ page, runAndTrace, server }) => {

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -108,7 +108,7 @@ test('should format JSON request body', async ({ runUITest, server }) => {
   await page.getByText('Network', { exact: true }).click();
 
   await page.getByText('post-data-1').click();
-
+  await page.getByRole('tab', { name: 'Payload' }).click();
   await expect(page.locator('.CodeMirror-code .CodeMirror-line').allInnerTexts()).resolves.toEqual([
     '{',
     '  "data": {',
@@ -151,14 +151,21 @@ test('should display list of query parameters (only if present)', async ({ runUI
 
   await page.getByText('call-with-query-params').click();
 
-  await expect(page.getByText('Query String Parameters')).toBeVisible();
-  await expect(page.getByText('param1: value1')).toBeVisible();
-  await expect(page.getByText('param1: value2')).toBeVisible();
-  await expect(page.getByText('param2: value2')).toBeVisible();
+  await page.getByRole('tab', { name: 'Payload' }).click();
+  const group = page.getByRole('group', { name: 'Query String Parameters' });
+  await expect(group.getByRole('table')).toMatchAriaSnapshot(
+      `- table:
+         - rowgroup:
+           - 'row "param1: value1"'
+           - 'row "param1: value2"'
+           - 'row "param2: value2"'
+      `
+  );
 
   await page.getByText('endpoint').click();
 
-  await expect(page.getByText('Query String Parameters')).not.toBeVisible();
+  await expect(page.getByText('No payload for this request')).toBeVisible();
+  await expect(group).not.toBeVisible();
 });
 
 test('should not duplicate network entries from beforeAll', {


### PR DESCRIPTION
Improvements to network resources tabs:
- Updated tab names/layout to be more in line with popular devtools
- Sections inside a tab can be collapsed (and is remember in storage)
- Copy buttons are now more visible inside a dropdown in the toolbar
- key-values can now easier be distinguished by the new spacing


Current situation:
![Image](https://github.com/user-attachments/assets/3b51d962-4c48-41f6-a3f5-ca3848d93429)

After:
![afbeelding](https://github.com/user-attachments/assets/c26d5f8a-7816-40b9-a1de-25438702c951)


Closes: #35214 