### PR TITLE
chore: beautify install --list output

### DIFF
--- a/packages/playwright-core/src/server/index.ts
+++ b/packages/playwright-core/src/server/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export type { Executable } from './registry';
+export type {  BrowserInfo, Executable } from './registry';
 export {
   Registry,
   installBrowsersForNpmInstall,

--- a/tests/installation/playwright-cli-install-should-work.spec.ts
+++ b/tests/installation/playwright-cli-install-should-work.spec.ts
@@ -38,16 +38,13 @@ test('install command should work', async ({ exec, checkInstalledSoftwareOnDisk 
 
   await test.step('playwright install --list', async () => {
     const result = await exec('npx playwright install --list');
-    const listed = new Set();
-    const regex = /Browser:\s+([\w-]+)/g;
-    let match;
-    while ((match = regex.exec(result)) !== null)
-      listed.add(match[1]);
-
-    const expected = ['android', 'chromium', 'ffmpeg', 'firefox', 'webkit'];
-    expected.forEach(browser => {
-      expect(listed.has(browser)).toBe(true);
-    });
+    console.log('result', result);
+    expect.soft(result).toMatch(/Playwright version: \d+\.\d+/);
+    expect.soft(result).toMatch(/chromium-\d+/);
+    expect.soft(result).toMatch(/chromium_headless_shell-\d+/);
+    expect.soft(result).toMatch(/ffmpeg-\d+/);
+    expect.soft(result).toMatch(/firefox-\d+/);
+    expect.soft(result).toMatch(/webkit-\d+/);
   });
 
   await exec('node sanity.js playwright', { env: { PLAYWRIGHT_BROWSERS_PATH: '0' } });


### PR DESCRIPTION
New output formatting:

```

Playwright version: 1.38.0
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1080
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1424
    /Users/yurys/Library/Caches/ms-playwright/webkit-1908
  References:
    /Users/yurys/sandbox/list/node_modules/playwright-core

Playwright version: 1.38.1
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1080
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1424
    /Users/yurys/Library/Caches/ms-playwright/webkit-1908
  References:
    /Users/yurys/sandbox/pwcr/node_modules/playwright-core
    /Users/yurys/sandbox/visual-pw/node_modules/playwright-core

Playwright version: 1.40.1
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1091
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1429
    /Users/yurys/Library/Caches/ms-playwright/webkit-1944
  References:
    /Users/yurys/sandbox/pwct/node_modules/playwright-core

Playwright version: 1.41.0
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1097
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1438
    /Users/yurys/Library/Caches/ms-playwright/webkit-1967
  References:
    /Users/yurys/sandbox/pw-bug/node_modules/playwright-core

Playwright version: 1.41.0-beta-1705101589000
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1097
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1438
    /Users/yurys/Library/Caches/ms-playwright/webkit-1967
  References:
    /Users/yurys/Library/Python/3.9/lib/python/site-packages/playwright/driver/package

Playwright version: 1.41.2
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1097
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1438
    /Users/yurys/Library/Caches/ms-playwright/webkit-1967
  References:
    /Users/yurys/sandbox/template-proj/node_modules/playwright-core

Playwright version: 1.44.0
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1117
    /Users/yurys/Library/Caches/ms-playwright/chromium_tip_of_tree-1215
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1449
    /Users/yurys/Library/Caches/ms-playwright/webkit-2003
  References:
    /Users/yurys/sandbox/aaa/node_modules/playwright-core
    /Users/yurys/sandbox/browser-fixture-override-bug/node_modules/playwright-core
    /Users/yurys/sandbox/no-run/node_modules/playwright-core

Playwright version: 1.44.1
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1117
    /Users/yurys/Library/Caches/ms-playwright/chromium_tip_of_tree-1215
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1449
    /Users/yurys/Library/Caches/ms-playwright/webkit-2003
  References:
    /Users/yurys/sandbox/bug-31314/node_modules/playwright-core

Playwright version: 1.45.0-alpha-2024-06-11
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1122
    /Users/yurys/Library/Caches/ms-playwright/chromium_tip_of_tree-1229
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1453
    /Users/yurys/Library/Caches/ms-playwright/webkit-2022
  References:
    /Users/yurys/sandbox/http2error/node_modules/playwright-core

Playwright version: 1.45.1
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1124
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1454
    /Users/yurys/Library/Caches/ms-playwright/webkit-2035
  References:
    /Users/yurys/sandbox/bug-31620/node_modules/playwright-core

Playwright version: 1.46.0
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1129
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1458
    /Users/yurys/Library/Caches/ms-playwright/webkit-2051
  References:
    /Users/yurys/sandbox/playwright-webkit-mobile-scroll-to-click/node_modules/playwright-core
    /Users/yurys/sandbox/vspw/ttt/nested/node_modules/playwright-core

Playwright version: 1.46.1
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1129
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1009
    /Users/yurys/Library/Caches/ms-playwright/firefox-1458
    /Users/yurys/Library/Caches/ms-playwright/webkit-2051
  References:
    /Users/yurys/sandbox/foo/node_modules/playwright-core

Playwright version: 1.47.0
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1134
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1010
    /Users/yurys/Library/Caches/ms-playwright/firefox-1463
    /Users/yurys/Library/Caches/ms-playwright/webkit-2070
  References:
    /Users/yurys/sandbox/examples/node_modules/playwright-core

Playwright version: 1.47.2
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1134
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1010
    /Users/yurys/Library/Caches/ms-playwright/firefox-1463
    /Users/yurys/Library/Caches/ms-playwright/webkit-2070
  References:
    /Users/yurys/sandbox/compo/node_modules/playwright-core

Playwright version: 1.49.1
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1148
    /Users/yurys/Library/Caches/ms-playwright/chromium_headless_shell-1148
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1010
    /Users/yurys/Library/Caches/ms-playwright/firefox-1466
    /Users/yurys/Library/Caches/ms-playwright/webkit-2104
  References:
    /Users/yurys/create-playwright/test-results/integration-should-generat-a0f4e-ct-in-the-current-directory-yarn/node_modules/playwright-core
    /Users/yurys/sandbox/ct-react17/node_modules/playwright-core
    /Users/yurys/sandbox/playwright-issue-34320/node_modules/playwright-core

Playwright version: 1.50.1
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1155
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1011
    /Users/yurys/Library/Caches/ms-playwright/firefox-1471
    /Users/yurys/Library/Caches/ms-playwright/webkit-2123
  References:
    /Users/yurys/sandbox/xx/node_modules/playwright-core

Playwright version: 1.50.1-beta-1738589118000
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1155
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1011
    /Users/yurys/Library/Caches/ms-playwright/firefox-1471
    /Users/yurys/Library/Caches/ms-playwright/webkit-2123
  References:
    /Users/yurys/sandbox/pwpython/env/lib/python3.9/site-packages/playwright/driver/package

Playwright version: 1.51.0
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium_headless_shell-1161
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1011
    /Users/yurys/Library/Caches/ms-playwright/firefox-1475
    /Users/yurys/Library/Caches/ms-playwright/webkit-2140
  References:
    /Users/yurys/sandbox/bug-35078/node_modules/playwright-core
    /Users/yurys/sandbox/mre-bundle-playwright-with-esbuild/with-1.51.0/node_modules/playwright-core

Playwright version: 1.51.1
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium_headless_shell-1161
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1011
    /Users/yurys/Library/Caches/ms-playwright/firefox-1475
    /Users/yurys/Library/Caches/ms-playwright/webkit-2140
  References:
    /Users/yurys/.npm/_npx/e41f203b7505f1fb/node_modules/playwright-core
    /Users/yurys/sandbox/arcgis-web-components/node_modules/.pnpm/playwright-core@1.51.1/node_modules/playwright-core
    /Users/yurys/sandbox/bug-35554/node_modules/playwright-core
    /Users/yurys/sandbox/bug-35582/node_modules/playwright-core
    /Users/yurys/sandbox/etsy/node_modules/playwright-core
    /Users/yurys/sandbox/parent/demo/node_modules/playwright-core
    /Users/yurys/sandbox/ppp/node_modules/playwright-core
    /Users/yurys/sandbox/pw-mcp-3p/node_modules/playwright-core
    /Users/yurys/sandbox/shopify/node_modules/playwright-core

Playwright version: 1.52.0
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1169
    /Users/yurys/Library/Caches/ms-playwright/chromium_headless_shell-1169
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1011
    /Users/yurys/Library/Caches/ms-playwright/firefox-1482
    /Users/yurys/Library/Caches/ms-playwright/webkit-2158
  References:
    /Users/yurys/sandbox/pwtest/node_modules/playwright-core

Playwright version: 1.53.0-alpha-1746832516000
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1172
    /Users/yurys/Library/Caches/ms-playwright/chromium_headless_shell-1172
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1011
    /Users/yurys/Library/Caches/ms-playwright/firefox-1483
    /Users/yurys/Library/Caches/ms-playwright/webkit-2169
  References:
    /Users/yurys/.npm/_npx/9833c18b2d85bc59/node_modules/playwright-core

Playwright version: 1.53.0-next
  Browsers:
    /Users/yurys/Library/Caches/ms-playwright/chromium-1177
    /Users/yurys/Library/Caches/ms-playwright/chromium_headless_shell-1177
    /Users/yurys/Library/Caches/ms-playwright/ffmpeg-1011
    /Users/yurys/Library/Caches/ms-playwright/firefox-1487
    /Users/yurys/Library/Caches/ms-playwright/firefox_beta-1482
    /Users/yurys/Library/Caches/ms-playwright/webkit-2178
  References:
    /Users/yurys/playwright/packages/playwright-core

```
Fixes https://github.com/microsoft/playwright/issues/34183