### PR TITLE
chore: report target connection errors in client certificates to DEBUG logs

### DIFF
--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -260,6 +260,7 @@ export class ClientCertificatesProxy {
         await connection.connect();
         this._connections.set(payload.uid, connection);
       } catch (error) {
+        debugLogger.log('client-certificates', `Failed to connect to ${payload.host}:${payload.port}: ${error.message}`);
         this._socksProxy.socketFailed({ uid: payload.uid, errorCode: error.code });
       }
     });


### PR DESCRIPTION
This fixes 3. of https://github.com/microsoft/playwright/issues/36775#issuecomment-3113136338.

The issue was that when there was a connection made to a known host, it was not visible to the users, even with debug logs. This commonly happened in scenarios where proxies were required for the connection to succeed.