### PR TITLE
chore(html): align trace button so it doesn't resize the test row

### DIFF
--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -41,6 +41,21 @@
   align-items: center;
 }
 
+.test-file-details-row-items {
+  display: flex;
+  height: 16px;
+}
+
+.test-file-details-row-items > .link-badge {
+  /* Align badges */
+  margin-top: -2px;
+}
+
+.test-file-details-row-items > .trace-link {
+  /* Center in row */
+  margin-top: -4px;
+}
+
 .test-file-path {
   text-overflow: ellipsis;
   overflow: hidden;

--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -59,12 +59,14 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
           <span data-testid='test-duration' style={{ minWidth: '50px', textAlign: 'right' }}>{msToString(test.duration)}</span>
         </div>
         <div className='test-file-details-row'>
-          <Link href={testResultHref({ test })} title={[...test.path, test.title].join(' › ')} className='test-file-path-link'>
-            <span className='test-file-path'>{test.location.file}:{test.location.line}</span>
-          </Link>
-          {imageDiffBadge(test)}
-          {videoBadge(test)}
-          <TraceLink test={test} dim={true} />
+          <div className='test-file-details-row-items'>
+            <Link href={testResultHref({ test })} title={[...test.path, test.title].join(' › ')} className='test-file-path-link'>
+              <span className='test-file-path'>{test.location.file}:{test.location.line}</span>
+            </Link>
+            {imageDiffBadge(test)}
+            {videoBadge(test)}
+            <TraceLink test={test} dim={true} />
+          </div>
         </div>
       </div>
     )}


### PR DESCRIPTION
The trace button previously grew the size of the test entry row, which made the UI inconsistent. Limit the height of the normal button footprint while still allowing the full highlight size from before. Additionally aligns all other badges (video, screenshots).

<img width="455" height="249" alt="Screenshot 2025-07-28 at 10 56 58 AM" src="https://github.com/user-attachments/assets/f7992222-f4a4-48fb-94ad-025334048ec7" />

<img width="394" height="249" alt="Screenshot 2025-07-28 at 10 57 03 AM" src="https://github.com/user-attachments/assets/3c5b2bf8-8e1b-4c11-9a01-cb64627220a7" />
