### PR TITLE
test: fix installation tests under Node.js 24

### DIFF
--- a/tests/installation/npmTest.ts
+++ b/tests/installation/npmTest.ts
@@ -107,6 +107,8 @@ export const test = _test
         const npmLines = [
           `registry = ${registry.url()}/`,
           `cache = ${testInfo.outputPath('npm_cache')}`,
+          // Required after https://github.com/npm/cli/pull/8185.
+          'replace-registry-host=never',
         ];
         if (!allowGlobalInstall) {
           yarnLines.push(`prefix "${testInfo.outputPath('npm_global')}"`);

--- a/tests/installation/playwright-cli-install-should-work.spec.ts
+++ b/tests/installation/playwright-cli-install-should-work.spec.ts
@@ -38,7 +38,6 @@ test('install command should work', async ({ exec, checkInstalledSoftwareOnDisk 
 
   await test.step('playwright install --list', async () => {
     const result = await exec('npx playwright install --list');
-    console.log('result', result);
     expect.soft(result).toMatch(/Playwright version: \d+\.\d+/);
     expect.soft(result).toMatch(/chromium-\d+/);
     expect.soft(result).toMatch(/chromium_headless_shell-\d+/);


### PR DESCRIPTION
The change which broke us in the NPM CLI was https://github.com/npm/cli/pull/8185. I didn't find a better way to fix it, so disabling the rewrite for now. We probably would have to parse out the response in tests/installation/registry.ts:113 and rewrite the response body there to include the new registry URL.

https://github.com/microsoft/playwright/issues/36404