### PR TITLE
chore(html): improve HTML report payload loading speeds

### DIFF
--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -38,7 +38,7 @@ const ReportLoader: React.FC = () => {
   React.useEffect(() => {
     const zipReport = new ZipReport();
     zipReport.load().then(() => {
-      // Drop node with duplicate data if it exists to free up memory
+      // Drop node after consumption
       document.getElementById('playwrightReportBase64')?.remove();
       setReport(zipReport);
     });

--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -36,11 +36,13 @@ document.head.appendChild(link);
 const ReportLoader: React.FC = () => {
   const [report, setReport] = React.useState<LoadedReport | undefined>();
   React.useEffect(() => {
-    if (report)
-      return;
     const zipReport = new ZipReport();
-    zipReport.load().then(() => setReport(zipReport));
-  }, [report]);
+    zipReport.load().then(() => {
+      // Drop node with duplicate data if it exists to free up memory
+      document.getElementById('playwrightReportBase64')?.remove();
+      setReport(zipReport);
+    });
+  }, []);
   return <SearchParamsProvider>
     <ReportView report={report} />
   </SearchParamsProvider>;
@@ -58,8 +60,9 @@ class ZipReport implements LoadedReport {
 
   async load() {
     const zipURI = await new Promise<string>(resolve => {
-      if (window.playwrightReportBase64)
-        return resolve(window.playwrightReportBase64);
+      const element = document.getElementById('playwrightReportBase64');
+      if (!!element?.textContent)
+        return resolve(element.textContent);
       if (window.opener) {
         const listener = (event: MessageEvent) => {
           if (event.source === window.opener) {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -329,7 +329,8 @@ class HtmlBuilder {
         const popup = window.open(hmrURL);
         const listener = (evt: MessageEvent) => {
           if (evt.source === popup && evt.data === 'ready') {
-            popup!.postMessage((window as any).playwrightReportBase64, hmrURL.origin);
+            const element = document.getElementById('playwrightReportBase64');
+            popup!.postMessage(element?.textContent ?? '', hmrURL.origin);
             window.removeEventListener('message', listener);
             // This is generally not allowed
             window.close();
@@ -372,7 +373,7 @@ class HtmlBuilder {
   }
 
   private async _writeReportData(filePath: string) {
-    fs.appendFileSync(filePath, '<script>\nwindow.playwrightReportBase64 = "data:application/zip;base64,');
+    fs.appendFileSync(filePath, '<script id="playwrightReportBase64" type="application/zip">data:application/zip;base64,');
     await new Promise(f => {
       this._dataZipFile!.end(undefined, () => {
         this._dataZipFile!.outputStream
@@ -380,7 +381,7 @@ class HtmlBuilder {
             .pipe(fs.createWriteStream(filePath, { flags: 'a' })).on('close', f);
       });
     });
-    fs.appendFileSync(filePath, '";</script>');
+    fs.appendFileSync(filePath, '"</script>');
   }
 
   private _addDataFile(fileName: string, data: any) {


### PR DESCRIPTION
Currently the HTML report embeds the entire report payload into a JavaScript `script` tag. This results in the browser HTML loading process passing over the bytes multiple times and increasing memory load. Move the data to be raw text, removing at least one pass and one in memory copy. Additionally delete the `script` tag once we've consumed the data, to ensure there's only one in memory copy at the end of loading.

In a large report scenario where a payload totaled ~165MB was loaded locally (thus with negligible network latency + throughput restriction), this change results in loading taking approximately half of the time on latest Chrome. This seemed to be consistent across reloads and restarts of Chrome, but will likely vary by browser and significantly by network.

### After

<img width="1709" height="1320" alt="Screenshot 2025-07-23 at 11 50 34 AM" src="https://github.com/user-attachments/assets/902851ef-68c5-4b1d-b946-fc51d10a95df" />

### Before

<img width="1709" height="1320" alt="Screenshot 2025-07-23 at 11 55 00 AM" src="https://github.com/user-attachments/assets/cfef112a-8ed5-4e5d-8d69-b27e7c8a1c9f" />

