### PR TITLE
Revert "fix(network): Include subdomains of localhost when including …

### DIFF
--- a/packages/playwright-core/src/server/cookieStore.ts
+++ b/packages/playwright-core/src/server/cookieStore.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isLocalHostname, kMaxCookieExpiresDateInSeconds } from './network';
+import { kMaxCookieExpiresDateInSeconds } from './network';
 
 import type * as channels from '@protocol/channels';
 
@@ -30,7 +30,7 @@ export class Cookie {
 
   // https://datatracker.ietf.org/doc/html/rfc6265#section-5.4
   matches(url: URL): boolean {
-    if (this._raw.secure && (url.protocol !== 'https:' && !isLocalHostname(url.hostname)))
+    if (this._raw.secure && (url.protocol !== 'https:' && url.hostname !== 'localhost'))
       return false;
     if (!domainMatches(url.hostname, this._raw.domain))
       return false;

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -43,16 +43,12 @@ export function filterCookies(cookies: channels.NetworkCookie[], urls: string[])
         continue;
       if (!parsedURL.pathname.startsWith(c.path))
         continue;
-      if (parsedURL.protocol !== 'https:' && !isLocalHostname(parsedURL.hostname) && c.secure)
+      if (parsedURL.protocol !== 'https:' && parsedURL.hostname !== 'localhost' && c.secure)
         continue;
       return true;
     }
     return false;
   });
-}
-
-export function isLocalHostname(hostname: string): boolean {
-  return hostname === 'localhost' || hostname.endsWith('.localhost');
 }
 
 // Rollover to 5-digit year:

--- a/tests/library/global-fetch-cookie.spec.ts
+++ b/tests/library/global-fetch-cookie.spec.ts
@@ -37,7 +37,7 @@ type StorageStateType = PromiseArg<ReturnType<APIRequestContext['storageState']>
 it.skip(({ mode }) => mode !== 'default');
 
 const __testHookLookup = (hostname: string): LookupAddress[] => {
-  if (hostname.endsWith('localhost') || hostname.endsWith('one.com') || hostname.endsWith('two.com'))
+  if (hostname === 'localhost' || hostname.endsWith('one.com') || hostname.endsWith('two.com'))
     return [{ address: '127.0.0.1', family: 4 }];
   else
     throw new Error(`Failed to resolve hostname: ${hostname}`);
@@ -136,20 +136,6 @@ it('should send secure cookie over http for localhost', async ({ request, server
   const [serverRequest] = await Promise.all([
     server.waitForRequest('/empty.html'),
     request.get(server.EMPTY_PAGE)
-  ]);
-  expect(serverRequest.headers.cookie).toBe('a=v; b=v');
-});
-
-it('should send secure cookie over http for subdomains of localhost', async ({ request, server }) => {
-  server.setRoute('/setcookie.html', (req, res) => {
-    res.setHeader('Set-Cookie', ['a=v; secure', 'b=v']);
-    res.end();
-  });
-  const prefix = `http://a.b.localhost:${server.PORT}`;
-  await request.get(`${prefix}/setcookie.html`);
-  const [serverRequest] = await Promise.all([
-    server.waitForRequest('/empty.html'),
-    request.get(`${prefix}/empty.html`)
   ]);
   expect(serverRequest.headers.cookie).toBe('a=v; b=v');
 });


### PR DESCRIPTION
…cookies (#35771)"

This reverts commit c3c842c77b3df9b62a2107ebbc76311ea6318e0e.

The new test is failing on Windows and macOS:

```
Error: apiRequestContext.get: getaddrinfo ENOTFOUND a.b.localhost
Call log:
  - → GET http://a.b.localhost:8911/setcookie.html
    - user-agent: Playwright/1.54.0-next (arm64; macOS 14.7) node/18.20 CI/1
    - accept: */*
    - accept-encoding: gzip,deflate,br

    at /Users/runner/work/playwright/playwright/tests/library/global-fetch-cookie.spec.ts:149:17
```

See https://github.com/microsoft/playwright/actions/runs/15570082779