### PR TITLE
fix(html): update video when clicking previous/next

### DIFF
--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -129,7 +129,7 @@ export const TestResultView: React.FC<{
 
     {!!videos.length && <Anchor id='attachment-video'><AutoChip header='Videos' revealOnAnchorId='attachment-video'>
       {videos.map((a, i) => <div key={`video-${i}`}>
-        <video key={a.path} controls>
+        <video key={a.path} controls> {/* key is required to ensure video is updated when the path changes */}
           <source src={a.path} type={a.contentType}/>
         </video>
         <AttachmentLink attachment={a} result={result}></AttachmentLink>

--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -85,6 +85,8 @@ export const TestResultView: React.FC<{
     return { screenshots: [...screenshots], videos, traces, otherAttachments, diffs, errors, otherAttachmentAnchors, screenshotAnchors };
   }, [result]);
 
+  console.log({videos})
+
   return <div className='test-result'>
     {!!errors.length && <AutoChip header='Errors'>
       {errors.map((error, index) => {
@@ -127,7 +129,7 @@ export const TestResultView: React.FC<{
 
     {!!videos.length && <Anchor id='attachment-video'><AutoChip header='Videos' revealOnAnchorId='attachment-video'>
       {videos.map((a, i) => <div key={`video-${i}`}>
-        <video controls>
+        <video key={a.path} controls>
           <source src={a.path} type={a.contentType}/>
         </video>
         <AttachmentLink attachment={a} result={result}></AttachmentLink>

--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -85,8 +85,6 @@ export const TestResultView: React.FC<{
     return { screenshots: [...screenshots], videos, traces, otherAttachments, diffs, errors, otherAttachmentAnchors, screenshotAnchors };
   }, [result]);
 
-  console.log({videos})
-
   return <div className='test-result'>
     {!!errors.length && <AutoChip header='Errors'>
       {errors.map((error, index) => {


### PR DESCRIPTION
`<video>` doesn't react to its property being updated, we either need to call `.load()` (unergonomic) or recreate the `<video>` element by adding a `key` (easy!).

Not sure how to test this, so i've added a comment instead.

Resolves https://github.com/microsoft/playwright/issues/35289.