### PR TITLE
chore: browser._launchServer

### DIFF
--- a/packages/playwright-core/src/browserServerImpl.ts
+++ b/packages/playwright-core/src/browserServerImpl.ts
@@ -30,7 +30,6 @@ import type { LaunchOptions, LaunchServerOptions, Logger, Env } from './client/t
 import type { ProtocolLogger } from './server/types';
 import type { WebSocketEventEmitter } from './utilsBundle';
 import type { Browser } from './server/browser';
-import type { Browser as ClientBrowser } from './client/browser';
 
 export class BrowserServerLauncherImpl implements BrowserServerLauncher {
   private _browserName: 'chromium' | 'firefox' | 'webkit' | '_bidiFirefox' | '_bidiChromium';
@@ -79,17 +78,10 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
       throw e;
     }
 
-    return this._launchServerOnExistingBrowser(browser, options);
+    return this.launchServerOnExistingBrowser(browser, options);
   }
 
-  async launchServerOnExistingBrowser(browser: ClientBrowser, options: LaunchServerOptions): Promise<BrowserServer> {
-    const browserImpl = browser._connection.toImpl?.(browser);
-    if (!browserImpl)
-      throw new Error('Launch server is not supported');
-    return this._launchServerOnExistingBrowser(browserImpl, options);
-  }
-
-  private async _launchServerOnExistingBrowser(browser: Browser, options: LaunchServerOptions): Promise<BrowserServer> {
+  async launchServerOnExistingBrowser(browser: Browser, options: LaunchServerOptions): Promise<BrowserServer> {
     const path = options.wsPath ? (options.wsPath.startsWith('/') ? options.wsPath : `/${options.wsPath}`) : `/${createGuid()}`;
 
     // 2. Start the server

--- a/packages/playwright-core/src/browserServerImpl.ts
+++ b/packages/playwright-core/src/browserServerImpl.ts
@@ -30,6 +30,7 @@ import type { LaunchOptions, LaunchServerOptions, Logger, Env } from './client/t
 import type { ProtocolLogger } from './server/types';
 import type { WebSocketEventEmitter } from './utilsBundle';
 import type { Browser } from './server/browser';
+import type { Browser as ClientBrowser } from './client/browser';
 
 export class BrowserServerLauncherImpl implements BrowserServerLauncher {
   private _browserName: 'chromium' | 'firefox' | 'webkit' | '_bidiFirefox' | '_bidiChromium';
@@ -78,10 +79,17 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
       throw e;
     }
 
-    return this.launchServerOnExistingBrowser(browser, options);
+    return this._launchServerOnExistingBrowser(browser, options);
   }
 
-  async launchServerOnExistingBrowser(browser: Browser, options: LaunchServerOptions): Promise<BrowserServer> {
+  async launchServerOnExistingBrowser(browser: ClientBrowser, options: LaunchServerOptions): Promise<BrowserServer> {
+    const browserImpl = browser._connection.toImpl?.(browser);
+    if (!browserImpl)
+      throw new Error('Launch server is not supported');
+    return this._launchServerOnExistingBrowser(browserImpl, options);
+  }
+
+  private async _launchServerOnExistingBrowser(browser: Browser, options: LaunchServerOptions): Promise<BrowserServer> {
     const path = options.wsPath ? (options.wsPath.startsWith('/') ? options.wsPath : `/${options.wsPath}`) : `/${createGuid()}`;
 
     // 2. Start the server

--- a/packages/playwright-core/src/browserServerImpl.ts
+++ b/packages/playwright-core/src/browserServerImpl.ts
@@ -93,7 +93,7 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
     const path = options.wsPath ? (options.wsPath.startsWith('/') ? options.wsPath : `/${options.wsPath}`) : `/${createGuid()}`;
 
     // 2. Start the server
-    const server = new PlaywrightServer({ mode: options._sharedBrowser ? 'launchServerShared' : 'launchServer', path, maxConnections: Infinity, preLaunchedBrowser: browser });
+    const server = new PlaywrightServer({ mode: options._sharedBrowser ? 'launchServerShared' : 'launchServer', path, maxConnections: Infinity, preLaunchedBrowser: browser, debugController: options._debugController });
     const wsEndpoint = await server.listen(options.port, options.host);
 
     // 3. Return the BrowserServer interface

--- a/packages/playwright-core/src/browserServerImpl.ts
+++ b/packages/playwright-core/src/browserServerImpl.ts
@@ -38,7 +38,7 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
     this._browserName = browserName;
   }
 
-  async launchServer(options: LaunchOptions & LaunchServerOptions & { _sharedBrowser?: boolean, _userDataDir?: string } = {}): Promise<BrowserServer> {
+  async launchServer(options: LaunchOptions & LaunchServerOptions & { _userDataDir?: string } = {}): Promise<BrowserServer> {
     const playwright = createPlaywright({ sdkLanguage: 'javascript', isServer: true });
     // 1. Pre-launch the browser
     const metadata = { id: '', startTime: 0, endTime: 0, type: 'Internal', method: '', params: {}, log: [], internal: true };
@@ -81,7 +81,7 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
     return this.launchServerOnExistingBrowser(browser, options);
   }
 
-  async launchServerOnExistingBrowser(browser: Browser, options: LaunchServerOptions & { _sharedBrowser?: boolean }): Promise<BrowserServer> {
+  async launchServerOnExistingBrowser(browser: Browser, options: LaunchServerOptions): Promise<BrowserServer> {
     const path = options.wsPath ? (options.wsPath.startsWith('/') ? options.wsPath : `/${options.wsPath}`) : `/${createGuid()}`;
 
     // 2. Start the server

--- a/packages/playwright-core/src/browserServerImpl.ts
+++ b/packages/playwright-core/src/browserServerImpl.ts
@@ -26,7 +26,7 @@ import * as validatorPrimitives from './protocol/validatorPrimitives';
 import { ProgressController } from './server/progress';
 
 import type { BrowserServer, BrowserServerLauncher } from './client/browserType';
-import type { LaunchServerOptions, Logger, Env } from './client/types';
+import type { LaunchOptions, LaunchServerOptions, Logger, Env } from './client/types';
 import type { ProtocolLogger } from './server/types';
 import type { WebSocketEventEmitter } from './utilsBundle';
 import type { Browser } from './server/browser';
@@ -38,7 +38,7 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
     this._browserName = browserName;
   }
 
-  async launchServer(options: LaunchServerOptions & { _sharedBrowser?: boolean, _userDataDir?: string } = {}): Promise<BrowserServer> {
+  async launchServer(options: LaunchOptions & LaunchServerOptions & { _sharedBrowser?: boolean, _userDataDir?: string } = {}): Promise<BrowserServer> {
     const playwright = createPlaywright({ sdkLanguage: 'javascript', isServer: true });
     // 1. Pre-launch the browser
     const metadata = { id: '', startTime: 0, endTime: 0, type: 'Internal', method: '', params: {}, log: [], internal: true };
@@ -78,6 +78,10 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
       throw e;
     }
 
+    return this.launchServerOnExistingBrowser(browser, options);
+  }
+
+  async launchServerOnExistingBrowser(browser: Browser, options: LaunchServerOptions & { _sharedBrowser?: boolean }): Promise<BrowserServer> {
     const path = options.wsPath ? (options.wsPath.startsWith('/') ? options.wsPath : `/${options.wsPath}`) : `/${createGuid()}`;
 
     // 2. Start the server

--- a/packages/playwright-core/src/browserServerImpl.ts
+++ b/packages/playwright-core/src/browserServerImpl.ts
@@ -85,7 +85,7 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
     const path = options.wsPath ? (options.wsPath.startsWith('/') ? options.wsPath : `/${options.wsPath}`) : `/${createGuid()}`;
 
     // 2. Start the server
-    const server = new PlaywrightServer({ mode: options._sharedBrowser ? 'launchServerShared' : 'launchServer', path, maxConnections: Infinity, preLaunchedBrowser: browser, debugController: options.debugController });
+    const server = new PlaywrightServer({ mode: options._sharedBrowser ? 'launchServerShared' : 'launchServer', path, maxConnections: Infinity, preLaunchedBrowser: browser, debugController: options._debugController });
     const wsEndpoint = await server.listen(options.port, options.host);
 
     // 3. Return the BrowserServer interface

--- a/packages/playwright-core/src/browserServerImpl.ts
+++ b/packages/playwright-core/src/browserServerImpl.ts
@@ -93,7 +93,7 @@ export class BrowserServerLauncherImpl implements BrowserServerLauncher {
     const path = options.wsPath ? (options.wsPath.startsWith('/') ? options.wsPath : `/${options.wsPath}`) : `/${createGuid()}`;
 
     // 2. Start the server
-    const server = new PlaywrightServer({ mode: options._sharedBrowser ? 'launchServerShared' : 'launchServer', path, maxConnections: Infinity, preLaunchedBrowser: browser, debugController: options._debugController });
+    const server = new PlaywrightServer({ mode: options._sharedBrowser ? 'launchServerShared' : 'launchServer', path, maxConnections: Infinity, preLaunchedBrowser: browser, debugController: options.debugController });
     const wsEndpoint = await server.listen(options.port, options.host);
 
     // 3. Return the BrowserServer interface

--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -22,7 +22,6 @@ import { isTargetClosedError } from './errors';
 import { Events } from './events';
 import { mkdirIfNeeded } from './fileUtils';
 
-import type { Browser as BrowserImpl } from '../server/browser';
 import type { BrowserType } from './browserType';
 import type { Page } from './page';
 import type { BrowserContextOptions, LaunchOptions, LaunchServerOptions, Logger } from './types';
@@ -148,11 +147,9 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
   }
 
   async _launchServer(options: LaunchServerOptions = {}) {
-    const serverLauncher = this._browserType._serverLauncher;
-    const browser: BrowserImpl = this._connection.toImpl?.(this);
-    if (!serverLauncher || !browser)
+    if (!this._browserType._serverLauncher)
       throw new Error('Launching server is not supported');
-    return await serverLauncher.launchServerOnExistingBrowser(browser, {
+    return await this._browserType._serverLauncher.launchServerOnExistingBrowser(this, {
       _sharedBrowser: true,
       ...options,
     });

--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -22,6 +22,7 @@ import { isTargetClosedError } from './errors';
 import { Events } from './events';
 import { mkdirIfNeeded } from './fileUtils';
 
+import type { Browser as BrowserImpl } from '../server/browser';
 import type { BrowserType } from './browserType';
 import type { Page } from './page';
 import type { BrowserContextOptions, LaunchOptions, Logger } from './types';
@@ -144,6 +145,14 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
 
   async newBrowserCDPSession(): Promise<api.CDPSession> {
     return CDPSession.from((await this._channel.newBrowserCDPSession()).session);
+  }
+
+  async _launchServer() {
+    const serverLauncher = this._browserType._serverLauncher;
+    const browser: BrowserImpl = this._connection.toImpl?.(this);
+    if (!serverLauncher || !browser)
+      throw new Error('Launching server is not supported');
+    return await serverLauncher.launchServerOnExistingBrowser(browser);
   }
 
   async startTracing(page?: Page, options: { path?: string; screenshots?: boolean; categories?: string[]; } = {}) {

--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -147,9 +147,11 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
   }
 
   async _launchServer(options: LaunchServerOptions = {}) {
-    if (!this._browserType._serverLauncher)
+    const serverLauncher = this._browserType._serverLauncher;
+    const browserImpl = this._connection.toImpl?.(this);
+    if (!serverLauncher || !browserImpl)
       throw new Error('Launching server is not supported');
-    return await this._browserType._serverLauncher.launchServerOnExistingBrowser(this, {
+    return await serverLauncher.launchServerOnExistingBrowser(browserImpl, {
       _sharedBrowser: true,
       ...options,
     });

--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -25,7 +25,7 @@ import { mkdirIfNeeded } from './fileUtils';
 import type { Browser as BrowserImpl } from '../server/browser';
 import type { BrowserType } from './browserType';
 import type { Page } from './page';
-import type { BrowserContextOptions, LaunchOptions, Logger } from './types';
+import type { BrowserContextOptions, LaunchOptions, LaunchServerOptions, Logger } from './types';
 import type * as api from '../../types/types';
 import type * as channels from '@protocol/channels';
 
@@ -147,12 +147,15 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
     return CDPSession.from((await this._channel.newBrowserCDPSession()).session);
   }
 
-  async _launchServer() {
+  async _launchServer(options: LaunchServerOptions = {}) {
     const serverLauncher = this._browserType._serverLauncher;
     const browser: BrowserImpl = this._connection.toImpl?.(this);
     if (!serverLauncher || !browser)
       throw new Error('Launching server is not supported');
-    return await serverLauncher.launchServerOnExistingBrowser(browser);
+    return await serverLauncher.launchServerOnExistingBrowser(browser, {
+      _sharedBrowser: true,
+      ...options,
+    });
   }
 
   async startTracing(page?: Page, options: { path?: string; screenshots?: boolean; categories?: string[]; } = {}) {

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -26,6 +26,7 @@ import { raceAgainstDeadline } from '../utils/isomorphic/timeoutRunner';
 import { connectOverWebSocket } from './webSocket';
 import { TimeoutSettings } from './timeoutSettings';
 
+import type { Browser as BrowserImpl } from '../server/browser';
 import type { Playwright } from './playwright';
 import type { ConnectOptions, LaunchOptions, LaunchPersistentContextOptions, LaunchServerOptions } from './types';
 import type * as api from '../../types/types';
@@ -34,6 +35,7 @@ import type { ChildProcess } from 'child_process';
 
 export interface BrowserServerLauncher {
   launchServer(options?: LaunchServerOptions): Promise<api.BrowserServer>;
+  launchServerOnExistingBrowser(browser: BrowserImpl): Promise<api.BrowserServer>;
 }
 
 // This is here just for api generation and checking.

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -26,7 +26,6 @@ import { raceAgainstDeadline } from '../utils/isomorphic/timeoutRunner';
 import { connectOverWebSocket } from './webSocket';
 import { TimeoutSettings } from './timeoutSettings';
 
-import type { Browser as BrowserImpl } from '../server/browser';
 import type { Playwright } from './playwright';
 import type { ConnectOptions, LaunchOptions, LaunchPersistentContextOptions, LaunchServerOptions } from './types';
 import type * as api from '../../types/types';
@@ -35,7 +34,7 @@ import type { ChildProcess } from 'child_process';
 
 export interface BrowserServerLauncher {
   launchServer(options?: LaunchOptions & LaunchServerOptions): Promise<api.BrowserServer>;
-  launchServerOnExistingBrowser(browser: BrowserImpl, options?: LaunchServerOptions): Promise<api.BrowserServer>;
+  launchServerOnExistingBrowser(browser: Browser, options?: LaunchServerOptions): Promise<api.BrowserServer>;
 }
 
 // This is here just for api generation and checking.

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -31,10 +31,11 @@ import type { ConnectOptions, LaunchOptions, LaunchPersistentContextOptions, Lau
 import type * as api from '../../types/types';
 import type * as channels from '@protocol/channels';
 import type { ChildProcess } from 'child_process';
+import type { Browser as BrowserImpl } from '../server/browser';
 
 export interface BrowserServerLauncher {
   launchServer(options?: LaunchOptions & LaunchServerOptions): Promise<api.BrowserServer>;
-  launchServerOnExistingBrowser(browser: Browser, options?: LaunchServerOptions): Promise<api.BrowserServer>;
+  launchServerOnExistingBrowser(browser: BrowserImpl, options?: LaunchServerOptions): Promise<api.BrowserServer>;
 }
 
 // This is here just for api generation and checking.

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -34,8 +34,8 @@ import type * as channels from '@protocol/channels';
 import type { ChildProcess } from 'child_process';
 
 export interface BrowserServerLauncher {
-  launchServer(options?: LaunchServerOptions): Promise<api.BrowserServer>;
-  launchServerOnExistingBrowser(browser: BrowserImpl): Promise<api.BrowserServer>;
+  launchServer(options?: LaunchOptions & LaunchServerOptions): Promise<api.BrowserServer>;
+  launchServerOnExistingBrowser(browser: BrowserImpl, options?: LaunchServerOptions): Promise<api.BrowserServer>;
 }
 
 // This is here just for api generation and checking.

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -109,6 +109,7 @@ export type LaunchServerOptions = {
   host?: string,
   port?: number,
   wsPath?: string,
+  _debugController?: boolean;
   _sharedBrowser?: boolean;
 };
 

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -109,7 +109,7 @@ export type LaunchServerOptions = {
   host?: string,
   port?: number,
   wsPath?: string,
-  debugController?: boolean;
+  _debugController?: boolean;
   _sharedBrowser?: boolean;
 };
 

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -109,6 +109,7 @@ export type LaunchServerOptions = {
   host?: string,
   port?: number,
   wsPath?: string,
+  _sharedBrowser?: boolean;
 };
 
 export type LaunchAndroidServerOptions = {

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -109,7 +109,7 @@ export type LaunchServerOptions = {
   host?: string,
   port?: number,
   wsPath?: string,
-  _debugController?: boolean;
+  debugController?: boolean;
   _sharedBrowser?: boolean;
 };
 

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -105,7 +105,7 @@ export type ConnectOptions = {
   timeout?: number,
   logger?: Logger,
 };
-export type LaunchServerOptions = LaunchOptions & {
+export type LaunchServerOptions = {
   host?: string,
   port?: number,
   wsPath?: string,

--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -86,6 +86,17 @@ export class PlaywrightServer {
       },
 
       onConnection: (request, url, ws, id) => {
+        if (url.searchParams.has('debug-controller')) {
+          return new PlaywrightConnection(
+              controllerSemaphore,
+              ws,
+              true,
+              this._playwright,
+              async () => { throw new Error('shouldnt be used'); },
+              id,
+          );
+        }
+
         const browserHeader = request.headers['x-playwright-browser'];
         const browserName = url.searchParams.get('browser') || (Array.isArray(browserHeader) ? browserHeader[0] : browserHeader) || null;
         const proxyHeader = request.headers['x-playwright-proxy'];
@@ -121,16 +132,6 @@ export class PlaywrightServer {
             );
           }
 
-          if (url.searchParams.has('debug-controller')) {
-            return new PlaywrightConnection(
-                controllerSemaphore,
-                ws,
-                true,
-                this._playwright,
-                async () => { throw new Error('shouldnt be used'); },
-                id,
-            );
-          }
           return new PlaywrightConnection(
               reuseBrowserSemaphore,
               ws,

--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -107,7 +107,9 @@ export class PlaywrightServer {
         const allowFSPaths = isExtension;
         launchOptions = filterLaunchOptions(launchOptions, allowFSPaths);
 
-        if ((this._options.debugController || isExtension) && url.searchParams.has('debug-controller')) {
+        if (url.searchParams.has('debug-controller')) {
+          if (!(this._options.debugController || isExtension))
+            throw new Error('Debug controller is not enabled');
           return new PlaywrightConnection(
               controllerSemaphore,
               ws,

--- a/packages/playwright-core/src/server/utils/wsServer.ts
+++ b/packages/playwright-core/src/server/utils/wsServer.ts
@@ -106,8 +106,13 @@ export class WSServer {
       const url = new URL('http://localhost' + (request.url || ''));
       const id = String(++lastConnectionId);
       debugLogger.log('server', `[${id}] serving connection: ${request.url}`);
-      const connection = this._delegate.onConnection(request, url, ws, id);
-      (ws as any)[kConnectionSymbol] = connection;
+      try {
+        const connection = this._delegate.onConnection(request, url, ws, id);
+        (ws as any)[kConnectionSymbol] = connection;
+      } catch (error) {
+        debugLogger.log('server', `[${id}] connection error: ${error}`);
+        ws.close(1011, String(error));
+      }
     });
 
     return wsEndpoint;

--- a/tests/config/debugControllerBackend.ts
+++ b/tests/config/debugControllerBackend.ts
@@ -153,6 +153,8 @@ export class Backend extends EventEmitter {
   }
 
   private _send(method: string, params: any = {}): Promise<any> {
+    if (this._transport.isClosed())
+      throw new Error('Transport is closed');
     return new Promise((fulfill, reject) => {
       const id = ++Backend._lastId;
       const command = { id, guid: 'DebugController', method, params, metadata: {} };

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -28,7 +28,6 @@ import type { Browser, ConnectOptions } from 'playwright-core';
 import { createHttpServer } from '../../packages/playwright-core/lib/server/utils/network';
 import { kTargetClosedErrorMessage } from '../config/errors';
 import { RunServer } from '../config/remoteServer';
-import type { Browser as BrowserImpl } from '../../packages/playwright-core/src/client/browser';
 
 type ExtraFixtures = {
   connect: (wsEndpoint: string, options?: ConnectOptions, redirectPortForTest?: number) => Promise<Browser>,
@@ -1048,10 +1047,9 @@ test.describe('launchServer only', () => {
     await expect(browser._parent.launch({ timeout: 0 })).rejects.toThrowError('Launching more browsers is not allowed.');
   });
 
-  test('should work with existing browser', async ({ connect, page }) => {
+  test('should work with existing browser', async ({ connect, page, browser }) => {
     await page.setContent('hello world');
-    const browserImpl = page.context().browser() as BrowserImpl;
-    const server = await browserImpl._launchServer();
+    const server = await (browser as any)._launchServer();
     const secondBrowser = await connect(server.wsEndpoint());
     const secondPage = secondBrowser.contexts()[0].pages()[0];
     expect(await secondPage.content()).toContain('hello world');

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -1057,6 +1057,7 @@ test.describe('launchServer only', () => {
     const secondPage = secondBrowser.contexts()[0].pages()[0];
     expect(await secondPage.content()).toContain('hello world');
     await server.close();
+    await browser.close();
   });
 });
 

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -1047,7 +1047,10 @@ test.describe('launchServer only', () => {
     await expect(browser._parent.launch({ timeout: 0 })).rejects.toThrowError('Launching more browsers is not allowed.');
   });
 
-  test('should work with existing browser', async ({ connect, page, browser }) => {
+  test('should work with existing browser', async ({ connect, browserType }) => {
+    // can't use browser fixture because it's shared across the worker, launching a server on that would infect other tests
+    const browser = await browserType.launch();
+    const page = await browser.newPage();
     await page.setContent('hello world');
     const server = await (browser as any)._launchServer();
     const secondBrowser = await connect(server.wsEndpoint());

--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -19,7 +19,6 @@ import { PlaywrightServer } from '../../packages/playwright-core/lib/remote/play
 import { createGuid } from '../../packages/playwright-core/lib/server/utils/crypto';
 import { Backend } from '../config/debugControllerBackend';
 import type { Browser, BrowserContext } from '@playwright/test';
-import type { Browser as BrowserImpl } from '../../packages/playwright-core/src/client/browser';
 import type * as channels from '@protocol/channels';
 import { roundBox } from '../page/pageTest';
 
@@ -311,8 +310,7 @@ test('should report error in aria template', async ({ backend }) => {
 });
 
 test('should work with browser._launchServer', async ({ browser }) => {
-  const browserImpl = browser as BrowserImpl;
-  const server = await browserImpl._launchServer({ debugController: true });
+  const server = await (browser as any)._launchServer({ debugController: true });
 
   const backend = new Backend();
   const connectionString = new URL(server.wsEndpoint());

--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -312,7 +312,7 @@ test('should report error in aria template', async ({ backend }) => {
 
 test('should work with browser._launchServer', async ({ browser }) => {
   const browserImpl = browser as BrowserImpl;
-  const server = await browserImpl._launchServer({});
+  const server = await browserImpl._launchServer({ _debugController: true });
 
   const backend = new Backend();
   const connectionString = new URL(server.wsEndpoint());

--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -310,7 +310,7 @@ test('should report error in aria template', async ({ backend }) => {
 });
 
 test('should work with browser._launchServer', async ({ browser }) => {
-  const server = await (browser as any)._launchServer({ debugController: true });
+  const server = await (browser as any)._launchServer({ _debugController: true });
 
   const backend = new Backend();
   const connectionString = new URL(server.wsEndpoint());
@@ -326,8 +326,8 @@ test('should work with browser._launchServer', async ({ browser }) => {
   expect(pageCounts).toEqual([1, 0]);
 });
 
-test('should not work with browser._launchServer(debugController: false)', async ({ browser }) => {
-  const server = await (browser as any)._launchServer({ debugController: false });
+test('should not work with browser._launchServer(_debugController: false)', async ({ browser }) => {
+  const server = await (browser as any)._launchServer({ _debugController: false });
 
   const backend = new Backend();
   const connectionString = new URL(server.wsEndpoint());

--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -312,7 +312,7 @@ test('should report error in aria template', async ({ backend }) => {
 
 test('should work with browser._launchServer', async ({ browser }) => {
   const browserImpl = browser as BrowserImpl;
-  const server = await browserImpl._launchServer({ _debugController: true });
+  const server = await browserImpl._launchServer({ debugController: true });
 
   const backend = new Backend();
   const connectionString = new URL(server.wsEndpoint());

--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -325,3 +325,15 @@ test('should work with browser._launchServer', async ({ browser }) => {
   await page.close();
   expect(pageCounts).toEqual([1, 0]);
 });
+
+test('should not work with browser._launchServer(debugController: false)', async ({ browser }) => {
+  const server = await (browser as any)._launchServer({ debugController: false });
+
+  const backend = new Backend();
+  const connectionString = new URL(server.wsEndpoint());
+  connectionString.searchParams.set('debug-controller', '');
+  await expect(async () => {
+    await backend.connect(connectionString.toString());
+    await backend.initialize();
+  }).rejects.toThrow();
+});


### PR DESCRIPTION
Adds a private method for launching a playwright server for an existing browser, for usage from inside MCP.