### PR TITLE
fix: PWDEBUG=console should still disable test timeout

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -236,7 +236,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
     if (testIdAttribute)
       playwrightLibrary.selectors.setTestIdAttribute(testIdAttribute);
     testInfo.snapshotSuffix = process.platform;
-    if (debugMode() === 'inspector')
+    if (debugMode())
       (testInfo as TestInfoImpl)._setDebugMode();
 
     playwright._defaultContextOptions = _combinedContextOptions;

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -963,3 +963,20 @@ test('init script should not observe playwright internals', async ({ server, run
   }, {}, { PWDEBUG: '0' });
   expect(result.exitCode).toBe(0);
 });
+
+test('PWDEBUG=console should disable test timeout', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { timeout: 5000 };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+
+      test('test', async ({ page }) => {
+        await page.waitForTimeout(2 * 5000);
+      });
+    `,
+  }, {}, { PWDEBUG: 'console' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/37275, fixes regression from https://github.com/microsoft/playwright/pull/36921.