### PR TITLE
fix(chromium): refer to x86 and x86_64 as "x86" arch

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -1216,7 +1216,7 @@ function calculateUserAgentMetadata(options: types.BrowserContextOptions) {
   const metadata: Protocol.Emulation.UserAgentMetadata = {
     mobile: !!options.isMobile,
     model: '',
-    architecture: 'x64',
+    architecture: 'x86',
     platform: 'Windows',
     platformVersion: '',
   };


### PR DESCRIPTION
Fixes #36184.

[Chromium never appears to use the current Playwright value of `x64`](https://source.chromium.org/chromium/chromium/src/+/main:components/embedder_support/user_agent_utils.cc;l=736;drc=3fff33d878f84c4d1bb71e5125ad70584152d8e2). The correct way of indicating this is using `x86` and the `64` bitness option.