### PR TITLE
chore: don't close other browsers in reuse-browsers mode

### DIFF
--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -189,15 +189,12 @@ export class PlaywrightServer {
       dispose: async () => {
         // Don't close the pages so that user could debug them,
         // but close all the empty browsers and contexts to clean up.
-        for (const browser of this._playwright.allBrowsers()) {
-          for (const context of browser.contexts()) {
-            if (!context.pages().length)
-              await context.close({ reason: 'Connection terminated' });
-            else
-              await context.stopPendingOperations('Connection closed');
-          }
-          if (!browser.contexts())
-            await browser.close({ reason: 'Connection terminated' });
+        // keep around browser so it can be reused by the next connection.
+        for (const context of browser.contexts()) {
+          if (!context.pages().length)
+            await context.close({ reason: 'Connection terminated' });
+          else
+            await context.stopPendingOperations('Connection closed');
         }
       }
     };

--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -188,7 +188,7 @@ export class PlaywrightServer {
       denyLaunch: true,
       dispose: async () => {
         // Don't close the pages so that user could debug them,
-        // but close all the empty browsers and contexts to clean up.
+        // but close all the empty contexts to clean up.
         // keep around browser so it can be reused by the next connection.
         for (const context of browser.contexts()) {
           if (!context.pages().length)


### PR DESCRIPTION
There's no need to manipulate other browsers on `this._playwright` upon disconnect. And the `!browser.contexts()` clause was busted all along - I replaced it with a comment.