### PR TITLE
fix(ui-mode): don't rerender trace snapshots on long running actions

### DIFF
--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -56,7 +56,7 @@ export const SnapshotTabsView: React.FunctionComponent<{
   const snapshots = React.useMemo(() => {
     return collectSnapshots(action);
   }, [action]);
-  const { snapshotInfoUrl, snapshotUrl, popoutUrl } = React.useMemo((): SnapshotUrls | { snapshotInfoUrl: undefined, snapshotUrl: undefined, popoutUrl: undefined } => {
+  const { snapshotInfoUrl, snapshotUrl, popoutUrl } = React.useMemo(() => {
     const snapshot = snapshots[snapshotTab];
     return snapshot ? extendSnapshot(snapshot, shouldPopulateCanvasFromScreenshot) : { snapshotInfoUrl: undefined, snapshotUrl: undefined, popoutUrl: undefined };
   }, [snapshots, snapshotTab, shouldPopulateCanvasFromScreenshot]);

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -110,9 +110,6 @@ export const SnapshotView: React.FunctionComponent<{
 
   React.useEffect(() => {
     (async () => {
-      if (snapshotInfo.snapshotInfoUrl === snapshotUrls?.snapshotInfoUrl)
-        return;
-
       const thisIteration = loadingRef.current.iteration + 1;
       const newVisibleIframe = 1 - loadingRef.current.visibleIframe;
       loadingRef.current.iteration = thisIteration;
@@ -315,7 +312,6 @@ export type Snapshot = {
 
 export type SnapshotInfo = {
   url: string;
-  snapshotInfoUrl?: string;
   viewport: { width: number, height: number };
   timestamp?: number;
   wallTime?: undefined;
@@ -413,8 +409,8 @@ export function extendSnapshot(snapshot: Snapshot, shouldPopulateCanvasFromScree
   return { snapshotInfoUrl, snapshotUrl, popoutUrl };
 }
 
-export async function fetchSnapshotInfo(snapshotInfoUrl: string | undefined): Promise<SnapshotInfo> {
-  const result = { url: '', snapshotInfoUrl, viewport: kDefaultViewport, timestamp: undefined, wallTime: undefined };
+export async function fetchSnapshotInfo(snapshotInfoUrl: string | undefined) {
+  const result = { url: '', viewport: kDefaultViewport, timestamp: undefined, wallTime: undefined };
   if (snapshotInfoUrl) {
     const response = await fetch(snapshotInfoUrl);
     const info = await response.json();

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -110,6 +110,9 @@ export const SnapshotView: React.FunctionComponent<{
 
   React.useEffect(() => {
     (async () => {
+      if (snapshotInfo.snapshotInfoUrl === snapshotUrls?.snapshotInfoUrl)
+        return;
+
       const thisIteration = loadingRef.current.iteration + 1;
       const newVisibleIframe = 1 - loadingRef.current.visibleIframe;
       loadingRef.current.iteration = thisIteration;
@@ -312,6 +315,7 @@ export type Snapshot = {
 
 export type SnapshotInfo = {
   url: string;
+  snapshotInfoUrl?: string;
   viewport: { width: number, height: number };
   timestamp?: number;
   wallTime?: undefined;
@@ -409,8 +413,8 @@ export function extendSnapshot(snapshot: Snapshot, shouldPopulateCanvasFromScree
   return { snapshotInfoUrl, snapshotUrl, popoutUrl };
 }
 
-export async function fetchSnapshotInfo(snapshotInfoUrl: string | undefined) {
-  const result = { url: '', viewport: kDefaultViewport, timestamp: undefined, wallTime: undefined };
+export async function fetchSnapshotInfo(snapshotInfoUrl: string | undefined): Promise<SnapshotInfo> {
+  const result = { url: '', snapshotInfoUrl, viewport: kDefaultViewport, timestamp: undefined, wallTime: undefined };
   if (snapshotInfoUrl) {
     const response = await fetch(snapshotInfoUrl);
     const info = await response.json();

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -56,10 +56,12 @@ export const SnapshotTabsView: React.FunctionComponent<{
   const snapshots = React.useMemo(() => {
     return collectSnapshots(action);
   }, [action]);
-  const snapshotUrls = React.useMemo(() => {
+  const { snapshotInfoUrl, snapshotUrl, popoutUrl } = React.useMemo((): SnapshotUrls | { snapshotInfoUrl: undefined, snapshotUrl: undefined, popoutUrl: undefined } => {
     const snapshot = snapshots[snapshotTab];
-    return snapshot ? extendSnapshot(snapshot, shouldPopulateCanvasFromScreenshot) : undefined;
+    return snapshot ? extendSnapshot(snapshot, shouldPopulateCanvasFromScreenshot) : { snapshotInfoUrl: undefined, snapshotUrl: undefined, popoutUrl: undefined };
   }, [snapshots, snapshotTab, shouldPopulateCanvasFromScreenshot]);
+
+  const snapshotUrls = React.useMemo((): SnapshotUrls | undefined => snapshotInfoUrl !== undefined ? { snapshotInfoUrl, snapshotUrl, popoutUrl } : undefined, [snapshotInfoUrl, snapshotUrl, popoutUrl]);
 
   return <div className='snapshot-tab vbox'>
     <Toolbar>

--- a/tests/playwright-test/ui-mode-test-progress.spec.ts
+++ b/tests/playwright-test/ui-mode-test-progress.spec.ts
@@ -245,6 +245,57 @@ test('should show trace w/ multiple contexts', async ({ runUITest, server, creat
   latch.open();
 });
 
+test('should not reload trace during long events', async ({ runUITest, createLatch }) => {
+  const latch = createLatch();
+
+  const { page } = await runUITest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('timeout test', async ({ page }) => {
+        await page.goto('about:blank');
+        await page.setContent('initial');
+        ${latch.blockingCode}
+        await page.waitForTimeout(5000);
+        await new Promise(() => {});
+      });
+    `,
+  });
+
+  await page.getByText('timeout test').dblclick();
+
+  const listItem = page.getByTestId('actions-tree').getByRole('treeitem');
+  await expect(listItem).toHaveText([
+    /Before Hooks[\d.]+m?s/,
+    /Navigate to "about:blank"/,
+    /Set content/,
+  ]);
+
+  await page.evaluate(() => {
+    (window as any)._reloadCount0 = 0;
+    (window as any)._reloadCount1 = 0;
+    const iframes = document.querySelectorAll('iframe');
+    for (let i = 0; i < iframes.length; i++) {
+      iframes[i].addEventListener('load', () => {
+        (window as any)[`_reloadCount${i}`] += 1;
+      });
+    }
+  });
+
+  latch.open();
+
+  await expect(listItem).toHaveText([
+    /Before Hooks[\d.]+m?s/,
+    /Navigate to "about:blank"/,
+    /Set content/,
+    /Wait for timeout5.0s/,
+  ]);
+
+  const [reloadCount0, reloadCount1] = await page.evaluate(() => [(window as any)._reloadCount0, (window as any)._reloadCount1]);
+  // Both iframes will load exactly once
+  expect(reloadCount0).toBe(1);
+  expect(reloadCount1).toBe(1);
+});
+
 test('should show live trace for serial', async ({ runUITest, server, createLatch }) => {
   const latch = createLatch();
 


### PR DESCRIPTION
Resolves #36633

Naively do not rerender snapshots to iframes if the source snapshot URL stays constant. This will only affect long running actions (such as `waitForTimeout` or an assertion).

Ideally this will be followed by changes to prevent rerenders across duplicate snapshots over many actions.