### PR TITLE
chore: use generated injected script in trace viewer snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules/
 yarn.lock
 /packages/playwright-core/src/generated
 /packages/playwright-ct-core/src/generated
+/packages/trace-viewer/src/generated
 packages/*/lib/
 drivers/
 .android-sdk/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,6 +49,7 @@ const ignores = [
   "packages/playwright-core/src/third_party/",
   "packages/playwright-core/types/*",
   "packages/playwright-ct-core/src/generated/*",
+  "packages/trace-viewer/src/generated/*",
   "packages/html-reporter/bundle.ts",
   "packages/html-reporter/playwright.config.ts",
   "packages/html-reporter/playwright/*",
@@ -220,7 +221,7 @@ const noBooleanCompareRules = {
 const noWebGlobalsRuleList = [
   { name: "window", message: "Use InjectedScript.window instead" },
   { name: "document", message: "Use InjectedScript.document instead" },
-  { name: "globalThis", message: "Use InjectedScript.window instead" },
+  { name: "globalThis", message: "Instead of using 'globalThis.Foo', use 'Foo'. Generated code ensures a builtin version." },
 ];
 
 const noNodeGlobalsRuleList = [{ name: "process" }];

--- a/packages/injected/src/recorder/pollingRecorder.ts
+++ b/packages/injected/src/recorder/pollingRecorder.ts
@@ -34,7 +34,7 @@ interface Embedder {
 export class PollingRecorder implements RecorderDelegate {
   private _recorder: Recorder;
   private _embedder: Embedder;
-  private _pollRecorderModeTimer: number | undefined;
+  private _pollRecorderModeTimer: NodeJS.Timeout | undefined;
   private _lastStateJSON: string | undefined;
 
   constructor(injectedScript: InjectedScript) {
@@ -54,10 +54,10 @@ export class PollingRecorder implements RecorderDelegate {
   private async _pollRecorderMode() {
     const pollPeriod = 1000;
     if (this._pollRecorderModeTimer)
-      this._recorder.injectedScript.utils.builtins.clearTimeout(this._pollRecorderModeTimer);
+      clearTimeout(this._pollRecorderModeTimer);
     const state = await this._embedder.__pw_recorderState().catch(() => null);
     if (!state) {
-      this._pollRecorderModeTimer = this._recorder.injectedScript.utils.builtins.setTimeout(() => this._pollRecorderMode(), pollPeriod);
+      this._pollRecorderModeTimer = setTimeout(() => this._pollRecorderMode(), pollPeriod);
       return;
     }
 
@@ -73,7 +73,7 @@ export class PollingRecorder implements RecorderDelegate {
       this._recorder.setUIState(state, this);
     }
 
-    this._pollRecorderModeTimer = this._recorder.injectedScript.utils.builtins.setTimeout(() => this._pollRecorderMode(), pollPeriod);
+    this._pollRecorderModeTimer = setTimeout(() => this._pollRecorderMode(), pollPeriod);
   }
 
   async performAction(action: actions.PerformOnRecordAction) {

--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -193,11 +193,11 @@ class RecordActionTool implements RecorderTool {
   private _hoveredElement: HTMLElement | null = null;
   private _activeModel: HighlightModelWithSelector | null = null;
   private _expectProgrammaticKeyUp = false;
-  private _pendingClickAction: { action: actions.ClickAction, timeout: number } | undefined;
+  private _pendingClickAction: { action: actions.ClickAction, timeout: NodeJS.Timeout } | undefined;
 
   constructor(recorder: Recorder) {
     this._recorder = recorder;
-    this._performingActions = new recorder.injectedScript.utils.builtins.Set();
+    this._performingActions = new Set();
   }
 
   cursor() {
@@ -251,7 +251,7 @@ class RecordActionTool implements RecorderTool {
           modifiers: modifiersForEvent(event),
           clickCount: event.detail
         },
-        timeout: this._recorder.injectedScript.utils.builtins.setTimeout(() => this._commitPendingClickAction(), 200)
+        timeout: setTimeout(() => this._commitPendingClickAction(), 200)
       };
     }
   }
@@ -288,7 +288,7 @@ class RecordActionTool implements RecorderTool {
 
   private _cancelPendingClickAction() {
     if (this._pendingClickAction)
-      this._recorder.injectedScript.utils.builtins.clearTimeout(this._pendingClickAction.timeout);
+      clearTimeout(this._pendingClickAction.timeout);
     this._pendingClickAction = undefined;
   }
 
@@ -599,7 +599,7 @@ class TextAssertionTool implements RecorderTool {
 
   constructor(recorder: Recorder, kind: 'text' | 'value' | 'snapshot') {
     this._recorder = recorder;
-    this._textCache = new recorder.injectedScript.utils.builtins.Map();
+    this._textCache = new Map();
     this._kind = kind;
     this._dialog = new Dialog(recorder);
   }
@@ -948,7 +948,7 @@ class Overlay {
     else
       element = this._assertValuesToggle;
     element.classList.add('succeeded');
-    this._recorder.injectedScript.utils.builtins.setTimeout(() => element.classList.remove('succeeded'), 2000);
+    setTimeout(() => element.classList.remove('succeeded'), 2000);
   }
 
   private _hideOverlay() {
@@ -1081,13 +1081,13 @@ export class Recorder {
 
     this.highlight.install();
     // some frameworks erase the DOM on hydration, this ensures it's reattached
-    let recreationInterval: number | undefined;
+    let recreationInterval: NodeJS.Timeout | undefined;
     const recreate = () => {
       this.highlight.install();
-      recreationInterval = this.injectedScript.utils.builtins.setTimeout(recreate, 500);
+      recreationInterval = setTimeout(recreate, 500);
     };
-    recreationInterval = this.injectedScript.utils.builtins.setTimeout(recreate, 500);
-    this._listeners.push(() => this.injectedScript.utils.builtins.clearTimeout(recreationInterval));
+    recreationInterval = setTimeout(recreate, 500);
+    this._listeners.push(() => clearTimeout(recreationInterval));
 
     this.highlight.appendChild(createSvgElement(this.document, clipPaths));
     this.overlay?.install();

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1567,9 +1567,9 @@ export class Frame extends SdkObject {
                 return;
               }
               if (typeof polling !== 'number')
-                injected.utils.builtins.requestAnimationFrame(next);
+                injected.utils.requestAnimationFrame(next);
               else
-                injected.utils.builtins.setTimeout(next, polling);
+                injected.utils.setTimeout(next, polling);
             } catch (e) {
               reject(e);
             }

--- a/packages/trace-viewer/src/sw/DEPS.list
+++ b/packages/trace-viewer/src/sw/DEPS.list
@@ -1,2 +1,3 @@
 [*]
 @isomorphic/**
+../generated/**

--- a/packages/trace-viewer/src/ui/DEPS.list
+++ b/packages/trace-viewer/src/ui/DEPS.list
@@ -1,5 +1,4 @@
 [*]
-@injected/**
 @isomorphic/**
 @trace/**
 @web/**

--- a/utils/generate_injected.js
+++ b/utils/generate_injected.js
@@ -39,9 +39,21 @@ const injectedScripts = [
     true,
   ],
   [
+    path.join(ROOT, 'packages', 'injected', 'src', 'injectedScript.ts'),
+    path.join(ROOT, 'packages', 'injected', 'lib'),
+    path.join(ROOT, 'packages', 'trace-viewer', 'src', 'generated'),
+    true,
+  ],
+  [
     path.join(ROOT, 'packages', 'injected', 'src', 'recorder', 'pollingRecorder.ts'),
     path.join(ROOT, 'packages', 'injected', 'lib'),
     path.join(ROOT, 'packages', 'playwright-core', 'src', 'generated'),
+    true,
+  ],
+  [
+    path.join(ROOT, 'packages', 'injected', 'src', 'recorder', 'recorder.ts'),
+    path.join(ROOT, 'packages', 'injected', 'lib'),
+    path.join(ROOT, 'packages', 'trace-viewer', 'src', 'generated'),
     true,
   ],
   [


### PR DESCRIPTION
This makes sure that InjectedScript is evaluated in the frame's context, not the trace viewer's context. Allows to remove all kinds of restrictions on window/document/builtins.