### PR TITLE
test(bidi) fix test expectations for BiDi

### DIFF
--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -56,7 +56,7 @@ it('should have browser', async ({ browserName, browser, contextFactory, server 
   await page.goto(server.EMPTY_PAGE);
   const log = await getLog();
 
-  expect(log.browser!.name.toLowerCase()).toBe(browserName);
+  expect(log.browser!.name).toBe(browserName);
   expect(log.browser!.version).toBe(browser.version());
 });
 
@@ -913,6 +913,6 @@ it('should not hang on slow chunked response', async ({ browserName, browser, co
   await page.evaluate(() => (window as any).receivedFirstData);
   const log = await getLog();
 
-  expect(log.browser!.name.toLowerCase()).toBe(browserName);
+  expect(log.browser!.name).toBe(browserName);
   expect(log.browser!.version).toBe(browser.version());
 });


### PR DESCRIPTION
Fixes the tests "should have browser" and "should not hang on slow chunked response" in `tests/library/har.spec.ts` in both Chrome and Firefox.