### PR TITLE
chore: turn PWDEBUG back to opt-in

### DIFF
--- a/packages/playwright-core/src/server/utils/debug.ts
+++ b/packages/playwright-core/src/server/utils/debug.ts
@@ -23,7 +23,7 @@ export function debugMode() {
     return 'console';
   if (_debugMode === '0' || _debugMode === 'false')
     return '';
-  return _debugMode ? 'inspector' : 'console';
+  return _debugMode ? 'inspector' : '';
 }
 
 const _isUnderTest = getAsBooleanFromENV('PWTEST_UNDER_TEST');

--- a/tests/library/inspector/pause.spec.ts
+++ b/tests/library/inspector/pause.spec.ts
@@ -88,7 +88,7 @@ it.describe('pause', () => {
       // @ts-ignore
       await page.pause({ __testHookKeepTestTimeout: true });
     })();
-    await page.waitForFunction(() => (window as any).playwright?.resume() !== false);
+    await page.waitForFunction(() => (window as any).playwright && (window as any).playwright.resume() !== false);
     await scriptPromise;
   });
 

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -912,7 +912,22 @@ test('window.playwright should be exposed by default', { annotation: { type: 'is
   expect(result.passed).toBe(1);
 });
 
-test('window.playwright should not override existing property', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36772' } }, async ({ runInlineTest }) => {
+test('window.playwright should be undefined by default', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+
+      test('test', async ({ page }) => {
+        await page.setContent('<body></body>');
+        expect(await page.evaluate(() => window.playwright)).toBeUndefined();
+      });
+    `,
+  }, {}, {});
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
+test('window.playwright should not override existing property', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
@@ -927,17 +942,17 @@ test('window.playwright should not override existing property', { annotation: { 
   expect(result.passed).toBe(1);
 });
 
-test('PWDEBUG=0 should opt-out from exposing window.playwright', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36772' } }, async ({ runInlineTest }) => {
+test('PWDEBUG=console should opt-in to exposing window.playwright', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
 
       test('test', async ({ page }) => {
         await page.setContent('<body></body>');
-        expect(await page.evaluate(() => window.playwright)).toBeUndefined();
+        expect(await page.evaluate(() => window.playwright)).toBeDefined();
       });
     `,
-  }, {}, { PWDEBUG: '0' });
+  }, {}, { PWDEBUG: 'console' });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
 });

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -937,7 +937,7 @@ test('window.playwright should not override existing property', async ({ runInli
         expect(await page.evaluate(() => window.playwright)).toBe('foo');
       });
     `,
-  }, {}, {});
+  }, {}, { PWDEBUG: 'console' });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
 });

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -896,22 +896,6 @@ test('page.pause() should disable test timeout', async ({ runInlineTest }) => {
   expect(result.output).toContain('success!');
 });
 
-test('window.playwright should be exposed by default', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36772' } }, async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'a.test.ts': `
-      import { test, expect } from '@playwright/test';
-
-      test('test', async ({ page }) => {
-        await page.setContent('<body></body>');
-        const bodyTag = await page.evaluate(() => window.playwright.$('body').tagName);
-        expect(bodyTag).toBe('BODY');
-      });
-    `,
-  }, {}, {});
-  expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(1);
-});
-
 test('window.playwright should be undefined by default', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `


### PR DESCRIPTION
Reverts the main behaviour change from https://github.com/microsoft/playwright/pull/36921, but keeps the code improvements.