### PR TITLE
docs: add instructions for viewing test report locallyt report readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,22 +161,18 @@ test('Intercept network requests', async ({ page }) => {
 ```
 ---
 
-## 📘 Test Report Download Instructions
+## 📘 Test Report Download Instructions 
 
 After running your tests using:
 
 ```bash
 npx playwright test
 
-
----
-
-## 📘 How to View Playwright Test Report Locally
-
-After running your tests using:
+To generate an HTML report, run:
 
 ```bash
-npx playwright test
+npx playwright test --reporter=html
+npx playwright show-report
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ After running your tests using:
 ```bash
 npx playwright test
 
+
+---
+
+## 📘 How to View Playwright Test Report Locally
+
+After running your tests using:
+
+```bash
+npx playwright test
+
 ## Resources
 
 * [Documentation](https://playwright.dev)

--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ test('Intercept network requests', async ({ page }) => {
   await page.goto('http://todomvc.com');
 });
 ```
+---
+
+## 📘 Test Report Download Instructions
+
+After running your tests using:
+
+```bash
+npx playwright test
 
 ## Resources
 


### PR DESCRIPTION
This PR adds a short guide to the README on how to generate and view the Playwright HTML test report locally using the `--reporter=html` flag.
