### PR TITLE
test(bidi): Fix badSSL error for selfsigned certificates

### DIFF
--- a/tests/config/utils.ts
+++ b/tests/config/utils.ts
@@ -64,6 +64,8 @@ export function expectedSSLError(browserName: string, platform: string): RegExp 
     else
       return /Unacceptable TLS certificate|Operation was cancelled/;
   }
+  if (browserName === '_bidiFirefox')
+    return /MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT/;
   return /SSL_ERROR_UNKNOWN/;
 }
 


### PR DESCRIPTION
With WebDriver BiDi Firefox reports are more detailed failure for an invalid certificate. Given that the Playwright test certificate is self-signed we should expect `MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT` to be present now.

FYI the full error is `Error: NS_ERROR_GENERATE_FAILURE(NS_ERROR_MODULE_SECURITY, MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT)`.

Before reviewing and landing the PR I would like to wait for the results and check if it may break some other tests. If not it would fix:

* page/page-goto.spec.ts › should fail when navigating to bad SSL
* page/page-goto.spec.ts › should fail when navigating to bad SSL after redirects