### PR TITLE
test: Allow third party cookies for Firefox with BiDi as well.

### DIFF
--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -67,7 +67,7 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
   }, { scope: 'worker' }],
 
   allowsThirdParty: [async ({ browserName }, run) => {
-    if (browserName === 'firefox')
+    if (browserName === 'firefox' || browserName as any === '_bidiFirefox')
       await run(true);
     else
       await run(false);


### PR DESCRIPTION
Looks like Firefox when setting cookies inside the iframe with localhost when top frame loaded also localhost and different port is not detected as a cross-origin case. And it works the same for BiDi. So I guess that should be equivalent to the case of `allowingThirdParty`.