### PR TITLE
fix(bidi): initialize utility script before adding bindings

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -21,6 +21,7 @@ import * as network from '../network';
 import { BidiConnection } from './bidiConnection';
 import { bidiBytesValueToString } from './bidiNetworkManager';
 import { addMainBindingSource, BidiPage, kPlaywrightBindingChannel } from './bidiPage';
+import { kUtilityInitScript } from '../page';
 import * as bidi from './third_party/bidiProtocol';
 
 import type { RegisteredListener } from '../utils/eventsHelper';
@@ -220,6 +221,7 @@ export class BidiBrowserContext extends BrowserContext {
     const promises: Promise<any>[] = [
       super._initialize(),
       this._installMainBinding(),
+      this._installUtilityScript(),
     ];
     if (this._options.viewport) {
       promises.push(this._browser._browserSession.send('browsingContext.setViewport', {
@@ -248,6 +250,13 @@ export class BidiBrowserContext extends BrowserContext {
     await this._browser._browserSession.send('script.addPreloadScript', {
       functionDeclaration: addMainBindingSource,
       arguments: args,
+      userContexts: [this._userContextId()],
+    });
+  }
+
+  private async _installUtilityScript() {
+    await this._browser._browserSession.send('script.addPreloadScript', {
+      functionDeclaration: `() => { return${kUtilityInitScript.source} }`,
       userContexts: [this._userContextId()],
     });
   }


### PR DESCRIPTION
This addresses the following feedback from @lutien:

`So in the log I can actually see the preload scripts to be run before the test tries to evaluate the test code. But when the preload scripts are evaluated there is a log message with javascript error: `TypeError: can't access property \"addBinding\", globalThis.__playwright_utility_script__570cfec23d52bffc85a9e4355cc5a843 is undefined`, so it looks like maybe bidi implementation misses to set the preload script which should initialize the `globalThis.__playwright_utility_script__*` (I also don't see this script in the log). This test also doesn't work for Chrome with BiDi. I coudn't really find the required code, so maybe, @yurys, could you take a look?`