### PR TITLE
test: move browser._launchServer in child process

### DIFF
--- a/tests/config/remote-server-impl.js
+++ b/tests/config/remote-server-impl.js
@@ -2,7 +2,8 @@ const fs = require('fs');
 const cluster = require('cluster');
 
 async function start() {
-  const { browserTypeName, launchOptions, stallOnClose, disconnectOnSIGHUP, exitOnFile, exitOnWarning, startStopAndRunHttp } = JSON.parse(process.argv[2]);
+  /** @type {import("./remoteServer").RemoteServerOptions} */
+  const { browserTypeName, launchOptions, stallOnClose, disconnectOnSIGHUP, exitOnFile, exitOnWarning, startStopAndRunHttp, existingBrowser } = JSON.parse(process.argv[2]);
   if (stallOnClose) {
     launchOptions.__testHookGracefullyClose = () => {
       console.log(`(stalled=>true)`);
@@ -25,7 +26,15 @@ async function start() {
     return;
   }
 
-  const browserServer = await playwright[browserTypeName].launchServer(launchOptions);
+  let browserServer;
+  if (existingBrowser) {
+    const browser = await playwright[browserTypeName].launch();
+    const page = await browser.newPage();
+    await page.setContent(existingBrowser.content);
+    browserServer = await browser._launchServer();
+  } else {
+    browserServer = await playwright[browserTypeName].launchServer(launchOptions);
+  }
   if (disconnectOnSIGHUP)
     process.on('SIGHUP', () => browserServer._disconnectForTest());
 

--- a/tests/config/remote-server-impl.js
+++ b/tests/config/remote-server-impl.js
@@ -28,7 +28,7 @@ async function start() {
 
   let browserServer;
   if (existingBrowser) {
-    const browser = await playwright[browserTypeName].launch();
+    const browser = await playwright[browserTypeName].launch(launchOptions);
     const page = await browser.newPage();
     await page.setContent(existingBrowser.content);
     browserServer = await browser._launchServer();

--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -69,6 +69,7 @@ export type RemoteServerOptions = {
   url?: string;
   startStopAndRunHttp?: boolean;
   sharedBrowser?: boolean;
+  existingBrowser?: { content: string };
 };
 
 export class RemoteServer implements PlaywrightServer {

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -1047,18 +1047,12 @@ test.describe('launchServer only', () => {
     await expect(browser._parent.launch({ timeout: 0 })).rejects.toThrowError('Launching more browsers is not allowed.');
   });
 
-  test('should work with existing browser', async ({ connect, browserType, mode }) => {
+  test('should work with existing browser', async ({ connect, startRemoteServer, mode }) => {
     test.skip(mode === 'driver', 'Driver mode does not support browserType.launchServer');
-    // can't use browser fixture because it's shared across the worker, launching a server on that would infect other tests
-    const browser = await browserType.launch();
-    const page = await browser.newPage();
-    await page.setContent('hello world');
-    const server = await (browser as any)._launchServer();
-    const secondBrowser = await connect(server.wsEndpoint());
-    const secondPage = secondBrowser.contexts()[0].pages()[0];
-    expect(await secondPage.content()).toContain('hello world');
-    await server.close();
-    await browser.close();
+    const remoteServer = await startRemoteServer('launchServer', { existingBrowser: { content: 'hello world' } });
+    const browser = await connect(remoteServer.wsEndpoint());
+    const page = browser.contexts()[0].pages()[0];
+    expect(await page.content()).toContain('hello world');
   });
 });
 


### PR DESCRIPTION
The [`connect`](https://github.com/microsoft/playwright/blob/a5daba92ac34a552216508d1eac83aa9f0677cee/tests/library/browsertype-connect.spec.ts#L1057) call in this test was causing all other browsers in the worker to be closed:

https://github.com/microsoft/playwright/blob/a5daba92ac34a552216508d1eac83aa9f0677cee/packages/playwright-core/src/remote/playwrightServer.ts#L257-L261

To prevent this contamination, i'm moving this test into subprocess, just like all the other tests in the file.