### PR TITLE
devops: remove PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD env var

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -41,9 +41,6 @@ runs:
         npm ci
         echo "::endgroup::"
       shell: bash
-      env:
-        DEBUG: pw:install
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
     - run: |
         echo "::group::npm run build"
         npm run build

--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -20,8 +20,6 @@ jobs:
         node-version: 18
     - run: npm ci
       env:
-        DEBUG: pw:install
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         ELECTRON_SKIP_BINARY_DOWNLOAD: 1
     - run: npm run build
 

--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -34,8 +34,6 @@ jobs:
       with:
         node-version: 20
     - run: npm ci
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
     - run: npm run build
     - run: npx playwright install --with-deps chromium
       if: matrix.channel == 'bidi-chromium'

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -135,8 +135,6 @@ jobs:
       with:
         node-version: 18
     - run: npm ci
-      env:
-        DEBUG: pw:install
     - run: npm run build
 
     - run: npx playwright install --with-deps


### PR DESCRIPTION
Previously we used `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` on our CI in order to prevent the browsers from getting downloaded using the `npm install` step. https://github.com/microsoft/playwright/pull/35472 was an experiment to go into the direction of using it everywhere. This helped me to understand that actually it will never install the browsers if the project is [not compiled](https://github.com/microsoft/playwright/blob/bc0d2c57e51824e49259e1c684a8e88c200494c3/packages/playwright-firefox/install.js#L23) before - so this env var was useless and we can safely remove it.

Closes https://github.com/microsoft/playwright/pull/35472
