### PR TITLE
docs: clarify handler arg count in description without changing type …

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3614,7 +3614,7 @@ A glob pattern, regex pattern, or predicate that receives a [URL] to match durin
 * langs: js, python
 - `handler` <[function]\([Route], [Request]\): [Promise<any>|any]>
 
-handler function to route the request.
+handler function to route the request. Supports both one- and two-argument handlers: ([function]\(\[Route\]\)) or ([function]\(\[Route\], \[Request\]\)).
 
 ### param: Page.route.handler
 * since: v1.8


### PR DESCRIPTION
…cell

docs: explicitly mention that handler supports both one- and two-argument forms

Keep original type cell to avoid breaking type parsing; updated description to clarify usage as ([Route]) or ([Route], [Request]) with brief examples.

https://github.com/microsoft/playwright-python/issues/2853