### PR TITLE
chore: remove --use-angle in Chromium switches

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -303,9 +303,6 @@ export class Chromium extends BrowserType {
       chromeArguments.push('--enable-use-zoom-for-dsf=false');
       // See https://issues.chromium.org/issues/40277080
       chromeArguments.push('--enable-unsafe-swiftshader');
-      // See https://bugs.chromium.org/p/chromium/issues/detail?id=1407025.
-      if (options.headless && (!options.channel || options.channel === 'chromium-headless-shell'))
-        chromeArguments.push('--use-angle');
     }
 
     if (options.devtools)


### PR DESCRIPTION
This fixes the webgl tests on macOS which broke after http://crrev.com/c/6488514.

See https://github.com/microsoft/playwright/pull/36606 for experiments with various flags.
See https://issues.chromium.org/u/1/issues/430336817 for the upstream discussion.