### PR TITLE
fix: reset proper properties on reused context

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -224,16 +224,7 @@ export class BidiBrowserContext extends BrowserContext {
     const promises: Promise<any>[] = [
       super._initialize(),
     ];
-    if (this._options.viewport) {
-      promises.push(this._browser._browserSession.send('browsingContext.setViewport', {
-        viewport: {
-          width: this._options.viewport.width,
-          height: this._options.viewport.height
-        },
-        devicePixelRatio: this._options.deviceScaleFactor || 1,
-        userContexts: [this._userContextId()],
-      }));
-    }
+    promises.push(this.doUpdateDefaultViewport());
     if (this._options.geolocation)
       promises.push(this.setGeolocation(this._options.geolocation));
     await Promise.all(promises);
@@ -387,6 +378,22 @@ export class BidiBrowserContext extends BrowserContext {
   }
 
   async doUpdateRequestInterception(): Promise<void> {
+  }
+
+  override async doUpdateDefaultViewport() {
+    if (!this._options.viewport)
+      return;
+    await this._browser._browserSession.send('browsingContext.setViewport', {
+      viewport: {
+        width: this._options.viewport.width,
+        height: this._options.viewport.height
+      },
+      devicePixelRatio: this._options.deviceScaleFactor || 1,
+      userContexts: [this._userContextId()],
+    });
+  }
+
+  override async doUpdateDefaultEmulatedMedia() {
   }
 
   override async doExposePlaywrightBinding() {

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -523,6 +523,14 @@ export class CRBrowserContext extends BrowserContext {
       await (sw as CRServiceWorker).updateRequestInterception();
   }
 
+  override async doUpdateDefaultViewport() {
+    // No-op, because each page resets its own viewport.
+  }
+
+  override async doUpdateDefaultEmulatedMedia() {
+    // No-op, because each page resets its own color scheme.
+  }
+
   override async doExposePlaywrightBinding() {
     for (const page of this._crPages())
       await page.exposePlaywrightBinding();

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -195,13 +195,7 @@ export class FFBrowserContext extends BrowserContext {
         },
       }));
     }
-    if (this._options.viewport) {
-      const viewport = {
-        viewportSize: { width: this._options.viewport.width, height: this._options.viewport.height },
-        deviceScaleFactor: this._options.deviceScaleFactor || 1,
-      };
-      promises.push(this._browser.session.send('Browser.setDefaultViewport', { browserContextId, viewport }));
-    }
+    promises.push(this.doUpdateDefaultViewport());
     if (this._options.hasTouch)
       promises.push(this._browser.session.send('Browser.setTouchOverride', { browserContextId, hasTouch: true }));
     if (this._options.userAgent)
@@ -224,30 +218,7 @@ export class FFBrowserContext extends BrowserContext {
       promises.push(this.setGeolocation(this._options.geolocation));
     if (this._options.offline)
       promises.push(this.doUpdateOffline());
-    if (this._options.colorScheme !== 'no-override') {
-      promises.push(this._browser.session.send('Browser.setColorScheme', {
-        browserContextId,
-        colorScheme: this._options.colorScheme !== undefined  ? this._options.colorScheme : 'light',
-      }));
-    }
-    if (this._options.reducedMotion !== 'no-override') {
-      promises.push(this._browser.session.send('Browser.setReducedMotion', {
-        browserContextId,
-        reducedMotion: this._options.reducedMotion !== undefined  ? this._options.reducedMotion : 'no-preference',
-      }));
-    }
-    if (this._options.forcedColors !== 'no-override') {
-      promises.push(this._browser.session.send('Browser.setForcedColors', {
-        browserContextId,
-        forcedColors: this._options.forcedColors !== undefined  ? this._options.forcedColors : 'none',
-      }));
-    }
-    if (this._options.contrast !== 'no-override') {
-      promises.push(this._browser.session.send('Browser.setContrast', {
-        browserContextId,
-        contrast: this._options.contrast !== undefined  ? this._options.contrast : 'no-preference',
-      }));
-    }
+    promises.push(this.doUpdateDefaultEmulatedMedia());
     if (this._options.recordVideo) {
       promises.push(this._ensureVideosPath().then(() => {
         return this._browser.session.send('Browser.setVideoRecordingOptions', {
@@ -405,6 +376,43 @@ export class FFBrowserContext extends BrowserContext {
       this._browser.session.send('Browser.setRequestInterception', { browserContextId: this._browserContextId, enabled: this.requestInterceptors.length > 0 }),
       this._browser.session.send('Browser.setCacheDisabled', { browserContextId: this._browserContextId, cacheDisabled: this.requestInterceptors.length > 0 }),
     ]);
+  }
+
+  override async doUpdateDefaultViewport() {
+    if (!this._options.viewport)
+      return;
+    const viewport = {
+      viewportSize: { width: this._options.viewport.width, height: this._options.viewport.height },
+      deviceScaleFactor: this._options.deviceScaleFactor || 1,
+    };
+    await this._browser.session.send('Browser.setDefaultViewport', { browserContextId: this._browserContextId, viewport });
+  }
+
+  override async doUpdateDefaultEmulatedMedia() {
+    if (this._options.colorScheme !== 'no-override') {
+      await this._browser.session.send('Browser.setColorScheme', {
+        browserContextId: this._browserContextId,
+        colorScheme: this._options.colorScheme !== undefined  ? this._options.colorScheme : 'light',
+      });
+    }
+    if (this._options.reducedMotion !== 'no-override') {
+      await this._browser.session.send('Browser.setReducedMotion', {
+        browserContextId: this._browserContextId,
+        reducedMotion: this._options.reducedMotion !== undefined  ? this._options.reducedMotion : 'no-preference',
+      });
+    }
+    if (this._options.forcedColors !== 'no-override') {
+      await this._browser.session.send('Browser.setForcedColors', {
+        browserContextId: this._browserContextId,
+        forcedColors: this._options.forcedColors !== undefined  ? this._options.forcedColors : 'none',
+      });
+    }
+    if (this._options.contrast !== 'no-override') {
+      await this._browser.session.send('Browser.setContrast', {
+        browserContextId: this._browserContextId,
+        contrast: this._options.contrast !== undefined  ? this._options.contrast : 'no-preference',
+      });
+    }
   }
 
   override async doExposePlaywrightBinding() {

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -253,18 +253,16 @@ export class Page extends SdkObject {
   }
 
   async resetForReuse(progress: Progress) {
-    this._locatorHandlers.clear();
-
     // Re-navigate once init scripts are gone.
-    // TODO: we should have a timeout for `resetForReuse`.
     await this.mainFrame().gotoImpl(progress, 'about:blank', {});
+
     this._emulatedSize = undefined;
     this._emulatedMedia = {};
     this._extraHTTPHeaders = undefined;
-
     await Promise.all([
       this.delegate.updateEmulatedViewportSize(),
       this.delegate.updateEmulateMedia(),
+      this.delegate.updateExtraHTTPHeaders(),
     ]);
 
     await this.delegate.resetForReuse(progress);

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -345,6 +345,14 @@ export class WKBrowserContext extends BrowserContext {
       await (page.delegate as WKPage).updateRequestInterception();
   }
 
+  override async doUpdateDefaultViewport() {
+    // No-op, because each page resets its own viewport.
+  }
+
+  override async doUpdateDefaultEmulatedMedia() {
+    // No-op, because each page resets its own color scheme.
+  }
+
   override async doExposePlaywrightBinding() {
     for (const page of this.pages())
       await (page.delegate as WKPage).exposePlaywrightBinding();


### PR DESCRIPTION
We should reset everything that belongs to `paramsThatAllowContextReuse` list, and all other properties do not need to be reset.

In some browsers, properties are applied context-wide, and in others they are applied per page. In the former case, we need to issue a browser command to update them.