### PR TITLE
test: skip permission tests on Debian 11

### DIFF
--- a/tests/library/permissions.spec.ts
+++ b/tests/library/permissions.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import { contextTest as it, expect } from '../config/browserTest';
+import { hostPlatform } from '../../packages/playwright-core/src/server/utils/hostPlatform';
 
 function getPermission(page, name) {
   return page.evaluate(name => navigator.permissions.query({ name }).then(result => result.state), name);
@@ -31,6 +32,7 @@ it.describe('permissions', () => {
 
   it('should deny permission when not listed', async ({ page, context, server, browserName, isMac, macVersion }) => {
     it.skip(browserName === 'webkit' && isMac && macVersion === 13, 'WebKit on macOS 13 is frozen.');
+    it.skip(hostPlatform.startsWith('debian11'), 'WebKit on Debian 11 is frozen.');
 
     await page.goto(server.EMPTY_PAGE);
     await context.grantPermissions([], { origin: server.EMPTY_PAGE });


### PR DESCRIPTION
This behaviour change is only available on more modern WebKit versions.