### PR TITLE
fix(network): Include subdomains of localhost when including cookies

### DIFF
--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -43,12 +43,16 @@ export function filterCookies(cookies: channels.NetworkCookie[], urls: string[])
         continue;
       if (!parsedURL.pathname.startsWith(c.path))
         continue;
-      if (parsedURL.protocol !== 'https:' && parsedURL.hostname !== 'localhost' && c.secure)
+      if (parsedURL.protocol !== 'https:' && !isLocalHostname(parsedURL.hostname) && c.secure)
         continue;
       return true;
     }
     return false;
   });
+}
+
+function isLocalHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname.endsWith('.localhost');
 }
 
 // Rollover to 5-digit year:


### PR DESCRIPTION
Replaced the direct check for `parsedURL.hostname === 'localhost'` with a new helper function `isLocalHostname`, which also considers hostnames ending with `.localhost` as local. This improves flexibility and correctness when handling local hostnames.

See also [RFC 6761 section 6.3](https://datatracker.ietf.org/doc/html/rfc6761#section-6.3) on handling of `localhost`.