### PR TITLE
docs(test-assertions): document soft assertions with expect.poll

### DIFF
--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -223,6 +223,17 @@ await expect.poll(async () => {
 }).toBe(200);
 ```
 
+You can combine expect.configure({ soft: true }) with expect.poll to perform soft assertions in polling logic.
+
+```js
+const softExpect = expect.configure({ soft: true });
+await softExpect.poll(async () => {
+  const response = await page.request.get('https://api.example.com');
+  return response.status();
+}, {}).toBe(200);
+```
+This allows the test to continue even if the assertion inside poll fails.
+
 ## expect.toPass
 
 You can retry blocks of code until they are passing successfully.


### PR DESCRIPTION
Based on the discussion in this issue: https://github.com/microsoft/playwright/issues/20773, it seems that many users aren’t aware that `expect.poll` can be used together with soft assertions via `expect.configure({ soft: true })`.

I’m proposing to include this as part of the documentation to make it more visible.
Maybe @debs-obrien could also mention it in a release video as a “Tip of the Day”? 😊