### PR TITLE
feat(ui-mode): support macOS alt key to expand/collapse sections of tree

### DIFF
--- a/packages/web/src/components/treeView.tsx
+++ b/packages/web/src/components/treeView.tsx
@@ -112,6 +112,20 @@ export function TreeView<T extends TreeItem>({
     setTreeState({ ...treeState });
   }, [treeItems, selectedItem, onSelected, treeState, setTreeState]);
 
+  const toggleSubtree = React.useCallback((item: T) => {
+    const { expanded } = treeItems.get(item)!;
+
+    const stack: TreeItem[] = [item];
+    while (stack.length) {
+      const current = stack.pop()!;
+      stack.push(...current.children);
+
+      treeState.expandedItems.set(current.id, !expanded);
+    }
+
+    setTreeState({ ...treeState });
+  }, [treeItems, treeState, setTreeState]);
+
   return <div className={clsx(`tree-view vbox`, name + '-tree-view')} role={'tree'} data-testid={dataTestId || (name + '-tree')}>
     <div
       className={clsx('tree-view-content')}
@@ -187,6 +201,7 @@ export function TreeView<T extends TreeItem>({
           onAccepted={onAccepted}
           isError={isError}
           toggleExpanded={toggleExpanded}
+          toggleSubtree={toggleSubtree}
           highlightedItem={highlightedItem}
           setHighlightedItem={setHighlightedItem}
           render={render}
@@ -205,6 +220,7 @@ type TreeItemHeaderProps<T> = {
   selectedItem: T | undefined,
   onSelected?: (item: T) => void,
   toggleExpanded: (item: T) => void,
+  toggleSubtree: (item: T) => void,
   highlightedItem: T | undefined,
   isError?: (item: T) => boolean,
   onAccepted?: (item: T) => void,
@@ -226,6 +242,7 @@ export function TreeItemHeader<T extends TreeItem>({
   isError,
   onAccepted,
   toggleExpanded,
+  toggleSubtree,
   render,
   title,
   icon,
@@ -276,7 +293,10 @@ export function TreeItemHeader<T extends TreeItem>({
         onClick={e => {
           e.stopPropagation();
           e.preventDefault();
-          toggleExpanded(item);
+          if (e.altKey)
+            toggleSubtree(item);
+          else
+            toggleExpanded(item);
         }}
       />
       {icon && <div className={'codicon ' + iconed} style={{ minWidth: 16, marginRight: 4 }} aria-label={'[' + iconed.replace('codicon', 'icon') + ']'}></div>}
@@ -294,6 +314,7 @@ export function TreeItemHeader<T extends TreeItem>({
           onAccepted={onAccepted}
           isError={isError}
           toggleExpanded={toggleExpanded}
+          toggleSubtree={toggleSubtree}
           highlightedItem={highlightedItem}
           setHighlightedItem={setHighlightedItem}
           render={render}


### PR DESCRIPTION
Resolves #37230

Support using Option/Alt to mass expand/collapse subtrees in our various tree views.