### PR TITLE
chore: follow-up to connectOverCDP fetch logic

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -383,7 +383,7 @@ async function urlToWSEndpoint(progress: Progress, endpointURL: string, headers:
   progress.log(`<ws preparing> retrieving websocket url from ${endpointURL}`);
   const url = new URL(endpointURL);
   if (!url.pathname.endsWith('/'))
-    url.pathname = url.pathname + '/';
+    url.pathname += '/';
   url.pathname += 'json/version/';
   const httpURL = url.toString();
 

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -41,23 +41,6 @@ test('should connect to an existing cdp session', async ({ browserType, mode }, 
   }
 });
 
-test('should connect to an existing cdp session with verbose path', async ({ browserType, mode }, testInfo) => {
-  const port = 9339 + testInfo.workerIndex;
-  const browserServer = await browserType.launch({
-    args: ['--remote-debugging-port=' + port]
-  });
-  try {
-    const cdpBrowser = await browserType.connectOverCDP({
-      endpointURL: `http://127.0.0.1:${port}/json/version/abcdefg`,
-    });
-    const contexts = cdpBrowser.contexts();
-    expect(contexts.length).toBe(1);
-    await cdpBrowser.close();
-  } finally {
-    await browserServer.close();
-  }
-});
-
 test('should use logger in default context', async ({ browserType }, testInfo) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/28813' });
   const port = 9339 + testInfo.workerIndex;
@@ -287,6 +270,30 @@ test('should send extra headers with connect request', async ({ browserType, ser
     expect(request.headers['user-agent']).toBe('Playwright');
     expect(request.headers['foo']).toBe('bar');
   }
+});
+
+test('should keep URL parameters when adding json/version', {
+  annotation: {
+    type: 'issue',
+    description: 'https://github.com/microsoft/playwright/issues/36097'
+  }
+}, async ({ browserType, server }) => {
+  await Promise.all([
+    server.waitForRequest('/browser/json/version/?foo=bar'),
+    browserType.connectOverCDP(`http://localhost:${server.PORT}/browser/?foo=bar`).catch(() => {})
+  ]);
+});
+
+test('should append /json/version with a slash if there isnt one', {
+  annotation: {
+    type: 'issue',
+    description: 'https://github.com/microsoft/playwright/issues/36357'
+  }
+}, async ({ browserType, server }) => {
+  await Promise.all([
+    server.waitForRequest('/browser/json/version/?foo=bar'),
+    browserType.connectOverCDP(`http://localhost:${server.PORT}/browser?foo=bar`).catch(() => {})
+  ]);
 });
 
 test('should send default User-Agent header with connect request', async ({ browserType, server }, testInfo) => {

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -287,7 +287,7 @@ test('should keep URL parameters when adding json/version', {
 test('should append /json/version with a slash if there isnt one', {
   annotation: {
     type: 'issue',
-    description: 'https://github.com/microsoft/playwright/issues/36357'
+    description: 'https://github.com/microsoft/playwright/issues/36378'
   }
 }, async ({ browserType, server }) => {
   await Promise.all([


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/playwright/pull/36357.

This patch adds test coverage for https://github.com/microsoft/playwright/pull/36098 which wasn't added back then and simplifies the test coverage for https://github.com/microsoft/playwright/pull/36357.

https://github.com/microsoft/playwright/pull/36098 introduced the regression in v1.53.0.