### PR TITLE
chore(bidi): compute resourceType for requests

### DIFF
--- a/tests/page/page-event-network.spec.ts
+++ b/tests/page/page-event-network.spec.ts
@@ -54,7 +54,7 @@ it('Page.Events.RequestFailed @smoke', async ({ page, server, browserName, platf
   expect(failedRequests[0].url()).toContain('one-style.css');
   expect(await failedRequests[0].response()).toBe(null);
   expect(failedRequests[0].resourceType()).toBe('stylesheet');
-  if (browserName === 'chromium') {
+  if (browserName === 'chromium' || browserName === '_bidiChromium') {
     expect(failedRequests[0].failure().errorText).toBe('net::ERR_EMPTY_RESPONSE');
   } else if (browserName === 'webkit') {
     if (platform === 'linux')


### PR DESCRIPTION
The logic for computing `resourceType` is based on [this table](https://fetch.spec.whatwg.org/#destination-table) in the fetch spec and on the current implementations in Chrome and Firefox (see also w3c/webdriver-bidi#992).
Fixes the following tests in both Chrome and Firefox:
- `tests/library/browsercontext-network-event.spec.ts`:
  - "BrowserContext.Events.RequestFailed"
- `tests/library/browsercontext-route.spec.ts`:
  - "should intercept"
- `tests/page/interception.spec.ts`:
  - "should work with regular expression passed from a different context"
- `tests/page/page-event-network.spec.ts`:
  - "Page.Events.Request smoke"
  - "Page.Events.RequestFailed smoke"
- `tests/page/page-event-request.spec.ts`:
  - "main resource xhr should have type xhr"
  - "\<picture\> resource should have type image"
- `tests/page/page-route.spec.ts`:
  - "should intercept smoke"
  - "should not work with redirects"
  - "should work with redirects for subresources"

Note that "should return event source" in `tests/page/page-network-request.spec.ts` still fails because an event source can't be identified using the information that browsers currently send.
