### PR TITLE
test: remove useless aria/active test

### DIFF
--- a/tests/playwright-test/aria-snapshot-file.spec.ts
+++ b/tests/playwright-test/aria-snapshot-file.spec.ts
@@ -250,26 +250,3 @@ test('should respect config.expect.toMatchAriaSnapshot.pathTemplate', async ({ r
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
 });
-
-test('should match active element after focus', async ({ runInlineTest }, testInfo) => {
-  const result = await runInlineTest({
-    'a.spec.ts-snapshots/test.aria.yml': `
-      - textbox "First input"
-      - textbox "Second input" [active]
-    `,
-    'a.spec.ts': `
-      import { test, expect } from '@playwright/test';
-      test('test', async ({ page }) => {
-        await page.setContent(\`
-          <input id="input1" placeholder="First input">
-          <input id="input2" placeholder="Second input">
-        \`);
-        // Focus the second input
-        await page.locator('#input2').focus();
-        await expect(page.locator('body')).toMatchAriaSnapshot({ name: 'test.aria.yml' });
-      });
-    `
-  });
-
-  expect(result.exitCode).toBe(0);
-});


### PR DESCRIPTION
This test was added in https://github.com/microsoft/playwright/pull/36506/commits/3e38ee6130b9e35d2730830eb2072911f408e1a5, but there's no functional changes to ARIA matching that make this test make sense. It was authored by Copilot, so it looks like it's a hallucinated test.

Since the PR that introduced it is about making `[active]` visible in AI snapshots, I don't think any change to ARIA matching was intended. At least I can't spot a functional change that would've led to that, so let's drop that stray test.