### PR TITLE
fix(trace-viewer): don't preserve network selections across runs

### DIFF
--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -84,12 +84,9 @@ export const NetworkTab: React.FunctionComponent<{
 
   const selectedEntry = React.useMemo(() => {
     // HAR entries don't have a concept of unique id. Attempt to treat index and frameref as the key
-    if (!selectedEntryKey)
+    if (!selectedEntryKey || renderedEntries.length <= selectedEntryKey.index)
       return undefined;
-    const index = renderedEntries.length > selectedEntryKey.index ? selectedEntryKey.index : undefined;
-    if (index === undefined)
-      return undefined;
-    const entry = renderedEntries[index];
+    const entry = renderedEntries[selectedEntryKey.index];
     return entry.frameref === selectedEntryKey.frameref ? entry : undefined;
   }, [selectedEntryKey, renderedEntries]);
 


### PR DESCRIPTION
Fixes #37223 

Selection in the network tab was duplicating HAR entries, rather than referring to them by ID. This requires special state management to prevent holding onto the reference for too long. To mitigate this, craft a pseudo ID using HAR index (unique per run) and frame ID to track which HAR entry is selected.