### PR TITLE
docs(tracing): clarify diff between test tracing and `context.tracing`

### DIFF
--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -74,7 +74,7 @@ await context.Tracing.StopAsync(new()
 Start tracing.
 
 :::note
-You probably want to [enable tracing in your config file](https://playwright.dev/docs/api/class-testoptions#test-options-trace) instead of using `context.tracing`.
+You probably want to [enable tracing in your config file](https://playwright.dev/docs/api/class-testoptions#test-options-trace) instead of using `Tracing.start`.
 
 The `context.tracing` API captures browser operations and network activity, but it doesn't record test assertions (like `expect` calls). We recommend [enabling tracing through Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace), which includes those assertions and provides a more complete trace for debugging test failures.
 :::

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -3,6 +3,10 @@
 
 API for collecting and saving Playwright traces. Playwright traces can be opened in [Trace Viewer](../trace-viewer.md) after Playwright script runs.
 
+:::note
+The `context.tracing` API records different information than the automatic tracing enabled through [Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace). This API records browser operations and network activity, but does not capture test assertions (`expect` calls).
+:::
+
 Start recording a trace before performing actions. At the end, stop tracing and save it to a file.
 
 ```js
@@ -11,6 +15,8 @@ const context = await browser.newContext();
 await context.tracing.start({ screenshots: true, snapshots: true });
 const page = await context.newPage();
 await page.goto('https://playwright.dev');
+// Not captured
+expect(page.url()).toBe('https://playwright.dev');
 await context.tracing.stop({ path: 'trace.zip' });
 ```
 
@@ -66,12 +72,18 @@ await context.Tracing.StopAsync(new()
 
 Start tracing.
 
+:::note
+This API records browser operations and network activity, but does not capture test assertions (`expect` calls).
+:::
+
 **Usage**
 
 ```js
 await context.tracing.start({ screenshots: true, snapshots: true });
 const page = await context.newPage();
 await page.goto('https://playwright.dev');
+// Not captured
+expect(page.url()).toBe('https://playwright.dev');
 await context.tracing.stop({ path: 'trace.zip' });
 ```
 

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -4,7 +4,9 @@
 API for collecting and saving Playwright traces. Playwright traces can be opened in [Trace Viewer](../trace-viewer.md) after Playwright script runs.
 
 :::note
-The `context.tracing` API records different information than the automatic tracing enabled through [Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace). This API records browser operations and network activity, but does not capture test assertions (`expect` calls).
+You probably want to [enable tracing in your config file](https://playwright.dev/docs/api/class-testoptions#test-options-trace) instead of using `context.tracing`.
+
+The `context.tracing` API captures browser operations and network activity, but it doesn't record test assertions (like `expect` calls). We recommend [enabling tracing through Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace), which includes those assertions and provides a more complete trace for debugging test failures.
 :::
 
 Start recording a trace before performing actions. At the end, stop tracing and save it to a file.
@@ -15,7 +17,6 @@ const context = await browser.newContext();
 await context.tracing.start({ screenshots: true, snapshots: true });
 const page = await context.newPage();
 await page.goto('https://playwright.dev');
-// Not captured
 expect(page.url()).toBe('https://playwright.dev');
 await context.tracing.stop({ path: 'trace.zip' });
 ```
@@ -73,7 +74,9 @@ await context.Tracing.StopAsync(new()
 Start tracing.
 
 :::note
-This API records browser operations and network activity, but does not capture test assertions (`expect` calls).
+You probably want to [enable tracing in your config file](https://playwright.dev/docs/api/class-testoptions#test-options-trace) instead of using `context.tracing`.
+
+The `context.tracing` API captures browser operations and network activity, but it doesn't record test assertions (like `expect` calls). We recommend [enabling tracing through Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace), which includes those assertions and provides a more complete trace for debugging test failures.
 :::
 
 **Usage**
@@ -82,7 +85,6 @@ This API records browser operations and network activity, but does not capture t
 await context.tracing.start({ screenshots: true, snapshots: true });
 const page = await context.newPage();
 await page.goto('https://playwright.dev');
-// Not captured
 expect(page.url()).toBe('https://playwright.dev');
 await context.tracing.stop({ path: 'trace.zip' });
 ```

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -21175,6 +21175,10 @@ export interface Touchscreen {
  * API for collecting and saving Playwright traces. Playwright traces can be opened in
  * [Trace Viewer](https://playwright.dev/docs/trace-viewer) after Playwright script runs.
  *
+ * **NOTE** The `context.tracing` API records different information than the automatic tracing enabled through
+ * [Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace). This API
+ * records browser operations and network activity, but does not capture test assertions (`expect` calls).
+ *
  * Start recording a trace before performing actions. At the end, stop tracing and save it to a file.
  *
  * ```js
@@ -21183,6 +21187,8 @@ export interface Touchscreen {
  * await context.tracing.start({ screenshots: true, snapshots: true });
  * const page = await context.newPage();
  * await page.goto('https://playwright.dev');
+ * // Not captured
+ * expect(page.url()).toBe('https://playwright.dev');
  * await context.tracing.stop({ path: 'trace.zip' });
  * ```
  *
@@ -21230,12 +21236,17 @@ export interface Tracing {
   /**
    * Start tracing.
    *
+   * **NOTE** This API records browser operations and network activity, but does not capture test assertions (`expect`
+   * calls).
+   *
    * **Usage**
    *
    * ```js
    * await context.tracing.start({ screenshots: true, snapshots: true });
    * const page = await context.newPage();
    * await page.goto('https://playwright.dev');
+   * // Not captured
+   * expect(page.url()).toBe('https://playwright.dev');
    * await context.tracing.stop({ path: 'trace.zip' });
    * ```
    *

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -21175,9 +21175,14 @@ export interface Touchscreen {
  * API for collecting and saving Playwright traces. Playwright traces can be opened in
  * [Trace Viewer](https://playwright.dev/docs/trace-viewer) after Playwright script runs.
  *
- * **NOTE** The `context.tracing` API records different information than the automatic tracing enabled through
- * [Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace). This API
- * records browser operations and network activity, but does not capture test assertions (`expect` calls).
+ * **NOTE** You probably want to
+ * [enable tracing in your config file](https://playwright.dev/docs/api/class-testoptions#test-options-trace) instead
+ * of using `context.tracing`.
+ *
+ * The `context.tracing` API captures browser operations and network activity, but it doesn't record test assertions
+ * (like `expect` calls). We recommend
+ * [enabling tracing through Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace),
+ * which includes those assertions and provides a more complete trace for debugging test failures.
  *
  * Start recording a trace before performing actions. At the end, stop tracing and save it to a file.
  *
@@ -21187,7 +21192,6 @@ export interface Touchscreen {
  * await context.tracing.start({ screenshots: true, snapshots: true });
  * const page = await context.newPage();
  * await page.goto('https://playwright.dev');
- * // Not captured
  * expect(page.url()).toBe('https://playwright.dev');
  * await context.tracing.stop({ path: 'trace.zip' });
  * ```
@@ -21236,8 +21240,14 @@ export interface Tracing {
   /**
    * Start tracing.
    *
-   * **NOTE** This API records browser operations and network activity, but does not capture test assertions (`expect`
-   * calls).
+   * **NOTE** You probably want to
+   * [enable tracing in your config file](https://playwright.dev/docs/api/class-testoptions#test-options-trace) instead
+   * of using `context.tracing`.
+   *
+   * The `context.tracing` API captures browser operations and network activity, but it doesn't record test assertions
+   * (like `expect` calls). We recommend
+   * [enabling tracing through Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace),
+   * which includes those assertions and provides a more complete trace for debugging test failures.
    *
    * **Usage**
    *
@@ -21245,7 +21255,6 @@ export interface Tracing {
    * await context.tracing.start({ screenshots: true, snapshots: true });
    * const page = await context.newPage();
    * await page.goto('https://playwright.dev');
-   * // Not captured
    * expect(page.url()).toBe('https://playwright.dev');
    * await context.tracing.stop({ path: 'trace.zip' });
    * ```

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -21242,7 +21242,7 @@ export interface Tracing {
    *
    * **NOTE** You probably want to
    * [enable tracing in your config file](https://playwright.dev/docs/api/class-testoptions#test-options-trace) instead
-   * of using `context.tracing`.
+   * of using `Tracing.start`.
    *
    * The `context.tracing` API captures browser operations and network activity, but it doesn't record test assertions
    * (like `expect` calls). We recommend

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21175,6 +21175,10 @@ export interface Touchscreen {
  * API for collecting and saving Playwright traces. Playwright traces can be opened in
  * [Trace Viewer](https://playwright.dev/docs/trace-viewer) after Playwright script runs.
  *
+ * **NOTE** The `context.tracing` API records different information than the automatic tracing enabled through
+ * [Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace). This API
+ * records browser operations and network activity, but does not capture test assertions (`expect` calls).
+ *
  * Start recording a trace before performing actions. At the end, stop tracing and save it to a file.
  *
  * ```js
@@ -21183,6 +21187,8 @@ export interface Touchscreen {
  * await context.tracing.start({ screenshots: true, snapshots: true });
  * const page = await context.newPage();
  * await page.goto('https://playwright.dev');
+ * // Not captured
+ * expect(page.url()).toBe('https://playwright.dev');
  * await context.tracing.stop({ path: 'trace.zip' });
  * ```
  *
@@ -21230,12 +21236,17 @@ export interface Tracing {
   /**
    * Start tracing.
    *
+   * **NOTE** This API records browser operations and network activity, but does not capture test assertions (`expect`
+   * calls).
+   *
    * **Usage**
    *
    * ```js
    * await context.tracing.start({ screenshots: true, snapshots: true });
    * const page = await context.newPage();
    * await page.goto('https://playwright.dev');
+   * // Not captured
+   * expect(page.url()).toBe('https://playwright.dev');
    * await context.tracing.stop({ path: 'trace.zip' });
    * ```
    *

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21175,9 +21175,14 @@ export interface Touchscreen {
  * API for collecting and saving Playwright traces. Playwright traces can be opened in
  * [Trace Viewer](https://playwright.dev/docs/trace-viewer) after Playwright script runs.
  *
- * **NOTE** The `context.tracing` API records different information than the automatic tracing enabled through
- * [Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace). This API
- * records browser operations and network activity, but does not capture test assertions (`expect` calls).
+ * **NOTE** You probably want to
+ * [enable tracing in your config file](https://playwright.dev/docs/api/class-testoptions#test-options-trace) instead
+ * of using `context.tracing`.
+ *
+ * The `context.tracing` API captures browser operations and network activity, but it doesn't record test assertions
+ * (like `expect` calls). We recommend
+ * [enabling tracing through Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace),
+ * which includes those assertions and provides a more complete trace for debugging test failures.
  *
  * Start recording a trace before performing actions. At the end, stop tracing and save it to a file.
  *
@@ -21187,7 +21192,6 @@ export interface Touchscreen {
  * await context.tracing.start({ screenshots: true, snapshots: true });
  * const page = await context.newPage();
  * await page.goto('https://playwright.dev');
- * // Not captured
  * expect(page.url()).toBe('https://playwright.dev');
  * await context.tracing.stop({ path: 'trace.zip' });
  * ```
@@ -21236,8 +21240,14 @@ export interface Tracing {
   /**
    * Start tracing.
    *
-   * **NOTE** This API records browser operations and network activity, but does not capture test assertions (`expect`
-   * calls).
+   * **NOTE** You probably want to
+   * [enable tracing in your config file](https://playwright.dev/docs/api/class-testoptions#test-options-trace) instead
+   * of using `context.tracing`.
+   *
+   * The `context.tracing` API captures browser operations and network activity, but it doesn't record test assertions
+   * (like `expect` calls). We recommend
+   * [enabling tracing through Playwright Test configuration](https://playwright.dev/docs/api/class-testoptions#test-options-trace),
+   * which includes those assertions and provides a more complete trace for debugging test failures.
    *
    * **Usage**
    *
@@ -21245,7 +21255,6 @@ export interface Tracing {
    * await context.tracing.start({ screenshots: true, snapshots: true });
    * const page = await context.newPage();
    * await page.goto('https://playwright.dev');
-   * // Not captured
    * expect(page.url()).toBe('https://playwright.dev');
    * await context.tracing.stop({ path: 'trace.zip' });
    * ```

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21242,7 +21242,7 @@ export interface Tracing {
    *
    * **NOTE** You probably want to
    * [enable tracing in your config file](https://playwright.dev/docs/api/class-testoptions#test-options-trace) instead
-   * of using `context.tracing`.
+   * of using `Tracing.start`.
    *
    * The `context.tracing` API captures browser operations and network activity, but it doesn't record test assertions
    * (like `expect` calls). We recommend


### PR DESCRIPTION
Explicitly document that `context.tracing` cannot trace everything that Playwright Test tracing can trace. Anything that stays local to the runner is not traced.