### PR TITLE
test(recorder): skip flaky CDP eval test on macOS < 15

### DIFF
--- a/tests/library/inspector/cli-codegen-2.spec.ts
+++ b/tests/library/inspector/cli-codegen-2.spec.ts
@@ -90,7 +90,9 @@ var page1 = await context.NewPageAsync();`);
 await page.CloseAsync();`);
   });
 
-  test('should not lead to an error if html gets clicked', async ({ openRecorder }) => {
+  test('should not lead to an error if html gets clicked', async ({ openRecorder, macVersion }) => {
+    test.skip(macVersion < 15, 'recorder.page.evaluate hangs on CDP layer for some reason on macOS 14.');
+
     const { page, recorder } = await openRecorder();
 
     await recorder.setContentAndWait('');

--- a/tests/library/inspector/cli-codegen-2.spec.ts
+++ b/tests/library/inspector/cli-codegen-2.spec.ts
@@ -90,8 +90,8 @@ var page1 = await context.NewPageAsync();`);
 await page.CloseAsync();`);
   });
 
-  test('should not lead to an error if html gets clicked', async ({ openRecorder, macVersion }) => {
-    test.skip(macVersion < 15, 'recorder.page.evaluate hangs on CDP layer for some reason on macOS 14.');
+  test('should not lead to an error if html gets clicked', async ({ openRecorder, platform, macVersion }) => {
+    test.skip(platform === 'darwin' && macVersion < 15, 'recorder.page.evaluate hangs on CDP layer for some reason on macOS 14.');
 
     const { page, recorder } = await openRecorder();
 


### PR DESCRIPTION
The 'should not lead to an error if html gets clicked' test times out on Chromium + macOS 14 due to a hanging `page.evaluate` call over CDP. Test passes on macOS 15, which will soon (https://github.com/actions/runner-images/issues/12520) be the default in GitHub Actions for macos-latest.

Closes https://github.com/microsoft/playwright/pull/36663
Closes https://github.com/microsoft/playwright/pull/36797