### PR TITLE
docs(Page.route): clarify handler argument signature

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3612,7 +3612,7 @@ A glob pattern, regex pattern, or predicate that receives a [URL] to match durin
 ### param: Page.route.handler
 * since: v1.8
 * langs: js, python
-- `handler` <[function]\([Route], [Request]\): [Promise<any>|any]>
+- `handler` <[function]\([Route]\): [Promise<any>|any]|[function]\([Route], [Request]\): [Promise<any>|any]>
 
 handler function to route the request.
 
@@ -3621,7 +3621,7 @@ handler function to route the request.
 * langs: csharp, java
 - `handler` <[function]\([Route]\)>
 
-handler function to route the request.
+handler function to route the request. Accepts either `(route)` or `(route, request)`.
 
 ### option: Page.route.times
 * since: v1.15


### PR DESCRIPTION
Update the documentation to reflect that the handler function can accept either a single argument (Route) or two arguments (Route, Request), improving accuracy and clarity.

https://github.com/microsoft/playwright-python/issues/2853