### PR TITLE
docs: update Windows requirements

### DIFF
--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -284,7 +284,7 @@ See our doc on [Running and Debugging Tests](./running-tests.md) to learn more a
 ## System requirements
 
 - Playwright is distributed as a .NET Standard 2.0 library. We recommend .NET 8.
-- Windows 10+, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
+- Windows 11, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
 - macOS 14 Ventura, or later.
 - Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
 

--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -284,7 +284,7 @@ See our doc on [Running and Debugging Tests](./running-tests.md) to learn more a
 ## System requirements
 
 - Playwright is distributed as a .NET Standard 2.0 library. We recommend .NET 8.
-- Windows 11, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
+- Windows 11+, Windows Server 2019+ or Windows Subsystem for Linux (WSL).
 - macOS 14 Ventura, or later.
 - Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
 

--- a/docs/src/intro-java.md
+++ b/docs/src/intro-java.md
@@ -129,7 +129,7 @@ By default browsers launched with Playwright run headless, meaning no browser UI
 ## System requirements
 
 - Java 8 or higher.
-- Windows 11, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
+- Windows 11+, Windows Server 2019+ or Windows Subsystem for Linux (WSL).
 - macOS 14 Ventura, or later.
 - Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
 

--- a/docs/src/intro-java.md
+++ b/docs/src/intro-java.md
@@ -129,7 +129,7 @@ By default browsers launched with Playwright run headless, meaning no browser UI
 ## System requirements
 
 - Java 8 or higher.
-- Windows 10+, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
+- Windows 11, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
 - macOS 14 Ventura, or later.
 - Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
 

--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -305,7 +305,7 @@ pnpm exec playwright --version
 ## System requirements
 
 - Node.js: latest 20.x, 22.x or 24.x.
-- Windows 11, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
+- Windows 11+, Windows Server 2019+ or Windows Subsystem for Linux (WSL).
 - macOS 14 (Ventura) or later.
 - Debian 12 / 13, Ubuntu 22.04 / 24.04 (x86-64 or arm64).
 

--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -305,7 +305,7 @@ pnpm exec playwright --version
 ## System requirements
 
 - Node.js: latest 20.x, 22.x or 24.x.
-- Windows 10+, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
+- Windows 11, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
 - macOS 14 (Ventura) or later.
 - Debian 12 / 13, Ubuntu 22.04 / 24.04 (x86-64 or arm64).
 

--- a/docs/src/intro-python.md
+++ b/docs/src/intro-python.md
@@ -100,7 +100,7 @@ pip install pytest-playwright playwright -U
 ## System requirements
 
 - Python 3.8 or higher.
-- Windows 10+, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
+- Windows 11, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
 - macOS 14 Ventura, or later.
 - Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
 

--- a/docs/src/intro-python.md
+++ b/docs/src/intro-python.md
@@ -100,7 +100,7 @@ pip install pytest-playwright playwright -U
 ## System requirements
 
 - Python 3.8 or higher.
-- Windows 11, Windows Server 2016+ or Windows Subsystem for Linux (WSL).
+- Windows 11+, Windows Server 2019+ or Windows Subsystem for Linux (WSL).
 - macOS 14 Ventura, or later.
 - Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
 


### PR DESCRIPTION
- We never tested on Windows 10 - so making a claim that we officially support it seems wrong.
- Windows Server 2016 falls under this as well, WebKit doesn't work there anymore https://github.com/microsoft/playwright/issues/36936.
- Windows Server 2019 works (tested manually). GitHub Actions e.g. deprecated windows-server-2019 already, so probably we should not add bots for it.
