### PR TITLE
chore: set package.json "node": ">=20"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "yaml": "2.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@actions/core": {
@@ -8033,7 +8033,7 @@
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -8048,7 +8048,7 @@
         "playwright-core": "1.54.0-next"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-browser-firefox": {
@@ -8060,7 +8060,7 @@
         "playwright-core": "1.54.0-next"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-browser-webkit": {
@@ -8072,7 +8072,7 @@
         "playwright-core": "1.54.0-next"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-chromium": {
@@ -8086,7 +8086,7 @@
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-client": {
@@ -8097,7 +8097,7 @@
         "playwright-core": "1.54.0-next"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-core": {
@@ -8107,7 +8107,7 @@
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-ct-core": {
@@ -8120,7 +8120,7 @@
         "vite": "^6.3.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-ct-react": {
@@ -8135,7 +8135,7 @@
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-ct-react17": {
@@ -8150,7 +8150,7 @@
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-ct-svelte": {
@@ -8168,7 +8168,7 @@
         "svelte": "^4.2.19"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-ct-svelte/node_modules/@esbuild/aix-ppc64": {
@@ -8726,7 +8726,7 @@
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-firefox": {
@@ -8740,7 +8740,7 @@
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-mcp": {
@@ -8784,7 +8784,7 @@
         "@types/debug": "^4.1.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-mdd/node_modules/mime": {
@@ -8813,7 +8813,7 @@
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright-tools": {
@@ -8844,7 +8844,7 @@
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/playwright/node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-browser-chromium/package.json
+++ b/packages/playwright-browser-chromium/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-browser-firefox/package.json
+++ b/packages/playwright-browser-firefox/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-browser-webkit/package.json
+++ b/packages/playwright-browser-webkit/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-chromium/package.json
+++ b/packages/playwright-chromium/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-client/package.json
+++ b/packages/playwright-client/package.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-ct-core/package.json
+++ b/packages/playwright-ct-core/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-ct-react/package.json
+++ b/packages/playwright-ct-react/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-ct-react17/package.json
+++ b/packages/playwright-ct-react17/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-ct-svelte/package.json
+++ b/packages/playwright-ct-svelte/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-ct-vue/package.json
+++ b/packages/playwright-ct-vue/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-firefox/package.json
+++ b/packages/playwright-firefox/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-mdd/package.json
+++ b/packages/playwright-mdd/package.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright-webkit/package.json
+++ b/packages/playwright-webkit/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Microsoft Corporation"

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://playwright.dev",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
We have three layers of protection to prevent users from using older version:
1. Our documentation: https://github.com/microsoft/playwright/pull/36580
2. A check in index.js which uses `requirement - 2` which most likely still works: https://github.com/microsoft/playwright/pull/36582
3. package.json required version, this will emit a warning: https://github.com/microsoft/playwright/pull/36581