### PR TITLE
test: fix fs.rmdir deprecation warning

### DIFF
--- a/tests/installation/playwright-cli.spec.ts
+++ b/tests/installation/playwright-cli.spec.ts
@@ -45,7 +45,7 @@ test('cli should work', async ({ exec, tmpWorkspace }) => {
       expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
       expect(result).toContain(`{ page }`);
     } finally {
-      fs.rmdirSync(userDataDir, { recursive: true });
+      fs.rmSync(userDataDir, { recursive: true });
     }
   });
 


### PR DESCRIPTION
This fixes:

```
(node:56000) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
    at emitRecursiveRmdirWarning (node:internal/fs/utils:872:13)
    at Object.rmdirSync (node:fs:1175:5)
    at /Users/maxschmitt/Developer/playwright/tests/installation/playwright-cli.spec.ts:48:10
```