### PR TITLE
fix: browser downloads with HTTPS_PROXY

### DIFF
--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -51,7 +51,7 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
   const proxyURL = getProxyForUrl(params.url);
   if (proxyURL) {
     const parsedProxyURL = new URL(proxyURL);
-    if (params.url.startsWith('http:')) {
+    if (parsedUrl.protocol === 'http:') {
       parsedUrl.pathname = parsedUrl.href;
       parsedUrl.host = parsedProxyURL.host;
     } else {
@@ -75,7 +75,7 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
       onResponse(res);
     }
   };
-  const request = options.protocol === 'https:' ?
+  const request = parsedUrl.protocol === 'https:' ?
     https.request(parsedUrl, options, requestCallback) :
     http.request(parsedUrl, options, requestCallback);
   request.on('error', onError);


### PR DESCRIPTION
In https://github.com/microsoft/playwright/commit/56594a09771ed2f899e609d2fad8f74fee8edf4c we changed this code and changed the contents of `options` so that it doesn't contain `options.protocol` anymore, but forgot to update this line where we're reading the field. This means we're now making all requests via the `http` library, including `https` requests. 

At first this seems like a catastrophic bug, but both our test suite and my manual testing couldn't find a defect caused by it. This is because the only difference between [`http.request`](https://github.com/nodejs/node/blob/0d128e39efaa82dc9550232a7382f70462c8eb4e/lib/http.js#L101) and [`https.request`](https://github.com/nodejs/node/blob/0d128e39efaa82dc9550232a7382f70462c8eb4e/lib/https.js#L364) is that https [has a different default Agent](https://github.com/nodejs/node/blob/0d128e39efaa82dc9550232a7382f70462c8eb4e/lib/https.js#L378). Since we [override the agent](https://github.com/Skn0tt/playwright/blob/27f776819e388e4f38821fd015cc5c831922c10b/packages/playwright-core/src/server/utils/network.ts#L44), this explains why this bug doesn't show up anywhere.

Let's still fix it for hygiene, who knows how this might change in future Node.js versions!


Edit: Turns out there's user reports, let's get this fixed. Closes https://github.com/microsoft/playwright/issues/36650

