### PR TITLE
fix(console api): injection into popups

### DIFF
--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -21,7 +21,7 @@ import { cacheNormalizedWhitespaces, normalizeWhiteSpace, trimStringWithEllipsis
 
 import { generateAriaTree, getAllByAria, matchesAriaTree, renderAriaTree } from './ariaSnapshot';
 import { enclosingShadowRootOrDocument, isElementVisible, isInsideScope, parentElementOrShadowHost, setGlobalOptions } from './domUtils';
-import { Highlight } from './highlight';
+// import { Highlight } from './highlight'; // Somehow this crashes the import of InjectedScript in the test?
 import { kLayoutSelectorNames, layoutSelectorScore } from './layoutSelectorUtils';
 import { createReactEngine } from './reactSelectorEngine';
 import { createRoleEngine } from './roleSelectorEngine';
@@ -89,6 +89,7 @@ export class InjectedScript {
   private _markedElements?: { callId: string, elements: Set<Element> };
   // eslint-disable-next-line no-restricted-globals
   readonly window: Window & typeof globalThis;
+  readonly document: Document;
   readonly consoleApi: ConsoleAPI;
   private _lastAriaSnapshot: AriaSnapshot | undefined;
 
@@ -121,6 +122,7 @@ export class InjectedScript {
   // eslint-disable-next-line no-restricted-globals
   constructor(window: Window & typeof globalThis, options: InjectedScriptOptions) {
     this.window = window;
+    this.document = window.document;
     this.isUnderTest = options.isUnderTest;
     // Make sure builtins are created from "window". This is important for InjectedScript instantiated
     // inside a trace viewer snapshot, where "window" differs from "globalThis".
@@ -241,9 +243,9 @@ export class InjectedScript {
       (this.window as any).__injectedScript = this;
   }
 
-  get document(): Document {
-    return this.window.document;
-  }
+  // get document(): Document {
+  //   return this.window.document;
+  // }
 
   eval(expression: string): any {
     return this.window.eval(expression);

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -89,7 +89,6 @@ export class InjectedScript {
   private _markedElements?: { callId: string, elements: Set<Element> };
   // eslint-disable-next-line no-restricted-globals
   readonly window: Window & typeof globalThis;
-  readonly document: Document;
   readonly consoleApi: ConsoleAPI;
   private _lastAriaSnapshot: AriaSnapshot | undefined;
 
@@ -122,7 +121,6 @@ export class InjectedScript {
   // eslint-disable-next-line no-restricted-globals
   constructor(window: Window & typeof globalThis, options: InjectedScriptOptions) {
     this.window = window;
-    this.document = window.document;
     this.isUnderTest = options.isUnderTest;
     // Make sure builtins are created from "window". This is important for InjectedScript instantiated
     // inside a trace viewer snapshot, where "window" differs from "globalThis".
@@ -241,6 +239,10 @@ export class InjectedScript {
 
     if (this.isUnderTest)
       (this.window as any).__injectedScript = this;
+  }
+
+  get document(): Document {
+    return this.window.document;
   }
 
   eval(expression: string): any {

--- a/tests/library/inspector/console-api.spec.ts
+++ b/tests/library/inspector/console-api.spec.ts
@@ -121,3 +121,36 @@ it('expected properties on playwright object', async ({ page }) => {
     'getByRole',
   ]);
 });
+
+
+it('should correcly inject itself into popups', async ({ page }) => {
+  const firstPageContent = `
+      <html>
+        <body>
+          <button onclick="openPopup()">open popup</button>
+          
+          <script>
+            const secondPageContent = \`
+            <html>
+              <body>
+                <input type="email">
+              </body>
+            </html>
+            \`;
+            
+            function openPopup() {
+              const popup = window.open('', '_blank', 'width=400,height=300');
+              popup.document.write(secondPageContent);
+              popup.document.close();
+            }
+          </script>
+        </body>
+      </html>
+    `;
+
+  await page.setContent(firstPageContent);
+  const newWindowPromise = page.waitForEvent('popup');
+  await page.getByRole('button', { name: 'open popup' }).click();
+  const newPage = await newWindowPromise;
+  expect(await newPage.evaluate("window.playwright.$$('input').length")).toBe(1);
+});

--- a/tests/library/inspector/console-api.spec.ts
+++ b/tests/library/inspector/console-api.spec.ts
@@ -15,6 +15,8 @@
  */
 
 import { test as it, expect } from './inspectorTest';
+import { InjectedScript } from 'packages/injected/src/injectedScript';
+import { ConsoleAPI } from 'packages/injected/src/consoleApi';
 
 it.skip(({ mode }) => mode !== 'default');
 
@@ -123,7 +125,22 @@ it('expected properties on playwright object', async ({ page }) => {
 });
 
 
-it('should correcly inject itself into popups', async ({ page }) => {
+it.only('should correcly inject itself into popups', async ({ context }) => {
+
+  await context.addInitScript(() => {
+    const injectedScript = new InjectedScript(window, {
+      isUnderTest: true,
+      sdkLanguage: 'javascript',
+      testIdAttributeName: 'data-testid',
+      stableRafCount: 0,
+      browserName: context.browser().browserType().name(),
+      customEngines: [],
+    });
+    const consoleApi = new ConsoleAPI(injectedScript);
+    consoleApi.install();
+  });
+  const page = await context.newPage();
+
   const firstPageContent = `
       <html>
         <body>


### PR DESCRIPTION
This patch fixes an issue where the document property of InjectedScript referres to a preliminary document that does not match window.document after the page has fully loaded, causing the ConsoleApi to return wrong results.

Fixes #36740