### PR TITLE
fix(expect): report expect.poll and expect.toPass as "expect" steps

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -265,7 +265,8 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
         if (!testInfo || data.apiName.includes('setTestIdAttribute') || data.apiName === 'tracing.groupEnd')
           return;
         const zone = currentZone().data<TestStepInternal>('stepZone');
-        if (zone && zone.category === 'expect') {
+        const isExpectCall = data.apiName === 'locator._expect' || data.apiName === 'frame._expect' || data.apiName === 'page._expectScreenshot';
+        if (zone && zone.category === 'expect' && isExpectCall) {
           // Display the internal locator._expect call under the name of the enclosing expect call,
           // and connect it to the existing expect step.
           if (zone.apiName)

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -351,7 +351,7 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
       // This looks like it is unnecessary, but it isn't - we need to filter
       // out all the frames that belong to the test runner from caught runtime errors.
       const stackFrames = filteredStackTrace(captureRawStack());
-      const category = matcherName === 'toPass' || this._info.poll ? 'test.step' : 'expect' as TestStepCategory;
+      const category = matcherName === 'toPass' ? 'test.step' : 'expect' as TestStepCategory;
 
       // toPass and poll matchers can contain other steps, expects and API calls,
       // so they behave like a retriable step.

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -68,7 +68,7 @@ import { TestInfoImpl } from '../worker/testInfo';
 
 import type { ExpectMatcherStateInternal } from './matchers';
 import type { Expect } from '../../types/test';
-import type { TestStepCategory, TestStepInfoImpl } from '../worker/testInfo';
+import type { TestStepInfoImpl } from '../worker/testInfo';
 
 
 // #region
@@ -351,12 +351,11 @@ class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
       // This looks like it is unnecessary, but it isn't - we need to filter
       // out all the frames that belong to the test runner from caught runtime errors.
       const stackFrames = filteredStackTrace(captureRawStack());
-      const category = matcherName === 'toPass' ? 'test.step' : 'expect' as TestStepCategory;
 
       // toPass and poll matchers can contain other steps, expects and API calls,
       // so they behave like a retriable step.
       const stepInfo = {
-        category,
+        category: 'expect' as const,
         apiName,
         title,
         params: args[0] ? { expected: args[0] } : undefined,

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -640,7 +640,7 @@ test('should not propagate errors from within toPass', async ({ runInlineTest })
   expect(result.exitCode).toBe(0);
   expect(result.output).toBe(`
 hook      |Before Hooks
-test.step |Expect "toPass" @ a.test.ts:7
+expect    |Expect "toPass" @ a.test.ts:7
 expect    |  Expect "toBe" @ a.test.ts:6
 expect    |  ↪ error: Error: expect(received).toBe(expected) // Object.is equality
 expect    |  Expect "toBe" @ a.test.ts:6
@@ -667,8 +667,8 @@ test('should show final toPass error', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(stripAnsi(result.output)).toBe(`
 hook      |Before Hooks
-test.step |Expect "toPass" @ a.test.ts:6
-test.step |↪ error: Error: expect(received).toBe(expected) // Object.is equality
+expect    |Expect "toPass" @ a.test.ts:6
+expect    |↪ error: Error: expect(received).toBe(expected) // Object.is equality
 expect    |  Expect "toBe" @ a.test.ts:5
 expect    |  ↪ error: Error: expect(received).toBe(expected) // Object.is equality
 hook      |After Hooks
@@ -934,7 +934,7 @@ test('step inside toPass', async ({ runInlineTest }) => {
   expect(stripAnsi(result.output)).toBe(`
 hook      |Before Hooks
 test.step |step 1 @ a.test.ts:4
-test.step |  Expect "toPass" @ a.test.ts:11
+expect    |  Expect "toPass" @ a.test.ts:11
 test.step |    step 2, attempt: 0 @ a.test.ts:7
 test.step |    ↪ error: Error: expect(received).toBe(expected) // Object.is equality
 expect    |      Expect "toBe" @ a.test.ts:9
@@ -981,7 +981,7 @@ fixture   |  Fixture "context"
 pw:api    |    Create context
 fixture   |  Fixture "page"
 pw:api    |    Create page
-test.step |Expect "toPass" @ a.test.ts:11
+expect    |Expect "toPass" @ a.test.ts:11
 pw:api    |  Navigate to "about:blank" @ a.test.ts:6
 test.step |  inner step attempt: 0 @ a.test.ts:7
 test.step |  ↪ error: Error: expect(received).toBe(expected) // Object.is equality

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -1033,7 +1033,7 @@ fixture   |  Fixture "context"
 pw:api    |    Create context
 fixture   |  Fixture "page"
 pw:api    |    Create page
-test.step |Expect "poll toHaveLength" @ a.test.ts:14
+expect    |Expect "poll toHaveLength" @ a.test.ts:14
 pw:api    |  Navigate to "about:blank" @ a.test.ts:7
 test.step |  inner step attempt: 0 @ a.test.ts:8
 expect    |    Expect "toBe" @ a.test.ts:10
@@ -1086,7 +1086,7 @@ pw:api    |    Create context
 fixture   |  Fixture "page"
 pw:api    |    Create page
 pw:api    |Set content @ a.test.ts:4
-test.step |Expect "poll toBe" @ a.test.ts:13
+expect    |Expect "poll toBe" @ a.test.ts:13
 expect    |  Expect "toHaveText" @ a.test.ts:7
 test.step |  iteration 1 @ a.test.ts:9
 expect    |    Expect "toBeVisible" @ a.test.ts:10
@@ -1746,7 +1746,7 @@ fixture   |  Fixture "page"
 pw:api    |    Create page
 pw:api    |Set content @ a.test.ts:16
 expect    |Expect "toBeInvisible" @ a.test.ts:17
-test.step |  Expect "poll toBe" @ a.test.ts:7
+expect    |  Expect "poll toBe" @ a.test.ts:7
 pw:api    |    Query count locator('div').filter({ visible: true }) @ a.test.ts:7
 expect    |    Expect "toBe" @ a.test.ts:7
 expect    |    ↪ error: Error: expect(received).toBe(expected) // Object.is equality


### PR DESCRIPTION
Previously, these were reported as "test.step" steps.

Fixes #37172.