### PR TITLE
fix(elementText): flatten <slot> contents

### DIFF
--- a/packages/injected/src/selectorUtils.ts
+++ b/packages/injected/src/selectorUtils.ts
@@ -81,8 +81,26 @@ export function elementText(cache: Map<Element | ShadowRoot, ElementText>, root:
             if (currentImmediate)
               value.immediate.push(currentImmediate);
             currentImmediate = '';
-            if (child.nodeType === Node.ELEMENT_NODE)
+            if (child.nodeType === Node.ELEMENT_NODE) {
+              const el = child as Element;
+              if (el.tagName === 'SLOT') {
+                for (const assigned of (el as HTMLSlotElement).assignedNodes({ flatten: true })) {
+                  if (assigned.nodeType === Node.TEXT_NODE) {
+                    const txt = assigned.nodeValue || '';
+                    value.full += txt;
+                    currentImmediate += txt;
+                  } else if (assigned.nodeType === Node.ELEMENT_NODE) {
+                    if (currentImmediate) {
+                      value.immediate.push(currentImmediate);
+                      currentImmediate = '';
+                    }
+                    value.full += elementText(cache, assigned as Element).full;
+                  }
+                }
+                continue;
+              }
               value.full += elementText(cache, child as Element).full;
+            }
           }
         }
         if (currentImmediate)

--- a/tests/page/locator-query.spec.ts
+++ b/tests/page/locator-query.spec.ts
@@ -144,6 +144,20 @@ it('should filter by regex with special symbols', async ({ page }) => {
   await expect(page.locator('div', { hasText: /^first\/".*"second\\$/si })).toHaveClass('test');
 });
 
+it('should filter by slotted content', async ({ page }) => {
+  await page.setContent(`
+    <div>
+      <template shadowrootmode="open">
+        <label for="input"><slot name="foo"></slot> & <slot name="bar"></slot></label>
+        <input id="input" type="text">
+      </template>
+      <span slot="foo">Foo</span><span slot="bar">Bar</span>
+    </div>
+  `);
+  await expect(page.locator('label', { hasText: 'Foo & Bar' })).toHaveCount(1);
+  await expect(page.locator('label', { hasText: 'Foo' })).toHaveText('Foo & Bar');
+});
+
 it('should support has:locator', async ({ page, trace }) => {
   it.skip(trace === 'on');
 
@@ -198,6 +212,25 @@ it('should support locator.filter', async ({ page, trace }) => {
   await expect(page.locator(`div`).filter({ hasNot: page.locator('span') })).toHaveCount(0);
   await expect(page.locator(`div`).filter({ hasNotText: 'hello' })).toHaveCount(1);
   await expect(page.locator(`div`).filter({ hasNotText: 'foo' })).toHaveCount(2);
+});
+
+it('should exclude elements by slotted', async ({ page }) => {
+  await page.setContent(`
+    <div>
+      <template shadowrootmode="open">
+        <label for="input"><slot name="foo"></slot></label>
+        <input id="input" type="text">
+      </template>
+      <span slot="foo">Foo</span>
+      <template shadowrootmode="open">
+        <label for="input2"><slot name="bar"></slot></label>
+        <input id="input2" type="text">
+      </template>
+      <span slot="bar">Bar</span>
+    </div>
+  `);
+  await expect(page.locator('label', { hasNotText: 'Bar' })).toHaveCount(1);
+  await expect(page.locator('label', { hasNotText: 'Bar' })).toHaveText('Foo');
 });
 
 it('should support locator.and', async ({ page }) => {

--- a/tests/page/locator-query.spec.ts
+++ b/tests/page/locator-query.spec.ts
@@ -145,15 +145,13 @@ it('should filter by regex with special symbols', async ({ page }) => {
 });
 
 it('should filter by slotted content', async ({ page }) => {
-  await page.setContent(`
-    <div>
-      <template shadowrootmode="open">
-        <label for="input"><slot name="foo"></slot> & <slot name="bar"></slot></label>
-        <input id="input" type="text">
-      </template>
-      <span slot="foo">Foo</span><span slot="bar">Bar</span>
-    </div>
-  `);
+  await page.setContent(`<div>
+    <template shadowrootmode="open">
+      <label for="input"><slot name="foo"></slot> & <slot name="bar"></slot></label>
+      <input id="input" type="text">
+    </template>
+    <span slot="foo">Foo</span><span slot="bar">Bar</span>
+  </div>`);
   await expect(page.locator('label', { hasText: 'Foo & Bar' })).toHaveCount(1);
   await expect(page.locator('label', { hasText: 'Foo' })).toHaveText('Foo & Bar');
 });
@@ -215,20 +213,18 @@ it('should support locator.filter', async ({ page, trace }) => {
 });
 
 it('should exclude elements by slotted', async ({ page }) => {
-  await page.setContent(`
-    <div>
-      <template shadowrootmode="open">
-        <label for="input"><slot name="foo"></slot></label>
-        <input id="input" type="text">
-      </template>
-      <span slot="foo">Foo</span>
-      <template shadowrootmode="open">
-        <label for="input2"><slot name="bar"></slot></label>
-        <input id="input2" type="text">
-      </template>
-      <span slot="bar">Bar</span>
-    </div>
-  `);
+  await page.setContent(`<div>
+    <template shadowrootmode="open">
+      <label for="input"><slot name="foo"></slot></label>
+      <input id="input" type="text">
+    </template>
+    <span slot="foo">Foo</span>
+    <template shadowrootmode="open">
+      <label for="input2"><slot name="bar"></slot></label>
+      <input id="input2" type="text">
+    </template>
+    <span slot="bar">Bar</span>
+  </div>`);
   await expect(page.locator('label', { hasNotText: 'Bar' })).toHaveCount(1);
   await expect(page.locator('label', { hasNotText: 'Bar' })).toHaveText('Foo');
 });

--- a/tests/page/selectors-get-by.spec.ts
+++ b/tests/page/selectors-get-by.spec.ts
@@ -135,23 +135,22 @@ it('getByLabel should work with slot', async ({ page }) => {
       </label>
       <input id=target type=checkbox>
     </template>
-    Slotted Text
+    Foo
   </div>`);
-  await expect(page.getByLabel('Slotted Text')).toBeVisible();
+  await expect(page.getByLabel('Foo')).toBeVisible();
 });
 
 it('getByLabel should work with multiple slots', async ({ page }) => {
   await page.setContent(`<div>
     <template shadowrootmode=open>
       <label for=target>
-        <slot name=foo></slot>
-        <slot name=bar></slot>
+        <slot name=foo></slot> & <slot name=bar></slot>
       </label>
       <input id=target type=text>
     </template>
     <span slot=foo>Foo</span><span slot=bar>Bar</span>
   </div>`);
-  await expect(page.getByLabel('Foo Bar')).toBeVisible();
+  await expect(page.getByLabel('Foo & Bar')).toBeVisible();
 });
 
 it('getByPlaceholder should work', async ({ page }) => {

--- a/tests/page/selectors-get-by.spec.ts
+++ b/tests/page/selectors-get-by.spec.ts
@@ -127,6 +127,33 @@ it('getByLabel should prioritize aria-labelledby over aria-label', async ({ page
   expect(await page.getByLabel('Other').evaluate(e => e.id)).toBe('target');
 });
 
+it('getByLabel should work with slot', async ({ page }) => {
+  await page.setContent(`<div>
+    <template shadowrootmode=open>
+      <label for=target>
+        <slot></slot>
+      </label>
+      <input id=target type=checkbox>
+    </template>
+    Slotted Text
+  </div>`);
+  await expect(page.getByLabel('Slotted Text')).toBeVisible();
+});
+
+it('getByLabel should work with multiple slots', async ({ page }) => {
+  await page.setContent(`<div>
+    <template shadowrootmode=open>
+      <label for=target>
+        <slot name=foo></slot>
+        <slot name=bar></slot>
+      </label>
+      <input id=target type=text>
+    </template>
+    <span slot=foo>Foo</span><span slot=bar>Bar</span>
+  </div>`);
+  await expect(page.getByLabel('Foo Bar')).toBeVisible();
+});
+
 it('getByPlaceholder should work', async ({ page }) => {
   await page.setContent(`<div>
     <input placeholder='Hello'>


### PR DESCRIPTION
Closes #35715

- Update `elementText` to flatten `<slot>` contents into its `full` and `normalized` output.
- Found the same bug in `locator`'s `hasText` and `hasNoText` which depend on `elementText`, so added regression tests.

Since changes to `elementText` could introduce overhead due to its wide usage, I’d like to know if that’s a concern. I’ve identified the affected methods and can split the PR to handle the fix within each lower-level method if needed.

Looking forward to the team’s feedback.