### PR TITLE
chore(bidi): report page errors

### DIFF
--- a/tests/page/page-event-pageerror.spec.ts
+++ b/tests/page/page-event-pageerror.spec.ts
@@ -25,7 +25,7 @@ it('should fire', async ({ page, server, browserName }) => {
   ]);
   expect(error.name).toBe('Error');
   expect(error.message).toBe('Fancy error!');
-  if (browserName === 'chromium') {
+  if (browserName === 'chromium' || browserName === '_bidiChromium' || browserName === '_bidiFirefox') {
     expect(error.stack).toBe(`Error: Fancy error!
     at c (myscript.js:14:11)
     at b (myscript.js:10:5)


### PR DESCRIPTION
Fixes the following tests:
- `tests/library/browsercontext-events.spec.ts`:
  - "weberror event should work"
- `tests/page/page-event-pageerror.spec.ts`:
  - all the tests in this file
- `tests/page/workers.spec.ts`:
  - "should report errors" (Firefox only)
