### PR TITLE
chore(expect): explicit errorMessage

### DIFF
--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -466,7 +466,7 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
     return (await this._channel.title()).value;
   }
 
-  async _expect(expression: string, options: Omit<channels.FrameExpectParams, 'expression'>): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean }> {
+  async _expect(expression: string, options: Omit<channels.FrameExpectParams, 'expression'>): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean, errorMessage?: string }> {
     const params: channels.FrameExpectParams = { expression, ...options, isNot: !!options.isNot };
     params.expectedValue = serializeArgument(options.expectedValue);
     const result = (await this._channel.expect(params));

--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -377,7 +377,7 @@ export class Locator implements api.Locator {
     await this._frame._channel.waitForSelector({ selector: this._selector, strict: true, omitReturnValue: true, ...options, timeout: this._frame._timeout(options) });
   }
 
-  async _expect(expression: string, options: FrameExpectParams): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean }> {
+  async _expect(expression: string, options: FrameExpectParams): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean, errorMessage?: string }> {
     return this._frame._expect(expression, {
       ...options,
       selector: this._selector,

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1922,6 +1922,7 @@ scheme.FrameExpectResult = tObject({
   matches: tBoolean,
   received: tOptional(tType('SerializedValue')),
   timedOut: tOptional(tBoolean),
+  errorMessage: tOptional(tString),
   log: tOptional(tArray(tString)),
 });
 scheme.WorkerInitializer = tObject({

--- a/packages/playwright/src/matchers/matcherHint.ts
+++ b/packages/playwright/src/matchers/matcherHint.ts
@@ -20,8 +20,6 @@ import type { ExpectMatcherState } from '../../types/test';
 import type { StackFrame } from '@protocol/channels';
 import type { Locator } from 'playwright-core';
 
-export const kNoElementsFoundError = '<element(s) not found>';
-
 export function matcherHint(state: ExpectMatcherState, locator: Locator | undefined, matcherName: string, expression: any, actual: any, matcherOptions: any, timeout: number | undefined, expectedReceivedString?: string, preventExtraStatIndent: boolean = false) {
   let header = state.utils.matcherHint(matcherName, expression, actual, matcherOptions).replace(/ \/\/ deep equality/, '') + ' failed\n\n';
   // Extra space added after locator and timeout to match Jest's received/expected output

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -34,11 +34,11 @@ import type { FrameExpectParams } from 'playwright-core/lib/client/types';
 export type ExpectMatcherStateInternal = ExpectMatcherState & { _stepInfo?: TestStepInfoImpl };
 
 export interface LocatorEx extends Locator {
-  _expect(expression: string, options: FrameExpectParams): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean }>;
+  _expect(expression: string, options: FrameExpectParams): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean, errorMessage?: string }>;
 }
 
 export interface FrameEx extends Frame {
-  _expect(expression: string, options: FrameExpectParams): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean }>;
+  _expect(expression: string, options: FrameExpectParams): Promise<{ matches: boolean, received?: any, log?: string[], timedOut?: boolean, errorMessage?: string }>;
 }
 
 interface APIResponseEx extends APIResponse {

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -3296,6 +3296,7 @@ export type FrameExpectResult = {
   matches: boolean,
   received?: SerializedValue,
   timedOut?: boolean,
+  errorMessage?: string,
   log?: string[],
 };
 

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -2803,6 +2803,7 @@ Frame:
         matches: boolean
         received: SerializedValue?
         timedOut: boolean?
+        errorMessage: string?
         log:
           type: array?
           items: string

--- a/tests/page/expect-boolean.spec.ts
+++ b/tests/page/expect-boolean.spec.ts
@@ -125,7 +125,7 @@ Timeout:  1000ms`);
 
 Locator:  locator('input2')
 Expected: not checked
-Received: <element(s) not found>
+Error: element(s) not found
 Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toBeChecked" with timeout 1000ms`);
     expect(stripAnsi(error.message)).toContain(`- waiting for locator(\'input2\')`);
@@ -468,7 +468,7 @@ test.describe('toBeHidden', () => {
 
 Locator:  locator('button')
 Expected: not hidden
-Received: <element(s) not found>
+Error: element(s) not found
 Timeout:  1000ms`);
     expect(stripAnsi(error.message)).toContain(`- Expect "not toBeHidden" with timeout 1000ms`);
   });

--- a/tests/page/expect-matcher-result.spec.ts
+++ b/tests/page/expect-matcher-result.spec.ts
@@ -77,7 +77,6 @@ test('toBeTruthy-based assertions should have matcher result', async ({ page }) 
     const e = await expect(page.locator('#node2')).toBeVisible({ timeout: 1 }).catch(e => e);
     e.matcherResult.message = stripAnsi(e.matcherResult.message);
     expect.soft(e.matcherResult).toEqual({
-      actual: '<element(s) not found>',
       expected: 'visible',
       message: expect.stringContaining(`expect(locator).toBeVisible() failed`),
       name: 'toBeVisible',
@@ -90,7 +89,7 @@ test('toBeTruthy-based assertions should have matcher result', async ({ page }) 
 
 Locator:  locator('#node2')
 Expected: visible
-Received: <element(s) not found>
+Error: element(s) not found
 Timeout:  1ms
 
 Call log`);

--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -582,3 +582,17 @@ test('toHaveText that does not match should not produce logs twice', async ({ pa
   expect(error.message).not.toContain('locator resolved to');
   expect(error.message.replace(waitingForMessage, '<redacted>')).not.toContain(waitingForMessage);
 });
+
+test('strict mode violation error format', async ({ page }) => {
+  await page.setContent('<div>hello</div><div>hi</div>');
+  const error = await expect(page.locator('div')).toBeVisible().catch(e => e);
+  expect(error.message).toContain('Expected: visible');
+  expect(error.message).toContain(`Error: strict mode violation: locator('div') resolved to 2 elements:`);
+});
+
+test('invalid selector error format', async ({ page }) => {
+  await page.setContent('<div>hello</div><div>hi</div>');
+  const error = await expect(page.locator('##')).toBeVisible().catch(e => e);
+  expect(error.message).toContain('Expected: visible');
+  expect(error.message).toContain(`Error: Unexpected token "#" while parsing css selector "##".`);
+});

--- a/tests/page/expect-timeout.spec.ts
+++ b/tests/page/expect-timeout.spec.ts
@@ -24,7 +24,7 @@ test('should print timed out error message', async ({ page }) => {
 
 Locator: locator('no-such-thing')
 Expected string: "hey"
-Received: <element(s) not found>
+Error: element(s) not found
 Timeout: 1000ms`);
 });
 
@@ -46,7 +46,7 @@ test('should print timed out error message with impossible timeout', async ({ pa
 
 Locator: locator('no-such-thing')
 Expected string: "hey"
-Received: <element(s) not found>
+Error: element(s) not found
 Timeout: 1ms`);
 });
 

--- a/tests/page/expect-to-have-text.spec.ts
+++ b/tests/page/expect-to-have-text.spec.ts
@@ -160,7 +160,7 @@ test.describe('not.toHaveText', () => {
     await page.setContent('<div>hello</div>');
     const error = await expect(page.locator('span')).not.toHaveText('hello', { timeout: 1000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain('Expected string: not "hello"');
-    expect(stripAnsi(error.message)).toContain('Received: <element(s) not found>');
+    expect(stripAnsi(error.message)).toContain('Error: element(s) not found');
     expect(stripAnsi(error.message)).toContain('waiting for locator(\'span\')');
   });
 });

--- a/tests/page/matchers.misc.spec.ts
+++ b/tests/page/matchers.misc.spec.ts
@@ -41,7 +41,7 @@ it('should print no-locator-resolved error when locator matcher did not resolve 
       const error = await matcher().catch(e => e);
       expect(error).toBeInstanceOf(Error);
       expect(error.message).toContain(`waiting for locator('.nonexisting')`);
-      expect(stripAnsi(error.message)).toMatch(/Received:  ?"?<element\(s\) not found>/);
+      expect(stripAnsi(error.message)).toContain('Error: element(s) not found');
     });
   }
 });

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -635,7 +635,7 @@ test('should print pending operations for toHaveText', async ({ runInlineTest })
   const output = result.output;
   expect(output).toContain(`expect(locator).toHaveText(expected)`);
   expect(output).toContain('Expected string: "Text"');
-  expect(output).toContain('Received: <element(s) not found>');
+  expect(output).toContain('Error: element(s) not found');
   expect(output).toContain('waiting for locator(\'no-such-thing\')');
 });
 

--- a/tests/playwright-test/update-aria-snapshot.spec.ts
+++ b/tests/playwright-test/update-aria-snapshot.spec.ts
@@ -519,7 +519,7 @@ test('should not update snapshots when locator did not match', async ({ runInlin
   expect(fs.existsSync(patchPath)).toBe(false);
   expect(result.output).not.toContain('New baselines created');
   expect(result.output).toContain('Expected: "- heading"');
-  expect(result.output).toContain('Received: <element not found>');
+  expect(result.output).toContain('Error: element(s) not found');
 });
 
 test.describe('update-snapshots none', () => {


### PR DESCRIPTION
This turns an error in the protocol into a successful call with the error message in the new `errorMessage` field. Existing "element(s) not found" error is migrated to this as well.

Note that expect protocol call may still throw for multiple reasons:
- server connection dropped
- failed to serialize expected/received value, e.g. in `toHaveJSProperty()`
- unexpected playwright bug

---

Strict mode violation

```
Error: expect(locator).toHaveText(expected) failed

Locator: locator('div')
Expected string: "foo"
Error: strict mode violation: locator('div') resolved to 2 elements:
    1) <div>a</div> aka getByText('a')
    2) <div>b</div> aka getByText('b')

Call log:
  - Expect "toHaveText" with timeout 5000ms
  - waiting for locator('div')
```

---

Invalid selector

```
Error: expect(locator).toBeVisible() failed

Locator:  ##
Expected: visible
Error: Unexpected token "#" while parsing css selector "##". Did you mean to CSS.escape it?

Call log:
  - Expect "toBeVisible" with timeout 5000ms
  - waiting for ##
```

---

New look for "element(s) not found" error

```
Error: expect(locator).toBeVisible() failed

Locator:  locator('span')
Expected: visible
Error: element(s) not found
Timeout:  5000ms

Call log:
  - Expect "toBeVisible" with timeout 5000ms
  - waiting for locator('span')
```
