### PR TITLE
fix: throw on locator.press with unknown key

### DIFF
--- a/packages/playwright-core/src/server/input.ts
+++ b/packages/playwright-core/src/server/input.ts
@@ -16,6 +16,7 @@
 
 import { assert } from '../utils';
 import * as keyboardLayout from './usKeyboardLayout';
+import { NonRecoverableDOMError } from './dom';
 
 import type { Progress } from './progress';
 import type { Page } from './page';
@@ -64,7 +65,8 @@ export class Keyboard {
   private _keyDescriptionForString(str: string): KeyDescription {
     const keyString = resolveSmartModifierString(str);
     let description = usKeyboardLayout.get(keyString);
-    assert(description, `Unknown key: "${keyString}"`);
+    if (!description)
+      throw new NonRecoverableDOMError(`Unknown key: "${keyString}"`);
     const shift = this._pressedModifiers.has('Shift');
     description = shift && description.shifted ? description.shifted : description;
 

--- a/tests/page/locator-misc-2.spec.ts
+++ b/tests/page/locator-misc-2.spec.ts
@@ -201,3 +201,11 @@ it('should fill programmatically enabled textarea', { annotation: { type: 'issue
   await page.locator('#text').fill('Hello');
   await expect(page.locator('#text')).toHaveValue('Hello');
 });
+
+it('press should throw on unknown keys', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36697' } }, async ({ page, server }) => {
+  await page.setContent(`<input type='text' value='hello' />`);
+  const locator = page.getByRole('textbox');
+  await expect(locator.press('NotARealKey')).rejects.toThrowError(/Unknown key: "NotARealKey"/);
+  await expect(locator.press('ё')).rejects.toThrowError(/Unknown key: "ё"/);
+  await expect(locator.press('😊')).rejects.toThrowError(/Unknown key: "😊"/);
+});


### PR DESCRIPTION
We were retrying indefinitely because `Unknown key:` wasn't marked as non-recoverable.
Closes https://github.com/microsoft/playwright/issues/36697.