### PR TITLE
accessibility-testing-js.md: Fix incorrect equality call

### DIFF
--- a/docs/src/accessibility-testing-js.md
+++ b/docs/src/accessibility-testing-js.md
@@ -44,7 +44,7 @@ test.describe('homepage', () => { // 2
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze(); // 4
 
-    expect(accessibilityScanResults.violations).toEqual([]); // 5
+    expect(accessibilityScanResults.violations).toStrictEqual([]); // 5
   });
 });
 ```
@@ -59,7 +59,7 @@ test.describe('homepage', () => { // 2
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze(); // 4
 
-    expect(accessibilityScanResults.violations).toEqual([]); // 5
+    expect(accessibilityScanResults.violations).toStrictEqual([]); // 5
   });
 });
 ```
@@ -89,7 +89,7 @@ test('navigation menu should not have automatically detectable accessibility vio
       .include('#navigation-menu-flyout')
       .analyze();
 
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(accessibilityScanResults.violations).toStrictEqual([]);
 });
 ```
 
@@ -109,7 +109,7 @@ test('should not have any automatically detectable WCAG A or AA violations', asy
       .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
       .analyze();
 
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(accessibilityScanResults.violations).toStrictEqual([]);
 });
 ```
 
@@ -139,7 +139,7 @@ test('should not have any accessibility violations outside of elements with know
       .exclude('#element-with-known-issue')
       .analyze();
 
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(accessibilityScanResults.violations).toStrictEqual([]);
 });
 ```
 
@@ -161,7 +161,7 @@ test('should not have any accessibility violations outside of rules with known i
       .disableRules(['duplicate-id'])
       .analyze();
 
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(accessibilityScanResults.violations).toStrictEqual([]);
 });
 ```
 
@@ -214,7 +214,7 @@ test('example with attachment', async ({ page }, testInfo) => {
     contentType: 'application/json'
   });
 
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(accessibilityScanResults.violations).toStrictEqual([]);
 });
 ```
 
@@ -291,6 +291,6 @@ test('example using custom fixture', async ({ page, makeAxeBuilder }) => {
       .include('#specific-element-under-test')
       .analyze();
 
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(accessibilityScanResults.violations).toStrictEqual([]);
 });
 ```


### PR DESCRIPTION
My tests were failing with the way mentioned in the docs. 

This was the error:
```js
1) [chromium] › headlamp.spec.ts:38:5 › service page should have headlamp service ────────────────
    Error: expect(received).toBe(expected) // Object.is equality
    If it should pass with deep equality, replace "toBe" with "toStrictEqual"
    Expected: []
    Received: serializes to the same string
       at headlampPage.ts:18
      16 |       console.error(JSON.stringify(accessibilityResults.violations));
      17 |     }
    > 18 |     expect(accessibilityResults.violations).toBe([]);
         |                                             ^
      19 |   }
      20 |
      21 |   async authenticate(token?: string) {
        at HeadlampPage.a11y (/home/runner/work/headlamp/headlamp/e2e-tests/tests/headlampPage.ts:18:45)
        at /home/runner/work/headlamp/headlamp/e2e-tests/tests/headlamp.spec.ts:44:3
```

toStrictEqual() works, so I made changes to the docs to use that.