### PR TITLE
fix(trace-viewer): prevent browser address bar bouncing based on URL

### DIFF
--- a/packages/trace-viewer/src/ui/browserFrame.css
+++ b/packages/trace-viewer/src/ui/browserFrame.css
@@ -18,8 +18,6 @@
   border-radius: 50%;
   display: inline-block;
   height: 12px;
-  margin-right: 6px;
-  margin-top: 4px;
   width: 12px;
 }
 
@@ -36,6 +34,7 @@
   white-space: nowrap;
   display: flex;
   align-items: center;
+  height: 28px;
 }
 
 .browser-frame-address-bar > button {
@@ -66,4 +65,12 @@
 
 body.dark-mode .browser-frame-header {
   background: #444950;
+}
+
+.browser-traffic-lights {
+  display: grid;
+  white-space: nowrap;
+  grid-template-columns: auto auto auto;
+  column-gap: 6px;
+  margin-right: 8px;
 }

--- a/packages/trace-viewer/src/ui/browserFrame.tsx
+++ b/packages/trace-viewer/src/ui/browserFrame.tsx
@@ -22,7 +22,7 @@ export const BrowserFrame: React.FunctionComponent<{
   url?: string,
 }> = ({ url }): React.ReactElement => {
   return <div className='browser-frame-header'>
-    <div style={{ whiteSpace: 'nowrap' }}>
+    <div className='browser-traffic-lights'>
       <span className='browser-frame-dot' style={{ backgroundColor: 'rgb(242, 95, 88)' }}></span>
       <span className='browser-frame-dot' style={{ backgroundColor: 'rgb(251, 190, 60)' }}></span>
       <span className='browser-frame-dot' style={{ backgroundColor: 'rgb(88, 203, 66)' }}></span>


### PR DESCRIPTION
The Trace Viewer browser snapshot view has an address bar that was varying in height based on the URL present in it. Make the height uniform, and properly vertically center the traffic lights that were positioned by hand previously.

### After

<img width="332" height="95" alt="Screenshot 2025-09-09 at 6 38 07 AM" src="https://github.com/user-attachments/assets/ec34f13d-ed37-4b8d-9265-15c05562fd43" />

<img width="240" height="98" alt="Screenshot 2025-09-09 at 6 38 17 AM" src="https://github.com/user-attachments/assets/d2a7447c-10d8-4a03-9137-67578eab536f" />

### Before

<img width="327" height="120" alt="Screenshot 2025-09-09 at 6 38 42 AM" src="https://github.com/user-attachments/assets/ddb64e72-20d8-42dc-bc35-cc595725499d" />

<img width="274" height="129" alt="Screenshot 2025-09-09 at 6 40 57 AM" src="https://github.com/user-attachments/assets/2ed0ede2-ec3b-479a-b097-e37c0dffa40a" />
