### PR TITLE
fix(library): indexedDB shouldn't stumble over `null` in Firefox

### DIFF
--- a/packages/playwright-core/src/server/storageScript.ts
+++ b/packages/playwright-core/src/server/storageScript.ts
@@ -37,7 +37,7 @@ export async function collect(serializers: ReturnType<typeof source>, isFirefox:
       const ctor = v?.constructor;
       if (isFirefox) {
         const constructorImpl = ctor?.toString();
-        if (constructorImpl.startsWith('function Object() {') && constructorImpl.includes('[native code]'))
+        if (constructorImpl && constructorImpl.startsWith('function Object() {') && constructorImpl.includes('[native code]'))
           return true;
       }
 

--- a/packages/playwright-core/src/server/storageScript.ts
+++ b/packages/playwright-core/src/server/storageScript.ts
@@ -36,8 +36,8 @@ export async function collect(serializers: ReturnType<typeof source>, isFirefox:
     function isPlainObject(v: any) {
       const ctor = v?.constructor;
       if (isFirefox) {
-        const constructorImpl = ctor?.toString();
-        if (constructorImpl && constructorImpl.startsWith('function Object() {') && constructorImpl.includes('[native code]'))
+        const constructorImpl = ctor?.toString() as string | undefined;
+        if (constructorImpl?.startsWith('function Object() {') && constructorImpl?.includes('[native code]'))
           return true;
       }
 

--- a/tests/library/browsercontext-storage-state.spec.ts
+++ b/tests/library/browsercontext-storage-state.spec.ts
@@ -95,7 +95,7 @@ it('should round-trip through the file', async ({ contextFactory }, testInfo) =>
         const transaction = openRequest.result.transaction(['store', 'store2'], 'readwrite');
         transaction
             .objectStore('store')
-            .put({ name: 'foo', date: new Date(0) });
+            .put({ name: 'foo', date: new Date(0), null: null });
         transaction
             .objectStore('store2')
             .put('bar', 'foo');
@@ -138,7 +138,7 @@ it('should round-trip through the file', async ({ contextFactory }, testInfo) =>
     openRequest.addEventListener('error', () => reject(openRequest.error));
   }));
   expect(idbValues).toEqual([
-    { name: 'foo', date: new Date(0) },
+    { name: 'foo', date: new Date(0), null: null },
     'bar'
   ]);
   await context2.close();


### PR DESCRIPTION
Resolves https://github.com/microsoft/playwright/issues/35302. We were missing a nullability check, and TypeScript didn't catch it because the type was "any".