### PR TITLE
chore: remove unused param

### DIFF
--- a/packages/playwright/src/runner/reporters.ts
+++ b/packages/playwright/src/runner/reporters.ts
@@ -77,7 +77,7 @@ export async function createReporters(config: FullConfigInternal, mode: 'list' |
     if (mode === 'list')
       reporters.unshift(new ListModeReporter());
     else if (mode !== 'merge')
-      reporters.unshift(!process.env.CI ? new LineReporter({ omitFailures: true }) : new DotReporter());
+      reporters.unshift(!process.env.CI ? new LineReporter() : new DotReporter());
   }
   return reporters;
 }


### PR DESCRIPTION
`LineReporter` doesn't pass the param upwards, so it's ignored.