### PR TITLE
devops: do not run npm ci when generating 3d party notice

### DIFF
--- a/utils/generate_third_party_notice.js
+++ b/utils/generate_third_party_notice.js
@@ -17,7 +17,6 @@
 const checker = require('license-checker');
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
 
 async function checkDir(dir) {
   return await new Promise((f, r) => {

--- a/utils/generate_third_party_notice.js
+++ b/utils/generate_third_party_notice.js
@@ -53,7 +53,6 @@ This project incorporates components from the projects listed below. The origina
       if (!bundle.isDirectory())
         continue;
       const dir = path.join(bundlesDir, bundle.name);
-      execSync('npm ci', { cwd: dir });
       const packages = await checkDir(dir);
       for (const [key, value] of Object.entries(packages)) {
         if (value.licenseText)


### PR DESCRIPTION
We run `npm ci` steps right before generating the license notice. This saves >3s on m1.

```bash
$ time node utils/generate_third_party_notice.js           
node utils/generate_third_party_notice.js  0.24s user 0.09s system 109% cpu 0.301 total
```
vs
```bash
$ time node utils/generate_third_party_notice.js
node utils/generate_third_party_notice.js  2.17s user 1.78s system 106% cpu 3.701 total
```