### PR TITLE
chore(chrome): add canary channel on linux

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -650,7 +650,7 @@ export class Registry {
     }));
 
     this._executables.push(this._createChromiumChannel('chrome-canary', {
-      'linux': '',
+      'linux': '/opt/google/chrome-canary/chrome',
       'darwin': '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
       'win32': `\\Google\\Chrome SxS\\Application\\chrome.exe`,
     }));
@@ -713,7 +713,7 @@ export class Registry {
       'win32': `\\Google\\Chrome\\Application\\chrome.exe`,
     }));
     this._executables.push(this._createBidiChromiumChannel('bidi-chrome-canary', {
-      'linux': '',
+      'linux': '/opt/google/chrome-canary/chrome',
       'darwin': '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
       'win32': `\\Google\\Chrome SxS\\Application\\chrome.exe`,
     }));


### PR DESCRIPTION
I've just installed in on Ubuntu, so it is available.