### PR TITLE
fix(toHaveScreenshot): nice error when rebasing with bad expectation

### DIFF
--- a/packages/playwright-core/src/server/utils/comparators.ts
+++ b/packages/playwright-core/src/server/utils/comparators.ts
@@ -98,11 +98,11 @@ function validateBuffer(buffer: Buffer, mimeType: string): void {
   if (mimeType === 'image/png') {
     const pngMagicNumber = [137, 80, 78, 71, 13, 10, 26, 10];
     if (buffer.length < pngMagicNumber.length || !pngMagicNumber.every((byte, index) => buffer[index] === byte))
-      throw new Error('could not decode image as PNG.');
+      throw new Error('Could not decode expected image as PNG.');
   } else if (mimeType === 'image/jpeg') {
     const jpegMagicNumber = [255, 216];
     if (buffer.length < jpegMagicNumber.length || !jpegMagicNumber.every((byte, index) => buffer[index] === byte))
-      throw new Error('could not decode image as JPEG.');
+      throw new Error('Could not decode expected image as JPEG.');
   }
 }
 

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -1350,8 +1350,26 @@ test('should throw pretty error if expected PNG file is not a PNG', async ({ run
     `,
   });
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('could not decode image as PNG.');
-  expect(result.output).toContain('could not decode image as JPEG.');
+  expect(result.output).toContain('Could not decode expected image as PNG.');
+  expect(result.output).toContain('Could not decode expected image as JPEG.');
+});
+
+test('should throw pretty error if expected PNG file is not a PNG while rebasing', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    ...playwrightConfig({
+      snapshotPathTemplate: '__screenshots__/{testFilePath}/{arg}{ext}',
+    }),
+    '__screenshots__/a.spec.js/snapshot.png': 'not a png',
+    'a.spec.js': `
+      const { test, expect } = require('@playwright/test');
+      test('png', async ({ page }) => {
+        await expect(page).toHaveScreenshot('snapshot.png');
+      });
+    `,
+  }, { 'update-snapshots': true });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Failed to re-generate expected.');
+  expect(result.output).toContain('Could not decode expected image as PNG.');
 });
 
 test('should support maskColor option', async ({ runInlineTest }) => {


### PR DESCRIPTION
Before, we swallowed the actual error `Could not decoded expected image as PNG` and instead tried to write `undefined` buffer to a file.

This produced a cryptic error message from Node.js with no clear signal to the user.

References #37222.