### PR TITLE
chore: use `runImmediately` option to ensure init script runs once

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -488,8 +488,6 @@ class FrameSession {
             grantUniveralAccess: true,
             worldName: UTILITY_WORLD_NAME,
           });
-          for (const initScript of this._crPage._page.allInitScripts())
-            frame.evaluateExpression(initScript.source).catch(e => {});
         }
 
         const isInitialEmptyPage = this._isMainFrame() && this._page.mainFrame().url() === ':';
@@ -542,7 +540,7 @@ class FrameSession {
       promises.push(this._updateEmulateMedia());
       promises.push(this._updateFileChooserInterception(true));
       for (const initScript of this._crPage._page.allInitScripts())
-        promises.push(this._evaluateOnNewDocument(initScript, 'main'));
+        promises.push(this._evaluateOnNewDocument(initScript, 'main', true /* runImmediately */));
       if (screencastOptions)
         promises.push(this._startVideoRecording(screencastOptions));
     }
@@ -1051,9 +1049,9 @@ class FrameSession {
     await this._client.send('Page.setInterceptFileChooserDialog', { enabled }).catch(() => {}); // target can be closed.
   }
 
-  async _evaluateOnNewDocument(initScript: InitScript, world: types.World): Promise<void> {
+  async _evaluateOnNewDocument(initScript: InitScript, world: types.World, runImmediately?: boolean): Promise<void> {
     const worldName = world === 'utility' ? UTILITY_WORLD_NAME : undefined;
-    const { identifier } = await this._client.send('Page.addScriptToEvaluateOnNewDocument', { source: initScript.source, worldName });
+    const { identifier } = await this._client.send('Page.addScriptToEvaluateOnNewDocument', { source: initScript.source, worldName, runImmediately });
     if (!initScript.internal)
       this._evaluateOnNewDocumentIdentifiers.push(identifier);
   }

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -29,7 +29,6 @@ import { ProgressController } from './progress';
 import { Screenshotter, validateScreenshotOptions } from './screenshotter';
 import { TimeoutSettings } from './timeoutSettings';
 import { LongStandingScope, assert, trimStringWithEllipsis } from '../utils';
-import { createGuid } from './utils/crypto';
 import { asLocator } from '../utils';
 import { getComparator } from './utils/comparators';
 import { debugLogger } from './utils/debugLogger';
@@ -905,17 +904,7 @@ export class InitScript {
   readonly name?: string;
 
   constructor(source: string, internal?: boolean, name?: string) {
-    const guid = createGuid();
     this.source = `(() => {
-      const name = '__pw_init_scripts__${js.runtimeGuid}';
-      if (!globalThis[name])
-        Object.defineProperty(globalThis, name, { value: {}, configurable: false, enumerable: false, writable: false });
-
-      const globalInitScripts = globalThis[name];
-      const hasInitScript = globalInitScripts[${JSON.stringify(guid)}];
-      if (hasInitScript)
-        return;
-      globalThis[name][${JSON.stringify(guid)}] = true;
       ${source}
     })();`;
     this.internal = !!internal;


### PR DESCRIPTION
There are three distinct scenarios possible in Chromium today:
- A page that is opened in a new renderer through `BeginNavigation`. Such a page will be always navigated to a new document with a new js context, so it does not matter whether we run the init script upon attach in the initial empty context or not.
- A `window.open`ed page in the same renderer. Such a page currently receives `Page.addScriptToEvaluateOnNewDocument` and immediately evaluates it. Switching to `runImmediately` has no effect.
- A new page created through `createWindow()` when web security is disabled. Such a page does not run the init script after loading the target url, because the js context is reused (due to security being disabled). In this case, it is essential to run the init script immediately, which the new flag does.

This is covered by `init script should run only once` tests. See #31458 and #31096 fir prior art.