### PR TITLE
chore: config.webServer.command cannot be empty

### DIFF
--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -210,6 +210,9 @@ export const webServerPluginsForConfig = (config: FullConfigInternal): TestRunne
     if (webServerConfig.port && webServerConfig.url)
       throw new Error(`Either 'port' or 'url' should be specified in config.webServer.`);
 
+    if (!webServerConfig.command)
+      throw new Error('config.webServer.command cannot be empty');
+
     let url: string | undefined;
     if (webServerConfig.port || webServerConfig.url) {
       url = webServerConfig.url || `http://localhost:${webServerConfig.port}`;

--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -94,6 +94,9 @@ export class WebServerPlugin implements TestRunnerPlugin {
       throw new Error(`${this._options.url ?? `http://localhost${port ? ':' + port : ''}`} is already used, make sure that nothing is running on the port/url or set reuseExistingServer:true in config.webServer.`);
     }
 
+    if (!this._options.command)
+      throw new Error('config.webServer.command cannot be empty');
+
     debugWebServer(`Starting WebServer process ${this._options.command}...`);
     const { launchedProcess, gracefullyClose } = await launchProcess({
       command: this._options.command,
@@ -209,9 +212,6 @@ export const webServerPluginsForConfig = (config: FullConfigInternal): TestRunne
   for (const webServerConfig of config.webServers) {
     if (webServerConfig.port && webServerConfig.url)
       throw new Error(`Either 'port' or 'url' should be specified in config.webServer.`);
-
-    if (!webServerConfig.command)
-      throw new Error('config.webServer.command cannot be empty');
 
     let url: string | undefined;
     if (webServerConfig.port || webServerConfig.url) {

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -864,3 +864,24 @@ test.describe('name option', () => {
     expect(result.output).toContain(`[${defaultPrefix}]`);
   });
 });
+
+test('should throw helpful error when command is empty', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async ({}) => {});
+    `,
+    'playwright.config.ts': `
+    module.exports = {
+      webServer: [
+        {
+          command: '',
+          url: 'http://localhost:3000',
+        }
+      ],
+    };
+  `,
+  }, undefined);
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('config.webServer.command cannot be empty');
+});

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -426,7 +426,6 @@ test(`should support self signed certificate`, async ({ runInlineTest, httpsServ
     'playwright.config.js': `
       module.exports = {
         webServer: {
-          command: 'unused',
           url: '${httpsServer.EMPTY_PAGE}',
           ignoreHTTPSErrors: true,
           reuseExistingServer: true,

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -426,6 +426,7 @@ test(`should support self signed certificate`, async ({ runInlineTest, httpsServ
     'playwright.config.js': `
       module.exports = {
         webServer: {
+          command: 'unused',
           url: '${httpsServer.EMPTY_PAGE}',
           ignoreHTTPSErrors: true,
           reuseExistingServer: true,


### PR DESCRIPTION
I tried running tests in https://github.com/surveyjs/survey-creator, but we threw a very unuseful error:

<img width="1576" height="912" alt="Screenshot 2025-08-21 at 17 07 25" src="https://github.com/user-attachments/assets/0ccbd246-bc36-4817-8dd8-1b6795a55cff" />
