### PR TITLE
chore: use utilityScript handle in bindings

### DIFF
--- a/tests/library/browsercontext-expose-function.spec.ts
+++ b/tests/library/browsercontext-expose-function.spec.ts
@@ -66,11 +66,11 @@ it('should be callable from-inside addInitScript', async ({ context, server }) =
   await context.addInitScript('window["woof"]("context")');
   const page = await context.newPage();
   await page.evaluate('undefined');
-  expect(args).toEqual(['context']);
+  await expect.poll(() => args).toEqual(['context']);
   args = [];
   await page.addInitScript('window["woof"]("page")');
   await page.reload();
-  expect(args).toEqual(['context', 'page']);
+  await expect.poll(() => args).toEqual(['context', 'page']);
 });
 
 it('exposeBindingHandle should work', async ({ context }) => {

--- a/tests/library/popup.spec.ts
+++ b/tests/library/popup.spec.ts
@@ -221,31 +221,25 @@ it('should expose function from browser context', async function({ browser, serv
 
 it('should not dispatch binding on a closed page', async function({ browser, server, browserName }) {
   const context = await browser.newContext();
-  const messages = [];
-  await context.exposeFunction('add', (a, b) => {
-    messages.push('binding');
+  let wasClosed: boolean | undefined;
+  await context.exposeBinding('add', (source, a, b) => {
+    wasClosed = source.page.isClosed();
     return a + b;
   });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
   await Promise.all([
-    page.waitForEvent('popup').then(popup => {
-      if (popup.isClosed())
-        messages.push('close');
-      else
-        return popup.waitForEvent('close').then(() => messages.push('close'));
-    }),
+    page.waitForEvent('popup'),
     page.evaluate(async () => {
       const win = window.open('about:blank');
       win['add'](9, 4);
       win.close();
     }),
   ]);
+  // Give it a chance to dispatch the binding on the closed page.
+  await page.waitForTimeout(1000);
   await context.close();
-  if (browserName === 'firefox')
-    expect(messages.join('|')).toBe('close');
-  else
-    expect(messages.join('|')).toBe('binding|close');
+  expect(wasClosed).not.toBeTruthy();
 });
 
 it('should not throttle rAF in the opener page', async ({ page, server }) => {

--- a/tests/page/page-expose-function.spec.ts
+++ b/tests/page/page-expose-function.spec.ts
@@ -95,7 +95,7 @@ it('should be callable from-inside addInitScript', async ({ page, server }) => {
   });
   await page.addInitScript(() => window['woof']());
   await page.reload();
-  expect(called).toBe(true);
+  await expect.poll(() => called).toBe(true);
 });
 
 it('should survive navigation', async ({ page, server }) => {


### PR DESCRIPTION
Some timings changed, so had to update a few racy tests.

References #35683.