### PR TITLE
fix(ai snapshot): wait for blocking CSS

### DIFF
--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -244,7 +244,7 @@ it('should auto-wait for navigation', async ({ page, server }) => {
 it('should auto-wait for blocking CSS', async ({ page, server }) => {
   server.setRoute('/css', (req, res) => {
     res.setHeader('Content-Type', 'text/css');
-    setTimeout(() => res.end(`body { monospace }`), 50);
+    setTimeout(() => res.end(`body { monospace }`), 1000);
   });
   await page.setContent(`
     <script src="${server.PREFIX}/css"></script>

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -240,3 +240,15 @@ it('should auto-wait for navigation', async ({ page, server }) => {
     - generic [ref=e2]: Hi, I'm frame
   `);
 });
+
+it('should auto-wait for blocking CSS', async ({ page, server }) => {
+  server.setRoute('/css', (req, res) => {
+    res.setHeader('Content-Type', 'text/css');
+    setTimeout(() => res.end(`body { monospace }`), 50);
+  });
+  await page.setContent(`
+    <script src="${server.PREFIX}/css"></script>
+    <p>Hello World</p>
+  `, { waitUntil: 'commit' });
+  expect(await snapshotForAI(page)).toContainYaml('Hello World');
+});


### PR DESCRIPTION
We're throwing this:

```js
 Error: page._snapshotForAI: TypeError: Cannot read properties of null (reading 'nodeType')
        at InjectedScript.ariaSnapshot (<anonymous>:6464:14)
        at eval (eval at evaluate (:291:30), <anonymous>:3:27)
        at UtilityScript.evaluate (<anonymous>:293:16)
        at UtilityScript.<anonymous> (<anonymous>:1:44)
        at InjectedScript.ariaSnapshot (<anonymous>:6464:14)
        at eval (eval at evaluate (:291:30), <anonymous>:3:27)
        at UtilityScript.evaluate (<anonymous>:293:16)
        at UtilityScript.<anonymous> (<anonymous>:1:44)
        at snapshotForAI (/Users/skn0tt/dev/microsoft/playwright/tests/page/page-aria-snapshot-ai.spec.ts:20:15)
        at /Users/skn0tt/dev/microsoft/playwright/tests/page/page-aria-snapshot-ai.spec.ts:253:16
        at InjectedScript.ariaSnapshot (<anonymous>:6464:14)
        at eval (eval at evaluate (:291:30), <anonymous>:3:27)
        at UtilityScript.evaluate (<anonymous>:293:16)
        at UtilityScript.<anonymous> (<anonymous>:1:44)
        at InjectedScript.ariaSnapshot (<anonymous>:6464:14)
        at eval (eval at evaluate (:291:30), <anonymous>:3:27)
        at UtilityScript.evaluate (<anonymous>:293:16)
        at UtilityScript.<anonymous> (<anonymous>:1:44)
```