### PR TITLE
fix: Consider metadata elements as visible in `waitForSelector`

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -184,7 +184,7 @@ Defaults to `'visible'`. Can be either:
 * `'attached'` - wait for element to be present in DOM.
 * `'detached'` - wait for element to not be present in DOM.
 * `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element without
-  any content or with `display:none` has an empty bounding box and is not considered visible.
+  any content or with `display:none` has an empty bounding box and is not considered visible. Metadata elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if they're attached.
 * `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or `visibility:hidden`.
   This is opposite to the `'visible'` option.
 

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -184,7 +184,7 @@ Defaults to `'visible'`. Can be either:
 * `'attached'` - wait for element to be present in DOM.
 * `'detached'` - wait for element to not be present in DOM.
 * `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element without
-  any content or with `display:none` has an empty bounding box and is not considered visible. Metadata elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if they're attached.
+  any content or with `display:none` has an empty bounding box and is not considered visible. Metadata elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<source>`, `<style>`, and `<title>`) are always considered visible if they're attached.
 * `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or `visibility:hidden`.
   This is opposite to the `'visible'` option.
 

--- a/packages/injected/src/domUtils.ts
+++ b/packages/injected/src/domUtils.ts
@@ -142,6 +142,7 @@ export function isMetadataElement(element: Element): boolean {
     || localName === 'link'
     || localName === 'meta'
     || localName === 'script'
+    || localName === 'source'
     || localName === 'style'
     || localName === 'title'
   );

--- a/packages/injected/src/domUtils.ts
+++ b/packages/injected/src/domUtils.ts
@@ -131,6 +131,22 @@ export function computeBox(element: Element): Box {
   return { rect, style, visible: rect.width > 0 && rect.height > 0, inline: style.display === 'inline' };
 }
 
+/**
+ * Elements that don't directly contribute to the visible content of the document.
+ * Generally these are elements for which you don't care about their visibility implicitly.
+ */
+export function isMetadataElement(element: Element): boolean {
+  const localName = element.localName;
+  return (
+    localName === 'base'
+    || localName === 'link'
+    || localName === 'meta'
+    || localName === 'script'
+    || localName === 'style'
+    || localName === 'title'
+  );
+}
+
 export function isElementVisible(element: Element): boolean {
   return computeBox(element).visible;
 }

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -20,7 +20,7 @@ import { parseAttributeSelector, parseSelector, stringifySelector, visitAllSelec
 import { cacheNormalizedWhitespaces, normalizeWhiteSpace, trimStringWithEllipsis } from '@isomorphic/stringUtils';
 
 import { generateAriaTree, getAllElementsMatchingExpectAriaTemplate, matchesExpectAriaTemplate, renderAriaTree } from './ariaSnapshot';
-import { enclosingShadowRootOrDocument, isElementVisible, isInsideScope, parentElementOrShadowHost, setGlobalOptions } from './domUtils';
+import { enclosingShadowRootOrDocument, isElementVisible, isMetadataElement, isInsideScope, parentElementOrShadowHost, setGlobalOptions } from './domUtils';
 import { Highlight } from './highlight';
 import { kLayoutSelectorNames, layoutSelectorScore } from './layoutSelectorUtils';
 import { createReactEngine } from './reactSelectorEngine';
@@ -103,6 +103,7 @@ export class InjectedScript {
     getElementAccessibleDescription,
     getElementAccessibleName,
     isElementVisible,
+    isMetadataElement,
     isInsideScope,
     normalizeWhiteSpace,
     parseAriaSnapshot,

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -14591,8 +14591,8 @@ export interface Locator {
      * - `'detached'` - wait for element to not be present in DOM.
      * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
      *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
-     *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
-     *   they're attached.
+     *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<source>`, `<style>`, and `<title>`) are always considered
+     *   visible if they're attached.
      * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
      *   `visibility:hidden`. This is opposite to the `'visible'` option.
      */
@@ -22030,8 +22030,8 @@ interface ElementHandleWaitForSelectorOptions {
    * - `'detached'` - wait for element to not be present in DOM.
    * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
    *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
-   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
-   *   they're attached.
+   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<source>`, `<style>`, and `<title>`) are always considered
+   *   visible if they're attached.
    * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
    *   `visibility:hidden`. This is opposite to the `'visible'` option.
    */
@@ -22547,8 +22547,8 @@ interface PageWaitForSelectorOptions {
    * - `'detached'` - wait for element to not be present in DOM.
    * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
    *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
-   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
-   *   they're attached.
+   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<source>`, `<style>`, and `<title>`) are always considered
+   *   visible if they're attached.
    * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
    *   `visibility:hidden`. This is opposite to the `'visible'` option.
    */

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -14590,7 +14590,9 @@ export interface Locator {
      * - `'attached'` - wait for element to be present in DOM.
      * - `'detached'` - wait for element to not be present in DOM.
      * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
-     *   without any content or with `display:none` has an empty bounding box and is not considered visible.
+     *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
+     *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
+     *   they're attached.
      * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
      *   `visibility:hidden`. This is opposite to the `'visible'` option.
      */
@@ -22027,7 +22029,9 @@ interface ElementHandleWaitForSelectorOptions {
    * - `'attached'` - wait for element to be present in DOM.
    * - `'detached'` - wait for element to not be present in DOM.
    * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
-   *   without any content or with `display:none` has an empty bounding box and is not considered visible.
+   *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
+   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
+   *   they're attached.
    * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
    *   `visibility:hidden`. This is opposite to the `'visible'` option.
    */
@@ -22542,7 +22546,9 @@ interface PageWaitForSelectorOptions {
    * - `'attached'` - wait for element to be present in DOM.
    * - `'detached'` - wait for element to not be present in DOM.
    * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
-   *   without any content or with `display:none` has an empty bounding box and is not considered visible.
+   *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
+   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
+   *   they're attached.
    * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
    *   `visibility:hidden`. This is opposite to the `'visible'` option.
    */

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -768,7 +768,14 @@ export class Frame extends SdkObject {
           throw injected.createStacklessError('Element is not attached to the DOM');
         const elements = injected.querySelectorAll(info.parsed, root || document);
         const element: Element | undefined  = elements[0];
-        const visible = element ? injected.utils.isElementVisible(element) : false;
+        const visible = element
+          ?
+          injected.utils.isMetadataElement(element)
+            // For e.g. `<title>`, there won't be a bounding box but it's safe to
+            // assume `waitForSelector('title')` is supposed to resolve if the element is attached.
+            ? true
+            : injected.utils.isElementVisible(element)
+          : false;
         let log = '';
         if (elements.length > 1) {
           if (info.strict)

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14591,8 +14591,8 @@ export interface Locator {
      * - `'detached'` - wait for element to not be present in DOM.
      * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
      *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
-     *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
-     *   they're attached.
+     *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<source>`, `<style>`, and `<title>`) are always considered
+     *   visible if they're attached.
      * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
      *   `visibility:hidden`. This is opposite to the `'visible'` option.
      */
@@ -22030,8 +22030,8 @@ interface ElementHandleWaitForSelectorOptions {
    * - `'detached'` - wait for element to not be present in DOM.
    * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
    *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
-   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
-   *   they're attached.
+   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<source>`, `<style>`, and `<title>`) are always considered
+   *   visible if they're attached.
    * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
    *   `visibility:hidden`. This is opposite to the `'visible'` option.
    */
@@ -22547,8 +22547,8 @@ interface PageWaitForSelectorOptions {
    * - `'detached'` - wait for element to not be present in DOM.
    * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
    *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
-   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
-   *   they're attached.
+   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<source>`, `<style>`, and `<title>`) are always considered
+   *   visible if they're attached.
    * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
    *   `visibility:hidden`. This is opposite to the `'visible'` option.
    */

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14590,7 +14590,9 @@ export interface Locator {
      * - `'attached'` - wait for element to be present in DOM.
      * - `'detached'` - wait for element to not be present in DOM.
      * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
-     *   without any content or with `display:none` has an empty bounding box and is not considered visible.
+     *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
+     *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
+     *   they're attached.
      * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
      *   `visibility:hidden`. This is opposite to the `'visible'` option.
      */
@@ -22027,7 +22029,9 @@ interface ElementHandleWaitForSelectorOptions {
    * - `'attached'` - wait for element to be present in DOM.
    * - `'detached'` - wait for element to not be present in DOM.
    * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
-   *   without any content or with `display:none` has an empty bounding box and is not considered visible.
+   *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
+   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
+   *   they're attached.
    * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
    *   `visibility:hidden`. This is opposite to the `'visible'` option.
    */
@@ -22542,7 +22546,9 @@ interface PageWaitForSelectorOptions {
    * - `'attached'` - wait for element to be present in DOM.
    * - `'detached'` - wait for element to not be present in DOM.
    * - `'visible'` - wait for element to have non-empty bounding box and no `visibility:hidden`. Note that element
-   *   without any content or with `display:none` has an empty bounding box and is not considered visible.
+   *   without any content or with `display:none` has an empty bounding box and is not considered visible. Metadata
+   *   elements (`<base>`, `<link>`, `<meta>`, `<script>`, `<style>`, and `<title>`) are always considered visible if
+   *   they're attached.
    * - `'hidden'` - wait for element to be either detached from DOM, or have an empty bounding box or
    *   `visibility:hidden`. This is opposite to the `'visible'` option.
    */

--- a/tests/page/page-wait-for-selector-2.spec.ts
+++ b/tests/page/page-wait-for-selector-2.spec.ts
@@ -64,12 +64,14 @@ it('should consider visible if metadata', async ({ page }) => {
     + `<script></script>`
     + `<template>Not visible</template>`
     + `<title>test</title>`
+    + `<video controls><source src="foo.webm"></video>`
   );
   await page.waitForSelector('base');
   await page.waitForSelector('link[rel="icon"]');
   await page.waitForSelector('meta[name="viewport"]');
-  await page.waitForSelector('style');
   await page.waitForSelector('script');
+  await page.waitForSelector('source');
+  await page.waitForSelector('style');
   await expect(page.waitForSelector('template', { timeout: 1000 })).rejects.toThrow('page.waitForSelector: Timeout 1000ms exceeded');
   await page.waitForSelector('title');
 });

--- a/tests/page/page-wait-for-selector-2.spec.ts
+++ b/tests/page/page-wait-for-selector-2.spec.ts
@@ -55,6 +55,25 @@ it('should not consider visible when zero-sized', async ({ page, server }) => {
   expect(await page.waitForSelector('div', { timeout: 1000 })).toBeTruthy();
 });
 
+it('should consider visible if metadata', async ({ page }) => {
+  await page.setContent(
+      `<base>`
+    + `<meta name="viewport" content="width=device-width, initial-scale=1">`
+    + `<link rel="icon" type="image/x-icon" href="/static/favicon.ico">`
+    + `<style></style>`
+    + `<script></script>`
+    + `<template>Not visible</template>`
+    + `<title>test</title>`
+  );
+  await page.waitForSelector('base');
+  await page.waitForSelector('link[rel="icon"]');
+  await page.waitForSelector('meta[name="viewport"]');
+  await page.waitForSelector('style');
+  await page.waitForSelector('script');
+  await expect(page.waitForSelector('template', { timeout: 1000 })).rejects.toThrow('page.waitForSelector: Timeout 1000ms exceeded');
+  await page.waitForSelector('title');
+});
+
 it('should wait for visible recursively', async ({ page, server }) => {
   let divVisible = false;
   const waitForSelector = page.waitForSelector('div#inner').then(() => divVisible = true);


### PR DESCRIPTION
Treats `<base>`, `<link>`, `<meta>`, `<script>`, `<style>` and `<title>` as visible if attached in `waitForSelector(selector)`.

The default of checking for visibility is generally desired. However, when selecting these metadata elements, you don't care about visibility since the user agent will never directly render the elements. You almost always just want to assert on their properties (text content of `<title>` or `value` attributes in `<meta>`). E.g. in vercel/next.js we have to switch the asserted state to `attached` whenever we want to select metadata elements. This provides no additional clarity in the test. Worse, we had to adjust the selectors to make it clear that `state: 'attached'` is safe for this specific selector.

Having to include `state: 'attached'` for these elements is cumbersome since you have to double check that the selector is actually targeting a metadata element to not risk accidentally selecting elements that should render something but aren't visible.

I excluded `<template>` from this lists since that may be a footgun to assert on its contents and consider it "visible".