### PR TITLE
chore: bump commander.js version to 13

### DIFF
--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -10,7 +10,7 @@ This project incorporates components from the projects listed below. The origina
 -	buffer-crc32@0.2.13 (https://github.com/brianloveswords/buffer-crc32)
 -	codemirror@5.65.18 (https://github.com/codemirror/CodeMirror)
 -	colors@1.4.0 (https://github.com/Marak/colors.js)
--	commander@8.3.0 (https://github.com/tj/commander.js)
+-	commander@13.1.0 (https://github.com/tj/commander.js)
 -	concat-map@0.0.1 (https://github.com/substack/node-concat-map)
 -	debug@4.3.4 (https://github.com/debug-js/debug)
 -	debug@4.4.0 (https://github.com/debug-js/debug)
@@ -331,7 +331,7 @@ THE SOFTWARE.
 =========================================
 END OF colors@1.4.0 AND INFORMATION
 
-%% commander@8.3.0 NOTICES AND INFORMATION BEGIN HERE
+%% commander@13.1.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 (The MIT License)
 
@@ -356,7 +356,7 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
-END OF commander@8.3.0 AND INFORMATION
+END OF commander@13.1.0 AND INFORMATION
 
 %% concat-map@0.0.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================

--- a/packages/playwright-core/bundles/utils/package-lock.json
+++ b/packages/playwright-core/bundles/utils/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "colors": "1.4.0",
-        "commander": "8.3.0",
+        "commander": "^13.0.0",
         "debug": "^4.3.4",
         "diff": "^7.0.0",
         "dotenv": "^16.4.5",
@@ -173,11 +173,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 12"
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {

--- a/packages/playwright-core/bundles/utils/package.json
+++ b/packages/playwright-core/bundles/utils/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "colors": "1.4.0",
-    "commander": "8.3.0",
+    "commander": "^13.0.0",
     "debug": "^4.3.4",
     "diff": "^7.0.0",
     "dotenv": "^16.4.5",

--- a/packages/playwright-core/src/cli/programWithTestStub.ts
+++ b/packages/playwright-core/src/cli/programWithTestStub.ts
@@ -55,7 +55,9 @@ const kExternalPlaywrightTestCommands = [
 ];
 function addExternalPlaywrightTestCommands() {
   for (const [command, description] of kExternalPlaywrightTestCommands) {
-    const playwrightTest = program.command(command).allowUnknownOption(true);
+    const playwrightTest = program.command(command)
+        .allowUnknownOption(true)
+        .allowExcessArguments(true);
     playwrightTest.description(`${description} Available in @playwright/test package.`);
     playwrightTest.action(async () => {
       printPlaywrightTestError(command);

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -382,7 +382,7 @@ const testOptions: [string, string][] = [
   ['--fully-parallel', `Run all tests in parallel (default: false)`],
   ['--global-timeout <timeout>', `Maximum time this test suite can run in milliseconds (default: unlimited)`],
   ['-g, --grep <grep>', `Only run tests matching this regular expression (default: ".*")`],
-  ['-gv, --grep-invert <grep>', `Only run tests that do not match this regular expression`],
+  ['--gv, --grep-invert <grep>', `Only run tests that do not match this regular expression`],
   ['--headed', `Run tests in headed browsers (default: headless)`],
   ['--ignore-snapshots', `Ignore screenshot and snapshot expectations`],
   ['--last-failed', `Only re-run the failures`],

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -382,7 +382,7 @@ const testOptions: [string, string][] = [
   ['--fully-parallel', `Run all tests in parallel (default: false)`],
   ['--global-timeout <timeout>', `Maximum time this test suite can run in milliseconds (default: unlimited)`],
   ['-g, --grep <grep>', `Only run tests matching this regular expression (default: ".*")`],
-  ['--gv, --grep-invert <grep>', `Only run tests that do not match this regular expression`],
+  ['--grep-invert <grep>', `Only run tests that do not match this regular expression`],
   ['--headed', `Run tests in headed browsers (default: headless)`],
   ['--ignore-snapshots', `Ignore screenshot and snapshot expectations`],
   ['--last-failed', `Only re-run the failures`],


### PR DESCRIPTION
Need support for `Option.preset()` and `Option.default()`. Latest Commander.js version is 14 but it requires Node.js >= 20 and we still support Node.js 18.

Deleted short option `-gv` to avoid the following error:
```
Error: option creation failed due to '-gv' in option flags '-gv, --grep-invert <grep>'
- a short flag is a single dash and a single character
  - either use a single dash and a single character (for a short flag)
  - or use a double dash for a long option (and can have two, like '--ws, --workspace')
```

Reference: https://github.com/microsoft/playwright/issues/36297