### PR TITLE
[DO NOT LAND] webgl test experiments

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -305,7 +305,7 @@ export class Chromium extends BrowserType {
       chromeArguments.push('--enable-unsafe-swiftshader');
       // See https://bugs.chromium.org/p/chromium/issues/detail?id=1407025.
       if (options.headless && (!options.channel || options.channel === 'chromium-headless-shell'))
-        chromeArguments.push('--use-angle');
+        chromeArguments.push('--enable-gpu');
     }
 
     if (options.devtools)

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -101,8 +101,7 @@ it('should play audio @smoke', async ({ page, server, browserName, platform }) =
   expect(await page.$eval('audio', e => e.currentTime)).toBeGreaterThan(0.2);
 });
 
-it('should support webgl @smoke', async ({ page, browserName, platform }) => {
-  it.fixme(browserName === 'chromium' && platform === 'darwin' && os.arch() === 'arm64', 'SwiftShader is not available on macOS-arm64 - https://github.com/microsoft/playwright/issues/28216');
+it.only('should support webgl @smoke', async ({ page, browserName, platform }) => {
   const hasWebGL = await page.evaluate(() => {
     const canvas = document.createElement('canvas');
     return !!canvas.getContext('webgl');
@@ -110,11 +109,9 @@ it('should support webgl @smoke', async ({ page, browserName, platform }) => {
   expect(hasWebGL).toBe(true);
 });
 
-it('should support webgl 2 @smoke', async ({ page, browserName, headless, isWindows, platform }) => {
+it.only('should support webgl 2 @smoke', async ({ page, browserName, headless, isWindows, platform }) => {
   it.skip(browserName === 'webkit', 'WebKit doesn\'t have webgl2 enabled yet upstream.');
   it.fixme(browserName === 'firefox' && isWindows);
-  it.fixme(browserName === 'chromium' && !headless, 'chromium doesn\'t like webgl2 when running under xvfb');
-  it.fixme(browserName === 'chromium' && platform === 'darwin' && os.arch() === 'arm64', 'SwiftShader is not available on macOS-arm64 - https://github.com/microsoft/playwright/issues/28216');
 
   const hasWebGL2 = await page.evaluate(() => {
     const canvas = document.createElement('canvas');

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -90,7 +90,7 @@ const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeW
   globalTimeout: 5400000,
   workers: process.env.CI ? 2 : undefined,
   fullyParallel: !process.env.CI,
-  forbidOnly: !!process.env.CI,
+  // forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 3 : 0,
   reporter: reporters(),
   projects: [],

--- a/tests/playwright-test/playwright.config.ts
+++ b/tests/playwright-test/playwright.config.ts
@@ -33,7 +33,7 @@ const reporters = () => {
 };
 export default defineConfig({
   timeout: 30000,
-  forbidOnly: !!process.env.CI,
+  // forbidOnly: !!process.env.CI,
   workers: process.env.CI ? 2 : undefined,
   snapshotPathTemplate: '__screenshots__/{testFilePath}/{arg}{ext}',
   projects: [


### PR DESCRIPTION
- Passing `--use-angle` and `--enable-unsafe-swiftshader`: failures on `macos-{13-large,14-large,13-xlarge,14-xlarge}`
- Passing no flags: failures on `macos-{13-xlarge,14-xlarge}`
- Passing `--enable-unsafe-swiftshader`: no failures
- Passing `--enable-gpu` and `--enable-unsafe-swiftshader`: no failures