### PR TITLE
test: prevent indexeddb race conditions

### DIFF
--- a/tests/library/browsercontext-storage-state.spec.ts
+++ b/tests/library/browsercontext-storage-state.spec.ts
@@ -360,10 +360,19 @@ it('should roundtrip local storage in third-party context', async ({ page, conte
 
 it('should support IndexedDB', async ({ page, server, contextFactory }) => {
   await page.goto(server.PREFIX + '/to-do-notifications/index.html');
+
+  await expect(page.locator('#notifications')).toMatchAriaSnapshot(`
+    - list:
+      - listitem: Database initialised.
+  `);
   await page.getByLabel('Task title').fill('Pet the cat');
   await page.getByLabel('Hours').fill('1');
   await page.getByLabel('Mins').fill('1');
   await page.getByText('Add Task').click();
+  await expect(page.locator('#notifications')).toMatchAriaSnapshot(`
+    - list:
+      - listitem: "Transaction completed: database modification finished."
+  `);
 
   const storageState = await page.context().storageState({ indexedDB: true });
   expect(storageState.origins).toEqual([


### PR DESCRIPTION
Test fails on Firefox CI sometimes - my hunch is that it's a race condition where either:

- we submit the task before the JS is wired up OR
- we capture storage state before the transaction committed.

Luckily, the test site already has a log available we can use to wait for both. Let's hope this helps.