### PR TITLE
feat:  Make request tab sections collapsible with visual hierarchy

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -65,6 +65,10 @@
   text-align: center;
 }
 
+.codicon-chevron {
+  margin-right: 4px;
+}
+
 .network-collapsible-section {
   margin-bottom: 12px;
 }
@@ -117,6 +121,7 @@
   font-weight: 600;
   word-break: break-word;
   flex: 1;
+  display: 'inline-flex';
 }
 
 .tab-network .toolbar {

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -101,19 +101,19 @@
 .network-collapsible-suffix {
   margin-left: 6px;
   opacity: 0.7;
-  font-size: 14px; /* 90% of 16px default font size */
+  font-size: 14px;
 }
 
 .network-key-value {
   display: flex;
-  margin-bottom: 4px; /* 0.25rem ≈ 4px */
+  margin-bottom: 4px;
   align-items: center;
 }
 
 .network-key {
   font-weight: 400;
-  margin-right: 8px; /* 0.5rem ≈ 8px */
-  min-width: 144px; /* 9rem ≈ 144px */
+  margin-right: 8px;
+  min-width: 144px;
   white-space: nowrap;
 }
 

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -65,6 +65,60 @@
   text-align: center;
 }
 
+.network-collapsible-section {
+  margin-bottom: 12px;
+}
+
+.network-collapsible-header {
+  font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+  position: relative;
+}
+
+.network-collapsible-header::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-color: currentColor;
+  opacity: 0.07;
+  pointer-events: none;
+  border-radius: 4px;
+}
+
+.network-collapsible-content {
+  padding-left: 16px;
+  white-space: pre-wrap;
+  font-family: monospace;
+}
+
+.network-collapsible-suffix {
+  margin-left: 6px;
+  opacity: 0.7;
+  font-size: 14px; /* 90% of 16px default font size */
+}
+
+.network-key-value {
+  display: flex;
+  margin-bottom: 4px; /* 0.25rem ≈ 4px */
+  align-items: center;
+}
+
+.network-key {
+  font-weight: 400;
+  margin-right: 8px; /* 0.5rem ≈ 8px */
+  min-width: 144px; /* 9rem ≈ 144px */
+  white-space: nowrap;
+}
+
+.network-value {
+  font-weight: 600;
+  word-break: break-word;
+  flex: 1;
+}
+
 .tab-network .toolbar {
   min-height: 30px !important;
   background-color: initial !important;

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -103,33 +103,111 @@ const CopyDropdown: React.FC<{
   );
 };
 
+const CollapsibleSection: React.FC<{
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  collapsedSuffix?: React.ReactNode;
+}> = ({ title, children, defaultOpen = true, collapsedSuffix }) => {
+  const [isOpen, setIsOpen] = React.useState(defaultOpen);
+
+  return (
+    <div className='network-collapsible-section'>
+      <div
+        className='network-collapsible-header'
+        onClick={() => setIsOpen(!isOpen)}
+        style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+      >
+        <span
+          className={`codicon ${isOpen ? 'codicon-chevron-down' : 'codicon-chevron-right'}`}
+          style={{ marginRight: 4 }}
+        />
+        <span>{title}</span>
+        {!isOpen && collapsedSuffix && (
+          <span
+            className='network-collapsible-suffix'
+          >
+            {collapsedSuffix}
+          </span>
+        )}
+      </div>
+      {isOpen && <div className='network-collapsible-content'>{children}</div>}
+    </div>
+  );
+};
+
 const RequestTab: React.FunctionComponent<{
   resource: ResourceSnapshot;
   startTimeOffset: number;
   requestBody: RequestBody,
 }> = ({ resource, startTimeOffset, requestBody }) => {
   return <div className='network-request-details-tab'>
-    <div className='network-request-details-header'>General</div>
-    <div className='network-request-details-url'>{`URL: ${resource.request.url}`}</div>
-    <div className='network-request-details-general'>{`Method: ${resource.request.method}`}</div>
-    {resource.response.status !== -1 && <div className='network-request-details-general' style={{ display: 'flex' }}>
-      Status Code: <span className={statusClass(resource.response.status)} style={{ display: 'inline-flex' }}>
-        {`${resource.response.status} ${resource.response.statusText}`}
-      </span></div>}
-    {resource.request.queryString.length ? <>
-      <div className='network-request-details-header'>Query String Parameters</div>
-      <div className='network-request-details-headers'>
-        {resource.request.queryString.map(param => `${param.name}: ${param.value}`).join('\n')}
-      </div>
-    </> : null}
-    <div className='network-request-details-header'>Request Headers</div>
-    <div className='network-request-details-headers'>{resource.request.headers.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
-    <div className='network-request-details-header'>Time</div>
-    <div className='network-request-details-general'>{`Start: ${msToString(startTimeOffset)}`}</div>
-    <div className='network-request-details-general'>{`Duration: ${msToString(resource.time)}`}</div>
+    <CollapsibleSection title="General" defaultOpen={true}>
+    <div className='network-key-value'>
+      <div className='network-key'>URL</div>
+      <div className='network-value'>{resource.request.url}</div>
+    </div>
+    <div className='network-key-value'>
+      <div className='network-key'>Method</div>
+      <div className='network-value'>{resource.request.method}</div>
+    </div>
+      {resource.response.status !== -1 && (
+        <div className='network-key-value'>
+        <div className='network-key'>Status Code</div>
+        <div className='network-value'>
+          <span className={statusClass(resource.response.status)} style={{ display: 'inline-flex' }}>
+            {`${resource.response.status} ${resource.response.statusText}`}
+          </span>
+        </div>
+      </div>      
+      )}
+    </CollapsibleSection>
 
-    {requestBody && <div className='network-request-details-header'>Request Body</div>}
-    {requestBody && <CodeMirrorWrapper text={requestBody.text} mimeType={requestBody.mimeType} readOnly lineNumbers={true}/>}
+    {resource.request.queryString.length > 0 && (
+  <CollapsibleSection title="Query String Parameters" defaultOpen={false}>
+    {resource.request.queryString.map(param => (
+      <div className='network-key-value' key={param.name}>
+        <div className='network-key'>{param.name}</div>
+        <div className='network-value'>{param.value}</div>
+      </div>
+    ))}
+  </CollapsibleSection>
+)}
+
+<CollapsibleSection   
+  title="Request Headers"
+  collapsedSuffix={`(${resource.request.headers.length})`}
+  defaultOpen={true}
+>
+  {resource.request.headers.map(header => (
+    <div className='network-key-value' key={header.name}>
+      <div className='network-key'>{header.name}</div>
+      <div className='network-value'>{header.value}</div>
+    </div>
+  ))}
+</CollapsibleSection>
+
+<CollapsibleSection title="Time" defaultOpen={true}>
+  <div className='network-key-value'>
+    <div className='network-key'>Start</div>
+    <div className='network-value'>{msToString(startTimeOffset)}</div>
+  </div>
+  <div className='network-key-value'>
+    <div className='network-key'>Duration</div>
+    <div className='network-value'>{msToString(resource.time)}</div>
+  </div>
+</CollapsibleSection>
+
+{requestBody && (
+  <CollapsibleSection title="Request Body" defaultOpen={true}>
+    <CodeMirrorWrapper
+      text={requestBody.text}
+      mimeType={requestBody.mimeType}
+      readOnly
+      lineNumbers={true}
+    />
+  </CollapsibleSection>
+)}
   </div>;
 };
 

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -142,72 +142,72 @@ const RequestTab: React.FunctionComponent<{
   requestBody: RequestBody,
 }> = ({ resource, startTimeOffset, requestBody }) => {
   return <div className='network-request-details-tab'>
-    <CollapsibleSection title="General" defaultOpen={true}>
-    <div className='network-key-value'>
-      <div className='network-key'>URL</div>
-      <div className='network-value'>{resource.request.url}</div>
-    </div>
-    <div className='network-key-value'>
-      <div className='network-key'>Method</div>
-      <div className='network-value'>{resource.request.method}</div>
-    </div>
+    <CollapsibleSection title='General' defaultOpen={true}>
+      <div className='network-key-value'>
+        <div className='network-key'>URL</div>
+        <div className='network-value'>{resource.request.url}</div>
+      </div>
+      <div className='network-key-value'>
+        <div className='network-key'>Method</div>
+        <div className='network-value'>{resource.request.method}</div>
+      </div>
       {resource.response.status !== -1 && (
         <div className='network-key-value'>
-        <div className='network-key'>Status Code</div>
-        <div className='network-value'>
-          <span className={statusClass(resource.response.status)} style={{ display: 'inline-flex' }}>
-            {`${resource.response.status} ${resource.response.statusText}`}
-          </span>
+          <div className='network-key'>Status Code</div>
+          <div className='network-value'>
+            <span className={statusClass(resource.response.status)} style={{ display: 'inline-flex' }}>
+              {`${resource.response.status} ${resource.response.statusText}`}
+            </span>
+          </div>
         </div>
-      </div>      
       )}
     </CollapsibleSection>
 
     {resource.request.queryString.length > 0 && (
-  <CollapsibleSection title="Query String Parameters" defaultOpen={false}>
-    {resource.request.queryString.map(param => (
-      <div className='network-key-value' key={param.name}>
-        <div className='network-key'>{param.name}</div>
-        <div className='network-value'>{param.value}</div>
+      <CollapsibleSection title='Query String Parameters' defaultOpen={false}>
+        {resource.request.queryString.map(param => (
+          <div className='network-key-value' key={param.name}>
+            <div className='network-key'>{param.name}</div>
+            <div className='network-value'>{param.value}</div>
+          </div>
+        ))}
+      </CollapsibleSection>
+    )}
+
+    <CollapsibleSection
+      title='Request Headers'
+      collapsedSuffix={`(${resource.request.headers.length})`}
+      defaultOpen={true}
+    >
+      {resource.request.headers.map(header => (
+        <div className='network-key-value' key={header.name}>
+          <div className='network-key'>{header.name}</div>
+          <div className='network-value'>{header.value}</div>
+        </div>
+      ))}
+    </CollapsibleSection>
+
+    <CollapsibleSection title='Time' defaultOpen={true}>
+      <div className='network-key-value'>
+        <div className='network-key'>Start</div>
+        <div className='network-value'>{msToString(startTimeOffset)}</div>
       </div>
-    ))}
-  </CollapsibleSection>
-)}
+      <div className='network-key-value'>
+        <div className='network-key'>Duration</div>
+        <div className='network-value'>{msToString(resource.time)}</div>
+      </div>
+    </CollapsibleSection>
 
-<CollapsibleSection   
-  title="Request Headers"
-  collapsedSuffix={`(${resource.request.headers.length})`}
-  defaultOpen={true}
->
-  {resource.request.headers.map(header => (
-    <div className='network-key-value' key={header.name}>
-      <div className='network-key'>{header.name}</div>
-      <div className='network-value'>{header.value}</div>
-    </div>
-  ))}
-</CollapsibleSection>
-
-<CollapsibleSection title="Time" defaultOpen={true}>
-  <div className='network-key-value'>
-    <div className='network-key'>Start</div>
-    <div className='network-value'>{msToString(startTimeOffset)}</div>
-  </div>
-  <div className='network-key-value'>
-    <div className='network-key'>Duration</div>
-    <div className='network-value'>{msToString(resource.time)}</div>
-  </div>
-</CollapsibleSection>
-
-{requestBody && (
-  <CollapsibleSection title="Request Body" defaultOpen={true}>
-    <CodeMirrorWrapper
-      text={requestBody.text}
-      mimeType={requestBody.mimeType}
-      readOnly
-      lineNumbers={true}
-    />
-  </CollapsibleSection>
-)}
+    {requestBody && (
+      <CollapsibleSection title='Request Body' defaultOpen={true}>
+        <CodeMirrorWrapper
+          text={requestBody.text}
+          mimeType={requestBody.mimeType}
+          readOnly
+          lineNumbers={true}
+        />
+      </CollapsibleSection>
+    )}
   </div>;
 };
 

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -116,11 +116,9 @@ const CollapsibleSection: React.FC<{
       <div
         className='network-collapsible-header'
         onClick={() => setIsOpen(!isOpen)}
-        style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
       >
         <span
           className={`codicon ${isOpen ? 'codicon-chevron-down' : 'codicon-chevron-right'}`}
-          style={{ marginRight: 4 }}
         />
         <span>{title}</span>
         {!isOpen && collapsedSuffix && (
@@ -155,7 +153,7 @@ const RequestTab: React.FunctionComponent<{
         <div className='network-key-value'>
           <div className='network-key'>Status Code</div>
           <div className='network-value'>
-            <span className={statusClass(resource.response.status)} style={{ display: 'inline-flex' }}>
+            <span className={statusClass(resource.response.status)}>
               {`${resource.response.status} ${resource.response.statusText}`}
             </span>
           </div>

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -156,6 +156,7 @@ test('should display list of query parameters (only if present)', async ({ runUI
   await page.getByText('call-with-query-params').click();
 
   await expect(page.getByText('Query String Parameters')).toBeVisible();
+  
   await expect(
       page.locator('.network-key-value:has(.network-key:text("param1"))').nth(0).locator('.network-value')
   ).toHaveText('value1');

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -156,9 +156,17 @@ test('should display list of query parameters (only if present)', async ({ runUI
   await page.getByText('call-with-query-params').click();
 
   await expect(page.getByText('Query String Parameters')).toBeVisible();
-  await expect(page.getByText('param1 value1')).toBeVisible();
-  await expect(page.getByText('param1 value2')).toBeVisible();
-  await expect(page.getByText('param2 value2')).toBeVisible();
+  await expect(
+      page.locator('.network-key-value', { hasText: 'param1' }).nth(0).locator('.network-value')
+  ).toHaveText('value1');
+
+  await expect(
+      page.locator('.network-key-value', { hasText: 'param1' }).nth(1).locator('.network-value')
+  ).toHaveText('value2');
+
+  await expect(
+      page.locator('.network-key-value', { hasText: 'param2' }).locator('.network-value')
+  ).toHaveText('value2');
 
   await page.getByText('endpoint').click();
 

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -156,7 +156,8 @@ test('should display list of query parameters (only if present)', async ({ runUI
   await page.getByText('call-with-query-params').click();
 
   await expect(page.getByText('Query String Parameters')).toBeVisible();
-  
+  await page.getByText('Query String Parameters').click();
+
   await expect(
       page.locator('.network-key-value:has(.network-key:text("param1"))').nth(0).locator('.network-value')
   ).toHaveText('value1');

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -157,15 +157,15 @@ test('should display list of query parameters (only if present)', async ({ runUI
 
   await expect(page.getByText('Query String Parameters')).toBeVisible();
   await expect(
-      page.locator('.network-key-value', { hasText: 'param1' }).nth(0).locator('.network-value')
+      page.locator('.network-key-value:has(.network-key:text("param1"))').nth(0).locator('.network-value')
   ).toHaveText('value1');
 
   await expect(
-      page.locator('.network-key-value', { hasText: 'param1' }).nth(1).locator('.network-value')
+      page.locator('.network-key-value:has(.network-key:text("param1"))').nth(1).locator('.network-value')
   ).toHaveText('value2');
 
   await expect(
-      page.locator('.network-key-value', { hasText: 'param2' }).locator('.network-value')
+      page.locator('.network-key-value:has(.network-key:text("param2"))').locator('.network-value')
   ).toHaveText('value2');
 
   await page.getByText('endpoint').click();

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -156,9 +156,9 @@ test('should display list of query parameters (only if present)', async ({ runUI
   await page.getByText('call-with-query-params').click();
 
   await expect(page.getByText('Query String Parameters')).toBeVisible();
-  await expect(page.getByText('param1: value1')).toBeVisible();
-  await expect(page.getByText('param1: value2')).toBeVisible();
-  await expect(page.getByText('param2: value2')).toBeVisible();
+  await expect(page.getByText('param1 value1')).toBeVisible();
+  await expect(page.getByText('param1 value2')).toBeVisible();
+  await expect(page.getByText('param2 value2')).toBeVisible();
 
   await page.getByText('endpoint').click();
 


### PR DESCRIPTION
- Adds collapsible sections for request tab headers like General, Request Headers, Query Parameters, etc.
- Introduces showing header count when header collapsed.
- Improves visual hierarchy of key-value pairs by styling keys with font weight and making the UI closer to Browser Dev Tools
- No new dependencies added.

Updates:
https://github.com/user-attachments/assets/67c63608-bd3e-48c8-9f68-19edd7445cfc

Images:
![image](https://github.com/user-attachments/assets/df056908-9192-485a-a8e0-3be0bc12b85d)
![image](https://github.com/user-attachments/assets/e520fa64-79d8-4f10-a949-5e70d40936c1)


Before:
![image](https://github.com/user-attachments/assets/7196a247-279c-4044-836c-c8a2cf55812b)



References: #35214 