### PR TITLE
test: unflake "watch all" test

### DIFF
--- a/tests/playwright-test/ui-mode-test-watch.spec.ts
+++ b/tests/playwright-test/ui-mode-test-watch.spec.ts
@@ -150,6 +150,8 @@ test('should watch all', async ({ runUITest, writeFiles }) => {
     'd.test.ts': `import { test } from '@playwright/test'; test('test', () => {});`,
   });
 
+  await page.getByTitle('Watch all').click();
+
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ◯ a.test.ts
         ◯ test
@@ -160,7 +162,6 @@ test('should watch all', async ({ runUITest, writeFiles }) => {
     ▼ ◯ d.test.ts
         ◯ test
   `);
-  await page.getByTitle('Watch all').click();
 
   await writeFiles({
     'a.test.ts': `import { test } from '@playwright/test'; test('test', () => {});`,


### PR DESCRIPTION
This test is flaky, I assume it's because there's a race between the "Watch All" command fully setting up the file watchers, and the test writing to disk. While not a perfect solution, moving the "Watch All" just a little earlier already helped a lot in my local testing.