### PR TITLE
fix: bundles watch mode

### DIFF
--- a/packages/playwright-core/bundles/utils/build.js
+++ b/packages/playwright-core/bundles/utils/build.js
@@ -43,7 +43,8 @@ if (!fs.existsSync(outdir))
   await ctx.rebuild();
   if (process.argv.includes('--watch'))
     await ctx.watch();
-  await ctx.dispose();
+  else
+    await ctx.dispose();
 })().catch(error => {
   console.error(error);
   process.exit(1);

--- a/packages/playwright-core/bundles/zip/build.js
+++ b/packages/playwright-core/bundles/zip/build.js
@@ -50,7 +50,8 @@ let patchFdSlicerToHideBufferDeprecationWarning = {
   await ctx.rebuild();
   if (process.argv.includes('--watch'))
     await ctx.watch();
-  await ctx.dispose();
+  else
+    await ctx.dispose();
 })().catch(error => {
   console.error(error);
   process.exit(1);

--- a/packages/playwright/bundles/utils/build.js
+++ b/packages/playwright/bundles/utils/build.js
@@ -33,7 +33,8 @@ const esbuild = require('esbuild');
   await ctx.rebuild();
   if (process.argv.includes('--watch'))
     await ctx.watch();
-  await ctx.dispose();
+  else
+    await ctx.dispose();
 })().catch(error => {
   console.error(error);
   process.exit(1);


### PR DESCRIPTION
From the esbuild [docs](https://esbuild.github.io/api/#build):

`"When you are done with a context object, you can call dispose() on the context to wait for existing builds to finish, stop watch and/or serve mode, and free up resources."`