### PR TITLE
Reland "fix: get rid of url.parse in network code"

### DIFF
--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -51,7 +51,7 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
   const proxyURL = getProxyForUrl(params.url);
   if (proxyURL) {
     const parsedProxyURL = new URL(proxyURL);
-    if (params.url.startsWith('http:')) {
+    if (parsedUrl.protocol === 'http:') {
       parsedUrl.pathname = parsedUrl.href;
       parsedUrl.host = parsedProxyURL.host;
     } else {
@@ -75,7 +75,7 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
       onResponse(res);
     }
   };
-  const request = options.protocol === 'https:' ?
+  const request = parsedUrl.protocol === 'https:' ?
     https.request(parsedUrl, options, requestCallback) :
     http.request(parsedUrl, options, requestCallback);
   request.on('error', onError);


### PR DESCRIPTION
Relands https://github.com/microsoft/playwright/pull/36423, but with the fix from https://github.com/microsoft/playwright/pull/36652. Should be safe because we added a regression test in the meantime.

Closes https://github.com/microsoft/playwright/issues/36404, https://github.com/microsoft/playwright/issues/36650.