### PR TITLE
fix(test): attaching in boxed fixture

### DIFF
--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -455,7 +455,10 @@ export class TestInfoImpl implements TestInfo {
       title: `Attach ${escapeWithQuotes(name, '"')}`,
       category: 'test.attach',
     });
-    this._attach(await normalizeAndSaveAttachment(this.outputPath(), name, options), step.stepId);
+    this._attach(
+        await normalizeAndSaveAttachment(this.outputPath(), name, options),
+        step.group ? undefined : step.stepId
+    );
     step.complete({});
   }
 


### PR DESCRIPTION
Resolves https://github.com/microsoft/playwright/issues/37147, which regressed in 5965db1bd78294cc0e94d7f9a25ca195bcb2b7fc. We're trying to report an attachment for a step that we skipped reporting, which leads to the error. The fix is to exclude the stepId when reporting the attachment.