### PR TITLE
chore: remove setUnderTest

### DIFF
--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -21,7 +21,7 @@ import { BrowserContext, assertBrowserContextIsNotOwned, verifyGeolocation } fro
 import { TargetClosedError } from '../errors';
 import { kPlaywrightBinding } from '../javascript';
 import * as network from '../network';
-import { getUtilityInitScript } from '../page';
+import { kUtilityInitScript } from '../page';
 import { ConnectionEvents, FFConnection  } from './ffConnection';
 import { FFPage } from './ffPage';
 
@@ -379,7 +379,7 @@ export class FFBrowserContext extends BrowserContext {
   private async _updateInitScripts() {
     const bindingScripts = [...this._pageBindings.values()].map(binding => binding.initScript.source);
     const initScripts = this.initScripts.map(script => script.source);
-    await this._browser.session.send('Browser.setInitScripts', { browserContextId: this._browserContextId, scripts: [getUtilityInitScript().source, ...bindingScripts, ...initScripts].map(script => ({ script })) });
+    await this._browser.session.send('Browser.setInitScripts', { browserContextId: this._browserContextId, scripts: [kUtilityInitScript.source, ...bindingScripts, ...initScripts].map(script => ({ script })) });
   }
 
   async doUpdateRequestInterception(): Promise<void> {

--- a/packages/playwright-core/src/server/utils/debug.ts
+++ b/packages/playwright-core/src/server/utils/debug.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getFromENV } from './env';
+import { getFromENV, getAsBooleanFromENV } from './env';
 
 const _debugMode = getFromENV('PWDEBUG') || '';
 
@@ -26,11 +26,7 @@ export function debugMode() {
   return _debugMode ? 'inspector' : '';
 }
 
-let _isUnderTest = !!process.env.PWTEST_UNDER_TEST;
-export function setUnderTest() {
-  _isUnderTest = true;
-}
-
+const _isUnderTest = getAsBooleanFromENV('PWTEST_UNDER_TEST');
 export function isUnderTest(): boolean {
   return _isUnderTest;
 }

--- a/tests/android/playwright.config.ts
+++ b/tests/android/playwright.config.ts
@@ -16,6 +16,7 @@
 
 import { config as loadEnv } from 'dotenv';
 loadEnv({ path: path.join(__dirname, '..', '..', '.env') });
+process.env.PWTEST_UNDER_TEST = '1';
 
 import type { Config, PlaywrightTestOptions, PlaywrightWorkerOptions } from '@playwright/test';
 import * as path from 'path';

--- a/tests/bidi/playwright.config.ts
+++ b/tests/bidi/playwright.config.ts
@@ -16,6 +16,7 @@
 
 import { config as loadEnv } from 'dotenv';
 loadEnv({ path: path.join(__dirname, '..', '..', '.env'), override: true });
+process.env.PWTEST_UNDER_TEST = '1';
 
 import { type Config, type PlaywrightTestOptions, type PlaywrightWorkerOptions, type ReporterDescription } from '@playwright/test';
 import * as path from 'path';

--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -35,7 +35,6 @@ export class RunServer implements PlaywrightServer {
       command,
       env: {
         ...process.env,
-        PWTEST_UNDER_TEST: '1',
         ...env,
       },
     });
@@ -109,7 +108,6 @@ export class RemoteServer implements PlaywrightServer {
     }
     this._process = childProcess({
       command: ['node', path.join(__dirname, 'remote-server-impl.js'), JSON.stringify(options)],
-      env: { ...process.env, PWTEST_UNDER_TEST: '1' },
     });
 
     let index = 0;

--- a/tests/config/testMode.ts
+++ b/tests/config/testMode.ts
@@ -30,7 +30,6 @@ export class DriverTestMode implements TestMode {
   async setup() {
     this._impl = await start({
       NODE_OPTIONS: undefined,  // Hide driver process while debugging.
-      PWTEST_UNDER_TEST: 1,
     });
     return this._impl.playwright;
   }

--- a/tests/config/testModeFixtures.ts
+++ b/tests/config/testModeFixtures.ts
@@ -42,7 +42,6 @@ export const testModeTest = test.extend<TestModeTestFixtures, TestModeWorkerOpti
       'service-grid': new DefaultTestMode(),
       'driver': new DriverTestMode(),
     }[mode];
-    require('playwright-core/lib/utils').setUnderTest();
     const playwright = await testMode.setup();
     playwright._setSelectors(playwrightLibrary.selectors);
     await run(playwright);

--- a/tests/electron/playwright.config.ts
+++ b/tests/electron/playwright.config.ts
@@ -16,6 +16,7 @@
 
 import { config as loadEnv } from 'dotenv';
 loadEnv({ path: path.join(__dirname, '..', '..', '.env') });
+process.env.PWTEST_UNDER_TEST = '1';
 
 import type { Config, PlaywrightTestOptions, PlaywrightWorkerOptions } from '@playwright/test';
 import * as path from 'path';

--- a/tests/library/events/check-listener-leaks.spec.ts
+++ b/tests/library/events/check-listener-leaks.spec.ts
@@ -22,11 +22,8 @@
 
 import events from 'events';
 import { EventEmitter } from './utils';
-import { setUnderTest } from '../../../packages/playwright-core/lib/server/utils/debug';
 import { test, expect } from '@playwright/test';
 import * as common from './utils';
-
-setUnderTest();
 
 test('defaultMaxListeners', () => {
   const e = new EventEmitter();

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -16,6 +16,7 @@
 
 import { config as loadEnv } from 'dotenv';
 loadEnv({ path: path.join(__dirname, '..', '..', '.env'), override: true });
+process.env.PWTEST_UNDER_TEST = '1';
 
 import { type Config, type PlaywrightTestOptions, type PlaywrightWorkerOptions, type ReporterDescription } from '@playwright/test';
 import * as path from 'path';
@@ -64,7 +65,6 @@ if (mode === 'service') {
     command: 'npx playwright run-server --port=3333',
     url: 'http://localhost:3333',
     reuseExistingServer: !process.env.CI,
-    env: { PWTEST_UNDER_TEST: '1' }
   };
 }
 if (mode === 'service2') {

--- a/tests/stress/playwright.config.ts
+++ b/tests/stress/playwright.config.ts
@@ -16,6 +16,8 @@
 
 import { defineConfig } from '@playwright/test';
 
+process.env.PWTEST_UNDER_TEST = '1';
+
 export default defineConfig({
   forbidOnly: !!process.env.CI,
   reporter: 'html',

--- a/tests/webview2/playwright.config.ts
+++ b/tests/webview2/playwright.config.ts
@@ -16,6 +16,7 @@
 
 import { config as loadEnv } from 'dotenv';
 loadEnv({ path: path.join(__dirname, '..', '..', '.env') });
+process.env.PWTEST_UNDER_TEST = '1';
 
 import type { Config, PlaywrightTestOptions, PlaywrightWorkerOptions } from '@playwright/test';
 import * as path from 'path';


### PR DESCRIPTION
Instead, use `PWTEST_UNDER_TEST` env variable. This ensures `isUnderTest()` is a static value, and removes the need for some lazy evaluations.

References #35683.