### PR TITLE
chore(bidi): add support for fetching response bodies

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -69,6 +69,11 @@ export class BidiBrowser extends Browser {
       ],
     });
 
+    await browser._browserSession.send('network.addDataCollector', {
+      dataTypes: [bidi.Network.DataType.Response],
+      maxEncodedDataSize: 20_000_000, // same default as in CDP: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/inspector/inspector_network_agent.cc;l=134;drc=4128411589187a396829a827f59a655bed876aa7
+    });
+
     if (options.persistent) {
       const context = new BidiBrowserContext(browser, undefined, options.persistent);
       browser._defaultContext = context;

--- a/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
+++ b/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
@@ -89,7 +89,9 @@ export class BidiNetworkManager {
     if (!request)
       return;
     const getResponseBody = async () => {
-      throw new Error(`Response body is not available for requests in Bidi`);
+      const { bytes } = await this._session.send('network.getData', { request: params.request.request, dataType: bidi.Network.DataType.Response });
+      const encoding = bytes.type === 'base64' ? 'base64' : 'utf8';
+      return Buffer.from(bytes.value, encoding);
     };
     const timings = params.request.timings;
     const startTime = timings.requestTime;

--- a/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
@@ -170,6 +170,19 @@ export interface Commands {
     returnType: Bidi.Storage.SetCookieParameters;
   };
 
+  'network.addDataCollector': {
+    params: Bidi.Network.AddDataCollectorParameters;
+    returnType: Bidi.Network.AddDataCollectorResult;
+  };
+  'network.removeDataCollector': {
+    params: Bidi.Network.RemoveDataCollectorParameters;
+    returnType: Bidi.Network.RemoveDataCollectorResult;
+  };
+  'network.getData': {
+    params: Bidi.Network.GetDataParameters;
+    returnType: Bidi.Network.GetDataResult;
+  };
+
   'network.addIntercept': {
     params: Bidi.Network.AddInterceptParameters;
     returnType: Bidi.Network.AddInterceptResult;


### PR DESCRIPTION
Fixes #37218 and (at least) the following tests in Firefox:
- `tests/library/browsercontext-base-url.spec.ts`:
  - "should be able to match a URL relative to its given URL with urlMatcher"
- `tests/library/browsercontext-credentials.spec.ts`:
  - "should return resource body"
- `tests/library/browsercontext-har.spec.ts`:
  - "should update extracted har.zip for page"
  - "should update har.zip for context"
  - "should update har.zip for page"
  - "should update har.zip for page with different options"
- `tests/library/browsertype-connect.spec.ts`:
  - "launchServer > should fulfill with global fetch result"
  - "run-server > should fulfill with global fetch result"
- `tests/library/har.spec.ts`:
  - "should attach content"
  - "should contain http2 for http2 requests"
  - "should include content smoke"
  - "should use attach mode for zip extension"
- `tests/page/frame-goto.spec.ts`:
  - "should return matching responses"
- `tests/page/page-event-request.spec.ts`:
  - "should return response body when Cross-Origin-Opener-Policy is set"
- `tests/page/page-history.spec.ts`:
  - "page.reload should not resolve with same-document navigation"
- `tests/page/page-network-response.spec.ts`:
  - "should return text"
  - "should return uncompressed text"
  - "should wait until response completes"
  - "should return json"
  - "should return body"
  - "should return body with compression"
  - "should return body for prefetch script"
- `tests/page/page-request-fallback.spec.ts`:
  - "should not chain fulfill"
  - "should chain once"
- `tests/page/page-request-fulfill.spec.ts`:
  - "should fulfill with global fetch result"
  - "should fulfill with fetch result"
  - "should fulfill with fetch result and overrides"
  - "should return body for fulfilled responses"
- `tests/page/page-request-intercept.spec.ts`:
  - "should fulfill with any response"
  - "should intercept with url override"
  - "should support fulfill after intercept"
- `tests/page/workers.spec.ts`:
  - "should report worker script as network request"
  - "should report worker script as network request after redirect"
