### PR TITLE
chore: remove unused disabled Chromium features

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -20,12 +20,8 @@
 const disabledFeatures = (assistantMode?: boolean) => [
   // See https://github.com/microsoft/playwright/pull/10380
   'AcceptCHFrame',
-  // See https://github.com/microsoft/playwright/pull/10679
-  'AutoExpandDetailsElement',
   // See https://github.com/microsoft/playwright/issues/14047
   'AvoidUnnecessaryBeforeUnloadCheckSync',
-  // See https://github.com/microsoft/playwright/pull/12992
-  'CertificateTransparencyComponentUpdater',
   'DestroyProfileOnBrowserClose',
   // See https://github.com/microsoft/playwright/pull/13854
   'DialMediaRouteProvider',
@@ -35,8 +31,6 @@ const disabledFeatures = (assistantMode?: boolean) => [
   'GlobalMediaControls',
   // See https://github.com/microsoft/playwright/pull/27605
   'HttpsUpgrades',
-  'ImprovedCookieControls',
-  'LazyFrameLoading',
   // Hides the Lens feature in the URL address bar. Its not working in unofficial builds.
   'LensOverlay',
   // See https://github.com/microsoft/playwright/pull/8162
@@ -45,8 +39,6 @@ const disabledFeatures = (assistantMode?: boolean) => [
   'PaintHolding',
   // See https://github.com/microsoft/playwright/issues/32230
   'ThirdPartyStoragePartitioning',
-  // See https://github.com/microsoft/playwright/issues/16126
-  'Translate',
   assistantMode ? 'AutomationControlled' : '',
 ].filter(Boolean);
 

--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -39,6 +39,8 @@ const disabledFeatures = (assistantMode?: boolean) => [
   'PaintHolding',
   // See https://github.com/microsoft/playwright/issues/32230
   'ThirdPartyStoragePartitioning',
+  // See https://github.com/microsoft/playwright/issues/16126
+  'Translate',
   assistantMode ? 'AutomationControlled' : '',
 ].filter(Boolean);
 


### PR DESCRIPTION
The following features were removed upstream:

- AutoExpandDetailsElement:  Sep 23, 2022 - https://chromium-review.googlesource.com/c/chromium/src/+/3828660
- CertificateTransparencyComponentUpdater: Dec 01, 2023 - https://chromium-review.googlesource.com/c/chromium/src/+/5077106
- ImprovedCookieControls: Aug 06, 2020 - https://chromium-review.googlesource.com/c/chromium/src/+/2328907
- LazyFrameLoading: Nov 10, 2023 - https://chromium-review.googlesource.com/c/chromium/src/+/5013805
- ~~Translate: May 22, 2025 - https://chromium-review.googlesource.com/c/chromium/src/+/6578953~~