### PR TITLE
fix(html): improve metadata section spacing

### DIFF
--- a/packages/html-reporter/src/headerView.css
+++ b/packages/html-reporter/src/headerView.css
@@ -24,6 +24,7 @@
 
 .header-view div {
   flex-shrink: 0;
+  flex-wrap: wrap;
 }
 
 .header-superheader {

--- a/packages/html-reporter/src/metadataView.css
+++ b/packages/html-reporter/src/metadataView.css
@@ -17,14 +17,13 @@
 .metadata-toggle {
   cursor: pointer;
   user-select: none;
-  margin-left: 8px;
   color: var(--color-fg-default);
 }
 
 .metadata-view {
   border: 1px solid var(--color-border-default);
   border-radius: 6px;
-  margin-top: 8px;
+  margin-top: 12px;
 }
 
 .metadata-view .metadata-section {

--- a/packages/html-reporter/src/metadataView.css
+++ b/packages/html-reporter/src/metadataView.css
@@ -20,6 +20,11 @@
   color: var(--color-fg-default);
 }
 
+.metadata-toggle-second-line {
+  margin-top: 8px;
+  margin-left: 8px;
+}
+
 .metadata-view {
   border: 1px solid var(--color-border-default);
   border-radius: 6px;

--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -62,6 +62,11 @@
 .test-file-header-info {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px 8px;
   color: var(--color-fg-muted);
+}
+
+.test-file-header-br {
+  flex-basis: 100%;
+  height: 0;
 }

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -71,9 +71,18 @@ export const TestFilesHeader: React.FC<{
   if (!report)
     return null;
 
+  const showProject = report.projectNames.length === 1 && !!report.projectNames[0];
+  const hasNonMetadataContent = showProject || filteredStats;
+
   const leftSuperHeader = <div className='test-file-header-info'>
-    {report.projectNames.length === 1 && !!report.projectNames[0] && <div data-testid='project-name'>Project: {report.projectNames[0]}</div>}
+    {showProject && <div data-testid='project-name'>Project: {report.projectNames[0]}</div>}
     {filteredStats && <div data-testid='filtered-tests-count'>Filtered: {filteredStats.total} {!!filteredStats.total && ('(' + msToString(filteredStats.duration) + ')')}</div>}
+    {!isMetadataEmpty(report.metadata) && <>
+      {hasNonMetadataContent && <div className='test-file-header-br' />}
+      <div className='metadata-toggle' role='button' onClick={toggleMetadataVisible} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
+        {metadataVisible ? icons.downArrow() : icons.rightArrow()}Metadata
+      </div>
+    </>}
   </div>;
 
   const rightSuperHeader = <>
@@ -83,9 +92,6 @@ export const TestFilesHeader: React.FC<{
 
   return <>
     <HeaderView title={report.title} leftSuperHeader={leftSuperHeader} rightSuperHeader={rightSuperHeader} />
-    {!isMetadataEmpty(report.metadata) && <div className='metadata-toggle' role='button' onClick={toggleMetadataVisible} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
-      {metadataVisible ? icons.downArrow() : icons.rightArrow()}Metadata
-    </div>}
     {metadataVisible && <MetadataView metadata={report.metadata}/>}
     {!!report.errors.length && <AutoChip header='Errors' dataTestId='report-errors'>
       {report.errors.map((error, index) => <CodeSnippet key={'test-report-error-message-' + index} code={error}/>)}

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -24,6 +24,7 @@ import { CodeSnippet } from './testErrorView';
 import * as icons from './icons';
 import { isMetadataEmpty, MetadataView } from './metadataView';
 import { HeaderView } from './headerView';
+import { clsx } from '@web/uiUtils';
 
 export const TestFilesView: React.FC<{
   tests: TestFileSummary[],
@@ -72,17 +73,18 @@ export const TestFilesHeader: React.FC<{
     return null;
 
   const showProject = report.projectNames.length === 1 && !!report.projectNames[0];
-  const hasNonMetadataContent = showProject || filteredStats;
+  const isMetadataInTopLine = !showProject && !filteredStats;
+
+  const metadataToggleButton = !isMetadataEmpty(report.metadata) && (
+    <div className={clsx('metadata-toggle', !isMetadataInTopLine && 'metadata-toggle-second-line')} role='button' onClick={toggleMetadataVisible} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
+      {metadataVisible ? icons.downArrow() : icons.rightArrow()}Metadata
+    </div>
+  );
 
   const leftSuperHeader = <div className='test-file-header-info'>
     {showProject && <div data-testid='project-name'>Project: {report.projectNames[0]}</div>}
     {filteredStats && <div data-testid='filtered-tests-count'>Filtered: {filteredStats.total} {!!filteredStats.total && ('(' + msToString(filteredStats.duration) + ')')}</div>}
-    {!isMetadataEmpty(report.metadata) && <>
-      {hasNonMetadataContent && <div className='test-file-header-br' />}
-      <div className='metadata-toggle' role='button' onClick={toggleMetadataVisible} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
-        {metadataVisible ? icons.downArrow() : icons.rightArrow()}Metadata
-      </div>
-    </>}
+    {isMetadataInTopLine && metadataToggleButton}
   </div>;
 
   const rightSuperHeader = <>
@@ -92,6 +94,7 @@ export const TestFilesHeader: React.FC<{
 
   return <>
     <HeaderView title={report.title} leftSuperHeader={leftSuperHeader} rightSuperHeader={rightSuperHeader} />
+    {!isMetadataInTopLine && metadataToggleButton}
     {metadataVisible && <MetadataView metadata={report.metadata}/>}
     {!!report.errors.length && <AutoChip header='Errors' dataTestId='report-errors'>
       {report.errors.map((error, index) => <CodeSnippet key={'test-report-error-message-' + index} code={error}/>)}


### PR DESCRIPTION
The HTML Report metadata toggle button and chip has poor positioning. Make it more regular. The mobile view continues to function as expected.

After:

<img width="183" height="130" alt="Screenshot 2025-07-16 at 8 38 38 AM" src="https://github.com/user-attachments/assets/11fa6c05-9499-440c-8cea-458316f5ae29" />
<img width="178" height="114" alt="Screenshot 2025-07-16 at 8 39 16 AM" src="https://github.com/user-attachments/assets/d59de9a9-90ce-4a6b-af7b-bcf6b437c14d" />

Before:

<img width="241" height="112" alt="Screenshot 2025-07-16 at 6 55 31 AM" src="https://github.com/user-attachments/assets/84669cdd-d875-4e19-87a0-a9f939185f2f" />
<img width="191" height="106" alt="Screenshot 2025-07-16 at 6 57 04 AM" src="https://github.com/user-attachments/assets/49f3a411-beea-456e-a938-6e796a2048e5" />
