### PR TITLE
chore(mcp): drop iconv-lite from bundle

### DIFF
--- a/packages/playwright/bundles/mcp/raw-body.ts
+++ b/packages/playwright/bundles/mcp/raw-body.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// @ts-expect-error untyped module
 import bytes from 'bytes';
 import type { IncomingMessage } from 'node:http';
 

--- a/packages/playwright/bundles/mcp/raw-body.ts
+++ b/packages/playwright/bundles/mcp/raw-body.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import bytes from 'bytes';
+import type { IncomingMessage } from 'node:http';
+
+export default function getRawBody(req: IncomingMessage, { limit, encoding }: { limit: string, encoding: BufferEncoding }) {
+  const limitNumber = bytes.parse(limit);
+  return new Promise<string>((resolve, reject) => {
+    let received = 0;
+
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => {
+      received += chunk.length;
+      if (received > limitNumber)
+        return reject(new Error(`Message size exceeds limit of ${limit} bytes`));
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      try {
+        resolve(Buffer.concat(chunks).toString(encoding));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on('error', error => {
+      reject(error);
+    });
+  });
+}

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -236,6 +236,7 @@ function copyFile(file, from, to) {
  *   outdir?: string,
  *   outfile?: string,
  *   minify?: boolean,
+ *   alias?: Record<string, string>,
  * }} BundleOptions
  */
 
@@ -260,6 +261,9 @@ bundles.push({
   outdir: 'packages/playwright/lib',
   entryPoints: ['src/mcpBundleImpl.ts'],
   external: ['express'],
+  alias: {
+    'raw-body': 'raw-body.ts',
+  },
 });
 
 bundles.push({
@@ -508,6 +512,7 @@ for (const bundle of bundles) {
     ...(bundle.outfile ? { outfile: filePath(bundle.outfile) } : {}),
     ...(bundle.external ? { external: bundle.external } : {}),
     ...(bundle.minify !== undefined ? { minify: bundle.minify } : {}),
+    alias: bundle.alias ? Object.fromEntries(Object.entries(bundle.alias).map(([k, v]) => [k, path.join(filePath(bundle.modulePath), v)])) : undefined,
     metafile: true,
     plugins: [pkgSizePlugin],
   };


### PR DESCRIPTION
Tested with `node packages/playwright/lib/mcp/test/program.js`, listing tools still works with the MCP inspector.

Before:

```
==== Running esbuild: packages/playwright/bundles/mcp/src/mcpBundleImpl.ts

Package contribution to bundle:
iconv-lite                     480.4 KB  63.10%
ajv                            98.5 KB  12.94%
@modelcontextprotocol/sdk      61.8 KB  8.12%
zod                            59.0 KB  7.75%
zod-to-json-schema             20.4 KB  2.67%
uri-js                         18.6 KB  2.44%
depd                           4.4 KB  0.58%
raw-body                       2.6 KB  0.34%
statuses                       2.4 KB  0.31%
http-errors                    2.4 KB  0.31%
content-type                   1.9 KB  0.25%
eventsource-parser             1.8 KB  0.23%
safer-buffer                   1.2 KB  0.16%
json-schema-traverse           1.2 KB  0.16%
bytes                          1.0 KB  0.14%
fast-json-stable-stringify     0.9 KB  0.12%
pkce-challenge                 0.8 KB  0.11%
fast-deep-equal                0.7 KB  0.09%
inherits                       0.5 KB  0.06%
unpipe                         0.4 KB  0.05%
setprototypeof                 0.2 KB  0.03%
toidentifier                   0.2 KB  0.02%
```

After:

```
==== Running esbuild: packages/playwright/bundles/mcp/src/mcpBundleImpl.ts

Package contribution to bundle:
ajv                            98.5 KB  36.95%
@modelcontextprotocol/sdk      61.8 KB  23.17%
zod                            59.0 KB  22.14%
zod-to-json-schema             20.4 KB  7.64%
uri-js                         18.6 KB  6.98%
content-type                   1.9 KB  0.70%
eventsource-parser             1.8 KB  0.67%
json-schema-traverse           1.2 KB  0.45%
bytes                          1.0 KB  0.39%
fast-json-stable-stringify     0.9 KB  0.33%
pkce-challenge                 0.8 KB  0.30%
fast-deep-equal                0.7 KB  0.27%
```