### PR TITLE
fix(a11y): track inert elements as hidden in snapshots only

### DIFF
--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -117,7 +117,7 @@ export function generateAriaTree(rootElement: Element, publicOptions: AriaTreeOp
       return;
 
     const element = node as Element;
-    const isElementVisibleForAria = !roleUtils.isElementHiddenForAria(element);
+    const isElementVisibleForAria = !roleUtils.isElementHiddenForAria(element, true);
     let visible = isElementVisibleForAria;
     if (options.visibility === 'ariaOrVisible')
       visible = isElementVisibleForAria || isElementVisible(element);

--- a/tests/library/role-utils.spec.ts
+++ b/tests/library/role-utils.spec.ts
@@ -564,6 +564,27 @@ test('should support search element', async ({ page }) => {
   await expect.soft(page.getByRole('search', { name: 'example' })).toBeVisible();
 });
 
+test('should consider inert elements to be visible', async ({ page }) => {
+  // For legacy reasons, inert elements are treated as visible for normal `toBeVisible`
+  await page.setContent(`
+    <div aria-hidden="true">
+      <button type="button">First</button>
+    </div>
+    <div inert>
+      <button type="button">Second</button>
+    </div>
+    <button type="button" inert>Third</button>
+  `);
+
+  await expect(page.getByRole('button', { name: 'First' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Second' })).toHaveCount(1);
+  await expect(page.getByRole('button', { name: 'Third' })).toHaveCount(1);
+
+  await expect(
+      page.getByRole('button', { name: 'First', includeHidden: true })
+  ).toHaveCount(1);
+});
+
 function toArray(x: any): any[] {
   return Array.isArray(x) ? x : [x];
 }

--- a/tests/page/page-aria-snapshot.spec.ts
+++ b/tests/page/page-aria-snapshot.spec.ts
@@ -669,3 +669,20 @@ it('should not show unhidden children of aria-hidden elements', { annotation: { 
 
   expect(await page.locator('body').ariaSnapshot()).toBe('');
 });
+
+it('should consider inert elements as hidden', async ({ page }) => {
+  await page.setContent(`
+    <button type="button">Not hidden</button>
+    <div aria-hidden="true">
+      <button type="button">First</button>
+    </div>
+    <div inert>
+      <button type="button">Second</button>
+    </div>
+    <button type="button" inert>Third</button>
+  `);
+
+  await checkAndMatchSnapshot(page.locator('body'), `
+    - button "Not hidden"
+  `);
+});


### PR DESCRIPTION
Expands on #36947 to only apply breaking changes to ARIA snapshots and not general visibility checks.

Resolves #36938.

Implement the somewhat vague [`inert` HTML attribute spec](https://html.spec.whatwg.org/multipage/interaction.html#modal-dialogs-and-inert-subtrees) for our accessibility tree.

My interpretation is that nodes are marked hidden, equivalent to `aria-hidden`, if they possess the `inert` attribute. This cascades to all "flat tree descendants", which are the standard descendants plus special handling for shadow DOM.

Some nodes can additionally opt out (by virtue of their tag, not by specifying a property, as it is not possible to supply an explicit `false` flag to `inert`, just the absence of the attribute). The spec lists modal `dialog`s as an example of a tag that escapes `inert`.

**This opt out behavior is not supported by this PR**