### PR TITLE
test: unflake 'TLS renegotiation' test

### DIFF
--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -552,6 +552,7 @@ test.describe('browser', () => {
           'Content-Encoding': 'gzip',
           'Transfer-Encoding': 'chunked'
         });
+        res.flushHeaders();
 
         await renegotiate();
 


### PR DESCRIPTION
We call `flushHeaders()` in other places as well. Verified this unflake locally.