### PR TITLE
chore: fix 'npm run watch' memory leak in esbuild

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -254,7 +254,7 @@ for (const pkg of workspace.packages()) {
       quotePath(path.join(pkg.path, 'src/**/*.ts')),
       `--outdir=${quotePath(path.join(pkg.path, 'lib'))}`,
       ...(withSourceMaps ? [`--sourcemap=linked`] : []),
-      ...(watchMode ? ['--watch=true'] : []),
+      ...(watchMode ? ['--watch'] : []),
       '--platform=node',
       '--format=cjs',
       ],


### PR DESCRIPTION
See https://github.com/evanw/esbuild/issues/4131