### PR TITLE
feat(trace-viewer): Move copy request buttons to toolbar

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -95,7 +95,7 @@
     flex-direction: column;
     width: 135px;
     z-index: 10;
-    backdrop-filter: blur(5px);
+    background-color: var(--vscode-list-dropBackground);
 
     button {
       padding: 8px;

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -49,12 +49,6 @@
   overflow: hidden;
 }
 
-.network-request-details-copy {
-  display: flex;
-  margin: 8px 10px;
-  gap: 8px;
-}
-
 .network-font-preview {
   font-family: font-preview;
   font-size: 30px;
@@ -83,6 +77,26 @@
 
 .tab-network .tabbed-pane-tab.selected {
   font-weight: bold;
+}
+
+.copy-request-dropdown {
+  .copy-request-dropdown-toggle {
+    margin-right: 14px;
+    width: 135px;
+  }
+
+  .copy-request-dropdown-menu {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    width: 135px;
+
+    button {
+      padding: 8px;
+      text-align: left;
+      z-index: 10;
+    }
+  }
 }
 
 .green-circle::before,

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -85,16 +85,21 @@
     width: 135px;
   }
 
+  &:not(:hover) .copy-request-dropdown-menu {
+    display: none;
+  }
+
   .copy-request-dropdown-menu {
     position: absolute;
     display: flex;
     flex-direction: column;
     width: 135px;
+    z-index: 10;
+    backdrop-filter: blur(5px);
 
     button {
       padding: 8px;
       text-align: left;
-      z-index: 10;
     }
   }
 }

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -88,25 +88,21 @@ const CopyDropdown: React.FC<{
   sdkLanguage: Language,
   requestBody: RequestBody,
 }> = ({ resource, sdkLanguage, requestBody }) => {
-  const [isOpen, setIsOpen] = React.useState(false);
-
   const copiedDescription = <><span className='codicon codicon-check' style={{ marginRight: '5px' }} /> Copied </>;
   const copyAsPlaywright = async () => getAPIRequestCodeGen(sdkLanguage).generatePlaywrightRequestCall(resource.request, requestBody?.text);
   return (
-    <div className='copy-request-dropdown' onMouseLeave={() => setIsOpen(false)} onMouseEnter={() => setIsOpen(true)}>
+    <div className='copy-request-dropdown'>
       <ToolbarButton className='copy-request-dropdown-toggle'>
         <span className='codicon codicon-copy' style={{ marginRight: '5px' }}/>
         Copy request
         <span className='codicon codicon-chevron-down' style={{ marginLeft: '5px' }}/>
       </ToolbarButton>
 
-      {isOpen && (
-        <div className='copy-request-dropdown-menu'>
-          <CopyToClipboardTextButton description='Copy as cURL' copiedDescription={copiedDescription} value={() => generateCurlCommand(resource)}/>
-          <CopyToClipboardTextButton description='Copy as Fetch' copiedDescription={copiedDescription} value={() => generateFetchCall(resource)}/>
-          <CopyToClipboardTextButton description='Copy as Playwright' copiedDescription={copiedDescription} value={copyAsPlaywright}/>
-        </div>
-      )}
+      <div className='copy-request-dropdown-menu'>
+        <CopyToClipboardTextButton description='Copy as cURL' copiedDescription={copiedDescription} value={() => generateCurlCommand(resource)}/>
+        <CopyToClipboardTextButton description='Copy as Fetch' copiedDescription={copiedDescription} value={() => generateFetchCall(resource)}/>
+        <CopyToClipboardTextButton description='Copy as Playwright' copiedDescription={copiedDescription} value={copyAsPlaywright}/>
+      </div>
     </div>
   );
 };

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -25,6 +25,10 @@ import { CopyToClipboardTextButton } from './copyToClipboard';
 import { getAPIRequestCodeGen } from './codegen';
 import type { Language } from '@isomorphic/locatorGenerators';
 import { msToString } from '@web/uiUtils';
+import type { Entry } from '@trace/har';
+
+type RequestBody = { text: string, mimeType?: string } | null;
+
 
 export const NetworkResourceDetails: React.FunctionComponent<{
   resource: ResourceSnapshot;
@@ -34,37 +38,7 @@ export const NetworkResourceDetails: React.FunctionComponent<{
 }> = ({ resource, sdkLanguage, startTimeOffset, onClose }) => {
   const [selectedTab, setSelectedTab] = React.useState('request');
 
-  return <TabbedPane
-    dataTestId='network-request-details'
-    leftToolbar={[<ToolbarButton key='close' icon='close' title='Close' onClick={onClose}></ToolbarButton>]}
-    tabs={[
-      {
-        id: 'request',
-        title: 'Request',
-        render: () => <RequestTab resource={resource} sdkLanguage={sdkLanguage} startTimeOffset={startTimeOffset} />,
-      },
-      {
-        id: 'response',
-        title: 'Response',
-        render: () => <ResponseTab resource={resource}/>,
-      },
-      {
-        id: 'body',
-        title: 'Body',
-        render: () => <BodyTab resource={resource}/>,
-      },
-    ]}
-    selectedTab={selectedTab}
-    setSelectedTab={setSelectedTab} />;
-};
-
-const RequestTab: React.FunctionComponent<{
-  resource: ResourceSnapshot;
-  sdkLanguage: Language;
-  startTimeOffset: number;
-}> = ({ resource, sdkLanguage, startTimeOffset }) => {
   const [requestBody, setRequestBody] = React.useState<{ text: string, mimeType?: string } | null>(null);
-
   React.useEffect(() => {
     const readResources = async  () => {
       if (resource.request.postData) {
@@ -83,6 +57,65 @@ const RequestTab: React.FunctionComponent<{
     readResources();
   }, [resource]);
 
+  return <TabbedPane
+    dataTestId='network-request-details'
+    leftToolbar={[<ToolbarButton key='close' icon='close' title='Close' onClick={onClose} />]}
+    rightToolbar={[<CopyDropdown key='dropdown' requestBody={requestBody} resource={resource} sdkLanguage={sdkLanguage} />]}
+    tabs={[
+      {
+        id: 'request',
+        title: 'Request',
+        render: () => <RequestTab resource={resource} startTimeOffset={startTimeOffset} requestBody={requestBody} />,
+      },
+      {
+        id: 'response',
+        title: 'Response',
+        render: () => <ResponseTab resource={resource}/>,
+      },
+      {
+        id: 'body',
+        title: 'Body',
+        render: () => <BodyTab resource={resource}/>,
+      },
+    ]}
+    selectedTab={selectedTab}
+    setSelectedTab={setSelectedTab} />;
+};
+
+
+const CopyDropdown: React.FC<{
+  resource: Entry,
+  sdkLanguage: Language,
+  requestBody: RequestBody,
+}> = ({ resource, sdkLanguage, requestBody }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const copiedDescription = <><span className='codicon codicon-check' style={{ marginRight: '5px' }} /> Copied </>;
+  const copyAsPlaywright = async () => getAPIRequestCodeGen(sdkLanguage).generatePlaywrightRequestCall(resource.request, requestBody?.text);
+  return (
+    <div className='copy-request-dropdown' onMouseLeave={() => setIsOpen(false)} onMouseEnter={() => setIsOpen(true)}>
+      <ToolbarButton className='copy-request-dropdown-toggle'>
+        <span className='codicon codicon-copy' style={{ marginRight: '5px' }}/>
+        Copy request
+        <span className='codicon codicon-chevron-down' style={{ marginLeft: '5px' }}/>
+      </ToolbarButton>
+
+      {isOpen && (
+        <div className='copy-request-dropdown-menu'>
+          <CopyToClipboardTextButton description='Copy as cURL' copiedDescription={copiedDescription} value={() => generateCurlCommand(resource)}/>
+          <CopyToClipboardTextButton description='Copy as Fetch' copiedDescription={copiedDescription} value={() => generateFetchCall(resource)}/>
+          <CopyToClipboardTextButton description='Copy as Playwright' copiedDescription={copiedDescription} value={copyAsPlaywright}/>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const RequestTab: React.FunctionComponent<{
+  resource: ResourceSnapshot;
+  startTimeOffset: number;
+  requestBody: RequestBody,
+}> = ({ resource, startTimeOffset, requestBody }) => {
   return <div className='network-request-details-tab'>
     <div className='network-request-details-header'>General</div>
     <div className='network-request-details-url'>{`URL: ${resource.request.url}`}</div>
@@ -102,12 +135,6 @@ const RequestTab: React.FunctionComponent<{
     <div className='network-request-details-header'>Time</div>
     <div className='network-request-details-general'>{`Start: ${msToString(startTimeOffset)}`}</div>
     <div className='network-request-details-general'>{`Duration: ${msToString(resource.time)}`}</div>
-
-    <div className='network-request-details-copy'>
-      <CopyToClipboardTextButton description='Copy as cURL' value={() => generateCurlCommand(resource)} />
-      <CopyToClipboardTextButton description='Copy as Fetch' value={() => generateFetchCall(resource)} />
-      <CopyToClipboardTextButton description='Copy as Playwright' value={async () => getAPIRequestCodeGen(sdkLanguage).generatePlaywrightRequestCall(resource.request, requestBody?.text)} />
-    </div>
 
     {requestBody && <div className='network-request-details-header'>Request Body</div>}
     {requestBody && <CodeMirrorWrapper text={requestBody.text} mimeType={requestBody.mimeType} readOnly lineNumbers={true}/>}

--- a/packages/web/src/components/toolbarButton.tsx
+++ b/packages/web/src/components/toolbarButton.tsx
@@ -20,11 +20,11 @@ import * as React from 'react';
 import { clsx } from '../uiUtils';
 
 export interface ToolbarButtonProps {
-  title: string,
+  title?: string,
   icon?: string,
   disabled?: boolean,
   toggled?: boolean,
-  onClick: (e: React.MouseEvent) => void,
+  onClick?: (e: React.MouseEvent) => void,
   style?: React.CSSProperties,
   testId?: string,
   className?: string,


### PR DESCRIPTION
Moves the copy request buttons to a dropdown on the toolbar:
![image](https://github.com/user-attachments/assets/1cf376f1-4698-485e-8015-8f2dbe1bb620)

Says 'copied' when option is pressed
![image](https://github.com/user-attachments/assets/03a801d2-2d5e-451f-b7d6-97c655d1ebba)


references: #35214