### PR TITLE
fix(snapshotForAI): prevent hanging on pages with lazy-loaded iframes

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -712,6 +712,10 @@ export class Frame extends SdkObject {
     });
   }
 
+  _isExistContext(world: types.World): boolean {
+    return !!this._contextData.get(world)?.context;
+  }
+
   _mainContext(): Promise<dom.FrameExecutionContext> {
     return this._context('main');
   }

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -1000,6 +1000,9 @@ class FrameThrottler {
 }
 
 async function snapshotFrameForAI(progress: Progress, frame: frames.Frame, frameOrdinal: number, frameIds: string[]): Promise<string[]> {
+  const hasUtilityContext = frame._isExistContext('utility');
+  if (!hasUtilityContext)
+    return [];
   // Only await the topmost navigations, inner frames will be empty when racing.
   const snapshot = await frame.retryWithProgressAndTimeouts(progress, [1000, 2000, 4000, 8000], async continuePolling => {
     try {

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -354,3 +354,23 @@ it('should mark iframe as active when it contains focused element', async ({ pag
         - textbox "Input in iframe" [active] [ref=f1e2]
   `);
 });
+
+it('return empty snapshot when iframe is not loaded', async ({ page, server }) => {
+  await page.setContent(`
+    <div style="height: 5000px;">Test</div>
+    <iframe loading="lazy" src="${server.PREFIX}/frame.html"></iframe>
+  `);
+
+  // Wait for the iframe to load
+  await page.waitForSelector('iframe');
+
+  // Get the snapshot of the page
+  const snapshot = await snapshotForAI(page);
+
+  // The iframe should be present but empty
+  expect(snapshot).toContainYaml(`
+    - generic [active] [ref=e1]:
+      - generic [ref=e2]: Test
+      - iframe [ref=e3]:
+  `);
+});


### PR DESCRIPTION
## Problem

The `snapshotForAI` function hangs indefinitely (the Promise never resolves) if the page contains iframe elements that have not yet been loaded (lazy-loaded iframes).

## Root Cause

The function attempts to access utility contexts of all frames without first verifying whether the frame contexts are available. For unloaded (lazy-loaded) iframes, this results in waiting indefinitely for a context that will never become available.

## Solution

Before attempting to snapshot an iframe, first check whether its utility context exists. If it doesn't exist (the iframe is not yet loaded), return an empty array as its snapshot. This ensures that the snapshot process completes without hanging.