### PR TITLE
feat(ui-mode): setting for running a single headed browser for tests

### DIFF
--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -100,6 +100,7 @@ export const UIModeView: React.FC<{}> = ({
   const [revealSource, setRevealSource] = React.useState(false);
   const onRevealSource = React.useCallback(() => setRevealSource(true), [setRevealSource]);
 
+  const [runHeaded, setRunHeaded] = useSetting<boolean>('run-headed', false);
   const [updateSnapshots, setUpdateSnapshots] = useSetting<reporterTypes.FullConfig['updateSnapshots']>('updateSnapshots', 'missing');
 
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -287,6 +288,8 @@ export const UIModeView: React.FC<{}> = ({
         projects: [...projectFilters].filter(([_, v]) => v).map(([p]) => p),
         updateSnapshots,
         reporters: queryParams.reporters,
+        headed: runHeaded,
+        workers: runHeaded ? 1 : undefined,
         trace: 'on',
       });
       // Clear pending tests in case of interrupt.
@@ -297,7 +300,7 @@ export const UIModeView: React.FC<{}> = ({
       setTestModel({ ...testModel });
       setRunningState(oldState => oldState ? ({ ...oldState, completed: true }) : undefined);
     });
-  }, [projectFilters, isRunningTest, testModel, testServerConnection, updateSnapshots]);
+  }, [projectFilters, isRunningTest, testModel, testServerConnection, updateSnapshots, runHeaded]);
 
   React.useEffect(() => {
     if (!testServerConnection || !teleSuiteUpdater)
@@ -501,6 +504,7 @@ export const UIModeView: React.FC<{}> = ({
           <div className='section-title'>Testing Options</div>
         </Toolbar>
         {testingOptionsVisible && <SettingsView settings={[
+          { type: 'check', value: runHeaded, set: setRunHeaded, name: 'Show browser — single worker' },
           { type: 'select', options: [
             { label: 'All', value: 'all' },
             { label: 'Changed', value: 'changed' },

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -100,7 +100,7 @@ export const UIModeView: React.FC<{}> = ({
   const [revealSource, setRevealSource] = React.useState(false);
   const onRevealSource = React.useCallback(() => setRevealSource(true), [setRevealSource]);
 
-  const [runHeaded, setRunHeaded] = useSetting<boolean>('run-headed', false);
+  const [showBrowser, setShowBrowser] = useSetting<boolean>('show-browser', false);
   const [updateSnapshots, setUpdateSnapshots] = useSetting<reporterTypes.FullConfig['updateSnapshots']>('updateSnapshots', 'missing');
 
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -288,8 +288,8 @@ export const UIModeView: React.FC<{}> = ({
         projects: [...projectFilters].filter(([_, v]) => v).map(([p]) => p),
         updateSnapshots,
         reporters: queryParams.reporters,
-        headed: runHeaded,
-        workers: runHeaded ? 1 : undefined,
+        headed: showBrowser,
+        workers: showBrowser ? 1 : undefined,
         trace: 'on',
       });
       // Clear pending tests in case of interrupt.
@@ -300,7 +300,7 @@ export const UIModeView: React.FC<{}> = ({
       setTestModel({ ...testModel });
       setRunningState(oldState => oldState ? ({ ...oldState, completed: true }) : undefined);
     });
-  }, [projectFilters, isRunningTest, testModel, testServerConnection, updateSnapshots, runHeaded]);
+  }, [projectFilters, isRunningTest, testModel, testServerConnection, updateSnapshots, showBrowser]);
 
   React.useEffect(() => {
     if (!testServerConnection || !teleSuiteUpdater)
@@ -504,7 +504,7 @@ export const UIModeView: React.FC<{}> = ({
           <div className='section-title'>Testing Options</div>
         </Toolbar>
         {testingOptionsVisible && <SettingsView settings={[
-          { type: 'check', value: runHeaded, set: setRunHeaded, name: 'Show browser — single worker' },
+          { type: 'check', value: showBrowser, set: setShowBrowser, name: 'Show browser — single worker' },
           { type: 'select', options: [
             { label: 'All', value: 'all' },
             { label: 'Changed', value: 'changed' },


### PR DESCRIPTION
Partially addresses #31380 and solves the root desire in #30304.

Adds a setting for enabling headed running in UI Mode. This will restrict the runner to only one worker and display the browser as the test is executed. Future changes will improve the styling and enable stopping execution on errors.

<img width="275" height="281" alt="Screenshot 2025-09-08 at 10 27 28 AM" src="https://github.com/user-attachments/assets/b192ecc2-97a0-4ee9-95fb-68c3ebbcf358" />
