### PR TITLE
chore(ui): remove custom dark mode scrollbar theming

### DIFF
--- a/packages/web/src/common.css
+++ b/packages/web/src/common.css
@@ -177,26 +177,6 @@ input[type=text], input[type=search] {
   outline: none;
 }
 
-body.dark-mode ::-webkit-scrollbar {
-  width: 10px;
-}
-
-body.dark-mode ::-webkit-scrollbar-thumb {
-  background-color: #555;
-}
-
-body.dark-mode ::-webkit-scrollbar-track {
-  background-color: #333;
-}
-
-body.dark-mode ::-webkit-scrollbar-thumb:hover {
-  background-color: #777;
-}
-
-body.dark-mode ::-webkit-scrollbar-track:hover {
-  background-color: #444;
-}
-
 .codicon-loading {
   animation: spin 1s infinite linear;
 }


### PR DESCRIPTION
Follow platform design guidelines and eliminate scrollbar differences between light and dark themes.

### After

<img width="1392" height="912" alt="Screenshot 2025-09-04 at 7 48 52 AM" src="https://github.com/user-attachments/assets/b89edfaf-a61c-429c-a6d8-e48380cf700f" />

<img width="1392" height="912" alt="Screenshot 2025-09-04 at 7 49 41 AM" src="https://github.com/user-attachments/assets/c3d95b14-22d9-4f7f-8bfd-4fb0a341df9b" />

<img width="1182" height="739" alt="Screenshot 2025-09-04 at 7 58 39 AM" src="https://github.com/user-attachments/assets/27ff6d87-5e83-410d-8d07-61a6b5dd032f" />

<img width="1177" height="738" alt="Screenshot 2025-09-04 at 7 58 17 AM" src="https://github.com/user-attachments/assets/7cbf011a-2757-4709-8d25-a9ac9553f43f" />

