### PR TITLE
devops: fix CQ-bidi label

### DIFF
--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   test_bidi:
-    if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'CQ-bidi') || github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CQ-bidi') }}
     name: BiDi
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The issue is that using:

```yaml
if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'CQ-bidi') || github.event_name != 'pull_request' }}
```

relies on the event payload having a property `label` at the top level—which only exists on a pull request event when its specific action is `labeled`. This works only for the exact moment when a new label is added.

However, in many cases you want to check the full list of labels on the PR rather than depending on a single event payload field. For example, if a PR already exists and later a label is added (or if the workflow might run due to another reason), relying solely on `github.event.label` can be unreliable.

A better strategy is to inspect the entire list of labels attached to the pull request. You can do this by using the built-in `contains()` function to check if the array of label names (found at `github.event.pull_request.labels`) includes the label you want. For example:

```yaml
if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CQ-bidi') }}
```

### Explanation

- **Using `contains()`:**  
  The expression `contains(github.event.pull_request.labels.*.name, 'CQ-bidi')` goes through the list of label names on the pull request and checks for the presence of `"CQ-bidi"`. This approach works regardless of whether the workflow was triggered specifically by a `labeled` action or another PR event.

- **Fallback for Non-PR Events:**  
  The condition `github.event_name != 'pull_request'` lets non-PR events (like pushes or scheduled runs) go ahead without needing the label check.

