### PR TITLE
test: re-generate SSL ticket keys for HTTPS server on TestServer reset

### DIFF
--- a/tests/config/testserver/index.ts
+++ b/tests/config/testserver/index.ts
@@ -18,6 +18,8 @@
 import fs from 'fs';
 import type http from 'http';
 import mime from 'mime';
+import https from 'node:https';
+import crypto from 'node:crypto';
 import type net from 'net';
 import path from 'path';
 import url from 'url';
@@ -202,6 +204,8 @@ export class TestServer {
     for (const subscriber of this._requestSubscribers.values())
       subscriber[rejectSymbol].call(null, error);
     this._requestSubscribers.clear();
+    if (this._server instanceof https.Server)
+      this._server.setTicketKeys(crypto.randomBytes(48));
   }
 
   _onRequest(request: http.IncomingMessage, response: http.ServerResponse) {


### PR DESCRIPTION
### TLS Session Resumption Issue in Test Server

**Problem**

Our test server was experiencing TLS session resumption between different test cases, causing certificate validation tests to behave inconsistently. When testing both "ignore certificates" and "enforce certificates" scenarios against the same HTTPS server, the second request would reuse the TLS session from the first request, bypassing certificate validation entirely.

**Root Cause**

TLS session resumption is a performance optimization that allows clients to skip the full TLS handshake (including certificate validation) on subsequent connections. The libsoup client was caching session tickets and reusing them between our test cases, making our certificate validation tests unreliable.

**Solution Applied**

We added TLS session invalidation to our test server's reset method:

```ts
if (this._server instanceof https.Server)
  this._server.setTicketKeys(crypto.randomBytes(48));
```

This approach generates new session ticket encryption keys, effectively invalidating all existing client-side session tickets and forcing fresh TLS handshakes.

### Alternative Solutions

**Server-side approaches:**

1. `SSL_OP_NO_TICKET` flag - Disable session tickets entirely in server options:

2. **Dynamic session context** - Change session ID context per test:

3. **Port rotation** - Use different ports for each test case to guarantee new connections

**Client-side approaches**:

1. **Session timeout** - Configure libsoup with idle-timeout: 0
2. **New session per test** - Create fresh SoupSession instances
3. **Connection pooling disabled** - Force new connections for each request

### Why This Matters

This fix ensures our certificate validation tests accurately reflect real-world behavior and don't give false positives due to session reuse. Each test case now performs proper certificate validation as intended.

Relates https://github.com/microsoft/playwright/issues/35870