### PR TITLE
test: rebase WebKit WSL headless tests

### DIFF
--- a/tests/library/browsertype-launch.spec.ts
+++ b/tests/library/browsertype-launch.spec.ts
@@ -72,11 +72,14 @@ it('should reject if launched browser fails immediately', async ({ mode, browser
     expect(waitError!.message).toContain(isWindows ? 'browserType.launch: spawn UNKNOWN' : 'Browser logs:');
 });
 
-it('should reject if executable path is invalid', async ({ browserType, mode }) => {
+it('should reject if executable path is invalid', async ({ browserType, mode, channel }) => {
   it.skip(mode.startsWith('service'), 'on service mode we dont allow passing custom executable path');
   let waitError: Error | undefined;
   await browserType.launch({ executablePath: 'random-invalid-path' }).catch(e => waitError = e);
-  expect(waitError!.message).toContain('Failed to launch');
+  if (channel === 'webkit-wsl')
+    expect(waitError!.message).toContain('Cannot specify executablePath when using the \"webkit-wsl\" channel.');
+  else
+    expect(waitError!.message).toContain('Failed to launch');
 });
 
 it('should handle timeout', async ({ browserType, mode }) => {

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -340,6 +340,7 @@ it('should throw if networkidle2 is passed as an option', async ({ page, server 
 });
 
 it('should fail when main resources failed to load', async ({ page, browserName, isWindows, mode, channel }) => {
+  it.skip(channel === 'webkit-wsl', 'Networking mode mirrored ends up stalling connections rather than terminating them, see https://github.com/microsoft/WSL/issues/10855.');
   let error = null;
   await page.goto('http://localhost:44123/non-existing-url').catch(e => error = e);
   if (browserName === 'chromium') {


### PR DESCRIPTION
This should make headless test suite green - headed test suite is next.

https://github.com/microsoft/playwright/issues/37036