### PR TITLE
chore: make sure dispatchers work with SdkObjects

### DIFF
--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -59,7 +59,6 @@ export interface DeviceBackend {
 }
 
 export interface SocketBackend extends EventEmitter {
-  guid: string;
   write(data: Buffer): Promise<void>;
   close(): void;
 }

--- a/packages/playwright-core/src/server/android/backendAdb.ts
+++ b/packages/playwright-core/src/server/android/backendAdb.ts
@@ -18,7 +18,6 @@ import { EventEmitter } from 'events';
 import net from 'net';
 
 import { assert } from '../../utils/isomorphic/assert';
-import { createGuid } from '../utils/crypto';
 import { debug } from '../../utilsBundle';
 
 import type { Backend, DeviceBackend, SocketBackend } from './android';
@@ -117,7 +116,6 @@ function encodeMessage(message: string): Buffer {
 }
 
 class BufferedSocketWrapper extends EventEmitter implements SocketBackend {
-  readonly guid = createGuid();
   private _socket: net.Socket;
   private _buffer = Buffer.from([]);
   private _isSocket = false;

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -56,6 +56,7 @@ export abstract class BrowserType extends SdkObject {
     super(parent, 'browser-type');
     this.attribution.browserType = this;
     this._name = browserName;
+    this.logName = 'browser';
   }
 
   executablePath(): string {
@@ -69,7 +70,6 @@ export abstract class BrowserType extends SdkObject {
   async launch(metadata: CallMetadata, options: types.LaunchOptions, protocolLogger?: types.ProtocolLogger): Promise<Browser> {
     options = this._validateLaunchOptions(options);
     const controller = new ProgressController(metadata, this);
-    controller.setLogName('browser');
     const browser = await controller.run(progress => {
       const seleniumHubUrl = (options as any).__testHookSeleniumRemoteURL || process.env.SELENIUM_REMOTE_URL;
       if (seleniumHubUrl)
@@ -82,7 +82,6 @@ export abstract class BrowserType extends SdkObject {
   async launchPersistentContext(metadata: CallMetadata, userDataDir: string, options: channels.BrowserTypeLaunchPersistentContextOptions & { timeout: number, cdpPort?: number, internalIgnoreHTTPSErrors?: boolean }): Promise<BrowserContext> {
     const launchOptions = this._validateLaunchOptions(options);
     const controller = new ProgressController(metadata, this);
-    controller.setLogName('browser');
     const browser = await controller.run(async progress => {
       // Note: Any initial TLS requests will fail since we rely on the Page/Frames initialize which sets ignoreHTTPSErrors.
       let clientCertificatesProxy: ClientCertificatesProxy | undefined;

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -64,7 +64,6 @@ export class Chromium extends BrowserType {
 
   override async connectOverCDP(metadata: CallMetadata, endpointURL: string, options: { slowMo?: number, headers?: types.HeadersArray, timeout: number }) {
     const controller = new ProgressController(metadata, this);
-    controller.setLogName('browser');
     return controller.run(async progress => {
       return await this._connectOverCDPInternal(progress, endpointURL, options);
     }, options.timeout);

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -58,7 +58,7 @@ export class CRBrowser extends Browser {
   static async connect(parent: SdkObject, transport: ConnectionTransport, options: BrowserOptions, devtools?: CRDevTools): Promise<CRBrowser> {
     // Make a copy in case we need to update `headful` property below.
     options = { ...options };
-    const connection = new CRConnection(transport, options.protocolLogger, options.browserLogsCollector);
+    const connection = new CRConnection(parent, transport, options.protocolLogger, options.browserLogsCollector);
     const browser = new CRBrowser(parent, connection, options);
     browser._devtools = devtools;
     if (browser.isClank())

--- a/packages/playwright-core/src/server/dispatchers/jsonPipeDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/jsonPipeDispatcher.ts
@@ -15,15 +15,15 @@
  */
 
 import { Dispatcher } from './dispatcher';
-import { createGuid } from '../utils/crypto';
+import { SdkObject } from '../instrumentation';
 
 import type { LocalUtilsDispatcher } from './localUtilsDispatcher';
 import type * as channels from '@protocol/channels';
 
-export class JsonPipeDispatcher extends Dispatcher<{ guid: string }, channels.JsonPipeChannel, LocalUtilsDispatcher> implements channels.JsonPipeChannel {
+export class JsonPipeDispatcher extends Dispatcher<SdkObject, channels.JsonPipeChannel, LocalUtilsDispatcher> implements channels.JsonPipeChannel {
   _type_JsonPipe = true;
   constructor(scope: LocalUtilsDispatcher) {
-    super(scope, { guid: 'jsonPipe@' + createGuid() }, 'JsonPipe', {});
+    super(scope, new SdkObject(scope._object, 'jsonPipe'), 'JsonPipe', {});
   }
 
   async send(params: channels.JsonPipeSendParams): Promise<channels.JsonPipeSendResult> {

--- a/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
@@ -34,13 +34,14 @@ import type * as channels from '@protocol/channels';
 import type * as http from 'http';
 import type { HTTPRequestParams } from '../utils/network';
 
-export class LocalUtilsDispatcher extends Dispatcher<{ guid: string }, channels.LocalUtilsChannel, RootDispatcher> implements channels.LocalUtilsChannel {
+export class LocalUtilsDispatcher extends Dispatcher<SdkObject, channels.LocalUtilsChannel, RootDispatcher> implements channels.LocalUtilsChannel {
   _type_LocalUtils: boolean;
   private _harBackends = new Map<string, HarBackend>();
   private _stackSessions = new Map<string, localUtils.StackSession>();
 
   constructor(scope: RootDispatcher, playwright: Playwright) {
     const localUtils = new SdkObject(playwright, 'localUtils', 'localUtils');
+    localUtils.logName = 'browser';
     const deviceDescriptors = Object.entries(descriptors)
         .map(([name, descriptor]) => ({ name, descriptor }));
     super(scope, localUtils, 'LocalUtils', {
@@ -82,8 +83,7 @@ export class LocalUtilsDispatcher extends Dispatcher<{ guid: string }, channels.
   }
 
   async connect(params: channels.LocalUtilsConnectParams, metadata: CallMetadata): Promise<channels.LocalUtilsConnectResult> {
-    const controller = new ProgressController(metadata, this._object as SdkObject);
-    controller.setLogName('browser');
+    const controller = new ProgressController(metadata, this._object);
     return await controller.run(async progress => {
       const wsHeaders = {
         'User-Agent': getUserAgent(),

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -25,7 +25,7 @@ import { RequestDispatcher } from './networkDispatchers';
 import { ResponseDispatcher } from './networkDispatchers';
 import { RouteDispatcher, WebSocketDispatcher } from './networkDispatchers';
 import { WebSocketRouteDispatcher } from './webSocketRouteDispatcher';
-import { createGuid } from '../utils/crypto';
+import { SdkObject } from '../instrumentation';
 import { urlMatches } from '../../utils/isomorphic/urlMatch';
 
 import type { Artifact } from '../artifact';
@@ -403,7 +403,7 @@ export class WorkerDispatcher extends Dispatcher<Worker, channels.WorkerChannel,
   }
 }
 
-export class BindingCallDispatcher extends Dispatcher<{ guid: string }, channels.BindingCallChannel, PageDispatcher | BrowserContextDispatcher> implements channels.BindingCallChannel {
+export class BindingCallDispatcher extends Dispatcher<SdkObject, channels.BindingCallChannel, PageDispatcher | BrowserContextDispatcher> implements channels.BindingCallChannel {
   _type_BindingCall = true;
   private _resolve: ((arg: any) => void) | undefined;
   private _reject: ((error: any) => void) | undefined;
@@ -411,7 +411,7 @@ export class BindingCallDispatcher extends Dispatcher<{ guid: string }, channels
 
   constructor(scope: PageDispatcher, name: string, needsHandle: boolean, source: { context: BrowserContext, page: Page, frame: Frame }, args: any[]) {
     const frameDispatcher = FrameDispatcher.from(scope.parentScope(), source.frame);
-    super(scope, { guid: 'bindingCall@' + createGuid() }, 'BindingCall', {
+    super(scope, new SdkObject(scope._object, 'bindingCall'), 'BindingCall', {
       frame: frameDispatcher,
       name,
       args: needsHandle ? undefined : args.map(serializeResult),

--- a/packages/playwright-core/src/server/dispatchers/playwrightDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/playwrightDispatcher.ts
@@ -24,7 +24,7 @@ import { Dispatcher } from './dispatcher';
 import { ElectronDispatcher } from './electronDispatcher';
 import { LocalUtilsDispatcher } from './localUtilsDispatcher';
 import { APIRequestContextDispatcher } from './networkDispatchers';
-import { createGuid } from '../utils/crypto';
+import { SdkObject } from '../instrumentation';
 import { eventsHelper  } from '../utils/eventsHelper';
 
 import type { RootDispatcher } from './dispatcher';
@@ -62,7 +62,7 @@ export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.Playwr
       android,
       electron: new ElectronDispatcher(scope, playwright.electron),
       utils: playwright.options.isServer ? undefined : new LocalUtilsDispatcher(scope, playwright),
-      socksSupport: options.socksProxy ? new SocksSupportDispatcher(scope, options.socksProxy) : undefined,
+      socksSupport: options.socksProxy ? new SocksSupportDispatcher(scope, playwright, options.socksProxy) : undefined,
     };
 
     let browserDispatcher: BrowserDispatcher | undefined;
@@ -101,13 +101,13 @@ export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.Playwr
   }
 }
 
-class SocksSupportDispatcher extends Dispatcher<{ guid: string }, channels.SocksSupportChannel, RootDispatcher> implements channels.SocksSupportChannel {
+class SocksSupportDispatcher extends Dispatcher<SdkObject, channels.SocksSupportChannel, RootDispatcher> implements channels.SocksSupportChannel {
   _type_SocksSupport: boolean;
   private _socksProxy: SocksProxy;
   private _socksListeners: RegisteredListener[];
 
-  constructor(scope: RootDispatcher, socksProxy: SocksProxy) {
-    super(scope, { guid: 'socksSupport@' + createGuid() }, 'SocksSupport', {});
+  constructor(scope: RootDispatcher, parent: SdkObject, socksProxy: SocksProxy) {
+    super(scope, new SdkObject(parent, 'socksSupport'), 'SocksSupport', {});
     this._type_SocksSupport = true;
     this._socksProxy = socksProxy;
     this._socksListeners = [

--- a/packages/playwright-core/src/server/dispatchers/streamDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/streamDispatcher.ts
@@ -16,18 +16,27 @@
 
 import { Dispatcher } from './dispatcher';
 import { ManualPromise } from '../../utils/isomorphic/manualPromise';
-import { createGuid } from '../utils/crypto';
+import { SdkObject } from '../instrumentation';
 
 import type { ArtifactDispatcher } from './artifactDispatcher';
 import type * as channels from '@protocol/channels';
 import type * as stream from 'stream';
 
-export class StreamDispatcher extends Dispatcher<{ guid: string, stream: stream.Readable }, channels.StreamChannel, ArtifactDispatcher> implements channels.StreamChannel {
+class StreamSdkObject extends SdkObject {
+  readonly stream: stream.Readable;
+
+  constructor(parent: SdkObject, stream: stream.Readable) {
+    super(parent, 'stream');
+    this.stream = stream;
+  }
+}
+
+export class StreamDispatcher extends Dispatcher<StreamSdkObject, channels.StreamChannel, ArtifactDispatcher> implements channels.StreamChannel {
   _type_Stream = true;
   private _ended: boolean = false;
 
   constructor(scope: ArtifactDispatcher, stream: stream.Readable) {
-    super(scope, { guid: 'stream@' + createGuid(), stream }, 'Stream', {});
+    super(scope, new StreamSdkObject(scope._object, stream), 'Stream', {});
     // In Node v12.9.0+ we can use readableEnded.
     stream.once('end', () => this._ended =  true);
     stream.once('error', () => this._ended =  true);

--- a/packages/playwright-core/src/server/dispatchers/webSocketRouteDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/webSocketRouteDispatcher.ts
@@ -18,7 +18,7 @@ import { Page } from '../page';
 import { Dispatcher } from './dispatcher';
 import { PageDispatcher } from './pageDispatcher';
 import * as rawWebSocketMockSource from '../../generated/webSocketMockSource';
-import { createGuid } from '../utils/crypto';
+import { SdkObject } from '../instrumentation';
 import { urlMatches } from '../../utils/isomorphic/urlMatch';
 import { eventsHelper } from '../utils/eventsHelper';
 
@@ -29,14 +29,14 @@ import type { Frame } from '../frames';
 import type * as ws from '@injected/webSocketMock';
 import type * as channels from '@protocol/channels';
 
-export class WebSocketRouteDispatcher extends Dispatcher<{ guid: string }, channels.WebSocketRouteChannel, PageDispatcher | BrowserContextDispatcher> implements channels.WebSocketRouteChannel {
+export class WebSocketRouteDispatcher extends Dispatcher<SdkObject, channels.WebSocketRouteChannel, PageDispatcher | BrowserContextDispatcher> implements channels.WebSocketRouteChannel {
   _type_WebSocketRoute = true;
   private _id: string;
   private _frame: Frame;
   private static _idToDispatcher = new Map<string, WebSocketRouteDispatcher>();
 
   constructor(scope: PageDispatcher | BrowserContextDispatcher, id: string, url: string, frame: Frame) {
-    super(scope, { guid: 'webSocketRoute@' + createGuid() }, 'WebSocketRoute', { url });
+    super(scope, new SdkObject(scope._object, 'webSocketRoute'), 'WebSocketRoute', { url });
     this._id = id;
     this._frame = frame;
     this._eventListeners.push(

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -250,7 +250,7 @@ export class Electron extends SdkObject {
 
       const nodeMatch = await nodeMatchPromise;
       const nodeTransport = await WebSocketTransport.connect(progress, nodeMatch[1]);
-      const nodeConnection = new CRConnection(nodeTransport, helper.debugProtocolLogger(), browserLogsCollector);
+      const nodeConnection = new CRConnection(this, nodeTransport, helper.debugProtocolLogger(), browserLogsCollector);
 
       // Immediately release exiting process under debug.
       debuggerDisconnectPromise.then(() => {

--- a/packages/playwright-core/src/server/instrumentation.ts
+++ b/packages/playwright-core/src/server/instrumentation.ts
@@ -29,6 +29,7 @@ import type { Page } from './page';
 import type { Playwright } from './playwright';
 import type { CallMetadata } from '@protocol/callMetadata';
 export type { CallMetadata } from '@protocol/callMetadata';
+import type { LogName } from './utils/debugLogger';
 
 export type Attribution = {
   playwright: Playwright;
@@ -43,6 +44,7 @@ export class SdkObject extends EventEmitter {
   guid: string;
   attribution: Attribution;
   instrumentation: Instrumentation;
+  logName?: LogName;
 
   constructor(parent: SdkObject, guidPrefix?: string, guid?: string) {
     super();
@@ -51,6 +53,13 @@ export class SdkObject extends EventEmitter {
     this.attribution = { ...parent.attribution };
     this.instrumentation = parent.instrumentation;
   }
+}
+
+export function createRootSdkObject() {
+  const fakeParent = { attribution: {}, instrumentation: createInstrumentation() };
+  const root = new SdkObject(fakeParent as any);
+  root.guid = '';
+  return root;
 }
 
 export interface Instrumentation {

--- a/packages/playwright-core/src/server/playwright.ts
+++ b/packages/playwright-core/src/server/playwright.ts
@@ -23,7 +23,7 @@ import { Chromium } from './chromium/chromium';
 import { DebugController } from './debugController';
 import { Electron } from './electron/electron';
 import { Firefox } from './firefox/firefox';
-import { SdkObject, createInstrumentation } from './instrumentation';
+import { SdkObject, createRootSdkObject } from './instrumentation';
 import { WebKit } from './webkit/webkit';
 
 import type { BrowserType } from './browserType';
@@ -53,7 +53,7 @@ export class Playwright extends SdkObject {
   private _allBrowsers = new Set<Browser>();
 
   constructor(options: PlaywrightOptions) {
-    super({ attribution: {}, instrumentation: createInstrumentation() } as any, undefined, 'Playwright');
+    super(createRootSdkObject(), undefined, 'Playwright');
     this.options = options;
     this.attribution.playwright = this;
     this.instrumentation.addListener({

--- a/packages/playwright-core/src/server/progress.ts
+++ b/packages/playwright-core/src/server/progress.ts
@@ -36,7 +36,7 @@ export class ProgressController {
   // Cleanups to be run only in the case of abort.
   private _cleanups: (() => any)[] = [];
 
-  private _logName = 'api';
+  private _logName: LogName;
   private _state: 'before' | 'running' | 'aborted' | 'finished' = 'before';
   private _deadline: number = 0;
   private _timeout: number = 0;
@@ -48,6 +48,7 @@ export class ProgressController {
     this.metadata = metadata;
     this.sdkObject = sdkObject;
     this.instrumentation = sdkObject.instrumentation;
+    this._logName = sdkObject.logName || 'api';
     this._forceAbortPromise.catch(e => null);  // Prevent unhandled promise rejection.
   }
 


### PR DESCRIPTION
The codebase was 90% there, but there were a few instances that were not an SdkObject.