### PR TITLE
chore(html): properly align test list text

### DIFF
--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -17,7 +17,7 @@
 .test-file-test {
   line-height: 32px;
   align-items: center;
-  padding: 2px 10px;
+  padding: 2px 8px;
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
The entire UI uses a 8px horizontal padding, but the titles and content of the test list were set to 10px. Properly align them.

Future work may want to increase this from 8px, as it seems rather constricted.

<img width="1012" height="350" alt="Screenshot 2025-07-29 at 10 47 26 AM" src="https://github.com/user-attachments/assets/61eec1c7-18c2-42cf-870c-9d300663dfeb" />
<img width="1034" height="372" alt="Screenshot 2025-07-29 at 10 47 14 AM" src="https://github.com/user-attachments/assets/d166c99d-c1e1-41b7-8feb-403fb7c3f69b" />
<img width="287" height="385" alt="Screenshot 2025-07-29 at 10 47 20 AM" src="https://github.com/user-attachments/assets/b46dd636-6918-436a-becb-ad9983c5da8e" />

