### PR TITLE
fix(url): add more custom prefixes captured by URL globbing

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/urlMatch.ts
+++ b/packages/playwright-core/src/utils/isomorphic/urlMatch.ts
@@ -128,7 +128,9 @@ function resolveGlobBase(baseURL: string | undefined, match: string): string {
     // Escaped `\\?` behaves the same as `?` in our glob patterns.
     match = match.replaceAll(/\\\\\?/g, '?');
     // Special case about: URLs as they are not relative to baseURL
-    if (match.startsWith('about:'))
+    if (match.startsWith('about:') || match.startsWith('data:')
+      || match.startsWith('chrome:') || match.startsWith('edge:')
+      || match.startsWith('file:'))
       return match;
     // Glob symbols may be escaped in the URL and some of them such as ? affect resolution,
     // so we replace them with safe components first.

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -129,11 +129,14 @@ it('should work with glob', async () => {
   expect(urlMatches('http://first.host/', 'http://second.host/foo', '**/foo')).toBeTruthy();
   expect(urlMatches('http://playwright.dev/', 'http://localhost/', '*//localhost/')).toBeTruthy();
 
-  expect(urlMatches('http://playwright.dev/', 'about:blank', 'about:blank')).toBeTruthy();
-  expect(urlMatches('http://playwright.dev/', 'about:blank', 'http://playwright.dev/')).toBeFalsy();
-  expect(urlMatches(undefined, 'about:blank', 'about:blank')).toBeTruthy();
-  expect(urlMatches(undefined, 'about:blank', 'about:*')).toBeTruthy();
-  expect(urlMatches(undefined, 'notabout:blank', 'about:*')).toBeFalsy();
+  const customPrefixes = ['about', 'data', 'chrome', 'edge', 'file'];
+  for (const prefix of customPrefixes) {
+    expect(urlMatches('http://playwright.dev/', `${prefix}:blank`, `${prefix}:blank`)).toBeTruthy();
+    expect(urlMatches('http://playwright.dev/', `${prefix}:blank`, `http://playwright.dev/`)).toBeFalsy();
+    expect(urlMatches(undefined, `${prefix}:blank`, `${prefix}:blank`)).toBeTruthy();
+    expect(urlMatches(undefined, `${prefix}:blank`, `${prefix}:*`)).toBeTruthy();
+    expect(urlMatches(undefined, `not${prefix}:blank`, `${prefix}:*`)).toBeFalsy();
+  }
 });
 
 it('should intercept by glob', async function({ page, server, isAndroid }) {


### PR DESCRIPTION
Continuing from #36180. Following API review, it was decided to add more built in URLs.