### PR TITLE
fix: do not pass unsafe `matcherResult` over IPC

### DIFF
--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -20,7 +20,6 @@ import { serializeCompilationCache } from '../transform/compilationCache';
 
 import type { ConfigLocation, FullConfigInternal } from './config';
 import type { ReporterDescription, TestInfoError, TestStatus } from '../../types/test';
-import type { MatcherResultProperty } from '../matchers/matcherHint';
 import type { SerializedCompilationCache  } from '../transform/compilationCache';
 
 export type ConfigCLIOverrides = {

--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -83,9 +83,7 @@ export type AttachmentPayload = {
   stepId?: string;
 };
 
-export type TestInfoErrorImpl = TestInfoError & {
-  matcherResult?: MatcherResultProperty;
-};
+export type TestInfoErrorImpl = TestInfoError;
 
 export type TestEndPayload = {
   testId: string;

--- a/packages/playwright/src/common/process.ts
+++ b/packages/playwright/src/common/process.ts
@@ -120,9 +120,8 @@ function sendMessageToParent(message: { method: string, params?: any }) {
     process.send!(message);
   } catch (e) {
     try {
-      // The process is created with { serialization: 'advanced' }, so it uses
-      // structured clone to send messages.
-      structuredClone(message);
+      // By default, the IPC messages are serialized as JSON.
+      JSON.stringify(message);
     } catch {
       // Always throw serialization errors.
       throw e;

--- a/packages/playwright/src/common/process.ts
+++ b/packages/playwright/src/common/process.ts
@@ -119,6 +119,14 @@ function sendMessageToParent(message: { method: string, params?: any }) {
   try {
     process.send!(message);
   } catch (e) {
+    try {
+      // The process is created with { serialization: 'advanced' }, so it uses
+      // structured clone to send messages.
+      structuredClone(message);
+    } catch {
+      // Always throw serialization errors.
+      throw e;
+    }
     // Can throw when closing.
   }
 }

--- a/packages/playwright/src/runner/processHost.ts
+++ b/packages/playwright/src/runner/processHost.ts
@@ -67,6 +67,7 @@ export class ProcessHost extends EventEmitter {
         'ipc',
       ],
       ...(process.env.PW_TS_ESM_LEGACY_LOADER_ON ? { execArgv: execArgvWithExperimentalLoaderOptions() } : {}),
+      serialization: 'advanced',
     });
     this.process.on('exit', async (code, signal) => {
       this._processDidExit = true;

--- a/packages/playwright/src/runner/processHost.ts
+++ b/packages/playwright/src/runner/processHost.ts
@@ -67,7 +67,6 @@ export class ProcessHost extends EventEmitter {
         'ipc',
       ],
       ...(process.env.PW_TS_ESM_LEGACY_LOADER_ON ? { execArgv: execArgvWithExperimentalLoaderOptions() } : {}),
-      serialization: 'advanced',
     });
     this.process.on('exit', async (code, signal) => {
       this._processDidExit = true;

--- a/packages/playwright/src/worker/util.ts
+++ b/packages/playwright/src/worker/util.ts
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-import { ExpectError } from '../matchers/matcherHint';
 import { serializeError } from '../util';
 
 import type { TestInfoErrorImpl } from '../common/ipc';
 
 export function testInfoError(error: Error | any): TestInfoErrorImpl {
-  const result = serializeError(error);
-  if (error instanceof ExpectError)
-    result.matcherResult = error.matcherResult;
-  return result;
+  return serializeError(error);
 }

--- a/tests/playwright-test/basic.spec.ts
+++ b/tests/playwright-test/basic.spec.ts
@@ -660,5 +660,5 @@ test('should report serialization error', async ({ runInlineTest }) => {
   });
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
-  expect(result.output).toContain('Error: () => {} could not be cloned.');
+  expect(result.output).toContain('Expected: {\"a\": [Function a]}');
 });

--- a/tests/playwright-test/basic.spec.ts
+++ b/tests/playwright-test/basic.spec.ts
@@ -617,3 +617,48 @@ test('should fail when test.fail.only passes unexpectedly', async ({ runInlineTe
   expect(result.output).not.toContain('test1 should not run');
   expect(result.output).not.toContain('test3 should not run');
 });
+
+test('should serialize circular objects', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'one-failure.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('circular dependency', () => {
+        const a = {};
+        a.b = a;
+        expect(1).toEqual(a);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(0);
+  expect(result.failed).toBe(1);
+  expect(result.output).toContain('Expected: {"b": [Circular]}');
+});
+
+test('should serialize BigInt', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'one-failure.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('BigInt', () => {
+        expect(1).toEqual(1n);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.output).toContain('Expected: 1n');
+});
+
+test('should report serialization error', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'one-failure.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('function', () => {
+        expect(1).toEqual({ a: () => {} });
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(0);
+  expect(result.output).toContain('Error: () => {} could not be cloned.');
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/35562