### PR TITLE
chore(bidi): check credentials' origin and send cancel when there are no matching credentials

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
+++ b/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
@@ -159,7 +159,7 @@ export class BidiNetworkManager {
   private _onAuthRequired(params: bidi.Network.AuthRequiredParameters) {
     const isBasic = params.response.authChallenges?.some(challenge => challenge.scheme.startsWith('Basic'));
     const credentials = this._page.browserContext._options.httpCredentials;
-    if (isBasic && credentials) {
+    if (isBasic && credentials && (!credentials.origin || (new URL(params.request.url).origin).toLowerCase() === credentials.origin.toLowerCase())) {
       if (this._attemptedAuthentications.has(params.request.request)) {
         this._session.sendMayFail('network.continueWithAuth', {
           request: params.request.request,
@@ -180,7 +180,7 @@ export class BidiNetworkManager {
     } else {
       this._session.sendMayFail('network.continueWithAuth', {
         request: params.request.request,
-        action: 'default',
+        action: 'cancel',
       });
     }
   }


### PR DESCRIPTION
This fixes the following tests in `tests/library/browsercontext-credentials.spec.ts`:
- "should fail with wrong credentials" in Chrome
- "should fail with correct credentials and mismatching scheme" in Chrome and Firefox
- "should fail with correct credentials and mismatching hostname" in Chrome and Firefox
- "should fail with correct credentials and mismatching port" in Chrome and Firefox

Note that the `default` action in the `network.continueWithAuth` command isn't useful in automated testing: with this action the browser will show the authentication prompt and wait for credentials to be entered manually.
