### PR TITLE
chore: set --enable-gpu on Chromium on macOS

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -304,8 +304,8 @@ export class Chromium extends BrowserType {
       // See https://issues.chromium.org/issues/40277080
       chromeArguments.push('--enable-unsafe-swiftshader');
       // See https://bugs.chromium.org/p/chromium/issues/detail?id=1407025.
-      if (options.headless && (!options.channel || options.channel === 'chromium-headless-shell'))
-        chromeArguments.push('--use-angle');
+      if (options.headless && (!options.channel || options.channel === 'chromium-headless-shell' || options.channel === 'chromium-tip-of-tree-headless-shell'))
+        chromeArguments.push('--enable-gpu');
     }
 
     if (options.devtools)

--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -112,15 +112,16 @@ browserTest.describe('page screenshot', () => {
 
   browserTest('should throw if screenshot size is too large with device scale factor', async ({ browser, browserName, isMac }) => {
     browserTest.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16727' });
+    const maxHeight = browserName === 'chromium' && isMac ? Math.pow(2, 13) : Math.pow(2, 15);
     const context = await browser.newContext({ viewport: { width: 500, height: 500 }, deviceScaleFactor: 2 });
     const page = await context.newPage();
     {
-      await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: 16383px; background: red;'></div>`);
+      await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: ${maxHeight}px; background: red;'></div>`);
       const result = await page.screenshot({ fullPage: true });
       expect(result).toBeTruthy();
     }
     {
-      await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: 16384px; background: red;'></div>`);
+      await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: ${maxHeight + 1}px; background: red;'></div>`);
       const exception = await page.screenshot({ fullPage: true }).catch(e => e);
       if (browserName === 'firefox' || (browserName === 'webkit' && !isMac))
         expect(exception.message).toContain('Cannot take screenshot larger than 32767');

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -286,7 +286,7 @@ it.describe('page screenshot', () => {
     await page.setViewportSize({ width: 500, height: 500 });
     await page.goto(server.PREFIX + '/screenshots/canvas.html');
     const screenshot = await page.screenshot();
-    if ((!isHeadlessShell && browserName === 'chromium' && isMac && os.arch() === 'arm64' && macVersion >= 14) ||
+    if ((browserName === 'chromium' && isMac && macVersion >= 14) ||
         (browserName === 'webkit' && isLinux && os.arch() === 'x64'))
       expect(screenshot).toMatchSnapshot('screenshot-canvas-with-accurate-corners.png');
     else
@@ -894,14 +894,15 @@ it.describe('page screenshot animations', () => {
 });
 
 it('should throw if screenshot size is too large', async ({ page, browserName, isMac }) => {
+  const maxHeight = browserName === 'chromium' && isMac ? Math.pow(2, 14) : Math.pow(2, 15);
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16727' });
   {
-    await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: 32767px; background: red;'></div>`);
+    await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: ${maxHeight}px; background: red;'></div>`);
     const result = await page.screenshot({ fullPage: true });
     expect(result).toBeTruthy();
   }
   {
-    await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: 32768px; background: red;'></div>`);
+    await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: ${maxHeight + 1}px; background: red;'></div>`);
     const exception = await page.screenshot({ fullPage: true }).catch(e => e);
     if (browserName === 'firefox' || (browserName === 'webkit' && !isMac))
       expect(exception.message).toContain('Cannot take screenshot larger than 32767');


### PR DESCRIPTION
Motivation: WebGL tests are currently not passing on @main. They are timing out because WebGL is not available on macOS.

Relates https://github.com/microsoft/playwright/pull/36528