### PR TITLE
fix: adding trialing slash detection logic back in urlToWSEndpoint

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -384,7 +384,7 @@ async function urlToWSEndpoint(progress: Progress, endpointURL: string, headers:
     return endpointURL;
   progress.log(`<ws preparing> retrieving websocket url from ${endpointURL}`);
   const url = new URL(endpointURL);
-  url.pathname += 'json/version/';
+  url.pathname += url.pathname.endsWith('/') ? 'json/version/' : '/json/version/';
   const httpURL = url.toString();
 
   const json = await fetchData({

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -384,7 +384,9 @@ async function urlToWSEndpoint(progress: Progress, endpointURL: string, headers:
     return endpointURL;
   progress.log(`<ws preparing> retrieving websocket url from ${endpointURL}`);
   const url = new URL(endpointURL);
-  url.pathname += url.pathname.endsWith('/') ? 'json/version/' : '/json/version/';
+  if (!url.pathname.endsWith('/'))
+    url.pathname = url.pathname + '/';
+  url.pathname += 'json/version/';
   const httpURL = url.toString();
 
   const json = await fetchData({

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -41,6 +41,23 @@ test('should connect to an existing cdp session', async ({ browserType, mode }, 
   }
 });
 
+test('should connect to an existing cdp session with verbose path', async ({ browserType, mode }, testInfo) => {
+  const port = 9339 + testInfo.workerIndex;
+  const browserServer = await browserType.launch({
+    args: ['--remote-debugging-port=' + port]
+  });
+  try {
+    const cdpBrowser = await browserType.connectOverCDP({
+      endpointURL: `http://127.0.0.1:${port}/json/version/abcdefg`,
+    });
+    const contexts = cdpBrowser.contexts();
+    expect(contexts.length).toBe(1);
+    await cdpBrowser.close();
+  } finally {
+    await browserServer.close();
+  }
+});
+
 test('should use logger in default context', async ({ browserType }, testInfo) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/28813' });
   const port = 9339 + testInfo.workerIndex;


### PR DESCRIPTION
This PR simply brings the previous behavior back before: https://github.com/microsoft/playwright/commit/eb5e3b37402bad85e6c2b976e1a596cca0e4f47c

This commit will break if the url has custom sections:
<img width="422" alt="image" src="https://github.com/user-attachments/assets/a67e543d-0f6b-4a1a-8969-f7ad06cb5395" />

For chrome cdp, it is possible to get `webSocketDebuggerUrl` by some verbose path:
<img width="975" alt="image" src="https://github.com/user-attachments/assets/1ef3e9ec-13bf-4344-9678-fba30b8e36e6" />

