### PR TITLE
fix: contrast on View Trace button

### DIFF
--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -97,7 +97,7 @@ function traceBadge(test: TestCaseSummary): JSX.Element | undefined {
     title={isFailed ? 'View Failing Trace' : 'View Trace'}
     className={clsx('test-file-badge', isFailed && 'button')}>
     {trace()}
-    {isFailed && <span style={{ color: 'var(--color-scale-gray-7)' }}>View Failing Trace</span>}
+    {isFailed && <span style={{ color: 'var(--color-fg-subtle)' }}>View Failing Trace</span>}
   </Link>;
 }
 


### PR DESCRIPTION
Old:
![IMAGE 2025-04-07 10:28:47](https://github.com/user-attachments/assets/0c57122b-b64e-4fca-a49d-06b2ce2fdebe)

New:
<img width="995" alt="Screenshot 2025-04-07 at 10 27 44" src="https://github.com/user-attachments/assets/09947cdc-1af1-441e-896e-de527a87ae87" />
<img width="1010" alt="Screenshot 2025-04-07 at 10 27 39" src="https://github.com/user-attachments/assets/bfd04151-9837-4e7a-b19a-532476e6692e" />
