### PR TITLE
chore(ui-mode): merge play/stop buttons into single button footprint

### DIFF
--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -462,8 +462,9 @@ export const UIModeView: React.FC<{}> = ({
           {isRunningTest && progress && <div data-testid='status-line' className='status-line'>
             <div>Running {progress.passed}/{runningState.testIds.size} passed ({(progress.passed / runningState.testIds.size) * 100 | 0}%)</div>
           </div>}
-          <ToolbarButton icon='play' title='Run all — F5' onClick={() => runTests('bounce-if-busy', visibleTestIds)} disabled={isRunningTest || isLoading}></ToolbarButton>
-          <ToolbarButton icon='debug-stop' title={'Stop — ' + (isMac ? '⇧F5' : 'Shift + F5')} onClick={() => testServerConnection?.stopTests({})} disabled={!isRunningTest || isLoading}></ToolbarButton>
+          {isRunningTest
+            ? <ToolbarButton icon='debug-stop' title={'Stop — ' + (isMac ? '⇧F5' : 'Shift + F5')} onClick={() => testServerConnection?.stopTests({})} disabled={!isRunningTest || isLoading} />
+            : <ToolbarButton icon='play' title='Run all — F5' onClick={() => runTests('bounce-if-busy', visibleTestIds)} disabled={isRunningTest || isLoading} />}
           <ToolbarButton icon='eye' title='Watch all' toggled={watchAll} onClick={() => {
             setWatchedTreeIds({ value: new Set() });
             setWatchAll(!watchAll);

--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -365,7 +365,6 @@ test('should stop', async ({ runUITest }) => {
   });
 
   await expect(page.getByTitle('Run all')).toBeEnabled();
-  await expect(page.getByTitle('Stop')).toBeDisabled();
 
   await page.getByTitle('Run all').click();
 
@@ -387,7 +386,6 @@ test('should stop', async ({ runUITest }) => {
           - treeitem ${/\[icon-clock\] test 3/}
   `);
 
-  await expect(page.getByTitle('Run all')).toBeDisabled();
   await expect(page.getByTitle('Stop')).toBeEnabled();
 
   await page.getByTitle('Stop').click();

--- a/tests/playwright-test/ui-mode-test-shortcut.spec.ts
+++ b/tests/playwright-test/ui-mode-test-shortcut.spec.ts
@@ -32,7 +32,6 @@ test('should run tests', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree);
 
   await expect(page.getByTitle('Run all')).toBeEnabled();
-  await expect(page.getByTitle('Stop')).toBeDisabled();
 
   await page.getByPlaceholder('Filter (e.g. text, @tag)').fill('test 3');
   await page.keyboard.press('F5');
@@ -64,7 +63,6 @@ test('should stop tests', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree);
 
   await expect(page.getByTitle('Run all')).toBeEnabled();
-  await expect(page.getByTitle('Stop')).toBeDisabled();
 
   await page.getByTitle('Run all').click();
 
@@ -86,7 +84,6 @@ test('should stop tests', async ({ runUITest }) => {
           - treeitem ${/\[icon-clock\] test 3/}
   `);
 
-  await expect(page.getByTitle('Run all')).toBeDisabled();
   await expect(page.getByTitle('Stop')).toBeEnabled();
 
   await page.keyboard.press('Shift+F5');
@@ -104,7 +101,6 @@ test('should toggle Terminal', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree);
 
   await expect(page.getByTitle('Run all')).toBeEnabled();
-  await expect(page.getByTitle('Stop')).toBeDisabled();
 
   await expect(page.getByTestId('output')).toBeHidden();
 


### PR DESCRIPTION
The play and stop buttons are mutually exclusive, so treat them as such in the UI. This allows users to not move their cursor to start and start, and gives us a little more space for the overall test run status.

### After

<img width="278" height="141" alt="Screenshot 2025-08-21 at 11 19 05 AM" src="https://github.com/user-attachments/assets/01b9c381-e7f2-4357-a761-60a40236610b" />

<img width="275" height="143" alt="Screenshot 2025-08-21 at 11 19 10 AM" src="https://github.com/user-attachments/assets/da554f2a-0aaf-4677-b84c-a6a68464a7df" />

### Before

<img width="267" height="155" alt="Screenshot 2025-08-21 at 11 19 29 AM" src="https://github.com/user-attachments/assets/65b0f3ef-f1c5-426d-ab33-8f6dc282e678" />
