### PR TITLE
chore: allow upstream TestServerConnection with 'ws' Node.js module

### DIFF
--- a/packages/playwright/src/isomorphic/testServerConnection.ts
+++ b/packages/playwright/src/isomorphic/testServerConnection.ts
@@ -38,7 +38,7 @@ export class WebSocketTestServerTransport implements TestServerTransport {
   }
 
   onmessage(listener: (message: string) => void) {
-    this._ws.addEventListener('message', event => listener(event.data));
+    this._ws.addEventListener('message', event => listener(event.data.toString()));
   }
 
   onopen(listener: () => void) {


### PR DESCRIPTION
Came up in https://github.com/microsoft/playwright-vscode/pull/618.