### PR TITLE
fix(test runner): unhandled rejection in test.fail should not skip other tests

### DIFF
--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -128,6 +128,7 @@ export type DonePayload = {
   fatalErrors: TestInfoErrorImpl[];
   skipTestsDueToSetupFailure: string[];  // test ids
   fatalUnknownTestIds?: string[];
+  stoppedDueToUnhandledErrorInTestFail?: boolean;
 };
 
 export type TestOutputPayload = {

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -459,7 +459,7 @@ class JobDispatcher {
     // - there are no remaining
     // - we are here not because something failed
     // - no unrecoverable worker error
-    if (!this._remainingByTestId.size && !this._failedTests.size && !params.fatalErrors.length && !params.skipTestsDueToSetupFailure.length && !params.fatalUnknownTestIds && !params.unexpectedExitError) {
+    if (!this._remainingByTestId.size && !this._failedTests.size && !params.fatalErrors.length && !params.skipTestsDueToSetupFailure.length && !params.fatalUnknownTestIds && !params.unexpectedExitError && !params.stoppedDueToUnhandledErrorInTestFail) {
       this._finished({ didFail: false });
       return;
     }


### PR DESCRIPTION
We stop the worker inside the `WorkerMain` upon unhandled rejection in `test.fail`. However, dispatcher does not know about that and sends a new batch of tests to the same worker, that ultimately end up as ignored because the worker has stopped.

An explicit flag in the `DonePayload` fixes the problem.

Fixes #37302.