### PR TITLE
fix(registry): find channels without proper win32 env

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -861,7 +861,9 @@ export class Registry {
         return undefined;
       }
       const prefixes = (process.platform === 'win32' ? [
-        process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']
+        process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)'],
+        // In some cases there is no PROGRAMFILES/(86) env var set but HOMEDRIVE is set.
+        process.env.HOMEDRIVE + '\\Program Files', process.env.HOMEDRIVE + '\\Program Files (x86)',
       ].filter(Boolean) : ['']) as string[];
 
       for (const prefix of prefixes) {
@@ -941,7 +943,9 @@ export class Registry {
         return undefined;
       }
       const prefixes = (process.platform === 'win32' ? [
-        process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']
+        process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)'],
+        // In some cases there is no PROGRAMFILES/(86) env var set but HOMEDRIVE is set.
+        process.env.HOMEDRIVE + '\\Program Files', process.env.HOMEDRIVE + '\\Program Files (x86)',
       ].filter(Boolean) : ['']) as string[];
 
       for (const prefix of prefixes) {

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -861,9 +861,12 @@ export class Registry {
         return undefined;
       }
       const prefixes = (process.platform === 'win32' ? [
-        process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)'],
+        process.env.LOCALAPPDATA,
+        process.env.PROGRAMFILES,
+        process.env['PROGRAMFILES(X86)'],
         // In some cases there is no PROGRAMFILES/(86) env var set but HOMEDRIVE is set.
-        process.env.HOMEDRIVE + '\\Program Files', process.env.HOMEDRIVE + '\\Program Files (x86)',
+        process.env.HOMEDRIVE + '\\Program Files',
+        process.env.HOMEDRIVE + '\\Program Files (x86)',
       ].filter(Boolean) : ['']) as string[];
 
       for (const prefix of prefixes) {
@@ -943,9 +946,12 @@ export class Registry {
         return undefined;
       }
       const prefixes = (process.platform === 'win32' ? [
-        process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)'],
+        process.env.LOCALAPPDATA,
+        process.env.PROGRAMFILES,
+        process.env['PROGRAMFILES(X86)'],
         // In some cases there is no PROGRAMFILES/(86) env var set but HOMEDRIVE is set.
-        process.env.HOMEDRIVE + '\\Program Files', process.env.HOMEDRIVE + '\\Program Files (x86)',
+        process.env.HOMEDRIVE + '\\Program Files',
+        process.env.HOMEDRIVE + '\\Program Files (x86)',
       ].filter(Boolean) : ['']) as string[];
 
       for (const prefix of prefixes) {


### PR DESCRIPTION
https://github.com/microsoft/playwright-mcp/issues/13

Background: `Claude Desktop` seems to start the MCP Servers without a proper env. This means there is no `PROGRAMFILES` etc. set which we use to locate Google Chrome. As a workaround we can rely on `HOMEDRIVE` env var which seems to be set all the time.