### PR TITLE
feat: Improvements to filtering in HTML Test Reporter

### DIFF
--- a/packages/html-reporter/src/chip.tsx
+++ b/packages/html-reporter/src/chip.tsx
@@ -23,23 +23,24 @@ import { clsx } from '@web/uiUtils';
 import { type AnchorID, useAnchor } from './links';
 
 export const Chip: React.FC<{
-  header: JSX.Element | string,
+  header: React.ReactNode,
   expanded?: boolean,
   noInsets?: boolean,
   setExpanded?: (expanded: boolean) => void,
-  children?: any,
+  children?: React.ReactNode,
   dataTestId?: string,
 }> = ({ header, expanded, setExpanded, children, noInsets, dataTestId }) => {
   const id = React.useId();
   return <div className='chip' data-testid={dataTestId}>
     <div
       role='button'
-      aria-expanded={!!expanded}
+      aria-expanded={expanded}
       aria-controls={id}
       className={clsx('chip-header', setExpanded && ' expanded-' + expanded)}
       onClick={() => setExpanded?.(!expanded)}
-      title={typeof header === 'string' ? header : undefined}>
-      {setExpanded && !!expanded && icons.downArrow()}
+      title={typeof header === 'string' ? header : undefined}
+    >
+      {setExpanded && expanded && icons.downArrow()}
       {setExpanded && !expanded && icons.rightArrow()}
       {header}
     </div>
@@ -48,10 +49,10 @@ export const Chip: React.FC<{
 };
 
 export const AutoChip: React.FC<{
-  header: JSX.Element | string,
+  header: string,
   initialExpanded?: boolean,
   noInsets?: boolean,
-  children?: any,
+  children?: React.ReactNode,
   dataTestId?: string,
   revealOnAnchorId?: AnchorID,
 }> = ({ header, initialExpanded, noInsets, children, dataTestId, revealOnAnchorId }) => {

--- a/packages/html-reporter/src/chip.tsx
+++ b/packages/html-reporter/src/chip.tsx
@@ -33,7 +33,7 @@ export const Chip: React.FC<React.PropsWithChildren<{
   return <div className='chip' data-testid={dataTestId}>
     <div
       role='button'
-      aria-expanded={expanded}
+      aria-expanded={!!expanded}
       aria-controls={id}
       className={clsx('chip-header', setExpanded && ' expanded-' + expanded)}
       onClick={() => setExpanded?.(!expanded)}
@@ -51,7 +51,6 @@ export const AutoChip: React.FC<React.PropsWithChildren<{
   header: string,
   initialExpanded?: boolean,
   noInsets?: boolean,
-  children?: React.ReactNode,
   dataTestId?: string,
   revealOnAnchorId?: AnchorID,
 }>> = ({ header, initialExpanded, noInsets, children, dataTestId, revealOnAnchorId }) => {

--- a/packages/html-reporter/src/chip.tsx
+++ b/packages/html-reporter/src/chip.tsx
@@ -22,14 +22,13 @@ import * as icons from './icons';
 import { clsx } from '@web/uiUtils';
 import { type AnchorID, useAnchor } from './links';
 
-export const Chip: React.FC<{
+export const Chip: React.FC<React.PropsWithChildren<{
   header: React.ReactNode,
   expanded?: boolean,
   noInsets?: boolean,
   setExpanded?: (expanded: boolean) => void,
-  children?: React.ReactNode,
   dataTestId?: string,
-}> = ({ header, expanded, setExpanded, children, noInsets, dataTestId }) => {
+}>> = ({ header, expanded, setExpanded, children, noInsets, dataTestId }) => {
   const id = React.useId();
   return <div className='chip' data-testid={dataTestId}>
     <div
@@ -48,14 +47,14 @@ export const Chip: React.FC<{
   </div>;
 };
 
-export const AutoChip: React.FC<{
+export const AutoChip: React.FC<React.PropsWithChildren<{
   header: string,
   initialExpanded?: boolean,
   noInsets?: boolean,
   children?: React.ReactNode,
   dataTestId?: string,
   revealOnAnchorId?: AnchorID,
-}> = ({ header, initialExpanded, noInsets, children, dataTestId, revealOnAnchorId }) => {
+}>> = ({ header, initialExpanded, noInsets, children, dataTestId, revealOnAnchorId }) => {
   const [expanded, setExpanded] = React.useState(initialExpanded ?? true);
   const onReveal = React.useCallback(() => setExpanded(true), []);
   useAnchor(revealOnAnchorId, onReveal);

--- a/packages/html-reporter/src/copyToClipboard.tsx
+++ b/packages/html-reporter/src/copyToClipboard.tsx
@@ -25,7 +25,7 @@ type CopyToClipboardProps = {
 /**
  * A copy to clipboard button.
  */
-export const CopyToClipboard: React.FunctionComponent<CopyToClipboardProps> = ({ value }) => {
+export const CopyToClipboard: React.FC<CopyToClipboardProps> = ({ value }) => {
   type IconType = 'copy' | 'check' | 'cross';
   const [icon, setIcon] = React.useState<IconType>('copy');
   const handleCopy = React.useCallback(() => {
@@ -42,14 +42,10 @@ export const CopyToClipboard: React.FunctionComponent<CopyToClipboardProps> = ({
   return <button className='copy-icon' title='Copy to clipboard' aria-label='Copy to clipboard' onClick={handleCopy}>{iconElement}</button>;
 };
 
-type CopyToClipboardContainerProps = CopyToClipboardProps & {
-  children: React.ReactNode
-};
-
 /**
  * Container for displaying a copy to clipboard button alongside children.
  */
-export const CopyToClipboardContainer: React.FunctionComponent<CopyToClipboardContainerProps> = ({ children, value }) => {
+export const CopyToClipboardContainer: React.FC<React.PropsWithChildren<CopyToClipboardProps>> = ({ children, value }) => {
   return <span className='copy-value-container'>
     {children}
     <span className='copy-button-container'>

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -183,7 +183,7 @@ function cacheSearchValues(test: TestCaseSummary & { [searchValuesSymbol]?: Sear
 }
 
 export function filterWithToken(searchParams: URLSearchParams, token: string, append: boolean): string {
-  const tokens = (searchParams.get('q') ?? '').split(' ');
+  const tokens = searchParams.get('q')?.split(' ') ?? [];
 
   let newTokens;
   if (append) {

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -183,22 +183,26 @@ function cacheSearchValues(test: TestCaseSummary & { [searchValuesSymbol]?: Sear
 }
 
 export function filterWithToken(tokens: string[], token: string, append: boolean): string {
+  let newTokens;
+
   if (append) {
     if (!tokens.includes(token))
-      return '#?q=' + [...tokens, token].join(' ').trim();
-    return '#?q=' + tokens.filter(t => t !== token).join(' ').trim();
+      newTokens = [...tokens, token];
+    else
+      newTokens = tokens.filter(t => t !== token);
+
+  } else {
+    // if metaKey or ctrlKey is not pressed, replace existing token with new token
+    let prefix: 's:' | 'p:' | '@';
+    if (token.startsWith('s:'))
+      prefix = 's:';
+    if (token.startsWith('p:'))
+      prefix = 'p:';
+    if (token.startsWith('@'))
+      prefix = '@';
+
+    newTokens = [...tokens.filter(t => !t.startsWith(prefix)), token];
   }
 
-  // if metaKey or ctrlKey is not pressed, replace existing token with new token
-  let prefix: 's:' | 'p:' | '@';
-  if (token.startsWith('s:'))
-    prefix = 's:';
-  if (token.startsWith('p:'))
-    prefix = 'p:';
-  if (token.startsWith('@'))
-    prefix = '@';
-
-  const newTokens = tokens.filter(t => !t.startsWith(prefix));
-  newTokens.push(token);
   return '#?q=' + newTokens.join(' ').trim();
 }

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -182,9 +182,10 @@ function cacheSearchValues(test: TestCaseSummary & { [searchValuesSymbol]?: Sear
   return searchValues;
 }
 
-export function filterWithToken(tokens: string[], token: string, append: boolean): string {
-  let newTokens;
+export function filterWithToken(searchParams: URLSearchParams, token: string, append: boolean): string {
+  const tokens = (searchParams.get('q') ?? '').split(' ');
 
+  let newTokens;
   if (append) {
     if (!tokens.includes(token))
       newTokens = [...tokens, token];
@@ -193,7 +194,7 @@ export function filterWithToken(tokens: string[], token: string, append: boolean
 
   } else {
     // if metaKey or ctrlKey is not pressed, replace existing token with new token
-    let prefix: 's:' | 'p:' | '@';
+    let prefix: 's:' | 'p:' | '@' | '' = '';
     if (token.startsWith('s:'))
       prefix = 's:';
     if (token.startsWith('p:'))
@@ -204,5 +205,5 @@ export function filterWithToken(tokens: string[], token: string, append: boolean
     newTokens = [...tokens.filter(t => !t.startsWith(prefix)), token];
   }
 
-  return '#?q=' + newTokens.join(' ').trim();
+  return '#?q=' + encodeURIComponent(newTokens.join(' ').trim());
 }

--- a/packages/html-reporter/src/headerView.spec.tsx
+++ b/packages/html-reporter/src/headerView.spec.tsx
@@ -27,7 +27,7 @@ test('should render counters', async ({ mount }) => {
     flaky: 17,
     skipped: 10,
     ok: false,
-  }} filterText='' setFilterText={() => { }}></HeaderView>);
+  }} filterText='' setFilterText={() => { }} />);
   await expect(component.locator('a', { hasText: 'All' }).locator('.counter')).toHaveText('90');
   await expect(component.locator('a', { hasText: 'Passed' }).locator('.counter')).toHaveText('42');
   await expect(component.locator('a', { hasText: 'Failed' }).locator('.counter')).toHaveText('31');
@@ -53,8 +53,7 @@ test('should toggle filters', async ({ page, mount }) => {
     }}
     filterText=''
     setFilterText={(filterText: string) => filters.push(filterText)}
-  >
-  </HeaderView>);
+  />);
   await component.locator('a', { hasText: 'All' }).click();
   await component.locator('a', { hasText: 'Passed' }).click();
   await expect(page).toHaveURL(/#\?q=s:passed/);

--- a/packages/html-reporter/src/headerView.spec.tsx
+++ b/packages/html-reporter/src/headerView.spec.tsx
@@ -16,18 +16,22 @@
 
 import { test, expect } from '@playwright/experimental-ct-react';
 import { HeaderView } from './headerView';
+import { SearchParamsProvider } from './links';
 
 test.use({ viewport: { width: 720, height: 200 } });
 
 test('should render counters', async ({ mount }) => {
-  const component = await mount(<HeaderView stats={{
-    total: 100,
-    expected: 42,
-    unexpected: 31,
-    flaky: 17,
-    skipped: 10,
-    ok: false,
-  }} filterText='' setFilterText={() => { }} />);
+  const component = await mount(<SearchParamsProvider>
+    <HeaderView stats={{
+      total: 100,
+      expected: 42,
+      unexpected: 31,
+      flaky: 17,
+      skipped: 10,
+      ok: false,
+    }} filterText='' setFilterText={() => { }} />
+  </SearchParamsProvider>);
+
   await expect(component.locator('a', { hasText: 'All' }).locator('.counter')).toHaveText('90');
   await expect(component.locator('a', { hasText: 'Passed' }).locator('.counter')).toHaveText('42');
   await expect(component.locator('a', { hasText: 'Failed' }).locator('.counter')).toHaveText('31');
@@ -42,27 +46,30 @@ test('should render counters', async ({ mount }) => {
 
 test('should toggle filters', async ({ page, mount }) => {
   const filters: string[] = [];
-  const component = await mount(<HeaderView
-    stats={{
-      total: 100,
-      expected: 42,
-      unexpected: 31,
-      flaky: 17,
-      skipped: 10,
-      ok: false,
-    }}
-    filterText=''
-    setFilterText={(filterText: string) => filters.push(filterText)}
-  />);
+  const component = await mount(<SearchParamsProvider>
+    <HeaderView
+      stats={{
+        total: 100,
+        expected: 42,
+        unexpected: 31,
+        flaky: 17,
+        skipped: 10,
+        ok: false,
+      }}
+      filterText=''
+      setFilterText={(filterText: string) => filters.push(filterText)}
+    />
+  </SearchParamsProvider>);
+
   await component.locator('a', { hasText: 'All' }).click();
   await component.locator('a', { hasText: 'Passed' }).click();
-  await expect(page).toHaveURL(/#\?q=s:passed/);
+  await expect(page).toHaveURL(/#\?q=s%3Apassed/);
   await component.locator('a', { hasText: 'Failed' }).click();
-  await expect(page).toHaveURL(/#\?q=s:failed/);
+  await expect(page).toHaveURL(/#\?q=s%3Afailed/);
   await component.locator('a', { hasText: 'Flaky' }).click();
-  await expect(page).toHaveURL(/#\?q=s:flaky/);
+  await expect(page).toHaveURL(/#\?q=s%3Aflaky/);
   await component.locator('a', { hasText: 'Skipped' }).click();
-  await expect(page).toHaveURL(/#\?q=s:skipped/);
+  await expect(page).toHaveURL(/#\?q=s%3Askipped/);
   await component.getByRole('textbox').fill('annot:annotation type=annotation description');
-  expect(filters).toEqual(['', 's:passed', 's:failed', 's:flaky', 's:skipped', 'annot:annotation type=annotation description']);
+  expect(filters).toEqual(['', '', 's:passed ', 's:failed ', 's:flaky ', 's:skipped ', 'annot:annotation type=annotation description']);
 });

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -23,12 +23,13 @@ import * as icons from './icons';
 import { Link, navigate, SearchParamsContext } from './links';
 import { statusIcon } from './statusIcon';
 import { filterWithToken } from './filter';
+import { FormEvent } from 'react';
 
-export const HeaderView: React.FC<React.PropsWithChildren<{
+export const HeaderView: React.FC<{
   stats: Stats,
   filterText: string,
   setFilterText: (filterText: string) => void,
-}>> = ({ stats, filterText, setFilterText }) => {
+}> = ({ stats, filterText, setFilterText }) => {
   const searchParams = React.useContext(SearchParamsContext);
   React.useEffect(() => {
     // Add an extra space such that users can easily add to query
@@ -36,24 +37,21 @@ export const HeaderView: React.FC<React.PropsWithChildren<{
     setFilterText(query ? `${query} ` : '');
   }, [searchParams, setFilterText]);
 
+  const updateQuery = (event: FormEvent) => {
+    event.preventDefault();
+    const url = new URL(window.location.href);
+    url.hash = filterText ? '?' + new URLSearchParams({ q: filterText }) : '';
+    navigate(url);
+  };
+
   return (<>
     <div className='pt-3'>
       <div className='header-view-status-container ml-2 pl-2 d-flex'>
-        <StatsNavView stats={stats}></StatsNavView>
+        <StatsNavView stats={stats} />
       </div>
-      <form className='subnav-search' onSubmit={
-        event => {
-          event.preventDefault();
-          const url = new URL(window.location.href);
-          url.hash = filterText ? '?' + new URLSearchParams({ q: filterText }) : '';
-          navigate(url);
-        }
-      }>
+      <form className='subnav-search' onSubmit={updateQuery} onBlur={updateQuery}>
         {icons.search()}
-        {/* Use navigationId to reset defaultValue */}
-        <input spellCheck={false} className='form-control subnav-search-input input-contrast width-full' value={filterText} onChange={e => {
-          setFilterText(e.target.value);
-        }}></input>
+        <input spellCheck={false} className='form-control subnav-search-input input-contrast width-full' value={filterText} onChange={e => { setFilterText(e.target.value); }} />
       </form>
     </div>
   </>);

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -29,17 +29,12 @@ export const HeaderView: React.FC<React.PropsWithChildren<{
   filterText: string,
   setFilterText: (filterText: string) => void,
 }>> = ({ stats, filterText, setFilterText }) => {
+  const searchParams = React.useContext(SearchParamsContext);
   React.useEffect(() => {
-    const popstateFn = () => {
-      const params = new URLSearchParams(window.location.hash.slice(1));
-      setFilterText(params.get('q') || '');
-    };
-    window.addEventListener('popstate', popstateFn);
-
-    return () => {
-      window.removeEventListener('popstate', popstateFn);
-    };
-  }, [setFilterText]);
+    // Add an extra space such that users can easily add to query
+    const query = searchParams.get('q');
+    setFilterText(query ? `${query} ` : '');
+  }, [searchParams, setFilterText]);
 
   return (<>
     <div className='pt-3'>

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -34,7 +34,7 @@ export const HeaderView: React.FC<{
   React.useEffect(() => {
     // Add an extra space such that users can easily add to query
     const query = searchParams.get('q');
-    setFilterText(query ? `${query} ` : '');
+    setFilterText(query ? `${query.trim()} ` : '');
   }, [searchParams, setFilterText]);
 
   const updateQuery = (event: FormEvent) => {

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -63,22 +63,21 @@ const StatsNavView: React.FC<{
   stats: Stats
 }> = ({ stats }) => {
   const searchParams = React.useContext(SearchParamsContext);
-  const q = searchParams.get('q')?.toString() || '';
-  const tokens = q.split(' ');
+
   return <nav>
-    <Link className='subnav-item' href='#?'>
+    <Link className='subnav-item' href='#'>
       All <span className='d-inline counter'>{stats.total - stats.skipped}</span>
     </Link>
-    <Link className='subnav-item' click={filterWithToken(tokens, 's:passed', false)} ctrlClick={filterWithToken(tokens, 's:passed', true)}>
+    <Link className='subnav-item' click={filterWithToken(searchParams, 's:passed', false)} ctrlClick={filterWithToken(searchParams, 's:passed', true)}>
       Passed <span className='d-inline counter'>{stats.expected}</span>
     </Link>
-    <Link className='subnav-item' click={filterWithToken(tokens, 's:failed', false)} ctrlClick={filterWithToken(tokens, 's:failed', true)}>
+    <Link className='subnav-item' click={filterWithToken(searchParams, 's:failed', false)} ctrlClick={filterWithToken(searchParams, 's:failed', true)}>
       {!!stats.unexpected && statusIcon('unexpected')} Failed <span className='d-inline counter'>{stats.unexpected}</span>
     </Link>
-    <Link className='subnav-item' click={filterWithToken(tokens, 's:flaky', false)} ctrlClick={filterWithToken(tokens, 's:flaky', true)}>
+    <Link className='subnav-item' click={filterWithToken(searchParams, 's:flaky', false)} ctrlClick={filterWithToken(searchParams, 's:flaky', true)}>
       {!!stats.flaky && statusIcon('flaky')} Flaky <span className='d-inline counter'>{stats.flaky}</span>
     </Link>
-    <Link className='subnav-item' click={filterWithToken(tokens, 's:skipped', false)} ctrlClick={filterWithToken(tokens, 's:skipped', true)}>
+    <Link className='subnav-item' click={filterWithToken(searchParams, 's:skipped', false)} ctrlClick={filterWithToken(searchParams, 's:skipped', true)}>
       Skipped <span className='d-inline counter'>{stats.skipped}</span>
     </Link>
   </nav>;

--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -23,7 +23,6 @@ import * as ReactDOM from 'react-dom/client';
 import './colors.css';
 import type { LoadedReport } from './loadedReport';
 import { ReportView } from './reportView';
-// @ts-ignore
 const zipjs = zipImport as typeof zip;
 
 import logo from '@web/assets/playwright-logo.svg';
@@ -72,7 +71,7 @@ class ZipReport implements LoadedReport {
         const oldReport = localStorage.getItem(kPlaywrightReportStorageForHMR);
         if (oldReport)
           return resolve(oldReport);
-        alert('couldnt find report, something with HMR is broken');
+        alert("Couldn't find report, something with HMR is broken");
       }
     });
 

--- a/packages/html-reporter/src/links.css
+++ b/packages/html-reporter/src/links.css
@@ -18,7 +18,6 @@
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
-  font-weight: 500;
   line-height: 18px;
   border: 1px solid transparent;
   border-radius: 2em;

--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -31,50 +31,49 @@ export function navigate(href: string | URL) {
   window.dispatchEvent(navEvent);
 }
 
-export const Route: React.FunctionComponent<{
+export const Route: React.FC<React.PropsWithChildren<{
   predicate: (params: URLSearchParams) => boolean,
-  children: React.ReactNode
-}> = ({ predicate, children }) => {
+}>> = ({ predicate, children }) => {
   const searchParams = React.useContext(SearchParamsContext);
   return predicate(searchParams) ? children : null;
 };
 
-export const Link: React.FunctionComponent<{
+export const Link: React.FC<React.PropsWithChildren<{
   href?: string,
   click?: string,
   ctrlClick?: string,
   className?: string,
   title?: string,
-  children: React.ReactNode,
-}> = ({ click, ctrlClick, children, ...rest }) => {
-  return <a {...rest} style={{ textDecoration: 'none', color: 'var(--color-fg-default)', cursor: 'pointer' }} onClick={e => {
-    if (click) {
-      e.preventDefault();
-      navigate(e.metaKey || e.ctrlKey ? ctrlClick || click : click);
-    }
-  }}>{children}</a>;
+}>> = ({ click, ctrlClick, children, ...rest }) => {
+  return <a {...rest} style={{ textDecoration: 'none', color: 'var(--color-fg-default)', cursor: 'pointer' }}
+    onClick={e => {
+      if (click) {
+        e.preventDefault();
+        navigate(e.metaKey || e.ctrlKey ? ctrlClick || click : click);
+      }
+    }}>{children}</a>;
 };
 
-export const LabelLink: React.FunctionComponent<{
+export const LabelLink: React.FC<{
   searchParams: URLSearchParams,
   name: string,
   prefix?: 'p:'
 }> = ({ searchParams, name, prefix = '' }) => {
   return <Link click={filterWithToken(searchParams, `${prefix}${name}`, false)} ctrlClick={filterWithToken(searchParams, `${prefix}${name}`, true)}>
-    <span style={{ margin: '6px 0 0 6px' }} className={clsx('label', `label-color-${hashStringToInt(name)}`)} >
+    <span style={{ margin: '6px 0 0 6px' }} className={clsx('label', `label-color-${hashStringToInt(name)}`)}>
       {name}
     </span>
   </Link>;
 };
 
-export const TagLinks: React.FunctionComponent<{
+export const TagLinks: React.FC<{
   searchParams: URLSearchParams,
   tags: string[],
 }> = ({ searchParams, tags }) => {
   return <>{tags.map(tag => (<LabelLink key={tag} searchParams={searchParams} name={tag}/>))}</>;
 };
 
-export const AttachmentLink: React.FunctionComponent<{
+export const AttachmentLink: React.FC<{
   attachment: TestAttachment,
   result: TestResult,
   href?: string,
@@ -83,22 +82,26 @@ export const AttachmentLink: React.FunctionComponent<{
 }> = ({ attachment, result, href, linkName, openInNewTab }) => {
   const [flash, triggerFlash] = useFlash();
   useAnchor('attachment-' + result.attachments.indexOf(attachment), triggerFlash);
-  return <TreeItem title={<span>
-    {attachment.contentType === kMissingContentType ? icons.warning() : icons.attachment()}
-    {attachment.path && <a href={href || attachment.path} download={downloadFileNameForAttachment(attachment)}>{linkName || attachment.name}</a>}
-    {!attachment.path && (
-      openInNewTab
-        ? <a href={URL.createObjectURL(new Blob([attachment.body!], { type: attachment.contentType }))} target='_blank' rel='noreferrer' onClick={e => e.stopPropagation()}>{attachment.name}</a>
-        : <span>{linkifyText(attachment.name)}</span>
-    )}
-  </span>} loadChildren={attachment.body ? () => {
-    return [<div key={1} className='attachment-body'><CopyToClipboard value={attachment.body!}/>{linkifyText(attachment.body!)}</div>];
-  } : undefined} depth={0} style={{ lineHeight: '32px' }} flash={flash}></TreeItem>;
+
+  return <TreeItem
+    title={<span>
+      {attachment.contentType === kMissingContentType ? icons.warning() : icons.attachment()}
+      {attachment.path && <a href={href || attachment.path} download={downloadFileNameForAttachment(attachment)}>{linkName || attachment.name}</a>}
+      {!attachment.path && (
+        openInNewTab
+          ? <a href={URL.createObjectURL(new Blob([attachment.body!], { type: attachment.contentType }))} target='_blank' rel='noreferrer' onClick={e => e.stopPropagation()}>{attachment.name}</a>
+          : <span>{linkifyText(attachment.name)}</span>
+      )}
+    </span>}
+    loadChildren={attachment.body ? () => [<div key={1} className='attachment-body'><CopyToClipboard value={attachment.body!}/>{linkifyText(attachment.body!)}</div>] : undefined} depth={0}
+    style={{ lineHeight: '32px' }}
+    flash={flash}
+  />;
 };
 
 export const SearchParamsContext = React.createContext<URLSearchParams>(new URLSearchParams(window.location.hash.slice(1)));
 
-export const SearchParamsProvider: React.FunctionComponent<React.PropsWithChildren> = ({ children }) => {
+export const SearchParamsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [searchParams, setSearchParams] = React.useState<URLSearchParams>(new URLSearchParams(window.location.hash.slice(1)));
 
   React.useEffect(() => {

--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -33,7 +33,7 @@ export function navigate(href: string | URL) {
 
 export const Route: React.FunctionComponent<{
   predicate: (params: URLSearchParams) => boolean,
-  children: any
+  children: React.ReactNode
 }> = ({ predicate, children }) => {
   const searchParams = React.useContext(SearchParamsContext);
   return predicate(searchParams) ? children : null;
@@ -45,7 +45,7 @@ export const Link: React.FunctionComponent<{
   ctrlClick?: string,
   className?: string,
   title?: string,
-  children: any,
+  children: React.ReactNode,
 }> = ({ click, ctrlClick, children, ...rest }) => {
   return <a {...rest} style={{ textDecoration: 'none', color: 'var(--color-fg-default)', cursor: 'pointer' }} onClick={e => {
     if (click) {
@@ -120,7 +120,7 @@ function downloadFileNameForAttachment(attachment: TestAttachment): string {
 }
 
 export function generateTraceUrl(traces: TestAttachment[]) {
-  return `trace/index.html?${traces.map((a, i) => `trace=${new URL(a.path!, window.location.href)}`).join('&')}`;
+  return `trace/index.html?${traces.map(a => `trace=${new URL(a.path!, window.location.href)}`).join('&')}`;
 }
 
 const kMissingContentType = 'x-playwright/missing';

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -48,7 +48,6 @@ export const ReportView: React.FC<{
   const searchParams = React.useContext(SearchParamsContext);
   const [expandedFiles, setExpandedFiles] = React.useState<Map<string, boolean>>(new Map());
   const [filterText, setFilterText] = React.useState(searchParams.get('q') || '');
-  const [metadataVisible, setMetadataVisible] = React.useState(false);
 
   const testIdToFileIdMap = React.useMemo(() => {
     const map = new Map<string, string>();
@@ -76,7 +75,7 @@ export const ReportView: React.FC<{
     <main>
       {report?.json() && <HeaderView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText}></HeaderView>}
       <Route predicate={testFilesRoutePredicate}>
-        <TestFilesHeader report={report?.json()} filteredStats={filteredStats} metadataVisible={metadataVisible} toggleMetadataVisible={() => setMetadataVisible(visible => !visible)}/>
+        <TestFilesHeader report={report?.json()} filteredStats={filteredStats} />
         <TestFilesView
           tests={filteredTests.files}
           expandedFiles={expandedFiles}

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -48,6 +48,7 @@ export const ReportView: React.FC<{
   const searchParams = React.useContext(SearchParamsContext);
   const [expandedFiles, setExpandedFiles] = React.useState<Map<string, boolean>>(new Map());
   const [filterText, setFilterText] = React.useState(searchParams.get('q') ?? '');
+  const [metadataVisible, setMetadataVisible] = React.useState(false);
 
   const testIdToFileIdMap = React.useMemo(() => {
     const map = new Map<string, string>();
@@ -75,7 +76,7 @@ export const ReportView: React.FC<{
     <main>
       {report?.json() && <HeaderView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText} />}
       <Route predicate={testFilesRoutePredicate}>
-        <TestFilesHeader report={report?.json()} filteredStats={filteredStats} />
+        <TestFilesHeader report={report?.json()} filteredStats={filteredStats} metadataVisible={metadataVisible} toggleMetadataVisible={() => setMetadataVisible(visible => !visible)}/>
         <TestFilesView
           tests={filteredTests.files}
           expandedFiles={expandedFiles}

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -47,7 +47,7 @@ export const ReportView: React.FC<{
 }> = ({ report }) => {
   const searchParams = React.useContext(SearchParamsContext);
   const [expandedFiles, setExpandedFiles] = React.useState<Map<string, boolean>>(new Map());
-  const [filterText, setFilterText] = React.useState(searchParams.get('q') || '');
+  const [filterText, setFilterText] = React.useState(searchParams.get('q') ?? '');
 
   const testIdToFileIdMap = React.useMemo(() => {
     const map = new Map<string, string>();
@@ -125,7 +125,6 @@ const TestCaseViewLoader: React.FC<{
   }, [test, report, testId, testIdToFileIdMap]);
 
   return <TestCaseView
-    projectNames={report.json().projectNames}
     next={next}
     prev={prev}
     test={test}

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -73,7 +73,7 @@ export const ReportView: React.FC<{
 
   return <div className='htmlreport vbox px-4 pb-4'>
     <main>
-      {report?.json() && <HeaderView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText}></HeaderView>}
+      {report?.json() && <HeaderView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText} />}
       <Route predicate={testFilesRoutePredicate}>
         <TestFilesHeader report={report?.json()} filteredStats={filteredStats} />
         <TestFilesView

--- a/packages/html-reporter/src/statusIcon.tsx
+++ b/packages/html-reporter/src/statusIcon.tsx
@@ -18,7 +18,7 @@ import * as icons from './icons';
 import './colors.css';
 import './common.css';
 
-export function statusIcon(status: 'failed' | 'timedOut' | 'skipped' | 'passed' | 'expected' | 'unexpected' | 'flaky' | 'interrupted'): JSX.Element {
+export function statusIcon(status: 'failed' | 'timedOut' | 'skipped' | 'passed' | 'expected' | 'unexpected' | 'flaky' | 'interrupted') {
   switch (status) {
     case 'failed':
     case 'unexpected':

--- a/packages/html-reporter/src/tabbedPane.tsx
+++ b/packages/html-reporter/src/tabbedPane.tsx
@@ -20,7 +20,7 @@ import * as React from 'react';
 
 export interface TabbedPaneTab {
   id: string;
-  title: string | JSX.Element;
+  title: React.ReactNode;
   count?: number;
   render: () => React.ReactElement;
 }

--- a/packages/html-reporter/src/tabbedPane.tsx
+++ b/packages/html-reporter/src/tabbedPane.tsx
@@ -19,16 +19,16 @@ import './tabbedPane.css';
 import * as React from 'react';
 
 export interface TabbedPaneTab {
-  id: string;
+  id: number;
   title: React.ReactNode;
   count?: number;
   render: () => React.ReactElement;
 }
 
-export const TabbedPane: React.FunctionComponent<{
+export const TabbedPane: React.FC<{
   tabs: TabbedPaneTab[],
-  selectedTab: string,
-  setSelectedTab: (tab: string) => void
+  selectedTab: number,
+  setSelectedTab: (tab: number) => void
 }> = ({ tabs, selectedTab, setSelectedTab }) => {
   return <div className='tabbed-pane'>
     <div className='vbox'>
@@ -40,8 +40,8 @@ export const TabbedPane: React.FunctionComponent<{
               key={tab.id}>
               <div className='tabbed-pane-tab-label'>{tab.title}</div>
             </div>
-          ))
-        }</div>
+          ))}
+        </div>
       </div>
       {
         tabs.map(tab => {

--- a/packages/html-reporter/src/tabbedPane.tsx
+++ b/packages/html-reporter/src/tabbedPane.tsx
@@ -37,7 +37,9 @@ export const TabbedPane: React.FC<{
           tabs.map(tab => (
             <div className={clsx('tabbed-pane-tab-element', selectedTab === tab.id && 'selected')}
               onClick={() => setSelectedTab(tab.id)}
-              key={tab.id}>
+              key={tab.id}
+              role='button'
+            >
               <div className='tabbed-pane-tab-label'>{tab.title}</div>
             </div>
           ))}

--- a/packages/html-reporter/src/testCaseView.spec.tsx
+++ b/packages/html-reporter/src/testCaseView.spec.tsx
@@ -110,21 +110,21 @@ const annotationLinkRenderingTestCase: TestCase = {
 };
 
 test('should correctly render links in annotations', async ({ mount }) => {
-  const component = await mount(<TestCaseView test={annotationLinkRenderingTestCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={annotationLinkRenderingTestCase} prev={undefined} next={undefined} run={0} />);
 
-  const firstLink = await component.getByText('https://playwright.dev/docs/intro').first();
+  const firstLink = component.getByText('https://playwright.dev/docs/intro').first();
   await expect(firstLink).toBeVisible();
   await expect(firstLink).toHaveAttribute('href', 'https://playwright.dev/docs/intro');
 
-  const secondLink = await component.getByText('https://playwright.dev/docs/api/class-playwright').first();
+  const secondLink = component.getByText('https://playwright.dev/docs/api/class-playwright').first();
   await expect(secondLink).toBeVisible();
   await expect(secondLink).toHaveAttribute('href', 'https://playwright.dev/docs/api/class-playwright');
 
-  const thirdLink = await component.getByText('https://github.com/microsoft/playwright/issues/23180').first();
+  const thirdLink = component.getByText('https://github.com/microsoft/playwright/issues/23180').first();
   await expect(thirdLink).toBeVisible();
   await expect(thirdLink).toHaveAttribute('href', 'https://github.com/microsoft/playwright/issues/23180');
 
-  const fourthLink = await component.getByText('https://github.com/microsoft/playwright/issues/23181').first();
+  const fourthLink = component.getByText('https://github.com/microsoft/playwright/issues/23181').first();
   await expect(fourthLink).toBeVisible();
   await expect(fourthLink).toHaveAttribute('href', 'https://github.com/microsoft/playwright/issues/23181');
 });
@@ -168,7 +168,21 @@ const attachmentLinkRenderingTestCase: TestCase = {
   results: [resultWithAttachment]
 };
 
-const testCaseSummary: TestCaseSummary = {
+const previousTestCaseSummary: TestCaseSummary = {
+  testId: 'previousTestId',
+  title: 'previous test',
+  path: [],
+  projectName: 'chromium',
+  location: { file: 'test.spec.ts', line: 42, column: 0 },
+  tags: [],
+  outcome: 'expected',
+  duration: 10,
+  ok: true,
+  annotations: [],
+  results: [resultWithAttachment]
+};
+
+const nextTestCaseSummary: TestCaseSummary = {
   testId: 'nextTestId',
   title: 'next test',
   path: [],
@@ -184,9 +198,9 @@ const testCaseSummary: TestCaseSummary = {
 
 
 test('should correctly render links in attachments', async ({ mount }) => {
-  const component = await mount(<TestCaseView test={attachmentLinkRenderingTestCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={attachmentLinkRenderingTestCase} prev={undefined} next={undefined} run={0} />);
   await component.getByText('first attachment').click();
-  const body = await component.getByText('The body with https://playwright.dev/docs/intro link');
+  const body = component.getByText('The body with https://playwright.dev/docs/intro link');
   await expect(body).toBeVisible();
   await expect(body.locator('a').filter({ hasText: 'playwright.dev' })).toHaveAttribute('href', 'https://playwright.dev/docs/intro');
   await expect(body.locator('a').filter({ hasText: 'github.com' })).toHaveAttribute('href', 'https://github.com/microsoft/playwright/issues/31284');
@@ -197,7 +211,7 @@ test('should correctly render links in attachments', async ({ mount }) => {
 });
 
 test('should correctly render links in attachment name', async ({ mount }) => {
-  const component = await mount(<TestCaseView test={attachmentLinkRenderingTestCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={attachmentLinkRenderingTestCase} prev={undefined} next={undefined} run={0} />);
   const link = component.getByText('attachment with inline link').locator('a');
   await expect(link).toHaveAttribute('href', 'https://github.com/microsoft/playwright/issues/31284');
   await expect(link).toHaveText('https://github.com/microsoft/playwright/issues/31284');
@@ -207,12 +221,14 @@ test('should correctly render links in attachment name', async ({ mount }) => {
 });
 
 test('should correctly render prev and next', async ({ mount }) => {
-  const component = await mount(<TestCaseView test={attachmentLinkRenderingTestCase} prev={testCaseSummary} next={testCaseSummary} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={attachmentLinkRenderingTestCase} prev={previousTestCaseSummary} next={nextTestCaseSummary} run={0} />);
   await expect(component).toMatchAriaSnapshot(`
     - text: group
-    - link "« previous"
-    - link "next »"
-    - text: "My test test.spec.ts:42 10ms"
+    - link "« previous":
+       - /url: "#?testId=previousTestId"
+    - link "next »":
+       - /url: "#?testId=nextTestId"
+    - text: "My test test.spec.ts:42 10ms chromium"
   `);
 });
 
@@ -235,17 +251,34 @@ const testCaseWithTwoAttempts: TestCase = {
 };
 
 test('total duration is selected run duration', async ({ mount, page }) => {
-  const component = await mount(<TestCaseView test={testCaseWithTwoAttempts} prev={undefined} next={undefined} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={testCaseWithTwoAttempts} prev={undefined} next={undefined} run={0} />);
+  const sharedSnapshot =  `
+    - text: My test test.spec.ts:42 200ms chromium
+    - button "Annotations" [expanded]
+    - region: "annotation: Annotation text annotation: Another annotation text"
+    - button "Run 50ms"
+    - 'button "Retry #1 150ms"'
+    `;
+
   await expect(component).toMatchAriaSnapshot(`
-    - text: "My test test.spec.ts:42 200ms"
-    - text: "Run 50ms Retry #1 150ms"
+    ${sharedSnapshot}
+    - button "Errors" [expanded]
+    - region: Error message
+    - button "Test Steps" [expanded]
+    - region: 10ms Outer step— test.spec.ts:62
   `);
-  await page.locator('.tabbed-pane-tab-label', { hasText: 'Run50ms' }).click();
+  await page.getByRole('button', { name: 'Run 50ms' }).click();
   await expect(component).toMatchAriaSnapshot(`
-    - text: "My test test.spec.ts:42 200ms"
+    ${sharedSnapshot}
+    - button "Errors" [expanded]
+    - region: Error message
+    - button "Test Steps" [expanded]
+    - region: 10ms Outer step— test.spec.ts:62
   `);
-  await page.locator('.tabbed-pane-tab-label', { hasText: 'Retry #1150ms' }).click();
+  await page.getByRole('button', { name: 'Retry #1 150ms' }).click();
   await expect(component).toMatchAriaSnapshot(`
-    - text: "My test test.spec.ts:42 200ms"
+    ${sharedSnapshot}
+    - button "Test Steps" [expanded]
+    - region: 10ms Outer step— test.spec.ts:62
   `);
 });

--- a/packages/html-reporter/src/testCaseView.spec.tsx
+++ b/packages/html-reporter/src/testCaseView.spec.tsx
@@ -65,7 +65,7 @@ const testCase: TestCase = {
 };
 
 test('should render test case', async ({ mount }) => {
-  const component = await mount(<TestCaseView projectNames={['chromium', 'webkit']} test={testCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={testCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
   await expect(component.getByText('Annotation text', { exact: false }).first()).toBeVisible();
   await expect(component.getByText('Hidden annotation')).toBeHidden();
   await component.getByText('Annotations').click();
@@ -81,7 +81,7 @@ test('should render test case', async ({ mount }) => {
 test('should render copy buttons for annotations', async ({ mount, page, context }) => {
   await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 
-  const component = await mount(<TestCaseView projectNames={['chromium', 'webkit']} test={testCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={testCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
   await expect(component.getByText('Annotation text', { exact: false }).first()).toBeVisible();
   await component.getByText('Annotation text', { exact: false }).first().hover();
   await expect(component.locator('.test-case-annotation').getByLabel('Copy to clipboard').first()).toBeVisible();
@@ -110,7 +110,7 @@ const annotationLinkRenderingTestCase: TestCase = {
 };
 
 test('should correctly render links in annotations', async ({ mount }) => {
-  const component = await mount(<TestCaseView projectNames={['chromium', 'webkit']} test={annotationLinkRenderingTestCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={annotationLinkRenderingTestCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
 
   const firstLink = await component.getByText('https://playwright.dev/docs/intro').first();
   await expect(firstLink).toBeVisible();
@@ -184,7 +184,7 @@ const testCaseSummary: TestCaseSummary = {
 
 
 test('should correctly render links in attachments', async ({ mount }) => {
-  const component = await mount(<TestCaseView projectNames={['chromium', 'webkit']} test={attachmentLinkRenderingTestCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={attachmentLinkRenderingTestCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
   await component.getByText('first attachment').click();
   const body = await component.getByText('The body with https://playwright.dev/docs/intro link');
   await expect(body).toBeVisible();
@@ -197,7 +197,7 @@ test('should correctly render links in attachments', async ({ mount }) => {
 });
 
 test('should correctly render links in attachment name', async ({ mount }) => {
-  const component = await mount(<TestCaseView projectNames={['chromium', 'webkit']} test={attachmentLinkRenderingTestCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={attachmentLinkRenderingTestCase} prev={undefined} next={undefined} run={0}></TestCaseView>);
   const link = component.getByText('attachment with inline link').locator('a');
   await expect(link).toHaveAttribute('href', 'https://github.com/microsoft/playwright/issues/31284');
   await expect(link).toHaveText('https://github.com/microsoft/playwright/issues/31284');
@@ -207,7 +207,7 @@ test('should correctly render links in attachment name', async ({ mount }) => {
 });
 
 test('should correctly render prev and next', async ({ mount }) => {
-  const component = await mount(<TestCaseView projectNames={['chromium', 'webkit']} test={attachmentLinkRenderingTestCase} prev={testCaseSummary} next={testCaseSummary} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={attachmentLinkRenderingTestCase} prev={testCaseSummary} next={testCaseSummary} run={0}></TestCaseView>);
   await expect(component).toMatchAriaSnapshot(`
     - text: group
     - link "« previous"
@@ -235,7 +235,7 @@ const testCaseWithTwoAttempts: TestCase = {
 };
 
 test('total duration is selected run duration', async ({ mount, page }) => {
-  const component = await mount(<TestCaseView projectNames={['chromium', 'webkit']} test={testCaseWithTwoAttempts} prev={undefined} next={undefined} run={0}></TestCaseView>);
+  const component = await mount(<TestCaseView test={testCaseWithTwoAttempts} prev={undefined} next={undefined} run={0}></TestCaseView>);
   await expect(component).toMatchAriaSnapshot(`
     - text: "My test test.spec.ts:42 200ms"
     - text: "Run 50ms Retry #1 150ms"

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -19,31 +19,23 @@ import * as React from 'react';
 import { TabbedPane } from './tabbedPane';
 import { AutoChip } from './chip';
 import './common.css';
-import { Link, ProjectLink, SearchParamsContext, testResultHref } from './links';
+import { Link, LabelLink, SearchParamsContext, TagLinks, testResultHref } from './links';
 import { statusIcon } from './statusIcon';
 import './testCaseView.css';
 import { TestResultView } from './testResultView';
 import { linkifyText } from '@web/renderUtils';
-import { hashStringToInt, msToString } from './utils';
+import { msToString } from './utils';
 import { clsx } from '@web/uiUtils';
 import { CopyToClipboardContainer } from './copyToClipboard';
 
 export const TestCaseView: React.FC<{
-  projectNames: string[],
   test: TestCase | undefined,
   next: TestCaseSummary | undefined,
   prev: TestCaseSummary | undefined,
   run: number,
-}> = ({ projectNames, test, run, next, prev }) => {
+}> = ({ test, run, next, prev }) => {
   const [selectedResultIndex, setSelectedResultIndex] = React.useState(run);
   const searchParams = React.useContext(SearchParamsContext);
-  const filterParam = searchParams.has('q') ? '&q=' + searchParams.get('q') : '';
-
-  const labels = React.useMemo(() => {
-    if (!test)
-      return undefined;
-    return test.tags;
-  }, [test]);
 
   const visibleAnnotations = React.useMemo(() => {
     return test?.annotations?.filter(annotation => !annotation.type.startsWith('_')) || [];
@@ -53,35 +45,40 @@ export const TestCaseView: React.FC<{
     {test && <div className='hbox'>
       <div className='test-case-path'>{test.path.join(' › ')}</div>
       <div style={{ flex: 'auto' }}></div>
-      <div className={clsx(!prev && 'hidden')}><Link href={testResultHref({ test: prev }) + filterParam}>« previous</Link></div>
+      <div className={clsx(!prev && 'hidden')}><Link href={testResultHref({ test: prev, filter: searchParams })}>« previous</Link></div>
       <div style={{ width: 10 }}></div>
-      <div className={clsx(!next && 'hidden')}><Link href={testResultHref({ test: next }) + filterParam}>next »</Link></div>
+      <div className={clsx(!next && 'hidden')}><Link href={testResultHref({ test: next, filter: searchParams })}>next »</Link></div>
     </div>}
-    {test && <div className='test-case-title'>{test?.title}</div>}
+
+    {test && <div className='test-case-title'>{test.title}</div>}
+
     {test && <div className='hbox'>
       <div className='test-case-location'>
-        <CopyToClipboardContainer value={`${test?.location.file}:${test?.location.line}`}>
+        <CopyToClipboardContainer value={`${test.location.file}:${test.location.line}`}>
           {test.location.file}:{test.location.line}
         </CopyToClipboardContainer>
       </div>
       <div style={{ flex: 'auto' }}></div>
       <div className='test-case-duration'>{msToString(test.duration)}</div>
     </div>}
-    {test && (!!test.projectName || labels) && <div className='test-case-project-labels-row'>
-      {test && !!test.projectName && <ProjectLink projectNames={projectNames} projectName={test.projectName}></ProjectLink>}
-      {labels && <LabelsLinkView labels={labels} />}
+
+    {(test?.projectName || test?.tags) && <div className='test-case-project-labels-row'>
+      {test.projectName && <LabelLink prefix='p:' searchParams={searchParams} name={test.projectName}/>}
+      <TagLinks searchParams={searchParams} tags={test.tags}/>
     </div>}
+
     {!!visibleAnnotations.length && <AutoChip header='Annotations'>
       {visibleAnnotations.map((annotation, index) => <TestCaseAnnotationView key={index} annotation={annotation} />)}
     </AutoChip>}
+
     {test && <TabbedPane tabs={
       test.results.map((result, index) => ({
         id: String(index),
         title: <div style={{ display: 'flex', alignItems: 'center' }}>
-          {statusIcon(result.status)} {retryLabel(index)}
+          {statusIcon(result.status)} {index === 0 ? 'Run' : `Retry #${index}`}
           {(test.results.length > 1) && <span className='test-case-run-duration'>{msToString(result.duration)}</span>}
         </div>,
-        render: () => <TestResultView test={test!} result={result} />
+        render: () => <TestResultView test={test} result={result} />
       })) || []} selectedTab={String(selectedResultIndex)} setSelectedTab={id => setSelectedResultIndex(+id)} />}
   </div>;
 };
@@ -94,25 +91,3 @@ function TestCaseAnnotationView({ annotation: { type, description } }: { annotat
     </div>
   );
 }
-
-function retryLabel(index: number) {
-  if (!index)
-    return 'Run';
-  return `Retry #${index}`;
-}
-
-const LabelsLinkView: React.FC<React.PropsWithChildren<{
-  labels: string[],
-}>> = ({ labels }) => {
-  return labels.length > 0 ? (
-    <>
-      {labels.map(label => (
-        <a key={label} style={{ textDecoration: 'none', color: 'var(--color-fg-default)' }} href={`#?q=${label}`} >
-          <span style={{ margin: '6px 0 0 6px', cursor: 'pointer' }} className={clsx('label', 'label-color-' + hashStringToInt(label))}>
-            {label.slice(1)}
-          </span>
-        </a>
-      ))}
-    </>
-  ) : null;
-};

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -73,13 +73,13 @@ export const TestCaseView: React.FC<{
 
     {test && <TabbedPane tabs={
       test.results.map((result, index) => ({
-        id: String(index),
+        id: index,
         title: <div style={{ display: 'flex', alignItems: 'center' }}>
           {statusIcon(result.status)} {index === 0 ? 'Run' : `Retry #${index}`}
           {(test.results.length > 1) && <span className='test-case-run-duration'>{msToString(result.duration)}</span>}
         </div>,
         render: () => <TestResultView test={test} result={result} />
-      })) || []} selectedTab={String(selectedResultIndex)} setSelectedTab={id => setSelectedResultIndex(+id)} />}
+      }))} selectedTab={selectedResultIndex} setSelectedTab={id => setSelectedResultIndex(id)} />}
   </div>;
 };
 

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -57,16 +57,16 @@ export const TestFilesView: React.FC<{
 export const TestFilesHeader: React.FC<{
   report: HTMLReport | undefined,
   filteredStats?: FilteredStats,
-}> = ({ report, filteredStats }) => {
-  const [metadataVisible, setMetadataVisible] = React.useState(false);
-
+  metadataVisible: boolean,
+  toggleMetadataVisible: () => void,
+}> = ({ report, filteredStats, metadataVisible, toggleMetadataVisible }) => {
   if (!report)
     return null;
 
   return <>
     <div className='mx-1' style={{ display: 'flex', marginTop: 10 }}>
       <div className='test-file-header-info'>
-        {!isMetadataEmpty(report.metadata) && <div className='metadata-toggle' role='button' onClick={() => setMetadataVisible(visible => !visible)} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
+        {!isMetadataEmpty(report.metadata) && <div className='metadata-toggle' role='button' onClick={toggleMetadataVisible} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
           {metadataVisible ? icons.downArrow() : icons.rightArrow()}Metadata
         </div>}
         {report.projectNames.length === 1 && !!report.projectNames[0] && <div data-testid='project-name'>Project: {report.projectNames[0]}</div>}

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -39,40 +39,34 @@ export const TestFilesView: React.FC<{
     }
     return result;
   }, [tests]);
+
   return <>
-    {filteredFiles.map(({ file, defaultExpanded }) => {
-      return <TestFileView
-        key={`file-${file.fileId}`}
+    {filteredFiles.map(({ file, defaultExpanded }) =>
+      <TestFileView
+        key={file.fileId}
         file={file}
         projectNames={projectNames}
-        isFileExpanded={fileId => {
-          const value = expandedFiles.get(fileId);
-          if (value === undefined)
-            return defaultExpanded;
-          return !!value;
-        }}
+        isFileExpanded={fileId => expandedFiles.get(fileId) ?? defaultExpanded}
         setFileExpanded={(fileId, expanded) => {
-          const newExpanded = new Map(expandedFiles);
-          newExpanded.set(fileId, expanded);
-          setExpandedFiles(newExpanded);
+          setExpandedFiles(new Map(expandedFiles).set(fileId, expanded));
         }}>
-      </TestFileView>;
-    })}
+      </TestFileView>)}
   </>;
 };
 
 export const TestFilesHeader: React.FC<{
   report: HTMLReport | undefined,
   filteredStats?: FilteredStats,
-  metadataVisible: boolean,
-  toggleMetadataVisible: () => void,
-}> = ({ report, filteredStats, metadataVisible, toggleMetadataVisible }) => {
+}> = ({ report, filteredStats }) => {
+  const [metadataVisible, setMetadataVisible] = React.useState(false);
+
   if (!report)
     return null;
+
   return <>
     <div className='mx-1' style={{ display: 'flex', marginTop: 10 }}>
       <div className='test-file-header-info'>
-        {!isMetadataEmpty(report.metadata) && <div className='metadata-toggle' role='button' onClick={toggleMetadataVisible} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
+        {!isMetadataEmpty(report.metadata) && <div className='metadata-toggle' role='button' onClick={() => setMetadataVisible(visible => !visible)} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
           {metadataVisible ? icons.downArrow() : icons.rightArrow()}Metadata
         </div>}
         {report.projectNames.length === 1 && !!report.projectNames[0] && <div data-testid='project-name'>Project: {report.projectNames[0]}</div>}
@@ -82,7 +76,9 @@ export const TestFilesHeader: React.FC<{
       <div data-testid='overall-time' style={{ color: 'var(--color-fg-subtle)', marginRight: '10px' }}>{report ? new Date(report.startTime).toLocaleString() : ''}</div>
       <div data-testid='overall-duration' style={{ color: 'var(--color-fg-subtle)' }}>Total time: {msToString(report.duration ?? 0)}</div>
     </div>
+
     {metadataVisible && <MetadataView metadata={report.metadata}/>}
+
     {!!report.errors.length && <AutoChip header='Errors' dataTestId='report-errors'>
       {report.errors.map((error, index) => <TestErrorView key={'test-report-error-message-' + index} error={error}></TestErrorView>)}
     </AutoChip>}

--- a/packages/html-reporter/src/treeItem.tsx
+++ b/packages/html-reporter/src/treeItem.tsx
@@ -20,8 +20,8 @@ import * as icons from './icons';
 import { clsx } from '@web/uiUtils';
 
 export const TreeItem: React.FunctionComponent<{
-  title: JSX.Element,
-  loadChildren?: () => JSX.Element[],
+  title: React.ReactNode,
+  loadChildren?: () => React.ReactNode[],
   onClick?: () => void,
   expandByDefault?: boolean,
   depth: number,
@@ -31,7 +31,7 @@ export const TreeItem: React.FunctionComponent<{
   const [expanded, setExpanded] = React.useState(expandByDefault || false);
   return <div className={clsx('tree-item', flash && 'yellow-flash')} style={style}>
     <span className='tree-item-title' style={{ whiteSpace: 'nowrap', paddingLeft: depth * 22 + 4 }} onClick={() => { onClick?.(); setExpanded(!expanded); }} >
-      {loadChildren && !!expanded && icons.downArrow()}
+      {loadChildren && expanded && icons.downArrow()}
       {loadChildren && !expanded && icons.rightArrow()}
       {!loadChildren && <span style={{ visibility: 'hidden' }}>{icons.rightArrow()}</span>}
       {title}

--- a/packages/html-reporter/src/treeItem.tsx
+++ b/packages/html-reporter/src/treeItem.tsx
@@ -19,7 +19,7 @@ import './treeItem.css';
 import * as icons from './icons';
 import { clsx } from '@web/uiUtils';
 
-export const TreeItem: React.FunctionComponent<{
+export const TreeItem: React.FC<{
   title: React.ReactNode,
   loadChildren?: () => React.ReactNode[],
   onClick?: () => void,


### PR DESCRIPTION
Implements the following points:

3. Add extra space after any special token (so if input contains 's:passed', I won't have to press space to add another search token)
6) Keep my query (except current project filter) when clicking project filter
7. `Ctrl` + click should also work with project labels (and not open new tab)
9) Prepend label tags with a '@' to distinguish them from project labels
14. Typing in input does not update URL (and thus state)

Implemented more points then initially agreed, but it was actually easier to implement them now (else I could not re-use part of code).
I tried my best to have each change in a separate commit. If you find it hard to read the PR, let me know.
I can also easily add the other points as well, let me know what you want to see.

References: #35212