### PR TITLE
fix(client-certificates): allow empty client-certificates array

### DIFF
--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -100,7 +100,9 @@ export abstract class Browser extends SdkObject {
   async newContext(progress: Progress, options: types.BrowserContextOptions): Promise<BrowserContext> {
     validateBrowserContextOptions(options, this.options);
     let clientCertificatesProxy: ClientCertificatesProxy | undefined;
-    if (options.clientCertificates?.length) {
+    // Empty array is valid for scenarios where a user wants to deny all client certificates. Without, the browser would
+    // show a certificate selection dialog.
+    if (options.clientCertificates !== undefined) {
       clientCertificatesProxy = await progress.raceWithCleanup(ClientCertificatesProxy.create(options), proxy => proxy.close());
       options = { ...options };
       options.proxyOverride = clientCertificatesProxy.proxySettings();

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -77,7 +77,9 @@ export abstract class BrowserType extends SdkObject {
     const launchOptions = this._validateLaunchOptions(options);
     // Note: Any initial TLS requests will fail since we rely on the Page/Frames initialize which sets ignoreHTTPSErrors.
     let clientCertificatesProxy: ClientCertificatesProxy | undefined;
-    if (options.clientCertificates?.length) {
+    // Empty array is valid for scenarios where a user wants to deny all client certificates. Without, the browser would
+    // show a certificate selection dialog.
+    if (options.clientCertificates !== undefined) {
       clientCertificatesProxy = await progress.raceWithCleanup(ClientCertificatesProxy.create(options), proxy => proxy.close());
       launchOptions.proxyOverride = clientCertificatesProxy.proxySettings();
       options = { ...options };

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -260,6 +260,7 @@ export class ClientCertificatesProxy {
         await connection.connect();
         this._connections.set(payload.uid, connection);
       } catch (error) {
+        debugLogger.log('client-certificates', `Failed to connect to ${payload.host}:${payload.port}: ${error.message}`);
         this._socksProxy.socketFailed({ uid: payload.uid, errorCode: error.code });
       }
     });


### PR DESCRIPTION
This addresses 1. and 3. of https://github.com/microsoft/playwright/issues/36775#issuecomment-3113136338.