### PR TITLE
chore: improve view trace button

### DIFF
--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -53,6 +53,16 @@
 
 .test-file-badge {
   flex: none;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.test-file-badge span {
+  color: var(--color-fg-subtle);
+}
+
+.test-file-badge:hover {
+  cursor: pointer;
 }
 
 .test-file-badge svg {
@@ -61,11 +71,6 @@
 
 .test-file-badge:hover svg {
   fill: var(--color-fg-muted);
-}
-
-.test-file-badge.button {
-  background-color: transparent;
-  border-color: transparent;
 }
 
 .test-file-test-outcome-skipped {

--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -65,6 +65,7 @@
 
 .test-file-badge.button {
   background-color: transparent;
+  border-color: transparent;
 }
 
 .test-file-test-outcome-skipped {

--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -94,10 +94,10 @@ function traceBadge(test: TestCaseSummary): JSX.Element | undefined {
 
   return <Link
     href={generateTraceUrl(firstTraces)}
-    title={isFailed ? 'View Failing Trace' : 'View Trace'}
+    title='View Trace'
     className={clsx('test-file-badge', isFailed && 'button')}>
     {trace()}
-    {isFailed && <span style={{ color: 'var(--color-fg-subtle)' }}>View Failing Trace</span>}
+    {isFailed && <span style={{ color: 'var(--color-fg-subtle)' }}>View Trace</span>}
   </Link>;
 }
 

--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -90,14 +90,12 @@ function traceBadge(test: TestCaseSummary): JSX.Element | undefined {
   if (!firstTraces)
     return undefined;
 
-  const isFailed = test.outcome === 'unexpected' || test.outcome === 'flaky';
-
   return <Link
     href={generateTraceUrl(firstTraces)}
     title='View Trace'
-    className={clsx('test-file-badge', isFailed && 'button')}>
+    className='button test-file-badge'>
     {trace()}
-    {isFailed && <span style={{ color: 'var(--color-fg-subtle)' }}>View Trace</span>}
+    <span>View Trace</span>
   </Link>;
 }
 

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -706,7 +706,7 @@ test('generate html with attachment urls', async ({ runInlineTest, mergeReports,
   await page.goBack();
 
   // Check that trace loads.
-  await page.locator('.test-file-test').filter({ hasText: /first/ }).getByRole('link', { name: 'View Trace' }).click();
+  await page.locator('.test-file-test').filter({ hasText: /failing 1/ }).getByRole('link', { name: 'View Trace' }).click();
   await expect(page).toHaveTitle('Playwright Trace Viewer');
   await expect(page.getByTestId('actions-tree').locator('div').filter({ hasText: /^expect\.toBe$/ })).toBeVisible();
 });

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -706,7 +706,7 @@ test('generate html with attachment urls', async ({ runInlineTest, mergeReports,
   await page.goBack();
 
   // Check that trace loads.
-  await page.getByRole('link', { name: 'View Trace' }).click();
+  await page.locator('.test-file-test').filter({ hasText: /first/ }).getByRole('link', { name: 'View Trace' }).click();
   await expect(page).toHaveTitle('Playwright Trace Viewer');
   await expect(page.getByTestId('actions-tree').locator('div').filter({ hasText: /^expect\.toBe$/ })).toBeVisible();
 });

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -706,7 +706,7 @@ test('generate html with attachment urls', async ({ runInlineTest, mergeReports,
   await page.goBack();
 
   // Check that trace loads.
-  await page.getByRole('link', { name: 'View Failing Trace' }).click();
+  await page.getByRole('link', { name: 'View Trace' }).click();
   await expect(page).toHaveTitle('Playwright Trace Viewer');
   await expect(page.getByTestId('actions-tree').locator('div').filter({ hasText: /^expect\.toBe$/ })).toBeVisible();
 });


### PR DESCRIPTION

https://github.com/user-attachments/assets/b89606c9-c85f-42b4-bf13-5cd804012e10

Here's how it'd look if we also showed it on successful tests:

<img width="733" alt="Screenshot 2025-04-08 at 10 14 48" src="https://github.com/user-attachments/assets/6f1995fc-2b82-4ab8-9b9e-5ee773e9f822" />
