### PR TITLE
chore(driver): replace legacy --production with --omit=dev

### DIFF
--- a/utils/build/build-playwright-driver.sh
+++ b/utils/build/build-playwright-driver.sh
@@ -52,7 +52,7 @@ function build {
   cp ./output/api.json ./output/playwright-${SUFFIX}/package/
   cp ./output/protocol.yml ./output/playwright-${SUFFIX}/package/
   cd ./output/playwright-${SUFFIX}/package
-  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 node "../../${NODE_DIR}/${NPM_PATH}" install --production --ignore-scripts
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 node "../../${NODE_DIR}/${NPM_PATH}" install --omit=dev --ignore-scripts
   rm package-lock.json
 
   cd ..


### PR DESCRIPTION
During building the driver the following warning came up:

    npm warn config production Use `--omit=dev` instead.