### PR TITLE
feat(fixtures): support `box: 'self'`

### DIFF
--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -760,6 +760,8 @@ export const test = base.extend({
 
 This is useful for non-interesting helper fixtures. For example, an [automatic](./test-fixtures.md#automatic-fixtures) fixture that sets up some common data can be safely hidden from a test report.
 
+You can also mark the fixture as `box: 'self'` to only hide that particular fixture, but include all the steps inside the fixture in the test report.
+
 ## Custom fixture title
 
 Instead of the usual fixture name, you can give fixtures a custom title that will be shown in test reports and error messages.

--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -25,7 +25,7 @@ import type { Location } from '../../types/testReporter';
 export type FixtureScope = 'test' | 'worker';
 type FixtureAuto = boolean | 'all-hooks-included';
 const kScopeOrder: FixtureScope[] = ['test', 'worker'];
-type FixtureOptions = { auto?: FixtureAuto, scope?: FixtureScope, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean };
+type FixtureOptions = { auto?: FixtureAuto, scope?: FixtureScope, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' };
 type FixtureTuple = [ value: any, options: FixtureOptions ];
 export type FixtureRegistration = {
   // Fixture registration location.
@@ -52,7 +52,7 @@ export type FixtureRegistration = {
   // Whether this fixture is an option override value set from the config.
   optionOverride?: boolean;
   // Do not generate the step for this fixture, consider it internal.
-  box?: boolean;
+  box?: boolean | 'self';
 };
 export type LoadError = {
   message: string;
@@ -105,7 +105,7 @@ export class FixturePool {
     for (const entry of Object.entries(fixtures)) {
       const name = entry[0];
       let value = entry[1];
-      let options: { auto: FixtureAuto, scope: FixtureScope, option: boolean, timeout: number | undefined, customTitle?: string, box?: boolean } | undefined;
+      let options: { auto: FixtureAuto, scope: FixtureScope, option: boolean, timeout: number | undefined, customTitle?: string, box?: boolean | 'self' } | undefined;
       if (isFixtureTuple(value)) {
         options = {
           auto: value[1].auto ?? false,

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6574,13 +6574,13 @@ export type WorkerFixture<R, Args extends {}> = (args: Args, use: (r: R) => Prom
 type TestFixtureValue<R, Args extends {}> = Exclude<R, Function> | TestFixture<R, Args>;
 type WorkerFixtureValue<R, Args extends {}> = Exclude<R, Function> | WorkerFixture<R, Args>;
 export type Fixtures<T extends {} = {}, W extends {} = {}, PT extends {} = {}, PW extends {} = {}> = {
-  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker', timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in Exclude<keyof W, keyof PW | keyof PT>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in Exclude<keyof W, keyof PW | keyof PT>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -1770,7 +1770,7 @@ pw:api    |    Close context
 `);
 });
 
-test('should box fixtures with everything inside them', async ({ runInlineTest }) => {
+test('should box fixtures', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'reporter.ts': stepIndentReporter,
     'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
@@ -1784,6 +1784,7 @@ test('should box fixtures with everything inside them', async ({ runInlineTest }
             await page.goto('data:text/html,<div>here we go</div>');
           });
           await use(1);
+          await page.setContent('<div>here we go</div>');
         }, { box: true }],
         bar: [async ({ page }, use) => {
           await page.setContent('<div>here we go</div>');
@@ -1791,13 +1792,23 @@ test('should box fixtures with everything inside them', async ({ runInlineTest }
             await page.goto('data:text/html,<div>here we go</div>');
           });
           await use(2);
+          await page.setContent('<div>here we go</div>');
         }, { box: false }],
+        baz: [async ({ page }, use) => {
+          await page.setContent('<div>here we go</div>');
+          await test.step('inner step', async () => {
+            await page.goto('data:text/html,<div>here we go</div>');
+          });
+          await use(3);
+          await page.setContent('<div>here we go</div>');
+        }, { box: 'self' }],
       });
 
-      test('test', async ({ foo, bar, page }) => {
+      test('test', async ({ foo, bar, baz, page }) => {
         await expect(page.locator('body')).toBeVisible();
         expect(foo).toBe(1);
         expect(bar).toBe(2);
+        expect(baz).toBe(3);
       });
     `
   }, { reporter: '' });
@@ -1812,14 +1823,20 @@ pw:api    |    Create context
 fixture   |  Fixture "page"
 pw:api    |    Create page
 fixture   |  Fixture "bar" @ a.test.ts:4
-pw:api    |    Set content @ a.test.ts:13
-test.step |    inner step @ a.test.ts:14
-pw:api    |      Navigate to "data:" @ a.test.ts:15
-expect    |Expect "toBeVisible" @ a.test.ts:22
-expect    |Expect "toBe" @ a.test.ts:23
-expect    |Expect "toBe" @ a.test.ts:24
+pw:api    |    Set content @ a.test.ts:14
+test.step |    inner step @ a.test.ts:15
+pw:api    |      Navigate to "data:" @ a.test.ts:16
+pw:api    |  Set content @ a.test.ts:22
+test.step |  inner step @ a.test.ts:23
+pw:api    |    Navigate to "data:" @ a.test.ts:24
+expect    |Expect "toBeVisible" @ a.test.ts:32
+expect    |Expect "toBe" @ a.test.ts:33
+expect    |Expect "toBe" @ a.test.ts:34
+expect    |Expect "toBe" @ a.test.ts:35
 hook      |After Hooks
+pw:api    |  Set content @ a.test.ts:27
 fixture   |  Fixture "bar" @ a.test.ts:4
+pw:api    |    Set content @ a.test.ts:19
 fixture   |  Fixture "page"
 fixture   |  Fixture "context"
 pw:api    |    Close context

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -191,13 +191,13 @@ export type WorkerFixture<R, Args extends {}> = (args: Args, use: (r: R) => Prom
 type TestFixtureValue<R, Args extends {}> = Exclude<R, Function> | TestFixture<R, Args>;
 type WorkerFixtureValue<R, Args extends {}> = Exclude<R, Function> | WorkerFixture<R, Args>;
 export type Fixtures<T extends {} = {}, W extends {} = {}, PT extends {} = {}, PW extends {} = {}> = {
-  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker', timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in Exclude<keyof W, keyof PW | keyof PT>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in Exclude<keyof W, keyof PW | keyof PT>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean }];
+  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';


### PR DESCRIPTION
Fixture marked as `box: 'self'` will be invisible in the report. However, all the child steps will be inlined instead of the boxed fixture - visible in the report as children of the boxed fixture's parent step.

No changes in the trace viewer, all boxed fixtures are hidden by default, and visible when "configuration" action filter is checked.

Fixes #37132.