### PR TITLE
fix(bidi): expose main binding in existing page

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -46,7 +46,7 @@ export class BidiPage implements PageDelegate {
   readonly _page: Page;
   readonly _session: BidiSession;
   readonly _opener: BidiPage | null;
-  private readonly _realmToContext: Map<string, dom.FrameExecutionContext>;
+  readonly _realmToContext: Map<string, dom.FrameExecutionContext>;
   private _sessionListeners: RegisteredListener[] = [];
   readonly _browserContext: BidiBrowserContext;
   readonly _networkManager: BidiNetworkManager;


### PR DESCRIPTION
`script.addPreloadScript` does not evaluate the script in the existing pages, so we have to additionally call `script.callFunction`.

Fixes https://github.com/microsoft/playwright/issues/35991