### PR TITLE
fix(tests): lookup localhost subdomains on Win and Mac

### DIFF
--- a/tests/library/global-fetch-cookie.spec.ts
+++ b/tests/library/global-fetch-cookie.spec.ts
@@ -146,7 +146,7 @@ it('should send secure cookie over http for subdomains of localhost', async ({ r
     res.end();
   });
   const prefix = `http://a.b.localhost:${server.PORT}`;
-  await request.get(`${prefix}/setcookie.html`);
+  await request.get(`${prefix}/setcookie.html`, {  __testHookLookup } as any);
   const [serverRequest] = await Promise.all([
     server.waitForRequest('/empty.html'),
     request.get(`${prefix}/empty.html`)


### PR DESCRIPTION
Fix for test failures from https://github.com/microsoft/playwright/pull/35771

The new test was failing on Windows and macOS:

```
Error: apiRequestContext.get: getaddrinfo ENOTFOUND a.b.localhost
Call log:
  - → GET http://a.b.localhost:8911/setcookie.html
    - user-agent: Playwright/1.54.0-next (arm64; macOS 14.7) node/18.20 CI/1
    - accept: */*
    - accept-encoding: gzip,deflate,br

    at /Users/runner/work/playwright/playwright/tests/library/global-fetch-cookie.spec.ts:149:17
```

See https://github.com/microsoft/playwright/actions/runs/15570082779