### PR TITLE
test: unflake a few tests

### DIFF
--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -76,14 +76,18 @@ const test = baseTest.extend<Fixtures>({
 test.slow(true, 'All controller tests are slow');
 test.skip(({ mode }) => mode.startsWith('service') || mode === 'driver');
 
+// Force a separate worker to avoid registered selector engines from other tests.
+// See https://github.com/microsoft/playwright/pull/37103.
+test.use({ launchOptions: {} });
+
 test('should pick element', async ({ backend, connectedBrowser }) => {
   const events = [];
   backend.on('inspectRequested', event => events.push(event));
 
-  const context = await connectedBrowser.newContextForReuse();
-  const page = await context.newPage();
-
   await backend.setRecorderMode({ mode: 'inspecting' });
+
+  const context = await connectedBrowser.newContextForReuse();
+  const [page] = context.pages();
 
   await page.setContent('<button>Submit</button>');
   await page.getByRole('button').click();

--- a/tests/library/inspector/inspectorTest.ts
+++ b/tests/library/inspector/inspectorTest.ts
@@ -273,7 +273,7 @@ class CLIMock {
 
   @step
   async waitFor(text: string): Promise<void> {
-    await expect.poll(() => this.text()).toContain(text);
+    await expect.poll(() => this.text(), { timeout: 30000 }).toContain(text);
   }
 
   @step

--- a/tests/library/permissions.spec.ts
+++ b/tests/library/permissions.spec.ts
@@ -241,8 +241,9 @@ it.describe(() => {
   // Secure context
   it.use({ ignoreHTTPSErrors: true, });
 
-  it('should be able to use the local-fonts API', async ({ page, context, httpsServer, browserName }) => {
+  it('should be able to use the local-fonts API', async ({ page, context, httpsServer, browserName, channel }) => {
     it.skip(browserName !== 'chromium', 'chromium-only api');
+    it.fixme(!!channel && channel.startsWith('msedge'), 'always times out in edge');
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36113' });
 
     await page.goto(httpsServer.EMPTY_PAGE);


### PR DESCRIPTION
- Force a separate worker for debug-controller.spec.
- Increase expect timeout in codegen tests.
- Disable always failing localFonts() test in msedge.