### PR TITLE
devops: eliminate race condition in browser roll PR creation

### DIFF
--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -33,17 +33,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 18
-    - name: Check if branch exists
-      id: check-branch
-      run: |
-        BRANCH_NAME="roll-into-pw-${BROWSER}/${REVISION}"
-        git fetch origin $BRANCH_NAME:$BRANCH_NAME || true
-        if git show-ref --verify --quiet refs/heads/$BRANCH_NAME; then
-          echo "exists=1" >> $GITHUB_OUTPUT
-          echo "branch $BRANCH_NAME already exists, exiting"
-          exit 0
-        fi
-        echo "exists=0" >> $GITHUB_OUTPUT
     - run: npm ci
     - run: npm run build
     - name: Install dependencies
@@ -57,6 +46,15 @@ jobs:
       run: |
         BRANCH_NAME="roll-into-pw-${BROWSER}/${REVISION}"
         echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+        git fetch origin $BRANCH_NAME:$BRANCH_NAME || true
+        if git show-ref --verify --quiet refs/heads/$BRANCH_NAME; then
+          echo "exists=1" >> $GITHUB_OUTPUT
+          echo "branch $BRANCH_NAME already exists, exiting"
+          exit 0
+        fi
+        echo "exists=0" >> $GITHUB_OUTPUT
+
         git config --global user.name microsoft-playwright-automation[bot]
         git config --global user.email 203992400+microsoft-playwright-automation[bot]@users.noreply.github.com
         git checkout -b "$BRANCH_NAME"
@@ -70,7 +68,7 @@ jobs:
         private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
     - name: Create Pull Request
       uses: actions/github-script@v7
-      if: ${{ steps.check-branch.outputs.exists == '0' }}
+      if: ${{ steps.prepare-branch.outputs.exists == '0' }}
       with:
         github-token: ${{ steps.app-token.outputs.token }}
         script: |

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -22,6 +22,9 @@ env:
 permissions:
   contents: write
 
+concurrency: 
+  group: 'roll-browser-into-playwright-${{ github.event.client_payload.browser || github.event.inputs.browser }}-${{ github.event.client_payload.revision || github.event.inputs.revision }}'
+
 jobs:
   roll:
     runs-on: ubuntu-24.04
@@ -30,6 +33,17 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 18
+    - name: Check if branch exists
+      id: check-branch
+      run: |
+        BRANCH_NAME="roll-into-pw-${BROWSER}/${REVISION}"
+        git fetch origin $BRANCH_NAME:$BRANCH_NAME || true
+        if git show-ref --verify --quiet refs/heads/$BRANCH_NAME; then
+          echo "exists=1" >> $GITHUB_OUTPUT
+          echo "branch $BRANCH_NAME already exists, exiting"
+          exit 0
+        fi
+        echo "exists=0" >> $GITHUB_OUTPUT
     - run: npm ci
     - run: npm run build
     - name: Install dependencies
@@ -56,6 +70,7 @@ jobs:
         private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
     - name: Create Pull Request
       uses: actions/github-script@v7
+      if: ${{ steps.check-branch.outputs.exists == '0' }}
       with:
         github-token: ${{ steps.app-token.outputs.token }}
         script: |

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -3,27 +3,17 @@ name: Roll Browser into Playwright
 on:
   repository_dispatch:
     types: [roll_into_pw]
-  workflow_dispatch:
-    inputs:
-      browser:
-        description: 'Browser name, e.g. chromium'
-        required: true
-        type: string
-      revision:
-        description: 'Browser revision without v prefix, e.g. 1234'
-        required: true
-        type: string
 
 env:
   ELECTRON_SKIP_BINARY_DOWNLOAD: 1
-  BROWSER: ${{ github.event.client_payload.browser || github.event.inputs.browser }}
-  REVISION: ${{ github.event.client_payload.revision || github.event.inputs.revision }}
+  BROWSER: ${{ github.event.client_payload.browser }}
+  REVISION: ${{ github.event.client_payload.revision }}
 
 permissions:
   contents: write
 
 concurrency: 
-  group: 'roll-browser-into-playwright-${{ github.event.client_payload.browser || github.event.inputs.browser }}-${{ github.event.client_payload.revision || github.event.inputs.revision }}'
+  group: 'roll-browser-into-playwright-${{ github.event.client_payload.browser }}-${{ github.event.client_payload.revision }}'
 
 jobs:
   roll:


### PR DESCRIPTION
**Problem:**

Parallel ESRP jobs finishing simultaneously triggered multiple instances of the browser roll workflow, leading to duplicate runs and force pushes for the same browser/revision.

**Solution:**

- Added `concurrency` to the workflow, grouped by browser and revision, to ensure only one run proceeds at a time per roll.
- Implemented a check to exit the workflow early if the target branch already exists, preventing redundant PR creation attempts.

This guarantees that only a single PR is created per browser roll.