### PR TITLE
chore: rename timeout to waitTimeout in waitForTimeout

### DIFF
--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -440,7 +440,7 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
   }
 
   async waitForTimeout(timeout: number) {
-    await this._channel.waitForTimeout({ timeout });
+    await this._channel.waitForTimeout({ waitTimeout: timeout });
   }
 
   async waitForFunction<R, Arg>(pageFunction: structs.PageFunction<Arg, R>, arg?: Arg, options: WaitForFunctionOptions = {}): Promise<structs.SmartHandle<R>> {

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1865,7 +1865,7 @@ scheme.FrameUncheckParams = tObject({
 });
 scheme.FrameUncheckResult = tOptional(tObject({}));
 scheme.FrameWaitForTimeoutParams = tObject({
-  timeout: tNumber,
+  waitTimeout: tNumber,
 });
 scheme.FrameWaitForTimeoutResult = tOptional(tObject({}));
 scheme.FrameWaitForFunctionParams = tObject({

--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -246,7 +246,7 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
   }
 
   async waitForTimeout(params: channels.FrameWaitForTimeoutParams, progress: Progress): Promise<void> {
-    return await this._frame.waitForTimeout(progress, params.timeout);
+    return await this._frame.waitForTimeout(progress, params.waitTimeout);
   }
 
   async waitForFunction(params: channels.FrameWaitForFunctionParams, progress: Progress): Promise<channels.FrameWaitForFunctionResult> {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1337,9 +1337,7 @@ export class Frame extends SdkObject {
   }
 
   async waitForTimeout(progress: Progress, timeout: number) {
-    // Silent catch to avoid the self-inflicted timeout error.
-    progress.legacyDisableTimeout();
-    return progress.wait(timeout).catch(() => {});
+    return progress.wait(timeout);
   }
 
   async ariaSnapshot(progress: Progress, selector: string, options: { forAI?: boolean }): Promise<string> {

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -3215,7 +3215,7 @@ export type FrameUncheckOptions = {
 };
 export type FrameUncheckResult = void;
 export type FrameWaitForTimeoutParams = {
-  timeout: number,
+  waitTimeout: number,
 };
 export type FrameWaitForTimeoutOptions = {
 

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -2644,7 +2644,7 @@ Frame:
     waitForTimeout:
       title: Wait for timeout
       parameters:
-        timeout: number
+        waitTimeout: number
       flags:
         snapshot: true
 


### PR DESCRIPTION
This avoids confusion between `timeout` being a parameter of the action vs being the timeout of the action.