### PR TITLE
Fix TypeError in codegen

### DIFF
--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -545,6 +545,10 @@ class RecordActionTool implements RecorderTool {
   }
 
   private _shouldGenerateKeyPressFor(event: KeyboardEvent): boolean {
+    // IME can generate keyboard events that don't provide a value for the key property (e.g. chrome autofill)
+    if (typeof event.key !== 'string')
+      return false;
+
     // Enter aka. new line is handled in input event.
     if (event.key === 'Enter' && (this._recorder.deepEventTarget(event).nodeName === 'TEXTAREA' || this._recorder.deepEventTarget(event).isContentEditable))
       return false;


### PR DESCRIPTION
Keydown events without key can be triggered by IMEs. One example is chrome autofill, but there are other scenarios where that could happen (e.g. https://issues.chromium.org/issues/40539270).

To replicate the issue:

- Launch codegen: `npx playwright codegen`
- Open chrome://settings/addresses, click **Addresses > Add**, set **Street address** to some value (e.g., `Sesame Street`) and click save
- Back in the recorded tab, navigate to https://fill.dev/form/identity-simple
- Click  on **Street address** input field
- Select the autofill suggestion
- Open devtools
- On console, it should have the following error:

```
VM42:491 Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at RecordActionTool._shouldGenerateKeyPressFor (eval at extend (identity-simple:6769:40), <anonymous>:491:19)
    at RecordActionTool.onKeyDown (eval at extend (identity-simple:6769:40), <anonymous>:369:15)
    at Recorder._onKeyDown (eval at extend (identity-simple:6769:40), <anonymous>:1126:75)
    at HTMLDocument.eval (eval at extend (identity-simple:6769:40), <anonymous>:925:66)
```
