### PR TITLE
Revert "feat: support proxy in connect/connectOverCDP (#35389)"

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -144,16 +144,6 @@ Some common examples:
 1. `"<loopback>"` to expose localhost network.
 1. `"*.test.internal-domain,*.staging.internal-domain,<loopback>"` to expose test/staging deployments and localhost.
 
-### option: BrowserType.connect.proxy
-* since: v1.52
-- `proxy` <[Object]>
-  - `server` <[string]> Proxy to be used for the remote connection. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-  - `bypass` ?<[string]> Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-  - `username` ?<[string]> Optional username to use if HTTP proxy requires authentication.
-  - `password` ?<[string]> Optional password to use if HTTP proxy requires authentication.
-
-Proxy settings to use for the connection between the client and the remote browser. Note this proxy **is not** used by the browser to load web pages.
-
 ## async method: BrowserType.connectOverCDP
 * since: v1.9
 - returns: <[Browser]>
@@ -241,16 +231,6 @@ Logger sink for Playwright logging. Optional.
 
 Maximum time in milliseconds to wait for the connection to be established. Defaults to
 `30000` (30 seconds). Pass `0` to disable timeout.
-
-### option: BrowserType.connectOverCDP.proxy
-* since: v1.52
-- `proxy` <[Object]>
-  - `server` <[string]> Proxy to be used for the remote connection. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-  - `bypass` ?<[string]> Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-  - `username` ?<[string]> Optional username to use if HTTP proxy requires authentication.
-  - `password` ?<[string]> Optional password to use if HTTP proxy requires authentication.
-
-Proxy settings to use for the connection between the client and the remote browser. Note this proxy **is not** used by the browser to load web pages.
 
 ## method: BrowserType.executablePath
 * since: v1.8

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -226,8 +226,10 @@ Dangerous option; use with care. Defaults to `false`.
 ## browser-option-proxy
 - `proxy` <[Object]>
   - `server` <[string]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example
-    `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-  - `bypass` ?<[string]> Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
+    `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP
+    proxy.
+  - `bypass` ?<[string]> Optional comma-separated domains to bypass proxy, for example `".com, chromium.org,
+    .domain.com"`.
   - `username` ?<[string]> Optional username to use if HTTP proxy requires authentication.
   - `password` ?<[string]> Optional password to use if HTTP proxy requires authentication.
 

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -21794,34 +21794,6 @@ export interface ConnectOverCDPOptions {
   logger?: Logger;
 
   /**
-   * Proxy settings to use for the connection between the client and the remote browser. Note this proxy **is not** used
-   * by the browser to load web pages.
-   */
-  proxy?: {
-    /**
-     * Proxy to be used for the remote connection. HTTP and SOCKS proxies are supported, for example
-     * `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP
-     * proxy.
-     */
-    server: string;
-
-    /**
-     * Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-     */
-    bypass?: string;
-
-    /**
-     * Optional username to use if HTTP proxy requires authentication.
-     */
-    username?: string;
-
-    /**
-     * Optional password to use if HTTP proxy requires authentication.
-     */
-    password?: string;
-  };
-
-  /**
    * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going
    * on. Defaults to 0.
    */
@@ -21861,34 +21833,6 @@ export interface ConnectOptions {
    * Logger sink for Playwright logging. Optional.
    */
   logger?: Logger;
-
-  /**
-   * Proxy settings to use for the connection between the client and the remote browser. Note this proxy **is not** used
-   * by the browser to load web pages.
-   */
-  proxy?: {
-    /**
-     * Proxy to be used for the remote connection. HTTP and SOCKS proxies are supported, for example
-     * `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP
-     * proxy.
-     */
-    server: string;
-
-    /**
-     * Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-     */
-    bypass?: string;
-
-    /**
-     * Optional username to use if HTTP proxy requires authentication.
-     */
-    username?: string;
-
-    /**
-     * Optional password to use if HTTP proxy requires authentication.
-     */
-    password?: string;
-  };
 
   /**
    * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -129,7 +129,6 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
         exposeNetwork: params.exposeNetwork ?? params._exposeNetwork,
         slowMo: params.slowMo,
         timeout: params.timeout,
-        proxy: params.proxy,
       };
       if ((params as any).__testHookRedirectPortForwarding)
         connectParams.socksProxyRedirectPortForTest = (params as any).__testHookRedirectPortForwarding;
@@ -189,8 +188,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
       endpointURL,
       headers,
       slowMo: params.slowMo,
-      timeout: params.timeout,
-      proxy: params.proxy,
+      timeout: params.timeout
     });
     const browser = Browser.from(result.browser);
     this._didLaunchBrowser(browser, {}, params.logger);

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -103,12 +103,6 @@ export type ConnectOptions = {
   slowMo?: number,
   timeout?: number,
   logger?: Logger,
-  proxy?: {
-    server: string,
-    bypass?: string,
-    username?: string,
-    password?: string
-  },
 };
 export type LaunchServerOptions = {
   channel?: channels.BrowserTypeLaunchOptions['channel'],

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -327,12 +327,6 @@ scheme.LocalUtilsConnectParams = tObject({
   exposeNetwork: tOptional(tString),
   slowMo: tOptional(tNumber),
   timeout: tOptional(tNumber),
-  proxy: tOptional(tObject({
-    server: tString,
-    bypass: tOptional(tString),
-    username: tOptional(tString),
-    password: tOptional(tString),
-  })),
   socksProxyRedirectPortForTest: tOptional(tNumber),
 });
 scheme.LocalUtilsConnectResult = tObject({
@@ -656,12 +650,6 @@ scheme.BrowserTypeConnectOverCDPParams = tObject({
   headers: tOptional(tArray(tType('NameValue'))),
   slowMo: tOptional(tNumber),
   timeout: tOptional(tNumber),
-  proxy: tOptional(tObject({
-    server: tString,
-    bypass: tOptional(tString),
-    username: tOptional(tString),
-    password: tOptional(tString),
-  })),
 });
 scheme.BrowserTypeConnectOverCDPResult = tObject({
   browser: tChannel(['Browser']),

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -292,7 +292,7 @@ export abstract class BrowserType extends SdkObject {
       await fs.promises.mkdir(options.tracesDir, { recursive: true });
   }
 
-  async connectOverCDP(metadata: CallMetadata, endpointURL: string, options: { slowMo?: number, proxy?: types.ProxySettings, timeout?: number, headers?: types.HeadersArray }): Promise<Browser> {
+  async connectOverCDP(metadata: CallMetadata, endpointURL: string, options: { slowMo?: number }, timeout?: number): Promise<Browser> {
     throw new Error('CDP connections are only supported by Chromium');
   }
 

--- a/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
@@ -43,7 +43,7 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.Brow
   }
 
   async connectOverCDP(params: channels.BrowserTypeConnectOverCDPParams, metadata: CallMetadata): Promise<channels.BrowserTypeConnectOverCDPResult> {
-    const browser = await this._object.connectOverCDP(metadata, params.endpointURL, params);
+    const browser = await this._object.connectOverCDP(metadata, params.endpointURL, params, params.timeout);
     const browserDispatcher = new BrowserDispatcher(this, browser);
     return {
       browser: browserDispatcher,

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -18,12 +18,14 @@ import http from 'http';
 import https from 'https';
 import { Transform, pipeline } from 'stream';
 import { TLSSocket } from 'tls';
+import url from 'url';
 import * as zlib from 'zlib';
 
 import { TimeoutSettings } from './timeoutSettings';
-import { assert, constructURLBasedOnBaseURL, createProxyAgent, eventsHelper, monotonicTime  } from '../utils';
+import { assert, constructURLBasedOnBaseURL, eventsHelper, monotonicTime  } from '../utils';
 import { createGuid } from './utils/crypto';
 import { getUserAgent } from './utils/userAgent';
+import { HttpsProxyAgent, SocksProxyAgent } from '../utilsBundle';
 import { BrowserContext, verifyClientCertificates } from './browserContext';
 import { CookieStore, domainMatches, parseRawCookie } from './cookieStore';
 import { MultipartFormData } from './formData';
@@ -181,8 +183,8 @@ export abstract class APIRequestContext extends SdkObject {
     let agent;
     // We skip 'per-context' in order to not break existing users. 'per-context' was previously used to
     // workaround an upstream Chromium bug. Can be removed in the future.
-    if (proxy?.server !== 'per-context')
-      agent = createProxyAgent(proxy, requestUrl);
+    if (proxy && proxy.server !== 'per-context' && !shouldBypassProxy(requestUrl, proxy.bypass))
+      agent = createProxyAgent(proxy);
 
     let maxRedirects = params.maxRedirects ?? (defaults.maxRedirects ?? 20);
     maxRedirects = maxRedirects === 0 ? -1 : maxRedirects;
@@ -645,6 +647,13 @@ export class GlobalAPIRequestContext extends APIRequestContext {
     const timeoutSettings = new TimeoutSettings();
     if (options.timeout !== undefined)
       timeoutSettings.setDefaultTimeout(options.timeout);
+    const proxy = options.proxy;
+    if (proxy?.server) {
+      let url = proxy?.server.trim();
+      if (!/^\w+:\/\//.test(url))
+        url = 'http://' + url;
+      proxy.server = url;
+    }
     if (options.storageState) {
       this._origins = options.storageState.origins?.map(origin => ({ indexedDB: [], ...origin }));
       this._cookieStore.addCookies(options.storageState.cookies || []);
@@ -659,7 +668,7 @@ export class GlobalAPIRequestContext extends APIRequestContext {
       maxRedirects: options.maxRedirects,
       httpCredentials: options.httpCredentials,
       clientCertificates: options.clientCertificates,
-      proxy: options.proxy,
+      proxy,
       timeoutSettings,
     };
     this._tracing = new Tracing(this, options.tracesDir);
@@ -694,6 +703,20 @@ export class GlobalAPIRequestContext extends APIRequestContext {
       origins: (this._origins || []).map(origin => ({ ...origin, indexedDB: indexedDB ? origin.indexedDB : [] })),
     };
   }
+}
+
+export function createProxyAgent(proxy: types.ProxySettings) {
+  const proxyOpts = url.parse(proxy.server);
+  if (proxyOpts.protocol?.startsWith('socks')) {
+    return new SocksProxyAgent({
+      host: proxyOpts.hostname,
+      port: proxyOpts.port || undefined,
+    });
+  }
+  if (proxy.username)
+    proxyOpts.auth = `${proxy.username}:${proxy.password || ''}`;
+  // TODO: We should use HttpProxyAgent conditional on proxyOpts.protocol instead of always using CONNECT method.
+  return new HttpsProxyAgent(proxyOpts);
 }
 
 function toHeadersArray(rawHeaders: string[]): types.HeadersArray {
@@ -766,6 +789,19 @@ function getHeader(headers: HeadersObject, name: string) {
 
 function removeHeader(headers: { [name: string]: string }, name: string) {
   delete headers[name];
+}
+
+function shouldBypassProxy(url: URL, bypass?: string): boolean {
+  if (!bypass)
+    return false;
+  const domains = bypass.split(',').map(s => {
+    s = s.trim();
+    if (!s.startsWith('.'))
+      s = '.' + s;
+    return s;
+  });
+  const domain = '.' + url.hostname;
+  return domains.some(d => domain.endsWith(d));
 }
 
 function setBasicAuthorizationHeader(headers: { [name: string]: string }, credentials: HTTPCredentials) {

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -23,7 +23,7 @@ import tls from 'tls';
 import { SocksProxy } from './utils/socksProxy';
 import { ManualPromise, escapeHTML, generateSelfSignedCertificate, rewriteErrorMessage } from '../utils';
 import { verifyClientCertificates } from './browserContext';
-import { createProxyAgent } from './utils/network';
+import { createProxyAgent } from './fetch';
 import { debugLogger } from './utils/debugLogger';
 import { createSocket, createTLSSocket } from './utils/happyEyeballs';
 
@@ -242,7 +242,7 @@ export class ClientCertificatesProxy {
   ignoreHTTPSErrors: boolean | undefined;
   secureContextMap: Map<string, tls.SecureContext> = new Map();
   alpnCache: ALPNCache;
-  proxyAgentFromOptions: ReturnType<typeof createProxyAgent>;
+  proxyAgentFromOptions: ReturnType<typeof createProxyAgent> | undefined;
 
   constructor(
     contextOptions: Pick<types.BrowserContextOptions, 'clientCertificates' | 'ignoreHTTPSErrors' | 'proxy'>
@@ -250,7 +250,7 @@ export class ClientCertificatesProxy {
     verifyClientCertificates(contextOptions.clientCertificates);
     this.alpnCache = new ALPNCache();
     this.ignoreHTTPSErrors = contextOptions.ignoreHTTPSErrors;
-    this.proxyAgentFromOptions = createProxyAgent(contextOptions.proxy);
+    this.proxyAgentFromOptions = contextOptions.proxy ? createProxyAgent(contextOptions.proxy) : undefined;
     this._initSecureContexts(contextOptions.clientCertificates);
     this._socksProxy = new SocksProxy();
     this._socksProxy.setPattern('*');

--- a/packages/playwright-core/src/server/transport.ts
+++ b/packages/playwright-core/src/server/transport.ts
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-import { createProxyAgent, makeWaitForNextTask } from '../utils';
+import { makeWaitForNextTask } from '../utils';
 import { httpHappyEyeballsAgent, httpsHappyEyeballsAgent } from './utils/happyEyeballs';
 import { ws } from '../utilsBundle';
 
 import type { WebSocket } from '../utilsBundle';
 import type { Progress } from './progress';
-import type { HeadersArray, ProxySettings } from './types';
+import type { HeadersArray } from './types';
 import type { ClientRequest, IncomingMessage } from 'http';
 
 export const perMessageDeflate = {
@@ -60,13 +60,6 @@ export interface ConnectionTransport {
   onclose?: (reason?: string) => void,
 }
 
-type WebSocketTransportOptions = {
-  headers?: { [key: string]: string; };
-  followRedirects?: boolean;
-  debugLogHeader?: string;
-  proxy?: ProxySettings;
-};
-
 export class WebSocketTransport implements ConnectionTransport {
   private _ws: WebSocket;
   private _progress?: Progress;
@@ -77,14 +70,14 @@ export class WebSocketTransport implements ConnectionTransport {
   readonly wsEndpoint: string;
   readonly headers: HeadersArray = [];
 
-  static async connect(progress: (Progress|undefined), url: string, options: WebSocketTransportOptions = {}): Promise<WebSocketTransport> {
-    return await WebSocketTransport._connect(progress, url, options, false /* hadRedirects */);
+  static async connect(progress: (Progress|undefined), url: string, headers?: { [key: string]: string; }, followRedirects?: boolean, debugLogHeader?: string): Promise<WebSocketTransport> {
+    return await WebSocketTransport._connect(progress, url, headers || {}, { follow: !!followRedirects, hadRedirects: false }, debugLogHeader);
   }
 
-  static async _connect(progress: (Progress|undefined), url: string, options: WebSocketTransportOptions, hadRedirects: boolean): Promise<WebSocketTransport> {
+  static async _connect(progress: (Progress|undefined), url: string, headers: { [key: string]: string; }, redirect: { follow: boolean, hadRedirects: boolean }, debugLogHeader?: string): Promise<WebSocketTransport> {
     const logUrl = stripQueryParams(url);
     progress?.log(`<ws connecting> ${logUrl}`);
-    const transport = new WebSocketTransport(progress, url, logUrl, { ...options, followRedirects: !!options.followRedirects && hadRedirects });
+    const transport = new WebSocketTransport(progress, url, logUrl, headers, redirect.follow && redirect.hadRedirects, debugLogHeader);
     let success = false;
     progress?.cleanupWhenAborted(async () => {
       if (!success)
@@ -101,13 +94,13 @@ export class WebSocketTransport implements ConnectionTransport {
         transport._ws.close();
       });
       transport._ws.on('unexpected-response', (request: ClientRequest, response: IncomingMessage) => {
-        if (options.followRedirects && !hadRedirects && (response.statusCode === 301 || response.statusCode === 302 || response.statusCode === 307 || response.statusCode === 308)) {
+        if (redirect.follow && !redirect.hadRedirects && (response.statusCode === 301 || response.statusCode === 302 || response.statusCode === 307 || response.statusCode === 308)) {
           fulfill({ redirect: response });
           transport._ws.close();
           return;
         }
         for (let i = 0; i < response.rawHeaders.length; i += 2) {
-          if (options.debugLogHeader && response.rawHeaders[i] === options.debugLogHeader)
+          if (debugLogHeader && response.rawHeaders[i] === debugLogHeader)
             progress?.log(response.rawHeaders[i + 1]);
         }
         const chunks: Buffer[] = [];
@@ -124,34 +117,32 @@ export class WebSocketTransport implements ConnectionTransport {
 
     if (result.redirect) {
       // Strip authorization headers from the redirected request.
-      const newHeaders = Object.fromEntries(Object.entries(options.headers || {}).filter(([name]) => {
+      const newHeaders = Object.fromEntries(Object.entries(headers || {}).filter(([name]) => {
         return !name.includes('access-key') && name.toLowerCase() !== 'authorization';
       }));
-      return WebSocketTransport._connect(progress, result.redirect.headers.location!, { ...options, headers: newHeaders }, true /* hadRedirects */);
+      return WebSocketTransport._connect(progress, result.redirect.headers.location!, newHeaders, { follow: true, hadRedirects: true }, debugLogHeader);
     }
 
     success = true;
     return transport;
   }
 
-  constructor(progress: Progress|undefined, url: string, logUrl: string, options: WebSocketTransportOptions) {
+  constructor(progress: Progress|undefined, url: string, logUrl: string, headers?: { [key: string]: string; }, followRedirects?: boolean, debugLogHeader?: string) {
     this.wsEndpoint = url;
     this._logUrl = logUrl;
-    const proxyAgent = createProxyAgent(options.proxy, new URL(url));
-    const happyEyeballsAgent = (/^(https|wss):\/\//.test(url)) ? httpsHappyEyeballsAgent : httpHappyEyeballsAgent;
     this._ws = new ws(url, [], {
       maxPayload: 256 * 1024 * 1024, // 256Mb,
       // Prevent internal http client error when passing negative timeout.
       handshakeTimeout: Math.max(progress?.timeUntilDeadline() ?? 30_000, 1),
-      headers: options.headers,
-      followRedirects: options.followRedirects,
-      agent: proxyAgent || happyEyeballsAgent,
+      headers,
+      followRedirects,
+      agent: (/^(https|wss):\/\//.test(url)) ? httpsHappyEyeballsAgent : httpHappyEyeballsAgent,
       perMessageDeflate,
     });
     this._ws.on('upgrade', response => {
       for (let i = 0; i < response.rawHeaders.length; i += 2) {
         this.headers.push({ name: response.rawHeaders[i], value: response.rawHeaders[i + 1] });
-        if (options.debugLogHeader && response.rawHeaders[i] === options.debugLogHeader)
+        if (debugLogHeader && response.rawHeaders[i] === debugLogHeader)
           progress?.log(response.rawHeaders[i + 1]);
       }
     });

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21794,34 +21794,6 @@ export interface ConnectOverCDPOptions {
   logger?: Logger;
 
   /**
-   * Proxy settings to use for the connection between the client and the remote browser. Note this proxy **is not** used
-   * by the browser to load web pages.
-   */
-  proxy?: {
-    /**
-     * Proxy to be used for the remote connection. HTTP and SOCKS proxies are supported, for example
-     * `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP
-     * proxy.
-     */
-    server: string;
-
-    /**
-     * Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-     */
-    bypass?: string;
-
-    /**
-     * Optional username to use if HTTP proxy requires authentication.
-     */
-    username?: string;
-
-    /**
-     * Optional password to use if HTTP proxy requires authentication.
-     */
-    password?: string;
-  };
-
-  /**
    * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going
    * on. Defaults to 0.
    */
@@ -21861,34 +21833,6 @@ export interface ConnectOptions {
    * Logger sink for Playwright logging. Optional.
    */
   logger?: Logger;
-
-  /**
-   * Proxy settings to use for the connection between the client and the remote browser. Note this proxy **is not** used
-   * by the browser to load web pages.
-   */
-  proxy?: {
-    /**
-     * Proxy to be used for the remote connection. HTTP and SOCKS proxies are supported, for example
-     * `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP
-     * proxy.
-     */
-    server: string;
-
-    /**
-     * Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-     */
-    bypass?: string;
-
-    /**
-     * Optional username to use if HTTP proxy requires authentication.
-     */
-    username?: string;
-
-    /**
-     * Optional password to use if HTTP proxy requires authentication.
-     */
-    password?: string;
-  };
 
   /**
    * Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -540,12 +540,6 @@ export type LocalUtilsConnectParams = {
   exposeNetwork?: string,
   slowMo?: number,
   timeout?: number,
-  proxy?: {
-    server: string,
-    bypass?: string,
-    username?: string,
-    password?: string,
-  },
   socksProxyRedirectPortForTest?: number,
 };
 export type LocalUtilsConnectOptions = {
@@ -553,12 +547,6 @@ export type LocalUtilsConnectOptions = {
   exposeNetwork?: string,
   slowMo?: number,
   timeout?: number,
-  proxy?: {
-    server: string,
-    bypass?: string,
-    username?: string,
-    password?: string,
-  },
   socksProxyRedirectPortForTest?: number,
 };
 export type LocalUtilsConnectResult = {
@@ -1177,23 +1165,11 @@ export type BrowserTypeConnectOverCDPParams = {
   headers?: NameValue[],
   slowMo?: number,
   timeout?: number,
-  proxy?: {
-    server: string,
-    bypass?: string,
-    username?: string,
-    password?: string,
-  },
 };
 export type BrowserTypeConnectOverCDPOptions = {
   headers?: NameValue[],
   slowMo?: number,
   timeout?: number,
-  proxy?: {
-    server: string,
-    bypass?: string,
-    username?: string,
-    password?: string,
-  },
 };
 export type BrowserTypeConnectOverCDPResult = {
   browser: BrowserChannel,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -702,13 +702,6 @@ LocalUtils:
         exposeNetwork: string?
         slowMo: number?
         timeout: number?
-        proxy:
-          type: object?
-          properties:
-            server: string
-            bypass: string?
-            username: string?
-            password: string?
         socksProxyRedirectPortForTest: number?
       returns:
         pipe: JsonPipe
@@ -1017,13 +1010,6 @@ BrowserType:
           items: NameValue
         slowMo: number?
         timeout: number?
-        proxy:
-          type: object?
-          properties:
-            server: string
-            bypass: string?
-            username: string?
-            password: string?
       returns:
         browser: Browser
         defaultContext: BrowserContext?

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -765,24 +765,6 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       await browser.close();
     });
 
-    test('should connect over http proxy', {
-      annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33894' },
-    }, async ({ connect, startRemoteServer, proxyServer }) => {
-      const remoteServer = await startRemoteServer(kind);
-      const url = new URL(remoteServer.wsEndpoint());
-      proxyServer.forwardTo(+url.port, { allowConnectRequests: true });
-      const browser = await connect(`http://some.random.host.does.not.exist:1337`, {
-        proxy: { server: `localhost:${proxyServer.PORT}` },
-      });
-      const page = await browser.newPage();
-      expect(await page.evaluate('11 * 11')).toBe(121);
-      await browser.close();
-      // We should "CONNECT" twice:
-      // - to convert http url into ws url
-      // - actually connect to the ws endpoint
-      expect(proxyServer.connectHosts).toEqual(['some.random.host.does.not.exist:1337', 'some.random.host.does.not.exist:1337']);
-    });
-
     test.describe('socks proxy', () => {
       test.skip(({ mode }) => mode !== 'default');
       test.skip(kind === 'launchServer', 'not supported yet');

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -446,32 +446,6 @@ test('should be able to connect via localhost', async ({ browserType }, testInfo
   }
 });
 
-test('should be able to connect over http proxy', {
-  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35206' },
-}, async ({ browserType, proxyServer }, testInfo) => {
-  const port = 9339 + testInfo.workerIndex;
-  const browserServer = await browserType.launch({
-    args: ['--remote-debugging-port=' + port]
-  });
-  proxyServer.forwardTo(port, { allowConnectRequests: true });
-  try {
-    const cdpBrowser = await browserType.connectOverCDP(`http://some.random.host.does.not.exist:1337`, {
-      proxy: { server: `localhost:${proxyServer.PORT}` },
-    });
-    const contexts = cdpBrowser.contexts();
-    expect(contexts.length).toBe(1);
-    const page = await contexts[0].newPage();
-    expect(await page.evaluate('11 * 11')).toBe(121);
-    await cdpBrowser.close();
-    // We should "CONNECT" twice:
-    // - to convert http url into ws url
-    // - actually connect to the ws endpoint
-    expect(proxyServer.connectHosts).toEqual(['some.random.host.does.not.exist:1337', 'some.random.host.does.not.exist:1337']);
-  } finally {
-    await browserServer.close();
-  }
-});
-
 test('emulate media should not be affected by second connectOverCDP', async ({ browserType }, testInfo) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/24109' });
   test.fixme();

--- a/tests/library/proxy.spec.ts
+++ b/tests/library/proxy.spec.ts
@@ -323,7 +323,7 @@ it('should use SOCKS proxy for websocket requests', async ({ browserType, server
   await closeProxyServer();
 });
 
-it('should use http proxy for websocket requests', async ({ isWindows, browserName, browserType, server, proxyServer }) => {
+it('should use http proxy for websocket requests', async ({ browserName, browserType, server, proxyServer }) => {
   proxyServer.forwardTo(server.PORT, { allowConnectRequests: true });
   const browser = await browserType.launch({
     proxy: { server: `localhost:${proxyServer.PORT}` }
@@ -350,7 +350,7 @@ it('should use http proxy for websocket requests', async ({ isWindows, browserNa
 
   // WebKit does not use CONNECT for websockets, but other browsers do.
   if (browserName === 'webkit')
-    expect(proxyServer.wsUrls).toContain(isWindows ? '/ws' : 'ws://fake-localhost-127-0-0-1.nip.io:1337/ws');
+    expect(proxyServer.wsUrls).toContain('ws://fake-localhost-127-0-0-1.nip.io:1337/ws');
   else
     expect(proxyServer.connectHosts).toContain('fake-localhost-127-0-0-1.nip.io:1337');
 


### PR DESCRIPTION
This reverts commit 471a28e0d51abca7ca2086c51b3efb3e81f4d458.

Reason: decided to skip an explicit API and instead follow Node.js attempts to supports HTTP_PROXY and HTTPS_PROXY.

Reopens #35206, reopens #33894.