### PR TITLE
chore: show snapshot for test.step

### DIFF
--- a/packages/trace-viewer/src/ui/modelUtil.ts
+++ b/packages/trace-viewer/src/ui/modelUtil.ts
@@ -25,8 +25,8 @@ import type { StackFrame } from '@protocol/channels';
 
 const contextSymbol = Symbol('context');
 const nextInContextSymbol = Symbol('nextInContext');
-const prevEndTimeSymbol = Symbol('prevEndTime');
-const nextStartTimeSymbol = Symbol('prevEndTime');
+const prevByEndTimeSymbol = Symbol('prevByEndTime');
+const nextByStartTimeSymbol = Symbol('nextByStartTime');
 const eventsSymbol = Symbol('events');
 
 export type SourceLocation = {
@@ -201,7 +201,7 @@ function mergeActionsAndUpdateTiming(contexts: ContextEntry[]) {
   });
 
   for (let i = 1; i < result.length; ++i)
-    (result[i] as any)[prevEndTimeSymbol] = result[i - 1];
+    (result[i] as any)[prevByEndTimeSymbol] = result[i - 1];
 
   result.sort((a1, a2) => {
     if (a2.parentId === a1.callId)
@@ -212,7 +212,7 @@ function mergeActionsAndUpdateTiming(contexts: ContextEntry[]) {
   });
 
   for (let i = 0; i + 1 < result.length; ++i)
-    (result[i] as any)[nextStartTimeSymbol] = result[i + 1];
+    (result[i] as any)[nextByStartTimeSymbol] = result[i + 1];
 
   return result;
 }
@@ -368,12 +368,12 @@ function nextInContext(action: ActionTraceEvent): ActionTraceEvent {
   return (action as any)[nextInContextSymbol];
 }
 
-export function prevEndTime(action: ActionTraceEvent): ActionTraceEvent {
-  return (action as any)[prevEndTimeSymbol];
+export function previousActionByEndTime(action: ActionTraceEvent): ActionTraceEvent {
+  return (action as any)[prevByEndTimeSymbol];
 }
 
-export function nextStartTime(action: ActionTraceEvent): ActionTraceEvent {
-  return (action as any)[nextStartTimeSymbol];
+export function nextActionByStartTime(action: ActionTraceEvent): ActionTraceEvent {
+  return (action as any)[nextByStartTimeSymbol];
 }
 
 export function stats(action: ActionTraceEvent): { errors: number, warnings: number } {

--- a/packages/trace-viewer/src/ui/modelUtil.ts
+++ b/packages/trace-viewer/src/ui/modelUtil.ts
@@ -24,8 +24,9 @@ import type { ActionEntry, ContextEntry, PageEntry } from '../types/entries';
 import type { StackFrame } from '@protocol/channels';
 
 const contextSymbol = Symbol('context');
-const nextInContextSymbol = Symbol('next');
+const nextInContextSymbol = Symbol('nextInContext');
 const prevInListSymbol = Symbol('prev');
+const nextInListSymbol = Symbol('next');
 const eventsSymbol = Symbol('events');
 
 export type SourceLocation = {
@@ -198,8 +199,10 @@ function mergeActionsAndUpdateTiming(contexts: ContextEntry[]) {
     return a1.startTime - a2.startTime;
   });
 
-  for (let i = 1; i < result.length; ++i)
+  for (let i = 0; i < result.length; ++i) {
     (result[i] as any)[prevInListSymbol] = result[i - 1];
+    (result[i] as any)[nextInListSymbol] = result[i + 1];
+  }
 
   return result;
 }
@@ -357,6 +360,10 @@ function nextInContext(action: ActionTraceEvent): ActionTraceEvent {
 
 export function prevInList(action: ActionTraceEvent): ActionTraceEvent {
   return (action as any)[prevInListSymbol];
+}
+
+export function nextInList(action: ActionTraceEvent): ActionTraceEvent {
+  return (action as any)[nextInListSymbol];
 }
 
 export function stats(action: ActionTraceEvent): { errors: number, warnings: number } {

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -367,7 +367,7 @@ export function collectSnapshots(action: ActionTraceEvent | undefined): Snapshot
     if (isTestStep(action)) {
       let last: ActionTraceEvent | undefined;
       for (let a = nextInList(action); a; a = nextInList(a)) {
-        if (a.endTime < action.endTime && a.afterSnapshot)
+        if (a.endTime <= action.endTime && a.afterSnapshot)
           last = a;
       }
       if (last)

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -17,7 +17,7 @@
 import './snapshotTab.css';
 import * as React from 'react';
 import type { ActionTraceEvent } from '@trace/trace';
-import { context, type MultiTraceModel, nextStartTime, prevEndTime } from './modelUtil';
+import { context, type MultiTraceModel, nextActionByStartTime, previousActionByEndTime } from './modelUtil';
 import { Toolbar } from '@web/components/toolbar';
 import { ToolbarButton } from '@web/components/toolbarButton';
 import { clsx, useMeasure, useSetting } from '@web/uiUtils';
@@ -332,7 +332,7 @@ export function collectSnapshots(action: ActionTraceEvent | undefined): Snapshot
   let beforeSnapshot: Snapshot | undefined = action.beforeSnapshot ? { action, snapshotName: action.beforeSnapshot } : undefined;
   if (!beforeSnapshot) {
     // If the action has no beforeSnapshot, use the last available afterSnapshot.
-    for (let a = prevEndTime(action); a; a = prevEndTime(a)) {
+    for (let a = previousActionByEndTime(action); a; a = previousActionByEndTime(a)) {
       if (a.endTime <= action.startTime && a.afterSnapshot) {
         beforeSnapshot = { action: a, snapshotName: a.afterSnapshot };
         break;
@@ -350,7 +350,7 @@ export function collectSnapshots(action: ActionTraceEvent | undefined): Snapshot
     //   for simple `expect(a).toBe(b);` case. Also if the action doesn't have
     //   afterSnapshot, it likely doesn't have its own beforeSnapshot either,
     //   and we calculated it above from a previous action.
-    for (let a = nextStartTime(action); a && a.startTime <= action.endTime; a = nextStartTime(a)) {
+    for (let a = nextActionByStartTime(action); a && a.startTime <= action.endTime; a = nextActionByStartTime(a)) {
       if (a.endTime > action.endTime || !a.afterSnapshot)
         continue;
       if (last && last.endTime > a.endTime)

--- a/tests/page/page-check.spec.ts
+++ b/tests/page/page-check.spec.ts
@@ -18,15 +18,9 @@
 import { test as it, expect } from './pageTest';
 
 it('should check the box @smoke', async ({ page }) => {
-  await it.step('first', async () => {
-    await page.setContent(`<input id='checkbox' type='checkbox'></input>`);
-  });
-  await it.step('middle', async () => {
-    await page.check('input');
-  });
-  await it.step('last', async () => {
-    expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);
-  });
+  await page.setContent(`<input id='checkbox' type='checkbox'></input>`);
+  await page.check('input');
+  expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);
 });
 
 it('should not check the checked box', async ({ page }) => {

--- a/tests/page/page-check.spec.ts
+++ b/tests/page/page-check.spec.ts
@@ -18,9 +18,15 @@
 import { test as it, expect } from './pageTest';
 
 it('should check the box @smoke', async ({ page }) => {
-  await page.setContent(`<input id='checkbox' type='checkbox'></input>`);
-  await page.check('input');
-  expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);
+  await it.step('first', async () => {
+    await page.setContent(`<input id='checkbox' type='checkbox'></input>`);
+  });
+  await it.step('middle', async () => {
+    await page.check('input');
+  });
+  await it.step('last', async () => {
+    expect(await page.evaluate(() => window['checkbox'].checked)).toBe(true);
+  });
 });
 
 it('should not check the checked box', async ({ page }) => {

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -150,6 +150,61 @@ test('should show snapshots for sync assertions', async ({ runUITest }) => {
   ).toHaveText('Submit');
 });
 
+test('should show snapshots for steps', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35285' }
+}, async ({ runUITest }) => {
+  const { page } = await runUITest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test.beforeEach(async ({ page }) => {
+        await page.setContent('<div>initial</div>');
+      });
+      test('steps test', async ({ page }) => {
+        await test.step('first', async () => {
+          await page.setContent("<div>foo</div>");
+        });
+        await test.step('middle', async () => {
+          await page.setContent("<div>bar</div>");
+        });
+        await test.step('last', async () => {
+          await page.setContent("<div>baz</div>");
+        });
+      });
+    `,
+  });
+
+  await page.getByText('steps test').dblclick();
+
+  await expect(page.getByTestId('actions-tree')).toMatchAriaSnapshot(`
+    - tree:
+      - treeitem /Before Hooks \\d+[hmsp]+/
+      - treeitem /first \\d+[hmsp]+/
+      - treeitem /middle \\d+[hmsp]+/
+      - treeitem /last \\d+[hmsp]+/
+      - treeitem /After Hooks \\d+[hmsp]+/
+  `);
+
+  await page.getByTestId('actions-tree').getByText('first').click();
+  const snapshot = page.frameLocator('iframe.snapshot-visible[name=snapshot]').locator('div');
+
+  await page.getByText('After', { exact: true }).click();
+  await expect(snapshot).toHaveText('foo');
+  await page.getByText('Before', { exact: true }).click();
+  await expect(snapshot).toHaveText('initial');
+
+  await page.getByTestId('actions-tree').getByText('middle').click();
+  await page.getByText('After', { exact: true }).click();
+  await expect(snapshot).toHaveText('bar');
+  await page.getByText('Before', { exact: true }).click();
+  await expect(snapshot).toHaveText('foo');
+
+  await page.getByTestId('actions-tree').getByText('last').click();
+  await page.getByText('After', { exact: true }).click();
+  await expect(snapshot).toHaveText('baz');
+  await page.getByText('Before', { exact: true }).click();
+  await expect(snapshot).toHaveText('bar');
+});
+
 test('should show image diff', async ({ runUITest }) => {
   const { page } = await runUITest({
     'playwright.config.js': `


### PR DESCRIPTION
We don't take before/after snapshot for `test.step`. To approximate the snapshots we could take either snapshots from the nested actions or from the outer ones. The current logic is the following:

**beforeSnapshot:**
- `beforeSnapshot` is always taken from the last finished action before the step. It also works nice for the actions without nested actions, such as simple `expect(1).toBe(1);`

**afterSnapshot:**
- We always use `afterSnapshot` from a "nested" action, if there is one. It is exactly what we want for `test.step` and it is acceptable for other actions.
- If there are no "nested" actions, use the `beforeSnapshot` 
  -  works best for simple `expect(a).toBe(b);` case
  - `test.step` without children with snapshot is likely a step with a bunch of `expect(a).toBe(b);` and the same logic as for single expect applies.

Fixes https://github.com/microsoft/playwright/issues/35285