### PR TITLE
fix(reporter): remove stale annotations from JsonTestEnd

### DIFF
--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -75,6 +75,8 @@ export type JsonTestEnd = {
   testId: string;
   expectedStatus: reporterTypes.TestStatus;
   timeout: number;
+  // Dropped in 1.52. Kept as empty array for backwards compatibility.
+  annotations: [];
 };
 
 export type JsonTestResultStart = {
@@ -234,6 +236,8 @@ export class TeleReporterReceiver {
     const test = this._tests.get(testEndPayload.testId)!;
     test.timeout = testEndPayload.timeout;
     test.expectedStatus = testEndPayload.expectedStatus;
+    // Should be empty array
+    test.annotations = testEndPayload.annotations;
     const result = test.results.find(r => r._id === payload.id)!;
     result.duration = payload.duration;
     result.status = payload.status;

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -236,8 +236,9 @@ export class TeleReporterReceiver {
     const test = this._tests.get(testEndPayload.testId)!;
     test.timeout = testEndPayload.timeout;
     test.expectedStatus = testEndPayload.expectedStatus;
-    // Should be empty array
-    test.annotations = testEndPayload.annotations;
+    // Should be empty array, but if it's not, it represents all annotations for that test
+    if (testEndPayload.annotations.length > 0)
+      test.annotations = testEndPayload.annotations;
     const result = test.results.find(r => r._id === payload.id)!;
     result.duration = payload.duration;
     result.status = payload.status;

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -75,7 +75,6 @@ export type JsonTestEnd = {
   testId: string;
   expectedStatus: reporterTypes.TestStatus;
   timeout: number;
-  annotations: Annotation[];
 };
 
 export type JsonTestResultStart = {
@@ -235,7 +234,6 @@ export class TeleReporterReceiver {
     const test = this._tests.get(testEndPayload.testId)!;
     test.timeout = testEndPayload.timeout;
     test.expectedStatus = testEndPayload.expectedStatus;
-    test.annotations = testEndPayload.annotations;
     const result = test.results.find(r => r._id === payload.id)!;
     result.duration = payload.duration;
     result.status = payload.status;

--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -73,7 +73,6 @@ export class TeleReporterEmitter implements ReporterV2 {
     const testEnd: teleReceiver.JsonTestEnd = {
       testId: test.id,
       expectedStatus: test.expectedStatus,
-      annotations: test.annotations,
       timeout: test.timeout,
     };
     this._messageSink({

--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -74,6 +74,7 @@ export class TeleReporterEmitter implements ReporterV2 {
       testId: test.id,
       expectedStatus: test.expectedStatus,
       timeout: test.timeout,
+      annotations: []
     };
     this._messageSink({
       method: 'onTestEnd',

--- a/packages/playwright/src/reporters/versions/blobV1.ts
+++ b/packages/playwright/src/reporters/versions/blobV1.ts
@@ -71,6 +71,7 @@ export type JsonTestEnd = {
   testId: string;
   expectedStatus: reporterTypes.TestStatus;
   timeout: number;
+  annotations: { type: string, description?: string }[];
 };
 
 export type JsonTestResultStart = {

--- a/packages/playwright/src/reporters/versions/blobV1.ts
+++ b/packages/playwright/src/reporters/versions/blobV1.ts
@@ -71,7 +71,6 @@ export type JsonTestEnd = {
   testId: string;
   expectedStatus: reporterTypes.TestStatus;
   timeout: number;
-  annotations: { type: string, description?: string }[];
 };
 
 export type JsonTestResultStart = {


### PR DESCRIPTION
#35292 split dynamic and static annotations. There is no longer a need to send any annotations with `JsonTestEnd`.