### PR TITLE
fix(storageState): enhance error handling for storage state setting

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -25,6 +25,7 @@ import { Debugger } from './debugger';
 import { DialogManager } from './dialog';
 import { BrowserContextAPIRequestContext } from './fetch';
 import { mkdirIfNeeded } from './utils/fileUtils';
+import { rewriteErrorMessage } from '../utils/isomorphic/stackTrace';
 import { HarRecorder } from './har/harRecorder';
 import { helper } from './helper';
 import { SdkObject } from './instrumentation';
@@ -644,6 +645,9 @@ export abstract class BrowserContext extends SdkObject {
         }
         await page.close();
       }
+    } catch (error) {
+      rewriteErrorMessage(error, `Error setting storage state:\n` + error.message);
+      throw error;
     } finally {
       this._settingStorageState = false;
     }

--- a/tests/library/browsercontext-storage-state.spec.ts
+++ b/tests/library/browsercontext-storage-state.spec.ts
@@ -74,6 +74,25 @@ it('should set local storage', async ({ contextFactory }) => {
   await context.close();
 });
 
+it('should report good error if the url is not valid', async ({ contextFactory }) => {
+  const error = await contextFactory({
+    storageState: {
+      cookies: [],
+      origins: [
+        {
+          origin: 'foo',
+          localStorage: [{
+            name: 'name1',
+            value: 'value1'
+          }]
+        },
+      ]
+    }
+  }).catch(e => e);
+  expect(error.message).toContain('browser.newContext: Error setting storage state:');
+  expect(error.message).toContain('foo');
+});
+
 it('should round-trip through the file', async ({ contextFactory }, testInfo) => {
   const context = await contextFactory();
   const page1 = await context.newPage();


### PR DESCRIPTION
Similar to https://github.com/microsoft/playwright/blob/ba32a2446742e1f571d1431523c3bb81a0a5898b/packages/playwright-core/src/client/browserContext.ts#L535-L537.

Before it was hard to follow what the error was. Just a navigation to an invalid URL wasn't helpful.

Fixes https://github.com/microsoft/playwright/issues/36753