### PR TITLE
fix(trace): avoid recording BindingCall actions

### DIFF
--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -841,6 +841,7 @@ export class BindingCall extends ChannelOwner<channels.BindingCallChannel> {
 
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.BindingCallInitializer) {
     super(parent, type, guid, initializer);
+    this.markAsInternalType();
   }
 
   async call(func: (source: structs.BindingSource, ...args: any[]) => any) {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -261,7 +261,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
       onApiCallBegin: (data: ApiCallData) => {
         const testInfo = currentTestInfo();
         // Some special calls do not get into steps.
-        if (!testInfo || !data.apiName || data.apiName.includes('setTestIdAttribute') || data.apiName === 'tracing.groupEnd')
+        if (!testInfo || data.apiName.includes('setTestIdAttribute') || data.apiName === 'tracing.groupEnd')
           return;
         const zone = currentZone().data<TestStepInternal>('stepZone');
         if (zone && zone.category === 'expect') {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -261,7 +261,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
       onApiCallBegin: (data: ApiCallData) => {
         const testInfo = currentTestInfo();
         // Some special calls do not get into steps.
-        if (!testInfo || data.apiName.includes('setTestIdAttribute') || data.apiName === 'tracing.groupEnd')
+        if (!testInfo || !data.apiName || data.apiName.includes('setTestIdAttribute') || data.apiName === 'tracing.groupEnd')
           return;
         const zone = currentZone().data<TestStepInternal>('stepZone');
         if (zone && zone.category === 'expect') {


### PR DESCRIPTION
Some interactions with the Playwright API pass through `wrapApiCall` but are not actually initiated by the user. Any such calls do not have a generated `apiName` because there's no non-Playwright code in the stack, thus the action gets recorded in the trace/reports as a completely empty entry. In this case the API being called is a page binding called through the browser.

<img width="392" alt="Screenshot 2025-05-05 at 7 55 35 AM" src="https://github.com/user-attachments/assets/7b8b9ce4-f4e5-452e-8fa0-2a909081923c" />

Do not emit any of these events to the trace.