### PR TITLE
chore: remove error context JSON format

### DIFF
--- a/packages/playwright/src/errorContext.ts
+++ b/packages/playwright/src/errorContext.ts
@@ -26,22 +26,7 @@ import type { MetadataWithCommitInfo } from './isomorphic/types';
 import type { TestInfoImpl } from './worker/testInfo';
 import type { Location } from '../types/test';
 
-export async function attachErrorContext(testInfo: TestInfoImpl, format: 'markdown' | 'json', sourceCache: Map<string, string>, ariaSnapshot: string | undefined) {
-  if (format === 'json') {
-    if (!ariaSnapshot)
-      return;
-
-    testInfo._attach({
-      name: `error-context`,
-      contentType: 'application/json',
-      body: Buffer.from(JSON.stringify({
-        pageSnapshot: ariaSnapshot,
-      })),
-    }, undefined);
-
-    return;
-  }
-
+export async function attachErrorContext(testInfo: TestInfoImpl, sourceCache: Map<string, string>, ariaSnapshot: string | undefined) {
   const meaningfulSingleLineErrors = new Set(testInfo.errors.filter(e => e.message && !e.message.includes('\n')).map(e => e.message!));
   for (const error of testInfo.errors) {
     for (const singleLineError of meaningfulSingleLineErrors.keys()) {

--- a/packages/playwright/src/isomorphic/testServerInterface.ts
+++ b/packages/playwright/src/isomorphic/testServerInterface.ts
@@ -102,7 +102,6 @@ export interface TestServerInterface {
     projects?: string[];
     reuseContext?: boolean;
     connectWsEndpoint?: string;
-    errorContext?: { format: 'json' | 'markdown' };
   }): Promise<{
     status: reporterTypes.FullResult['status'];
   }>;

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -316,7 +316,6 @@ export class TestServerDispatcher implements TestServerInterface {
         ...(params.headed !== undefined ? { headless: !params.headed } : {}),
         _optionContextReuseMode: params.reuseContext ? 'when-possible' : undefined,
         _optionConnectOptions: params.connectWsEndpoint ? { wsEndpoint: params.connectWsEndpoint } : undefined,
-        _optionErrorContext: params.errorContext,
       },
       ...(params.updateSnapshots ? { updateSnapshots: params.updateSnapshots } : {}),
       ...(params.updateSourceMethod ? { updateSourceMethod: params.updateSourceMethod } : {}),

--- a/tests/playwright-test/reporter-json.spec.ts
+++ b/tests/playwright-test/reporter-json.spec.ts
@@ -355,26 +355,3 @@ test('should report parallelIndex', async ({ runInlineTest }, testInfo) => {
   expect(result.report.suites[0].specs[1].tests[0].results[0].parallelIndex).toBe(1);
   expect(result.report.suites[0].specs[2].tests[0].results[0].parallelIndex).toBe(1);
 });
-
-test('attaches error context', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'playwright.config.ts': `
-          export default { use: { _optionErrorContext: { format: 'json' } } };
-    `,
-    'a.test.js': `
-      const { test, expect } = require('@playwright/test');
-      test('one', async ({ page }, testInfo) => {
-        await page.setContent('<button>Click me</button>');
-        throw new Error('kaboom');
-      });
-    `,
-  }, { reporter: 'json' });
-
-  const errorContext = result.report.suites[0].specs[0].tests[0].results[0].attachments.find(a => a.name === 'error-context');
-  expect(errorContext).toBeDefined();
-  expect(errorContext!.contentType).toBe('application/json');
-  const json = JSON.parse(Buffer.from(errorContext!.body, 'base64').toString('utf-8'));
-  expect(json).toEqual({
-    pageSnapshot: expect.any(String),
-  });
-});


### PR DESCRIPTION
VS Code will also consume markdown, so we don't need a format toggle.

Split out from https://github.com/microsoft/playwright/pull/36089.

