### PR TITLE
chore(build): make build automatically install browsers

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -589,7 +589,7 @@ onChanges.push({
   script: 'utils/generate_types/index.js',
 });
 
-if (!disableInstall) {
+if (watchMode && !disableInstall) {
   // Keep browser installs up to date.
   onChanges.push({
     inputs: ['packages/playwright-core/browsers.json'],

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -68,7 +68,7 @@ const copyFiles = [];
 
 const watchMode = process.argv.slice(2).includes('--watch');
 const withSourceMaps = watchMode;
-const installMode = process.argv.slice(2).includes('--install');
+const disableInstall = process.argv.slice(2).includes('--disable-install');
 const ROOT = path.join(__dirname, '..', '..');
 
 /**
@@ -589,7 +589,7 @@ onChanges.push({
   script: 'utils/generate_types/index.js',
 });
 
-if (installMode) {
+if (!disableInstall) {
   // Keep browser installs up to date.
   onChanges.push({
     inputs: ['packages/playwright-core/browsers.json'],


### PR DESCRIPTION
Follow up from #35639. Always automatically install browsers when building (primarily `npm run watch`). Can be opted out by providing `--disable-install`.