### PR TITLE
chore: reduce scrolling during clicks

### DIFF
--- a/tests/page/page-click-timeout-4.spec.ts
+++ b/tests/page/page-click-timeout-4.spec.ts
@@ -48,3 +48,51 @@ it('should click for the second time after first timeout', async ({ page, server
   await page.click('button');
   expect(await page.evaluate('result')).toBe('Clicked');
 });
+
+it('should fail to click the button behind a large header after scrolling around', async ({ page }) => {
+  await page.setViewportSize({ width: 500, height: 240 });
+  await page.setContent(`
+    <style>
+    * {
+      padding: 0;
+      margin: 0;
+    }
+    li {
+      height: 80px;
+      border: 1px solid black;
+    }
+    ol {
+      padding-top: 160px;
+    }
+    div.fixed {
+      position: fixed;
+      z-index: 1001;
+      width: 100%;
+      background: rgba(255, 0, 0, 0.2);
+      height: 2000px;
+    }
+    </style>
+
+    <div class=fixed></div>
+
+    <ol>
+    <li>hi1</li><li>hi2</li><li>hi3</li><li>hi4</li><li>hi5</li><li>hi6</li><li>hi7</li><li>hi8</li>
+    <li id=target onclick="window.__clicked = true">hi9</li>
+    <li>hi10</li><li>hi11</li><li>hi12</li><li>hi13</li><li id=li14>hi14</li>
+    </ol>
+
+    <script>
+      window.scrollTops = [];
+      window.addEventListener('scroll', () => {
+        window.scrollTops.push(window.scrollY);
+      });
+    </script>
+  `);
+  await page.$eval('#li14', e => e.scrollIntoView());
+  const error = await page.click('#target', { timeout: 1500 }).catch(e => e);
+  expect(error.message).toContain(`<div class="fixed"></div> intercepts pointer events`);
+  expect(await page.evaluate(() => window['__clicked'])).toBe(undefined);
+  const scrollTops = await page.evaluate(() => window['scrollTops']);
+  const distinct = new Set(scrollTops);
+  expect(distinct.size).toBeGreaterThan(2);  // At least three different scroll positions.
+});


### PR DESCRIPTION
Existing logic always tries to scroll to a different position after clicking at a wrong hit target. This is done to scroll out from under a sticky/fixed header.

However, it does not make sense to scroll if the sticky/fixed header is not a parent of the wrong hit target element, or is a common parent of the hit target and the actual target element.

This change restricts the scrolling logic to be only applied when there is a sticky/fixed element in the DOM chain between the hit target and its least common ancestor with the target element.