### PR TITLE
chore: use detail/summary for html reporter attachments

### DIFF
--- a/packages/html-reporter/src/expandable.css
+++ b/packages/html-reporter/src/expandable.css
@@ -1,0 +1,22 @@
+/*
+  Copyright (c) Microsoft Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+.expandable-summary {
+  cursor: pointer;
+  list-style: none;
+  white-space: nowrap;
+  padding-left: 4px;
+}

--- a/packages/html-reporter/src/expandable.tsx
+++ b/packages/html-reporter/src/expandable.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import * as icons from './icons';
+
+import './expandable.css';
+
+export const Expandable: React.FunctionComponent<{
+  summary: React.ReactNode,
+  children: React.ReactNode,
+  className?: string,
+  style?: React.CSSProperties,
+}> = ({ summary, children, className, style }) => {
+  const [expanded, setExpanded] = React.useState(false);
+
+  const handleToggle = (e: React.SyntheticEvent<HTMLDetailsElement>) => {
+    setExpanded(e.currentTarget.open);
+  };
+
+  return (
+    <details
+      style={style}
+      className={className}
+      onToggle={handleToggle}
+    >
+      <summary className='expandable-summary'>
+        {expanded ? icons.downArrow() : icons.rightArrow()}
+        {summary}
+      </summary>
+      {children}
+    </details>
+  );
+};

--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -17,7 +17,6 @@
 import type { TestAttachment, TestCase, TestCaseSummary, TestResult, TestResultSummary } from './types';
 import * as React from 'react';
 import * as icons from './icons';
-import { TreeItem } from './treeItem';
 import { CopyToClipboard } from './copyToClipboard';
 import './links.css';
 import { linkifyText } from '@web/renderUtils';
@@ -78,30 +77,61 @@ export const AttachmentLink: React.FunctionComponent<{
   openInNewTab?: boolean,
 }> = ({ attachment, result, href, linkName, openInNewTab }) => {
   const [flash, triggerFlash] = useFlash();
+  const [expanded, setExpanded] = React.useState(false);
   useAnchor('attachment-' + result.attachments.indexOf(attachment), triggerFlash);
-  return <TreeItem title={<span>
-    {attachment.contentType === kMissingContentType ? icons.warning() : icons.attachment()}
-    {attachment.path && (
-      openInNewTab
-        ? <a href={href || attachment.path} target='_blank' rel='noreferrer'>{linkName || attachment.name}</a>
-        : <a href={href || attachment.path} download={downloadFileNameForAttachment(attachment)}>{linkName || attachment.name}</a>
-    )}
-    {!attachment.path && (
-      openInNewTab
-        ? (
-          <a
-            href={URL.createObjectURL(new Blob([attachment.body!], { type: attachment.contentType }))}
-            target='_blank' rel='noreferrer'
-            onClick={e => e.stopPropagation() /* dont expand the tree item */}
-          >
-            {attachment.name}
-          </a>
-        )
-        : <span>{linkifyText(attachment.name)}</span>
-    )}
-  </span>} loadChildren={attachment.body ? () => {
-    return [<div key={1} className='attachment-body'><CopyToClipboard value={attachment.body!}/>{linkifyText(attachment.body!)}</div>];
-  } : undefined} depth={0} style={{ lineHeight: '32px' }} flash={flash}></TreeItem>;
+
+  const summaryContent = (
+    <span>
+      {attachment.contentType === kMissingContentType ? icons.warning() : icons.attachment()}
+      {attachment.path && (
+        openInNewTab
+          ? <a href={href || attachment.path} target='_blank' rel='noreferrer'>{linkName || attachment.name}</a>
+          : <a href={href || attachment.path} download={downloadFileNameForAttachment(attachment)}>{linkName || attachment.name}</a>
+      )}
+      {!attachment.path && (
+        openInNewTab
+          ? (
+            <a
+              href={URL.createObjectURL(new Blob([attachment.body!], { type: attachment.contentType }))}
+              target='_blank' rel='noreferrer'
+              onClick={e => e.stopPropagation() /* dont expand the details */}
+            >
+              {attachment.name}
+            </a>
+          )
+          : <span>{linkifyText(attachment.name)}</span>
+      )}
+    </span>
+  );
+
+  if (!attachment.body) {
+    return (
+      <div
+        style={{ lineHeight: '32px', whiteSpace: 'nowrap', paddingLeft: 4 }}
+        className={clsx(flash && 'flash')}
+      >
+        <span style={{ visibility: 'hidden' }}>{icons.rightArrow()}</span>
+        {summaryContent}
+      </div>
+    );
+  }
+
+  return (
+    <details
+      style={{ lineHeight: '32px' }}
+      className={clsx(flash && 'flash')}
+      onToggle={e => setExpanded(e.currentTarget.open)}
+    >
+      <summary style={{ cursor: 'pointer', listStyle: 'none', whiteSpace: 'nowrap', paddingLeft: 4 }}>
+        {expanded ? icons.downArrow() : icons.rightArrow()}
+        {summaryContent}
+      </summary>
+      <div className='attachment-body'>
+        <CopyToClipboard value={attachment.body!}/>
+        {linkifyText(attachment.body!)}
+      </div>
+    </details>
+  );
 };
 
 export const TraceLink: React.FC<{ test: TestCaseSummary, trailingSeparator?: boolean, dim?: boolean }> = ({ test, trailingSeparator, dim }) => {

--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -69,6 +69,33 @@ export const ProjectLink: React.FunctionComponent<{
   </Link>;
 };
 
+export const Expandable: React.FunctionComponent<{
+  summary: React.ReactNode,
+  children: React.ReactNode,
+  className?: string,
+  style?: React.CSSProperties,
+}> = ({ summary, children, className, style }) => {
+  const [expanded, setExpanded] = React.useState(false);
+
+  const handleToggle = (e: React.SyntheticEvent<HTMLDetailsElement>) => {
+    setExpanded(e.currentTarget.open);
+  };
+
+  return (
+    <details
+      style={style}
+      className={className}
+      onToggle={handleToggle}
+    >
+      <summary style={{ cursor: 'pointer', listStyle: 'none', whiteSpace: 'nowrap', paddingLeft: 4 }}>
+        {expanded ? icons.downArrow() : icons.rightArrow()}
+        {summary}
+      </summary>
+      {children}
+    </details>
+  );
+};
+
 export const AttachmentLink: React.FunctionComponent<{
   attachment: TestAttachment,
   result: TestResult,
@@ -77,7 +104,6 @@ export const AttachmentLink: React.FunctionComponent<{
   openInNewTab?: boolean,
 }> = ({ attachment, result, href, linkName, openInNewTab }) => {
   const [flash, triggerFlash] = useFlash();
-  const [expanded, setExpanded] = React.useState(false);
   useAnchor('attachment-' + result.attachments.indexOf(attachment), triggerFlash);
 
   const summaryContent = (
@@ -117,20 +143,16 @@ export const AttachmentLink: React.FunctionComponent<{
   }
 
   return (
-    <details
+    <Expandable
       style={{ lineHeight: '32px' }}
       className={clsx(flash && 'flash')}
-      onToggle={e => setExpanded(e.currentTarget.open)}
+      summary={summaryContent}
     >
-      <summary style={{ cursor: 'pointer', listStyle: 'none', whiteSpace: 'nowrap', paddingLeft: 4 }}>
-        {expanded ? icons.downArrow() : icons.rightArrow()}
-        {summaryContent}
-      </summary>
       <div className='attachment-body'>
         <CopyToClipboard value={attachment.body!}/>
         {linkifyText(attachment.body!)}
       </div>
-    </details>
+    </Expandable>
   );
 };
 

--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -22,6 +22,7 @@ import './links.css';
 import { linkifyText } from '@web/renderUtils';
 import { clsx, useFlash } from '@web/uiUtils';
 import { trace } from './icons';
+import { Expandable } from './expandable';
 
 export function navigate(href: string | URL) {
   window.history.pushState({}, '', href);
@@ -67,33 +68,6 @@ export const ProjectLink: React.FunctionComponent<{
       {projectName}
     </span>
   </Link>;
-};
-
-export const Expandable: React.FunctionComponent<{
-  summary: React.ReactNode,
-  children: React.ReactNode,
-  className?: string,
-  style?: React.CSSProperties,
-}> = ({ summary, children, className, style }) => {
-  const [expanded, setExpanded] = React.useState(false);
-
-  const handleToggle = (e: React.SyntheticEvent<HTMLDetailsElement>) => {
-    setExpanded(e.currentTarget.open);
-  };
-
-  return (
-    <details
-      style={style}
-      className={className}
-      onToggle={handleToggle}
-    >
-      <summary style={{ cursor: 'pointer', listStyle: 'none', whiteSpace: 'nowrap', paddingLeft: 4 }}>
-        {expanded ? icons.downArrow() : icons.rightArrow()}
-        {summary}
-      </summary>
-      {children}
-    </details>
-  );
 };
 
 export const AttachmentLink: React.FunctionComponent<{

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -513,9 +513,9 @@ for (const useIntermediateMergeReport of [true, false] as const) {
 
       await showReport();
       await page.getByRole('link', { name: 'fails' }).click();
-      await page.locator('text=stdout').click();
-      await expect(page.locator('.attachment-body')).toHaveText('First line\nSecond line');
-      await page.locator('text=stderr').click();
+      await page.getByText('stdout').click();
+      await expect(page.locator('.attachment-body').nth(0)).toHaveText('First line\nSecond line');
+      await page.getByText('stderr').click();
       await expect(page.locator('.attachment-body').nth(1)).toHaveText('Third line');
     });
 
@@ -2960,7 +2960,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
 
       await showReport();
       await page.getByText('my test').click();
-      await expect(page.locator('.tree-item', { hasText: 'stdout' })).toHaveCount(1);
+      await expect(page.getByTestId('attachments').getByText('stdout')).toHaveCount(1);
     });
 
     test('should include diff in AI prompt', async ({ runInlineTest, writeFiles, showReport, page }) => {


### PR DESCRIPTION
What does it fix?

The browser by default when you use the native search functionality only looks at visible nodes. For detail/summary it includes it as well and automatically expands them. This is handy for e.g. attachments (stdout/stderr) in the html reporter. Since we previously didn't use them, the expansion had to be done manually. This PR addresses that so that command + F and search for the query does automatically expand it.

There should be no other UI changes besides that, it should look and behave the same.