### PR TITLE
chore(client): remove unneeded _wrapApiCall(internal)

### DIFF
--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -203,7 +203,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
         this._routes.splice(index, 1);
       const handled = await routeHandler.handle(route);
       if (!this._routes.length)
-        this._wrapApiCall(() => this._updateInterceptionPatterns(), { internal: true }).catch(() => {});
+        this._updateInterceptionPatterns().catch(() => {});
       if (handled)
         return;
     }
@@ -398,7 +398,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     } finally {
       if (remove)
         this._locatorHandlers.delete(uid);
-      this._wrapApiCall(() => this._channel.resolveLocatorHandlerNoReply({ uid, remove }), { internal: true }).catch(() => {});
+      this._channel.resolveLocatorHandlerNoReply({ uid, remove }).catch(() => {});
     }
   }
 


### PR DESCRIPTION
Both methods are listed as internal in protocol.yaml, so this override isn't needed.