### PR TITLE
fix(html): don't display a chip with empty content with no projects

### DIFF
--- a/packages/html-reporter/src/labels.tsx
+++ b/packages/html-reporter/src/labels.tsx
@@ -44,7 +44,10 @@ export const ProjectAndTagLabelsView: React.FC<{
   useLinks?: boolean,
   style?: React.CSSProperties,
 }> = ({ projectNames, activeProjectName, otherLabels, useLinks, style }) => {
-  return (projectNames.length > 0 || otherLabels.length > 0) && <span className='label-row' style={style ?? {}}>
+  // We can have an empty project name if we have no projects specified in the config
+  const hasProjectNames = projectNames.length > 0 && !!activeProjectName;
+
+  return (hasProjectNames || otherLabels.length > 0) && <span className='label-row' style={style ?? {}}>
     <ProjectLink projectNames={projectNames} projectName={activeProjectName} />
     {!!useLinks ? <LabelsLinkView labels={otherLabels} /> : <LabelsClickView labels={otherLabels} />}
   </span>;

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1717,6 +1717,25 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(page.locator('.label')).toHaveText('webkit');
       });
 
+      test('project label should not show if there are no explicit projects', async ({ runInlineTest, showReport, page }) => {
+        const result = await runInlineTest({
+          'a.test.js': `
+            const { expect, test } = require('@playwright/test');
+            test('pass', async ({}) => {
+              expect(1).toBe(1);
+            });
+          `,
+        }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.passed).toBe(1);
+
+        await showReport();
+
+        await expect(page.locator('.test-file-test .label')).toHaveCount(0);
+        await expect(page.locator('.label-row')).not.toBeVisible();
+      });
+
       test('testCaseView - after click test label and go back, testCaseView should be visible', async ({ runInlineTest, showReport, page }) => {
         const result = await runInlineTest({
           'playwright.config.js': `


### PR DESCRIPTION
#37146 

For some reason when we have no user specified projects, we insert a project with the empty string as its name. This was getting displayed following #36866.