### PR TITLE
test: mark inspector tests as slow

### DIFF
--- a/tests/library/inspector/inspectorTest.ts
+++ b/tests/library/inspector/inspectorTest.ts
@@ -69,6 +69,7 @@ export const test = contextTest.extend<CLITestArgs>({
   },
 
   runCLI: async ({ childProcess, browserName, channel, headless, mode, launchOptions }, run, testInfo) => {
+    testInfo.slow();
     testInfo.skip(mode.startsWith('service'));
 
     await run((cliArgs, { autoExitWhen } = {}) => {


### PR DESCRIPTION
Inspector tests are usually slower than normal tests. Some are failing just because of test timeouts.

e.g. ✖ library/inspector/cli-codegen-2.spec.ts - cli codegen › should save assets via SIGINT