### PR TITLE
chore(dotnet): remove nullable compiler directives

### DIFF
--- a/utils/doclint/templates/interface.cs
+++ b/utils/doclint/templates/interface.cs
@@ -35,10 +35,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.Playwright;
 
 [CONTENT]
-
-#nullable disable


### PR DESCRIPTION
In .NET we used to enable nullable per file - as part of https://github.com/microsoft/playwright-dotnet/issues/3163 we'll enable it globally in the `Microsoft.Playwright` project (.NET recommendation). From the consumer point of view there is no difference.

Relates https://github.com/microsoft/playwright-dotnet/issues/3163