### PR TITLE
chore: make progress strict by default

### DIFF
--- a/.github/workflows/tests_others.yml
+++ b/.github/workflows/tests_others.yml
@@ -134,6 +134,27 @@ jobs:
       env:
         PW_CLOCK: ${{ matrix.clock }}
 
+  test_legacy_progress_timeouts:
+    name: legacy progress timeouts
+    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
+    permissions:
+      id-token: write   # This is required for OIDC login (azure/login) to succeed
+      contents: read    # This is required for actions/checkout to succeed
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/run-test
+      with:
+        node-version: 20
+        browsers-to-install: chromium
+        command: npm run test -- --project=chromium-*
+        bot-name: "legacy-progress-timeouts-linux"
+        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
+        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
+        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
+      env:
+        PLAYWRIGHT_LEGACY_TIMEOUTS: 1
+
   test_electron:
     name: Electron - ${{ matrix.os }}
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -260,7 +260,7 @@ export class AndroidDevice extends SdkObject {
   }
 
   async launchBrowser(metadata: CallMetadata, pkg: string = 'com.android.chrome', options: channels.AndroidDeviceLaunchBrowserParams): Promise<BrowserContext> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       debug('pw:android')('Force-stopping', pkg);
       await this._backend.runCommand(`shell:am force-stop ${pkg}`);
@@ -306,7 +306,7 @@ export class AndroidDevice extends SdkObject {
   }
 
   async connectToWebView(metadata: CallMetadata, socketName: string): Promise<BrowserContext> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       const webView = this._webViews.get(socketName);
       if (!webView)

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -368,7 +368,7 @@ export class BidiPage implements PageDelegate {
 
   async takeScreenshot(progress: Progress, format: string, documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined, fitsViewport: boolean, scale: 'css' | 'device'): Promise<Buffer> {
     const rect = (documentRect || viewportRect)!;
-    const { data } = await this._session.send('browsingContext.captureScreenshot', {
+    const { data } = await progress.race(this._session.send('browsingContext.captureScreenshot', {
       context: this._session.sessionId,
       format: {
         type: `image/${format === 'png' ? 'png' : 'jpeg'}`,
@@ -379,7 +379,7 @@ export class BidiPage implements PageDelegate {
         type: 'box',
         ...rect,
       }
-    });
+    }));
     return Buffer.from(data, 'base64');
   }
 

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -93,7 +93,7 @@ export abstract class Browser extends SdkObject {
   }
 
   newContextFromMetadata(metadata: CallMetadata, options: types.BrowserContextOptions): Promise<BrowserContext> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(progress => this.newContext(progress, options));
   }
 

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -191,7 +191,7 @@ export abstract class BrowserContext extends SdkObject {
   }
 
   async resetForReuse(metadata: CallMetadata, params: channels.BrowserNewContextForReuseParams | null) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(progress => this.resetForReuseImpl(progress, params));
   }
 
@@ -515,7 +515,7 @@ export abstract class BrowserContext extends SdkObject {
   }
 
   newPageFromMetadata(metadata: CallMetadata): Promise<Page> {
-    const contoller = new ProgressController(metadata, this, 'strict');
+    const contoller = new ProgressController(metadata, this);
     return contoller.run(progress => this.newPage(progress, false));
   }
 
@@ -535,7 +535,7 @@ export abstract class BrowserContext extends SdkObject {
   }
 
   storageState(indexedDB = false): Promise<channels.BrowserContextStorageStateResult> {
-    const controller = new ProgressController(serverSideCallMetadata(), this, 'strict');
+    const controller = new ProgressController(serverSideCallMetadata(), this);
     return controller.run(progress => this.storageStateImpl(progress, indexedDB));
   }
 

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -69,7 +69,7 @@ export abstract class BrowserType extends SdkObject {
 
   async launch(metadata: CallMetadata, options: types.LaunchOptions, protocolLogger?: types.ProtocolLogger): Promise<Browser> {
     options = this._validateLaunchOptions(options);
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     const browser = await controller.run(progress => {
       const seleniumHubUrl = (options as any).__testHookSeleniumRemoteURL || process.env.SELENIUM_REMOTE_URL;
       if (seleniumHubUrl)
@@ -81,7 +81,7 @@ export abstract class BrowserType extends SdkObject {
 
   async launchPersistentContext(metadata: CallMetadata, userDataDir: string, options: channels.BrowserTypeLaunchPersistentContextOptions & { timeout: number, cdpPort?: number, internalIgnoreHTTPSErrors?: boolean, socksProxyPort?: number }): Promise<BrowserContext> {
     const launchOptions = this._validateLaunchOptions(options);
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     const browser = await controller.run(async progress => {
       // Note: Any initial TLS requests will fail since we rely on the Page/Frames initialize which sets ignoreHTTPSErrors.
       let clientCertificatesProxy: ClientCertificatesProxy | undefined;
@@ -259,7 +259,7 @@ export abstract class BrowserType extends SdkObject {
       close: () => closeOrKill((options as any).__testHookBrowserCloseTimeout || DEFAULT_PLAYWRIGHT_TIMEOUT),
       kill
     };
-    progress.cleanupWhenAborted(() => closeOrKill(progress.timeUntilDeadline()));
+    progress.cleanupWhenAborted(() => closeOrKill(DEFAULT_PLAYWRIGHT_TIMEOUT));
     const { wsEndpoint } = await progress.race([
       this.waitForReadyState(options, browserLogsCollector),
       exitPromise.then(() => ({ wsEndpoint: undefined })),

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -63,7 +63,7 @@ export class Chromium extends BrowserType {
   }
 
   override async connectOverCDP(metadata: CallMetadata, endpointURL: string, options: { slowMo?: number, headers?: types.HeadersArray, timeout: number }) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return await this._connectOverCDPInternal(progress, endpointURL, options);
     }, options.timeout);
@@ -199,7 +199,7 @@ export class Chromium extends BrowserType {
     }
 
     progress.log(`<selenium> connecting to ${hubUrl}`);
-    const response = await fetchData({
+    const response = await fetchData(progress, {
       url: hubUrl + 'session',
       method: 'POST',
       headers: {
@@ -209,7 +209,6 @@ export class Chromium extends BrowserType {
       data: JSON.stringify({
         capabilities: { alwaysMatch: desiredCapabilities }
       }),
-      timeout: progress.timeUntilDeadline(),
     }, seleniumErrorHandler);
     const value = JSON.parse(response).value;
     const sessionId = value.sessionId;
@@ -217,7 +216,8 @@ export class Chromium extends BrowserType {
 
     const disconnectFromSelenium = async () => {
       progress.log(`<selenium> disconnecting from sessionId=${sessionId}`);
-      await fetchData({
+      // Do not pass "progress" to disconnect even after the progress has aborted.
+      await fetchData(undefined, {
         url: hubUrl + 'session/' + sessionId,
         method: 'DELETE',
         headers,
@@ -253,10 +253,9 @@ export class Chromium extends BrowserType {
         if (endpointURL.hostname === 'localhost' || endpointURL.hostname === '127.0.0.1') {
           const sessionInfoUrl = new URL(hubUrl).origin + '/grid/api/testsession?session=' + sessionId;
           try {
-            const sessionResponse = await fetchData({
+            const sessionResponse = await fetchData(progress, {
               url: sessionInfoUrl,
               method: 'GET',
-              timeout: progress.timeUntilDeadline(),
               headers,
             }, seleniumErrorHandler);
             const proxyId = JSON.parse(sessionResponse).proxyId;
@@ -385,10 +384,9 @@ async function urlToWSEndpoint(progress: Progress, endpointURL: string, headers:
   url.pathname += 'json/version/';
   const httpURL = url.toString();
 
-  const json = await fetchData({
+  const json = await fetchData(progress, {
     url: httpURL,
     headers,
-    timeout: progress.timeUntilDeadline(),
   }, async (_, resp) => new Error(`Unexpected status ${resp.statusCode} when connecting to ${httpURL}.\n` +
     `This does not look like a DevTools server, try connecting via ws://.`)
   );

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -256,7 +256,7 @@ export class CRPage implements PageDelegate {
   }
 
   async takeScreenshot(progress: Progress, format: 'png' | 'jpeg', documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined, fitsViewport: boolean, scale: 'css' | 'device'): Promise<Buffer> {
-    const { visualViewport } = await this._mainFrameSession._client.send('Page.getLayoutMetrics');
+    const { visualViewport } = await progress.race(this._mainFrameSession._client.send('Page.getLayoutMetrics'));
     if (!documentRect) {
       documentRect = {
         x: visualViewport.pageX + viewportRect!.x,
@@ -274,8 +274,7 @@ export class CRPage implements PageDelegate {
       const deviceScaleFactor = this._browserContext._options.deviceScaleFactor || 1;
       clip.scale /= deviceScaleFactor;
     }
-    progress.throwIfAborted();
-    const result = await this._mainFrameSession._client.send('Page.captureScreenshot', { format, quality, clip, captureBeyondViewport: !fitsViewport });
+    const result = await progress.race(this._mainFrameSession._client.send('Page.captureScreenshot', { format, quality, clip, captureBeyondViewport: !fitsViewport }));
     return Buffer.from(result.data, 'base64');
   }
 

--- a/packages/playwright-core/src/server/chromium/videoRecorder.ts
+++ b/packages/playwright-core/src/server/chromium/videoRecorder.ts
@@ -42,7 +42,7 @@ export class VideoRecorder {
     if (!options.outputFile.endsWith('.webm'))
       throw new Error('File must have .webm extension');
 
-    const controller = new ProgressController(serverSideCallMetadata(), page, 'strict');
+    const controller = new ProgressController(serverSideCallMetadata(), page);
     controller.setLogName('browser');
     return await controller.run(async progress => {
       const recorder = new VideoRecorder(page, ffmpegPath, progress);

--- a/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
@@ -83,7 +83,7 @@ export class LocalUtilsDispatcher extends Dispatcher<SdkObject, channels.LocalUt
   }
 
   async connect(params: channels.LocalUtilsConnectParams, metadata: CallMetadata): Promise<channels.LocalUtilsConnectResult> {
-    const controller = new ProgressController(metadata, this._object, 'strict');
+    const controller = new ProgressController(metadata, this._object);
     return await controller.run(async progress => {
       const wsHeaders = {
         'User-Agent': getUserAgent(),
@@ -137,10 +137,9 @@ async function urlToWSEndpoint(progress: Progress, endpointURL: string): Promise
   if (!fetchUrl.pathname.endsWith('/'))
     fetchUrl.pathname += '/';
   fetchUrl.pathname += 'json';
-  const json = await fetchData({
+  const json = await fetchData(progress, {
     url: fetchUrl.toString(),
     method: 'GET',
-    timeout: progress.timeUntilDeadline(),
     headers: { 'User-Agent': getUserAgent() },
   }, async (params: HTTPRequestParams, response: http.IncomingMessage) => {
     return new Error(`Unexpected status ${response.statusCode} when connecting to ${fetchUrl.toString()}.\n` +

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -258,7 +258,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async scrollIntoViewIfNeeded(metadata: CallMetadata, options: types.TimeoutOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(
         progress => this._waitAndScrollIntoViewIfNeeded(progress, false /* waitForVisible */),
         options.timeout);
@@ -337,7 +337,6 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const waitTime = [0, 20, 100, 100, 500];
 
     while (true) {
-      progress.throwIfAborted();
       if (retry) {
         progress.log(`retrying ${actionName} action${options.trial ? ' (trial run)' : ''}`);
         const timeout = waitTime[Math.min(retry - 1, waitTime.length - 1)];
@@ -427,7 +426,6 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       // Best-effort scroll to make sure any iframes containing this element are scrolled
       // into view and visible, so they are not throttled.
       // See https://github.com/microsoft/playwright/issues/27196 for an example.
-      progress.throwIfAborted();  // Avoid action that has side-effects.
       await progress.race(doScrollIntoView().catch(() => {}));
     }
 
@@ -449,7 +447,6 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       await progress.race((options as any).__testHookAfterStable());
 
     progress.log('  scrolling into view if needed');
-    progress.throwIfAborted();  // Avoid action that has side-effects.
     const scrolled = await progress.race(doScrollIntoView());
     if (scrolled !== 'done')
       return scrolled;
@@ -495,7 +492,6 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     const actionResult = await this._page.frameManager.waitForSignalsCreatedBy(progress, options.waitAfter === true, async () => {
       if ((options as any).__testHookBeforePointerAction)
         await progress.race((options as any).__testHookBeforePointerAction());
-      progress.throwIfAborted();  // Avoid action that has side-effects.
       let restoreModifiers: types.KeyboardModifier[] | undefined;
       if (options && options.modifiers)
         restoreModifiers = await this._page.keyboard.ensureModifiers(progress, options.modifiers);
@@ -539,7 +535,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async hover(metadata: CallMetadata, options: types.PointerActionOptions & types.PointerActionWaitOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       await this._markAsTargetElement(progress);
       const result = await this._hover(progress, options);
@@ -552,7 +548,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async click(metadata: CallMetadata, options: { noWaitAfter?: boolean } & types.MouseClickOptions & types.PointerActionWaitOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       await this._markAsTargetElement(progress);
       const result = await this._click(progress, { ...options, waitAfter: !options.noWaitAfter });
@@ -565,7 +561,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async dblclick(metadata: CallMetadata, options: types.MouseMultiClickOptions & types.PointerActionWaitOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       await this._markAsTargetElement(progress);
       const result = await this._dblclick(progress, options);
@@ -578,7 +574,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async tap(metadata: CallMetadata, options: types.PointerActionWaitOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       await this._markAsTargetElement(progress);
       const result = await this._tap(progress, options);
@@ -591,7 +587,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async selectOption(metadata: CallMetadata, elements: ElementHandle[], values: types.SelectOption[], options: types.CommonActionOptions): Promise<string[]> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       await this._markAsTargetElement(progress);
       const result = await this._selectOption(progress, elements, values, options);
@@ -627,7 +623,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async fill(metadata: CallMetadata, value: string, options: types.CommonActionOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       await this._markAsTargetElement(progress);
       const result = await this._fill(progress, value, options);
@@ -649,7 +645,6 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
         }
         return injected.fill(node, value);
       }, { value, force: options.force }));
-      progress.throwIfAborted();  // Avoid action that has side-effects.
       if (result === 'needsinput') {
         if (value)
           await this._page.keyboard._insertText(progress, value);
@@ -663,7 +658,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async selectText(metadata: CallMetadata, options: types.CommonActionOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       const result = await this._retryAction(progress, 'selectText', async () => {
         if (!options.force)
@@ -682,7 +677,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async setInputFiles(metadata: CallMetadata, params: channels.ElementHandleSetInputFilesParams) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       const inputFileItems = await progress.race(prepareFilesForUpload(this._frame, params));
       await this._markAsTargetElement(progress);
@@ -732,7 +727,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async focus(metadata: CallMetadata): Promise<void> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     await controller.run(async progress => {
       await this._markAsTargetElement(progress);
       const result = await this._focus(progress);
@@ -749,7 +744,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async type(metadata: CallMetadata, text: string, options: { delay?: number } & types.TimeoutOptions & types.StrictOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       await this._markAsTargetElement(progress);
       const result = await this._type(progress, text, options);
@@ -768,7 +763,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async press(metadata: CallMetadata, key: string, options: { delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions & types.StrictOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       await this._markAsTargetElement(progress);
       const result = await this._press(progress, key, options);
@@ -789,7 +784,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async check(metadata: CallMetadata, options: { position?: types.Point } & types.PointerActionWaitOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       const result = await this._setChecked(progress, true, options);
       return assertDone(throwRetargetableDOMError(result));
@@ -797,7 +792,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async uncheck(metadata: CallMetadata, options: { position?: types.Point } & types.PointerActionWaitOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       const result = await this._setChecked(progress, false, options);
       return assertDone(throwRetargetableDOMError(result));
@@ -833,7 +828,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async screenshot(metadata: CallMetadata, options: ScreenshotOptions & types.TimeoutOptions): Promise<Buffer> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(
         progress => this._page.screenshotter.screenshotElement(progress, this, options),
         options.timeout);
@@ -880,7 +875,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   async waitForElementState(metadata: CallMetadata, state: 'visible' | 'hidden' | 'stable' | 'enabled' | 'disabled' | 'editable', options: types.TimeoutOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       const actionName = `wait for ${state}`;
       const result = await this._retryAction(progress, actionName, async () => {

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -156,7 +156,7 @@ export class Electron extends SdkObject {
   }
 
   async launch(metadata: CallMetadata, options: channels.ElectronLaunchParams): Promise<ElectronApplication> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       let app: ElectronApplication | undefined = undefined;
       // --remote-debugging-port=0 must be the last playwright's argument, loader.ts relies on it.

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -201,7 +201,7 @@ export abstract class APIRequestContext extends SdkObject {
     const postData = serializePostData(params, headers);
     if (postData)
       setHeader(headers, 'content-length', String(postData.byteLength));
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     const fetchResponse = await controller.run(progress => {
       return this._sendRequestWithRetries(progress, requestUrl, options, postData, params.maxRetries);
     }, params.timeout);

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -419,12 +419,12 @@ export class FFPage implements PageDelegate {
         height: viewportRect!.height,
       };
     }
-    const { data } = await this._session.send('Page.screenshot', {
+    const { data } = await progress.race(this._session.send('Page.screenshot', {
       mimeType: ('image/' + format) as ('image/png' | 'image/jpeg'),
       clip: documentRect,
       quality,
       omitDeviceScaleFactor: scale === 'css',
-    });
+    }));
     return Buffer.from(data, 'base64');
   }
 

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -600,7 +600,7 @@ export class Frame extends SdkObject {
   }
 
   redirectNavigation(url: string, documentId: string, referer: string | undefined) {
-    const controller = new ProgressController(serverSideCallMetadata(), this, 'strict');
+    const controller = new ProgressController(serverSideCallMetadata(), this);
     const data = {
       url,
       gotoPromise: controller.run(progress => this.gotoImpl(progress, url, { referer }), 0),
@@ -610,7 +610,7 @@ export class Frame extends SdkObject {
   }
 
   async goto(metadata: CallMetadata, url: string, options: types.GotoOptions): Promise<network.Response | null> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(progress => {
       const constructedNavigationURL = constructURLBasedOnBaseURL(this._page.browserContext._options.baseURL, url);
       return this.raceNavigationAction(progress, async () => this.gotoImpl(progress, constructedNavigationURL, options));
@@ -744,7 +744,7 @@ export class Frame extends SdkObject {
   }
 
   async waitForSelector(metadata: CallMetadata, selector: string, options: types.WaitForElementOptions, scope?: dom.ElementHandle): Promise<dom.ElementHandle<Element> | null> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       if ((options as any).visibility)
         throw new Error('options.visibility is not supported, did you mean options.state?');
@@ -871,7 +871,7 @@ export class Frame extends SdkObject {
   }
 
   async setContent(metadata: CallMetadata, html: string, options: types.NavigateOptions): Promise<void> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       await this.raceNavigationAction(progress, async () => {
         const waitUntil = options.waitUntil === undefined ? 'load' : options.waitUntil;
@@ -1142,21 +1142,21 @@ export class Frame extends SdkObject {
   }
 
   async click(metadata: CallMetadata, selector: string, options: { noWaitAfter?: boolean } & types.MouseClickOptions & types.PointerActionWaitOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options.strict, !options.force /* performActionPreChecks */, handle => handle._click(progress, { ...options, waitAfter: !options.noWaitAfter })));
     }, options.timeout);
   }
 
   async dblclick(metadata: CallMetadata, selector: string, options: types.MouseMultiClickOptions & types.PointerActionWaitOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options.strict, !options.force /* performActionPreChecks */, handle => handle._dblclick(progress, options)));
     }, options.timeout);
   }
 
   async dragAndDrop(metadata: CallMetadata, source: string, target: string, options: types.DragActionOptions & types.PointerActionWaitOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     await controller.run(async progress => {
       dom.assertDone(await this._retryWithProgressIfNotConnected(progress, source, options.strict, !options.force /* performActionPreChecks */, async handle => {
         return handle._retryPointerAction(progress, 'move and down', false, async point => {
@@ -1183,7 +1183,7 @@ export class Frame extends SdkObject {
   }
 
   async tap(metadata: CallMetadata, selector: string, options: types.PointerActionWaitOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       if (!this._page.browserContext._options.hasTouch)
         throw new Error('The page does not support tap. Use hasTouch context option to enable touch support.');
@@ -1192,21 +1192,21 @@ export class Frame extends SdkObject {
   }
 
   async fill(metadata: CallMetadata, selector: string, value: string, options: types.TimeoutOptions & types.StrictOptions & { force?: boolean }) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options.strict, !options.force /* performActionPreChecks */, handle => handle._fill(progress, value, options)));
     }, options.timeout);
   }
 
   async focus(metadata: CallMetadata, selector: string, options: types.TimeoutOptions & types.StrictOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     await controller.run(async progress => {
       dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options.strict, true /* performActionPreChecks */, handle => handle._focus(progress)));
     }, options.timeout);
   }
 
   async blur(metadata: CallMetadata, selector: string, options: types.TimeoutOptions & types.StrictOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     await controller.run(async progress => {
       dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options.strict, true /* performActionPreChecks */, handle => handle._blur(progress)));
     }, options.timeout);
@@ -1270,7 +1270,7 @@ export class Frame extends SdkObject {
   }
 
   async isVisible(metadata: CallMetadata, selector: string, options: types.StrictOptions = {}, scope?: dom.ElementHandle): Promise<boolean> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       progress.log(`  checking visibility of ${this._asLocator(selector)}`);
       return await this.isVisibleInternal(progress, selector, options, scope);
@@ -1315,14 +1315,14 @@ export class Frame extends SdkObject {
   }
 
   async hover(metadata: CallMetadata, selector: string, options: types.PointerActionOptions & types.PointerActionWaitOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options.strict, !options.force /* performActionPreChecks */, handle => handle._hover(progress, options)));
     }, options.timeout);
   }
 
   async selectOption(metadata: CallMetadata, selector: string, elements: dom.ElementHandle[], values: types.SelectOption[], options: types.CommonActionOptions): Promise<string[]> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return await this._retryWithProgressIfNotConnected(progress, selector, options.strict, !options.force /* performActionPreChecks */, handle => handle._selectOption(progress, elements, values, options));
     }, options.timeout);
@@ -1330,47 +1330,47 @@ export class Frame extends SdkObject {
 
   async setInputFiles(metadata: CallMetadata, selector: string, params: channels.FrameSetInputFilesParams): Promise<channels.FrameSetInputFilesResult> {
     const inputFileItems = await prepareFilesForUpload(this, params);
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, params.strict, true /* performActionPreChecks */, handle => handle._setInputFiles(progress, inputFileItems)));
     }, params.timeout);
   }
 
   async type(metadata: CallMetadata, selector: string, text: string, options: { delay?: number } & types.TimeoutOptions & types.StrictOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options.strict, true /* performActionPreChecks */, handle => handle._type(progress, text, options)));
     }, options.timeout);
   }
 
   async press(metadata: CallMetadata, selector: string, key: string, options: { delay?: number, noWaitAfter?: boolean } & types.TimeoutOptions & types.StrictOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options.strict, true /* performActionPreChecks */, handle => handle._press(progress, key, options)));
     }, options.timeout);
   }
 
   async check(metadata: CallMetadata, selector: string, options: types.PointerActionWaitOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options.strict, !options.force /* performActionPreChecks */, handle => handle._setChecked(progress, true, options)));
     }, options.timeout);
   }
 
   async uncheck(metadata: CallMetadata, selector: string, options: types.PointerActionWaitOptions) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options.strict, !options.force /* performActionPreChecks */, handle => handle._setChecked(progress, false, options)));
     }, options.timeout);
   }
 
   async waitForTimeout(metadata: CallMetadata, timeout: number) {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(progress => progress.wait(timeout));
   }
 
   async ariaSnapshot(metadata: CallMetadata, selector: string, options: { forAI?: boolean } & types.TimeoutOptions): Promise<string> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       return await this._retryWithProgressIfNotConnected(progress, selector, true /* strict */, true /* performActionPreChecks */, handle => progress.race(handle.ariaSnapshot(options)));
     }, options.timeout);
@@ -1391,7 +1391,7 @@ export class Frame extends SdkObject {
       const start = timeout > 0 ? monotonicTime() : 0;
 
       // Step 1: perform locator handlers checkpoint with a specified timeout.
-      await (new ProgressController(metadata, this, 'strict')).run(async progress => {
+      await (new ProgressController(metadata, this)).run(async progress => {
         progress.log(`${renderTitleForCall(metadata)}${timeout ? ` with timeout ${timeout}ms` : ''}`);
         if (selector)
           progress.log(`waiting for ${this._asLocator(selector)}`);
@@ -1402,7 +1402,7 @@ export class Frame extends SdkObject {
       // Supports the case of `expect(locator).toBeVisible({ timeout: 1 })`
       // that should succeed when the locator is already visible.
       try {
-        const resultOneShot = await (new ProgressController(metadata, this, 'strict')).run(async progress => {
+        const resultOneShot = await (new ProgressController(metadata, this)).run(async progress => {
           return await this._expectInternal(progress, selector, options, lastIntermediateResult);
         });
         if (resultOneShot.matches !== options.isNot)
@@ -1420,7 +1420,7 @@ export class Frame extends SdkObject {
         return { matches: options.isNot, log: compressCallLog(metadata.log), timedOut: true, received: lastIntermediateResult.received };
 
       // Step 3: auto-retry expect with increasing timeouts. Bounded by the total remaining time.
-      return await (new ProgressController(metadata, this, 'strict')).run(async progress => {
+      return await (new ProgressController(metadata, this)).run(async progress => {
         return await this.retryWithProgressAndTimeouts(progress, [100, 250, 500, 1000], async continuePolling => {
           await this._page.performActionPreChecks(progress);
           const { matches, received } = await this._expectInternal(progress, selector, options, lastIntermediateResult);
@@ -1483,7 +1483,7 @@ export class Frame extends SdkObject {
   }
 
   async waitForFunctionExpression<R>(metadata: CallMetadata, expression: string, isFunction: boolean | undefined, arg: any, options: types.WaitForFunctionOptions): Promise<js.SmartHandle<R>> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(progress => this.waitForFunctionExpressionImpl(progress, expression, isFunction, arg, options, 'main'), options.timeout);
   }
 
@@ -1590,7 +1590,7 @@ export class Frame extends SdkObject {
   }
 
   private async _callOnElementOnceMatches<T, R>(metadata: CallMetadata, selector: string, body: ElementCallback<T, R>, taskData: T, options: types.TimeoutOptions & types.StrictOptions & { mainWorld?: boolean }, scope?: dom.ElementHandle): Promise<R> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       const callbackText = body.toString();
       progress.log(`waiting for ${this._asLocator(selector)}`);

--- a/packages/playwright-core/src/server/input.ts
+++ b/packages/playwright-core/src/server/input.ts
@@ -55,7 +55,7 @@ export class Keyboard {
   }
 
   async down(metadata: CallMetadata, key: string) {
-    const controller = new ProgressController(metadata, this._page, 'strict');
+    const controller = new ProgressController(metadata, this._page);
     return controller.run(progress => this._down(progress, key));
   }
 
@@ -82,7 +82,7 @@ export class Keyboard {
   }
 
   async up(metadata: CallMetadata, key: string) {
-    const controller = new ProgressController(metadata, this._page, 'strict');
+    const controller = new ProgressController(metadata, this._page);
     return controller.run(progress => this._up(progress, key));
   }
 
@@ -95,7 +95,7 @@ export class Keyboard {
   }
 
   async insertText(metadata: CallMetadata, text: string) {
-    const controller = new ProgressController(metadata, this._page, 'strict');
+    const controller = new ProgressController(metadata, this._page);
     return controller.run(progress => this._insertText(progress, text));
   }
 
@@ -104,7 +104,7 @@ export class Keyboard {
   }
 
   async type(metadata: CallMetadata, text: string, options?: { delay?: number }) {
-    const controller = new ProgressController(metadata, this._page, 'strict');
+    const controller = new ProgressController(metadata, this._page);
     return controller.run(progress => this._type(progress, text, options));
   }
 
@@ -122,7 +122,7 @@ export class Keyboard {
   }
 
   async press(metadata: CallMetadata, key: string, options: { delay?: number }) {
-    const controller = new ProgressController(metadata, this._page, 'strict');
+    const controller = new ProgressController(metadata, this._page);
     return controller.run(progress => this._press(progress, key, options));
   }
 
@@ -214,7 +214,7 @@ export class Mouse {
   }
 
   async move(metadata: CallMetadata, x: number, y: number, options: { steps?: number, forClick?: boolean }) {
-    const controller = new ProgressController(metadata, this._page, 'strict');
+    const controller = new ProgressController(metadata, this._page);
     return controller.run(progress => this._move(progress, x, y, options));
   }
 
@@ -232,7 +232,7 @@ export class Mouse {
   }
 
   async down(metadata: CallMetadata, options: { button?: types.MouseButton, clickCount?: number }) {
-    const controller = new ProgressController(metadata, this._page, 'strict');
+    const controller = new ProgressController(metadata, this._page);
     return controller.run(progress => this._down(progress, options));
   }
 
@@ -244,7 +244,7 @@ export class Mouse {
   }
 
   async up(metadata: CallMetadata, options: { button?: types.MouseButton, clickCount?: number }) {
-    const controller = new ProgressController(metadata, this._page, 'strict');
+    const controller = new ProgressController(metadata, this._page);
     return controller.run(progress => this._up(progress, options));
   }
 
@@ -256,7 +256,7 @@ export class Mouse {
   }
 
   async click(metadata: CallMetadata, x: number, y: number, options: { delay?: number, button?: types.MouseButton, clickCount?: number }) {
-    const controller = new ProgressController(metadata, this._page, 'strict');
+    const controller = new ProgressController(metadata, this._page);
     return controller.run(progress => this._click(progress, x, y, options));
   }
 
@@ -283,7 +283,7 @@ export class Mouse {
   }
 
   async wheel(metadata: CallMetadata, deltaX: number, deltaY: number) {
-    const controller = new ProgressController(metadata, this._page, 'strict');
+    const controller = new ProgressController(metadata, this._page);
     return controller.run(async progress => {
       await this._raw.wheel(progress, this._x, this._y, this._buttons, this._keyboard._modifiers(), deltaX, deltaY);
     });
@@ -364,7 +364,7 @@ export class Touchscreen {
   }
 
   async tap(metadata: CallMetadata, x: number, y: number) {
-    const controller = new ProgressController(metadata, this._page, 'strict');
+    const controller = new ProgressController(metadata, this._page);
     return controller.run(progress => this._tap(progress, x, y));
   }
 

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -369,7 +369,7 @@ export class Page extends SdkObject {
   }
 
   async reload(metadata: CallMetadata, options: types.NavigateOptions): Promise<network.Response | null> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(progress => this.mainFrame().raceNavigationAction(progress, async () => {
       // Note: waitForNavigation may fail before we get response to reload(),
       // so we should await it immediately.
@@ -383,7 +383,7 @@ export class Page extends SdkObject {
   }
 
   async goBack(metadata: CallMetadata, options: types.NavigateOptions): Promise<network.Response | null> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(progress => this.mainFrame().raceNavigationAction(progress, async () => {
       // Note: waitForNavigation may fail before we get response to goBack,
       // so we should catch it immediately.
@@ -405,7 +405,7 @@ export class Page extends SdkObject {
   }
 
   async goForward(metadata: CallMetadata, options: types.NavigateOptions): Promise<network.Response | null> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(progress => this.mainFrame().raceNavigationAction(progress, async () => {
       // Note: waitForNavigation may fail before we get response to goForward,
       // so we should catch it immediately.
@@ -452,9 +452,7 @@ export class Page extends SdkObject {
 
   async performActionPreChecks(progress: Progress) {
     await this._performWaitForNavigationCheck(progress);
-    progress.throwIfAborted();
     await this._performLocatorHandlersCheckpoint(progress);
-    progress.throwIfAborted();
     // Wait once again, just in case a locator handler caused a navigation.
     await this._performWaitForNavigationCheck(progress);
   }
@@ -490,7 +488,6 @@ export class Page extends SdkObject {
         ++this._locatorHandlerRunningCounter;
         progress.log(`  found ${asLocator(this.browserContext._browser.sdkLanguage(), handler.selector)}, intercepting action to run the handler`);
         const promise = handler.resolved.then(async () => {
-          progress.throwIfAborted();
           if (!handler.noWaitAfter) {
             progress.log(`  locator handler has finished, waiting for ${asLocator(this.browserContext._browser.sdkLanguage(), handler.selector)} to be hidden`);
             await this.mainFrame().waitForSelectorInternal(progress, handler.selector, false, { state: 'hidden' });
@@ -600,7 +597,7 @@ export class Page extends SdkObject {
     };
 
     const comparator = getComparator('image/png');
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     if (!options.expected && options.isNot)
       return { errorMessage: '"not" matcher requires expected result' };
     try {
@@ -813,7 +810,7 @@ export class Page extends SdkObject {
   }
 
   snapshotForAI(metadata: CallMetadata): Promise<string> {
-    const controller = new ProgressController(metadata, this, 'strict');
+    const controller = new ProgressController(metadata, this);
     return controller.run(async progress => {
       this.lastSnapshotFrameIds = [];
       const snapshot = await snapshotFrameForAI(progress, this.mainFrame(), 0, this.lastSnapshotFrameIds);

--- a/packages/playwright-core/src/server/progress.ts
+++ b/packages/playwright-core/src/server/progress.ts
@@ -45,13 +45,6 @@ export interface Progress {
   metadata: CallMetadata;
 }
 
-let isStrictModeCached: boolean | undefined;
-function isStrictMode() {
-  if (isStrictModeCached === undefined)
-    isStrictModeCached = !process.env.PLAYWRIGHT_LEGACY_TIMEOUTS;
-  return isStrictModeCached;
-}
-
 export class ProgressController {
   private _forceAbortPromise = new ManualPromise<any>();
   private _donePromise = new ManualPromise<void>();
@@ -73,7 +66,7 @@ export class ProgressController {
   readonly sdkObject: SdkObject;
 
   constructor(metadata: CallMetadata, sdkObject: SdkObject) {
-    this._strictMode = isStrictMode();
+    this._strictMode = !process.env.PLAYWRIGHT_LEGACY_TIMEOUTS;
     this.metadata = metadata;
     this.sdkObject = sdkObject;
     this.instrumentation = sdkObject.instrumentation;

--- a/packages/playwright-core/src/server/progress.ts
+++ b/packages/playwright-core/src/server/progress.ts
@@ -15,21 +15,41 @@
  */
 
 import { TimeoutError } from './errors';
-import { assert, monotonicTime } from '../utils';
+import { assert } from '../utils';
 import { ManualPromise } from '../utils/isomorphic/manualPromise';
 
 import type { CallMetadata, Instrumentation, SdkObject } from './instrumentation';
 import type { LogName } from './utils/debugLogger';
 
+// Most server operations are run inside a Progress instance.
+// Each method that takes a Progress must result in one of the three outcomes:
+//   - It finishes successfully, returning a value, before the Progress is aborted.
+//   - It throws some error, before the Progress is aborted.
+//   - It throws the Progress's aborted error, because the Progress was aborted before
+//     the method could finish.
+// As a rule of thumb, the above is achieved by:
+//   - Passing the Progress instance when awaiting other methods.
+//   - Using `progress.race()` when awaiting other methods that do not take a Progress argument.
+//     In this case, it is important that awaited method has no side effects, for example
+//     it is a read-only browser protocol call.
+//   - In rare cases, when the awaited method does not take a Progress argument,
+//     but it does have side effects such as creating a page -  a proper cleanup
+//     must be taken in case Progress is aborted before the awaited method finishes.
+//     That's usually done by `progress.raceWithCleanup()` or `progress.cleanupWhenAborted()`.
 export interface Progress {
   log(message: string): void;
-  timeUntilDeadline(): number;
-  cleanupWhenAborted(cleanup: () => any): void;
-  throwIfAborted(): void;
+  cleanupWhenAborted(cleanup: (error: Error | undefined) => any): void;
   race<T>(promise: Promise<T> | Promise<T>[]): Promise<T>;
   raceWithCleanup<T>(promise: Promise<T>, cleanup: (result: T) => any): Promise<T>;
   wait(timeout: number): Promise<void>;
   metadata: CallMetadata;
+}
+
+let isStrictModeCached: boolean | undefined;
+function isStrictMode() {
+  if (isStrictModeCached === undefined)
+    isStrictModeCached = !process.env.PLAYWRIGHT_LEGACY_TIMEOUTS;
+  return isStrictModeCached;
 }
 
 export class ProgressController {
@@ -37,7 +57,7 @@ export class ProgressController {
   private _donePromise = new ManualPromise<void>();
 
   // Cleanups to be run only in the case of abort.
-  private _cleanups: (() => any)[] = [];
+  private _cleanups: ((error: Error | undefined) => any)[] = [];
 
   // Lenient mode races against the timeout. This guarantees that timeout is respected,
   // but may have some work being done after the timeout due to parallel control flow.
@@ -48,13 +68,12 @@ export class ProgressController {
 
   private _logName: LogName;
   private _state: 'before' | 'running' | { error: Error } | 'finished' = 'before';
-  private _deadline: number = 0;
   readonly metadata: CallMetadata;
   readonly instrumentation: Instrumentation;
   readonly sdkObject: SdkObject;
 
-  constructor(metadata: CallMetadata, sdkObject: SdkObject, strictMode?: 'strict') {
-    this._strictMode = strictMode === 'strict';
+  constructor(metadata: CallMetadata, sdkObject: SdkObject) {
+    this._strictMode = isStrictMode();
     this.metadata = metadata;
     this.sdkObject = sdkObject;
     this.instrumentation = sdkObject.instrumentation;
@@ -77,8 +96,6 @@ export class ProgressController {
   }
 
   async run<T>(task: (progress: Progress) => Promise<T>, timeout?: number): Promise<T> {
-    this._deadline = timeout ? monotonicTime() + timeout : 0;
-
     assert(this._state === 'before');
     this._state = 'running';
     this.sdkObject.attribution.context?._activeProgressControllers.add(this);
@@ -90,16 +107,17 @@ export class ProgressController {
         // Note: we might be sending logs after progress has finished, for example browser logs.
         this.instrumentation.onCallLog(this.sdkObject, this.metadata, this._logName, message);
       },
-      timeUntilDeadline: () => this._deadline ? this._deadline - monotonicTime() : 2147483647, // 2^31-1 safe setTimeout in Node.
-      cleanupWhenAborted: (cleanup: () => any) => {
+      cleanupWhenAborted: (cleanup: (error: Error | undefined) => any) => {
+        if (this._strictMode) {
+          if (this._state !== 'running')
+            throw new Error('Internal error: cannot register cleanup after operation has finished.');
+          this._cleanups.push(cleanup);
+          return;
+        }
         if (this._state === 'running')
           this._cleanups.push(cleanup);
         else
-          runCleanup(cleanup);
-      },
-      throwIfAborted: () => {
-        if (typeof this._state === 'object')
-          throw this._state.error;
+          runCleanup(typeof this._state === 'object' ? this._state.error : undefined, cleanup);
       },
       metadata: this.metadata,
       race: <T>(promise: Promise<T> | Promise<T>[]) => {
@@ -119,13 +137,17 @@ export class ProgressController {
       },
     };
 
-    const timeoutError = new TimeoutError(`Timeout ${timeout}ms exceeded.`);
-    const timer = setTimeout(() => {
-      if (this._state === 'running') {
-        this._state = { error: timeoutError };
-        this._forceAbortPromise.reject(timeoutError);
-      }
-    }, progress.timeUntilDeadline());
+    let timer: NodeJS.Timeout | undefined;
+    if (timeout) {
+      const timeoutError = new TimeoutError(`Timeout ${timeout}ms exceeded.`);
+      timer = setTimeout(() => {
+        if (this._state === 'running') {
+          this._state = { error: timeoutError };
+          this._forceAbortPromise.reject(timeoutError);
+        }
+      }, Math.min(timeout, 2147483647)); // 2^31-1 safe setTimeout in Node.
+    }
+
     try {
       const promise = task(progress);
       const result = this._strictMode ? await promise : await Promise.race([promise, this._forceAbortPromise]);
@@ -133,7 +155,7 @@ export class ProgressController {
       return result;
     } catch (error) {
       this._state = { error };
-      await Promise.all(this._cleanups.splice(0).map(runCleanup));
+      await Promise.all(this._cleanups.splice(0).map(cleanup => runCleanup(error, cleanup)));
       throw error;
     } finally {
       this.sdkObject.attribution.context?._activeProgressControllers.delete(this);
@@ -143,9 +165,9 @@ export class ProgressController {
   }
 }
 
-async function runCleanup(cleanup: () => any) {
+async function runCleanup(error: Error | undefined, cleanup: (error: Error | undefined) => any) {
   try {
-    await cleanup();
+    await cleanup(error);
   } catch (e) {
   }
 }

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -121,7 +121,7 @@ export class RecorderApp extends EventEmitter implements IRecorderApp {
         timeout: 0,
       }
     });
-    const controller = new ProgressController(serverSideCallMetadata(), context._browser, 'strict');
+    const controller = new ProgressController(serverSideCallMetadata(), context._browser);
     await controller.run(async progress => {
       await context._browser._defaultContext!._loadDefaultContextAsIs(progress);
     });

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -1197,7 +1197,7 @@ export class Registry {
   private async _installMSEdgeChannel(channel: 'msedge'|'msedge-beta'|'msedge-dev', scripts: Record<'linux' | 'darwin' | 'win32', string>) {
     const scriptArgs: string[] = [];
     if (process.platform !== 'linux') {
-      const products = lowercaseAllKeys(JSON.parse(await fetchData({ url: 'https://edgeupdates.microsoft.com/api/products' })));
+      const products = lowercaseAllKeys(JSON.parse(await fetchData(undefined, { url: 'https://edgeupdates.microsoft.com/api/products' })));
 
       const productName = {
         'msedge': 'Stable',

--- a/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
+++ b/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
@@ -48,13 +48,11 @@ function downloadFile(options: DownloadParams): Promise<void> {
   let totalBytes = 0;
 
   const promise = new ManualPromise<void>();
-
-  httpRequest({
+  const { cancel } = httpRequest({
     url: options.url,
     headers: {
       'User-Agent': options.userAgent,
     },
-    timeout: options.socketTimeout,
   }, response => {
     log(`-- response status code: ${response.statusCode}`);
     if (response.statusCode !== 200) {
@@ -97,6 +95,8 @@ function downloadFile(options: DownloadParams): Promise<void> {
       }
     });
   }, (error: any) => promise.reject(error));
+  const timer = setTimeout(() => cancel(new Error(`Request to ${options.url} timed out after ${options.socketTimeout}ms`)), options.socketTimeout);
+  promise.finally(() => clearTimeout(timer));
   return promise;
 
   function onData(chunk: string) {

--- a/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
+++ b/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
@@ -48,11 +48,12 @@ function downloadFile(options: DownloadParams): Promise<void> {
   let totalBytes = 0;
 
   const promise = new ManualPromise<void>();
-  const { cancel } = httpRequest({
+  httpRequest({
     url: options.url,
     headers: {
       'User-Agent': options.userAgent,
     },
+    socketTimeout: options.socketTimeout,
   }, response => {
     log(`-- response status code: ${response.statusCode}`);
     if (response.statusCode !== 200) {
@@ -95,8 +96,6 @@ function downloadFile(options: DownloadParams): Promise<void> {
       }
     });
   }, (error: any) => promise.reject(error));
-  const timer = setTimeout(() => cancel(new Error(`Request to ${options.url} timed out after ${options.socketTimeout}ms`)), options.socketTimeout);
-  promise.finally(() => clearTimeout(timer));
   return promise;
 
   function onData(chunk: string) {

--- a/packages/playwright-core/src/server/screenshotter.ts
+++ b/packages/playwright-core/src/server/screenshotter.ts
@@ -303,7 +303,7 @@ export class Screenshotter {
 
     const cleanupHighlight = await this._maskElements(progress, options);
     const quality = format === 'jpeg' ? options.quality ?? 80 : undefined;
-    const buffer = await progress.race(this._page.delegate.takeScreenshot(progress, format, documentRect, viewportRect, quality, fitsViewport, options.scale || 'device'));
+    const buffer = await this._page.delegate.takeScreenshot(progress, format, documentRect, viewportRect, quality, fitsViewport, options.scale || 'device');
     await cleanupHighlight();
 
     if (shouldSetDefaultBackground)

--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -180,7 +180,7 @@ export async function openTraceViewerApp(url: string, browserName: string, optio
     },
   });
 
-  const controller = new ProgressController(serverSideCallMetadata(), context._browser, 'strict');
+  const controller = new ProgressController(serverSideCallMetadata(), context._browser);
   await controller.run(async progress => {
     await context._browser._defaultContext!._loadDefaultContextAsIs(progress);
   });

--- a/packages/playwright-core/src/server/transport.ts
+++ b/packages/playwright-core/src/server/transport.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { DEFAULT_PLAYWRIGHT_TIMEOUT, makeWaitForNextTask } from '../utils';
+import { makeWaitForNextTask } from '../utils';
 import { httpHappyEyeballsAgent, httpsHappyEyeballsAgent } from './utils/happyEyeballs';
 import { ws } from '../utilsBundle';
 
@@ -133,8 +133,6 @@ export class WebSocketTransport implements ConnectionTransport {
     this._logUrl = logUrl;
     this._ws = new ws(url, [], {
       maxPayload: 256 * 1024 * 1024, // 256Mb,
-      // Prevent internal http client error when passing negative timeout.
-      handshakeTimeout: Math.max(progress?.timeUntilDeadline() ?? DEFAULT_PLAYWRIGHT_TIMEOUT, 1),
       headers: options.headers,
       followRedirects: options.followRedirects,
       agent: (/^(https|wss):\/\//.test(url)) ? httpsHappyEyeballsAgent : httpHappyEyeballsAgent,

--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -33,6 +33,7 @@ export type HTTPRequestParams = {
   headers?: http.OutgoingHttpHeaders,
   data?: string | Buffer,
   rejectUnauthorized?: boolean,
+  socketTimeout?: number,
 };
 
 export const NET_DEFAULT_TIMEOUT = 30_000;
@@ -83,6 +84,12 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
     https.request(options, requestCallback) :
     http.request(options, requestCallback);
   request.on('error', onError);
+  if (params.socketTimeout !== undefined) {
+    request.setTimeout(params.socketTimeout, () =>  {
+      onError(new Error(`Request to ${params.url} timed out after ${params.socketTimeout}ms`));
+      request.abort();
+    });
+  }
   cancelRequest = e => request.destroy(e);
   request.end(params.data);
   return { cancel: e => cancelRequest(e) };

--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -25,19 +25,19 @@ import { httpHappyEyeballsAgent, httpsHappyEyeballsAgent } from './happyEyeballs
 
 import type net from 'net';
 import type { ProxySettings } from '../types';
+import type { Progress } from '../progress';
 
 export type HTTPRequestParams = {
   url: string,
   method?: string,
   headers?: http.OutgoingHttpHeaders,
   data?: string | Buffer,
-  timeout?: number,
   rejectUnauthorized?: boolean,
 };
 
 export const NET_DEFAULT_TIMEOUT = 30_000;
 
-export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.IncomingMessage) => void, onError: (error: Error) => void) {
+export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.IncomingMessage) => void, onError: (error: Error) => void): { cancel(error: Error | undefined): void } {
   const parsedUrl = url.parse(params.url);
   let options: https.RequestOptions = {
     ...parsedUrl,
@@ -47,8 +47,6 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
   };
   if (params.rejectUnauthorized !== undefined)
     options.rejectUnauthorized = params.rejectUnauthorized;
-
-  const timeout = params.timeout ?? NET_DEFAULT_TIMEOUT;
 
   const proxyURL = getProxyForUrl(params.url);
   if (proxyURL) {
@@ -69,13 +67,14 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
     }
   }
 
+  let cancelRequest: (e: Error | undefined) => void;
   const requestCallback = (res: http.IncomingMessage) => {
     const statusCode = res.statusCode || 0;
     if (statusCode >= 300 && statusCode < 400 && res.headers.location) {
       // Close the original socket before following the redirect. Otherwise
       // it may stay idle and cause a timeout error.
       request.destroy();
-      httpRequest({ ...params, url: new URL(res.headers.location, params.url).toString() }, onResponse, onError);
+      cancelRequest = httpRequest({ ...params, url: new URL(res.headers.location, params.url).toString() }, onResponse, onError).cancel;
     } else {
       onResponse(res);
     }
@@ -84,23 +83,14 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
     https.request(options, requestCallback) :
     http.request(options, requestCallback);
   request.on('error', onError);
-  if (timeout !== undefined) {
-    const rejectOnTimeout = () =>  {
-      onError(new Error(`Request to ${params.url} timed out after ${timeout}ms`));
-      request.abort();
-    };
-    if (timeout <= 0) {
-      rejectOnTimeout();
-      return;
-    }
-    request.setTimeout(timeout, rejectOnTimeout);
-  }
+  cancelRequest = e => request.destroy(e);
   request.end(params.data);
+  return { cancel: e => cancelRequest(e) };
 }
 
-export function fetchData(params: HTTPRequestParams, onError?: (params: HTTPRequestParams, response: http.IncomingMessage) => Promise<Error>): Promise<string> {
-  return new Promise((resolve, reject) => {
-    httpRequest(params, async response => {
+export function fetchData(progress: Progress | undefined, params: HTTPRequestParams, onError?: (params: HTTPRequestParams, response: http.IncomingMessage) => Promise<Error>): Promise<string> {
+  const promise = new Promise<string>((resolve, reject) => {
+    const { cancel } = httpRequest(params, async response => {
       if (response.statusCode !== 200) {
         const error = onError ? await onError(params, response) : new Error(`fetch failed: server returned code ${response.statusCode}. URL: ${params.url}`);
         reject(error);
@@ -111,7 +101,9 @@ export function fetchData(params: HTTPRequestParams, onError?: (params: HTTPRequ
       response.on('error', (error: any) => reject(error));
       response.on('end', () => resolve(body));
     }, reject);
+    progress?.cleanupWhenAborted(cancel);
   });
+  return progress ? progress.race(promise) : promise;
 }
 
 function shouldBypassProxy(url: URL, bypass?: string): boolean {

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -869,7 +869,7 @@ export class WKPage implements PageDelegate {
     const omitDeviceScaleFactor = scale === 'css';
     this.validateScreenshotDimension(rect.width, omitDeviceScaleFactor);
     this.validateScreenshotDimension(rect.height, omitDeviceScaleFactor);
-    const result = await this._session.send('Page.snapshotRect', { ...rect, coordinateSystem: documentRect ? 'Page' : 'Viewport', omitDeviceScaleFactor });
+    const result = await progress.race(this._session.send('Page.snapshotRect', { ...rect, coordinateSystem: documentRect ? 'Page' : 'Viewport', omitDeviceScaleFactor }));
     const prefix = 'data:image/png;base64,';
     let buffer: Buffer = Buffer.from(result.dataURL.substr(prefix.length), 'base64');
     if (format === 'jpeg')

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1283,7 +1283,7 @@ it('should support SameSite cookie attribute over https', async ({ contextFactor
   // we do HTTPS navigation.
   const context = await contextFactory({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
-  for (const value of ['None', 'Lax']) {
+  for (const value of ['None', 'Lax', 'Strict']) {
     await it.step(`SameSite=${value}`, async () => {
       httpsServer.setRoute('/empty.html', (req, res) => {
         res.setHeader('Set-Cookie', `SID=2022; Path=/; Secure; SameSite=${value}`);
@@ -1323,7 +1323,7 @@ it('fetch should not throw on long set-cookie value', async ({ context, server }
 });
 
 it('should support set-cookie with SameSite and without Secure attribute over HTTP', async ({ page, server, browserName, isWindows, isLinux }) => {
-  for (const value of ['None', 'Lax']) {
+  for (const value of ['None', 'Lax', 'Strict']) {
     await it.step(`SameSite=${value}`, async () => {
       server.setRoute('/empty.html', (req, res) => {
         res.setHeader('Set-Cookie', `SID=2022; Path=/; SameSite=${value}`);

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1283,7 +1283,7 @@ it('should support SameSite cookie attribute over https', async ({ contextFactor
   // we do HTTPS navigation.
   const context = await contextFactory({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
-  for (const value of ['None', 'Lax', 'Strict']) {
+  for (const value of ['None', 'Lax']) {
     await it.step(`SameSite=${value}`, async () => {
       httpsServer.setRoute('/empty.html', (req, res) => {
         res.setHeader('Set-Cookie', `SID=2022; Path=/; Secure; SameSite=${value}`);
@@ -1323,7 +1323,7 @@ it('fetch should not throw on long set-cookie value', async ({ context, server }
 });
 
 it('should support set-cookie with SameSite and without Secure attribute over HTTP', async ({ page, server, browserName, isWindows, isLinux }) => {
-  for (const value of ['None', 'Lax', 'Strict']) {
+  for (const value of ['None', 'Lax']) {
     await it.step(`SameSite=${value}`, async () => {
       server.setRoute('/empty.html', (req, res) => {
         res.setHeader('Set-Cookie', `SID=2022; Path=/; SameSite=${value}`);


### PR DESCRIPTION
A few changes:
- progress is now strict by default, `PLAYWRIGHT_LEGACY_TIMEOUTS` opts out;
- new bot that tests the old behavior;
- removed `Progress.timeUntilDeadline()` and `Progress.throwIfAborted()`;
- passing `Progress` to `fetchData`.