### PR TITLE
fix(reporters): error context exception with page.evaluate

### DIFF
--- a/packages/playwright/src/errorContext.ts
+++ b/packages/playwright/src/errorContext.ts
@@ -167,7 +167,7 @@ async function loadSourceCached(file: string, sourceCache: Map<string, string>):
   let source = sourceCache.get(file);
   if (!source) {
     try {
-    // A mild race is Ok here.
+      // A mild race is Ok here.
       source = await fs.readFile(file, 'utf8');
       sourceCache.set(file, source);
     } catch (e) {

--- a/packages/playwright/src/errorContext.ts
+++ b/packages/playwright/src/errorContext.ts
@@ -24,6 +24,7 @@ import { codeFrameColumns } from './transform/babelBundle';
 
 import type { MetadataWithCommitInfo } from './isomorphic/types';
 import type { TestInfoImpl } from './worker/testInfo';
+import type { Location } from '../types/test';
 
 export async function attachErrorContext(testInfo: TestInfoImpl, format: 'markdown' | 'json', sourceCache: Map<string, string>, ariaSnapshot: string | undefined) {
   if (format === 'json') {
@@ -139,12 +140,6 @@ export async function attachErrorContext(testInfo: TestInfoImpl, format: 'markdo
     }, undefined);
   }
 }
-
-type Location = {
-  file: string,
-  line: number,
-  column: number,
-};
 
 async function loadSource(
   errorLocation: Location | undefined,

--- a/packages/playwright/src/errorContext.ts
+++ b/packages/playwright/src/errorContext.ts
@@ -17,7 +17,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-import { parseErrorStack } from 'playwright-core/lib/utils';
+import { existsAsync, parseErrorStack } from 'playwright-core/lib/utils';
 
 import { stripAnsiEscapes } from './util';
 import { codeFrameColumns } from './transform/babelBundle';
@@ -93,29 +93,31 @@ export async function attachErrorContext(testInfo: TestInfoImpl, format: 'markdo
     const inlineMessage = stripAnsiEscapes(parsedError?.message || error.message || '').split('\n')[0];
     const location = parsedError?.location || { file: testInfo.file, line: testInfo.line, column: testInfo.column };
     const source = await loadSource(location.file, sourceCache);
-    const codeFrame = codeFrameColumns(
-        source,
-        {
-          start: {
-            line: location.line,
-            column: location.column
+    if (source) {
+      const codeFrame = codeFrameColumns(
+          source,
+          {
+            start: {
+              line: location.line,
+              column: location.column
+            },
           },
-        },
-        {
-          highlightCode: false,
-          linesAbove: 100,
-          linesBelow: 100,
-          message: inlineMessage || undefined,
-        }
-    );
-    lines.push(
-        '',
-        '# Test source',
-        '',
-        '```ts',
-        codeFrame,
-        '```',
-    );
+          {
+            highlightCode: false,
+            linesAbove: 100,
+            linesBelow: 100,
+            message: inlineMessage || undefined,
+          }
+      ) ;
+      lines.push(
+          '',
+          '# Test source',
+          '',
+          '```ts',
+          codeFrame,
+          '```',
+      );
+    }
 
     if (metadata.gitDiff) {
       lines.push(
@@ -141,10 +143,12 @@ export async function attachErrorContext(testInfo: TestInfoImpl, format: 'markdo
 
 async function loadSource(file: string, sourceCache: Map<string, string>) {
   let source = sourceCache.get(file);
-  if (!source) {
-    // A mild race is Ok here.
-    source = await fs.readFile(file, 'utf8');
-    sourceCache.set(file, source);
-  }
+  if (source)
+    return source;
+  if (!await existsAsync(file))
+    return undefined;
+  // A mild race is Ok here.
+  source = await fs.readFile(file, 'utf8');
+  sourceCache.set(file, source);
   return source;
 }

--- a/tests/playwright-test/reporter-line.spec.ts
+++ b/tests/playwright-test/reporter-line.spec.ts
@@ -206,5 +206,24 @@ for (const useIntermediateMergeReport of [false, true] as const) {
         expect(text).toContain(`Error Context: ${path.join('test-results', 'a-one', 'error-context.md')}`);
       expect(result.exitCode).toBe(1);
     });
+
+    test.fixme('should show error context if exception contains non-existent file', async ({ runInlineTest, useIntermediateMergeReport }) => {
+      const result = await runInlineTest({
+        'a.test.js': `
+          const { test, expect } = require('@playwright/test');
+          test('one', async ({ page }) => {
+            await page.evaluate(() => {
+              throw new Error('error');
+            });
+          });
+        `,
+      }, { reporter: 'line' });
+      const text = result.output;
+      if (useIntermediateMergeReport)
+        expect(text).toContain(`Error Context: ${path.join('blob-report', 'resources')}`);
+      else
+        expect(text).toContain(`Error Context: ${path.join('test-results', 'a-one', 'error-context.md')}`);
+      expect(result.exitCode).toBe(1);
+    });
   });
 }

--- a/tests/playwright-test/reporter-line.spec.ts
+++ b/tests/playwright-test/reporter-line.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import path from 'path';
+import fs from 'fs';
 import { test, expect } from './playwright-test-fixtures';
 
 for (const useIntermediateMergeReport of [false, true] as const) {
@@ -218,11 +219,13 @@ for (const useIntermediateMergeReport of [false, true] as const) {
           });
         `,
       }, { reporter: 'line' });
-      const text = result.output;
       if (useIntermediateMergeReport)
-        expect(text).toContain(`Error Context: ${path.join('blob-report', 'resources')}`);
+        expect(result.output).toContain(`Error Context: ${path.join('blob-report', 'resources')}`);
       else
-        expect(text).toContain(`Error Context: ${path.join('test-results', 'a-one', 'error-context.md')}`);
+        expect(result.output).toContain(`Error Context: ${path.join('test-results', 'a-one', 'error-context.md')}`);
+      const file = /Error Context: (.*)/.exec(result.output)?.[1];
+      const content = await fs.promises.readFile(path.join(result.report.config.rootDir, file), 'utf8');
+      expect(content).toContain('^ Error: page.evaluate: Error: error');
       expect(result.exitCode).toBe(1);
     });
   });

--- a/tests/playwright-test/reporter-line.spec.ts
+++ b/tests/playwright-test/reporter-line.spec.ts
@@ -207,7 +207,7 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(result.exitCode).toBe(1);
     });
 
-    test.fixme('should show error context if exception contains non-existent file', async ({ runInlineTest, useIntermediateMergeReport }) => {
+    test('should show error context if exception contains non-existent file', async ({ runInlineTest, useIntermediateMergeReport }) => {
       const result = await runInlineTest({
         'a.test.js': `
           const { test, expect } = require('@playwright/test');


### PR DESCRIPTION
Minimal repro:

```ts
const { test, expect } = require('@playwright/test');
test('one', async ({ page }) => {
  await page.evaluate(() => {
    throw new Error('error');
  });
});
```

Stack:

```ts

    Error: ENOENT: no such file or directory, open 'eval at evaluate (:313:29), <anonymous>'
        at open (node:internal/fs/promises:638:25)
        at Object.readFile (node:internal/fs/promises:1242:14)
        at loadSource (/Users/maxschmitt/Developer/playwright/packages/playwright/src/errorContext.ts:146:14)
        at attachErrorContext (/Users/maxschmitt/Developer/playwright/packages/playwright/src/errorContext.ts:95:20)
        at ArtifactsRecorder.didFinishTest (/Users/maxschmitt/Developer/playwright/packages/playwright/src/index.ts:725:7)
        at Object.playwrightFixtures._setupArtifacts.auto [as fn] (/Users/maxschmitt/Developer/playwright/packages/playwright/src/index.ts:326:5)
        at /Users/maxschmitt/Developer/playwright/packages/playwright/src/worker/fixtureRunner.ts:116:9
        at Fixture._teardownInternal (/Users/maxschmitt/Developer/playwright/packages/playwright/src/worker/fixtureRunner.ts:160:7)
        at /Users/maxschmitt/Developer/playwright/packages/playwright/src/worker/testInfo.ts:364:11
        at TimeoutManager.withRunnable (/Users/maxschmitt/Developer/playwright/packages/playwright/src/worker/timeoutManager.ts:100:14)
        at TestInfoImpl._runWithTimeout (/Users/maxschmitt/Developer/playwright/packages/playwright/src/worker/testInfo.ts:362:7)
        at Fixture.teardown (/Users/maxschmitt/Developer/playwright/packages/playwright/src/worker/fixtureRunner.ts:138:11)
        at FixtureRunner.teardownScope (/Users/maxschmitt/Developer/playwright/packages/playwright/src/worker/fixtureRunner.ts:211:9)
        at /Users/maxschmitt/Developer/playwright/packages/playwright/src/worker/workerMain.ts:408:9
        at TestInfoImpl._runAsStep (/Users/maxschmitt/Developer/playwright/packages/playwright/src/worker/testInfo.ts:352:7)
        at WorkerMain._runTest (/Users/maxschmitt/Developer/playwright/packages/playwright/src/worker/workerMain.ts:385:5)
        at WorkerMain.runTestGroup (/Users/maxschmitt/Developer/playwright/packages/playwright/src/worker/workerMain.ts:231:11)
        at process.<anonymous> (/Users/maxschmitt/Developer/playwright/packages/playwright/src/common/process.ts:88:22)
```

We can fix it separately I think. We should re-visit our idea of making `page.evaluate` errors an `error.cause` + make this non-throwing.