### PR TITLE
fix(bidi): do not report internal pages

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -93,6 +93,12 @@ export class BidiPage implements PageDelegate {
     await Promise.all([
       this.updateHttpCredentials(),
       this.updateRequestInterception(),
+      // If the page is created by the Playwright client's call, some initialization
+      // may be pending. Wait for it to complete before reporting the page as new.
+      //
+      // TODO: ideally we'd wait only for the commands that created this page, but currently
+      // there is no way in Bidi to track which command created this page.
+      this._browserContext.waitForBlockingPageCreationCommands(),
     ]);
   }
 

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -98,7 +98,7 @@ export class BidiPage implements PageDelegate {
       //
       // TODO: ideally we'd wait only for the commands that created this page, but currently
       // there is no way in Bidi to track which command created this page.
-      this._browserContext.waitForBlockingPageCreationCommands(),
+      this._browserContext.waitForBlockingPageCreations(),
     ]);
   }
 

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -267,7 +267,7 @@ export abstract class BrowserContext extends SdkObject {
 
   // BrowserContext methods.
   abstract possiblyUninitializedPages(): Page[];
-  abstract doCreateNewPage(): Promise<Page>;
+  abstract doCreateNewPage(markAsServerSideOnly?: boolean): Promise<Page>;
   abstract addCookies(cookies: channels.SetNetworkCookie[]): Promise<void>;
   abstract setGeolocation(geolocation?: types.Geolocation): Promise<void>;
   abstract setExtraHTTPHeaders(headers: types.HeadersArray): Promise<void>;
@@ -495,7 +495,7 @@ export abstract class BrowserContext extends SdkObject {
   }
 
   async newPage(metadata: CallMetadata): Promise<Page> {
-    const page = await this.doCreateNewPage();
+    const page = await this.doCreateNewPage(metadata.isServerSide);
     if (metadata.isServerSide)
       page.markAsServerSideOnly();
     const pageOrError = await page.waitForInitializedOrError();

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -496,8 +496,6 @@ export abstract class BrowserContext extends SdkObject {
 
   async newPage(metadata: CallMetadata): Promise<Page> {
     const page = await this.doCreateNewPage(metadata.isServerSide);
-    if (metadata.isServerSide)
-      page.markAsServerSideOnly();
     const pageOrError = await page.waitForInitializedOrError();
     if (pageOrError instanceof Page) {
       if (pageOrError.isClosed())

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -371,9 +371,12 @@ export class CRBrowserContext extends BrowserContext {
     return this._crPages().map(crPage => crPage._page);
   }
 
-  override async doCreateNewPage(): Promise<Page> {
+  override async doCreateNewPage(markAsServerSideOnly?: boolean): Promise<Page> {
     const { targetId } = await this._browser._session.send('Target.createTarget', { url: 'about:blank', browserContextId: this._browserContextId });
-    return this._browser._crPages.get(targetId)!._page;
+    const page = this._browser._crPages.get(targetId)!._page;
+    if (markAsServerSideOnly)
+      page.markAsServerSideOnly();
+    return page;
   }
 
   async doGetCookies(urls: string[]): Promise<channels.NetworkCookie[]> {

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -281,7 +281,7 @@ export class FFBrowserContext extends BrowserContext {
     return this._ffPages().map(ffPage => ffPage._page);
   }
 
-  override async doCreateNewPage(): Promise<Page> {
+  override async doCreateNewPage(markAsServerSideOnly?: boolean): Promise<Page> {
     const { targetId } = await this._browser.session.send('Browser.newPage', {
       browserContextId: this._browserContextId
     }).catch(e =>  {
@@ -289,7 +289,11 @@ export class FFBrowserContext extends BrowserContext {
         throw new Error(`Invalid timezone ID: ${this._options.timezoneId}`);
       throw e;
     });
-    return this._browser._ffPages.get(targetId)!._page;
+    const page = this._browser._ffPages.get(targetId)!._page;
+    if (markAsServerSideOnly)
+      page.markAsServerSideOnly();
+    return page;
+
   }
 
   async doGetCookies(urls: string[]): Promise<channels.NetworkCookie[]> {

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -244,9 +244,12 @@ export class WKBrowserContext extends BrowserContext {
     return this._wkPages().map(wkPage => wkPage._page);
   }
 
-  override async doCreateNewPage(): Promise<Page> {
+  override async doCreateNewPage(markAsServerSideOnly?: boolean): Promise<Page> {
     const { pageProxyId } = await this._browser._browserSession.send('Playwright.createPage', { browserContextId: this._browserContextId });
-    return this._browser._wkPages.get(pageProxyId)!._page;
+    const page = this._browser._wkPages.get(pageProxyId)!._page;
+    if (markAsServerSideOnly)
+      page.markAsServerSideOnly();
+    return page;
   }
 
   async doGetCookies(urls: string[]): Promise<channels.NetworkCookie[]> {

--- a/tests/library/browsercontext-storage-state.spec.ts
+++ b/tests/library/browsercontext-storage-state.spec.ts
@@ -184,7 +184,7 @@ it('should capture cookies', async ({ server, context, page, contextFactory }) =
   ]);
 });
 
-it('should not emit events about internal page', async ({ contextFactory }) => {
+it.only('should not emit events about internal page', async ({ contextFactory }) => {
   const context = await contextFactory();
   const page = await context.newPage();
   await page.route('**/*', route => {

--- a/tests/library/browsercontext-storage-state.spec.ts
+++ b/tests/library/browsercontext-storage-state.spec.ts
@@ -184,7 +184,7 @@ it('should capture cookies', async ({ server, context, page, contextFactory }) =
   ]);
 });
 
-it.only('should not emit events about internal page', async ({ contextFactory }) => {
+it('should not emit events about internal page', async ({ contextFactory }) => {
   const context = await contextFactory();
   const page = await context.newPage();
   await page.route('**/*', route => {


### PR DESCRIPTION
Make sure that page event is emitted on the context only after the creator got a chance to mark it as internal.

Fixes: https://github.com/microsoft/playwright/issues/35864