### PR TITLE
devops: custom watch for bundle esbuild steps

### DIFF
--- a/packages/playwright-client/build.js
+++ b/packages/playwright-client/build.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+const path = require('path');
+const esbuild = require('esbuild');
+
+
+/**
+ * @param {boolean} watchMode
+ * @returns {import('esbuild').BuildOptions}
+ */
+function esbuildOptions(watchMode) {
+  return {
+    entryPoints: [path.join(__dirname, 'src/index.ts')],
+    bundle: true,
+    outdir: path.join(__dirname, 'lib'),
+    format: 'cjs',
+    platform: 'node',
+    target: 'ES2019',
+    sourcemap: watchMode,
+  };
+}
+
+async function main() {
+  const watchMode = process.argv.includes('--watch');
+  const ctx = await esbuild.context(esbuildOptions(watchMode));
+  await ctx.rebuild();
+  if (watchMode)
+    await ctx.watch();
+  else
+    await ctx.dispose();
+}
+
+module.exports = { esbuildOptions };
+
+if (require.main === module)
+  main();

--- a/packages/playwright-client/package.json
+++ b/packages/playwright-client/package.json
@@ -25,8 +25,9 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "esbuild ./src/index.ts --outdir=lib --format=cjs --bundle --platform=node --target=ES2019",
-    "watch": "esbuild ./src/index.ts --outdir=lib --format=cjs --bundle --platform=node --target=ES2019 --watch"
+    "esbuild": "node build.js",
+    "build": "npm run esbuild",
+    "watch": "npm run esbuild -- --watch"
   },
   "dependencies": {
     "playwright-core": "1.53.0-next"

--- a/packages/playwright-core/bundles/utils/package.json
+++ b/packages/playwright-core/bundles/utils/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "esbuild": "node build.js",
-    "build": "npm run esbuild -- --minify",
-    "watch": "npm run esbuild -- --watch --sourcemap",
+    "build": "npm run esbuild",
+    "watch": "npm run esbuild -- --watch",
     "generate-license": "node ../../../../utils/generate_third_party_notice.js"
   },
   "dependencies": {

--- a/packages/playwright-core/bundles/zip/package.json
+++ b/packages/playwright-core/bundles/zip/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "esbuild": "node build.js",
-    "build": "npm run esbuild -- --minify",
-    "watch": "npm run esbuild -- --watch --sourcemap",
+    "build": "npm run esbuild",
+    "watch": "npm run esbuild -- --watch",
     "generate-license": "node ../../../../utils/generate_third_party_notice.js"
   },
   "dependencies": {

--- a/packages/playwright/bundles/babel/build.js
+++ b/packages/playwright/bundles/babel/build.js
@@ -24,9 +24,10 @@ const esbuild = require('esbuild');
  */
 function esbuildOptions(watchMode) {
   return {
-    entryPoints: [path.join(__dirname, 'src/zipBundleImpl.ts')],
+    entryPoints: [path.join(__dirname, 'src/babelBundleImpl.ts')],
+    external: ['playwright'],
     bundle: true,
-    outdir: path.join(__dirname, '../../lib'),
+    outdir: path.join(__dirname, '../../lib/transform'),
     format: 'cjs',
     platform: 'node',
     target: 'ES2019',

--- a/packages/playwright/bundles/babel/package.json
+++ b/packages/playwright/bundles/babel/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "esbuild": "esbuild ./src/babelBundleImpl.ts --bundle --outdir=../../lib/transform --format=cjs --platform=node --target=ES2019 --external:playwright",
-    "build": "npm run esbuild -- --minify",
-    "watch": "npm run esbuild -- --watch --sourcemap",
+    "esbuild": "node build.js",
+    "build": "npm run esbuild",
+    "watch": "npm run esbuild -- --watch",
     "generate-license": "node ../../../../utils/generate_third_party_notice.js"
   },
   "dependencies": {

--- a/packages/playwright/bundles/expect/build.js
+++ b/packages/playwright/bundles/expect/build.js
@@ -24,9 +24,9 @@ const esbuild = require('esbuild');
  */
 function esbuildOptions(watchMode) {
   return {
-    entryPoints: [path.join(__dirname, 'src/zipBundleImpl.ts')],
+    entryPoints: [path.join(__dirname, 'src/expectBundleImpl.ts')],
     bundle: true,
-    outdir: path.join(__dirname, '../../lib'),
+    outdir: path.join(__dirname, '../../lib/common'),
     format: 'cjs',
     platform: 'node',
     target: 'ES2019',

--- a/packages/playwright/bundles/expect/package.json
+++ b/packages/playwright/bundles/expect/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "esbuild": "esbuild ./src/expectBundleImpl.ts --bundle --outdir=../../lib/common --format=cjs --platform=node --target=ES2019",
-    "build": "npm run esbuild -- --minify",
-    "watch": "npm run esbuild -- --watch --sourcemap",
+    "esbuild": "node build.js",
+    "build": "npm run esbuild",
+    "watch": "npm run esbuild -- --watch",
     "generate-license": "node ../../../../utils/generate_third_party_notice.js"
   },
   "dependencies": {

--- a/packages/playwright/bundles/utils/package.json
+++ b/packages/playwright/bundles/utils/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "esbuild": "node build.js",
-    "build": "npm run esbuild -- --minify",
-    "watch": "npm run esbuild -- --watch --sourcemap",
+    "build": "npm run esbuild",
+    "watch": "npm run esbuild -- --watch",
     "generate-license": "node ../../../../utils/generate_third_party_notice.js"
   },
   "dependencies": {

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -67,8 +67,7 @@ const onChanges = [];
 const copyFiles = [];
 
 const watchMode = process.argv.slice(2).includes('--watch');
-const lintMode = process.argv.slice(2).includes('--lint');
-const withSourceMaps = process.argv.slice(2).includes('--sourcemap') || watchMode;
+const withSourceMaps = watchMode;
 const installMode = process.argv.slice(2).includes('--install');
 const ROOT = path.join(__dirname, '..', '..');
 
@@ -292,7 +291,7 @@ class EsbuildStep extends Step {
     if (watchMode) {
       await this._ensureWatching();
     } else {
-      console.log('==== Running esbuild', this._options.entryPoints.map(e => path.relative(ROOT, e)).join(', '));
+      console.log('==== Running esbuild:', this._relativeEntryPoints().join(', '));
       const start = Date.now();
       await build(this._options);
       console.log('==== Done in', Date.now() - start, 'ms');
@@ -311,7 +310,7 @@ class EsbuildStep extends Step {
     watcher.on('all', () => this._rebuild());
 
     await this._rebuild();
-    console.log('==== Esbuild watching', this._options.entryPoints, `(started in ${Date.now() - start}ms)`);
+    console.log('==== Esbuild watching:', this._relativeEntryPoints().join(', '), `(started in ${Date.now() - start}ms)`);
   }
 
   async _rebuild() {
@@ -331,6 +330,21 @@ class EsbuildStep extends Step {
 
       this._rebuilding = false;
     } while (this._sourcesChanged);
+  }
+
+  _relativeEntryPoints() {
+    return this._options.entryPoints.map(e => path.relative(ROOT, e));
+  }
+}
+
+class CustomCallbackStep extends Step {
+  constructor(callback) {
+    super({ concurrent: false });
+    this._callback = callback;
+  }
+
+  async run() {
+    await this._callback();
   }
 }
 
@@ -353,17 +367,14 @@ for (const pkg of workspace.packages()) {
 
 // Build/watch bundles.
 for (const bundle of bundles) {
-  steps.push(new ProgramStep({
-    command: 'npm',
-    args: [
-      'run',
-      watchMode ? 'watch' : 'build',
-      ...(withSourceMaps ? ['--', '--sourcemap'] : [])
-    ],
-    shell: true,
-    cwd: bundle,
-    concurrent: true,
-  }));
+  const buildFile = path.join(bundle, 'build.js');
+  if (!fs.existsSync(buildFile))
+    throw new Error(`Build file ${buildFile} does not exist`);
+  const { esbuildOptions, beforeEsbuild } = require(buildFile);
+  if (beforeEsbuild)
+    steps.push(new CustomCallbackStep(beforeEsbuild));
+  const options = esbuildOptions(watchMode);
+  steps.push(new EsbuildStep(options));
 }
 
 // Build/watch playwright-client.
@@ -528,7 +539,7 @@ copyFiles.push({
   to: 'packages/playwright-core/lib',
 });
 
-if (lintMode) {
+if (watchMode) {
   // Run TypeScript for type checking.
   steps.push(new ProgramStep({
     command: 'npx',


### PR DESCRIPTION
* Each bundle has `build.js`. It can be used for a standalone build and also exports `esbuildOptions` and optional `beforeBuild` step (which is only needed for `copyXdgOpen`, that must run after `npm ci` for the bundle).
* Dropped separate --lint, --sourcemaps and --minify options as all of them depended on --watch

Reference https://github.com/microsoft/playwright/issues/35846