### PR TITLE
chore: unflake page.pause() keyboard test

### DIFF
--- a/packages/recorder/src/recorder.tsx
+++ b/packages/recorder/src/recorder.tsx
@@ -92,7 +92,7 @@ export const Recorder: React.FC<RecorderProps> = ({
   }, [messagesEndRef]);
 
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       switch (event.key) {
         case 'F8':

--- a/tests/library/inspector/pause.spec.ts
+++ b/tests/library/inspector/pause.spec.ts
@@ -77,6 +77,7 @@ it.describe('pause', () => {
       await page.pause({ __testHookKeepTestTimeout: true });
     })();
     const recorderPage = await recorderPageGetter();
+    await expect(recorderPage.getByRole('button', { name: 'Resume' })).toBeEnabled();
     await recorderPage.keyboard.press('F8');
     await scriptPromise;
   });


### PR DESCRIPTION
What happened during the flaky test?

- The first render of `<Recorder/>` happens with `paused = false`.
- That render’s `useEffect` installs a keydown listener whose closure “remembers” `false`.
- React then updates state to `paused = true`, re-renders, and the UI reflects the new value.
- Before the next `useEffect` runs and replaces the listener, a quick F8 press is still handled by the old listener, so its not entering the right code path and not continuing. 

Fix: move the listener setup/cleanup to useLayoutEffect. Also waiting for the UI to reflect it ifs actually currently paused makes sense, like we have in the other places.

