### PR TITLE
chore: speed up strict mode violation suggestions

### DIFF
--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -91,6 +91,7 @@ export class FrameExecutionContext extends js.ExecutionContext {
         testIdAttributeName: selectorsRegistry.testIdAttributeName(),
         stableRafCount: this.frame._page.delegate.rafCountForStablePosition(),
         browserName: this.frame._page.browserContext._browser.options.name,
+        isUtilityWorld: this.world === 'utility',
         customEngines,
       };
       const source = `


### PR DESCRIPTION
- Reuse a single cache for all generated locators. This gives ~2x on all browsers.
- Limit the number of suggestions to 2 in Firefox utility world, where DOM bindings are especially slow.

References #36822.