### PR TITLE
test: enable route.continue cookie tests in firefox

### DIFF
--- a/tests/android/androidTest.ts
+++ b/tests/android/androidTest.ts
@@ -82,5 +82,6 @@ export const androidTest = baseTest.extend<PageTestFixtures & AndroidTestFixture
       await androidContext.pages()[1].close();
     const page = await androidContext.newPage();
     await run(page);
+    await androidContext.clearCookies();
   },
 });

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -484,8 +484,7 @@ it('continue should not override cookie', {
   annotation: [
     { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35168' },
   ]
-}, async ({ page, server, browserName }) => {
-  it.fixme(browserName === 'firefox', 'We currently clear all headers during interception in firefox');
+}, async ({ page, server }) => {
   server.setRoute('/set-cookie', (request, response) => {
     response.writeHead(200, { 'Set-Cookie': 'foo=bar;' });
     response.end();

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -767,7 +767,8 @@ it('propagate headers cross origin redirect after interception', {
     { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32045' },
     { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35154' },
   ]
-}, async ({ page, server, browserName }) => {
+}, async ({ page, server, browserName, isAndroid }) => {
+  it.skip(isAndroid, 'Context is reused, so the cookies are not isolated between tests.');
   await page.goto(server.PREFIX + '/empty.html');
   let resolve;
   const serverRequestPromise = new Promise<http.IncomingMessage>(f => resolve = f);

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -767,8 +767,7 @@ it('propagate headers cross origin redirect after interception', {
     { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32045' },
     { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35154' },
   ]
-}, async ({ page, server, browserName, isAndroid }) => {
-  it.skip(isAndroid, 'Context is reused, so the cookies are not isolated between tests.');
+}, async ({ page, server, browserName }) => {
   await page.goto(server.PREFIX + '/empty.html');
   let resolve;
   const serverRequestPromise = new Promise<http.IncomingMessage>(f => resolve = f);

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -168,7 +168,6 @@ it('should properly return navigation response when URL has cookies', async ({ p
 
 it('should not override cookie header', async ({ page, server, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16773' });
-  it.fixme(browserName === 'firefox', 'We currently clear all headers during interception in firefox');
 
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => document.cookie = 'original=value');


### PR DESCRIPTION
The problem was fixed by https://github.com/microsoft/playwright-browsers/pull/1558

Fixes: https://github.com/microsoft/playwright/issues/35154