### PR TITLE
chore: remove bindings and init scripts upon client disconnect

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -372,8 +372,14 @@ export class BidiBrowserContext extends BrowserContext {
       functionDeclaration: `() => { return ${initScript.source} }`,
       userContexts: [this._browserContextId || 'default'],
     });
+    initScript.implData = script;
     if (!initScript.internal)
       this._initScriptIds.push(script);
+  }
+
+  async doRemoveInitScript(initScript: InitScript) {
+    this._initScriptIds = this._initScriptIds.filter(script => script !== initScript.implData);
+    this._browser._browserSession.send('script.removePreloadScript', { script: initScript.implData });
   }
 
   async doRemoveNonInternalInitScripts() {

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -343,8 +343,14 @@ export class BidiPage implements PageDelegate {
       // TODO: push to iframes?
       contexts: [this._session.sessionId],
     });
+    initScript.implData = { script };
     if (!initScript.internal)
       this._initScriptIds.push(script);
+  }
+
+  async removeInitScript(initScript: InitScript): Promise<void> {
+    this._initScriptIds = this._initScriptIds.filter(script => script !== initScript.implData);
+    this._session.send('script.removePreloadScript', { script: initScript.implData });
   }
 
   async removeNonInternalInitScripts() {

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -51,7 +51,6 @@ export class BidiPage implements PageDelegate {
   readonly _browserContext: BidiBrowserContext;
   readonly _networkManager: BidiNetworkManager;
   private readonly _pdf: BidiPDF;
-  private _initScriptIds: bidi.Script.PreloadScript[] = [];
 
   constructor(browserContext: BidiBrowserContext, bidiSession: BidiSession, opener: BidiPage | null) {
     this._session = bidiSession;
@@ -343,20 +342,11 @@ export class BidiPage implements PageDelegate {
       // TODO: push to iframes?
       contexts: [this._session.sessionId],
     });
-    initScript.implData = { script };
-    if (!initScript.internal)
-      this._initScriptIds.push(script);
+    initScript.auxData = script;
   }
 
-  async removeInitScript(initScript: InitScript): Promise<void> {
-    this._initScriptIds = this._initScriptIds.filter(script => script !== initScript.implData);
-    this._session.send('script.removePreloadScript', { script: initScript.implData });
-  }
-
-  async removeNonInternalInitScripts() {
-    const promises = this._initScriptIds.map(script => this._session.send('script.removePreloadScript', { script }));
-    this._initScriptIds = [];
-    await Promise.all(promises);
+  async removeInitScripts(initScripts: InitScript[]): Promise<void> {
+    await Promise.all(initScripts.map(script => this._session.send('script.removePreloadScript', { script: script.auxData })));
   }
 
   async closePage(runBeforeUnload: boolean): Promise<void> {

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -476,14 +476,9 @@ export class CRBrowserContext extends BrowserContext {
       await (page.delegate as CRPage).addInitScript(initScript);
   }
 
-  async doRemoveInitScript(initScript: InitScript) {
+  async doRemoveInitScripts(initScripts: InitScript[]) {
     for (const page of this.pages())
-      await (page.delegate as CRPage).removeInitScript(initScript);
-  }
-
-  async doRemoveNonInternalInitScripts() {
-    for (const page of this.pages())
-      await (page.delegate as CRPage).removeNonInternalInitScripts();
+      await (page.delegate as CRPage).removeInitScripts(initScripts);
   }
 
   async doUpdateRequestInterception(): Promise<void> {

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -476,6 +476,11 @@ export class CRBrowserContext extends BrowserContext {
       await (page.delegate as CRPage).addInitScript(initScript);
   }
 
+  async doRemoveInitScript(initScript: InitScript) {
+    for (const page of this.pages())
+      await (page.delegate as CRPage).removeInitScript(initScript);
+  }
+
   async doRemoveNonInternalInitScripts() {
     for (const page of this.pages())
       await (page.delegate as CRPage).removeNonInternalInitScripts();

--- a/packages/playwright-core/src/server/clock.ts
+++ b/packages/playwright-core/src/server/clock.ts
@@ -17,77 +17,78 @@
 import * as rawClockSource from '../generated/clockSource';
 
 import type { BrowserContext } from './browserContext';
+import type { InitScript } from './page';
 
 export class Clock {
   private _browserContext: BrowserContext;
-  private _scriptInstalled = false;
+  private _initScripts: InitScript[] = [];
 
   constructor(browserContext: BrowserContext) {
     this._browserContext = browserContext;
   }
 
-  markAsUninstalled() {
-    this._scriptInstalled = false;
+  async resetForReuse() {
+    await this._browserContext.removeInitScripts(this._initScripts);
+    this._initScripts = [];
   }
 
   async fastForward(ticks: number | string) {
     await this._installIfNeeded();
     const ticksMillis = parseTicks(ticks);
-    await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('fastForward', ${Date.now()}, ${ticksMillis})`);
+    this._initScripts.push(await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('fastForward', ${Date.now()}, ${ticksMillis})`));
     await this._evaluateInFrames(`globalThis.__pwClock.controller.fastForward(${ticksMillis})`);
   }
 
   async install(time: number | string | undefined) {
     await this._installIfNeeded();
     const timeMillis = time !== undefined ? parseTime(time) : Date.now();
-    await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('install', ${Date.now()}, ${timeMillis})`);
+    this._initScripts.push(await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('install', ${Date.now()}, ${timeMillis})`));
     await this._evaluateInFrames(`globalThis.__pwClock.controller.install(${timeMillis})`);
   }
 
   async pauseAt(ticks: number | string) {
     await this._installIfNeeded();
     const timeMillis = parseTime(ticks);
-    await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('pauseAt', ${Date.now()}, ${timeMillis})`);
+    this._initScripts.push(await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('pauseAt', ${Date.now()}, ${timeMillis})`));
     await this._evaluateInFrames(`globalThis.__pwClock.controller.pauseAt(${timeMillis})`);
   }
 
   async resume() {
     await this._installIfNeeded();
-    await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('resume', ${Date.now()})`);
+    this._initScripts.push(await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('resume', ${Date.now()})`));
     await this._evaluateInFrames(`globalThis.__pwClock.controller.resume()`);
   }
 
   async setFixedTime(time: string | number) {
     await this._installIfNeeded();
     const timeMillis = parseTime(time);
-    await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('setFixedTime', ${Date.now()}, ${timeMillis})`);
+    this._initScripts.push(await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('setFixedTime', ${Date.now()}, ${timeMillis})`));
     await this._evaluateInFrames(`globalThis.__pwClock.controller.setFixedTime(${timeMillis})`);
   }
 
   async setSystemTime(time: string | number) {
     await this._installIfNeeded();
     const timeMillis = parseTime(time);
-    await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('setSystemTime', ${Date.now()}, ${timeMillis})`);
+    this._initScripts.push(await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('setSystemTime', ${Date.now()}, ${timeMillis})`));
     await this._evaluateInFrames(`globalThis.__pwClock.controller.setSystemTime(${timeMillis})`);
   }
 
   async runFor(ticks: number | string) {
     await this._installIfNeeded();
     const ticksMillis = parseTicks(ticks);
-    await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('runFor', ${Date.now()}, ${ticksMillis})`);
+    this._initScripts.push(await this._browserContext.addInitScript(`globalThis.__pwClock.controller.log('runFor', ${Date.now()}, ${ticksMillis})`));
     await this._evaluateInFrames(`globalThis.__pwClock.controller.runFor(${ticksMillis})`);
   }
 
   private async _installIfNeeded() {
-    if (this._scriptInstalled)
+    if (this._initScripts.length)
       return;
-    this._scriptInstalled = true;
     const script = `(() => {
       const module = {};
       ${rawClockSource.source}
       globalThis.__pwClock = (module.exports.inject())(globalThis);
     })();`;
-    await this._browserContext.addInitScript(script);
+    this._initScripts.push(await this._browserContext.addInitScript(script));
     await this._evaluateInFrames(script);
   }
 

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -40,7 +40,7 @@ import type { ConsoleMessage } from '../console';
 import type { Dialog } from '../dialog';
 import type { CallMetadata } from '../instrumentation';
 import type { Request, Response } from '../network';
-import type { Page, PageBinding } from '../page';
+import type { InitScript, Page, PageBinding } from '../page';
 import type { DispatcherScope } from './dispatcher';
 import type { FrameDispatcher } from './frameDispatcher';
 import type * as channels from '@protocol/channels';
@@ -51,7 +51,8 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   private _context: BrowserContext;
   private _subscriptions = new Set<channels.BrowserContextUpdateSubscriptionParams['event']>();
   _webSocketInterceptionPatterns: channels.BrowserContextSetWebSocketInterceptionPatternsParams['patterns'] = [];
-  private _bindings = new Set<PageBinding>();
+  private _bindings: PageBinding[] = [];
+  private _initScritps: InitScript[] = [];
 
   static from(parentScope: DispatcherScope, context: BrowserContext): BrowserContextDispatcher {
     const result = parentScope.connection.existingDispatcher<BrowserContextDispatcher>(context);
@@ -217,7 +218,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
       this._dispatchEvent('bindingCall', { binding });
       return binding.promise();
     });
-    this._bindings.add(binding);
+    this._bindings.push(binding);
   }
 
   async newPage(params: channels.BrowserContextNewPageParams, metadata: CallMetadata): Promise<channels.BrowserContextNewPageResult> {
@@ -268,7 +269,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   }
 
   async addInitScript(params: channels.BrowserContextAddInitScriptParams): Promise<void> {
-    await this._context.addInitScript(params.source);
+    this._initScritps.push(await this._context.addInitScript(params.source));
   }
 
   async setNetworkInterceptionPatterns(params: channels.BrowserContextSetNetworkInterceptionPatternsParams): Promise<void> {
@@ -375,11 +376,12 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
 
   override _onDispose() {
     // Avoid protocol calls for the closed context.
-    if (!this._context.isClosingOrClosed()) {
-      this._context.setRequestInterceptor(undefined).catch(() => {});
-      for (const binding of this._bindings)
-        this._context.removeExposedBinding(binding).catch(() => {});
-      this._bindings.clear();
-    }
+    if (this._context.isClosingOrClosed())
+      return;
+    this._context.setRequestInterceptor(undefined).catch(() => {});
+    this._context.removeExposedBindings(this._bindings).catch(() => {});
+    this._bindings = [];
+    this._context.removeInitScripts(this._initScritps).catch(() => {});
+    this._initScritps = [];
   }
 }

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -378,7 +378,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     if (!this._context.isClosingOrClosed()) {
       this._context.setRequestInterceptor(undefined).catch(() => {});
       for (const binding of this._bindings)
-        binding.dispose().catch(() => {});
+        this._context.removeExposedBinding(binding).catch(() => {});
       this._bindings.clear();
     }
   }

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -332,7 +332,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     if (!this._page.isClosedOrClosingOrCrashed()) {
       this._page.setClientRequestInterceptor(undefined).catch(() => {});
       for (const binding of this._bindings)
-        binding.dispose().catch(() => {});
+        this._page.removeExposedBinding(binding).catch(() => {});
       this._bindings.clear();
     }
   }

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -37,6 +37,7 @@ import type { CallMetadata } from '../instrumentation';
 import type { JSHandle } from '../javascript';
 import type { BrowserContextDispatcher } from './browserContextDispatcher';
 import type { Frame } from '../frames';
+import type { PageBinding } from '../page';
 import type * as channels from '@protocol/channels';
 
 export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, BrowserContextDispatcher> implements channels.PageChannel {
@@ -45,6 +46,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
   private _page: Page;
   _subscriptions = new Set<channels.PageUpdateSubscriptionParams['event']>();
   _webSocketInterceptionPatterns: channels.PageSetWebSocketInterceptionPatternsParams['patterns'] = [];
+  private _bindings = new Set<PageBinding>();
 
   static from(parentScope: BrowserContextDispatcher, page: Page): PageDispatcher {
     return PageDispatcher.fromNullable(parentScope, page)!;
@@ -107,7 +109,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
   }
 
   async exposeBinding(params: channels.PageExposeBindingParams, metadata: CallMetadata): Promise<void> {
-    await this._page.exposeBinding(params.name, !!params.needsHandle, (source, ...args) => {
+    const binding = await this._page.exposeBinding(params.name, !!params.needsHandle, (source, ...args) => {
       // When reusing the context, we might have some bindings called late enough,
       // after context and page dispatchers have been disposed.
       if (this._disposed)
@@ -116,6 +118,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
       this._dispatchEvent('bindingCall', { binding });
       return binding.promise();
     });
+    this._bindings.add(binding);
   }
 
   async setExtraHTTPHeaders(params: channels.PageSetExtraHTTPHeadersParams, metadata: CallMetadata): Promise<void> {
@@ -326,8 +329,12 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
 
   override _onDispose() {
     // Avoid protocol calls for the closed page.
-    if (!this._page.isClosedOrClosingOrCrashed())
+    if (!this._page.isClosedOrClosingOrCrashed()) {
       this._page.setClientRequestInterceptor(undefined).catch(() => {});
+      for (const binding of this._bindings)
+        binding.dispose().catch(() => {});
+      this._bindings.clear();
+    }
   }
 }
 

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -373,6 +373,10 @@ export class FFBrowserContext extends BrowserContext {
     await this._updateInitScripts();
   }
 
+  async doRemoveInitScript(initScript: InitScript) {
+    await this._updateInitScripts();
+  }
+
   async doRemoveNonInternalInitScripts() {
     await this._updateInitScripts();
   }

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -373,11 +373,7 @@ export class FFBrowserContext extends BrowserContext {
     await this._updateInitScripts();
   }
 
-  async doRemoveInitScript(initScript: InitScript) {
-    await this._updateInitScripts();
-  }
-
-  async doRemoveNonInternalInitScripts() {
+  async doRemoveInitScripts(initScripts: InitScript[]) {
     await this._updateInitScripts();
   }
 

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -108,7 +108,7 @@ export class FFPage implements PageDelegate {
     });
     // Ideally, we somehow ensure that utility world is created before Page.ready arrives, but currently it is racy.
     // Therefore, we can end up with an initialized page without utility world, although very unlikely.
-    this.addInitScript(new InitScript('', true), UTILITY_WORLD_NAME).catch(e => this._markAsError(e));
+    this.addInitScript(new InitScript(''), UTILITY_WORLD_NAME).catch(e => this._markAsError(e));
   }
 
   async _markAsError(error: Error) {
@@ -390,13 +390,9 @@ export class FFPage implements PageDelegate {
     await this._updateInitScripts();
   }
 
-  async removeInitScript(initScript: InitScript): Promise<void> {
-    this._initScripts = this._initScripts.filter(s => s.initScript !== initScript);
-    await this._updateInitScripts();
-  }
-
-  async removeNonInternalInitScripts() {
-    this._initScripts = this._initScripts.filter(s => s.initScript.internal);
+  async removeInitScripts(initScripts: InitScript[]): Promise<void> {
+    const set = new Set(initScripts);
+    this._initScripts = this._initScripts.filter(s => !set.has(s.initScript));
     await this._updateInitScripts();
   }
 

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -387,11 +387,20 @@ export class FFPage implements PageDelegate {
 
   async addInitScript(initScript: InitScript, worldName?: string): Promise<void> {
     this._initScripts.push({ initScript, worldName });
-    await this._session.send('Page.setInitScripts', { scripts: this._initScripts.map(s => ({ script: s.initScript.source, worldName: s.worldName })) });
+    await this._updateInitScripts();
+  }
+
+  async removeInitScript(initScript: InitScript): Promise<void> {
+    this._initScripts = this._initScripts.filter(s => s.initScript !== initScript);
+    await this._updateInitScripts();
   }
 
   async removeNonInternalInitScripts() {
     this._initScripts = this._initScripts.filter(s => s.initScript.internal);
+    await this._updateInitScripts();
+  }
+
+  private async _updateInitScripts() {
     await this._session.send('Page.setInitScripts', { scripts: this._initScripts.map(s => ({ script: s.initScript.source, worldName: s.worldName })) });
   }
 

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -126,7 +126,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     // Discard previous chunk if any and ignore any errors there.
     await this.stopChunk({ mode: 'discard' }).catch(() => {});
     await this.stop();
-    this._snapshotter?.resetForReuse();
+    await this._snapshotter?.resetForReuse();
   }
 
   async start(options: TracerOptions) {

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -319,12 +319,7 @@ export class WKBrowserContext extends BrowserContext {
       await (page.delegate as WKPage)._updateBootstrapScript();
   }
 
-  async doRemoveInitScript(initScript: InitScript) {
-    for (const page of this.pages())
-      await (page.delegate as WKPage)._updateBootstrapScript();
-  }
-
-  async doRemoveNonInternalInitScripts() {
+  async doRemoveInitScripts(initScripts: InitScript[]) {
     for (const page of this.pages())
       await (page.delegate as WKPage)._updateBootstrapScript();
   }

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -319,6 +319,11 @@ export class WKBrowserContext extends BrowserContext {
       await (page.delegate as WKPage)._updateBootstrapScript();
   }
 
+  async doRemoveInitScript(initScript: InitScript) {
+    for (const page of this.pages())
+      await (page.delegate as WKPage)._updateBootstrapScript();
+  }
+
   async doRemoveNonInternalInitScripts() {
     for (const page of this.pages())
       await (page.delegate as WKPage)._updateBootstrapScript();

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -768,11 +768,7 @@ export class WKPage implements PageDelegate {
     await this._updateBootstrapScript();
   }
 
-  async removeInitScript(initScript: InitScript): Promise<void> {
-    await this._updateBootstrapScript();
-  }
-
-  async removeNonInternalInitScripts() {
+  async removeInitScripts(initScripts: InitScript[]): Promise<void> {
     await this._updateBootstrapScript();
   }
 

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -768,6 +768,10 @@ export class WKPage implements PageDelegate {
     await this._updateBootstrapScript();
   }
 
+  async removeInitScript(initScript: InitScript): Promise<void> {
+    await this._updateBootstrapScript();
+  }
+
   async removeNonInternalInitScripts() {
     await this._updateBootstrapScript();
   }

--- a/tests/library/multiclient.spec.ts
+++ b/tests/library/multiclient.spec.ts
@@ -133,7 +133,7 @@ test('last emulateMedia wins', async ({ twoPages }) => {
   expect(await pageA.evaluate(() => window.matchMedia('print').matches)).toBe(false);
 });
 
-test('should dispose of bindings upon disconnect', async ({ twoPages }) => {
+test('should remove exposed bindings upon disconnect', async ({ twoPages }) => {
   const { pageA, pageB } = twoPages;
 
   await pageA.exposeBinding('pageBindingA', () => 'pageBindingAResult');

--- a/tests/library/multiclient.spec.ts
+++ b/tests/library/multiclient.spec.ts
@@ -20,6 +20,7 @@ import type { Browser, BrowserContext, BrowserServer, ConnectOptions, Page } fro
 type ExtraFixtures = {
   remoteServer: BrowserServer;
   connect: (wsEndpoint: string, options?: ConnectOptions) => Promise<Browser>,
+  twoPages: { pageA: Page, pageB: Page },
 };
 const test = playwrightTest.extend<ExtraFixtures>({
   remoteServer: async ({ browserType }, use) => {
@@ -34,6 +35,17 @@ const test = playwrightTest.extend<ExtraFixtures>({
       return browser;
     });
     await browser?.close();
+  },
+  twoPages: async ({ remoteServer, connect }, use) => {
+    const browserA = await connect(remoteServer.wsEndpoint());
+    const contextA = await browserA.newContext();
+    const pageA = await contextA.newPage();
+
+    const browserB = await connect(remoteServer.wsEndpoint());
+    const contextB = browserB.contexts()[0];
+    const pageB = contextB.pages()[0];
+
+    await use({ pageA, pageB });
   },
 });
 
@@ -65,4 +77,85 @@ test('should connect two clients', async ({ connect, remoteServer, server }) => 
   const pageB2 = await pageEventPromise;
   await pageA2.goto('/frames/frame.html');
   await expect(pageB2).toHaveURL('/frames/frame.html');
+
+  // Both contexts and pages should be still operational after any client disconnects.
+  await browserA.close();
+  await expect(pageB1).toHaveURL(server.EMPTY_PAGE);
+  await expect(pageB2).toHaveURL(server.PREFIX + '/frames/frame.html');
+});
+
+test('should have separate default timeouts', async ({ twoPages }) => {
+  const { pageA, pageB } = twoPages;
+  pageA.setDefaultTimeout(500);
+  pageB.setDefaultTimeout(600);
+
+  const [errorA, errorB] = await Promise.all([
+    pageA.click('div').catch(e => e),
+    pageB.click('div').catch(e => e),
+  ]);
+  expect(errorA.message).toContain('Timeout 500ms exceeded');
+  expect(errorB.message).toContain('Timeout 600ms exceeded');
+});
+
+test('should receive viewport size changes', async ({ twoPages }) => {
+  const { pageA, pageB } = twoPages;
+
+  await pageA.setViewportSize({ width: 567, height: 456 });
+  expect(pageA.viewportSize()).toEqual({ width: 567, height: 456 });
+  await expect.poll(() => pageB.viewportSize()).toEqual({ width: 567, height: 456 });
+
+  await pageB.setViewportSize({ width: 456, height: 567 });
+  expect(pageB.viewportSize()).toEqual({ width: 456, height: 567 });
+  await expect.poll(() => pageA.viewportSize()).toEqual({ width: 456, height: 567 });
+});
+
+test('should not allow parallel js coverage', async ({ twoPages }) => {
+  const { pageA, pageB } = twoPages;
+  await pageA.coverage.startJSCoverage();
+  const error = await pageB.coverage.startJSCoverage().catch(e => e);
+  expect(error.message).toContain('JSCoverage is already enabled');
+});
+
+test('should not allow parallel css coverage', async ({ twoPages }) => {
+  const { pageA, pageB } = twoPages;
+  await pageA.coverage.startCSSCoverage();
+  const error = await pageB.coverage.startCSSCoverage().catch(e => e);
+  expect(error.message).toContain('CSSCoverage is already enabled');
+});
+
+test('last emulateMedia wins', async ({ twoPages }) => {
+  const { pageA, pageB } = twoPages;
+  await pageA.emulateMedia({ media: 'print' });
+  expect(await pageB.evaluate(() => window.matchMedia('screen').matches)).toBe(false);
+  expect(await pageA.evaluate(() => window.matchMedia('print').matches)).toBe(true);
+  await pageB.emulateMedia({ media: 'screen' });
+  expect(await pageB.evaluate(() => window.matchMedia('screen').matches)).toBe(true);
+  expect(await pageA.evaluate(() => window.matchMedia('print').matches)).toBe(false);
+});
+
+test('should dispose of bindings upon disconnect', async ({ twoPages }) => {
+  const { pageA, pageB } = twoPages;
+
+  await pageA.exposeBinding('pageBindingA', () => 'pageBindingAResult');
+  await pageA.evaluate(() => {
+    (window as any).pageBindingACopy = (window as any).pageBindingA;
+  });
+  expect(await pageB.evaluate(() => (window as any).pageBindingA())).toBe('pageBindingAResult');
+  expect(await pageB.evaluate(() => !!(window as any).pageBindingACopy)).toBe(true);
+
+  await pageA.context().exposeBinding('contextBindingA', () => 'contextBindingAResult');
+  expect(await pageB.evaluate(() => (window as any).contextBindingA())).toBe('contextBindingAResult');
+
+  await pageB.exposeBinding('pageBindingB', () => 'pageBindingBResult');
+  expect(await pageA.evaluate(() => (window as any).pageBindingB())).toBe('pageBindingBResult');
+  await pageB.context().exposeBinding('contextBindingB', () => 'contextBindingBResult');
+  expect(await pageA.evaluate(() => (window as any).contextBindingB())).toBe('contextBindingBResult');
+
+  await pageA.context().browser().close();
+  expect(await pageB.evaluate(() => (window as any).pageBindingA)).toBe(undefined);
+  expect(await pageB.evaluate(() => (window as any).contextBindingA)).toBe(undefined);
+  const error = await pageB.evaluate(() => (window as any).pageBindingACopy()).catch(e => e);
+  expect(error.message).toContain('binding "pageBindingA" has been removed');
+
+  expect(await pageB.evaluate(() => (window as any).pageBindingB())).toBe('pageBindingBResult');
 });


### PR DESCRIPTION
Drive-by: no need to remove bindings and init scripts upon context reuse, because previous client is forcefully disconnected and cleans up anyway.

References #35987.