### PR TITLE
chore(bidi): pass proxy to createUserContext

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -458,7 +458,7 @@ function getProxyConfiguration(proxySettings?: types.ProxySettings): bidi.Sessio
       proxy.httpProxy = url.host;
       break;
     case 'https:':
-      proxy.httpsProxy = url.host;
+      proxy.sslProxy = url.host;
       break;
     case 'socks4:':
       proxy.socksProxy = url.host;

--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -47,40 +47,11 @@ export class BidiBrowser extends Browser {
     if ((options as any).__testHookOnConnectToBrowser)
       await (options as any).__testHookOnConnectToBrowser();
 
-    let proxy: bidi.Session.ManualProxyConfiguration | undefined;
-    if (options.proxy) {
-      proxy = {
-        proxyType: 'manual',
-      };
-      const url = new URL(options.proxy.server);  // Validate proxy server.
-      switch (url.protocol) {
-        case 'http:':
-          proxy.httpProxy = url.host;
-          break;
-        case 'https:':
-          proxy.httpsProxy = url.host;
-          break;
-        case 'socks4:':
-          proxy.socksProxy = url.host;
-          proxy.socksVersion = 4;
-          break;
-        case 'socks5:':
-          proxy.socksProxy = url.host;
-          proxy.socksVersion = 5;
-          break;
-        default:
-          throw new Error('Invalid proxy server protocol: ' + options.proxy.server);
-      }
-      if (options.proxy.bypass)
-        proxy.noProxy = options.proxy.bypass.split(',');
-      // TODO: support authentication.
-    }
-
     browser._bidiSessionInfo = await browser._browserSession.send('session.new', {
       capabilities: {
         alwaysMatch: {
           acceptInsecureCerts: false,
-          proxy,
+          proxy: getProxyConfiguration(options.proxy),
           unhandledPromptBehavior: {
             default: bidi.Session.UserPromptHandlerType.Ignore,
           },
@@ -126,6 +97,7 @@ export class BidiBrowser extends Browser {
   async doCreateNewContext(options: types.BrowserContextOptions): Promise<BrowserContext> {
     const { userContext } = await this._browserSession.send('browser.createUserContext', {
       acceptInsecureCerts: options.ignoreHTTPSErrors,
+      proxy: getProxyConfiguration(options.proxy),
     });
     const context = new BidiBrowserContext(this, userContext, options);
     await context._initialize();
@@ -471,6 +443,39 @@ function toBidiSameSite(sameSite: channels.SetNetworkCookie['sameSite']): bidi.N
     case 'None': return bidi.Network.SameSite.None;
   }
   return bidi.Network.SameSite.None;
+}
+
+function getProxyConfiguration(proxySettings?: types.ProxySettings): bidi.Session.ManualProxyConfiguration | undefined {
+  if (!proxySettings)
+    return undefined;
+
+  const proxy: bidi.Session.ManualProxyConfiguration = {
+    proxyType: 'manual',
+  };
+  const url = new URL(proxySettings.server);  // Validate proxy server.
+  switch (url.protocol) {
+    case 'http:':
+      proxy.httpProxy = url.host;
+      break;
+    case 'https:':
+      proxy.httpsProxy = url.host;
+      break;
+    case 'socks4:':
+      proxy.socksProxy = url.host;
+      proxy.socksVersion = 4;
+      break;
+    case 'socks5:':
+      proxy.socksProxy = url.host;
+      proxy.socksVersion = 5;
+      break;
+    default:
+      throw new Error('Invalid proxy server protocol: ' + proxySettings.server);
+  }
+  if (proxySettings.bypass)
+    proxy.noProxy = proxySettings.bypass.split(',');
+  // TODO: support authentication.
+
+  return proxy;
 }
 
 export namespace Network {


### PR DESCRIPTION
Fixes #36207

On Firefox this fixes the following tests in `tests/library/browsercontext-proxy.spec.ts` (note that tests 3, 4, 6 and 7 need `PWTEST_FIREFOX_USER_PREFS="{\"network.proxy.allow_hijacking_localhost\": true}"` to pass):
1. should work when passing the proxy only on the context level
2. should use proxy
3. should proxy local network requests › by default › localhost
4. should proxy local network requests › by default › loopback address
5. should proxy local network requests › by default › link-local
6. should proxy local network requests › with other bypasses › localhost
7. should proxy local network requests › with other bypasses › loopback address
8. should proxy local network requests › with other bypasses › link-local
9. should use ipv6 proxy
10. should use proxy twice
11. should use proxy for second page
12. should work with IP:PORT notion
13. should authenticate
14. should authenticate with empty password

The following tests are still failing in Firefox:
1. should send secure cookies to subdomain.localhost (needs investigation)
7. should use proxy for https urls ([1977168](https://bugzilla.mozilla.org/show_bug.cgi?id=1977168))
8. should isolate proxy credentials between contexts ([1977378](https://bugzilla.mozilla.org/show_bug.cgi?id=1977378))
16. should exclude patterns ([1977180](https://bugzilla.mozilla.org/show_bug.cgi?id=1977180))
17. should use socks proxy ([1977175](https://bugzilla.mozilla.org/show_bug.cgi?id=1977175))
18. should use socks proxy in second page ([1977175](https://bugzilla.mozilla.org/show_bug.cgi?id=1977175))
19. should isolate proxy credentials between contexts on navigation ([1977378](https://bugzilla.mozilla.org/show_bug.cgi?id=1977378))
