### PR TITLE
chore: replace ESLint indent rule with @stylistic/indent

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -184,7 +184,7 @@ export const baseRules = {
   "no-mixed-spaces-and-tabs": 2,
   "no-trailing-spaces": 2,
   "linebreak-style": [process.platform === "win32" ? 0 : 2, "unix"],
-  indent: [
+  "@stylistic/indent": [
     2,
     2,
     { SwitchCase: 1, CallExpression: { arguments: 2 }, MemberExpression: 2 },

--- a/packages/playwright-core/src/server/accessibility.ts
+++ b/packages/playwright-core/src/server/accessibility.ts
@@ -19,11 +19,11 @@ import type * as dom from './dom';
 import type * as channels from '@protocol/channels';
 
 export interface AXNode {
-    isInteresting(insideControl: boolean): boolean;
-    isLeafNode(): boolean;
-    isControl(): boolean;
-    serialize(): channels.AXNode;
-    children(): Iterable<AXNode>;
+  isInteresting(insideControl: boolean): boolean;
+  isLeafNode(): boolean;
+  isControl(): boolean;
+  serialize(): channels.AXNode;
+  children(): Iterable<AXNode>;
 }
 
 export class Accessibility {
@@ -33,9 +33,9 @@ export class Accessibility {
   }
 
   async snapshot(options: {
-      interestingOnly?: boolean;
-      root?: dom.ElementHandle;
-    } = {}): Promise<channels.AXNode | null> {
+    interestingOnly?: boolean;
+    root?: dom.ElementHandle;
+  } = {}): Promise<channels.AXNode | null> {
     const {
       interestingOnly = true,
       root = null,

--- a/packages/playwright-core/src/server/bidi/third_party/bidiProtocolCore.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiProtocolCore.ts
@@ -164,8 +164,8 @@ export namespace Session {
     httpProxy?: string;
     sslProxy?: string;
   } & ({} | Session.SocksProxyConfiguration) & {
-      noProxy?: [...string[]];
-    } & Extensible;
+    noProxy?: [...string[]];
+  } & Extensible;
 }
 export namespace Session {
   export type SocksProxyConfiguration = {
@@ -1013,11 +1013,11 @@ export namespace Emulation {
 export namespace Emulation {
   export type SetGeolocationOverrideParameters = (
     | {
-        coordinates: Emulation.GeolocationCoordinates | null;
-      }
+      coordinates: Emulation.GeolocationCoordinates | null;
+    }
     | {
-        error: Emulation.GeolocationPositionError;
-      }
+      error: Emulation.GeolocationPositionError;
+    }
   ) & {
     contexts?: [
       BrowsingContext.BrowsingContext,

--- a/packages/playwright-core/src/server/bidi/third_party/bidiSerializer.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiSerializer.ts
@@ -9,7 +9,7 @@
 
 import type * as Bidi from './bidiProtocol';
 
-/* eslint-disable curly, indent */
+/* eslint-disable curly */
 
 /**
  * @internal
@@ -123,7 +123,7 @@ export class BidiSerializer {
     }
 
     throw new UnserializableError(
-      'Custom object serialization not possible. Use plain objects instead.'
+        'Custom object serialization not possible. Use plain objects instead.'
     );
   }
 }

--- a/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
@@ -9,7 +9,7 @@
 import fs from 'fs';
 import path from 'path';
 
-/* eslint-disable curly, indent */
+/* eslint-disable curly */
 
 interface ProfileOptions {
   preferences: Record<string, unknown>;
@@ -291,14 +291,14 @@ async function writePreferences(options: ProfileOptions): Promise<void> {
     fs.promises.writeFile(path.join(options.path, 'user.js'), lines.join('\n')),
     // Create a backup of the preferences file if it already exitsts.
     fs.promises.access(prefsPath, fs.constants.F_OK).then(
-      async () => {
-        await fs.promises.copyFile(
-          prefsPath,
-          path.join(options.path, 'prefs.js.playwright')
-        );
-      },
-      // Swallow only if file does not exist
-      () => {}
+        async () => {
+          await fs.promises.copyFile(
+              prefsPath,
+              path.join(options.path, 'prefs.js.playwright')
+          );
+        },
+        // Swallow only if file does not exist
+        () => {}
     ),
   ]);
   for (const command of result) {

--- a/packages/playwright-core/src/server/chromium/crCoverage.ts
+++ b/packages/playwright-core/src/server/chromium/crCoverage.ts
@@ -238,9 +238,9 @@ class CSSCoverage {
 }
 
 function convertToDisjointRanges(nestedRanges: {
-    startOffset: number;
-    endOffset: number;
-    count: number; }[]): { start: number; end: number; }[] {
+  startOffset: number;
+  endOffset: number;
+  count: number; }[]): { start: number; end: number; }[] {
   const points = [];
   for (const range of nestedRanges) {
     points.push({ offset: range.startOffset, type: 0, range });

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -918,10 +918,10 @@ export class Frame extends SdkObject {
   }
 
   async addScriptTag(params: {
-      url?: string,
-      content?: string,
-      type?: string,
-    }): Promise<dom.ElementHandle> {
+    url?: string,
+    content?: string,
+    type?: string,
+  }): Promise<dom.ElementHandle> {
     const {
       url = null,
       content = null,

--- a/packages/playwright-core/src/server/harBackend.ts
+++ b/packages/playwright-core/src/server/harBackend.ts
@@ -39,12 +39,13 @@ export class HarBackend {
   }
 
   async lookup(url: string, method: string, headers: HeadersArray, postData: Buffer | undefined, isNavigationRequest: boolean): Promise<{
-      action: 'error' | 'redirect' | 'fulfill' | 'noentry',
-      message?: string,
-      redirectURL?: string,
-      status?: number,
-      headers?: HeadersArray,
-      body?: Buffer }> {
+    action: 'error' | 'redirect' | 'fulfill' | 'noentry',
+    message?: string,
+    redirectURL?: string,
+    status?: number,
+    headers?: HeadersArray,
+    body?: Buffer
+  }> {
     let entry;
     try {
       entry = await this._harFindResponse(url, method, headers, postData);

--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -32,14 +32,14 @@ interface TaggedAsElementHandle<T> {
 type NoHandles<Arg> = Arg extends TaggedAsJSHandle<any> ? never : (Arg extends object ? { [Key in keyof Arg]: NoHandles<Arg[Key]> } : Arg);
 type Unboxed<Arg> =
   Arg extends TaggedAsElementHandle<infer T> ? T :
-  Arg extends TaggedAsJSHandle<infer T> ? T :
-  Arg extends NoHandles<Arg> ? Arg :
-  Arg extends [infer A0] ? [Unboxed<A0>] :
-  Arg extends [infer A0, infer A1] ? [Unboxed<A0>, Unboxed<A1>] :
-  Arg extends [infer A0, infer A1, infer A2] ? [Unboxed<A0>, Unboxed<A1>, Unboxed<A2>] :
-  Arg extends Array<infer T> ? Array<Unboxed<T>> :
-  Arg extends object ? { [Key in keyof Arg]: Unboxed<Arg[Key]> } :
-  Arg;
+    Arg extends TaggedAsJSHandle<infer T> ? T :
+      Arg extends NoHandles<Arg> ? Arg :
+        Arg extends [infer A0] ? [Unboxed<A0>] :
+          Arg extends [infer A0, infer A1] ? [Unboxed<A0>, Unboxed<A1>] :
+            Arg extends [infer A0, infer A1, infer A2] ? [Unboxed<A0>, Unboxed<A1>, Unboxed<A2>] :
+              Arg extends Array<infer T> ? Array<Unboxed<T>> :
+                Arg extends object ? { [Key in keyof Arg]: Unboxed<Arg[Key]> } :
+                  Arg;
 export type Func0<R> = string | (() => R | Promise<R>);
 export type Func1<Arg, R> = string | ((arg: Unboxed<Arg>) => R | Promise<R>);
 export type FuncOn<On, Arg2, R> = string | ((on: On, arg2: Unboxed<Arg2>) => R | Promise<R>);

--- a/packages/playwright-core/src/server/utils/eventsHelper.ts
+++ b/packages/playwright-core/src/server/utils/eventsHelper.ts
@@ -33,10 +33,10 @@ class EventsHelper {
   }
 
   static removeEventListeners(listeners: Array<{
-      emitter: EventEmitter;
-      eventName: (string | symbol);
-      handler: (...args: any[]) => void;
-    }>) {
+    emitter: EventEmitter;
+    eventName: (string | symbol);
+    handler: (...args: any[]) => void;
+  }>) {
     for (const listener of listeners)
       listener.emitter.removeListener(listener.eventName, listener.handler);
     listeners.splice(0, listeners.length);

--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -653,15 +653,15 @@ function resolveFromEnv(name: string): string | undefined {
 // In addition to `outputFile` the function returns `outputDir` which should
 // be cleaned up if present by some reporters contract.
 export function resolveOutputFile(reporterName: string, options: {
-    configDir: string,
-    outputDir?: string,
-    fileName?: string,
-    outputFile?: string,
-    default?: {
-      fileName: string,
-      outputDir: string,
-    }
-  }): { outputFile: string, outputDir?: string } | undefined {
+  configDir: string,
+  outputDir?: string,
+  fileName?: string,
+  outputFile?: string,
+  default?: {
+    fileName: string,
+    outputDir: string,
+  }
+}): { outputFile: string, outputDir?: string } | undefined {
   const name = reporterName.toUpperCase();
   let outputFile = resolveFromEnv(`PLAYWRIGHT_${name}_OUTPUT_FILE`);
   if (!outputFile && options.outputFile)

--- a/packages/playwright/src/runner/watchMode.ts
+++ b/packages/playwright/src/runner/watchMode.ts
@@ -301,9 +301,9 @@ function readKeyPress<T extends string>(handler: (text: string, key: any) => T |
 const isInterrupt = (text: string, key: any) => text === '\x03' || text === '\x1B' || (key && key.name === 'escape') || (key && key.ctrl && key.name === 'c');
 
 async function runTests(watchOptions: WatchModeOptions, testServerConnection: TestServerConnection, options?: {
-    title?: string,
-    testIds?: string[],
-  }) {
+  title?: string,
+  testIds?: string[],
+}) {
   printConfiguration(watchOptions, options?.title);
 
   const waitForDone = readKeyPress((text: string, key: any) => {

--- a/tests/library/browsercontext-fetch-happy-eyeballs.spec.ts
+++ b/tests/library/browsercontext-fetch-happy-eyeballs.spec.ts
@@ -58,8 +58,10 @@ it('get should work on request fixture', async ({ request, server }) => {
 });
 
 it('https post should work with ignoreHTTPSErrors option', async ({ context, httpsServer }) => {
-  const response = await context.request.post(httpsServer.EMPTY_PAGE,
-    { ignoreHTTPSErrors: true, __testHookLookup } as any);
+  const response = await context.request.post(httpsServer.EMPTY_PAGE, {
+    ignoreHTTPSErrors: true,
+    __testHookLookup
+  } as any);
   expect(response.status()).toBe(200);
   expect(interceptedHostnameLookup).toBe('localhost');
 });

--- a/tests/library/chromium/extensions.spec.ts
+++ b/tests/library/chromium/extensions.spec.ts
@@ -20,22 +20,22 @@ import { playwrightTest as base, expect } from '../../config/browserTest';
 
 const it = base.extend<{
   launchPersistentContext: (extensionPath: string, options?: Parameters<BrowserType['launchPersistentContext']>[1]) => Promise<BrowserContext>;
-      }>({
-        launchPersistentContext: async ({ browserType }, use) => {
-          const browsers: BrowserContext[] = [];
-          await use(async (extensionPath, options = {}) => {
-            const extensionOptions = {
-              ...options,
-              args: [
-                `--disable-extensions-except=${extensionPath}`,
-                `--load-extension=${extensionPath}`,
-              ],
-            };
-            return await browserType.launchPersistentContext('', extensionOptions);
-          });
-          await Promise.all(browsers.map(browser => browser.close()));
-        }
-      });
+}>({
+  launchPersistentContext: async ({ browserType }, use) => {
+    const browsers: BrowserContext[] = [];
+    await use(async (extensionPath, options = {}) => {
+      const extensionOptions = {
+        ...options,
+        args: [
+          `--disable-extensions-except=${extensionPath}`,
+          `--load-extension=${extensionPath}`,
+        ],
+      };
+      return await browserType.launchPersistentContext('', extensionOptions);
+    });
+    await Promise.all(browsers.map(browser => browser.close()));
+  }
+});
 
 it.skip(({ isHeadlessShell }) => isHeadlessShell, 'Headless Shell has no support for extensions');
 

--- a/tests/page/page-request-fulfill.spec.ts
+++ b/tests/page/page-request-fulfill.spec.ts
@@ -25,15 +25,15 @@ const it = base.extend<{
   // which is actually forwarded to the desktop localhost.
   // To use request such an url with apiRequestContext on the desktop, we need to change it back to localhost.
   rewriteAndroidLoopbackURL(url: string): string
-      }>({
-        rewriteAndroidLoopbackURL: ({ isAndroid }, use) => use(givenURL => {
-          if (!isAndroid)
-            return givenURL;
-          const requestURL = new URL(givenURL);
-          requestURL.hostname = 'localhost';
-          return requestURL.toString();
-        })
-      });
+}>({
+  rewriteAndroidLoopbackURL: ({ isAndroid }, use) => use(givenURL => {
+    if (!isAndroid)
+      return givenURL;
+    const requestURL = new URL(givenURL);
+    requestURL.hostname = 'localhost';
+    return requestURL.toString();
+  })
+});
 
 it('should work', async ({ page, server }) => {
   await page.route('**/*', route => {

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -33,18 +33,18 @@ const NEGATIVE_STATUS_MARK = DOES_NOT_SUPPORT_UTF8_IN_TERMINAL ? 'x ' : '✘ ';
 
 const test = baseTest.extend<{
   showReport: (reportFolder?: string) => Promise<void>
-      }>({
-        showReport: async ({ page }, use) => {
-          let server: HttpServer | undefined;
-          await use(async (reportFolder?: string) => {
-            reportFolder ??= test.info().outputPath('playwright-report');
-            server = startHtmlReportServer(reportFolder) as HttpServer;
-            await server.start();
-            await page.goto(server.urlPrefix('precise'));
-          });
-          await server?.stop();
-        }
-      });
+}>({
+  showReport: async ({ page }, use) => {
+    let server: HttpServer | undefined;
+    await use(async (reportFolder?: string) => {
+      reportFolder ??= test.info().outputPath('playwright-report');
+      server = startHtmlReportServer(reportFolder) as HttpServer;
+      await server.start();
+      await page.goto(server.urlPrefix('precise'));
+    });
+    await server?.stop();
+  }
+});
 
 test.use({ channel: 'chrome' });
 test.slow(!!process.env.CI);


### PR DESCRIPTION
The ESLint [indent](https://eslint.org/docs/latest/rules/indent) rule is deprecated and does not support TypeScript 5.9.
It’s unlikely to be fixed, so replacing it with its successor unblocks TypeScript 5.9.

Refs: https://github.com/typescript-eslint/typescript-eslint/issues/11455 https://github.com/microsoft/TypeScript/issues/62188
