### PR TITLE
chore: browserserver, design two

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -119,8 +119,8 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
     });
   }
 
-  connect(options: api.ConnectOptions & { wsEndpoint: string }): Promise<api.Browser>;
-  connect(wsEndpoint: string, options?: api.ConnectOptions): Promise<api.Browser>;
+  connect(options: api.ConnectOptions & { wsEndpoint: string }): Promise<Browser>;
+  connect(wsEndpoint: string, options?: api.ConnectOptions): Promise<Browser>;
   async connect(optionsOrWsEndpoint: string | (api.ConnectOptions & { wsEndpoint: string }), options?: api.ConnectOptions): Promise<Browser>{
     if (typeof optionsOrWsEndpoint === 'string')
       return await this._connect({ ...options, wsEndpoint: optionsOrWsEndpoint });

--- a/packages/playwright-core/src/remote/playwrightConnection.ts
+++ b/packages/playwright-core/src/remote/playwrightConnection.ts
@@ -26,6 +26,10 @@ import { PlaywrightDispatcherOptions } from '../server/dispatchers/playwrightDis
 import type { DispatcherScope, Playwright } from '../server';
 import type { WebSocket } from '../utilsBundle';
 
+export interface PlaywrightInitializeResult extends PlaywrightDispatcherOptions {
+  dispose?(): Promise<void>;
+}
+
 export class PlaywrightConnection {
   private _ws: WebSocket;
   private _semaphore: Semaphore;
@@ -36,7 +40,7 @@ export class PlaywrightConnection {
   private _root: DispatcherScope;
   private _profileName: string;
 
-  constructor(semaphore: Semaphore, ws: WebSocket, controller: boolean, playwright: Playwright, initialize: () => Promise<PlaywrightDispatcherOptions & { dispose?(): Promise<void> }>, id: string) {
+  constructor(semaphore: Semaphore, ws: WebSocket, controller: boolean, playwright: Playwright, initialize: () => Promise<PlaywrightInitializeResult>, id: string) {
     this._ws = ws;
     this._semaphore = semaphore;
     this._id = id;


### PR DESCRIPTION
Second revision of the browser server sketch. It facilitates sharing browser amongst Playwright MCP, the VS Code Extension and CLI Clients like `npx playwright open` or `npx playwright test`.

Implemented using a new connection mode that's similar to "reuse browsers", but that doesn't close anything on connect.  For now, you can only specify `connect=first` to get access to the first browser.

Demo still works the same as in the previous revision:

https://github.com/user-attachments/assets/3a7dc93f-5d3c-4d59-9442-85d251154774

You can also do `nxp playwright open` with the `PW_BROWSER_SERVER` env var. There's no support in test runner yet.

See https://github.com/microsoft/playwright-mcp/pull/579 and https://github.com/microsoft/playwright-vscode/pull/647 for the other side of the demo.
