### PR TITLE
fix(ui-mode): properly align error and warning icons in the ActionsList

### DIFF
--- a/packages/trace-viewer/src/ui/actionList.css
+++ b/packages/trace-viewer/src/ui/actionList.css
@@ -14,6 +14,10 @@
   limitations under the License.
 */
 
+.action-title > .hbox {
+  align-items: center;
+}
+
 .action-title-line {
   display: block;
   overflow: hidden;


### PR DESCRIPTION
Likely regressed in #36025.

Align error and warning icons vertically within the action.

After:
<img width="250" height="117" alt="Screenshot 2025-07-15 at 12 06 10 PM" src="https://github.com/user-attachments/assets/6860255c-df51-4037-a355-e70e0a162cb7" />

Before:
<img width="244" height="135" alt="Screenshot 2025-07-15 at 12 05 55 PM" src="https://github.com/user-attachments/assets/416d7e54-b49f-4fed-92b3-ab2916a7aacc" />
