### PR TITLE
test: use http endpoint instead of local file for codegen tests

### DIFF
--- a/tests/library/inspector/cli-codegen-javascript.spec.ts
+++ b/tests/library/inspector/cli-codegen-javascript.spec.ts
@@ -15,17 +15,14 @@
  */
 
 import fs from 'fs';
-import path from 'path';
 import { test, expect } from './inspectorTest';
-
-const emptyHTML = new URL('file://' + path.join(__dirname, '..', '..', 'assets', 'empty.html')).toString();
 
 const launchOptions = (channel: string) => {
   return channel ? `channel: '${channel}',\n    headless: false` : 'headless: false';
 };
 
-test('should print the correct imports and context options', async ({ browserName, channel, runCLI }) => {
-  const cli = runCLI(['--target=javascript', emptyHTML]);
+test('should print the correct imports and context options', async ({ browserName, channel, runCLI, server }) => {
+  const cli = runCLI(['--target=javascript', server.EMPTY_PAGE]);
   const expectedResult = `const { ${browserName} } = require('playwright');
 
 (async () => {
@@ -36,8 +33,8 @@ test('should print the correct imports and context options', async ({ browserNam
   await cli.waitFor(expectedResult);
 });
 
-test('should print the correct context options for custom settings', async ({ browserName, channel, runCLI }) => {
-  const cli = runCLI(['--color-scheme=light', '--target=javascript', emptyHTML]);
+test('should print the correct context options for custom settings', async ({ browserName, channel, runCLI, server }) => {
+  const cli = runCLI(['--color-scheme=light', '--target=javascript', server.EMPTY_PAGE]);
   const expectedResult = `const { ${browserName} } = require('playwright');
 
 (async () => {
@@ -51,10 +48,10 @@ test('should print the correct context options for custom settings', async ({ br
 });
 
 
-test('should print the correct context options when using a device', async ({ browserName, channel, runCLI }) => {
+test('should print the correct context options when using a device', async ({ browserName, channel, runCLI, server }) => {
   test.skip(browserName !== 'chromium');
 
-  const cli = runCLI(['--device=Pixel 2', '--target=javascript', emptyHTML]);
+  const cli = runCLI(['--device=Pixel 2', '--target=javascript', server.EMPTY_PAGE]);
   const expectedResult = `const { chromium, devices } = require('playwright');
 
 (async () => {
@@ -67,10 +64,10 @@ test('should print the correct context options when using a device', async ({ br
   await cli.waitFor(expectedResult);
 });
 
-test('should print the correct context options when using a device and additional options', async ({ browserName, channel, runCLI }) => {
+test('should print the correct context options when using a device and additional options', async ({ browserName, channel, runCLI, server }) => {
   test.skip(browserName !== 'webkit');
 
-  const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', '--target=javascript', emptyHTML]);
+  const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', '--target=javascript', server.EMPTY_PAGE]);
   const expectedResult = `const { webkit, devices } = require('playwright');
 
 (async () => {
@@ -84,9 +81,9 @@ test('should print the correct context options when using a device and additiona
   await cli.waitFor(expectedResult);
 });
 
-test('should save the codegen output to a file if specified', async ({ browserName, channel, runCLI }, testInfo) => {
+test('should save the codegen output to a file if specified', async ({ browserName, channel, runCLI, server }, testInfo) => {
   const tmpFile = testInfo.outputPath('script.js');
-  const cli = runCLI(['--output', tmpFile, '--target=javascript', emptyHTML], {
+  const cli = runCLI(['--output', tmpFile, '--target=javascript', server.EMPTY_PAGE], {
     autoExitWhen: 'await page.goto', // We have to wait for the initial navigation to be recorded.
   });
   await cli.waitForCleanExit();
@@ -99,7 +96,7 @@ test('should save the codegen output to a file if specified', async ({ browserNa
   });
   const context = await browser.newContext();
   const page = await context.newPage();
-  await page.goto('${emptyHTML}');
+  await page.goto('${server.EMPTY_PAGE}');
   await page.close();
 
   // ---------------------
@@ -108,11 +105,11 @@ test('should save the codegen output to a file if specified', async ({ browserNa
 })();`);
 });
 
-test('should print load/save storageState', async ({ browserName, channel, runCLI }, testInfo) => {
+test('should print load/save storageState', async ({ browserName, channel, runCLI, server }, testInfo) => {
   const loadFileName = testInfo.outputPath('load.json');
   const saveFileName = testInfo.outputPath('save.json');
   await fs.promises.writeFile(loadFileName, JSON.stringify({ cookies: [], origins: [] }), 'utf8');
-  const cli = runCLI([`--load-storage=${loadFileName}`, `--save-storage=${saveFileName}`, '--target=javascript', emptyHTML]);
+  const cli = runCLI([`--load-storage=${loadFileName}`, `--save-storage=${saveFileName}`, '--target=javascript', server.EMPTY_PAGE]);
   const expectedResult1 = `const { ${browserName} } = require('playwright');
 
 (async () => {

--- a/tests/library/inspector/cli-codegen-pytest.spec.ts
+++ b/tests/library/inspector/cli-codegen-pytest.spec.ts
@@ -15,13 +15,10 @@
  */
 
 import fs from 'fs';
-import path from 'path';
 import { test, expect } from './inspectorTest';
 
-const emptyHTML = new URL('file://' + path.join(__dirname, '..', '..', 'assets', 'empty.html')).toString();
-
-test('should print the correct imports and context options', async ({ runCLI }) => {
-  const cli = runCLI(['--target=python-pytest', emptyHTML]);
+test('should print the correct imports and context options', async ({ runCLI, server }) => {
+  const cli = runCLI(['--target=python-pytest', server.EMPTY_PAGE]);
   const expectedResult = `import re
 from playwright.sync_api import Page, expect
 
@@ -30,11 +27,11 @@ def test_example(page: Page) -> None:`;
   await cli.waitFor(expectedResult);
 });
 
-test('should print the correct context options when using a device and lang', async ({ browserName, runCLI }, testInfo) => {
+test('should print the correct context options when using a device and lang', async ({ browserName, runCLI, server }, testInfo) => {
   test.skip(browserName !== 'webkit');
 
   const tmpFile = testInfo.outputPath('script.js');
-  const cli = runCLI(['--target=python-pytest', '--device=iPhone 11', '--lang=en-US', '--output', tmpFile, emptyHTML], {
+  const cli = runCLI(['--target=python-pytest', '--device=iPhone 11', '--lang=en-US', '--output', tmpFile, server.EMPTY_PAGE], {
     autoExitWhen: 'page.goto',
   });
   await cli.waitForCleanExit();
@@ -50,13 +47,13 @@ def browser_context_args(browser_context_args, playwright):
 
 
 def test_example(page: Page) -> None:
-    page.goto("${emptyHTML}")
+    page.goto("${server.EMPTY_PAGE}")
 `);
 });
 
-test('should save the codegen output to a file if specified', async ({ runCLI }, testInfo) => {
+test('should save the codegen output to a file if specified', async ({ runCLI, server }, testInfo) => {
   const tmpFile = testInfo.outputPath('test_example.py');
-  const cli = runCLI(['--target=python-pytest', '--output', tmpFile, emptyHTML], {
+  const cli = runCLI(['--target=python-pytest', '--output', tmpFile, server.EMPTY_PAGE], {
     autoExitWhen: 'page.goto',
   });
   await cli.waitForCleanExit();
@@ -66,7 +63,7 @@ from playwright.sync_api import Page, expect
 
 
 def test_example(page: Page) -> None:
-    page.goto("${emptyHTML}")
+    page.goto("${server.EMPTY_PAGE}")
 `);
 });
 

--- a/tests/library/inspector/cli-codegen-python-async.spec.ts
+++ b/tests/library/inspector/cli-codegen-python-async.spec.ts
@@ -15,16 +15,14 @@
  */
 
 import fs from 'fs';
-import path from 'path';
 import { test, expect } from './inspectorTest';
 
-const emptyHTML = new URL('file://' + path.join(__dirname, '..', '..', 'assets', 'empty.html')).toString();
 const launchOptions = (channel: string) => {
   return channel ? `channel="${channel}", headless=False` : 'headless=False';
 };
 
-test('should print the correct imports and context options', async ({ browserName, channel, runCLI }) => {
-  const cli = runCLI(['--target=python-async', emptyHTML]);
+test('should print the correct imports and context options', async ({ browserName, channel, runCLI, server }) => {
+  const cli = runCLI(['--target=python-async', server.EMPTY_PAGE]);
   const expectedResult = `import asyncio
 import re
 from playwright.async_api import Playwright, async_playwright, expect
@@ -36,8 +34,8 @@ async def run(playwright: Playwright) -> None:
   await cli.waitFor(expectedResult);
 });
 
-test('should print the correct context options for custom settings', async ({ browserName, channel, runCLI }) => {
-  const cli = runCLI(['--color-scheme=light', '--target=python-async', emptyHTML]);
+test('should print the correct context options for custom settings', async ({ browserName, channel, runCLI, server }) => {
+  const cli = runCLI(['--color-scheme=light', '--target=python-async', server.EMPTY_PAGE]);
   const expectedResult = `import asyncio
 import re
 from playwright.async_api import Playwright, async_playwright, expect
@@ -49,10 +47,10 @@ async def run(playwright: Playwright) -> None:
   await cli.waitFor(expectedResult);
 });
 
-test('should print the correct context options when using a device', async ({ browserName, channel, runCLI }) => {
+test('should print the correct context options when using a device', async ({ browserName, channel, runCLI, server }) => {
   test.skip(browserName !== 'chromium');
 
-  const cli = runCLI(['--device=Pixel 2', '--target=python-async', emptyHTML]);
+  const cli = runCLI(['--device=Pixel 2', '--target=python-async', server.EMPTY_PAGE]);
   const expectedResult = `import asyncio
 import re
 from playwright.async_api import Playwright, async_playwright, expect
@@ -64,10 +62,10 @@ async def run(playwright: Playwright) -> None:
   await cli.waitFor(expectedResult);
 });
 
-test('should print the correct context options when using a device and additional options', async ({ browserName, channel, runCLI }) => {
+test('should print the correct context options when using a device and additional options', async ({ browserName, channel, runCLI, server }) => {
   test.skip(browserName !== 'webkit');
 
-  const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', '--target=python-async', emptyHTML]);
+  const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', '--target=python-async', server.EMPTY_PAGE]);
   const expectedResult = `import asyncio
 import re
 from playwright.async_api import Playwright, async_playwright, expect
@@ -79,9 +77,9 @@ async def run(playwright: Playwright) -> None:
   await cli.waitFor(expectedResult);
 });
 
-test('should save the codegen output to a file if specified', async ({ browserName, channel, runCLI }, testInfo) => {
+test('should save the codegen output to a file if specified', async ({ browserName, channel, runCLI, server }, testInfo) => {
   const tmpFile = testInfo.outputPath('example.py');
-  const cli = runCLI(['--target=python-async', '--output', tmpFile, emptyHTML], {
+  const cli = runCLI(['--target=python-async', '--output', tmpFile, server.EMPTY_PAGE], {
     autoExitWhen: 'page.goto',
   });
   await cli.waitForCleanExit();
@@ -95,7 +93,7 @@ async def run(playwright: Playwright) -> None:
     browser = await playwright.${browserName}.launch(${launchOptions(channel)})
     context = await browser.new_context()
     page = await context.new_page()
-    await page.goto("${emptyHTML}")
+    await page.goto("${server.EMPTY_PAGE}")
     await page.close()
 
     # ---------------------
@@ -112,11 +110,11 @@ asyncio.run(main())
 `);
 });
 
-test('should print load/save storage_state', async ({ browserName, channel, runCLI }, testInfo) => {
+test('should print load/save storage_state', async ({ browserName, channel, runCLI, server }, testInfo) => {
   const loadFileName = testInfo.outputPath('load.json');
   const saveFileName = testInfo.outputPath('save.json');
   await fs.promises.writeFile(loadFileName, JSON.stringify({ cookies: [], origins: [] }), 'utf8');
-  const cli = runCLI([`--load-storage=${loadFileName}`, `--save-storage=${saveFileName}`, '--target=python-async', emptyHTML]);
+  const cli = runCLI([`--load-storage=${loadFileName}`, `--save-storage=${saveFileName}`, '--target=python-async', server.EMPTY_PAGE]);
   const expectedResult1 = `import asyncio
 import re
 from playwright.async_api import Playwright, async_playwright, expect

--- a/tests/library/inspector/cli-codegen-python.spec.ts
+++ b/tests/library/inspector/cli-codegen-python.spec.ts
@@ -15,16 +15,14 @@
  */
 
 import fs from 'fs';
-import path from 'path';
 import { test, expect } from './inspectorTest';
 
-const emptyHTML = new URL('file://' + path.join(__dirname, '..', '..', 'assets', 'empty.html')).toString();
 const launchOptions = (channel: string) => {
   return channel ? `channel="${channel}", headless=False` : 'headless=False';
 };
 
-test('should print the correct imports and context options', async ({ runCLI, channel, browserName }) => {
-  const cli = runCLI(['--target=python', emptyHTML]);
+test('should print the correct imports and context options', async ({ runCLI, channel, browserName, server }) => {
+  const cli = runCLI(['--target=python', server.EMPTY_PAGE]);
   const expectedResult = `import re
 from playwright.sync_api import Playwright, sync_playwright, expect
 
@@ -35,8 +33,8 @@ def run(playwright: Playwright) -> None:
   await cli.waitFor(expectedResult);
 });
 
-test('should print the correct context options for custom settings', async ({ runCLI, channel, browserName }) => {
-  const cli = runCLI(['--color-scheme=light', '--target=python', emptyHTML]);
+test('should print the correct context options for custom settings', async ({ runCLI, channel, browserName, server }) => {
+  const cli = runCLI(['--color-scheme=light', '--target=python', server.EMPTY_PAGE]);
   const expectedResult = `import re
 from playwright.sync_api import Playwright, sync_playwright, expect
 
@@ -47,10 +45,10 @@ def run(playwright: Playwright) -> None:
   await cli.waitFor(expectedResult);
 });
 
-test('should print the correct context options when using a device', async ({ browserName, channel, runCLI }) => {
+test('should print the correct context options when using a device', async ({ browserName, channel, runCLI, server }) => {
   test.skip(browserName !== 'chromium');
 
-  const cli = runCLI(['--device=Pixel 2', '--target=python', emptyHTML]);
+  const cli = runCLI(['--device=Pixel 2', '--target=python', server.EMPTY_PAGE]);
   const expectedResult = `import re
 from playwright.sync_api import Playwright, sync_playwright, expect
 
@@ -61,10 +59,10 @@ def run(playwright: Playwright) -> None:
   await cli.waitFor(expectedResult);
 });
 
-test('should print the correct context options when using a device and additional options', async ({ browserName, channel, runCLI }) => {
+test('should print the correct context options when using a device and additional options', async ({ browserName, channel, runCLI, server }) => {
   test.skip(browserName !== 'webkit');
 
-  const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', '--target=python', emptyHTML]);
+  const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', '--target=python', server.EMPTY_PAGE]);
   const expectedResult = `import re
 from playwright.sync_api import Playwright, sync_playwright, expect
 
@@ -75,9 +73,9 @@ def run(playwright: Playwright) -> None:
   await cli.waitFor(expectedResult);
 });
 
-test('should save the codegen output to a file if specified', async ({ runCLI, channel, browserName }, testInfo) => {
+test('should save the codegen output to a file if specified', async ({ runCLI, channel, browserName, server }, testInfo) => {
   const tmpFile = testInfo.outputPath('example.py');
-  const cli = runCLI(['--target=python', '--output', tmpFile, emptyHTML], {
+  const cli = runCLI(['--target=python', '--output', tmpFile, server.EMPTY_PAGE], {
     autoExitWhen: 'page.goto',
   });
   await cli.waitForCleanExit();
@@ -90,7 +88,7 @@ def run(playwright: Playwright) -> None:
     browser = playwright.${browserName}.launch(${launchOptions(channel)})
     context = browser.new_context()
     page = context.new_page()
-    page.goto("${emptyHTML}")
+    page.goto("${server.EMPTY_PAGE}")
     page.close()
 
     # ---------------------
@@ -103,11 +101,11 @@ with sync_playwright() as playwright:
 `);
 });
 
-test('should print load/save storage_state', async ({ runCLI, channel, browserName }, testInfo) => {
+test('should print load/save storage_state', async ({ runCLI, channel, browserName, server }, testInfo) => {
   const loadFileName = testInfo.outputPath('load.json');
   const saveFileName = testInfo.outputPath('save.json');
   await fs.promises.writeFile(loadFileName, JSON.stringify({ cookies: [], origins: [] }), 'utf8');
-  const cli = runCLI([`--load-storage=${loadFileName}`, `--save-storage=${saveFileName}`, '--target=python', emptyHTML]);
+  const cli = runCLI([`--load-storage=${loadFileName}`, `--save-storage=${saveFileName}`, '--target=python', server.EMPTY_PAGE]);
   const expectedResult1 = `import re
 from playwright.sync_api import Playwright, sync_playwright, expect
 

--- a/tests/library/inspector/cli-codegen-test.spec.ts
+++ b/tests/library/inspector/cli-codegen-test.spec.ts
@@ -15,13 +15,10 @@
  */
 
 import fs from 'fs';
-import path from 'path';
 import { test, expect } from './inspectorTest';
 
-const emptyHTML = new URL('file://' + path.join(__dirname, '..', '..', 'assets', 'empty.html')).toString();
-
-test('should print the correct imports and context options', async ({ runCLI }) => {
-  const cli = runCLI([emptyHTML]);
+test('should print the correct imports and context options', async ({ runCLI, server }) => {
+  const cli = runCLI([server.EMPTY_PAGE]);
   const expectedResult = `import { test, expect } from '@playwright/test';
 
 test('test', async ({ page }) => {
@@ -29,8 +26,8 @@ test('test', async ({ page }) => {
   await cli.waitFor(expectedResult);
 });
 
-test('should print the correct context options for custom settings', async ({ browserName, channel, runCLI }) => {
-  const cli = runCLI(['--color-scheme=light', emptyHTML]);
+test('should print the correct context options for custom settings', async ({ runCLI, server }) => {
+  const cli = runCLI(['--color-scheme=light', server.EMPTY_PAGE]);
   const expectedResult = `import { test, expect } from '@playwright/test';
 
 test.use({
@@ -42,10 +39,10 @@ test('test', async ({ page }) => {`;
 });
 
 
-test('should print the correct context options when using a device', async ({ browserName, channel, runCLI }) => {
+test('should print the correct context options when using a device', async ({ browserName, runCLI, server }) => {
   test.skip(browserName !== 'chromium');
 
-  const cli = runCLI(['--device=Pixel 2', emptyHTML]);
+  const cli = runCLI(['--device=Pixel 2', server.EMPTY_PAGE]);
   const expectedResult = `import { test, expect, devices } from '@playwright/test';
 
 test.use({
@@ -56,10 +53,10 @@ test('test', async ({ page }) => {`;
   await cli.waitFor(expectedResult);
 });
 
-test('should print the correct context options when using a device and additional options', async ({ browserName, channel, runCLI }) => {
+test('should print the correct context options when using a device and additional options', async ({ browserName, server, runCLI }) => {
   test.skip(browserName !== 'webkit');
 
-  const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', emptyHTML]);
+  const cli = runCLI(['--color-scheme=light', '--device=iPhone 11', server.EMPTY_PAGE]);
   const expectedResult = `import { test, expect, devices } from '@playwright/test';
 
 test.use({
@@ -71,10 +68,10 @@ test('test', async ({ page }) => {`;
   await cli.waitFor(expectedResult);
 });
 
-test('should print load storageState', async ({ browserName, channel, runCLI }, testInfo) => {
+test('should print load storageState', async ({ runCLI, server }, testInfo) => {
   const loadFileName = testInfo.outputPath('load.json');
   await fs.promises.writeFile(loadFileName, JSON.stringify({ cookies: [], origins: [] }), 'utf8');
-  const cli = runCLI([`--load-storage=${loadFileName}`, emptyHTML]);
+  const cli = runCLI([`--load-storage=${loadFileName}`, server.EMPTY_PAGE]);
   const expectedResult = `import { test, expect } from '@playwright/test';
 
 test.use({


### PR DESCRIPTION
Motivation: Our codegen users don't use `file://` and this will simplify WSL tests (https://github.com/microsoft/playwright/pull/36358), since there `file://` would require FS path mapping.