### PR TITLE
chore(reporter): strict typing for teleReceiver and merge

### DIFF
--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { BlobReportMetadata } from '../reporters/blob';
-
 import type { Metadata, TestAnnotation } from '../../types/test';
 import type * as reporterTypes from '../../types/testReporter';
 import type { ReporterV2 } from '../reporters/reporterV2';
@@ -224,6 +222,14 @@ export type JsonOnEndEvent = {
 export type JsonOnExitEvent = {
   method: 'onExit';
   params: undefined;
+};
+
+export type BlobReportMetadata = {
+  version: number;
+  userAgent: string;
+  name?: string;
+  shard?: { total: number, current: number };
+  pathSeparator?: string;
 };
 
 type TeleReporterReceiverOptions = {

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { BlobReportMetadata } from '../reporters/blob';
+
 import type { Metadata, TestAnnotation } from '../../types/test';
 import type * as reporterTypes from '../../types/testReporter';
 import type { ReporterV2 } from '../reporters/reporterV2';
@@ -127,9 +129,101 @@ export type JsonFullResult = {
   duration: number;
 };
 
-export type JsonEvent = {
-  method: string;
-  params: any
+export type JsonEvent = JsonOnConfigureEvent | JsonOnBlobReportMetadataEvent | JsonOnEndEvent | JsonOnExitEvent | JsonOnProjectEvent | JsonOnBeginEvent | JsonOnTestBeginEvent
+  | JsonOnTestEndEvent | JsonOnStepBeginEvent | JsonOnStepEndEvent | JsonOnAttachEvent | JsonOnErrorEvent | JsonOnStdIOEvent;
+
+export type JsonOnConfigureEvent = {
+  method: 'onConfigure';
+  params: {
+    config: JsonConfig;
+  };
+};
+
+export type JsonOnBlobReportMetadataEvent = {
+  method: 'onBlobReportMetadata';
+  params: BlobReportMetadata;
+};
+
+export type JsonOnProjectEvent = {
+  method: 'onProject';
+  params: {
+    project: JsonProject;
+  };
+};
+
+export type JsonOnBeginEvent = {
+  method: 'onBegin';
+  params: undefined;
+};
+
+export type JsonOnTestBeginEvent = {
+  method: 'onTestBegin';
+  params: {
+    testId: string;
+    result: JsonTestResultStart;
+  };
+};
+
+export type JsonOnTestEndEvent = {
+  method: 'onTestEnd';
+  params: {
+    test: JsonTestEnd;
+    testId?: string;
+    result: JsonTestResultEnd;
+  };
+};
+
+export type JsonOnStepBeginEvent = {
+  method: 'onStepBegin';
+  params: {
+    testId: string;
+    resultId: string;
+    step: JsonTestStepStart;
+  };
+};
+
+export type JsonOnStepEndEvent = {
+  method: 'onStepEnd';
+  params: {
+    testId: string;
+    resultId: string;
+    step: JsonTestStepEnd;
+  };
+};
+
+export type JsonOnAttachEvent = {
+  method: 'onAttach';
+  params: JsonTestResultOnAttach;
+};
+
+export type JsonOnErrorEvent = {
+  method: 'onError';
+  params: {
+    error: reporterTypes.TestError;
+  };
+};
+
+export type JsonOnStdIOEvent = {
+  method: 'onStdIO';
+  params: {
+    type: JsonStdIOType;
+    testId?: string;
+    resultId?: string;
+    data: string;
+    isBase64: boolean;
+  };
+};
+
+export type JsonOnEndEvent = {
+  method: 'onEnd';
+  params: {
+    result: JsonFullResult;
+  };
+};
+
+export type JsonOnExitEvent = {
+  method: 'onExit';
+  params: undefined;
 };
 
 type TeleReporterReceiverOptions = {

--- a/packages/playwright/src/reporters/blob.ts
+++ b/packages/playwright/src/reporters/blob.ts
@@ -28,18 +28,10 @@ import { TeleReporterEmitter } from './teleEmitter';
 
 import type { BlobReporterOptions } from '../../types/test';
 import type { FullConfig, FullResult, TestResult } from '../../types/testReporter';
-import type { JsonAttachment, JsonEvent } from '../isomorphic/teleReceiver';
+import type { BlobReportMetadata, JsonAttachment, JsonEvent } from '../isomorphic/teleReceiver';
 import type { EventEmitter } from 'events';
 
 export const currentBlobReportVersion = 2;
-
-export type BlobReportMetadata = {
-  version: number;
-  userAgent: string;
-  name?: string;
-  shard?: { total: number, current: number };
-  pathSeparator?: string;
-};
 
 export class BlobReporter extends TeleReporterEmitter {
   private readonly _messages: JsonEvent[] = [];

--- a/packages/playwright/src/reporters/merge.ts
+++ b/packages/playwright/src/reporters/merge.ts
@@ -30,7 +30,7 @@ import type { BlobReportMetadata } from './blob';
 import type { ReporterDescription } from '../../types/test';
 import type { TestError } from '../../types/testReporter';
 import type { FullConfigInternal } from '../common/config';
-import type { JsonAttachment, JsonConfig, JsonEvent, JsonFullResult, JsonLocation, JsonProject, JsonSuite, JsonTestCase, JsonTestResultEnd, JsonTestResultOnAttach, JsonTestStepEnd, JsonTestStepStart } from '../isomorphic/teleReceiver';
+import type { JsonAttachment, JsonConfig, JsonEvent, JsonFullResult, JsonLocation, JsonOnConfigureEvent, JsonOnEndEvent, JsonOnProjectEvent, JsonProject, JsonSuite, JsonTestCase } from '../isomorphic/teleReceiver';
 import type * as blobV1 from './versions/blobV1';
 
 type StatusCallback = (message: string) => void;
@@ -165,18 +165,23 @@ async function extractAndParseReports(dir: string, shardFiles: string[], interna
 function findMetadata(events: JsonEvent[], file: string): BlobReportMetadata {
   if (events[0]?.method !== 'onBlobReportMetadata')
     throw new Error(`No metadata event found in ${file}`);
-  const metadata = (events[0].params as BlobReportMetadata);
+  const metadata = events[0].params;
   if (metadata.version > currentBlobReportVersion)
     throw new Error(`Blob report ${file} was created with a newer version of Playwright.`);
   return metadata;
 }
 
-async function mergeEvents(dir: string, shardReportFiles: string[], stringPool: StringInternPool, printStatus: StatusCallback, rootDirOverride: string | undefined) {
+async function mergeEvents(dir: string, shardReportFiles: string[], stringPool: StringInternPool, printStatus: StatusCallback, rootDirOverride: string | undefined): Promise<{
+  prologue: JsonEvent[];
+  reports: ReportData[];
+  epilogue: JsonEvent[];
+  pathSeparatorFromMetadata?: string;
+}> {
   const internalizer = new JsonStringInternalizer(stringPool);
 
-  const configureEvents: JsonEvent[] = [];
-  const projectEvents: JsonEvent[] = [];
-  const endEvents: JsonEvent[] = [];
+  const configureEvents: JsonOnConfigureEvent[] = [];
+  const projectEvents: JsonOnProjectEvent[] = [];
+  const endEvents: JsonOnEndEvent[] = [];
 
   const blobs = await extractAndParseReports(dir, shardReportFiles, internalizer, printStatus);
   // Sort by (report name; shard; file name), so that salt generation below is deterministic when:
@@ -247,7 +252,7 @@ async function mergeEvents(dir: string, shardReportFiles: string[], stringPool: 
   };
 }
 
-function mergeConfigureEvents(configureEvents: JsonEvent[], rootDirOverride: string | undefined): JsonEvent {
+function mergeConfigureEvents(configureEvents: JsonOnConfigureEvent[], rootDirOverride: string | undefined): JsonEvent {
   if (!configureEvents.length)
     throw new Error('No configure events found');
   let config: JsonConfig = {
@@ -305,13 +310,13 @@ function mergeConfigs(to: JsonConfig, from: JsonConfig): JsonConfig {
   };
 }
 
-function mergeEndEvents(endEvents: JsonEvent[]): JsonEvent {
+function mergeEndEvents(endEvents: JsonOnEndEvent[]): JsonEvent {
   let startTime = endEvents.length ? 10000000000000 : Date.now();
   let status: JsonFullResult['status'] = 'passed';
   let duration: number = 0;
 
   for (const event of endEvents) {
-    const shardResult: JsonFullResult = event.params.result;
+    const shardResult = event.params.result;
     if (shardResult.status === 'failed')
       status = 'failed';
     else if (shardResult.status === 'timedout' && status !== 'failed')
@@ -395,7 +400,7 @@ class IdsPatcher {
       case 'onStepBegin':
       case 'onStepEnd':
       case 'onStdIO':
-        params.testId = this._mapTestId(params.testId);
+        params.testId = params.testId ? this._mapTestId(params.testId) : undefined;
         return;
       case 'onTestEnd':
         params.test.testId = this._mapTestId(params.test.testId);
@@ -449,9 +454,9 @@ class AttachmentPathPatcher {
 
   patchEvent(event: JsonEvent) {
     if (event.method === 'onAttach')
-      this._patchAttachments((event.params as JsonTestResultOnAttach).attachments);
+      this._patchAttachments(event.params.attachments);
     else if (event.method === 'onTestEnd')
-      this._patchAttachments((event.params.result as JsonTestResultEnd).attachments ?? []);
+      this._patchAttachments(event.params.result.attachments ?? []);
   }
 
   private _patchAttachments(attachments: JsonAttachment[]) {
@@ -476,11 +481,11 @@ class PathSeparatorPatcher {
     if (this._from === this._to)
       return;
     if (jsonEvent.method === 'onProject') {
-      this._updateProject(jsonEvent.params.project as JsonProject);
+      this._updateProject(jsonEvent.params.project);
       return;
     }
     if (jsonEvent.method === 'onTestEnd') {
-      const testResult = jsonEvent.params.result as JsonTestResultEnd;
+      const testResult = jsonEvent.params.result;
       testResult.errors.forEach(error => this._updateErrorLocations(error));
       (testResult.attachments ?? []).forEach(attachment => {
         if (attachment.path)
@@ -489,17 +494,17 @@ class PathSeparatorPatcher {
       return;
     }
     if (jsonEvent.method === 'onStepBegin') {
-      const step = jsonEvent.params.step as JsonTestStepStart;
+      const step = jsonEvent.params.step;
       this._updateLocation(step.location);
       return;
     }
     if (jsonEvent.method === 'onStepEnd') {
-      const step = jsonEvent.params.step as JsonTestStepEnd;
+      const step = jsonEvent.params.step;
       this._updateErrorLocations(step.error);
       return;
     }
     if (jsonEvent.method === 'onAttach') {
-      const attach = jsonEvent.params as JsonTestResultOnAttach;
+      const attach = jsonEvent.params;
       attach.attachments.forEach(attachment => {
         if (attachment.path)
           attachment.path = this._updatePath(attachment.path);
@@ -554,7 +559,7 @@ class GlobalErrorPatcher {
   patchEvent(event: JsonEvent) {
     if (event.method !== 'onError')
       return;
-    const error = event.params.error as TestError;
+    const error = event.params.error;
     if (error.message !== undefined)
       error.message = this._prefix + error.message;
     if (error.stack !== undefined)
@@ -602,7 +607,7 @@ class BlobModernizer {
           return { entries: [...newSuites, ...tests], ...remainder };
         };
         const project = event.params.project;
-        project.suites = project.suites.map(modernizeSuite);
+        project.suites = (project.suites as unknown as blobV1.JsonSuite[]).map(modernizeSuite);
       }
       return event;
     });

--- a/packages/playwright/src/reporters/merge.ts
+++ b/packages/playwright/src/reporters/merge.ts
@@ -26,11 +26,10 @@ import { TeleReporterReceiver } from '../isomorphic/teleReceiver';
 import { createReporters } from '../runner/reporters';
 import { relativeFilePath } from '../util';
 
-import type { BlobReportMetadata } from './blob';
 import type { ReporterDescription } from '../../types/test';
 import type { TestError } from '../../types/testReporter';
 import type { FullConfigInternal } from '../common/config';
-import type { JsonAttachment, JsonConfig, JsonEvent, JsonFullResult, JsonLocation, JsonOnConfigureEvent, JsonOnEndEvent, JsonOnProjectEvent, JsonProject, JsonSuite, JsonTestCase } from '../isomorphic/teleReceiver';
+import type { BlobReportMetadata, JsonAttachment, JsonConfig, JsonEvent, JsonFullResult, JsonLocation, JsonOnConfigureEvent, JsonOnEndEvent, JsonOnProjectEvent, JsonProject, JsonSuite, JsonTestCase } from '../isomorphic/teleReceiver';
 import type * as blobV1 from './versions/blobV1';
 
 type StatusCallback = (message: string) => void;


### PR DESCRIPTION
Lack of strict typing/many casts in reporter `teleReceiver.ts` resulted in the issue fixed by #36443. Add strict types for all blob events.