### PR TITLE
chore(html): display warning annotations in HTML reporter

### DIFF
--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -52,7 +52,7 @@ export const TestCaseView: React.FC<{
     const annotations = [...test.annotations];
     if (test.results[selectedResultIndex])
       annotations.push(...test.results[selectedResultIndex].annotations);
-    return annotations.filter(annotation => !annotation.type.startsWith('_'));
+    return annotations.filter(annotation => !annotation.type.startsWith('_') && annotation.type !== 'warning');
   }, [test, selectedResultIndex]);
 
   return <div className='test-case-column vbox'>

--- a/packages/html-reporter/src/testResultView.css
+++ b/packages/html-reporter/src/testResultView.css
@@ -45,6 +45,10 @@
   padding: 2px 8px;
 }
 
+.test-result-warning-title {
+  color: var(--color-fg-muted);
+}
+
 @media(prefers-color-scheme: light) {
   .test-result-counter {
     background: var(--color-scale-gray-5);

--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -86,15 +86,15 @@ export const TestResultView: React.FC<{
     const errors = classifyErrors(result.errors, diffs, result.attachments);
     const warnings = result.annotations.filter(a => a.type === 'warning');
     warnings.sort((a, b) => {
-      if (!a || !a.location)
+      const aLocationKey = a.location ? `${a.location.file}:${a.location.line}:${a.location.column}` : undefined;
+      const bLocationKey = b.location ? `${b.location.file}:${b.location.line}:${b.location.column}` : undefined;
+      if (!aLocationKey && !bLocationKey)
+        return 0;
+      if (!aLocationKey)
         return 1;
-      if (!b || !b.location)
+      if (!bLocationKey)
         return -1;
-      if (a.location.line !== b.location.line)
-        return a.location.line - b.location.line;
-      if (a.location.column !== b.location.column)
-        return a.location.column - b.location.column;
-      return 0;
+      return aLocationKey.localeCompare(bLocationKey);
     });
     return { screenshots: [...screenshots], videos, traces, otherAttachments, diffs, errors, warnings, otherAttachmentAnchors, screenshotAnchors };
   }, [result]);

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -503,7 +503,7 @@ class HtmlBuilder {
 
   private _serializeAnnotations(annotations: api.TestCase['annotations']): TestAnnotation[] {
     // Annotations can be pushed directly, with a wrong type.
-    return annotations.map(a => ({ type: a.type, description: a.description === undefined ? undefined : String(a.description), location: a.location }));
+    return annotations.map(a => ({ type: a.type, description: a.description === undefined ? undefined : String(a.description), location: this._relativeLocation(a.location) }));
   }
 
   private _createTestResult(test: api.TestCase, result: api.TestResult): TestResult {


### PR DESCRIPTION
Moves warning annotations into their own section in HTML reporter. This section starts collapsed. Continuation of #35443.

<img width="1030" alt="Screenshot 2025-04-07 at 11 34 44 AM" src="https://github.com/user-attachments/assets/1582049c-271a-4864-8471-0dcd096e7462" />
