### PR TITLE
chore(bidi): add support for the browsingContext.historyUpdated event

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -72,6 +72,7 @@ export class BidiPage implements PageDelegate {
       eventsHelper.addEventListener(bidiSession, 'browsingContext.navigationAborted', this._onNavigationAborted.bind(this)),
       eventsHelper.addEventListener(bidiSession, 'browsingContext.navigationFailed', this._onNavigationFailed.bind(this)),
       eventsHelper.addEventListener(bidiSession, 'browsingContext.fragmentNavigated', this._onFragmentNavigated.bind(this)),
+      eventsHelper.addEventListener(bidiSession, 'browsingContext.historyUpdated', this._onHistoryUpdated.bind(this)),
       eventsHelper.addEventListener(bidiSession, 'browsingContext.domContentLoaded', this._onDomContentLoaded.bind(this)),
       eventsHelper.addEventListener(bidiSession, 'browsingContext.load', this._onLoad.bind(this)),
       eventsHelper.addEventListener(bidiSession, 'browsingContext.userPromptOpened', this._onUserPromptOpened.bind(this)),
@@ -216,6 +217,10 @@ export class BidiPage implements PageDelegate {
   }
 
   private _onFragmentNavigated(params: bidi.BrowsingContext.NavigationInfo) {
+    this._page.frameManager.frameCommittedSameDocumentNavigation(params.context, params.url);
+  }
+
+  private _onHistoryUpdated(params: bidi.BrowsingContext.HistoryUpdatedParameters) {
     this._page.frameManager.frameCommittedSameDocumentNavigation(params.context, params.url);
   }
 


### PR DESCRIPTION
Fixes #36174 and the following tests:
- in `tests/page/page-history.spec.ts`:
  - page.goBack should work with HistoryAPI
- in `tests/page/page-wait-for-navigation.spec.ts`:
  - should work with history.pushState()
  - should work with history.replaceState()
  - should work with DOM history.back()/history.forward()
  - should work with url match for same document navigations
- in `tests/page/page-wait-for-url.spec.ts`:
  - should work with history.pushState()
  - should work with history.replaceState()
  - should work with DOM history.back()/history.forward()
  - should work with url match for same document navigations
