### PR TITLE
test: unflake'TLS 1.2 handshake' test

### DIFF
--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -247,9 +247,7 @@ class SocksProxyConnection {
           'Content-Length: ' + Buffer.byteLength(responseBody),
           '',
           responseBody,
-        ].join('\r\n'), () => {
-          this._browserEncrypted.destroy();
-        });
+        ].join('\r\n'));
       }
     });
   }


### PR DESCRIPTION
We call `this._browserEncrypted.destroy()` already in two places:
- `SocksProxyConnection.onClose`
- Via `browserDecrypted.end` which bubbles into the `browserEncrypted`.

This fixes an issue that we were sometimes closing before we were writing.