### PR TITLE
devops: fix bidi trigger

### DIFF
--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   test_bidi:
-    if: (github.event_name == 'pull_request' && github.event.label.name == 'CQ-bidi') || github.event_name != 'pull_request'
+    if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'CQ-bidi') || github.event_name != 'pull_request' }}
     name: BiDi
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This PR fixes a bug where a GitHub Actions `if` condition was not properly evaluated because it was missing the `${{ }}` expression syntax.

Previously, the workflow had:

```yaml
if: github.event.label.name == 'label_name'
```

which led to incorrect or skipped evaluations in certain contexts. In some cases, GitHub Actions expects the condition to be wrapped explicitly in `${{ }}` to properly parse and evaluate the expression.

**Fixed to:**

```yaml
if: ${{ github.event.label.name == 'label_name' }}
```

Follow-up to https://github.com/microsoft/playwright/pull/35515.
