### PR TITLE
fix: ensure ElementHandlerDispatcher has FrameDispatcher parent

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/electronDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/electronDispatcher.ts
@@ -16,8 +16,7 @@
 
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 import { Dispatcher } from './dispatcher';
-import { ElementHandleDispatcher } from './elementHandlerDispatcher';
-import { parseArgument, serializeResult } from './jsHandleDispatcher';
+import { JSHandleDispatcher, parseArgument, serializeResult } from './jsHandleDispatcher';
 import { ElectronApplication } from '../electron/electron';
 
 import type { RootDispatcher } from './dispatcher';
@@ -59,7 +58,7 @@ export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplicatio
       this._dispatchEvent('console', {
         type: message.type(),
         text: message.text(),
-        args: message.args().map(a => ElementHandleDispatcher.fromJSHandle(this, a)),
+        args: message.args().map(a => JSHandleDispatcher.fromJSHandle(this, a)),
         location: message.location()
       });
     });
@@ -67,7 +66,7 @@ export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplicatio
 
   async browserWindow(params: channels.ElectronApplicationBrowserWindowParams): Promise<channels.ElectronApplicationBrowserWindowResult> {
     const handle = await this._object.browserWindow((params.page as PageDispatcher).page());
-    return { handle: ElementHandleDispatcher.fromJSHandle(this, handle) };
+    return { handle: JSHandleDispatcher.fromJSHandle(this, handle) };
   }
 
   async evaluateExpression(params: channels.ElectronApplicationEvaluateExpressionParams): Promise<channels.ElectronApplicationEvaluateExpressionResult> {
@@ -78,7 +77,7 @@ export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplicatio
   async evaluateExpressionHandle(params: channels.ElectronApplicationEvaluateExpressionHandleParams): Promise<channels.ElectronApplicationEvaluateExpressionHandleResult> {
     const handle = await this._object._nodeElectronHandlePromise;
     const result = await handle.evaluateExpressionHandle(params.expression, { isFunction: params.isFunction }, parseArgument(params.arg));
-    return { handle: ElementHandleDispatcher.fromJSHandle(this, result) };
+    return { handle: JSHandleDispatcher.fromJSHandle(this, result) };
   }
 
   async updateSubscription(params: channels.ElectronApplicationUpdateSubscriptionParams): Promise<void> {

--- a/packages/playwright-core/src/server/dispatchers/elementHandlerDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/elementHandlerDispatcher.ts
@@ -16,14 +16,12 @@
 
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 import { FrameDispatcher } from './frameDispatcher';
-import { PageDispatcher } from './pageDispatcher';
 import { JSHandleDispatcher, parseArgument, serializeResult } from './jsHandleDispatcher';
 
 import type { ElementHandle } from '../dom';
 import type { Frame } from '../frames';
 import type { CallMetadata } from '../instrumentation';
 import type * as js from '../javascript';
-import type { JSHandleDispatcherParentScope } from './jsHandleDispatcher';
 import type * as channels from '@protocol/channels';
 
 
@@ -42,17 +40,13 @@ export class ElementHandleDispatcher extends JSHandleDispatcher<FrameDispatcher>
     return scope.connection.existingDispatcher<ElementHandleDispatcher>(handle) || new ElementHandleDispatcher(scope, handle);
   }
 
-  static fromJSHandle(scope: JSHandleDispatcherParentScope, handle: js.JSHandle): JSHandleDispatcher {
+  static fromJSOrElementHandle(scope: FrameDispatcher, handle: js.JSHandle): JSHandleDispatcher {
     const result = scope.connection.existingDispatcher<JSHandleDispatcher>(handle);
     if (result)
       return result;
     const elementHandle = handle.asElement();
     if (!elementHandle)
       return new JSHandleDispatcher(scope, handle);
-    if (scope instanceof PageDispatcher)
-      scope = FrameDispatcher.from(scope.parentScope(), elementHandle._frame);
-    if (!(scope instanceof FrameDispatcher))
-      throw new Error('ElementHandle can only be created from FrameDispatcher');
     return new ElementHandleDispatcher(scope, elementHandle);
   }
 

--- a/packages/playwright-core/src/server/dispatchers/elementHandlerDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/elementHandlerDispatcher.ts
@@ -16,6 +16,7 @@
 
 import { BrowserContextDispatcher } from './browserContextDispatcher';
 import { FrameDispatcher } from './frameDispatcher';
+import { PageDispatcher } from './pageDispatcher';
 import { JSHandleDispatcher, parseArgument, serializeResult } from './jsHandleDispatcher';
 
 import type { ElementHandle } from '../dom';
@@ -48,6 +49,8 @@ export class ElementHandleDispatcher extends JSHandleDispatcher<FrameDispatcher>
     const elementHandle = handle.asElement();
     if (!elementHandle)
       return new JSHandleDispatcher(scope, handle);
+    if (scope instanceof PageDispatcher)
+      scope = FrameDispatcher.from(scope.parentScope(), elementHandle._frame);
     if (!(scope instanceof FrameDispatcher))
       throw new Error('ElementHandle can only be created from FrameDispatcher');
     return new ElementHandleDispatcher(scope, elementHandle);

--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -88,7 +88,7 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
   }
 
   async evaluateExpressionHandle(params: channels.FrameEvaluateExpressionHandleParams, metadata: CallMetadata): Promise<channels.FrameEvaluateExpressionHandleResult> {
-    return { handle: ElementHandleDispatcher.fromJSHandle(this, await this._frame.evaluateExpressionHandle(params.expression, { isFunction: params.isFunction }, parseArgument(params.arg))) };
+    return { handle: ElementHandleDispatcher.fromJSOrElementHandle(this, await this._frame.evaluateExpressionHandle(params.expression, { isFunction: params.isFunction }, parseArgument(params.arg))) };
   }
 
   async waitForSelector(params: channels.FrameWaitForSelectorParams, metadata: CallMetadata): Promise<channels.FrameWaitForSelectorResult> {
@@ -246,7 +246,7 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
   }
 
   async waitForFunction(params: channels.FrameWaitForFunctionParams, metadata: CallMetadata): Promise<channels.FrameWaitForFunctionResult> {
-    return { handle: ElementHandleDispatcher.fromJSHandle(this, await this._frame._waitForFunctionExpression(metadata, params.expression, params.isFunction, parseArgument(params.arg), params)) };
+    return { handle: ElementHandleDispatcher.fromJSOrElementHandle(this, await this._frame._waitForFunctionExpression(metadata, params.expression, params.isFunction, parseArgument(params.arg), params)) };
   }
 
   async title(params: channels.FrameTitleParams, metadata: CallMetadata): Promise<channels.FrameTitleResult> {

--- a/packages/playwright-core/src/server/dispatchers/jsHandleDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/jsHandleDispatcher.ts
@@ -30,6 +30,10 @@ export type JSHandleDispatcherParentScope = PageDispatcher | FrameDispatcher | W
 export class JSHandleDispatcher<ParentScope extends JSHandleDispatcherParentScope = JSHandleDispatcherParentScope> extends Dispatcher<js.JSHandle, channels.JSHandleChannel, ParentScope> implements channels.JSHandleChannel {
   _type_JSHandle = true;
 
+  static fromJSHandle(scope: JSHandleDispatcherParentScope, handle: js.JSHandle): JSHandleDispatcher {
+    return scope.connection.existingDispatcher<JSHandleDispatcher>(handle) || new JSHandleDispatcher(scope, handle);
+  }
+
   protected constructor(scope: ParentScope, jsHandle: js.JSHandle) {
     // Do not call this directly, use createHandle() instead.
     super(scope, jsHandle, jsHandle.asElement() ? 'ElementHandle' : 'JSHandle', {
@@ -44,19 +48,23 @@ export class JSHandleDispatcher<ParentScope extends JSHandleDispatcherParentScop
 
   async evaluateExpressionHandle(params: channels.JSHandleEvaluateExpressionHandleParams): Promise<channels.JSHandleEvaluateExpressionHandleResult> {
     const jsHandle = await this._object.evaluateExpressionHandle(params.expression, { isFunction: params.isFunction }, parseArgument(params.arg));
-    return { handle: ElementHandleDispatcher.fromJSHandle(this.parentScope(), jsHandle) };
+    // If "jsHandle" is an ElementHandle, it belongs to the same frame as "this".
+    return { handle: ElementHandleDispatcher.fromJSOrElementHandle(this.parentScope() as FrameDispatcher, jsHandle) };
   }
 
   async getProperty(params: channels.JSHandleGetPropertyParams): Promise<channels.JSHandleGetPropertyResult> {
     const jsHandle = await this._object.getProperty(params.name);
-    return { handle: ElementHandleDispatcher.fromJSHandle(this.parentScope(), jsHandle) };
+    // If "jsHandle" is an ElementHandle, it belongs to the same frame as "this".
+    return { handle: ElementHandleDispatcher.fromJSOrElementHandle(this.parentScope() as FrameDispatcher, jsHandle) };
   }
 
   async getPropertyList(): Promise<channels.JSHandleGetPropertyListResult> {
     const map = await this._object.getProperties();
     const properties = [];
-    for (const [name, value] of map)
-      properties.push({ name, value: ElementHandleDispatcher.fromJSHandle(this.parentScope(), value) });
+    for (const [name, value] of map) {
+      // If "jsHandle" is an ElementHandle, it belongs to the same frame as "this".
+      properties.push({ name, value: ElementHandleDispatcher.fromJSOrElementHandle(this.parentScope() as FrameDispatcher, value) });
+    }
     return { properties };
   }
 

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -20,7 +20,7 @@ import { parseError } from '../errors';
 import { ArtifactDispatcher } from './artifactDispatcher';
 import { ElementHandleDispatcher } from './elementHandlerDispatcher';
 import { FrameDispatcher } from './frameDispatcher';
-import { parseArgument, serializeResult } from './jsHandleDispatcher';
+import { JSHandleDispatcher, parseArgument, serializeResult } from './jsHandleDispatcher';
 import { RequestDispatcher } from './networkDispatchers';
 import { ResponseDispatcher } from './networkDispatchers';
 import { RouteDispatcher, WebSocketDispatcher } from './networkDispatchers';
@@ -399,7 +399,7 @@ export class WorkerDispatcher extends Dispatcher<Worker, channels.WorkerChannel,
   }
 
   async evaluateExpressionHandle(params: channels.WorkerEvaluateExpressionHandleParams, metadata: CallMetadata): Promise<channels.WorkerEvaluateExpressionHandleResult> {
-    return { handle: ElementHandleDispatcher.fromJSHandle(this, await this._object.evaluateExpressionHandle(params.expression, params.isFunction, parseArgument(params.arg))) };
+    return { handle: JSHandleDispatcher.fromJSHandle(this, await this._object.evaluateExpressionHandle(params.expression, params.isFunction, parseArgument(params.arg))) };
   }
 }
 
@@ -415,7 +415,7 @@ export class BindingCallDispatcher extends Dispatcher<{ guid: string }, channels
       frame: frameDispatcher,
       name,
       args: needsHandle ? undefined : args.map(serializeResult),
-      handle: needsHandle ? ElementHandleDispatcher.fromJSHandle(frameDispatcher, args[0] as JSHandle) : undefined,
+      handle: needsHandle ? ElementHandleDispatcher.fromJSOrElementHandle(frameDispatcher, args[0] as JSHandle) : undefined,
     });
     this._promise = new Promise((resolve, reject) => {
       this._resolve = resolve;

--- a/tests/library/browsercontext-events.spec.ts
+++ b/tests/library/browsercontext-events.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import { browserTest as test, expect } from '../config/browserTest';
+import type { ElementHandle } from 'playwright-core';
 
 test('console event should work @smoke', async ({ page }) => {
   const [, message] = await Promise.all([
@@ -24,6 +25,17 @@ test('console event should work @smoke', async ({ page }) => {
 
   expect(message.text()).toBe('hello');
   expect(message.page()).toBe(page);
+});
+
+test('console event should work with element handles', async ({ page }) => {
+  await page.setContent('<body>hello</body>');
+  const [, message] = await Promise.all([
+    page.evaluate(() => console.log(document.body)),
+    page.context().waitForEvent('console'),
+  ]);
+  const body = message.args()[0];
+  expect(await body.evaluate(x => x.nodeName)).toBe('BODY');
+  await (body as ElementHandle).click();
 });
 
 test('console event should work in popup', async ({ page }) => {


### PR DESCRIPTION
This was not the case for console message arguments.

Fixes https://github.com/microsoft/playwright-mcp/issues/524.