### PR TITLE
fix(testServer): add location to config loading errors

### DIFF
--- a/packages/playwright/src/common/testLoader.ts
+++ b/packages/playwright/src/common/testLoader.ts
@@ -82,7 +82,7 @@ export async function loadTestFile(file: string, rootDir: string, testErrors?: T
   return suite;
 }
 
-function serializeLoadError(file: string, error: Error | any): TestError {
+export function serializeLoadError(file: string, error: Error | any): TestError {
   if (error instanceof Error) {
     const result: TestError = filterStackTrace(error);
     // Babel parse errors have location.

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -32,9 +32,8 @@ import { filterProjects } from './runner/projectUtils';
 import { Runner } from './runner/runner';
 import * as testServer from './runner/testServer';
 import { runWatchModeLoop } from './runner/watchMode';
-import { serializeError } from './util';
+import { serializeLoadError } from './util';
 
-import type { TestError } from '../types/testReporter';
 import type { ConfigCLIOverrides } from './common/ipc';
 import type { TraceMode } from '../types/test';
 import type { ReporterDescription } from '../types/test';
@@ -249,8 +248,7 @@ export async function withRunnerAndMutedWrite(configFile: string | undefined, ca
       gracefullyProcessExitDoNotHang(0);
     });
   } catch (e) {
-    const error: TestError = serializeError(e);
-    error.location = prepareErrorStack(e.stack).location;
+    const error = serializeLoadError(e, resolveConfigLocation(configFile).resolvedConfigFile);
     stdoutWrite(JSON.stringify({ error }, undefined, 2), () => {
       gracefullyProcessExitDoNotHang(0);
     });

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -33,7 +33,7 @@ import { internalScreen } from '../reporters/base';
 import { InternalReporter } from '../reporters/internalReporter';
 import ListReporter from '../reporters/list';
 import { affectedTestFiles, collectAffectedTestFiles, dependenciesForTestFile } from '../transform/compilationCache';
-import { serializeError } from '../util';
+import { serializeLoadError } from '../util';
 
 import type * as reporterTypes from '../../types/testReporter';
 import type { ConfigLocation, FullConfigInternal } from '../common/config';
@@ -43,7 +43,6 @@ import type { TestRunnerPluginRegistration } from '../plugins';
 import type { ReporterV2 } from '../reporters/reporterV2';
 import type { TraceViewerRedirectOptions, TraceViewerServerOptions } from 'playwright-core/lib/server/trace/viewer/traceViewer';
 import type { HttpServer, Transport } from 'playwright-core/lib/utils';
-import { serializeLoadError } from '../common/testLoader';
 
 const originalStdoutWrite = process.stdout.write;
 const originalStderrWrite = process.stderr.write;
@@ -419,7 +418,7 @@ export class TestServerDispatcher implements TestServerInterface {
       }
       return { config };
     } catch (e) {
-      return { config: null, error: this._configLocation.resolvedConfigFile ? serializeLoadError(this._configLocation.resolvedConfigFile, e) : serializeError(e) };
+      return { config: null, error: serializeLoadError(e, this._configLocation.resolvedConfigFile) };
     }
   }
 

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -43,6 +43,7 @@ import type { TestRunnerPluginRegistration } from '../plugins';
 import type { ReporterV2 } from '../reporters/reporterV2';
 import type { TraceViewerRedirectOptions, TraceViewerServerOptions } from 'playwright-core/lib/server/trace/viewer/traceViewer';
 import type { HttpServer, Transport } from 'playwright-core/lib/utils';
+import { serializeLoadError } from '../common/testLoader';
 
 const originalStdoutWrite = process.stdout.write;
 const originalStderrWrite = process.stderr.write;
@@ -418,7 +419,7 @@ export class TestServerDispatcher implements TestServerInterface {
       }
       return { config };
     } catch (e) {
-      return { config: null, error: serializeError(e) };
+      return { config: null, error: this._configLocation.resolvedConfigFile ? serializeLoadError(this._configLocation.resolvedConfigFile, e) : serializeError(e) };
     }
   }
 

--- a/tests/playwright-test/list-files.spec.ts
+++ b/tests/playwright-test/list-files.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import path from 'path';
 import { test, expect } from './playwright-test-fixtures';
 
 test('should list files', async ({ runCLICommand }) => {
@@ -96,6 +97,28 @@ test('should report error', async ({ runCLICommand }) => {
       },
       message: 'TypeError: Assignment to constant variable.',
       stack: expect.stringContaining('TypeError: Assignment to constant variable.'),
+    }
+  });
+});
+
+test('should report SyntaxErrors', async ({ runCLICommand }) => {
+  const result = await runCLICommand({
+    'playwright.config.ts': `
+      !?NotAValidConfig
+    `,
+  }, 'list-files');
+  expect(result.exitCode).toBe(0);
+
+  const data = JSON.parse(result.stdout);
+  expect(data).toEqual({
+    error: {
+      location: {
+        file: expect.stringContaining('playwright.config.ts'),
+        line: 2,
+        column: 7,
+      },
+      message: expect.stringContaining(`SyntaxError: ${path.join(test.info().outputDir, 'playwright.config.ts')}: Unexpected token (2:7)`),
+      stack: expect.stringContaining(`SyntaxError: ${path.join(test.info().outputDir, 'playwright.config.ts')}: Unexpected token (2:7)`),
     }
   });
 });


### PR DESCRIPTION
When having e.g. a `SyntaxError` or a `throw new Error` inside a config and using the VSCode extension, there was no error shown in the problems tab. This is because we didn't add the [`location` property](https://github.com/mxschmitt/playwright/blob/4c85672f022beac27a98288a524be2f3687a88f2/packages/playwright/src/runner/testServer.ts#L421) to the `TestError` which we sent back over to VSCode.

Looks like it regressed when migrating to TestServer. Or a bit after it. When using CLI, we add the `location` property` [here](https://github.com/microsoft/playwright/blob/69ffff95e06cc3e3a0c05f1cc7b2776b6301db5f/packages/playwright/src/program.ts#L253).
