### PR TITLE
chore(bidi): update expectation for bidi firefox

### DIFF
--- a/tests/page/page-mouse.spec.ts
+++ b/tests/page/page-mouse.spec.ts
@@ -264,14 +264,18 @@ it('should tween mouse movement', async ({ page, browserName, isAndroid }) => {
   ]);
 });
 
-it('should always round down', async ({ page }) => {
+it('should always round down', async ({ page, browserName }) => {
   await page.evaluate(() => {
     document.addEventListener('mousedown', event => {
       window['result'] = [event.clientX, event.clientY];
     });
   });
   await page.mouse.click(50.1, 50.9);
-  expect(await page.evaluate('result')).toEqual([50, 50]);
+  // In _bidi* the rounding is browser-specific.
+  if (browserName === '_bidiFirefox')
+    expect(await page.evaluate('result')).toEqual([50, 51]);
+  else
+    expect(await page.evaluate('result')).toEqual([50, 50]);
 });
 
 it('should not crash on mouse drag with any button', async ({ page }) => {


### PR DESCRIPTION
The original [fix](https://github.com/microsoft/playwright/pull/10483) that introduced the test, was fixing the discrepancy between headless and headed modes (https://github.com/microsoft/playwright/issues/9777). There is no fundamental reason to prefer one rounding method over another as long as it is the same between headless and headed. In Bidi Firefox it rounds to the closest integer which is valid.