### PR TITLE
fix(network): Include subdomains of localhost when including cookies

### DIFF
--- a/packages/playwright-core/src/server/cookieStore.ts
+++ b/packages/playwright-core/src/server/cookieStore.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { kMaxCookieExpiresDateInSeconds } from './network';
+import { isLocalHostname, kMaxCookieExpiresDateInSeconds } from './network';
 
 import type * as channels from '@protocol/channels';
 
@@ -30,7 +30,7 @@ class Cookie {
 
   // https://datatracker.ietf.org/doc/html/rfc6265#section-5.4
   matches(url: URL): boolean {
-    if (this._raw.secure && (url.protocol !== 'https:' && url.hostname !== 'localhost'))
+    if (this._raw.secure && (url.protocol !== 'https:' && !isLocalHostname(url.hostname)))
       return false;
     if (!domainMatches(url.hostname, this._raw.domain))
       return false;

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -43,12 +43,16 @@ export function filterCookies(cookies: channels.NetworkCookie[], urls: string[])
         continue;
       if (!parsedURL.pathname.startsWith(c.path))
         continue;
-      if (parsedURL.protocol !== 'https:' && parsedURL.hostname !== 'localhost' && c.secure)
+      if (parsedURL.protocol !== 'https:' && !isLocalHostname(parsedURL.hostname) && c.secure)
         continue;
       return true;
     }
     return false;
   });
+}
+
+function isLocalHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname.endsWith('.localhost');
 }
 
 // Rollover to 5-digit year:

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -51,7 +51,7 @@ export function filterCookies(cookies: channels.NetworkCookie[], urls: string[])
   });
 }
 
-function isLocalHostname(hostname: string): boolean {
+export function isLocalHostname(hostname: string): boolean {
   return hostname === 'localhost' || hostname.endsWith('.localhost');
 }
 

--- a/tests/library/global-fetch-cookie.spec.ts
+++ b/tests/library/global-fetch-cookie.spec.ts
@@ -145,10 +145,11 @@ it('should send secure cookie over http for subdomains of localhost', async ({ r
     res.setHeader('Set-Cookie', ['a=v; secure', 'b=v']);
     res.end();
   });
-  await request.get(`${`http://a.b.localhost:${server.PORT}`}/setcookie.html`);
+  const prefix = `http://a.b.localhost:${server.PORT}`;
+  await request.get(`${prefix}/setcookie.html`);
   const [serverRequest] = await Promise.all([
     server.waitForRequest('/empty.html'),
-    request.get(server.EMPTY_PAGE)
+    request.get(`${prefix}/empty.html`)
   ]);
   expect(serverRequest.headers.cookie).toBe('a=v; b=v');
 });


### PR DESCRIPTION
Replaced the direct check for `parsedURL.hostname === 'localhost'` with a new helper function `isLocalHostname`, which also considers hostnames ending with `.localhost` as local. This improves flexibility and correctness when handling local hostnames.

See also [RFC 6761 section 6.3](https://datatracker.ietf.org/doc/html/rfc6761#section-6.3) on handling of `localhost`.