### PR TITLE
Remove FIXME placeholders from generated doc snippets

### DIFF
--- a/utils/doclint/generateJavaSnippets.js
+++ b/utils/doclint/generateJavaSnippets.js
@@ -116,7 +116,8 @@ function toTitleCase(name) {
 function generateComment(node) {
   const commentNode = md.clone(node)
   commentNode.codeLang = 'java';
-  commentNode.lines = ['// FIXME', ...transformValue(node.lines).split("\n")];
+  // Remove placeholder and directly include transformed snippet lines
+  commentNode.lines = [...transformValue(node.lines).split("\n")];
   return commentNode;
 }
 

--- a/utils/doclint/generatePythonSnippets.js
+++ b/utils/doclint/generatePythonSnippets.js
@@ -75,7 +75,8 @@ function transformValue(input, isSync) {
 function generateComment(node, isSync) {
   const commentNode = md.clone(node)
   commentNode.codeLang = isSync ? "python sync" : "python async";
-  commentNode.lines = ['# FIXME', ...transformValue(node.lines, isSync).split("\n")];
+  // Remove placeholder and directly include transformed snippet lines
+  commentNode.lines = [...transformValue(node.lines, isSync).split("\n")];
   return commentNode;
 }
 


### PR DESCRIPTION
The Python and Java snippet generators ([utils/doclint/generatePythonSnippets.js](cci:7://file:///d:/Github/playwright/utils/doclint/generatePythonSnippets.js:0:0-0:0)
and [utils/doclint/generateJavaSnippets.js](cci:7://file:///d:/Github/playwright/utils/doclint/generateJavaSnippets.js:0:0-0:0)) prepended every generated example
with a `# FIXME` / `// FIXME` placeholder comment.  
These lines leaked into the public docs, confusing readers, polluting copy-pasted
code, and adding unnecessary noise to documentation diffs.

This patch simply removes the placeholder prefix so the generators now emit
clean, production-ready code snippets.