### PR TITLE
fix: allow matching against `about:blank` and other custom URLs

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/urlMatch.ts
+++ b/packages/playwright-core/src/utils/isomorphic/urlMatch.ts
@@ -127,6 +127,11 @@ function resolveGlobBase(baseURL: string | undefined, match: string): string {
     }
     // Escaped `\\?` behaves the same as `?` in our glob patterns.
     match = match.replaceAll(/\\\\\?/g, '?');
+    // Node URL constructors automatically uses colon as an indicator of a base URL, such as with `about:blank`
+    const splitScheme = match.split('://');
+    const schemelessPath = splitScheme.length === 1 ? splitScheme[0] : splitScheme[1];
+    if (schemelessPath !== undefined && schemelessPath.indexOf(':') !== -1)
+      return match;
     // Glob symbols may be escaped in the URL and some of them such as ? affect resolution,
     // so we replace them with safe components first.
     const relativePath = match.split('/').map((token, index) => {

--- a/packages/playwright-core/src/utils/isomorphic/urlMatch.ts
+++ b/packages/playwright-core/src/utils/isomorphic/urlMatch.ts
@@ -129,19 +129,24 @@ function resolveGlobBase(baseURL: string | undefined, match: string): string {
     match = match.replaceAll(/\\\\\?/g, '?');
     // Node URL constructors automatically uses colon as an indicator of a base URL, such as with `about:blank`
     // Only perform special handling if we have a specified base URL
-    const splitScheme = match.split('://');
-    const schemelessPath = splitScheme.length === 1 ? splitScheme[0] : splitScheme[1];
-    if (schemelessPath !== undefined && baseURL !== undefined && schemelessPath.indexOf(':') !== -1)
-      return match;
+    let ignoreBaseURL = false;
     // Glob symbols may be escaped in the URL and some of them such as ? affect resolution,
     // so we replace them with safe components first.
     const relativePath = match.split('/').map((token, index) => {
       if (token === '.' || token === '..' || token === '')
         return token;
-      // Handle special case of http*://, note that the new schema has to be
-      // a web schema so that slashes are properly inserted after domain.
-      if (index === 0 && token.endsWith(':'))
-        return mapToken(token, 'http:');
+      if (index === 0) {
+        // Handle special case of http*://, note that the new schema has to be
+        // a web schema so that slashes are properly inserted after domain.
+        if (token.endsWith(':')) {
+          return mapToken(token, 'http:');
+        } else if (token.indexOf(':') !== -1) {
+          // First token wasn't of the form /\w+:\//, but it still contains a colon
+          // Node URL constructors automatically uses colon as an indicator of a base URL, such as with `about:blank`
+          // Ignore baseURL but tokenize normally
+          ignoreBaseURL = true;
+        }
+      }
       const questionIndex = token.indexOf('?');
       if (questionIndex === -1)
         return mapToken(token, `$_${index}_$`);
@@ -149,7 +154,7 @@ function resolveGlobBase(baseURL: string | undefined, match: string): string {
       const newSuffix = mapToken(token.substring(questionIndex), `?$_${index}_$`);
       return newPrefix + newSuffix;
     }).join('/');
-    let resolved = constructURLBasedOnBaseURL(baseURL, relativePath);
+    let resolved = constructURLBasedOnBaseURL(!ignoreBaseURL ? baseURL : undefined, relativePath);
     for (const [token, original] of tokenMap)
       resolved = resolved.replace(token, original);
     match = resolved;

--- a/packages/playwright-core/src/utils/isomorphic/urlMatch.ts
+++ b/packages/playwright-core/src/utils/isomorphic/urlMatch.ts
@@ -128,9 +128,10 @@ function resolveGlobBase(baseURL: string | undefined, match: string): string {
     // Escaped `\\?` behaves the same as `?` in our glob patterns.
     match = match.replaceAll(/\\\\\?/g, '?');
     // Node URL constructors automatically uses colon as an indicator of a base URL, such as with `about:blank`
+    // Only perform special handling if we have a specified base URL
     const splitScheme = match.split('://');
     const schemelessPath = splitScheme.length === 1 ? splitScheme[0] : splitScheme[1];
-    if (schemelessPath !== undefined && schemelessPath.indexOf(':') !== -1)
+    if (schemelessPath !== undefined && baseURL !== undefined && schemelessPath.indexOf(':') !== -1)
       return match;
     // Glob symbols may be escaped in the URL and some of them such as ? affect resolution,
     // so we replace them with safe components first.

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -128,6 +128,12 @@ it('should work with glob', async () => {
   expect(urlMatches('http://playwright.dev/foo', 'http://playwright.dev/foo?bar', '\\\\?bar')).toBeTruthy();
   expect(urlMatches('http://first.host/', 'http://second.host/foo', '**/foo')).toBeTruthy();
   expect(urlMatches('http://playwright.dev/', 'http://localhost/', '*//localhost/')).toBeTruthy();
+
+  expect(urlMatches('http://playwright.dev/', 'about:blank', 'about:blank')).toBeTruthy();
+  expect(urlMatches('http://playwright.dev/', 'about:blank', 'http://playwright.dev/')).toBeFalsy();
+  expect(urlMatches(undefined, 'about:blank', 'about:blank')).toBeTruthy();
+  expect(urlMatches(undefined, 'about:blank', 'about:*')).toBeTruthy();
+  expect(urlMatches(undefined, 'notabout:blank', 'about:*')).toBeFalsy();
 });
 
 it('should intercept by glob', async function({ page, server, isAndroid }) {


### PR DESCRIPTION
Fixes #36162.

The JavaScript URL constructor uses any non-scheme colon to indicate the URL hostname, such as with `about:blank`. This was regressed in #34923, which hides the current value of the URL "path" from the URL constructor. Add a specific check for this case.

This will require similar handling in the ports.
