### PR TITLE
fix(types): Properly format nested test type docstrings

### DIFF
--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -2892,1233 +2892,1233 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
    */
   describe: {
     /**
-   * Declares a group of tests.
-   * - `test.describe(title, callback)`
-   * - `test.describe(callback)`
-   * - `test.describe(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * You can declare a group of tests with a title. The title will be visible in the test report as a part of each
-   * test's title.
-   *
-   * ```js
-   * test.describe('two tests', () => {
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * **Anonymous group**
-   *
-   * You can also declare a test group without a title. This is convenient to give a group of tests a common option with
-   * [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
-   *
-   * ```js
-   * test.describe(() => {
-   *   test.use({ colorScheme: 'dark' });
-   *
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * **Tags**
-   *
-   * You can tag all tests in a group by providing additional details. Note that each tag must start with `@` symbol.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.describe('two tagged tests', {
-   *   tag: '@smoke',
-   * }, () => {
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
-   *
-   * **Annotations**
-   *
-   * You can annotate all tests in a group by providing additional details.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.describe('two annotated tests', {
-   *   annotation: {
-   *     type: 'issue',
-   *     description: 'https://github.com/microsoft/playwright/issues/23180',
-   *   },
-   * }, () => {
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
-   * @param title Group title.
-   * @param details Additional details for all tests in the group.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests
-   * declared in this callback will belong to the group.
-   */
-  (title: string, callback: () => void): void;
+     * Declares a group of tests.
+     * - `test.describe(title, callback)`
+     * - `test.describe(callback)`
+     * - `test.describe(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * You can declare a group of tests with a title. The title will be visible in the test report as a part of each
+     * test's title.
+     *
+     * ```js
+     * test.describe('two tests', () => {
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * **Anonymous group**
+     *
+     * You can also declare a test group without a title. This is convenient to give a group of tests a common option with
+     * [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
+     *
+     * ```js
+     * test.describe(() => {
+     *   test.use({ colorScheme: 'dark' });
+     *
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * **Tags**
+     *
+     * You can tag all tests in a group by providing additional details. Note that each tag must start with `@` symbol.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.describe('two tagged tests', {
+     *   tag: '@smoke',
+     * }, () => {
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
+     *
+     * **Annotations**
+     *
+     * You can annotate all tests in a group by providing additional details.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.describe('two annotated tests', {
+     *   annotation: {
+     *     type: 'issue',
+     *     description: 'https://github.com/microsoft/playwright/issues/23180',
+     *   },
+     * }, () => {
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
+     * @param title Group title.
+     * @param details Additional details for all tests in the group.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests
+     * declared in this callback will belong to the group.
+     */
+    (title: string, callback: () => void): void;
     /**
-   * Declares a group of tests.
-   * - `test.describe(title, callback)`
-   * - `test.describe(callback)`
-   * - `test.describe(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * You can declare a group of tests with a title. The title will be visible in the test report as a part of each
-   * test's title.
-   *
-   * ```js
-   * test.describe('two tests', () => {
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * **Anonymous group**
-   *
-   * You can also declare a test group without a title. This is convenient to give a group of tests a common option with
-   * [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
-   *
-   * ```js
-   * test.describe(() => {
-   *   test.use({ colorScheme: 'dark' });
-   *
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * **Tags**
-   *
-   * You can tag all tests in a group by providing additional details. Note that each tag must start with `@` symbol.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.describe('two tagged tests', {
-   *   tag: '@smoke',
-   * }, () => {
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
-   *
-   * **Annotations**
-   *
-   * You can annotate all tests in a group by providing additional details.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.describe('two annotated tests', {
-   *   annotation: {
-   *     type: 'issue',
-   *     description: 'https://github.com/microsoft/playwright/issues/23180',
-   *   },
-   * }, () => {
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
-   * @param title Group title.
-   * @param details Additional details for all tests in the group.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests
-   * declared in this callback will belong to the group.
-   */
-  (callback: () => void): void;
+     * Declares a group of tests.
+     * - `test.describe(title, callback)`
+     * - `test.describe(callback)`
+     * - `test.describe(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * You can declare a group of tests with a title. The title will be visible in the test report as a part of each
+     * test's title.
+     *
+     * ```js
+     * test.describe('two tests', () => {
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * **Anonymous group**
+     *
+     * You can also declare a test group without a title. This is convenient to give a group of tests a common option with
+     * [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
+     *
+     * ```js
+     * test.describe(() => {
+     *   test.use({ colorScheme: 'dark' });
+     *
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * **Tags**
+     *
+     * You can tag all tests in a group by providing additional details. Note that each tag must start with `@` symbol.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.describe('two tagged tests', {
+     *   tag: '@smoke',
+     * }, () => {
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
+     *
+     * **Annotations**
+     *
+     * You can annotate all tests in a group by providing additional details.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.describe('two annotated tests', {
+     *   annotation: {
+     *     type: 'issue',
+     *     description: 'https://github.com/microsoft/playwright/issues/23180',
+     *   },
+     * }, () => {
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
+     * @param title Group title.
+     * @param details Additional details for all tests in the group.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests
+     * declared in this callback will belong to the group.
+     */
+    (callback: () => void): void;
     /**
-   * Declares a group of tests.
-   * - `test.describe(title, callback)`
-   * - `test.describe(callback)`
-   * - `test.describe(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * You can declare a group of tests with a title. The title will be visible in the test report as a part of each
-   * test's title.
-   *
-   * ```js
-   * test.describe('two tests', () => {
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * **Anonymous group**
-   *
-   * You can also declare a test group without a title. This is convenient to give a group of tests a common option with
-   * [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
-   *
-   * ```js
-   * test.describe(() => {
-   *   test.use({ colorScheme: 'dark' });
-   *
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * **Tags**
-   *
-   * You can tag all tests in a group by providing additional details. Note that each tag must start with `@` symbol.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.describe('two tagged tests', {
-   *   tag: '@smoke',
-   * }, () => {
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
-   *
-   * **Annotations**
-   *
-   * You can annotate all tests in a group by providing additional details.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.describe('two annotated tests', {
-   *   annotation: {
-   *     type: 'issue',
-   *     description: 'https://github.com/microsoft/playwright/issues/23180',
-   *   },
-   * }, () => {
-   *   test('one', async ({ page }) => {
-   *     // ...
-   *   });
-   *
-   *   test('two', async ({ page }) => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
-   * @param title Group title.
-   * @param details Additional details for all tests in the group.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests
-   * declared in this callback will belong to the group.
-   */
-  (title: string, details: TestDetails, callback: () => void): void;
+     * Declares a group of tests.
+     * - `test.describe(title, callback)`
+     * - `test.describe(callback)`
+     * - `test.describe(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * You can declare a group of tests with a title. The title will be visible in the test report as a part of each
+     * test's title.
+     *
+     * ```js
+     * test.describe('two tests', () => {
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * **Anonymous group**
+     *
+     * You can also declare a test group without a title. This is convenient to give a group of tests a common option with
+     * [test.use(options)](https://playwright.dev/docs/api/class-test#test-use).
+     *
+     * ```js
+     * test.describe(() => {
+     *   test.use({ colorScheme: 'dark' });
+     *
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * **Tags**
+     *
+     * You can tag all tests in a group by providing additional details. Note that each tag must start with `@` symbol.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.describe('two tagged tests', {
+     *   tag: '@smoke',
+     * }, () => {
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * Learn more about [tagging](https://playwright.dev/docs/test-annotations#tag-tests).
+     *
+     * **Annotations**
+     *
+     * You can annotate all tests in a group by providing additional details.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.describe('two annotated tests', {
+     *   annotation: {
+     *     type: 'issue',
+     *     description: 'https://github.com/microsoft/playwright/issues/23180',
+     *   },
+     * }, () => {
+     *   test('one', async ({ page }) => {
+     *     // ...
+     *   });
+     *
+     *   test('two', async ({ page }) => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * Learn more about [test annotations](https://playwright.dev/docs/test-annotations).
+     * @param title Group title.
+     * @param details Additional details for all tests in the group.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Any tests
+     * declared in this callback will belong to the group.
+     */
+    (title: string, details: TestDetails, callback: () => void): void;
 
     /**
-   * Declares a focused group of tests. If there are some focused tests or suites, all of them will be run but nothing
-   * else.
-   * - `test.describe.only(title, callback)`
-   * - `test.describe.only(callback)`
-   * - `test.describe.only(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.only('focused group', () => {
-   *   test('in the focused group', async ({ page }) => {
-   *     // This test will run
-   *   });
-   * });
-   * test('not in the focused group', async ({ page }) => {
-   *   // This test will not run
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.only(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-only).
-   * Any tests added in this callback will belong to the group.
-   */
-  only(title: string, callback: () => void): void;
+     * Declares a focused group of tests. If there are some focused tests or suites, all of them will be run but nothing
+     * else.
+     * - `test.describe.only(title, callback)`
+     * - `test.describe.only(callback)`
+     * - `test.describe.only(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.only('focused group', () => {
+     *   test('in the focused group', async ({ page }) => {
+     *     // This test will run
+     *   });
+     * });
+     * test('not in the focused group', async ({ page }) => {
+     *   // This test will not run
+     * });
+     * ```
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.only(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-only).
+     * Any tests added in this callback will belong to the group.
+     */
+    only(title: string, callback: () => void): void;
     /**
-   * Declares a focused group of tests. If there are some focused tests or suites, all of them will be run but nothing
-   * else.
-   * - `test.describe.only(title, callback)`
-   * - `test.describe.only(callback)`
-   * - `test.describe.only(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.only('focused group', () => {
-   *   test('in the focused group', async ({ page }) => {
-   *     // This test will run
-   *   });
-   * });
-   * test('not in the focused group', async ({ page }) => {
-   *   // This test will not run
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.only(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-only).
-   * Any tests added in this callback will belong to the group.
-   */
-  only(callback: () => void): void;
+     * Declares a focused group of tests. If there are some focused tests or suites, all of them will be run but nothing
+     * else.
+     * - `test.describe.only(title, callback)`
+     * - `test.describe.only(callback)`
+     * - `test.describe.only(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.only('focused group', () => {
+     *   test('in the focused group', async ({ page }) => {
+     *     // This test will run
+     *   });
+     * });
+     * test('not in the focused group', async ({ page }) => {
+     *   // This test will not run
+     * });
+     * ```
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.only(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-only).
+     * Any tests added in this callback will belong to the group.
+     */
+    only(callback: () => void): void;
     /**
-   * Declares a focused group of tests. If there are some focused tests or suites, all of them will be run but nothing
-   * else.
-   * - `test.describe.only(title, callback)`
-   * - `test.describe.only(callback)`
-   * - `test.describe.only(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.only('focused group', () => {
-   *   test('in the focused group', async ({ page }) => {
-   *     // This test will run
-   *   });
-   * });
-   * test('not in the focused group', async ({ page }) => {
-   *   // This test will not run
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.only(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-only).
-   * Any tests added in this callback will belong to the group.
-   */
-  only(title: string, details: TestDetails, callback: () => void): void;
+     * Declares a focused group of tests. If there are some focused tests or suites, all of them will be run but nothing
+     * else.
+     * - `test.describe.only(title, callback)`
+     * - `test.describe.only(callback)`
+     * - `test.describe.only(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.only('focused group', () => {
+     *   test('in the focused group', async ({ page }) => {
+     *     // This test will run
+     *   });
+     * });
+     * test('not in the focused group', async ({ page }) => {
+     *   // This test will not run
+     * });
+     * ```
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.only(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-only).
+     * Any tests added in this callback will belong to the group.
+     */
+    only(title: string, details: TestDetails, callback: () => void): void;
 
     /**
-   * Declares a skipped test group, similarly to
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in the
-   * skipped group are never run.
-   * - `test.describe.skip(title, callback)`
-   * - `test.describe.skip(title)`
-   * - `test.describe.skip(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.skip('skipped group', () => {
-   *   test('example', async ({ page }) => {
-   *     // This test will not run
-   *   });
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.skip(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.skip(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-skip).
-   * Any tests added in this callback will belong to the group, and will not be run.
-   */
-  skip(title: string, callback: () => void): void;
+     * Declares a skipped test group, similarly to
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in the
+     * skipped group are never run.
+     * - `test.describe.skip(title, callback)`
+     * - `test.describe.skip(title)`
+     * - `test.describe.skip(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.skip('skipped group', () => {
+     *   test('example', async ({ page }) => {
+     *     // This test will not run
+     *   });
+     * });
+     * ```
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.skip(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.skip(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-skip).
+     * Any tests added in this callback will belong to the group, and will not be run.
+     */
+    skip(title: string, callback: () => void): void;
     /**
-   * Declares a skipped test group, similarly to
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in the
-   * skipped group are never run.
-   * - `test.describe.skip(title, callback)`
-   * - `test.describe.skip(title)`
-   * - `test.describe.skip(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.skip('skipped group', () => {
-   *   test('example', async ({ page }) => {
-   *     // This test will not run
-   *   });
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.skip(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.skip(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-skip).
-   * Any tests added in this callback will belong to the group, and will not be run.
-   */
-  skip(callback: () => void): void;
+     * Declares a skipped test group, similarly to
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in the
+     * skipped group are never run.
+     * - `test.describe.skip(title, callback)`
+     * - `test.describe.skip(title)`
+     * - `test.describe.skip(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.skip('skipped group', () => {
+     *   test('example', async ({ page }) => {
+     *     // This test will not run
+     *   });
+     * });
+     * ```
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.skip(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.skip(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-skip).
+     * Any tests added in this callback will belong to the group, and will not be run.
+     */
+    skip(callback: () => void): void;
     /**
-   * Declares a skipped test group, similarly to
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in the
-   * skipped group are never run.
-   * - `test.describe.skip(title, callback)`
-   * - `test.describe.skip(title)`
-   * - `test.describe.skip(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.skip('skipped group', () => {
-   *   test('example', async ({ page }) => {
-   *     // This test will not run
-   *   });
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.skip(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.skip(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-skip).
-   * Any tests added in this callback will belong to the group, and will not be run.
-   */
-  skip(title: string, details: TestDetails, callback: () => void): void;
+     * Declares a skipped test group, similarly to
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in the
+     * skipped group are never run.
+     * - `test.describe.skip(title, callback)`
+     * - `test.describe.skip(title)`
+     * - `test.describe.skip(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.skip('skipped group', () => {
+     *   test('example', async ({ page }) => {
+     *     // This test will not run
+     *   });
+     * });
+     * ```
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.skip(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.skip(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-skip).
+     * Any tests added in this callback will belong to the group, and will not be run.
+     */
+    skip(title: string, details: TestDetails, callback: () => void): void;
 
     /**
-   * Declares a test group similarly to
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in
-   * this group are marked as "fixme" and will not be executed.
-   * - `test.describe.fixme(title, callback)`
-   * - `test.describe.fixme(callback)`
-   * - `test.describe.fixme(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.fixme('broken tests that should be fixed', () => {
-   *   test('example', async ({ page }) => {
-   *     // This test will not run
-   *   });
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.fixme(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.fixme([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-fixme).
-   * Any tests added in this callback will belong to the group, and will not be run.
-   */
-  fixme(title: string, callback: () => void): void;
+     * Declares a test group similarly to
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in
+     * this group are marked as "fixme" and will not be executed.
+     * - `test.describe.fixme(title, callback)`
+     * - `test.describe.fixme(callback)`
+     * - `test.describe.fixme(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.fixme('broken tests that should be fixed', () => {
+     *   test('example', async ({ page }) => {
+     *     // This test will not run
+     *   });
+     * });
+     * ```
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.fixme(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.fixme([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-fixme).
+     * Any tests added in this callback will belong to the group, and will not be run.
+     */
+    fixme(title: string, callback: () => void): void;
     /**
-   * Declares a test group similarly to
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in
-   * this group are marked as "fixme" and will not be executed.
-   * - `test.describe.fixme(title, callback)`
-   * - `test.describe.fixme(callback)`
-   * - `test.describe.fixme(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.fixme('broken tests that should be fixed', () => {
-   *   test('example', async ({ page }) => {
-   *     // This test will not run
-   *   });
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.fixme(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.fixme([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-fixme).
-   * Any tests added in this callback will belong to the group, and will not be run.
-   */
-  fixme(callback: () => void): void;
+     * Declares a test group similarly to
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in
+     * this group are marked as "fixme" and will not be executed.
+     * - `test.describe.fixme(title, callback)`
+     * - `test.describe.fixme(callback)`
+     * - `test.describe.fixme(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.fixme('broken tests that should be fixed', () => {
+     *   test('example', async ({ page }) => {
+     *     // This test will not run
+     *   });
+     * });
+     * ```
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.fixme(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.fixme([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-fixme).
+     * Any tests added in this callback will belong to the group, and will not be run.
+     */
+    fixme(callback: () => void): void;
     /**
-   * Declares a test group similarly to
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in
-   * this group are marked as "fixme" and will not be executed.
-   * - `test.describe.fixme(title, callback)`
-   * - `test.describe.fixme(callback)`
-   * - `test.describe.fixme(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.fixme('broken tests that should be fixed', () => {
-   *   test('example', async ({ page }) => {
-   *     // This test will not run
-   *   });
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.fixme(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.fixme([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-fixme).
-   * Any tests added in this callback will belong to the group, and will not be run.
-   */
-  fixme(title: string, details: TestDetails, callback: () => void): void;
+     * Declares a test group similarly to
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe). Tests in
+     * this group are marked as "fixme" and will not be executed.
+     * - `test.describe.fixme(title, callback)`
+     * - `test.describe.fixme(callback)`
+     * - `test.describe.fixme(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.fixme('broken tests that should be fixed', () => {
+     *   test('example', async ({ page }) => {
+     *     // This test will not run
+     *   });
+     * });
+     * ```
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.fixme(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.fixme([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-fixme).
+     * Any tests added in this callback will belong to the group, and will not be run.
+     */
+    fixme(title: string, details: TestDetails, callback: () => void): void;
 
     /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a group of tests that should always be run serially. If one of the tests fails, all subsequent tests are
-   * skipped. All tests in a group are retried together.
-   *
-   * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
-   * independently.
-   *
-   * - `test.describe.serial(title, callback)`
-   * - `test.describe.serial(title)`
-   * - `test.describe.serial(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.serial('group', () => {
-   *   test('runs first', async ({ page }) => {});
-   *   test('runs second', async ({ page }) => {});
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.serial(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.serial([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial).
-   * Any tests added in this callback will belong to the group.
-   */
-  serial: {
+     * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+     * the preferred way of configuring the execution mode.
+     *
+     * Declares a group of tests that should always be run serially. If one of the tests fails, all subsequent tests are
+     * skipped. All tests in a group are retried together.
+     *
+     * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
+     * independently.
+     *
+     * - `test.describe.serial(title, callback)`
+     * - `test.describe.serial(title)`
+     * - `test.describe.serial(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.serial('group', () => {
+     *   test('runs first', async ({ page }) => {});
+     *   test('runs second', async ({ page }) => {});
+     * });
+     * ```
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.serial(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.serial([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial).
+     * Any tests added in this callback will belong to the group.
+     */
+    serial: {
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a group of tests that should always be run serially. If one of the tests fails, all subsequent tests are
-   * skipped. All tests in a group are retried together.
-   *
-   * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
-   * independently.
-   *
-   * - `test.describe.serial(title, callback)`
-   * - `test.describe.serial(title)`
-   * - `test.describe.serial(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.serial('group', () => {
-   *   test('runs first', async ({ page }) => {});
-   *   test('runs second', async ({ page }) => {});
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.serial(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.serial([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial).
-   * Any tests added in this callback will belong to the group.
-   */
-  (title: string, callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a group of tests that should always be run serially. If one of the tests fails, all subsequent tests are
+       * skipped. All tests in a group are retried together.
+       *
+       * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
+       * independently.
+       *
+       * - `test.describe.serial(title, callback)`
+       * - `test.describe.serial(title)`
+       * - `test.describe.serial(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.serial('group', () => {
+       *   test('runs first', async ({ page }) => {});
+       *   test('runs second', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.serial(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.serial([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial).
+       * Any tests added in this callback will belong to the group.
+       */
+      (title: string, callback: () => void): void;
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a group of tests that should always be run serially. If one of the tests fails, all subsequent tests are
-   * skipped. All tests in a group are retried together.
-   *
-   * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
-   * independently.
-   *
-   * - `test.describe.serial(title, callback)`
-   * - `test.describe.serial(title)`
-   * - `test.describe.serial(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.serial('group', () => {
-   *   test('runs first', async ({ page }) => {});
-   *   test('runs second', async ({ page }) => {});
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.serial(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.serial([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial).
-   * Any tests added in this callback will belong to the group.
-   */
-  (callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a group of tests that should always be run serially. If one of the tests fails, all subsequent tests are
+       * skipped. All tests in a group are retried together.
+       *
+       * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
+       * independently.
+       *
+       * - `test.describe.serial(title, callback)`
+       * - `test.describe.serial(title)`
+       * - `test.describe.serial(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.serial('group', () => {
+       *   test('runs first', async ({ page }) => {});
+       *   test('runs second', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.serial(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.serial([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial).
+       * Any tests added in this callback will belong to the group.
+       */
+      (callback: () => void): void;
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a group of tests that should always be run serially. If one of the tests fails, all subsequent tests are
-   * skipped. All tests in a group are retried together.
-   *
-   * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
-   * independently.
-   *
-   * - `test.describe.serial(title, callback)`
-   * - `test.describe.serial(title)`
-   * - `test.describe.serial(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.serial('group', () => {
-   *   test('runs first', async ({ page }) => {});
-   *   test('runs second', async ({ page }) => {});
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.serial(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.serial([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial).
-   * Any tests added in this callback will belong to the group.
-   */
-  (title: string, details: TestDetails, callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a group of tests that should always be run serially. If one of the tests fails, all subsequent tests are
+       * skipped. All tests in a group are retried together.
+       *
+       * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
+       * independently.
+       *
+       * - `test.describe.serial(title, callback)`
+       * - `test.describe.serial(title)`
+       * - `test.describe.serial(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.serial('group', () => {
+       *   test('runs first', async ({ page }) => {});
+       *   test('runs second', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.serial(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.serial([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial).
+       * Any tests added in this callback will belong to the group.
+       */
+      (title: string, details: TestDetails, callback: () => void): void;
 
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a focused group of tests that should always be run serially. If one of the tests fails, all subsequent
-   * tests are skipped. All tests in a group are retried together. If there are some focused tests or suites, all of
-   * them will be run but nothing else.
-   *
-   * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
-   * independently.
-   *
-   * - `test.describe.serial.only(title, callback)`
-   * - `test.describe.serial.only(title)`
-   * - `test.describe.serial.only(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.serial.only('group', () => {
-   *   test('runs first', async ({ page }) => {
-   *   });
-   *   test('runs second', async ({ page }) => {
-   *   });
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.serial.only(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.serial.only(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial-only).
-   * Any tests added in this callback will belong to the group.
-   */
-  only(title: string, callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a focused group of tests that should always be run serially. If one of the tests fails, all subsequent
+       * tests are skipped. All tests in a group are retried together. If there are some focused tests or suites, all of
+       * them will be run but nothing else.
+       *
+       * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
+       * independently.
+       *
+       * - `test.describe.serial.only(title, callback)`
+       * - `test.describe.serial.only(title)`
+       * - `test.describe.serial.only(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.serial.only('group', () => {
+       *   test('runs first', async ({ page }) => {
+       *   });
+       *   test('runs second', async ({ page }) => {
+       *   });
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.serial.only(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.serial.only(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial-only).
+       * Any tests added in this callback will belong to the group.
+       */
+      only(title: string, callback: () => void): void;
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a focused group of tests that should always be run serially. If one of the tests fails, all subsequent
-   * tests are skipped. All tests in a group are retried together. If there are some focused tests or suites, all of
-   * them will be run but nothing else.
-   *
-   * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
-   * independently.
-   *
-   * - `test.describe.serial.only(title, callback)`
-   * - `test.describe.serial.only(title)`
-   * - `test.describe.serial.only(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.serial.only('group', () => {
-   *   test('runs first', async ({ page }) => {
-   *   });
-   *   test('runs second', async ({ page }) => {
-   *   });
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.serial.only(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.serial.only(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial-only).
-   * Any tests added in this callback will belong to the group.
-   */
-  only(callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a focused group of tests that should always be run serially. If one of the tests fails, all subsequent
+       * tests are skipped. All tests in a group are retried together. If there are some focused tests or suites, all of
+       * them will be run but nothing else.
+       *
+       * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
+       * independently.
+       *
+       * - `test.describe.serial.only(title, callback)`
+       * - `test.describe.serial.only(title)`
+       * - `test.describe.serial.only(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.serial.only('group', () => {
+       *   test('runs first', async ({ page }) => {
+       *   });
+       *   test('runs second', async ({ page }) => {
+       *   });
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.serial.only(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.serial.only(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial-only).
+       * Any tests added in this callback will belong to the group.
+       */
+      only(callback: () => void): void;
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a focused group of tests that should always be run serially. If one of the tests fails, all subsequent
-   * tests are skipped. All tests in a group are retried together. If there are some focused tests or suites, all of
-   * them will be run but nothing else.
-   *
-   * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
-   * independently.
-   *
-   * - `test.describe.serial.only(title, callback)`
-   * - `test.describe.serial.only(title)`
-   * - `test.describe.serial.only(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.serial.only('group', () => {
-   *   test('runs first', async ({ page }) => {
-   *   });
-   *   test('runs second', async ({ page }) => {
-   *   });
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.serial.only(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.serial.only(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial-only).
-   * Any tests added in this callback will belong to the group.
-   */
-  only(title: string, details: TestDetails, callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a focused group of tests that should always be run serially. If one of the tests fails, all subsequent
+       * tests are skipped. All tests in a group are retried together. If there are some focused tests or suites, all of
+       * them will be run but nothing else.
+       *
+       * **NOTE** Using serial is not recommended. It is usually better to make your tests isolated, so they can be run
+       * independently.
+       *
+       * - `test.describe.serial.only(title, callback)`
+       * - `test.describe.serial.only(title)`
+       * - `test.describe.serial.only(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.serial.only('group', () => {
+       *   test('runs first', async ({ page }) => {
+       *   });
+       *   test('runs second', async ({ page }) => {
+       *   });
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.serial.only(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.serial.only(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-serial-only).
+       * Any tests added in this callback will belong to the group.
+       */
+      only(title: string, details: TestDetails, callback: () => void): void;
     };
 
     /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a group of tests that could be run in parallel. By default, tests in a single test file run one after
-   * another, but using
-   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel)
-   * allows them to run in parallel.
-   * - `test.describe.parallel(title, callback)`
-   * - `test.describe.parallel(callback)`
-   * - `test.describe.parallel(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.parallel('group', () => {
-   *   test('runs in parallel 1', async ({ page }) => {});
-   *   test('runs in parallel 2', async ({ page }) => {});
-   * });
-   * ```
-   *
-   * Note that parallel tests are executed in separate processes and cannot share any state or global variables. Each of
-   * the parallel tests executes all relevant hooks.
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.parallel(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel).
-   * Any tests added in this callback will belong to the group.
-   */
-  parallel: {
+     * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+     * the preferred way of configuring the execution mode.
+     *
+     * Declares a group of tests that could be run in parallel. By default, tests in a single test file run one after
+     * another, but using
+     * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel)
+     * allows them to run in parallel.
+     * - `test.describe.parallel(title, callback)`
+     * - `test.describe.parallel(callback)`
+     * - `test.describe.parallel(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.parallel('group', () => {
+     *   test('runs in parallel 1', async ({ page }) => {});
+     *   test('runs in parallel 2', async ({ page }) => {});
+     * });
+     * ```
+     *
+     * Note that parallel tests are executed in separate processes and cannot share any state or global variables. Each of
+     * the parallel tests executes all relevant hooks.
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.parallel(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel).
+     * Any tests added in this callback will belong to the group.
+     */
+    parallel: {
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a group of tests that could be run in parallel. By default, tests in a single test file run one after
-   * another, but using
-   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel)
-   * allows them to run in parallel.
-   * - `test.describe.parallel(title, callback)`
-   * - `test.describe.parallel(callback)`
-   * - `test.describe.parallel(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.parallel('group', () => {
-   *   test('runs in parallel 1', async ({ page }) => {});
-   *   test('runs in parallel 2', async ({ page }) => {});
-   * });
-   * ```
-   *
-   * Note that parallel tests are executed in separate processes and cannot share any state or global variables. Each of
-   * the parallel tests executes all relevant hooks.
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.parallel(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel).
-   * Any tests added in this callback will belong to the group.
-   */
-  (title: string, callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a group of tests that could be run in parallel. By default, tests in a single test file run one after
+       * another, but using
+       * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel)
+       * allows them to run in parallel.
+       * - `test.describe.parallel(title, callback)`
+       * - `test.describe.parallel(callback)`
+       * - `test.describe.parallel(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.parallel('group', () => {
+       *   test('runs in parallel 1', async ({ page }) => {});
+       *   test('runs in parallel 2', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * Note that parallel tests are executed in separate processes and cannot share any state or global variables. Each of
+       * the parallel tests executes all relevant hooks.
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.parallel(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel).
+       * Any tests added in this callback will belong to the group.
+       */
+      (title: string, callback: () => void): void;
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a group of tests that could be run in parallel. By default, tests in a single test file run one after
-   * another, but using
-   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel)
-   * allows them to run in parallel.
-   * - `test.describe.parallel(title, callback)`
-   * - `test.describe.parallel(callback)`
-   * - `test.describe.parallel(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.parallel('group', () => {
-   *   test('runs in parallel 1', async ({ page }) => {});
-   *   test('runs in parallel 2', async ({ page }) => {});
-   * });
-   * ```
-   *
-   * Note that parallel tests are executed in separate processes and cannot share any state or global variables. Each of
-   * the parallel tests executes all relevant hooks.
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.parallel(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel).
-   * Any tests added in this callback will belong to the group.
-   */
-  (callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a group of tests that could be run in parallel. By default, tests in a single test file run one after
+       * another, but using
+       * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel)
+       * allows them to run in parallel.
+       * - `test.describe.parallel(title, callback)`
+       * - `test.describe.parallel(callback)`
+       * - `test.describe.parallel(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.parallel('group', () => {
+       *   test('runs in parallel 1', async ({ page }) => {});
+       *   test('runs in parallel 2', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * Note that parallel tests are executed in separate processes and cannot share any state or global variables. Each of
+       * the parallel tests executes all relevant hooks.
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.parallel(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel).
+       * Any tests added in this callback will belong to the group.
+       */
+      (callback: () => void): void;
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a group of tests that could be run in parallel. By default, tests in a single test file run one after
-   * another, but using
-   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel)
-   * allows them to run in parallel.
-   * - `test.describe.parallel(title, callback)`
-   * - `test.describe.parallel(callback)`
-   * - `test.describe.parallel(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.parallel('group', () => {
-   *   test('runs in parallel 1', async ({ page }) => {});
-   *   test('runs in parallel 2', async ({ page }) => {});
-   * });
-   * ```
-   *
-   * Note that parallel tests are executed in separate processes and cannot share any state or global variables. Each of
-   * the parallel tests executes all relevant hooks.
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.parallel(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel).
-   * Any tests added in this callback will belong to the group.
-   */
-  (title: string, details: TestDetails, callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a group of tests that could be run in parallel. By default, tests in a single test file run one after
+       * another, but using
+       * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel)
+       * allows them to run in parallel.
+       * - `test.describe.parallel(title, callback)`
+       * - `test.describe.parallel(callback)`
+       * - `test.describe.parallel(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.parallel('group', () => {
+       *   test('runs in parallel 1', async ({ page }) => {});
+       *   test('runs in parallel 2', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * Note that parallel tests are executed in separate processes and cannot share any state or global variables. Each of
+       * the parallel tests executes all relevant hooks.
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.parallel(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel).
+       * Any tests added in this callback will belong to the group.
+       */
+      (title: string, details: TestDetails, callback: () => void): void;
 
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a focused group of tests that could be run in parallel. This is similar to
-   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel),
-   * but focuses the group. If there are some focused tests or suites, all of them will be run but nothing else.
-   * - `test.describe.parallel.only(title, callback)`
-   * - `test.describe.parallel.only(callback)`
-   * - `test.describe.parallel.only(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.parallel.only('group', () => {
-   *   test('runs in parallel 1', async ({ page }) => {});
-   *   test('runs in parallel 2', async ({ page }) => {});
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.parallel.only(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.parallel.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel-only).
-   * Any tests added in this callback will belong to the group.
-   */
-  only(title: string, callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a focused group of tests that could be run in parallel. This is similar to
+       * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel),
+       * but focuses the group. If there are some focused tests or suites, all of them will be run but nothing else.
+       * - `test.describe.parallel.only(title, callback)`
+       * - `test.describe.parallel.only(callback)`
+       * - `test.describe.parallel.only(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.parallel.only('group', () => {
+       *   test('runs in parallel 1', async ({ page }) => {});
+       *   test('runs in parallel 2', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.parallel.only(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.parallel.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel-only).
+       * Any tests added in this callback will belong to the group.
+       */
+      only(title: string, callback: () => void): void;
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a focused group of tests that could be run in parallel. This is similar to
-   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel),
-   * but focuses the group. If there are some focused tests or suites, all of them will be run but nothing else.
-   * - `test.describe.parallel.only(title, callback)`
-   * - `test.describe.parallel.only(callback)`
-   * - `test.describe.parallel.only(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.parallel.only('group', () => {
-   *   test('runs in parallel 1', async ({ page }) => {});
-   *   test('runs in parallel 2', async ({ page }) => {});
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.parallel.only(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.parallel.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel-only).
-   * Any tests added in this callback will belong to the group.
-   */
-  only(callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a focused group of tests that could be run in parallel. This is similar to
+       * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel),
+       * but focuses the group. If there are some focused tests or suites, all of them will be run but nothing else.
+       * - `test.describe.parallel.only(title, callback)`
+       * - `test.describe.parallel.only(callback)`
+       * - `test.describe.parallel.only(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.parallel.only('group', () => {
+       *   test('runs in parallel 1', async ({ page }) => {});
+       *   test('runs in parallel 2', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.parallel.only(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.parallel.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel-only).
+       * Any tests added in this callback will belong to the group.
+       */
+      only(callback: () => void): void;
       /**
-   * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
-   * the preferred way of configuring the execution mode.
-   *
-   * Declares a focused group of tests that could be run in parallel. This is similar to
-   * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel),
-   * but focuses the group. If there are some focused tests or suites, all of them will be run but nothing else.
-   * - `test.describe.parallel.only(title, callback)`
-   * - `test.describe.parallel.only(callback)`
-   * - `test.describe.parallel.only(title, details, callback)`
-   *
-   * **Usage**
-   *
-   * ```js
-   * test.describe.parallel.only('group', () => {
-   *   test('runs in parallel 1', async ({ page }) => {});
-   *   test('runs in parallel 2', async ({ page }) => {});
-   * });
-   * ```
-   *
-   * You can also omit the title.
-   *
-   * ```js
-   * test.describe.parallel.only(() => {
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Group title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
-   * details description.
-   * @param callback A callback that is run immediately when calling
-   * [test.describe.parallel.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel-only).
-   * Any tests added in this callback will belong to the group.
-   */
-  only(title: string, details: TestDetails, callback: () => void): void;
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a focused group of tests that could be run in parallel. This is similar to
+       * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel),
+       * but focuses the group. If there are some focused tests or suites, all of them will be run but nothing else.
+       * - `test.describe.parallel.only(title, callback)`
+       * - `test.describe.parallel.only(callback)`
+       * - `test.describe.parallel.only(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.parallel.only('group', () => {
+       *   test('runs in parallel 1', async ({ page }) => {});
+       *   test('runs in parallel 2', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.parallel.only(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.parallel.only([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel-only).
+       * Any tests added in this callback will belong to the group.
+       */
+      only(title: string, details: TestDetails, callback: () => void): void;
     };
 
     /**
-   * Configures the enclosing scope. Can be executed either on the top level or inside a describe. Configuration applies
-   * to the entire scope, regardless of whether it run before or after the test declaration.
-   *
-   * Learn more about the execution modes [here](https://playwright.dev/docs/test-parallel).
-   *
-   * **Usage**
-   * - Running tests in parallel.
-   *
-   *   ```js
-   *   // Run all the tests in the file concurrently using parallel workers.
-   *   test.describe.configure({ mode: 'parallel' });
-   *   test('runs in parallel 1', async ({ page }) => {});
-   *   test('runs in parallel 2', async ({ page }) => {});
-   *   ```
-   *
-   * - Running tests in order, retrying each failed test independetly.
-   *
-   *   This is the default mode. It can be useful to set it explicitly to override project configuration that uses
-   *   `fullyParallel`.
-   *
-   *   ```js
-   *   // Tests in this file run in order. Retries, if any, run independently.
-   *   test.describe.configure({ mode: 'default' });
-   *   test('runs first', async ({ page }) => {});
-   *   test('runs second', async ({ page }) => {});
-   *   ```
-   *
-   * - Running tests serially, retrying from the start. If one of the serial tests fails, all subsequent tests are
-   *   skipped.
-   *
-   *   **NOTE** Running serially is not recommended. It is usually better to make your tests isolated, so they can be
-   *   run independently.
-   *
-   *   ```js
-   *   // Annotate tests as inter-dependent.
-   *   test.describe.configure({ mode: 'serial' });
-   *   test('runs first', async ({ page }) => {});
-   *   test('runs second', async ({ page }) => {});
-   *   ```
-   *
-   * - Configuring retries and timeout for each test.
-   *
-   *   ```js
-   *   // Each test in the file will be retried twice and have a timeout of 20 seconds.
-   *   test.describe.configure({ retries: 2, timeout: 20_000 });
-   *   test('runs first', async ({ page }) => {});
-   *   test('runs second', async ({ page }) => {});
-   *   ```
-   *
-   * - Run multiple describes in parallel, but tests inside each describe in order.
-   *
-   *   ```js
-   *   test.describe.configure({ mode: 'parallel' });
-   *
-   *   test.describe('A, runs in parallel with B', () => {
-   *     test.describe.configure({ mode: 'default' });
-   *     test('in order A1', async ({ page }) => {});
-   *     test('in order A2', async ({ page }) => {});
-   *   });
-   *
-   *   test.describe('B, runs in parallel with A', () => {
-   *     test.describe.configure({ mode: 'default' });
-   *     test('in order B1', async ({ page }) => {});
-   *     test('in order B2', async ({ page }) => {});
-   *   });
-   *   ```
-   *
-   * @param options
-   */
-  configure: (options: { mode?: 'default' | 'parallel' | 'serial', retries?: number, timeout?: number }) => void;
+     * Configures the enclosing scope. Can be executed either on the top level or inside a describe. Configuration applies
+     * to the entire scope, regardless of whether it run before or after the test declaration.
+     *
+     * Learn more about the execution modes [here](https://playwright.dev/docs/test-parallel).
+     *
+     * **Usage**
+     * - Running tests in parallel.
+     *
+     *   ```js
+     *   // Run all the tests in the file concurrently using parallel workers.
+     *   test.describe.configure({ mode: 'parallel' });
+     *   test('runs in parallel 1', async ({ page }) => {});
+     *   test('runs in parallel 2', async ({ page }) => {});
+     *   ```
+     *
+     * - Running tests in order, retrying each failed test independetly.
+     *
+     *   This is the default mode. It can be useful to set it explicitly to override project configuration that uses
+     *   `fullyParallel`.
+     *
+     *   ```js
+     *   // Tests in this file run in order. Retries, if any, run independently.
+     *   test.describe.configure({ mode: 'default' });
+     *   test('runs first', async ({ page }) => {});
+     *   test('runs second', async ({ page }) => {});
+     *   ```
+     *
+     * - Running tests serially, retrying from the start. If one of the serial tests fails, all subsequent tests are
+     *   skipped.
+     *
+     *   **NOTE** Running serially is not recommended. It is usually better to make your tests isolated, so they can be
+     *   run independently.
+     *
+     *   ```js
+     *   // Annotate tests as inter-dependent.
+     *   test.describe.configure({ mode: 'serial' });
+     *   test('runs first', async ({ page }) => {});
+     *   test('runs second', async ({ page }) => {});
+     *   ```
+     *
+     * - Configuring retries and timeout for each test.
+     *
+     *   ```js
+     *   // Each test in the file will be retried twice and have a timeout of 20 seconds.
+     *   test.describe.configure({ retries: 2, timeout: 20_000 });
+     *   test('runs first', async ({ page }) => {});
+     *   test('runs second', async ({ page }) => {});
+     *   ```
+     *
+     * - Run multiple describes in parallel, but tests inside each describe in order.
+     *
+     *   ```js
+     *   test.describe.configure({ mode: 'parallel' });
+     *
+     *   test.describe('A, runs in parallel with B', () => {
+     *     test.describe.configure({ mode: 'default' });
+     *     test('in order A1', async ({ page }) => {});
+     *     test('in order A2', async ({ page }) => {});
+     *   });
+     *
+     *   test.describe('B, runs in parallel with A', () => {
+     *     test.describe.configure({ mode: 'default' });
+     *     test('in order B1', async ({ page }) => {});
+     *     test('in order B2', async ({ page }) => {});
+     *   });
+     *   ```
+     *
+     * @param options
+     */
+    configure: (options: { mode?: 'default' | 'parallel' | 'serial', retries?: number, timeout?: number }) => void;
   };
 
   /**
@@ -4996,451 +4996,451 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
    */
   fail: {
     /**
-   * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
-   * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
-   *
-   * To declare a "failing" test:
-   * - `test.fail(title, body)`
-   * - `test.fail(title, details, body)`
-   *
-   * To annotate test as "failing" at runtime:
-   * - `test.fail(condition, description)`
-   * - `test.fail(callback, description)`
-   * - `test.fail()`
-   *
-   * **Usage**
-   *
-   * You can declare a test as failing, so that Playwright ensures it actually fails.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail('not yet ready', async ({ page }) => {
-   *   // ...
-   * });
-   * ```
-   *
-   * If your test fails in some configurations, but not all, you can mark the test as failing inside the test body based
-   * on some condition. We recommend passing a `description` argument in this case.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('fail in WebKit', async ({ page, browserName }) => {
-   *   test.fail(browserName === 'webkit', 'This feature is not implemented for Mac yet');
-   *   // ...
-   * });
-   * ```
-   *
-   * You can mark all tests in a file or
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
-   * "should fail" based on some condition with a single `test.fail(callback, description)` call.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail(({ browserName }) => browserName === 'webkit', 'not implemented yet');
-   *
-   * test('fail in WebKit 1', async ({ page }) => {
-   *   // ...
-   * });
-   * test('fail in WebKit 2', async ({ page }) => {
-   *   // ...
-   * });
-   * ```
-   *
-   * You can also call `test.fail()` without arguments inside the test body to always mark the test as failed. We
-   * recommend declaring a failing test with `test.fail(title, body)` instead.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('less readable', async ({ page }) => {
-   *   test.fail();
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Test title.
-   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
-   * description.
-   * @param body Test body that takes one or two arguments: an object with fixtures and optional
-   * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
-   * @param condition Test is marked as "should fail" when the condition is `true`.
-   * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
-   * "should fail" when the return value is `true`.
-   * @param description Optional description that will be reflected in a test report.
-   */
-  (title: string, body: TestBody<TestArgs & WorkerArgs>): void;
+     * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
+     * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
+     *
+     * To declare a "failing" test:
+     * - `test.fail(title, body)`
+     * - `test.fail(title, details, body)`
+     *
+     * To annotate test as "failing" at runtime:
+     * - `test.fail(condition, description)`
+     * - `test.fail(callback, description)`
+     * - `test.fail()`
+     *
+     * **Usage**
+     *
+     * You can declare a test as failing, so that Playwright ensures it actually fails.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail('not yet ready', async ({ page }) => {
+     *   // ...
+     * });
+     * ```
+     *
+     * If your test fails in some configurations, but not all, you can mark the test as failing inside the test body based
+     * on some condition. We recommend passing a `description` argument in this case.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('fail in WebKit', async ({ page, browserName }) => {
+     *   test.fail(browserName === 'webkit', 'This feature is not implemented for Mac yet');
+     *   // ...
+     * });
+     * ```
+     *
+     * You can mark all tests in a file or
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+     * "should fail" based on some condition with a single `test.fail(callback, description)` call.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail(({ browserName }) => browserName === 'webkit', 'not implemented yet');
+     *
+     * test('fail in WebKit 1', async ({ page }) => {
+     *   // ...
+     * });
+     * test('fail in WebKit 2', async ({ page }) => {
+     *   // ...
+     * });
+     * ```
+     *
+     * You can also call `test.fail()` without arguments inside the test body to always mark the test as failed. We
+     * recommend declaring a failing test with `test.fail(title, body)` instead.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('less readable', async ({ page }) => {
+     *   test.fail();
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Test title.
+     * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+     * description.
+     * @param body Test body that takes one or two arguments: an object with fixtures and optional
+     * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
+     * @param condition Test is marked as "should fail" when the condition is `true`.
+     * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
+     * "should fail" when the return value is `true`.
+     * @param description Optional description that will be reflected in a test report.
+     */
+    (title: string, body: TestBody<TestArgs & WorkerArgs>): void;
     /**
-   * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
-   * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
-   *
-   * To declare a "failing" test:
-   * - `test.fail(title, body)`
-   * - `test.fail(title, details, body)`
-   *
-   * To annotate test as "failing" at runtime:
-   * - `test.fail(condition, description)`
-   * - `test.fail(callback, description)`
-   * - `test.fail()`
-   *
-   * **Usage**
-   *
-   * You can declare a test as failing, so that Playwright ensures it actually fails.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail('not yet ready', async ({ page }) => {
-   *   // ...
-   * });
-   * ```
-   *
-   * If your test fails in some configurations, but not all, you can mark the test as failing inside the test body based
-   * on some condition. We recommend passing a `description` argument in this case.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('fail in WebKit', async ({ page, browserName }) => {
-   *   test.fail(browserName === 'webkit', 'This feature is not implemented for Mac yet');
-   *   // ...
-   * });
-   * ```
-   *
-   * You can mark all tests in a file or
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
-   * "should fail" based on some condition with a single `test.fail(callback, description)` call.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail(({ browserName }) => browserName === 'webkit', 'not implemented yet');
-   *
-   * test('fail in WebKit 1', async ({ page }) => {
-   *   // ...
-   * });
-   * test('fail in WebKit 2', async ({ page }) => {
-   *   // ...
-   * });
-   * ```
-   *
-   * You can also call `test.fail()` without arguments inside the test body to always mark the test as failed. We
-   * recommend declaring a failing test with `test.fail(title, body)` instead.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('less readable', async ({ page }) => {
-   *   test.fail();
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Test title.
-   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
-   * description.
-   * @param body Test body that takes one or two arguments: an object with fixtures and optional
-   * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
-   * @param condition Test is marked as "should fail" when the condition is `true`.
-   * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
-   * "should fail" when the return value is `true`.
-   * @param description Optional description that will be reflected in a test report.
-   */
-  (title: string, details: TestDetails, body: TestBody<TestArgs & WorkerArgs>): void;
+     * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
+     * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
+     *
+     * To declare a "failing" test:
+     * - `test.fail(title, body)`
+     * - `test.fail(title, details, body)`
+     *
+     * To annotate test as "failing" at runtime:
+     * - `test.fail(condition, description)`
+     * - `test.fail(callback, description)`
+     * - `test.fail()`
+     *
+     * **Usage**
+     *
+     * You can declare a test as failing, so that Playwright ensures it actually fails.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail('not yet ready', async ({ page }) => {
+     *   // ...
+     * });
+     * ```
+     *
+     * If your test fails in some configurations, but not all, you can mark the test as failing inside the test body based
+     * on some condition. We recommend passing a `description` argument in this case.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('fail in WebKit', async ({ page, browserName }) => {
+     *   test.fail(browserName === 'webkit', 'This feature is not implemented for Mac yet');
+     *   // ...
+     * });
+     * ```
+     *
+     * You can mark all tests in a file or
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+     * "should fail" based on some condition with a single `test.fail(callback, description)` call.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail(({ browserName }) => browserName === 'webkit', 'not implemented yet');
+     *
+     * test('fail in WebKit 1', async ({ page }) => {
+     *   // ...
+     * });
+     * test('fail in WebKit 2', async ({ page }) => {
+     *   // ...
+     * });
+     * ```
+     *
+     * You can also call `test.fail()` without arguments inside the test body to always mark the test as failed. We
+     * recommend declaring a failing test with `test.fail(title, body)` instead.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('less readable', async ({ page }) => {
+     *   test.fail();
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Test title.
+     * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+     * description.
+     * @param body Test body that takes one or two arguments: an object with fixtures and optional
+     * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
+     * @param condition Test is marked as "should fail" when the condition is `true`.
+     * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
+     * "should fail" when the return value is `true`.
+     * @param description Optional description that will be reflected in a test report.
+     */
+    (title: string, details: TestDetails, body: TestBody<TestArgs & WorkerArgs>): void;
     /**
-   * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
-   * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
-   *
-   * To declare a "failing" test:
-   * - `test.fail(title, body)`
-   * - `test.fail(title, details, body)`
-   *
-   * To annotate test as "failing" at runtime:
-   * - `test.fail(condition, description)`
-   * - `test.fail(callback, description)`
-   * - `test.fail()`
-   *
-   * **Usage**
-   *
-   * You can declare a test as failing, so that Playwright ensures it actually fails.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail('not yet ready', async ({ page }) => {
-   *   // ...
-   * });
-   * ```
-   *
-   * If your test fails in some configurations, but not all, you can mark the test as failing inside the test body based
-   * on some condition. We recommend passing a `description` argument in this case.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('fail in WebKit', async ({ page, browserName }) => {
-   *   test.fail(browserName === 'webkit', 'This feature is not implemented for Mac yet');
-   *   // ...
-   * });
-   * ```
-   *
-   * You can mark all tests in a file or
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
-   * "should fail" based on some condition with a single `test.fail(callback, description)` call.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail(({ browserName }) => browserName === 'webkit', 'not implemented yet');
-   *
-   * test('fail in WebKit 1', async ({ page }) => {
-   *   // ...
-   * });
-   * test('fail in WebKit 2', async ({ page }) => {
-   *   // ...
-   * });
-   * ```
-   *
-   * You can also call `test.fail()` without arguments inside the test body to always mark the test as failed. We
-   * recommend declaring a failing test with `test.fail(title, body)` instead.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('less readable', async ({ page }) => {
-   *   test.fail();
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Test title.
-   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
-   * description.
-   * @param body Test body that takes one or two arguments: an object with fixtures and optional
-   * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
-   * @param condition Test is marked as "should fail" when the condition is `true`.
-   * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
-   * "should fail" when the return value is `true`.
-   * @param description Optional description that will be reflected in a test report.
-   */
-  (condition: boolean, description?: string): void;
+     * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
+     * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
+     *
+     * To declare a "failing" test:
+     * - `test.fail(title, body)`
+     * - `test.fail(title, details, body)`
+     *
+     * To annotate test as "failing" at runtime:
+     * - `test.fail(condition, description)`
+     * - `test.fail(callback, description)`
+     * - `test.fail()`
+     *
+     * **Usage**
+     *
+     * You can declare a test as failing, so that Playwright ensures it actually fails.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail('not yet ready', async ({ page }) => {
+     *   // ...
+     * });
+     * ```
+     *
+     * If your test fails in some configurations, but not all, you can mark the test as failing inside the test body based
+     * on some condition. We recommend passing a `description` argument in this case.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('fail in WebKit', async ({ page, browserName }) => {
+     *   test.fail(browserName === 'webkit', 'This feature is not implemented for Mac yet');
+     *   // ...
+     * });
+     * ```
+     *
+     * You can mark all tests in a file or
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+     * "should fail" based on some condition with a single `test.fail(callback, description)` call.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail(({ browserName }) => browserName === 'webkit', 'not implemented yet');
+     *
+     * test('fail in WebKit 1', async ({ page }) => {
+     *   // ...
+     * });
+     * test('fail in WebKit 2', async ({ page }) => {
+     *   // ...
+     * });
+     * ```
+     *
+     * You can also call `test.fail()` without arguments inside the test body to always mark the test as failed. We
+     * recommend declaring a failing test with `test.fail(title, body)` instead.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('less readable', async ({ page }) => {
+     *   test.fail();
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Test title.
+     * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+     * description.
+     * @param body Test body that takes one or two arguments: an object with fixtures and optional
+     * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
+     * @param condition Test is marked as "should fail" when the condition is `true`.
+     * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
+     * "should fail" when the return value is `true`.
+     * @param description Optional description that will be reflected in a test report.
+     */
+    (condition: boolean, description?: string): void;
     /**
-   * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
-   * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
-   *
-   * To declare a "failing" test:
-   * - `test.fail(title, body)`
-   * - `test.fail(title, details, body)`
-   *
-   * To annotate test as "failing" at runtime:
-   * - `test.fail(condition, description)`
-   * - `test.fail(callback, description)`
-   * - `test.fail()`
-   *
-   * **Usage**
-   *
-   * You can declare a test as failing, so that Playwright ensures it actually fails.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail('not yet ready', async ({ page }) => {
-   *   // ...
-   * });
-   * ```
-   *
-   * If your test fails in some configurations, but not all, you can mark the test as failing inside the test body based
-   * on some condition. We recommend passing a `description` argument in this case.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('fail in WebKit', async ({ page, browserName }) => {
-   *   test.fail(browserName === 'webkit', 'This feature is not implemented for Mac yet');
-   *   // ...
-   * });
-   * ```
-   *
-   * You can mark all tests in a file or
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
-   * "should fail" based on some condition with a single `test.fail(callback, description)` call.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail(({ browserName }) => browserName === 'webkit', 'not implemented yet');
-   *
-   * test('fail in WebKit 1', async ({ page }) => {
-   *   // ...
-   * });
-   * test('fail in WebKit 2', async ({ page }) => {
-   *   // ...
-   * });
-   * ```
-   *
-   * You can also call `test.fail()` without arguments inside the test body to always mark the test as failed. We
-   * recommend declaring a failing test with `test.fail(title, body)` instead.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('less readable', async ({ page }) => {
-   *   test.fail();
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Test title.
-   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
-   * description.
-   * @param body Test body that takes one or two arguments: an object with fixtures and optional
-   * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
-   * @param condition Test is marked as "should fail" when the condition is `true`.
-   * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
-   * "should fail" when the return value is `true`.
-   * @param description Optional description that will be reflected in a test report.
-   */
-  (callback: ConditionBody<TestArgs & WorkerArgs>, description?: string): void;
+     * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
+     * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
+     *
+     * To declare a "failing" test:
+     * - `test.fail(title, body)`
+     * - `test.fail(title, details, body)`
+     *
+     * To annotate test as "failing" at runtime:
+     * - `test.fail(condition, description)`
+     * - `test.fail(callback, description)`
+     * - `test.fail()`
+     *
+     * **Usage**
+     *
+     * You can declare a test as failing, so that Playwright ensures it actually fails.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail('not yet ready', async ({ page }) => {
+     *   // ...
+     * });
+     * ```
+     *
+     * If your test fails in some configurations, but not all, you can mark the test as failing inside the test body based
+     * on some condition. We recommend passing a `description` argument in this case.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('fail in WebKit', async ({ page, browserName }) => {
+     *   test.fail(browserName === 'webkit', 'This feature is not implemented for Mac yet');
+     *   // ...
+     * });
+     * ```
+     *
+     * You can mark all tests in a file or
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+     * "should fail" based on some condition with a single `test.fail(callback, description)` call.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail(({ browserName }) => browserName === 'webkit', 'not implemented yet');
+     *
+     * test('fail in WebKit 1', async ({ page }) => {
+     *   // ...
+     * });
+     * test('fail in WebKit 2', async ({ page }) => {
+     *   // ...
+     * });
+     * ```
+     *
+     * You can also call `test.fail()` without arguments inside the test body to always mark the test as failed. We
+     * recommend declaring a failing test with `test.fail(title, body)` instead.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('less readable', async ({ page }) => {
+     *   test.fail();
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Test title.
+     * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+     * description.
+     * @param body Test body that takes one or two arguments: an object with fixtures and optional
+     * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
+     * @param condition Test is marked as "should fail" when the condition is `true`.
+     * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
+     * "should fail" when the return value is `true`.
+     * @param description Optional description that will be reflected in a test report.
+     */
+    (callback: ConditionBody<TestArgs & WorkerArgs>, description?: string): void;
     /**
-   * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
-   * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
-   *
-   * To declare a "failing" test:
-   * - `test.fail(title, body)`
-   * - `test.fail(title, details, body)`
-   *
-   * To annotate test as "failing" at runtime:
-   * - `test.fail(condition, description)`
-   * - `test.fail(callback, description)`
-   * - `test.fail()`
-   *
-   * **Usage**
-   *
-   * You can declare a test as failing, so that Playwright ensures it actually fails.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail('not yet ready', async ({ page }) => {
-   *   // ...
-   * });
-   * ```
-   *
-   * If your test fails in some configurations, but not all, you can mark the test as failing inside the test body based
-   * on some condition. We recommend passing a `description` argument in this case.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('fail in WebKit', async ({ page, browserName }) => {
-   *   test.fail(browserName === 'webkit', 'This feature is not implemented for Mac yet');
-   *   // ...
-   * });
-   * ```
-   *
-   * You can mark all tests in a file or
-   * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
-   * "should fail" based on some condition with a single `test.fail(callback, description)` call.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail(({ browserName }) => browserName === 'webkit', 'not implemented yet');
-   *
-   * test('fail in WebKit 1', async ({ page }) => {
-   *   // ...
-   * });
-   * test('fail in WebKit 2', async ({ page }) => {
-   *   // ...
-   * });
-   * ```
-   *
-   * You can also call `test.fail()` without arguments inside the test body to always mark the test as failed. We
-   * recommend declaring a failing test with `test.fail(title, body)` instead.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('less readable', async ({ page }) => {
-   *   test.fail();
-   *   // ...
-   * });
-   * ```
-   *
-   * @param title Test title.
-   * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
-   * description.
-   * @param body Test body that takes one or two arguments: an object with fixtures and optional
-   * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
-   * @param condition Test is marked as "should fail" when the condition is `true`.
-   * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
-   * "should fail" when the return value is `true`.
-   * @param description Optional description that will be reflected in a test report.
-   */
-  (): void;
+     * Marks a test as "should fail". Playwright runs this test and ensures that it is actually failing. This is useful
+     * for documentation purposes to acknowledge that some functionality is broken until it is fixed.
+     *
+     * To declare a "failing" test:
+     * - `test.fail(title, body)`
+     * - `test.fail(title, details, body)`
+     *
+     * To annotate test as "failing" at runtime:
+     * - `test.fail(condition, description)`
+     * - `test.fail(callback, description)`
+     * - `test.fail()`
+     *
+     * **Usage**
+     *
+     * You can declare a test as failing, so that Playwright ensures it actually fails.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail('not yet ready', async ({ page }) => {
+     *   // ...
+     * });
+     * ```
+     *
+     * If your test fails in some configurations, but not all, you can mark the test as failing inside the test body based
+     * on some condition. We recommend passing a `description` argument in this case.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('fail in WebKit', async ({ page, browserName }) => {
+     *   test.fail(browserName === 'webkit', 'This feature is not implemented for Mac yet');
+     *   // ...
+     * });
+     * ```
+     *
+     * You can mark all tests in a file or
+     * [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) group as
+     * "should fail" based on some condition with a single `test.fail(callback, description)` call.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail(({ browserName }) => browserName === 'webkit', 'not implemented yet');
+     *
+     * test('fail in WebKit 1', async ({ page }) => {
+     *   // ...
+     * });
+     * test('fail in WebKit 2', async ({ page }) => {
+     *   // ...
+     * });
+     * ```
+     *
+     * You can also call `test.fail()` without arguments inside the test body to always mark the test as failed. We
+     * recommend declaring a failing test with `test.fail(title, body)` instead.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('less readable', async ({ page }) => {
+     *   test.fail();
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Test title.
+     * @param details See [test.(call)(title[, details, body])](https://playwright.dev/docs/api/class-test#test-call) for test details
+     * description.
+     * @param body Test body that takes one or two arguments: an object with fixtures and optional
+     * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
+     * @param condition Test is marked as "should fail" when the condition is `true`.
+     * @param callback A function that returns whether to mark as "should fail", based on test fixtures. Test or tests are marked as
+     * "should fail" when the return value is `true`.
+     * @param description Optional description that will be reflected in a test report.
+     */
+    (): void;
 
     /**
-   * You can use `test.fail.only` to focus on a specific test that is expected to fail. This is particularly useful when
-   * debugging a failing test or working on a specific issue.
-   *
-   * To declare a focused "failing" test:
-   * - `test.fail.only(title, body)`
-   * - `test.fail.only(title, details, body)`
-   *
-   * **Usage**
-   *
-   * You can declare a focused failing test, so that Playwright runs only this test and ensures it actually fails.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail.only('focused failing test', async ({ page }) => {
-   *   // This test is expected to fail
-   * });
-   * test('not in the focused group', async ({ page }) => {
-   *   // This test will not run
-   * });
-   * ```
-   *
-   * @param title Test title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for test
-   * details description.
-   * @param body Test body that takes one or two arguments: an object with fixtures and optional
-   * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
-   */
-  only(title: string, body: TestBody<TestArgs & WorkerArgs>): void;
+     * You can use `test.fail.only` to focus on a specific test that is expected to fail. This is particularly useful when
+     * debugging a failing test or working on a specific issue.
+     *
+     * To declare a focused "failing" test:
+     * - `test.fail.only(title, body)`
+     * - `test.fail.only(title, details, body)`
+     *
+     * **Usage**
+     *
+     * You can declare a focused failing test, so that Playwright runs only this test and ensures it actually fails.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail.only('focused failing test', async ({ page }) => {
+     *   // This test is expected to fail
+     * });
+     * test('not in the focused group', async ({ page }) => {
+     *   // This test will not run
+     * });
+     * ```
+     *
+     * @param title Test title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for test
+     * details description.
+     * @param body Test body that takes one or two arguments: an object with fixtures and optional
+     * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
+     */
+    only(title: string, body: TestBody<TestArgs & WorkerArgs>): void;
     /**
-   * You can use `test.fail.only` to focus on a specific test that is expected to fail. This is particularly useful when
-   * debugging a failing test or working on a specific issue.
-   *
-   * To declare a focused "failing" test:
-   * - `test.fail.only(title, body)`
-   * - `test.fail.only(title, details, body)`
-   *
-   * **Usage**
-   *
-   * You can declare a focused failing test, so that Playwright runs only this test and ensures it actually fails.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test.fail.only('focused failing test', async ({ page }) => {
-   *   // This test is expected to fail
-   * });
-   * test('not in the focused group', async ({ page }) => {
-   *   // This test will not run
-   * });
-   * ```
-   *
-   * @param title Test title.
-   * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for test
-   * details description.
-   * @param body Test body that takes one or two arguments: an object with fixtures and optional
-   * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
-   */
-  only(title: string, details: TestDetails, body: TestBody<TestArgs & WorkerArgs>): void;
+     * You can use `test.fail.only` to focus on a specific test that is expected to fail. This is particularly useful when
+     * debugging a failing test or working on a specific issue.
+     *
+     * To declare a focused "failing" test:
+     * - `test.fail.only(title, body)`
+     * - `test.fail.only(title, details, body)`
+     *
+     * **Usage**
+     *
+     * You can declare a focused failing test, so that Playwright runs only this test and ensures it actually fails.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test.fail.only('focused failing test', async ({ page }) => {
+     *   // This test is expected to fail
+     * });
+     * test('not in the focused group', async ({ page }) => {
+     *   // This test will not run
+     * });
+     * ```
+     *
+     * @param title Test title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for test
+     * details description.
+     * @param body Test body that takes one or two arguments: an object with fixtures and optional
+     * [TestInfo](https://playwright.dev/docs/api/class-testinfo).
+     */
+    only(title: string, details: TestDetails, body: TestBody<TestArgs & WorkerArgs>): void;
   }
 
   /**
@@ -6274,192 +6274,192 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
    */
   step: {
     /**
-   * Declares a test step that is shown in the report.
-   *
-   * **Usage**
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('test', async ({ page }) => {
-   *   await test.step('Log in', async () => {
-   *     // ...
-   *   });
-   *
-   *   await test.step('Outer step', async () => {
-   *     // ...
-   *     // You can nest steps inside each other.
-   *     await test.step('Inner step', async () => {
-   *       // ...
-   *     });
-   *   });
-   * });
-   * ```
-   *
-   * **Details**
-   *
-   * The method returns the value returned by the step callback.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('test', async ({ page }) => {
-   *   const user = await test.step('Log in', async () => {
-   *     // ...
-   *     return 'john';
-   *   });
-   *   expect(user).toBe('john');
-   * });
-   * ```
-   *
-   * **Decorator**
-   *
-   * You can use TypeScript method decorators to turn a method into a step. Each call to the decorated method will show
-   * up as a step in the report.
-   *
-   * ```js
-   * function step(target: Function, context: ClassMethodDecoratorContext) {
-   *   return function replacementMethod(...args: any) {
-   *     const name = this.constructor.name + '.' + (context.name as string);
-   *     return test.step(name, async () => {
-   *       return await target.call(this, ...args);
-   *     });
-   *   };
-   * }
-   *
-   * class LoginPage {
-   *   constructor(readonly page: Page) {}
-   *
-   *   @step
-   *   async login() {
-   *     const account = { username: 'Alice', password: 's3cr3t' };
-   *     await this.page.getByLabel('Username or email address').fill(account.username);
-   *     await this.page.getByLabel('Password').fill(account.password);
-   *     await this.page.getByRole('button', { name: 'Sign in' }).click();
-   *     await expect(this.page.getByRole('button', { name: 'View profile and more' })).toBeVisible();
-   *   }
-   * }
-   *
-   * test('example', async ({ page }) => {
-   *   const loginPage = new LoginPage(page);
-   *   await loginPage.login();
-   * });
-   * ```
-   *
-   * **Boxing**
-   *
-   * When something inside a step fails, you would usually see the error pointing to the exact action that failed. For
-   * example, consider the following login step:
-   *
-   * ```js
-   * async function login(page) {
-   *   await test.step('login', async () => {
-   *     const account = { username: 'Alice', password: 's3cr3t' };
-   *     await page.getByLabel('Username or email address').fill(account.username);
-   *     await page.getByLabel('Password').fill(account.password);
-   *     await page.getByRole('button', { name: 'Sign in' }).click();
-   *     await expect(page.getByRole('button', { name: 'View profile and more' })).toBeVisible();
-   *   });
-   * }
-   *
-   * test('example', async ({ page }) => {
-   *   await page.goto('https://github.com/login');
-   *   await login(page);
-   * });
-   * ```
-   *
-   * ```txt
-   * Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
-   *   ... error details omitted ...
-   *
-   *    8 |     await page.getByRole('button', { name: 'Sign in' }).click();
-   * >  9 |     await expect(page.getByRole('button', { name: 'View profile and more' })).toBeVisible();
-   *      |                                                                               ^
-   *   10 |   });
-   * ```
-   *
-   * As we see above, the test may fail with an error pointing inside the step. If you would like the error to highlight
-   * the "login" step instead of its internals, use the `box` option. An error inside a boxed step points to the step
-   * call site.
-   *
-   * ```js
-   * async function login(page) {
-   *   await test.step('login', async () => {
-   *     // ...
-   *   }, { box: true });  // Note the "box" option here.
-   * }
-   * ```
-   *
-   * ```txt
-   * Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
-   *   ... error details omitted ...
-   *
-   *   14 |   await page.goto('https://github.com/login');
-   * > 15 |   await login(page);
-   *      |         ^
-   *   16 | });
-   * ```
-   *
-   * You can also create a TypeScript decorator for a boxed step, similar to a regular step decorator above:
-   *
-   * ```js
-   * function boxedStep(target: Function, context: ClassMethodDecoratorContext) {
-   *   return function replacementMethod(...args: any) {
-   *     const name = this.constructor.name + '.' + (context.name as string);
-   *     return test.step(name, async () => {
-   *       return await target.call(this, ...args);
-   *     }, { box: true });  // Note the "box" option here.
-   *   };
-   * }
-   *
-   * class LoginPage {
-   *   constructor(readonly page: Page) {}
-   *
-   *   @boxedStep
-   *   async login() {
-   *     // ....
-   *   }
-   * }
-   *
-   * test('example', async ({ page }) => {
-   *   const loginPage = new LoginPage(page);
-   *   await loginPage.login();  // <-- Error will be reported on this line.
-   * });
-   * ```
-   *
-   * @param title Step name.
-   * @param body Step body.
-   * @param options
-   */
-  <T>(title: string, body: (step: TestStepInfo) => T | Promise<T>, options?: { box?: boolean, location?: Location, timeout?: number }): Promise<T>;
+     * Declares a test step that is shown in the report.
+     *
+     * **Usage**
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('test', async ({ page }) => {
+     *   await test.step('Log in', async () => {
+     *     // ...
+     *   });
+     *
+     *   await test.step('Outer step', async () => {
+     *     // ...
+     *     // You can nest steps inside each other.
+     *     await test.step('Inner step', async () => {
+     *       // ...
+     *     });
+     *   });
+     * });
+     * ```
+     *
+     * **Details**
+     *
+     * The method returns the value returned by the step callback.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('test', async ({ page }) => {
+     *   const user = await test.step('Log in', async () => {
+     *     // ...
+     *     return 'john';
+     *   });
+     *   expect(user).toBe('john');
+     * });
+     * ```
+     *
+     * **Decorator**
+     *
+     * You can use TypeScript method decorators to turn a method into a step. Each call to the decorated method will show
+     * up as a step in the report.
+     *
+     * ```js
+     * function step(target: Function, context: ClassMethodDecoratorContext) {
+     *   return function replacementMethod(...args: any) {
+     *     const name = this.constructor.name + '.' + (context.name as string);
+     *     return test.step(name, async () => {
+     *       return await target.call(this, ...args);
+     *     });
+     *   };
+     * }
+     *
+     * class LoginPage {
+     *   constructor(readonly page: Page) {}
+     *
+     *   @step
+     *   async login() {
+     *     const account = { username: 'Alice', password: 's3cr3t' };
+     *     await this.page.getByLabel('Username or email address').fill(account.username);
+     *     await this.page.getByLabel('Password').fill(account.password);
+     *     await this.page.getByRole('button', { name: 'Sign in' }).click();
+     *     await expect(this.page.getByRole('button', { name: 'View profile and more' })).toBeVisible();
+     *   }
+     * }
+     *
+     * test('example', async ({ page }) => {
+     *   const loginPage = new LoginPage(page);
+     *   await loginPage.login();
+     * });
+     * ```
+     *
+     * **Boxing**
+     *
+     * When something inside a step fails, you would usually see the error pointing to the exact action that failed. For
+     * example, consider the following login step:
+     *
+     * ```js
+     * async function login(page) {
+     *   await test.step('login', async () => {
+     *     const account = { username: 'Alice', password: 's3cr3t' };
+     *     await page.getByLabel('Username or email address').fill(account.username);
+     *     await page.getByLabel('Password').fill(account.password);
+     *     await page.getByRole('button', { name: 'Sign in' }).click();
+     *     await expect(page.getByRole('button', { name: 'View profile and more' })).toBeVisible();
+     *   });
+     * }
+     *
+     * test('example', async ({ page }) => {
+     *   await page.goto('https://github.com/login');
+     *   await login(page);
+     * });
+     * ```
+     *
+     * ```txt
+     * Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
+     *   ... error details omitted ...
+     *
+     *    8 |     await page.getByRole('button', { name: 'Sign in' }).click();
+     * >  9 |     await expect(page.getByRole('button', { name: 'View profile and more' })).toBeVisible();
+     *      |                                                                               ^
+     *   10 |   });
+     * ```
+     *
+     * As we see above, the test may fail with an error pointing inside the step. If you would like the error to highlight
+     * the "login" step instead of its internals, use the `box` option. An error inside a boxed step points to the step
+     * call site.
+     *
+     * ```js
+     * async function login(page) {
+     *   await test.step('login', async () => {
+     *     // ...
+     *   }, { box: true });  // Note the "box" option here.
+     * }
+     * ```
+     *
+     * ```txt
+     * Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
+     *   ... error details omitted ...
+     *
+     *   14 |   await page.goto('https://github.com/login');
+     * > 15 |   await login(page);
+     *      |         ^
+     *   16 | });
+     * ```
+     *
+     * You can also create a TypeScript decorator for a boxed step, similar to a regular step decorator above:
+     *
+     * ```js
+     * function boxedStep(target: Function, context: ClassMethodDecoratorContext) {
+     *   return function replacementMethod(...args: any) {
+     *     const name = this.constructor.name + '.' + (context.name as string);
+     *     return test.step(name, async () => {
+     *       return await target.call(this, ...args);
+     *     }, { box: true });  // Note the "box" option here.
+     *   };
+     * }
+     *
+     * class LoginPage {
+     *   constructor(readonly page: Page) {}
+     *
+     *   @boxedStep
+     *   async login() {
+     *     // ....
+     *   }
+     * }
+     *
+     * test('example', async ({ page }) => {
+     *   const loginPage = new LoginPage(page);
+     *   await loginPage.login();  // <-- Error will be reported on this line.
+     * });
+     * ```
+     *
+     * @param title Step name.
+     * @param body Step body.
+     * @param options
+     */
+    <T>(title: string, body: (step: TestStepInfo) => T | Promise<T>, options?: { box?: boolean, location?: Location, timeout?: number }): Promise<T>;
     /**
-   * Mark a test step as "skip" to temporarily disable its execution, useful for steps that are currently failing and
-   * planned for a near-term fix. Playwright will not run the step. See also
-   * [testStepInfo.skip(condition[, description])](https://playwright.dev/docs/api/class-teststepinfo#test-step-info-skip-2).
-   *
-   * We recommend [testStepInfo.skip()](https://playwright.dev/docs/api/class-teststepinfo#test-step-info-skip-1)
-   * instead.
-   *
-   * **Usage**
-   *
-   * You can declare a skipped step, and Playwright will not run it.
-   *
-   * ```js
-   * import { test, expect } from '@playwright/test';
-   *
-   * test('my test', async ({ page }) => {
-   *   // ...
-   *   await test.step.skip('not yet ready', async () => {
-   *     // ...
-   *   });
-   * });
-   * ```
-   *
-   * @param title Step name.
-   * @param body Step body.
-   * @param options
-   */
-  skip(title: string, body: (step: TestStepInfo) => any | Promise<any>, options?: { box?: boolean, location?: Location, timeout?: number }): Promise<void>;
+     * Mark a test step as "skip" to temporarily disable its execution, useful for steps that are currently failing and
+     * planned for a near-term fix. Playwright will not run the step. See also
+     * [testStepInfo.skip(condition[, description])](https://playwright.dev/docs/api/class-teststepinfo#test-step-info-skip-2).
+     *
+     * We recommend [testStepInfo.skip()](https://playwright.dev/docs/api/class-teststepinfo#test-step-info-skip-1)
+     * instead.
+     *
+     * **Usage**
+     *
+     * You can declare a skipped step, and Playwright will not run it.
+     *
+     * ```js
+     * import { test, expect } from '@playwright/test';
+     *
+     * test('my test', async ({ page }) => {
+     *   // ...
+     *   await test.step.skip('not yet ready', async () => {
+     *     // ...
+     *   });
+     * });
+     * ```
+     *
+     * @param title Step name.
+     * @param body Step body.
+     * @param options
+     */
+    skip(title: string, body: (step: TestStepInfo) => any | Promise<any>, options?: { box?: boolean, location?: Location, timeout?: number }): Promise<void>;
   }
   /**
    * `expect` function can be used to create test assertions. Read more about [test assertions](https://playwright.dev/docs/test-assertions).

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -92,7 +92,7 @@ class TypesGenerator {
         return '';
       handledClasses.add(className);
       return this.writeComment(docClass.comment, '') + '\n';
-    }, (className, methodName, overloadIndex) => {
+    }, (className, methodName, overloadIndex, indent) => {
       if (methodName === '__call')
         methodName = '(call)';
       const docClass = this.docClassForName(className);
@@ -110,7 +110,7 @@ class TypesGenerator {
           return '';
         throw new Error(`Unknown override method "${className}.${methodName}"`);
       }
-      return this.memberJSDOC(method, '  ').trimLeft();
+      return this.memberJSDOC(method, indent).trimLeft();
     }, (className) => {
       const docClass = this.docClassForName(className);
       if (!docClass || !this.shouldGenerate(docClass.name))

--- a/utils/generate_types/parseOverrides.js
+++ b/utils/generate_types/parseOverrides.js
@@ -20,7 +20,7 @@ const ts = require('typescript');
 /**
  * @param {string} filePath
  * @param {(className: string) => string} commentForClass
- * @param {(className: string, methodName: string, overloadIndex: number) => string} commentForMethod
+ * @param {(className: string, methodName: string, overloadIndex: number, indent: string) => string} commentForMethod
  * @param {(className: string) => string} extraForClass
  */
 async function parseOverrides(filePath, commentForClass, commentForMethod, extraForClass) {
@@ -41,6 +41,18 @@ async function parseOverrides(filePath, commentForClass, commentForMethod, extra
     src = src.substring(0, replacer.pos) + replacer.text + src.substring(replacer.pos);
   }
   return src;
+
+  /**
+   * @param {number} pos
+   * @returns {string}
+   */
+  function getIndentationAtPos(pos) {
+    const text = file.text;
+    const lineStart = text.lastIndexOf('\n', pos - 1) + 1;
+    const textBeforeNodeOnLine = text.substring(lineStart, pos);
+    const match = textBeforeNodeOnLine.match(/^(\s*)/);
+    return match ? match[1] : '';
+  }
 
     /**
    * @param {!ts.Node} node
@@ -83,7 +95,7 @@ async function parseOverrides(filePath, commentForClass, commentForMethod, extra
         const pos = declaration.getStart(file, false);
         replacers.push({
           pos,
-          text: commentForMethod(className, name, index),
+          text: commentForMethod(className, name, index, getIndentationAtPos(pos)),
         });
         if (ts.isPropertySignature(declaration))
           ts.forEachChild(declaration, child => visitProperties(className, name, child));
@@ -108,14 +120,14 @@ async function parseOverrides(filePath, commentForClass, commentForMethod, extra
       const pos = node.getStart(file, false);
       replacers.push({
         pos,
-        text: commentForMethod(className, `${prefix}.${name}`, 0),
+        text: commentForMethod(className, `${prefix}.${name}`, 0, getIndentationAtPos(pos)),
       });
       ts.forEachChild(node, child => visitProperties(className, `${prefix}.${name}`, child));
     } else if (ts.isCallSignatureDeclaration(node)) {
       const pos = node.getStart(file, false);
       replacers.push({
         pos,
-        text: commentForMethod(className, `${prefix}`, 0),
+        text: commentForMethod(className, `${prefix}`, 0, getIndentationAtPos(pos)),
       });
     } else if (ts.isIntersectionTypeNode(node) || ts.isTypeLiteralNode(node)) {
       ts.forEachChild(node, child => visitProperties(className, prefix, child));


### PR DESCRIPTION
When exploring our public types I discovered a formatting error with nested type docstrings. This appears to have become an issue when the new `step` APIs were added.