### PR TITLE
Revert "devops: pin NPM on Node.js 24 (#36924)"

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -35,11 +35,6 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-    # See https://github.com/microsoft/playwright/issues/36923
-    - name: Pin NPM (if Node.js 24)
-      if: ${{ inputs.node-version == '24' }}
-      run: npm i -g npm@10.4
-      shell: bash
     - uses: ./.github/actions/enable-microphone-access
     - run: |
         echo "::group::npm ci"


### PR DESCRIPTION
This reverts commit 77dca52ec94758f2704cc83e1faec8b90c97e539.

Fixes https://github.com/microsoft/playwright/issues/36923