### PR TITLE
devops: move WebKit Tracing tests to Ubuntu 24.04

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -178,11 +178,16 @@ jobs:
       matrix:
         include:
           - browser: chromium
+            runs-on: ubuntu-22.04
           - browser: firefox
+            runs-on: ubuntu-22.04
+          # See https://github.com/microsoft/playwright/issues/35586
           - browser: webkit
+            runs-on: ubuntu-24.04
           - browser: chromium
+            runs-on: ubuntu-22.04
             channel: chromium-tip-of-tree
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/run-test


### PR DESCRIPTION
See https://github.com/microsoft/playwright/issues/35586.