### PR TITLE
fix(ui-mode): prevent OOM crash when DEBUG logging enabled

### DIFF
--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -45,6 +45,7 @@ import type { ReporterV2 } from '../reporters/reporterV2';
 import type { TraceViewerRedirectOptions, TraceViewerServerOptions } from 'playwright-core/lib/server/trace/viewer/traceViewer';
 import type { HttpServer, Transport } from 'playwright-core/lib/utils';
 
+const originalDebugLog = debug.log;
 const originalStdoutWrite = process.stdout.write;
 const originalStderrWrite = process.stderr.write;
 
@@ -388,11 +389,13 @@ export class TestServerDispatcher implements TestServerInterface {
     if (process.env.PWTEST_DEBUG)
       return;
     if (intercept) {
-      // Don't intercept any DEBUG=* logging
-      debug.log = (...args) => {
-        const string = util.format(...args) + '\n';
-        return (originalStderrWrite as any).apply(process.stderr, [string]);
-      };
+      if (debug.log === originalDebugLog) {
+        // Only if debug.log hasn't already been tampered with, don't intercept any DEBUG=* logging
+        debug.log = (...args) => {
+          const string = util.format(...args) + '\n';
+          return (originalStderrWrite as any).apply(process.stderr, [string]);
+        };
+      }
       process.stdout.write = (chunk: string | Buffer) => {
         this._dispatchEvent('stdio', chunkToPayload('stdout', chunk));
         return true;
@@ -402,6 +405,7 @@ export class TestServerDispatcher implements TestServerInterface {
         return true;
       };
     } else {
+      debug.log = originalDebugLog;
       process.stdout.write = originalStdoutWrite;
       process.stderr.write = originalStderrWrite;
     }


### PR DESCRIPTION
When UI mode is launched with enough `debug` logging enabled (such as `DEBUG=*`), Playwright would end up crashing with an OOM error after a few seconds. This has been reported several times recently (#35706, #33086, #35152, and likely more).

This change prevents any `debug` logging generated in the runner process from being redirected for further processing (such as sending to the UI). This _does not_ block all `debug` logging from getting to the UI; logs created in workers and possibly other processes are no longer "labeled" once reaching this redirection code, and thus are still sent along. This appears to be sufficient to solve the crash. These untouched `debug` logs appear in the global UI mode console.