### PR TITLE
chore(html): revert baded72 and use existing linkifyText

### DIFF
--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -20,9 +20,10 @@ import './colors.css';
 import './common.css';
 import './headerView.css';
 import * as icons from './icons';
-import { Link, LinkifyText, navigate, SearchParamsContext } from './links';
+import { Link, navigate, SearchParamsContext } from './links';
 import { statusIcon } from './statusIcon';
 import { filterWithToken } from './filter';
+import { linkifyText } from '@web/renderUtils';
 
 export const HeaderView: React.FC<{
   title: string | undefined,
@@ -35,7 +36,7 @@ export const HeaderView: React.FC<{
       <div style={{ flex: 'auto' }}></div>
       {rightSuperHeader}
     </div>
-    {title && <div className='header-title'><LinkifyText text={title} /></div>}
+    {title && <div className='header-title'>{linkifyText(title)}</div>}
   </div>;
 };
 

--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -114,41 +114,6 @@ export const SearchParamsProvider: React.FunctionComponent<React.PropsWithChildr
   return <SearchParamsContext.Provider value={searchParams}>{children}</SearchParamsContext.Provider>;
 };
 
-const LINKIFY_REGEX = /https?:\/\/[^\s]+/g;
-
-export const LinkifyText: React.FunctionComponent<{ text: string }> = ({ text }) => {
-  const parts = React.useMemo(() => {
-    const matches = [...text.matchAll(LINKIFY_REGEX)];
-    if (matches.length === 0)
-      return [text];
-    const result: Array<React.ReactElement | string> = [];
-    let lastIndex = 0;
-
-    for (const match of matches) {
-      const url = match[0];
-      const startIndex = match.index!;
-
-      // Add text before the URL
-      if (startIndex > lastIndex)
-        result.push(text.slice(lastIndex, startIndex));
-      result.push(
-          <a key={startIndex} href={url} target='_blank' rel='noopener noreferrer'>
-            {url}
-          </a>
-      );
-
-      lastIndex = startIndex + url.length;
-    }
-
-    // Add any text after the last URL
-    if (lastIndex < text.length)
-      result.push(text.slice(lastIndex));
-    return result;
-  }, [text]);
-
-  return <>{parts}</>;
-};
-
 function downloadFileNameForAttachment(attachment: TestAttachment): string {
   if (attachment.name.includes('.') || !attachment.path)
     return attachment.name;


### PR DESCRIPTION
Resolves #36308. Reverts #36326.

`linkifyText` already existed. Use it instead.