### PR TITLE
chore: provide error context to test server

### DIFF
--- a/packages/playwright/src/isomorphic/testServerInterface.ts
+++ b/packages/playwright/src/isomorphic/testServerInterface.ts
@@ -102,6 +102,7 @@ export interface TestServerInterface {
     projects?: string[];
     reuseContext?: boolean;
     connectWsEndpoint?: string;
+    attachErrorContext?: boolean;
   }): Promise<{
     status: reporterTypes.FullResult['status'];
   }>;

--- a/packages/playwright/src/prompt.ts
+++ b/packages/playwright/src/prompt.ts
@@ -139,7 +139,7 @@ export async function attachErrorContext(testInfo: TestInfo, ariaSnapshot: strin
       name: `_error-context-${index}`,
       contentType: 'application/json',
       body: Buffer.from(JSON.stringify({
-        ariaSnapshot,
+        pageSnapshot: ariaSnapshot,
       })),
     }, undefined);
   }

--- a/packages/playwright/src/prompt.ts
+++ b/packages/playwright/src/prompt.ts
@@ -127,6 +127,31 @@ export async function attachErrorPrompts(testInfo: TestInfo, sourceCache: Map<st
   }
 }
 
+export async function attachErrorContext(testInfo: TestInfo, ariaSnapshot: string | undefined) {
+  for (const [index] of testInfo.errors.entries()) {
+    if (testInfo.attachments.find(a => a.name === `_error-context-${index}`))
+      continue;
+
+    const promptParts = [];
+
+    if (ariaSnapshot) {
+      promptParts.push(
+          '# Page snapshot',
+          '',
+          '```yaml',
+          ariaSnapshot,
+          '```',
+      );
+    }
+
+    (testInfo as TestInfoImpl)._attach({
+      name: `_error-context-${index}`,
+      contentType: 'text/markdown',
+      body: Buffer.from(promptParts.join('\n')),
+    }, undefined);
+  }
+}
+
 async function loadSource(file: string, sourceCache: Map<string, string>) {
   let source = sourceCache.get(file);
   if (!source) {

--- a/packages/playwright/src/prompt.ts
+++ b/packages/playwright/src/prompt.ts
@@ -131,18 +131,13 @@ export async function attachErrorContext(testInfo: TestInfo, ariaSnapshot: strin
   if (!ariaSnapshot)
     return;
 
-  for (const [index] of testInfo.errors.entries()) {
-    if (testInfo.attachments.find(a => a.name === `_error-context-${index}`))
-      continue;
-
-    (testInfo as TestInfoImpl)._attach({
-      name: `_error-context-${index}`,
-      contentType: 'application/json',
-      body: Buffer.from(JSON.stringify({
-        pageSnapshot: ariaSnapshot,
-      })),
-    }, undefined);
-  }
+  (testInfo as TestInfoImpl)._attach({
+    name: `_error-context`,
+    contentType: 'application/json',
+    body: Buffer.from(JSON.stringify({
+      pageSnapshot: ariaSnapshot,
+    })),
+  }, undefined);
 }
 
 async function loadSource(file: string, sourceCache: Map<string, string>) {

--- a/packages/playwright/src/prompt.ts
+++ b/packages/playwright/src/prompt.ts
@@ -135,18 +135,12 @@ export async function attachErrorContext(testInfo: TestInfo, ariaSnapshot: strin
     if (testInfo.attachments.find(a => a.name === `_error-context-${index}`))
       continue;
 
-    const promptParts = [
-      '# Page snapshot',
-      '',
-      '```yaml',
-      ariaSnapshot,
-      '```',
-    ];
-
     (testInfo as TestInfoImpl)._attach({
       name: `_error-context-${index}`,
-      contentType: 'text/markdown',
-      body: Buffer.from(promptParts.join('\n')),
+      contentType: 'application/json',
+      body: Buffer.from(JSON.stringify({
+        ariaSnapshot,
+      })),
     }, undefined);
   }
 }

--- a/packages/playwright/src/prompt.ts
+++ b/packages/playwright/src/prompt.ts
@@ -128,21 +128,20 @@ export async function attachErrorPrompts(testInfo: TestInfo, sourceCache: Map<st
 }
 
 export async function attachErrorContext(testInfo: TestInfo, ariaSnapshot: string | undefined) {
+  if (!ariaSnapshot)
+    return;
+
   for (const [index] of testInfo.errors.entries()) {
     if (testInfo.attachments.find(a => a.name === `_error-context-${index}`))
       continue;
 
-    const promptParts = [];
-
-    if (ariaSnapshot) {
-      promptParts.push(
-          '# Page snapshot',
-          '',
-          '```yaml',
-          ariaSnapshot,
-          '```',
-      );
-    }
+    const promptParts = [
+      '# Page snapshot',
+      '',
+      '```yaml',
+      ariaSnapshot,
+      '```',
+    ];
 
     (testInfo as TestInfoImpl)._attach({
       name: `_error-context-${index}`,

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -314,6 +314,7 @@ export class TestServerDispatcher implements TestServerInterface {
         ...(params.headed !== undefined ? { headless: !params.headed } : {}),
         _optionContextReuseMode: params.reuseContext ? 'when-possible' : undefined,
         _optionConnectOptions: params.connectWsEndpoint ? { wsEndpoint: params.connectWsEndpoint } : undefined,
+        _optionAttachErrorContext: params.attachErrorContext,
       },
       ...(params.updateSnapshots ? { updateSnapshots: params.updateSnapshots } : {}),
       ...(params.updateSourceMethod ? { updateSourceMethod: params.updateSourceMethod } : {}),

--- a/tests/playwright-test/reporter-json.spec.ts
+++ b/tests/playwright-test/reporter-json.spec.ts
@@ -370,7 +370,7 @@ test('attaches error context', async ({ runInlineTest }) => {
     `,
   }, { reporter: 'json' });
 
-  const errorContext = result.report.suites[0].specs[0].tests[0].results[0].attachments.find(a => a.name === '_error-context-0');
+  const errorContext = result.report.suites[0].specs[0].tests[0].results[0].attachments.find(a => a.name === '_error-context');
   expect(errorContext).toBeDefined();
   expect(errorContext!.contentType).toBe('application/json');
   const json = JSON.parse(Buffer.from(errorContext!.body, 'base64').toString('utf-8'));

--- a/tests/playwright-test/reporter-json.spec.ts
+++ b/tests/playwright-test/reporter-json.spec.ts
@@ -355,3 +355,25 @@ test('should report parallelIndex', async ({ runInlineTest }, testInfo) => {
   expect(result.report.suites[0].specs[1].tests[0].results[0].parallelIndex).toBe(1);
   expect(result.report.suites[0].specs[2].tests[0].results[0].parallelIndex).toBe(1);
 });
+
+test('attaches error context', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+          export default { use: { _optionAttachErrorContext: true } };
+    `,
+    'a.test.js': `
+      const { test, expect } = require('@playwright/test');
+      test('one', async ({ page }, testInfo) => {
+        await page.setContent('<button>Click me</button>');
+        throw new Error('kaboom');
+      });
+    `,
+  }, { reporter: 'json' });
+
+  expect(result.report.suites[0].specs[0].tests[0].results[0].attachments).toEqual([
+    expect.objectContaining({
+      name: '_error-context-0',
+      contentType: 'text/markdown',
+    }),
+  ]);
+});

--- a/tests/playwright-test/reporter-json.spec.ts
+++ b/tests/playwright-test/reporter-json.spec.ts
@@ -375,6 +375,6 @@ test('attaches error context', async ({ runInlineTest }) => {
   expect(errorContext!.contentType).toBe('application/json');
   const json = JSON.parse(Buffer.from(errorContext!.body, 'base64').toString('utf-8'));
   expect(json).toEqual({
-    ariaSnapshot: expect.any(String),
+    pageSnapshot: expect.any(String),
   });
 });

--- a/tests/playwright-test/reporter-json.spec.ts
+++ b/tests/playwright-test/reporter-json.spec.ts
@@ -370,10 +370,11 @@ test('attaches error context', async ({ runInlineTest }) => {
     `,
   }, { reporter: 'json' });
 
-  expect(result.report.suites[0].specs[0].tests[0].results[0].attachments).toEqual([
-    expect.objectContaining({
-      name: '_error-context-0',
-      contentType: 'text/markdown',
-    }),
-  ]);
+  const errorContext = result.report.suites[0].specs[0].tests[0].results[0].attachments.find(a => a.name === '_error-context-0');
+  expect(errorContext).toBeDefined();
+  expect(errorContext!.contentType).toBe('application/json');
+  const json = JSON.parse(Buffer.from(errorContext!.body, 'base64').toString('utf-8'));
+  expect(json).toEqual({
+    ariaSnapshot: expect.any(String),
+  });
 });


### PR DESCRIPTION
Gives the VS Code extension a trimmed down version of the `Copy Prompt` to enrich its error details for LLM consumption. At the moment, it contains only the page snapshot.