### PR TITLE
chore: accept Progress instance for raw input

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiInput.ts
+++ b/packages/playwright-core/src/server/bidi/bidiInput.ts
@@ -21,6 +21,7 @@ import * as bidi from './third_party/bidiProtocol';
 import type * as input from '../input';
 import type * as types from '../types';
 import type { BidiSession } from './bidiConnection';
+import type { Progress } from '../progress';
 
 export class RawKeyboardImpl implements input.RawKeyboard {
   private _session: BidiSession;
@@ -33,31 +34,31 @@ export class RawKeyboardImpl implements input.RawKeyboard {
     this._session = session;
   }
 
-  async keydown(modifiers: Set<types.KeyboardModifier>, keyName: string, description: input.KeyDescription, autoRepeat: boolean): Promise<void> {
+  async keydown(progress: Progress, modifiers: Set<types.KeyboardModifier>, keyName: string, description: input.KeyDescription, autoRepeat: boolean): Promise<void> {
     keyName = resolveSmartModifierString(keyName);
     const actions: bidi.Input.KeySourceAction[] = [];
     actions.push({ type: 'keyDown', value: getBidiKeyValue(keyName) });
-    await this._performActions(actions);
+    await this._performActions(progress, actions);
   }
 
-  async keyup(modifiers: Set<types.KeyboardModifier>, keyName: string, description: input.KeyDescription): Promise<void> {
+  async keyup(progress: Progress, modifiers: Set<types.KeyboardModifier>, keyName: string, description: input.KeyDescription): Promise<void> {
     keyName = resolveSmartModifierString(keyName);
     const actions: bidi.Input.KeySourceAction[] = [];
     actions.push({ type: 'keyUp', value: getBidiKeyValue(keyName) });
-    await this._performActions(actions);
+    await this._performActions(progress, actions);
   }
 
-  async sendText(text: string): Promise<void> {
+  async sendText(progress: Progress, text: string): Promise<void> {
     const actions: bidi.Input.KeySourceAction[] = [];
     for (const char of text) {
       const value = getBidiKeyValue(char);
       actions.push({ type: 'keyDown', value });
       actions.push({ type: 'keyUp', value });
     }
-    await this._performActions(actions);
+    await this._performActions(progress, actions);
   }
 
-  private async _performActions(actions: bidi.Input.KeySourceAction[]) {
+  private async _performActions(progress: Progress, actions: bidi.Input.KeySourceAction[]) {
     await this._session.send('input.performActions', {
       context: this._session.sessionId,
       actions: [
@@ -68,6 +69,7 @@ export class RawKeyboardImpl implements input.RawKeyboard {
         }
       ]
     });
+    progress.throwIfAborted();
   }
 }
 
@@ -78,19 +80,19 @@ export class RawMouseImpl implements input.RawMouse {
     this._session = session;
   }
 
-  async move(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void> {
-    await this._performActions([{ type: 'pointerMove', x, y }]);
+  async move(progress: Progress, x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void> {
+    await this._performActions(progress, [{ type: 'pointerMove', x, y }]);
   }
 
-  async down(x: number, y: number, button: types.MouseButton, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, clickCount: number): Promise<void> {
-    await this._performActions([{ type: 'pointerDown', button: toBidiButton(button) }]);
+  async down(progress: Progress, x: number, y: number, button: types.MouseButton, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, clickCount: number): Promise<void> {
+    await this._performActions(progress, [{ type: 'pointerDown', button: toBidiButton(button) }]);
   }
 
-  async up(x: number, y: number, button: types.MouseButton, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, clickCount: number): Promise<void> {
-    await this._performActions([{ type: 'pointerUp', button: toBidiButton(button) }]);
+  async up(progress: Progress, x: number, y: number, button: types.MouseButton, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, clickCount: number): Promise<void> {
+    await this._performActions(progress, [{ type: 'pointerUp', button: toBidiButton(button) }]);
   }
 
-  async wheel(x: number, y: number, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, deltaX: number, deltaY: number): Promise<void> {
+  async wheel(progress: Progress, x: number, y: number, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, deltaX: number, deltaY: number): Promise<void> {
     // Bidi throws when x/y are not integers.
     x = Math.floor(x);
     y = Math.floor(y);
@@ -104,9 +106,10 @@ export class RawMouseImpl implements input.RawMouse {
         }
       ]
     });
+    progress.throwIfAborted();
   }
 
-  private async _performActions(actions: bidi.Input.PointerSourceAction[]) {
+  private async _performActions(progress: Progress, actions: bidi.Input.PointerSourceAction[]) {
     await this._session.send('input.performActions', {
       context: this._session.sessionId,
       actions: [
@@ -120,6 +123,7 @@ export class RawMouseImpl implements input.RawMouse {
         }
       ]
     });
+    progress.throwIfAborted();
   }
 }
 
@@ -130,7 +134,7 @@ export class RawTouchscreenImpl implements input.RawTouchscreen {
     this._session = session;
   }
 
-  async tap(x: number, y: number, modifiers: Set<types.KeyboardModifier>) {
+  async tap(progress: Progress, x: number, y: number, modifiers: Set<types.KeyboardModifier>) {
   }
 }
 

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -510,7 +510,7 @@ export class BidiPage implements PageDelegate {
   async inputActionEpilogue(): Promise<void> {
   }
 
-  async resetForReuse(): Promise<void> {
+  async resetForReuse(progress: Progress): Promise<void> {
   }
 
   async pdf(options: channels.PagePdfParams): Promise<Buffer> {

--- a/packages/playwright-core/src/server/chromium/crInput.ts
+++ b/packages/playwright-core/src/server/chromium/crInput.ts
@@ -24,6 +24,7 @@ import type * as types from '../types';
 import type { CRSession } from './crConnection';
 import type { DragManager } from './crDragDrop';
 import type { CRPage } from './crPage';
+import type { Progress } from '../progress';
 
 
 export class RawKeyboardImpl implements input.RawKeyboard {
@@ -52,10 +53,11 @@ export class RawKeyboardImpl implements input.RawKeyboard {
     return commands.map(c => c.substring(0, c.length - 1));
   }
 
-  async keydown(modifiers: Set<types.KeyboardModifier>, keyName: string, description: input.KeyDescription, autoRepeat: boolean): Promise<void> {
+  async keydown(progress: Progress, modifiers: Set<types.KeyboardModifier>, keyName: string, description: input.KeyDescription, autoRepeat: boolean): Promise<void> {
     const { code, key, location, text } = description;
     if (code === 'Escape' && await this._dragManger.cancelDrag())
       return;
+    progress.throwIfAborted();
     const commands = this._commandsForCode(code, modifiers);
     await this._client.send('Input.dispatchKeyEvent', {
       type: text ? 'keyDown' : 'rawKeyDown',
@@ -70,9 +72,10 @@ export class RawKeyboardImpl implements input.RawKeyboard {
       location,
       isKeypad: location === input.keypadLocation
     });
+    progress.throwIfAborted();
   }
 
-  async keyup(modifiers: Set<types.KeyboardModifier>, keyName: string, description: input.KeyDescription): Promise<void> {
+  async keyup(progress: Progress, modifiers: Set<types.KeyboardModifier>, keyName: string, description: input.KeyDescription): Promise<void> {
     const { code, key, location } = description;
     await this._client.send('Input.dispatchKeyEvent', {
       type: 'keyUp',
@@ -82,10 +85,12 @@ export class RawKeyboardImpl implements input.RawKeyboard {
       code,
       location
     });
+    progress.throwIfAborted();
   }
 
-  async sendText(text: string): Promise<void> {
+  async sendText(progress: Progress, text: string): Promise<void> {
     await this._client.send('Input.insertText', { text });
+    progress.throwIfAborted();
   }
 }
 
@@ -100,7 +105,7 @@ export class RawMouseImpl implements input.RawMouse {
     this._dragManager = dragManager;
   }
 
-  async move(x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void> {
+  async move(progress: Progress, x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void> {
     const actualMove = async () => {
       await this._client.send('Input.dispatchMouseEvent', {
         type: 'mouseMoved',
@@ -115,12 +120,14 @@ export class RawMouseImpl implements input.RawMouse {
     if (forClick) {
       // Avoid extra protocol calls related to drag and drop, because click relies on
       // move-down-up protocol commands being sent synchronously.
-      return actualMove();
+      await actualMove();
+      progress.throwIfAborted();
+      return;
     }
-    await this._dragManager.interceptDragCausedByMove(x, y, button, buttons, modifiers, actualMove);
+    await this._dragManager.interceptDragCausedByMove(progress, x, y, button, buttons, modifiers, actualMove);
   }
 
-  async down(x: number, y: number, button: types.MouseButton, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, clickCount: number): Promise<void> {
+  async down(progress: Progress, x: number, y: number, button: types.MouseButton, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, clickCount: number): Promise<void> {
     if (this._dragManager.isDragging())
       return;
     await this._client.send('Input.dispatchMouseEvent', {
@@ -133,11 +140,12 @@ export class RawMouseImpl implements input.RawMouse {
       clickCount,
       force: buttons.size > 0 ? 0.5 : 0,
     });
+    progress.throwIfAborted();
   }
 
-  async up(x: number, y: number, button: types.MouseButton, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, clickCount: number): Promise<void> {
+  async up(progress: Progress, x: number, y: number, button: types.MouseButton, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, clickCount: number): Promise<void> {
     if (this._dragManager.isDragging()) {
-      await this._dragManager.drop(x, y, modifiers);
+      await this._dragManager.drop(progress, x, y, modifiers);
       return;
     }
     await this._client.send('Input.dispatchMouseEvent', {
@@ -149,9 +157,10 @@ export class RawMouseImpl implements input.RawMouse {
       modifiers: toModifiersMask(modifiers),
       clickCount
     });
+    progress.throwIfAborted();
   }
 
-  async wheel(x: number, y: number, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, deltaX: number, deltaY: number): Promise<void> {
+  async wheel(progress: Progress, x: number, y: number, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, deltaX: number, deltaY: number): Promise<void> {
     await this._client.send('Input.dispatchMouseEvent', {
       type: 'mouseWheel',
       x,
@@ -160,6 +169,7 @@ export class RawMouseImpl implements input.RawMouse {
       deltaX,
       deltaY,
     });
+    progress.throwIfAborted();
   }
 }
 
@@ -169,7 +179,7 @@ export class RawTouchscreenImpl implements input.RawTouchscreen {
   constructor(client: CRSession) {
     this._client = client;
   }
-  async tap(x: number, y: number, modifiers: Set<types.KeyboardModifier>) {
+  async tap(progress: Progress, x: number, y: number, modifiers: Set<types.KeyboardModifier>) {
     await Promise.all([
       this._client.send('Input.dispatchTouchEvent', {
         type: 'touchStart',
@@ -184,5 +194,6 @@ export class RawTouchscreenImpl implements input.RawTouchscreen {
         touchPoints: []
       }),
     ]);
+    progress.throwIfAborted();
   }
 }

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -339,9 +339,9 @@ export class CRPage implements PageDelegate {
     await this._mainFrameSession._client.send('Page.enable').catch(e => {});
   }
 
-  async resetForReuse(): Promise<void> {
+  async resetForReuse(progress: Progress): Promise<void> {
     // See https://github.com/microsoft/playwright/issues/22432.
-    await this.rawMouse.move(-1, -1, 'none', new Set(), new Set(), true);
+    await this.rawMouse.move(progress, -1, -1, 'none', new Set(), new Set(), true);
   }
 
   async pdf(options: channels.PagePdfParams): Promise<Buffer> {

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -238,7 +238,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
   async close(params: channels.PageCloseParams, metadata: CallMetadata): Promise<void> {
     if (!params.runBeforeUnload)
       metadata.potentiallyClosesScope = true;
-    await this._page.close(metadata, params);
+    await this._page.close(params);
   }
 
   async updateSubscription(params: channels.PageUpdateSubscriptionParams): Promise<void> {
@@ -251,47 +251,52 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
   }
 
   async keyboardDown(params: channels.PageKeyboardDownParams, metadata: CallMetadata): Promise<void> {
-    await this._page.keyboard.down(params.key);
+    await this._page.keyboard.down(metadata, params.key);
   }
 
   async keyboardUp(params: channels.PageKeyboardUpParams, metadata: CallMetadata): Promise<void> {
-    await this._page.keyboard.up(params.key);
+    await this._page.keyboard.up(metadata, params.key);
   }
 
   async keyboardInsertText(params: channels.PageKeyboardInsertTextParams, metadata: CallMetadata): Promise<void> {
-    await this._page.keyboard.insertText(params.text);
+    await this._page.keyboard.insertText(metadata, params.text);
   }
 
   async keyboardType(params: channels.PageKeyboardTypeParams, metadata: CallMetadata): Promise<void> {
-    await this._page.keyboard.type(params.text, params);
+    await this._page.keyboard.type(metadata, params.text, params);
   }
 
   async keyboardPress(params: channels.PageKeyboardPressParams, metadata: CallMetadata): Promise<void> {
-    await this._page.keyboard.press(params.key, params);
+    await this._page.keyboard.press(metadata, params.key, params);
   }
 
   async mouseMove(params: channels.PageMouseMoveParams, metadata: CallMetadata): Promise<void> {
-    await this._page.mouse.move(params.x, params.y, params, metadata);
+    metadata.point = { x: params.x, y: params.y };
+    await this._page.mouse.move(metadata, params.x, params.y, params);
   }
 
   async mouseDown(params: channels.PageMouseDownParams, metadata: CallMetadata): Promise<void> {
-    await this._page.mouse.down(params, metadata);
+    metadata.point = this._page.mouse.currentPoint();
+    await this._page.mouse.down(metadata, params);
   }
 
   async mouseUp(params: channels.PageMouseUpParams, metadata: CallMetadata): Promise<void> {
-    await this._page.mouse.up(params, metadata);
+    metadata.point = this._page.mouse.currentPoint();
+    await this._page.mouse.up(metadata, params);
   }
 
   async mouseClick(params: channels.PageMouseClickParams, metadata: CallMetadata): Promise<void> {
-    await this._page.mouse.click(params.x, params.y, params, metadata);
+    metadata.point = { x: params.x, y: params.y };
+    await this._page.mouse.click(metadata, params.x, params.y, params);
   }
 
   async mouseWheel(params: channels.PageMouseWheelParams, metadata: CallMetadata): Promise<void> {
-    await this._page.mouse.wheel(params.deltaX, params.deltaY);
+    await this._page.mouse.wheel(metadata, params.deltaX, params.deltaY);
   }
 
   async touchscreenTap(params: channels.PageTouchscreenTapParams, metadata: CallMetadata): Promise<void> {
-    await this._page.touchscreen.tap(params.x, params.y, metadata);
+    metadata.point = { x: params.x, y: params.y };
+    await this._page.touchscreen.tap(metadata, params.x, params.y);
   }
 
   async accessibilitySnapshot(params: channels.PageAccessibilitySnapshotParams, metadata: CallMetadata): Promise<channels.PageAccessibilitySnapshotResult> {

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -545,12 +545,12 @@ export class FFPage implements PageDelegate {
   async inputActionEpilogue(): Promise<void> {
   }
 
-  async resetForReuse(): Promise<void> {
+  async resetForReuse(progress: Progress): Promise<void> {
     // Firefox sometimes keeps the last mouse position in the page,
     // which affects things like hovered state.
     // See https://github.com/microsoft/playwright/issues/22432.
     // Move mouse to (-1, -1) to avoid anything being hovered.
-    await this.rawMouse.move(-1, -1, 'none', new Set(), new Set(), false);
+    await this.rawMouse.move(progress, -1, -1, 'none', new Set(), new Set(), false);
   }
 
   async getFrameElement(frame: frames.Frame): Promise<dom.ElementHandle> {

--- a/packages/playwright-core/src/server/launchApp.ts
+++ b/packages/playwright-core/src/server/launchApp.ts
@@ -65,7 +65,7 @@ export async function launchApp(browserType: BrowserType, options: {
     context.on('page', async (newPage: Page) => {
       if (newPage.mainFrame().url() === 'chrome://new-tab-page/') {
         await page.bringToFront();
-        await newPage.close(serverSideCallMetadata());
+        await newPage.close();
       }
     });
   }

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -94,7 +94,7 @@ export interface PageDelegate {
   // Work around for asynchronously dispatched CSP errors in Firefox.
   readonly cspErrorsAsynchronousForInlineScripts?: boolean;
   // Work around for mouse position in Firefox.
-  resetForReuse(): Promise<void>;
+  resetForReuse(progress: Progress): Promise<void>;
   // WebKit hack.
   shouldToggleStyleSheetToSyncAnimations(): boolean;
 }
@@ -180,7 +180,7 @@ export class Page extends SdkObject {
     this.delegate = delegate;
     this.browserContext = browserContext;
     this.accessibility = new accessibility.Accessibility(delegate.getAccessibilityTree.bind(delegate));
-    this.keyboard = new input.Keyboard(delegate.rawKeyboard);
+    this.keyboard = new input.Keyboard(delegate.rawKeyboard, this);
     this.mouse = new input.Mouse(delegate.rawMouse, this);
     this.touchscreen = new input.Touchscreen(delegate.rawTouchscreen, this);
     this.screenshotter = new Screenshotter(this);
@@ -254,12 +254,12 @@ export class Page extends SdkObject {
       this._eventsToEmitAfterInitialized.push({ event, args });
   }
 
-  async resetForReuse(metadata: CallMetadata) {
+  async resetForReuse(progress: Progress) {
     this._locatorHandlers.clear();
 
     // Re-navigate once init scripts are gone.
     // TODO: we should have a timeout for `resetForReuse`.
-    await this.mainFrame().goto(metadata, 'about:blank', { timeout: 0 });
+    await this.mainFrame().gotoImpl(progress, 'about:blank', {});
     this._emulatedSize = undefined;
     this._emulatedMedia = {};
     this._extraHTTPHeaders = undefined;
@@ -269,7 +269,7 @@ export class Page extends SdkObject {
       this.delegate.updateEmulateMedia(),
     ]);
 
-    await this.delegate.resetForReuse();
+    await this.delegate.resetForReuse(progress);
   }
 
   _didClose() {
@@ -697,7 +697,7 @@ export class Page extends SdkObject {
         options.timeout);
   }
 
-  async close(metadata: CallMetadata, options: { runBeforeUnload?: boolean, reason?: string } = {}) {
+  async close(options: { runBeforeUnload?: boolean, reason?: string } = {}) {
     if (this._closedState === 'closed')
       return;
     if (options.reason)

--- a/packages/playwright-core/src/server/recorder/recorderRunner.ts
+++ b/packages/playwright-core/src/server/recorder/recorderRunner.ts
@@ -39,7 +39,7 @@ export async function performAction(pageAliases: Map<Page, string>, actionInCont
     throw Error('Not reached');
 
   if (action.name === 'closePage') {
-    await mainFrame._page.close(callMetadata);
+    await mainFrame._page.close();
     return;
   }
 

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -994,7 +994,7 @@ export class WKPage implements PageDelegate {
   async inputActionEpilogue(): Promise<void> {
   }
 
-  async resetForReuse(): Promise<void> {
+  async resetForReuse(progress: Progress): Promise<void> {
   }
 
   async getFrameElement(frame: frames.Frame): Promise<dom.ElementHandle> {


### PR DESCRIPTION
Raw input actions now follow the contract - either they finish successfully until the progress aborts, or they throw.

References #35987.