### PR TITLE
docs: add test report download instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ test('Intercept network requests', async ({ page }) => {
   await page.goto('http://todomvc.com');
 });
 ```
+---
+
+## 📘 Test Report Download Instructions
+
+After running your tests using:
+
+```bash
+npx playwright test
 
 ## Resources
 


### PR DESCRIPTION
This PR adds instructions to the README for downloading test reports when using Playwright. It helps users understand how to retrieve reports after test execution.
