### PR TITLE
fix: avoid broken URL in reporter message

### DIFF
--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -285,7 +285,7 @@ export class TerminalReporter implements ReporterV2 {
       console.log(this.screen.colors.yellow('  Slow test file: ') + file + this.screen.colors.yellow(` (${milliseconds(duration)})`));
     });
     if (slowTests.length)
-      console.log(this.screen.colors.yellow('  Consider running tests from slow files in parallel, see https://playwright.dev/docs/test-parallel.'));
+      console.log(this.screen.colors.yellow('  Consider running tests from slow files in parallel. See: https://playwright.dev/docs/test-parallel'));
   }
 
   private _printSummary(summary: string) {


### PR DESCRIPTION
The period after the URL was being interpreted as part of the URL in some terminals. This fix removes period after URL to ensure it's clickable and valid.

Closes https://github.com/microsoft/playwright/issues/35831