### PR TITLE
fix(waitForFunction): eval func once

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1455,19 +1455,23 @@ export class Frame extends SdkObject {
       const context = world === 'main' ? await progress.race(this._mainContext()) : await progress.race(this._utilityContext());
       const injectedScript = await progress.race(context.injectedScript());
       const handle = await progress.race(injectedScript.evaluateHandle((injected, { expression, isFunction, polling, arg }) => {
+        let evaledExpression: any;
         const predicate = (): R => {
           // NOTE: make sure to use `globalThis.eval` instead of `self.eval` due to a bug with sandbox isolation
           // in firefox.
           // See https://bugzilla.mozilla.org/show_bug.cgi?id=1814898
-          let result = globalThis.eval(expression);
+          let result = evaledExpression ?? globalThis.eval(expression);
           if (isFunction === true) {
+            evaledExpression = result;
             result = result(arg);
           } else if (isFunction === false) {
             result = result;
           } else {
             // auto detect.
-            if (typeof result === 'function')
+            if (typeof result === 'function') {
+              evaledExpression = result;
               result = result(arg);
+            }
           }
           return result;
         };

--- a/tests/page/page-wait-for-function.spec.ts
+++ b/tests/page/page-wait-for-function.spec.ts
@@ -106,7 +106,7 @@ it('should work with strict CSP policy', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   let error = null;
   const p = page.waitForFunction(() => window['__FOO'] === 'hit', {}, { polling: 'raf' }).catch(e => error = e);
-  await page.waitForTimeout(100);
+  await page.waitForTimeout(1000);
   await page.evaluate(() => window['__FOO'] = 'hit');
   await p;
   expect(error).toBe(null);

--- a/tests/page/page-wait-for-function.spec.ts
+++ b/tests/page/page-wait-for-function.spec.ts
@@ -105,10 +105,10 @@ it('should work with strict CSP policy', async ({ page, server }) => {
   server.setCSP('/empty.html', 'script-src ' + server.PREFIX);
   await page.goto(server.EMPTY_PAGE);
   let error = null;
-  await Promise.all([
-    page.waitForFunction(() => window['__FOO'] === 'hit', {}, { polling: 'raf' }).catch(e => error = e),
-    page.evaluate(() => window['__FOO'] = 'hit')
-  ]);
+  const p = page.waitForFunction(() => window['__FOO'] === 'hit', {}, { polling: 'raf' }).catch(e => error = e);
+  await page.waitForTimeout(100);
+  await page.evaluate(() => window['__FOO'] = 'hit');
+  await p;
   expect(error).toBe(null);
 });
 


### PR DESCRIPTION
On a CSP page, `eval` is only disabled in the synchronous part of a `Runtime.evaluate` expression. When we actually call it multiple times (as the test change ensures), it fails. We can prevent that by reusing the first `eval` result.