### PR TITLE
fix: java style selector string

### DIFF
--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -86,7 +86,7 @@ export class FrameExecutionContext extends js.ExecutionContext {
       const customEngines: InjectedScriptOptions['customEngines'] = [];
       const selectorsRegistry = this.frame._page.browserContext.selectors();
       for (const [name, { source }] of selectorsRegistry._engines)
-        customEngines.push({ name, source });
+        customEngines.push({ name, source: `(${source})` });
       const sdkLanguage = this.frame.attribution.playwright.options.sdkLanguage;
       const options: InjectedScriptOptions = {
         isUnderTest: isUnderTest(),

--- a/tests/page/selectors-register.spec.ts
+++ b/tests/page/selectors-register.spec.ts
@@ -128,3 +128,17 @@ it('isVisible should be atomic', async ({ playwright, page }) => {
   expect(result).toBe(true);
   expect(await page.evaluate(() => document.querySelector('div').style.display)).toBe('none');
 });
+
+it('should take java-style string', async ({ playwright, page }) => {
+  const createDummySelector = `{
+    query(root, selector) {
+      return root.querySelector(selector);
+    },
+    queryAll(root, selector) {
+      return root.querySelectorAll(selector);
+    }
+  }`;
+  await playwright.selectors.register('textContent', createDummySelector);
+  await page.setContent(`<div>Hello</div>`);
+  await page.textContent('textContent=div');
+});

--- a/tests/page/selectors-register.spec.ts
+++ b/tests/page/selectors-register.spec.ts
@@ -138,7 +138,7 @@ it('should take java-style string', async ({ playwright, page }) => {
       return root.querySelectorAll(selector);
     }
   }`;
-  await playwright.selectors.register('textContent', createDummySelector);
+  await playwright.selectors.register('objectLiteral', createDummySelector);
   await page.setContent(`<div>Hello</div>`);
-  await page.textContent('textContent=div');
+  await page.textContent('objectLiteral=div');
 });


### PR DESCRIPTION
In Java and DotNet, we don't document wrapping parantheses: https://playwright.dev/java/docs/api/class-selectors#selectors-register

Without them, we throw an error though since https://github.com/microsoft/playwright/commit/3371fb9bea8789e17c02f415e5621ec1e3f1d96c:

```ts
Error: page.textContent: SyntaxError: Unexpected token '{'
        at eval (<anonymous>)
        at InjectedScript.eval (<anonymous>:6418:24)
        at new InjectedScript (<anonymous>:6408:36)
        at <anonymous>:7741:16
        at <anonymous>:7742:11
    Call log:
      - waiting for locator('textContent=div')

        at InjectedScript.eval (<anonymous>:6418:24)
        at InjectedScript (<anonymous>:6408:36)
        at <anonymous>:7741:16
        at <anonymous>:7742:11
        at /Users/skn0tt/dev/microsoft/playwright/tests/page/selectors-register.spec.ts:143:14
        at InjectedScript.eval (<anonymous>:6418:24)
        at InjectedScript (<anonymous>:6408:36)
        at <anonymous>:7741:16
        at <anonymous>:7742:11
        at InjectedScript.eval (<anonymous>:6418:24)
        at InjectedScript (<anonymous>:6408:36)
        at <anonymous>:7741:16
        at <anonymous>:7742:11
```