### PR TITLE
chore: add chrome-canary installation channel

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -209,7 +209,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [chrome, chrome-beta, msedge, msedge-beta, msedge-dev]
+        channel: [chrome, chrome-beta, chrome-canary, msedge, msedge-beta, msedge-dev]
         runs-on: [ubuntu-22.04, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4

--- a/packages/playwright-core/bin/reinstall_chrome_canary_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_canary_linux.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+if [[ $(arch) == "aarch64" ]]; then
+  echo "ERROR: not supported on Linux Arm64"
+  exit 1
+fi
+
+if [ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ]; then
+  if [[ ! -f "/etc/os-release" ]]; then
+    echo "ERROR: cannot install on unknown linux distribution (/etc/os-release is missing)"
+    exit 1
+  fi
+
+  ID=$(bash -c 'source /etc/os-release && echo $ID')
+  if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" ]]; then
+    echo "ERROR: cannot install on $ID distribution - only Ubuntu and Debian are supported"
+    exit 1
+  fi
+fi
+
+# 1. make sure to remove old canary if any.
+if dpkg --get-selections | grep -q "^google-chrome-unstable[[:space:]]*install$" >/dev/null; then
+  apt-get remove -y google-chrome-unstable
+fi
+
+# 2. Update apt lists (needed to install curl and chrome dependencies)
+apt-get update
+
+# 3. Install curl to download chrome
+if ! command -v curl >/dev/null; then
+  apt-get install -y curl
+fi
+
+# 4. download chrome canary from dl.google.com and install it.
+cd /tmp
+curl -O https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
+apt-get install -y ./google-chrome-unstable_current_amd64.deb
+rm -rf ./google-chrome-unstable_current_amd64.deb
+cd -
+google-chrome-unstable --version

--- a/packages/playwright-core/bin/reinstall_chrome_canary_mac.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_canary_mac.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+rm -rf "/Applications/Google Chrome Canary.app"
+cd /tmp
+curl --retry 3 -o ./googlechromecanary.dmg -k https://dl.google.com/chrome/mac/universal/canary/googlechromecanary.dmg
+hdiutil attach -nobrowse -quiet -noautofsck -noautoopen -mountpoint /Volumes/googlechromecanary.dmg ./googlechromecanary.dmg
+cp -pR "/Volumes/googlechromecanary.dmg/Google Chrome Canary.app" /Applications
+hdiutil detach /Volumes/googlechromecanary.dmg
+rm -rf /tmp/googlechromecanary.dmg
+
+/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --version

--- a/packages/playwright-core/bin/reinstall_chrome_canary_win.ps1
+++ b/packages/playwright-core/bin/reinstall_chrome_canary_win.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = 'Stop'
+
+$url = 'https://dl.google.com/tag/s/dl/chrome/install/dev/googlechromestandaloneenterprise64.msi'
+
+Write-Host "Downloading Google Chrome Canary"
+$wc = New-Object net.webclient
+$msiInstaller = "$env:temp\google-chrome-canary.msi"
+$wc.Downloadfile($url, $msiInstaller)
+
+Write-Host "Installing Google Chrome Canary"
+$arguments = "/i `"$msiInstaller`" /quiet"
+Start-Process msiexec.exe -ArgumentList $arguments -Wait
+Remove-Item $msiInstaller
+
+$suffix = "\\Google\\Chrome SxS\\Application\\chrome.exe"
+if (Test-Path "${env:ProgramFiles(x86)}$suffix") {
+    (Get-Item "${env:ProgramFiles(x86)}$suffix").VersionInfo
+} elseif (Test-Path "${env:ProgramFiles}$suffix") {
+    (Get-Item "${env:ProgramFiles}$suffix").VersionInfo
+} else {
+    Write-Host "ERROR: Failed to install Google Chrome Canary."
+    Write-Host "ERROR: This could be due to insufficient privileges, in which case re-running as Administrator may help."
+    exit 1
+}

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -653,7 +653,11 @@ export class Registry {
       'linux': '/opt/google/chrome-canary/chrome',
       'darwin': '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
       'win32': `\\Google\\Chrome SxS\\Application\\chrome.exe`,
-    }));
+    }, () => this._installChromiumChannel('chrome-canary', {
+      'linux': 'reinstall_chrome_canary_linux.sh',
+      'darwin': 'reinstall_chrome_canary_mac.sh',
+      'win32': 'reinstall_chrome_canary_win.ps1',
+    })));
 
     this._executables.push(this._createChromiumChannel('msedge', {
       'linux': '/opt/microsoft/msedge/msedge',


### PR DESCRIPTION
Seems available now and follows what we have for other Chromium channels / Edge channels.

