### PR TITLE
chore(bidi): don't await browsingContext.close with runBeforeUnload

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -344,10 +344,17 @@ export class BidiPage implements PageDelegate {
   }
 
   async closePage(runBeforeUnload: boolean): Promise<void> {
-    await this._session.send('browsingContext.close', {
-      context: this._session.sessionId,
-      promptUnload: runBeforeUnload,
-    });
+    if (runBeforeUnload) {
+      this._session.sendMayFail('browsingContext.close', {
+        context: this._session.sessionId,
+        promptUnload: runBeforeUnload,
+      });
+    } else {
+      await this._session.send('browsingContext.close', {
+        context: this._session.sessionId,
+        promptUnload: runBeforeUnload,
+      });
+    }
   }
 
   async setBackgroundColor(color?: { r: number; g: number; b: number; a: number; }): Promise<void> {


### PR DESCRIPTION
Playwright expects `page.close({ runBeforeUnload: true })` to resolve while the beforeunload dialog is still open but the BiDi command `browsingContext.close` only resolves after the dialog has been accepted or dismissed, so the implementation of `page.close()` should not await the response for `browsingContext.close` in this case.

Fixes:
- `tests/library/beforeunload.spec.ts`:
  - "should run beforeunload if asked for smoke"
  - "should access page after beforeunload"
- `tests/library/headful.spec.ts`:
  - "should close browsercontext with pending beforeunload dialog"
