### PR TITLE
fix: throw pretty error if opening userDataDir twice

### DIFF
--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -272,7 +272,9 @@ export abstract class BrowserType extends SdkObject {
     progress.cleanupWhenAborted(() => closeOrKill(progress.timeUntilDeadline()));
     const wsEndpoint = (await readyState?.waitUntilReady())?.wsEndpoint;
     if (options.cdpPort !== undefined || !this.supportsPipeTransport()) {
-      transport = await WebSocketTransport.connect(progress, wsEndpoint!);
+      if (!wsEndpoint)
+        throw new Error('Unable to determine wsEndpoint.');
+      transport = await WebSocketTransport.connect(progress, wsEndpoint);
     } else {
       const stdio = launchedProcess.stdio as unknown as [NodeJS.ReadableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.ReadableStream];
       transport = new PipeTransport(stdio[3], stdio[4]);

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -157,7 +157,7 @@ export abstract class BrowserType extends SdkObject {
     if (persistent)
       validateBrowserContextOptions(persistent, browserOptions);
     copyTestHooks(options, browserOptions);
-    const browser = await this.connectToTransport(transport, browserOptions);
+    const browser = await this.connectToTransport(transport, browserOptions, browserLogsCollector);
     (browser as any)._userDataDirForTest = userDataDir;
     // We assume no control when using custom arguments, and do not prepare the default context in that case.
     if (persistent && !options.ignoreAllDefaultArgs)
@@ -272,9 +272,7 @@ export abstract class BrowserType extends SdkObject {
     progress.cleanupWhenAborted(() => closeOrKill(progress.timeUntilDeadline()));
     const wsEndpoint = (await readyState?.waitUntilReady())?.wsEndpoint;
     if (options.cdpPort !== undefined || !this.supportsPipeTransport()) {
-      if (!wsEndpoint)
-        throw new Error('Unable to determine wsEndpoint.');
-      transport = await WebSocketTransport.connect(progress, wsEndpoint);
+      transport = await WebSocketTransport.connect(progress, wsEndpoint!);
     } else {
       const stdio = launchedProcess.stdio as unknown as [NodeJS.ReadableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.WritableStream, NodeJS.ReadableStream];
       transport = new PipeTransport(stdio[3], stdio[4]);
@@ -344,7 +342,7 @@ export abstract class BrowserType extends SdkObject {
   }
 
   abstract defaultArgs(options: types.LaunchOptions, isPersistent: boolean, userDataDir: string): string[];
-  abstract connectToTransport(transport: ConnectionTransport, options: BrowserOptions): Promise<Browser>;
+  abstract connectToTransport(transport: ConnectionTransport, options: BrowserOptions, browserLogsCollector: RecentLogsCollector): Promise<Browser>;
   abstract amendEnvironment(env: Env, userDataDir: string, executable: string, browserArguments: string[]): Env;
   abstract doRewriteStartupLog(error: ProtocolError): ProtocolError;
   abstract attemptToGracefullyCloseBrowser(transport: ConnectionTransport): void;

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -126,13 +126,23 @@ export class Chromium extends BrowserType {
     return directory ? new CRDevTools(path.join(directory, 'devtools-preferences.json')) : undefined;
   }
 
-  override async connectToTransport(transport: ConnectionTransport, options: BrowserOptions): Promise<CRBrowser> {
+  override async connectToTransport(transport: ConnectionTransport, options: BrowserOptions, browserLogsCollector: RecentLogsCollector): Promise<CRBrowser> {
     let devtools = this._devtools;
     if ((options as any).__testHookForDevTools) {
       devtools = this._createDevTools();
       await (options as any).__testHookForDevTools(devtools);
     }
-    return CRBrowser.connect(this.attribution.playwright, transport, options, devtools);
+    try {
+      return await CRBrowser.connect(this.attribution.playwright, transport, options, devtools);
+    } catch (e) {
+      if (browserLogsCollector.recentLogs().some(log => log.includes('Failed to create a ProcessSingleton for your profile directory.'))) {
+        throw new Error(
+            'Failed to create a ProcessSingleton for your profile directory. ' +
+            'This usually means that the profile is already in use by another instance of Chromium.'
+        );
+      }
+      throw e;
+    }
   }
 
   override doRewriteStartupLog(error: ProtocolError): ProtocolError {
@@ -358,6 +368,10 @@ export class Chromium extends BrowserType {
 
 class ChromiumReadyState extends BrowserReadyState {
   override onBrowserOutput(message: string): void {
+    if (message.includes('Failed to create a ProcessSingleton for your profile directory.')) {
+      this._wsEndpoint.reject(new Error('Failed to create a ProcessSingleton for your profile directory. ' +
+        'This usually means that the profile is already in use by another instance of Chromium.'));
+    }
     const match = message.match(/DevTools listening on (.*)/);
     if (match)
       this._wsEndpoint.resolve(match[1]);

--- a/tests/library/chromium/chromium.spec.ts
+++ b/tests/library/chromium/chromium.spec.ts
@@ -630,3 +630,18 @@ test.describe('PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1', () => {
     expect(req.headers['x-custom-header']).toBe('custom!');
   });
 });
+
+test('should throw when connecting twice to an already running persistent context (--remote-debugging-port)', async ({ browserType, channel, createUserDataDir }) => {
+  test.skip(!['chrome', 'msedge'].includes(channel), 'normal Chromium allows to open a userDataDir twice while Chrome/Edge does not');
+  const userDataDir = await createUserDataDir();
+  const options = {
+    cdpPort: 60483,
+  } as any;
+  const browser = await browserType.launchPersistentContext(userDataDir, options);
+  try {
+    const error = await browserType.launchPersistentContext(userDataDir, options).catch(e => e);
+    expect(error.message).toContain('Unable to determine wsEndpoint.')
+  } finally {
+    await browser.close();
+  }
+});

--- a/tests/library/chromium/chromium.spec.ts
+++ b/tests/library/chromium/chromium.spec.ts
@@ -631,8 +631,9 @@ test.describe('PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1', () => {
   });
 });
 
-test('should throw when connecting twice to an already running persistent context (--remote-debugging-port)', async ({ browserType, createUserDataDir, isHeadlessShell }) => {
+test('should throw when connecting twice to an already running persistent context (--remote-debugging-port)', async ({ browserType, createUserDataDir, platform, isHeadlessShell }) => {
   test.skip(isHeadlessShell, 'Headless shell does not create a ProcessSingleton');
+  test.fixme(platform === 'win32', 'Windows does not print something to the console when the profile is already in use by another instance of Chromium.');
   const userDataDir = await createUserDataDir();
   const browser = await browserType.launchPersistentContext(userDataDir, {
     cdpPort: 9222,
@@ -647,8 +648,9 @@ test('should throw when connecting twice to an already running persistent contex
   }
 });
 
-test('should throw when connecting twice to an already running persistent context (--remote-debugging-pipe)', async ({ browserType, createUserDataDir, isHeadlessShell }) => {
+test('should throw when connecting twice to an already running persistent context (--remote-debugging-pipe)', async ({ browserType, createUserDataDir, platform, isHeadlessShell }) => {
   test.skip(isHeadlessShell, 'Headless shell does not create a ProcessSingleton');
+  test.fixme(platform === 'win32', 'Windows does not print something to the console when the profile is already in use by another instance of Chromium.');
   const userDataDir = await createUserDataDir();
   const browser = await browserType.launchPersistentContext(userDataDir);
   try {


### PR DESCRIPTION
**What happened?**

In the scenario of that a persistent browser profile is already used, the browser is directly exiting with an error message to stderr. This **only** happens with Chrome/Edge. Not with normal Chromium.

>   pw:browser [pid=27879][err] [27879:1132024:0519/185553.390665:ERROR:chrome/browser/process_singleton_posix.cc:346] Failed to create /private/var/folders/gs/d87p6_k17rz4ww4jr7kndrmr0000gn/T/playwright-test-vnBakK/SingletonLock: File exists (17) +145ms
>  pw:browser [pid=27879][err] [27879:1132024:0519/185553.391204:ERROR:chrome/app/chrome_main_delegate.cc:679] Failed to create a ProcessSingleton for your profile directory. This means that running multiple instances would start multiple browser processes rather than opening a new window in the existing process. Aborting now to avoid profile corruption

When that happens, we [resolve the readyState to undefined](https://github.com/microsoft/playwright/blob/cee8fb28a67998d48507b368837bcbc77a549bed/packages/playwright-core/src/server/browserType.ts#L248). This will then [resolve the wsEndpoint](https://github.com/microsoft/playwright/blob/cee8fb28a67998d48507b368837bcbc77a549bed/packages/playwright-core/src/server/browserType.ts#L273) and try to connect to it even tho its `undefined`.

Relates https://github.com/microsoft/playwright-mcp/issues/366 (does not fix it but throws a better error now)