### PR TITLE
chore: replace some progress.cleanup calls with try/catch

### DIFF
--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -34,7 +34,7 @@ import { removeFolders } from '../utils/fileUtils';
 import { helper } from '../helper';
 import { SdkObject, serverSideCallMetadata } from '../instrumentation';
 import { gracefullyCloseSet } from '../utils/processLauncher';
-import { isAbortError, Progress, ProgressController } from '../progress';
+import { isAbortError, Progress, ProgressController, raceUncancellableOperationWithCleanup } from '../progress';
 import { registry } from '../registry';
 
 import type { BrowserOptions, BrowserProcess } from '../browser';
@@ -272,8 +272,13 @@ export class AndroidDevice extends SdkObject {
     await progress.race(this._backend.runCommand(`shell:echo "${Buffer.from(commandLine).toString('base64')}" | base64 -d > /data/local/tmp/chrome-command-line`));
     await progress.race(this._backend.runCommand(`shell:am start -a android.intent.action.VIEW -d about:blank ${pkg}`));
     const browserContext = await this._connectToBrowser(progress, socketName, options);
-    await progress.race(this._backend.runCommand(`shell:rm /data/local/tmp/chrome-command-line`));
-    return browserContext;
+    try {
+      await progress.race(this._backend.runCommand(`shell:rm /data/local/tmp/chrome-command-line`));
+      return browserContext;
+    } catch (error) {
+      await browserContext.close({ reason: 'Failed to launch' }).catch(() => {});
+      throw error;
+    }
   }
 
   private _defaultArgs(options: channels.AndroidDeviceLaunchBrowserParams, socketName: string): string[] {
@@ -314,58 +319,50 @@ export class AndroidDevice extends SdkObject {
 
   private async _connectToBrowser(progress: Progress, socketName: string, options: types.BrowserContextOptions = {}): Promise<BrowserContext> {
     const socket = await this._waitForLocalAbstract(progress, socketName);
-    const androidBrowser = new AndroidBrowser(this, socket);
-    progress.cleanupWhenAborted(() => androidBrowser.close());
-    await progress.race(androidBrowser._init());
-    this._browserConnections.add(androidBrowser);
-
-    const artifactsDir = await progress.race(fs.promises.mkdtemp(ARTIFACTS_FOLDER));
-    const cleanupArtifactsDir = async () => {
-      const errors = (await removeFolders([artifactsDir])).filter(Boolean);
-      for (let i = 0; i < (errors || []).length; ++i)
-        debug('pw:android')(`exception while removing ${artifactsDir}: ${errors[i]}`);
-    };
-    progress.cleanupWhenAborted(cleanupArtifactsDir);
-    gracefullyCloseSet.add(cleanupArtifactsDir);
-    socket.on('close', async () => {
-      gracefullyCloseSet.delete(cleanupArtifactsDir);
-      cleanupArtifactsDir().catch(e => debug('pw:android')(`could not cleanup artifacts dir: ${e}`));
-    });
-    const browserOptions: BrowserOptions = {
-      name: 'clank',
-      isChromium: true,
-      slowMo: 0,
-      persistent: { ...options, noDefaultViewport: true },
-      artifactsDir,
-      downloadsPath: artifactsDir,
-      tracesDir: artifactsDir,
-      browserProcess: new ClankBrowserProcess(androidBrowser),
-      proxy: options.proxy,
-      protocolLogger: helper.debugProtocolLogger(),
-      browserLogsCollector: new RecentLogsCollector(),
-      originalLaunchOptions: {},
-    };
-    validateBrowserContextOptions(options, browserOptions);
-
-    const browser = await progress.race(CRBrowser.connect(this.attribution.playwright, androidBrowser, browserOptions));
-    const defaultContext = browser._defaultContext!;
-    await defaultContext._loadDefaultContextAsIs(progress);
-    return defaultContext;
-  }
-
-  private async _open(progress: Progress, command: string): Promise<SocketBackend> {
-    let aborted = false;
     try {
-      return await progress.race(this._backend.open(command).then(socket => {
-        // Make sure to close the opened socket if progress was aborted before that.
-        if (aborted)
-          socket.close();
-        return socket;
-      }));
+      const androidBrowser = new AndroidBrowser(this, socket);
+      await progress.race(androidBrowser._init());
+      this._browserConnections.add(androidBrowser);
+
+      const artifactsDir = await progress.race(fs.promises.mkdtemp(ARTIFACTS_FOLDER));
+      const cleanupArtifactsDir = async () => {
+        const errors = (await removeFolders([artifactsDir])).filter(Boolean);
+        for (let i = 0; i < (errors || []).length; ++i)
+          debug('pw:android')(`exception while removing ${artifactsDir}: ${errors[i]}`);
+      };
+      gracefullyCloseSet.add(cleanupArtifactsDir);
+      socket.on('close', async () => {
+        gracefullyCloseSet.delete(cleanupArtifactsDir);
+        cleanupArtifactsDir().catch(e => debug('pw:android')(`could not cleanup artifacts dir: ${e}`));
+      });
+      const browserOptions: BrowserOptions = {
+        name: 'clank',
+        isChromium: true,
+        slowMo: 0,
+        persistent: { ...options, noDefaultViewport: true },
+        artifactsDir,
+        downloadsPath: artifactsDir,
+        tracesDir: artifactsDir,
+        browserProcess: new ClankBrowserProcess(androidBrowser),
+        proxy: options.proxy,
+        protocolLogger: helper.debugProtocolLogger(),
+        browserLogsCollector: new RecentLogsCollector(),
+        originalLaunchOptions: {},
+      };
+      validateBrowserContextOptions(options, browserOptions);
+
+      const browser = await progress.race(CRBrowser.connect(this.attribution.playwright, androidBrowser, browserOptions));
+      const defaultContext = browser._defaultContext!;
+      await defaultContext._loadDefaultContextAsIs(progress);
+      return defaultContext;
     } catch (error) {
-      aborted = true;
+      socket.close();
       throw error;
     }
+  }
+
+  private _open(progress: Progress, command: string): Promise<SocketBackend> {
+    return raceUncancellableOperationWithCleanup(progress, () => this._backend.open(command), socket => socket.close());
   }
 
   webViews(): channels.AndroidWebView[] {

--- a/packages/playwright-core/src/server/bidi/bidiChromium.ts
+++ b/packages/playwright-core/src/server/bidi/bidiChromium.ts
@@ -82,6 +82,7 @@ export class BidiChromium extends BrowserType {
   }
 
   override attemptToGracefullyCloseBrowser(transport: ConnectionTransport): void {
+    // Note that it's fine to reuse the transport, since our connection ignores kBrowserCloseMessageId.
     const bidiTransport = (transport as any)[kBidiOverCdpWrapper];
     if (bidiTransport)
       transport = bidiTransport;

--- a/packages/playwright-core/src/server/bidi/bidiFirefox.ts
+++ b/packages/playwright-core/src/server/bidi/bidiFirefox.ts
@@ -78,6 +78,7 @@ export class BidiFirefox extends BrowserType {
   }
 
   override attemptToGracefullyCloseBrowser(transport: ConnectionTransport): void {
+    // Note that it's fine to reuse the transport, since our connection ignores kBrowserCloseMessageId.
     transport.send({ method: 'browser.close', params: {}, id: kBrowserCloseMessageId });
   }
 

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -20,9 +20,7 @@ import { Download } from './download';
 import { SdkObject } from './instrumentation';
 import { Page } from './page';
 import { ClientCertificatesProxy } from './socksClientCertificatesInterceptor';
-import { ProgressController } from './progress';
 
-import type { CallMetadata } from './instrumentation';
 import type * as types from './types';
 import type { ProxySettings } from './types';
 import type { RecentLogsCollector } from './utils/debugLogger';
@@ -90,11 +88,6 @@ export abstract class Browser extends SdkObject {
 
   sdkLanguage() {
     return this.options.sdkLanguage || this.attribution.playwright.options.sdkLanguage;
-  }
-
-  newContextFromMetadata(metadata: CallMetadata, options: types.BrowserContextOptions): Promise<BrowserContext> {
-    const controller = new ProgressController(metadata, this);
-    return controller.run(progress => this.newContext(progress, options));
   }
 
   async newContext(progress: Progress, options: types.BrowserContextOptions): Promise<BrowserContext> {

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -334,10 +334,14 @@ export abstract class BrowserContext extends SdkObject {
     const binding = new PageBinding(name, playwrightBinding, needsHandle);
     binding.forClient = forClient;
     this._pageBindings.set(name, binding);
-    progress.cleanupWhenAborted(() => this._pageBindings.delete(name));
-    await progress.race(this.doAddInitScript(binding.initScript));
-    await progress.race(this.safeNonStallingEvaluateInAllFrames(binding.initScript.source, 'main'));
-    return binding;
+    try {
+      await progress.race(this.doAddInitScript(binding.initScript));
+      await progress.race(this.safeNonStallingEvaluateInAllFrames(binding.initScript.source, 'main'));
+      return binding;
+    } catch (error) {
+      this._pageBindings.delete(name);
+      throw error;
+    }
   }
 
   async removeExposedBindings(bindings: PageBinding[]) {
@@ -370,21 +374,27 @@ export abstract class BrowserContext extends SdkObject {
   async setExtraHTTPHeaders(progress: Progress, headers: types.HeadersArray) {
     const oldHeaders = this._options.extraHTTPHeaders;
     this._options.extraHTTPHeaders = headers;
-    progress.cleanupWhenAborted(async () => {
+    try {
+      await progress.race(this.doUpdateExtraHTTPHeaders());
+    } catch (error) {
       this._options.extraHTTPHeaders = oldHeaders;
-      await this.doUpdateExtraHTTPHeaders();
-    });
-    await progress.race(this.doUpdateExtraHTTPHeaders());
+      // Note: no await, headers will be reset in the background as soon as possible.
+      this.doUpdateExtraHTTPHeaders().catch(() => {});
+      throw error;
+    }
   }
 
   async setOffline(progress: Progress, offline: boolean) {
     const oldOffline = this._options.offline;
     this._options.offline = offline;
-    progress.cleanupWhenAborted(async () => {
+    try {
+      await progress.race(this.doUpdateOffline());
+    } catch (error) {
       this._options.offline = oldOffline;
-      await this.doUpdateOffline();
-    });
-    await progress.race(this.doUpdateOffline());
+      // Note: no await, offline will be reset in the background as soon as possible.
+      this.doUpdateOffline().catch(() => {});
+      throw error;
+    }
   }
 
   async _loadDefaultContextAsIs(progress: Progress): Promise<Page | undefined> {
@@ -442,13 +452,18 @@ export abstract class BrowserContext extends SdkObject {
   async addInitScript(progress: Progress | undefined, source: string) {
     const initScript = new InitScript(source);
     this.initScripts.push(initScript);
-    progress?.cleanupWhenAborted(() => this.removeInitScripts([initScript]));
-    const promise = this.doAddInitScript(initScript);
-    if (progress)
-      await progress.race(promise);
-    else
-      await promise;
-    return initScript;
+    try {
+      const promise = this.doAddInitScript(initScript);
+      if (progress)
+        await progress.race(promise);
+      else
+        await promise;
+      return initScript;
+    } catch (error) {
+      // Note: no await, init script will be removed in the background as soon as possible.
+      this.removeInitScripts([initScript]).catch(() => {});
+      throw error;
+    }
   }
 
   async removeInitScripts(initScripts: InitScript[]) {
@@ -528,9 +543,8 @@ export abstract class BrowserContext extends SdkObject {
   }
 
   async newPage(progress: Progress, isServerSide: boolean): Promise<Page> {
-    let page: Page | undefined;
+    const page = await progress.race(this.doCreateNewPage(isServerSide));
     try {
-      page = await progress.race(this.doCreateNewPage(isServerSide));
       const pageOrError = await progress.race(page.waitForInitializedOrError());
       if (pageOrError instanceof Page) {
         if (pageOrError.isClosed())
@@ -539,7 +553,7 @@ export abstract class BrowserContext extends SdkObject {
       }
       throw pageOrError;
     } catch (error) {
-      await page?.close({ reason: 'Failed to create page' }).catch(() => {});
+      await page.close({ reason: 'Failed to create page' }).catch(() => {});
       throw error;
     }
   }
@@ -580,17 +594,20 @@ export abstract class BrowserContext extends SdkObject {
     // If there are still origins to save, create a blank page to iterate over origins.
     if (originsToSave.size)  {
       const page = await this.newPage(progress, true);
-      await page.addRequestInterceptor(progress, route => {
-        route.fulfill({ body: '<html></html>' }).catch(() => {});
-      }, 'prepend');
-      for (const origin of originsToSave) {
-        const frame = page.mainFrame();
-        await frame.gotoImpl(progress, origin, {});
-        const storage: SerializedStorage = await progress.race(frame.evaluateExpression(collectScript, { world: 'utility' }));
-        if (storage.localStorage.length || storage.indexedDB?.length)
-          result.origins.push({ origin, localStorage: storage.localStorage, indexedDB: storage.indexedDB });
+      try {
+        await page.addRequestInterceptor(progress, route => {
+          route.fulfill({ body: '<html></html>' }).catch(() => {});
+        }, 'prepend');
+        for (const origin of originsToSave) {
+          const frame = page.mainFrame();
+          await frame.gotoImpl(progress, origin, {});
+          const storage: SerializedStorage = await progress.race(frame.evaluateExpression(collectScript, { world: 'utility' }));
+          if (storage.localStorage.length || storage.indexedDB?.length)
+            result.origins.push({ origin, localStorage: storage.localStorage, indexedDB: storage.indexedDB });
+        }
+      } finally {
+        await page.close();
       }
-      await page.close();
     }
     return result;
   }
@@ -608,20 +625,20 @@ export abstract class BrowserContext extends SdkObject {
     const interceptor = (route: network.Route) => {
       route.fulfill({ body: '<html></html>' }).catch(() => {});
     };
-
-    progress.cleanupWhenAborted(() => page.removeRequestInterceptor(interceptor));
     await page.addRequestInterceptor(progress, interceptor, 'prepend');
 
-    for (const origin of new Set([...oldOrigins, ...newOrigins.keys()])) {
-      const frame = page.mainFrame();
-      await frame.gotoImpl(progress, origin, {});
-      await progress.race(frame.resetStorageForCurrentOriginBestEffort(newOrigins.get(origin)));
+    try {
+      for (const origin of new Set([...oldOrigins, ...newOrigins.keys()])) {
+        const frame = page.mainFrame();
+        await frame.gotoImpl(progress, origin, {});
+        await progress.race(frame.resetStorageForCurrentOriginBestEffort(newOrigins.get(origin)));
+      }
+
+      this._origins = new Set([...newOrigins.keys()]);
+      // It is safe to not restore the URL to about:blank since we are doing it in Page::resetForReuse.
+    } finally {
+      await page.removeRequestInterceptor(interceptor);
     }
-
-    await page.removeRequestInterceptor(interceptor);
-
-    this._origins = new Set([...newOrigins.keys()]);
-    // It is safe to not restore the URL to about:blank since we are doing it in Page::resetForReuse.
   }
 
   isSettingStorageState(): boolean {
@@ -629,12 +646,13 @@ export abstract class BrowserContext extends SdkObject {
   }
 
   async setStorageState(progress: Progress, state: NonNullable<channels.BrowserNewContextParams['storageState']>) {
+    let page: Page | undefined;
     this._settingStorageState = true;
     try {
       if (state.cookies)
         await progress.race(this.addCookies(state.cookies));
       if (state.origins && state.origins.length)  {
-        const page = await this.newPage(progress, true);
+        page = await this.newPage(progress, true);
         await page.addRequestInterceptor(progress, route => {
           route.fulfill({ body: '<html></html>' }).catch(() => {});
         }, 'prepend');
@@ -649,12 +667,12 @@ export abstract class BrowserContext extends SdkObject {
           })()`;
           await progress.race(frame.evaluateExpression(restoreScript, { world: 'utility' }));
         }
-        await page.close();
       }
     } catch (error) {
       rewriteErrorMessage(error, `Error setting storage state:\n` + error.message);
       throw error;
     } finally {
+      await page?.close();
       this._settingStorageState = false;
     }
   }

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -163,6 +163,7 @@ export class Chromium extends BrowserType {
   }
 
   override attemptToGracefullyCloseBrowser(transport: ConnectionTransport): void {
+    // Note that it's fine to reuse the transport, since our connection ignores kBrowserCloseMessageId.
     const message: ProtocolRequest = { method: 'Browser.close', id: kBrowserCloseMessageId, params: {} };
     transport.send(message);
   }

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -76,40 +76,47 @@ export class Chromium extends BrowserType {
       headersMap['User-Agent'] = getUserAgent();
 
     const artifactsDir = await progress.race(fs.promises.mkdtemp(ARTIFACTS_FOLDER));
-
-    const wsEndpoint = await urlToWSEndpoint(progress, endpointURL, headersMap);
-    const chromeTransport = await WebSocketTransport.connect(progress, wsEndpoint, { headers: headersMap });
-    progress.cleanupWhenAborted(() => chromeTransport.close());
-    const cleanedUp = new ManualPromise<void>();
     const doCleanup = async () => {
       await removeFolders([artifactsDir]);
-      await onClose?.();
-      cleanedUp.resolve();
+      const cb = onClose;
+      onClose = undefined; // Make sure to only call onClose once.
+      await cb?.();
     };
+
+    let chromeTransport: WebSocketTransport | undefined;
     const doClose = async () => {
-      await chromeTransport.closeAndWait();
-      await cleanedUp;
+      await chromeTransport?.closeAndWait();
+      await doCleanup();
     };
-    const browserProcess: BrowserProcess = { close: doClose, kill: doClose };
-    const persistent: types.BrowserContextOptions = { noDefaultViewport: true };
-    const browserOptions: BrowserOptions = {
-      slowMo: options.slowMo,
-      name: 'chromium',
-      isChromium: true,
-      persistent,
-      browserProcess,
-      protocolLogger: helper.debugProtocolLogger(),
-      browserLogsCollector: new RecentLogsCollector(),
-      artifactsDir,
-      downloadsPath: options.downloadsPath || artifactsDir,
-      tracesDir: options.tracesDir || artifactsDir,
-      originalLaunchOptions: {},
-    };
-    validateBrowserContextOptions(persistent, browserOptions);
-    const browser = await progress.race(CRBrowser.connect(this.attribution.playwright, chromeTransport, browserOptions));
-    browser._isCollocatedWithServer = false;
-    browser.on(Browser.Events.Disconnected, doCleanup);
-    return browser;
+
+    try {
+      const wsEndpoint = await urlToWSEndpoint(progress, endpointURL, headersMap);
+      chromeTransport = await WebSocketTransport.connect(progress, wsEndpoint, { headers: headersMap });
+
+      const browserProcess: BrowserProcess = { close: doClose, kill: doClose };
+      const persistent: types.BrowserContextOptions = { noDefaultViewport: true };
+      const browserOptions: BrowserOptions = {
+        slowMo: options.slowMo,
+        name: 'chromium',
+        isChromium: true,
+        persistent,
+        browserProcess,
+        protocolLogger: helper.debugProtocolLogger(),
+        browserLogsCollector: new RecentLogsCollector(),
+        artifactsDir,
+        downloadsPath: options.downloadsPath || artifactsDir,
+        tracesDir: options.tracesDir || artifactsDir,
+        originalLaunchOptions: {},
+      };
+      validateBrowserContextOptions(persistent, browserOptions);
+      const browser = await progress.race(CRBrowser.connect(this.attribution.playwright, chromeTransport, browserOptions));
+      browser._isCollocatedWithServer = false;
+      browser.on(Browser.Events.Disconnected, doCleanup);
+      return browser;
+    } catch (error) {
+      await doClose().catch(() => {});
+      throw error;
+    }
   }
 
   private _createDevTools() {

--- a/packages/playwright-core/src/server/chromium/crCoverage.ts
+++ b/packages/playwright-core/src/server/chromium/crCoverage.ts
@@ -17,6 +17,7 @@
 
 import { assert } from '../../utils';
 import { eventsHelper } from '../utils/eventsHelper';
+import { raceUncancellableOperationWithCleanup } from '../progress';
 
 import type { CRSession } from './crConnection';
 import type { Protocol } from './protocol';
@@ -35,8 +36,7 @@ export class CRCoverage {
   }
 
   async startJSCoverage(progress: Progress, options: channels.PageStartJSCoverageParams) {
-    progress.cleanupWhenAborted(() => this._jsCoverage.stop());
-    await progress.race(this._jsCoverage.start(options));
+    await raceUncancellableOperationWithCleanup(progress, () => this._jsCoverage.start(options), () => this._jsCoverage.stop());
   }
 
   async stopJSCoverage(): Promise<channels.PageStopJSCoverageResult> {
@@ -44,8 +44,7 @@ export class CRCoverage {
   }
 
   async startCSSCoverage(progress: Progress, options: channels.PageStartCSSCoverageParams) {
-    progress.cleanupWhenAborted(() => this._cssCoverage.stop());
-    await progress.race(this._cssCoverage.start(options));
+    await raceUncancellableOperationWithCleanup(progress, () => this._cssCoverage.start(options), () => this._cssCoverage.stop());
   }
 
   async stopCSSCoverage(): Promise<channels.PageStopCSSCoverageResult> {

--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -65,6 +65,7 @@ export class Firefox extends BrowserType {
   }
 
   override attemptToGracefullyCloseBrowser(transport: ConnectionTransport): void {
+    // Note that it's fine to reuse the transport, since our connection ignores kBrowserCloseMessageId.
     const message = { method: 'Browser.close', params: {}, id: kBrowserCloseMessageId };
     transport.send(message);
   }

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -761,7 +761,7 @@ export class Frame extends SdkObject {
           return null;
         return continuePolling;
       }
-      const result = await progress.raceWithCleanup(resolved.injected.evaluateHandle((injected, { info, root }) => {
+      const result = await progress.race(resolved.injected.evaluateHandle((injected, { info, root }) => {
         if (root && !root.isConnected)
           throw injected.createStacklessError('Element is not attached to the DOM');
         const elements = injected.querySelectorAll(info.parsed, root || document);
@@ -776,7 +776,7 @@ export class Frame extends SdkObject {
           log = `  locator resolved to ${visible ? 'visible' : 'hidden'} ${injected.previewNode(element)}`;
         }
         return { log, element, visible, attached: !!element };
-      }, { info: resolved.info, root: resolved.frame === this ? scope : undefined }), handle => handle.dispose());
+      }, { info: resolved.info, root: resolved.frame === this ? scope : undefined }));
       const { log, visible, attached } = await progress.race(result.evaluate(r => ({ log: r.log, visible: r.visible, attached: r.attached })));
       if (log)
         progress.log(log);
@@ -1085,7 +1085,7 @@ export class Frame extends SdkObject {
       const resolved = await progress.race(this.selectors.resolveInjectedForSelector(selector, { strict }));
       if (!resolved)
         return continuePolling;
-      const result = await progress.raceWithCleanup(resolved.injected.evaluateHandle((injected, { info, callId }) => {
+      const result = await progress.race(resolved.injected.evaluateHandle((injected, { info, callId }) => {
         const elements = injected.querySelectorAll(info.parsed, document);
         if (callId)
           injected.markTargetElements(new Set(elements), callId);
@@ -1099,7 +1099,7 @@ export class Frame extends SdkObject {
           log = `  locator resolved to ${injected.previewNode(element)}`;
         }
         return { log, success: !!element, element };
-      }, { info: resolved.info, callId: progress.metadata.id }), handle => handle.dispose());
+      }, { info: resolved.info, callId: progress.metadata.id }));
       const { log, success } = await progress.race(result.evaluate(r => ({ log: r.log, success: r.success })));
       if (log)
         progress.log(log);

--- a/packages/playwright-core/src/server/progress.ts
+++ b/packages/playwright-core/src/server/progress.ts
@@ -78,15 +78,6 @@ export class ProgressController {
         const promises = Array.isArray(promise) ? promise : [promise];
         return Promise.race([...promises, this._forceAbortPromise]);
       },
-      raceWithCleanup: <T>(promise: Promise<T>, cleanup: (result: T) => any) => {
-        return progress.race(promise.then(result => {
-          if (this._state !== 'running')
-            cleanup(result);
-          else
-            this._cleanups.push(() => cleanup(result));
-          return result;
-        }));
-      },
       wait: async (timeout: number) => {
         let timer: NodeJS.Timeout;
         const promise = new Promise<void>(f => timer = setTimeout(f, timeout));

--- a/packages/playwright-core/src/server/utils/processLauncher.ts
+++ b/packages/playwright-core/src/server/utils/processLauncher.ts
@@ -164,7 +164,10 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     spawnedProcess.once('error', error => {
       failed(new Error('Failed to launch: ' + error));
     });
-    return failedPromise.then(e => Promise.reject(e));
+    return failedPromise.then(async error => {
+      await cleanup();
+      throw error;
+    });
   }
   options.log(`<launched> pid=${spawnedProcess.pid}`);
 

--- a/packages/playwright-core/src/server/webkit/webkit.ts
+++ b/packages/playwright-core/src/server/webkit/webkit.ts
@@ -54,6 +54,7 @@ export class WebKit extends BrowserType {
   }
 
   override attemptToGracefullyCloseBrowser(transport: ConnectionTransport): void {
+    // Note that it's fine to reuse the transport, since our connection ignores kBrowserCloseMessageId.
     transport.send({ method: 'Playwright.close', params: {}, id: kBrowserCloseMessageId });
   }
 

--- a/packages/protocol/src/progress.d.ts
+++ b/packages/protocol/src/progress.d.ts
@@ -28,14 +28,13 @@ import type { CallMetadata } from './callMetadata';
 //     In this case, it is important that awaited method has no side effects, for example
 //     it is a read-only browser protocol call.
 //   - In rare cases, when the awaited method does not take a Progress argument,
-//     but it does have side effects such as creating a page -  a proper cleanup
+//     but it does have side effects such as creating a page - a proper cleanup
 //     must be taken in case Progress is aborted before the awaited method finishes.
-//     That's usually done by `progress.raceWithCleanup()` or `progress.cleanupWhenAborted()`.
+//     That's usually done by `progress.cleanupWhenAborted()`.
 export interface Progress {
   log(message: string): void;
   cleanupWhenAborted(cleanup: (error: Error | undefined) => any): void;
   race<T>(promise: Promise<T> | Promise<T>[]): Promise<T>;
-  raceWithCleanup<T>(promise: Promise<T>, cleanup: (result: T) => any): Promise<T>;
   wait(timeout: number): Promise<void>;
   metadata: CallMetadata;
 }


### PR DESCRIPTION
- Now that legacy timeout mechanism is gone, we can replace all kinds of cleanups with an explicit try/catch.
- This removes `progress.raceWithCleanup()` due to unclear semantics, and replaces it with a helper `raceUncancellableOperationWithCleanup()` that should be rarely used.