### PR TITLE
chore: Fix select warning when panes docked on right

### DIFF
--- a/packages/web/src/components/tabbedPane.tsx
+++ b/packages/web/src/components/tabbedPane.tsx
@@ -45,9 +45,8 @@ export const TabbedPane: React.FunctionComponent<{
   return <div className='tabbed-pane' data-testid={dataTestId}>
     <div className='vbox'>
       <Toolbar>
-        { leftToolbar && <div style={{ flex: 'none', display: 'flex', margin: '0 4px', alignItems: 'center' }}>
-          {...leftToolbar}
-        </div>}
+        { leftToolbar && <div style={{ flex: 'none', display: 'flex', margin: '0 4px', alignItems: 'center' }}>{...leftToolbar}</div>}
+
         {mode === 'default' && <div style={{ flex: 'auto', display: 'flex', height: '100%', overflow: 'hidden' }} role='tablist'>
           {[...tabs.map(tab => (
             <TabbedPaneTab
@@ -62,8 +61,9 @@ export const TabbedPane: React.FunctionComponent<{
             />)),
           ]}
         </div>}
+
         {mode === 'select' && <div style={{ flex: 'auto', display: 'flex', height: '100%', overflow: 'hidden' }} role='tablist'>
-          <select style={{ width: '100%', background: 'none', cursor: 'pointer' }} onChange={e => {
+          <select style={{ width: '100%', background: 'none', cursor: 'pointer' }} value={selectedTab} onChange={e => {
             setSelectedTab?.(tabs[e.currentTarget.selectedIndex].id);
           }}>
             {tabs.map(tab => {
@@ -72,14 +72,14 @@ export const TabbedPane: React.FunctionComponent<{
                 suffix = ` (${tab.count})`;
               if (tab.errorCount)
                 suffix = ` (${tab.errorCount})`;
-              return <option key={tab.id} value={tab.id} selected={tab.id === selectedTab} role='tab' aria-controls={`${id}-${tab.id}`}>{tab.title}{suffix}</option>;
+              return <option key={tab.id} value={tab.id} role='tab' aria-controls={`${id}-${tab.id}`}>{tab.title}{suffix}</option>;
             })}
           </select>
         </div>}
-        {rightToolbar && <div style={{ flex: 'none', display: 'flex', alignItems: 'center' }}>
-          {...rightToolbar}
-        </div>}
+
+        {rightToolbar && <div style={{ flex: 'none', display: 'flex', alignItems: 'center' }}>{...rightToolbar}</div>}
       </Toolbar>
+
       {
         tabs.map(tab => {
           const className = 'tab-content tab-' + tab.id;

--- a/packages/web/src/components/tabbedPane.tsx
+++ b/packages/web/src/components/tabbedPane.tsx
@@ -45,8 +45,9 @@ export const TabbedPane: React.FunctionComponent<{
   return <div className='tabbed-pane' data-testid={dataTestId}>
     <div className='vbox'>
       <Toolbar>
-        { leftToolbar && <div style={{ flex: 'none', display: 'flex', margin: '0 4px', alignItems: 'center' }}>{...leftToolbar}</div>}
-
+        { leftToolbar && <div style={{ flex: 'none', display: 'flex', margin: '0 4px', alignItems: 'center' }}>
+          {...leftToolbar}
+        </div>}
         {mode === 'default' && <div style={{ flex: 'auto', display: 'flex', height: '100%', overflow: 'hidden' }} role='tablist'>
           {[...tabs.map(tab => (
             <TabbedPaneTab
@@ -61,7 +62,6 @@ export const TabbedPane: React.FunctionComponent<{
             />)),
           ]}
         </div>}
-
         {mode === 'select' && <div style={{ flex: 'auto', display: 'flex', height: '100%', overflow: 'hidden' }} role='tablist'>
           <select style={{ width: '100%', background: 'none', cursor: 'pointer' }} value={selectedTab} onChange={e => {
             setSelectedTab?.(tabs[e.currentTarget.selectedIndex].id);
@@ -76,10 +76,10 @@ export const TabbedPane: React.FunctionComponent<{
             })}
           </select>
         </div>}
-
-        {rightToolbar && <div style={{ flex: 'none', display: 'flex', alignItems: 'center' }}>{...rightToolbar}</div>}
+        {rightToolbar && <div style={{ flex: 'none', display: 'flex', alignItems: 'center' }}>
+          {...rightToolbar}
+        </div>}
       </Toolbar>
-
       {
         tabs.map(tab => {
           const className = 'tab-content tab-' + tab.id;


### PR DESCRIPTION
Fixes the following development warning when having the panes docked to the right:

![image](https://github.com/user-attachments/assets/f08e33ee-0bd7-4118-b84d-b683fc7a8e81)

See: https://react.dev/reference/react-dom/components/select#caveats