### PR TITLE
Add newline to make sure the failures end up on newline

### DIFF
--- a/packages/playwright/src/reporters/github.ts
+++ b/packages/playwright/src/reporters/github.ts
@@ -109,6 +109,7 @@ export class GitHubReporter extends TerminalReporter {
   }
 
   private _printFailureAnnotations(failures: TestCase[]) {
+    process.stdout.write('\n');
     failures.forEach((test, index) => {
       const title = this.formatTestTitle(test);
       const header = this.formatTestHeader(test, { indent: '  ', index: index + 1, mode: 'error' });


### PR DESCRIPTION
Hello! 

I'm definitely not confident with these changes - just want to submit what helped me fixed my issue. 

In github CI, the `::error` annotation needs to start on a newline. When combining this reporter with another reporter (in this case the dot reporter), this won't always work as expected. By inserting a newline before printing the errors, the github annotations work correctly for us. 


I'm not deep into the architecture of helpers here, and there might be a better way to solve this problem, I just wanted to let you know.


<img width="1338" alt="image" src="https://github.com/user-attachments/assets/8734732d-94bf-4b86-8438-7cad2eb1215d" />
