### PR TITLE
test: rebase 'init script should not observe playwright internals'

### DIFF
--- a/tests/library/browsercontext-add-init-script.spec.ts
+++ b/tests/library/browsercontext-add-init-script.spec.ts
@@ -66,3 +66,15 @@ it('should work with browser context scripts for already created pages', async (
   await page.goto(server.PREFIX + '/tamperable.html');
   expect(await page.evaluate(() => (window as any)['result'])).toBe(123);
 });
+
+it('init script should run only once in popup', async ({ context }) => {
+  await context.addInitScript(() => {
+    window['callCount'] = (window['callCount'] || 0) + 1;
+  });
+  const page = await context.newPage();
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.evaluate(() => window.open('about:blank')),
+  ]);
+  expect(await popup.evaluate('callCount')).toEqual(1);
+});

--- a/tests/page/page-add-init-script.spec.ts
+++ b/tests/page/page-add-init-script.spec.ts
@@ -99,19 +99,9 @@ it('init script should run only once in iframe', async ({ page, server, browserN
   ]);
 });
 
-it('init script should run only once in popup', async ({ page, browserName }) => {
-  await page.context().addInitScript(() => {
-    window['callCount'] = (window['callCount'] || 0) + 1;
-  });
-  const [popup] = await Promise.all([
-    page.waitForEvent('popup'),
-    page.evaluate(() => window.open('about:blank')),
-  ]);
-  expect(await popup.evaluate('callCount')).toEqual(1);
-});
-
-it('init script should not observe playwright internals', async ({ server, page }) => {
+it('init script should not observe playwright internals', async ({ server, page, trace }) => {
   it.skip(!!process.env.PW_CLOCK, 'clock installs globalThis.__pwClock');
+  it.fixme(trace === 'on', 'tracing installs __playwright_snapshot_streamer');
 
   await page.addInitScript(() => {
     window['check'] = () => {


### PR DESCRIPTION
- Mark as fixme when tracing is enabled - we should fix it.
- Move a different init script test that affects `context` outside of page tests.