### PR TITLE
chore(bidi): use channel for preinstalled browsers, env for downloaded

### DIFF
--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -37,12 +37,17 @@ jobs:
     - run: npm run build
     - run: npx playwright install --with-deps chromium
       if: matrix.channel == 'bidi-chromium'
-    - run: npx -y @puppeteer/browsers install firefox@nightly
-      if: matrix.channel == 'bidi-firefox-nightly'
+    - if: matrix.channel == 'bidi-firefox-nightly'
+      id: install_firefox
+      run: |
+        npx -y @puppeteer/browsers install firefox@nightly |\
+          awk 'END { $1=""; sub(/^ /,""); print "bidi_ffpath="$0 }' |\
+          tee -a $GITHUB_OUTPUT
     - name: Run tests
       run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run biditest -- --project=${{ matrix.channel }}*
       env:
         PWTEST_USE_BIDI_EXPECTATIONS: '1'
+        BIDI_FFPATH: ${{ steps.install_firefox.outputs.bidi_ffpath }}
     - name: Upload csv report to GitHub
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -683,27 +683,27 @@ export class Registry {
     }));
 
     this._executables.push(this._createBidiFirefoxChannel('bidi-firefox-stable', {
-      'linux': '/firefox/firefox',
-      'darwin': '/Firefox.app/Contents/MacOS/firefox',
-      'win32': '\\core\\firefox.exe',
+      'linux': '/snap/bin/firefox',
+      'darwin': '/Applications/Firefox.app/Contents/MacOS/firefox',
+      'win32': '\\Mozilla Firefox\\firefox.exe',
     }));
     this._executables.push(this._createBidiFirefoxChannel('bidi-firefox-beta', {
-      'linux': '/firefox/firefox',
-      'darwin': '/Firefox.app/Contents/MacOS/firefox',
-      'win32': '\\core\\firefox.exe',
+      'linux': '/opt/firefox-beta/firefox',
+      'darwin': '/Applications/Firefox.app/Contents/MacOS/firefox',
+      'win32': '\\Mozilla Firefox\\firefox.exe',
     }));
     this._executables.push(this._createBidiFirefoxChannel('bidi-firefox-nightly', {
-      'linux': '/firefox/firefox',
-      'darwin': '/Firefox Nightly.app/Contents/MacOS/firefox',
-      'win32': '\\firefox\\firefox.exe',
+      'linux': '/opt/firefox-nightly/firefox',
+      'darwin': '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
+      'win32': '\\Mozilla Firefox\\firefox.exe',
     }));
 
-    this._executables.push(this._createBidiChannel('bidi-chrome-stable', {
+    this._executables.push(this._createBidiChromiumChannel('bidi-chrome-stable', {
       'linux': '/opt/google/chrome/chrome',
       'darwin': '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
       'win32': `\\Google\\Chrome\\Application\\chrome.exe`,
     }));
-    this._executables.push(this._createBidiChannel('bidi-chrome-canary', {
+    this._executables.push(this._createBidiChromiumChannel('bidi-chrome-canary', {
       'linux': '',
       'darwin': '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
       'win32': `\\Google\\Chrome SxS\\Application\\chrome.exe`,
@@ -903,24 +903,22 @@ export class Registry {
           throw new Error(`Firefox distribution '${name}' is not supported on ${process.platform}`);
         return undefined;
       }
-      const folder = path.resolve('firefox');
-      let channelName = 'stable';
-      if (name.includes('beta'))
-        channelName = 'beta';
-      else if (name.includes('nightly'))
-        channelName = 'nightly';
-      const installedVersions = fs.readdirSync(folder);
-      const found = installedVersions.filter(e => e.includes(channelName));
-      if (found.length === 1)
-        return path.join(folder, found[0], suffix);
-      if (found.length > 1) {
-        if (shouldThrow)
-          throw new Error(`Multiple Firefox installations found for channel '${name}': ${found.join(', ')}`);
-        else
-          return undefined;
+      const prefixes = (process.platform === 'win32' ? [
+        process.env.LOCALAPPDATA,
+        process.env.PROGRAMFILES,
+        process.env['PROGRAMFILES(X86)'],
+        // In some cases there is no PROGRAMFILES/(86) env var set but HOMEDRIVE is set.
+        process.env.HOMEDRIVE + '\\Program Files',
+        process.env.HOMEDRIVE + '\\Program Files (x86)',
+      ].filter(Boolean) : ['']) as string[];
+
+      for (const prefix of prefixes) {
+        const executablePath = path.join(prefix, suffix);
+        if (canAccessFile(executablePath))
+          return executablePath;
       }
       if (shouldThrow)
-        throw new Error(`Cannot find Firefox installation for channel '${name}' under ${folder}`);
+        throw new Error(`Cannot find Firefox installation for channel '${name}' at the standard system paths or ${folder}`);
       return undefined;
     };
     return {
@@ -937,7 +935,7 @@ export class Registry {
     };
   }
 
-  private _createBidiChannel(name: BidiChannel, lookAt: Record<'linux' | 'darwin' | 'win32', string>, install?: () => Promise<void>): ExecutableImpl {
+  private _createBidiChromiumChannel(name: BidiChannel, lookAt: Record<'linux' | 'darwin' | 'win32', string>, install?: () => Promise<void>): ExecutableImpl {
     const executablePath = (sdkLanguage: string, shouldThrow: boolean) => {
       const suffix = lookAt[process.platform as 'linux' | 'darwin' | 'win32'];
       if (!suffix) {
@@ -964,7 +962,7 @@ export class Registry {
 
       const location = prefixes.length ? ` at ${path.join(prefixes[0], suffix)}` : ``;
       const installation = install ? `\nRun "${buildPlaywrightCLICommand(sdkLanguage, 'install ' + name)}"` : '';
-      throw new Error(`Firefox distribution '${name}' is not found${location}${installation}`);
+      throw new Error(`Chromium distribution '${name}' is not found${location}${installation}`);
     };
     return {
       type: 'channel',

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -918,7 +918,7 @@ export class Registry {
           return executablePath;
       }
       if (shouldThrow)
-        throw new Error(`Cannot find Firefox installation for channel '${name}' at the standard system paths or ${folder}`);
+        throw new Error(`Cannot find Firefox installation for channel '${name}' at the standard system paths.`);
       return undefined;
     };
     return {

--- a/tests/bidi/playwright.config.ts
+++ b/tests/bidi/playwright.config.ts
@@ -65,15 +65,25 @@ const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeW
   projects: [],
 };
 
-const executablePath = process.env.BIDIPATH;
-if (executablePath && !process.env.TEST_WORKER_INDEX)
-  console.error(`Using executable at ${executablePath}`);
+type BrowserName = '_bidiChromium' | '_bidiFirefox';
+
+const getExecutablePath = (browserName: BrowserName) => {
+  if (browserName === '_bidiChromium')
+    return process.env.BIDI_CRPATH;
+  if (browserName === '_bidiFirefox')
+    return process.env.BIDI_FFPATH;
+};
+
 const browserToChannels = {
   '_bidiChromium': ['bidi-chromium', 'bidi-chrome-canary', 'bidi-chrome-stable'],
   '_bidiFirefox': ['bidi-firefox-nightly', 'bidi-firefox-beta', 'bidi-firefox-stable'],
 };
+
 for (const [key, channels] of Object.entries(browserToChannels)) {
   const browserName: any = key;
+  const executablePath = getExecutablePath(browserName);
+  if (executablePath && !process.env.TEST_WORKER_INDEX)
+    console.error(`Using executable at ${executablePath}`);
   for (const channel of channels) {
     const testIgnore: RegExp[] = [
       /library\/debug-controller/,


### PR DESCRIPTION
* Use `BIDI_FFPATH` and `BIDI_CRPATH` for passing explicit browser executable path in the tests. Previously it was one `BIDIPATH` for both.
* `bidi-firefox-{stable, beta, nightly}` now refer to preinstalled system browser.

Reference: https://github.com/microsoft/playwright-mcp/issues/94