### PR TITLE
chore(dotnet): make WebSocketRoute.onClose.handler 'reason' nullable

### DIFF
--- a/docs/src/api/class-websocketroute.md
+++ b/docs/src/api/class-websocketroute.md
@@ -333,7 +333,7 @@ Function that will handle WebSocket closure. Received an optional [close code](h
 ### param: WebSocketRoute.onClose.handler
 * since: v1.48
 * langs: csharp
-- `handler` <[function]\([int?], [string]\)>
+- `handler` <[function]\([int?], [string?]\)>
 
 Function that will handle WebSocket closure. Received an optional [close code](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#code) and an optional [close reason](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason).
 


### PR DESCRIPTION
Found while working on https://github.com/microsoft/playwright-dotnet/issues/3163. This should be nullable like in JS: https://github.com/microsoft/playwright/blob/main/docs/src/api/class-websocketroute.md#param-websocketrouteonclosehandler