### PR TITLE
test: add cross origin test support to Android

### DIFF
--- a/tests/android/browser.spec.ts
+++ b/tests/android/browser.spec.ts
@@ -19,7 +19,7 @@ import { androidTest as test, expect } from './androidTest';
 
 test('androidDevice.model', async function({ androidDevice }) {
   expect(androidDevice.model()).toContain('sdk_gphone');
-  expect(androidDevice.model()).toContain('x86_64');
+  expect(androidDevice.model()).toContain(process.arch === 'arm64' ? 'arm64' : 'x86_64');
 });
 
 test('androidDevice.launchBrowser', async function({ androidDevice }) {
@@ -53,11 +53,11 @@ test('androidDevice.launchBrowser should throw for bad proxy server value', asyn
   expect(error.message).toContain('proxy.server: expected string, got number');
 });
 
-test('androidDevice.launchBrowser should pass proxy config', async ({ androidDevice, server, mode, loopback }) => {
+test('androidDevice.launchBrowser should pass proxy config', async ({ androidDevice, server }) => {
   server.setRoute('/target.html', async (req, res) => {
     res.end('<html><title>Served by the proxy</title></html>');
   });
-  const context = await androidDevice.launchBrowser({ proxy: { server: `${loopback}:${server.PORT}` } });
+  const context = await androidDevice.launchBrowser({ proxy: { server: new URL(server.EMPTY_PAGE).host } });
   const page = await context.newPage();
   await page.goto('http://non-existent.com/target.html');
   expect(await page.title()).toBe('Served by the proxy');

--- a/tests/android/playwright.config.ts
+++ b/tests/android/playwright.config.ts
@@ -49,26 +49,29 @@ const metadata = {
   video: false,
 };
 
+const use: typeof config.projects[0]['use'] = {
+  sameOriginHost: '10.0.2.2',
+  // sslip.io is a free service that provides wildcard DNS for any IP address.
+  // It allows us to use a domain name that resolves to the local machine's IP address.
+  // Modifying /etc/hosts is not necessary by that and would be hard.
+  crossOriginHost: '10.0.2.2.sslip.io',
+  browserName: 'chromium',
+};
+
 config.projects!.push({
   name: 'android-native',
-  use: {
-    loopback: '10.0.2.2',
-    browserName: 'chromium',
-  },
   snapshotPathTemplate: '{testDir}/{testFileDir}/{testFileName}-snapshots/{arg}-android{ext}',
   testDir: path.join(testDir, 'android'),
   metadata,
+  use,
 });
 
 config.projects!.push({
   name: 'android-page',
-  use: {
-    loopback: '10.0.2.2',
-    browserName: 'chromium',
-  },
   snapshotPathTemplate: '{testDir}/{testFileDir}/{testFileName}-snapshots/{arg}-android{ext}',
   testDir: path.join(testDir, 'page'),
   metadata,
+  use,
 });
 
 export default config;

--- a/tests/config/serverFixtures.ts
+++ b/tests/config/serverFixtures.ts
@@ -23,7 +23,8 @@ import type { SocksSocketRequestedPayload } from 'playwright-core/src/server/uti
 import { SocksProxy } from '../../packages/playwright-core/lib/server/utils/socksProxy';
 
 export type ServerWorkerOptions = {
-  loopback?: string;
+  sameOriginHost?: string;
+  crossOriginHost?: string;
   __servers: ServerFixtures;
 };
 
@@ -36,17 +37,18 @@ export type ServerFixtures = {
 };
 
 export const serverFixtures: Fixtures<ServerFixtures, ServerWorkerOptions> = {
-  loopback: [undefined, { scope: 'worker', option: true }],
-  __servers: [async ({ loopback }, run, workerInfo) => {
+  sameOriginHost: [undefined, { scope: 'worker', option: true }],
+  crossOriginHost: [undefined, { scope: 'worker', option: true }],
+  __servers: [async ({ sameOriginHost, crossOriginHost }, run, workerInfo) => {
     const assetsPath = path.join(__dirname, '..', 'assets');
     const cachedPath = path.join(__dirname, '..', 'assets', 'cached');
 
     const port = 8907 + workerInfo.workerIndex * 4;
-    const server = await TestServer.create(assetsPath, port, loopback);
+    const server = await TestServer.create(assetsPath, port, sameOriginHost, crossOriginHost);
     server.enableHTTPCache(cachedPath);
 
     const httpsPort = port + 1;
-    const httpsServer = await TestServer.createHTTPS(assetsPath, httpsPort, loopback);
+    const httpsServer = await TestServer.createHTTPS(assetsPath, httpsPort, sameOriginHost, crossOriginHost);
     httpsServer.enableHTTPCache(cachedPath);
 
     const socksServer = new MockSocksServer();

--- a/tests/config/testserver/index.ts
+++ b/tests/config/testserver/index.ts
@@ -56,14 +56,14 @@ export class TestServer {
   readonly CROSS_PROCESS_PREFIX: string;
   readonly EMPTY_PAGE: string;
 
-  static async create(dirPath: string, port: number, loopback?: string): Promise<TestServer> {
-    const server = new TestServer(dirPath, port, loopback);
+  static async create(dirPath: string, port: number, sameOriginHost?: string, crossOriginHost?: string): Promise<TestServer> {
+    const server = new TestServer(dirPath, port, sameOriginHost, crossOriginHost);
     await new Promise(x => server._server.once('listening', x));
     return server;
   }
 
-  static async createHTTPS(dirPath: string, port: number, loopback?: string): Promise<TestServer> {
-    const server = new TestServer(dirPath, port, loopback, {
+  static async createHTTPS(dirPath: string, port: number, sameOriginHost?: string, crossOriginHost?: string): Promise<TestServer> {
+    const server = new TestServer(dirPath, port, sameOriginHost, crossOriginHost, {
       key: await fs.promises.readFile(path.join(__dirname, 'key.pem')),
       cert: await fs.promises.readFile(path.join(__dirname, 'cert.pem')),
       passphrase: 'aaaa',
@@ -72,7 +72,7 @@ export class TestServer {
     return server;
   }
 
-  constructor(dirPath: string, port: number, loopback?: string, sslOptions?: object) {
+  constructor(dirPath: string, port: number, sameOriginHost?: string, crossOriginHost?: string, sslOptions?: object) {
     if (sslOptions)
       this._server = createHttpsServer(sslOptions, this._onRequest.bind(this));
     else
@@ -112,8 +112,8 @@ export class TestServer {
     this._startTime = new Date();
     this._cachedPathPrefix = null;
 
-    const cross_origin = loopback || '127.0.0.1';
-    const same_origin = loopback || 'localhost';
+    const cross_origin = crossOriginHost || '127.0.0.1';
+    const same_origin = sameOriginHost || 'localhost';
     const protocol = sslOptions ? 'https' : 'http';
     this.PORT = port;
     this.PREFIX = `${protocol}://${same_origin}:${port}`;

--- a/tests/page/frame-evaluate.spec.ts
+++ b/tests/page/frame-evaluate.spec.ts
@@ -95,9 +95,7 @@ it('should allow cross-frame element handles', async ({ page, server }) => {
   expect(result.trim()).toBe('<div>Hi, I\'m frame</div>');
 });
 
-it('should not allow cross-frame element handles when frames do not script each other', async ({ page, server, isAndroid }) => {
-  it.skip(isAndroid, 'No cross-process on Android');
-
+it('should not allow cross-frame element handles when frames do not script each other', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const frame = await attachFrame(page, 'frame1', server.CROSS_PROCESS_PREFIX + '/empty.html');
   const bodyHandle = await frame.$('body');

--- a/tests/page/frame-hierarchy.spec.ts
+++ b/tests/page/frame-hierarchy.spec.ts
@@ -35,16 +35,15 @@ function dumpFrames(frame: Frame, indentation: string = ''): string[] {
   return result;
 }
 
-it('should handle nested frames @smoke', async ({ page, server, isAndroid }) => {
-  it.skip(isAndroid, 'No cross-process on Android');
-
+it('should handle nested frames @smoke', async ({ page, server }) => {
+  const localhost = new URL(server.EMPTY_PAGE).hostname;
   await page.goto(server.PREFIX + '/frames/nested-frames.html');
   expect(dumpFrames(page.mainFrame())).toEqual([
-    'http://localhost:<PORT>/frames/nested-frames.html',
-    '    http://localhost:<PORT>/frames/frame.html (aframe)',
-    '    http://localhost:<PORT>/frames/two-frames.html (2frames)',
-    '        http://localhost:<PORT>/frames/frame.html (dos)',
-    '        http://localhost:<PORT>/frames/frame.html (uno)',
+    `http://${localhost}:<PORT>/frames/nested-frames.html`,
+    `    http://${localhost}:<PORT>/frames/frame.html (aframe)`,
+    `    http://${localhost}:<PORT>/frames/two-frames.html (2frames)`,
+    `        http://${localhost}:<PORT>/frames/frame.html (dos)`,
+    `        http://${localhost}:<PORT>/frames/frame.html (uno)`,
   ]);
 });
 

--- a/tests/page/page-add-script-tag.spec.ts
+++ b/tests/page/page-add-script-tag.spec.ts
@@ -98,9 +98,7 @@ it('should throw when added with content to the CSP page', async ({ page, server
   expect(error).toBeTruthy();
 });
 
-it('should throw when added with URL to the CSP page', async ({ page, server, isAndroid }) => {
-  it.skip(isAndroid, 'No cross-process on Android');
-
+it('should throw when added with URL to the CSP page', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/csp.html');
   let error = null;
   await page.addScriptTag({ url: server.CROSS_PROCESS_PREFIX + '/injectedfile.js' }).catch(e => error = e);

--- a/tests/page/page-add-style-tag.spec.ts
+++ b/tests/page/page-add-style-tag.spec.ts
@@ -76,9 +76,7 @@ it('should throw when added with content to the CSP page', async ({ page, server
   expect(error).toBeTruthy();
 });
 
-it('should throw when added with URL to the CSP page', async ({ page, server, isAndroid }) => {
-  it.skip(isAndroid, 'No cross-process on Android');
-
+it('should throw when added with URL to the CSP page', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/csp.html');
   let error = null;
   await page.addStyleTag({ url: server.CROSS_PROCESS_PREFIX + '/injectedstyle.css' }).catch(e => error = e);

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -864,9 +864,9 @@ it('should wait for load when iframe attaches and detaches', async ({ page, serv
   expect(await page.$('iframe')).toBe(null);
 });
 
-it('should return url with basic auth info', async ({ page, server, loopback }) => {
+it('should return url with basic auth info', async ({ page, server }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23138' });
-  const url = `http://admin:admin@${loopback || 'localhost'}:${server.PORT}/empty.html`;
+  const url = `http://admin:admin@${new URL(server.PREFIX).host}/empty.html`;
   await page.goto(url);
   expect(page.url()).toBe(url);
 });

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -372,9 +372,8 @@ it('should work with Cross-Origin-Opener-Policy', async ({ page, server, browser
   expect(response.request().failure()).toBeNull();
 });
 
-it('should delete the origin header', async ({ page, server, isAndroid, browserName }) => {
+it('should delete the origin header', async ({ page, server, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/13106' });
-  it.skip(isAndroid, 'No cross-process on Android');
   it.fail(browserName === 'webkit', 'Does not delete origin in webkit');
 
   await page.goto(server.PREFIX + '/empty.html');

--- a/tests/page/page-request-fulfill.spec.ts
+++ b/tests/page/page-request-fulfill.spec.ts
@@ -229,9 +229,7 @@ it('should not modify the headers sent to the server', async ({ page, server }) 
   expect(interceptedRequests[1].headers).toEqual(interceptedRequests[0].headers);
 });
 
-it('should include the origin header', async ({ page, server, isAndroid }) => {
-  it.skip(isAndroid, 'No cross-process on Android');
-
+it('should include the origin header', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/empty.html');
   let interceptedRequest;
   await page.route(server.CROSS_PROCESS_PREFIX + '/something', (route, request) => {


### PR DESCRIPTION
This would make `tests/page/page-request-continue.spec.ts:764:3` and other related tests pass which are relying on having a separate cross-origin host which points to `127.0.0.1`. On our normal tests we use localhost vs. 127.0.0.1 and on Android we either need to rewrite hosts file or use e.g. sslip.io.