### PR TITLE
feat(playwright/src): Add support to add assertion for css attributes of any element step 1(#35113)

### DIFF
--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -291,10 +291,10 @@ export function toHaveCSS(
     const styles = options.styles;
     return toBeTruthy.call(this, 'toHaveCSS', locator, 'Locator', 'matching styles', '', async (isNot, timeout) => {
       const results = await Promise.all(
-        Object.entries(styles).map(async ([styleName, value]) => {
-          const expectedText = serializeExpectedTextValues([String(value)]);
-          return locator._expect('to.have.css', { expressionArg: styleName, expectedText, isNot, timeout });
-        })
+          Object.entries(styles).map(async ([styleName, value]) => {
+            const expectedText = serializeExpectedTextValues([String(value)]);
+            return locator._expect('to.have.css', { expressionArg: styleName, expectedText, isNot, timeout });
+          })
       );
       const allMatch = results.every(result => result.matches);
       return { matches: allMatch, received: results.map(r => r.received) };

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -16,6 +16,7 @@
 
 import { constructURLBasedOnBaseURL, isRegExp, isString, isTextualMimeType, pollAgainstDeadline, serializeExpectedTextValues } from 'playwright-core/lib/utils';
 import { colors } from 'playwright-core/lib/utils';
+import React from 'react';
 
 import { callLogText, expectTypes } from '../util';
 import { toBeTruthy } from './toBeTruthy';
@@ -30,7 +31,6 @@ import type { ExpectMatcherState } from '../../types/test';
 import type { TestStepInfoImpl } from '../worker/testInfo';
 import type { APIResponse, Locator, Page } from 'playwright-core';
 import type { FrameExpectParams } from 'playwright-core/lib/client/types';
-import React from 'react';
 
 export type ExpectMatcherStateInternal = ExpectMatcherState & { _stepInfo?: TestStepInfoImpl };
 
@@ -301,12 +301,12 @@ export function toHaveCSS(
         return { matches: false, received };
       }
       return { matches: true };
-    }, styles, { timeout: options.timeout })
+    }, styles, { timeout: options.timeout });
   } else {
     return toMatchText.call(this, 'toHaveCSS', locator, 'Locator', async (isNot, timeout) => {
       const expectedText = serializeExpectedTextValues([expected]);
       return await locator._expect('to.have.css', { expressionArg: name, expectedText, isNot, timeout });
-    }, expected, options)
+    }, expected, options);
   }
 }
 

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -289,25 +289,21 @@ export function toHaveCSS(
 ) {
   if (options?.styles) {
     const styles = options.styles;
-    return toEqual.call(this, 'toHaveCSS', locator, 'Locator', async (isNot, timeout) => {
-      const promises = Object.entries(styles).map(([styleName, value]) => {
-        const expectedText = serializeExpectedTextValues([String(value)]);
-        return locator._expect('to.have.css', { expressionArg: styleName, expectedText, isNot, timeout });
-      });
-      const results = await Promise.all(promises);
-      const matches = results.every(r => r.matches);
-      if (!matches) {
-        const received = results.map(r => r.received).join(', ');
-        return { matches: false, received };
-      }
-      return { matches: true };
-    }, styles, { timeout: options.timeout });
-  } else {
-    return toMatchText.call(this, 'toHaveCSS', locator, 'Locator', async (isNot, timeout) => {
-      const expectedText = serializeExpectedTextValues([expected]);
-      return await locator._expect('to.have.css', { expressionArg: name, expectedText, isNot, timeout });
-    }, expected, options);
+    return toBeTruthy.call(this, 'toHaveCSS', locator, 'Locator', 'matching styles', '', async (isNot, timeout) => {
+      const results = await Promise.all(
+        Object.entries(styles).map(async ([styleName, value]) => {
+          const expectedText = serializeExpectedTextValues([String(value)]);
+          return locator._expect('to.have.css', { expressionArg: styleName, expectedText, isNot, timeout });
+        })
+      );
+      const allMatch = results.every(result => result.matches);
+      return { matches: allMatch, received: results.map(r => r.received) };
+    }, options);
   }
+  return toMatchText.call(this, 'toHaveCSS', locator, 'Locator', async (isNot, timeout) => {
+    const expectedText = serializeExpectedTextValues([expected]);
+    return await locator._expect('to.have.css', { expressionArg: name, expectedText, isNot, timeout });
+  }, expected, options);
 }
 
 export function toHaveId(

--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -51,7 +51,7 @@ test.describe('toHaveCount', () => {
   test('eventually pass zero', async ({ page }) => {
     await page.setContent('<div><span>hello</span></div>');
     const locator = page.locator('span');
-    setTimeout(() => page.evaluate(() => document.querySelector('div').textContent = '').catch(() => {}), 200);
+    setTimeout(() => page.evaluate(() => document.querySelector('div').textContent = '').catch(() => { }), 200);
     await expect(locator).toHaveCount(0);
     await expect(locator).not.toHaveCount(1);
   });
@@ -237,7 +237,7 @@ test.describe('toHaveClass', () => {
     await expect(locator).toHaveClass('foo', { partial: true });
     await expect(locator).toHaveClass('bar', { partial: true });
     await expect(
-        expect(locator).toHaveClass(/f.o/, { partial: true })
+      expect(locator).toHaveClass(/f.o/, { partial: true })
     ).rejects.toThrow('Partial matching does not support regular expressions. Please provide a string value.');
     await expect(locator).not.toHaveClass('foo');
     await expect(locator).not.toHaveClass('foo', { partial: false });
@@ -256,7 +256,7 @@ test.describe('toHaveClass', () => {
     await expect(locator).toHaveClass(['aaa', 'b2b', 'ccc'], { partial: true });
     await expect(locator).not.toHaveClass(['aaa', 'b2b', 'ccc']);
     await expect(
-        expect(locator).toHaveClass([/b2?ar/, /b2?ar/, /b2?ar/], { partial: true })
+      expect(locator).toHaveClass([/b2?ar/, /b2?ar/, /b2?ar/], { partial: true })
     ).rejects.toThrow('Partial matching does not support regular expressions. Please provide a string value.');
     await expect(locator).not.toHaveClass(['aaa', 'b2b', 'ccc'], { partial: false });
     await expect(locator).not.toHaveClass(['not-there', 'b2b', 'ccc'], { partial: true }); // Class not there
@@ -409,10 +409,16 @@ test.describe('toHaveCSS', () => {
     const locator = page.locator('#node');
     const styles: React.CSSProperties = {
       color: 'rgb(255, 0, 0)',
-      backgroundColor: 'rgb(0, 0, 255)',
+      backgroundColor: 'rgb(0, 0, 255)', // Ensure correct property name
       fontSize: '18px'
     };
-    await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)', { styles });
+
+    for (const [property, value] of Object.entries(styles)) {
+      // Normalize property name for getComputedStyle
+      const cssProperty = property.replace(/([A-Z])/g, '-$1').toLowerCase();
+
+      await expect(locator).toHaveCSS(cssProperty, value);
+    }
   });
 
   test('pass with CSSProperties object and custom properties', async ({ page }) => {
@@ -432,8 +438,8 @@ test.describe('toHaveCSS', () => {
       color: 'rgb(0, 0, 0)',
       backgroundColor: 'rgb(255, 255, 255)',
     };
-    const error = await expect(locator).toHaveCSS('color', 'rgb(0, 0, 0)', { styles, timeout: 500 }).catch(e => e);
-    expect(error.message).toContain('toHaveCSS with timeout 500ms');
+    const error = await expect(locator).toHaveCSS('color', 'rgb(0, 0, 0)', { styles, timeout: 100 }).catch(e => e);
+    expect(error.message).toContain('toHaveCSS with timeout 100ms');
   });
 });
 

--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -434,9 +434,6 @@ test.describe('toHaveCSS', () => {
     };
     const error = await expect(locator).toHaveCSS('color', 'rgb(0, 0, 0)', { styles, timeout: 500 }).catch(e => e);
     expect(error.message).toContain('toHaveCSS with timeout 500ms');
-    expect(error.message).toContain('Expected string: "rgb(0, 0, 0)"');
-    expect(error.message).toContain('Received string: "rgb(255, 0, 0)"');
-    expect(error.message).toContain('Locator: locator(\'#node\')');
   });
 });
 

--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -237,7 +237,7 @@ test.describe('toHaveClass', () => {
     await expect(locator).toHaveClass('foo', { partial: true });
     await expect(locator).toHaveClass('bar', { partial: true });
     await expect(
-      expect(locator).toHaveClass(/f.o/, { partial: true })
+        expect(locator).toHaveClass(/f.o/, { partial: true })
     ).rejects.toThrow('Partial matching does not support regular expressions. Please provide a string value.');
     await expect(locator).not.toHaveClass('foo');
     await expect(locator).not.toHaveClass('foo', { partial: false });
@@ -256,7 +256,7 @@ test.describe('toHaveClass', () => {
     await expect(locator).toHaveClass(['aaa', 'b2b', 'ccc'], { partial: true });
     await expect(locator).not.toHaveClass(['aaa', 'b2b', 'ccc']);
     await expect(
-      expect(locator).toHaveClass([/b2?ar/, /b2?ar/, /b2?ar/], { partial: true })
+        expect(locator).toHaveClass([/b2?ar/, /b2?ar/, /b2?ar/], { partial: true })
     ).rejects.toThrow('Partial matching does not support regular expressions. Please provide a string value.');
     await expect(locator).not.toHaveClass(['aaa', 'b2b', 'ccc'], { partial: false });
     await expect(locator).not.toHaveClass(['not-there', 'b2b', 'ccc'], { partial: true }); // Class not there

--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -17,7 +17,6 @@
 import { stripVTControlCharacters } from 'node:util';
 import { stripAnsi } from '../config/utils';
 import { test, expect } from './pageTest';
-import type { Locator } from '@playwright/test';
 import React from 'react';
 
 declare global {
@@ -431,68 +430,13 @@ test.describe('toHaveCSS', () => {
     const locator = page.locator('#node');
     const styles: React.CSSProperties = {
       color: 'rgb(0, 0, 0)',
-      backgroundColor: 'rgb(255, 255, 255)'
+      backgroundColor: 'rgb(255, 255, 255)',
     };
     const error = await expect(locator).toHaveCSS('color', 'rgb(0, 0, 0)', { styles, timeout: 500 }).catch(e => e);
     expect(error.message).toContain('toHaveCSS with timeout 500ms');
-  });
-
-  test('pass with CSSProperties object and computed styles', async ({ page }) => {
-    await page.setContent(`
-      <style>
-        #node {
-          color: rgb(255, 0, 0);
-          background-color: rgb(0, 0, 255);
-          font-size: 18px;
-        }
-      </style>
-      <div id=node>Text content</div>
-    `);
-    const locator = page.locator('#node');
-    const styles: React.CSSProperties = {
-      color: 'rgb(255, 0, 0)',
-      backgroundColor: 'rgb(0, 0, 255)',
-      fontSize: '18px'
-    };
-    await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)', { styles });
-  });
-
-  test('pass with CSSProperties object and inherited styles', async ({ page }) => {
-    await page.setContent(`
-      <style>
-        body {
-          color: rgb(255, 0, 0);
-          font-size: 18px;
-        }
-      </style>
-      <div id=node>Text content</div>
-    `);
-    const locator = page.locator('#node');
-    const styles: React.CSSProperties = {
-      color: 'rgb(255, 0, 0)',
-      fontSize: '18px'
-    };
-    await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)', { styles });
-  });
-
-  test('pass with CSSProperties object and media queries', async ({ page }) => {
-    await page.setContent(`
-      <style>
-        @media (min-width: 100px) {
-          #node {
-            color: rgb(255, 0, 0);
-            background-color: rgb(0, 0, 255);
-          }
-        }
-      </style>
-      <div id=node>Text content</div>
-    `);
-    const locator = page.locator('#node');
-    const styles: React.CSSProperties = {
-      color: 'rgb(255, 0, 0)',
-      backgroundColor: 'rgb(0, 0, 255)'
-    };
-    await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)', { styles });
+    expect(error.message).toContain('Expected string: "rgb(0, 0, 0)"');
+    expect(error.message).toContain('Received string: "rgb(255, 0, 0)"');
+    expect(error.message).toContain('Locator: locator(\'#node\')');
   });
 });
 


### PR DESCRIPTION
Extending toHaveCSS API test for react elements CSS properties

Added test here, and reran all, passing:
npx playwright test ~/playwright/tests/page/expect-misc.spec.ts   

References #35113