### PR TITLE
Update README.md to standardise Looking for

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Playwright is a framework for Web Testing and Automation. It allows testing [Chr
 
 Headless execution is supported for all browsers on all platforms. Check out [system requirements](https://playwright.dev/docs/intro#system-requirements) for details.
 
-Looking for Playwright for [Python](https://playwright.dev/python/docs/intro), [.NET](https://playwright.dev/dotnet/docs/intro), or [Java](https://playwright.dev/java/docs/intro)?
+Looking for Playwright for [TypeScript](https://playwright.dev/docs/intro), [JavaScript](https://playwright.dev/docs/intro), [Python](https://playwright.dev/python/docs/intro), [.NET](https://playwright.dev/dotnet/docs/intro), or [Java](https://playwright.dev/java/docs/intro)?
 
 ## Installation
 


### PR DESCRIPTION
docs - standardise 'Looking for Playwright for...'

The sentence 'Looking for Playwright for...' is different in the top 'Documentation' section and the 'Capabilities' section. So just standardised it to include all the languages playwright is available on.

<img width="1212" height="1004" alt="image" src="https://github.com/user-attachments/assets/3e86393b-e623-4985-b1a6-01bc53b0098b" />

<img width="1410" height="322" alt="image" src="https://github.com/user-attachments/assets/5688c7e9-730f-4093-86d0-7471dcbeca2f" />
