### PR TITLE
feat: allow Playwright to run on Android with opt-in env flag

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -406,11 +406,12 @@ export const registryDirectory = (() => {
       cacheDirectory = path.join(os.homedir(), 'Library', 'Caches');
     else if (process.platform === 'win32')
       cacheDirectory = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
-    else if (process.platform === 'android' && process.env.PLAYWRIGHT_ALLOW_ANDROID === '1') {
-      cacheDirectory = import_path.default.join(import_os.default.homedir(), '.cache');
-    } else {
+    else if (process.platform === 'android' && !process.env.PLAYWRIGHT_ALLOW_ANDROID)
+      throw new Error('Playwright is not officially supported on Android. Set PLAYWRIGHT_ALLOW_ANDROID=1 to proceed.');
+    else if (process.platform === 'android')
+      cacheDirectory = path.join(os.homedir(), '.cache');
+    else
       throw new Error('Unsupported platform: ' + process.platform);
-    }
     result = path.join(cacheDirectory, 'ms-playwright');
   }
 

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -406,8 +406,11 @@ export const registryDirectory = (() => {
       cacheDirectory = path.join(os.homedir(), 'Library', 'Caches');
     else if (process.platform === 'win32')
       cacheDirectory = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
-    else
+    else if (process.platform === 'android' && process.env.PLAYWRIGHT_ALLOW_ANDROID === '1') {
+      cacheDirectory = import_path.default.join(import_os.default.homedir(), '.cache');
+    } else {
       throw new Error('Unsupported platform: ' + process.platform);
+    }
     result = path.join(cacheDirectory, 'ms-playwright');
   }
 


### PR DESCRIPTION
### Summary

This change allows advanced users to run Playwright on Android (e.g. via Termux) by setting an environment variable `PLAYWRIGHT_ALLOW_ANDROID=1`.

By default, Android remains unsupported. This opt-in flag is useful for cases where users provide their own Chromium and are aware of the limitations.

### Motivation

Currently, Playwright throws an "Unsupported platform: android" error even if Chromium works and headless scripts function correctly in Termux.

This patch:
- Keeps current platform safety behavior
- Adds a safe override for power users
- Helps open up use cases for scripting, scraping, and automation on Android

### Notes

- No browser binaries are bundled or downloaded
- Chromium must be installed manually
- Tested successfully with `playwright-core` + Termux + Chromium + pnpm + tsx