### PR TITLE
chore: group attachments in terminal reporters

### DIFF
--- a/packages/html-reporter/src/testErrorView.tsx
+++ b/packages/html-reporter/src/testErrorView.tsx
@@ -47,16 +47,10 @@ export const PromptButton: React.FC<{ prompt: string }> = ({ prompt }) => {
 };
 
 export const TestScreenshotErrorView: React.FC<{
-  errorPrefix?: string,
   diff: ImageDiff,
-  errorSuffix?: string,
-}> = ({ errorPrefix, diff, errorSuffix }) => {
-  const prefixHtml = React.useMemo(() => ansiErrorToHtml(errorPrefix), [errorPrefix]);
-  const suffixHtml = React.useMemo(() => ansiErrorToHtml(errorSuffix), [errorSuffix]);
+}> = ({ diff }) => {
   return <div data-testid='test-screenshot-error-view' className='test-error-view'>
-    <div dangerouslySetInnerHTML={{ __html: prefixHtml || '' }} className='test-error-text' style={{ marginBottom: 20 }}></div>
     <ImageDiffView key='image-diff' diff={diff} hideDetails={true}></ImageDiffView>
-    <div data-testid='error-suffix' dangerouslySetInnerHTML={{ __html: suffixHtml || '' }} className='test-error-text'></div>
   </div>;
 };
 

--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -354,29 +354,49 @@ export function formatFailure(screen: Screen, config: FullConfig, test: TestCase
       resultLines.push(screen.colors.gray(separator(screen, `    Retry #${result.retry}`)));
     }
     resultLines.push(...errors.map(error => '\n' + error.message));
-    for (let i = 0; i < result.attachments.length; ++i) {
-      const attachment = result.attachments[i];
+    const attachmentGroups = groupAttachments(result.attachments);
+    for (let i = 0; i < attachmentGroups.length; ++i) {
+      const attachment = attachmentGroups[i];
       if (attachment.name === 'error-context' && attachment.path) {
         resultLines.push('');
         resultLines.push(screen.colors.dim(`    Error Context: ${relativeFilePath(screen, config, attachment.path)}`));
         continue;
       }
+
       if (attachment.name.startsWith('_'))
         continue;
+
       const hasPrintableContent = attachment.contentType.startsWith('text/');
       if (!attachment.path && !hasPrintableContent)
         continue;
+
       resultLines.push('');
-      resultLines.push(screen.colors.cyan(separator(screen, `    attachment #${i + 1}: ${attachment.name} (${attachment.contentType})`)));
-      if (attachment.path) {
-        const relativePath = path.relative(process.cwd(), attachment.path);
-        resultLines.push(screen.colors.cyan(`    ${relativePath}`));
+      resultLines.push(screen.colors.dim(separator(screen, `    attachment #${i + 1}: ${screen.colors.bold(attachment.name)} (${attachment.contentType})`)));
+
+      if (attachment.actual?.path) {
+        if (attachment.expected?.path) {
+          const expectedPath = relativeFilePath(screen, config, attachment.expected.path);
+          resultLines.push(screen.colors.dim(`    Expected: ${expectedPath}`));
+        }
+        const actualPath = relativeFilePath(screen, config, attachment.actual.path);
+        resultLines.push(screen.colors.dim(`    Received: ${actualPath}`));
+        if (attachment.previous?.path) {
+          const previousPath = relativeFilePath(screen, config, attachment.previous.path);
+          resultLines.push(screen.colors.dim(`    Previous: ${previousPath}`));
+        }
+        if (attachment.diff?.path) {
+          const diffPath = relativeFilePath(screen, config, attachment.diff.path);
+          resultLines.push(screen.colors.dim(`    Diff:     ${diffPath}`));
+        }
+      } else if (attachment.path) {
+        const relativePath = relativeFilePath(screen, config, attachment.path);
+        resultLines.push(screen.colors.dim(`    ${relativePath}`));
         // Make this extensible
         if (attachment.name === 'trace') {
           const packageManagerCommand = getPackageManagerExecCommand();
-          resultLines.push(screen.colors.cyan(`    Usage:`));
+          resultLines.push(screen.colors.dim(`    Usage:`));
           resultLines.push('');
-          resultLines.push(screen.colors.cyan(`        ${packageManagerCommand} playwright show-trace ${quotePathIfNeeded(relativePath)}`));
+          resultLines.push(screen.colors.dim(`        ${packageManagerCommand} playwright show-trace ${quotePathIfNeeded(relativePath)}`));
           resultLines.push('');
         }
       } else {
@@ -385,10 +405,10 @@ export function formatFailure(screen: Screen, config: FullConfig, test: TestCase
           if (text.length > 300)
             text = text.slice(0, 300) + '...';
           for (const line of text.split('\n'))
-            resultLines.push(screen.colors.cyan(`    ${line}`));
+            resultLines.push(screen.colors.dim(`    ${line}`));
         }
       }
-      resultLines.push(screen.colors.cyan(separator(screen, '   ')));
+      resultLines.push(screen.colors.dim(separator(screen, '   ')));
     }
     lines.push(...resultLines);
   }
@@ -532,7 +552,7 @@ export function separator(screen: Screen, text: string = ''): string {
   if (text)
     text += ' ';
   const columns = Math.min(100, screen.ttyWidth || 100);
-  return text + screen.colors.dim('─'.repeat(Math.max(0, columns - text.length)));
+  return text + screen.colors.dim('─'.repeat(Math.max(0, columns - stripAnsiEscapes(text).length)));
 }
 
 function indent(lines: string, tab: string) {
@@ -639,4 +659,47 @@ export function resolveOutputFile(reporterName: string, options: {
   outputFile = path.resolve(outputDir, reportName);
 
   return { outputFile, outputDir };
+}
+
+type TestAttachment = TestResult['attachments'][number];
+
+type TestAttachmentGroup = TestAttachment & {
+  expected?: TestAttachment;
+  actual?: TestAttachment;
+  diff?: TestAttachment;
+  previous?: TestAttachment;
+};
+
+function groupAttachments(attachments: TestResult['attachments']): TestAttachmentGroup[] {
+  const result: TestAttachmentGroup[] = [];
+  const attachmentsByPrefix = new Map<string, TestAttachment>();
+  for (const attachment of attachments) {
+    if (!attachment.path) {
+      result.push(attachment);
+      continue;
+    }
+
+    const match = attachment.name.match(/^(.*)-(expected|actual|diff|previous)(\.[^.]+)?$/);
+    if (!match) {
+      result.push(attachment);
+      continue;
+    }
+
+    const [, name, category] = match;
+    let group: TestAttachmentGroup | undefined = attachmentsByPrefix.get(name);
+    if (!group) {
+      group = { ...attachment, name };
+      attachmentsByPrefix.set(name, group);
+      result.push(group);
+    }
+    if (category === 'expected')
+      group.expected = attachment;
+    else if (category === 'actual')
+      group.actual = attachment;
+    else if (category === 'diff')
+      group.diff = attachment;
+    else if (category === 'previous')
+      group.previous = attachment;
+  }
+  return result;
 }

--- a/tests/page/expect-matcher-result.spec.ts
+++ b/tests/page/expect-matcher-result.spec.ts
@@ -298,6 +298,5 @@ test('toHaveScreenshot should populate matcherResult', async ({ page, server, is
   expect.soft(stripAnsi(e.toString())).toContain(`Error: expect(page).toHaveScreenshot(expected)
 
   23362 pixels (ratio 0.10 of all image pixels) are different.
-
-Expected:`);
+`);
 });

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -228,7 +228,7 @@ test('should write detailed failure result to an output folder', async ({ runInl
   const expectedSnapshotArtifactPath = testInfo.outputPath('test-results', 'a-is-a-test', 'snapshot-expected.txt');
   const actualSnapshotArtifactPath = testInfo.outputPath('test-results', 'a-is-a-test', 'snapshot-actual.txt');
   expect(outputText).toMatch(/Expected:.*a\.spec\.js-snapshots.snapshot\.txt/);
-  expect(outputText).toContain(`Received: ${actualSnapshotArtifactPath}`);
+  expect(outputText).toContain(`Received: test-results${path.sep}a-is-a-test${path.sep}snapshot-actual.txt`);
   expect(fs.existsSync(expectedSnapshotArtifactPath)).toBe(true);
   expect(fs.existsSync(actualSnapshotArtifactPath)).toBe(true);
 });
@@ -672,8 +672,8 @@ test('should compare different PNG images', async ({ runInlineTest }, testInfo) 
   const actualSnapshotArtifactPath = testInfo.outputPath('test-results', 'a-is-a-test', 'snapshot-actual.png');
   const diffSnapshotArtifactPath = testInfo.outputPath('test-results', 'a-is-a-test', 'snapshot-diff.png');
   expect(outputText).toMatch(/Expected:.*a\.spec\.js-snapshots.snapshot\.png/);
-  expect(outputText).toContain(`Received: ${actualSnapshotArtifactPath}`);
-  expect(outputText).toContain(`Diff: ${diffSnapshotArtifactPath}`);
+  expect(outputText).toContain(`Received: test-results${path.sep}a-is-a-test${path.sep}snapshot-actual.png`);
+  expect(outputText).toContain(`Diff:     test-results${path.sep}a-is-a-test${path.sep}snapshot-diff.png`);
   expect(fs.existsSync(expectedSnapshotArtifactPath)).toBe(true);
   expect(fs.existsSync(actualSnapshotArtifactPath)).toBe(true);
   expect(fs.existsSync(diffSnapshotArtifactPath)).toBe(true);

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -157,6 +157,8 @@ test.describe('expect config animations option', () => {
       `
     }, { 'update-snapshots': true });
     expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('is-a-test-1-actual.png');
+    expect(result.output).toContain('is-a-test-1-previous.png');
     expect(result.output).toContain('is-a-test-1-diff.png');
   });
 });


### PR DESCRIPTION
HTML before:
![image](https://github.com/user-attachments/assets/a65a2c1b-bb62-414f-bfa5-e236518068eb)

HTML after:
![image](https://github.com/user-attachments/assets/24fbf014-02cd-4b93-a807-f483fd25b448)
