### PR TITLE
chore: download browser downloads in-memory

### DIFF
--- a/packages/playwright-core/bundles/zip/src/third_party/extract-zip.d.ts
+++ b/packages/playwright-core/bundles/zip/src/third_party/extract-zip.d.ts
@@ -49,7 +49,7 @@ declare namespace extract {
 }
 
 declare function extract(
-  zipPath: string,
+  zipPath: Buffer,
   opts: extract.Options,
 ): Promise<void>;
 

--- a/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
+++ b/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
@@ -25,7 +25,6 @@ export type DownloadParams = {
   title: string;
   browserDirectory: string;
   url: string;
-  zipPath: string;
   executablePath: string | undefined;
   socketTimeout: number;
   userAgent: string;
@@ -43,11 +42,11 @@ function browserDirectoryToMarkerFilePath(browserDirectory: string): string {
   return path.join(browserDirectory, 'INSTALLATION_COMPLETE');
 }
 
-function downloadFile(options: DownloadParams): Promise<void> {
+function downloadFile(options: DownloadParams): Promise<Buffer> {
   let downloadedBytes = 0;
   let totalBytes = 0;
 
-  const promise = new ManualPromise<void>();
+  const promise = new ManualPromise<Buffer>();
 
   httpRequest({
     url: options.url,
@@ -73,21 +72,22 @@ function downloadFile(options: DownloadParams): Promise<void> {
     }
     totalBytes = parseInt(response.headers['content-length'] || '0', 10);
     log(`-- total bytes: ${totalBytes}`);
-    const file = fs.createWriteStream(options.zipPath);
-    file.on('finish', () => {
+    const chunks: Buffer[] = [];
+    response.on('end', () => {
       if (downloadedBytes !== totalBytes) {
         log(`-- download failed, size mismatch: ${downloadedBytes} != ${totalBytes}`);
         promise.reject(new Error(`Download failed: size mismatch, file size: ${downloadedBytes}, expected size: ${totalBytes} URL: ${options.url}`));
       } else {
         log(`-- download complete, size: ${downloadedBytes}`);
-        promise.resolve();
+        promise.resolve(Buffer.concat(chunks));
       }
     });
-    file.on('error', error => promise.reject(error));
-    response.pipe(file);
-    response.on('data', onData);
+    response.on('data', chunk => {
+      chunks.push(chunk);
+      downloadedBytes += chunk.length;
+      progress(downloadedBytes, totalBytes);
+    });
     response.on('error', (error: any) => {
-      file.close();
       if (error?.code === 'ECONNRESET') {
         log(`-- download failed, server closed connection`);
         promise.reject(new Error(`Download failed: server closed connection. URL: ${options.url}`));
@@ -98,18 +98,13 @@ function downloadFile(options: DownloadParams): Promise<void> {
     });
   }, (error: any) => promise.reject(error));
   return promise;
-
-  function onData(chunk: string) {
-    downloadedBytes += chunk.length;
-    progress(downloadedBytes, totalBytes);
-  }
 }
 
 async function main(options: DownloadParams) {
-  await downloadFile(options);
+  const zipFile = await downloadFile(options);
   log(`SUCCESS downloading ${options.title}`);
   log(`extracting archive`);
-  await extract(options.zipPath, { dir: options.browserDirectory });
+  await extract(zipFile, { dir: options.browserDirectory });
   if (options.executablePath) {
     log(`fixing permissions at ${options.executablePath}`);
     await fs.promises.chmod(options.executablePath, 0o755);

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -283,7 +283,7 @@ it('should round-trip extracted har.zip', async ({ contextFactory, server }, tes
   await context1.close();
 
   const harDir = testInfo.outputPath('hardir');
-  await extractZip(harPath, { dir: harDir });
+  await extractZip(await fs.promises.readFile(harPath), { dir: harDir });
 
   const context2 = await contextFactory();
   await context2.routeFromHAR(path.join(harDir, 'har.har'));

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -1438,7 +1438,7 @@ test('blob report should include version', async ({ runInlineTest }) => {
 });
 
 async function extractReport(reportZipFile: string, unzippedReportDir: string): Promise<any[]> {
-  await extractZip(reportZipFile, { dir: unzippedReportDir });
+  await extractZip(await fs.promises.readFile(reportZipFile), { dir: unzippedReportDir });
   const reportFile = path.join(unzippedReportDir, 'report.jsonl');
   const data = await fs.promises.readFile(reportFile, 'utf8');
   const events = data.split('\n').filter(Boolean).map(line => JSON.parse(line));


### PR DESCRIPTION
When installing browsers, we currently first download them to disk (zip file) and then extract them. This means we write N MB to disk and read it again from disk. Since we vendored extract-zip, we can make this small modification which saves us around 300-400 MB per `npx playwright install`. Especially on slow disks this should be very noticeable.