### PR TITLE
test: rebase test-output test

### DIFF
--- a/tests/playwright-test/ui-mode-test-output.spec.ts
+++ b/tests/playwright-test/ui-mode-test-output.spec.ts
@@ -205,7 +205,9 @@ test('should format console messages in page', async ({ runUITest }, testInfo) =
 
   const link = page.getByText('https://fb.me/react-devtools');
   await expect(link).toHaveCSS('color', 'rgb(0, 0, 255)');
-  await expect(link).toHaveCSS('text-decoration', 'none solid rgb(0, 0, 255)');
+  await expect(link).toHaveCSS('text-decoration-color', 'rgb(0, 0, 255)');
+  await expect(link).toHaveCSS('text-decoration-style', 'solid');
+  await expect(link).toHaveCSS('text-decoration-line', 'none');
 });
 
 test('should stream console messages live', async ({ runUITest }) => {


### PR DESCRIPTION
Not sure if its worth filing upstream:

```
Locator: getByText('https://fb.me/react-devtools')
Expected string: "none solid rgb(0, 0, 255)"
Received string: "rgb(0, 0, 255)"
```

looks like a bug but we can workaround it easily.