### PR TITLE
fix(firefox): filter host header from overrides

### DIFF
--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -349,8 +349,12 @@ export class Route extends SdkObject {
       if (oldUrl.protocol !== newUrl.protocol)
         throw new Error('New URL must have same protocol as overridden URL');
     }
-    if (overrides.headers)
-      overrides.headers = overrides.headers?.filter(header => header.name.toLowerCase() !== 'cookie');
+    if (overrides.headers) {
+      overrides.headers = overrides.headers?.filter(header => {
+        const headerName = header.name.toLowerCase();
+        return headerName !== 'cookie' && headerName !== 'host';
+      });
+    }
     overrides = this._request._applyOverrides(overrides);
 
     const nextHandler = this._futureHandlers.shift();

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -59,15 +59,10 @@ it('should not allow to override unsafe HTTP headers', async ({ page, server, br
     // but doesn't throw an error either.
     expect(error).toBeFalsy();
     serverRequestPromise.catch(() => {});
-  } else if (browserName === 'chromium') {
-    expect(error.message).toContain('Unsafe header');
-    serverRequestPromise.catch(() => {});
   } else {
     expect(error).toBeFalsy();
-    // These lines just document current behavior in FF and WK,
-    // we don't necessarily want to maintain this behavior.
     const serverRequest = await serverRequestPromise;
-    expect(serverRequest.headers['host']).toBe('bar');
+    expect(serverRequest.headers['host']).toBe(new URL(server.EMPTY_PAGE).host);
   }
 });
 

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -51,7 +51,8 @@ it('should not allow to override unsafe HTTP headers', async ({ page, server, br
   const error = await route.continue({
     headers: {
       ...route.request().headers(),
-      host: 'bar'
+      host: 'bar',
+      trailer: 'baz',
     }
   }).catch(e => e);
   if (isElectron) {
@@ -59,9 +60,15 @@ it('should not allow to override unsafe HTTP headers', async ({ page, server, br
     // but doesn't throw an error either.
     expect(error).toBeFalsy();
     serverRequestPromise.catch(() => {});
+  } else if (browserName === 'chromium') {
+    expect(error.message).toContain('Unsafe header');
+    serverRequestPromise.catch(() => {});
   } else {
     expect(error).toBeFalsy();
+    // These lines just document current behavior in FF and WK,
+    // we don't necessarily want to maintain this behavior.
     const serverRequest = await serverRequestPromise;
+    expect(serverRequest.headers['trailer']).toBe('baz');
     expect(serverRequest.headers['host']).toBe(new URL(server.EMPTY_PAGE).host);
   }
 });


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/36719