### PR TITLE
devops: fix crash in build.js watch mode with SyntaxError

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -316,7 +316,13 @@ class EsbuildStep extends Step {
     do {
       this._sourcesChanged = false;
       this._rebuilding = true;
-      await this._context?.rebuild();
+      try {
+        await this._context?.rebuild();
+      } catch (e) {
+
+        console.error('Rebuild failed:', e);
+      }
+
       this._rebuilding = false;
     } while (this._sourcesChanged);
   }

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -287,7 +287,7 @@ class EsbuildStep extends Step {
     if (watchMode) {
       await this._ensureWatching();
     } else {
-      console.log('==== Running esbuild', this._options.entryPoints);
+      console.log('==== Running esbuild', this._options.entryPoints.map(e => path.relative(ROOT, e)).join(', '));
       const start = Date.now();
       await build(this._options);
       console.log('==== Done in', Date.now() - start, 'ms');


### PR DESCRIPTION
After https://github.com/microsoft/playwright/pull/35867 it ended up in

```
/Users/maxschmitt/Developer/playwright/node_modules/esbuild/lib/main.js:1477
  let error = new Error(text);
              ^

Error: Build failed with 1 error:
packages/playwright-core/src/client/page.ts:39:32: ERROR: Expected "from" but found "froms"
    at failureErrorWithLog (/Users/maxschmitt/Developer/playwright/node_modules/esbuild/lib/main.js:1477:15)
    at /Users/maxschmitt/Developer/playwright/node_modules/esbuild/lib/main.js:946:25
    at /Users/maxschmitt/Developer/playwright/node_modules/esbuild/lib/main.js:898:52
    at buildResponseToResult (/Users/maxschmitt/Developer/playwright/node_modules/esbuild/lib/main.js:944:7)
    at /Users/maxschmitt/Developer/playwright/node_modules/esbuild/lib/main.js:956:9
    at new Promise (<anonymous>)
    at requestCallbacks.on-end (/Users/maxschmitt/Developer/playwright/node_modules/esbuild/lib/main.js:955:54)
    at handleRequest (/Users/maxschmitt/Developer/playwright/node_modules/esbuild/lib/main.js:648:17)
    at handleIncomingPacket (/Users/maxschmitt/Developer/playwright/node_modules/esbuild/lib/main.js:673:7)
    at Socket.readFromStdout (/Users/maxschmitt/Developer/playwright/node_modules/esbuild/lib/main.js:601:7) {
  errors: [Getter/Setter],
  warnings: [Getter/Setter]
}

Node.js v22.15.0
```

if there was a SyntaxError and the whole `build.js` process crashed. I think we should try/catch and report the errors to the console?

NOTE: Usually the error gets reported twice: via TSC & via ESBuild.