### PR TITLE
docs: Add await to response.json() for async ApiResponse class example

### DIFF
--- a/docs/src/api/class-apiresponse.md
+++ b/docs/src/api/class-apiresponse.md
@@ -13,7 +13,8 @@ async def run(playwright: Playwright):
     assert response.ok
     assert response.status == 200
     assert response.headers["content-type"] == "application/json; charset=utf-8"
-    assert response.json()["name"] == "foobar"
+    json_data = await response.json()
+    assert json_data["name"] == "foobar"
     assert await response.body() == '{"status": "ok"}'
 
 


### PR DESCRIPTION
The current async [APIResponse class documentation in API Reference](https://playwright.dev/python/docs/api/class-apiresponse) has an incorrect line in the example - 

`assert response.json()["name"] == "foobar"`

As the async APIResponse `response.json()` returns a coroutine, this line will raise a `TypeError: 'coroutine' object is not subscriptable` exception.

Replacing it with 
```
json_data = await response.json()
assert json_data["name"] == "foobar"
```
will solve this and show the correct way to use `response.json()`
