### PR TITLE
chore(deps): bump chromium-bidi to ^7.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@zip.js/zip.js": "^2.7.29",
         "ansi-styles": "^4.3.0",
         "chokidar": "^3.5.3",
-        "chromium-bidi": "^5.3.1",
+        "chromium-bidi": "^7.2.0",
         "colors": "^1.4.0",
         "concurrently": "^6.2.1",
         "cross-env": "^7.0.3",
@@ -2891,9 +2891,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-5.3.1.tgz",
-      "integrity": "sha512-fbkgn0/m6RIRknVEez+QOYuvukUomBC0XnS8fgdbl9FeunjR3vUvPN6iYrbzXIuaJXYOwGU8FZgOTDzBImGvLw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-7.2.0.tgz",
+      "integrity": "sha512-gREyhyBstermK+0RbcJLbFhcQctg92AGgDe/h/taMJEOLRdtSswBAO9KmvltFSQWgM2LrwWu5SIuEUbdm3JsyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@zip.js/zip.js": "^2.7.29",
     "ansi-styles": "^4.3.0",
     "chokidar": "^3.5.3",
-    "chromium-bidi": "^5.3.1",
+    "chromium-bidi": "^7.2.0",
     "colors": "^1.4.0",
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
it should allow using the latest bidi features like https://github.com/microsoft/playwright/pull/36862 and others.