### PR TITLE
fix(test runner): do not use config.workers as project.workers

### DIFF
--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -130,7 +130,8 @@ export class FullConfigInternal {
       this.webServers = [];
     }
 
-    const projectConfigs = configCLIOverrides.projects || userConfig.projects || [userConfig];
+    // When no projects are defined, do not use config.workers as a hard limit for project.workers.
+    const projectConfigs = configCLIOverrides.projects || userConfig.projects || [{ ...userConfig, workers: undefined }];
     this.projects = projectConfigs.map(p => new FullProjectInternal(configDir, userConfig, this, p, this.configCLIOverrides, packageJsonDir));
     resolveProjectDependencies(this.projects);
     this._assignUniqueProjectIds(this.projects);

--- a/tests/playwright-test/worker-index.spec.ts
+++ b/tests/playwright-test/worker-index.spec.ts
@@ -324,3 +324,24 @@ test('should respect project.workers>1', async ({ runInlineTest }) => {
     'test1-end',
   ]);
 });
+
+test('should not inherit config.workers into project.workers', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      export default {
+        workers: 1,
+      };
+    `,
+    'a.test.js': `
+      import { test, expect } from '@playwright/test';
+      test.describe.configure({ mode: 'parallel' });
+      test('test1', async ({}, testInfo) => {
+      });
+      test('test2', async ({}, testInfo) => {
+      });
+    `,
+  }, { workers: 2 });
+  expect(result.passed).toBe(2);
+  expect(result.exitCode).toBe(0);
+  expect(result.output).toContain('Running 2 tests using 2 workers');
+});


### PR DESCRIPTION
These two have different semantics, so we should not inherit the value.

Fixes #37232.