### PR TITLE
chore: page.close -> `Close page` in steps

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
+++ b/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
@@ -98,7 +98,7 @@ export const methodMetainfo = new Map<string, { internal?: boolean, title?: stri
   ['BrowserContext.clockSetFixedTime', { title: 'Set fixed time "{timeNumber}{timeString}"', }],
   ['BrowserContext.clockSetSystemTime', { title: 'Set system time "{timeNumber}{timeString}"', }],
   ['Page.addInitScript', { }],
-  ['Page.close', { title: 'Close', }],
+  ['Page.close', { title: 'Close page', }],
   ['Page.emulateMedia', { title: 'Emulate media', snapshot: true, }],
   ['Page.exposeBinding', { title: 'Expose binding', }],
   ['Page.goBack', { title: 'Go back', slowMo: true, snapshot: true, }],

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1554,7 +1554,7 @@ Page:
         source: string
 
     close:
-      title: Close
+      title: Close page
       parameters:
         runBeforeUnload: boolean?
         reason: string?

--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -52,7 +52,7 @@ test('should collect trace with resources, but no js', async ({ context, page, s
     'Navigate to "/input/fileupload.html"',
     'Set input files',
     'Wait for timeout',
-    'Close',
+    'Close page',
   ]);
 
   expect(events.some(e => e.type === 'frame-snapshot')).toBeTruthy();
@@ -200,7 +200,7 @@ test('should collect two traces', async ({ context, page, server }, testInfo) =>
     expect(events[0].type).toBe('context-options');
     expect(actions).toEqual([
       'Double click',
-      'Close',
+      'Close page',
     ]);
   }
 });


### PR DESCRIPTION
This follows what we do for context for consistency reasons:

```yml
    close:
      title: Close context
      parameters:
        reason: string?
```

BrowserContext.close -> `Close context`.
Page.close -> `Close page`.