### PR TITLE
docs: Fix example codes of toContainClass to work

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -1087,7 +1087,7 @@ await Expect(locator).ToContainClassAsync("row middle");
 When an array is passed, the method asserts that the list of elements located matches the corresponding list of expected class lists. Each element's class attribute is matched against the corresponding class in the array:
 
 ```html
-<div class='list'></div>
+<div class='list'>
   <div class='component inactive'></div>
   <div class='component active'></div>
   <div class='component inactive'></div>
@@ -1095,30 +1095,30 @@ When an array is passed, the method asserts that the list of elements located ma
 ```
 
 ```js
-const locator = page.locator('list > .component');
+const locator = page.locator('.list > .component');
 await expect(locator).toContainClass(['inactive', 'active', 'inactive']);
 ```
 
 ```java
-assertThat(page.locator("list > .component")).containsClass(new String[] {"inactive", "active", "inactive"});
+assertThat(page.locator(".list > .component")).containsClass(new String[] {"inactive", "active", "inactive"});
 ```
 
 ```python async
 from playwright.async_api import expect
 
-locator = page.locator("list > .component")
+locator = page.locator(".list > .component")
 await expect(locator).to_contain_class(["inactive", "active", "inactive"])
 ```
 
 ```python sync
 from playwright.sync_api import expect
 
-locator = page.locator("list > .component")
+locator = page.locator(".list > .component")
 await expect(locator).to_contain_class(["inactive", "active", "inactive"])
 ```
 
 ```csharp
-var locator = Page.Locator("list > .component");
+var locator = Page.Locator(".list > .component");
 await Expect(locator).ToContainClassAsync(new string[]{"inactive", "active", "inactive"});
 ```
 
@@ -1591,30 +1591,30 @@ await Expect(locator).ToHaveClassAsync(new Regex("(^|\\s)selected(\\s|$)"));
 When an array is passed, the method asserts that the list of elements located matches the corresponding list of expected class values. Each element's class attribute is matched against the corresponding string or regular expression in the array:
 
 ```js
-const locator = page.locator('list > .component');
+const locator = page.locator('.list > .component');
 await expect(locator).toHaveClass(['component', 'component selected', 'component']);
 ```
 
 ```java
-assertThat(page.locator("list > .component")).hasClass(new String[] {"component", "component selected", "component"});
+assertThat(page.locator(".list > .component")).hasClass(new String[] {"component", "component selected", "component"});
 ```
 
 ```python async
 from playwright.async_api import expect
 
-locator = page.locator("list > .component")
+locator = page.locator(".list > .component")
 await expect(locator).to_have_class(["component", "component selected", "component"])
 ```
 
 ```python sync
 from playwright.sync_api import expect
 
-locator = page.locator("list > .component")
+locator = page.locator(".list > .component")
 expect(locator).to_have_class(["component", "component selected", "component"])
 ```
 
 ```csharp
-var locator = Page.Locator("list > .component");
+var locator = Page.Locator(".list > .component");
 await Expect(locator).ToHaveClassAsync(new string[]{"component", "component selected", "component"});
 ```
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -8746,7 +8746,7 @@ interface LocatorAssertions {
    * expected class lists. Each element's class attribute is matched against the corresponding class in the array:
    *
    * ```html
-   * <div class='list'></div>
+   * <div class='list'>
    *   <div class='component inactive'></div>
    *   <div class='component active'></div>
    *   <div class='component inactive'></div>
@@ -8754,7 +8754,7 @@ interface LocatorAssertions {
    * ```
    *
    * ```js
-   * const locator = page.locator('list > .component');
+   * const locator = page.locator('.list > .component');
    * await expect(locator).toContainClass(['inactive', 'active', 'inactive']);
    * ```
    *
@@ -8996,7 +8996,7 @@ interface LocatorAssertions {
    * expression in the array:
    *
    * ```js
-   * const locator = page.locator('list > .component');
+   * const locator = page.locator('.list > .component');
    * await expect(locator).toHaveClass(['component', 'component selected', 'component']);
    * ```
    *


### PR DESCRIPTION
### before

```
Failures:                                                                                                                  
                                                                                                                           
  1) example for ExampleCodes LocatorAssertions should work with #be_contain_class                                         
     Failure/Error: example_455090a7c2a4f6e5fb33ee5e77e3a0f64a98a60561f61a459a2dd67f9d52d065(page: page)                   
                                                                                                                           
       /Users/yusuke-iwaki/src/github/YusukeIwaki/playwright-ruby-client/lib/playwright/locator_assertions_impl.rb:53:in `expect_impl':  (Playwright::AssertionError)                                                                                 
       Locator expected to contain class names '["inactive", "active", "inactive"]'                                        
       Actual value []                                                                                                     
       Call log:                                                                                                           
        - locator#expect with timeout 5000ms                                                                               
         - waiting for locator(".list .component")                                                                         
           9 ?? locator resolved to 0 elements       
```

```
example
  for ExampleCodes
    LocatorAssertions

From: /Users/yusuke-iwaki/src/github/YusukeIwaki/playwright-ruby-client/development/generate_api/example_codes.rb @ line 1269 :

    1264:   end
    1265: 
    1266:   # LocatorAssertions#to_contain_class
    1267:   def example_455090a7c2a4f6e5fb33ee5e77e3a0f64a98a60561f61a459a2dd67f9d52d065(page:)
    1268:     locator = page.locator("list > .component")
 => 1269:     binding.irb
    1270:     expect(locator).to contain_class(["inactive", "active", "inactive"])
    1271:   end
    1272: 
    1273:   # LocatorAssertions#to_contain_text
    1274:   def example_3553a48e2a15853f4869604ef20dae14952c16abfa0570b8f02e9b74e3d84faa(page:)

irb(#<RSpec::ExampleGroups::Example::ForExampleCodes::LocatorAssertions:0x00000001041f4f28>):001:0> locator.count
=> 0
```

### after

```
example
  for ExampleCodes
    LocatorAssertions
      should work with #be_contain_class

Finished in 0.5072 seconds (files took 0.1502 seconds to load)
1 example, 0 failures
```