### PR TITLE
chore: chain routes from multiple connections

### DIFF
--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -84,7 +84,7 @@ export class CRServiceWorker extends Worker {
   }
 
   needsRequestInterception(): boolean {
-    return this._isNetworkInspectionEnabled() && !!this.browserContext._requestInterceptor;
+    return this._isNetworkInspectionEnabled() && this.browserContext.requestInterceptors.length > 0;
   }
 
   reportRequestFinished(request: network.Request, response: network.Response | null) {
@@ -101,12 +101,8 @@ export class CRServiceWorker extends Worker {
 
   requestStarted(request: network.Request, route?: network.RouteDelegate) {
     this.browserContext.emit(BrowserContext.Events.Request, request);
-    if (route) {
-      const r = new network.Route(request, route);
-      if (this.browserContext._requestInterceptor?.(r, request))
-        return;
-      r.continue({ isFallback: true }).catch(() => {});
-    }
+    if (route)
+      new network.Route(request, route).handle(this.browserContext.requestInterceptors);
   }
 
   private _isNetworkInspectionEnabled(): boolean {

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -39,7 +39,7 @@ import type { Artifact } from '../artifact';
 import type { ConsoleMessage } from '../console';
 import type { Dialog } from '../dialog';
 import type { CallMetadata } from '../instrumentation';
-import type { Request, Response } from '../network';
+import type { Request, Response, RouteHandler } from '../network';
 import type { InitScript, Page, PageBinding } from '../page';
 import type { DispatcherScope } from './dispatcher';
 import type { FrameDispatcher } from './frameDispatcher';
@@ -55,6 +55,8 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   private _initScritps: InitScript[] = [];
   private _dialogHandler: (dialog: Dialog) => boolean;
   private _clockPaused = false;
+  private _requestInterceptor: RouteHandler;
+  private _interceptionUrlMatchers: (string | RegExp)[] = [];
 
   static from(parentScope: DispatcherScope, context: BrowserContext): BrowserContextDispatcher {
     const result = parentScope.connection.existingDispatcher<BrowserContextDispatcher>(context);
@@ -76,9 +78,21 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     this.adopt(requestContext);
     this.adopt(tracing);
 
+    this._requestInterceptor = (route, request) => {
+      const matchesSome = this._interceptionUrlMatchers.some(urlMatch => urlMatches(this._context._options.baseURL, request.url(), urlMatch));
+      // If there is already a dispatcher, that means we've already routed this request through page.
+      // Client expects a single `route` event, either on the page or on the context, so we can just fallback here.
+      const routeDispatcher = this.connection.existingDispatcher<RouteDispatcher>(route);
+      if (!matchesSome || routeDispatcher) {
+        route.continue({ isFallback: true }).catch(() => {});
+        return;
+      }
+      this._dispatchEvent('route', { route: new RouteDispatcher(RequestDispatcher.from(this, request), route) });
+    };
+
     this._context = context;
-    // Note: when launching persistent context, dispatcher is created very late,
-    // so we can already have pages, videos and everything else.
+    // Note: when launching persistent context, or connecting to an existing browser,
+    // dispatcher is created very late, so we can already have pages, videos and everything else.
 
     const onVideo = (artifact: Artifact) => {
       // Note: Video must outlive Page and BrowserContext, so that client can saveAs it
@@ -276,18 +290,18 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   }
 
   async setNetworkInterceptionPatterns(params: channels.BrowserContextSetNetworkInterceptionPatternsParams): Promise<void> {
+    const hadMatchers = this._interceptionUrlMatchers.length > 0;
     if (!params.patterns.length) {
-      await this._context.setRequestInterceptor(undefined);
-      return;
+      // Note: it is important to remove the interceptor when there are no patterns,
+      // because that disables the slow-path interception in the browser itself.
+      if (hadMatchers)
+        await this._context.removeRequestInterceptor(this._requestInterceptor);
+      this._interceptionUrlMatchers = [];
+    } else {
+      this._interceptionUrlMatchers = params.patterns.map(pattern => pattern.regexSource ? new RegExp(pattern.regexSource, pattern.regexFlags!) : pattern.glob!);
+      if (!hadMatchers)
+        await this._context.addRequestInterceptor(this._requestInterceptor);
     }
-    const urlMatchers = params.patterns.map(pattern => pattern.regexSource ? new RegExp(pattern.regexSource, pattern.regexFlags!) : pattern.glob!);
-    await this._context.setRequestInterceptor((route, request) => {
-      const matchesSome = urlMatchers.some(urlMatch => urlMatches(this._context._options.baseURL, request.url(), urlMatch));
-      if (!matchesSome)
-        return false;
-      this._dispatchEvent('route', { route: RouteDispatcher.from(RequestDispatcher.from(this, request), route) });
-      return true;
-    });
   }
 
   async setWebSocketInterceptionPatterns(params: channels.PageSetWebSocketInterceptionPatternsParams, metadata: CallMetadata): Promise<void> {
@@ -383,8 +397,11 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     // Avoid protocol calls for the closed context.
     if (this._context.isClosingOrClosed())
       return;
+
+    // Cleanup properly and leave the page in a good state. Other clients may still connect and use it.
     this._context.dialogManager.removeDialogHandler(this._dialogHandler);
-    this._context.setRequestInterceptor(undefined).catch(() => {});
+    this._interceptionUrlMatchers = [];
+    this._context.removeRequestInterceptor(this._requestInterceptor).catch(() => {});
     this._context.removeExposedBindings(this._bindings).catch(() => {});
     this._bindings = [];
     this._context.removeInitScripts(this._initScritps).catch(() => {});

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -387,8 +387,8 @@ export class FFBrowserContext extends BrowserContext {
 
   async doUpdateRequestInterception(): Promise<void> {
     await Promise.all([
-      this._browser.session.send('Browser.setRequestInterception', { browserContextId: this._browserContextId, enabled: !!this._requestInterceptor }),
-      this._browser.session.send('Browser.setCacheDisabled', { browserContextId: this._browserContextId, cacheDisabled: !!this._requestInterceptor }),
+      this._browser.session.send('Browser.setRequestInterception', { browserContextId: this._browserContextId, enabled: this.requestInterceptors.length > 0 }),
+      this._browser.session.send('Browser.setCacheDisabled', { browserContextId: this._browserContextId, cacheDisabled: this.requestInterceptors.length > 0 }),
     ]);
   }
 

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -301,16 +301,8 @@ export class FrameManager {
       return;
     }
     this._page.emitOnContext(BrowserContext.Events.Request, request);
-    if (route) {
-      const r = new network.Route(request, route);
-      if (this._page.serverRequestInterceptor?.(r, request))
-        return;
-      if (this._page.clientRequestInterceptor?.(r, request))
-        return;
-      if (this._page.browserContext._requestInterceptor?.(r, request))
-        return;
-      r.continue({ isFallback: true }).catch(() => {});
-    }
+    if (route)
+      new network.Route(request, route).handle([...this._page.requestInterceptors, ...this._page.browserContext.requestInterceptors]);
   }
 
   requestReceivedResponse(response: network.Response) {

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -292,7 +292,7 @@ export class HarTracer {
   }
 
   private _recordRequestOverrides(harEntry: har.Entry, request: network.Request) {
-    if (!request._hasOverrides() || !this._options.recordRequestOverrides)
+    if (!request.overrides() || !this._options.recordRequestOverrides)
       return;
     harEntry.request.method = request.method();
     harEntry.request.url = request.url();


### PR DESCRIPTION
Server side now has a list of network interceptors that are called in sequence, as long as they call `route.fallback()`. Once any interceptors handles the route by calling `continue()`, `abort()` or `fulfill()`, the chain stops.

All page interceptors take priority over context interceptors. Upon disconnect, client interceptors are removed.

A small caveat: client expects **either** `page.onRoute` **or** `context.onRoute` protocol call, but **not both**. This is also important so that one client handles the same request both on page- and context-level routes, before server proceeds to another client. To achieve this, `BrowserContextDispatcher` knows that it should ignore some routes because `PageDispatcher` has handled them already.

References #35987.