### PR TITLE
chore: use different babel import in tsxTransform

### DIFF
--- a/packages/playwright-ct-core/src/tsxTransform.ts
+++ b/packages/playwright-ct-core/src/tsxTransform.ts
@@ -19,7 +19,7 @@ import path from 'path';
 import { declare, traverse, types } from 'playwright/lib/transform/babelBundle';
 import { setTransformData } from 'playwright/lib/transform/transform';
 
-import type { BabelAPI, PluginObj, T } from 'playwright/src/transform/babelBundle';
+import type { BabelAPI, PluginObj, T } from 'playwright/lib/transform/babelBundle';
 const t: typeof T = types;
 
 let jsxComponentNames: Set<string>;


### PR DESCRIPTION
Rationale: TypeScript Native aka. TypeScript 7 does not support such imports anymore because this goes over the package.json route and we don't have an export for `src`. Lets use instead our rewrite from [`lib->src`](https://github.com/microsoft/playwright/blob/55cb7c916c820c85813ce7eab40914a35586c714/tsconfig.json#L22).