### PR TITLE
feat: "Show all actions" setting in the trace viewer

### DIFF
--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -130,7 +130,8 @@ export class FixturePool {
           continue;
         }
       } else if (previous) {
-        options = { auto: previous.auto, scope: previous.scope, option: previous.option, timeout: previous.timeout, customTitle: previous.customTitle, box: previous.box };
+        // Note: deliberately not inheriting "options.box" so that fixture override is visible by default.
+        options = { auto: previous.auto, scope: previous.scope, option: previous.option, timeout: previous.timeout, customTitle: previous.customTitle };
       } else if (!options) {
         options = { auto: false, scope: 'test', option: false, timeout: undefined };
       }

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -69,20 +69,20 @@ type WorkerFixtures = PlaywrightWorkerArgs & PlaywrightWorkerOptions & {
 };
 
 const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
-  defaultBrowserType: ['chromium', { scope: 'worker', option: true }],
-  browserName: [({ defaultBrowserType }, use) => use(defaultBrowserType), { scope: 'worker', option: true }],
+  defaultBrowserType: ['chromium', { scope: 'worker', option: true, box: true }],
+  browserName: [({ defaultBrowserType }, use) => use(defaultBrowserType), { scope: 'worker', option: true, box: true }],
   playwright: [async ({}, use) => {
     await use(require('playwright-core'));
   }, { scope: 'worker', box: true }],
-  headless: [({ launchOptions }, use) => use(launchOptions.headless ?? true), { scope: 'worker', option: true }],
-  channel: [({ launchOptions }, use) => use(launchOptions.channel), { scope: 'worker', option: true }],
-  launchOptions: [{}, { scope: 'worker', option: true }],
+  headless: [({ launchOptions }, use) => use(launchOptions.headless ?? true), { scope: 'worker', option: true, box: true }],
+  channel: [({ launchOptions }, use) => use(launchOptions.channel), { scope: 'worker', option: true, box: true }],
+  launchOptions: [{}, { scope: 'worker', option: true, box: true }],
   connectOptions: [async ({ _optionConnectOptions }, use) => {
     await use(connectOptionsFromEnv() || _optionConnectOptions);
-  }, { scope: 'worker', option: true }],
-  screenshot: ['off', { scope: 'worker', option: true }],
-  video: ['off', { scope: 'worker', option: true }],
-  trace: ['off', { scope: 'worker', option: true }],
+  }, { scope: 'worker', option: true, box: true }],
+  screenshot: ['off', { scope: 'worker', option: true, box: true }],
+  video: ['off', { scope: 'worker', option: true, box: true }],
+  trace: ['off', { scope: 'worker', option: true, box: true }],
 
   _browserOptions: [async ({ playwright, headless, channel, launchOptions }, use) => {
     const options: LaunchOptions = {
@@ -124,34 +124,34 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
     await browser.close({ reason: 'Test ended.' });
   }, { scope: 'worker', timeout: 0 }],
 
-  acceptDownloads: [({ contextOptions }, use) => use(contextOptions.acceptDownloads ?? true), { option: true }],
-  bypassCSP: [({ contextOptions }, use) => use(contextOptions.bypassCSP ?? false), { option: true }],
-  colorScheme: [({ contextOptions }, use) => use(contextOptions.colorScheme === undefined ? 'light' : contextOptions.colorScheme), { option: true }],
-  deviceScaleFactor: [({ contextOptions }, use) => use(contextOptions.deviceScaleFactor), { option: true }],
-  extraHTTPHeaders: [({ contextOptions }, use) => use(contextOptions.extraHTTPHeaders), { option: true }],
-  geolocation: [({ contextOptions }, use) => use(contextOptions.geolocation), { option: true }],
-  hasTouch: [({ contextOptions }, use) => use(contextOptions.hasTouch ?? false), { option: true }],
-  httpCredentials: [({ contextOptions }, use) => use(contextOptions.httpCredentials), { option: true }],
-  ignoreHTTPSErrors: [({ contextOptions }, use) => use(contextOptions.ignoreHTTPSErrors ?? false), { option: true }],
-  isMobile: [({ contextOptions }, use) => use(contextOptions.isMobile ?? false), { option: true }],
-  javaScriptEnabled: [({ contextOptions }, use) => use(contextOptions.javaScriptEnabled ?? true), { option: true }],
-  locale: [({ contextOptions }, use) => use(contextOptions.locale ?? 'en-US'), { option: true }],
-  offline: [({ contextOptions }, use) => use(contextOptions.offline ?? false), { option: true }],
-  permissions: [({ contextOptions }, use) => use(contextOptions.permissions), { option: true }],
-  proxy: [({ contextOptions }, use) => use(contextOptions.proxy), { option: true }],
-  storageState: [({ contextOptions }, use) => use(contextOptions.storageState), { option: true }],
-  clientCertificates: [({ contextOptions }, use) => use(contextOptions.clientCertificates), { option: true }],
-  timezoneId: [({ contextOptions }, use) => use(contextOptions.timezoneId), { option: true }],
-  userAgent: [({ contextOptions }, use) => use(contextOptions.userAgent), { option: true }],
-  viewport: [({ contextOptions }, use) => use(contextOptions.viewport === undefined ? { width: 1280, height: 720 } : contextOptions.viewport), { option: true }],
-  actionTimeout: [0, { option: true }],
-  testIdAttribute: ['data-testid', { option: true }],
-  navigationTimeout: [0, { option: true }],
+  acceptDownloads: [({ contextOptions }, use) => use(contextOptions.acceptDownloads ?? true), { option: true, box: true }],
+  bypassCSP: [({ contextOptions }, use) => use(contextOptions.bypassCSP ?? false), { option: true, box: true }],
+  colorScheme: [({ contextOptions }, use) => use(contextOptions.colorScheme === undefined ? 'light' : contextOptions.colorScheme), { option: true, box: true }],
+  deviceScaleFactor: [({ contextOptions }, use) => use(contextOptions.deviceScaleFactor), { option: true, box: true }],
+  extraHTTPHeaders: [({ contextOptions }, use) => use(contextOptions.extraHTTPHeaders), { option: true, box: true }],
+  geolocation: [({ contextOptions }, use) => use(contextOptions.geolocation), { option: true, box: true }],
+  hasTouch: [({ contextOptions }, use) => use(contextOptions.hasTouch ?? false), { option: true, box: true }],
+  httpCredentials: [({ contextOptions }, use) => use(contextOptions.httpCredentials), { option: true, box: true }],
+  ignoreHTTPSErrors: [({ contextOptions }, use) => use(contextOptions.ignoreHTTPSErrors ?? false), { option: true, box: true }],
+  isMobile: [({ contextOptions }, use) => use(contextOptions.isMobile ?? false), { option: true, box: true }],
+  javaScriptEnabled: [({ contextOptions }, use) => use(contextOptions.javaScriptEnabled ?? true), { option: true, box: true }],
+  locale: [({ contextOptions }, use) => use(contextOptions.locale ?? 'en-US'), { option: true, box: true }],
+  offline: [({ contextOptions }, use) => use(contextOptions.offline ?? false), { option: true, box: true }],
+  permissions: [({ contextOptions }, use) => use(contextOptions.permissions), { option: true, box: true }],
+  proxy: [({ contextOptions }, use) => use(contextOptions.proxy), { option: true, box: true }],
+  storageState: [({ contextOptions }, use) => use(contextOptions.storageState), { option: true, box: true }],
+  clientCertificates: [({ contextOptions }, use) => use(contextOptions.clientCertificates), { option: true, box: true }],
+  timezoneId: [({ contextOptions }, use) => use(contextOptions.timezoneId), { option: true, box: true }],
+  userAgent: [({ contextOptions }, use) => use(contextOptions.userAgent), { option: true, box: true }],
+  viewport: [({ contextOptions }, use) => use(contextOptions.viewport === undefined ? { width: 1280, height: 720 } : contextOptions.viewport), { option: true, box: true }],
+  actionTimeout: [0, { option: true, box: true }],
+  testIdAttribute: ['data-testid', { option: true, box: true }],
+  navigationTimeout: [0, { option: true, box: true }],
   baseURL: [async ({ }, use) => {
     await use(process.env.PLAYWRIGHT_TEST_BASE_URL);
-  }, { option: true }],
-  serviceWorkers: [({ contextOptions }, use) => use(contextOptions.serviceWorkers ?? 'allow'), { option: true }],
-  contextOptions: [{}, { option: true }],
+  }, { option: true, box: true }],
+  serviceWorkers: [({ contextOptions }, use) => use(contextOptions.serviceWorkers ?? 'allow'), { option: true, box: true }],
+  contextOptions: [{}, { option: true, box: true }],
 
   _combinedContextOptions: [async ({
     acceptDownloads,
@@ -398,8 +398,8 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
     await Promise.all([...contexts.values()].map(data => data.close()));
   }, { scope: 'test',  title: 'context', box: true }],
 
-  _optionContextReuseMode: ['none', { scope: 'worker', option: true }],
-  _optionConnectOptions: [undefined, { scope: 'worker', option: true }],
+  _optionContextReuseMode: ['none', { scope: 'worker', option: true, box: true }],
+  _optionConnectOptions: [undefined, { scope: 'worker', option: true, box: true }],
 
   _reuseContext: [async ({ video, _optionContextReuseMode }, use) => {
     let mode = _optionContextReuseMode;

--- a/packages/playwright/src/worker/fixtureRunner.ts
+++ b/packages/playwright/src/worker/fixtureRunner.ts
@@ -19,7 +19,7 @@ import { ManualPromise } from 'playwright-core/lib/utils';
 import { fixtureParameterNames } from '../common/fixtures';
 import { filterStackFile, formatLocation } from '../util';
 
-import type { TestInfoImpl } from './testInfo';
+import type { TestInfoImpl, TestStepVisibility } from './testInfo';
 import type { FixtureDescription, RunnableDescription } from './timeoutManager';
 import type { WorkerInfo } from '../../types/test';
 import type { Location } from '../../types/testReporter';
@@ -35,7 +35,7 @@ class Fixture {
   private _selfTeardownComplete: Promise<void> | undefined;
   private _setupDescription: FixtureDescription;
   private _teardownDescription: FixtureDescription;
-  private _stepInfo: { title: string, category: 'fixture', location?: Location, hidden?: boolean };
+  private _stepInfo: { title: string, category: 'fixture', location?: Location, visibility?: TestStepVisibility };
   _deps = new Set<Fixture>();
   _usages = new Set<Fixture>();
 
@@ -43,11 +43,12 @@ class Fixture {
     this.runner = runner;
     this.registration = registration;
     this.value = null;
-    const hidden = this.registration.box || this.registration.option;
     const isUserFixture = this.registration.location && filterStackFile(this.registration.location.file);
     const title = this.registration.customTitle || this.registration.name;
     const location = isUserFixture ? this.registration.location : undefined;
-    this._stepInfo = { title, category: 'fixture', location, hidden };
+    this._stepInfo = { title, category: 'fixture', location };
+    if (this.registration.box)
+      this._stepInfo.visibility = isUserFixture ? 'hidden' : 'internal';
     this._setupDescription = {
       title,
       phase: 'setup',

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -264,18 +264,19 @@ export class TestTracing {
     });
   }
 
-  appendBeforeActionForStep(callId: string, parentId: string | undefined, options: { title: string, category: TestStepCategory, params?: Record<string, any>, stack: StackFrame[] }) {
+  appendBeforeActionForStep(options: { stepId: string, parentId?: string, title: string, category: TestStepCategory, params?: Record<string, any>, stack: StackFrame[], visibility?: 'hidden' }) {
     this._appendTraceEvent({
       type: 'before',
-      callId,
-      stepId: callId,
-      parentId,
+      callId: options.stepId,
+      stepId: options.stepId,
+      parentId: options.parentId,
       startTime: monotonicTime(),
       class: 'Test',
-      method: 'step',
+      method: options.category,
       title: stepTitle(options.category, options.title),
       params: Object.fromEntries(Object.entries(options.params || {}).map(([name, value]) => [name, generatePreview(value)])),
       stack: options.stack,
+      visibility: options.visibility,
     });
   }
 

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -122,7 +122,7 @@ export const renderAction = (
 
   const locator = action.params.selector ? asLocatorDescription(sdkLanguage || 'javascript', action.params.selector) : undefined;
 
-  const isSkipped = action.class === 'Test' && action.method === 'step' && action.annotations?.some(a => a.type === 'skip');
+  const isSkipped = action.class === 'Test' && action.method === 'test.step' && action.annotations?.some(a => a.type === 'skip');
   let time: string = '';
   if (action.endTime)
     time = msToString(action.endTime - action.startTime);

--- a/packages/trace-viewer/src/ui/defaultSettingsView.tsx
+++ b/packages/trace-viewer/src/ui/defaultSettingsView.tsx
@@ -27,6 +27,7 @@ export const DefaultSettingsView: React.FC<{}> = () => {
     shouldPopulateCanvasFromScreenshot,
     setShouldPopulateCanvasFromScreenshot,
   ] = useSetting('shouldPopulateCanvasFromScreenshot', false);
+  const [showAllActions, setShowAllActions] = useSetting('showAllActions', false);
   const [darkMode, setDarkMode] = useDarkModeSetting();
 
   return (
@@ -37,7 +38,12 @@ export const DefaultSettingsView: React.FC<{}> = () => {
           value: shouldPopulateCanvasFromScreenshot,
           set: setShouldPopulateCanvasFromScreenshot,
           name: 'Display canvas content',
-          title: 'Attempt to display the captured canvas appearance in the snapshot preview. May not be accurate.'
+          title: 'Attempt to display the captured canvas appearance in the snapshot preview. May not be accurate.',
+        },
+        {
+          value: showAllActions,
+          set: setShowAllActions,
+          name: 'Show all actions',
         },
       ]}
     />

--- a/packages/trace-viewer/src/ui/modelUtil.ts
+++ b/packages/trace-viewer/src/ui/modelUtil.ts
@@ -120,6 +120,10 @@ export class MultiTraceModel {
     return this.actions.findLast(a => a.error);
   }
 
+  filteredActions(showAllActions: boolean) {
+    return showAllActions ? this.actions : this.actions.filter(a => a.visibility !== 'hidden');
+  }
+
   private _errorDescriptorsFromActions(): ErrorDescription[] {
     const errors: ErrorDescription[] = [];
     for (const action of this.actions || []) {
@@ -268,6 +272,8 @@ function mergeActionsAndUpdateTimingSameTrace(contexts: ContextEntry[]): ActionT
           existing.annotations = action.annotations;
         if (action.parentId)
           existing.parentId = nonPrimaryIdToPrimaryId.get(action.parentId) ?? action.parentId;
+        if (action.visibility === 'hidden')
+          existing.visibility = 'hidden';
         // For the events that are present in the test runner context, always take
         // their time from the test runner context to preserve client side order.
         existing.startTime = action.startTime;

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -50,8 +50,7 @@ export const SnapshotTabsView: React.FunctionComponent<{
 }> = ({ action, sdkLanguage, testIdAttributeName, isInspecting, setIsInspecting, highlightedElement, setHighlightedElement }) => {
   const [snapshotTab, setSnapshotTab] = React.useState<'action'|'before'|'after'>('action');
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [shouldPopulateCanvasFromScreenshot, _] = useSetting('shouldPopulateCanvasFromScreenshot', false);
+  const [shouldPopulateCanvasFromScreenshot] = useSetting('shouldPopulateCanvasFromScreenshot', false);
 
   const snapshots = React.useMemo(() => {
     return collectSnapshots(action);

--- a/packages/trace-viewer/src/ui/timeline.tsx
+++ b/packages/trace-viewer/src/ui/timeline.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { clsx, msToString, useMeasure } from '@web/uiUtils';
+import { useSetting, clsx, msToString, useMeasure } from '@web/uiUtils';
 import { GlassPane } from '@web/shared/glassPane';
 import * as React from 'react';
 import type { Boundaries } from './geometry';
@@ -53,6 +53,7 @@ export const Timeline: React.FunctionComponent<{
   const [measure, ref] = useMeasure<HTMLDivElement>();
   const [dragWindow, setDragWindow] = React.useState<{ startX: number, endX: number, pivot?: number, type: 'resize' | 'move' } | undefined>();
   const [previewPoint, setPreviewPoint] = React.useState<FilmStripPreviewPoint | undefined>();
+  const [showAllActions] = useSetting('showAllActions', false);
 
   const { offsets, curtainLeft, curtainRight } = React.useMemo(() => {
     let activeWindow = selectedTime || boundaries;
@@ -67,9 +68,11 @@ export const Timeline: React.FunctionComponent<{
     return { offsets: calculateDividerOffsets(measure.width, boundaries), curtainLeft, curtainRight };
   }, [selectedTime, boundaries, dragWindow, measure]);
 
+  const actions = React.useMemo(() => model?.filteredActions(showAllActions), [model, showAllActions]);
+
   const bars = React.useMemo(() => {
     const bars: TimelineBar[] = [];
-    for (const entry of model?.actions || []) {
+    for (const entry of actions || []) {
       if (entry.class === 'Test')
         continue;
       bars.push({
@@ -110,7 +113,7 @@ export const Timeline: React.FunctionComponent<{
     }
 
     return bars;
-  }, [model, consoleEntries, boundaries, measure]);
+  }, [model, actions, consoleEntries, boundaries, measure]);
 
   React.useMemo(() => {
     for (const bar of bars) {
@@ -154,7 +157,7 @@ export const Timeline: React.FunctionComponent<{
       return;
     const x = event.clientX - ref.current.getBoundingClientRect().left;
     const time = positionToTime(measure.width, boundaries, x);
-    const action = model?.actions.findLast(action => action.startTime <= time);
+    const action = actions?.findLast(action => action.startTime <= time);
 
     if (!event.buttons) {
       setDragWindow(undefined);
@@ -192,7 +195,7 @@ export const Timeline: React.FunctionComponent<{
     const time2 = positionToTime(measure.width, boundaries, newDragWindow.endX);
     if (time1 !== time2)
       setSelectedTime({ minimum: Math.min(time1, time2), maximum: Math.max(time1, time2) });
-  }, [boundaries, dragWindow, measure, model, onSelected, ref, setSelectedTime]);
+  }, [boundaries, dragWindow, measure, actions, onSelected, ref, setSelectedTime]);
 
   const onGlassPaneMouseUp = React.useCallback(() => {
     setPreviewPoint(undefined);
@@ -204,22 +207,22 @@ export const Timeline: React.FunctionComponent<{
       setSelectedTime({ minimum: Math.min(time1, time2), maximum: Math.max(time1, time2) });
     } else {
       const time = positionToTime(measure.width, boundaries, dragWindow.startX);
-      const action = model?.actions.findLast(action => action.startTime <= time);
+      const action = actions?.findLast(action => action.startTime <= time);
       if (action)
         onSelected(action);
       setSelectedTime(undefined);
     }
     setDragWindow(undefined);
-  }, [boundaries, dragWindow, measure, model, setSelectedTime, onSelected]);
+  }, [boundaries, dragWindow, measure, actions, setSelectedTime, onSelected]);
 
   const onMouseMove = React.useCallback((event: React.MouseEvent) => {
     if (!ref.current)
       return;
     const x = event.clientX - ref.current.getBoundingClientRect().left;
     const time = positionToTime(measure.width, boundaries, x);
-    const action = model?.actions.findLast(action => action.startTime <= time);
+    const action = actions?.findLast(action => action.startTime <= time);
     setPreviewPoint({ x, clientY: event.clientY, action, sdkLanguage });
-  }, [boundaries, measure, model, ref, sdkLanguage]);
+  }, [boundaries, measure, actions, ref, sdkLanguage]);
 
   const onMouseLeave = React.useCallback(() => {
     setPreviewPoint(undefined);

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -71,15 +71,18 @@ export const Workbench: React.FunctionComponent<{
   const [highlightedElement, setHighlightedElement] = React.useState<HighlightedElement>({ lastEdited: 'none' });
   const [selectedTime, setSelectedTime] = React.useState<Boundaries | undefined>();
   const [sidebarLocation, setSidebarLocation] = useSetting<'bottom' | 'right'>('propertiesSidebarLocation', 'bottom');
+  const [showAllActions] = useSetting('showAllActions', false);
 
   const setSelectedAction = React.useCallback((action: modelUtil.ActionTraceEventInContext | undefined) => {
     setSelectedCallId(action?.callId);
     setRevealedError(undefined);
   }, []);
 
+  const actions = React.useMemo(() => model?.filteredActions(showAllActions), [model, showAllActions]);
+
   const highlightedAction = React.useMemo(() => {
-    return model?.actions.find(a => a.callId === highlightedCallId);
-  }, [model, highlightedCallId]);
+    return actions?.find(a => a.callId === highlightedCallId);
+  }, [actions, highlightedCallId]);
 
   const setHighlightedAction = React.useCallback((highlightedAction: modelUtil.ActionTraceEventInContext | undefined) => {
     setHighlightedCallId(highlightedAction?.callId);
@@ -94,7 +97,7 @@ export const Workbench: React.FunctionComponent<{
 
   const selectedAction = React.useMemo(() => {
     if (selectedCallId) {
-      const action = model?.actions.find(a => a.callId === selectedCallId);
+      const action = actions?.find(a => a.callId === selectedCallId);
       if (action)
         return action;
     }
@@ -103,18 +106,18 @@ export const Workbench: React.FunctionComponent<{
     if (failedAction)
       return failedAction;
 
-    if (model?.actions.length) {
+    if (actions?.length) {
       // Select the last non-after hooks item.
-      let index = model.actions.length - 1;
-      for (let i = 0; i < model.actions.length; ++i) {
-        if (model.actions[i].title === 'After Hooks' && i) {
+      let index = actions.length - 1;
+      for (let i = 0; i < actions.length; ++i) {
+        if (actions[i].title === 'After Hooks' && i) {
           index = i - 1;
           break;
         }
       }
-      return model.actions[index];
+      return actions[index];
     }
-  }, [model, selectedCallId]);
+  }, [model, actions, selectedCallId]);
 
   const activeAction = React.useMemo(() => {
     return highlightedAction || selectedAction;
@@ -301,7 +304,7 @@ export const Workbench: React.FunctionComponent<{
       </div>}
       <ActionList
         sdkLanguage={sdkLanguage}
-        actions={model?.actions || []}
+        actions={actions || []}
         selectedAction={model ? selectedAction : undefined}
         selectedTime={selectedTime}
         setSelectedTime={setSelectedTime}

--- a/packages/trace/src/trace.ts
+++ b/packages/trace/src/trace.ts
@@ -70,6 +70,7 @@ export type BeforeActionTraceEvent = {
   stack?: StackFrame[];
   pageId?: string;
   parentId?: string;
+  visibility?: 'hidden';
 };
 
 export type InputActionTraceEvent = {

--- a/tests/config/utils.ts
+++ b/tests/config/utils.ts
@@ -163,7 +163,8 @@ export async function parseTrace(file: string): Promise<{ resources: Map<string,
   const traceModel = new TraceModel();
   await traceModel.load(backend, () => {});
   const model = new MultiTraceModel(traceModel.contextEntries);
-  const { rootItem } = buildActionTree(model.actions);
+  const actions = model.filteredActions(false);
+  const { rootItem } = buildActionTree(actions);
   const actionTree: string[] = [];
   const visit = (actionItem: ActionTreeItem, indent: string) => {
     const title = renderTitleForCall({ ...actionItem.action, type: actionItem.action.class });
@@ -173,9 +174,9 @@ export async function parseTrace(file: string): Promise<{ resources: Map<string,
   };
   rootItem.children.forEach(a => visit(a, ''));
   return {
-    titles: model.actions.map(a => renderTitleForCall({ ...a, type: a.class })),
+    titles: actions.map(a => renderTitleForCall({ ...a, type: a.class })),
     resources: backend.entries,
-    actions: model.actions,
+    actions,
     events: model.events,
     errors: model.errors.map(e => e.message),
     model,

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -480,6 +480,53 @@ test('should show custom fixture titles in actions tree', async ({ runUITest }) 
   ]);
 });
 
+test('should hide boxed fixtures and contents, reveal upon show all actions setting', async ({ runUITest }) => {
+  const { page } = await runUITest({
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+
+      const test = base.extend({
+        fixture: [async ({ page }, use) => {
+          await page.setContent('<div>hello</div>');
+          await use();
+        }, { auto: true, boxed: true }],
+      });
+
+      test('example', async ({ page }) => {
+        await expect(page.locator('body')).toBeVisible();
+      });
+    `,
+  });
+
+  await page.getByText('example').dblclick();
+  await expect(page.getByTestId('actions-tree')).toMatchAriaSnapshot(`
+    - tree:
+      - treeitem /Before Hooks/
+      - treeitem /Expect "toBeVisible"/
+      - treeitem /After Hooks/
+  `);
+
+  await page.getByText('Settings').click();
+  await page.getByText('Show all actions').click();
+
+  await page.getByTestId('actions-tree').getByRole('treeitem', { name: 'Before Hooks' }).locator('.codicon-chevron-right').click();
+  await page.getByTestId('actions-tree').getByRole('treeitem', { name: 'Fixture "fixture"' }).locator('.codicon-chevron-right').click();
+
+  await expect(page.getByTestId('actions-tree')).toMatchAriaSnapshot(`
+    - tree:
+      - treeitem /Before Hooks/:
+        - group:
+          - treeitem /Fixture "browser"/
+          - treeitem /Fixture "context"/
+          - treeitem /Fixture "page"/
+          - treeitem /Fixture "fixture"/:
+            - group:
+              - treeitem /Set content/
+      - treeitem /Expect "toBeVisible"/
+      - treeitem /After Hooks/
+  `);
+});
+
 test('attachments tab shows all but top-level .push attachments', async ({ runUITest }) => {
   const { page } = await runUITest({
     'a.test.ts': `


### PR DESCRIPTION
For now, this setting toggles whether to show boxed fixtures and their contents.

In the future, we'll add hidden-by-default playwright actions like routing or getters.

References #35184.

----

### Trace viewer settings

<img width="205" height="153" alt="Screenshot 2025-08-05 at 4 30 16 PM" src="https://github.com/user-attachments/assets/ddf70553-8952-494e-98fd-e95cb5742b1e" />

### Default actions

<img width="453" height="273" alt="Screenshot 2025-08-05 at 4 30 45 PM" src="https://github.com/user-attachments/assets/281b60ad-c71a-4070-af1e-caf7ed20f599" />

### All actions

<img width="452" height="321" alt="Screenshot 2025-08-05 at 4 31 11 PM" src="https://github.com/user-attachments/assets/89745ac9-b9b0-4056-b286-26ac7015f5df" />

---
