### PR TITLE
chore(bidi): add support for emulation.setTimezoneOverride

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -205,6 +205,12 @@ export class BidiBrowserContext extends BrowserContext {
         userContexts: [this._userContextId()],
       }));
     }
+    if (this._options.timezoneId) {
+      promises.push(this._browser._browserSession.send('emulation.setTimezoneOverride', {
+        timezone: this._options.timezoneId,
+        userContexts: [this._userContextId()],
+      }));
+    }
     await Promise.all(promises);
   }
 

--- a/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
@@ -117,6 +117,10 @@ export interface Commands {
     params: Bidi.Emulation.SetGeolocationOverrideParameters;
     returnType: Bidi.EmptyResult;
   };
+  'emulation.setTimezoneOverride': {
+    params: Bidi.Emulation.SetTimezoneOverrideParameters;
+    returnType: Bidi.EmptyResult;
+  };
 
   'emulation.setLocaleOverride': {
     params: Bidi.Emulation.SetLocaleOverrideParameters;


### PR DESCRIPTION
Fixes #37242 and the following tests in Firefox:
- `tests/library/browsercontext-timezone-id.spec.ts`:
  - "should work smoke"
  - "should not change default timezone in another context"
  - "should affect Intl.DateTimeFormat().resolvedOptions().timeZone"
- `tests/library/defaultbrowsercontext-2.spec.ts`:
  - "should support timezoneId option"
