### PR TITLE
fix(html): display error when test cannot be displayed

### DIFF
--- a/packages/html-reporter/src/parsedReport.ts
+++ b/packages/html-reporter/src/parsedReport.ts
@@ -16,7 +16,7 @@
 
 import type { HTMLReport } from './types';
 
-export interface LoadedReport {
+export interface ParsedReport {
   json(): HTMLReport;
   entry(name: string): Promise<Object | undefined>;
 }

--- a/packages/html-reporter/src/reportView.css
+++ b/packages/html-reporter/src/reportView.css
@@ -29,7 +29,9 @@ body {
   width: 100%;
 }
 
-.error {
+.fatal-report-error {
+  display: flex;
+  justify-content: center;
   margin-top: 10px;
 }
 

--- a/packages/html-reporter/src/reportView.css
+++ b/packages/html-reporter/src/reportView.css
@@ -29,6 +29,10 @@ body {
   width: 100%;
 }
 
+.error {
+  margin-top: 10px;
+}
+
 .test-file-test:not(:first-child) {
   border-top: 1px solid var(--color-border-default);
 }

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -62,13 +62,11 @@ export const TestFilesView: React.FC<{
 };
 
 export const TestFilesHeader: React.FC<{
-  report: HTMLReport | undefined,
+  report: HTMLReport,
   filteredStats?: FilteredStats,
   metadataVisible: boolean,
   toggleMetadataVisible: () => void,
 }> = ({ report, filteredStats, metadataVisible, toggleMetadataVisible }) => {
-  if (!report)
-    return null;
   return <>
     <div className='mx-1' style={{ display: 'flex', marginTop: 10 }}>
       <div className='test-file-header-info'>

--- a/packages/html-reporter/src/types.d.ts
+++ b/packages/html-reporter/src/types.d.ts
@@ -113,3 +113,12 @@ export type TestStep = {
   count: number;
   skipped?: boolean;
 };
+
+export type AsyncResult<T> = {
+  type: 'loading'
+} | {
+  type: 'data',
+  data: T,
+} | {
+  type: 'error',
+};

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2933,6 +2933,25 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       const prompt = await page.evaluate(() => navigator.clipboard.readText());
       expect(prompt, 'contains snapshot').toContain('- button "Click me"');
     });
+
+    test('should show error if test ID not found', async ({ runInlineTest, showReport, page }) => {
+      const result = await runInlineTest({
+        'example.spec.ts': `
+          import { test, expect } from '@playwright/test';
+          test('sample', async ({ browser }) => {
+            const page = await browser.newPage();
+            await page.setContent('<button>Click me</button>');
+            expect(2).toBe(2);
+          });
+        `,
+      }, { reporter: 'html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+      expect(result.exitCode).toBe(0);
+      await showReport();
+
+      await page.goto(`${page.url()}#?testId=non-existing-test-id`);
+
+      await expect(page.getByText('Test not found')).toBeVisible();
+    });
   });
 }
 


### PR DESCRIPTION
Display a simple error message when the user navigates to an invalid URL (for example, reloading between report generations).

<img width="1563" alt="Screenshot 2025-04-17 at 11 07 14 AM" src="https://github.com/user-attachments/assets/97e84033-6d1c-4e6e-9a56-81e6a26be7a5" />

