### PR TITLE
chore: do not build playwright-client twice

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -244,6 +244,9 @@ steps.push({
 for (const pkg of workspace.packages()) {
   if (!fs.existsSync(path.join(pkg.path, 'src')))
     continue;
+  // These packages have their own build step.
+  if (['@playwright/client'].includes(pkg.name))
+    continue;
   steps.push({
     command: 'npx',
     args: [


### PR DESCRIPTION
The problem was that we were building `playwright-client` twice:

a) With 'esbuild'  - expected because we want to bundle it to a single file.
b) Via the common babel build infra [here](https://github.com/microsoft/playwright/blob/dbd3b6753cb92fba56b105521e1c3d5857e0b308/utils/build/build.js#L244) (unexpected).

There is no need to build it twice. One produced a bundled build one didn't. Lets ignore packages for now if the package.json has a custom 'build' script.