### PR TITLE
test: unflake 'should pick element'

### DIFF
--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -80,10 +80,10 @@ test('should pick element', async ({ backend, connectedBrowser }) => {
   const events = [];
   backend.on('inspectRequested', event => events.push(event));
 
-  await backend.setRecorderMode({ mode: 'inspecting' });
-
   const context = await connectedBrowser.newContextForReuse();
-  const [page] = context.pages();
+  const page = context.pages().length ? context.pages()[0] : await context.newPage();
+
+  await backend.setRecorderMode({ mode: 'inspecting' });
 
   await page.setContent('<button>Submit</button>');
   await page.getByRole('button').click();


### PR DESCRIPTION
- Running these two tests after each other makes the latter one fail:
  - `npm run ctest -- --workers=1  library/browsertype-connect.spec.ts:437:5  ibrary/debug-controller.spec.ts:79:1`
- The default `context` can be mutated via adding selector engines.
- This causes the [`reusableContextHash`](https://github.com/microsoft/playwright/blob/b0bb1049b4e96b0d0e1faddef292df8efd198874/packages/playwright-core/src/server/browser.ts#L119) to be different.
- In this case when its different we throw away the previous context and create a new one with no pages. This causes the test to fail:

```
  1) [chromium-library] › tests/library/debug-controller.spec.ts:79:1 › should pick element ────────

    TypeError: Cannot read properties of undefined (reading 'setContent')

      86 |   const [page] = context.pages();
      87 |
    > 88 |   await page.setContent('<button>Submit</button>');
         |              ^
      89 |   await page.getByRole('button').click();
      90 |   await page.getByRole('button').click();
      91 |
        at /Users/maxschmitt/Developer/playwright/tests/library/debug-controller.spec.ts:88:14
```

In our test-runner e.g. we always call `newPage`. Looks like a fair assumption to make to create the page if needed before starting the `'inspecting'` mode.