### PR TITLE
chore: update vite to 5.4.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9406,9 +9406,9 @@
       }
     },
     "packages/playwright-ct-svelte/node_modules/vite": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
-      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.15.tgz",
+      "integrity": "sha512-6ANcZRivqL/4WtwPGTKNaosuNJr5tWiftOC7liM7G9+rMb8+oeJeyzymDu4rTN93seySBmbjSfsS3Vzr19KNtA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
This fixes `npm audit`.