### PR TITLE
chore: unship clock.uninstall

### DIFF
--- a/docs/src/api/class-clock.md
+++ b/docs/src/api/class-clock.md
@@ -340,8 +340,3 @@ Time to be set.
 - `time` <[string]|[Date]>
 
 Time to be set.
-
-## async method: Clock.uninstall
-* since: v1.55
-
-Uninstall fake clock. Note that any currently open page will be still affected by the fake clock, until it navigates away to a new document.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -18856,12 +18856,6 @@ export interface Clock {
    * @param time Time to be set in milliseconds.
    */
   setSystemTime(time: number|string|Date): Promise<void>;
-
-  /**
-   * Uninstall fake clock. Note that any currently open page will be still affected by the fake clock, until it
-   * navigates away to a new document.
-   */
-  uninstall(): Promise<void>;
 }
 
 /**

--- a/packages/playwright-core/src/client/clock.ts
+++ b/packages/playwright-core/src/client/clock.ts
@@ -51,10 +51,6 @@ export class Clock implements api.Clock {
   async setSystemTime(time: string | number | Date) {
     await this._browserContext._channel.clockSetSystemTime(parseTime(time));
   }
-
-  async uninstall() {
-    await this._browserContext._channel.clockUninstall();
-  }
 }
 
 function parseTime(time: string | number | Date): { timeNumber?: number, timeString?: string } {

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1165,8 +1165,6 @@ scheme.BrowserContextClockSetSystemTimeParams = tObject({
   timeString: tOptional(tString),
 });
 scheme.BrowserContextClockSetSystemTimeResult = tOptional(tObject({}));
-scheme.BrowserContextClockUninstallParams = tOptional(tObject({}));
-scheme.BrowserContextClockUninstallResult = tOptional(tObject({}));
 scheme.PageInitializer = tObject({
   mainFrame: tChannel(['Frame']),
   viewportSize: tOptional(tObject({

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -404,10 +404,6 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     await this._context.clock.setSystemTime(progress, params.timeString ?? params.timeNumber ?? 0);
   }
 
-  async clockUninstall(params: channels.BrowserContextClockUninstallParams, progress: Progress): Promise<channels.BrowserContextClockUninstallResult> {
-    await this._context.clock.uninstall(progress);
-  }
-
   async updateSubscription(params: channels.BrowserContextUpdateSubscriptionParams, progress: Progress): Promise<void> {
     if (params.enabled)
       this._subscriptions.add(params.event);

--- a/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
+++ b/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
@@ -98,7 +98,6 @@ export const methodMetainfo = new Map<string, { internal?: boolean, title?: stri
   ['BrowserContext.clockRunFor', { title: 'Run clock "{ticksNumber|ticksString}"', }],
   ['BrowserContext.clockSetFixedTime', { title: 'Set fixed time "{timeNumber|timeString}"', }],
   ['BrowserContext.clockSetSystemTime', { title: 'Set system time "{timeNumber|timeString}"', }],
-  ['BrowserContext.clockUninstall', { title: 'Uninstall clock', }],
   ['Page.addInitScript', { title: 'Add init script', group: 'configuration', }],
   ['Page.close', { title: 'Close page', pausesBeforeAction: true, }],
   ['Page.emulateMedia', { title: 'Emulate media', snapshot: true, pausesBeforeAction: true, }],

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -18856,12 +18856,6 @@ export interface Clock {
    * @param time Time to be set in milliseconds.
    */
   setSystemTime(time: number|string|Date): Promise<void>;
-
-  /**
-   * Uninstall fake clock. Note that any currently open page will be still affected by the fake clock, until it
-   * navigates away to a new document.
-   */
-  uninstall(): Promise<void>;
 }
 
 /**

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -1628,7 +1628,6 @@ export interface BrowserContextChannel extends BrowserContextEventTarget, EventT
   clockRunFor(params: BrowserContextClockRunForParams, progress?: Progress): Promise<BrowserContextClockRunForResult>;
   clockSetFixedTime(params: BrowserContextClockSetFixedTimeParams, progress?: Progress): Promise<BrowserContextClockSetFixedTimeResult>;
   clockSetSystemTime(params: BrowserContextClockSetSystemTimeParams, progress?: Progress): Promise<BrowserContextClockSetSystemTimeResult>;
-  clockUninstall(params?: BrowserContextClockUninstallParams, progress?: Progress): Promise<BrowserContextClockUninstallResult>;
 }
 export type BrowserContextBindingCallEvent = {
   binding: BindingCallChannel,
@@ -2017,9 +2016,6 @@ export type BrowserContextClockSetSystemTimeOptions = {
   timeString?: string,
 };
 export type BrowserContextClockSetSystemTimeResult = void;
-export type BrowserContextClockUninstallParams = {};
-export type BrowserContextClockUninstallOptions = {};
-export type BrowserContextClockUninstallResult = void;
 
 export interface BrowserContextEvents {
   'bindingCall': BrowserContextBindingCallEvent;

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1484,9 +1484,6 @@ BrowserContext:
         timeNumber: float?
         timeString: string?
 
-    clockUninstall:
-      title: Uninstall clock
-
   events:
 
     bindingCall:

--- a/tests/library/page-clock.spec.ts
+++ b/tests/library/page-clock.spec.ts
@@ -565,16 +565,3 @@ it('correctly increments Date.now()/performance.now() during blocking execution'
   await page.goto(server.PREFIX + '/repro.html');
   await waitForDone;
 });
-
-it('should uninstall', async ({ page }) => {
-  await page.clock.install({ time: 0 });
-  await page.clock.pauseAt(1000);
-  expect(await page.evaluate(() => Date.now())).toBe(1000);
-
-  await page.goto('about:blank');
-  expect(await page.evaluate(() => Date.now())).toBe(1000);
-
-  await page.clock.uninstall();
-  await page.goto('about:blank');
-  expect(await page.evaluate(() => Date.now())).not.toBe(1000);
-});


### PR DESCRIPTION
Probably to be replaced by `removeAllInitScripts`.