### PR TITLE
fix(runner): incorporate set project worker count into status messages

### DIFF
--- a/tests/playwright-test/test-parallel.spec.ts
+++ b/tests/playwright-test/test-parallel.spec.ts
@@ -246,4 +246,29 @@ test('parallel mode should display worker count taking project workers into acco
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(4);
   expect(result.output).toContain('Running 4 tests using 3 workers');
+
+  // Multiple parallel projects
+  const result2 = await runInlineTest({
+    'playwright.config.ts': `
+      export default {
+        workers: 12,
+        fullyParallel: true,
+        projects: [
+          { name: 'project1', workers: 3 },
+          { name: 'project2', workers: 4 },
+          { name: 'project3', workers: 4 },
+        ],
+      };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('test1', () => {});
+      test('test2', () => {});
+      test('test3', () => {});
+      test('test4', () => {});
+    `,
+  }, { workers: 12 });
+  expect(result2.exitCode).toBe(0);
+  expect(result2.passed).toBe(12);
+  expect(result2.output).toContain('Running 12 tests using 11 workers');
 });

--- a/tests/playwright-test/test-parallel.spec.ts
+++ b/tests/playwright-test/test-parallel.spec.ts
@@ -223,3 +223,27 @@ test('parallel mode should minimize running beforeAll/afterAll hooks 2', async (
   expect(countTimes(result.output, '%%beforeAll')).toBe(2);
   expect(countTimes(result.output, '%%afterAll')).toBe(2);
 });
+
+test('parallel mode should display worker count taking project workers into account', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      export default {
+        workers: 10,
+        fullyParallel: true,
+        projects: [
+          { name: 'project1', workers: 3 },
+        ],
+      };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('test1', () => {});
+      test('test2', () => {});
+      test('test3', () => {});
+      test('test4', () => {});
+    `,
+  }, { workers: 10 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(4);
+  expect(result.output).toContain('Running 4 tests using 3 workers');
+});


### PR DESCRIPTION
Fixes #35700.

Make sure our metadata override for worker count takes into consideration the active project worker count. As projects can have a variable number of workers, we take the max of these as it is most representative.