### PR TITLE
feat(trace-viewer): Improve spacing and layout in and between network details sections

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -19,34 +19,32 @@
   height: 100%;
   user-select: text;
   line-height: 24px;
-  margin-left: 10px;
   overflow: auto;
-}
 
-.network-request-details-url {
-  white-space: normal;
-  word-wrap: break-word;
-  margin-left: 10px;
-}
+  em {
+    margin: 10px
+  }
 
-.network-request-details-headers {
-  white-space: pre;
-  overflow: hidden;
-  margin-left: 10px;
-}
+  .network-details {
+    margin-bottom: 8px;
 
-.network-request-details-header {
-  margin: 3px 0;
-  font-weight: bold;
-}
+    summary {
+      font-weight: bold;
+      cursor: pointer;
+      background-color: var(--vscode-sideBar-background);
+      padding: 4px;
+    }
 
-.network-request-details-general {
-  white-space: pre;
-  margin-left: 10px;
-}
+    table {
+      white-space: pre-wrap;
+      margin-left: 12px;
+      word-break: break-word;
 
-.network-request-details-tab .cm-wrapper {
-  overflow: hidden;
+      td:first-of-type {
+        width: 200px;
+      }
+    }
+  }
 }
 
 .network-font-preview {

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -150,11 +150,14 @@ test('should display list of query parameters (only if present)', async ({ runUI
   await page.getByText('Network', { exact: true }).click();
 
   await page.getByText('call-with-query-params').click();
-
-  await expect(page.getByText('Query String Parameters')).toBeVisible();
-  await expect(page.getByText('param1: value1')).toBeVisible();
-  await expect(page.getByText('param1: value2')).toBeVisible();
-  await expect(page.getByText('param2: value2')).toBeVisible();
+  await expect(page.getByRole('group', { name: 'Query String Parameters' })).toMatchAriaSnapshot(
+      `- table:
+         - rowgroup:
+           - 'row "param1: value1"'
+           - 'row "param1: value2"'
+           - 'row "param2: value2"'
+      `
+  );
 
   await page.getByText('endpoint').click();
 


### PR DESCRIPTION
- Sections inside a tab can now be collapsed (and is remember in storage)
  - Shows number of items when collapsed for request/response headers
- key-values can now easier be distinguished by the new spacing
- (keeps the current order intact, will re-order in next PR)

![image](https://github.com/user-attachments/assets/abc3d708-5bd9-45db-8d7a-4e487d030d7e)


References: #35214