### PR TITLE
fix(locator): improve error message when unchecking radio buttons

### DIFF
--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -51,7 +51,7 @@ export type FrameExpectParams = Omit<channels.FrameExpectParams, 'expectedValue'
 
 export type ElementState = 'visible' | 'hidden' | 'enabled' | 'disabled' | 'editable' | 'checked' | 'unchecked' | 'indeterminate' | 'stable';
 export type ElementStateWithoutStable = Exclude<ElementState, 'stable'>;
-export type ElementStateQueryResult = { matches: boolean, received?: string | 'error:notconnected' };
+export type ElementStateQueryResult = { matches: boolean, received?: string | 'error:notconnected', isRadio?: boolean };
 
 export type HitTargetInterceptionResult = {
   stop: () => 'done' | { hitTargetDescription: string };
@@ -697,12 +697,7 @@ export class InjectedScript {
     return { queryAll };
   }
 
-  isRadioButton(node: Node): boolean {
-    const element = this.retarget(node, 'follow-label');
-    if (!element || element.nodeName !== 'INPUT')
-      return false;
-    return (element as HTMLInputElement).type === 'radio';
-  }
+
 
   elementState(node: Node, state: ElementStateWithoutStable): ElementStateQueryResult {
     const element = this.retarget(node, ['visible', 'hidden'].includes(state) ? 'none' : 'follow-label');
@@ -744,9 +739,11 @@ export class InjectedScript {
       const checked = getCheckedWithoutMixed(element);
       if (checked === 'error')
         throw this.createStacklessError('Not a checkbox or radio button');
+      const isRadio = element.nodeName === 'INPUT' && (element as HTMLInputElement).type === 'radio';
       return {
         matches: need === checked,
         received: checked ? 'checked' : 'unchecked',
+        isRadio,
       };
     }
 

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -697,6 +697,13 @@ export class InjectedScript {
     return { queryAll };
   }
 
+  isRadioButton(node: Node): boolean {
+    const element = this.retarget(node, 'follow-label');
+    if (!element || element.nodeName !== 'INPUT')
+      return false;
+    return (element as HTMLInputElement).type === 'radio';
+  }
+
   elementState(node: Node, state: ElementStateWithoutStable): ElementStateQueryResult {
     const element = this.retarget(node, ['visible', 'hidden'].includes(state) ? 'none' : 'follow-label');
     if (!element || !element.isConnected) {

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -697,8 +697,6 @@ export class InjectedScript {
     return { queryAll };
   }
 
-
-
   elementState(node: Node, state: ElementStateWithoutStable): ElementStateQueryResult {
     const element = this.retarget(node, ['visible', 'hidden'].includes(state) ? 'none' : 'follow-label');
     if (!element || !element.isConnected) {

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -743,12 +743,11 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     await this._markAsTargetElement(progress);
     if (await isChecked() === state)
       return 'done';
-
-    // Radio buttons cannot be unchecked by clicking - only by selecting another radio in the same group
+    
     if (!state && await isRadio()) {
       throw new NonRecoverableDOMError('Cannot uncheck radio button. Radio buttons can only be unchecked by selecting another radio button in the same group.');
     }
-
+    
     const result = await this._click(progress, { ...options, waitAfter: 'disabled' });
     if (result !== 'done')
       return result;

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -730,30 +730,21 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       const result = await progress.race(this.evaluateInUtility(([injected, node]) => injected.elementState(node, 'checked'), {}));
       if (result === 'error:notconnected' || result.received === 'error:notconnected')
         throwElementIsNotAttached();
-      return result.matches;
+      return { matches: result.matches, isRadio: result.isRadio };
     };
-
-    const isRadio = async () => {
-      const result = await progress.race(this.evaluateInUtility(([injected, node]) => injected.isRadioButton(node), {}));
-      if (result === 'error:notconnected')
-        throwElementIsNotAttached();
-      return result;
-    };
-
     await this._markAsTargetElement(progress);
-    if (await isChecked() === state)
+    const checkedState = await isChecked();
+    if (checkedState.matches === state)
       return 'done';
-    
-    if (!state && await isRadio()) {
+    if (!state && checkedState.isRadio)
       throw new NonRecoverableDOMError('Cannot uncheck radio button. Radio buttons can only be unchecked by selecting another radio button in the same group.');
-    }
-    
     const result = await this._click(progress, { ...options, waitAfter: 'disabled' });
     if (result !== 'done')
       return result;
     if (options.trial)
       return 'done';
-    if (await isChecked() !== state)
+    const finalState = await isChecked();
+    if (finalState.matches !== state)
       throw new NonRecoverableDOMError('Clicking the checkbox did not change its state');
     return 'done';
   }

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -732,9 +732,23 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
         throwElementIsNotAttached();
       return result.matches;
     };
+
+    const isRadio = async () => {
+      const result = await progress.race(this.evaluateInUtility(([injected, node]) => injected.isRadioButton(node), {}));
+      if (result === 'error:notconnected')
+        throwElementIsNotAttached();
+      return result;
+    };
+
     await this._markAsTargetElement(progress);
     if (await isChecked() === state)
       return 'done';
+
+    // Radio buttons cannot be unchecked by clicking - only by selecting another radio in the same group
+    if (!state && await isRadio()) {
+      throw new NonRecoverableDOMError('Cannot uncheck radio button. Radio buttons can only be unchecked by selecting another radio button in the same group.');
+    }
+
     const result = await this._click(progress, { ...options, waitAfter: 'disabled' });
     if (result !== 'done')
       return result;

--- a/tests/page/page-check.spec.ts
+++ b/tests/page/page-check.spec.ts
@@ -145,3 +145,9 @@ it('should check the box using setChecked', async ({ page }) => {
   await page.setChecked('input', false);
   expect(await page.evaluate(() => window['checkbox'].checked)).toBe(false);
 });
+
+it('should throw when trying to uncheck radio button', async ({ page }) => {
+  await page.setContent(`<input type='radio' name='test' checked id='radio'>`);
+  const error = await page.uncheck('#radio').catch(e => e);
+  expect(error.message).toContain('Cannot uncheck radio button');
+});


### PR DESCRIPTION
fix(locator): improve error message when unchecking radio buttons

This patch improves the error message when attempting to uncheck radio buttons using uncheck(), setChecked(false), or page.uncheck(). Previously, these operations would fail with a confusing error message "Clicking the checkbox did not change its state" that didn't clearly explain why the operation failed.

Radio buttons cannot be unchecked by clicking - they can only be unchecked by selecting another radio button in the same group. The new error message clearly explains this behavior and guides users toward the correct approach.

**Before:** Error: locator.uncheck: Clicking the checkbox did not change its state

**After:** Error: locator.uncheck: Cannot uncheck radio button. Radio buttons can only be unchecked by selecting another radio button in the same group.


**Changes:**
- Added `isRadioButton()` utility method to injected script for radio button detection
- Enhanced `_setChecked()` method in ElementHandle to detect radio buttons and provide clear error messaging
- Added test case to verify the new error behavior

**Testing:**
- All existing check/uncheck tests continue to pass
- New test verifies proper error message for radio button uncheck attempts
- Checkbox functionality remains unaffected

Fixes #37178