### PR TITLE
chore: close connect=first browser

### DIFF
--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -196,8 +196,6 @@ export class PlaywrightServer {
     for (const b of this._playwright.allBrowsers()) {
       if (b === browser)
         continue;
-      if (this._dontReuseBrowsers.has(b))
-        continue;
       if (b.options.name === browserName && b.options.channel === launchOptions.channel)
         await b.close({ reason: 'Connection terminated' });
     }


### PR DESCRIPTION
If Copilot calls `browser_navigate` before the first test run, it'll have started it's own browser that's in the `_dontReuseBrowsers` set. We don't want that to be reused, because we want the test runner to always start its own browser. But we also don't want it to stick around, because we want Copilot and the test runner to always talk to the same browser.