### PR TITLE
chore: set minimum Node.js version to 18

### DIFF
--- a/packages/playwright-core/index.js
+++ b/packages/playwright-core/index.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const minimumMajorNodeVersion = 14;
+const minimumMajorNodeVersion = 18;
 const currentNodeVersion = process.versions.node;
 const semver = currentNodeVersion.split('.');
 const [major] = [+semver[0]];


### PR DESCRIPTION
We have three layers of protection to prevent users from using older version:
1. Our documentation: https://github.com/microsoft/playwright/pull/36580
2. This check which uses `requirement - 2` which most likely still works.
3. package.json required version, this will emit a warning: https://github.com/microsoft/playwright/pull/36581