### PR TITLE
test: skip newly added client-cert test on service mode

### DIFF
--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -372,7 +372,7 @@ test.describe('browser', () => {
   });
 
   test('should pass with matching certificates and when a http proxy is used from env', async ({ mode, browser, startCCServer, asset, browserName, proxyServer, isMac }) => {
-    test.skip(mode !== 'default'); // Out of process transport does not allow us to set env vars dynamically.
+    test.skip(mode !== 'default', 'Out of process transport does not allow us to set env vars dynamically');
     process.env.HTTPS_PROXY = `http://localhost:${proxyServer.PORT}`;
     const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && isMac });
     proxyServer.forwardTo(parseInt(new URL(serverURL).port, 10), { allowConnectRequests: true });

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -371,7 +371,8 @@ test.describe('browser', () => {
     await page.close();
   });
 
-  test('should pass with matching certificates and when a http proxy is used from env', async ({ browser, startCCServer, asset, browserName, proxyServer, isMac }) => {
+  test('should pass with matching certificates and when a http proxy is used from env', async ({ mode, browser, startCCServer, asset, browserName, proxyServer, isMac }) => {
+    test.skip(mode !== 'default'); // Out of process transport does not allow us to set env vars dynamically.
     process.env.HTTPS_PROXY = `http://localhost:${proxyServer.PORT}`;
     const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && isMac });
     proxyServer.forwardTo(parseInt(new URL(serverURL).port, 10), { allowConnectRequests: true });


### PR DESCRIPTION
Similar to here:

https://github.com/microsoft/playwright/blob/98caf348e79355c1e5c67a2d93dcf1ad8bafcb95/tests/library/chromium/connect-over-cdp.spec.ts#L343