### PR TITLE
feat(ui-mode): enhance status-line to show passed, failed, and skipped test counts

### DIFF
--- a/packages/trace-viewer/src/ui/statusLine.css
+++ b/packages/trace-viewer/src/ui/statusLine.css
@@ -1,32 +1,41 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 .status-line {
-  flex: auto;
-  align-items: center;
+  display: block;
+  width: 100%;
   white-space: nowrap;
-  line-height: 22px;
-  display: flex;
-  flex-direction: row;
-  height: 30px;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 30px;
+  height: 30px;
   padding-left: 5px;
-  gap: 8px;
+  cursor: pointer;
 }
 
-.status-line > * {
-  flex-shrink: 0;
-}
-
-.status-line > div {
-  display: flex;
+.status-line > span:not(:first-child) {
+  display: inline-flex;
   align-items: center;
   gap: 4px;
-  cursor: pointer;
   user-select: none;
+  margin-left: 8px;
 }
 
 .status-line-count {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 8px;
 }

--- a/packages/trace-viewer/src/ui/statusLine.css
+++ b/packages/trace-viewer/src/ui/statusLine.css
@@ -22,7 +22,7 @@
   text-overflow: ellipsis;
   line-height: 30px;
   height: 30px;
-  padding-left: 5px;
+  margin-left: 5px;
   cursor: pointer;
 }
 

--- a/packages/trace-viewer/src/ui/statusLine.css
+++ b/packages/trace-viewer/src/ui/statusLine.css
@@ -23,7 +23,7 @@
   line-height: 30px;
   height: 30px;
   margin-left: 5px;
-  cursor: pointer;
+  cursor: default;
 }
 
 .status-line > span:not(:first-child) {

--- a/packages/trace-viewer/src/ui/statusLine.css
+++ b/packages/trace-viewer/src/ui/statusLine.css
@@ -32,12 +32,14 @@
   gap: 4px;
   user-select: none;
   margin-left: 8px;
+  vertical-align: sub;
 }
 
 .status-line-count {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  vertical-align: sub;
 }
 
 .status-passed {

--- a/packages/trace-viewer/src/ui/statusLine.css
+++ b/packages/trace-viewer/src/ui/statusLine.css
@@ -1,0 +1,44 @@
+
+.status-line {
+  flex: auto;
+  align-items: center;
+  white-space: nowrap;
+  line-height: 22px;
+  display: flex;
+  flex-direction: row;
+  height: 30px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-left: 5px;
+  gap: 8px;
+}
+
+.status-line > * {
+  flex-shrink: 0;
+}
+
+.status-line > div {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.status-line-count {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-passed {
+  color: var(--vscode-debugIcon-restartForeground);
+}
+
+.status-failed {
+  color: var(--vscode-list-errorForeground);
+}
+
+.status-skipped {
+  color: var(--vscode-foreground);
+}

--- a/packages/trace-viewer/src/ui/statusLine.tsx
+++ b/packages/trace-viewer/src/ui/statusLine.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '@web/third_party/vscode/codicon.css';
+import '@web/common.css';
+import './statusLine.css';
+import React from 'react';
+import { clsx } from '@web/uiUtils';
+import { testStatusIcon } from './testUtils';
+interface StatusLineProps {
+  passed: number;
+  failed: number;
+  skipped: number;
+  total: number;
+  isRunning: boolean;
+}
+
+export const StatusLine: React.FC<StatusLineProps> = ({ passed, failed, skipped, total, isRunning }) => {
+  const count = passed + failed + skipped;
+  return (
+    <div data-testid='status-line' className='status-line' title={`${passed} passed, ${failed} failed, ${skipped} skipped`}>
+      <span className='status-line-count'>
+        <span className={clsx('codicon', isRunning ? testStatusIcon('running') : testStatusIcon('none'))} />
+        <span data-testid='test-count'>{count}/{total}</span>
+      </span>
+      <div className='status-passed'>
+        <span className={clsx('codicon', testStatusIcon('passed'))} />{passed || 0}
+      </div>
+      <div className='status-failed'>
+        <span className={clsx('codicon', testStatusIcon('failed'))} />{failed || 0}
+      </div>
+      <div className='status-skipped'>
+        <span className={clsx('codicon', testStatusIcon('skipped'))} />{skipped || 0}
+      </div>
+    </div>
+  );
+};

--- a/packages/trace-viewer/src/ui/statusLine.tsx
+++ b/packages/trace-viewer/src/ui/statusLine.tsx
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@web/third_party/vscode/codicon.css';
 import '@web/common.css';
 import './statusLine.css';
 import React from 'react';
 import { clsx } from '@web/uiUtils';
 import { testStatusIcon } from './testUtils';
+
 interface StatusLineProps {
   passed: number;
   failed: number;
@@ -32,18 +34,18 @@ export const StatusLine: React.FC<StatusLineProps> = ({ passed, failed, skipped,
   return (
     <div data-testid='status-line' className='status-line' title={`${passed} passed, ${failed} failed, ${skipped} skipped`}>
       <span className='status-line-count'>
-        <span className={clsx('codicon', isRunning ? testStatusIcon('running') : testStatusIcon('none'))} />
+        <i className={clsx('codicon', isRunning ? testStatusIcon('running') : testStatusIcon('none'))} />
         <span data-testid='test-count'>{count}/{total}</span>
       </span>
-      <div className='status-passed'>
-        <span className={clsx('codicon', testStatusIcon('passed'))} />{passed || 0}
-      </div>
-      <div className='status-failed'>
-        <span className={clsx('codicon', testStatusIcon('failed'))} />{failed || 0}
-      </div>
-      <div className='status-skipped'>
-        <span className={clsx('codicon', testStatusIcon('skipped'))} />{skipped || 0}
-      </div>
+      <span className='status-passed'>
+        <i className={clsx('codicon', testStatusIcon('passed'))} />{passed || 0}
+      </span>
+      <span className='status-failed'>
+        <i className={clsx('codicon', testStatusIcon('failed'))} />{failed || 0}
+      </span>
+      <span className='status-skipped'>
+        <i className={clsx('codicon', testStatusIcon('skipped'))} />{skipped || 0}
+      </span>
     </div>
   );
 };

--- a/packages/trace-viewer/src/ui/uiModeView.css
+++ b/packages/trace-viewer/src/ui/uiModeView.css
@@ -82,28 +82,6 @@
   margin-bottom: 30px;
 }
 
-.status-line {
-  flex: auto;
-  white-space: nowrap;
-  line-height: 22px;
-  padding-left: 10px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  height: 30px;
-  overflow: hidden;
-  gap: 6px;
-}
-
-.status-line > * {
-  flex-shrink: 0;
-}
-
-.status-line > div {
-  display: flex;
-  align-items: center;
-}
-
 .ui-mode-sidebar input[type=search] {
   flex: auto;
   padding: 0 5px;
@@ -113,18 +91,4 @@
   border: none;
   color: var(--vscode-input-foreground);
   background-color: var(--vscode-input-background);
-}
-
-.status-passed {
-  color: var(--vscode-debugIcon-restartForeground);
-  gap: 2px;
-}
-
-.status-failed {
-  color: var(--vscode-list-errorForeground);
-  gap: 3px;
-}
-
-.status-skipped {
-  gap: 3px;
 }

--- a/packages/trace-viewer/src/ui/uiModeView.css
+++ b/packages/trace-viewer/src/ui/uiModeView.css
@@ -91,11 +91,17 @@
   flex-direction: row;
   align-items: center;
   height: 30px;
+  overflow: hidden;
+  gap: 6px;
+}
+
+.status-line > * {
+  flex-shrink: 0;
 }
 
 .status-line > div {
-  overflow: hidden;
-  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
 }
 
 .ui-mode-sidebar input[type=search] {
@@ -107,4 +113,18 @@
   border: none;
   color: var(--vscode-input-foreground);
   background-color: var(--vscode-input-background);
+}
+
+.status-passed {
+  color: var(--vscode-debugIcon-restartForeground);
+  gap: 2px;
+}
+
+.status-failed {
+  color: var(--vscode-list-errorForeground);
+  gap: 3px;
+}
+
+.status-skipped {
+  gap: 3px;
 }

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -461,20 +461,13 @@ export const UIModeView: React.FC<{}> = ({
           testModel={testModel}
           runTests={() => runTests('bounce-if-busy', visibleTestIds)} />
         <Toolbar noMinHeight={true}>
-          {!progress ? (<StatusLine
-            passed={0}
-            failed={0}
-            skipped={0}
-            total={visibleTestIds.size}
-            isRunning={false}
-          />) : (<StatusLine
-            passed={progress.passed}
-            failed={progress.failed}
-            skipped={progress.skipped}
-            total={isRunningTest ? runningState.testIds.size : progress.total}
+          <StatusLine
+            passed={progress?.passed ?? 0}
+            failed={progress?.failed ?? 0}
+            skipped={progress?.skipped ?? 0}
+            total={progress ? (isRunningTest ? runningState.testIds.size : progress.total) : visibleTestIds.size}
             isRunning={!!isRunningTest}
           />
-          )}
           <ToolbarButton icon='play' title='Run all — F5' onClick={() => runTests('bounce-if-busy', visibleTestIds)} disabled={isRunningTest || isLoading}></ToolbarButton>
           <ToolbarButton icon='debug-stop' title={'Stop — ' + (isMac ? '⇧F5' : 'Shift + F5')} onClick={() => testServerConnection?.stopTests({})} disabled={!isRunningTest || isLoading}></ToolbarButton>
           <ToolbarButton icon='eye' title='Watch all' toggled={watchAll} onClick={() => {

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -37,7 +37,7 @@ import { TestListView } from './uiModeTestListView';
 import { TraceView } from './uiModeTraceView';
 import { SettingsView } from './settingsView';
 import { DefaultSettingsView } from './defaultSettingsView';
-import { testStatusIcon } from './testUtils';
+import { StatusLine } from './statusLine';
 
 let xtermSize = { cols: 80, rows: 24 };
 const xtermDataSource: XtermDataSource = {
@@ -461,20 +461,20 @@ export const UIModeView: React.FC<{}> = ({
           testModel={testModel}
           runTests={() => runTests('bounce-if-busy', visibleTestIds)} />
         <Toolbar noMinHeight={true}>
-          {!isRunningTest && !progress && <div className='section-title'>Tests</div>}
-          {!isRunningTest && progress && <div data-testid='status-line' className='status-line' title={`${progress.passed} passed, ${progress.failed} failed, ${progress.skipped} skipped`}>
-            <span data-testid='test-count'>{progress.passed + progress.failed + progress.skipped}/{progress.total}</span>
-            <div className='status-passed'><span className={clsx('codicon', testStatusIcon('passed'))}/>{progress.passed}</div>
-            <div className='status-failed'><span className={clsx('codicon', testStatusIcon('failed'))}/>{progress.failed}</div>
-            <div className='status-skipped'><span className={clsx('codicon', testStatusIcon('skipped'))}/>{progress.skipped}</div>
-          </div>}
-          {isRunningTest && progress && <div data-testid='status-line' className='status-line' title={`${progress.passed} passed, ${progress.failed} failed, ${progress.skipped} skipped`}>
-            <span className={clsx('codicon', testStatusIcon('running'))}/>
-            <span data-testid='test-count'>{progress.passed + progress.failed + progress.skipped}/{runningState.testIds.size}</span>
-            <div className='status-passed'><span className={clsx('codicon', testStatusIcon('passed'))}/>{progress.passed}</div>
-            <div className='status-failed'><span className={clsx('codicon', testStatusIcon('failed'))}/>{progress.failed}</div>
-            <div className='status-skipped'><span className={clsx('codicon', testStatusIcon('skipped'))}/>{progress.skipped}</div>
-          </div>}
+          {!progress ? (<StatusLine
+            passed={0}
+            failed={0}
+            skipped={0}
+            total={visibleTestIds.size}
+            isRunning={false}
+          />) : (<StatusLine
+            passed={progress.passed}
+            failed={progress.failed}
+            skipped={progress.skipped}
+            total={isRunningTest ? runningState.testIds.size : progress.total}
+            isRunning={!!isRunningTest}
+          />
+          )}
           <ToolbarButton icon='play' title='Run all — F5' onClick={() => runTests('bounce-if-busy', visibleTestIds)} disabled={isRunningTest || isLoading}></ToolbarButton>
           <ToolbarButton icon='debug-stop' title={'Stop — ' + (isMac ? '⇧F5' : 'Shift + F5')} onClick={() => testServerConnection?.stopTests({})} disabled={!isRunningTest || isLoading}></ToolbarButton>
           <ToolbarButton icon='eye' title='Watch all' toggled={watchAll} onClick={() => {

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -37,6 +37,7 @@ import { TestListView } from './uiModeTestListView';
 import { TraceView } from './uiModeTraceView';
 import { SettingsView } from './settingsView';
 import { DefaultSettingsView } from './defaultSettingsView';
+import { testStatusIcon } from './testUtils';
 
 let xtermSize = { cols: 80, rows: 24 };
 const xtermDataSource: XtermDataSource = {
@@ -461,11 +462,18 @@ export const UIModeView: React.FC<{}> = ({
           runTests={() => runTests('bounce-if-busy', visibleTestIds)} />
         <Toolbar noMinHeight={true}>
           {!isRunningTest && !progress && <div className='section-title'>Tests</div>}
-          {!isRunningTest && progress && <div data-testid='status-line' className='status-line'>
-            <div>{progress.passed}/{progress.total} passed ({(progress.passed / progress.total) * 100 | 0}%)</div>
+          {!isRunningTest && progress && <div data-testid='status-line' className='status-line' title={`${progress.passed} passed, ${progress.failed} failed, ${progress.skipped} skipped`}>
+            <span data-testid='test-count'>{progress.passed + progress.failed + progress.skipped}/{progress.total}</span>
+            <div className='status-passed'><span className={clsx('codicon', testStatusIcon('passed'))}/>{progress.passed}</div>
+            <div className='status-failed'><span className={clsx('codicon', testStatusIcon('failed'))}/>{progress.failed}</div>
+            <div className='status-skipped'><span className={clsx('codicon', testStatusIcon('skipped'))}/>{progress.skipped}</div>
           </div>}
-          {isRunningTest && progress && <div data-testid='status-line' className='status-line'>
-            <div>Running {progress.passed}/{runningState.testIds.size} passed ({(progress.passed / runningState.testIds.size) * 100 | 0}%)</div>
+          {isRunningTest && progress && <div data-testid='status-line' className='status-line' title={`${progress.passed} passed, ${progress.failed} failed, ${progress.skipped} skipped`}>
+            <span className={clsx('codicon', testStatusIcon('running'))}/>
+            <span data-testid='test-count'>{progress.passed + progress.failed + progress.skipped}/{runningState.testIds.size}</span>
+            <div className='status-passed'><span className={clsx('codicon', testStatusIcon('passed'))}/>{progress.passed}</div>
+            <div className='status-failed'><span className={clsx('codicon', testStatusIcon('failed'))}/>{progress.failed}</div>
+            <div className='status-skipped'><span className={clsx('codicon', testStatusIcon('skipped'))}/>{progress.skipped}</div>
           </div>}
           <ToolbarButton icon='play' title='Run all — F5' onClick={() => runTests('bounce-if-busy', visibleTestIds)} disabled={isRunningTest || isLoading}></ToolbarButton>
           <ToolbarButton icon='debug-stop' title={'Stop — ' + (isMac ? '⇧F5' : 'Shift + F5')} onClick={() => testServerConnection?.stopTests({})} disabled={!isRunningTest || isLoading}></ToolbarButton>

--- a/tests/playwright-test/ui-mode-metadata.spec.ts
+++ b/tests/playwright-test/ui-mode-metadata.spec.ts
@@ -41,7 +41,11 @@ test('should render html report git info metadata', async ({ runUITest }) => {
   });
 
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByTitle('Toggle output').click();
 
   await expect(page.getByTestId('output')).toContainText('ci.link: https://playwright.dev');

--- a/tests/playwright-test/ui-mode-test-annotations.spec.ts
+++ b/tests/playwright-test/ui-mode-test-annotations.spec.ts
@@ -32,7 +32,11 @@ test('should display annotations', async ({ runUITest }) => {
     `,
   });
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByRole('treeitem', { name: 'suite' }).locator('.codicon-chevron-right').click();
   await page.getByText('annotation test').click();
   await page.getByText('Annotations', { exact: true }).click();

--- a/tests/playwright-test/ui-mode-test-attachments.spec.ts
+++ b/tests/playwright-test/ui-mode-test-attachments.spec.ts
@@ -33,7 +33,11 @@ test('should contain text attachment', async ({ runUITest }) => {
   });
   await page.getByText('attach test').click();
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByText('Attachments').click();
 
   await page.locator('.tab-attachments').getByText('text attachment').click();
@@ -69,7 +73,11 @@ test('should contain binary attachment', async ({ runUITest }) => {
   });
   await page.getByText('attach test').click();
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByText('Attachments').click();
   const downloadPromise = page.waitForEvent('download');
   await page.getByRole('link', { name: 'download' }).click();
@@ -89,7 +97,11 @@ test('should contain string attachment', async ({ runUITest }) => {
   });
   await page.getByText('attach test').click();
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByText('Attachments').click();
   await page.getByText('note', { exact: true }).click();
   const downloadPromise = page.waitForEvent('download');
@@ -116,7 +128,11 @@ test('should linkify string attachments', async ({ runUITest, server }) => {
   });
   await page.getByText('attach test').click();
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByText('Attachments').click();
 
   const attachmentsPane = page.locator('.attachments-tab');
@@ -162,7 +178,11 @@ test('should link from attachment step to attachments view', async ({ runUITest 
 
   await page.getByText('attach test').click();
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByRole('tab', { name: 'Attachments' }).click();
 
   const panel = page.getByRole('tabpanel', { name: 'Attachments' });

--- a/tests/playwright-test/ui-mode-test-output.spec.ts
+++ b/tests/playwright-test/ui-mode-test-output.spec.ts
@@ -250,7 +250,11 @@ test('should print beforeAll console messages once', async ({ runUITest }, testI
   await page.getByTitle('Run all').click();
   await page.getByText('Console').click();
   await page.getByText('print').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await expect(page.locator('.console-tab .console-line-message')).toHaveText([
     'before all log',
     'test log',

--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -111,10 +111,10 @@ test('should show running progress', async ({ runUITest }) => {
   await expect(statusLine.locator('.status-failed')).toHaveText('0');
   await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByTitle('Reload').click();
-  await expect(statusLine.getByTestId('test-count')).toBeHidden();
-  await expect(statusLine.locator('.status-passed')).toBeHidden();
-  await expect(statusLine.locator('.status-failed')).toBeHidden();
-  await expect(statusLine.locator('.status-skipped')).toBeHidden();
+  await expect(statusLine.getByTestId('test-count')).toHaveText('0/4');
+  await expect(statusLine.locator('.status-passed')).toHaveText('0');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 });
 
 test('should run on hover', async ({ runUITest }) => {

--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -81,7 +81,11 @@ test('should run visible', async ({ runUITest }) => {
           - treeitem "[icon-circle-slash] skipped"
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('4/8 passed (50%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('8/8');
+  await expect(statusLine.locator('.status-passed')).toHaveText('4');
+  await expect(statusLine.locator('.status-failed')).toHaveText('3');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('1');
 });
 
 test('should show running progress', async ({ runUITest }) => {
@@ -96,11 +100,21 @@ test('should show running progress', async ({ runUITest }) => {
   });
 
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/4');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByTitle('Stop').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/4 passed (25%)');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/4');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByTitle('Reload').click();
-  await expect(page.getByTestId('status-line')).toBeHidden();
+  await expect(statusLine.getByTestId('test-count')).toBeHidden();
+  await expect(statusLine.locator('.status-passed')).toBeHidden();
+  await expect(statusLine.locator('.status-failed')).toBeHidden();
+  await expect(statusLine.locator('.status-skipped')).toBeHidden();
 });
 
 test('should run on hover', async ({ runUITest }) => {
@@ -491,7 +505,11 @@ test('should show time', async ({ runUITest }) => {
           - treeitem "[icon-circle-slash] skipped"
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('4/8 passed (50%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('8/8');
+  await expect(statusLine.locator('.status-passed')).toHaveText('4');
+  await expect(statusLine.locator('.status-failed')).toHaveText('3');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('1');
 });
 
 test('should show test.fail as passing', async ({ runUITest }) => {
@@ -522,7 +540,11 @@ test('should show test.fail as passing', async ({ runUITest }) => {
           - treeitem ${/\[icon-check\] should fail \d+m?s/}
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 });
 
 test('should ignore repeatEach', async ({ runUITest }) => {
@@ -558,7 +580,11 @@ test('should ignore repeatEach', async ({ runUITest }) => {
           - treeitem ${/\[icon-check\] should pass/}
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 });
 
 test('should remove output folder before test run', async ({ runUITest }) => {
@@ -593,7 +619,11 @@ test('should remove output folder before test run', async ({ runUITest }) => {
           - treeitem ${/\[icon-check\] should pass/}
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 
   await page.getByTitle('Run all').click();
   await expect.poll(dumpTestTree(page)).toBe(`
@@ -608,7 +638,10 @@ test('should remove output folder before test run', async ({ runUITest }) => {
           - treeitem ${/\[icon-check\] should pass/}
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 });
 
 test('should show proper total when using deps', async ({ runUITest }) => {
@@ -660,7 +693,11 @@ test('should show proper total when using deps', async ({ runUITest }) => {
           - treeitem "[icon-circle-outline] run @chromium chromium"
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 
   await page.getByTitle('run @chromium').dblclick();
   await expect.poll(dumpTestTree(page)).toBe(`
@@ -680,7 +717,10 @@ test('should show proper total when using deps', async ({ runUITest }) => {
             - button "Watch"
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('2/2 passed (100%)');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('2/2');
+  await expect(statusLine.locator('.status-passed')).toHaveText('2');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 });
 
 test('should respect --tsconfig option', {
@@ -746,7 +786,11 @@ test('should respect --tsconfig option', {
           - treeitem ${/\[icon-check\] test/}
   `);
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 });
 
 test('should respect --ignore-snapshots option', {

--- a/tests/playwright-test/ui-mode-test-screencast.spec.ts
+++ b/tests/playwright-test/ui-mode-test-screencast.spec.ts
@@ -35,7 +35,11 @@ test('should show screenshots', async ({ runUITest }) => {
     `,
   });
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('2/2 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('2/2');
+  await expect(statusLine.locator('.status-passed')).toHaveText('2');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 
   await page.getByText('test 1', { exact: true }).click();
   await expect(page.getByTestId('actions-tree')).toContainText('Expect');

--- a/tests/playwright-test/ui-mode-test-setup.spec.ts
+++ b/tests/playwright-test/ui-mode-test-setup.spec.ts
@@ -47,7 +47,11 @@ test('should run global setup and teardown', async ({ runUITest }, testInfo) => 
     `
   }, undefined, { additionalArgs: ['--output=foo'] });
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 
   await page.getByTitle('Toggle output').click();
   const output = page.getByTestId('output');
@@ -85,7 +89,11 @@ test('should teardown on sigint', async ({ runUITest, nodeVersion }) => {
     `
   });
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByTitle('Toggle output').click();
   await expect(page.getByTestId('output')).toContainText('from-global-setup');
 
@@ -335,7 +343,11 @@ for (const useWeb of [true, false]) {
         `
       }, null, { useWeb });
       await page.getByTitle('Run all').click();
-      await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+      const statusLine = page.getByTestId('status-line');
+      await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+      await expect(statusLine.locator('.status-passed')).toHaveText('1');
+      await expect(statusLine.locator('.status-failed')).toHaveText('0');
+      await expect(statusLine.locator('.status-skipped')).toHaveText('0');
       await testProcess.kill('SIGINT');
       await expect.poll(() => testProcess.outputLines()).toEqual([
         'from-global-teardown0000',
@@ -368,7 +380,11 @@ test('should restart webserver on reload', async ({ runUITest }) => {
     `
   }, { DEBUG: 'pw:webserver' });
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 
   await page.getByTitle('Toggle output').click();
   await expect(page.getByTestId('output')).toContainText('[WebServer] listening');
@@ -381,5 +397,8 @@ test('should restart webserver on reload', async ({ runUITest }) => {
   await expect(page.getByTestId('output')).not.toContainText('set reuseExistingServer:true');
 
   await page.getByTitle('Run all').click();
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 });

--- a/tests/playwright-test/ui-mode-test-shortcut.spec.ts
+++ b/tests/playwright-test/ui-mode-test-shortcut.spec.ts
@@ -37,7 +37,11 @@ test('should run tests', async ({ runUITest }) => {
   await page.getByPlaceholder('Filter (e.g. text, @tag)').fill('test 3');
   await page.keyboard.press('F5');
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   await page.getByPlaceholder('Filter (e.g. text, @tag)').fill('');
 
   // Only the filtered test was run.

--- a/tests/playwright-test/ui-mode-test-watch.spec.ts
+++ b/tests/playwright-test/ui-mode-test-watch.spec.ts
@@ -128,7 +128,10 @@ test('should batch watch updates', async ({ runUITest, writeFiles }) => {
     'd.test.ts': `import { test } from '@playwright/test'; test('test', () => {});`,
   });
 
-  await expect(page.getByTestId('status-line')).toHaveText('4/4 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.locator('.status-passed')).toHaveText('4');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ✅ a.test.ts 👁
@@ -167,7 +170,11 @@ test('should watch all', async ({ runUITest, writeFiles }) => {
     'd.test.ts': `import { test } from '@playwright/test'; test('test', () => {});`,
   });
 
-  await expect(page.getByTestId('status-line')).toHaveText('2/2 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('2/2');
+  await expect(statusLine.locator('.status-passed')).toHaveText('2');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ✅ a.test.ts
@@ -210,7 +217,11 @@ test('should watch new file', async ({ runUITest, writeFiles }) => {
     'b.test.ts': ` import { test } from '@playwright/test'; test('test', () => {});`,
   });
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ◯ a.test.ts
@@ -276,7 +287,11 @@ test('should queue watches', async ({ runUITest, writeFiles, createLatch }) => {
   await page.getByTitle('Watch all').click();
   await page.getByTitle('Run all').click();
 
-  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/4');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 
   await writeFiles({
     'a.test.ts': `import { test } from '@playwright/test'; test('test', () => {});`,
@@ -286,12 +301,18 @@ test('should queue watches', async ({ runUITest, writeFiles, createLatch }) => {
 
   // Now watches should not kick in.
   await new Promise(f => setTimeout(f, 1000));
-  await expect(page.getByTestId('status-line')).toHaveText('Running 1/4 passed (25%)');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/4');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 
   // Allow test to finish and new watch to  kick in.
   latch.open();
 
-  await expect(page.getByTestId('status-line')).toHaveText('3/3 passed (100%)');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('3/3');
+  await expect(statusLine.locator('.status-passed')).toHaveText('3');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
 });
 
 test('should not watch output', async ({ runUITest }) => {
@@ -316,7 +337,11 @@ test('should not watch output', async ({ runUITest }) => {
 
   await page.getByTitle('Run all').click();
 
-  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+  const statusLine = page.getByTestId('status-line');
+  await expect(statusLine.getByTestId('test-count')).toHaveText('1/1');
+  await expect(statusLine.locator('.status-passed')).toHaveText('1');
+  await expect(statusLine.locator('.status-failed')).toHaveText('0');
+  await expect(statusLine.locator('.status-skipped')).toHaveText('0');
   expect(commands).toContain('runTests');
   expect(commands).not.toContain('listTests');
 });


### PR DESCRIPTION
Closes #34444 (assignee @agg23)

- [x] Show passed, failed, and skipped test counts on status line
- [x] Update regression tests

Implemented [prior discussion and feedback](https://github.com/microsoft/playwright/issues/34444#issuecomment-2828091994)

Looking forward to the team’s feedback. Thank you :)

<div align="center">
  <table>
    <tr>
      <th>Running</th>
      <th>Stopped</th>
    </tr>
    <tr>
      <td valign="top">
<img width="830" alt="image" src="https://github.com/user-attachments/assets/4cf2b4e6-bd88-4abe-be5a-c64b8df2b2ba" />
      </td>
      <td valign="top">
<img width="830" alt="image" src="https://github.com/user-attachments/assets/e204a8ca-fd1a-406b-8117-5fe5188417e8" />
      </td>
    </tr>
  </table>
</div>