### PR TITLE
fix(esm): prevent ESM loading deadlock in certain import chains

### DIFF
--- a/packages/playwright/src/transform/esmLoader.ts
+++ b/packages/playwright/src/transform/esmLoader.ts
@@ -75,9 +75,11 @@ async function load(moduleUrl: string, context: { format?: string }, defaultLoad
   // Under certain conditions with ESM -> CJS -> CJS imports, we can enter deadlock awaiting the
   // MessagePort transfer simultaneously with the Node.js worker thread that is performing the load().
   // Purposefully do not await
-  if (transformed.serializedCache)
+  if (transformed.serializedCache) {
     transport?.send('pushToCompilationCache', { cache: transformed.serializedCache })
-      .catch(e => console.error('Failed to push compilation cache', e));
+        // eslint-disable-next-line no-console
+        .catch(e => console.error('Failed to push compilation cache', e));
+  }
 
   // Output format is required, so we determine it manually when unknown.
   // shortCircuit is required by Node >= 18.6 to designate no more loaders should be called.

--- a/packages/playwright/src/transform/esmLoader.ts
+++ b/packages/playwright/src/transform/esmLoader.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import url from 'url';
 
-import { raceAgainstDeadline } from 'playwright-core/lib/utils';
+import { monotonicTime, raceAgainstDeadline } from 'playwright-core/lib/utils';
 
 import { addToCompilationCache, currentFileDepsCollector, serializeCompilationCache, startCollectingFileDeps, stopCollectingFileDeps } from './compilationCache';
 import { PortTransport } from './portTransport';
@@ -100,7 +100,7 @@ async function pushToCompilationCache(transport: PortTransport, cache: any) {
     return;
   }
 
-  const { timedOut } = await raceAgainstDeadline(() => transport.send('pushToCompilationCache', { cache }), 1000);
+  const { timedOut } = await raceAgainstDeadline(() => transport.send('pushToCompilationCache', { cache }), monotonicTime() + 1000);
   if (timedOut) {
     debugTest('Falling back to unawaited compilation cache');
     workerShouldFallbackCompilationCache = true;

--- a/packages/playwright/src/transform/esmLoader.ts
+++ b/packages/playwright/src/transform/esmLoader.ts
@@ -20,7 +20,7 @@ import url from 'url';
 import { addToCompilationCache, currentFileDepsCollector, serializeCompilationCache, startCollectingFileDeps, stopCollectingFileDeps } from './compilationCache';
 import { PortTransport } from './portTransport';
 import { resolveHook, setSingleTSConfig, setTransformConfig, shouldTransform, transformHook } from './transform';
-import { fileIsModule } from '../util';
+import { debugTest, fileIsModule } from '../util';
 
 // Node < 18.6: defaultResolve takes 3 arguments.
 // Node >= 18.6: nextResolve from the chain takes 2 arguments.
@@ -77,8 +77,7 @@ async function load(moduleUrl: string, context: { format?: string }, defaultLoad
   // Purposefully do not await
   if (transformed.serializedCache) {
     transport?.send('pushToCompilationCache', { cache: transformed.serializedCache })
-        // eslint-disable-next-line no-console
-        .catch(e => console.error('Failed to push compilation cache', e));
+        .catch(e => debugTest('Failed to push compilation cache', e));
   }
 
   // Output format is required, so we determine it manually when unknown.


### PR DESCRIPTION
Fixes #35706.

After a long investigation I narrowed the error condition to an ESM loading deadlock in certain import chains. When ESM imports a nested CJS package that has another CJS `require` inside, the Playwright loading process would freeze, preventing any further interaction (including `SIGINT`):

```
[ESM]
fail.spec.js
[CJS]
inner_package/require_me.js
inner_package/subdependency.js
```

The Node.js import worker sends events to our ESM loader, which then processes the load asynchronously and returns to the requesting process. Under this scenario, our `esmLoader.ts` attempts to run:

```ts
if (transformed.serializedCache)
  await transport?.send('pushToCompilationCache', { cache: transformed.serializedCache });
```

Which is a `Promise` wrapping the synchronous `MessagePort.postMessage`:

```ts
  async send(method: string, params: any) {
    return await new Promise<any>(f => {
      const id = ++this._lastId;
      this._callbacks.set(id, f);
      this._resetRef();
      this._port.postMessage({ id, method, params });
    });
  }
```

`postMessage()` does not return until the message is accepted by the other port. Since Node.js is already waiting on other work from the ESM loader (the `load` request that is awaiting `transport.send()`) we are in deadlock, and never recover.

----

Issue was bisected to be introduced with #28526 (7670fd21e2efd1118d182b1f0bc396dcbc5c4505), which is the change that introduced the modern ESM loading mechanism.

----

**EDIT:** Looking at this in-depth again after a weekend makes the cause obvious. The following are logs with comments with `NODE_DEBUG=*`:
```
// We finish the load() request for require_me.js, our first CJS package. Notice that it's an "async" response

ESM 31912: got async response from worker {
  method: 'load',
  args: [
    'file:///inner_package/require_me.js',
    {
      format: 'commonjs',
      importAttributes: [Object: null prototype] {}
    }
  ]
}

...

// Node examines the contents of the newly loaded file. It finds a require pointing at fails_require.js
// getModuleJobForRequireInImportedCJS() is called. This calls resolveSync, because we're resolving CJS.
// We ask the custom Playwright loader to resolve this file

ESM 31912: post sync message to worker {
  method: 'resolve',
  args: [
    'file:///inner_package/require_me.js',
    'file:///inner_package/fails_require.js',
    [Object: null prototype] {}
  ],
  transferList: undefined
}

// We begin waiting for the response synchronously, which blocks our runloop

ESM 31912: wait for sync response from worker {
  method: 'resolve',
  args: [
    'file:///inner_package/require_me.js',
    'file:///inner_package/fails_require.js',
    [Object: null prototype] {}
  ]
}
```

Inside of Playwright's `load`, which is called immediately after `resolve`, we call:

```ts
  if (transformed.serializedCache)
    await transport?.send('pushToCompilationCache', { cache: transformed.serializedCache });
```

`postMessage()` does not return until the message is accepted by the other port. Since Node.js is already waiting on other work from the ESM loader, we are in deadlock, and never recover.

---

See https://nodejs.org/api/module.html#caveat-in-the-asynchronous-load-hook for an explanation of:
- why esm loader is engaged for these `require` calls;
- why esm loader is incompatible with namespace imports of cjs.