### PR TITLE
devops: remove unnecessary install-deps

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -24,8 +24,7 @@ jobs:
         node-version: 18
     - run: npm ci
     - run: npm run build
-    - run: npx playwright install-deps
-    - run: npx playwright install
+    - run: npx playwright install --with-deps
     - run: npm run lint
     - name: Verify clean tree
       run: |

--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -28,7 +28,6 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - run: npm ci
     - run: npm run build
-    - run: npx playwright install-deps
     - name: "@next: publish with commit timestamp (triggered manually)"
       if: contains(github.ref, 'main') && github.event_name == 'workflow_dispatch'
       run: |

--- a/.github/workflows/publish_release_docker.yml
+++ b/.github/workflows/publish_release_docker.yml
@@ -29,7 +29,6 @@ jobs:
         platforms: arm64
     - run: npm ci
     - run: npm run build
-    - run: npx playwright install-deps
     - name: Azure Login
       uses: azure/login@v2
       with:

--- a/.github/workflows/publish_release_driver.yml
+++ b/.github/workflows/publish_release_driver.yml
@@ -24,7 +24,6 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - run: npm ci
     - run: npm run build
-    - run: npx playwright install-deps
     - run: utils/build/build-playwright-driver.sh
     - name: Azure Login
       uses: azure/login@v2

--- a/.github/workflows/publish_release_npm.yml
+++ b/.github/workflows/publish_release_npm.yml
@@ -23,7 +23,6 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - run: npm ci
     - run: npm run build
-    - run: npx playwright install-deps
     - run: utils/publish_all_packages.sh --release-candidate
       if: ${{ github.event.release.prerelease }}
       env:

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -186,7 +186,7 @@ jobs:
       run: node -e "const p = require('./package.json'); delete p.devDependencies['@playwright/test']; fs.writeFileSync('./package.json', JSON.stringify(p, null, 2));"
       working-directory: ./playwright-vscode
     - name: Build extension
-      run: npm install && npm run build
+      run: npm ci && npm run build
       working-directory: ./playwright-vscode
     - name: Run extension tests
       run: npm run test -- --workers=1

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -295,7 +295,6 @@ jobs:
         node-version: 18
     - run: npm ci
     - run: npm run build
-    - run: npx playwright install-deps
     - run: utils/build/build-playwright-driver.sh
 
   test_channel_chromium:


### PR DESCRIPTION
The following workflows should not require any browser system dependencies. We don't have the browsers yet so we should be able to safely remove this 1 minute long step.