### PR TITLE
fix(aria): Improved Aria snapshot diffing

### DIFF
--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -49,11 +49,6 @@ type InternalMatchEntry = {
   node: AriaNode | string;
 };
 
-export interface AriaMatch {
-  templateLineNumber?: number;
-  isFromTemplateRegex?: boolean; // True if this failure was due to a regex in the template name/prop
-}
-
 type AriaRef = {
   role: string;
   name: string;

--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -345,43 +345,7 @@ function matchesNode(
   isDeepEqual: boolean,
   foundMatchEntries: InternalMatchEntry[],
 ): boolean {
-  function doesMatchNode(): boolean {
-    if (typeof node === 'string' && template.kind === 'text')
-      return matchesTextNode(node, template);
-
-    if (node === null || typeof node !== 'object' || template.kind !== 'role')
-      return false;
-
-    if (template.role !== 'fragment' && template.role !== node.role)
-      return false;
-    if (template.checked !== undefined && template.checked !== node.checked)
-      return false;
-    if (template.disabled !== undefined && template.disabled !== node.disabled)
-      return false;
-    if (template.expanded !== undefined && template.expanded !== node.expanded)
-      return false;
-    if (template.level !== undefined && template.level !== node.level)
-      return false;
-    if (template.pressed !== undefined && template.pressed !== node.pressed)
-      return false;
-    if (template.selected !== undefined && template.selected !== node.selected)
-      return false;
-    if (!matchesName(node.name, template))
-      return false;
-    if (!matchesText(node.props.url, template.props?.url))
-      return false;
-
-    // Proceed based on the container mode.
-    if (template.containerMode === 'contain')
-      return containsList(node.children || [], template.children || [], foundMatchEntries);
-    else if (template.containerMode === 'equal')
-      return listEqual(node.children || [], template.children || [], false, foundMatchEntries);
-    else if (template.containerMode === 'deep-equal' || isDeepEqual)
-      return listEqual(node.children || [], template.children || [], true, foundMatchEntries);
-    return containsList(node.children || [], template.children || [], foundMatchEntries);
-  }
-
-  const didMatch = doesMatchNode();
+  const didMatch = _doesMatchNode(node, template, isDeepEqual, foundMatchEntries);
   if (didMatch) {
     foundMatchEntries.push({
       templateLineNumber: template.lineNumber,
@@ -391,12 +355,48 @@ function matchesNode(
   return didMatch;
 }
 
-function listEqual(
-  children: (AriaNode | string)[],
-  template: AriaTemplateNode[],
+function _doesMatchNode(
+  node: AriaNode | string,
+  template: AriaTemplateNode,
   isDeepEqual: boolean,
   foundMatchEntries: InternalMatchEntry[],
 ): boolean {
+  if (typeof node === 'string' && template.kind === 'text')
+    return matchesTextNode(node, template);
+
+  if (node === null || typeof node !== 'object' || template.kind !== 'role')
+    return false;
+
+  if (template.role !== 'fragment' && template.role !== node.role)
+    return false;
+  if (template.checked !== undefined && template.checked !== node.checked)
+    return false;
+  if (template.disabled !== undefined && template.disabled !== node.disabled)
+    return false;
+  if (template.expanded !== undefined && template.expanded !== node.expanded)
+    return false;
+  if (template.level !== undefined && template.level !== node.level)
+    return false;
+  if (template.pressed !== undefined && template.pressed !== node.pressed)
+    return false;
+  if (template.selected !== undefined && template.selected !== node.selected)
+    return false;
+  if (!matchesName(node.name, template))
+    return false;
+  if (!matchesText(node.props.url, template.props?.url))
+    return false;
+
+  // Proceed based on the container mode.
+  if (template.containerMode === 'contain')
+    return containsList(node.children || [], template.children || [], foundMatchEntries);
+  else if (template.containerMode === 'equal')
+    return listEqual(node.children || [], template.children || [], false, foundMatchEntries);
+  else if (template.containerMode === 'deep-equal' || isDeepEqual)
+    return listEqual(node.children || [], template.children || [], true, foundMatchEntries);
+  return containsList(node.children || [], template.children || [], foundMatchEntries);
+}
+
+function listEqual(children: (AriaNode | string)[], template: AriaTemplateNode[], isDeepEqual: boolean, foundMatchEntries: InternalMatchEntry[]): boolean {
   let match = true;
   const length = Math.min(children.length, template.length);
   for (let i = 0; i < length; ++i) {

--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -426,22 +426,30 @@ function listEqual(
 }
 
 function containsList(children: (AriaNode | string)[], template: AriaTemplateNode[], matchEntriesCollector: InternalMatchEntry[]): boolean {
-  // if (template.length > children.length)
-  //   return false;
   console.log('containsList', children, template);
-  const cc = children.slice();
+  let cc = children.slice();
   const tt = template.slice();
+  let match = true;
+  let childrenAtStartOfTemplate = [];
   for (const t of tt) {
+    // At start of template node store where we are in the children list
+    childrenAtStartOfTemplate = cc.slice();
     let c = cc.shift();
     while (c) {
       if (matchesNode(c, t, false, matchEntriesCollector))
         break;
       c = cc.shift();
+      console.log('Incremented children', cc);
     }
-    if (!c)
-      return false;
+    if (!c) {
+      console.log('Failing containsList');
+      cc = childrenAtStartOfTemplate;
+      match = false;
   }
-  return true;
+    console.log('Incremented template', tt);
+  }
+  console.log('Passing containsList');
+  return match;
 }
 
 function matchesNodeDeep(

--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -316,9 +316,7 @@ export type MatcherReceived = {
 export function matchesAriaTree(rootElement: Element, template: AriaTemplateNode): { matches: AriaNode[], received: MatcherReceived } {
   const snapshot = generateAriaTree(rootElement);
   const internalMatchEntries: InternalMatchEntry[] = [];
-  console.log('matchesAriaTree');
   const matches = matchesNodeDeep(snapshot.root, template, false, false, internalMatchEntries);
-  console.log('allmatches', internalMatchEntries);
   const rawTree = renderAriaTree(snapshot, { mode: 'raw' });
   const matchEntries = internalMatchEntries.flatMap(entry => {
     const index = rawTree.findIndex(({ ariaNode }) => ariaNode === entry.node);
@@ -354,11 +352,9 @@ function matchesNode(
   isDeepEqual: boolean,
   matchEntriesCollector: InternalMatchEntry[],
 ): boolean {
-  console.log('matchesNode', node, template);
   if (typeof node === 'string' && template.kind === 'text') {
     const didMatch = matchesTextNode(node, template);
     if (didMatch) {
-      console.log('Matching', template.lineNumber);
       matchEntriesCollector.push({
         templateLineNumber: template.lineNumber,
         node
@@ -401,7 +397,6 @@ function matchesNode(
     childrenMatch = containsList(node.children || [], template.children || [], matchEntriesCollector);
 
   if (childrenMatch) {
-    console.log('Matching', template.lineNumber);
     matchEntriesCollector.push({
       templateLineNumber: template.lineNumber,
       node
@@ -426,7 +421,6 @@ function listEqual(
 }
 
 function containsList(children: (AriaNode | string)[], template: AriaTemplateNode[], matchEntriesCollector: InternalMatchEntry[]): boolean {
-  console.log('containsList', children, template);
   let cc = children.slice();
   const tt = template.slice();
   let match = true;
@@ -439,16 +433,12 @@ function containsList(children: (AriaNode | string)[], template: AriaTemplateNod
       if (matchesNode(c, t, false, matchEntriesCollector))
         break;
       c = cc.shift();
-      console.log('Incremented children', cc);
     }
     if (!c) {
-      console.log('Failing containsList');
       cc = childrenAtStartOfTemplate;
       match = false;
+    }
   }
-    console.log('Incremented template', tt);
-  }
-  console.log('Passing containsList');
   return match;
 }
 

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -301,7 +301,7 @@ export class InjectedScript {
     if (node.nodeType !== Node.ELEMENT_NODE)
       throw this.createStacklessError('Can only capture aria snapshot of Element nodes.');
     this._lastAriaSnapshot = generateAriaTree(node as Element, options);
-    return renderAriaTree(this._lastAriaSnapshot, options);
+    return renderAriaTree(this._lastAriaSnapshot, options).map(({ line }) => line).join('\n');
   }
 
   getAllByAria(document: Document, template: AriaTemplateNode): Element[] {

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -155,13 +155,13 @@ export async function toMatchAriaSnapshot(
   //     }
   //   }
   // }
-  for (const entry of typedReceived.matchEntries) {
-    if (entry.templateLineNumber === undefined) {
-      console.log(`No template line number for ${entry.ariaNodeDFSIndex}`);
+  for (const { templateLineNumber, actualLineNumber } of typedReceived.matchEntries) {
+    if (templateLineNumber === undefined) {
+      console.log(`No template line number for ${actualLineNumber}`);
       continue;
     }
-    console.log(`Copying "${actualLines[entry.ariaNodeDFSIndex - 1]}" to ${expectedLines[entry.templateLineNumber - 1]}`);
-    expectedLines[entry.templateLineNumber - 1] = actualLines[entry.ariaNodeDFSIndex - 1];
+    console.log(`Copying "${actualLines[actualLineNumber]}" to ${expectedLines[templateLineNumber]}`);
+    expectedLines[templateLineNumber] = actualLines[actualLineNumber];
   }
 
   const receivedText = actualLines.join('\n');

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -98,6 +98,8 @@ export async function toMatchAriaSnapshot(
   const { matches: pass, received, log, timedOut } = await receiver._expect('to.match.aria', { expectedValue: expected, isNot: this.isNot, timeout });
   const typedReceived = received as MatcherReceived | typeof kNoElementsFoundError;
 
+  console.log(typedReceived);
+
   const messagePrefix = matcherHint(this, receiver, matcherName, 'locator', undefined, matcherOptions, timedOut ? timeout : undefined);
   const notFound = typedReceived === kNoElementsFoundError;
   if (notFound) {
@@ -112,46 +114,54 @@ export async function toMatchAriaSnapshot(
   const expectedLines = expected.split('\n');
   const actualLines = typedReceived.raw.split('\n');
 
-  const length = Math.min(actualLines.length, expectedLines.length);
+  // const length = Math.min(actualLines.length, expectedLines.length);
 
-  for (let i = 0; i < length; i++) {
-    const expectedLine = expectedLines[i];
-    const actualLine = actualLines[i];
+  // for (let i = 0; i < length; i++) {
+  //   const expectedLine = expectedLines[i];
+  //   const actualLine = actualLines[i];
 
-    const expectedMatch = expectedLine.match(/\/(.*)\//);
-    if (expectedMatch && expectedMatch.index !== undefined) {
-      try {
-        const regex = new RegExp(expectedMatch[1]);
+  //   const expectedMatch = expectedLine.match(/\/(.*)\//);
+  //   if (expectedMatch && expectedMatch.index !== undefined) {
+  //     try {
+  //       const regex = new RegExp(expectedMatch[1]);
 
-        const actualMatch = actualLine.match(regex);
-        if (actualMatch)
-          expectedLines[i] = expectedLine.slice(0, expectedMatch.index) + actualMatch[0] + expectedLine.slice(expectedMatch.index + expectedMatch[0].length);
-      } catch (e) {
-        // Skip invalid regex
-      }
+  //       const actualMatch = actualLine.match(regex);
+  //       if (actualMatch)
+  //         expectedLines[i] = expectedLine.slice(0, expectedMatch.index) + actualMatch[0] + expectedLine.slice(expectedMatch.index + expectedMatch[0].length);
+  //     } catch (e) {
+  //       // Skip invalid regex
+  //     }
+  //   }
+
+  //   const expectedProps = extractProperties(expectedLine);
+  //   const actualProps = extractProperties(actualLine);
+  //   const actualPropsMap = new Map(actualProps.map(({ key, value }) => [key, value]));
+
+  //   let propsMatch = true;
+
+  //   for (const { key, value } of expectedProps) {
+  //     const actualValue = actualPropsMap.get(key);
+  //     if (!actualValue || actualValue !== value) {
+  //       propsMatch = false;
+  //       break;
+  //     }
+  //   }
+
+  //   if (propsMatch) {
+  //     actualLines[i] = actualLines[i].split(ARIA_PROPERTY_REGEX)[0].trimEnd();
+  //     if (expectedProps.length > 0) {
+  //       const actualPropsString = expectedProps.map(({ key, value }) => `[${key}${value ? '=' + value : ''}]`).join(' ');
+  //       actualLines[i] += ` ${actualPropsString}`;
+  //     }
+  //   }
+  // }
+  for (const entry of typedReceived.matchEntries) {
+    if (entry.templateLineNumber === undefined) {
+      console.log(`No template line number for ${entry.ariaNodeDFSIndex}`);
+      continue;
     }
-
-    const expectedProps = extractProperties(expectedLine);
-    const actualProps = extractProperties(actualLine);
-    const actualPropsMap = new Map(actualProps.map(({ key, value }) => [key, value]));
-
-    let propsMatch = true;
-
-    for (const { key, value } of expectedProps) {
-      const actualValue = actualPropsMap.get(key);
-      if (!actualValue || actualValue !== value) {
-        propsMatch = false;
-        break;
-      }
-    }
-
-    if (propsMatch) {
-      actualLines[i] = actualLines[i].split(ARIA_PROPERTY_REGEX)[0].trimEnd();
-      if (expectedProps.length > 0) {
-        const actualPropsString = expectedProps.map(({ key, value }) => `[${key}${value ? '=' + value : ''}]`).join(' ');
-        actualLines[i] += ` ${actualPropsString}`;
-      }
-    }
+    console.log(`Copying "${actualLines[entry.ariaNodeDFSIndex - 1]}" to ${expectedLines[entry.templateLineNumber - 1]}`);
+    expectedLines[entry.templateLineNumber - 1] = actualLines[entry.ariaNodeDFSIndex - 1];
   }
 
   const receivedText = actualLines.join('\n');

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -37,13 +37,6 @@ type ToMatchAriaSnapshotExpected = {
   timeout?: number;
 } | string;
 
-type AriaProperty = {
-  key: string;
-  value?: string;
-};
-
-const ARIA_PROPERTY_REGEX = /\[(\w+)(=(\w+))?\]/g;
-
 export async function toMatchAriaSnapshot(
   this: ExpectMatcherState,
   receiver: LocatorEx,
@@ -98,8 +91,6 @@ export async function toMatchAriaSnapshot(
   const { matches: pass, received, log, timedOut } = await receiver._expect('to.match.aria', { expectedValue: expected, isNot: this.isNot, timeout });
   const typedReceived = received as MatcherReceived | typeof kNoElementsFoundError;
 
-  console.log(typedReceived);
-
   const messagePrefix = matcherHint(this, receiver, matcherName, 'locator', undefined, matcherOptions, timedOut ? timeout : undefined);
   const notFound = typedReceived === kNoElementsFoundError;
   if (notFound) {
@@ -114,57 +105,13 @@ export async function toMatchAriaSnapshot(
   const expectedLines = expected.split('\n');
   const actualLines = typedReceived.raw.split('\n');
 
-  // const length = Math.min(actualLines.length, expectedLines.length);
-
-  // for (let i = 0; i < length; i++) {
-  //   const expectedLine = expectedLines[i];
-  //   const actualLine = actualLines[i];
-
-  //   const expectedMatch = expectedLine.match(/\/(.*)\//);
-  //   if (expectedMatch && expectedMatch.index !== undefined) {
-  //     try {
-  //       const regex = new RegExp(expectedMatch[1]);
-
-  //       const actualMatch = actualLine.match(regex);
-  //       if (actualMatch)
-  //         expectedLines[i] = expectedLine.slice(0, expectedMatch.index) + actualMatch[0] + expectedLine.slice(expectedMatch.index + expectedMatch[0].length);
-  //     } catch (e) {
-  //       // Skip invalid regex
-  //     }
-  //   }
-
-  //   const expectedProps = extractProperties(expectedLine);
-  //   const actualProps = extractProperties(actualLine);
-  //   const actualPropsMap = new Map(actualProps.map(({ key, value }) => [key, value]));
-
-  //   let propsMatch = true;
-
-  //   for (const { key, value } of expectedProps) {
-  //     const actualValue = actualPropsMap.get(key);
-  //     if (!actualValue || actualValue !== value) {
-  //       propsMatch = false;
-  //       break;
-  //     }
-  //   }
-
-  //   if (propsMatch) {
-  //     actualLines[i] = actualLines[i].split(ARIA_PROPERTY_REGEX)[0].trimEnd();
-  //     if (expectedProps.length > 0) {
-  //       const actualPropsString = expectedProps.map(({ key, value }) => `[${key}${value ? '=' + value : ''}]`).join(' ');
-  //       actualLines[i] += ` ${actualPropsString}`;
-  //     }
-  //   }
-  // }
   for (const { templateLineNumber, actualLineNumber } of typedReceived.matchEntries) {
-    if (templateLineNumber === undefined) {
-      console.log(`No template line number for ${actualLineNumber}`);
+    if (templateLineNumber === undefined)
       continue;
-    }
-    console.log(`Copying "${actualLines[actualLineNumber]}" to ${expectedLines[templateLineNumber]}`);
     expectedLines[templateLineNumber] = actualLines[actualLineNumber];
   }
 
-  const receivedText = actualLines.join('\n');
+  const receivedText = typedReceived.raw;
   expected = expectedLines.join('\n');
   const message = () => {
     if (pass) {
@@ -239,16 +186,4 @@ function unshift(snapshot: string): string {
 
 function indent(snapshot: string, indent: string): string {
   return snapshot.split('\n').map(line => indent + line).join('\n');
-}
-
-function extractProperties(line: string): AriaProperty[] {
-  const props: AriaProperty[] = [];
-
-  for (const match of line.matchAll(ARIA_PROPERTY_REGEX)) {
-    const key = match[1];
-    const value = match[3];
-    props.push({ key, value });
-  }
-
-  return props;
 }

--- a/tests/page/to-match-aria-snapshot.spec.ts
+++ b/tests/page/to-match-aria-snapshot.spec.ts
@@ -806,8 +806,7 @@ test(`should only highlight regex patterns that don't match`, async ({ page }) =
     `, { timeout: 1000 }).catch(e => e);
 
     expect(stripAnsi(error.message)).toContain(`
-- - heading Title 123
-+ - heading "Title 123"
+  - heading "Title 123" [level=1]
   - text: Content with value 456
 - - text: "This text doesn't exist"`);
   });

--- a/tests/page/to-match-aria-snapshot.spec.ts
+++ b/tests/page/to-match-aria-snapshot.spec.ts
@@ -416,13 +416,12 @@ test('expected formatter', async ({ page }) => {
 
   expect(stripAnsi(error.message)).toContain(`
 Locator: locator('body')
-- Expected  - 2
-+ Received  + 3
+- Expected  - 1
++ Received  + 2
 
-- - heading "todos"
-- - textbox "Wrong text"
 + - banner:
-+   - heading "todos" [level=1]
+    - heading "todos" [level=1]
+- - textbox "Wrong text"
 +   - textbox "What needs to be done?"`);
 });
 
@@ -847,5 +846,28 @@ test(`should only highlight regex patterns that don't match`, async ({ page }) =
 -   - listitem: "One more row"
 +   - listitem: Another row
 +   - listitem: One more row`);
+  });
+
+  await test.step('regex with attributes', async () => {
+    await page.setContent(`
+      <h1>Title 123</h1>
+      <h2>Heading 2 456</h2>
+    `);
+
+    const error = await expect(page.locator('body')).toMatchAriaSnapshot(`
+      - heading /Title \\d+/ [level=1]
+      - heading /Heading 2 \\d+/ [level=2]
+      - text: "This text doesn't exist"
+    `, { timeout: 1000 }).catch(e => e);
+
+    expect(stripAnsi(error.message)).toContain(`
+  - heading "Title 123" [level=1]
+  - heading "Heading 2 456" [level=2]
+- - text: "This text doesn't exist"`);
+
+    await expect(page.locator('body')).toMatchAriaSnapshot(`
+      - heading /Title \\d+/
+      - heading /Heading 2 \\d+/
+    `, { timeout: 1000 });
   });
 });

--- a/tests/page/to-match-aria-snapshot.spec.ts
+++ b/tests/page/to-match-aria-snapshot.spec.ts
@@ -843,9 +843,8 @@ test(`should only highlight regex patterns that don't match`, async ({ page }) =
 -     - link /Link2 \\d+/:
 +     - link "Link 123":
         - /url: about:blank
--   - listitem: "One more row"
 +   - listitem: Another row
-+   - listitem: One more row`);
+    - listitem: One more row`);
   });
 
   await test.step('regex with attributes', async () => {
@@ -1076,30 +1075,28 @@ test('should properly highlight regex failures in equal', async ({ page }) => {
 
   const error = await expect(page.locator('body')).toMatchAriaSnapshot(`
     - list:
-      - /children: deep-equal
+      - /children: equal
       - listitem:
         - list:
           - listitem: /a value/
       - listitem:
         - list:
           - listitem: 2.1
-
   `, { timeout: 1000 }).catch(e => e);
 
   expect(stripAnsi(error.message)).toContain(`
   - list:
--   - /children: deep-equal
+-   - /children: equal
 -   - listitem:
--     - list:
 +   - listitem:
+-     - list:
 +     - list:
 +       - listitem: \"1.1\"
 -       - listitem: /a value/
 +       - listitem: \"1.2\"
     - listitem:
       - list:
--       - listitem: 2.1
-+       - listitem: \"2.1\"
+        - listitem: \"2.1\"
 +       - listitem: \"2.2\"`);
 });
 


### PR DESCRIPTION
Fixes #34555.

The current implementation of Aria Snapshots is tailored towards automated workflows and doesn't handle well when humans have to interact with failures. In particular, the result of our snapshotting algorithm is naively diffed by the Jest string comparison function. Aria snapshots support more complex constructs like embedded regex (via `/some\wregex/`), and thus any failure in a snapshot will flag all regular expressions as a diff, highlighting them in red. In any situation this is hard to parse, but on larger snapshots it requires manual evaluation of every regex in the template to find the actual line that's causing your failure.

This solution annotates our match result with the actual lines in the final rendered "template" string we know are matching. For a given matched line, the `toMatchAriaSnapshot()` matcher copies the actual received string over to the expected template string, which is passed to the Jest differ as before.

The result is that any lines we considered to be matching will also be considered matching by Jest, therefore not notifying the user of fake problems.