### PR TITLE
chore: remove PLAYWRIGHT_SKIP_NAVIGATION_CHECK

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -455,8 +455,6 @@ export class Page extends SdkObject {
   }
 
   private async _performWaitForNavigationCheck(progress: Progress) {
-    if (process.env.PLAYWRIGHT_SKIP_NAVIGATION_CHECK)
-      return;
     const mainFrame = this.frameManager.mainFrame();
     if (!mainFrame || !mainFrame.pendingDocument())
       return;


### PR DESCRIPTION
This was an escape hatch for the new navigation waiting functionality introduced 6 months ago, and it is unused on GitHub.