### PR TITLE
chore: push browser to the client when launching persistent

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -112,6 +112,8 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
     };
     return await this._wrapApiCall(async () => {
       const result = await this._channel.launchPersistentContext(persistentParams);
+      const browser = Browser.from(result.browser);
+      this._didLaunchBrowser(browser, options, logger);
       const context = BrowserContext.from(result.context);
       await context._initializeHarFromOptions(options.recordHar);
       await this._didCreateContext(context, contextParams, options, logger);

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -192,7 +192,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     const routeHandlers = this._routes.slice();
     for (const routeHandler of routeHandlers) {
       // If the page was closed we stall all requests right away.
-      if (this._closeWasCalled || this._browserContext._closeWasCalled)
+      if (this._closeWasCalled || this._browserContext._closingStatus !== 'none')
         return;
       if (!routeHandler.matches(route.request().url()))
         continue;

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -640,6 +640,7 @@ scheme.BrowserTypeLaunchPersistentContextParams = tObject({
   slowMo: tOptional(tNumber),
 });
 scheme.BrowserTypeLaunchPersistentContextResult = tObject({
+  browser: tChannel(['Browser']),
   context: tChannel(['BrowserContext']),
 });
 scheme.BrowserTypeConnectOverCDPParams = tObject({

--- a/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
@@ -39,7 +39,9 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.Brow
 
   async launchPersistentContext(params: channels.BrowserTypeLaunchPersistentContextParams, metadata: CallMetadata): Promise<channels.BrowserTypeLaunchPersistentContextResult> {
     const browserContext = await this._object.launchPersistentContext(metadata, params.userDataDir, params);
-    return { context: new BrowserContextDispatcher(this, browserContext) };
+    const browserDispatcher = new BrowserDispatcher(this, browserContext._browser);
+    const contextDispatcher = new BrowserContextDispatcher(browserDispatcher, browserContext);
+    return { browser: browserDispatcher, context: contextDispatcher };
   }
 
   async connectOverCDP(params: channels.BrowserTypeConnectOverCDPParams, metadata: CallMetadata): Promise<channels.BrowserTypeConnectOverCDPResult> {

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -1135,6 +1135,7 @@ export type BrowserTypeLaunchPersistentContextOptions = {
   slowMo?: number,
 };
 export type BrowserTypeLaunchPersistentContextResult = {
+  browser: BrowserChannel,
   context: BrowserContextChannel,
 };
 export type BrowserTypeConnectOverCDPParams = {

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1033,6 +1033,7 @@ BrowserType:
         userDataDir: string
         slowMo: number?
       returns:
+        browser: Browser
         context: BrowserContext
 
     connectOverCDP:

--- a/tests/library/defaultbrowsercontext-2.spec.ts
+++ b/tests/library/defaultbrowsercontext-2.spec.ts
@@ -269,3 +269,16 @@ it('dialog.accept should work', {
   expect(shown).toBe(true);
   await context.close();
 });
+
+it('exposes browser', async ({ launchPersistent }) => {
+  const { context } = await launchPersistent();
+  const browser = context.browser();
+  expect(browser.version()).toBeTruthy();
+  const page = await browser.newPage();
+  await page.goto('data:text/html,<html><title>Title</title></html>');
+  expect(await page.title()).toBe('Title');
+  await browser.close();
+  expect(context.pages().length).toBe(0);
+  // Next line should not throw.
+  await context.close();
+});


### PR DESCRIPTION
This makes `context.browser()` to not be `null`.

References #35987.