### PR TITLE
chore(bidi): add support for the default SameSite value

### DIFF
--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -135,7 +135,7 @@ scheme.SetNetworkCookie = tObject({
   expires: tOptional(tFloat),
   httpOnly: tOptional(tBoolean),
   secure: tOptional(tBoolean),
-  sameSite: tOptional(tEnum(['Strict', 'Lax', 'None'])),
+  sameSite: tOptional(tEnum(['Strict', 'Lax', 'None', 'Default'])),
   partitionKey: tOptional(tString),
   _crHasCrossSiteAncestor: tOptional(tBoolean),
 });
@@ -147,7 +147,7 @@ scheme.NetworkCookie = tObject({
   expires: tFloat,
   httpOnly: tBoolean,
   secure: tBoolean,
-  sameSite: tEnum(['Strict', 'Lax', 'None']),
+  sameSite: tEnum(['Strict', 'Lax', 'None', 'Default']),
   partitionKey: tOptional(tString),
   _crHasCrossSiteAncestor: tOptional(tBoolean),
 });

--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -419,8 +419,9 @@ function fromBidiSameSite(sameSite: bidi.Network.SameSite): channels.NetworkCook
     case 'strict': return 'Strict';
     case 'lax': return 'Lax';
     case 'none': return 'None';
+    case 'default': return 'Default';
   }
-  return 'None';
+  return 'Default';
 }
 
 function toBidiSameSite(sameSite: channels.SetNetworkCookie['sameSite']): bidi.Network.SameSite {
@@ -428,8 +429,9 @@ function toBidiSameSite(sameSite: channels.SetNetworkCookie['sameSite']): bidi.N
     case 'Strict': return bidi.Network.SameSite.Strict;
     case 'Lax': return bidi.Network.SameSite.Lax;
     case 'None': return bidi.Network.SameSite.None;
+    case 'Default': return bidi.Network.SameSite.Default;
   }
-  return bidi.Network.SameSite.None;
+  return bidi.Network.SameSite.Default;
 }
 
 function getProxyConfiguration(proxySettings?: types.ProxySettings): bidi.Session.ManualProxyConfiguration | undefined {

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -260,7 +260,7 @@ export type SetNetworkCookie = {
   expires?: number,
   httpOnly?: boolean,
   secure?: boolean,
-  sameSite?: 'Strict' | 'Lax' | 'None',
+  sameSite?: 'Strict' | 'Lax' | 'None' | 'Default',
   partitionKey?: string,
   _crHasCrossSiteAncestor?: boolean,
 };
@@ -273,7 +273,7 @@ export type NetworkCookie = {
   expires: number,
   httpOnly: boolean,
   secure: boolean,
-  sameSite: 'Strict' | 'Lax' | 'None',
+  sameSite: 'Strict' | 'Lax' | 'None' | 'Default',
   partitionKey?: string,
   _crHasCrossSiteAncestor?: boolean,
 };

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -223,6 +223,7 @@ SetNetworkCookie:
       - Strict
       - Lax
       - None
+      - Default
     partitionKey: string?
     _crHasCrossSiteAncestor: boolean?
 
@@ -243,6 +244,7 @@ NetworkCookie:
       - Strict
       - Lax
       - None
+      - Default
     partitionKey: string?
     _crHasCrossSiteAncestor: boolean?
 

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -80,8 +80,10 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
       await run('Lax');
     else if (browserName === 'webkit')
       await run('None'); // Windows + older macOS
-    else if (browserName === 'firefox' || browserName as any === '_bidiFirefox')
+    else if (browserName === 'firefox')
       await run('None');
+    else if (browserName as any === '_bidiFirefox')
+      await run('Default');
     else
       throw new Error('unknown browser - ' + browserName);
   }, { scope: 'worker' }],

--- a/tests/library/browsercontext-cookies-third-party.spec.ts
+++ b/tests/library/browsercontext-cookies-third-party.spec.ts
@@ -523,16 +523,16 @@ test('should be able to send third party cookies via an iframe', async ({ browse
   }
 });
 
-test('should(not) block third party cookies - persistent context', async ({ httpsServer, launchPersistent, allowsThirdParty }) => {
+test('should(not) block third party cookies - persistent context', async ({ httpsServer, launchPersistent, allowsThirdParty, defaultSameSiteCookieValue }) => {
   const { page, context } = await launchPersistent();
-  await testThirdPartyCookiesAreBlocked(page, context, httpsServer, allowsThirdParty);
+  await testThirdPartyCookiesAreBlocked(page, context, httpsServer, allowsThirdParty, defaultSameSiteCookieValue);
 });
 
-test('should(not) block third party cookies - ephemeral context', async ({ page, context, httpsServer, allowsThirdParty }) => {
-  await testThirdPartyCookiesAreBlocked(page, context, httpsServer, allowsThirdParty);
+test('should(not) block third party cookies - ephemeral context', async ({ page, context, httpsServer, allowsThirdParty, defaultSameSiteCookieValue }) => {
+  await testThirdPartyCookiesAreBlocked(page, context, httpsServer, allowsThirdParty, defaultSameSiteCookieValue);
 });
 
-async function testThirdPartyCookiesAreBlocked(page: Page, context: BrowserContext, server: TestServer, allowsThirdParty: boolean) {
+async function testThirdPartyCookiesAreBlocked(page: Page, context: BrowserContext, server: TestServer, allowsThirdParty: boolean, defaultSameSiteCookieValue: string) {
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(src => {
     let fulfill;
@@ -558,7 +558,7 @@ async function testThirdPartyCookiesAreBlocked(page: Page, context: BrowserConte
         'httpOnly': false,
         'name': 'username',
         'path': '/',
-        'sameSite': 'None',
+        'sameSite': defaultSameSiteCookieValue,
         'secure': false,
         'value': 'John Doe'
       }


### PR DESCRIPTION
This PR fixes #36225 and #36877 for BiDi (but doesn't change how cookies are handled when Playwright doesn't use BiDi) and the following tests in Firefox:

in `tests/library/browsercontext-add-cookies.spec.ts`:
- "should roundtrip cookie"

in `tests/library/browsercontext-clearcookies.spec.ts`:
- "should remove cookies by name"
- "should remove cookies by name regex"
- "should remove cookies by domain"
- "should remove cookies by path"
- "should remove cookies by name and domain"
