### PR TITLE
fix(ai): properly capture iframe properties in AI snapshots

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -1034,7 +1034,7 @@ async function snapshotFrameForAI(progress: Progress, frame: frames.Frame, frame
   const lines = snapshot.split('\n');
   const result = [];
   for (const line of lines) {
-    const match = line.match(/^(\s*)- iframe (?:\[active\] )?\[ref=(.*)\]/);
+    const match = line.match(/^(\s*)- iframe (?:\[active\] )?\[ref=([^\]]*)\]/);
     if (!match) {
       result.push(line);
       continue;

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -374,3 +374,21 @@ it('return empty snapshot when iframe is not loaded', { annotation: { type: 'iss
       - iframe [ref=e3]
   `);
 });
+
+it('should support many properties on iframes', async ({ page }) => {
+  await page.setContent(`
+    <input id="regular-input" placeholder="Regular input">
+    <iframe style='cursor: pointer' src="data:text/html,<input id='iframe-input' placeholder='Input in iframe'/>" tabindex="0"></iframe>
+  `);
+
+  // Test 1: Focus the input inside the iframe
+  await page.frameLocator('iframe').locator('#iframe-input').focus();
+  const inputInIframeFocusedSnapshot = await snapshotForAI(page);
+
+  expect(inputInIframeFocusedSnapshot).toContainYaml(`
+    - generic [ref=e1]:
+      - textbox "Regular input" [ref=e2]
+      - iframe [active] [ref=e3] [cursor=pointer]:
+        - textbox "Input in iframe" [active] [ref=f1e2]
+  `);
+});


### PR DESCRIPTION
Resolves #36931.

Don't allow the `iframe` Aria regex to escape the bounds of the `ref` property.