### PR TITLE
chore: update generateDotNetApi

### DIFF
--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -732,8 +732,6 @@ function translateType(type, parent, generateNameCallback = t => t.name, optiona
       console.warn(`${type.name} should be a 'string', but was a ${type.expression}`);
       return `string`;
     }
-    if (type.union.length === 2 && type.union[1].name === 'Array' && type.union[1].templates[0].name === type.union[0].name)
-      return `IEnumerable<${type.union[0].name}>`; // an example of this is [string]|[Array]<[string]>
     if (type.expression === '[float]|"raf"')
       return `Polling`; // hardcoded because there's no other way to denote this
 


### PR DESCRIPTION
Do not merge `string|Array<string>` into `IEnumerable<String>`. This was only used for `BrowserContext.cookies()` that now gets 3 overloads: `String`, `IEnumerable<String>` and no arguments.

Allows for two overloads of `toContainClass` - with `String` and `IEnumerable<String>`.