### PR TITLE
chore(html): normalize header between views

### DIFF
--- a/packages/html-reporter/src/headerView.css
+++ b/packages/html-reporter/src/headerView.css
@@ -38,6 +38,15 @@
 }
 
 @media only screen and (max-width: 600px) {
+  .header-view {
+    padding: 0;
+  }
+
+  .header-view div {
+    /* Allow all header elements to wrap */
+    flex-shrink: 1;
+  }
+
   .header-view-status-container {
     float: none;
     margin: 0 0 10px 0 !important;

--- a/packages/html-reporter/src/headerView.css
+++ b/packages/html-reporter/src/headerView.css
@@ -18,12 +18,23 @@
   float: right;
 }
 
+.header-view {
+  padding: 12px 8px 0 8px;
+}
+
+.header-view div {
+  flex-shrink: 0;
+}
+
+.header-superheader {
+  color: var(--color-fg-muted);
+}
+
 .header-title {
   flex: none;
-  padding: 8px;
   font-weight: 400;
-  font-size: 32px !important;
-  line-height: 1.25 !important;
+  font-size: 32px;
+  line-height: 1.25;
 }
 
 @media only screen and (max-width: 600px) {

--- a/packages/html-reporter/src/headerView.spec.tsx
+++ b/packages/html-reporter/src/headerView.spec.tsx
@@ -15,14 +15,14 @@
  */
 
 import { test, expect } from '@playwright/experimental-ct-react';
-import { HeaderView } from './headerView';
+import { GlobalFilterView } from './headerView';
 import { SearchParamsProvider } from './links';
 
 test.use({ viewport: { width: 720, height: 200 } });
 
 test('should render counters', async ({ mount }) => {
   const component = await mount(<SearchParamsProvider>
-    <HeaderView stats={{
+    <GlobalFilterView stats={{
       total: 100,
       expected: 42,
       unexpected: 31,
@@ -46,7 +46,7 @@ test('should render counters', async ({ mount }) => {
 test('should toggle filters', async ({ page, mount }) => {
   const filters: string[] = [];
   const component = await mount(<SearchParamsProvider>
-    <HeaderView
+    <GlobalFilterView
       stats={{
         total: 100,
         expected: 42,

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -25,6 +25,21 @@ import { statusIcon } from './statusIcon';
 import { filterWithToken } from './filter';
 
 export const HeaderView: React.FC<{
+  title: string | undefined,
+  leftSuperHeader?: React.ReactNode,
+  rightSuperHeader?: React.ReactNode,
+}> = ({ title, leftSuperHeader, rightSuperHeader }) => {
+  return <div className='header-view'>
+    <div className='hbox header-superheader'>
+      {leftSuperHeader}
+      <div style={{ flex: 'auto' }}></div>
+      {rightSuperHeader}
+    </div>
+    {title && <div className='header-title'>{title}</div>}
+  </div>;
+};
+
+export const GlobalFilterView: React.FC<{
   stats: Stats,
   filterText: string,
   setFilterText: (filterText: string) => void,
@@ -58,8 +73,6 @@ export const HeaderView: React.FC<{
     </div>
   </>);
 };
-
-export const HeaderTitleView: React.FC<{ title: string }> = ({ title }) => <div className='header-title'>{title}</div>;
 
 const StatsNavView: React.FC<{
   stats: Stats

--- a/packages/html-reporter/src/metadataView.css
+++ b/packages/html-reporter/src/metadataView.css
@@ -17,7 +17,7 @@
 .metadata-toggle {
   cursor: pointer;
   user-select: none;
-  margin-left: 5px;
+  margin-left: 8px;
   color: var(--color-fg-default);
 }
 

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -83,7 +83,7 @@ export const ReportView: React.FC<{
 
   return <div className='htmlreport vbox px-4 pb-4'>
     <main>
-      {report?.json() && <GlobalFilterView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText}></GlobalFilterView>}
+      {report?.json() && <GlobalFilterView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText} />}
       <Route predicate={testFilesRoutePredicate}>
         <TestFilesHeader report={report?.json()} filteredStats={filteredStats} metadataVisible={metadataVisible} toggleMetadataVisible={() => setMetadataVisible(visible => !visible)}/>
         <TestFilesView

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -19,7 +19,7 @@ import * as React from 'react';
 import './colors.css';
 import './common.css';
 import { Filter } from './filter';
-import { HeaderTitleView, HeaderView } from './headerView';
+import { HeaderView, GlobalFilterView } from './headerView';
 import { Route, SearchParamsContext } from './links';
 import type { LoadedReport } from './loadedReport';
 import './reportView.css';
@@ -83,7 +83,7 @@ export const ReportView: React.FC<{
 
   return <div className='htmlreport vbox px-4 pb-4'>
     <main>
-      {report?.json() && <HeaderView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText}></HeaderView>}
+      {report?.json() && <GlobalFilterView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText}></GlobalFilterView>}
       <Route predicate={testFilesRoutePredicate}>
         <TestFilesHeader report={report?.json()} filteredStats={filteredStats} metadataVisible={metadataVisible} toggleMetadataVisible={() => setMetadataVisible(visible => !visible)}/>
         <TestFilesView
@@ -136,7 +136,7 @@ const TestCaseViewLoader: React.FC<{
 
   if (test === 'not-found') {
     return <div className='test-case-column vbox'>
-      <HeaderTitleView title='Test not found' />
+      <HeaderView title='Test not found' />
       <div className='test-case-location'>Test ID: {testId}</div>
     </div>;
   }

--- a/packages/html-reporter/src/testCaseView.css
+++ b/packages/html-reporter/src/testCaseView.css
@@ -16,7 +16,7 @@
 
 .test-case-column {
   border-radius: 6px;
-  margin: 12px 0 24px 0;
+  margin-bottom: 24px;
 }
 
 .test-case-column .tab-element.selected {
@@ -47,10 +47,11 @@
   padding-left: 8px;
 }
 
-.test-case-path {
+.header-view .test-case-path {
   flex: none;
+  flex-shrink: 1;
   align-items: center;
-  padding: 0 8px;
+  padding-right: 8px;
 }
 
 .test-case-annotation {

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -28,7 +28,7 @@ import { linkifyText } from '@web/renderUtils';
 import { hashStringToInt, msToString } from './utils';
 import { clsx } from '@web/uiUtils';
 import { CopyToClipboardContainer } from './copyToClipboard';
-import { HeaderTitleView } from './headerView';
+import { HeaderView } from './headerView';
 
 export const TestCaseView: React.FC<{
   projectNames: string[],
@@ -45,14 +45,15 @@ export const TestCaseView: React.FC<{
   const visibleTestAnnotations = test.annotations.filter(a => !a.type.startsWith('_')) ?? [];
 
   return <>
-    <div className='hbox'>
-      <div className='test-case-path'>{test.path.join(' › ')}</div>
-      <div style={{ flex: 'auto' }}></div>
-      <div className={clsx(!prev && 'hidden')}><Link href={testResultHref({ test: prev }) + filterParam}>« previous</Link></div>
-      <div style={{ width: 10 }}></div>
-      <div className={clsx(!next && 'hidden')}><Link href={testResultHref({ test: next }) + filterParam}>next »</Link></div>
-    </div>
-    <HeaderTitleView title={test.title} />
+    <HeaderView
+      title={test.title}
+      leftSuperHeader={<div className='test-case-path'>{test.path.join(' › ')}</div>}
+      rightSuperHeader={<>
+        <div className={clsx(!prev && 'hidden')}><Link href={testResultHref({ test: prev }) + filterParam}>« previous</Link></div>
+        <div style={{ width: 10 }}></div>
+        <div className={clsx(!next && 'hidden')}><Link href={testResultHref({ test: next }) + filterParam}>next »</Link></div>
+      </>}
+    />
     <div className='hbox'>
       <div className='test-case-location'>
         <CopyToClipboardContainer value={`${test.location.file}:${test.location.line}`}>

--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -85,5 +85,5 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--color-fg-subtle);
+  color: var(--color-fg-muted);
 }

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -23,7 +23,7 @@ import { AutoChip } from './chip';
 import { TestErrorView } from './testErrorView';
 import * as icons from './icons';
 import { isMetadataEmpty, MetadataView } from './metadataView';
-import { HeaderTitleView } from './headerView';
+import { HeaderView } from './headerView';
 
 export const TestFilesView: React.FC<{
   tests: TestFileSummary[],
@@ -70,21 +70,23 @@ export const TestFilesHeader: React.FC<{
 }> = ({ report, filteredStats, metadataVisible, toggleMetadataVisible }) => {
   if (!report)
     return null;
+
+  const leftSuperHeader = <div className='test-file-header-info'>
+    {report.projectNames.length === 1 && !!report.projectNames[0] && <div data-testid='project-name'>Project: {report.projectNames[0]}</div>}
+    {filteredStats && <div data-testid='filtered-tests-count'>Filtered: {filteredStats.total} {!!filteredStats.total && ('(' + msToString(filteredStats.duration) + ')')}</div>}
+  </div>;
+
+  const rightSuperHeader = <>
+    <div data-testid='overall-time' style={{ marginRight: '10px' }}>{report ? new Date(report.startTime).toLocaleString() : ''}</div>
+    <div data-testid='overall-duration'>Total time: {msToString(report.duration ?? 0)}</div>
+  </>;
+
   return <>
-    <div className='mx-1' style={{ display: 'flex', marginTop: 10 }}>
-      <div className='test-file-header-info'>
-        {!isMetadataEmpty(report.metadata) && <div className='metadata-toggle' role='button' onClick={toggleMetadataVisible} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
-          {metadataVisible ? icons.downArrow() : icons.rightArrow()}Metadata
-        </div>}
-        {report.projectNames.length === 1 && !!report.projectNames[0] && <div data-testid='project-name'>Project: {report.projectNames[0]}</div>}
-        {filteredStats && <div data-testid='filtered-tests-count'>Filtered: {filteredStats.total} {!!filteredStats.total && ('(' + msToString(filteredStats.duration) + ')')}</div>}
-      </div>
-      <div style={{ flex: 'auto' }}></div>
-      <div data-testid='overall-time' style={{ color: 'var(--color-fg-subtle)', marginRight: '10px' }}>{report ? new Date(report.startTime).toLocaleString() : ''}</div>
-      <div data-testid='overall-duration' style={{ color: 'var(--color-fg-subtle)' }}>Total time: {msToString(report.duration ?? 0)}</div>
-    </div>
+    <HeaderView title={report.title} leftSuperHeader={leftSuperHeader} rightSuperHeader={rightSuperHeader} />
+    {!isMetadataEmpty(report.metadata) && <div className='metadata-toggle' role='button' onClick={toggleMetadataVisible} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
+      {metadataVisible ? icons.downArrow() : icons.rightArrow()}Metadata
+    </div>}
     {metadataVisible && <MetadataView metadata={report.metadata}/>}
-    {report.title && <HeaderTitleView title={report.title} />}
     {!!report.errors.length && <AutoChip header='Errors' dataTestId='report-errors'>
       {report.errors.map((error, index) => <TestErrorView key={'test-report-error-message-' + index} error={error}></TestErrorView>)}
     </AutoChip>}


### PR DESCRIPTION
Normalize how headers are displayed between the test list and on test cases/results. Contains the fix of #35781 (fixes #35699).

Additionally fixes some color and padding issues.

----

I am not happy with the spacing with the row immediately below the title (metadata dropdown, if available, or the test file and execution time), but it is consistent and unchanged.

<img width="1000" alt="Screenshot 2025-04-29 at 12 51 17 PM" src="https://github.com/user-attachments/assets/8f11e0a2-36c9-4301-9a46-851a6c35d253" />

<img width="995" alt="Screenshot 2025-04-29 at 12 46 32 PM" src="https://github.com/user-attachments/assets/d5ffb923-b1b7-4a79-b867-bee6ad3ddef4" />

<img width="1001" alt="Screenshot 2025-04-29 at 12 46 36 PM" src="https://github.com/user-attachments/assets/955e9cec-a9e6-41c2-bf65-309f97c71059" />

<img width="998" alt="Screenshot 2025-04-29 at 12 48 07 PM" src="https://github.com/user-attachments/assets/c44fad9e-91f1-4312-8c3b-0ad58bf5954f" />

<img width="1007" alt="Screenshot 2025-04-29 at 12 48 31 PM" src="https://github.com/user-attachments/assets/bb389a91-3c1a-4109-96ca-7ceb136bfc8c" />
