### PR TITLE
test: add repro for broken cookies in frames in webkit on linux

### DIFF
--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -431,7 +431,9 @@ it('should parse cookie with large Max-Age correctly', async ({ server, page, de
 });
 
 it('iframe should inherit cookies from parent', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35439' } }, async ({ page, isLinux, browserName }) => {
-  await page.route('**', async (route, request) => {
+  it.fixme(browserName === 'webkit' && isLinux);
+
+  await page.route('**/*', async (route, request) => {
     if (request.url().includes('sub.example.test')) {
       await route.fulfill({
         body: `
@@ -456,10 +458,5 @@ it('iframe should inherit cookies from parent', { annotation: { type: 'issue', d
   await page.goto('http://example.test');
 
   await expect(page.locator('body')).toContainText('testCookie=value');
-
-  // webkit on linux is broken!
-  if (browserName === 'webkit' && isLinux)
-    await expect(page.frameLocator('iframe').locator('body')).toContainText('no cookies');
-  else
-    await expect(page.frameLocator('iframe').locator('body')).toContainText('testCookie=value');
+  await expect(page.frameLocator('iframe').locator('body')).toContainText('testCookie=value');
 });

--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -431,7 +431,7 @@ it('should parse cookie with large Max-Age correctly', async ({ server, page, de
 });
 
 it('iframe should inherit cookies from parent', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35439' } }, async ({ page, isLinux, browserName }) => {
-  it.fixme(browserName === 'webkit' && isLinux);
+  it.fixme(browserName === 'webkit' && isLinux, 'https://bugs.webkit.org/show_bug.cgi?id=291194');
 
   await page.route('**/*', async (route, request) => {
     if (request.url().includes('sub.example.test')) {

--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -429,3 +429,37 @@ it('should parse cookie with large Max-Age correctly', async ({ server, page, de
     },
   ]);
 });
+
+it('iframe should inherit cookies from parent', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35439' } }, async ({ page, isLinux, browserName }) => {
+  await page.route('**', async (route, request) => {
+    if (request.url().includes('sub.example.test')) {
+      await route.fulfill({
+        body: `
+            <p id="result"></p>
+            <script>document.getElementById('result').textContent = document.cookie || 'no cookies';</script>
+        `,
+        contentType: 'text/html',
+      });
+      return;
+    }
+    await route.fulfill({
+      headers: { 'set-cookie': 'testCookie=value; SameSite=Lax; Domain=example.test' },
+      contentType: 'text/html',
+      body: `
+          <p id="result"></p>
+          <script>document.getElementById('result').textContent = document.cookie || 'no cookies';</script>
+          <iframe src="http://sub.example.test"></iframe>
+      `
+    });
+  });
+
+  await page.goto('http://example.test');
+
+  await expect(page.locator('body')).toContainText('testCookie=value');
+
+  // webkit on linux is broken!
+  if (browserName === 'webkit' && isLinux)
+    await expect(page.frameLocator('iframe').locator('body')).toContainText('no cookies');
+  else
+    await expect(page.frameLocator('iframe').locator('body')).toContainText('testCookie=value');
+});


### PR DESCRIPTION
Adds a repro test for the broken behaviour reported in https://github.com/microsoft/playwright/issues/35439.