### PR TITLE
fix(client-certificates): auto detect proxy in the browser

### DIFF
--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -371,6 +371,49 @@ test.describe('browser', () => {
     await page.close();
   });
 
+  test('should pass with matching certificates and when a http proxy is used from env', async ({ browser, startCCServer, asset, browserName, proxyServer, isMac }) => {
+    process.env.HTTPS_PROXY = `http://localhost:${proxyServer.PORT}`;
+    const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && isMac });
+    proxyServer.forwardTo(parseInt(new URL(serverURL).port, 10), { allowConnectRequests: true });
+    const page = await browser.newPage({
+      ignoreHTTPSErrors: true,
+      clientCertificates: [{
+        origin: new URL(serverURL).origin,
+        certPath: asset('client-certificates/client/trusted/cert.pem'),
+        keyPath: asset('client-certificates/client/trusted/key.pem'),
+      }],
+    });
+    expect(proxyServer.connectHosts).toEqual([]);
+    await page.goto(serverURL);
+    const host = browserName === 'webkit' && isMac ? 'localhost' : '127.0.0.1';
+    expect([...new Set(proxyServer.connectHosts)]).toEqual([`${host}:${new URL(serverURL).port}`]);
+    await expect(page.getByTestId('message')).toHaveText('Hello Alice, your certificate was issued by localhost!');
+    await page.close();
+    delete process.env.HTTPS_PROXY;
+  });
+
+  test('should pass with matching certificates and when a http proxy is used from config but env is there', async ({ browser, startCCServer, asset, browserName, proxyServer, isMac }) => {
+    process.env.HTTPS_PROXY = `http://this-should-not-taken-into-account:424242`;
+    const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && isMac });
+    proxyServer.forwardTo(parseInt(new URL(serverURL).port, 10), { allowConnectRequests: true });
+    const page = await browser.newPage({
+      ignoreHTTPSErrors: true,
+      clientCertificates: [{
+        origin: new URL(serverURL).origin,
+        certPath: asset('client-certificates/client/trusted/cert.pem'),
+        keyPath: asset('client-certificates/client/trusted/key.pem'),
+      }],
+      proxy: { server: `localhost:${proxyServer.PORT}` }
+    });
+    expect(proxyServer.connectHosts).toEqual([]);
+    await page.goto(serverURL);
+    const host = browserName === 'webkit' && isMac ? 'localhost' : '127.0.0.1';
+    expect([...new Set(proxyServer.connectHosts)]).toEqual([`${host}:${new URL(serverURL).port}`]);
+    await expect(page.getByTestId('message')).toHaveText('Hello Alice, your certificate was issued by localhost!');
+    await page.close();
+    delete process.env.HTTPS_PROXY;
+  });
+
   test('should pass with matching certificates and when a socks proxy is used', async ({ browser, startCCServer, asset, browserName, isMac }) => {
     const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && isMac });
     const serverPort = parseInt(new URL(serverURL).port, 10);

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -393,7 +393,7 @@ test.describe('browser', () => {
   });
 
   test('should pass with matching certificates and when a http proxy is used from config but env is there', async ({ browser, startCCServer, asset, browserName, proxyServer, isMac }) => {
-    process.env.HTTPS_PROXY = `http://this-should-not-taken-into-account:424242`;
+    process.env.HTTPS_PROXY = `http://this-should-not-taken-into-account:4242`;
     const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && isMac });
     proxyServer.forwardTo(parseInt(new URL(serverURL).port, 10), { allowConnectRequests: true });
     const page = await browser.newPage({


### PR DESCRIPTION
**Background**

Client certificates affect two components in Playwright:
1. Fetch API
2. Browser

This patch addresses (2). In the Fetch API (1), we don’t auto-detect the HTTP_PROXY/HTTPS_PROXY environment variables by design, so no changes are needed there.

However, in the browser, proxy auto-detection typically works—unless the user sets client certificates. In that case, Playwright uses a SOCKS proxy to intercept TLS traffic. When this happens, the browser is unaware of any system-wide proxy configuration, because the user (i.e. Playwright) has explicitly set up a proxy already.

To fix this, we now auto-detect the HTTP_PROXY/HTTPS_PROXY environment variables inside our internal SOCKS proxy. This enables Playwright to keep working in enterprise environments without requiring users to manually re-specify the proxy.

---

Fixes
- Enables auto-detection of system proxies when using client certificates in the browser.
- Resolves: https://github.com/microsoft/playwright/issues/36775
- Fixes finding (1) from https://github.com/microsoft/playwright/issues/36775#issuecomment-3113136338