### PR TITLE
chore: Use › as separator between the filename and test in the CSV reporter as well

### DIFF
--- a/tests/bidi/csvReporter.ts
+++ b/tests/bidi/csvReporter.ts
@@ -51,7 +51,7 @@ class CsvReporter implements Reporter {
             continue;
           const row = [];
           const [, , , ...titles] = test.titlePath();
-          row.push(csvEscape(`${file.title} :: ${titles.join(' › ')}`));
+          row.push(csvEscape(`${file.title} › ${titles.join(' › ')}`));
           row.push(test.expectedStatus);
           row.push(test.outcome());
           if (fixme) {


### PR DESCRIPTION
The expectation files like `tests/bidi/expectations/moz-firefox-library.txt` use ` › ` as separator between the filename and the test while in the CSV file we have ` :: `. This causes more efforts when copying those entries over into the expectation file because I need to update this separator. It would be good to have the same usage of ` › ` here as well.