### PR TITLE
test: fix webview2 tests

### DIFF
--- a/tests/webview2/webview2-app/webview2.csproj
+++ b/tests/webview2/webview2-app/webview2.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3240.44" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Looks like https://github.com/microsoft/playwright/pull/21220 is not always working and we see [this](https://github.com/microsoft/playwright/actions/runs/15397954312/job/43323349187?pr=36164#step:6:311) over and over again.

The actual fix is the `waitForURL`. The other two changes (error handling + updating the package are for good measure).