### PR TITLE
fix(android): don't deny launching browsers

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/androidDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/androidDispatcher.ts
@@ -27,10 +27,8 @@ import type { Progress } from '@protocol/progress';
 
 export class AndroidDispatcher extends Dispatcher<Android, channels.AndroidChannel, RootDispatcher> implements channels.AndroidChannel {
   _type_Android = true;
-  _denyLaunch: boolean;
-  constructor(scope: RootDispatcher, android: Android, denyLaunch: boolean) {
+  constructor(scope: RootDispatcher, android: Android) {
     super(scope, android, 'Android', {});
-    this._denyLaunch = denyLaunch;
   }
 
   async devices(params: channels.AndroidDevicesParams, progress: Progress): Promise<channels.AndroidDevicesResult> {
@@ -161,8 +159,6 @@ export class AndroidDeviceDispatcher extends Dispatcher<AndroidDevice, channels.
   }
 
   async launchBrowser(params: channels.AndroidDeviceLaunchBrowserParams, progress: Progress): Promise<channels.AndroidDeviceLaunchBrowserResult> {
-    if (this.parentScope()._denyLaunch)
-      throw new Error(`Launching more browsers is not allowed.`);
     const context = await this._object.launchBrowser(progress, params.pkg, params);
     return { context: BrowserContextDispatcher.from(this, context) };
   }
@@ -172,8 +168,6 @@ export class AndroidDeviceDispatcher extends Dispatcher<AndroidDevice, channels.
   }
 
   async connectToWebView(params: channels.AndroidDeviceConnectToWebViewParams, progress: Progress): Promise<channels.AndroidDeviceConnectToWebViewResult> {
-    if (this.parentScope()._denyLaunch)
-      throw new Error(`Launching more browsers is not allowed.`);
     return { context: BrowserContextDispatcher.from(this, await this._object.connectToWebView(progress, params.socketName)) };
   }
 }

--- a/packages/playwright-core/src/server/dispatchers/playwrightDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/playwrightDispatcher.ts
@@ -55,7 +55,7 @@ export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.Playwr
     const webkit = new BrowserTypeDispatcher(scope, playwright.webkit, denyLaunch);
     const _bidiChromium = new BrowserTypeDispatcher(scope, playwright._bidiChromium, denyLaunch);
     const _bidiFirefox = new BrowserTypeDispatcher(scope, playwright._bidiFirefox, denyLaunch);
-    const android = new AndroidDispatcher(scope, playwright.android, denyLaunch);
+    const android = new AndroidDispatcher(scope, playwright.android);
     const initializer: channels.PlaywrightInitializer = {
       chromium,
       firefox,

--- a/tests/android/launch-server.spec.ts
+++ b/tests/android/launch-server.spec.ts
@@ -153,3 +153,15 @@ test('android.launchServer should terminate WS connection when device gets disco
     await new Promise(f => forwardingServer.close(f));
   }
 });
+
+test('android.launchServer should be able to launch browser', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36911' } }, async ({ playwright }) => {
+  const browserServer = await playwright._android.launchServer();
+  const device = await playwright._android.connect(browserServer.wsEndpoint());
+  const context = await device.launchBrowser();
+  const [page] = context.pages();
+  await page.goto('data:text/html,<title>Hello world!</title>');
+  expect(await page.title()).toBe('Hello world!');
+  await context.close();
+  await device.close();
+  await browserServer.close();
+});


### PR DESCRIPTION
We got a little bit too eager in https://github.com/microsoft/playwright/pull/36353. The purpose of `denyLaunch` is to prevent launching more browsers if there's a prelaunched *browser*. In this Android case though, there's just a prelaunched *android device*; and we were still denying launch of more browsers.

Closes https://github.com/microsoft/playwright/issues/36911