### PR TITLE
chore: fix Electron/WebView2/Android tests

### DIFF
--- a/tests/android/playwright.config.ts
+++ b/tests/android/playwright.config.ts
@@ -29,6 +29,9 @@ const testDir = path.join(__dirname, '..');
 const config: Config<ServerWorkerOptions & PlaywrightWorkerOptions & PlaywrightTestOptions> = {
   testDir,
   outputDir,
+  expect: {
+    timeout: 10000,
+  },
   timeout: 120000,
   globalTimeout: 7200000,
   workers: 1,

--- a/tests/electron/playwright.config.ts
+++ b/tests/electron/playwright.config.ts
@@ -28,6 +28,9 @@ const testDir = path.join(__dirname, '..');
 const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions> = {
   testDir,
   outputDir,
+  expect: {
+    timeout: 10000,
+  },
   timeout: 30000,
   globalTimeout: 5400000,
   workers: process.env.CI ? 1 : undefined,

--- a/tests/webview2/playwright.config.ts
+++ b/tests/webview2/playwright.config.ts
@@ -28,6 +28,9 @@ const testDir = path.join(__dirname, '..');
 const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions> = {
   testDir,
   outputDir,
+  expect: {
+    timeout: 10000,
+  },
   timeout: 30000,
   globalTimeout: 5400000,
   workers: process.env.CI ? 1 : undefined,


### PR DESCRIPTION
This aligns it with the [normal config we use](https://github.com/microsoft/playwright/blob/6d3ee50a0258f26e2cc267f389d1e8584290e2a4/tests/library/playwright.config.ts) for library tests. Before it was generating different timeout errors between library and Electron/WebView2/Android tests.