### PR TITLE
devops: fix backport client side changes bot

### DIFF
--- a/.github/workflows/pr_check_client_side_changes.yml
+++ b/.github/workflows/pr_check_client_side_changes.yml
@@ -46,7 +46,7 @@ jobs:
             const title = '[Ports]: Backport client side changes for ' + currentPlaywrightVersion;
             for (const repo of ['playwright-python', 'playwright-java', 'playwright-dotnet']) {
               const { data: issuesData } = await github.rest.search.issuesAndPullRequests({
-                q: `is:issue is:open repo:microsoft/${repo} in:title "${title}" author:playwrightmachine`
+                q: `is:issue is:open repo:microsoft/${repo} in:title "${title}"`
               })
               let issueNumber = null;
               let issueBody = '';


### PR DESCRIPTION
Matching by title seems to be save enough I'd say? Seems unique enough.