### PR TITLE
fix(ui-mode): ensure page exists before fetching snapshot

### DIFF
--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -57,7 +57,7 @@ export const SnapshotTabsView: React.FunctionComponent<{
   }, [action]);
   const { snapshotInfoUrl, snapshotUrl, popoutUrl } = React.useMemo(() => {
     const snapshot = snapshots[snapshotTab];
-    return snapshot ? extendSnapshot(snapshot, shouldPopulateCanvasFromScreenshot) : { snapshotInfoUrl: undefined, snapshotUrl: undefined, popoutUrl: undefined };
+    return (snapshot && extendSnapshot(snapshot, shouldPopulateCanvasFromScreenshot)) ?? { snapshotInfoUrl: undefined, snapshotUrl: undefined, popoutUrl: undefined };
   }, [snapshots, snapshotTab, shouldPopulateCanvasFromScreenshot]);
 
   const snapshotUrls = React.useMemo((): SnapshotUrls | undefined => snapshotInfoUrl !== undefined ? { snapshotInfoUrl, snapshotUrl, popoutUrl } : undefined, [snapshotInfoUrl, snapshotUrl, popoutUrl]);
@@ -377,7 +377,10 @@ export function collectSnapshots(action: ActionTraceEvent | undefined): Snapshot
 const isUnderTest = new URLSearchParams(window.location.search).has('isUnderTest');
 const serverParam = new URLSearchParams(window.location.search).get('server');
 
-export function extendSnapshot(snapshot: Snapshot, shouldPopulateCanvasFromScreenshot: boolean): SnapshotUrls {
+export function extendSnapshot(snapshot: Snapshot, shouldPopulateCanvasFromScreenshot: boolean): SnapshotUrls | undefined {
+  if (!snapshot.action.pageId)
+    return undefined;
+
   const params = new URLSearchParams();
   params.set('trace', context(snapshot.action).traceUrl);
   params.set('name', snapshot.snapshotName);

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -312,7 +312,7 @@ export type Snapshot = {
   hasInputTarget?: boolean;
 };
 
-const createSnapshot = (action: ActionTraceEvent, snapshotNameKey: keyof ActionTraceEvent, hasInputTarget: boolean = false): Snapshot | undefined => {
+const createSnapshot = (action: ActionTraceEvent, snapshotNameKey: 'beforeSnapshot' | 'afterSnapshot' | 'inputSnapshot', hasInputTarget: boolean = false): Snapshot | undefined => {
   if (!action)
     return undefined;
 
@@ -393,7 +393,7 @@ export function collectSnapshots(action: ActionTraceEvent | undefined): Snapshot
       afterSnapshot = beforeSnapshot;
   }
 
-  const actionSnapshot: Snapshot | undefined = action.inputSnapshot && action.pageId ? { action, snapshotName: action.inputSnapshot, pageId: action.pageId, hasInputTarget: true } : afterSnapshot;
+  const actionSnapshot = createSnapshot(action, 'inputSnapshot', true) ?? afterSnapshot;
   if (actionSnapshot)
     actionSnapshot.point = action.point;
   return { action: actionSnapshot, before: beforeSnapshot, after: afterSnapshot };


### PR DESCRIPTION
If UI Mode is run on a test that never actually creates a page, or the page is created for a very short period of time, it will attempt to load a snapshot for that page, which is `undefined`. This removes the unnecessary network request that will always fail.