### PR TITLE
docs(component testing): add Svelte hooks example

### DIFF
--- a/docs/src/test-components-js.md
+++ b/docs/src/test-components-js.md
@@ -474,9 +474,10 @@ You can use `beforeMount` and `afterMount` hooks to configure your app. This let
   defaultValue="react"
   values={[
     {label: 'React', value: 'react'},
+    {label: 'Svelte', value: 'svelte'},
     {label: 'Vue', value: 'vue'},
-  ]
-}>
+  ]}
+>
   <TabItem value="react">
 
   ```js title="playwright/index.tsx"
@@ -503,6 +504,41 @@ You can use `beforeMount` and `afterMount` hooks to configure your app. This let
       hooksConfig: { enableRouting: true },
     });
     await expect(component.getByRole('link')).toHaveAttribute('href', '/products/42');
+  });
+  ```
+
+  </TabItem>
+
+  <TabItem value="svelte">
+
+  ```js title="playwright/index.ts"
+  import { beforeMount, afterMount } from '@playwright/experimental-ct-svelte/hooks';
+
+  export type HooksConfig = {
+    context?: string;
+  }
+
+  beforeMount<HooksConfig>(async ({ hooksConfig, App }) => {
+    return new App({
+      context: new Map([
+        ['context-key', hooksConfig?.context]
+      ]),
+    });
+  });
+  ```
+
+  ```js title="context.spec.ts"
+  import { test, expect } from '@playwright/experimental-ct-svelte';
+  import type { HooksConfig } from '../playwright';
+  import Context from './Context.svelte';
+
+  test('context', async ({ mount }) => {
+    const component = await mount<HooksConfig>(Context, {
+      hooksConfig: {
+        context: 'context-value',
+      }
+    });
+    await expect(component).toContainText('context-value');
   });
   ```
 


### PR DESCRIPTION
This patch adds the missing Svelte component testing hooks example to the documentation, showing how to use beforeMount and afterMount hooks with hooksConfig for setting up component context.

Fixes #31367