### PR TITLE
chore(ui-mode): improve toolbar alignment and remove some odd sizings

### DIFF
--- a/packages/trace-viewer/src/ui/timeline.css
+++ b/packages/trace-viewer/src/ui/timeline.css
@@ -14,12 +14,17 @@
   limitations under the License.
 */
 
+.timeline-view-container {
+  flex: none;
+  border-bottom: 1px solid var(--vscode-panel-border);
+}
+
 .timeline-view {
   flex: none;
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: 20px 0 5px;
+  padding: 20px 0 4px;
   cursor: text;
   user-select: none;
   margin-left: 10px;

--- a/packages/trace-viewer/src/ui/timeline.tsx
+++ b/packages/trace-viewer/src/ui/timeline.tsx
@@ -233,7 +233,7 @@ export const Timeline: React.FunctionComponent<{
     setSelectedTime(undefined);
   }, [setSelectedTime]);
 
-  return <div style={{ flex: 'none', borderBottom: '1px solid var(--vscode-panel-border)' }}>
+  return <div className='timeline-view-container'>
     {!!dragWindow && <GlassPane
       cursor={dragWindow?.type === 'resize' ? 'ew-resize' : 'grab'}
       onPaneMouseUp={onGlassPaneMouseUp}

--- a/packages/trace-viewer/src/ui/uiModeView.css
+++ b/packages/trace-viewer/src/ui/uiModeView.css
@@ -39,6 +39,10 @@
   color: var(--vscode-debugIcon-stopForeground);
 }
 
+.ui-mode .section-toolbar {
+  border-top: 1px solid var(--vscode-panel-border);
+}
+
 .ui-mode .section-title {
   display: flex;
   flex: auto;

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -454,7 +454,7 @@ export const UIModeView: React.FC<{}> = ({
           setProjectFilters={setProjectFilters}
           testModel={testModel}
           runTests={() => runTests('bounce-if-busy', visibleTestIds)} />
-        <Toolbar noMinHeight={true}>
+        <Toolbar className='section-toolbar' noMinHeight={true}>
           {!isRunningTest && !progress && <div className='section-title'>Tests</div>}
           {!isRunningTest && progress && <div data-testid='status-line' className='status-line'>
             <div>{progress.passed}/{progress.total} passed ({(progress.passed / progress.total) * 100 | 0}%)</div>

--- a/packages/web/src/components/toolbar.css
+++ b/packages/web/src/components/toolbar.css
@@ -18,7 +18,7 @@
   position: relative;
   display: flex;
   color: var(--vscode-sideBarTitle-foreground);
-  min-height: 35px;
+  min-height: 30px;
   align-items: center;
   flex: none;
   padding-right: 4px;


### PR DESCRIPTION
Improves toolbar alignment in UI Mode to be consistent across sections of the UI. In particular, the "Tests" title section now lines up with the toolbar containing "Actions" and "Metadata". This results in an overall smaller toolbar height that makes the UI feel more cohesive (and is very Chrome Dev Tools-like).

### After

<img width="1162" height="978" alt="Screenshot 2025-08-21 at 5 50 19 AM" src="https://github.com/user-attachments/assets/f0fe5bc3-d1d2-4c7b-a28a-8feae33bd358" />

<img width="1162" height="978" alt="Screenshot 2025-08-21 at 5 50 32 AM" src="https://github.com/user-attachments/assets/0be40b54-da94-458c-affb-443a72dc0c7e" />

<img width="1162" height="978" alt="Screenshot 2025-08-21 at 5 50 45 AM" src="https://github.com/user-attachments/assets/0ee17ee2-1466-4c66-b4a9-bd9352b3e45f" />

### Before

<img width="1348" height="868" alt="Screenshot 2025-08-21 at 5 57 15 AM" src="https://github.com/user-attachments/assets/26166131-e396-4b49-a367-65339383ddd7" />

<img width="1162" height="978" alt="Screenshot 2025-08-21 at 5 57 36 AM" src="https://github.com/user-attachments/assets/0fd7136b-8b99-4e97-8571-dba41f5b4190" />

<img width="1162" height="978" alt="Screenshot 2025-08-21 at 5 57 51 AM" src="https://github.com/user-attachments/assets/4c230fa8-d0a0-4af2-8fee-fecde49b0740" />
