### PR TITLE
chore: throw pretty error if launchApp is launched using channel

### DIFF
--- a/packages/playwright-core/src/server/launchApp.ts
+++ b/packages/playwright-core/src/server/launchApp.ts
@@ -17,9 +17,9 @@
 import fs from 'fs';
 import path from 'path';
 
-import { isUnderTest } from '../utils';
+import { isUnderTest, rewriteErrorMessage, wrapInASCIIBox } from '../utils';
 import { serverSideCallMetadata } from './instrumentation';
-import { findChromiumChannel } from './registry';
+import { buildPlaywrightCLICommand, findChromiumChannelBestEffort } from './registry';
 import { registryDirectory } from './registry';
 import { ProgressController } from './progress';
 
@@ -46,19 +46,32 @@ export async function launchApp(browserType: BrowserType, options: {
         '--test-type=',
     );
     if (!channel && !options.persistentContextOptions?.executablePath)
-      channel = findChromiumChannel(options.sdkLanguage);
+      channel = findChromiumChannelBestEffort(options.sdkLanguage);
   }
 
   const controller = new ProgressController(serverSideCallMetadata(), browserType);
-  const context = await controller.run(progress => browserType.launchPersistentContext(progress, '', {
-    ignoreDefaultArgs: ['--enable-automation'],
-    ...options?.persistentContextOptions,
-    channel,
-    noDefaultViewport: options.persistentContextOptions?.noDefaultViewport ?? true,
-    acceptDownloads: options?.persistentContextOptions?.acceptDownloads ?? (isUnderTest() ? 'accept' : 'internal-browser-default'),
-    colorScheme: options?.persistentContextOptions?.colorScheme ?? 'no-override',
-    args,
-  }), 0); // Deliberately no timeout for our apps.
+  let context;
+  try {
+    context = await controller.run(progress => browserType.launchPersistentContext(progress, '', {
+      ignoreDefaultArgs: ['--enable-automation'],
+      ...options?.persistentContextOptions,
+      channel,
+      noDefaultViewport: options.persistentContextOptions?.noDefaultViewport ?? true,
+      acceptDownloads: options?.persistentContextOptions?.acceptDownloads ?? (isUnderTest() ? 'accept' : 'internal-browser-default'),
+      colorScheme: options?.persistentContextOptions?.colorScheme ?? 'no-override',
+      args,
+    }), 0); // Deliberately no timeout for our apps.
+  } catch (error) {
+    if (channel) {
+      error = rewriteErrorMessage(error, [
+        `Failed to launch ${browserType.name()} with channel "${channel}".`,
+        'Using custom channels could lead to unexpected behavior due to Enterprise policies (chrome://policy).',
+        'Try launching with the default channel instead and install the browser using the Playwright CLI:',
+        wrapInASCIIBox(`${buildPlaywrightCLICommand(options.sdkLanguage, 'install')}`, 2),
+      ].join('\n'));
+    }
+    throw error;
+  }
   const [page] = context.pages();
   // Chromium on macOS opens a new tab when clicking on the dock icon.
   // See https://github.com/microsoft/playwright/issues/9434

--- a/packages/playwright-core/src/server/launchApp.ts
+++ b/packages/playwright-core/src/server/launchApp.ts
@@ -66,7 +66,7 @@ export async function launchApp(browserType: BrowserType, options: {
       error = rewriteErrorMessage(error, [
         `Failed to launch "${channel}" channel.`,
         'Using custom channels could lead to unexpected behavior due to Enterprise policies (chrome://policy).',
-        'Try launching with the default channel instead and install the browser using the Playwright CLI:',
+        'Install the default browser instead:',
         wrapInASCIIBox(`${buildPlaywrightCLICommand(options.sdkLanguage, 'install')}`, 2),
       ].join('\n'));
     }

--- a/packages/playwright-core/src/server/launchApp.ts
+++ b/packages/playwright-core/src/server/launchApp.ts
@@ -64,7 +64,7 @@ export async function launchApp(browserType: BrowserType, options: {
   } catch (error) {
     if (channel) {
       error = rewriteErrorMessage(error, [
-        `Failed to launch ${browserType.name()} with channel "${channel}".`,
+        `Failed to launch "${channel}" channel.`,
         'Using custom channels could lead to unexpected behavior due to Enterprise policies (chrome://policy).',
         'Try launching with the default channel instead and install the browser using the Playwright CLI:',
         wrapInASCIIBox(`${buildPlaywrightCLICommand(options.sdkLanguage, 'install')}`, 2),

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -1363,7 +1363,8 @@ export async function installBrowsersForNpmInstall(browsers: string[]) {
   await registry.install(executables, false /* forceReinstall */);
 }
 
-export function findChromiumChannel(sdkLanguage: string): string | undefined {
+// for launchApp -> UI Mode / Trace Viewer
+export function findChromiumChannelBestEffort(sdkLanguage: string): string | undefined {
   // Fall back to the stable channels of popular vendors to work out of the box.
   // Null means no installation and no channels found.
   let channel = null;


### PR DESCRIPTION
This will make it easier to spot if a missing Chromium browser is the cause of UI Mode / Trace Viewer failing to launch if e.g. Chrome Policies break the startup of the browser.

https://github.com/microsoft/playwright/issues/36714#issuecomment-3140078756