### PR TITLE
fix(aria): toMatchAriaSnapshot with timeout: 0 should be able to generate baseline

### DIFF
--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -100,6 +100,8 @@ export async function toMatchAriaSnapshot(
     } else {
       // When generating new baseline, run entire pipeline against impossible match.
       expected = `- none "Generating new baseline"`;
+      if (timeout === 0)
+        timeout = 1; // one shot timeout
     }
   }
 

--- a/tests/playwright-test/aria-snapshot-file.spec.ts
+++ b/tests/playwright-test/aria-snapshot-file.spec.ts
@@ -194,6 +194,22 @@ test('should respect timeout', async ({ runInlineTest }, testInfo) => {
   expect(result.output).toContain(`Timed out 1ms waiting for`);
 });
 
+test('should immediately produce new snapshot if timeout is 0', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35461' } }, async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      import path from 'path';
+      test('test', async ({ page }) => {
+        await page.setContent(\`<h1>hello world</h1>\`);
+        await expect(page.locator('body')).toMatchAriaSnapshot({ timeout: 0 });
+      });
+    `,
+  });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`A snapshot doesn't exist at`);
+});
+
 test('should respect config.snapshotPathTemplate', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
Resolves https://github.com/microsoft/playwright/issues/35461. The user has a nifty workflow where they use `timeout: 0` to stall the test while they're iterating on the website. This breaks if there's no baseline, because we compare to `- none "Generating new baseline"` infinitely. Adding a special case so that we take the first shot fixes it.

This mirrors our behaviour for `toMatchSnapshot({ timeout: 0 })` on missing baselines, where we take the first stable snapshot.