### PR TITLE
chore: remove browser.on('context') event

### DIFF
--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -72,12 +72,6 @@ await page.GotoAsync("https://www.bing.com");
 await browser.CloseAsync();
 ```
 
-## event: Browser.context
-* since: v1.53
-- argument: <[BrowserContext]>
-
-Emitted when a new [BrowserContext] is created in the browser.
-
 ## event: Browser.disconnected
 * since: v1.8
 - argument: <[Browser]>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -9551,12 +9551,6 @@ export interface Browser {
     behavior?: 'wait'|'ignoreErrors'|'default'
   }): Promise<void>;
   /**
-   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
-   * browser.
-   */
-  on(event: 'context', listener: (browserContext: BrowserContext) => any): this;
-
-  /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
    * following:
    * - Browser application is closed or crashed.
@@ -9567,18 +9561,7 @@ export interface Browser {
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
-  once(event: 'context', listener: (browserContext: BrowserContext) => any): this;
-
-  /**
-   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
-   */
   once(event: 'disconnected', listener: (browser: Browser) => any): this;
-
-  /**
-   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
-   * browser.
-   */
-  addListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
@@ -9591,28 +9574,12 @@ export interface Browser {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
-  removeListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
   removeListener(event: 'disconnected', listener: (browser: Browser) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
-  off(event: 'context', listener: (browserContext: BrowserContext) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
   off(event: 'disconnected', listener: (browser: Browser) => any): this;
-
-  /**
-   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
-   * browser.
-   */
-  prependListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the

--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -108,7 +108,6 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
     // and will be configured later in `_connectToBrowserType`.
     if (this._browserType)
       this._setupBrowserContext(context);
-    this.emit(Events.Browser.Context, context);
   }
 
   private _setupBrowserContext(context: BrowserContext) {

--- a/packages/playwright-core/src/client/events.ts
+++ b/packages/playwright-core/src/client/events.ts
@@ -31,7 +31,6 @@ export const Events = {
   },
 
   Browser: {
-    Context: 'context',
     Disconnected: 'disconnected'
   },
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9551,12 +9551,6 @@ export interface Browser {
     behavior?: 'wait'|'ignoreErrors'|'default'
   }): Promise<void>;
   /**
-   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
-   * browser.
-   */
-  on(event: 'context', listener: (browserContext: BrowserContext) => any): this;
-
-  /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
    * following:
    * - Browser application is closed or crashed.
@@ -9567,18 +9561,7 @@ export interface Browser {
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
-  once(event: 'context', listener: (browserContext: BrowserContext) => any): this;
-
-  /**
-   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
-   */
   once(event: 'disconnected', listener: (browser: Browser) => any): this;
-
-  /**
-   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
-   * browser.
-   */
-  addListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
@@ -9591,28 +9574,12 @@ export interface Browser {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
-  removeListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
   removeListener(event: 'disconnected', listener: (browser: Browser) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
-  off(event: 'context', listener: (browserContext: BrowserContext) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
   off(event: 'disconnected', listener: (browser: Browser) => any): this;
-
-  /**
-   * Emitted when a new [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) is created in the
-   * browser.
-   */
-  prependListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the

--- a/tests/library/browsercontext-basic.spec.ts
+++ b/tests/library/browsercontext-basic.spec.ts
@@ -22,14 +22,10 @@ import type { Page } from '@playwright/test';
 
 it('should create new context @smoke', async function({ browser }) {
   expect(browser.contexts().length).toBe(0);
-  let contextFromEvent;
-  browser.on('context', context => contextFromEvent = context);
   const context = await browser.newContext();
-  expect(contextFromEvent).toBe(context);
   expect(browser.contexts()).toEqual([context]);
   expect(browser).toBe(context.browser());
   const context2 = await browser.newContext();
-  expect(contextFromEvent).toBe(context2);
   expect(browser.contexts()).toEqual([context, context2]);
   await context.close();
   expect(browser.contexts()).toEqual([context2]);

--- a/tests/library/multiclient.spec.ts
+++ b/tests/library/multiclient.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { expect, playwrightTest } from '../config/browserTest';
-import type { Browser, BrowserContext, BrowserServer, ConnectOptions, Page } from 'playwright-core';
+import type { Browser, BrowserServer, ConnectOptions, Page } from 'playwright-core';
 
 type ExtraFixtures = {
   remoteServer: BrowserServer;
@@ -72,10 +72,10 @@ test('should connect two clients', async ({ connect, remoteServer, server }) => 
   const pageB1 = contextB1.pages()[0];
   await expect(pageB1).toHaveURL(server.EMPTY_PAGE);
 
-  const contextEventPromise = new Promise<BrowserContext>(f => browserA.on('context', f));
   const contextB2 = await browserB.newContext({ baseURL: server.PREFIX });
   expect(browserB.contexts()).toEqual([contextB1, contextB2]);
-  const contextA2 = await contextEventPromise;
+  await expect.poll(() => browserA.contexts().length).toBe(2);
+  const contextA2 = browserA.contexts()[1];
   expect(browserA.contexts()).toEqual([contextA1, contextA2]);
 
   const pageEventPromise = new Promise<Page>(f => contextB2.on('page', f));


### PR DESCRIPTION
Synchronous event promotes error-prone patterns.