### PR TITLE
chore: use path as key in div

### DIFF
--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -126,8 +126,8 @@ export const TestResultView: React.FC<{
     </AutoChip></Anchor>}
 
     {!!videos.length && <Anchor id='attachment-video'><AutoChip header='Videos' revealOnAnchorId='attachment-video'>
-      {videos.map((a, i) => <div key={`video-${i}`}>
-        <video key={a.path} controls> {/* key is required to ensure video is updated when the path changes */}
+      {videos.map(a => <div key={a.path}>
+        <video controls>
           <source src={a.path} type={a.contentType}/>
         </video>
         <AttachmentLink attachment={a} result={result}></AttachmentLink>


### PR DESCRIPTION
follow-up to https://github.com/microsoft/playwright/pull/35309 - there already was a `key` prop that I didn't see :facepalm: