### PR TITLE
fix(run-server): don't share browsers

### DIFF
--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -292,7 +292,6 @@ export class PlaywrightServer {
     return {
       preLaunchedBrowser: browser,
       socksProxy,
-      sharedBrowser: true,
       denyLaunch: true,
       dispose: async () => {
         await browser.close({ reason: 'Connection terminated' });


### PR DESCRIPTION
In https://github.com/microsoft/playwright/pull/36369, we accidentally enabled multiclient for the connection mode that's used with `run-server`. While it helped us uncover https://github.com/microsoft/playwright/pull/36688, we still shouldn't.