### PR TITLE
test: unflake "should pick element"

### DIFF
--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -80,10 +80,10 @@ test('should pick element', async ({ backend, connectedBrowser }) => {
   const events = [];
   backend.on('inspectRequested', event => events.push(event));
 
-  await backend.setRecorderMode({ mode: 'inspecting' });
-
   const context = await connectedBrowser.newContextForReuse();
-  const [page] = context.pages();
+  const page = await context.newPage();
+
+  await backend.setRecorderMode({ mode: 'inspecting' });
 
   await page.setContent('<button>Submit</button>');
   await page.getByRole('button').click();


### PR DESCRIPTION
Running these two tests after each other makes the latter one fail: `npm run ctest -- --workers=1  library/browsertype-connect.spec.ts:437:5  ibrary/debug-controller.spec.ts:79:1`. This is because the first test populates `playwright.selectors`, which becomes part of the context's reusable hash.
The second test depends on the context + page created by `setRecorderMode`:

https://github.com/microsoft/playwright/blob/72e47728ba845709f62addb45b719df4abb77f3f/packages/playwright-core/src/server/debugController.ts#L110-L111

This is a server-side call, and the `{}` params don't include the `playwright.selectors` options, so the `connectedBrowser.newContextForReuse()` call doesn't get that context, but an empty new one instead.

We can fix this by creating the page earlier, from the client side. This is similar on how other tests are doing it / how we do it in VSCode.

Closes https://github.com/microsoft/playwright/pull/37096