### PR TITLE
chore: remove unused eslint-disable directives

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -217,32 +217,27 @@ const noBooleanCompareRules = {
   "@typescript-eslint/no-unnecessary-boolean-literal-compare": 2,
 };
 
-const noWebGlobalsRules = {
-  // This should contain every bulitin from builtins.ts.
-  "no-restricted-globals": [
-    "error",
-    { "name": "window", "message": "Use InjectedScript.window instead" },
-    { "name": "document", "message": "Use InjectedScript.document instead" },
-    { "name": "globalThis", "message": "Use InjectedScript.window instead" },
-    { "name": "setTimeout", "message": "Use InjectedScript.builtins.setTimeout instead" },
-    { "name": "clearTimeout", "message": "Use InjectedScript.builtins.clearTimeout instead" },
-    { "name": "setInterval", "message": "Use InjectedScript.builtins.setInterval instead" },
-    { "name": "clearInterval", "message": "Use InjectedScript.builtins.clearInterval instead" },
-    { "name": "requestAnimationFrame", "message": "Use InjectedScript.builtins.requestAnimationFrame instead" },
-    { "name": "cancelAnimationFrame", "message": "Use InjectedScript.builtins.cancelAnimationFrame instead" },
-    { "name": "requestIdleCallback", "message": "Use InjectedScript.builtins.requestIdleCallback instead" },
-    { "name": "cancelIdleCallback", "message": "Use InjectedScript.builtins.cancelIdleCallback instead" },
-    { "name": "performance", "message": "Use InjectedScript.builtins.performance instead" },
-    { "name": "eval", "message": "Use InjectedScript.builtins.eval instead" },
-    { "name": "Date", "message": "Use InjectedScript.builtins.Date instead" },
-    { "name": "Map", "message": "Use InjectedScript.builtins.Map instead" },
-    { "name": "Set", "message": "Use InjectedScript.builtins.Set instead" },
-  ],
-};
+// This should contain every builtin from builtins.ts.
+const noWebGlobalsRuleList = [
+  { name: "window", message: "Use InjectedScript.window instead" },
+  { name: "document", message: "Use InjectedScript.document instead" },
+  { name: "globalThis", message: "Use InjectedScript.window instead" },
+  { name: "setTimeout", message: "Use InjectedScript.builtins.setTimeout instead" },
+  { name: "clearTimeout", message: "Use InjectedScript.builtins.clearTimeout instead" },
+  { name: "setInterval", message: "Use InjectedScript.builtins.setInterval instead" },
+  { name: "clearInterval", message: "Use InjectedScript.builtins.clearInterval instead" },
+  { name: "requestAnimationFrame", message: "Use InjectedScript.builtins.requestAnimationFrame instead" },
+  { name: "cancelAnimationFrame", message: "Use InjectedScript.builtins.cancelAnimationFrame instead" },
+  { name: "requestIdleCallback", message: "Use InjectedScript.builtins.requestIdleCallback instead" },
+  { name: "cancelIdleCallback", message: "Use InjectedScript.builtins.cancelIdleCallback instead" },
+  { name: "performance", message: "Use InjectedScript.builtins.performance instead" },
+  { name: "eval", message: "Use InjectedScript.builtins.eval instead" },
+  { name: "Date", message: "Use InjectedScript.builtins.Date instead" },
+  { name: "Map", message: "Use InjectedScript.builtins.Map instead" },
+  { name: "Set", message: "Use InjectedScript.builtins.Set instead" },
+];
 
-const noNodeGlobalsRules = {
-  "no-restricted-globals": ["error", { name: "process" }],
-};
+const noNodeGlobalsRuleList = [{ name: "process" }];
 
 const importOrderRules = {
   "import/order": [
@@ -369,14 +364,32 @@ export default [
   },
   {
     files: [
+      "packages/playwright-core/src/utils/**/*.ts",
+    ],
+    languageOptions: languageOptionsWithTsConfig,
+    rules: {
+      "no-restricted-globals": [
+        "error",
+        ...noNodeGlobalsRuleList,
+        // TODO: reenable once the violations are fixed is utils/isomorphic/*.
+        // ...noWebGlobalsRules,
+      ],
+      ...noFloatingPromisesRules,
+      ...noBooleanCompareRules,
+    },
+  },
+  {
+    files: [
       "packages/playwright-core/src/server/injected/**/*.ts",
-      "packages/playwright-core/src/utils/isomorphic/**/*.ts",
       "packages/playwright-core/src/server/pageBinding.ts",
       "packages/playwright-core/src/server/storageScript.ts",
     ],
     languageOptions: languageOptionsWithTsConfig,
     rules: {
-      ...noWebGlobalsRules,
+      "no-restricted-globals": [
+        "error",
+        ...noWebGlobalsRuleList,
+      ],
       ...noFloatingPromisesRules,
       ...noBooleanCompareRules,
     },
@@ -385,11 +398,13 @@ export default [
     files: [
       "packages/playwright-core/src/client/**/*.ts",
       "packages/playwright-core/src/protocol/**/*.ts",
-      "packages/playwright-core/src/utils/**/*.ts",
     ],
     languageOptions: languageOptionsWithTsConfig,
     rules: {
-      ...noNodeGlobalsRules,
+      "no-restricted-globals": [
+        "error",
+        ...noNodeGlobalsRuleList,
+      ],
       ...noFloatingPromisesRules,
       ...noBooleanCompareRules,
     },

--- a/packages/playwright-core/src/utils/DEPS.list
+++ b/packages/playwright-core/src/utils/DEPS.list
@@ -1,6 +1,0 @@
-[*]
-./
-./isomorphic
-../utilsBundle.ts
-../zipBundle.ts
-../utils/isomorphic

--- a/packages/playwright-core/src/utils/isomorphic/builtins.ts
+++ b/packages/playwright-core/src/utils/isomorphic/builtins.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-restricted-globals */
-
 // Make sure to update eslint.config.mjs when changing the list of builitins.
 export type Builtins = {
   setTimeout: Window['setTimeout'],

--- a/packages/playwright-core/src/utils/isomorphic/utilityScriptSerializers.ts
+++ b/packages/playwright-core/src/utils/isomorphic/utilityScriptSerializers.ts
@@ -178,13 +178,10 @@ export function source(builtins: Builtins) {
 
   function serialize(value: any, handleSerializer: (value: any) => HandleOrValue, visitorInfo: VisitorInfo): SerializedValue {
     if (value && typeof value === 'object') {
-      // eslint-disable-next-line no-restricted-globals
       if (typeof globalThis.Window === 'function' && value instanceof globalThis.Window)
         return 'ref: <Window>';
-      // eslint-disable-next-line no-restricted-globals
       if (typeof globalThis.Document === 'function' && value instanceof globalThis.Document)
         return 'ref: <Document>';
-      // eslint-disable-next-line no-restricted-globals
       if (typeof globalThis.Node === 'function' && value instanceof globalThis.Node)
         return 'ref: <Node>';
     }


### PR DESCRIPTION
* Update eslint rule definitions for `packages/playwright-core/src/utils/`. There must be one rule definition per path. Previously, there were multiple rule definitions for the same path (`packages/playwright-core/src/utils/isomorphic/**/*.ts` and `packages/playwright-core/src/utils/**/*.ts`) and only one rule set worked, while we wanted to actually apply both `noWebGlobalsRules` and `noNodeGlobalsRules`. `noWebGlobalsRules` is commented out for now until newly found violations in `packages/playwright-core/src/utils/` are fixed or we chose a different way to address the builtins issue.
* Drive-by remove stale DEPS.list from utils/isomorphic.