### PR TITLE
fix(webkit): do not crash in headless tests on ubuntu 22.04

### DIFF
--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -710,15 +710,16 @@ export class WKPage implements PageDelegate {
         height: screenSize.height,
       }),
     ];
-    // WPE WebKit is failing in mesa due to a race condition if we start interacting
-    // with the page too quickly.
-    if (!this._browserContext._browser?.options.headful && hostPlatform === 'ubuntu22.04-x64')
-      promises.push(new Promise(r => setTimeout(r, 500)));
     if (options.isMobile) {
       const angle = viewportSize.width > viewportSize.height ? 90 : 0;
       promises.push(this._pageProxySession.send('Emulation.setOrientationOverride', { angle }));
     }
     await Promise.all(promises);
+
+    // WPE WebKit is failing in mesa due to a race condition if we start interacting
+    // with the page too quickly.
+    if (!this._browserContext._browser?.options.headful && hostPlatform === 'ubuntu22.04-x64')
+      await new Promise(r => setTimeout(r, 500));
   }
 
   async updateRequestInterception(): Promise<void> {

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -710,6 +710,10 @@ export class WKPage implements PageDelegate {
         height: screenSize.height,
       }),
     ];
+    // WPE WebKit is failing in mesa due to a race condition if we start interacting
+    // with the page too quickly.
+    if (!this._browserContext._browser?.options.headful && hostPlatform === 'ubuntu22.04-x64')
+      promises.push(new Promise(r => setTimeout(r, 500)));
     if (options.isMobile) {
       const angle = viewportSize.width > viewportSize.height ? 90 : 0;
       promises.push(this._pageProxySession.send('Emulation.setOrientationOverride', { angle }));


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/35586