### PR TITLE
fix(webkit): download navigations do not have frame id

### DIFF
--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -121,7 +121,14 @@ export class WKBrowser extends Browser {
     // TODO: this is racy, because download might be unrelated any navigation, and we will
     // abort navigation that is still running. We should be able to fix this by
     // instrumenting policy decision start/proceed/cancel.
-    page._page.frameManager.frameAbortedNavigation(payload.frameId, 'Download is starting');
+    //
+    // Since https://commits.webkit.org/298732@main, WebKit doesn't provide frame id for
+    // navigations converted into downloads and the download has a fake frameId. We map it
+    // to the main frame.
+    let frameId = payload.frameId;
+    if (!page._page.frameManager.frame(frameId))
+      frameId = page._page.mainFrame()._id;
+    page._page.frameManager.frameAbortedNavigation(frameId, 'Download is starting');
     let originPage = page._page.initializedOrUndefined();
     // If it's a new window download, report it on the opener page.
     if (!originPage) {


### PR DESCRIPTION
Since https://commits.webkit.org/298732@main, WebKit doesn't provide frame id for navigations converted into downloads. The downloads use `FrameInfo` generated by [`legacyEmptyFrameInfo`](https://github.com/WebKit/WebKit/blob/278449c45cfd92b44d8337d8d3c46632f2f7e86a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp#L65), which [generates a new frame id](https://github.com/WebKit/WebKit/blob/278449c45cfd92b44d8337d8d3c46632f2f7e86a/Source/WebKit/Shared/FrameInfoData.cpp#L43) and that id is used in downloadCreated event. To mitigate that, we always map unknown frame id to the main frame for the downloads.

This fixes download tests otherwise failing with https://github.com/microsoft/playwright-browsers/pull/1801

```
[webkit-library] › tests/library/download.spec.ts:54:5 › download event › should report download when navigation turns into download @smoke 
[webkit-library] › tests/library/download.spec.ts:75:5 › download event › should work with Cross-Origin-Opener-Policy 
```