### PR TITLE
fix(ui-mode): use stored theme;  defaulting to prefersDarkTheme

### DIFF
--- a/packages/web/src/theme.ts
+++ b/packages/web/src/theme.ts
@@ -36,9 +36,11 @@ export function applyTheme() {
     document.body.classList.add('inactive');
   }, false);
 
-  const currentTheme = settings.getString('theme', 'light-mode');
   const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-  if (currentTheme === 'dark-mode' || prefersDarkScheme.matches)
+  const defaultTheme = prefersDarkScheme.matches ? 'dark-mode' : 'light-mode';
+
+  const currentTheme = settings.getString('theme', defaultTheme);
+  if (currentTheme === 'dark-mode')
     document.body.classList.add('dark-mode');
 }
 


### PR DESCRIPTION
The UI theme logic was always considering `prefersDarkScheme` on load, rather than using that as a default that is overridden by a user setting. This had the effect of ignoring the user's setting if they are using OS dark theme.

Properly integrate `prefersDarkScheme` only as a default.