### PR TITLE
docs: add clarity to CLI options

### DIFF
--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -841,7 +841,7 @@ test('test customer login', {
 npx playwright test --grep @fast
 ```
 
-- `--project` command line [flag](./test-cli#reference) now supports '*' wildcard:
+- `--project` command line [flag](./test-cli#all-options) now supports '*' wildcard:
 ```sh
 npx playwright test --project='*mobile*'
 ```

--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -105,7 +105,7 @@ test.describe('group', {
 });
 ```
 
-You can now run tests that have a particular tag with [`--grep`](./test-cli.md#reference) command line option.
+You can now run tests that have a particular tag with [`--grep`](./test-cli.md#all-options) command line option.
 
 ```bash tab=bash-bash
 npx playwright test --grep @fast

--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -56,7 +56,7 @@ test('another test @smoke', async ({ page }) => {
 Test tags are displayed in the test report, and are available to a custom reporter via `TestCase.tags` property.
 
 You can also filter tests by their tags during test execution:
-* in the [command line](../test-cli.md#reference);
+* in the [command line](../test-cli.md#all-options);
 * in the config with [`property: TestConfig.grep`] and [`property: TestProject.grep`];
 
 Learn more about [tagging](../test-annotations.md#tag-tests).

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -29,8 +29,8 @@ npx playwright test tests/todo-page.spec.ts
 # Run a set of test files
 npx playwright test tests/todo-page/ tests/landing-page/
 
-# Run files by name pattern
-npx playwright test my-spec my-spec-2
+# Run files that have `my-spec` or `another-spec` in the file name
+npx playwright test my-spec another-spec-2
 
 # Run tests at a specific line
 npx playwright test my-spec.ts:42
@@ -81,7 +81,6 @@ npx playwright test --ui
 | `-g <grep>` or `--grep <grep>` | Only run tests matching this regular expression (default: ".*"). |
 | `--project <project-name...>` | Only run tests from the specified list of projects, supports '*' wildcard (default: run all projects). |
 | `--ui` | Run tests in interactive UI mode. |
-| `-u` or `--update-snapshots [mode]` | Update snapshots with actual results. Possible values are "all", "changed", "missing", and "none". Running tests without the flag defaults to "missing"; running tests with the flag but without a value defaults to "changed". |
 | `-j <workers>` or `--workers <workers>` | Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker (default: 50%). |
 
 #### All Options
@@ -155,7 +154,7 @@ npx playwright show-report --port 8080
 
 ### Install Browsers
 
-Install browsers required by Playwright.
+Install browsers required by Playwright. [Read more about Playwright's browser support](./browsers.md).
 
 #### Syntax
 
@@ -238,7 +237,7 @@ Analyze and view test traces for debugging. [Read more about Trace Viewer](./tra
 #### Syntax
 
 ```bash
-npx playwright show-trace [options] [trace...]
+npx playwright show-trace [options] <trace>
 ```
 
 #### Examples
@@ -268,7 +267,7 @@ Read [blob](./test-reporters#blob-reporter) reports and combine them. [Read more
 #### Syntax
 
 ```bash
-npx playwright merge-reports [options] [blob dir]
+npx playwright merge-reports [options] <blob dir>
 ```
 
 #### Examples

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -5,7 +5,7 @@ title: "Command line"
 
 Playwright provides a powerful command line interface for running tests, generating code, debugging, and more. The most up to date list of commands and arguments available on the CLI can always be retrieved via `npx playwright --help`.
 
-## Standard Operation
+## Essential Commands
 
 ### Run Tests
 
@@ -16,57 +16,6 @@ Run your Playwright tests. [Read more about running tests](./running-tests.md).
 ```bash
 npx playwright test [options] [test-filter...]
 ```
-
-#### Common Options
-
-| Option | Description |
-| :--- | :--- |
-| `--debug` | Run tests with Playwright Inspector. Shortcut for `PWDEBUG=1` environment variable and `--timeout=0 --max-failures=1 --headed --workers=1` options. |
-| `--headed` | Run tests in headed browsers (default: headless). |
-| `-g <grep>` or `--grep <grep>` | Only run tests matching this regular expression (default: ".*"). |
-| `--project <project-name...>` | Only run tests from the specified list of projects, supports '*' wildcard (default: run all projects). |
-| `--ui` | Run tests in interactive UI mode. |
-| `-u` or `--update-snapshots [mode]` | Update snapshots with actual results. Possible values are "all", "changed", "missing", and "none". Running tests without the flag defaults to "missing"; running tests with the flag but without a value defaults to "changed". |
-| `-j <workers>` or `--workers <workers>` | Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker (default: 50%). |
-
-#### All Options
-
-| Option | Description |
-| :--- | :--- |
-| Non-option arguments | Each argument is treated as a regular expression matched against the full test file path. Only tests from files matching the pattern will be executed. Special symbols like `$` or `*` should be escaped with `\`. In many shells/terminals you may need to quote the arguments. |
-| `-c <file>` or `--config <file>` | Configuration file, or a test directory with optional "playwright.config.&#123;m,c&#125;?&#123;js,ts&#125;". Defaults to `playwright.config.ts` or `playwright.config.js` in the current directory. |
-| `--debug` | Run tests with Playwright Inspector. Shortcut for `PWDEBUG=1` environment variable and `--timeout=0 --max-failures=1 --headed --workers=1` options. |
-| `--fail-on-flaky-tests` | Fail if any test is flagged as flaky (default: false). |
-| `--forbid-only` | Fail if `test.only` is called (default: false). Useful on CI. |
-| `--fully-parallel` | Run all tests in parallel (default: false). |
-| `--global-timeout <timeout>` | Maximum time this test suite can run in milliseconds (default: unlimited). |
-| `-g <grep>` or `--grep <grep>` | Only run tests matching this regular expression (default: ".*"). |
-| `-gv <grep>` or `--grep-invert <grep>` | Only run tests that do not match this regular expression. |
-| `--headed` | Run tests in headed browsers (default: headless). |
-| `--ignore-snapshots` | Ignore screenshot and snapshot expectations. |
-| `-j <workers>` or `--workers <workers>` | Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker (default: 50%). |
-| `--last-failed` | Only re-run the failures. |
-| `--list` | Collect all the tests and report them, but do not run. |
-| `--max-failures <N>` or `-x` | Stop after the first `N` failures. Passing `-x` stops after the first failure. |
-| `--no-deps` | Do not run project dependencies. |
-| `--output <dir>` | Folder for output artifacts (default: "test-results"). |
-| `--only-changed [ref]` | Only run test files that have been changed between 'HEAD' and 'ref'. Defaults to running all uncommitted changes. Only supports Git. |
-| `--pass-with-no-tests` | Makes test run succeed even if no tests were found. |
-| `--project <project-name...>` | Only run tests from the specified list of projects, supports '*' wildcard (default: run all projects). |
-| `--quiet` | Suppress stdio. |
-| `--repeat-each <N>` | Run each test `N` times (default: 1). |
-| `--reporter <reporter>` | Reporter to use, comma-separated, can be "dot", "line", "list", or others (default: "list"). You can also pass a path to a custom reporter file. |
-| `--retries <retries>` | Maximum retry count for flaky tests, zero for no retries (default: no retries). |
-| `--shard <shard>` | Shard tests and execute only the selected shard, specified in the form "current/all", 1-based, e.g., "3/5". |
-| `--timeout <timeout>` | Specify test timeout threshold in milliseconds, zero for unlimited (default: 30 seconds). |
-| `--trace <mode>` | Force tracing mode, can be `on`, `off`, `on-first-retry`, `on-all-retries`, `retain-on-failure`, `retain-on-first-failure`. |
-| `--tsconfig <path>` | Path to a single tsconfig applicable to all imported files (default: look up tsconfig for each imported file separately). |
-| `--ui` | Run tests in interactive UI mode. |
-| `--ui-host <host>` | Host to serve UI on; specifying this option opens UI in a browser tab. |
-| `--ui-port <port>` | Port to serve UI on, 0 for any free port; specifying this option opens UI in a browser tab. |
-| `-u` or `--update-snapshots [mode]` | Update snapshots with actual results. Possible values are "all", "changed", "missing", and "none". Running tests without the flag defaults to "missing"; running tests with the flag but without a value defaults to "changed". |
-| `--update-source-method [mode]` | Update snapshots with actual results. Possible values are "patch" (default), "3way" and "overwrite". "Patch" creates a unified diff file that can be used to update the source code later. "3way" generates merge conflict markers in source code. "Overwrite" overwrites the source code with the new snapshot values.|
-| `-x` | Stop after the first failure. |
 
 #### Examples
 
@@ -123,6 +72,57 @@ npx playwright test --debug
 npx playwright test --ui
 ```
 
+#### Common Options
+
+| Option | Description |
+| :--- | :--- |
+| `--debug` | Run tests with Playwright Inspector. Shortcut for `PWDEBUG=1` environment variable and `--timeout=0 --max-failures=1 --headed --workers=1` options. |
+| `--headed` | Run tests in headed browsers (default: headless). |
+| `-g <grep>` or `--grep <grep>` | Only run tests matching this regular expression (default: ".*"). |
+| `--project <project-name...>` | Only run tests from the specified list of projects, supports '*' wildcard (default: run all projects). |
+| `--ui` | Run tests in interactive UI mode. |
+| `-u` or `--update-snapshots [mode]` | Update snapshots with actual results. Possible values are "all", "changed", "missing", and "none". Running tests without the flag defaults to "missing"; running tests with the flag but without a value defaults to "changed". |
+| `-j <workers>` or `--workers <workers>` | Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker (default: 50%). |
+
+#### All Options
+
+| Option | Description |
+| :--- | :--- |
+| Non-option arguments | Each argument is treated as a regular expression matched against the full test file path. Only tests from files matching the pattern will be executed. Special symbols like `$` or `*` should be escaped with `\`. In many shells/terminals you may need to quote the arguments. |
+| `-c <file>` or `--config <file>` | Configuration file, or a test directory with optional "playwright.config.&#123;m,c&#125;?&#123;js,ts&#125;". Defaults to `playwright.config.ts` or `playwright.config.js` in the current directory. |
+| `--debug` | Run tests with Playwright Inspector. Shortcut for `PWDEBUG=1` environment variable and `--timeout=0 --max-failures=1 --headed --workers=1` options. |
+| `--fail-on-flaky-tests` | Fail if any test is flagged as flaky (default: false). |
+| `--forbid-only` | Fail if `test.only` is called (default: false). Useful on CI. |
+| `--fully-parallel` | Run all tests in parallel (default: false). |
+| `--global-timeout <timeout>` | Maximum time this test suite can run in milliseconds (default: unlimited). |
+| `-g <grep>` or `--grep <grep>` | Only run tests matching this regular expression (default: ".*"). |
+| `-gv <grep>` or `--grep-invert <grep>` | Only run tests that do not match this regular expression. |
+| `--headed` | Run tests in headed browsers (default: headless). |
+| `--ignore-snapshots` | Ignore screenshot and snapshot expectations. |
+| `-j <workers>` or `--workers <workers>` | Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker (default: 50%). |
+| `--last-failed` | Only re-run the failures. |
+| `--list` | Collect all the tests and report them, but do not run. |
+| `--max-failures <N>` or `-x` | Stop after the first `N` failures. Passing `-x` stops after the first failure. |
+| `--no-deps` | Do not run project dependencies. |
+| `--output <dir>` | Folder for output artifacts (default: "test-results"). |
+| `--only-changed [ref]` | Only run test files that have been changed between 'HEAD' and 'ref'. Defaults to running all uncommitted changes. Only supports Git. |
+| `--pass-with-no-tests` | Makes test run succeed even if no tests were found. |
+| `--project <project-name...>` | Only run tests from the specified list of projects, supports '*' wildcard (default: run all projects). |
+| `--quiet` | Suppress stdio. |
+| `--repeat-each <N>` | Run each test `N` times (default: 1). |
+| `--reporter <reporter>` | Reporter to use, comma-separated, can be "dot", "line", "list", or others (default: "list"). You can also pass a path to a custom reporter file. |
+| `--retries <retries>` | Maximum retry count for flaky tests, zero for no retries (default: no retries). |
+| `--shard <shard>` | Shard tests and execute only the selected shard, specified in the form "current/all", 1-based, e.g., "3/5". |
+| `--timeout <timeout>` | Specify test timeout threshold in milliseconds, zero for unlimited (default: 30 seconds). |
+| `--trace <mode>` | Force tracing mode, can be `on`, `off`, `on-first-retry`, `on-all-retries`, `retain-on-failure`, `retain-on-first-failure`. |
+| `--tsconfig <path>` | Path to a single tsconfig applicable to all imported files (default: look up tsconfig for each imported file separately). |
+| `--ui` | Run tests in interactive UI mode. |
+| `--ui-host <host>` | Host to serve UI on; specifying this option opens UI in a browser tab. |
+| `--ui-port <port>` | Port to serve UI on, 0 for any free port; specifying this option opens UI in a browser tab. |
+| `-u` or `--update-snapshots [mode]` | Update snapshots with actual results. Possible values are "all", "changed", "missing", and "none". Running tests without the flag defaults to "missing"; running tests with the flag but without a value defaults to "changed". |
+| `--update-source-method [mode]` | Update snapshots with actual results. Possible values are "patch" (default), "3way" and "overwrite". "Patch" creates a unified diff file that can be used to update the source code later. "3way" generates merge conflict markers in source code. "Overwrite" overwrites the source code with the new snapshot values.|
+| `-x` | Stop after the first failure. |
+
 ### Show Report
 
 Display HTML report from previous test run. [Read more about the HTML reporter](./test-reporters#html-reporter).
@@ -132,13 +132,6 @@ Display HTML report from previous test run. [Read more about the HTML reporter](
 ```bash
 npx playwright show-report [report] [options]
 ```
-
-#### Options
-
-| Option | Description |
-| :--- | :--- |
-| `--host <host>` | Host to serve report on (default: localhost) |
-| `--port <port>` | Port to serve report on (default: 9323) |
 
 #### Examples
 
@@ -153,6 +146,13 @@ npx playwright show-report playwright-report/
 npx playwright show-report --port 8080
 ```
 
+#### Options
+
+| Option | Description |
+| :--- | :--- |
+| `--host <host>` | Host to serve report on (default: localhost) |
+| `--port <port>` | Port to serve report on (default: 9323) |
+
 ### Install Browsers
 
 Install browsers required by Playwright.
@@ -163,6 +163,22 @@ Install browsers required by Playwright.
 npx playwright install [options] [browser...]
 npx playwright install-deps [options] [browser...]
 npx playwright uninstall
+```
+
+#### Examples
+
+```bash
+# Install all browsers
+npx playwright install
+
+# Install only Chromium
+npx playwright install chromium
+
+# Install specific browsers
+npx playwright install chromium webkit
+
+# Install browsers with dependencies
+npx playwright install --with-deps
 ```
 
 #### Install Options
@@ -181,22 +197,6 @@ npx playwright uninstall
 | :--- | :--- |
 | `--dry-run` | Don't perform installation, just print information |
 
-#### Examples
-
-```bash
-# Install all browsers
-npx playwright install
-
-# Install only Chromium
-npx playwright install chromium
-
-# Install specific browsers
-npx playwright install chromium webkit
-
-# Install browsers with dependencies
-npx playwright install --with-deps
-```
-
 ## Generation & Debugging Tools
 
 ### Code Generation
@@ -208,15 +208,6 @@ Record actions and generate tests for multiple languages. [Read more about Codeg
 ```bash
 npx playwright codegen [options] [url]
 ```
-
-#### Options
-
-| Option | Description |
-| :--- | :--- |
-| `-b, --browser <name>` | Browser to use: chromium, firefox, or webkit (default: chromium) |
-| `-o, --output <file>` | Output file for the generated script |
-| `--target <language>` | Language to use: javascript, playwright-test, python, etc. |
-| `--test-id-attribute <attr>` | Attribute to use for test IDs |
 
 #### Examples
 
@@ -231,6 +222,15 @@ npx playwright codegen https://playwright.dev
 npx playwright codegen --target=python
 ```
 
+#### Options
+
+| Option | Description |
+| :--- | :--- |
+| `-b, --browser <name>` | Browser to use: chromium, firefox, or webkit (default: chromium) |
+| `-o, --output <file>` | Output file for the generated script |
+| `--target <language>` | Language to use: javascript, playwright-test, python, etc. |
+| `--test-id-attribute <attr>` | Attribute to use for test IDs |
+
 ### Trace Viewer
 
 Analyze and view test traces for debugging. [Read more about Trace Viewer](./trace-viewer.md).
@@ -241,14 +241,6 @@ Analyze and view test traces for debugging. [Read more about Trace Viewer](./tra
 npx playwright show-trace [options] [trace...]
 ```
 
-#### Options
-
-| Option | Description |
-| :--- | :--- |
-| `-b, --browser <name>` | Browser to use: chromium, firefox, or webkit (default: chromium) |
-| `-h, --host <host>` | Host to serve trace on |
-| `-p, --port <port>` | Port to serve trace on |
-
 #### Examples
 
 ```bash
@@ -258,6 +250,14 @@ npx playwright show-trace trace.zip
 # View trace from directory
 npx playwright show-trace trace/
 ```
+
+#### Options
+
+| Option | Description |
+| :--- | :--- |
+| `-b, --browser <name>` | Browser to use: chromium, firefox, or webkit (default: chromium) |
+| `-h, --host <host>` | Host to serve trace on |
+| `-p, --port <port>` | Port to serve trace on |
 
 ## Specialized Commands
 
@@ -271,19 +271,19 @@ Read [blob](./test-reporters#blob-reporter) reports and combine them. [Read more
 npx playwright merge-reports [options] [blob dir]
 ```
 
-#### Options
-
-| Option | Description |
-| :--- | :--- |
-| `-c, --config <file>` | Configuration file. Can be used to specify additional configuration for the output report |
-| `--reporter <reporter>` | Reporter to use, comma-separated, can be "list", "line", "dot", "json", "junit", "null", "github", "html", "blob" (default: "list") |
-
 #### Examples
 
 ```bash
 # Combine test reports
 npx playwright merge-reports ./reports
 ```
+
+#### Options
+
+| Option | Description |
+| :--- | :--- |
+| `-c, --config <file>` | Configuration file. Can be used to specify additional configuration for the output report |
+| `--reporter <reporter>` | Reporter to use, comma-separated, can be "list", "line", "dot", "json", "junit", "null", "github", "html", "blob" (default: "list") |
 
 ### Clear Cache
 
@@ -293,96 +293,4 @@ Clear all Playwright caches.
 
 ```bash
 npx playwright clear-cache
-```
-
-
-### Image Screenshot
-
-Capture screenshot of a particular website. Uses [`method: Page.screenshot`] to generate the screenshot.
-
-#### Syntax
-
-```bash
-npx playwright screenshot [options] <url> <filename>
-```
-
-#### Options
-
-| Option | Description |
-| :--- | :--- |
-| `-b, --browser <name>` | Browser to use: chromium, firefox, or webkit (default: chromium) |
-| `--wait-for-selector <selector>` | Wait for element matching selector before capturing |
-| `--wait-for-timeout <timeout>` | Wait for timeout in milliseconds before capturing |
-| `--full-page` | Capture full scrollable page, not just viewport |
-
-#### Examples
-
-```bash
-# Take screenshot of website
-npx playwright screenshot https://playwright.dev example.png
-
-# Full page screenshot
-npx playwright screenshot --full-page https://github.com github.png
-```
-
-### PDF Screenshot
-
-Generate PDF documents from websites. Uses [`method: Page.pdf`] to generate the PDF.
-
-#### Syntax
-
-```bash
-npx playwright pdf [options] <url> <filename>
-```
-
-#### Options
-
-| Option | Description |
-| :--- | :--- |
-| `-b, --browser <name>` | Browser to use: chromium (only Chromium supported) |
-| `--wait-for-selector <selector>` | Wait for element matching selector before capturing |
-| `--paper-format <format>` | Paper format: Letter, A4, etc. (default: Letter) |
-| `--landscape` | Set landscape paper orientation |
-
-#### Examples
-
-```bash
-# Generate PDF of website
-npx playwright pdf https://playwright.dev doc.pdf
-
-# Use A4 paper format
-npx playwright pdf --paper-format=A4 https://playwright.dev doc.pdf
-```
-
-### Playwright Server
-
-Start a remote server for Playwright automation.
-
-#### Syntax
-
-```bash
-npx playwright run-server [options]
-```
-
-#### Options
-
-| Option | Description |
-| :--- | :--- |
-| `--port <port>` | Server port |
-| `--host <host>` | Server host |
-| `--path <path>` | Endpoint path (default: /) |
-| `--max-clients <number>` | Maximum number of client connections |
-| `--mode <mode>` | Server mode: "default" or "extension" |
-
-#### Examples
-
-```bash
-# Start with default settings
-npx playwright run-server
-
-# Start on custom port
-npx playwright run-server --port 8080
-
-# Run in extension mode
-npx playwright run-server --mode extension
 ```

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -3,83 +3,36 @@ id: test-cli
 title: "Command line"
 ---
 
-## Introduction
+Playwright provides a powerful command line interface for running tests, generating code, debugging, and more. The most up to date list of commands and arguments available on the CLI can always be retrieved via `npx playwright --help`.
 
-Here are the most common options available in the command line.
+## Standard Operation
 
-- Run all the tests
-  ```bash
-  npx playwright test
-  ```
+### Run Tests
 
-- Run a single test file
-  ```bash
-  npx playwright test tests/todo-page.spec.ts
-  ```
+Run your Playwright tests. [Read more about running tests](./running-tests.md).
 
-- Run a set of test files
-  ```bash
-  npx playwright test tests/todo-page/ tests/landing-page/
-  ```
+#### Syntax
 
-- Run files that have `my-spec` or `my-spec-2` in the file name
-  ```bash
-  npx playwright test my-spec my-spec-2
-  ```
+```bash
+npx playwright test [options] [test-filter...]
+```
 
-- Run tests that are in line 42 in my-spec.ts
-  ```bash
-  npx playwright test my-spec.ts:42
-  ```
-
-- Run the test with the title
-  ```bash
-  npx playwright test -g "add a todo item"
-  ```
-
-- Run tests in headed browsers
-  ```bash
-  npx playwright test --headed
-  ```
-
-- Run all the tests against a specific project
-  ```bash
-  npx playwright test --project=chromium
-  ```
-
-- Disable [parallelization](./test-parallel.md)
-  ```bash
-  npx playwright test --workers=1
-  ```
-
-- Choose a [reporter](./test-reporters.md)
-  ```bash
-  npx playwright test --reporter=dot
-  ```
-
-- Run in debug mode with [Playwright Inspector](./debug.md)
-  ```bash
-  npx playwright test --debug
-  ```
-
-- Run tests in interactive UI mode, with a built-in watch mode (Preview)
-  ```bash
-  npx playwright test --ui
-  ```
-
-- Ask for help
-  ```bash
-  npx playwright test --help
-  ```
-
-## Reference
-
-Complete set of Playwright Test options is available in the [configuration file](./test-use-options.md). Following options can be passed to a command line and take priority over the configuration file:
-
-<!-- // Note: packages/playwright/src/program.ts is the source of truth. -->
+#### Common Options
 
 | Option | Description |
-| :- | :- |
+| :--- | :--- |
+| `--debug` | Run tests with Playwright Inspector. Shortcut for `PWDEBUG=1` environment variable and `--timeout=0 --max-failures=1 --headed --workers=1` options. |
+| `--headed` | Run tests in headed browsers (default: headless). |
+| `-g <grep>` or `--grep <grep>` | Only run tests matching this regular expression (default: ".*"). |
+| `--project <project-name...>` | Only run tests from the specified list of projects, supports '*' wildcard (default: run all projects). |
+| `--ui` | Run tests in interactive UI mode. |
+| `-u` or `--update-snapshots [mode]` | Update snapshots with actual results. Possible values are "all", "changed", "missing", and "none". Running tests without the flag defaults to "missing"; running tests with the flag but without a value defaults to "changed". |
+| `-j <workers>` or `--workers <workers>` | Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker (default: 50%). |
+
+#### All Options
+
+| Option | Description |
+| :--- | :--- |
 | Non-option arguments | Each argument is treated as a regular expression matched against the full test file path. Only tests from files matching the pattern will be executed. Special symbols like `$` or `*` should be escaped with `\`. In many shells/terminals you may need to quote the arguments. |
 | `-c <file>` or `--config <file>` | Configuration file, or a test directory with optional "playwright.config.&#123;m,c&#125;?&#123;js,ts&#125;". Defaults to `playwright.config.ts` or `playwright.config.js` in the current directory. |
 | `--debug` | Run tests with Playwright Inspector. Shortcut for `PWDEBUG=1` environment variable and `--timeout=0 --max-failures=1 --headed --workers=1` options. |
@@ -91,6 +44,7 @@ Complete set of Playwright Test options is available in the [configuration file]
 | `-gv <grep>` or `--grep-invert <grep>` | Only run tests that do not match this regular expression. |
 | `--headed` | Run tests in headed browsers (default: headless). |
 | `--ignore-snapshots` | Ignore screenshot and snapshot expectations. |
+| `-j <workers>` or `--workers <workers>` | Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker (default: 50%). |
 | `--last-failed` | Only re-run the failures. |
 | `--list` | Collect all the tests and report them, but do not run. |
 | `--max-failures <N>` or `-x` | Stop after the first `N` failures. Passing `-x` stops after the first failure. |
@@ -105,12 +59,330 @@ Complete set of Playwright Test options is available in the [configuration file]
 | `--retries <retries>` | Maximum retry count for flaky tests, zero for no retries (default: no retries). |
 | `--shard <shard>` | Shard tests and execute only the selected shard, specified in the form "current/all", 1-based, e.g., "3/5". |
 | `--timeout <timeout>` | Specify test timeout threshold in milliseconds, zero for unlimited (default: 30 seconds). |
-| `--trace <mode>` | Force tracing mode, can be "on", "off", "on-first-retry", "on-all-retries", "retain-on-failure", "retain-on-first-failure". |
+| `--trace <mode>` | Force tracing mode, can be `on`, `off`, `on-first-retry`, `on-all-retries`, `retain-on-failure`, `retain-on-first-failure`. |
 | `--tsconfig <path>` | Path to a single tsconfig applicable to all imported files (default: look up tsconfig for each imported file separately). |
 | `--ui` | Run tests in interactive UI mode. |
 | `--ui-host <host>` | Host to serve UI on; specifying this option opens UI in a browser tab. |
 | `--ui-port <port>` | Port to serve UI on, 0 for any free port; specifying this option opens UI in a browser tab. |
 | `-u` or `--update-snapshots [mode]` | Update snapshots with actual results. Possible values are "all", "changed", "missing", and "none". Running tests without the flag defaults to "missing"; running tests with the flag but without a value defaults to "changed". |
 | `--update-source-method [mode]` | Update snapshots with actual results. Possible values are "patch" (default), "3way" and "overwrite". "Patch" creates a unified diff file that can be used to update the source code later. "3way" generates merge conflict markers in source code. "Overwrite" overwrites the source code with the new snapshot values.|
-| `-j <workers>` or `--workers <workers>` | Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker (default: 50%). |
 | `-x` | Stop after the first failure. |
+
+#### Examples
+
+```bash
+# Run all tests
+npx playwright test
+
+# Run a single test file
+npx playwright test tests/todo-page.spec.ts
+
+# Run a set of test files
+npx playwright test tests/todo-page/ tests/landing-page/
+
+# Run files by name pattern
+npx playwright test my-spec my-spec-2
+
+# Run tests at a specific line
+npx playwright test my-spec.ts:42
+
+# Run tests by title
+npx playwright test -g "add a todo item"
+
+# Run tests in headed browsers
+npx playwright test --headed
+
+# Run tests for a specific project
+npx playwright test --project=chromium
+
+# Get help
+npx playwright test --help
+```
+
+**Disable [parallelization](./test-parallel.md)**
+
+```bash
+npx playwright test --workers=1
+```
+
+**Choose a [reporter](./test-reporters.md)**
+
+```bash
+npx playwright test --reporter=dot
+```
+
+**Run in debug mode with [Playwright Inspector](./debug.md)**
+
+```bash
+npx playwright test --debug
+```
+
+**Run tests in interactive [UI mode](./test-ui-mode.md)**
+
+```bash
+npx playwright test --ui
+```
+
+### Show Report
+
+Display HTML report from previous test run. [Read more about the HTML reporter](./test-reporters#html-reporter).
+
+#### Syntax
+
+```bash
+npx playwright show-report [report] [options]
+```
+
+#### Options
+
+| Option | Description |
+| :--- | :--- |
+| `--host <host>` | Host to serve report on (default: localhost) |
+| `--port <port>` | Port to serve report on (default: 9323) |
+
+#### Examples
+
+```bash
+# Show latest test report
+npx playwright show-report
+
+# Show a specific report
+npx playwright show-report playwright-report/
+
+# Show report on custom port
+npx playwright show-report --port 8080
+```
+
+### Install Browsers
+
+Install browsers required by Playwright.
+
+#### Syntax
+
+```bash
+npx playwright install [options] [browser...]
+npx playwright install-deps [options] [browser...]
+npx playwright uninstall
+```
+
+#### Install Options
+
+| Option | Description |
+| :--- | :--- |
+| `--force` | Force reinstall of stable browser channels |
+| `--with-deps` | Install browser system dependencies |
+| `--dry-run` | Don't perform installation, just print information |
+| `--only-shell` | Only install chromium-headless-shell instead of full Chromium |
+| `--no-shell` | Don't install chromium-headless-shell |
+
+#### Install Deps Options
+
+| Option | Description |
+| :--- | :--- |
+| `--dry-run` | Don't perform installation, just print information |
+
+#### Examples
+
+```bash
+# Install all browsers
+npx playwright install
+
+# Install only Chromium
+npx playwright install chromium
+
+# Install specific browsers
+npx playwright install chromium webkit
+
+# Install browsers with dependencies
+npx playwright install --with-deps
+```
+
+## Generation & Debugging Tools
+
+### Code Generation
+
+Record actions and generate tests for multiple languages. [Read more about Codegen](./codegen-intro.md).
+
+#### Syntax
+
+```bash
+npx playwright codegen [options] [url]
+```
+
+#### Options
+
+| Option | Description |
+| :--- | :--- |
+| `-b, --browser <name>` | Browser to use: chromium, firefox, or webkit (default: chromium) |
+| `-o, --output <file>` | Output file for the generated script |
+| `--target <language>` | Language to use: javascript, playwright-test, python, etc. |
+| `--test-id-attribute <attr>` | Attribute to use for test IDs |
+
+#### Examples
+
+```bash
+# Start recording with interactive UI
+npx playwright codegen
+
+# Record on specific site
+npx playwright codegen https://playwright.dev
+
+# Generate Python code
+npx playwright codegen --target=python
+```
+
+### Trace Viewer
+
+Analyze and view test traces for debugging. [Read more about Trace Viewer](./trace-viewer.md).
+
+#### Syntax
+
+```bash
+npx playwright show-trace [options] [trace...]
+```
+
+#### Options
+
+| Option | Description |
+| :--- | :--- |
+| `-b, --browser <name>` | Browser to use: chromium, firefox, or webkit (default: chromium) |
+| `-h, --host <host>` | Host to serve trace on |
+| `-p, --port <port>` | Port to serve trace on |
+
+#### Examples
+
+```bash
+# View a trace file
+npx playwright show-trace trace.zip
+
+# View trace from directory
+npx playwright show-trace trace/
+```
+
+## Specialized Commands
+
+### Merge Reports
+
+Read [blob](./test-reporters#blob-reporter) reports and combine them. [Read more about merge-reports](./test-sharding.md).
+
+#### Syntax
+
+```bash
+npx playwright merge-reports [options] [blob dir]
+```
+
+#### Options
+
+| Option | Description |
+| :--- | :--- |
+| `-c, --config <file>` | Configuration file. Can be used to specify additional configuration for the output report |
+| `--reporter <reporter>` | Reporter to use, comma-separated, can be "list", "line", "dot", "json", "junit", "null", "github", "html", "blob" (default: "list") |
+
+#### Examples
+
+```bash
+# Combine test reports
+npx playwright merge-reports ./reports
+```
+
+### Clear Cache
+
+Clear all Playwright caches.
+
+#### Syntax
+
+```bash
+npx playwright clear-cache
+```
+
+
+### Image Screenshot
+
+Capture screenshot of a particular website. Uses [`method: Page.screenshot`] to generate the screenshot.
+
+#### Syntax
+
+```bash
+npx playwright screenshot [options] <url> <filename>
+```
+
+#### Options
+
+| Option | Description |
+| :--- | :--- |
+| `-b, --browser <name>` | Browser to use: chromium, firefox, or webkit (default: chromium) |
+| `--wait-for-selector <selector>` | Wait for element matching selector before capturing |
+| `--wait-for-timeout <timeout>` | Wait for timeout in milliseconds before capturing |
+| `--full-page` | Capture full scrollable page, not just viewport |
+
+#### Examples
+
+```bash
+# Take screenshot of website
+npx playwright screenshot https://playwright.dev example.png
+
+# Full page screenshot
+npx playwright screenshot --full-page https://github.com github.png
+```
+
+### PDF Screenshot
+
+Generate PDF documents from websites. Uses [`method: Page.pdf`] to generate the PDF.
+
+#### Syntax
+
+```bash
+npx playwright pdf [options] <url> <filename>
+```
+
+#### Options
+
+| Option | Description |
+| :--- | :--- |
+| `-b, --browser <name>` | Browser to use: chromium (only Chromium supported) |
+| `--wait-for-selector <selector>` | Wait for element matching selector before capturing |
+| `--paper-format <format>` | Paper format: Letter, A4, etc. (default: Letter) |
+| `--landscape` | Set landscape paper orientation |
+
+#### Examples
+
+```bash
+# Generate PDF of website
+npx playwright pdf https://playwright.dev doc.pdf
+
+# Use A4 paper format
+npx playwright pdf --paper-format=A4 https://playwright.dev doc.pdf
+```
+
+### Playwright Server
+
+Start a remote server for Playwright automation.
+
+#### Syntax
+
+```bash
+npx playwright run-server [options]
+```
+
+#### Options
+
+| Option | Description |
+| :--- | :--- |
+| `--port <port>` | Server port |
+| `--host <host>` | Server host |
+| `--path <path>` | Endpoint path (default: /) |
+| `--max-clients <number>` | Maximum number of client connections |
+| `--mode <mode>` | Server mode: "default" or "extension" |
+
+#### Examples
+
+```bash
+# Start with default settings
+npx playwright run-server
+
+# Start on custom port
+npx playwright run-server --port 8080
+
+# Run in extension mode
+npx playwright run-server --mode extension
+```

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -29,9 +29,6 @@ npx playwright test tests/todo-page.spec.ts
 # Run a set of test files
 npx playwright test tests/todo-page/ tests/landing-page/
 
-# Run files that have `my-spec` or `another-spec` in the file name
-npx playwright test my-spec another-spec-2
-
 # Run tests at a specific line
 npx playwright test my-spec.ts:42
 
@@ -52,12 +49,6 @@ npx playwright test --help
 
 ```bash
 npx playwright test --workers=1
-```
-
-**Choose a [reporter](./test-reporters.md)**
-
-```bash
-npx playwright test --reporter=dot
 ```
 
 **Run in debug mode with [Playwright Inspector](./debug.md)**

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -2640,7 +2640,7 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
    * Test tags are displayed in the test report, and are available to a custom reporter via `TestCase.tags` property.
    *
    * You can also filter tests by their tags during test execution:
-   * - in the [command line](https://playwright.dev/docs/test-cli#reference);
+   * - in the [command line](https://playwright.dev/docs/test-cli#all-options);
    * - in the config with [testConfig.grep](https://playwright.dev/docs/api/class-testconfig#test-config-grep) and
    *   [testProject.grep](https://playwright.dev/docs/api/class-testproject#test-project-grep);
    *
@@ -2717,7 +2717,7 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
    * Test tags are displayed in the test report, and are available to a custom reporter via `TestCase.tags` property.
    *
    * You can also filter tests by their tags during test execution:
-   * - in the [command line](https://playwright.dev/docs/test-cli#reference);
+   * - in the [command line](https://playwright.dev/docs/test-cli#all-options);
    * - in the config with [testConfig.grep](https://playwright.dev/docs/api/class-testconfig#test-config-grep) and
    *   [testProject.grep](https://playwright.dev/docs/api/class-testproject#test-project-grep);
    *


### PR DESCRIPTION
Experimenting with reformatting the CLI docs for additional clarity and similarity with other software projects.

<img width="1291" alt="Screenshot 2025-05-14 at 10 41 42 AM" src="https://github.com/user-attachments/assets/acd7f957-b56b-4d18-bf46-dbd3cc0b1ec3" />

<img width="1276" alt="Screenshot 2025-05-14 at 10 41 53 AM" src="https://github.com/user-attachments/assets/cb3a0061-68e9-489e-b3a6-85ceb5a6b7fc" />
