### PR TITLE
Export type of describe configuration options

### DIFF
--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -23,7 +23,7 @@ import { expect } from '../matchers/expect';
 import { wrapFunctionWithLocation } from '../transform/transform';
 
 import type { FixturesWithLocation } from './config';
-import type { Fixtures, TestDetails, TestStepInfo, TestType } from '../../types/test';
+import type { DescribeConfigureOptions, Fixtures, TestDetails, TestStepInfo, TestType } from '../../types/test';
 import type { Location } from '../../types/testReporter';
 
 const testTypeSymbol = Symbol('testType');
@@ -182,7 +182,7 @@ export class TestTypeImpl {
     suite._hooks.push({ type: name, fn: fn!, title, location });
   }
 
-  private _configure(location: Location, options: { mode?: 'default' | 'parallel' | 'serial', retries?: number, timeout?: number }) {
+  private _configure(location: Location, options: DescribeConfigureOptions) {
     throwIfRunningInsideJest();
     const suite = this._currentSuite(location, `test.describe.configure()`);
     if (!suite)

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -2584,6 +2584,11 @@ export type TestDetails = {
 
 type TestBody<TestArgs> = (args: TestArgs, testInfo: TestInfo) => Promise<void> | void;
 type ConditionBody<TestArgs> = (args: TestArgs) => boolean;
+export type DescribeConfigureOptions = {
+  mode?: 'default' | 'parallel' | 'serial',
+  retries?: number,
+  timeout?: number
+};
 
 /**
  * Playwright Test provides a `test` function to declare tests and `expect` function to write assertions.
@@ -4118,7 +4123,7 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
      *
      * @param options
      */
-    configure: (options: { mode?: 'default' | 'parallel' | 'serial', retries?: number, timeout?: number }) => void;
+    configure: (options: DescribeConfigureOptions) => void;
   };
 
   /**

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -90,6 +90,11 @@ export type TestDetails = {
 
 type TestBody<TestArgs> = (args: TestArgs, testInfo: TestInfo) => Promise<void> | void;
 type ConditionBody<TestArgs> = (args: TestArgs) => boolean;
+export type DescribeConfigureOptions = {
+  mode?: 'default' | 'parallel' | 'serial',
+  retries?: number,
+  timeout?: number
+};
 
 export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
   (title: string, body: TestBody<TestArgs & WorkerArgs>): void;
@@ -135,7 +140,7 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
       only(title: string, details: TestDetails, callback: () => void): void;
     };
 
-    configure: (options: { mode?: 'default' | 'parallel' | 'serial', retries?: number, timeout?: number }) => void;
+    configure: (options: DescribeConfigureOptions) => void;
   };
 
   skip(title: string, body: TestBody<TestArgs & WorkerArgs>): void;


### PR DESCRIPTION
#36146 

This pull request introduces changes to the `packages/playwright/src/common/testType.ts` file to enhance type definitions and simplify the configuration logic in the `TestTypeImpl` class. The most important changes include the addition of a new type, `DescribeConfigureOptions`, and its integration into the `_configure`  #method.

### Type Definition Enhancements:
* [`packages/playwright/src/common/testType.ts`](diffhunk://#diff-edb4c598486b343b637139cec102da570417c68f56549f09db811765922c7b4dL26-R26): Added `DescribeConfigureOptions` to the imported types from `../../types/test`. This improves type clarity and ensures better handling of configuration options in `test.describe.configure()`.

### Configuration Logic Simplification:
* [`packages/playwright/src/common/testType.ts`](diffhunk://#diff-edb4c598486b343b637139cec102da570417c68f56549f09db811765922c7b4dL185-R185): Updated the `_configure` method in the `TestTypeImpl` class to use the new `DescribeConfigureOptions` type, replacing the inline object definition for configuration options. This simplifies the method signature and makes the code more maintainable.
