### PR TITLE
chore: make input actions "strict" in terms of timeout/abort

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiInput.ts
+++ b/packages/playwright-core/src/server/bidi/bidiInput.ts
@@ -59,7 +59,7 @@ export class RawKeyboardImpl implements input.RawKeyboard {
   }
 
   private async _performActions(progress: Progress, actions: bidi.Input.KeySourceAction[]) {
-    await this._session.send('input.performActions', {
+    await progress.race(this._session.send('input.performActions', {
       context: this._session.sessionId,
       actions: [
         {
@@ -68,8 +68,7 @@ export class RawKeyboardImpl implements input.RawKeyboard {
           actions,
         }
       ]
-    });
-    progress.throwIfAborted();
+    }));
   }
 }
 
@@ -96,7 +95,7 @@ export class RawMouseImpl implements input.RawMouse {
     // Bidi throws when x/y are not integers.
     x = Math.floor(x);
     y = Math.floor(y);
-    await this._session.send('input.performActions', {
+    await progress.race(this._session.send('input.performActions', {
       context: this._session.sessionId,
       actions: [
         {
@@ -105,12 +104,11 @@ export class RawMouseImpl implements input.RawMouse {
           actions: [{ type: 'scroll', x, y, deltaX, deltaY }],
         }
       ]
-    });
-    progress.throwIfAborted();
+    }));
   }
 
   private async _performActions(progress: Progress, actions: bidi.Input.PointerSourceAction[]) {
-    await this._session.send('input.performActions', {
+    await progress.race(this._session.send('input.performActions', {
       context: this._session.sessionId,
       actions: [
         {
@@ -122,8 +120,7 @@ export class RawMouseImpl implements input.RawMouse {
           actions,
         }
       ]
-    });
-    progress.throwIfAborted();
+    }));
   }
 }
 

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -168,8 +168,7 @@ export abstract class BrowserContext extends SdkObject {
   async stopPendingOperations(reason: string) {
     // When using context reuse, stop pending operations to gracefully terminate all the actions
     // with a user-friendly error message containing operation log.
-    for (const controller of this._activeProgressControllers)
-      controller.abort(new Error(reason));
+    await Promise.all(Array.from(this._activeProgressControllers).map(controller => controller.abort(reason)));
     // Let rejections in microtask generate events before returning.
     await new Promise(f => setTimeout(f, 0));
   }

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 
 import * as js from './javascript';
-import { ProgressController } from './progress';
+import { isAbortError, ProgressController } from './progress';
 import { asLocator, isUnderTest } from '../utils';
 import { prepareFilesForUpload } from './fileUploadUtils';
 import { isSessionClosedError } from './protocolError';
@@ -141,7 +141,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       const utility = await this._frame._utilityContext();
       return await utility.evaluate(pageFunction, [await utility.injectedScript(), this, arg]);
     } catch (e) {
-      if (js.isJavaScriptErrorInEvaluate(e) || isSessionClosedError(e))
+      if (isAbortError(e) || js.isJavaScriptErrorInEvaluate(e) || isSessionClosedError(e))
         throw e;
       return 'error:notconnected';
     }
@@ -152,7 +152,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       const utility = await this._frame._utilityContext();
       return await utility.evaluateHandle(pageFunction, [await utility.injectedScript(), this, arg]);
     } catch (e) {
-      if (js.isJavaScriptErrorInEvaluate(e) || isSessionClosedError(e))
+      if (isAbortError(e) || js.isJavaScriptErrorInEvaluate(e) || isSessionClosedError(e))
         throw e;
       return 'error:notconnected';
     }
@@ -240,25 +240,25 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return this._frame.dispatchEvent(metadata, ':scope', type, eventInit, { timeout: 0 }, this);
   }
 
-  async _scrollRectIntoViewIfNeeded(rect?: types.Rect): Promise<'error:notvisible' | 'error:notconnected' | 'done'> {
-    return await this._page.delegate.scrollRectIntoViewIfNeeded(this, rect);
+  async _scrollRectIntoViewIfNeeded(progress: Progress, rect?: types.Rect): Promise<'error:notvisible' | 'error:notconnected' | 'done'> {
+    return await progress.race(this._page.delegate.scrollRectIntoViewIfNeeded(this, rect));
   }
 
   async _waitAndScrollIntoViewIfNeeded(progress: Progress, waitForVisible: boolean): Promise<void> {
     const result = await this._retryAction(progress, 'scroll into view', async () => {
       progress.log(`  waiting for element to be stable`);
-      const waitResult = await this.evaluateInUtility(async ([injected, node, { waitForVisible }]) => {
+      const waitResult = await progress.race(this.evaluateInUtility(async ([injected, node, { waitForVisible }]) => {
         return await injected.checkElementStates(node, waitForVisible ? ['visible', 'stable'] : ['stable']);
-      }, { waitForVisible });
+      }, { waitForVisible }));
       if (waitResult)
         return waitResult;
-      return await this._scrollRectIntoViewIfNeeded();
+      return await this._scrollRectIntoViewIfNeeded(progress);
     }, {});
     assertDone(throwRetargetableDOMError(result));
   }
 
   async scrollIntoViewIfNeeded(metadata: CallMetadata, options: types.TimeoutOptions) {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(
         progress => this._waitAndScrollIntoViewIfNeeded(progress, false /* waitForVisible */),
         options.timeout);
@@ -336,13 +336,14 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     // We progressively wait longer between retries, up to 500ms.
     const waitTime = [0, 20, 100, 100, 500];
 
-    while (progress.isRunning()) {
+    while (true) {
+      progress.throwIfAborted();
       if (retry) {
         progress.log(`retrying ${actionName} action${options.trial ? ' (trial run)' : ''}`);
         const timeout = waitTime[Math.min(retry - 1, waitTime.length - 1)];
         if (timeout) {
           progress.log(`  waiting ${timeout}ms`);
-          const result = await this.evaluateInUtility(([injected, node, timeout]) => new Promise<void>(f => setTimeout(f, timeout)), timeout);
+          const result = await progress.race(this.evaluateInUtility(([injected, node, timeout]) => new Promise<void>(f => setTimeout(f, timeout)), timeout));
           if (result === 'error:notconnected')
             return result;
         }
@@ -379,11 +380,10 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       }
       return result;
     }
-    return 'done';
   }
 
   async _retryPointerAction(progress: Progress, actionName: ActionName, waitForEnabled: boolean, action: (point: types.Point) => Promise<void>,
-    options: { waitAfter: boolean | 'disabled' } & types.PointerActionOptions & types.PointerActionWaitOptions): Promise<'error:notconnected' | 'done'> {
+    options: Omit<{ waitAfter: boolean | 'disabled' } & types.PointerActionOptions & types.PointerActionWaitOptions, 'timeout'>): Promise<'error:notconnected' | 'done'> {
     // Note: do not perform locator handlers checkpoint to avoid moving the mouse in the middle of a drag operation.
     const skipActionPreChecks = actionName === 'move and up';
     // By default, we scroll with protocol method to reveal the action point.
@@ -414,7 +414,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     waitForEnabled: boolean,
     action: (point: types.Point) => Promise<void>,
     forceScrollOptions: ScrollIntoViewOptions | undefined,
-    options: { waitAfter: boolean | 'disabled' } & types.PointerActionOptions & types.PointerActionWaitOptions,
+    options: Omit<{ waitAfter: boolean | 'disabled' } & types.PointerActionOptions & types.PointerActionWaitOptions, 'timeout'>,
   ): Promise<PerformActionResult> {
     const { force = false, position } = options;
 
@@ -426,7 +426,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
           return 'done' as const;
         }, forceScrollOptions);
       }
-      return await this._scrollRectIntoViewIfNeeded(position ? { x: position.x, y: position.y, width: 0, height: 0 } : undefined);
+      return await this._scrollRectIntoViewIfNeeded(progress, position ? { x: position.x, y: position.y, width: 0, height: 0 } : undefined);
     };
 
     if (this._frame.parentFrame()) {
@@ -434,53 +434,53 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       // into view and visible, so they are not throttled.
       // See https://github.com/microsoft/playwright/issues/27196 for an example.
       progress.throwIfAborted();  // Avoid action that has side-effects.
-      await doScrollIntoView().catch(() => {});
+      await progress.race(doScrollIntoView().catch(() => {}));
     }
 
     if ((options as any).__testHookBeforeStable)
-      await (options as any).__testHookBeforeStable();
+      await progress.race((options as any).__testHookBeforeStable());
 
     if (!force) {
       const elementStates: ElementState[] = waitForEnabled ? ['visible', 'enabled', 'stable'] : ['visible', 'stable'];
       progress.log(`  waiting for element to be ${waitForEnabled ? 'visible, enabled and stable' : 'visible and stable'}`);
-      const result = await this.evaluateInUtility(async ([injected, node, { elementStates }]) => {
+      const result = await progress.race(this.evaluateInUtility(async ([injected, node, { elementStates }]) => {
         return await injected.checkElementStates(node, elementStates);
-      }, { elementStates });
+      }, { elementStates }));
       if (result)
         return result;
       progress.log(`  element is ${waitForEnabled ? 'visible, enabled and stable' : 'visible and stable'}`);
     }
 
     if ((options as any).__testHookAfterStable)
-      await (options as any).__testHookAfterStable();
+      await progress.race((options as any).__testHookAfterStable());
 
     progress.log('  scrolling into view if needed');
     progress.throwIfAborted();  // Avoid action that has side-effects.
-    const scrolled = await doScrollIntoView();
+    const scrolled = await progress.race(doScrollIntoView());
     if (scrolled !== 'done')
       return scrolled;
     progress.log('  done scrolling');
 
-    const maybePoint = position ? await this._offsetPoint(position) : await this._clickablePoint();
+    const maybePoint = position ? await progress.race(this._offsetPoint(position)) : await progress.race(this._clickablePoint());
     if (typeof maybePoint === 'string')
       return maybePoint;
     const point = roundPoint(maybePoint);
     progress.metadata.point = point;
-    await this.instrumentation.onBeforeInputAction(this, progress.metadata);
+    await progress.race(this.instrumentation.onBeforeInputAction(this, progress.metadata));
 
     let hitTargetInterceptionHandle: js.JSHandle<HitTargetInterceptionResult> | undefined;
     if (force) {
       progress.log(`  forcing action`);
     } else {
       if ((options as any).__testHookBeforeHitTarget)
-        await (options as any).__testHookBeforeHitTarget();
+        await progress.race((options as any).__testHookBeforeHitTarget());
 
-      const frameCheckResult = await this._checkFrameIsHitTarget(point);
+      const frameCheckResult = await progress.race(this._checkFrameIsHitTarget(point));
       if (frameCheckResult === 'error:notconnected' || ('hitTargetDescription' in frameCheckResult))
         return frameCheckResult;
       const hitPoint = frameCheckResult.framePoint;
       const actionType = actionName === 'move and up' ? 'drag' : ((actionName === 'hover' || actionName === 'tap') ? actionName : 'mouse');
-      const handle = await this.evaluateHandleInUtility(([injected, node, { actionType, hitPoint, trial }]) => injected.setupHitTargetInterceptor(node, actionType, hitPoint, trial), { actionType, hitPoint, trial: !!options.trial } as const);
+      const handle = await progress.race(this.evaluateHandleInUtility(([injected, node, { actionType, hitPoint, trial }]) => injected.setupHitTargetInterceptor(node, actionType, hitPoint, trial), { actionType, hitPoint, trial: !!options.trial } as const));
       if (handle === 'error:notconnected')
         return handle;
       if (!handle._objectId) {
@@ -500,7 +500,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
     const actionResult = await this._page.frameManager.waitForSignalsCreatedBy(progress, options.waitAfter === true, async () => {
       if ((options as any).__testHookBeforePointerAction)
-        await (options as any).__testHookBeforePointerAction();
+        await progress.race((options as any).__testHookBeforePointerAction());
       progress.throwIfAborted();  // Avoid action that has side-effects.
       let restoreModifiers: types.KeyboardModifier[] | undefined;
       if (options && options.modifiers)
@@ -518,7 +518,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
         if (options.waitAfter !== false) {
           // When noWaitAfter is passed, we do not want to accidentally stall on
           // non-committed navigation blocking the evaluate.
-          const hitTargetResult = await stopHitTargetInterception;
+          const hitTargetResult = await progress.race(stopHitTargetInterception);
           if (hitTargetResult !== 'done')
             return hitTargetResult;
         }
@@ -526,7 +526,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       progress.log(`  ${options.trial ? 'trial ' : ''}${actionName} action done`);
       progress.log('  waiting for scheduled navigations to finish');
       if ((options as any).__testHookAfterPointerAction)
-        await (options as any).__testHookAfterPointerAction();
+        await progress.race((options as any).__testHookAfterPointerAction());
       return 'done';
     });
     if (actionResult !== 'done')
@@ -535,19 +535,19 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return 'done';
   }
 
-  private async _markAsTargetElement(metadata: CallMetadata) {
-    if (!metadata.id)
+  private async _markAsTargetElement(progress: Progress) {
+    if (!progress.metadata.id)
       return;
-    await this.evaluateInUtility(([injected, node, callId]) => {
+    await progress.race(this.evaluateInUtility(([injected, node, callId]) => {
       if (node.nodeType === 1 /* Node.ELEMENT_NODE */)
         injected.markTargetElements(new Set([node as Node as Element]), callId);
-    }, metadata.id);
+    }, progress.metadata.id));
   }
 
   async hover(metadata: CallMetadata, options: types.PointerActionOptions & types.PointerActionWaitOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
-      await this._markAsTargetElement(metadata);
+      await this._markAsTargetElement(progress);
       const result = await this._hover(progress, options);
       return assertDone(throwRetargetableDOMError(result));
     }, options.timeout);
@@ -558,9 +558,9 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async click(metadata: CallMetadata, options: { noWaitAfter?: boolean } & types.MouseClickOptions & types.PointerActionWaitOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
-      await this._markAsTargetElement(metadata);
+      await this._markAsTargetElement(progress);
       const result = await this._click(progress, { ...options, waitAfter: !options.noWaitAfter });
       return assertDone(throwRetargetableDOMError(result));
     }, options.timeout);
@@ -571,9 +571,9 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async dblclick(metadata: CallMetadata, options: types.MouseMultiClickOptions & types.PointerActionWaitOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
-      await this._markAsTargetElement(metadata);
+      await this._markAsTargetElement(progress);
       const result = await this._dblclick(progress, options);
       return assertDone(throwRetargetableDOMError(result));
     }, options.timeout);
@@ -584,9 +584,9 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async tap(metadata: CallMetadata, options: types.PointerActionWaitOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
-      await this._markAsTargetElement(metadata);
+      await this._markAsTargetElement(progress);
       const result = await this._tap(progress, options);
       return assertDone(throwRetargetableDOMError(result));
     }, options.timeout);
@@ -597,9 +597,9 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async selectOption(metadata: CallMetadata, elements: ElementHandle[], values: types.SelectOption[], options: types.CommonActionOptions): Promise<string[]> {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
-      await this._markAsTargetElement(metadata);
+      await this._markAsTargetElement(progress);
       const result = await this._selectOption(progress, elements, values, options);
       return throwRetargetableDOMError(result);
     }, options.timeout);
@@ -608,18 +608,18 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async _selectOption(progress: Progress, elements: ElementHandle[], values: types.SelectOption[], options: types.CommonActionOptions): Promise<string[] | 'error:notconnected'> {
     let resultingOptions: string[] = [];
     const result = await this._retryAction(progress, 'select option', async () => {
-      await this.instrumentation.onBeforeInputAction(this, progress.metadata);
+      await progress.race(this.instrumentation.onBeforeInputAction(this, progress.metadata));
       if (!options.force)
         progress.log(`  waiting for element to be visible and enabled`);
       const optionsToSelect = [...elements, ...values];
-      const result = await this.evaluateInUtility(async ([injected, node, { optionsToSelect, force }]) => {
+      const result = await progress.race(this.evaluateInUtility(async ([injected, node, { optionsToSelect, force }]) => {
         if (!force) {
           const checkResult = await injected.checkElementStates(node, ['visible', 'enabled']);
           if (checkResult)
             return checkResult;
         }
         return injected.selectOptions(node, optionsToSelect);
-      }, { optionsToSelect, force: options.force });
+      }, { optionsToSelect, force: options.force }));
       if (Array.isArray(result)) {
         progress.log('  selected specified option(s)');
         resultingOptions = result;
@@ -633,9 +633,9 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async fill(metadata: CallMetadata, value: string, options: types.CommonActionOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
-      await this._markAsTargetElement(metadata);
+      await this._markAsTargetElement(progress);
       const result = await this._fill(progress, value, options);
       assertDone(throwRetargetableDOMError(result));
     }, options.timeout);
@@ -644,17 +644,17 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async _fill(progress: Progress, value: string, options: types.CommonActionOptions): Promise<'error:notconnected' | 'done'> {
     progress.log(`  fill("${value}")`);
     return await this._retryAction(progress, 'fill', async () => {
-      await this.instrumentation.onBeforeInputAction(this, progress.metadata);
+      await progress.race(this.instrumentation.onBeforeInputAction(this, progress.metadata));
       if (!options.force)
         progress.log('  waiting for element to be visible, enabled and editable');
-      const result = await this.evaluateInUtility(async ([injected, node, { value, force }]) => {
+      const result = await progress.race(this.evaluateInUtility(async ([injected, node, { value, force }]) => {
         if (!force) {
           const checkResult = await injected.checkElementStates(node, ['visible', 'enabled', 'editable']);
           if (checkResult)
             return checkResult;
         }
         return injected.fill(node, value);
-      }, { value, force: options.force });
+      }, { value, force: options.force }));
       progress.throwIfAborted();  // Avoid action that has side-effects.
       if (result === 'needsinput') {
         if (value)
@@ -669,29 +669,29 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async selectText(metadata: CallMetadata, options: types.CommonActionOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
       const result = await this._retryAction(progress, 'selectText', async () => {
         if (!options.force)
           progress.log('  waiting for element to be visible');
-        return await this.evaluateInUtility(async ([injected, node, { force }]) => {
+        return await progress.race(this.evaluateInUtility(async ([injected, node, { force }]) => {
           if (!force) {
             const checkResult = await injected.checkElementStates(node, ['visible']);
             if (checkResult)
               return checkResult;
           }
           return injected.selectText(node);
-        }, { force: options.force });
+        }, { force: options.force }));
       }, options);
       assertDone(throwRetargetableDOMError(result));
     }, options.timeout);
   }
 
   async setInputFiles(metadata: CallMetadata, params: channels.ElementHandleSetInputFilesParams) {
-    const inputFileItems = await prepareFilesForUpload(this._frame, params);
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
-      await this._markAsTargetElement(metadata);
+      const inputFileItems = await progress.race(prepareFilesForUpload(this._frame, params));
+      await this._markAsTargetElement(progress);
       const result = await this._setInputFiles(progress, inputFileItems);
       return assertDone(throwRetargetableDOMError(result));
     }, params.timeout);
@@ -700,7 +700,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async _setInputFiles(progress: Progress, items: InputFilesItems): Promise<'error:notconnected' | 'done'> {
     const { filePayloads, localPaths, localDirectory } = items;
     const multiple = filePayloads && filePayloads.length > 1 || localPaths && localPaths.length > 1;
-    const result = await this.evaluateHandleInUtility(([injected, node, { multiple, directoryUpload }]): Element | undefined => {
+    const result = await progress.race(this.evaluateHandleInUtility(([injected, node, { multiple, directoryUpload }]): Element | undefined => {
       const element = injected.retarget(node, 'follow-label');
       if (!element)
         return;
@@ -714,53 +714,50 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       if (!directoryUpload && inputElement.webkitdirectory)
         throw injected.createStacklessError('[webkitdirectory] input requires passing a path to a directory');
       return inputElement;
-    }, { multiple, directoryUpload: !!localDirectory });
+    }, { multiple, directoryUpload: !!localDirectory }));
     if (result === 'error:notconnected' || !result.asElement())
       return 'error:notconnected';
     const retargeted = result.asElement() as ElementHandle<HTMLInputElement>;
-    await this.instrumentation.onBeforeInputAction(this, progress.metadata);
-    progress.throwIfAborted();  // Avoid action that has side-effects.
+    await progress.race(this.instrumentation.onBeforeInputAction(this, progress.metadata));
     if (localPaths || localDirectory) {
       const localPathsOrDirectory = localDirectory ? [localDirectory] : localPaths!;
-      await Promise.all((localPathsOrDirectory).map(localPath => (
+      await progress.race(Promise.all((localPathsOrDirectory).map(localPath => (
         fs.promises.access(localPath, fs.constants.F_OK)
-      )));
+      ))));
       // Browsers traverse the given directory asynchronously and we want to ensure all files are uploaded.
       const waitForInputEvent = localDirectory ? this.evaluate(node => new Promise<any>(fulfill => {
         node.addEventListener('input', fulfill, { once: true });
       })).catch(() => {}) : Promise.resolve();
-      await this._page.delegate.setInputFilePaths(retargeted, localPathsOrDirectory);
-      await waitForInputEvent;
+      await progress.race(this._page.delegate.setInputFilePaths(retargeted, localPathsOrDirectory));
+      await progress.race(waitForInputEvent);
     } else {
-      await retargeted.evaluateInUtility(([injected, node, files]) =>
-        injected.setInputFiles(node, files), filePayloads!);
+      await progress.race(retargeted.evaluateInUtility(([injected, node, files]) =>
+        injected.setInputFiles(node, files), filePayloads!));
     }
     return 'done';
   }
 
   async focus(metadata: CallMetadata): Promise<void> {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     await controller.run(async progress => {
-      await this._markAsTargetElement(metadata);
+      await this._markAsTargetElement(progress);
       const result = await this._focus(progress);
       return assertDone(throwRetargetableDOMError(result));
     }, 0);
   }
 
   async _focus(progress: Progress, resetSelectionIfNotFocused?: boolean): Promise<'error:notconnected' | 'done'> {
-    progress.throwIfAborted();  // Avoid action that has side-effects.
-    return await this.evaluateInUtility(([injected, node, resetSelectionIfNotFocused]) => injected.focusNode(node, resetSelectionIfNotFocused), resetSelectionIfNotFocused);
+    return await progress.race(this.evaluateInUtility(([injected, node, resetSelectionIfNotFocused]) => injected.focusNode(node, resetSelectionIfNotFocused), resetSelectionIfNotFocused));
   }
 
   async _blur(progress: Progress): Promise<'error:notconnected' | 'done'> {
-    progress.throwIfAborted();  // Avoid action that has side-effects.
-    return await this.evaluateInUtility(([injected, node]) => injected.blurNode(node), {});
+    return await progress.race(this.evaluateInUtility(([injected, node]) => injected.blurNode(node), {}));
   }
 
   async type(metadata: CallMetadata, text: string, options: { delay?: number } & types.TimeoutOptions & types.StrictOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
-      await this._markAsTargetElement(metadata);
+      await this._markAsTargetElement(progress);
       const result = await this._type(progress, text, options);
       return assertDone(throwRetargetableDOMError(result));
     }, options.timeout);
@@ -768,19 +765,18 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
   async _type(progress: Progress, text: string, options: { delay?: number } & types.TimeoutOptions & types.StrictOptions): Promise<'error:notconnected' | 'done'> {
     progress.log(`elementHandle.type("${text}")`);
-    await this.instrumentation.onBeforeInputAction(this, progress.metadata);
+    await progress.race(this.instrumentation.onBeforeInputAction(this, progress.metadata));
     const result = await this._focus(progress, true /* resetSelectionIfNotFocused */);
     if (result !== 'done')
       return result;
-    progress.throwIfAborted();  // Avoid action that has side-effects.
     await this._page.keyboard._type(progress, text, options);
     return 'done';
   }
 
   async press(metadata: CallMetadata, key: string, options: { delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions & types.StrictOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
-      await this._markAsTargetElement(metadata);
+      await this._markAsTargetElement(progress);
       const result = await this._press(progress, key, options);
       return assertDone(throwRetargetableDOMError(result));
     }, options.timeout);
@@ -788,19 +784,18 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
   async _press(progress: Progress, key: string, options: { delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions & types.StrictOptions): Promise<'error:notconnected' | 'done'> {
     progress.log(`elementHandle.press("${key}")`);
-    await this.instrumentation.onBeforeInputAction(this, progress.metadata);
+    await progress.race(this.instrumentation.onBeforeInputAction(this, progress.metadata));
     return this._page.frameManager.waitForSignalsCreatedBy(progress, !options.noWaitAfter, async () => {
       const result = await this._focus(progress, true /* resetSelectionIfNotFocused */);
       if (result !== 'done')
         return result;
-      progress.throwIfAborted();  // Avoid action that has side-effects.
       await this._page.keyboard._press(progress, key, options);
       return 'done';
     });
   }
 
   async check(metadata: CallMetadata, options: { position?: types.Point } & types.PointerActionWaitOptions) {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
       const result = await this._setChecked(progress, true, options);
       return assertDone(throwRetargetableDOMError(result));
@@ -808,7 +803,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async uncheck(metadata: CallMetadata, options: { position?: types.Point } & types.PointerActionWaitOptions) {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
       const result = await this._setChecked(progress, false, options);
       return assertDone(throwRetargetableDOMError(result));
@@ -817,12 +812,12 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
   async _setChecked(progress: Progress, state: boolean, options: { position?: types.Point } & types.PointerActionWaitOptions): Promise<'error:notconnected' | 'done'> {
     const isChecked = async () => {
-      const result = await this.evaluateInUtility(([injected, node]) => injected.elementState(node, 'checked'), {});
+      const result = await progress.race(this.evaluateInUtility(([injected, node]) => injected.elementState(node, 'checked'), {}));
       if (result === 'error:notconnected' || result.received === 'error:notconnected')
         throwElementIsNotAttached();
       return result.matches;
     };
-    await this._markAsTargetElement(progress.metadata);
+    await this._markAsTargetElement(progress);
     if (await isChecked() === state)
       return 'done';
     const result = await this._click(progress, { ...options, waitAfter: 'disabled' });
@@ -891,13 +886,13 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async waitForElementState(metadata: CallMetadata, state: 'visible' | 'hidden' | 'stable' | 'enabled' | 'disabled' | 'editable', options: types.TimeoutOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this);
+    const controller = new ProgressController(metadata, this, 'strict');
     return controller.run(async progress => {
       const actionName = `wait for ${state}`;
       const result = await this._retryAction(progress, actionName, async () => {
-        return await this.evaluateInUtility(async ([injected, node, state]) => {
+        return await progress.race(this.evaluateInUtility(async ([injected, node, state]) => {
           return (await injected.checkElementStates(node, [state])) || 'done';
-        }, state);
+        }, state));
       }, {});
       assertDone(throwRetargetableDOMError(result));
     }, options.timeout);

--- a/packages/playwright-core/src/server/helper.ts
+++ b/packages/playwright-core/src/server/helper.ts
@@ -55,7 +55,7 @@ class Helper {
     return null;
   }
 
-  static waitForEvent(progress: Progress | null, emitter: EventEmitter, event: string | symbol, predicate?: Function): { promise: Promise<any>, dispose: () => void } {
+  static waitForEvent(progress: Progress, emitter: EventEmitter, event: string | symbol, predicate?: Function): { promise: Promise<any>, dispose: () => void } {
     const listeners: RegisteredListener[] = [];
     const promise = new Promise((resolve, reject) => {
       listeners.push(eventsHelper.addEventListener(emitter, event, eventArg => {
@@ -71,8 +71,7 @@ class Helper {
       }));
     });
     const dispose = () => eventsHelper.removeEventListeners(listeners);
-    if (progress)
-      progress.cleanupWhenAborted(dispose);
+    progress.cleanupWhenAborted(dispose);
     return { promise, dispose };
   }
 

--- a/packages/playwright-core/src/server/input.ts
+++ b/packages/playwright-core/src/server/input.ts
@@ -55,7 +55,7 @@ export class Keyboard {
   }
 
   async down(metadata: CallMetadata, key: string) {
-    const controller = new ProgressController(metadata, this._page);
+    const controller = new ProgressController(metadata, this._page, 'strict');
     return controller.run(progress => this._down(progress, key));
   }
 
@@ -82,7 +82,7 @@ export class Keyboard {
   }
 
   async up(metadata: CallMetadata, key: string) {
-    const controller = new ProgressController(metadata, this._page);
+    const controller = new ProgressController(metadata, this._page, 'strict');
     return controller.run(progress => this._up(progress, key));
   }
 
@@ -95,7 +95,7 @@ export class Keyboard {
   }
 
   async insertText(metadata: CallMetadata, text: string) {
-    const controller = new ProgressController(metadata, this._page);
+    const controller = new ProgressController(metadata, this._page, 'strict');
     return controller.run(progress => this._insertText(progress, text));
   }
 
@@ -104,7 +104,7 @@ export class Keyboard {
   }
 
   async type(metadata: CallMetadata, text: string, options?: { delay?: number }) {
-    const controller = new ProgressController(metadata, this._page);
+    const controller = new ProgressController(metadata, this._page, 'strict');
     return controller.run(progress => this._type(progress, text, options));
   }
 
@@ -115,14 +115,14 @@ export class Keyboard {
         await this._press(progress, char, { delay });
       } else {
         if (delay)
-          await wait(progress, delay);
+          await progress.wait(delay);
         await this._insertText(progress, char);
       }
     }
   }
 
   async press(metadata: CallMetadata, key: string, options: { delay?: number }) {
-    const controller = new ProgressController(metadata, this._page);
+    const controller = new ProgressController(metadata, this._page, 'strict');
     return controller.run(progress => this._press(progress, key, options));
   }
 
@@ -148,7 +148,7 @@ export class Keyboard {
       await this._down(progress, tokens[i]);
     await this._down(progress, key);
     if (options.delay)
-      await wait(progress, options.delay);
+      await progress.wait(options.delay);
     await this._up(progress, key);
     for (let i = tokens.length - 2; i >= 0; --i)
       await this._up(progress, tokens[i]);
@@ -214,7 +214,7 @@ export class Mouse {
   }
 
   async move(metadata: CallMetadata, x: number, y: number, options: { steps?: number, forClick?: boolean }) {
-    const controller = new ProgressController(metadata, this._page);
+    const controller = new ProgressController(metadata, this._page, 'strict');
     return controller.run(progress => this._move(progress, x, y, options));
   }
 
@@ -232,7 +232,7 @@ export class Mouse {
   }
 
   async down(metadata: CallMetadata, options: { button?: types.MouseButton, clickCount?: number }) {
-    const controller = new ProgressController(metadata, this._page);
+    const controller = new ProgressController(metadata, this._page, 'strict');
     return controller.run(progress => this._down(progress, options));
   }
 
@@ -244,7 +244,7 @@ export class Mouse {
   }
 
   async up(metadata: CallMetadata, options: { button?: types.MouseButton, clickCount?: number }) {
-    const controller = new ProgressController(metadata, this._page);
+    const controller = new ProgressController(metadata, this._page, 'strict');
     return controller.run(progress => this._up(progress, options));
   }
 
@@ -256,7 +256,7 @@ export class Mouse {
   }
 
   async click(metadata: CallMetadata, x: number, y: number, options: { delay?: number, button?: types.MouseButton, clickCount?: number }) {
-    const controller = new ProgressController(metadata, this._page);
+    const controller = new ProgressController(metadata, this._page, 'strict');
     return controller.run(progress => this._click(progress, x, y, options));
   }
 
@@ -266,10 +266,10 @@ export class Mouse {
       this._move(progress, x, y, { forClick: true });
       for (let cc = 1; cc <= clickCount; ++cc) {
         await this._down(progress, { ...options, clickCount: cc });
-        await wait(progress, delay);
+        await progress.wait(delay);
         await this._up(progress, { ...options, clickCount: cc });
         if (cc < clickCount)
-          await wait(progress, delay);
+          await progress.wait(delay);
       }
     } else {
       const promises = [];
@@ -283,7 +283,7 @@ export class Mouse {
   }
 
   async wheel(metadata: CallMetadata, deltaX: number, deltaY: number) {
-    const controller = new ProgressController(metadata, this._page);
+    const controller = new ProgressController(metadata, this._page, 'strict');
     return controller.run(async progress => {
       await this._raw.wheel(progress, this._x, this._y, this._buttons, this._keyboard._modifiers(), deltaX, deltaY);
     });
@@ -364,7 +364,7 @@ export class Touchscreen {
   }
 
   async tap(metadata: CallMetadata, x: number, y: number) {
-    const controller = new ProgressController(metadata, this._page);
+    const controller = new ProgressController(metadata, this._page, 'strict');
     return controller.run(progress => this._tap(progress, x, y));
   }
 
@@ -373,9 +373,4 @@ export class Touchscreen {
       throw new Error('hasTouch must be enabled on the browser context before using the touchscreen.');
     await this._raw.tap(progress, x, y, this._page.keyboard._modifiers());
   }
-}
-
-async function wait(progress: Progress, ms: number) {
-  await new Promise(f => setTimeout(f, Math.min(ms, progress.timeUntilDeadline())));
-  progress.throwIfAborted();
 }

--- a/packages/playwright-core/src/server/progress.ts
+++ b/packages/playwright-core/src/server/progress.ts
@@ -24,27 +24,37 @@ import type { LogName } from './utils/debugLogger';
 export interface Progress {
   log(message: string): void;
   timeUntilDeadline(): number;
-  isRunning(): boolean;
   cleanupWhenAborted(cleanup: () => any): void;
   throwIfAborted(): void;
+  race<T>(promise: Promise<T> | Promise<T>[]): Promise<T>;
+  raceWithCleanup<T>(promise: Promise<T>, cleanup: (result: T) => any): Promise<T>;
+  wait(timeout: number): Promise<void>;
   metadata: CallMetadata;
 }
 
 export class ProgressController {
   private _forceAbortPromise = new ManualPromise<any>();
+  private _donePromise = new ManualPromise<void>();
 
   // Cleanups to be run only in the case of abort.
   private _cleanups: (() => any)[] = [];
 
+  // Lenient mode races against the timeout. This guarantees that timeout is respected,
+  // but may have some work being done after the timeout due to parallel control flow.
+  //
+  // Strict mode aborts the progress and requires the code to react to it. This way,
+  // progress only finishes after the inner callback exits, guaranteeing no work after the timeout.
+  private _strictMode = false;
+
   private _logName: LogName;
-  private _state: 'before' | 'running' | 'aborted' | 'finished' = 'before';
+  private _state: 'before' | 'running' | { error: Error } | 'finished' = 'before';
   private _deadline: number = 0;
-  private _timeout: number = 0;
   readonly metadata: CallMetadata;
   readonly instrumentation: Instrumentation;
   readonly sdkObject: SdkObject;
 
-  constructor(metadata: CallMetadata, sdkObject: SdkObject) {
+  constructor(metadata: CallMetadata, sdkObject: SdkObject, strictMode?: 'strict') {
+    this._strictMode = strictMode === 'strict';
     this.metadata = metadata;
     this.sdkObject = sdkObject;
     this.instrumentation = sdkObject.instrumentation;
@@ -56,15 +66,18 @@ export class ProgressController {
     this._logName = logName;
   }
 
-  abort(error: Error) {
-    this._forceAbortPromise.reject(error);
+  async abort(message: string) {
+    if (this._state === 'running') {
+      const error = new AbortedError(message);
+      this._state = { error };
+      this._forceAbortPromise.reject(error);
+    }
+    if (this._strictMode)
+      await this._donePromise;
   }
 
   async run<T>(task: (progress: Progress) => Promise<T>, timeout?: number): Promise<T> {
-    if (timeout) {
-      this._timeout = timeout;
-      this._deadline = timeout ? monotonicTime() + timeout : 0;
-    }
+    this._deadline = timeout ? monotonicTime() + timeout : 0;
 
     assert(this._state === 'before');
     this._state = 'running';
@@ -78,7 +91,6 @@ export class ProgressController {
         this.instrumentation.onCallLog(this.sdkObject, this.metadata, this._logName, message);
       },
       timeUntilDeadline: () => this._deadline ? this._deadline - monotonicTime() : 2147483647, // 2^31-1 safe setTimeout in Node.
-      isRunning: () => this._state === 'running',
       cleanupWhenAborted: (cleanup: () => any) => {
         if (this._state === 'running')
           this._cleanups.push(cleanup);
@@ -86,26 +98,47 @@ export class ProgressController {
           runCleanup(cleanup);
       },
       throwIfAborted: () => {
-        if (this._state === 'aborted')
-          throw new AbortedError();
+        if (typeof this._state === 'object')
+          throw this._state.error;
       },
-      metadata: this.metadata
+      metadata: this.metadata,
+      race: <T>(promise: Promise<T> | Promise<T>[]) => {
+        const promises = Array.isArray(promise) ? promise : [promise];
+        return Promise.race([...promises, this._forceAbortPromise]);
+      },
+      raceWithCleanup: <T>(promise: Promise<T>, cleanup: (result: T) => any) => {
+        return progress.race(promise.then(result => {
+          progress.cleanupWhenAborted(() => cleanup(result));
+          return result;
+        }));
+      },
+      wait: async (timeout: number) => {
+        let timer: NodeJS.Timeout;
+        const promise = new Promise<void>(f => timer = setTimeout(f, timeout));
+        return progress.race(promise).finally(() => clearTimeout(timer));
+      },
     };
 
-    const timeoutError = new TimeoutError(`Timeout ${this._timeout}ms exceeded.`);
-    const timer = setTimeout(() => this._forceAbortPromise.reject(timeoutError), progress.timeUntilDeadline());
+    const timeoutError = new TimeoutError(`Timeout ${timeout}ms exceeded.`);
+    const timer = setTimeout(() => {
+      if (this._state === 'running') {
+        this._state = { error: timeoutError };
+        this._forceAbortPromise.reject(timeoutError);
+      }
+    }, progress.timeUntilDeadline());
     try {
       const promise = task(progress);
-      const result = await Promise.race([promise, this._forceAbortPromise]);
+      const result = this._strictMode ? await promise : await Promise.race([promise, this._forceAbortPromise]);
       this._state = 'finished';
       return result;
-    } catch (e) {
-      this._state = 'aborted';
+    } catch (error) {
+      this._state = { error };
       await Promise.all(this._cleanups.splice(0).map(runCleanup));
-      throw e;
+      throw error;
     } finally {
       this.sdkObject.attribution.context?._activeProgressControllers.delete(this);
       clearTimeout(timer);
+      this._donePromise.resolve();
     }
   }
 }
@@ -118,3 +151,7 @@ async function runCleanup(cleanup: () => any) {
 }
 
 class AbortedError extends Error {}
+
+export function isAbortError(error: Error): boolean {
+  return error instanceof AbortedError || error instanceof TimeoutError;
+}

--- a/tests/page/page-add-locator-handler.spec.ts
+++ b/tests/page/page-add-locator-handler.spec.ts
@@ -313,7 +313,7 @@ test('should wait for hidden by default 2', async ({ page, server }) => {
   });
   const error = await page.locator('#target').click({ timeout: 3000 }).catch(e => e);
   expect(await page.evaluate('window.clicked')).toBe(0);
-  await expect(page.locator('#interstitial')).toBeVisible();
+  expect(await page.locator('#interstitial').isVisible()).toBe(true);
   expect(called).toBe(1);
   expect(error.message).toContain(`locator handler has finished, waiting for getByRole('button', { name: 'close' }) to be hidden`);
 });


### PR DESCRIPTION
This introduces a "strict" mode to `Progress`, where it waits until the action completes instead of racing against a timeout.

The action is responsible to terminate upon progress being aborted. The "rule of thumb" is - whenever a method accepts a progress, it must either succeed before the progress aborts or throw an error.

To support this new scheme, some new APIs have been added to the progress:
- `race()` to race any promise against the abort. Useful for things like `evaluate()` that do not change the state of the page, or single protocol commands. Many places now use this method to ensure they terminate when the progress is aborted.
- `raceWithCleanup()` that combines `race()` and `cleanupWhenAborted()`.
- `wait()` that waits for a timeout, but is aware of progress abort.

References #35987.