### PR TITLE
feat(html): add view trace button to top of test view

### DIFF
--- a/packages/html-reporter/src/links.css
+++ b/packages/html-reporter/src/links.css
@@ -110,3 +110,39 @@
   right: 5px;
   top: 5px;
 }
+
+.link-badge {
+  flex: none;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.link-badge-dim span {
+  color: var(--color-fg-muted);
+}
+
+.link-badge:hover {
+  cursor: pointer;
+}
+
+.link-badge svg {
+  fill: var(--color-fg-default);
+}
+
+.link-badge-dim svg {
+  fill: var(--color-fg-muted);
+}
+
+.link-badge-dim:hover svg {
+  fill: var(--color-fg-muted);
+}
+
+.trace-link {
+  /* Trace link button has 1px border and 4px padding, so we need 3px right margin to match content on the other side of divider */
+  margin-right: 3px;
+}
+
+.trace-link-separator {
+  color: var(--color-fg-muted);
+  user-select: none;
+}

--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -22,6 +22,7 @@ import { CopyToClipboard } from './copyToClipboard';
 import './links.css';
 import { linkifyText } from '@web/renderUtils';
 import { clsx, useFlash } from '@web/uiUtils';
+import { trace } from './icons';
 
 export function navigate(href: string | URL) {
   window.history.pushState({}, '', href);
@@ -37,14 +38,15 @@ export const Route: React.FunctionComponent<{
   return predicate(searchParams) ? children : null;
 };
 
-export const Link: React.FunctionComponent<{
+type LinkProps = React.PropsWithChildren<{
   href?: string,
   click?: string,
   ctrlClick?: string,
   className?: string,
   title?: string,
-  children: any,
-}> = ({ click, ctrlClick, children, ...rest }) => {
+}>;
+
+export const Link: React.FunctionComponent<LinkProps> = ({ click, ctrlClick, children, ...rest }) => {
   return <a {...rest} style={{ textDecoration: 'none', color: 'var(--color-fg-default)', cursor: 'pointer' }} onClick={e => {
     if (click) {
       e.preventDefault();
@@ -52,6 +54,8 @@ export const Link: React.FunctionComponent<{
     }
   }}>{children}</a>;
 };
+
+export const LinkBadge: React.FunctionComponent<LinkProps & { dim?: boolean }> = ({ className, ...props }) => <Link {...props} className={clsx('link-badge', props.dim && 'link-badge-dim', className)} />;
 
 export const ProjectLink: React.FunctionComponent<{
   projectNames: string[],
@@ -98,6 +102,26 @@ export const AttachmentLink: React.FunctionComponent<{
   </span>} loadChildren={attachment.body ? () => {
     return [<div key={1} className='attachment-body'><CopyToClipboard value={attachment.body!}/>{linkifyText(attachment.body!)}</div>];
   } : undefined} depth={0} style={{ lineHeight: '32px' }} flash={flash}></TreeItem>;
+};
+
+export const TraceLink: React.FC<{ test: TestCaseSummary, trailingSeparator?: boolean, dim?: boolean }> = ({ test, trailingSeparator, dim }) => {
+  const firstTraces = test.results.map(result => result.attachments.filter(attachment => attachment.name === 'trace')).filter(traces => traces.length > 0)[0];
+  if (!firstTraces)
+    return undefined;
+
+  return (
+    <>
+      <LinkBadge
+        href={generateTraceUrl(firstTraces)}
+        title='View Trace'
+        className='button trace-link'
+        dim={dim}>
+        {trace()}
+        <span>View Trace</span>
+      </LinkBadge>
+      {trailingSeparator && <div className='trace-link-separator'>|</div>}
+    </>
+  );
 };
 
 export const SearchParamsContext = React.createContext<URLSearchParams>(new URLSearchParams(window.location.hash.slice(1)));

--- a/packages/html-reporter/src/testCaseView.css
+++ b/packages/html-reporter/src/testCaseView.css
@@ -39,7 +39,6 @@
   flex: none;
   align-items: center;
   padding: 0 8px 8px;
-  line-height: 24px;
 }
 
 .test-case-run-duration {

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -20,7 +20,7 @@ import * as React from 'react';
 import { TabbedPane } from './tabbedPane';
 import { AutoChip } from './chip';
 import './common.css';
-import { Link, ProjectLink, SearchParamsContext, testResultHref } from './links';
+import { Link, ProjectLink, SearchParamsContext, testResultHref, TraceLink } from './links';
 import { statusIcon } from './statusIcon';
 import './testCaseView.css';
 import { TestResultView } from './testResultView';
@@ -56,13 +56,14 @@ export const TestCaseView: React.FC<{
         <div className={clsx(!next && 'hidden')}><Link href={testResultHref({ test: next }) + filterParam}>next »</Link></div>
       </>}
     />
-    <div className='hbox'>
+    <div className='hbox' style={{ lineHeight: '24px' }}>
       <div className='test-case-location'>
         <CopyToClipboardContainer value={`${test.location.file}:${test.location.line}`}>
           {test.location.file}:{test.location.line}
         </CopyToClipboardContainer>
       </div>
       <div style={{ flex: 'auto' }}></div>
+      <TraceLink test={test} trailingSeparator={true} />
       <div className='test-case-duration'>{msToString(test.duration)}</div>
     </div>
     {(!!test.projectName || labels) && <div className='test-case-project-labels-row'>

--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -51,28 +51,6 @@
   margin-right: 10px;
 }
 
-.test-file-badge {
-  flex: none;
-  background-color: transparent;
-  border-color: transparent;
-}
-
-.test-file-badge span {
-  color: var(--color-fg-muted);
-}
-
-.test-file-badge:hover {
-  cursor: pointer;
-}
-
-.test-file-badge svg {
-  fill: var(--color-fg-muted);
-}
-
-.test-file-badge:hover svg {
-  fill: var(--color-fg-muted);
-}
-
 .test-file-test-outcome-skipped {
   color: var(--color-fg-muted);
 }

--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -19,10 +19,10 @@ import * as React from 'react';
 import { hashStringToInt, msToString } from './utils';
 import { Chip } from './chip';
 import { filterWithToken } from './filter';
-import { generateTraceUrl, Link, navigate, ProjectLink, SearchParamsContext, testResultHref } from './links';
+import { Link, LinkBadge, navigate, ProjectLink, SearchParamsContext, testResultHref, TraceLink } from './links';
 import { statusIcon } from './statusIcon';
 import './testFileView.css';
-import { video, image, trace } from './icons';
+import { video, image } from './icons';
 import { clsx } from '@web/uiUtils';
 
 export const TestFileView: React.FC<React.PropsWithChildren<{
@@ -64,7 +64,7 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
           </Link>
           {imageDiffBadge(test)}
           {videoBadge(test)}
-          {traceBadge(test)}
+          <TraceLink test={test} dim={true} />
         </div>
       </div>
     )}
@@ -75,28 +75,14 @@ function imageDiffBadge(test: TestCaseSummary): JSX.Element | undefined {
   for (const result of test.results) {
     for (const attachment of result.attachments) {
       if (attachment.contentType.startsWith('image/') && !!attachment.name.match(/-(expected|actual|diff)/))
-        return <Link href={testResultHref({ test, result, anchor: `attachment-${result.attachments.indexOf(attachment)}` })} title='View images' className='test-file-badge'>{image()}</Link>;
+        return <LinkBadge href={testResultHref({ test, result, anchor: `attachment-${result.attachments.indexOf(attachment)}` })} title='View images' dim={true}>{image()}</LinkBadge>;
     }
   }
 }
 
 function videoBadge(test: TestCaseSummary): JSX.Element | undefined {
   const resultWithVideo = test.results.find(result => result.attachments.some(attachment => attachment.name === 'video'));
-  return resultWithVideo ? <Link href={testResultHref({ test, result: resultWithVideo, anchor: 'attachment-video' })}  title='View video' className='test-file-badge'>{video()}</Link> : undefined;
-}
-
-function traceBadge(test: TestCaseSummary): JSX.Element | undefined {
-  const firstTraces = test.results.map(result => result.attachments.filter(attachment => attachment.name === 'trace')).filter(traces => traces.length > 0)[0];
-  if (!firstTraces)
-    return undefined;
-
-  return <Link
-    href={generateTraceUrl(firstTraces)}
-    title='View Trace'
-    className='button test-file-badge'>
-    {trace()}
-    <span>View Trace</span>
-  </Link>;
+  return resultWithVideo ? <LinkBadge href={testResultHref({ test, result: resultWithVideo, anchor: 'attachment-video' })} title='View video' dim={true}>{video()}</LinkBadge> : undefined;
 }
 
 const LabelsClickView: React.FC<React.PropsWithChildren<{


### PR DESCRIPTION
Addresses #36141.

Adds a "View trace" button to the top right of the test view header in HTML report. This button follows the same style as the existing button in the list of tests view. This button directly opens the first trace in Trace Viewer.

<img width="1029" alt="Screenshot 2025-07-01 at 9 27 18 AM" src="https://github.com/user-attachments/assets/4e2d00f6-df68-4f4e-85cf-2c8a28619239" />

The existing button:

<img width="1022" alt="Screenshot 2025-07-01 at 9 27 07 AM" src="https://github.com/user-attachments/assets/08a593cd-8857-4473-ae5b-1dfdd1e536cd" />

----

Preferably this would be on the left side like in the list of tests view, but due to the test path copy button, there's no obvious way to place it there.