### PR TITLE
test: unskip routing test in firefox after roll to 1482

### DIFF
--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -1031,7 +1031,6 @@ it('should intercept when postData is more than 1MB', async ({ page, server }) =
 
 it('should be able to intercept every navigation to a page controlled by service worker', async ({ page, server, isElectron, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33561' });
-  it.fixme(browserName === 'firefox');
   it.skip(isElectron);
 
   let interceptions = 0;


### PR DESCRIPTION
Recent [roll to 1482](https://github.com/microsoft/playwright/pull/35557) fixed this.

Closes #33561.