### PR TITLE
fix(android): trace action titles on Android

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -760,7 +760,7 @@ class ArtifactsRecorder {
 function renderTitle(type: string, method: string, params: Record<string, string> | undefined, title?: string) {
   const prefix = renderTitleForCall({ title, type, method, params });
   let selector;
-  if (params?.['selector'])
+  if (params?.['selector'] && typeof params.selector === 'string')
     selector = asLocatorDescription('javascript', params.selector);
   return prefix + (selector ? ` ${selector}` : '');
 }


### PR DESCRIPTION
We have protocol methods like `Android.fill` which have a `selector` object. This confused this check since an object has no `includes` function and then it was throwing.

Fixes https://github.com/microsoft/playwright-browsers/actions/runs/15220665523/job/42815563544#step:13:45