### PR TITLE
chore: allow ^_ to ignore unused variables

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,7 +64,13 @@ const ignores = [
 export const baseRules = {
   "@typescript-eslint/no-unused-vars": [
     2,
-    { args: "none", caughtErrors: "none" },
+    {
+      args: "none",
+      caughtErrors: "none",
+      caughtErrorsIgnorePattern: "^_",
+      destructuredArrayIgnorePattern: "^_",
+      varsIgnorePattern: "^_",
+    },
   ],
 
   /**


### PR DESCRIPTION
It's a fairly standard and useful modern JavaScript pattern to allow unused variables that are prefixed with `_`:

```ts
const _foo = something();
const [value, _skipped, value2] = another();
```