### PR TITLE
fix(trace-viewer): show fallback command on less precise paths

### DIFF
--- a/packages/trace-viewer/index.html
+++ b/packages/trace-viewer/index.html
@@ -32,7 +32,7 @@
     <script>
       if (!/^https?:/.test(window.location.protocol)) {
         const fallbackErrorDialog = document.getElementById('fallback-error');
-        const isTraceViewerInsidePlaywrightReport = window.location.protocol === 'file:' && window.location.pathname.endsWith('/playwright-report/trace/index.html');
+        const isTraceViewerInsidePlaywrightReport = window.location.protocol === 'file:' && window.location.pathname.endsWith('/trace/index.html');
         // Best-effort to show the report path in the dialog.
         if (isTraceViewerInsidePlaywrightReport) {
           const reportPath = (() => {


### PR DESCRIPTION
Fixes #36144.

When Trace Viewer is not launched through a server (such as with `show-report`), it will display an error message to that effect. If it can determine where the trace is likely located, it will also give the user a command to launch the Trace Viewer with the correct path.

Slightly relax this heuristic to include renamed report folder (no longer requiring it to be named `playwright-report`).