### PR TITLE
test: throw better error if ffmpeg doesn't exist

### DIFF
--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -23,7 +23,7 @@ import { registry } from '../../packages/playwright-core/lib/server';
 import { expect, browserTest as it } from '../config/browserTest';
 import { parseTraceRaw } from '../config/utils';
 
-const ffmpeg = registry.findExecutable('ffmpeg')!.executablePath('javascript');
+const ffmpeg = registry.findExecutable('ffmpeg')!.executablePathOrDie('javascript');
 
 export class VideoPlayer {
   fileName: string;


### PR DESCRIPTION
Before this patch it did just report this (hard to understand):

```
env➜  playwright git:(main) ✗ npm run wtest video:187

> playwright-internal@1.56.0-next wtest
> playwright test --config=tests/library/playwright.config.ts --project=webkit-* video:187


Running 1 test using 1 worker
  1) [webkit-library] › tests/library/video.spec.ts:187:5 › screencast › should capture static page 

    TypeError: Cannot read properties of undefined (reading 'toString')

      39 |     // Force output frame rate to 25 fps as otherwise it would produce one image per timebase unit
      40 |     // which is 1 / (25 * 1000).
    > 41 |     this.output = spawnSync(ffmpeg, ['-i', this.fileName, '-r', '25', `${this.fileName}-%03d.png`]).stderr.toString();
         |                                                                                                           ^
      42 |
      43 |     const lines = this.output.split('\n');
      44 |     let framesLine = lines.find(l => l.startsWith('frame='))!;
        at VideoPlayer (/Users/maxschmitt/Developer/playwright/tests/library/video.spec.ts:41:107)
        at expectRedFrames (/Users/maxschmitt/Developer/playwright/tests/library/video.spec.ts:137:23)
        at /Users/maxschmitt/Developer/playwright/tests/library/video.spec.ts:204:5

  1 failed
    [webkit-library] › tests/library/video.spec.ts:187:5 › screencast › should capture static page ─

To open last HTML report run:

  npx playwright show-report

```

after this patch it will report:

```
env➜  playwright git:(main) ✗ npm run wtest video:187

> playwright-internal@1.56.0-next wtest
> playwright test --config=tests/library/playwright.config.ts --project=webkit-* video:187

Error: Executable doesn't exist at /Users/maxschmitt/Library/Caches/ms-playwright/ffmpeg-1011/ffmpeg-mac
╔═════════════════════════════════════════════════════════════════════════╗
║ Looks like Playwright Test or Playwright was just installed or updated. ║
║ Please run the following command to download new browsers:              ║
║                                                                         ║
║     npx playwright install                                              ║
║                                                                         ║
║ <3 Playwright Team                                                      ║
╚═════════════════════════════════════════════════════════════════════════╝

   at library/video.spec.ts:26

  24 | import { parseTraceRaw } from '../config/utils';
  25 |
> 26 | const ffmpeg = registry.findExecutable('ffmpeg')!.executablePathOrDie('javascript');
     |                                                   ^
  27 |
  28 | export class VideoPlayer {
  29 |   fileName: string;
    at Object.<anonymous> (/Users/maxschmitt/Developer/playwright/tests/library/video.spec.ts:26:51)

Error: No tests found.
Make sure that arguments are regular expressions matching test files.
You may need to escape symbols like "$" or "*" and quote the arguments.

To open last HTML report run:

  npx playwright show-report
```