### PR TITLE
test(bidi): add Firefox prefs for proxying localhost in BiDi tests

### DIFF
--- a/tests/bidi/playwright.config.ts
+++ b/tests/bidi/playwright.config.ts
@@ -27,10 +27,14 @@ const trace = !!process.env.PWTEST_TRACE;
 const hasDebugOutput = process.env.DEBUG?.includes('pw:');
 
 function firefoxUserPrefs() {
+  const defaultPrefs = {
+    'network.proxy.allow_hijacking_localhost': true,
+    'network.proxy.testing_localhost_is_secure_when_hijacked': true,
+  };
   const prefsString = process.env.PWTEST_FIREFOX_USER_PREFS;
   if (!prefsString)
-    return undefined;
-  return JSON.parse(prefsString);
+    return defaultPrefs;
+  return { ...defaultPrefs, ...JSON.parse(prefsString) };
 }
 
 const outputDir = path.join(__dirname, '..', '..', 'test-results');


### PR DESCRIPTION
Followup to #36676 - this will fix the following tests in `tests/library/browsercontext-proxy.spec.ts`:
1. should proxy local network requests › by default › localhost
2. should proxy local network requests › by default › loopback address
3. should proxy local network requests › with other bypasses › localhost
4. should proxy local network requests › with other bypasses › loopback address
5. should send secure cookies to subdomain.localhost
