### PR TITLE
feat(trace-viewer): Added test results to status line

### DIFF
--- a/packages/trace-viewer/src/ui/uiModeView.css
+++ b/packages/trace-viewer/src/ui/uiModeView.css
@@ -82,23 +82,35 @@
   margin-bottom: 30px;
 }
 
-.status-line {
+.status-line-wrapper {
+  align-items: center;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   flex: auto;
-  height: 40px;
+  height: 30px;
   line-height: 22px;
   padding-left: 10px;
   white-space: nowrap;
 }
 
-.status-line > div {
+.status-line {
+  display: flex;
+  gap: 10px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
+.status-line .progress,
+.test-results .test-result {
+  align-items: center;
+  display: flex;
+  gap: 3px;
+}
+
 .status-line .test-results {
-  //
+  align-items: center;
+  display: flex;
+  gap: 7px;
 }
 
 .ui-mode-sidebar input[type=search] {

--- a/packages/trace-viewer/src/ui/uiModeView.css
+++ b/packages/trace-viewer/src/ui/uiModeView.css
@@ -83,19 +83,22 @@
 }
 
 .status-line {
+  display: flex;
+  flex-direction: column;
   flex: auto;
-  white-space: nowrap;
+  height: 40px;
   line-height: 22px;
   padding-left: 10px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  height: 30px;
+  white-space: nowrap;
 }
 
 .status-line > div {
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.status-line .test-results {
+  //
 }
 
 .ui-mode-sidebar input[type=search] {

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -37,7 +37,6 @@ import { TestListView } from './uiModeTestListView';
 import { TraceView } from './uiModeTraceView';
 import { SettingsView } from './settingsView';
 import { DefaultSettingsView } from './defaultSettingsView';
-import { testStatusIcon } from './testUtils';
 
 let xtermSize = { cols: 80, rows: 24 };
 const xtermDataSource: XtermDataSource = {

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -462,23 +462,26 @@ export const UIModeView: React.FC<{}> = ({
           runTests={() => runTests('bounce-if-busy', visibleTestIds)} />
         <Toolbar noMinHeight={true}>
           {!isRunningTest && !progress && <div className='section-title'>Tests</div>}
-          {progress && <div data-testid='status-line' className='status-line'>
-            <div>
-              {isRunningTest && <span className='codicon codicon-loading' />}
-              {(progress.passed + progress.failed + progress.skipped)}/{progress.total} complete ({((progress.passed + progress.failed + progress.skipped) / progress.total) * 100 | 0}%)
-            </div>
-            <div className='test-results'>
-              <span>
-                <span className='codicon codicon-check'/>
-                {progress.passed}
+          {progress && <div data-testid='status-line' className='status-line-wrapper'>
+            <div className='status-line'>
+              <span className='progress'>
+                {!isRunningTest && <span className='codicon codicon-clock'/>}
+                {isRunningTest && <span className='codicon codicon-loading' />}
+                <span>{(progress.passed + progress.failed + progress.skipped)}/{progress.total} complete ({((progress.passed + progress.failed + progress.skipped) / progress.total) * 100 | 0}%)</span>
               </span>
-              <span>
-                <span className='codicon codicon-error' />
-                {progress.failed}
-              </span>
-              <span>
-                <span className={clsx('action-skipped', 'codicon', testStatusIcon('skipped'))} title='skipped' />
-                {progress.skipped}
+              <span className='test-results'>
+                <span className='test-result'>
+                  <span className='codicon codicon-check'/>
+                  <span>{progress.passed}</span>
+                </span>
+                <span className='test-result'>
+                  <span className='codicon codicon-error'/>
+                  <span>{progress.failed}</span>
+                </span>
+                <span className='test-result'>
+                  <span className='codicon codicon-circle-slash' title='skipped'/>
+                  <span>{progress.skipped}</span>
+                </span>
               </span>
             </div>
           </div>}

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -37,6 +37,7 @@ import { TestListView } from './uiModeTestListView';
 import { TraceView } from './uiModeTraceView';
 import { SettingsView } from './settingsView';
 import { DefaultSettingsView } from './defaultSettingsView';
+import { testStatusIcon } from './testUtils';
 
 let xtermSize = { cols: 80, rows: 24 };
 const xtermDataSource: XtermDataSource = {
@@ -461,11 +462,25 @@ export const UIModeView: React.FC<{}> = ({
           runTests={() => runTests('bounce-if-busy', visibleTestIds)} />
         <Toolbar noMinHeight={true}>
           {!isRunningTest && !progress && <div className='section-title'>Tests</div>}
-          {!isRunningTest && progress && <div data-testid='status-line' className='status-line'>
-            <div>{progress.passed}/{progress.total} passed ({(progress.passed / progress.total) * 100 | 0}%)</div>
-          </div>}
-          {isRunningTest && progress && <div data-testid='status-line' className='status-line'>
-            <div>Running {progress.passed}/{runningState.testIds.size} passed ({(progress.passed / runningState.testIds.size) * 100 | 0}%)</div>
+          {progress && <div data-testid='status-line' className='status-line'>
+            <div>
+              {isRunningTest && <span className='codicon codicon-loading' />}
+              {(progress.passed + progress.failed + progress.skipped)}/{progress.total} complete ({((progress.passed + progress.failed + progress.skipped) / progress.total) * 100 | 0}%)
+            </div>
+            <div className='test-results'>
+              <span>
+                <span className='codicon codicon-check'/>
+                {progress.passed}
+              </span>
+              <span>
+                <span className='codicon codicon-error' />
+                {progress.failed}
+              </span>
+              <span>
+                <span className={clsx('action-skipped', 'codicon', testStatusIcon('skipped'))} title='skipped' />
+                {progress.skipped}
+              </span>
+            </div>
           </div>}
           <ToolbarButton icon='play' title='Run all — F5' onClick={() => runTests('bounce-if-busy', visibleTestIds)} disabled={isRunningTest || isLoading}></ToolbarButton>
           <ToolbarButton icon='debug-stop' title={'Stop — ' + (isMac ? '⇧F5' : 'Shift + F5')} onClick={() => testServerConnection?.stopTests({})} disabled={!isRunningTest || isLoading}></ToolbarButton>

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -461,25 +461,25 @@ export const UIModeView: React.FC<{}> = ({
           runTests={() => runTests('bounce-if-busy', visibleTestIds)} />
         <Toolbar noMinHeight={true}>
           {!isRunningTest && !progress && <div className='section-title'>Tests</div>}
-          {progress && <div data-testid='status-line' className='status-line-wrapper'>
+          {progress && <div className='status-line-wrapper'>
             <div className='status-line'>
               <span className='progress'>
                 {!isRunningTest && <span className='codicon codicon-clock'/>}
                 {isRunningTest && <span className='codicon codicon-loading' />}
-                <span>{(progress.passed + progress.failed + progress.skipped)}/{progress.total} complete ({((progress.passed + progress.failed + progress.skipped) / progress.total) * 100 | 0}%)</span>
+                <span data-testid='progress'>{(progress.passed + progress.failed + progress.skipped)}/{progress.total} complete ({((progress.passed + progress.failed + progress.skipped) / progress.total) * 100 | 0}%)</span>
               </span>
               <span className='test-results'>
                 <span className='test-result'>
                   <span className='codicon codicon-check'/>
-                  <span>{progress.passed}</span>
+                  <span data-testid='test-result-passed'>{progress.passed}</span>
                 </span>
                 <span className='test-result'>
                   <span className='codicon codicon-error'/>
-                  <span>{progress.failed}</span>
+                  <span data-testid='test-result-failed'>{progress.failed}</span>
                 </span>
                 <span className='test-result'>
                   <span className='codicon codicon-circle-slash' title='skipped'/>
-                  <span>{progress.skipped}</span>
+                  <span data-testid='test-result-skipped'>{progress.skipped}</span>
                 </span>
               </span>
             </div>

--- a/tests/playwright-test/ui-mode-metadata.spec.ts
+++ b/tests/playwright-test/ui-mode-metadata.spec.ts
@@ -41,7 +41,8 @@ test('should render html report git info metadata', async ({ runUITest }) => {
   });
 
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByTitle('Toggle output').click();
 
   await expect(page.getByTestId('output')).toContainText('ci.link: https://playwright.dev');

--- a/tests/playwright-test/ui-mode-test-annotations.spec.ts
+++ b/tests/playwright-test/ui-mode-test-annotations.spec.ts
@@ -32,7 +32,8 @@ test('should display annotations', async ({ runUITest }) => {
     `,
   });
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByRole('treeitem', { name: 'suite' }).locator('.codicon-chevron-right').click();
   await page.getByText('annotation test').click();
   await page.getByText('Annotations', { exact: true }).click();

--- a/tests/playwright-test/ui-mode-test-attachments.spec.ts
+++ b/tests/playwright-test/ui-mode-test-attachments.spec.ts
@@ -33,7 +33,8 @@ test('should contain text attachment', async ({ runUITest }) => {
   });
   await page.getByText('attach test').click();
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByText('Attachments').click();
 
   await page.locator('.tab-attachments').getByText('text attachment').click();
@@ -69,7 +70,8 @@ test('should contain binary attachment', async ({ runUITest }) => {
   });
   await page.getByText('attach test').click();
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByText('Attachments').click();
   const downloadPromise = page.waitForEvent('download');
   await page.getByRole('link', { name: 'download' }).click();
@@ -89,7 +91,8 @@ test('should contain string attachment', async ({ runUITest }) => {
   });
   await page.getByText('attach test').click();
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByText('Attachments').click();
   await page.getByText('attach "note"', { exact: true }).click();
   const downloadPromise = page.waitForEvent('download');
@@ -116,7 +119,8 @@ test('should linkify string attachments', async ({ runUITest, server }) => {
   });
   await page.getByText('attach test').click();
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByText('Attachments').click();
 
   const attachmentsPane = page.locator('.attachments-tab');
@@ -162,7 +166,8 @@ test('should link from attachment step to attachments view', async ({ runUITest 
 
   await page.getByText('attach test').click();
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByRole('tab', { name: 'Attachments' }).click();
 
   const panel = page.getByRole('tabpanel', { name: 'Attachments' });

--- a/tests/playwright-test/ui-mode-test-output.spec.ts
+++ b/tests/playwright-test/ui-mode-test-output.spec.ts
@@ -250,7 +250,8 @@ test('should print beforeAll console messages once', async ({ runUITest }, testI
   await page.getByTitle('Run all').click();
   await page.getByText('Console').click();
   await page.getByText('print').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await expect(page.locator('.console-tab .console-line-message')).toHaveText([
     'before all log',
     'test log',

--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -81,7 +81,7 @@ test('should run visible', async ({ runUITest }) => {
           - treeitem "[icon-circle-slash] skipped"
   `);
 
-  await expect(page.getByTestId('progress')).toHaveText('8/8 complete (50%)');
+  await expect(page.getByTestId('progress')).toHaveText('8/8 complete (100%)');
   await expect(page.getByTestId('test-result-passed')).toHaveText('4');
 });
 
@@ -97,10 +97,10 @@ test('should show running progress', async ({ runUITest }) => {
   });
 
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('progress')).toHaveText('Running 4/4 complete (25%)');
+  await expect(page.getByTestId('progress')).toHaveText('Running 4/4 complete (100%)');
   await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByTitle('Stop').click();
-  await expect(page.getByTestId('progress')).toHaveText('4/4 complete (25%)');
+  await expect(page.getByTestId('progress')).toHaveText('4/4 complete (100%)');
   await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByTitle('Reload').click();
   await expect(page.getByTestId('progress')).toBeHidden();
@@ -494,7 +494,7 @@ test('should show time', async ({ runUITest }) => {
           - treeitem "[icon-circle-slash] skipped"
   `);
 
-  await expect(page.getByTestId('progress')).toHaveText('8/8 complete (50%)');
+  await expect(page.getByTestId('progress')).toHaveText('8/8 complete (100%)');
   await expect(page.getByTestId('test-result-passed')).toHaveText('4');
 });
 

--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -81,7 +81,8 @@ test('should run visible', async ({ runUITest }) => {
           - treeitem "[icon-circle-slash] skipped"
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('4/8 passed (50%)');
+  await expect(page.getByTestId('progress')).toHaveText('8/8 complete (50%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('4');
 });
 
 test('should show running progress', async ({ runUITest }) => {
@@ -96,11 +97,13 @@ test('should show running progress', async ({ runUITest }) => {
   });
 
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
+  await expect(page.getByTestId('progress')).toHaveText('Running 4/4 complete (25%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByTitle('Stop').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/4 passed (25%)');
+  await expect(page.getByTestId('progress')).toHaveText('4/4 complete (25%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByTitle('Reload').click();
-  await expect(page.getByTestId('status-line')).toBeHidden();
+  await expect(page.getByTestId('progress')).toBeHidden();
 });
 
 test('should run on hover', async ({ runUITest }) => {
@@ -491,7 +494,8 @@ test('should show time', async ({ runUITest }) => {
           - treeitem "[icon-circle-slash] skipped"
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('4/8 passed (50%)');
+  await expect(page.getByTestId('progress')).toHaveText('8/8 complete (50%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('4');
 });
 
 test('should show test.fail as passing', async ({ runUITest }) => {
@@ -522,7 +526,8 @@ test('should show test.fail as passing', async ({ runUITest }) => {
           - treeitem ${/\[icon-check\] should fail \d+m?s/}
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 });
 
 test('should ignore repeatEach', async ({ runUITest }) => {
@@ -558,7 +563,8 @@ test('should ignore repeatEach', async ({ runUITest }) => {
           - treeitem ${/\[icon-check\] should pass/}
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 });
 
 test('should remove output folder before test run', async ({ runUITest }) => {
@@ -593,7 +599,8 @@ test('should remove output folder before test run', async ({ runUITest }) => {
           - treeitem ${/\[icon-check\] should pass/}
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 
   await page.getByTitle('Run all').click();
   await expect.poll(dumpTestTree(page)).toBe(`
@@ -608,7 +615,8 @@ test('should remove output folder before test run', async ({ runUITest }) => {
           - treeitem ${/\[icon-check\] should pass/}
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 });
 
 test('should show proper total when using deps', async ({ runUITest }) => {
@@ -660,7 +668,8 @@ test('should show proper total when using deps', async ({ runUITest }) => {
           - treeitem "[icon-circle-outline] run @chromium chromium"
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 
   await page.getByTitle('run @chromium').dblclick();
   await expect.poll(dumpTestTree(page)).toBe(`
@@ -680,7 +689,8 @@ test('should show proper total when using deps', async ({ runUITest }) => {
             - button "Watch"
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('2/2 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('2/2 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('2');
 });
 
 test('should respect --tsconfig option', {
@@ -746,7 +756,8 @@ test('should respect --tsconfig option', {
           - treeitem ${/\[icon-check\] test/}
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 });
 
 test('should respect --ignore-snapshots option', {

--- a/tests/playwright-test/ui-mode-test-screencast.spec.ts
+++ b/tests/playwright-test/ui-mode-test-screencast.spec.ts
@@ -35,7 +35,8 @@ test('should show screenshots', async ({ runUITest }) => {
     `,
   });
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('2/2 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('2/2 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('2');
 
   await page.getByText('test 1', { exact: true }).click();
   await expect(page.getByTestId('actions-tree')).toContainText('expect.toBeVisible');

--- a/tests/playwright-test/ui-mode-test-setup.spec.ts
+++ b/tests/playwright-test/ui-mode-test-setup.spec.ts
@@ -47,7 +47,8 @@ test('should run global setup and teardown', async ({ runUITest }, testInfo) => 
     `
   }, undefined, { additionalArgs: ['--output=foo'] });
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 
   await page.getByTitle('Toggle output').click();
   const output = page.getByTestId('output');
@@ -85,7 +86,8 @@ test('should teardown on sigint', async ({ runUITest, nodeVersion }) => {
     `
   });
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByTitle('Toggle output').click();
   await expect(page.getByTestId('output')).toContainText('from-global-setup');
 
@@ -335,7 +337,8 @@ for (const useWeb of [true, false]) {
         `
       }, null, { useWeb });
       await page.getByTitle('Run all').click();
-      await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+      await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+      await expect(page.getByTestId('test-result-passed')).toHaveText('1');
       await testProcess.kill('SIGINT');
       await expect.poll(() => testProcess.outputLines()).toEqual([
         'from-global-teardown0000',
@@ -368,7 +371,8 @@ test('should restart webserver on reload', async ({ runUITest }) => {
     `
   }, { DEBUG: 'pw:webserver' });
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 
   await page.getByTitle('Toggle output').click();
   await expect(page.getByTestId('output')).toContainText('[WebServer] listening');
@@ -381,5 +385,6 @@ test('should restart webserver on reload', async ({ runUITest }) => {
   await expect(page.getByTestId('output')).not.toContainText('set reuseExistingServer:true');
 
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 });

--- a/tests/playwright-test/ui-mode-test-shortcut.spec.ts
+++ b/tests/playwright-test/ui-mode-test-shortcut.spec.ts
@@ -37,7 +37,8 @@ test('should run tests', async ({ runUITest }) => {
   await page.getByPlaceholder('Filter (e.g. text, @tag)').fill('test 3');
   await page.keyboard.press('F5');
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   await page.getByPlaceholder('Filter (e.g. text, @tag)').fill('');
 
   // Only the filtered test was run.

--- a/tests/playwright-test/ui-mode-test-watch.spec.ts
+++ b/tests/playwright-test/ui-mode-test-watch.spec.ts
@@ -279,7 +279,7 @@ test('should queue watches', async ({ runUITest, writeFiles, createLatch }) => {
   await page.getByTitle('Watch all').click();
   await page.getByTitle('Run all').click();
 
-  await expect(page.getByTestId('progress')).toHaveText('Running 4/4 complete (25%)');
+  await expect(page.getByTestId('progress')).toHaveText('Running 4/4 complete (100%)');
   await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 
   await writeFiles({
@@ -290,7 +290,7 @@ test('should queue watches', async ({ runUITest, writeFiles, createLatch }) => {
 
   // Now watches should not kick in.
   await new Promise(f => setTimeout(f, 1000));
-  await expect(page.getByTestId('progress')).toHaveText('Running 1/4 complete (25%)');
+  await expect(page.getByTestId('progress')).toHaveText('Running 1/4 complete (100%)');
   await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 
   // Allow test to finish and new watch to  kick in.

--- a/tests/playwright-test/ui-mode-test-watch.spec.ts
+++ b/tests/playwright-test/ui-mode-test-watch.spec.ts
@@ -128,7 +128,8 @@ test('should batch watch updates', async ({ runUITest, writeFiles }) => {
     'd.test.ts': `import { test } from '@playwright/test'; test('test', () => {});`,
   });
 
-  await expect(page.getByTestId('status-line')).toHaveText('4/4 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('4/4 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('4');
 
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ✅ a.test.ts 👁
@@ -167,7 +168,8 @@ test('should watch all', async ({ runUITest, writeFiles }) => {
     'd.test.ts': `import { test } from '@playwright/test'; test('test', () => {});`,
   });
 
-  await expect(page.getByTestId('status-line')).toHaveText('2/2 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('2/2 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('2');
 
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ✅ a.test.ts
@@ -210,7 +212,8 @@ test('should watch new file', async ({ runUITest, writeFiles }) => {
     'b.test.ts': ` import { test } from '@playwright/test'; test('test', () => {});`,
   });
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ◯ a.test.ts
@@ -276,7 +279,8 @@ test('should queue watches', async ({ runUITest, writeFiles, createLatch }) => {
   await page.getByTitle('Watch all').click();
   await page.getByTitle('Run all').click();
 
-  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
+  await expect(page.getByTestId('progress')).toHaveText('Running 4/4 complete (25%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 
   await writeFiles({
     'a.test.ts': `import { test } from '@playwright/test'; test('test', () => {});`,
@@ -286,12 +290,14 @@ test('should queue watches', async ({ runUITest, writeFiles, createLatch }) => {
 
   // Now watches should not kick in.
   await new Promise(f => setTimeout(f, 1000));
-  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
+  await expect(page.getByTestId('progress')).toHaveText('Running 1/4 complete (25%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 
   // Allow test to finish and new watch to  kick in.
   latch.open();
 
-  await expect(page.getByTestId('status-line')).toHaveText('3/3 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('3/3 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('3');
 });
 
 test('should not watch output', async ({ runUITest }) => {
@@ -316,7 +322,8 @@ test('should not watch output', async ({ runUITest }) => {
 
   await page.getByTitle('Run all').click();
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('1/1 complete (100%)');
+  await expect(page.getByTestId('test-result-passed')).toHaveText('1');
   expect(commands).toContain('runTests');
   expect(commands).not.toContain('listTests');
 });

--- a/tests/playwright-test/ui-mode-test-watch.spec.ts
+++ b/tests/playwright-test/ui-mode-test-watch.spec.ts
@@ -290,7 +290,7 @@ test('should queue watches', async ({ runUITest, writeFiles, createLatch }) => {
 
   // Now watches should not kick in.
   await new Promise(f => setTimeout(f, 1000));
-  await expect(page.getByTestId('progress')).toHaveText('Running 1/4 complete (100%)');
+  await expect(page.getByTestId('progress')).toHaveText('Running 4/4 complete (100%)');
   await expect(page.getByTestId('test-result-passed')).toHaveText('1');
 
   // Allow test to finish and new watch to  kick in.


### PR DESCRIPTION
This adds test results to the status line, showing how many tests passed, failed and was skipped.
It also changes the UI logic in that it show the same UI while running tests and after.

Fixes #34444 