### PR TITLE
test: skip debug-controller tests in driver mode

### DIFF
--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -74,7 +74,7 @@ const test = baseTest.extend<Fixtures>({
 });
 
 test.slow(true, 'All controller tests are slow');
-test.skip(({ mode }) => mode.startsWith('service'));
+test.skip(({ mode }) => mode.startsWith('service') || mode === 'driver');
 
 test('should pick element', async ({ backend, connectedBrowser }) => {
   const events = [];


### PR DESCRIPTION
```
  1) [chromium-library] › tests/library/debug-controller.spec.ts:364:1 › should work with browser._launchServer 

    Error: Launching server is not supported

      364 | test('should work with browser._launchServer', async ({ browserType }) => {
      365 |   const browser = await browserType.launch();
    > 366 |   const server = await (browser as any)._launchServer({ _debugController: true });
          |                                         ^
      367 |
      368 |   const backend = new Backend();
      369 |   const connectionString = new URL(server.wsEndpoint());
        at /Users/maxschmitt/Developer/playwright/tests/library/debug-controller.spec.ts:366:41
```

I don't think debug-controller is a thing in driver mode.