### PR TITLE
feat: chromium{Enable,Disable}Features launch options

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -300,6 +300,12 @@ describes some differences for Linux users.
 ### option: BrowserType.launch.firefoxUserPrefs2 = %%-csharp-java-browser-option-firefoxuserprefs-%%
 * since: v1.8
 
+### option: BrowserType.launch.chromiumDisableFeatures = %%-browser-option-chromiumdisablefeatures-%%
+* since: v1.55
+
+### option: BrowserType.launch.chromiumEnableFeatures = %%-browser-option-chromiumenablefeatures-%%
+* since: v1.55
+
 ### option: BrowserType.launch.logger = %%-browser-option-logger-%%
 * since: v1.8
 
@@ -354,6 +360,12 @@ Note that browsers do not allow launching multiple instances with the same User 
 ### option: BrowserType.launchPersistentContext.firefoxUserPrefs2 = %%-csharp-java-browser-option-firefoxuserprefs-%%
 * since: v1.40
 
+### option: BrowserType.launchPersistentContext.chromiumDisableFeatures = %%-browser-option-chromiumdisablefeatures-%%
+* since: v1.55
+
+### option: BrowserType.launchPersistentContext.chromiumEnableFeatures = %%-browser-option-chromiumenablefeatures-%%
+* since: v1.55
+
 ### option: BrowserType.launchPersistentContext.clientCertificates = %%-context-option-clientCertificates-%%
 * since: 1.46
 
@@ -390,6 +402,12 @@ const { chromium } = require('playwright');  // Or 'webkit' or 'firefox'.
 
 ### option: BrowserType.launchServer.firefoxUserPrefs2 = %%-csharp-java-browser-option-firefoxuserprefs-%%
 * since: v1.8
+
+### option: BrowserType.launchServer.chromiumDisableFeatures = %%-browser-option-chromiumdisablefeatures-%%
+* since: v1.55
+
+### option: BrowserType.launchServer.chromiumEnableFeatures = %%-browser-option-chromiumenablefeatures-%%
+* since: v1.55
 
 ### option: BrowserType.launchServer.logger = %%-browser-option-logger-%%
 * since: v1.8

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -1028,6 +1028,18 @@ Use "chrome", "chrome-beta", "chrome-dev", "chrome-canary", "msedge", "msedge-be
 Enable Chromium sandboxing. Defaults to `false`.
 
 
+## browser-option-chromiumdisablefeatures
+- `chromiumDisableFeatures` <[Array]<[string]>>
+
+Disable specific [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies after features enabled/disabled by default in Playwright.
+
+
+## browser-option-chromiumenablefeatures
+- `chromiumEnableFeatures` <[Array]<[string]>>
+
+Enable specific [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies after features enabled/disabled by default in Playwright, and after [`option: chromiumDisableFeatures`].
+
+
 ## browser-option-downloadspath
 - `downloadsPath` <[path]>
 

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -14807,6 +14807,21 @@ export interface BrowserType<Unused = {}> {
     channel?: string;
 
     /**
+     * Disable specific
+     * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+     * after features enabled/disabled by default in Playwright.
+     */
+    chromiumDisableFeatures?: Array<string>;
+
+    /**
+     * Enable specific
+     * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+     * after features enabled/disabled by default in Playwright, and after
+     * [`chromiumDisableFeatures`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-persistent-context-option-chromium-disable-features).
+     */
+    chromiumEnableFeatures?: Array<string>;
+
+    /**
      * Enable Chromium sandboxing. Defaults to `false`.
      */
     chromiumSandbox?: boolean;
@@ -15315,6 +15330,21 @@ export interface BrowserType<Unused = {}> {
      * "msedge-canary" to use branded [Google Chrome and Microsoft Edge](https://playwright.dev/docs/browsers#google-chrome--microsoft-edge).
      */
     channel?: string;
+
+    /**
+     * Disable specific
+     * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+     * after features enabled/disabled by default in Playwright.
+     */
+    chromiumDisableFeatures?: Array<string>;
+
+    /**
+     * Enable specific
+     * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+     * after features enabled/disabled by default in Playwright, and after
+     * [`chromiumDisableFeatures`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server-option-chromium-disable-features).
+     */
+    chromiumEnableFeatures?: Array<string>;
 
     /**
      * Enable Chromium sandboxing. Defaults to `false`.
@@ -21726,6 +21756,21 @@ export interface LaunchOptions {
    * "msedge-canary" to use branded [Google Chrome and Microsoft Edge](https://playwright.dev/docs/browsers#google-chrome--microsoft-edge).
    */
   channel?: string;
+
+  /**
+   * Disable specific
+   * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+   * after features enabled/disabled by default in Playwright.
+   */
+  chromiumDisableFeatures?: Array<string>;
+
+  /**
+   * Enable specific
+   * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+   * after features enabled/disabled by default in Playwright, and after
+   * [`chromiumDisableFeatures`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-chromium-disable-features).
+   */
+  chromiumEnableFeatures?: Array<string>;
 
   /**
    * Enable Chromium sandboxing. Defaults to `false`.

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -554,6 +554,8 @@ scheme.BrowserTypeLaunchParams = tObject({
   tracesDir: tOptional(tString),
   chromiumSandbox: tOptional(tBoolean),
   firefoxUserPrefs: tOptional(tAny),
+  chromiumDisableFeatures: tOptional(tArray(tString)),
+  chromiumEnableFeatures: tOptional(tArray(tString)),
   cdpPort: tOptional(tNumber),
   slowMo: tOptional(tNumber),
 });
@@ -584,6 +586,8 @@ scheme.BrowserTypeLaunchPersistentContextParams = tObject({
   tracesDir: tOptional(tString),
   chromiumSandbox: tOptional(tBoolean),
   firefoxUserPrefs: tOptional(tAny),
+  chromiumDisableFeatures: tOptional(tArray(tString)),
+  chromiumEnableFeatures: tOptional(tArray(tString)),
   cdpPort: tOptional(tNumber),
   noDefaultViewport: tOptional(tBoolean),
   viewport: tOptional(tObject({

--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -365,6 +365,8 @@ function filterLaunchOptions(options: LaunchOptionsWithTimeout, allowFSPaths: bo
     proxy: options.proxy,
     chromiumSandbox: options.chromiumSandbox,
     firefoxUserPrefs: options.firefoxUserPrefs,
+    chromiumDisableFeatures: options.chromiumDisableFeatures,
+    chromiumEnableFeatures: options.chromiumEnableFeatures,
     slowMo: options.slowMo,
     executablePath: (isUnderTest() || allowFSPaths) ? options.executablePath : undefined,
     downloadsPath: allowFSPaths ? options.downloadsPath : undefined,

--- a/packages/playwright-core/src/server/bidi/bidiChromium.ts
+++ b/packages/playwright-core/src/server/bidi/bidiChromium.ts
@@ -116,7 +116,7 @@ export class BidiChromium extends BrowserType {
       throw new Error('Playwright manages remote debugging connection itself.');
     if (args.find(arg => !arg.startsWith('-')))
       throw new Error('Arguments can not specify page to be opened');
-    const chromeArguments = [...chromiumSwitches(options.assistantMode)];
+    const chromeArguments = [...chromiumSwitches(options)];
 
     if (os.platform() === 'darwin') {
       // See https://issues.chromium.org/issues/40277080

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -296,7 +296,7 @@ export class Chromium extends BrowserType {
       throw new Error('Playwright manages remote debugging connection itself.');
     if (args.find(arg => !arg.startsWith('-')))
       throw new Error('Arguments can not specify page to be opened');
-    const chromeArguments = [...chromiumSwitches(options.assistantMode, options.channel)];
+    const chromeArguments = [...chromiumSwitches(options)];
 
     if (os.platform() === 'darwin') {
       // See https://issues.chromium.org/issues/40277080

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14807,6 +14807,21 @@ export interface BrowserType<Unused = {}> {
     channel?: string;
 
     /**
+     * Disable specific
+     * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+     * after features enabled/disabled by default in Playwright.
+     */
+    chromiumDisableFeatures?: Array<string>;
+
+    /**
+     * Enable specific
+     * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+     * after features enabled/disabled by default in Playwright, and after
+     * [`chromiumDisableFeatures`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-persistent-context-option-chromium-disable-features).
+     */
+    chromiumEnableFeatures?: Array<string>;
+
+    /**
      * Enable Chromium sandboxing. Defaults to `false`.
      */
     chromiumSandbox?: boolean;
@@ -15315,6 +15330,21 @@ export interface BrowserType<Unused = {}> {
      * "msedge-canary" to use branded [Google Chrome and Microsoft Edge](https://playwright.dev/docs/browsers#google-chrome--microsoft-edge).
      */
     channel?: string;
+
+    /**
+     * Disable specific
+     * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+     * after features enabled/disabled by default in Playwright.
+     */
+    chromiumDisableFeatures?: Array<string>;
+
+    /**
+     * Enable specific
+     * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+     * after features enabled/disabled by default in Playwright, and after
+     * [`chromiumDisableFeatures`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server-option-chromium-disable-features).
+     */
+    chromiumEnableFeatures?: Array<string>;
 
     /**
      * Enable Chromium sandboxing. Defaults to `false`.
@@ -21726,6 +21756,21 @@ export interface LaunchOptions {
    * "msedge-canary" to use branded [Google Chrome and Microsoft Edge](https://playwright.dev/docs/browsers#google-chrome--microsoft-edge).
    */
   channel?: string;
+
+  /**
+   * Disable specific
+   * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+   * after features enabled/disabled by default in Playwright.
+   */
+  chromiumDisableFeatures?: Array<string>;
+
+  /**
+   * Enable specific
+   * [Chromium features](https://chromium.googlesource.com/chromium/src/+/main/docs/configuration.md#Features). Applies
+   * after features enabled/disabled by default in Playwright, and after
+   * [`chromiumDisableFeatures`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-chromium-disable-features).
+   */
+  chromiumEnableFeatures?: Array<string>;
 
   /**
    * Enable Chromium sandboxing. Defaults to `false`.

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -942,6 +942,8 @@ export type BrowserTypeLaunchParams = {
   tracesDir?: string,
   chromiumSandbox?: boolean,
   firefoxUserPrefs?: any,
+  chromiumDisableFeatures?: string[],
+  chromiumEnableFeatures?: string[],
   cdpPort?: number,
   slowMo?: number,
 };
@@ -968,6 +970,8 @@ export type BrowserTypeLaunchOptions = {
   tracesDir?: string,
   chromiumSandbox?: boolean,
   firefoxUserPrefs?: any,
+  chromiumDisableFeatures?: string[],
+  chromiumEnableFeatures?: string[],
   cdpPort?: number,
   slowMo?: number,
 };
@@ -998,6 +1002,8 @@ export type BrowserTypeLaunchPersistentContextParams = {
   tracesDir?: string,
   chromiumSandbox?: boolean,
   firefoxUserPrefs?: any,
+  chromiumDisableFeatures?: string[],
+  chromiumEnableFeatures?: string[],
   cdpPort?: number,
   noDefaultViewport?: boolean,
   viewport?: {
@@ -1081,6 +1087,8 @@ export type BrowserTypeLaunchPersistentContextOptions = {
   tracesDir?: string,
   chromiumSandbox?: boolean,
   firefoxUserPrefs?: any,
+  chromiumDisableFeatures?: string[],
+  chromiumEnableFeatures?: string[],
   cdpPort?: number,
   noDefaultViewport?: boolean,
   viewport?: {

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -522,6 +522,12 @@ LaunchOptions:
     tracesDir: string?
     chromiumSandbox: boolean?
     firefoxUserPrefs: json?
+    chromiumDisableFeatures:
+      type: array?
+      items: string
+    chromiumEnableFeatures:
+      type: array?
+      items: string
     cdpPort: number?
 
 

--- a/tests/library/chromium/extensions.spec.ts
+++ b/tests/library/chromium/extensions.spec.ts
@@ -42,6 +42,11 @@ it.skip(({ isHeadlessShell }) => isHeadlessShell, 'Headless Shell has no support
 it.describe('MV2', () => {
   it.skip(({ channel }) => channel?.startsWith('chrome'), '--load-extension is not supported in Chrome anymore. https://groups.google.com/a/chromium.org/g/chromium-extensions/c/1-g8EFx2BBY/m/S0ET5wPjCAAJ');
 
+  // Chromium is disabling manifest version 2. Allow testing it as long as Chromium can actually run it.
+  // Disabled in https://chromium-review.googlesource.com/c/chromium/src/+/6265903 and
+  // https://chromium-review.googlesource.com/c/chromium/src/+/6711453.
+  const chromiumDisableFeatures = ['ExtensionManifestV2Disabled', 'ExtensionManifestV2Unsupported'];
+
   it('should return background pages', async ({ browserType, asset }) => {
     const extensionPath = asset('extension-mv2-simple');
     const extensionOptions = {
@@ -49,6 +54,7 @@ it.describe('MV2', () => {
         `--disable-extensions-except=${extensionPath}`,
         `--load-extension=${extensionPath}`,
       ],
+      chromiumDisableFeatures,
     };
     const context = await browserType.launchPersistentContext('', extensionOptions);
     const backgroundPages = context.backgroundPages();
@@ -70,6 +76,7 @@ it.describe('MV2', () => {
         `--disable-extensions-except=${extensionPath}`,
         `--load-extension=${extensionPath}`,
       ],
+      chromiumDisableFeatures,
       recordVideo: {
         dir: testInfo.outputPath(''),
       },
@@ -96,6 +103,7 @@ it.describe('MV2', () => {
         `--disable-extensions-except=${extensionPath}`,
         `--load-extension=${extensionPath}`,
       ],
+      chromiumDisableFeatures,
     };
     const context = await browserType.launchPersistentContext('', extensionOptions);
     const backgroundPages = context.backgroundPages();


### PR DESCRIPTION
Drive-by: remove extension-related features from the default list, explicitly pass them in tests.

References #36459.