### PR TITLE
fix(html): allow long test paths to wrap

### DIFF
--- a/packages/html-reporter/src/testCaseView.css
+++ b/packages/html-reporter/src/testCaseView.css
@@ -34,6 +34,20 @@
   color: var(--color-fg-default);
 }
 
+.test-case-header div {
+  flex-shrink: 0;
+}
+
+.test-case-header div.test-case-path {
+  flex-shrink: 1;
+}
+
+.test-case-path {
+  flex: none;
+  align-items: center;
+  padding: 0 8px;
+}
+
 .test-case-title {
   flex: none;
   padding: 8px;
@@ -53,12 +67,6 @@
 .test-case-run-duration {
   color: var(--color-fg-subtle);
   padding-left: 8px;
-}
-
-.test-case-path {
-  flex: none;
-  align-items: center;
-  padding: 0 8px;
 }
 
 .test-case-annotation {

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -44,7 +44,7 @@ export const TestCaseView: React.FC<{
   const visibleTestAnnotations = test.annotations.filter(a => !a.type.startsWith('_')) ?? [];
 
   return <>
-    <div className='hbox'>
+    <div className='hbox test-case-header'>
       <div className='test-case-path'>{test.path.join(' › ')}</div>
       <div style={{ flex: 'auto' }}></div>
       <div className={clsx(!prev && 'hidden')}><Link href={testResultHref({ test: prev }) + filterParam}>« previous</Link></div>


### PR DESCRIPTION
Properly mark test path `div` as being able to shrink.

## Before

<img width="1347" alt="Screenshot 2025-04-28 at 8 56 11 AM" src="https://github.com/user-attachments/assets/1f0e50d3-9332-451e-8e48-817d530316dd" />

## After

<img width="1029" alt="Screenshot 2025-04-28 at 10 17 08 AM" src="https://github.com/user-attachments/assets/a81cc335-4b5f-48df-bb3f-956c76b3c05c" />

Fixes #35699.