### PR TITLE
fix(snapshotter): mismatching snapshot index

### DIFF
--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -318,9 +318,11 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
       }
     }
 
-    captureSnapshot(): SnapshotData | undefined {
+    captureSnapshot(needsReset: boolean): SnapshotData | undefined {
       const timestamp = performance.now();
       const snapshotNumber = ++this._lastSnapshotNumber;
+      if (needsReset)
+        this.reset();
       let nodeCounter = 0;
       let shadowDomNesting = 0;
       let headNesting = 0;


### PR DESCRIPTION
When we fail to capture snapshot in a frame, for example when the frame is blocked on a sync javascript dialog, we can end up in a situation where:
- snapshotter injected script has incremented the snapshotNumber
- meanwhile, snapshotter in node has dropped a snapshot

Now, all subsequent snapshots in the same frame will have mismatching snapshot numbers between injected and node sides. This means all "reference nodes" will be wrong and re-combined snapshots will be incorrect.

The fix is to force a reset after a failed snapshot, so that future snapshots do not reference old nodes.

Fixes #37192.