### PR TITLE
chore(bidi): map BiDi SameSite value 'default' to 'Lax'

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -420,6 +420,7 @@ function fromBidiSameSite(sameSite: bidi.Network.SameSite): channels.NetworkCook
     case 'strict': return 'Strict';
     case 'lax': return 'Lax';
     case 'none': return 'None';
+    case 'default': return 'Lax';
   }
   return 'None';
 }

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -74,13 +74,13 @@ const test = baseTest.extend<BrowserTestTestFixtures, BrowserTestWorkerFixtures>
   }, { scope: 'worker' }],
 
   defaultSameSiteCookieValue: [async ({ browserName, platform, macVersion }, run) => {
-    if (browserName === 'chromium' || browserName as any === '_bidiChromium')
+    if (browserName === 'chromium' || browserName as any === '_bidiChromium' || browserName as any === '_bidiFirefox')
       await run('Lax');
     else if (browserName === 'webkit' && platform === 'linux')
       await run('Lax');
     else if (browserName === 'webkit')
       await run('None'); // Windows + older macOS
-    else if (browserName === 'firefox' || browserName as any === '_bidiFirefox')
+    else if (browserName === 'firefox')
       await run('None');
     else
       throw new Error('unknown browser - ' + browserName);

--- a/tests/library/browsercontext-cookies-third-party.spec.ts
+++ b/tests/library/browsercontext-cookies-third-party.spec.ts
@@ -523,16 +523,16 @@ test('should be able to send third party cookies via an iframe', async ({ browse
   }
 });
 
-test('should(not) block third party cookies - persistent context', async ({ httpsServer, launchPersistent, allowsThirdParty }) => {
+test('should(not) block third party cookies - persistent context', async ({ httpsServer, launchPersistent, allowsThirdParty, defaultSameSiteCookieValue }) => {
   const { page, context } = await launchPersistent();
-  await testThirdPartyCookiesAreBlocked(page, context, httpsServer, allowsThirdParty);
+  await testThirdPartyCookiesAreBlocked(page, context, httpsServer, allowsThirdParty, defaultSameSiteCookieValue);
 });
 
-test('should(not) block third party cookies - ephemeral context', async ({ page, context, httpsServer, allowsThirdParty }) => {
-  await testThirdPartyCookiesAreBlocked(page, context, httpsServer, allowsThirdParty);
+test('should(not) block third party cookies - ephemeral context', async ({ page, context, httpsServer, allowsThirdParty, defaultSameSiteCookieValue }) => {
+  await testThirdPartyCookiesAreBlocked(page, context, httpsServer, allowsThirdParty, defaultSameSiteCookieValue);
 });
 
-async function testThirdPartyCookiesAreBlocked(page: Page, context: BrowserContext, server: TestServer, allowsThirdParty: boolean) {
+async function testThirdPartyCookiesAreBlocked(page: Page, context: BrowserContext, server: TestServer, allowsThirdParty: boolean, defaultSameSiteCookieValue: string) {
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(src => {
     let fulfill;
@@ -558,7 +558,7 @@ async function testThirdPartyCookiesAreBlocked(page: Page, context: BrowserConte
         'httpOnly': false,
         'name': 'username',
         'path': '/',
-        'sameSite': 'None',
+        'sameSite': defaultSameSiteCookieValue,
         'secure': false,
         'value': 'John Doe'
       }


### PR DESCRIPTION
This PR fixes #36225 and the following tests in Firefox:

in `tests/library/browsercontext-add-cookies.spec.ts`:
- "should roundtrip cookie"

in `tests/library/browsercontext-clearcookies.spec.ts`:
- "should remove cookies by name"
- "should remove cookies by name regex"
- "should remove cookies by domain"
- "should remove cookies by path"
- "should remove cookies by name and domain"
