### PR TITLE
chore(expect): more consistent display of expect timeout error messages

### DIFF
--- a/packages/playwright/src/matchers/matcherHint.ts
+++ b/packages/playwright/src/matchers/matcherHint.ts
@@ -22,14 +22,16 @@ import type { Locator } from 'playwright-core';
 
 export const kNoElementsFoundError = '<element(s) not found>';
 
-export function matcherHint(state: ExpectMatcherState, locator: Locator | undefined, matcherName: string, expression: any, actual: any, matcherOptions: any, timeout: number | undefined, expectedReceivedString?: string) {
+export function matcherHint(state: ExpectMatcherState, locator: Locator | undefined, matcherName: string, expression: any, actual: any, matcherOptions: any, timeout: number | undefined, expectedReceivedString?: string, preventExtraStatIndent: boolean = false) {
   let header = state.utils.matcherHint(matcherName, expression, actual, matcherOptions).replace(/ \/\/ deep equality/, '') + ' failed\n\n';
+  // Extra space added after locator and timeout to match Jest's received/expected output
+  const extraSpace = preventExtraStatIndent ? '' : ' ';
   if (locator)
-    header += `Locator: ${String(locator)}\n`;
+    header += `Locator: ${extraSpace}${String(locator)}\n`;
   if (expectedReceivedString)
     header += `${expectedReceivedString}\n`;
   if (timeout)
-    header += `Timeout: ${timeout}ms\n`;
+    header += `Timeout: ${extraSpace}${timeout}ms\n`;
   return header;
 }
 

--- a/packages/playwright/src/matchers/matcherHint.ts
+++ b/packages/playwright/src/matchers/matcherHint.ts
@@ -27,15 +27,10 @@ export function matcherHint(state: ExpectMatcherState, locator: Locator | undefi
   if (locator)
     header += `Locator: ${String(locator)}\n`;
   if (expectedReceivedString)
-    header += expectedReceivedString;
-  if (timeout) {
-    const lastCharIsNewline = header.length > 0 && header[header.length - 1] === '\n';
-    if (!lastCharIsNewline)
-      header += '\n';
-    // Make sure to terminate header with the same newline (or lack thereof) used in the `expectedReceivedString`
-    header += `Timeout: ${timeout}ms${lastCharIsNewline ? '\n' : ''}`;
-  }
-  return `${header}\n`;
+    header += `${expectedReceivedString}\n`;
+  if (timeout)
+    header += `Timeout: ${timeout}ms\n`;
+  return header;
 }
 
 export type MatcherResult<E, A> = {

--- a/packages/playwright/src/matchers/matcherHint.ts
+++ b/packages/playwright/src/matchers/matcherHint.ts
@@ -22,13 +22,20 @@ import type { Locator } from 'playwright-core';
 
 export const kNoElementsFoundError = '<element(s) not found>';
 
-export function matcherHint(state: ExpectMatcherState, locator: Locator | undefined, matcherName: string, expression: any, actual: any, matcherOptions: any, timeout?: number) {
+export function matcherHint(state: ExpectMatcherState, locator: Locator | undefined, matcherName: string, expression: any, actual: any, matcherOptions: any, timeout: number | undefined, expectedReceivedString?: string) {
   let header = state.utils.matcherHint(matcherName, expression, actual, matcherOptions).replace(/ \/\/ deep equality/, '') + ' failed\n\n';
   if (locator)
     header += `Locator: ${String(locator)}\n`;
-  if (timeout)
-    header += `Timeout: ${timeout}ms\n`;
-  return header;
+  if (expectedReceivedString)
+    header += expectedReceivedString;
+  if (timeout) {
+    const lastCharIsNewline = header.length > 0 && header[header.length - 1] === '\n';
+    if (!lastCharIsNewline)
+      header += '\n';
+    // Make sure to terminate header with the same newline (or lack thereof) used in the `expectedReceivedString`
+    header += `Timeout: ${timeout}ms${lastCharIsNewline ? '\n' : ''}`;
+  }
+  return `${header}\n`;
 }
 
 export type MatcherResult<E, A> = {

--- a/packages/playwright/src/matchers/matcherHint.ts
+++ b/packages/playwright/src/matchers/matcherHint.ts
@@ -15,7 +15,6 @@
  */
 
 import { stringifyStackFrames } from 'playwright-core/lib/utils';
-import { colors } from 'playwright-core/lib/utils';
 
 import type { ExpectMatcherState } from '../../types/test';
 import type { StackFrame } from '@protocol/channels';
@@ -24,11 +23,11 @@ import type { Locator } from 'playwright-core';
 export const kNoElementsFoundError = '<element(s) not found>';
 
 export function matcherHint(state: ExpectMatcherState, locator: Locator | undefined, matcherName: string, expression: any, actual: any, matcherOptions: any, timeout?: number) {
-  let header = state.utils.matcherHint(matcherName, expression, actual, matcherOptions).replace(/ \/\/ deep equality/, '') + '\n\n';
-  if (timeout)
-    header = colors.red(`Timed out ${timeout}ms waiting for `) + header;
+  let header = state.utils.matcherHint(matcherName, expression, actual, matcherOptions).replace(/ \/\/ deep equality/, '') + ' failed\n\n';
   if (locator)
     header += `Locator: ${String(locator)}\n`;
+  if (timeout)
+    header += `Timeout: ${timeout}ms\n`;
   return header;
 }
 

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -262,7 +262,7 @@ export function toHaveClass(
     return toEqual.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout) => {
       const expectedText = serializeExpectedTextValues(expected);
       return await locator._expect('to.have.class.array', { expectedText, isNot, timeout });
-    }, expected, options);
+    }, expected, options, true);
   } else {
     return toMatchText.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout) => {
       const expectedText = serializeExpectedTextValues([expected]);
@@ -283,7 +283,7 @@ export function toContainClass(
     return toEqual.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout) => {
       const expectedText = serializeExpectedTextValues(expected);
       return await locator._expect('to.contain.class.array', { expectedText, isNot, timeout });
-    }, expected, options);
+    }, expected, options, true);
   } else {
     if (isRegExp(expected))
       throw new Error(`"expected" argument in toContainClass cannot be a RegExp value`);

--- a/packages/playwright/src/matchers/toBeTruthy.ts
+++ b/packages/playwright/src/matchers/toBeTruthy.ts
@@ -60,9 +60,9 @@ export async function toBeTruthy(
     printedReceived = `Received: ${notFound ? kNoElementsFoundError : received}`;
   }
   const message = () => {
-    const header = matcherHint(this, receiver, matcherName, 'locator', arg, matcherOptions, timedOut ? timeout : undefined);
+    const header = matcherHint(this, receiver, matcherName, 'locator', arg, matcherOptions, timedOut ? timeout : undefined, `${printedExpected}\n${printedReceived}`);
     const logText = callLogText(log);
-    return `${header}${printedExpected}\n${printedReceived}${logText}`;
+    return `${header}${logText}`;
   };
   return {
     message,

--- a/packages/playwright/src/matchers/toEqual.ts
+++ b/packages/playwright/src/matchers/toEqual.ts
@@ -35,6 +35,7 @@ export async function toEqual<T>(
   query: (isNot: boolean, timeout: number) => Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean }>,
   expected: T,
   options: { timeout?: number, contains?: boolean } = {},
+  messagePreventExtraStatIndent?: boolean
 ): Promise<MatcherResult<any, any>> {
   expectTypes(receiver, [receiverType], matcherName);
 
@@ -88,7 +89,7 @@ export async function toEqual<T>(
   }
   const message = () => {
     const details = printedDiff || `${printedExpected}\n${printedReceived}`;
-    const header = matcherHint(this, receiver, matcherName, 'locator', undefined, matcherOptions, timedOut ? timeout : undefined, details);
+    const header = matcherHint(this, receiver, matcherName, 'locator', undefined, matcherOptions, timedOut ? timeout : undefined, details, messagePreventExtraStatIndent);
     return `${header}${callLogText(log)}`;
   };
   // Passing the actual and expected objects so that a custom reporter

--- a/packages/playwright/src/matchers/toEqual.ts
+++ b/packages/playwright/src/matchers/toEqual.ts
@@ -87,9 +87,9 @@ export async function toEqual<T>(
     );
   }
   const message = () => {
-    const header = matcherHint(this, receiver, matcherName, 'locator', undefined, matcherOptions, timedOut ? timeout : undefined);
     const details = printedDiff || `${printedExpected}\n${printedReceived}`;
-    return `${header}${details}${callLogText(log)}`;
+    const header = matcherHint(this, receiver, matcherName, 'locator', undefined, matcherOptions, timedOut ? timeout : undefined, details);
+    return `${header}${callLogText(log)}`;
   };
   // Passing the actual and expected objects so that a custom reporter
   // could access them, for example in order to display a custom visual diff,

--- a/packages/playwright/src/matchers/toHaveURL.ts
+++ b/packages/playwright/src/matchers/toHaveURL.ts
@@ -42,9 +42,9 @@ export async function toHaveURLWithPredicate(
     throw new Error(
         [
           // Always display `expected` in expectation place
-          matcherHint(this, undefined, matcherName, expression, undefined, matcherOptions),
+          matcherHint(this, undefined, matcherName, expression, undefined, matcherOptions, undefined),
           `${colors.bold('Matcher error')}: ${EXPECTED_COLOR('expected')} value must be a string, regular expression, or predicate`,
-          this.utils.printWithType('Expected', expected, this.utils.printExpected,),
+          this.utils.printWithType('Expected', expected, this.utils.printExpected),
         ].join('\n\n'),
     );
   }

--- a/packages/playwright/src/matchers/toHaveURL.ts
+++ b/packages/playwright/src/matchers/toHaveURL.ts
@@ -42,7 +42,7 @@ export async function toHaveURLWithPredicate(
     throw new Error(
         [
           // Always display `expected` in expectation place
-          matcherHint(this, undefined, matcherName, expression, undefined, matcherOptions, undefined),
+          matcherHint(this, undefined, matcherName, expression, undefined, matcherOptions, undefined, undefined, true),
           `${colors.bold('Matcher error')}: ${EXPECTED_COLOR('expected')} value must be a string, regular expression, or predicate`,
           this.utils.printWithType('Expected', expected, this.utils.printExpected),
         ].join('\n\n'),
@@ -118,7 +118,7 @@ function toHaveURLMessage(
     promise: state.promise,
   };
   const receivedString = received || '';
-  const messagePrefix = matcherHint(state, undefined, matcherName, expression, undefined, matcherOptions, didTimeout ? timeout : undefined);
+  const messagePrefix = matcherHint(state, undefined, matcherName, expression, undefined, matcherOptions, didTimeout ? timeout : undefined, undefined, true);
 
   let printedReceived: string | undefined;
   let printedExpected: string | undefined;

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -96,7 +96,6 @@ export async function toMatchAriaSnapshot(
     return matcherHint(this, receiver, matcherName, 'locator', undefined, matcherOptions, timedOut ? timeout : undefined, expectedReceivedString);
   };
 
-  // const messagePrefix = matcherHint(this, receiver, matcherName, 'locator', undefined, matcherOptions, timedOut ? timeout : undefined);
   const notFound = typedReceived === kNoElementsFoundError;
   if (notFound) {
     return {

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -92,12 +92,16 @@ export async function toMatchAriaSnapshot(
   const { matches: pass, received, log, timedOut } = await receiver._expect('to.match.aria', { expectedValue: expected, isNot: this.isNot, timeout });
   const typedReceived = received as MatcherReceived | typeof kNoElementsFoundError;
 
-  const messagePrefix = matcherHint(this, receiver, matcherName, 'locator', undefined, matcherOptions, timedOut ? timeout : undefined);
+  const matcherHintWithExpect = (expectedReceivedString: string) => {
+    return matcherHint(this, receiver, matcherName, 'locator', undefined, matcherOptions, timedOut ? timeout : undefined, expectedReceivedString);
+  };
+
+  // const messagePrefix = matcherHint(this, receiver, matcherName, 'locator', undefined, matcherOptions, timedOut ? timeout : undefined);
   const notFound = typedReceived === kNoElementsFoundError;
   if (notFound) {
     return {
       pass: this.isNot,
-      message: () => messagePrefix + `Expected: ${this.utils.printExpected(expected)}\nReceived: ${EXPECTED_COLOR('<element not found>')}` + callLogText(log),
+      message: () => matcherHintWithExpect(`Expected: ${this.utils.printExpected(expected)}\nReceived: ${EXPECTED_COLOR('<element not found>')}`) + callLogText(log),
       name: 'toMatchAriaSnapshot',
       expected,
     };
@@ -106,15 +110,13 @@ export async function toMatchAriaSnapshot(
   const receivedText = typedReceived.raw;
   const message = () => {
     if (pass) {
-      if (notFound)
-        return messagePrefix + `Expected: not ${this.utils.printExpected(expected)}\nReceived: ${receivedText}` + callLogText(log);
-      const printedReceived = printReceivedStringContainExpectedSubstring(receivedText, receivedText.indexOf(expected), expected.length);
-      return messagePrefix + `Expected: not ${this.utils.printExpected(expected)}\nReceived: ${printedReceived}` + callLogText(log);
+      const receivedString = notFound ? receivedText : printReceivedStringContainExpectedSubstring(receivedText, receivedText.indexOf(expected), expected.length);
+      const expectedReceivedString = `Expected: not ${this.utils.printExpected(expected)}\nReceived: ${receivedString}`;
+      return matcherHintWithExpect(expectedReceivedString) + callLogText(log);
     } else {
       const labelExpected = `Expected`;
-      if (notFound)
-        return messagePrefix + `${labelExpected}: ${this.utils.printExpected(expected)}\nReceived: ${receivedText}` + callLogText(log);
-      return messagePrefix + this.utils.printDiffOrStringify(expected, receivedText, labelExpected, 'Received', false) + callLogText(log);
+      const expectedReceivedString = notFound ? `${labelExpected}: ${this.utils.printExpected(expected)}\nReceived: ${receivedText}` : this.utils.printDiffOrStringify(expected, receivedText, labelExpected, 'Received', false);
+      return matcherHintWithExpect(expectedReceivedString) + callLogText(log);
     }
   };
 

--- a/packages/playwright/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchSnapshot.ts
@@ -300,7 +300,7 @@ export function toMatchSnapshot(
     return helper.handleMatching();
 
   const receiver = isString(received) ? 'string' : 'Buffer';
-  const header = matcherHint(this, undefined, 'toMatchSnapshot', receiver, undefined, undefined);
+  const header = matcherHint(this, undefined, 'toMatchSnapshot', receiver, undefined, undefined, undefined);
   return helper.handleDifferent(received, expected, undefined, result.diff, header, result.errorMessage, undefined, this._stepInfo);
 }
 

--- a/packages/playwright/src/matchers/toMatchText.ts
+++ b/packages/playwright/src/matchers/toMatchText.ts
@@ -51,7 +51,7 @@ export async function toMatchText(
   ) {
     // Same format as jest's matcherErrorMessage
     throw new Error([
-      matcherHint(this, receiverType === 'Locator' ? receiver as Locator : undefined, matcherName, options.receiverLabel ?? receiver, expected, matcherOptions),
+      matcherHint(this, receiverType === 'Locator' ? receiver as Locator : undefined, matcherName, options.receiverLabel ?? receiver, expected, matcherOptions, undefined),
       `${colors.bold('Matcher error')}: ${EXPECTED_COLOR('expected',)} value must be a string or regular expression`,
       this.utils.printWithType('Expected', expected, this.utils.printExpected)
     ].join('\n\n'));
@@ -71,7 +71,6 @@ export async function toMatchText(
 
   const stringSubstring = options.matchSubstring ? 'substring' : 'string';
   const receivedString = received || '';
-  const messagePrefix = matcherHint(this, receiverType === 'Locator' ? receiver as Locator : undefined, matcherName, options.receiverLabel ?? 'locator', undefined, matcherOptions, timedOut ? timeout : undefined);
   const notFound = received === kNoElementsFoundError;
 
   let printedReceived: string | undefined;
@@ -109,7 +108,8 @@ export async function toMatchText(
 
   const message = () => {
     const resultDetails = printedDiff ? printedDiff : printedExpected + '\n' + printedReceived;
-    return messagePrefix + resultDetails + callLogText(log);
+    const hints = matcherHint(this, receiverType === 'Locator' ? receiver as Locator : undefined, matcherName, options.receiverLabel ?? 'locator', undefined, matcherOptions, timedOut ? timeout : undefined, resultDetails);
+    return hints + callLogText(log);
   };
 
   return {

--- a/packages/playwright/src/matchers/toMatchText.ts
+++ b/packages/playwright/src/matchers/toMatchText.ts
@@ -51,7 +51,7 @@ export async function toMatchText(
   ) {
     // Same format as jest's matcherErrorMessage
     throw new Error([
-      matcherHint(this, receiverType === 'Locator' ? receiver as Locator : undefined, matcherName, options.receiverLabel ?? receiver, expected, matcherOptions, undefined),
+      matcherHint(this, receiverType === 'Locator' ? receiver as Locator : undefined, matcherName, options.receiverLabel ?? receiver, expected, matcherOptions, undefined, undefined, true),
       `${colors.bold('Matcher error')}: ${EXPECTED_COLOR('expected',)} value must be a string or regular expression`,
       this.utils.printWithType('Expected', expected, this.utils.printExpected)
     ].join('\n\n'));
@@ -108,7 +108,7 @@ export async function toMatchText(
 
   const message = () => {
     const resultDetails = printedDiff ? printedDiff : printedExpected + '\n' + printedReceived;
-    const hints = matcherHint(this, receiverType === 'Locator' ? receiver as Locator : undefined, matcherName, options.receiverLabel ?? 'locator', undefined, matcherOptions, timedOut ? timeout : undefined, resultDetails);
+    const hints = matcherHint(this, receiverType === 'Locator' ? receiver as Locator : undefined, matcherName, options.receiverLabel ?? 'locator', undefined, matcherOptions, timedOut ? timeout : undefined, resultDetails, true);
     return hints + callLogText(log);
   };
 

--- a/tests/page/expect-boolean.spec.ts
+++ b/tests/page/expect-boolean.spec.ts
@@ -55,7 +55,8 @@ test.describe('toBeChecked', () => {
     await page.setContent('<input type=checkbox></input>');
     const locator = page.locator('input');
     const error = await expect(locator).toBeChecked({ timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toBeChecked()`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked() failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toBeChecked" with timeout 1000ms`);
   });
 
@@ -75,7 +76,8 @@ test.describe('toBeChecked', () => {
     await page.setContent('<input type=checkbox checked></input>');
     const locator = page.locator('input');
     const error = await expect(locator).not.toBeChecked({ timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).not.toBeChecked()`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeChecked() failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toBeChecked" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain(`locator resolved to <input checked type="checkbox"/>`);
   });
@@ -84,7 +86,8 @@ test.describe('toBeChecked', () => {
     await page.setContent('<input type=checkbox checked></input>');
     const locator = page.locator('input');
     const error = await expect(locator).toBeChecked({ checked: false, timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toBeChecked({ checked: false })`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked({ checked: false }) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toBeChecked" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain(`locator resolved to <input checked type="checkbox"/>`);
   });
@@ -93,7 +96,8 @@ test.describe('toBeChecked', () => {
     await page.setContent('<input type=checkbox></input>');
     const locator = page.locator('input');
     const error = await expect(locator).toBeChecked({ indeterminate: true, timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toBeChecked({ indeterminate: true })`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked({ indeterminate: true }) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toBeChecked" with timeout 1000ms`);
   });
 
@@ -101,7 +105,8 @@ test.describe('toBeChecked', () => {
     await page.setContent('<div>no inputs here</div>');
     const locator2 = page.locator('input2');
     const error = await expect(locator2).not.toBeChecked({ timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).not.toBeChecked()`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeChecked() failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toBeChecked" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- waiting for locator(\'input2\')`);
   });
@@ -439,7 +444,8 @@ test.describe('toBeHidden', () => {
     await page.setContent('<div></div>');
     const locator = page.locator('button');
     const error = await expect(locator).not.toBeHidden({ timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).not.toBeHidden()`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeHidden() failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toBeHidden" with timeout 1000ms`);
   });
 

--- a/tests/page/expect-boolean.spec.ts
+++ b/tests/page/expect-boolean.spec.ts
@@ -57,10 +57,10 @@ test.describe('toBeChecked', () => {
     const error = await expect(locator).toBeChecked({ timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked() failed
 
-Locator: locator('input')
+Locator:  locator('input')
 Expected: checked
 Received: unchecked
-Timeout: 1000ms`);
+Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toBeChecked" with timeout 1000ms`);
   });
 
@@ -82,10 +82,10 @@ Timeout: 1000ms`);
     const error = await expect(locator).not.toBeChecked({ timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeChecked() failed
 
-Locator: locator('input')
+Locator:  locator('input')
 Expected: not checked
 Received: checked
-Timeout: 1000ms`);
+Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toBeChecked" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain(`locator resolved to <input checked type="checkbox"/>`);
   });
@@ -96,10 +96,10 @@ Timeout: 1000ms`);
     const error = await expect(locator).toBeChecked({ checked: false, timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked({ checked: false }) failed
 
-Locator: locator('input')
+Locator:  locator('input')
 Expected: unchecked
 Received: checked
-Timeout: 1000ms`);
+Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toBeChecked" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain(`locator resolved to <input checked type="checkbox"/>`);
   });
@@ -110,10 +110,10 @@ Timeout: 1000ms`);
     const error = await expect(locator).toBeChecked({ indeterminate: true, timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked({ indeterminate: true }) failed
 
-Locator: locator('input')
+Locator:  locator('input')
 Expected: indeterminate
 Received: unchecked
-Timeout: 1000ms`);
+Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toBeChecked" with timeout 1000ms`);
   });
 
@@ -123,10 +123,10 @@ Timeout: 1000ms`);
     const error = await expect(locator2).not.toBeChecked({ timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeChecked() failed
 
-Locator: locator('input2')
+Locator:  locator('input2')
 Expected: not checked
 Received: <element(s) not found>
-Timeout: 1000ms`);
+Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toBeChecked" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- waiting for locator(\'input2\')`);
   });
@@ -466,10 +466,10 @@ test.describe('toBeHidden', () => {
     const error = await expect(locator).not.toBeHidden({ timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeHidden() failed
 
-Locator: locator('button')
+Locator:  locator('button')
 Expected: not hidden
 Received: <element(s) not found>
-Timeout: 1000ms`);
+Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toBeHidden" with timeout 1000ms`);
   });
 

--- a/tests/page/expect-boolean.spec.ts
+++ b/tests/page/expect-boolean.spec.ts
@@ -55,8 +55,12 @@ test.describe('toBeChecked', () => {
     await page.setContent('<input type=checkbox></input>');
     const locator = page.locator('input');
     const error = await expect(locator).toBeChecked({ timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked() failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked() failed
+
+Locator: locator('input')
+Expected: checked
+Received: unchecked
+Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toBeChecked" with timeout 1000ms`);
   });
 
@@ -76,8 +80,12 @@ test.describe('toBeChecked', () => {
     await page.setContent('<input type=checkbox checked></input>');
     const locator = page.locator('input');
     const error = await expect(locator).not.toBeChecked({ timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeChecked() failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeChecked() failed
+
+Locator: locator('input')
+Expected: not checked
+Received: checked
+Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toBeChecked" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain(`locator resolved to <input checked type="checkbox"/>`);
   });
@@ -86,8 +94,12 @@ test.describe('toBeChecked', () => {
     await page.setContent('<input type=checkbox checked></input>');
     const locator = page.locator('input');
     const error = await expect(locator).toBeChecked({ checked: false, timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked({ checked: false }) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked({ checked: false }) failed
+
+Locator: locator('input')
+Expected: unchecked
+Received: checked
+Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toBeChecked" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain(`locator resolved to <input checked type="checkbox"/>`);
   });
@@ -96,8 +108,12 @@ test.describe('toBeChecked', () => {
     await page.setContent('<input type=checkbox></input>');
     const locator = page.locator('input');
     const error = await expect(locator).toBeChecked({ indeterminate: true, timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked({ indeterminate: true }) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toBeChecked({ indeterminate: true }) failed
+
+Locator: locator('input')
+Expected: indeterminate
+Received: unchecked
+Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toBeChecked" with timeout 1000ms`);
   });
 
@@ -105,8 +121,12 @@ test.describe('toBeChecked', () => {
     await page.setContent('<div>no inputs here</div>');
     const locator2 = page.locator('input2');
     const error = await expect(locator2).not.toBeChecked({ timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeChecked() failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeChecked() failed
+
+Locator: locator('input2')
+Expected: not checked
+Received: <element(s) not found>
+Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toBeChecked" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- waiting for locator(\'input2\')`);
   });
@@ -444,8 +464,12 @@ test.describe('toBeHidden', () => {
     await page.setContent('<div></div>');
     const locator = page.locator('button');
     const error = await expect(locator).not.toBeHidden({ timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeHidden() failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toBeHidden() failed
+
+Locator: locator('button')
+Expected: not hidden
+Received: <element(s) not found>
+Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toBeHidden" with timeout 1000ms`);
   });
 

--- a/tests/page/expect-matcher-result.spec.ts
+++ b/tests/page/expect-matcher-result.spec.ts
@@ -27,16 +27,17 @@ test('toMatchText-based assertions should have matcher result', async ({ page })
     expect.soft(e.matcherResult).toEqual({
       actual: 'Text content',
       expected: /Text2/,
-      message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).toHaveText(expected)`),
+      message: expect.stringContaining(`expect(locator).toHaveText(expected) failed`),
       name: 'toHaveText',
       pass: false,
       log: expect.any(Array),
       timeout: 1,
     });
 
-    expect.soft(stripAnsi(e.toString())).toContain(`Error: Timed out 1ms waiting for expect(locator).toHaveText(expected)
+    expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toHaveText(expected) failed
 
 Locator: locator('#node')
+Timeout: 1ms
 Expected pattern: /Text2/
 Received string:  \"Text content\"
 Call log`);
@@ -49,15 +50,16 @@ Call log`);
     expect.soft(e.matcherResult).toEqual({
       actual: 'Text content',
       expected: /Text/,
-      message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).not.toHaveText(expected)`),
+      message: expect.stringContaining(`expect(locator).not.toHaveText(expected) failed`),
       name: 'toHaveText',
       pass: true,
       log: expect.any(Array),
       timeout: 1,
     });
-    expect.soft(stripAnsi(e.toString())).toContain(`Error: Timed out 1ms waiting for expect(locator).not.toHaveText(expected)
+    expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toHaveText(expected) failed
 
 Locator: locator('#node')
+Timeout: 1ms
 Expected pattern: not /Text/
 Received string: \"Text content\"
 Call log`);
@@ -75,16 +77,17 @@ test('toBeTruthy-based assertions should have matcher result', async ({ page }) 
     expect.soft(e.matcherResult).toEqual({
       actual: '<element(s) not found>',
       expected: 'visible',
-      message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).toBeVisible()`),
+      message: expect.stringContaining(`expect(locator).toBeVisible() failed`),
       name: 'toBeVisible',
       pass: false,
       log: expect.any(Array),
       timeout: 1,
     });
 
-    expect.soft(stripAnsi(e.toString())).toContain(`Error: Timed out 1ms waiting for expect(locator).toBeVisible()
+    expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeVisible() failed
 
 Locator: locator('#node2')
+Timeout: 1ms
 Expected: visible
 Received: <element(s) not found>
 Call log`);
@@ -97,16 +100,17 @@ Call log`);
     expect.soft(e.matcherResult).toEqual({
       actual: 'visible',
       expected: 'visible',
-      message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).not.toBeVisible()`),
+      message: expect.stringContaining(`expect(locator).not.toBeVisible() failed`),
       name: 'toBeVisible',
       pass: true,
       log: expect.any(Array),
       timeout: 1,
     });
 
-    expect.soft(stripAnsi(e.toString())).toContain(`Error: Timed out 1ms waiting for expect(locator).not.toBeVisible()
+    expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toBeVisible() failed
 
 Locator: locator('#node')
+Timeout: 1ms
 Expected: not visible
 Received: visible
 Call log`);
@@ -123,16 +127,17 @@ test('toEqual-based assertions should have matcher result', async ({ page }) => 
     expect.soft(e.matcherResult).toEqual({
       actual: 0,
       expected: 1,
-      message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).toHaveCount(expected)`),
+      message: expect.stringContaining(`expect(locator).toHaveCount(expected) failed`),
       name: 'toHaveCount',
       pass: false,
       log: expect.any(Array),
       timeout: 1,
     });
 
-    expect.soft(stripAnsi(e.toString())).toContain(`Error: Timed out 1ms waiting for expect(locator).toHaveCount(expected)
+    expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toHaveCount(expected) failed
 
 Locator: locator('#node2')
+Timeout: 1ms
 Expected: 1
 Received: 0
 Call log`);
@@ -144,16 +149,17 @@ Call log`);
     expect.soft(e.matcherResult).toEqual({
       actual: 1,
       expected: 1,
-      message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).not.toHaveCount(expected)`),
+      message: expect.stringContaining(`expect(locator).not.toHaveCount(expected) failed`),
       name: 'toHaveCount',
       pass: true,
       log: expect.any(Array),
       timeout: 1,
     });
 
-    expect.soft(stripAnsi(e.toString())).toContain(`Error: Timed out 1ms waiting for expect(locator).not.toHaveCount(expected)
+    expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toHaveCount(expected) failed
 
 Locator: locator('#node')
+Timeout: 1ms
 Expected: not 1
 Received: 1
 Call log`);
@@ -173,16 +179,17 @@ test('toBeChecked({ checked }) should have expected', async ({ page }) => {
     expect.soft(e.matcherResult).toEqual({
       actual: 'unchecked',
       expected: 'checked',
-      message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).toBeChecked()`),
+      message: expect.stringContaining(`expect(locator).toBeChecked() failed`),
       name: 'toBeChecked',
       pass: false,
       log: expect.any(Array),
       timeout: 1,
     });
 
-    expect.soft(stripAnsi(e.toString())).toContain(`Error: Timed out 1ms waiting for expect(locator).toBeChecked()
+    expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeChecked() failed
 
 Locator: locator('#unchecked')
+Timeout: 1ms
 Expected: checked
 Received: unchecked
 Call log`);
@@ -195,16 +202,17 @@ Call log`);
     expect.soft(e.matcherResult).toEqual({
       actual: 'checked',
       expected: 'checked',
-      message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).not.toBeChecked()`),
+      message: expect.stringContaining(`expect(locator).not.toBeChecked() failed`),
       name: 'toBeChecked',
       pass: true,
       log: expect.any(Array),
       timeout: 1,
     });
 
-    expect.soft(stripAnsi(e.toString())).toContain(`Error: Timed out 1ms waiting for expect(locator).not.toBeChecked()
+    expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toBeChecked() failed
 
 Locator: locator('#checked')
+Timeout: 1ms
 Expected: not checked
 Received: checked
 Call log`);
@@ -217,16 +225,17 @@ Call log`);
     expect.soft(e.matcherResult).toEqual({
       actual: 'checked',
       expected: 'unchecked',
-      message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).toBeChecked({ checked: false })`),
+      message: expect.stringContaining(`expect(locator).toBeChecked({ checked: false }) failed`),
       name: 'toBeChecked',
       pass: false,
       log: expect.any(Array),
       timeout: 1,
     });
 
-    expect.soft(stripAnsi(e.toString())).toContain(`Error: Timed out 1ms waiting for expect(locator).toBeChecked({ checked: false })
+    expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeChecked({ checked: false }) failed
 
 Locator: locator('#checked')
+Timeout: 1ms
 Expected: unchecked
 Received: checked
 Call log`);
@@ -239,16 +248,17 @@ Call log`);
     expect.soft(e.matcherResult).toEqual({
       actual: 'unchecked',
       expected: 'unchecked',
-      message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).not.toBeChecked({ checked: false })`),
+      message: expect.stringContaining(`expect(locator).not.toBeChecked({ checked: false }) failed`),
       name: 'toBeChecked',
       pass: true,
       log: expect.any(Array),
       timeout: 1,
     });
 
-    expect.soft(stripAnsi(e.toString())).toContain(`Error: Timed out 1ms waiting for expect(locator).not.toBeChecked({ checked: false })
+    expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toBeChecked({ checked: false }) failed
 
 Locator: locator('#unchecked')
+Timeout: 1ms
 Expected: not unchecked
 Received: unchecked
 Call log`);
@@ -261,16 +271,17 @@ Call log`);
     expect.soft(e.matcherResult).toEqual({
       actual: 'unchecked',
       expected: 'indeterminate',
-      message: expect.stringContaining(`Timed out 1ms waiting for expect(locator).toBeChecked({ indeterminate: true })`),
+      message: expect.stringContaining(`expect(locator).toBeChecked({ indeterminate: true }) failed`),
       name: 'toBeChecked',
       pass: false,
       log: expect.any(Array),
       timeout: 1,
     });
 
-    expect.soft(stripAnsi(e.toString())).toContain(`Error: Timed out 1ms waiting for expect(locator).toBeChecked({ indeterminate: true })
+    expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeChecked({ indeterminate: true }) failed
 
 Locator: locator('#unchecked')
+Timeout: 1ms
 Expected: indeterminate
 Received: unchecked
 Call log`);
@@ -295,7 +306,7 @@ test('toHaveScreenshot should populate matcherResult', async ({ page, server, is
     log: expect.any(Array),
   });
 
-  expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(page).toHaveScreenshot(expected)
+  expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(page).toHaveScreenshot(expected) failed
 
   23362 pixels (ratio 0.10 of all image pixels) are different.
 

--- a/tests/page/expect-matcher-result.spec.ts
+++ b/tests/page/expect-matcher-result.spec.ts
@@ -37,9 +37,10 @@ test('toMatchText-based assertions should have matcher result', async ({ page })
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toHaveText(expected) failed
 
 Locator: locator('#node')
-Timeout: 1ms
 Expected pattern: /Text2/
 Received string:  \"Text content\"
+Timeout: 1ms
+
 Call log`);
 
   }
@@ -59,9 +60,10 @@ Call log`);
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toHaveText(expected) failed
 
 Locator: locator('#node')
-Timeout: 1ms
 Expected pattern: not /Text/
 Received string: \"Text content\"
+Timeout: 1ms
+
 Call log`);
 
   }
@@ -87,9 +89,10 @@ test('toBeTruthy-based assertions should have matcher result', async ({ page }) 
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeVisible() failed
 
 Locator: locator('#node2')
-Timeout: 1ms
 Expected: visible
 Received: <element(s) not found>
+Timeout: 1ms
+
 Call log`);
 
   }
@@ -110,11 +113,11 @@ Call log`);
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toBeVisible() failed
 
 Locator: locator('#node')
-Timeout: 1ms
 Expected: not visible
 Received: visible
-Call log`);
+Timeout: 1ms
 
+Call log`);
   }
 });
 
@@ -137,9 +140,10 @@ test('toEqual-based assertions should have matcher result', async ({ page }) => 
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toHaveCount(expected) failed
 
 Locator: locator('#node2')
-Timeout: 1ms
 Expected: 1
 Received: 0
+Timeout: 1ms
+
 Call log`);
   }
 
@@ -159,9 +163,10 @@ Call log`);
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toHaveCount(expected) failed
 
 Locator: locator('#node')
-Timeout: 1ms
 Expected: not 1
 Received: 1
+Timeout: 1ms
+
 Call log`);
 
   }
@@ -189,9 +194,10 @@ test('toBeChecked({ checked }) should have expected', async ({ page }) => {
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeChecked() failed
 
 Locator: locator('#unchecked')
-Timeout: 1ms
 Expected: checked
 Received: unchecked
+Timeout: 1ms
+
 Call log`);
 
   }
@@ -212,9 +218,10 @@ Call log`);
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toBeChecked() failed
 
 Locator: locator('#checked')
-Timeout: 1ms
 Expected: not checked
 Received: checked
+Timeout: 1ms
+
 Call log`);
 
   }
@@ -235,9 +242,10 @@ Call log`);
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeChecked({ checked: false }) failed
 
 Locator: locator('#checked')
-Timeout: 1ms
 Expected: unchecked
 Received: checked
+Timeout: 1ms
+
 Call log`);
 
   }
@@ -258,9 +266,10 @@ Call log`);
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toBeChecked({ checked: false }) failed
 
 Locator: locator('#unchecked')
-Timeout: 1ms
 Expected: not unchecked
 Received: unchecked
+Timeout: 1ms
+
 Call log`);
 
   }
@@ -281,9 +290,10 @@ Call log`);
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeChecked({ indeterminate: true }) failed
 
 Locator: locator('#unchecked')
-Timeout: 1ms
 Expected: indeterminate
 Received: unchecked
+Timeout: 1ms
+
 Call log`);
 
   }

--- a/tests/page/expect-matcher-result.spec.ts
+++ b/tests/page/expect-matcher-result.spec.ts
@@ -88,10 +88,10 @@ test('toBeTruthy-based assertions should have matcher result', async ({ page }) 
 
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeVisible() failed
 
-Locator: locator('#node2')
+Locator:  locator('#node2')
 Expected: visible
 Received: <element(s) not found>
-Timeout: 1ms
+Timeout:  1ms
 
 Call log`);
 
@@ -112,10 +112,10 @@ Call log`);
 
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toBeVisible() failed
 
-Locator: locator('#node')
+Locator:  locator('#node')
 Expected: not visible
 Received: visible
-Timeout: 1ms
+Timeout:  1ms
 
 Call log`);
   }
@@ -139,10 +139,10 @@ test('toEqual-based assertions should have matcher result', async ({ page }) => 
 
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toHaveCount(expected) failed
 
-Locator: locator('#node2')
+Locator:  locator('#node2')
 Expected: 1
 Received: 0
-Timeout: 1ms
+Timeout:  1ms
 
 Call log`);
   }
@@ -162,10 +162,10 @@ Call log`);
 
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toHaveCount(expected) failed
 
-Locator: locator('#node')
+Locator:  locator('#node')
 Expected: not 1
 Received: 1
-Timeout: 1ms
+Timeout:  1ms
 
 Call log`);
 
@@ -193,10 +193,10 @@ test('toBeChecked({ checked }) should have expected', async ({ page }) => {
 
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeChecked() failed
 
-Locator: locator('#unchecked')
+Locator:  locator('#unchecked')
 Expected: checked
 Received: unchecked
-Timeout: 1ms
+Timeout:  1ms
 
 Call log`);
 
@@ -217,10 +217,10 @@ Call log`);
 
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toBeChecked() failed
 
-Locator: locator('#checked')
+Locator:  locator('#checked')
 Expected: not checked
 Received: checked
-Timeout: 1ms
+Timeout:  1ms
 
 Call log`);
 
@@ -241,10 +241,10 @@ Call log`);
 
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeChecked({ checked: false }) failed
 
-Locator: locator('#checked')
+Locator:  locator('#checked')
 Expected: unchecked
 Received: checked
-Timeout: 1ms
+Timeout:  1ms
 
 Call log`);
 
@@ -265,10 +265,10 @@ Call log`);
 
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).not.toBeChecked({ checked: false }) failed
 
-Locator: locator('#unchecked')
+Locator:  locator('#unchecked')
 Expected: not unchecked
 Received: unchecked
-Timeout: 1ms
+Timeout:  1ms
 
 Call log`);
 
@@ -289,10 +289,10 @@ Call log`);
 
     expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(locator).toBeChecked({ indeterminate: true }) failed
 
-Locator: locator('#unchecked')
+Locator:  locator('#unchecked')
 Expected: indeterminate
 Received: unchecked
-Timeout: 1ms
+Timeout:  1ms
 
 Call log`);
 

--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -68,8 +68,12 @@ test.describe('toHaveCount', () => {
     await page.setContent('<div><span></span></div>');
     const locator = page.locator('span');
     const error = await expect(locator).toHaveCount(0, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveCount(expected) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveCount(expected) failed
+
+Locator: locator('span')
+Expected: 0
+Received: 1
+Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveCount" with timeout 1000ms`);
   });
 
@@ -77,8 +81,12 @@ test.describe('toHaveCount', () => {
     await page.setContent('<div><span></span></div>');
     const locator = page.locator('span');
     const error = await expect(locator).not.toHaveCount(1, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveCount(expected) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveCount(expected) failed
+
+Locator: locator('span')
+Expected: not 1
+Received: 1
+Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toHaveCount" with timeout 1000ms`);
   });
 });
@@ -111,8 +119,12 @@ test.describe('toHaveJSProperty', () => {
     await page.$eval('div', e => (e as any).foo = 'string');
     const locator = page.locator('div');
     const error = await expect(locator).toHaveJSProperty('foo', 'error', { timeout: 200 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 200ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed
+
+Locator: locator('div')
+Expected: "error"
+Received: "string"
+Timeout: 200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 
@@ -128,8 +140,12 @@ test.describe('toHaveJSProperty', () => {
     await page.$eval('div', e => (e as any).foo = 2021);
     const locator = page.locator('div');
     const error = await expect(locator).toHaveJSProperty('foo', 1, { timeout: 200 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 200ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed
+
+Locator: locator('div')
+Expected: 1
+Received: 2021
+Timeout: 200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 
@@ -145,8 +161,12 @@ test.describe('toHaveJSProperty', () => {
     await page.$eval('div', e => (e as any).foo = false);
     const locator = page.locator('div');
     const error = await expect(locator).toHaveJSProperty('foo', true, { timeout: 200 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 200ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed
+
+Locator: locator('div')
+Expected: true
+Received: false
+Timeout: 200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 
@@ -162,8 +182,12 @@ test.describe('toHaveJSProperty', () => {
     await page.$eval('div', e => (e as any).foo = false);
     const locator = page.locator('div');
     const error = await expect(locator).toHaveJSProperty('foo', true, { timeout: 200 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 200ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed
+
+Locator: locator('div')
+Expected: true
+Received: false
+Timeout: 200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 
@@ -217,8 +241,12 @@ test.describe('toHaveClass', () => {
     await page.setContent('<div class="bar baz"></div>');
     const locator = page.locator('div');
     const error = await expect(locator).toHaveClass('foo bar baz', { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveClass(expected) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveClass(expected) failed
+
+Locator: locator('div')
+Expected string: "foo bar baz"
+Received string: "bar baz"
+Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveClass" with timeout 1000ms`);
   });
 
@@ -259,8 +287,12 @@ test.describe('toContainClass', () => {
     await page.setContent('<div class="bar baz"></div>');
     const locator = page.locator('div');
     const error = await expect(locator).toContainClass('does-not-exist', { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(locator).toContainClass(expected) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toContainClass(expected) failed
+
+Locator: locator('div')
+Expected string: "does-not-exist"
+Received string: "bar baz"
+Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toContainClass" with timeout 1000ms`);
   });
 
@@ -292,8 +324,11 @@ test.describe('toHaveTitle', () => {
   test('fail', async ({ page }) => {
     await page.setContent('<title>Bye</title>');
     const error = await expect(page).toHaveTitle('Hello', { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(page).toHaveTitle(expected) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(page).toHaveTitle(expected) failed
+
+Expected string: "Hello"
+Received string: "Bye"
+Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveTitle" with timeout 1000ms`);
   });
 });
@@ -307,8 +342,11 @@ test.describe('toHaveURL', () => {
   test('fail string', async ({ page }) => {
     await page.goto('data:text/html,<div>A</div>');
     const error = await expect(page).toHaveURL('wrong', { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`expect(page).toHaveURL(expected) failed`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`expect(page).toHaveURL(expected) failed
+
+Expected string: "wrong"
+Received string: "data:text/html,<div>A</div>"
+Timeout: 1000ms`);
     expect(stripVTControlCharacters(error.message)).toContain('Expected string: "wrong"\nReceived string: "data:text/html,<div>A</div>"');
   });
 
@@ -364,14 +402,22 @@ test.describe('toHaveAttribute', () => {
     const locator = page.locator('#node');
     {
       const error = await expect(locator).toHaveAttribute('disabled', '', { timeout: 1000 }).catch(e => e);
-      expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveAttribute(expected) failed`);
-      expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+      expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveAttribute(expected) failed
+
+Locator: locator('#node')
+Expected string: ""
+Received string: serializes to the same string
+Timeout: 1000ms`);
       expect(stripAnsi(error.message)).toContain(`- Expect "toHaveAttribute" with timeout 1000ms`);
     }
     {
       const error = await expect(locator).toHaveAttribute('disabled', /.*/, { timeout: 1000 }).catch(e => e);
-      expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveAttribute(expected) failed`);
-      expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+      expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveAttribute(expected) failed
+
+Locator: locator('#node')
+Expected pattern: /.*/
+Received string:  ""
+Timeout: 1000ms`);
       expect(stripAnsi(error.message)).toContain(`- Expect "toHaveAttribute" with timeout 1000ms`);
     }
     await expect(locator).not.toHaveAttribute('disabled', '');
@@ -385,14 +431,22 @@ test.describe('toHaveAttribute', () => {
     await expect(locator).toHaveAttribute('checked', /.*/);
     {
       const error = await expect(locator).not.toHaveAttribute('checked', '', { timeout: 1000 }).catch(e => e);
-      expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveAttribute(expected) failed`);
-      expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+      expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveAttribute(expected) failed
+
+Locator: locator('#node')
+Expected string: not ""
+Received string: ""
+Timeout: 1000ms`);
       expect(stripAnsi(error.message)).toContain(`- Expect "not toHaveAttribute" with timeout 1000ms`);
     }
     {
       const error = await expect(locator).not.toHaveAttribute('checked', /.*/, { timeout: 1000 }).catch(e => e);
-      expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveAttribute(expected) failed`);
-      expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+      expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveAttribute(expected) failed
+
+Locator: locator('#node')
+Expected pattern: not /.*/
+Received string: ""
+Timeout: 1000ms`);
       expect(stripAnsi(error.message)).toContain(`- Expect "not toHaveAttribute" with timeout 1000ms`);
     }
   });

--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -68,7 +68,8 @@ test.describe('toHaveCount', () => {
     await page.setContent('<div><span></span></div>');
     const locator = page.locator('span');
     const error = await expect(locator).toHaveCount(0, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toHaveCount(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveCount(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveCount" with timeout 1000ms`);
   });
 
@@ -76,7 +77,8 @@ test.describe('toHaveCount', () => {
     await page.setContent('<div><span></span></div>');
     const locator = page.locator('span');
     const error = await expect(locator).not.toHaveCount(1, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).not.toHaveCount(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveCount(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toHaveCount" with timeout 1000ms`);
   });
 });
@@ -109,7 +111,8 @@ test.describe('toHaveJSProperty', () => {
     await page.$eval('div', e => (e as any).foo = 'string');
     const locator = page.locator('div');
     const error = await expect(locator).toHaveJSProperty('foo', 'error', { timeout: 200 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 200ms waiting for expect(locator).toHaveJSProperty(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 
@@ -125,7 +128,8 @@ test.describe('toHaveJSProperty', () => {
     await page.$eval('div', e => (e as any).foo = 2021);
     const locator = page.locator('div');
     const error = await expect(locator).toHaveJSProperty('foo', 1, { timeout: 200 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 200ms waiting for expect(locator).toHaveJSProperty(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 
@@ -141,7 +145,8 @@ test.describe('toHaveJSProperty', () => {
     await page.$eval('div', e => (e as any).foo = false);
     const locator = page.locator('div');
     const error = await expect(locator).toHaveJSProperty('foo', true, { timeout: 200 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 200ms waiting for expect(locator).toHaveJSProperty(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 
@@ -157,7 +162,8 @@ test.describe('toHaveJSProperty', () => {
     await page.$eval('div', e => (e as any).foo = false);
     const locator = page.locator('div');
     const error = await expect(locator).toHaveJSProperty('foo', true, { timeout: 200 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 200ms waiting for expect(locator).toHaveJSProperty(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 
@@ -211,7 +217,8 @@ test.describe('toHaveClass', () => {
     await page.setContent('<div class="bar baz"></div>');
     const locator = page.locator('div');
     const error = await expect(locator).toHaveClass('foo bar baz', { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toHaveClass(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveClass(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveClass" with timeout 1000ms`);
   });
 
@@ -225,7 +232,8 @@ test.describe('toHaveClass', () => {
     await page.setContent('<div class="foo"></div><div class="bar"></div><div class="bar"></div>');
     const locator = page.locator('div');
     const error = await expect(locator).toHaveClass(['foo', 'bar', /[a-z]az/], { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toHaveClass(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveClass(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveClass" with timeout 1000ms`);
   });
 });
@@ -251,7 +259,8 @@ test.describe('toContainClass', () => {
     await page.setContent('<div class="bar baz"></div>');
     const locator = page.locator('div');
     const error = await expect(locator).toContainClass('does-not-exist', { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toContainClass(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toContainClass(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toContainClass" with timeout 1000ms`);
   });
 
@@ -268,7 +277,8 @@ test.describe('toContainClass', () => {
     await page.setContent('<div class="foo"></div><div class="bar"></div><div class="bar"></div>');
     const locator = page.locator('div');
     const error = await expect(locator).toContainClass(['foo', 'bar', 'baz'], { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toContainClass(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toContainClass(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toContainClass" with timeout 1000ms`);
   });
 });
@@ -282,7 +292,8 @@ test.describe('toHaveTitle', () => {
   test('fail', async ({ page }) => {
     await page.setContent('<title>Bye</title>');
     const error = await expect(page).toHaveTitle('Hello', { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(page).toHaveTitle(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(page).toHaveTitle(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveTitle" with timeout 1000ms`);
   });
 });
@@ -296,7 +307,8 @@ test.describe('toHaveURL', () => {
   test('fail string', async ({ page }) => {
     await page.goto('data:text/html,<div>A</div>');
     const error = await expect(page).toHaveURL('wrong', { timeout: 1000 }).catch(e => e);
-    expect(stripVTControlCharacters(error.message)).toContain('Timed out 1000ms waiting for expect(page).toHaveURL(expected)');
+    expect(stripAnsi(error.message)).toContain(`expect(page).toHaveURL(expected) failed`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripVTControlCharacters(error.message)).toContain('Expected string: "wrong"\nReceived string: "data:text/html,<div>A</div>"');
   });
 
@@ -352,12 +364,14 @@ test.describe('toHaveAttribute', () => {
     const locator = page.locator('#node');
     {
       const error = await expect(locator).toHaveAttribute('disabled', '', { timeout: 1000 }).catch(e => e);
-      expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toHaveAttribute(expected)`);
+      expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveAttribute(expected) failed`);
+      expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
       expect(stripAnsi(error.message)).toContain(`- Expect "toHaveAttribute" with timeout 1000ms`);
     }
     {
       const error = await expect(locator).toHaveAttribute('disabled', /.*/, { timeout: 1000 }).catch(e => e);
-      expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toHaveAttribute(expected)`);
+      expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveAttribute(expected) failed`);
+      expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
       expect(stripAnsi(error.message)).toContain(`- Expect "toHaveAttribute" with timeout 1000ms`);
     }
     await expect(locator).not.toHaveAttribute('disabled', '');
@@ -371,12 +385,14 @@ test.describe('toHaveAttribute', () => {
     await expect(locator).toHaveAttribute('checked', /.*/);
     {
       const error = await expect(locator).not.toHaveAttribute('checked', '', { timeout: 1000 }).catch(e => e);
-      expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).not.toHaveAttribute(expected)`);
+      expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveAttribute(expected) failed`);
+      expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
       expect(stripAnsi(error.message)).toContain(`- Expect "not toHaveAttribute" with timeout 1000ms`);
     }
     {
       const error = await expect(locator).not.toHaveAttribute('checked', /.*/, { timeout: 1000 }).catch(e => e);
-      expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).not.toHaveAttribute(expected)`);
+      expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveAttribute(expected) failed`);
+      expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
       expect(stripAnsi(error.message)).toContain(`- Expect "not toHaveAttribute" with timeout 1000ms`);
     }
   });

--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -70,10 +70,10 @@ test.describe('toHaveCount', () => {
     const error = await expect(locator).toHaveCount(0, { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveCount(expected) failed
 
-Locator: locator('span')
+Locator:  locator('span')
 Expected: 0
 Received: 1
-Timeout: 1000ms`);
+Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveCount" with timeout 1000ms`);
   });
 
@@ -83,10 +83,10 @@ Timeout: 1000ms`);
     const error = await expect(locator).not.toHaveCount(1, { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveCount(expected) failed
 
-Locator: locator('span')
+Locator:  locator('span')
 Expected: not 1
 Received: 1
-Timeout: 1000ms`);
+Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toHaveCount" with timeout 1000ms`);
   });
 });
@@ -121,10 +121,10 @@ test.describe('toHaveJSProperty', () => {
     const error = await expect(locator).toHaveJSProperty('foo', 'error', { timeout: 200 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed
 
-Locator: locator('div')
+Locator:  locator('div')
 Expected: "error"
 Received: "string"
-Timeout: 200ms`);
+Timeout:  200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 
@@ -142,10 +142,10 @@ Timeout: 200ms`);
     const error = await expect(locator).toHaveJSProperty('foo', 1, { timeout: 200 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed
 
-Locator: locator('div')
+Locator:  locator('div')
 Expected: 1
 Received: 2021
-Timeout: 200ms`);
+Timeout:  200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 
@@ -163,10 +163,10 @@ Timeout: 200ms`);
     const error = await expect(locator).toHaveJSProperty('foo', true, { timeout: 200 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed
 
-Locator: locator('div')
+Locator:  locator('div')
 Expected: true
 Received: false
-Timeout: 200ms`);
+Timeout:  200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 
@@ -184,10 +184,10 @@ Timeout: 200ms`);
     const error = await expect(locator).toHaveJSProperty('foo', true, { timeout: 200 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveJSProperty(expected) failed
 
-Locator: locator('div')
+Locator:  locator('div')
 Expected: true
 Received: false
-Timeout: 200ms`);
+Timeout:  200ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveJSProperty" with timeout 200ms`);
   });
 

--- a/tests/page/expect-timeout.spec.ts
+++ b/tests/page/expect-timeout.spec.ts
@@ -20,29 +20,45 @@ import { test, expect } from './pageTest';
 test('should print timed out error message', async ({ page }) => {
   await page.setContent('<div id=node>Text content</div>');
   const error = await expect(page.locator('no-such-thing')).toHaveText('hey', { timeout: 1000 }).catch(e => e);
-  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed`);
-  expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed
+
+Locator: locator('no-such-thing')
+Expected string: "hey"
+Received: <element(s) not found>
+Timeout: 1000ms`);
 });
 
 test('should print timed out error message when value does not match', async ({ page }) => {
   await page.setContent('<div id=node>Text content</div>');
   const error = await expect(page.locator('div')).toHaveText('hey', { timeout: 1000 }).catch(e => e);
-  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed`);
-  expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed
+
+Locator: locator('div')
+Expected string: "hey"
+Received string: "Text content"
+Timeout: 1000ms`);
 });
 
 test('should print timed out error message with impossible timeout', async ({ page }) => {
   await page.setContent('<div id=node>Text content</div>');
   const error = await expect(page.locator('no-such-thing')).toHaveText('hey', { timeout: 1 }).catch(e => e);
-  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed`);
-  expect(stripAnsi(error.message)).toContain(`Timeout: 1ms`);
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed
+
+Locator: locator('no-such-thing')
+Expected string: "hey"
+Received: <element(s) not found>
+Timeout: 1ms`);
 });
 
 test('should print timed out error message when value does not match with impossible timeout', async ({ page }) => {
   await page.setContent('<div id=node>Text content</div>');
   const error = await expect(page.locator('div')).toHaveText('hey', { timeout: 1 }).catch(e => e);
-  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed`);
-  expect(stripAnsi(error.message)).toContain(`Timeout: 1ms`);
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed
+
+Locator: locator('div')
+Expected string: "hey"
+Received string: "Text content"
+Timeout: 1ms`);
 });
 
 test('should have timeout error name', async ({ page }) => {
@@ -71,8 +87,12 @@ test('should timeout during first locator handler check', async ({ page, server 
   await page.addLocatorHandler(page.locator('div'), async locator => {});
   await page.setContent(`<div>hello</div><span>bye</span>`);
   const error = await expect(page.locator('span')).toHaveText('bye', { timeout: 3000 }).catch(e => e);
-  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed`);
-  expect(error.message).toContain(`Timeout: 3000ms`);
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed
+
+Locator: locator('span')
+Expected string: "bye"
+Received string: ""
+Timeout: 3000ms`);
   expect(error.message).toContain(`locator handler has finished, waiting for locator('div') to be hidden`);
   expect(error.message).toContain(`locator resolved to visible <div>hello</div>`);
 });

--- a/tests/page/expect-timeout.spec.ts
+++ b/tests/page/expect-timeout.spec.ts
@@ -20,25 +20,29 @@ import { test, expect } from './pageTest';
 test('should print timed out error message', async ({ page }) => {
   await page.setContent('<div id=node>Text content</div>');
   const error = await expect(page.locator('no-such-thing')).toHaveText('hey', { timeout: 1000 }).catch(e => e);
-  expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toHaveText(expected)`);
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed`);
+  expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
 });
 
 test('should print timed out error message when value does not match', async ({ page }) => {
   await page.setContent('<div id=node>Text content</div>');
   const error = await expect(page.locator('div')).toHaveText('hey', { timeout: 1000 }).catch(e => e);
-  expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toHaveText(expected)`);
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed`);
+  expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
 });
 
 test('should print timed out error message with impossible timeout', async ({ page }) => {
   await page.setContent('<div id=node>Text content</div>');
   const error = await expect(page.locator('no-such-thing')).toHaveText('hey', { timeout: 1 }).catch(e => e);
-  expect(stripAnsi(error.message)).toContain(`Timed out 1ms waiting for expect(locator).toHaveText(expected)`);
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed`);
+  expect(stripAnsi(error.message)).toContain(`Timeout: 1ms`);
 });
 
 test('should print timed out error message when value does not match with impossible timeout', async ({ page }) => {
   await page.setContent('<div id=node>Text content</div>');
   const error = await expect(page.locator('div')).toHaveText('hey', { timeout: 1 }).catch(e => e);
-  expect(stripAnsi(error.message)).toContain(`Timed out 1ms waiting for expect(locator).toHaveText(expected)`);
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed`);
+  expect(stripAnsi(error.message)).toContain(`Timeout: 1ms`);
 });
 
 test('should have timeout error name', async ({ page }) => {
@@ -67,7 +71,8 @@ test('should timeout during first locator handler check', async ({ page, server 
   await page.addLocatorHandler(page.locator('div'), async locator => {});
   await page.setContent(`<div>hello</div><span>bye</span>`);
   const error = await expect(page.locator('span')).toHaveText('bye', { timeout: 3000 }).catch(e => e);
-  expect(error.message).toContain('Timed out 3000ms waiting for');
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed`);
+  expect(error.message).toContain(`Timeout: 3000ms`);
   expect(error.message).toContain(`locator handler has finished, waiting for locator('div') to be hidden`);
   expect(error.message).toContain(`locator resolved to visible <div>hello</div>`);
 });

--- a/tests/page/expect-to-have-text.spec.ts
+++ b/tests/page/expect-to-have-text.spec.ts
@@ -208,7 +208,8 @@ test.describe('toHaveText with array', () => {
     await page.setContent('<div></div>');
     const locator = page.locator('p');
     const error = await expect(locator).not.toHaveText([], { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).not.toHaveText(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveText(expected)`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toHaveText" with timeout 1000ms`);
   });
 
@@ -226,7 +227,8 @@ test.describe('toHaveText with array', () => {
     const locator = page.locator('div');
     const error = await expect(locator).toHaveText(['Text 1', /Text \d/, 'Extra'], { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain('-   "Extra"');
-    expect(stripAnsi(error.message)).toContain(`Timed out 1000ms waiting for expect(locator).toHaveText(expected)`);
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected)`);
+    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveText" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain('waiting for locator(\'div\')');
     expect(stripAnsi(error.message)).toContain('locator resolved to 2 elements');

--- a/tests/page/expect-to-have-text.spec.ts
+++ b/tests/page/expect-to-have-text.spec.ts
@@ -209,7 +209,7 @@ test.describe('toHaveText with array', () => {
     const locator = page.locator('p');
     const error = await expect(locator).not.toHaveText([], { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`expect(locator).not.toHaveText(expected)`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toHaveText" with timeout 1000ms`);
   });
 
@@ -228,7 +228,7 @@ test.describe('toHaveText with array', () => {
     const error = await expect(locator).toHaveText(['Text 1', /Text \d/, 'Extra'], { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain('-   "Extra"');
     expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected)`);
-    expect(stripAnsi(error.message)).toContain(`Timeout: 1000ms`);
+    expect(stripAnsi(error.message)).toContain(`Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "toHaveText" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain('waiting for locator(\'div\')');
     expect(stripAnsi(error.message)).toContain('locator resolved to 2 elements');

--- a/tests/page/to-match-aria-snapshot.spec.ts
+++ b/tests/page/to-match-aria-snapshot.spec.ts
@@ -149,7 +149,7 @@ test('checked attribute', async ({ page }) => {
       - checkbox [checked=false]
     `, { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
-    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
+    expect(stripAnsi(e.message)).toContain('Timeout:  1000ms');
   }
 
   {
@@ -157,7 +157,7 @@ test('checked attribute', async ({ page }) => {
       - checkbox [checked=mixed]
     `, { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
-    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
+    expect(stripAnsi(e.message)).toContain('Timeout:  1000ms');
   }
 
   {
@@ -190,7 +190,7 @@ test('disabled attribute', async ({ page }) => {
       - button [disabled=false]
     `, { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
-    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
+    expect(stripAnsi(e.message)).toContain('Timeout:  1000ms');
   }
 
   {
@@ -223,7 +223,7 @@ test('expanded attribute', async ({ page }) => {
       - button [expanded=false]
     `, { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
-    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
+    expect(stripAnsi(e.message)).toContain('Timeout:  1000ms');
   }
 
   {
@@ -252,7 +252,7 @@ test('level attribute', async ({ page }) => {
       - heading [level=3]
     `, { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
-    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
+    expect(stripAnsi(e.message)).toContain('Timeout:  1000ms');
   }
 
   {
@@ -285,7 +285,7 @@ test('pressed attribute', async ({ page }) => {
       - button [pressed=false]
     `, { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
-    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
+    expect(stripAnsi(e.message)).toContain('Timeout:  1000ms');
   }
 
   // Test for 'mixed' state
@@ -302,7 +302,7 @@ test('pressed attribute', async ({ page }) => {
       - button [pressed=true]
     `, { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
-    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
+    expect(stripAnsi(e.message)).toContain('Timeout:  1000ms');
   }
 
   {
@@ -339,7 +339,7 @@ test('selected attribute', async ({ page }) => {
       - row [selected=false]
     `, { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
-    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
+    expect(stripAnsi(e.message)).toContain('Timeout:  1000ms');
   }
 
   {
@@ -423,7 +423,7 @@ test('expected formatter', async ({ page }) => {
   `, { timeout: 1 }).catch(e => e);
 
   expect(stripAnsi(error.message)).toContain(`
-Locator: locator('body')
+Locator:  locator('body')
 - Expected  - 2
 + Received  + 3
 
@@ -432,7 +432,7 @@ Locator: locator('body')
 + - banner:
 +   - heading "todos" [level=1]
 +   - textbox "What needs to be done?"
-Timeout: 1ms`);
+Timeout:  1ms`);
 });
 
 test('should unpack escaped names', async ({ page }) => {
@@ -726,7 +726,7 @@ test('should detect unexpected children: equal', async ({ page }) => {
   `, { timeout: 1000 }).catch(e => e);
 
   expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
-  expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
+  expect(stripAnsi(e.message)).toContain('Timeout:  1000ms');
   expect(stripAnsi(e.message)).toContain('+   - listitem: Two');
 });
 
@@ -766,7 +766,7 @@ test('should detect unexpected children: deep-equal', async ({ page }) => {
   `, { timeout: 1000 }).catch(e => e);
 
   expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
-  expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
+  expect(stripAnsi(e.message)).toContain('Timeout:  1000ms');
   expect(stripAnsi(e.message)).toContain('+       - listitem: \"1.2\"');
 });
 
@@ -791,7 +791,7 @@ test('should allow restoring contain mode inside deep-equal', async ({ page }) =
   `, { timeout: 1000 }).catch(e => e);
 
   expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
-  expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
+  expect(stripAnsi(e.message)).toContain('Timeout:  1000ms');
   expect(stripAnsi(e.message)).toContain('+       - listitem: \"1.2\"');
 
   await expect(page.locator('body')).toMatchAriaSnapshot(`

--- a/tests/page/to-match-aria-snapshot.spec.ts
+++ b/tests/page/to-match-aria-snapshot.spec.ts
@@ -424,7 +424,6 @@ test('expected formatter', async ({ page }) => {
 
   expect(stripAnsi(error.message)).toContain(`
 Locator: locator('body')
-Timeout: 1ms
 - Expected  - 2
 + Received  + 3
 
@@ -432,7 +431,8 @@ Timeout: 1ms
 - - textbox "Wrong text"
 + - banner:
 +   - heading "todos" [level=1]
-+   - textbox "What needs to be done?"`);
++   - textbox "What needs to be done?"
+Timeout: 1ms`);
 });
 
 test('should unpack escaped names', async ({ page }) => {

--- a/tests/page/to-match-aria-snapshot.spec.ts
+++ b/tests/page/to-match-aria-snapshot.spec.ts
@@ -148,14 +148,16 @@ test('checked attribute', async ({ page }) => {
     const e = await expect(page.locator('body')).toMatchAriaSnapshot(`
       - checkbox [checked=false]
     `, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(e.message)).toContain('Timed out 1000ms waiting for expect');
+    expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
+    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
   }
 
   {
     const e = await expect(page.locator('body')).toMatchAriaSnapshot(`
       - checkbox [checked=mixed]
     `, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(e.message)).toContain('Timed out 1000ms waiting for expect');
+    expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
+    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
   }
 
   {
@@ -187,7 +189,8 @@ test('disabled attribute', async ({ page }) => {
     const e = await expect(page.locator('body')).toMatchAriaSnapshot(`
       - button [disabled=false]
     `, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(e.message)).toContain('Timed out 1000ms waiting for expect');
+    expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
+    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
   }
 
   {
@@ -219,7 +222,8 @@ test('expanded attribute', async ({ page }) => {
     const e = await expect(page.locator('body')).toMatchAriaSnapshot(`
       - button [expanded=false]
     `, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(e.message)).toContain('Timed out 1000ms waiting for expect');
+    expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
+    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
   }
 
   {
@@ -247,7 +251,8 @@ test('level attribute', async ({ page }) => {
     const e = await expect(page.locator('body')).toMatchAriaSnapshot(`
       - heading [level=3]
     `, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(e.message)).toContain('Timed out 1000ms waiting for expect');
+    expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
+    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
   }
 
   {
@@ -279,7 +284,8 @@ test('pressed attribute', async ({ page }) => {
     const e = await expect(page.locator('body')).toMatchAriaSnapshot(`
       - button [pressed=false]
     `, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(e.message)).toContain('Timed out 1000ms waiting for expect');
+    expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
+    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
   }
 
   // Test for 'mixed' state
@@ -295,7 +301,8 @@ test('pressed attribute', async ({ page }) => {
     const e = await expect(page.locator('body')).toMatchAriaSnapshot(`
       - button [pressed=true]
     `, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(e.message)).toContain('Timed out 1000ms waiting for expect');
+    expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
+    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
   }
 
   {
@@ -331,7 +338,8 @@ test('selected attribute', async ({ page }) => {
     const e = await expect(page.locator('body')).toMatchAriaSnapshot(`
       - row [selected=false]
     `, { timeout: 1000 }).catch(e => e);
-    expect(stripAnsi(e.message)).toContain('Timed out 1000ms waiting for expect');
+    expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
+    expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
   }
 
   {
@@ -416,6 +424,7 @@ test('expected formatter', async ({ page }) => {
 
   expect(stripAnsi(error.message)).toContain(`
 Locator: locator('body')
+Timeout: 1ms
 - Expected  - 2
 + Received  + 3
 
@@ -716,7 +725,8 @@ test('should detect unexpected children: equal', async ({ page }) => {
       - listitem: "Three"
   `, { timeout: 1000 }).catch(e => e);
 
-  expect(e.message).toContain('Timed out 1000ms waiting');
+  expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
+  expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
   expect(stripAnsi(e.message)).toContain('+   - listitem: Two');
 });
 
@@ -755,7 +765,8 @@ test('should detect unexpected children: deep-equal', async ({ page }) => {
           - listitem: 1.1
   `, { timeout: 1000 }).catch(e => e);
 
-  expect(e.message).toContain('Timed out 1000ms waiting');
+  expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
+  expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
   expect(stripAnsi(e.message)).toContain('+       - listitem: \"1.2\"');
 });
 
@@ -779,7 +790,8 @@ test('should allow restoring contain mode inside deep-equal', async ({ page }) =
           - listitem: 1.1
   `, { timeout: 1000 }).catch(e => e);
 
-  expect(e.message).toContain('Timed out 1000ms waiting');
+  expect(stripAnsi(e.message)).toContain('expect(locator).toMatchAriaSnapshot(expected) failed');
+  expect(stripAnsi(e.message)).toContain('Timeout: 1000ms');
   expect(stripAnsi(e.message)).toContain('+       - listitem: \"1.2\"');
 
   await expect(page.locator('body')).toMatchAriaSnapshot(`

--- a/tests/playwright-test/aria-snapshot-file.spec.ts
+++ b/tests/playwright-test/aria-snapshot-file.spec.ts
@@ -192,7 +192,7 @@ test('should respect timeout', async ({ runInlineTest }, testInfo) => {
 
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain(`expect(locator).toMatchAriaSnapshot(expected) failed`);
-  expect(result.output).toContain('Timeout: 1ms');
+  expect(result.output).toContain('Timeout:  1ms');
 });
 
 test('should respect config.snapshotPathTemplate', async ({ runInlineTest }, testInfo) => {

--- a/tests/playwright-test/aria-snapshot-file.spec.ts
+++ b/tests/playwright-test/aria-snapshot-file.spec.ts
@@ -191,7 +191,8 @@ test('should respect timeout', async ({ runInlineTest }, testInfo) => {
   });
 
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain(`Timed out 1ms waiting for`);
+  expect(result.output).toContain(`expect(locator).toMatchAriaSnapshot(expected) failed`);
+  expect(result.output).toContain('Timeout: 1ms');
 });
 
 test('should respect config.snapshotPathTemplate', async ({ runInlineTest }, testInfo) => {

--- a/tests/playwright-test/expect-configure.spec.ts
+++ b/tests/playwright-test/expect-configure.spec.ts
@@ -48,7 +48,8 @@ test('should configure message', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(0);
   expect(result.output).toContain('Error: x-foo must be visible');
-  expect(result.output).toContain(`Timed out 1ms waiting for expect(locator).toBeVisible()`);
+  expect(result.output).toContain('expect(locator).toBeVisible() failed');
+  expect(result.output).toContain('Timeout: 1ms');
   expect(result.output).toContain('Call log:');
 });
 
@@ -66,7 +67,8 @@ test('should prefer local message', async ({ runInlineTest }) => {
   expect(result.passed).toBe(0);
 
   expect(result.output).toContain('Error: overridden');
-  expect(result.output).toContain(`Timed out 1ms waiting for expect(locator).toBeVisible()`);
+  expect(result.output).toContain(`expect(locator).toBeVisible() failed`);
+  expect(result.output).toContain('Timeout: 1ms');
   expect(result.output).toContain('Call log:');
 });
 

--- a/tests/playwright-test/expect-configure.spec.ts
+++ b/tests/playwright-test/expect-configure.spec.ts
@@ -49,7 +49,7 @@ test('should configure message', async ({ runInlineTest }) => {
   expect(result.passed).toBe(0);
   expect(result.output).toContain('Error: x-foo must be visible');
   expect(result.output).toContain('expect(locator).toBeVisible() failed');
-  expect(result.output).toContain('Timeout: 1ms');
+  expect(result.output).toContain('Timeout:  1ms');
   expect(result.output).toContain('Call log:');
 });
 
@@ -68,7 +68,7 @@ test('should prefer local message', async ({ runInlineTest }) => {
 
   expect(result.output).toContain('Error: overridden');
   expect(result.output).toContain(`expect(locator).toBeVisible() failed`);
-  expect(result.output).toContain('Timeout: 1ms');
+  expect(result.output).toContain('Timeout:  1ms');
   expect(result.output).toContain('Call log:');
 });
 

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -67,7 +67,8 @@ test('should include custom expect message with web-first assertions', async ({ 
   expect(result.passed).toBe(0);
 
   expect(result.output).toContain('Error: x-foo must be visible');
-  expect(result.output).toContain(`Timed out 1ms waiting for expect(locator).toBeVisible()`);
+  expect(result.output).toContain('expect(locator).toBeVisible() failed');
+  expect(result.output).toContain('Timeout: 1ms');
   expect(result.output).toContain('Call log:');
 });
 
@@ -548,7 +549,8 @@ test('should respect expect.timeout', async ({ runInlineTest }) => {
       test('timeout', async ({ page }) => {
         await page.goto('data:text/html,<div>A</div>');
         const error = await expect(page).toHaveURL('data:text/html,<div>B</div>').catch(e => e);
-        expect(stripVTControlCharacters(error.message)).toContain('Timed out 1000ms waiting for expect(page).toHaveURL(expected)');
+        expect(stripVTControlCharacters(error.message)).toContain('expect(page).toHaveURL(expected) failed');
+        expect(stripVTControlCharacters(error.message)).toContain('Timeout: 1000ms');
         expect(error.message).toContain('data:text/html,<div>');
       });
       `,
@@ -567,7 +569,8 @@ test('should support toHaveURL predicate', async ({ runInlineTest }) => {
       test('predicate', async ({ page }) => {
         await page.goto('data:text/html,<div>A</div>');
         const error = await expect(page).toHaveURL(url => url === 'data:text/html,<div>B</div>').catch(e => e);
-        expect(stripVTControlCharacters(error.message)).toContain('Timed out 1000ms waiting for expect(page).toHaveURL(expected)');
+        expect(stripVTControlCharacters(error.message)).toContain('expect(page).toHaveURL(expected) failed');
+        expect(stripVTControlCharacters(error.message)).toContain('Timeout: 1000ms');
         expect(error.message).toContain('data:text/html,<div>');
       });
       `,
@@ -706,7 +709,7 @@ test('should not print timed out error message when test times out', async ({ ru
   expect(result.exitCode).toBe(1);
   const output = result.output;
   expect(output).toContain('Test timeout of 3000ms exceeded');
-  expect(output).not.toContain('Timed out 5000ms waiting for expect');
+  expect(output).not.toContain('Timeout: 5000ms');
   expect(output).toContain(`Error: expect(locator).toHaveText(expected)`);
 });
 
@@ -1020,7 +1023,8 @@ test('should respect timeout from configured expect when used outside of the tes
 
   expect(code).toBe(1);
   expect(stdout).toBe('');
-  expect(stripAnsi(stderr)).toContain('Timed out 10ms waiting for expect(locator).toBeAttached()');
+  expect(stripAnsi(stderr)).toContain('expect(locator).toBeAttached() failed');
+  expect(stripAnsi(stderr)).toContain('Timeout: 10ms');
 });
 
 test('should expose timeout to custom matchers', async ({ runInlineTest, runTSC }) => {

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -68,7 +68,7 @@ test('should include custom expect message with web-first assertions', async ({ 
 
   expect(result.output).toContain('Error: x-foo must be visible');
   expect(result.output).toContain('expect(locator).toBeVisible() failed');
-  expect(result.output).toContain('Timeout: 1ms');
+  expect(result.output).toContain('Timeout:  1ms');
   expect(result.output).toContain('Call log:');
 });
 
@@ -709,7 +709,7 @@ test('should not print timed out error message when test times out', async ({ ru
   expect(result.exitCode).toBe(1);
   const output = result.output;
   expect(output).toContain('Test timeout of 3000ms exceeded');
-  expect(output).not.toContain('Timeout: 5000ms');
+  expect(output).not.toContain('Timeout:  5000ms');
   expect(output).toContain(`Error: expect(locator).toHaveText(expected)`);
 });
 
@@ -1024,7 +1024,7 @@ test('should respect timeout from configured expect when used outside of the tes
   expect(code).toBe(1);
   expect(stdout).toBe('');
   expect(stripAnsi(stderr)).toContain('expect(locator).toBeAttached() failed');
-  expect(stripAnsi(stderr)).toContain('Timeout: 10ms');
+  expect(stripAnsi(stderr)).toContain('Timeout:  10ms');
 });
 
 test('should expose timeout to custom matchers', async ({ runInlineTest, runTSC }) => {

--- a/tests/playwright-test/watch.spec.ts
+++ b/tests/playwright-test/watch.spec.ts
@@ -720,7 +720,8 @@ test('should run CT on changed deps', async ({ runWatchTest, writeFiles }) => {
 
   await testProcess.waitForOutput(`src${path.sep}button.spec.tsx:4:11 › pass`);
   expect(testProcess.output).not.toContain(`src${path.sep}link.spec.tsx`);
-  await testProcess.waitForOutput(`Error: Timed out 1000ms waiting for expect(locator).toHaveText(expected)`);
+  await testProcess.waitForOutput(`Error: expect(locator).toHaveText(expected) failed`);
+  await testProcess.waitForOutput('Timeout: 1000ms');
   await testProcess.waitForOutput('Waiting for file changes.');
 });
 


### PR DESCRIPTION
Related to #36205.

Changes `expect` error messages to be of the form:

```
Error: expect(locator).toBeHidden() failed

Locator:  locator('h1')
Expected: hidden
Received: visible
Timeout:  5000ms

Call log:
  - Expect "toBeHidden" with timeout 5000ms
  - waiting for locator('h1')
    9 × locator resolved to <h1 class="hero__title heroTitle_ohkl">…</h1>
      - unexpected value "visible"


  824 | test('foobar', async ({ page }) => {
  825 |   await page.goto('https://playwright.dev/');
> 826 |   await expect(page.locator('h1')).toBeHidden();
      |                                    ^
  827 | });
  828 |
    at /Users/agastineau/code/playwright/examples/todomvc/tests/random.spec.ts:826:36
 ```

This message previous looked like:

```
Error: Timed out 5000ms waiting for expect(locator).toBeHidden()

Locator: locator('h1')
Expected: hidden
Received: visible
Call log:
  - Expect "toBeHidden" with timeout 5000ms
  - waiting for locator('h1')
    9 × locator resolved to <h1 class="hero__title heroTitle_ohkl">…</h1>
      - unexpected value "visible"


  824 | test('foobar', async ({ page }) => {
  825 |   await page.goto('https://playwright.dev/');
> 826 |   await expect(page.locator('h1')).toBeHidden();
      |                                    ^
  827 | });
  828 |
    at /Users/agastineau/code/playwright/examples/todomvc/tests/random.spec.ts:826:36
```