### PR TITLE
chore(dotnet): allow nullable channels

### DIFF
--- a/utils/generate_dotnet_channels.js
+++ b/utils/generate_dotnet_channels.js
@@ -144,7 +144,10 @@ function properties(properties, indent, onlyOptional, parentName, level) {
         continue;
       ts.push('');
       ts.push(`${indent}[JsonPropertyName("${name}")]`);
-      ts.push(`${indent}public ${inner.ts}${nullableSuffix(inner)} ${toTitleCase(name)} { get; set; }`);
+      let suffix = ''
+      if (!['bool', 'int', 'System.Text.Json.JsonElement'].includes(inner.ts))
+        suffix = ' = null!;'
+      ts.push(`${indent}public ${inner.ts}${nullableSuffix(inner)} ${toTitleCase(name)} { get; set; }${suffix}`);
       const wrapped = inner.optional ? `tOptional(${inner.scheme})` : inner.scheme;
       scheme.push(`${indent}${name}: ${wrapped},`);
     }


### PR DESCRIPTION
This patch updates the .NET channel generator to support nullable reference types. Although objects are constructed via `System.Text.Json` deserialization, the compiler still requires non-nullable reference properties to be initialized. To avoid warnings when nullable is enabled, this change adds `= null!;` for reference types (excluding `bool`, `int`, and `JsonElement`).

https://github.com/microsoft/playwright-dotnet/issues/3163