### PR TITLE
chore(build): add --install watch flag for automatic browser install

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -63,6 +63,7 @@ const copyFiles = [];
 const watchMode = process.argv.slice(2).includes('--watch');
 const lintMode = process.argv.slice(2).includes('--lint');
 const withSourceMaps = process.argv.slice(2).includes('--sourcemap') || watchMode;
+const installMode = process.argv.slice(2).includes('--install');
 const ROOT = path.join(__dirname, '..', '..');
 
 /**
@@ -404,6 +405,15 @@ onChanges.push({
   ],
   script: 'utils/generate_types/index.js',
 });
+
+if (installMode) {
+  // Keep browser installs up to date.
+  onChanges.push({
+    inputs: ['packages/playwright-core/browsers.json'],
+    command: 'npx',
+    args: ['playwright', 'install'],
+  });
+}
 
 // The recorder and trace viewer have an app_icon.png that needs to be copied.
 copyFiles.push({


### PR DESCRIPTION
Switching between branches with various browser rolls can get annoying quickly. If you have `npm run watch -- --install` running, automatically install the browsers corresponding with the current commit.