### PR TITLE
fix(markdown-reporter): improve formatting for GitHub comments

### DIFF
--- a/packages/playwright/src/reporters/markdown.ts
+++ b/packages/playwright/src/reporters/markdown.ts
@@ -136,11 +136,13 @@ function formatTestTitle(rootDir: string, test: TestCase): string {
   // root, project, file, ...describes, test
   const [, projectName, , ...titles] = test.titlePath();
   const relativeTestPath = path.relative(rootDir, test.location.file);
-  const location = `${relativeTestPath}:${test.location.line}:${test.location.column}`;
+  // intentionally add a zero-width space to prevent creating markdown icons on GitHub comments
+  const location = `${relativeTestPath}:​${test.location.line}:${test.location.column}`;
   const projectTitle = projectName ? `[${projectName}] › ` : '';
   const testTitle = `${projectTitle}${location} › ${titles.join(' › ')}`;
   const extraTags = test.tags.filter(t => !testTitle.includes(t));
-  return `${testTitle}${extraTags.length ? ' ' + extraTags.join(' ') : ''}`;
+  const formattedTags = extraTags.map(t => `\`${t}\``).join(' ');
+  return `${testTitle}${extraTags.length ? ' ' + formattedTags : ''}`;
 }
 
 export default MarkdownReporter;

--- a/packages/playwright/src/reporters/markdown.ts
+++ b/packages/playwright/src/reporters/markdown.ts
@@ -73,7 +73,6 @@ class MarkdownReporter implements Reporter {
     const skipped = summary.skipped ? `, ${summary.skipped} skipped` : '';
     const didNotRun = summary.didNotRun ? `, ${summary.didNotRun} did not run` : '';
     lines.push(`**${summary.expected} passed${skipped}${didNotRun}**`);
-    lines.push(`:heavy_check_mark::heavy_check_mark::heavy_check_mark:`);
     lines.push(``);
 
     await this.publishReport(lines.join('\n'));
@@ -136,7 +135,7 @@ function formatTestTitle(rootDir: string, test: TestCase): string {
   // root, project, file, ...describes, test
   const [, projectName, , ...titles] = test.titlePath();
   const relativeTestPath = path.relative(rootDir, test.location.file);
-  // intentionally add a zero-width space to prevent creating markdown icons on GitHub comments
+  // intentionally add a zero-width space to prevent creating markdown icons on GitHub
   const location = `${relativeTestPath}:​${test.location.line}:${test.location.column}`;
   const projectTitle = projectName ? `[${projectName}] › ` : '';
   const testTitle = `${projectTitle}${location} › ${titles.join(' › ')}`;

--- a/tests/config/ghaMarkdownReporter.ts
+++ b/tests/config/ghaMarkdownReporter.ts
@@ -112,6 +112,8 @@ class GHAMarkdownReporter extends MarkdownReporter {
       `### ${reportUrl ? `[Test results](${reportUrl})` : 'Test results'} for "${this._workflowRunName()}"`,
       report,
       '',
+      '---',
+      '',
       `Merge [workflow run](${mergeWorkflowUrl}).`
     ]);
 

--- a/tests/playwright-test/reporter-markdown.spec.ts
+++ b/tests/playwright-test/reporter-markdown.spec.ts
@@ -66,13 +66,13 @@ test('simple report', async ({ runInlineTest }) => {
   expect(exitCode).toBe(1);
   const reportFile = await fs.promises.readFile(test.info().outputPath('report.md'));
   expect(reportFile.toString()).toContain(`**2 failed**
-:x: dir1${path.sep}a.test.js:6:11 › failing 1
-:x: dir2${path.sep}b.test.js:6:11 › failing 2
+:x: dir1${path.sep}a.test.js:​6:11 › failing 1
+:x: dir2${path.sep}b.test.js:​6:11 › failing 2
 
 <details>
 <summary><b>2 flaky</b></summary>
-:warning: c.test.js:6:11 › flaky 2 <br/>
-:warning: dir1${path.sep}a.test.js:9:11 › flaky 1 <br/>
+:warning: c.test.js:​6:11 › flaky 2 <br/>
+:warning: dir1${path.sep}a.test.js:​9:11 › flaky 1 <br/>
 
 </details>
 
@@ -125,7 +125,7 @@ test('report error without snippet', async ({ runInlineTest }) => {
   await runInlineTest(files);
   const reportFile = await fs.promises.readFile(test.info().outputPath('report.md'));
   expect(reportFile.toString()).toContain(`**1 failed**
-:x: a.test.js:3:11 › math 1
+:x: a.test.js:​3:11 › math 1
 
 **0 passed**
 :heavy_check_mark::heavy_check_mark::heavy_check_mark:
@@ -157,4 +157,54 @@ test('report with worker error', async ({ runInlineTest }) => {
 **0 passed**
 :heavy_check_mark::heavy_check_mark::heavy_check_mark:
 `);
+});
+
+test('report with annotations', async ({ runInlineTest }) => {
+  const files = {
+    'playwright.config.ts': `
+      module.exports = {
+        retries: 0,
+        reporter: ${JSON.stringify(markdownReporter)},
+      };
+    `,
+    'a.test.js': `
+      import { test, expect } from '@playwright/test';
+      
+      test('test login page', {
+        annotation: {
+          type: 'issue',
+          description: 'https://github.com/microsoft/playwright/issues/23180',
+        },
+        tag: '@login',
+      }, async ({ page }) => {
+        expect(1 + 1).toBe(2);
+      });
+      
+      test('failing test with annotation', {
+        annotation: [
+          { type: 'bug', description: 'Known issue' },
+          { type: 'performance', description: 'slow test' }
+        ],
+        tag: '@slow',
+      }, async ({ page }) => {
+        expect(1).toBe(2);
+      });
+    `,
+  };
+
+  const { exitCode } = await runInlineTest(files);
+  expect(exitCode).toBe(1);
+  const reportFile = await fs.promises.readFile(test.info().outputPath('report.md'));
+  const reportContent = reportFile.toString();
+
+  // Check that failed tests are reported with tags
+  expect(reportContent).toContain(`**1 failed**
+:x: a.test.js:​14:11 › failing test with annotation \`@slow\``);
+
+  // Check that passed tests are reported (but without individual titles)
+  expect(reportContent).toContain(`**1 passed**
+:heavy_check_mark::heavy_check_mark::heavy_check_mark:`);
+
+  // Check that tags are included in the failed test output
+  expect(reportContent).toContain('`@slow`');
 });

--- a/tests/playwright-test/reporter-markdown.spec.ts
+++ b/tests/playwright-test/reporter-markdown.spec.ts
@@ -77,7 +77,6 @@ test('simple report', async ({ runInlineTest }) => {
 </details>
 
 **3 passed, 3 skipped**
-:heavy_check_mark::heavy_check_mark::heavy_check_mark:
 `);
 });
 
@@ -100,7 +99,6 @@ test('custom report file', async ({ runInlineTest }) => {
   expect(exitCode).toBe(0);
   const reportFile = await fs.promises.readFile(test.info().outputPath('my-report.md'));
   expect(reportFile.toString()).toBe(`**1 passed**
-:heavy_check_mark::heavy_check_mark::heavy_check_mark:
 `);
 });
 
@@ -128,7 +126,6 @@ test('report error without snippet', async ({ runInlineTest }) => {
 :x: a.test.js:​3:11 › math 1
 
 **0 passed**
-:heavy_check_mark::heavy_check_mark::heavy_check_mark:
 `);
 });
 
@@ -155,7 +152,6 @@ test('report with worker error', async ({ runInlineTest }) => {
   const reportFile = await fs.promises.readFile(test.info().outputPath('report.md'));
   expect(reportFile.toString()).toContain(`**3 fatal errors, not part of any test**
 **0 passed**
-:heavy_check_mark::heavy_check_mark::heavy_check_mark:
 `);
 });
 
@@ -202,8 +198,7 @@ test('report with annotations', async ({ runInlineTest }) => {
 :x: a.test.js:​14:11 › failing test with annotation \`@slow\``);
 
   // Check that passed tests are reported (but without individual titles)
-  expect(reportContent).toContain(`**1 passed**
-:heavy_check_mark::heavy_check_mark::heavy_check_mark:`);
+  expect(reportContent).toContain(`**1 passed**`);
 
   // Check that tags are included in the failed test output
   expect(reportContent).toContain('`@slow`');


### PR DESCRIPTION
- Add zero-width space after colon in file locations to prevent GitHub from rendering markdown icons in PR comments
  - e.g. shown in https://github.com/microsoft/playwright/pull/37004#issuecomment-3182996935
- Format test tags with backticks for better readability in markdown output
- Change 3 confusing looking ✔️ symbols to a horizontal line.

This seems a common workaround as suggested here: https://stackoverflow.com/a/50662126/6512681