### PR TITLE
chore: cleanup api calls in builtin fixtures

### DIFF
--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -60,20 +60,18 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
   }
 
   async _newContextForReuse(options: BrowserContextOptions = {}): Promise<BrowserContext> {
-    return await this._wrapApiCall(() => this._innerNewContext(options, true), { internal: true });
+    return await this._innerNewContext(options, true);
   }
 
   async _disconnectFromReusedContext(reason: string) {
-    return await this._wrapApiCall(async () => {
-      const context = [...this._contexts].find(context => context._forReuse);
-      if (!context)
-        return;
-      await this._instrumentation.runBeforeCloseBrowserContext(context);
-      for (const page of context.pages())
-        page._onClose();
-      context._onClose();
-      await this._channel.disconnectFromReusedContext({ reason });
-    }, { internal: true });
+    const context = [...this._contexts].find(context => context._forReuse);
+    if (!context)
+      return;
+    await this._instrumentation.runBeforeCloseBrowserContext(context);
+    for (const page of context.pages())
+      page._onClose();
+    context._onClose();
+    await this._channel.disconnectFromReusedContext({ reason });
   }
 
   async _innerNewContext(options: BrowserContextOptions = {}, forReuse: boolean): Promise<BrowserContext> {

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -495,8 +495,8 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     this._closeReason = options.reason;
     this._closingStatus = 'closing';
     await this.request.dispose(options);
+    await this._instrumentation.runBeforeCloseBrowserContext(this);
     await this._wrapApiCall(async () => {
-      await this._instrumentation.runBeforeCloseBrowserContext(this);
       for (const [harId, harParams] of this._harRecorders) {
         const har = await this._channel.harExport({ harId });
         const artifact = Artifact.from(har.artifact);

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -108,15 +108,16 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
       userDataDir: (this._platform.path().isAbsolute(userDataDir) || !userDataDir) ? userDataDir : this._platform.path().resolve(userDataDir),
       timeout: new TimeoutSettings(this._platform).launchTimeout(options),
     };
-    return await this._wrapApiCall(async () => {
+    const context = await this._wrapApiCall(async () => {
       const result = await this._channel.launchPersistentContext(persistentParams);
       const browser = Browser.from(result.browser);
       browser._connectToBrowserType(this, options, logger);
       const context = BrowserContext.from(result.context);
       await context._initializeHarFromOptions(options.recordHar);
-      await this._instrumentation.runAfterCreateBrowserContext(context);
       return context;
     });
+    await this._instrumentation.runAfterCreateBrowserContext(context);
+    return context;
   }
 
   connect(options: api.ConnectOptions & { wsEndpoint: string }): Promise<Browser>;

--- a/packages/playwright-ct-core/src/mount.ts
+++ b/packages/playwright-ct-core/src/mount.ts
@@ -21,7 +21,7 @@ import type { ContextReuseMode, FullConfigInternal } from '../../playwright/src/
 import type { RouterFixture } from '../index';
 import type { ImportRef } from './injected/importRegistry';
 import type { Component, JsxComponent, MountOptions, ObjectComponentOptions } from '../types/component';
-import type { BrowserContext, BrowserContextOptions, Fixtures, Locator, Page, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions } from 'playwright/test';
+import type { Fixtures, Locator, Page, PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions } from 'playwright/test';
 import type { Page as PageImpl } from 'playwright-core/lib/client/page';
 
 let boundCallbacksForMount: Function[] = [];
@@ -37,7 +37,6 @@ type TestFixtures = PlaywrightTestArgs & PlaywrightTestOptions & {
 };
 type WorkerFixtures = PlaywrightWorkerArgs & PlaywrightWorkerOptions;
 type BaseTestFixtures = {
-  _contextFactory: (options?: BrowserContextOptions) => Promise<BrowserContext>,
   _optionContextReuseMode: ContextReuseMode
 };
 

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -105,7 +105,10 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
   }, { scope: 'worker' }],
 
   contextFactory: async ({ _contextFactory }: any, run) => {
-    await run(_contextFactory);
+    await run(async options => {
+      const { context } = await _contextFactory(options);
+      return context;
+    });
   },
 
   createUserDataDir: async ({ mode }, run) => {

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -168,6 +168,8 @@ test('should open simple trace viewer', async ({ showTraceViewer }) => {
     /Wait for timeout/,
     /Navigate to "\/frames\/frame.html"/,
     /Set viewport size/,
+    /Hover/,
+    /Close page/,
   ]);
 });
 
@@ -1597,7 +1599,8 @@ test('should not leak recorders', {
     return frame;
   };
 
-  await expect(traceViewer.snapshotContainer.contentFrame().locator('body')).toContainText(`Hi, I'm frame`);
+  const frame0 = await traceViewer.snapshotFrame('Set viewport');
+  await expect(frame0.locator('body')).toContainText(`Hi, I'm frame`);
 
   const frame1 = await forceRecorder('Navigate');
   await expect(frame1.locator('body')).toContainText('Hello world');
@@ -1845,6 +1848,8 @@ test('should render blob trace received from message', async ({ showTraceViewer 
     /Wait for timeout/,
     /Navigate to "\/frames\/frame.html"/,
     /Set viewport size/,
+    /Hover/,
+    /Close page/,
   ]);
 });
 

--- a/tests/playwright-test/playwright.connect.spec.ts
+++ b/tests/playwright-test/playwright.connect.spec.ts
@@ -223,6 +223,7 @@ test('should record trace', async ({ runInlineTest }) => {
     'After Hooks',
     'Fixture "page"',
     'Fixture "context"',
+    'Close context',
     'Worker Cleanup',
     'Fixture "browser"',
   ]);

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -102,6 +102,7 @@ test('should record api trace', async ({ runInlineTest, server }, testInfo) => {
     'After Hooks',
     '  Fixture "page"',
     '  Fixture "context"',
+    '    Close context',
     '  Fixture "request"',
   ]);
   const trace2 = await parseTrace(testInfo.outputPath('test-results', 'a-api-pass', 'trace.zip'));
@@ -126,6 +127,7 @@ test('should record api trace', async ({ runInlineTest, server }, testInfo) => {
     'After Hooks',
     '  Fixture "page"',
     '  Fixture "context"',
+    '    Close context',
     '  Fixture "request"',
     'Worker Cleanup',
     '  Fixture "browser"',
@@ -325,6 +327,7 @@ test('should not override trace file in afterAll', async ({ runInlineTest, serve
     'After Hooks',
     '  Fixture "page"',
     '  Fixture "context"',
+    '    Close context',
     '  afterAll hook',
     '    Fixture "request"',
     '      Create request context',
@@ -615,6 +618,7 @@ test('should expand expect.toPass', async ({ runInlineTest }, testInfo) => {
     'After Hooks',
     '  Fixture "page"',
     '  Fixture "context"',
+    '    Close context',
   ]);
 });
 
@@ -648,6 +652,7 @@ test('should show non-expect error in trace', async ({ runInlineTest }, testInfo
     'After Hooks',
     '  Fixture "page"',
     '  Fixture "context"',
+    '    Close context',
     'Worker Cleanup',
     '  Fixture "browser"',
   ]);
@@ -776,6 +781,7 @@ test('should use custom expect message in trace', async ({ runInlineTest }, test
     'After Hooks',
     '  Fixture "page"',
     '  Fixture "context"',
+    '    Close context',
   ]);
 });
 
@@ -959,6 +965,7 @@ test('should record nested steps, even after timeout', async ({ runInlineTest },
     '      Set content',
     '  Fixture "page"',
     '  Fixture "context"',
+    '    Close context',
     '  afterAll hook',
     '    Fixture "barPage"',
     '      Expect "barPage setup"',
@@ -1018,6 +1025,7 @@ test('should not produce an action entry for calling a binding', async ({ runInl
     'After Hooks',
     '  Fixture "page"',
     '  Fixture "context"',
+    '    Close context',
   ]);
 });
 
@@ -1248,6 +1256,7 @@ test('should not nest top level expect into unfinished api calls ', {
     'After Hooks',
     '  Fixture "page"',
     '  Fixture "context"',
+    '    Close context',
   ]);
 });
 

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -153,6 +153,7 @@ test.step |  inner step 2.2 @ a.test.ts:10
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -217,6 +218,7 @@ test.step |my step @ a.test.ts:4
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 hook      |Worker Cleanup
 fixture   |  browser
           |Test timeout of 2000ms exceeded.
@@ -566,6 +568,7 @@ hook      |  afterEach hook @ a.test.ts:15
 test.step |    in afterEach @ a.test.ts:16
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 hook      |  afterAll hook @ a.test.ts:7
 test.step |    in afterAll @ a.test.ts:8
 `);
@@ -893,6 +896,7 @@ expect    |Checking color @ a.test.ts:6
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -989,6 +993,7 @@ expect    |    toBe @ a.test.ts:9
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -1041,6 +1046,7 @@ expect    |  toHaveLength @ a.test.ts:6
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -1093,6 +1099,7 @@ expect    |  toBe @ a.test.ts:6
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -1142,6 +1149,7 @@ expect    |not toHaveTitle @ a.test.ts:11
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -1230,6 +1238,7 @@ hook      |After Hooks
 fixture   |  request
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -1265,6 +1274,7 @@ pw:api    |↪ error: TimeoutError: page.click: Timeout 1ms exceeded.
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 hook      |Worker Cleanup
 fixture   |  browser
           |TimeoutError: page.click: Timeout 1ms exceeded.
@@ -1301,6 +1311,7 @@ pw:api    |Evaluate locator('button') @ a.test.ts:6
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -1390,6 +1401,7 @@ pw:api    |        Set content @ a.test.ts:8
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -1444,6 +1456,7 @@ expect    |toBe @ a.test.ts:18
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -1480,6 +1493,7 @@ pw:api    |Navigate to "/empty.html" @ a.test.ts:10
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -1524,6 +1538,7 @@ expect    |  toBe @ a.test.ts:8
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });
 
@@ -1749,5 +1764,6 @@ pw:api    |Set content @ a.test.ts:19
 hook      |After Hooks
 fixture   |  page
 fixture   |  context
+pw:api    |    Close context
 `);
 });

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -268,6 +268,7 @@ test('should report toHaveScreenshot step with expectation name in title', async
     `end [expect] toHaveScreenshot(foo.png)`,
     `end [expect] toHaveScreenshot(is-a-test-1.png)`,
     `end [fixture] page`,
+    `end [pw:api] Close context`,
     `end [fixture] context`,
     `end [hook] After Hooks`,
   ]);


### PR DESCRIPTION
- Make sure `wrapApiCall` with `internal` flag happens on the right calls.
- Do not `wrapApiCall` client instrumentation, leave that decision to the embedder.
- Cleanup some unnecessary typecasts.
- Make sure `Close context` actually happens inside the `context` fixture.

Fixes issues discovered by #36929.