### PR TITLE
fix(chromium): WebGL on macOS after chromium 139

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -303,9 +303,6 @@ export class Chromium extends BrowserType {
       chromeArguments.push('--enable-use-zoom-for-dsf=false');
       // See https://issues.chromium.org/issues/40277080
       chromeArguments.push('--enable-unsafe-swiftshader');
-      // See https://bugs.chromium.org/p/chromium/issues/detail?id=1407025.
-      if (options.headless && (!options.channel || options.channel === 'chromium-headless-shell'))
-        chromeArguments.push('--use-angle');
     }
 
     if (options.devtools)

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -303,6 +303,12 @@ export class Chromium extends BrowserType {
       chromeArguments.push('--enable-use-zoom-for-dsf=false');
       // See https://issues.chromium.org/issues/40277080
       chromeArguments.push('--enable-unsafe-swiftshader');
+      // See https://bugs.chromium.org/p/chromium/issues/detail?id=1407025.
+      if (options.headless && (!options.channel || options.channel === 'chromium-headless-shell' || options.channel === 'chromium-tip-of-tree-headless-shell')) {
+        // See also https://github.com/microsoft/playwright/issues/30585
+        // and chromium fix at https://issues.chromium.org/issues/338414704.
+        chromeArguments.push('--enable-gpu');
+      }
     }
 
     if (options.devtools)


### PR DESCRIPTION
Motivation: WebGL tests are currently not passing on @main. They are timing out because WebGL is not available on macOS.

Timeline:

- 3127571b24e1a8a93960fa4a24fa011c3df20989 Reverted below since https://issues.chromium.org/u/1/issues/354621201 is fixed
- d0b052e1e0599499bc3431fb53292d612c397511 Remove `--use-angle` and use `--enable-gpu` because of https://issues.chromium.org/issues/338414704 https://github.com/microsoft/playwright/issues/30585 
- 332dbc5bf6cf68c3fad5857ebc30ed09599333c5 Add `--use-angle` because of https://bugs.chromium.org/p/chromium/issues/detail?id=1407025

