### PR TITLE
chore: disable url.parse deprecation warning

### DIFF
--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -49,6 +49,7 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
   if (params.rejectUnauthorized !== undefined)
     options.rejectUnauthorized = params.rejectUnauthorized;
 
+  // passing in parsed URL instead of string, otherwise getProxyForUrl prints a deprecation warning
   const proxyURL = getProxyForUrl(urlParse(params.url));
   if (proxyURL) {
     const parsedProxyURL = urlParse(proxyURL);


### PR DESCRIPTION
As per https://github.com/microsoft/playwright/pull/36666#issuecomment-3074314169.

Closes https://github.com/microsoft/playwright/issues/36404.