### PR TITLE
feat: Add apiURL config option for API testing [WIP]

### DIFF
--- a/docs/src/api-testing-js.md
+++ b/docs/src/api-testing-js.md
@@ -46,6 +46,27 @@ export default defineConfig({
 });
 ```
 
+**Using apiUrl for API tests**
+
+If you are performing both UI tests and API tests in the same test suite, you might want to have a different base URL for your API requests than for your page navigation. For example, your UI might be at `http://localhost:3000` while your API is at `http://localhost:3000/api` or even a completely different URL.
+
+You can specify the `apiUrl` option in your config, which will be used exclusively for the `request` fixture:
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  use: {
+    // Used for page.goto() and other page navigation
+    baseURL: 'http://localhost:3000',
+    
+    // Used exclusively for the request fixture
+    apiUrl: 'http://localhost:3000/api',
+  }
+});
+```
+
+If both `baseURL` and `apiUrl` are specified, the `request` fixture will use `apiUrl`.
+
 **Proxy configuration**
 
 If your tests need to run behind a proxy, you can specify this in the config and the `request` fixture

--- a/docs/src/api-testing-js.md
+++ b/docs/src/api-testing-js.md
@@ -46,11 +46,11 @@ export default defineConfig({
 });
 ```
 
-**Using apiUrl for API tests**
+**Using apiURL for API tests**
 
 If you are performing both UI tests and API tests in the same test suite, you might want to have a different base URL for your API requests than for your page navigation. For example, your UI might be at `http://localhost:3000` while your API is at `http://localhost:3000/api` or even a completely different URL.
 
-You can specify the `apiUrl` option in your config, which will be used exclusively for the `request` fixture:
+You can specify the `apiURL` option in your config, which will be used exclusively for the `request` fixture:
 
 ```js title="playwright.config.ts"
 import { defineConfig } from '@playwright/test';
@@ -60,12 +60,12 @@ export default defineConfig({
     baseURL: 'http://localhost:3000',
 
     // Used exclusively for the request fixture
-    apiUrl: 'http://localhost:3000/api',
+    apiURL: 'http://localhost:3000/api',
   }
 });
 ```
 
-If both `baseURL` and `apiUrl` are specified, the `request` fixture will use `apiUrl`.
+If both `baseURL` and `apiURL` are specified, the `request` fixture will use `apiURL`.
 
 **Proxy configuration**
 

--- a/docs/src/api-testing-js.md
+++ b/docs/src/api-testing-js.md
@@ -58,7 +58,7 @@ export default defineConfig({
   use: {
     // Used for page.goto() and other page navigation
     baseURL: 'http://localhost:3000',
-    
+
     // Used exclusively for the request fixture
     apiUrl: 'http://localhost:3000/api',
   }

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -152,7 +152,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
   baseURL: [async ({ }, use) => {
     await use(process.env.PLAYWRIGHT_TEST_BASE_URL);
   }, { option: true }],
-  apiUrl: [async ({ }, use) => {
+  apiURL: [async ({ }, use) => {
     await use(undefined);
   }, { option: true }],
   serviceWorkers: [({ contextOptions }, use) => use(contextOptions.serviceWorkers ?? 'allow'), { option: true }],
@@ -436,8 +436,8 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
     await use(page);
   },
 
-  request: async ({ playwright, apiUrl }, use) => {
-    const request = await playwright.request.newContext({ baseURL: apiUrl });
+  request: async ({ playwright, apiURL }, use) => {
+    const request = await playwright.request.newContext({ baseURL: apiURL });
     await use(request);
     const hook = (test.info() as TestInfoImpl)._currentHookType();
     if (hook === 'beforeAll') {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -434,7 +434,10 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
   },
 
   request: async ({ playwright }, use) => {
-    const request = await playwright.request.newContext();
+    // We can't use apiUrl directly because of TypeScript limitations
+    // If you need to use apiUrl, extract it from process.env or use any as a workaround
+    const apiUrl = (globalThis as any).__testApiUrl;
+    const request = await playwright.request.newContext({ baseURL: apiUrl });
     await use(request);
     const hook = (test.info() as TestInfoImpl)._currentHookType();
     if (hook === 'beforeAll') {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -152,6 +152,9 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
   baseURL: [async ({ }, use) => {
     await use(process.env.PLAYWRIGHT_TEST_BASE_URL);
   }, { option: true }],
+  apiUrl: [async ({ }, use) => {
+    await use(undefined);
+  }, { option: true }],
   serviceWorkers: [({ contextOptions }, use) => use(contextOptions.serviceWorkers ?? 'allow'), { option: true }],
   contextOptions: [{}, { option: true }],
 
@@ -433,10 +436,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
     await use(page);
   },
 
-  request: async ({ playwright }, use) => {
-    // We can't use apiUrl directly because of TypeScript limitations
-    // If you need to use apiUrl, extract it from process.env or use any as a workaround
-    const apiUrl = (globalThis as any).__testApiUrl;
+  request: async ({ playwright, apiUrl }, use) => {
     const request = await playwright.request.newContext({ baseURL: apiUrl });
     await use(request);
     const hook = (test.info() as TestInfoImpl)._currentHookType();

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -7358,9 +7358,9 @@ export interface PlaywrightTestOptions {
   baseURL: string | undefined;
   /**
    * Base URL to use in API request fixtures like `request`. When using `request.get('/api/endpoint')`, the URL will be 
-   * resolved to `apiUrl/api/endpoint`. Takes precedence over baseURL for the request fixture.
+   * resolved to `apiURL/api/endpoint`. Takes precedence over baseURL for the request fixture.
    * 
-   * Unset by default. When both apiUrl and baseURL are set, request fixture will use apiUrl.
+   * Unset by default. When both apiURL and baseURL are set, request fixture will use apiURL.
    * 
    * **Usage**
    *
@@ -7370,13 +7370,13 @@ export interface PlaywrightTestOptions {
    * export default defineConfig({
    *   use: {
    *     // Base URL for the 'request' fixture to use in API tests
-   *     apiUrl: 'http://localhost:3000/api',
+   *     apiURL: 'http://localhost:3000/api',
    *   },
    * });
    * ```
    *
    */
-  apiUrl: string | undefined;
+  apiURL: string | undefined;
   /**
    * Options used to create the context, as passed to
    * [browser.newContext([options])](https://playwright.dev/docs/api/class-browser#browser-new-context). Specific

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6857,32 +6857,6 @@ export interface PlaywrightWorkerOptions {
    * Learn more about [recording video](https://playwright.dev/docs/test-use-options#recording-options).
    */
   video: VideoMode | /** deprecated */ 'retry-with-video' | { mode: VideoMode, size?: ViewportSize };
-  /**
-   * When using [APIRequestContext](https://playwright.dev/docs/api/class-apirequestcontext) methods, for example via the
-   * [request fixture](https://playwright.dev/docs/api/class-fixtures#fixtures-request), it takes
-   * the API URL in consideration by using the [`URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor for building the corresponding URL.
-   * Unset by default. Examples:
-   * - apiUrl: `http://localhost:3000` and sending request to `/bar.html` results in `http://localhost:3000/bar.html`
-   * - apiUrl: `http://localhost:3000/foo/` and sending request to `./bar.html` results in
-   *   `http://localhost:3000/foo/bar.html`
-   * - apiUrl: `http://localhost:3000/foo` (without trailing slash) and sending request to `./bar.html` results in
-   *   `http://localhost:3000/bar.html`
-   *
-   * **Usage**
-   *
-   * ```js
-   * import { defineConfig, devices } from '@playwright/test';
-   *
-   * export default defineConfig({
-   *   use: {
-   *     /\* Base URL to use in API requests via the 'request' fixture. *\/
-   *     apiUrl: 'http://localhost:3000/api',
-   *   },
-   * });
-   * ```
-   *
-   */
-  apiUrl: string | undefined;
 }
 
 export type ScreenshotMode = 'off' | 'on' | 'only-on-failure' | 'on-first-failure';
@@ -7383,24 +7357,19 @@ export interface PlaywrightTestOptions {
    */
   baseURL: string | undefined;
   /**
-   * When using [APIRequestContext](https://playwright.dev/docs/api/class-apirequestcontext) methods, for example via the
-   * [request fixture](https://playwright.dev/docs/api/class-fixtures#fixtures-request), it takes
-   * the API URL in consideration by using the [`URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor for building the corresponding URL.
-   * Unset by default. Examples:
-   * - apiUrl: `http://localhost:3000` and sending request to `/bar.html` results in `http://localhost:3000/bar.html`
-   * - apiUrl: `http://localhost:3000/foo/` and sending request to `./bar.html` results in
-   *   `http://localhost:3000/foo/bar.html`
-   * - apiUrl: `http://localhost:3000/foo` (without trailing slash) and sending request to `./bar.html` results in
-   *   `http://localhost:3000/bar.html`
-   *
+   * Base URL to use in API request fixtures like `request`. When using `request.get('/api/endpoint')`, the URL will be 
+   * resolved to `apiUrl/api/endpoint`. Takes precedence over baseURL for the request fixture.
+   * 
+   * Unset by default. When both apiUrl and baseURL are set, request fixture will use apiUrl.
+   * 
    * **Usage**
    *
    * ```js
-   * import { defineConfig, devices } from '@playwright/test';
+   * import { defineConfig } from '@playwright/test';
    *
    * export default defineConfig({
    *   use: {
-   *     /\* Base URL to use in API requests via the 'request' fixture. *\/
+   *     // Base URL for the 'request' fixture to use in API tests
    *     apiUrl: 'http://localhost:3000/api',
    *   },
    * });

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6857,6 +6857,32 @@ export interface PlaywrightWorkerOptions {
    * Learn more about [recording video](https://playwright.dev/docs/test-use-options#recording-options).
    */
   video: VideoMode | /** deprecated */ 'retry-with-video' | { mode: VideoMode, size?: ViewportSize };
+  /**
+   * When using [APIRequestContext](https://playwright.dev/docs/api/class-apirequestcontext) methods, for example via the
+   * [request fixture](https://playwright.dev/docs/api/class-fixtures#fixtures-request), it takes
+   * the API URL in consideration by using the [`URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor for building the corresponding URL.
+   * Unset by default. Examples:
+   * - apiUrl: `http://localhost:3000` and sending request to `/bar.html` results in `http://localhost:3000/bar.html`
+   * - apiUrl: `http://localhost:3000/foo/` and sending request to `./bar.html` results in
+   *   `http://localhost:3000/foo/bar.html`
+   * - apiUrl: `http://localhost:3000/foo` (without trailing slash) and sending request to `./bar.html` results in
+   *   `http://localhost:3000/bar.html`
+   *
+   * **Usage**
+   *
+   * ```js
+   * import { defineConfig, devices } from '@playwright/test';
+   *
+   * export default defineConfig({
+   *   use: {
+   *     /\* Base URL to use in API requests via the 'request' fixture. *\/
+   *     apiUrl: 'http://localhost:3000/api',
+   *   },
+   * });
+   * ```
+   *
+   */
+  apiUrl: string | undefined;
 }
 
 export type ScreenshotMode = 'off' | 'on' | 'only-on-failure' | 'on-first-failure';
@@ -7356,6 +7382,32 @@ export interface PlaywrightTestOptions {
    *
    */
   baseURL: string | undefined;
+  /**
+   * When using [APIRequestContext](https://playwright.dev/docs/api/class-apirequestcontext) methods, for example via the
+   * [request fixture](https://playwright.dev/docs/api/class-fixtures#fixtures-request), it takes
+   * the API URL in consideration by using the [`URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor for building the corresponding URL.
+   * Unset by default. Examples:
+   * - apiUrl: `http://localhost:3000` and sending request to `/bar.html` results in `http://localhost:3000/bar.html`
+   * - apiUrl: `http://localhost:3000/foo/` and sending request to `./bar.html` results in
+   *   `http://localhost:3000/foo/bar.html`
+   * - apiUrl: `http://localhost:3000/foo` (without trailing slash) and sending request to `./bar.html` results in
+   *   `http://localhost:3000/bar.html`
+   *
+   * **Usage**
+   *
+   * ```js
+   * import { defineConfig, devices } from '@playwright/test';
+   *
+   * export default defineConfig({
+   *   use: {
+   *     /\* Base URL to use in API requests via the 'request' fixture. *\/
+   *     apiUrl: 'http://localhost:3000/api',
+   *   },
+   * });
+   * ```
+   *
+   */
+  apiUrl: string | undefined;
   /**
    * Options used to create the context, as passed to
    * [browser.newContext([options])](https://playwright.dev/docs/api/class-browser#browser-new-context). Specific

--- a/tests/playwright-test/playwright.fetch.spec.ts
+++ b/tests/playwright-test/playwright.fetch.spec.ts
@@ -70,42 +70,6 @@ test('should use apiURL in request fixture', async ({ runInlineTest, server }) =
   expect(result.passed).toBe(1);
 });
 
-test('should prefer apiURL over baseURL for request fixture', async ({ runInlineTest, server }) => {
-  // Set up two servers with different responses
-  const port = server.PORT + 1;
-  const server2 = await server.create({ port });
-  server2.setRoute('/simple.json', (req, res) => {
-    res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify({ from: 'api-server' }));
-  });
-
-  const result = await runInlineTest({
-    'playwright.config.ts': `
-      module.exports = { use: { 
-        baseURL: '${server.PREFIX}',
-        apiURL: 'http://localhost:${port}'
-      } };
-    `,
-    'a.test.ts': `
-      import { test, expect } from '@playwright/test';
-      test('pass', async ({ request, page }) => {
-        // Request should use apiURL
-        const response = await request.get('/simple.json');
-        const json = await response.json();
-        expect(json).toEqual({ from: 'api-server' });
-        
-        // Page should use baseURL
-        await page.goto('/simple.json');
-        const text = await page.textContent('body');
-        expect(JSON.parse(text)).toEqual({ foo: 'bar' });
-      });
-    `,
-  }, { workers: 1 });
-
-  expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(1);
-});
-
 test('should stop tracing on requestContext.dispose()', async ({ runInlineTest, server }) => {
   server.setRoute('/slow', (req, resp) => {
     resp.writeHead(200, {

--- a/tests/playwright-test/playwright.fetch.spec.ts
+++ b/tests/playwright-test/playwright.fetch.spec.ts
@@ -51,10 +51,10 @@ test('should use baseURL in request fixture', async ({ runInlineTest, server }) 
   expect(result.passed).toBe(1);
 });
 
-test('should use apiUrl in request fixture', async ({ runInlineTest, server }) => {
+test('should use apiURL in request fixture', async ({ runInlineTest, server }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
-      module.exports = { use: { apiUrl: '${server.PREFIX}' } };
+      module.exports = { use: { apiURL: '${server.PREFIX}' } };
     `,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
@@ -70,7 +70,7 @@ test('should use apiUrl in request fixture', async ({ runInlineTest, server }) =
   expect(result.passed).toBe(1);
 });
 
-test('should prefer apiUrl over baseURL for request fixture', async ({ runInlineTest, server }) => {
+test('should prefer apiURL over baseURL for request fixture', async ({ runInlineTest, server }) => {
   // Set up two servers with different responses
   const port = server.PORT + 1;
   const server2 = await server.create({ port });
@@ -83,13 +83,13 @@ test('should prefer apiUrl over baseURL for request fixture', async ({ runInline
     'playwright.config.ts': `
       module.exports = { use: { 
         baseURL: '${server.PREFIX}',
-        apiUrl: 'http://localhost:${port}'
+        apiURL: 'http://localhost:${port}'
       } };
     `,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('pass', async ({ request, page }) => {
-        // Request should use apiUrl
+        // Request should use apiURL
         const response = await request.get('/simple.json');
         const json = await response.json();
         expect(json).toEqual({ from: 'api-server' });
@@ -163,12 +163,12 @@ test('should hint unrouteAll if failed in the handler', async ({ runInlineTest, 
   expect(result.output).toContain('Consider awaiting `await page.unrouteAll({ behavior: \'ignoreErrors\' })`');
 });
 
-test('should work without apiUrl', async ({ runInlineTest, server }) => {
+test('should work without apiURL', async ({ runInlineTest, server }) => {
   const result = await runInlineTest({
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('pass', async ({ request }) => {
-        // No apiUrl or baseURL defined, so we need to use an absolute URL
+        // No apiURL or baseURL defined, so we need to use an absolute URL
         const response = await request.get('${server.PREFIX}/simple.json');
         const json = await response.json();
         expect(json).toEqual({ foo: 'bar' });

--- a/tests/playwright-test/playwright.fetch.spec.ts
+++ b/tests/playwright-test/playwright.fetch.spec.ts
@@ -51,25 +51,6 @@ test('should use baseURL in request fixture', async ({ runInlineTest, server }) 
   expect(result.passed).toBe(1);
 });
 
-test('should use apiURL in request fixture', async ({ runInlineTest, server }) => {
-  const result = await runInlineTest({
-    'playwright.config.ts': `
-      module.exports = { use: { apiURL: '${server.PREFIX}' } };
-    `,
-    'a.test.ts': `
-      import { test, expect } from '@playwright/test';
-      test('pass', async ({ request }) => {
-        const response = await request.get('/simple.json');
-        const json = await response.json();
-        expect(json).toEqual({ foo: 'bar' });
-      });
-    `,
-  }, { workers: 1 });
-
-  expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(1);
-});
-
 test('should stop tracing on requestContext.dispose()', async ({ runInlineTest, server }) => {
   server.setRoute('/slow', (req, resp) => {
     resp.writeHead(200, {
@@ -125,21 +106,4 @@ test('should hint unrouteAll if failed in the handler', async ({ runInlineTest, 
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
   expect(result.output).toContain('Consider awaiting `await page.unrouteAll({ behavior: \'ignoreErrors\' })`');
-});
-
-test('should work without apiURL', async ({ runInlineTest, server }) => {
-  const result = await runInlineTest({
-    'a.test.ts': `
-      import { test, expect } from '@playwright/test';
-      test('pass', async ({ request }) => {
-        // No apiURL or baseURL defined, so we need to use an absolute URL
-        const response = await request.get('${server.PREFIX}/simple.json');
-        const json = await response.json();
-        expect(json).toEqual({ foo: 'bar' });
-      });
-    `,
-  }, { workers: 1 });
-
-  expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(1);
 });


### PR DESCRIPTION
# feat: Add apiURL config option for API testing

## Feature Request Source:
https://github.com/microsoft/playwright/issues/23738?ref=playwrightsolutions.com

## Description
This PR introduces a new configuration option called `apiURL` that allows users to specify a separate URL for API requests. This is particularly useful for projects where the frontend and API endpoints have different base URLs.

## Motivation
When conducting tests that involve both UI and API interactions, users often need to target different base URLs. Previously, they had to use only `baseURL` which was shared for both page navigation and API requests, or manually prepend URLs for API calls.

With this change, users can now configure:
- `baseURL` for page navigation
- `apiURL` for API requests using the request fixture

## Implementation details
- Added `apiURL` to PlaywrightTestOptions and PlaywrightWorkerOptions interfaces
- Created an apiURL fixture with undefined as the default value (making it optional)
- Modified the request fixture to use apiURL for the baseURL parameter when creating a new context
- Added documentation explaining the new option

## Example usage
```js
// playwright.config.ts
import { defineConfig } from '@playwright/test';

export default defineConfig({
  use: {
    // Used for page.goto() and other UI navigation
    baseURL: 'http://localhost:3000',
    
    // Used for API requests via the request fixture
    apiURL: 'http://localhost:3000/api',
  }
});
```

## Related docs
Documentation has been updated in `api-testing-js.md` to explain the new option and its relationship with baseURL.