### PR TITLE
Docs: mention trace viewer as debugging tool for the Mouse API class

### DIFF
--- a/docs/src/api/class-mouse.md
+++ b/docs/src/api/class-mouse.md
@@ -4,8 +4,7 @@
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 
 :::tip
-If you want to debug where the mouse moved, you can use the [Trace viewer](../trace-viewer-intro.md) or 
-[Playwright Inspector](../running-tests.md#debug-tests-with-the-playwright-inspector). A red dot showing the location of the mouse will be shown for every mouse action.
+If you want to debug where the mouse moved, you can use the [Trace viewer](../trace-viewer-intro.md). A red dot showing the location of the mouse will be shown for every mouse action.
 :::
 
 Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].

--- a/docs/src/api/class-mouse.md
+++ b/docs/src/api/class-mouse.md
@@ -4,7 +4,7 @@
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 
 :::tip
-If you want to debug where the mouse moved, you can use the [Playwright Inspector](../running-tests.md#debug-tests-with-the-playwright-inspector). A red dot showing the location of the mouse will be shown for every mouse action.
+If you want to debug where the mouse moved, you can use the [Trace viewer](../trace-viewer-intro.md) or [Playwright Inspector](../running-tests.md). A red dot showing the location of the mouse will be shown for every mouse action.
 :::
 
 Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].

--- a/docs/src/api/class-mouse.md
+++ b/docs/src/api/class-mouse.md
@@ -3,7 +3,7 @@
 
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 
-::: tip
+:::tip
 If you want to debug where the mouse moved, you can use the [Trace viewer](/trace-viewer-intro). A red dot showing the location of the mouse will be shown for every mouse action
 :::
 

--- a/docs/src/api/class-mouse.md
+++ b/docs/src/api/class-mouse.md
@@ -4,7 +4,7 @@
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 
 ::: tip
-If you want to debug where the mouse moved, you can use the [Trace viewer](/docs/trace-viewer-intro). A red dot showing the location of the mouse will be shown for every mouse action
+If you want to debug where the mouse moved, you can use the [Trace viewer](/trace-viewer-intro). A red dot showing the location of the mouse will be shown for every mouse action
 :::
 
 Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].

--- a/docs/src/api/class-mouse.md
+++ b/docs/src/api/class-mouse.md
@@ -4,7 +4,8 @@
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 
 :::tip
-If you want to debug where the mouse moved, you can use the [Trace viewer](../trace-viewer-intro.md) or [Playwright Inspector](../running-tests.md#debug-tests-with-the-playwright-inspector). A red dot showing the location of the mouse will be shown for every mouse action.
+If you want to debug where the mouse moved, you can use the [Trace viewer](../trace-viewer-intro.md) or 
+[Playwright Inspector](../running-tests.md#debug-tests-with-the-playwright-inspector). A red dot showing the location of the mouse will be shown for every mouse action.
 :::
 
 Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].

--- a/docs/src/api/class-mouse.md
+++ b/docs/src/api/class-mouse.md
@@ -4,7 +4,7 @@
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 
 :::tip
-If you want to debug where the mouse moved, you can use the [Trace viewer](../trace-viewer-intro.md) or [Playwright Inspector](../running-tests#debug-tests-with-the-playwright-inspector.md). A red dot showing the location of the mouse will be shown for every mouse action.
+If you want to debug where the mouse moved, you can use the [Trace viewer](../trace-viewer-intro.md) or [Playwright Inspector](../running-tests.md#debug-tests-with-the-playwright-inspector). A red dot showing the location of the mouse will be shown for every mouse action.
 :::
 
 Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].

--- a/docs/src/api/class-mouse.md
+++ b/docs/src/api/class-mouse.md
@@ -3,6 +3,10 @@
 
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 
+::: tip
+If you want to debug where the mouse moved, you can use the [Trace viewer](/docs/trace-viewer-intro). A red dot showing the location of the mouse will be shown for every mouse action
+:::
+
 Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].
 
 ```js

--- a/docs/src/api/class-mouse.md
+++ b/docs/src/api/class-mouse.md
@@ -4,7 +4,7 @@
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 
 :::tip
-If you want to debug where the mouse moved, you can use the [Trace viewer](/trace-viewer-intro). A red dot showing the location of the mouse will be shown for every mouse action
+If you want to debug where the mouse moved, you can use the [Trace viewer](./trace-viewer-intro) or [Playwright Inspector](./running-tests#debug-tests-with-the-playwright-inspector). A red dot showing the location of the mouse will be shown for every mouse action.
 :::
 
 Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].

--- a/docs/src/api/class-mouse.md
+++ b/docs/src/api/class-mouse.md
@@ -4,7 +4,7 @@
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 
 :::tip
-If you want to debug where the mouse moved, you can use the [Trace viewer](../trace-viewer-intro) or [Playwright Inspector](../running-tests#debug-tests-with-the-playwright-inspector). A red dot showing the location of the mouse will be shown for every mouse action.
+If you want to debug where the mouse moved, you can use the [Trace viewer](../trace-viewer-intro.md) or [Playwright Inspector](../running-tests#debug-tests-with-the-playwright-inspector.md). A red dot showing the location of the mouse will be shown for every mouse action.
 :::
 
 Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].

--- a/docs/src/api/class-mouse.md
+++ b/docs/src/api/class-mouse.md
@@ -4,7 +4,7 @@
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 
 :::tip
-If you want to debug where the mouse moved, you can use the [Trace viewer](./trace-viewer-intro) or [Playwright Inspector](./running-tests#debug-tests-with-the-playwright-inspector). A red dot showing the location of the mouse will be shown for every mouse action.
+If you want to debug where the mouse moved, you can use the [Trace viewer](../trace-viewer-intro) or [Playwright Inspector](../running-tests#debug-tests-with-the-playwright-inspector). A red dot showing the location of the mouse will be shown for every mouse action.
 :::
 
 Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].

--- a/docs/src/api/class-mouse.md
+++ b/docs/src/api/class-mouse.md
@@ -4,7 +4,7 @@
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
 
 :::tip
-If you want to debug where the mouse moved, you can use the [Trace viewer](../trace-viewer-intro.md). A red dot showing the location of the mouse will be shown for every mouse action.
+If you want to debug where the mouse moved, you can use the [Playwright Inspector](../running-tests.md#debug-tests-with-the-playwright-inspector). A red dot showing the location of the mouse will be shown for every mouse action.
 :::
 
 Every `page` object has its own Mouse, accessible with [`property: Page.mouse`].

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -20140,6 +20140,10 @@ export interface Logger {
  * Every `page` object has its own Mouse, accessible with
  * [page.mouse](https://playwright.dev/docs/api/class-page#page-mouse).
  *
+ * **NOTE** If you want to debug where the mouse moved, you can use the [Trace viewer](https://playwright.dev/docs/trace-viewer-intro) or
+ * [Playwright Inspector](https://playwright.dev/docs/running-tests). A red dot showing the location of the mouse will be shown for every
+ * mouse action.
+ *
  * ```js
  * // Using ‘page.mouse’ to trace a 100x100 square.
  * await page.mouse.move(0, 0);

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -20137,12 +20137,12 @@ export interface Logger {
 /**
  * The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
  *
- * Every `page` object has its own Mouse, accessible with
- * [page.mouse](https://playwright.dev/docs/api/class-page#page-mouse).
- *
  * **NOTE** If you want to debug where the mouse moved, you can use the [Trace viewer](https://playwright.dev/docs/trace-viewer-intro) or
  * [Playwright Inspector](https://playwright.dev/docs/running-tests). A red dot showing the location of the mouse will be shown for every
  * mouse action.
+ *
+ * Every `page` object has its own Mouse, accessible with
+ * [page.mouse](https://playwright.dev/docs/api/class-page#page-mouse).
  *
  * ```js
  * // Using ‘page.mouse’ to trace a 100x100 square.

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -20140,6 +20140,10 @@ export interface Logger {
  * Every `page` object has its own Mouse, accessible with
  * [page.mouse](https://playwright.dev/docs/api/class-page#page-mouse).
  *
+ * **NOTE** If you want to debug where the mouse moved, you can use the [Trace viewer](https://playwright.dev/docs/trace-viewer-intro) or
+ * [Playwright Inspector](https://playwright.dev/docs/running-tests). A red dot showing the location of the mouse will be shown for every
+ * mouse action.
+ *
  * ```js
  * // Using ‘page.mouse’ to trace a 100x100 square.
  * await page.mouse.move(0, 0);

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -20137,12 +20137,12 @@ export interface Logger {
 /**
  * The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.
  *
- * Every `page` object has its own Mouse, accessible with
- * [page.mouse](https://playwright.dev/docs/api/class-page#page-mouse).
- *
  * **NOTE** If you want to debug where the mouse moved, you can use the [Trace viewer](https://playwright.dev/docs/trace-viewer-intro) or
  * [Playwright Inspector](https://playwright.dev/docs/running-tests). A red dot showing the location of the mouse will be shown for every
  * mouse action.
+ *
+ * Every `page` object has its own Mouse, accessible with
+ * [page.mouse](https://playwright.dev/docs/api/class-page#page-mouse).
  *
  * ```js
  * // Using ‘page.mouse’ to trace a 100x100 square.


### PR DESCRIPTION
I had to go search this and found out about this way of seeing where the mouse is through #16546 

Putting it in the docs will save people some time :)