### PR TITLE
feat(trace): allow adding custom action messages to improve trace readability

### DIFF
--- a/docs/src/frames.md
+++ b/docs/src/frames.md
@@ -11,6 +11,8 @@ A [Page] can have one or more [Frame] objects attached to it. Each page has a ma
 A page can have additional frames attached with the `iframe` HTML tag. These frames can be accessed for interactions
 inside the frame.
 
+You can optionally add a custom `message` when interacting inside frames. This message will appear in traces and logs to make tests easier to understand.
+
 ```js
 // Locate element inside frame
 const username = await page.frameLocator('.frame-class').getByLabel('User Name');
@@ -20,26 +22,26 @@ await username.fill('John');
 ```java
 // Locate element inside frame
 Locator username = page.frameLocator(".frame-class").getByLabel("User Name");
-username.fill("John");
+username.fill("John", new FillOptions().setMessage("Filling username inside frame"));
 ```
 
 ```python async
 # Locate element inside frame
 username = await page.frame_locator('.frame-class').get_by_label('User Name')
-await username.fill('John')
+await username.fill('John', message="Filling username inside frame")
 ```
 
 ```python sync
 # Locate element inside frame
 # Get frame using any other selector
 username = page.frame_locator('.frame-class').get_by_label('User Name')
-username.fill('John')
+username.fill('John', message="Filling username inside frame")
 ```
 
 ```csharp
 // Locate element inside frame
 var username = await page.FrameLocator(".frame-class").GetByLabel("User Name");
-await username.FillAsync("John");
+await username.FillAsync("John", new LocatorFillOptions { Message = "Filling username inside frame" });
 ```
 
 ## Frame objects
@@ -53,8 +55,8 @@ const frame = page.frame('frame-login');
 // Get frame using frame's URL
 const frame = page.frame({ url: /.*domain.*/ });
 
-// Interact with the frame
-await frame.fill('#username-input', 'John');
+// Interact with the frame, with a custom message
+await frame.fill('#username-input', 'John', { message: 'Filling username via frame object' });
 ```
 
 ```java
@@ -64,8 +66,8 @@ Frame frame = page.frame("frame-login");
 // Get frame using frame"s URL
 Frame frame = page.frameByUrl(Pattern.compile(".*domain.*"));
 
-// Interact with the frame
-frame.fill("#username-input", "John");
+// Interact with the frame, with a custom message
+frame.fill("#username-input", "John", new FillOptions().setMessage("Filling username via frame object"));
 ```
 
 ```python async
@@ -75,8 +77,8 @@ frame = page.frame('frame-login')
 # Get frame using frame's URL
 frame = page.frame(url=r'.*domain.*')
 
-# Interact with the frame
-await frame.fill('#username-input', 'John')
+# Interact with the frame, with a custom message
+await frame.fill('#username-input', 'John', message="Filling username via frame object")
 ```
 
 ```python sync
@@ -86,8 +88,8 @@ frame = page.frame('frame-login')
 # Get frame using frame's URL
 frame = page.frame(url=r'.*domain.*')
 
-# Interact with the frame
-frame.fill('#username-input', 'John')
+# Interact with the frame, with a custom message
+frame.fill('#username-input', 'John', message="Filling username via frame object")
 ```
 
 ```csharp

--- a/docs/src/pages.md
+++ b/docs/src/pages.md
@@ -29,11 +29,11 @@ Page page = context.newPage();
 
 // Navigate explicitly, similar to entering a URL in the browser.
 page.navigate("http://example.com");
-// Fill an input.
-page.locator("#search").fill("query");
+// Fill an input with a message.
+page.locator("#search").fill("query", new FillOptions().setMessage("Filling search input"));
 
-// Navigate implicitly by clicking a link.
-page.locator("#submit").click();
+// Navigate implicitly by clicking a link with a message.
+page.locator("#submit").click(new ClickOptions().setMessage("Clicking submit button"));
 // Expect a new url.
 System.out.println(page.url());
 ```

--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -28,6 +28,7 @@ import { Waiter } from './waiter';
 import { assert } from '../utils/isomorphic/assert';
 import { getByAltTextSelector, getByLabelSelector, getByPlaceholderSelector, getByRoleSelector, getByTestIdSelector, getByTextSelector, getByTitleSelector } from '../utils/isomorphic/locatorUtils';
 import { urlMatches } from '../utils/isomorphic/urlMatch';
+import type { CallMetadata } from '../server/instrumentation.ts'
 
 import type { LocatorOptions } from './locator';
 import type { Page } from './page';
@@ -281,10 +282,19 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
     }
     return ElementHandle.from((await this._channel.addStyleTag({ ...copy })).element);
   }
+  
 
-  async click(selector: string, options: channels.FrameClickOptions = {}) {
-    return await this._channel.click({ selector, ...options });
+
+  async click(selector: string, options?: channels.FrameClickOptions & { message?: string }): Promise<void> {
+    return this._wrapApiCall(async metadata => {
+      const callMetadata = metadata as any as CallMetadata;
+      if (options?.message)
+        callMetadata.message = options.message;
+      return this._channel.click({ selector, ...options }, callMetadata);
+    }, false); 
   }
+  
+  
 
   async dblclick(selector: string, options: channels.FrameDblclickOptions = {}) {
     return await this._channel.dblclick({ selector, ...options });
@@ -298,8 +308,12 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
     return await this._channel.tap({ selector, ...options });
   }
 
-  async fill(selector: string, value: string, options: channels.FrameFillOptions = {}) {
-    return await this._channel.fill({ selector, value, ...options });
+  async fill(selector: string, value: string, options?: channels.FrameFillOptions): Promise<void> {
+    return this._wrapApiCall(async metadata => {
+      const callMetadata = metadata as any as CallMetadata;
+      if (options?.message) callMetadata.message = options.message;
+      return this._channel.fill({ selector, value, ...options }, callMetadata);
+    }, false);
   }
 
   async _highlight(selector: string) {
@@ -392,8 +406,12 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
     return (await this._channel.isVisible({ selector, ...options })).value;
   }
 
-  async hover(selector: string, options: channels.FrameHoverOptions = {}) {
-    await this._channel.hover({ selector, ...options });
+  async hover(selector: string, options?: channels.FrameHoverOptions): Promise<void> {
+    return this._wrapApiCall(async metadata => {
+      const callMetadata = metadata as any as CallMetadata;
+      if (options?.message) callMetadata.message = options.message;
+      return this._channel.hover({ selector, ...options }, callMetadata);
+    }, false);
   }
 
   async selectOption(selector: string, values: string | api.ElementHandle | SelectOption | string[] | api.ElementHandle[] | SelectOption[] | null, options: SelectOptionOptions & StrictOptions = {}): Promise<string[]> {

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -650,9 +650,10 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     return this._closed;
   }
 
-  async click(selector: string, options?: channels.FrameClickOptions) {
+  async click(selector: string, options?: channels.FrameClickOptions & { message?: string }): Promise<void> {
     return await this._mainFrame.click(selector, options);
-  }
+  }  
+  
 
   async dragAndDrop(source: string, target: string, options?: channels.FrameDragAndDropOptions) {
     return await this._mainFrame.dragAndDrop(source, target, options);
@@ -666,7 +667,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     return await this._mainFrame.tap(selector, options);
   }
 
-  async fill(selector: string, value: string, options?: channels.FrameFillOptions) {
+  async fill(selector: string, value: string, options?: channels.FrameFillOptions): Promise<void> {
     return await this._mainFrame.fill(selector, value, options);
   }
 
@@ -754,7 +755,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     return await this._mainFrame.isVisible(selector, options);
   }
 
-  async hover(selector: string, options?: channels.FrameHoverOptions) {
+  async hover(selector: string, options?: channels.FrameHoverOptions): Promise<void> {
     return await this._mainFrame.hover(selector, options);
   }
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2255,6 +2255,12 @@ export interface Page {
      * are pressed.
      */
     trial?: boolean;
+
+    /**
+     * An optional human-readable message describing the intent of the action. 
+     * This message will appear in traces and logs to make it easier to understand the purpose of each step.
+     */
+     message?: string;
   }): Promise<void>;
 
   /**

--- a/packages/protocol/src/callMetadata.d.ts
+++ b/packages/protocol/src/callMetadata.d.ts
@@ -43,4 +43,5 @@ export type CallMetadata = {
   pageId?: string;
   frameId?: string;
   potentiallyClosesScope?: boolean;
+  message?: string;
 };

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -2749,6 +2749,7 @@ export type FrameClickOptions = {
   clickCount?: number,
   timeout?: number,
   trial?: boolean,
+  message?: string
 };
 export type FrameClickResult = void;
 export type FrameContentParams = {};
@@ -2842,6 +2843,7 @@ export type FrameFillOptions = {
   strict?: boolean,
   force?: boolean,
   timeout?: number,
+  message: string,
 };
 export type FrameFillResult = void;
 export type FrameFocusParams = {
@@ -2909,6 +2911,7 @@ export type FrameHoverOptions = {
   position?: Point,
   timeout?: number,
   trial?: boolean,
+  message: string,
 };
 export type FrameHoverResult = void;
 export type FrameInnerHTMLParams = {

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -130,7 +130,8 @@ export const renderAction = (
     time = '-';
   return <>
     <div className='action-title' title={action.apiName}>
-      <span>{action.apiName}</span>
+      <span>{action.apiName}</span>   
+     {action.message && <span className="action-message"> — {action.message}</span>}
       {parameterString &&
           (parameterString.type === 'locator' ? (
             <>

--- a/packages/trace/src/trace.ts
+++ b/packages/trace/src/trace.ts
@@ -70,6 +70,7 @@ export type BeforeActionTraceEvent = {
   stack?: StackFrame[];
   pageId?: string;
   parentId?: string;
+  message?: string;
 };
 
 export type InputActionTraceEvent = {

--- a/tests/page/page-messages.spec.ts
+++ b/tests/page/page-messages.spec.ts
@@ -1,0 +1,34 @@
+// tests/page-messages.spec.ts
+import { test, expect } from '@playwright/test';
+import StreamZip from 'node-stream-zip';
+
+test('should record custom action message in trace', async ({ page, context }, testInfo) => {
+ 
+    await context.tracing.start({ screenshots: false, snapshots: false, sources: false });
+
+  await page.setContent(`<button id="btn">Click me</button>`);
+
+  // Perform action with custom message
+  await page.click('#btn', { message: 'Custom click message' });
+
+  // Stop tracing to a file
+  const tracePath = testInfo.outputPath('trace.zip');
+  await context.tracing.stop({ path: tracePath });
+
+  // Unzip and read any JSON files in the trace archive
+  const zip = new StreamZip.async({ file: tracePath });
+  const entries = await zip.entries();
+  let combined = '';
+
+  for (const entryName of Object.keys(entries)) {
+    if (entryName.endsWith('.json')) {
+      const content = await zip.entryData(entryName);
+      combined += content.toString();
+    }
+  }
+
+  await zip.close();
+
+  // Assert custom message shows up in the raw trace data
+  expect(combined).toContain('Custom click message');
+});


### PR DESCRIPTION
Introduced a new  option to input actions like , , etc. Custom messages are recorded in the trace alongside actions, making traces more human-readable and easier to debug.