### PR TITLE
test: make babel test pass under Node.js 24

### DIFF
--- a/tests/playwright-test/babel.spec.ts
+++ b/tests/playwright-test/babel.spec.ts
@@ -145,11 +145,15 @@ test('should not transform external', async ({ runInlineTest }) => {
     'a.spec.ts': `
       const { test, expect, Page } = require('@playwright/test');
       let page: Page;
-      test('succeeds', () => {});
+      enum MyEnum { Value = 'value' }
+
+      test('succeeds', () => {
+        expect(MyEnum.Value).toBe('value');
+      });
     `
   });
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain(`SyntaxError: Unexpected token ':'`);
+  expect(result.output).toMatch(/(SyntaxError: Unexpected token ':')|(SyntaxError: TypeScript enum is not supported)/);
 });
 
 for (const type of ['module', undefined]) {


### PR DESCRIPTION
```
(node:34672) ExperimentalWarning: Type Stripping is an experimental feature and might change at any time
    (Use `node --trace-warnings ...` to show where the warning was created)
    SyntaxError: TypeScript enum is not supported in strip-only mode
```

https://github.com/microsoft/playwright/issues/36404