### PR TITLE
fix(test runner): do not install custom loader hook for '.cjs'

### DIFF
--- a/packages/playwright/ThirdPartyNotices.txt
+++ b/packages/playwright/ThirdPartyNotices.txt
@@ -125,7 +125,6 @@ This project incorporates components from the projects listed below. The origina
 -	picocolors@1.1.0 (https://github.com/alexeyraspopov/picocolors)
 -	picocolors@1.1.1 (https://github.com/alexeyraspopov/picocolors)
 -	picomatch@2.3.1 (https://github.com/micromatch/picomatch)
--	pirates@4.0.4 (https://github.com/danez/pirates)
 -	pretty-format@29.7.0 (https://github.com/jestjs/jest)
 -	react-is@18.3.1 (https://github.com/facebook/react)
 -	readdirp@3.6.0 (https://github.com/paulmillr/readdirp)
@@ -3631,32 +3630,6 @@ THE SOFTWARE.
 =========================================
 END OF picomatch@2.3.1 AND INFORMATION
 
-%% pirates@4.0.4 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-MIT License
-
-Copyright (c) 2016-2018 Ari Porad
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-=========================================
-END OF pirates@4.0.4 AND INFORMATION
-
 %% pretty-format@29.7.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 MIT License
@@ -4006,6 +3979,6 @@ END OF yallist@3.1.1 AND INFORMATION
 
 SUMMARY BEGIN HERE
 =========================================
-Total Packages: 137
+Total Packages: 136
 =========================================
 END OF SUMMARY

--- a/packages/playwright/bundles/utils/package-lock.json
+++ b/packages/playwright/bundles/utils/package-lock.json
@@ -12,7 +12,6 @@
         "enquirer": "2.3.6",
         "get-east-asian-width": "1.3.0",
         "json5": "2.2.3",
-        "pirates": "4.0.4",
         "source-map-support": "0.5.21",
         "stoppable": "1.1.0"
       },
@@ -238,14 +237,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pirates": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
-      "integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -442,11 +433,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
-    },
-    "pirates": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
-      "integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw=="
     },
     "readdirp": {
       "version": "3.6.0",

--- a/packages/playwright/bundles/utils/package.json
+++ b/packages/playwright/bundles/utils/package.json
@@ -7,7 +7,6 @@
     "enquirer": "2.3.6",
     "get-east-asian-width": "1.3.0",
     "json5": "2.2.3",
-    "pirates": "4.0.4",
     "source-map-support": "0.5.21",
     "stoppable": "1.1.0"
   },

--- a/packages/playwright/bundles/utils/src/utilsBundleImpl.ts
+++ b/packages/playwright/bundles/utils/src/utilsBundleImpl.ts
@@ -19,9 +19,6 @@
 import json5Library from 'json5';
 export const json5 = json5Library;
 
-import * as piratesLibrary from 'pirates';
-export const pirates = piratesLibrary;
-
 import sourceMapSupportLibrary from 'source-map-support';
 export const sourceMapSupport = sourceMapSupportLibrary;
 

--- a/packages/playwright/src/third_party/pirates.ts
+++ b/packages/playwright/src/third_party/pirates.ts
@@ -1,0 +1,59 @@
+/**
+ *  MIT License
+ *
+ *  Copyright (c) 2016-2018 Ari Porad
+ *  Modifications copyright (c) Microsoft Corporation.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+import Module from 'module';
+import path from 'path';
+
+export function addHook(transformHook: (code: string, filename: string) => string, shouldTransform: (filename: string) => boolean, extensions: string[]) {
+  // This is a shortened and slightly changed version of https://github.com/danez/pirates.
+  //
+  // We cannot use pirates directly due to https://github.com/microsoft/playwright/issues/35812.
+  // If we overwrite the '.cjs', the following code does not run because there is a custom loader defined:
+  // https://github.com/nodejs/node/blob/b1973550e09d5a2a07c70be5de6e3ae4722ad230/lib/internal/modules/esm/translators.js#L397-L403
+  //
+  // Here we rely on the default '.js' loader to handle '.cjs' files.
+  const extensionsToOverwrite = extensions.filter(e => e !== '.cjs');
+  const allSupportedExtensions = new Set(extensions);
+  const loaders = (Module as any)._extensions;
+  const jsLoader = loaders['.js'];
+  for (const extension of extensionsToOverwrite) {
+    const originalLoader = loaders[extension] || jsLoader;
+    function newLoader(this: any, mod: any, filename: string, ...loaderArgs: any[]) {
+      if (allSupportedExtensions.has(path.extname(filename)) && shouldTransform(filename)) {
+        const oldCompile = mod._compile;
+        function newCompile(this: any, code: string, file: string, ...ignoredArgs: any[]) {
+          // Note: we do not pass |args| downstream to make sure "esm modules" loaded through here
+          // are treated as "commonjs", for example for ".mjs" files.
+          // In theory, we should fix this, but it is a breaking change, even for playwright's own tests.
+          mod._compile = oldCompile;
+          return oldCompile.call(this, transformHook(code, filename), file);
+        }
+        mod._compile = newCompile;
+      }
+      originalLoader.call(this, mod, filename, ...loaderArgs);
+    }
+    loaders[extension] = newLoader;
+  }
+}

--- a/packages/playwright/src/transform/DEPS.list
+++ b/packages/playwright/src/transform/DEPS.list
@@ -1,5 +1,6 @@
 [*]
 ../util.ts
 ../utilsBundle.ts
+../third_party/pirates.ts
 ../third_party/tsconfig-loader.ts
 ../common/globals.ts

--- a/packages/playwright/src/utilsBundle.ts
+++ b/packages/playwright/src/utilsBundle.ts
@@ -15,7 +15,6 @@
  */
 
 export const json5: typeof import('../bundles/utils/node_modules/json5/lib') = require('./utilsBundleImpl').json5;
-export const pirates: typeof import('../bundles/utils/node_modules/pirates') = require('./utilsBundleImpl').pirates;
 export const sourceMapSupport: typeof import('../bundles/utils/node_modules/@types/source-map-support') = require('./utilsBundleImpl').sourceMapSupport;
 export const stoppable: typeof import('../bundles/utils/node_modules/@types/stoppable') = require('./utilsBundleImpl').stoppable;
 export const enquirer: typeof import('../bundles/utils/node_modules/enquirer') = require('./utilsBundleImpl').enquirer;

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -1085,7 +1085,7 @@ test('should remove import css', async ({ runInlineTest }) => {
   expect(result.passed).toBe(1);
 });
 
-test.fixme('should dynamically import re-exported cjs namespace', {
+test('should dynamically import re-exported cjs namespace', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35812' },
 }, async ({ runInlineTest }) => {
   const result = await runInlineTest({


### PR DESCRIPTION
This requires vendoring `pirates` and changing the logic there.

Closes #35812.