### PR TITLE
fix(codegen): auto-select the right source

### DIFF
--- a/packages/playwright-core/src/server/codegen/languages.ts
+++ b/packages/playwright-core/src/server/codegen/languages.ts
@@ -21,6 +21,8 @@ import { JsonlLanguageGenerator } from './jsonl';
 import { PythonLanguageGenerator } from './python';
 
 export function languageSet() {
+  // Note: generators are ordered in the order of preference for each language.
+  // For example, 'playwright-test' comes before 'javascript'.
   return new Set([
     new JavaScriptLanguageGenerator(/* isPlaywrightTest */true),
     new JavaScriptLanguageGenerator(/* isPlaywrightTest */false),

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -61,7 +61,7 @@ export type RecorderEventMap = {
   [RecorderEvent.ModeChanged]: [mode: Mode];
   [RecorderEvent.ElementPicked]: [elementInfo: ElementInfo, userGesture?: boolean];
   [RecorderEvent.CallLogsUpdated]: [callLogs: CallLog[]];
-  [RecorderEvent.UserSourcesChanged]: [sources: Source[]];
+  [RecorderEvent.UserSourcesChanged]: [sources: Source[], pausedSourceId?: string];
   [RecorderEvent.ActionAdded]: [action: actions.ActionInContext];
   [RecorderEvent.SignalAdded]: [signal: actions.SignalInContext];
   [RecorderEvent.PageNavigated]: [url: string];
@@ -305,6 +305,17 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
     this._refreshOverlay();
   }
 
+  pausedSourceId() {
+    for (const { metadata } of this._debugger.pausedDetails()) {
+      if (!metadata.location)
+        continue;
+      const source = this._userSources.get(metadata.location.file);
+      if (!source)
+        continue;
+      return source.id;
+    }
+  }
+
   userSources() {
     return [...this._userSources.values()];
   }
@@ -368,7 +379,6 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
 
   private _updateUserSources() {
     // Remove old decorations.
-    const timestamp = monotonicTime();
     for (const source of this._userSources.values()) {
       source.highlight = [];
       source.revealLine = undefined;
@@ -381,7 +391,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
       const { file, line } = metadata.location;
       let source = this._userSources.get(file);
       if (!source) {
-        source = { isPrimary: false, isRecorded: false, label: file, id: file, text: this._readSource(file), highlight: [], language: languageForFile(file), timestamp };
+        source = { isRecorded: false, label: file, id: file, text: this._readSource(file), highlight: [], language: languageForFile(file) };
         this._userSources.set(file, source);
       }
       if (line) {
@@ -390,7 +400,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
         source.revealLine = line;
       }
     }
-    this.emit(RecorderEvent.UserSourcesChanged, this.userSources());
+    this.emit(RecorderEvent.UserSourcesChanged, this.userSources(), this.pausedSourceId());
   }
 
   async onBeforeInputAction(sdkObject: SdkObject, metadata: CallMetadata) {

--- a/packages/recorder/src/recorder.tsx
+++ b/packages/recorder/src/recorder.tsx
@@ -48,22 +48,7 @@ export const Recorder: React.FC<RecorderProps> = ({
   const [selectedTab, setSelectedTab] = useSetting<string>('recorderPropertiesTab', 'log');
   const [ariaSnapshot, setAriaSnapshot] = React.useState<string | undefined>();
   const [ariaSnapshotErrors, setAriaSnapshotErrors] = React.useState<SourceHighlight[]>();
-
-  React.useEffect(() => {
-    if (!sources.length)
-      return;
-    // When no selected file id present, pick the primary source (target language).
-    let fileId = selectedFileId ?? sources.find(s => s.isPrimary)?.id;
-    const selectedSource = sources.find(s => s.id === fileId);
-    const newestSource = sources.sort((a, b) => b.timestamp - a.timestamp)[0];
-    if (!selectedSource || newestSource.isRecorded !== selectedSource.isRecorded) {
-      // When debugger kicks in, or recording is resumed switch the selection to the newest source.
-      fileId = newestSource.id;
-    }
-    // If changes above force the selection to change, update the state.
-    if (fileId !== selectedFileId)
-      setSelectedFileId(fileId);
-  }, [sources, selectedFileId]);
+  window.playwrightSelectSource = selectedSourceId => setSelectedFileId(selectedSourceId);
 
   const source = React.useMemo(() => {
     const source = sources.find(s => s.id === selectedFileId);

--- a/packages/recorder/src/recorderTypes.d.ts
+++ b/packages/recorder/src/recorderTypes.d.ts
@@ -83,14 +83,12 @@ export type SourceHighlight = {
 };
 
 export type Source = {
-  isPrimary: boolean;
   isRecorded: boolean;
   id: string;
   label: string;
   text: string;
   language: Language;
   highlight: SourceHighlight[];
-  timestamp: number;
   revealLine?: number;
   // used to group the language generators
   group?: string;
@@ -104,6 +102,7 @@ declare global {
     playwrightSetMode: (mode: Mode) => void;
     playwrightSetPaused: (paused: boolean) => void;
     playwrightSetSources: (sources: Source[]) => void;
+    playwrightSelectSource: (sourceId: string) => void;
     playwrightSetPageURL: (url: string | undefined) => void;
     playwrightSetOverlayVisible: (visible: boolean) => void;
     playwrightUpdateLogs: (callLogs: CallLog[]) => void;

--- a/packages/web/src/components/sourceChooser.tsx
+++ b/packages/web/src/components/sourceChooser.tsx
@@ -53,8 +53,6 @@ function renderSourceOptions(sources: Source[]): React.ReactNode {
 export function emptySource(): Source {
   return {
     id: 'default',
-    timestamp: 0,
-    isPrimary: false,
     isRecorded: false,
     text: '',
     language: 'javascript',

--- a/tests/library/inspector/pause-helper.ts
+++ b/tests/library/inspector/pause-helper.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Page } from 'playwright-core';
+
+export async function pauseHelper(page: Page) {
+  await page.setContent('<div>here we go</div>');
+}

--- a/tests/library/inspector/pause.spec.ts
+++ b/tests/library/inspector/pause.spec.ts
@@ -19,6 +19,7 @@ import { test as it, expect, Recorder } from './inspectorTest';
 import { waitForTestLog } from '../../config/utils';
 import { roundBox } from '../../page/pageTest';
 import type { BoundingBox } from '../../page/pageTest';
+import { pauseHelper } from './pause-helper';
 
 it('should resume when closing inspector', async ({ page, recorderPageGetter, closeRecorder, mode }) => {
   it.skip(mode !== 'default');
@@ -106,11 +107,16 @@ it.describe('pause', () => {
     const scriptPromise = (async () => {
       // @ts-ignore
       await page.pause({ __testHookKeepTestTimeout: true });
+      await pauseHelper(page);
     })();
     const recorderPage = await recorderPageGetter();
     await expect(recorderPage.getByRole('combobox', { name: 'Source chooser' })).toHaveValue(/pause\.spec\.ts/);
-    const source = await recorderPage.textContent('.source-line-paused');
-    expect(source).toContain('page.pause({ __testHookKeepTestTimeout: true })');
+    await expect(recorderPage.locator('.source-line-paused')).toContainText('page.pause({ __testHookKeepTestTimeout: true })');
+
+    await recorderPage.click('[title="Step over (F10)"]');
+    await expect(recorderPage.getByRole('combobox', { name: 'Source chooser' })).toHaveValue(/pause-helper\.ts/);
+    await expect(recorderPage.locator('.source-line-paused')).toContainText('page.setContent(\'<div>here we go</div>\')');
+
     await recorderPage.click('[title="Resume (F8)"]');
     await scriptPromise;
   });


### PR DESCRIPTION
When recording, show the source that was last picked by the user, or the primary one.
When stepping over, show the paused line source.

Fixes #36965.