### PR TITLE
chore: widen aria iframe regex

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -1024,7 +1024,7 @@ async function snapshotFrameForAI(progress: Progress, frame: frames.Frame, frame
   const lines = snapshot.split('\n');
   const result = [];
   for (const line of lines) {
-    const match = line.match(/^(\s*)- iframe (?:\[active\] )?\[ref=(.*)\]/);
+    const match = line.match(/^(\s*)- iframe .*\[ref=(.*)\]/);
     if (!match) {
       result.push(line);
       continue;


### PR DESCRIPTION
We added a special case for `[active]` in https://github.com/microsoft/playwright/pull/36506/commits/3e38ee6130b9e35d2730830eb2072911f408e1a5#diff-087773eea292da9db5a3f27de8f1a2940cdb895383ad750c3cd8e01772a35b40R1030, but I don't think we should add every single possible attribute there. Replacing this with `.*` seems good enough, the only thing we care about is the `- iframe` start and the fact that there's a `ref`.