### PR TITLE
feat: browser.on('context') event

### DIFF
--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -72,6 +72,12 @@ await page.GotoAsync("https://www.bing.com");
 await browser.CloseAsync();
 ```
 
+## event: Browser.context
+* since: v1.53
+- argument: <[BrowserContext]>
+
+Emitted when a new [BrowserContext] is created in the browser.
+
 ## event: Browser.disconnected
 * since: v1.8
 - argument: <[Browser]>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -9551,6 +9551,12 @@ export interface Browser {
     behavior?: 'wait'|'ignoreErrors'|'default'
   }): Promise<void>;
   /**
+   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
+   * browser.
+   */
+  on(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
    * following:
    * - Browser application is closed or crashed.
@@ -9561,7 +9567,18 @@ export interface Browser {
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
+  once(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
+   */
   once(event: 'disconnected', listener: (browser: Browser) => any): this;
+
+  /**
+   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
+   * browser.
+   */
+  addListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
@@ -9574,12 +9591,28 @@ export interface Browser {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  removeListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   removeListener(event: 'disconnected', listener: (browser: Browser) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  off(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   off(event: 'disconnected', listener: (browser: Browser) => any): this;
+
+  /**
+   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
+   * browser.
+   */
+  prependListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the

--- a/packages/playwright-core/src/client/android.ts
+++ b/packages/playwright-core/src/client/android.ts
@@ -258,7 +258,6 @@ export class AndroidDevice extends ChannelOwner<channels.AndroidDeviceChannel> i
     const contextOptions = await prepareBrowserContextParams(this._platform, options);
     const result = await this._channel.launchBrowser(contextOptions);
     const context = BrowserContext.from(result.context) as BrowserContext;
-    context._setOptions(contextOptions, {});
     await context._initializeHarFromOptions(options.recordHar);
     return context;
   }

--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -24,7 +24,7 @@ import { mkdirIfNeeded } from './fileUtils';
 
 import type { BrowserType } from './browserType';
 import type { Page } from './page';
-import type { BrowserContextOptions, LaunchOptions } from './types';
+import type { BrowserContextOptions, LaunchOptions, Logger } from './types';
 import type * as api from '../../types/types';
 import type * as channels from '@protocol/channels';
 
@@ -46,6 +46,7 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.BrowserInitializer) {
     super(parent, type, guid, initializer);
     this._name = initializer.name;
+    this._channel.on('context', ({ context }) => this._didCreateContext(BrowserContext.from(context)));
     this._channel.on('close', () => this._didClose());
     this._closedPromise = new Promise(f => this.once(Events.Browser.Disconnected, f));
   }
@@ -61,7 +62,7 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
   async _newContextForReuse(options: BrowserContextOptions = {}): Promise<BrowserContext> {
     return await this._wrapApiCall(async () => {
       for (const context of this._contexts) {
-        await this._browserType._willCloseContext(context);
+        await this._instrumentation.runBeforeCloseBrowserContext(context);
         for (const page of context.pages())
           page._onClose();
         context._onClose();
@@ -84,9 +85,40 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
     const contextOptions = await prepareBrowserContextParams(this._platform, options);
     const response = forReuse ? await this._channel.newContextForReuse(contextOptions) : await this._channel.newContext(contextOptions);
     const context = BrowserContext.from(response.context);
+    if (options.logger)
+      context._logger = options.logger;
     await context._initializeHarFromOptions(options.recordHar);
-    await this._browserType._didCreateContext(context, contextOptions, this._options, options.logger || this._logger);
+    await this._instrumentation.runAfterCreateBrowserContext(context);
     return context;
+  }
+
+  _connectToBrowserType(browserType: BrowserType, browserOptions: LaunchOptions, logger: Logger | undefined) {
+    // Note: when using connect(), `browserType` is different from `this._parent`.
+    // This is why browser type is not wired up in the constructor,
+    // and instead this separate method is called later on.
+    this._browserType = browserType;
+    this._options = browserOptions;
+    this._logger = logger;
+    for (const context of this._contexts)
+      this._setupBrowserContext(context);
+  }
+
+  private _didCreateContext(context: BrowserContext) {
+    context._browser = this;
+    this._contexts.add(context);
+    // Note: when connecting to a browser, initial contexts arrive before `browserType` is set,
+    // and will be configured later in `_connectToBrowserType`.
+    if (this._browserType)
+      this._setupBrowserContext(context);
+    this.emit(Events.Browser.Context, context);
+  }
+
+  private _setupBrowserContext(context: BrowserContext) {
+    context._logger = this._logger;
+    context.tracing._tracesDir = this._options.tracesDir;
+    this._browserType._contexts.add(context);
+    context.setDefaultTimeout(this._browserType._playwright._defaultContextTimeout);
+    context.setDefaultNavigationTimeout(this._browserType._playwright._defaultContextNavigationTimeout);
   }
 
   contexts(): BrowserContext[] {

--- a/packages/playwright-core/src/client/electron.ts
+++ b/packages/playwright-core/src/client/electron.ts
@@ -61,7 +61,7 @@ export class Electron extends ChannelOwner<channels.ElectronChannel> implements 
     };
     const app = ElectronApplication.from((await this._channel.launch(params)).electronApplication);
     await app._context._initializeHarFromOptions(options.recordHar);
-    app._context._setOptions(params, options);
+    app._context.tracing._tracesDir = options.tracesDir;
     return app;
   }
 }

--- a/packages/playwright-core/src/client/events.ts
+++ b/packages/playwright-core/src/client/events.ts
@@ -31,6 +31,7 @@ export const Events = {
   },
 
   Browser: {
+    Context: 'context',
     Disconnected: 'disconnected'
   },
 

--- a/packages/playwright-core/src/client/playwright.ts
+++ b/packages/playwright-core/src/client/playwright.ts
@@ -77,7 +77,7 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel> {
 
   _preLaunchedBrowser(): Browser {
     const browser = Browser.from(this._initializer.preLaunchedBrowser!);
-    browser._browserType = this[browser._name as 'chromium' | 'firefox' | 'webkit'];
+    browser._connectToBrowserType(this[browser._name as 'chromium' | 'firefox' | 'webkit'], {}, undefined);
     return browser;
   }
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -657,6 +657,9 @@ scheme.BrowserInitializer = tObject({
   version: tString,
   name: tString,
 });
+scheme.BrowserContextEvent = tObject({
+  context: tChannel(['BrowserContext']),
+});
 scheme.BrowserCloseEvent = tOptional(tObject({}));
 scheme.BrowserCloseParams = tObject({
   reason: tOptional(tString),
@@ -853,6 +856,64 @@ scheme.BrowserContextInitializer = tObject({
   isChromium: tBoolean,
   requestContext: tChannel(['APIRequestContext']),
   tracing: tChannel(['Tracing']),
+  options: tObject({
+    noDefaultViewport: tOptional(tBoolean),
+    viewport: tOptional(tObject({
+      width: tNumber,
+      height: tNumber,
+    })),
+    screen: tOptional(tObject({
+      width: tNumber,
+      height: tNumber,
+    })),
+    ignoreHTTPSErrors: tOptional(tBoolean),
+    clientCertificates: tOptional(tArray(tObject({
+      origin: tString,
+      cert: tOptional(tBinary),
+      key: tOptional(tBinary),
+      passphrase: tOptional(tString),
+      pfx: tOptional(tBinary),
+    }))),
+    javaScriptEnabled: tOptional(tBoolean),
+    bypassCSP: tOptional(tBoolean),
+    userAgent: tOptional(tString),
+    locale: tOptional(tString),
+    timezoneId: tOptional(tString),
+    geolocation: tOptional(tObject({
+      longitude: tNumber,
+      latitude: tNumber,
+      accuracy: tOptional(tNumber),
+    })),
+    permissions: tOptional(tArray(tString)),
+    extraHTTPHeaders: tOptional(tArray(tType('NameValue'))),
+    offline: tOptional(tBoolean),
+    httpCredentials: tOptional(tObject({
+      username: tString,
+      password: tString,
+      origin: tOptional(tString),
+      send: tOptional(tEnum(['always', 'unauthorized'])),
+    })),
+    deviceScaleFactor: tOptional(tNumber),
+    isMobile: tOptional(tBoolean),
+    hasTouch: tOptional(tBoolean),
+    colorScheme: tOptional(tEnum(['dark', 'light', 'no-preference', 'no-override'])),
+    reducedMotion: tOptional(tEnum(['reduce', 'no-preference', 'no-override'])),
+    forcedColors: tOptional(tEnum(['active', 'none', 'no-override'])),
+    acceptDownloads: tOptional(tEnum(['accept', 'deny', 'internal-browser-default'])),
+    contrast: tOptional(tEnum(['no-preference', 'more', 'no-override'])),
+    baseURL: tOptional(tString),
+    recordVideo: tOptional(tObject({
+      dir: tString,
+      size: tOptional(tObject({
+        width: tNumber,
+        height: tNumber,
+      })),
+    })),
+    strictSelectors: tOptional(tBoolean),
+    serviceWorkers: tOptional(tEnum(['allow', 'block'])),
+    selectorEngines: tOptional(tArray(tType('SelectorEngine'))),
+    testIdAttributeName: tOptional(tString),
+  }),
 });
 scheme.BrowserContextBindingCallEvent = tObject({
   binding: tChannel(['BindingCall']),

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -58,6 +58,7 @@ export type BrowserOptions = {
 export abstract class Browser extends SdkObject {
 
   static Events = {
+    Context: 'context',
     Disconnected: 'disconnected',
   };
 
@@ -102,6 +103,7 @@ export abstract class Browser extends SdkObject {
     context._clientCertificatesProxy = clientCertificatesProxy;
     if (options.storageState)
       await context.setStorageState(metadata, options.storageState);
+    this.emit(Browser.Events.Context, context);
     return context;
   }
 

--- a/packages/playwright-core/src/server/dispatchers/androidDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/androidDispatcher.ts
@@ -158,7 +158,7 @@ export class AndroidDeviceDispatcher extends Dispatcher<AndroidDevice, channels.
 
   async launchBrowser(params: channels.AndroidDeviceLaunchBrowserParams): Promise<channels.AndroidDeviceLaunchBrowserResult> {
     const context = await this._object.launchBrowser(params.pkg, params);
-    return { context: new BrowserContextDispatcher(this, context) };
+    return { context: BrowserContextDispatcher.from(this, context) };
   }
 
   async close(params: channels.AndroidDeviceCloseParams) {
@@ -166,7 +166,7 @@ export class AndroidDeviceDispatcher extends Dispatcher<AndroidDevice, channels.
   }
 
   async connectToWebView(params: channels.AndroidDeviceConnectToWebViewParams): Promise<channels.AndroidDeviceConnectToWebViewResult> {
-    return { context: new BrowserContextDispatcher(this, await this._object.connectToWebView(params.socketName)) };
+    return { context: BrowserContextDispatcher.from(this, await this._object.connectToWebView(params.socketName)) };
   }
 }
 

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -52,16 +52,21 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   private _subscriptions = new Set<channels.BrowserContextUpdateSubscriptionParams['event']>();
   _webSocketInterceptionPatterns: channels.BrowserContextSetWebSocketInterceptionPatternsParams['patterns'] = [];
 
-  constructor(parentScope: DispatcherScope, context: BrowserContext) {
+  static from(parentScope: DispatcherScope, context: BrowserContext): BrowserContextDispatcher {
+    const result = parentScope.connection.existingDispatcher<BrowserContextDispatcher>(context);
+    return result || new BrowserContextDispatcher(parentScope, context);
+  }
+
+  private constructor(parentScope: DispatcherScope, context: BrowserContext) {
     // We will reparent these to the context below.
     const requestContext = APIRequestContextDispatcher.from(parentScope as BrowserContextDispatcher, context.fetchRequest);
     const tracing = TracingDispatcher.from(parentScope as BrowserContextDispatcher, context.tracing);
 
     super(parentScope, context, 'BrowserContext', {
       isChromium: context._browser.options.isChromium,
-      isLocalBrowserOnServer: context._browser._isCollocatedWithServer,
       requestContext,
       tracing,
+      options: context._options,
     });
 
     this.adopt(requestContext);

--- a/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
@@ -40,7 +40,7 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.Brow
   async launchPersistentContext(params: channels.BrowserTypeLaunchPersistentContextParams, metadata: CallMetadata): Promise<channels.BrowserTypeLaunchPersistentContextResult> {
     const browserContext = await this._object.launchPersistentContext(metadata, params.userDataDir, params);
     const browserDispatcher = new BrowserDispatcher(this, browserContext._browser);
-    const contextDispatcher = new BrowserContextDispatcher(browserDispatcher, browserContext);
+    const contextDispatcher = BrowserContextDispatcher.from(browserDispatcher, browserContext);
     return { browser: browserDispatcher, context: contextDispatcher };
   }
 
@@ -49,7 +49,7 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.Brow
     const browserDispatcher = new BrowserDispatcher(this, browser);
     return {
       browser: browserDispatcher,
-      defaultContext: browser._defaultContext ? new BrowserContextDispatcher(browserDispatcher, browser._defaultContext) : undefined,
+      defaultContext: browser._defaultContext ? BrowserContextDispatcher.from(browserDispatcher, browser._defaultContext) : undefined,
     };
   }
 }

--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -59,7 +59,7 @@ export class Dispatcher<Type extends { guid: string }, ChannelType, ParentScopeT
   _object: Type;
   private _openScope = new LongStandingScope();
 
-  constructor(parent: ParentScopeType | DispatcherConnection, object: Type, type: string, initializer: channels.InitializerTraits<Type>, gcBucket?: string) {
+  constructor(parent: ParentScopeType | DispatcherConnection, object: Type, type: string, initializer: channels.InitializerTraits<ChannelType>, gcBucket?: string) {
     super();
 
     this.connection = parent instanceof DispatcherConnection ? parent : parent.connection;

--- a/packages/playwright-core/src/server/dispatchers/electronDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/electronDispatcher.ts
@@ -47,7 +47,7 @@ export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplicatio
 
   constructor(scope: ElectronDispatcher, electronApplication: ElectronApplication) {
     super(scope, electronApplication, 'ElectronApplication', {
-      context: new BrowserContextDispatcher(scope, electronApplication.context())
+      context: BrowserContextDispatcher.from(scope, electronApplication.context())
     });
     this.addObjectListener(ElectronApplication.Events.Close, () => {
       this._dispatchEvent('close');

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9551,6 +9551,12 @@ export interface Browser {
     behavior?: 'wait'|'ignoreErrors'|'default'
   }): Promise<void>;
   /**
+   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
+   * browser.
+   */
+  on(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
    * following:
    * - Browser application is closed or crashed.
@@ -9561,7 +9567,18 @@ export interface Browser {
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
+  once(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
+   */
   once(event: 'disconnected', listener: (browser: Browser) => any): this;
+
+  /**
+   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
+   * browser.
+   */
+  addListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
@@ -9574,12 +9591,28 @@ export interface Browser {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  removeListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   removeListener(event: 'disconnected', listener: (browser: Browser) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  off(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   off(event: 'disconnected', listener: (browser: Browser) => any): this;
+
+  /**
+   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
+   * browser.
+   */
+  prependListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -1162,6 +1162,7 @@ export type BrowserInitializer = {
   name: string,
 };
 export interface BrowserEventTarget {
+  on(event: 'context', callback: (params: BrowserContextEvent) => void): this;
   on(event: 'close', callback: (params: BrowserCloseEvent) => void): this;
 }
 export interface BrowserChannel extends BrowserEventTarget, Channel {
@@ -1176,6 +1177,9 @@ export interface BrowserChannel extends BrowserEventTarget, Channel {
   startTracing(params: BrowserStartTracingParams, metadata?: CallMetadata): Promise<BrowserStartTracingResult>;
   stopTracing(params?: BrowserStopTracingParams, metadata?: CallMetadata): Promise<BrowserStopTracingResult>;
 }
+export type BrowserContextEvent = {
+  context: BrowserContextChannel,
+};
 export type BrowserCloseEvent = {};
 export type BrowserCloseParams = {
   reason?: string,
@@ -1500,6 +1504,7 @@ export type BrowserStopTracingResult = {
 };
 
 export interface BrowserEvents {
+  'context': BrowserContextEvent;
   'close': BrowserCloseEvent;
 }
 
@@ -1533,6 +1538,64 @@ export type BrowserContextInitializer = {
   isChromium: boolean,
   requestContext: APIRequestContextChannel,
   tracing: TracingChannel,
+  options: {
+    noDefaultViewport?: boolean,
+    viewport?: {
+      width: number,
+      height: number,
+    },
+    screen?: {
+      width: number,
+      height: number,
+    },
+    ignoreHTTPSErrors?: boolean,
+    clientCertificates?: {
+      origin: string,
+      cert?: Binary,
+      key?: Binary,
+      passphrase?: string,
+      pfx?: Binary,
+    }[],
+    javaScriptEnabled?: boolean,
+    bypassCSP?: boolean,
+    userAgent?: string,
+    locale?: string,
+    timezoneId?: string,
+    geolocation?: {
+      longitude: number,
+      latitude: number,
+      accuracy?: number,
+    },
+    permissions?: string[],
+    extraHTTPHeaders?: NameValue[],
+    offline?: boolean,
+    httpCredentials?: {
+      username: string,
+      password: string,
+      origin?: string,
+      send?: 'always' | 'unauthorized',
+    },
+    deviceScaleFactor?: number,
+    isMobile?: boolean,
+    hasTouch?: boolean,
+    colorScheme?: 'dark' | 'light' | 'no-preference' | 'no-override',
+    reducedMotion?: 'reduce' | 'no-preference' | 'no-override',
+    forcedColors?: 'active' | 'none' | 'no-override',
+    acceptDownloads?: 'accept' | 'deny' | 'internal-browser-default',
+    contrast?: 'no-preference' | 'more' | 'no-override',
+    baseURL?: string,
+    recordVideo?: {
+      dir: string,
+      size?: {
+        width: number,
+        height: number,
+      },
+    },
+    strictSelectors?: boolean,
+    serviceWorkers?: 'allow' | 'block',
+    selectorEngines?: SelectorEngine[],
+    testIdAttributeName?: string,
+  },
 };
 export interface BrowserContextEventTarget {
   on(event: 'bindingCall', callback: (params: BrowserContextBindingCallEvent) => void): this;

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1145,6 +1145,10 @@ Browser:
 
   events:
 
+    context:
+      parameters:
+        context: BrowserContext
+
     close:
 
 ConsoleMessage:
@@ -1195,6 +1199,10 @@ BrowserContext:
     isChromium: boolean
     requestContext: APIRequestContext
     tracing: Tracing
+    options:
+      type: object
+      properties:
+        $mixin: ContextOptions
 
   commands:
 

--- a/tests/library/browsercontext-basic.spec.ts
+++ b/tests/library/browsercontext-basic.spec.ts
@@ -22,13 +22,19 @@ import type { Page } from '@playwright/test';
 
 it('should create new context @smoke', async function({ browser }) {
   expect(browser.contexts().length).toBe(0);
+  let contextFromEvent;
+  browser.on('context', context => contextFromEvent = context);
   const context = await browser.newContext();
-  expect(browser.contexts().length).toBe(1);
-  expect(browser.contexts().indexOf(context) !== -1).toBe(true);
+  expect(contextFromEvent).toBe(context);
+  expect(browser.contexts()).toEqual([context]);
   expect(browser).toBe(context.browser());
+  const context2 = await browser.newContext();
+  expect(contextFromEvent).toBe(context2);
+  expect(browser.contexts()).toEqual([context, context2]);
   await context.close();
-  expect(browser.contexts().length).toBe(0);
+  expect(browser.contexts()).toEqual([context2]);
   expect(browser).toBe(context.browser());
+  await context2.close();
 });
 
 it('should be able to click across browser contexts', async function({ browser }) {


### PR DESCRIPTION
- Context is now wired up to the browser based on this event.
- Context options are now a part of its initializer, sent from the server, needed for multiclient.
- Client-side instrumentation is inlined.

References #35987.