### PR TITLE
test: unskip "calling window.stop sync"

### DIFF
--- a/tests/page/page-autowaiting-no-hang.spec.ts
+++ b/tests/page/page-autowaiting-no-hang.spec.ts
@@ -32,7 +32,6 @@ it('calling window.stop async', async ({ page, server }) => {
 });
 
 it('calling window.stop sync', async ({ page, server, browserName }) => {
-  it.fixme(browserName === 'chromium', 'https://github.com/microsoft/playwright/issues/35147');
   await page.evaluate(url => {
     window.location.href = url;
     window.stop();


### PR DESCRIPTION
Closes #35147.