### PR TITLE
Revert "test: roll Android WebView to ToT (#35456)"

### DIFF
--- a/tests/android/webview.spec.ts
+++ b/tests/android/webview.spec.ts
@@ -70,7 +70,7 @@ test('select webview from socketName', async function({ androidDevice }) {
   await context.close();
 });
 
-test('should be able to receive webView cookies', {
+test.fixme('should be able to receive webView cookies', {
   annotation: {
     type: 'issue',
     description: 'https://github.com/microsoft/playwright/issues/35392',

--- a/tests/android/webview.spec.ts
+++ b/tests/android/webview.spec.ts
@@ -70,7 +70,9 @@ test('select webview from socketName', async function({ androidDevice }) {
   await context.close();
 });
 
-test.fixme('should be able to receive webView cookies', {
+// Requires a newer WebView version with
+// https://chromium-review.googlesource.com/c/chromium/src/+/6411892
+test.fail('should be able to receive webView cookies', {
   annotation: {
     type: 'issue',
     description: 'https://github.com/microsoft/playwright/issues/35392',

--- a/utils/avd_start.sh
+++ b/utils/avd_start.sh
@@ -10,26 +10,18 @@ bash $PWD/utils/avd_stop.sh
 
 echo "Starting emulator"
 # nohup ${ANDROID_HOME}/emulator/emulator -avd android35 -gpu swiftshader &
-nohup ${ANDROID_HOME}/emulator/emulator -avd android35 -no-audio -no-window -no-boot-anim -no-snapshot -writable-system &
+nohup ${ANDROID_HOME}/emulator/emulator -avd android35 -no-audio -no-window -no-boot-anim -no-snapshot &
 ${ANDROID_HOME}/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
 ${ANDROID_HOME}/platform-tools/adb devices
 echo "Emulator started"
 
 echo "Installing Chromium WebView"
 # See here for the latest revision: https://storage.googleapis.com/chromium-browser-snapshots/Android/LAST_CHANGE
-CHROMIUM_ANDROID_REVISION="1441404"
+CHROMIUM_ANDROID_REVISION="1340145"
 WEBVIEW_TMP_DIR="$(mktemp -d)"
-
-curl -s --fail --retry 5 -o "$WEBVIEW_TMP_DIR/chrome-android.zip" "https://storage.googleapis.com/chromium-browser-snapshots/Android/${CHROMIUM_ANDROID_REVISION}/chrome-android.zip"
-unzip -q "$WEBVIEW_TMP_DIR/chrome-android.zip" -d "${WEBVIEW_TMP_DIR}"
-
-if [[ "$(uname -m)" == "arm64" ]]; then
-    curl -s --fail --retry 5 -o "$WEBVIEW_TMP_DIR/chrome-android-arm64.zip" "https://storage.googleapis.com/chromium-browser-snapshots/Android_Arm64/${CHROMIUM_ANDROID_REVISION}/chrome-android.zip"
-    unzip -o -q "$WEBVIEW_TMP_DIR/chrome-android-arm64.zip" -d "${WEBVIEW_TMP_DIR}"
-fi
-# SystemWebViewShell.apk is ABI-neutral, so we can use it for both arm and arm64. Its not contained in the arm64 zip.
+WEBVIEW_TMP_FILE="$WEBVIEW_TMP_DIR/chrome-android-zip"
+curl -s -o "${WEBVIEW_TMP_FILE}" "https://storage.googleapis.com/chromium-browser-snapshots/Android/${CHROMIUM_ANDROID_REVISION}/chrome-android.zip"
+unzip -q "${WEBVIEW_TMP_FILE}" -d "${WEBVIEW_TMP_DIR}"
 ${ANDROID_HOME}/platform-tools/adb install -r "${WEBVIEW_TMP_DIR}/chrome-android/apks/SystemWebViewShell.apk"
-${ANDROID_HOME}/platform-tools/adb install -r "${WEBVIEW_TMP_DIR}/chrome-android/apks/SystemWebView.apk"
-
 rm -rf "${WEBVIEW_TMP_DIR}"
 echo "Chromium WebView installed"


### PR DESCRIPTION
There is no native Android Webview on the snapshots server as of today for x86_64. using the AndroidDesktop ones would work but is not ideal. Lets just wait for the next Android version to have the fix included.