### PR TITLE
feat(cookie): export/import chips cookies

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -363,7 +363,7 @@ await context.AddCookiesAsync(new[] { cookie1, cookie2 });
   - `httpOnly` ?<[boolean]> Optional.
   - `secure` ?<[boolean]> Optional.
   - `sameSite` ?<[SameSiteAttribute]<"Strict"|"Lax"|"None">> Optional.
-  - `topLevelSite` ?<[string]> For partitioned third-party cookies (aka [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)), the top level site (scheme and host) used as the partition key. Optional.
+  - `partitionKey` ?<[string]> For partitioned third-party cookies (aka [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)), the partition key. Optional.
 
 ## async method: BrowserContext.addInitScript
 * since: v1.8
@@ -603,10 +603,10 @@ The default browser context cannot be closed.
   - `httpOnly` <[boolean]>
   - `secure` <[boolean]>
   - `sameSite` <[SameSiteAttribute]<"Strict"|"Lax"|"None">>
-  - `topLevelSite` ?<[string]>
+  - `partitionKey` ?<[string]>
 
 If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those URLs
-are returned. Note that cookies are matched based on the URLs regardless of their `topLevelSite` value.
+are returned. Note that cookies are matched based on the URLs regardless of their `partitionKey` value.
 
 ### param: BrowserContext.cookies.urls
 * since: v1.8
@@ -1506,7 +1506,7 @@ Whether to emulate network being offline for the browser context.
     - `httpOnly` <[boolean]>
     - `secure` <[boolean]>
     - `sameSite` <[SameSiteAttribute]<"Strict"|"Lax"|"None">>
-    - `topLevelSite` ?<[string]>
+    - `partitionKey` ?<[string]>
   - `origins` <[Array]<[Object]>>
     - `origin` <[string]>
     - `localStorage` <[Array]<[Object]>>

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -606,7 +606,7 @@ The default browser context cannot be closed.
   - `partitionKey` ?<[string]>
 
 If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those URLs
-are returned. Note that cookies are matched based on the URLs regardless of their `partitionKey` value.
+are returned.
 
 ### param: BrowserContext.cookies.urls
 * since: v1.8

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -363,6 +363,7 @@ await context.AddCookiesAsync(new[] { cookie1, cookie2 });
   - `httpOnly` ?<[boolean]> Optional.
   - `secure` ?<[boolean]> Optional.
   - `sameSite` ?<[SameSiteAttribute]<"Strict"|"Lax"|"None">> Optional.
+  - `topLevelSite` ?<[string]> For partitioned third-party cookies (aka [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)), the top level site (scheme and host) used as the partition key. Optional.
 
 ## async method: BrowserContext.addInitScript
 * since: v1.8
@@ -602,9 +603,10 @@ The default browser context cannot be closed.
   - `httpOnly` <[boolean]>
   - `secure` <[boolean]>
   - `sameSite` <[SameSiteAttribute]<"Strict"|"Lax"|"None">>
+  - `topLevelSite` ?<[string]>
 
 If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those URLs
-are returned.
+are returned. Note that cookies are matched based on the URLs regardless of their `topLevelSite` value.
 
 ### param: BrowserContext.cookies.urls
 * since: v1.8
@@ -1504,6 +1506,7 @@ Whether to emulate network being offline for the browser context.
     - `httpOnly` <[boolean]>
     - `secure` <[boolean]>
     - `sameSite` <[SameSiteAttribute]<"Strict"|"Lax"|"None">>
+    - `topLevelSite` ?<[string]>
   - `origins` <[Array]<[Object]>>
     - `origin` <[string]>
     - `localStorage` <[Array]<[Object]>>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -8833,10 +8833,10 @@ export interface BrowserContext {
 
     /**
      * For partitioned third-party cookies (aka
-     * [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)), the top
-     * level site (scheme and host) used as the partition key. Optional.
+     * [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)), the
+     * partition key. Optional.
      */
-    topLevelSite?: string;
+    partitionKey?: string;
   }>): Promise<void>;
 
   /**
@@ -8915,7 +8915,7 @@ export interface BrowserContext {
 
   /**
    * If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those
-   * URLs are returned. Note that cookies are matched based on the URLs regardless of their `topLevelSite` value.
+   * URLs are returned. Note that cookies are matched based on the URLs regardless of their `partitionKey` value.
    * @param urls Optional list of URLs.
    */
   cookies(urls?: string|ReadonlyArray<string>): Promise<Array<Cookie>>;
@@ -9312,7 +9312,7 @@ export interface BrowserContext {
 
       sameSite: "Strict"|"Lax"|"None";
 
-      topLevelSite?: string;
+      partitionKey?: string;
     }>;
 
     origins: Array<{
@@ -22511,7 +22511,7 @@ export interface Cookie {
 
   sameSite: "Strict"|"Lax"|"None";
 
-  topLevelSite?: string;
+  partitionKey?: string;
 }
 
 interface PageWaitForSelectorOptions {

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -8830,6 +8830,13 @@ export interface BrowserContext {
      * Optional.
      */
     sameSite?: "Strict"|"Lax"|"None";
+
+    /**
+     * For partitioned third-party cookies (aka
+     * [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)), the top
+     * level site (scheme and host) used as the partition key. Optional.
+     */
+    topLevelSite?: string;
   }>): Promise<void>;
 
   /**
@@ -8908,7 +8915,7 @@ export interface BrowserContext {
 
   /**
    * If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those
-   * URLs are returned.
+   * URLs are returned. Note that cookies are matched based on the URLs regardless of their `topLevelSite` value.
    * @param urls Optional list of URLs.
    */
   cookies(urls?: string|ReadonlyArray<string>): Promise<Array<Cookie>>;
@@ -9304,6 +9311,8 @@ export interface BrowserContext {
       secure: boolean;
 
       sameSite: "Strict"|"Lax"|"None";
+
+      topLevelSite?: string;
     }>;
 
     origins: Array<{
@@ -22501,6 +22510,8 @@ export interface Cookie {
   secure: boolean;
 
   sameSite: "Strict"|"Lax"|"None";
+
+  topLevelSite?: string;
 }
 
 interface PageWaitForSelectorOptions {

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -8915,7 +8915,7 @@ export interface BrowserContext {
 
   /**
    * If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those
-   * URLs are returned. Note that cookies are matched based on the URLs regardless of their `partitionKey` value.
+   * URLs are returned.
    * @param urls Optional list of URLs.
    */
   cookies(urls?: string|ReadonlyArray<string>): Promise<Array<Cookie>>;

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -137,7 +137,7 @@ scheme.SetNetworkCookie = tObject({
   secure: tOptional(tBoolean),
   sameSite: tOptional(tEnum(['Strict', 'Lax', 'None'])),
   partitionKey: tOptional(tString),
-  _chromiumHasCrossSiteAncestor: tOptional(tBoolean),
+  _crHasCrossSiteAncestor: tOptional(tBoolean),
 });
 scheme.NetworkCookie = tObject({
   name: tString,
@@ -149,7 +149,7 @@ scheme.NetworkCookie = tObject({
   secure: tBoolean,
   sameSite: tEnum(['Strict', 'Lax', 'None']),
   partitionKey: tOptional(tString),
-  _chromiumHasCrossSiteAncestor: tOptional(tBoolean),
+  _crHasCrossSiteAncestor: tOptional(tBoolean),
 });
 scheme.NameValue = tObject({
   name: tString,

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -136,10 +136,8 @@ scheme.SetNetworkCookie = tObject({
   httpOnly: tOptional(tBoolean),
   secure: tOptional(tBoolean),
   sameSite: tOptional(tEnum(['Strict', 'Lax', 'None'])),
-  partitionKey: tOptional(tObject({
-    topLevelSite: tString,
-    hasCrossSiteAncestor: tBoolean,
-  })),
+  topLevelSite: tOptional(tString),
+  _chromiumHasCrossSiteAncestor: tOptional(tBoolean),
 });
 scheme.NetworkCookie = tObject({
   name: tString,
@@ -150,10 +148,8 @@ scheme.NetworkCookie = tObject({
   httpOnly: tBoolean,
   secure: tBoolean,
   sameSite: tEnum(['Strict', 'Lax', 'None']),
-  partitionKey: tOptional(tObject({
-    topLevelSite: tString,
-    hasCrossSiteAncestor: tBoolean,
-  })),
+  topLevelSite: tOptional(tString),
+  _chromiumHasCrossSiteAncestor: tOptional(tBoolean),
 });
 scheme.NameValue = tObject({
   name: tString,

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -136,6 +136,10 @@ scheme.SetNetworkCookie = tObject({
   httpOnly: tOptional(tBoolean),
   secure: tOptional(tBoolean),
   sameSite: tOptional(tEnum(['Strict', 'Lax', 'None'])),
+  partitionKey: tOptional(tObject({
+    topLevelSite: tString,
+    hasCrossSiteAncestor: tBoolean,
+  })),
 });
 scheme.NetworkCookie = tObject({
   name: tString,
@@ -146,6 +150,10 @@ scheme.NetworkCookie = tObject({
   httpOnly: tBoolean,
   secure: tBoolean,
   sameSite: tEnum(['Strict', 'Lax', 'None']),
+  partitionKey: tOptional(tObject({
+    topLevelSite: tString,
+    hasCrossSiteAncestor: tBoolean,
+  })),
 });
 scheme.NameValue = tObject({
   name: tString,

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -136,7 +136,7 @@ scheme.SetNetworkCookie = tObject({
   httpOnly: tOptional(tBoolean),
   secure: tOptional(tBoolean),
   sameSite: tOptional(tEnum(['Strict', 'Lax', 'None'])),
-  topLevelSite: tOptional(tString),
+  partitionKey: tOptional(tString),
   _chromiumHasCrossSiteAncestor: tOptional(tBoolean),
 });
 scheme.NetworkCookie = tObject({
@@ -148,7 +148,7 @@ scheme.NetworkCookie = tObject({
   httpOnly: tBoolean,
   secure: tBoolean,
   sameSite: tEnum(['Strict', 'Lax', 'None']),
-  topLevelSite: tOptional(tString),
+  partitionKey: tOptional(tString),
   _chromiumHasCrossSiteAncestor: tOptional(tBoolean),
 });
 scheme.NameValue = tObject({

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -381,42 +381,54 @@ export class CRBrowserContext extends BrowserContext {
   async doGetCookies(urls: string[]): Promise<channels.NetworkCookie[]> {
     const { cookies } = await this._browser._session.send('Storage.getCookies', { browserContextId: this._browserContextId });
     return network.filterCookies(cookies.map(c => {
-      const copy: any = { sameSite: 'Lax', ...c };
-      delete copy.size;
-      delete copy.priority;
-      delete copy.session;
-      delete copy.sameParty;
-      delete copy.sourceScheme;
-      delete copy.sourcePort;
-      delete copy.partitionKey;
+      const { name, value, domain, path, expires, httpOnly, secure, sameSite } = c;
+      const copy: channels.NetworkCookie = {
+        name,
+        value,
+        domain,
+        path,
+        expires,
+        httpOnly,
+        secure,
+        sameSite: sameSite ?? 'Lax',
+      };
       // If hasCrossSiteAncestor is false, the cookie is a partitioned first party cookie,
       // this is Chromium specific, see https://chromestatus.com/feature/5144832583663616
       // and https://github.com/explainers-by-googlers/CHIPS-spec.
       if (c.partitionKey) {
         copy._chromiumHasCrossSiteAncestor = c.partitionKey.hasCrossSiteAncestor;
-        copy.topLevelSite = c.partitionKey.topLevelSite;
+        copy.partitionKey = c.partitionKey.topLevelSite;
       }
-      return copy as channels.NetworkCookie;
+      return copy;
     }), urls);
   }
 
   async addCookies(cookies: channels.SetNetworkCookie[]) {
     function toChromiumCookie(cookie: channels.SetNetworkCookie) {
-      const { topLevelSite, _chromiumHasCrossSiteAncestor, ...rest } = cookie;
-      if (!topLevelSite)
-        return cookie;
-      return {
-        ...rest,
-        partitionKey: {
-          topLevelSite,
+      const { name, value, url, domain, path, expires, httpOnly, secure, sameSite, partitionKey, _chromiumHasCrossSiteAncestor } = cookie;
+      const copy: Protocol.Network.CookieParam = {
+        name,
+        value,
+        url,
+        domain,
+        path,
+        expires,
+        httpOnly,
+        secure,
+        sameSite
+      };
+      if (partitionKey) {
+        copy.partitionKey = {
+          topLevelSite: partitionKey,
           // _chromiumHasCrossSiteAncestor is non-standard, set it true by default if the cookie is partitioned.
           hasCrossSiteAncestor: _chromiumHasCrossSiteAncestor ?? true,
-        },
-      };
+        };
+      }
+      return copy;
     }
 
     await this._browser._session.send('Storage.setCookies', {
-      cookies: network.rewriteCookies(cookies.map(toChromiumCookie)),
+      cookies: network.rewriteCookies(cookies).map(toChromiumCookie),
       browserContextId: this._browserContextId
     });
   }

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -396,7 +396,7 @@ export class CRBrowserContext extends BrowserContext {
       // this is Chromium specific, see https://chromestatus.com/feature/5144832583663616
       // and https://github.com/explainers-by-googlers/CHIPS-spec.
       if (c.partitionKey) {
-        copy._chromiumHasCrossSiteAncestor = c.partitionKey.hasCrossSiteAncestor;
+        copy._crHasCrossSiteAncestor = c.partitionKey.hasCrossSiteAncestor;
         copy.partitionKey = c.partitionKey.topLevelSite;
       }
       return copy;
@@ -405,7 +405,7 @@ export class CRBrowserContext extends BrowserContext {
 
   async addCookies(cookies: channels.SetNetworkCookie[]) {
     function toChromiumCookie(cookie: channels.SetNetworkCookie) {
-      const { name, value, url, domain, path, expires, httpOnly, secure, sameSite, partitionKey, _chromiumHasCrossSiteAncestor } = cookie;
+      const { name, value, url, domain, path, expires, httpOnly, secure, sameSite, partitionKey, _crHasCrossSiteAncestor } = cookie;
       const copy: Protocol.Network.CookieParam = {
         name,
         value,
@@ -420,8 +420,8 @@ export class CRBrowserContext extends BrowserContext {
       if (partitionKey) {
         copy.partitionKey = {
           topLevelSite: partitionKey,
-          // _chromiumHasCrossSiteAncestor is non-standard, set it true by default if the cookie is partitioned.
-          hasCrossSiteAncestor: _chromiumHasCrossSiteAncestor ?? true,
+          // _crHasCrossSiteAncestor is non-standard, set it true by default if the cookie is partitioned.
+          hasCrossSiteAncestor: _crHasCrossSiteAncestor ?? true,
         };
       }
       return copy;

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -297,20 +297,33 @@ export class FFBrowserContext extends BrowserContext {
   async doGetCookies(urls: string[]): Promise<channels.NetworkCookie[]> {
     const { cookies } = await this._browser.session.send('Browser.getCookies', { browserContextId: this._browserContextId });
     return network.filterCookies(cookies.map(c => {
-      const copy: any = { ... c };
-      delete copy.size;
-      delete copy.session;
-      return copy as channels.NetworkCookie;
+      const { name, value, domain, path, expires, httpOnly, secure, sameSite } = c;
+      return {
+        name,
+        value,
+        domain,
+        path,
+        expires,
+        httpOnly,
+        secure,
+        sameSite,
+      };
     }), urls);
   }
 
   async addCookies(cookies: channels.SetNetworkCookie[]) {
     const cc = network.rewriteCookies(cookies).map(c => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { _chromiumHasCrossSiteAncestor, topLevelSite, ...rest } = c;
+      const { name, value, url, domain, path, expires, httpOnly, secure, sameSite } = c;
       return {
-        ...rest,
-        expires: c.expires === -1 ? undefined : c.expires,
+        name,
+        value,
+        url,
+        domain,
+        path,
+        expires: expires === -1 ? undefined : expires,
+        httpOnly,
+        secure,
+        sameSite
       };
     });
     await this._browser.session.send('Browser.setCookies', { browserContextId: this._browserContextId, cookies: cc });

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -305,10 +305,14 @@ export class FFBrowserContext extends BrowserContext {
   }
 
   async addCookies(cookies: channels.SetNetworkCookie[]) {
-    const cc = network.rewriteCookies(cookies).map(c => ({
-      ...c,
-      expires: c.expires === -1 ? undefined : c.expires,
-    }));
+    const cc = network.rewriteCookies(cookies).map(c => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { _chromiumHasCrossSiteAncestor, topLevelSite, ...rest } = c;
+      return {
+        ...rest,
+        expires: c.expires === -1 ? undefined : c.expires,
+      };
+    });
     await this._browser.session.send('Browser.setCookies', { browserContextId: this._browserContextId, cookies: cc });
   }
 

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -255,19 +255,37 @@ export class WKBrowserContext extends BrowserContext {
   async doGetCookies(urls: string[]): Promise<channels.NetworkCookie[]> {
     const { cookies } = await this._browser._browserSession.send('Playwright.getAllCookies', { browserContextId: this._browserContextId });
     return network.filterCookies(cookies.map((c: channels.NetworkCookie) => {
-      const copy: any = { ... c };
-      copy.expires = c.expires === -1 ? -1 : c.expires / 1000;
-      delete copy.session;
-      return copy as channels.NetworkCookie;
+      const { name, value, domain, path, expires, httpOnly, secure, sameSite } = c;
+      const copy: channels.NetworkCookie = {
+        name,
+        value,
+        domain,
+        path,
+        expires: expires === -1 ? -1 : expires / 1000,
+        httpOnly,
+        secure,
+        sameSite,
+      };
+      return copy;
     }), urls);
   }
 
   async addCookies(cookies: channels.SetNetworkCookie[]) {
-    const cc = network.rewriteCookies(cookies).map(c => ({
-      ...c,
-      session: c.expires === -1 || c.expires === undefined,
-      expires: c.expires && c.expires !== -1 ? c.expires * 1000 : c.expires,
-    })) as Protocol.Playwright.SetCookieParam[];
+    const cc = network.rewriteCookies(cookies).map(c => {
+      const { name, value, domain, path, expires, httpOnly, secure, sameSite } = c;
+      const copy: Protocol.Playwright.SetCookieParam = {
+        name,
+        value,
+        domain: domain!,
+        path: path!,
+        expires: expires && expires !== -1 ? expires * 1000 : expires,
+        httpOnly,
+        secure,
+        sameSite,
+        session: expires === -1 || expires === undefined,
+      };
+      return copy;
+    });
     await this._browser._browserSession.send('Playwright.setCookies', { cookies: cc, browserContextId: this._browserContextId });
   }
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8833,10 +8833,10 @@ export interface BrowserContext {
 
     /**
      * For partitioned third-party cookies (aka
-     * [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)), the top
-     * level site (scheme and host) used as the partition key. Optional.
+     * [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)), the
+     * partition key. Optional.
      */
-    topLevelSite?: string;
+    partitionKey?: string;
   }>): Promise<void>;
 
   /**
@@ -8915,7 +8915,7 @@ export interface BrowserContext {
 
   /**
    * If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those
-   * URLs are returned. Note that cookies are matched based on the URLs regardless of their `topLevelSite` value.
+   * URLs are returned. Note that cookies are matched based on the URLs regardless of their `partitionKey` value.
    * @param urls Optional list of URLs.
    */
   cookies(urls?: string|ReadonlyArray<string>): Promise<Array<Cookie>>;
@@ -9312,7 +9312,7 @@ export interface BrowserContext {
 
       sameSite: "Strict"|"Lax"|"None";
 
-      topLevelSite?: string;
+      partitionKey?: string;
     }>;
 
     origins: Array<{
@@ -22511,7 +22511,7 @@ export interface Cookie {
 
   sameSite: "Strict"|"Lax"|"None";
 
-  topLevelSite?: string;
+  partitionKey?: string;
 }
 
 interface PageWaitForSelectorOptions {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8830,6 +8830,13 @@ export interface BrowserContext {
      * Optional.
      */
     sameSite?: "Strict"|"Lax"|"None";
+
+    /**
+     * For partitioned third-party cookies (aka
+     * [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)), the top
+     * level site (scheme and host) used as the partition key. Optional.
+     */
+    topLevelSite?: string;
   }>): Promise<void>;
 
   /**
@@ -8908,7 +8915,7 @@ export interface BrowserContext {
 
   /**
    * If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those
-   * URLs are returned.
+   * URLs are returned. Note that cookies are matched based on the URLs regardless of their `topLevelSite` value.
    * @param urls Optional list of URLs.
    */
   cookies(urls?: string|ReadonlyArray<string>): Promise<Array<Cookie>>;
@@ -9304,6 +9311,8 @@ export interface BrowserContext {
       secure: boolean;
 
       sameSite: "Strict"|"Lax"|"None";
+
+      topLevelSite?: string;
     }>;
 
     origins: Array<{
@@ -22501,6 +22510,8 @@ export interface Cookie {
   secure: boolean;
 
   sameSite: "Strict"|"Lax"|"None";
+
+  topLevelSite?: string;
 }
 
 interface PageWaitForSelectorOptions {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8915,7 +8915,7 @@ export interface BrowserContext {
 
   /**
    * If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those
-   * URLs are returned. Note that cookies are matched based on the URLs regardless of their `partitionKey` value.
+   * URLs are returned.
    * @param urls Optional list of URLs.
    */
   cookies(urls?: string|ReadonlyArray<string>): Promise<Array<Cookie>>;

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -260,10 +260,8 @@ export type SetNetworkCookie = {
   httpOnly?: boolean,
   secure?: boolean,
   sameSite?: 'Strict' | 'Lax' | 'None',
-  partitionKey?: {
-    topLevelSite: string,
-    hasCrossSiteAncestor: boolean,
-  },
+  topLevelSite?: string,
+  _chromiumHasCrossSiteAncestor?: boolean,
 };
 
 export type NetworkCookie = {
@@ -275,10 +273,8 @@ export type NetworkCookie = {
   httpOnly: boolean,
   secure: boolean,
   sameSite: 'Strict' | 'Lax' | 'None',
-  partitionKey?: {
-    topLevelSite: string,
-    hasCrossSiteAncestor: boolean,
-  },
+  topLevelSite?: string,
+  _chromiumHasCrossSiteAncestor?: boolean,
 };
 
 export type NameValue = {

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -261,7 +261,7 @@ export type SetNetworkCookie = {
   secure?: boolean,
   sameSite?: 'Strict' | 'Lax' | 'None',
   partitionKey?: string,
-  _chromiumHasCrossSiteAncestor?: boolean,
+  _crHasCrossSiteAncestor?: boolean,
 };
 
 export type NetworkCookie = {
@@ -274,7 +274,7 @@ export type NetworkCookie = {
   secure: boolean,
   sameSite: 'Strict' | 'Lax' | 'None',
   partitionKey?: string,
-  _chromiumHasCrossSiteAncestor?: boolean,
+  _crHasCrossSiteAncestor?: boolean,
 };
 
 export type NameValue = {

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -260,6 +260,10 @@ export type SetNetworkCookie = {
   httpOnly?: boolean,
   secure?: boolean,
   sameSite?: 'Strict' | 'Lax' | 'None',
+  partitionKey?: {
+    topLevelSite: string,
+    hasCrossSiteAncestor: boolean,
+  },
 };
 
 export type NetworkCookie = {
@@ -271,6 +275,10 @@ export type NetworkCookie = {
   httpOnly: boolean,
   secure: boolean,
   sameSite: 'Strict' | 'Lax' | 'None',
+  partitionKey?: {
+    topLevelSite: string,
+    hasCrossSiteAncestor: boolean,
+  },
 };
 
 export type NameValue = {

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -260,7 +260,7 @@ export type SetNetworkCookie = {
   httpOnly?: boolean,
   secure?: boolean,
   sameSite?: 'Strict' | 'Lax' | 'None',
-  topLevelSite?: string,
+  partitionKey?: string,
   _chromiumHasCrossSiteAncestor?: boolean,
 };
 
@@ -273,7 +273,7 @@ export type NetworkCookie = {
   httpOnly: boolean,
   secure: boolean,
   sameSite: 'Strict' | 'Lax' | 'None',
-  topLevelSite?: string,
+  partitionKey?: string,
   _chromiumHasCrossSiteAncestor?: boolean,
 };
 

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -223,11 +223,8 @@ SetNetworkCookie:
       - Strict
       - Lax
       - None
-    partitionKey:
-      type: object?
-      properties:
-        topLevelSite: string
-        hasCrossSiteAncestor: boolean
+    topLevelSite: string?
+    _chromiumHasCrossSiteAncestor: boolean?
 
 
 NetworkCookie:
@@ -246,11 +243,8 @@ NetworkCookie:
       - Strict
       - Lax
       - None
-    partitionKey:
-      type: object?
-      properties:
-        topLevelSite: string
-        hasCrossSiteAncestor: boolean
+    topLevelSite: string?
+    _chromiumHasCrossSiteAncestor: boolean?
 
 
 NameValue:

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -223,6 +223,11 @@ SetNetworkCookie:
       - Strict
       - Lax
       - None
+    partitionKey:
+      type: object?
+      properties:
+        topLevelSite: string
+        hasCrossSiteAncestor: boolean
 
 
 NetworkCookie:
@@ -241,6 +246,11 @@ NetworkCookie:
       - Strict
       - Lax
       - None
+    partitionKey:
+      type: object?
+      properties:
+        topLevelSite: string
+        hasCrossSiteAncestor: boolean
 
 
 NameValue:

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -224,7 +224,7 @@ SetNetworkCookie:
       - Lax
       - None
     partitionKey: string?
-    _chromiumHasCrossSiteAncestor: boolean?
+    _crHasCrossSiteAncestor: boolean?
 
 
 NetworkCookie:
@@ -244,7 +244,7 @@ NetworkCookie:
       - Lax
       - None
     partitionKey: string?
-    _chromiumHasCrossSiteAncestor: boolean?
+    _crHasCrossSiteAncestor: boolean?
 
 
 NameValue:

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -223,7 +223,7 @@ SetNetworkCookie:
       - Strict
       - Lax
       - None
-    topLevelSite: string?
+    partitionKey: string?
     _chromiumHasCrossSiteAncestor: boolean?
 
 
@@ -243,7 +243,7 @@ NetworkCookie:
       - Strict
       - Lax
       - None
-    topLevelSite: string?
+    partitionKey: string?
     _chromiumHasCrossSiteAncestor: boolean?
 
 

--- a/tests/library/browsercontext-cookies-third-party.spec.ts
+++ b/tests/library/browsercontext-cookies-third-party.spec.ts
@@ -330,7 +330,7 @@ test(`add 'Partitioned;' cookie via API`, async ({ page, context, browserName, h
       secure: true,
       sameSite: 'None',
       partitionKey: 'https://localhost',
-      _chromiumHasCrossSiteAncestor: false
+      _crHasCrossSiteAncestor: false
     } as any,
     {
       name: 'top-level-non-partitioned',
@@ -352,7 +352,7 @@ test(`add 'Partitioned;' cookie via API`, async ({ page, context, browserName, h
       secure: true,
       sameSite: 'None',
       partitionKey: 'https://127.0.0.1',
-      _chromiumHasCrossSiteAncestor: true
+      _crHasCrossSiteAncestor: true
     } as any,
     {
       name: 'frame-non-partitioned',

--- a/tests/library/browsercontext-cookies-third-party.spec.ts
+++ b/tests/library/browsercontext-cookies-third-party.spec.ts
@@ -111,7 +111,7 @@ function expectPartitionKey(cookies: Cookie[], name: string, partitionKey: strin
     throw new Error(`Cookie ${name} has partitionKey ${cookie.partitionKey} but expected ${partitionKey}.`);
 }
 
-async function runNonPartitionedTest(page: Page, httpsServer: TestServer, browserName: string, isMac: boolean, urls: TestUrls) {
+async function runNonPartitionedTest(page: Page, httpsServer: TestServer, browserName: string, isMac: boolean, isLinux: boolean, urls: TestUrls) {
   addCommonCookieHandlers(httpsServer, urls);
   httpsServer.setRoute('/set-cookie.html', (req, res) => {
     res.setHeader('Set-Cookie', `${req.headers.referer ? 'frame' : 'top-level'}=value; SameSite=None; Path=/; Secure;`);
@@ -136,14 +136,14 @@ async function runNonPartitionedTest(page: Page, httpsServer: TestServer, browse
   await page.goto(urls.set_origin2_origin1);
   await page.goto(urls.read_origin2_origin1);
   const expectedThirdParty = browserName === 'webkit' && isMac ?
-    'Received cookie: undefined' : browserName === 'webkit' ?
+    'Received cookie: undefined' : browserName === 'webkit' && isLinux ?
       'Received cookie: top-level=value' :
       'Received cookie: frame=value; top-level=value';
   await expect(frameBody).toHaveText(expectedThirdParty, { timeout: 1000 });
 
   // Check again the top-level cookie.
   await page.goto(urls.read_origin1);
-  const expectedTopLevel = browserName === 'webkit' ?
+  const expectedTopLevel = browserName === 'webkit' && (isMac || isLinux) ?
     'Received cookie: top-level=value' :
     'Received cookie: frame=value; top-level=value';
   expect(await page.locator('body').textContent()).toBe(expectedTopLevel);
@@ -154,13 +154,13 @@ async function runNonPartitionedTest(page: Page, httpsServer: TestServer, browse
   };
 }
 
-test(`third party non-partitioned cookies`, async ({ page, browserName, httpsServer, isMac, urls }) => {
-  await runNonPartitionedTest(page, httpsServer, browserName, isMac, urls);
+test(`third party non-partitioned cookies`, async ({ page, browserName, httpsServer, isMac, isLinux, urls }) => {
+  await runNonPartitionedTest(page, httpsServer, browserName, isMac, isLinux, urls);
 });
 
-test(`save/load third party non-partitioned cookies`, async ({ page, browserName, httpsServer, isMac, browser, urls }) => {
+test(`save/load third party non-partitioned cookies`, async ({ page, browserName, httpsServer, isMac, isLinux, browser, urls }) => {
   // Run the test to populate the cookies.
-  const { expectedTopLevel, expectedThirdParty } = await runNonPartitionedTest(page, httpsServer, browserName, isMac, urls);
+  const { expectedTopLevel, expectedThirdParty } = await runNonPartitionedTest(page, httpsServer, browserName, isMac, isLinux, urls);
 
   async function checkCookies(page: Page) {
     // Check top-level cookie first.


### PR DESCRIPTION
Export/import topLevelSite cookie property. It is used to partition cookies, see https://github.com/privacycg/CHIPS.

Additionally add private `_chromiumHasCrossSiteAncestor` which is non-standard and used only in Chromium, see https://chromestatus.com/feature/5144832583663616. It allows to support export/import storage state scenarios while does not allow to set it via public API.

The field is private because of this note in the feature description above:
```
Specification
https://github.com/explainers-by-googlers/CHIPS-spec

Spec status: Proposal in a personal repository, no adoption from community
```

Reference: https://github.com/microsoft/playwright/issues/35598