### PR TITLE
test(bidi): add browser-specific expectations for _bidiFirefox

### DIFF
--- a/tests/library/headful.spec.ts
+++ b/tests/library/headful.spec.ts
@@ -119,7 +119,7 @@ it('should close browser after context menu was triggered', async ({ browserType
   await browser.close();
 });
 
-it('should(not) block third party cookies', async ({ page, server, allowsThirdParty }) => {
+it('should(not) block third party cookies', async ({ page, server, allowsThirdParty, defaultSameSiteCookieValue }) => {
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(src => {
     let fulfill;
@@ -145,7 +145,7 @@ it('should(not) block third party cookies', async ({ page, server, allowsThirdPa
         'httpOnly': false,
         'name': 'username',
         'path': '/',
-        'sameSite': 'None',
+        'sameSite': defaultSameSiteCookieValue,
         'secure': false,
         'value': 'John Doe'
       }

--- a/tests/library/page-close.spec.ts
+++ b/tests/library/page-close.spec.ts
@@ -153,7 +153,7 @@ test('interrupt request.response() and request.allHeaders() on page.close', asyn
   await page.close();
   expect((await respPromise).message).toContain(kTargetClosedErrorMessage);
   // All headers are the same as "provisional" headers in Firefox.
-  if (browserName === 'firefox')
+  if (browserName === 'firefox' || browserName as any === '_bidiFirefox')
     expect((await headersPromise)['user-agent']).toBeTruthy();
   else
     expect((await headersPromise).message).toContain(kTargetClosedErrorMessage);

--- a/tests/page/page-basic.spec.ts
+++ b/tests/page/page-basic.spec.ts
@@ -125,7 +125,7 @@ it('should have sane user agent', async ({ page, browserName, isElectron, isAndr
   // Second part in parenthesis is platform - ignore it.
 
   // Third part for Firefox is the last one and encodes engine and browser versions.
-  if (browserName === 'firefox') {
+  if (browserName === 'firefox' || browserName as any === '_bidiFirefox') {
     const [engine, browser] = part3.split(' ');
     expect(engine.startsWith('Gecko')).toBe(true);
     expect(browser.startsWith('Firefox')).toBe(true);

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -295,6 +295,8 @@ it('should fail when navigating to bad url', async ({ mode, page, browserName })
   await page.goto('asdfasdf').catch(e => error = e);
   if (browserName === 'chromium' || browserName === 'webkit')
     expect(error.message).toContain('Cannot navigate to invalid URL');
+  else if (browserName === '_bidiFirefox')
+    expect(error.message).toContain('NS_ERROR_MALFORMED_URI');
   else
     expect(error.message).toContain('Invalid url');
 });

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -353,6 +353,8 @@ it('should fail navigation when aborting main resource', async ({ page, server, 
     expect(error.message).toContain(isMac && macVersion < 11 ? 'Request intercepted' : 'Blocked by Web Inspector');
   else if (browserName === 'firefox')
     expect(error.message).toContain('NS_ERROR_FAILURE');
+  else if (browserName === '_bidiFirefox')
+    expect(error.message).toContain('NS_ERROR_ABORT');
   else
     expect(error.message).toContain('net::ERR_FAILED');
 });


### PR DESCRIPTION
These tests contain browser-specific expectations for `firefox` but not `_bidiFirefox`.
Fixes the following tests:
- `tests/library/headful.spec.ts`:
  - "should(not) block third party cookies"
- `tests/library/page-close.spec.ts`:
  - "interrupt request.response() and request.allHeaders() on page.close"
- `tests/page/page-basic.spec.ts`:
  - "should have sane user agent"
- `tests/page/page-goto.spec.ts`:
  - "should fail when navigating to bad url"
- `tests/page/page-route.spec.ts`:
  - "should fail navigation when aborting main resource"
