### PR TITLE
fix(html): prevent unnecessary text selection on chips

### DIFF
--- a/packages/html-reporter/src/chip.css
+++ b/packages/html-reporter/src/chip.css
@@ -27,6 +27,11 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  user-select: none;
+}
+
+.chip-header-allow-selection {
+  user-select: text;
 }
 
 .chip-header.expanded-false {

--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -37,7 +37,7 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
     expanded={isFileExpanded(file.fileId)}
     noInsets={true}
     setExpanded={(expanded => setFileExpanded(file.fileId, expanded))}
-    header={<span>
+    header={<span className='chip-header-allow-selection'>
       {file.fileName}
     </span>}>
     {file.tests.map(test =>


### PR DESCRIPTION
Clicking on chip (collapsible header) sections in the HTML report will often select the text of the control, which is generally not desirable. Completely disable text selection on chip headers unless it is a test filename, which users may want to copy.