### PR TITLE
chore: remove CallMetadata.isServerSide

### DIFF
--- a/packages/playwright-core/src/server/instrumentation.ts
+++ b/packages/playwright-core/src/server/instrumentation.ts
@@ -121,6 +121,5 @@ export function serverSideCallMetadata(): CallMetadata {
     method: '',
     params: {},
     log: [],
-    isServerSide: true,
   };
 }

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -459,7 +459,9 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
   }
 
   onCallLog(sdkObject: SdkObject, metadata: CallMetadata, logName: string, message: string) {
-    if (metadata.isServerSide || metadata.internal)
+    if (!this._state?.callIds.has(metadata.id))
+      return;
+    if (metadata.internal)
       return;
     if (logName !== 'api')
       return;

--- a/packages/protocol/src/callMetadata.d.ts
+++ b/packages/protocol/src/callMetadata.d.ts
@@ -29,9 +29,6 @@ export type CallMetadata = {
   // Client is making an internal call that should not show up in
   // the inspector or trace.
   internal?: boolean;
-  // Service-side is making a call to itself, this metadata does not go
-  // through the dispatcher, so is always excluded from inspector / tracing.
-  isServerSide?: boolean;
   // Test runner step id.
   stepId?: string;
   location?: { file: string, line?: number, column?: number };


### PR DESCRIPTION
It is not actually useful now. For server-side calls, we don't get `onBeforeCall` instrumentation signal, and so we ignore all other signals after that anyway.