### PR TITLE
test: unflake multiclient spec

### DIFF
--- a/tests/library/multiclient.spec.ts
+++ b/tests/library/multiclient.spec.ts
@@ -54,9 +54,10 @@ test.slow(true, 'All connect tests are slow');
 test.skip(({ mode }) => mode !== 'default');
 
 async function disconnect(page: Page) {
+  const waitForClose = new Promise(f => page.context().browser().once('disconnected', f));
   await page.context().browser().close();
   // Give disconnect some time to cleanup.
-  await new Promise(f => setTimeout(f, 1000));
+  await waitForClose;
 }
 
 test('should connect two clients', async ({ connect, remoteServer, server }) => {


### PR DESCRIPTION
Fixes

```
Error: expect(received).toBe(expected) // Object.is equality

Expected: 226
Received: 697
    at /home/runner/work/playwright/playwright/tests/library/multiclient.spec.ts:367:19
```