### PR TITLE
feat(codegen): right-click for more actions

### DIFF
--- a/packages/injected/src/highlight.css
+++ b/packages/injected/src/highlight.css
@@ -51,11 +51,6 @@ x-pw-tooltip-line {
   cursor: pointer;
 }
 
-x-pw-tooltip-line.selectable:hover {
-  background-color: hsl(0, 0%, 95%);
-  overflow: hidden;
-}
-
 x-pw-tooltip-footer {
   display: flex;
   max-width: 600px;
@@ -72,10 +67,13 @@ x-pw-dialog {
   display: flex;
   flex-direction: column;
   position: absolute;
-  width: 400px;
-  height: 150px;
   z-index: 10;
   font-size: 13px;
+}
+
+x-pw-dialog:not(.autosize) {
+  width: 400px;
+  height: 150px;
 }
 
 x-pw-dialog-body {
@@ -314,4 +312,26 @@ x-locator-editor.does-not-match {
 .CodeMirror {
   width: 100% !important;
   height: 100% !important;
+}
+
+x-pw-action-list {
+  flex: auto;
+  display: flex;
+  flex-direction: column;
+  user-select: none;
+}
+
+x-pw-action-item {
+  padding: 6px 10px;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+x-pw-action-item:hover {
+  background-color: hsl(0, 0%, 95%);
+}
+
+x-pw-action-item:last-child {
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
 }

--- a/packages/injected/src/highlight.ts
+++ b/packages/injected/src/highlight.ts
@@ -65,12 +65,6 @@ export class Highlight {
     this._glassPaneElement.style.pointerEvents = 'none';
     this._glassPaneElement.style.display = 'flex';
     this._glassPaneElement.style.backgroundColor = 'transparent';
-    for (const eventName of ['click', 'auxclick', 'dragstart', 'input', 'keydown', 'keyup', 'pointerdown', 'pointerup', 'mousedown', 'mouseup', 'mouseleave', 'focus', 'scroll']) {
-      this._glassPaneElement.addEventListener(eventName, e => {
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-      });
-    }
     this._actionPointElement = document.createElement('x-pw-action-point');
     this._actionPointElement.setAttribute('hidden', 'true');
     this._glassPaneShadow = this._glassPaneElement.attachShadow({ mode: this._isUnderTest ? 'open' : 'closed' });
@@ -204,20 +198,37 @@ export class Highlight {
     return this._renderedEntries[0]?.box;
   }
 
+  firstTooltipBox(): DOMRect | undefined {
+    const entry = this._renderedEntries[0];
+    if (!entry || !entry.tooltipElement || entry.tooltipLeft === undefined || entry.tooltipTop === undefined)
+      return;
+    return {
+      x: entry.tooltipLeft,
+      y: entry.tooltipTop,
+      left: entry.tooltipLeft,
+      top: entry.tooltipTop,
+      width: entry.tooltipElement.offsetWidth,
+      height: entry.tooltipElement.offsetHeight,
+      bottom: entry.tooltipTop + entry.tooltipElement.offsetHeight,
+      right: entry.tooltipLeft + entry.tooltipElement.offsetWidth,
+      toJSON: () => {},
+    };
+  }
+
   tooltipPosition(box: DOMRect, tooltipElement: HTMLElement) {
     const tooltipWidth = tooltipElement.offsetWidth;
     const tooltipHeight = tooltipElement.offsetHeight;
     const totalWidth = this._glassPaneElement.offsetWidth;
     const totalHeight = this._glassPaneElement.offsetHeight;
 
-    let anchorLeft = box.left;
+    let anchorLeft = Math.max(5, box.left);
     if (anchorLeft + tooltipWidth > totalWidth - 5)
       anchorLeft = totalWidth - tooltipWidth - 5;
-    let anchorTop = box.bottom + 5;
+    let anchorTop = Math.max(0, box.bottom) + 5;
     if (anchorTop + tooltipHeight > totalHeight - 5) {
       // If can't fit below, either position above...
-      if (box.top > tooltipHeight + 5) {
-        anchorTop = box.top - tooltipHeight - 5;
+      if (Math.max(0, box.top) > tooltipHeight + 5) {
+        anchorTop = Math.max(0, box.top) - tooltipHeight - 5;
       } else {
         // Or on top in case of large element
         anchorTop = totalHeight - 5 - tooltipHeight;
@@ -250,5 +261,17 @@ export class Highlight {
 
   appendChild(element: Element) {
     this._glassPaneShadow.appendChild(element);
+  }
+
+  onGlassPaneClick(handler: (event: MouseEvent) => void) {
+    this._glassPaneElement.style.pointerEvents = 'auto';
+    this._glassPaneElement.style.backgroundColor = 'rgba(0, 0, 0, 0.3)';
+    this._glassPaneElement.addEventListener('click', handler);
+  }
+
+  offGlassPaneClick(handler: (event: MouseEvent) => void) {
+    this._glassPaneElement.style.pointerEvents = 'none';
+    this._glassPaneElement.style.backgroundColor = 'transparent';
+    this._glassPaneElement.removeEventListener('click', handler);
   }
 }

--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -194,10 +194,12 @@ class RecordActionTool implements RecorderTool {
   private _expectProgrammaticKeyUp = false;
   private _pendingClickAction: { action: actions.ClickAction, timeout: number } | undefined;
   private _observer: MutationObserver | null = null;
+  private _dialog: Dialog;
 
   constructor(recorder: Recorder) {
     this._recorder = recorder;
     this._performingActions = new Set();
+    this._dialog = new Dialog(recorder);
   }
 
   cursor() {
@@ -229,15 +231,15 @@ class RecordActionTool implements RecorderTool {
     this._hoveredElement = null;
     this._activeModel = null;
     this._expectProgrammaticKeyUp = false;
+    this._dialog.close();
   }
 
   onClick(event: MouseEvent) {
+    if (this._dialog.isShowing())
+      return;
     // in webkit, sliding a range element may trigger a click event with a different target if the mouse is released outside the element bounding box.
     // So we check the hovered element instead, and if it is a range input, we skip click handling
     if (isRangeInput(this._hoveredElement))
-      return;
-    // Right clicks are handled by 'contextmenu' event if its auxclick
-    if (event.button === 2 && event.type === 'auxclick')
       return;
     if (this._shouldIgnoreMouseEvent(event))
       return;
@@ -245,6 +247,11 @@ class RecordActionTool implements RecorderTool {
       return;
     if (this._consumedDueToNoModel(event, this._hoveredModel))
       return;
+
+    if (event.button === 2 && event.type === 'auxclick') {
+      this._showDialog(this._hoveredModel!, positionForEvent(event));
+      return;
+    }
 
     const checkbox = asCheckbox(this._recorder.deepEventTarget(event));
     if (checkbox && event.detail === 1) {
@@ -277,6 +284,8 @@ class RecordActionTool implements RecorderTool {
   }
 
   onDblClick(event: MouseEvent) {
+    if (this._dialog.isShowing())
+      return;
     if (isRangeInput(this._hoveredElement))
       return;
     if (this._shouldIgnoreMouseEvent(event))
@@ -313,40 +322,36 @@ class RecordActionTool implements RecorderTool {
   }
 
   onContextMenu(event: MouseEvent) {
-    // the 'contextmenu' event is triggered by a right-click or equivalent action,
-    // and it prevents the click event from firing for that action, so we always
-    // convert 'contextmenu' into a right-click.
+    if (this._dialog.isShowing())
+      return;
     if (this._shouldIgnoreMouseEvent(event))
       return;
     if (this._actionInProgress(event))
       return;
     if (this._consumedDueToNoModel(event, this._hoveredModel))
       return;
-
-    this._performAction({
-      name: 'click',
-      selector: this._hoveredModel!.selector,
-      position: positionForEvent(event),
-      signals: [],
-      button: 'right',
-      modifiers: 0,
-      clickCount: 0
-    });
+    this._showDialog(this._hoveredModel!, positionForEvent(event));
   }
 
   onPointerDown(event: PointerEvent) {
+    if (this._dialog.isShowing())
+      return;
     if (this._shouldIgnoreMouseEvent(event))
       return;
     this._consumeWhenAboutToPerform(event);
   }
 
   onPointerUp(event: PointerEvent) {
+    if (this._dialog.isShowing())
+      return;
     if (this._shouldIgnoreMouseEvent(event))
       return;
     this._consumeWhenAboutToPerform(event);
   }
 
   onMouseDown(event: MouseEvent) {
+    if (this._dialog.isShowing())
+      return;
     if (this._shouldIgnoreMouseEvent(event))
       return;
     this._consumeWhenAboutToPerform(event);
@@ -354,12 +359,16 @@ class RecordActionTool implements RecorderTool {
   }
 
   onMouseUp(event: MouseEvent) {
+    if (this._dialog.isShowing())
+      return;
     if (this._shouldIgnoreMouseEvent(event))
       return;
     this._consumeWhenAboutToPerform(event);
   }
 
   onMouseMove(event: MouseEvent) {
+    if (this._dialog.isShowing())
+      return;
     const target = this._recorder.deepEventTarget(event);
     if (this._hoveredElement === target)
       return;
@@ -368,6 +377,8 @@ class RecordActionTool implements RecorderTool {
   }
 
   onMouseLeave(event: MouseEvent) {
+    if (this._dialog.isShowing())
+      return;
     const window = this._recorder.injectedScript.window;
     // Leaving iframe.
     if (window.top !== window && this._recorder.deepEventTarget(event).nodeType === Node.DOCUMENT_NODE) {
@@ -377,10 +388,14 @@ class RecordActionTool implements RecorderTool {
   }
 
   onFocus(event: Event) {
+    if (this._dialog.isShowing())
+      return;
     this._onFocus(true);
   }
 
   onInput(event: Event) {
+    if (this._dialog.isShowing())
+      return;
     const target = this._recorder.deepEventTarget(event);
 
     if (target.nodeName === 'INPUT' && (target as HTMLInputElement).type.toLowerCase() === 'file') {
@@ -433,6 +448,8 @@ class RecordActionTool implements RecorderTool {
   }
 
   onKeyDown(event: KeyboardEvent) {
+    if (this._dialog.isShowing())
+      return;
     if (!this._shouldGenerateKeyPressFor(event))
       return;
     if (this._actionInProgress(event)) {
@@ -464,6 +481,8 @@ class RecordActionTool implements RecorderTool {
   }
 
   onKeyUp(event: KeyboardEvent) {
+    if (this._dialog.isShowing())
+      return;
     if (!this._shouldGenerateKeyPressFor(event))
       return;
 
@@ -476,7 +495,93 @@ class RecordActionTool implements RecorderTool {
   }
 
   onScroll(event: Event) {
+    if (this._dialog.isShowing())
+      return;
     this._resetHoveredModel();
+  }
+
+  private _showDialog(model: HighlightModelWithSelector, actionPosition: Point | undefined) {
+    const listElement = this._recorder.document.createElement('x-pw-action-list');
+    listElement.setAttribute('role', 'list');
+    listElement.setAttribute('aria-label', 'Choose action');
+
+    const clickElement = this._recorder.document.createElement('x-pw-action-item');
+    clickElement.setAttribute('role', 'listitem');
+    clickElement.textContent = 'Click';
+    clickElement.setAttribute('aria-label', 'Click');
+    clickElement.addEventListener('click', () => {
+      this._dialog.close();
+      this._performAction({
+        name: 'click',
+        selector: model.selector,
+        position: actionPosition,
+        signals: [],
+        button: 'left',
+        modifiers: 0,
+        clickCount: 0,
+      });
+    });
+    listElement.appendChild(clickElement);
+
+    const rightClickElement = this._recorder.document.createElement('x-pw-action-item');
+    rightClickElement.setAttribute('role', 'listitem');
+    rightClickElement.textContent = 'Right click';
+    rightClickElement.setAttribute('aria-label', 'Right click');
+    rightClickElement.addEventListener('click', () => {
+      this._dialog.close();
+      this._performAction({
+        name: 'click',
+        selector: model.selector,
+        position: actionPosition,
+        signals: [],
+        button: 'right',
+        modifiers: 0,
+        clickCount: 0,
+      });
+    });
+    listElement.appendChild(rightClickElement);
+
+    const doubleClickElement = this._recorder.document.createElement('x-pw-action-item');
+    doubleClickElement.setAttribute('role', 'listitem');
+    doubleClickElement.textContent = 'Double click';
+    doubleClickElement.setAttribute('aria-label', 'Double click');
+    doubleClickElement.addEventListener('click', () => {
+      this._dialog.close();
+      this._performAction({
+        name: 'click',
+        selector: model.selector,
+        position: actionPosition,
+        signals: [],
+        button: 'left',
+        modifiers: 0,
+        clickCount: 2,
+      });
+    });
+    listElement.appendChild(doubleClickElement);
+
+    const hoverElement = this._recorder.document.createElement('x-pw-action-item');
+    hoverElement.setAttribute('role', 'listitem');
+    hoverElement.textContent = 'Hover';
+    hoverElement.setAttribute('aria-label', 'Hover');
+    hoverElement.addEventListener('click', () => {
+      this._dialog.close();
+      this._performAction({
+        name: 'hover',
+        selector: model.selector,
+        position: actionPosition,
+        signals: [],
+      });
+    });
+    listElement.appendChild(hoverElement);
+
+    const dialogElement = this._dialog.show({
+      label: 'Choose action',
+      body: listElement,
+      autosize: true,
+    });
+    const anchorBox = this._recorder.highlight.firstTooltipBox() || model.elements[0].getBoundingClientRect();
+    const dialogPosition = this._recorder.highlight.tooltipPosition(anchorBox, dialogElement);
+    this._dialog.moveTo(dialogPosition.anchorTop, dialogPosition.anchorLeft);
   }
 
   private _resetHoveredModel() {
@@ -516,7 +621,7 @@ class RecordActionTool implements RecorderTool {
     for (const action of this._performingActions) {
       if (isKeyEvent && action.name === 'press' && event.key === action.key)
         return true;
-      if (isMouseOrPointerEvent && (action.name === 'click' || action.name === 'check' || action.name === 'uncheck'))
+      if (isMouseOrPointerEvent && (action.name === 'click' || action.name === 'hover' || action.name === 'check' || action.name === 'uncheck'))
         return true;
     }
 
@@ -1615,6 +1720,7 @@ class Dialog {
   private _recorder: Recorder;
   private _dialogElement: HTMLElement | null = null;
   private _keyboardListener: ((event: KeyboardEvent) => void) | undefined;
+  private _onGlassPaneClickHandler: ((event: MouseEvent) => void) | undefined;
 
   constructor(recorder: Recorder) {
     this._recorder = recorder;
@@ -1627,14 +1733,15 @@ class Dialog {
   show(options: {
     label: string;
     body: Element;
-    onCommit: () => void;
+    onCommit?: () => void;
     onCancel?: () => void;
+    autosize?: boolean;
   }) {
     const acceptButton = this._recorder.document.createElement('x-pw-tool-item');
     acceptButton.title = 'Accept';
     acceptButton.classList.add('accept');
     acceptButton.appendChild(this._recorder.document.createElement('x-div'));
-    acceptButton.addEventListener('click', () => options.onCommit());
+    acceptButton.addEventListener('click', () => options.onCommit?.());
 
     const cancelButton = this._recorder.document.createElement('x-pw-tool-item');
     cancelButton.title = 'Close';
@@ -1646,26 +1753,34 @@ class Dialog {
     });
 
     this._dialogElement = this._recorder.document.createElement('x-pw-dialog');
+    if (options.autosize)
+      this._dialogElement.classList.add('autosize');
+
     this._keyboardListener = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         this.close();
         options.onCancel?.();
         return;
       }
-      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+      if (options.onCommit && event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
         if (this._dialogElement)
           options.onCommit();
         return;
       }
     };
 
-    this._recorder.document.addEventListener('keydown', this._keyboardListener, true);
+    this._onGlassPaneClickHandler = (event: MouseEvent) => {
+      this.close();
+      options.onCancel?.();
+    };
+
     const toolbarElement = this._recorder.document.createElement('x-pw-tools-list');
     const labelElement = this._recorder.document.createElement('label');
     labelElement.textContent = options.label;
     toolbarElement.appendChild(labelElement);
     toolbarElement.appendChild(this._recorder.document.createElement('x-spacer'));
-    toolbarElement.appendChild(acceptButton);
+    if (options.onCommit)
+      toolbarElement.appendChild(acceptButton);
     toolbarElement.appendChild(cancelButton);
 
     this._dialogElement.appendChild(toolbarElement);
@@ -1673,6 +1788,8 @@ class Dialog {
     bodyElement.appendChild(options.body);
     this._dialogElement.appendChild(bodyElement);
     this._recorder.highlight.appendChild(this._dialogElement);
+    this._recorder.highlight.onGlassPaneClick(this._onGlassPaneClickHandler);
+    this._recorder.document.addEventListener('keydown', this._keyboardListener, true);
     return this._dialogElement;
   }
 
@@ -1687,6 +1804,7 @@ class Dialog {
     if (!this._dialogElement)
       return;
     this._dialogElement.remove();
+    this._recorder.highlight.offGlassPaneClick(this._onGlassPaneClickHandler!);
     this._recorder.document.removeEventListener('keydown', this._keyboardListener!);
     this._dialogElement = null;
   }

--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -501,78 +501,68 @@ class RecordActionTool implements RecorderTool {
   }
 
   private _showDialog(model: HighlightModelWithSelector, actionPosition: Point | undefined) {
+    const actions: { title: string, action: actions.PerformOnRecordAction }[] = [
+      {
+        title: 'Click',
+        action: {
+          name: 'click',
+          selector: model.selector,
+          position: actionPosition,
+          signals: [],
+          button: 'left',
+          modifiers: 0,
+          clickCount: 0,
+        }
+      },
+      {
+        title: 'Right click',
+        action: {
+          name: 'click',
+          selector: model.selector,
+          position: actionPosition,
+          signals: [],
+          button: 'right',
+          modifiers: 0,
+          clickCount: 0,
+        }
+      },
+      {
+        title: 'Double click',
+        action: {
+          name: 'click',
+          selector: model.selector,
+          position: actionPosition,
+          signals: [],
+          button: 'left',
+          modifiers: 0,
+          clickCount: 2,
+        }
+      },
+      {
+        title: 'Hover',
+        action: {
+          name: 'hover',
+          selector: model.selector,
+          position: actionPosition,
+          signals: [],
+        }
+      },
+    ];
+
     const listElement = this._recorder.document.createElement('x-pw-action-list');
     listElement.setAttribute('role', 'list');
     listElement.setAttribute('aria-label', 'Choose action');
-
-    const clickElement = this._recorder.document.createElement('x-pw-action-item');
-    clickElement.setAttribute('role', 'listitem');
-    clickElement.textContent = 'Click';
-    clickElement.setAttribute('aria-label', 'Click');
-    clickElement.addEventListener('click', () => {
-      this._dialog.close();
-      this._performAction({
-        name: 'click',
-        selector: model.selector,
-        position: actionPosition,
-        signals: [],
-        button: 'left',
-        modifiers: 0,
-        clickCount: 0,
+    for (const action of actions) {
+      const actionElement = this._recorder.document.createElement('x-pw-action-item');
+      actionElement.setAttribute('role', 'listitem');
+      actionElement.textContent = action.title;
+      actionElement.setAttribute('aria-label', action.title);
+      actionElement.addEventListener('click', () => {
+        this._dialog.close();
+        this._performAction(action.action);
       });
-    });
-    listElement.appendChild(clickElement);
-
-    const rightClickElement = this._recorder.document.createElement('x-pw-action-item');
-    rightClickElement.setAttribute('role', 'listitem');
-    rightClickElement.textContent = 'Right click';
-    rightClickElement.setAttribute('aria-label', 'Right click');
-    rightClickElement.addEventListener('click', () => {
-      this._dialog.close();
-      this._performAction({
-        name: 'click',
-        selector: model.selector,
-        position: actionPosition,
-        signals: [],
-        button: 'right',
-        modifiers: 0,
-        clickCount: 0,
-      });
-    });
-    listElement.appendChild(rightClickElement);
-
-    const doubleClickElement = this._recorder.document.createElement('x-pw-action-item');
-    doubleClickElement.setAttribute('role', 'listitem');
-    doubleClickElement.textContent = 'Double click';
-    doubleClickElement.setAttribute('aria-label', 'Double click');
-    doubleClickElement.addEventListener('click', () => {
-      this._dialog.close();
-      this._performAction({
-        name: 'click',
-        selector: model.selector,
-        position: actionPosition,
-        signals: [],
-        button: 'left',
-        modifiers: 0,
-        clickCount: 2,
-      });
-    });
-    listElement.appendChild(doubleClickElement);
-
-    const hoverElement = this._recorder.document.createElement('x-pw-action-item');
-    hoverElement.setAttribute('role', 'listitem');
-    hoverElement.textContent = 'Hover';
-    hoverElement.setAttribute('aria-label', 'Hover');
-    hoverElement.addEventListener('click', () => {
-      this._dialog.close();
-      this._performAction({
-        name: 'hover',
-        selector: model.selector,
-        position: actionPosition,
-        signals: [],
-      });
-    });
-    listElement.appendChild(hoverElement);
+      listElement.appendChild(actionElement);
+    }
 
     const dialogElement = this._dialog.show({
       label: 'Choose action',

--- a/packages/playwright-core/src/server/codegen/csharp.ts
+++ b/packages/playwright-core/src/server/codegen/csharp.ts
@@ -129,6 +129,10 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
         const optionsString = formatObject(options, '    ', 'Locator' + method + 'Options');
         return `await ${subject}.${this._asLocator(action.selector)}.${method}Async(${optionsString});`;
       }
+      case 'hover': {
+        const optionsString = action.position ? formatObject({ position: action.position }, '    ', 'LocatorHoverOptions') : '';
+        return `await ${subject}.${this._asLocator(action.selector)}.HoverAsync(${optionsString});`;
+      }
       case 'check':
         return `await ${subject}.${this._asLocator(action.selector)}.CheckAsync();`;
       case 'uncheck':

--- a/packages/playwright-core/src/server/codegen/java.ts
+++ b/packages/playwright-core/src/server/codegen/java.ts
@@ -107,6 +107,10 @@ export class JavaLanguageGenerator implements LanguageGenerator {
         const optionsText = formatClickOptions(options);
         return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.${method}(${optionsText});`;
       }
+      case 'hover': {
+        const optionsText = action.position ? `new Locator.HoverOptions().setPosition(${action.position.x}, ${action.position.y})` : '';
+        return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.hover(${optionsText});`;
+      }
       case 'check':
         return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.check();`;
       case 'uncheck':

--- a/packages/playwright-core/src/server/codegen/javascript.ts
+++ b/packages/playwright-core/src/server/codegen/javascript.ts
@@ -91,6 +91,8 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
         const optionsString = formatOptions(options, false);
         return `await ${subject}.${this._asLocator(action.selector)}.${method}(${optionsString});`;
       }
+      case 'hover':
+        return `await ${subject}.${this._asLocator(action.selector)}.hover(${formatOptions({ position: action.position }, false)});`;
       case 'check':
         return `await ${subject}.${this._asLocator(action.selector)}.check();`;
       case 'uncheck':
@@ -182,7 +184,7 @@ ${useText ? '\ntest.use(' + useText + ');\n' : ''}
 }
 
 function formatOptions(value: any, hasArguments: boolean): string {
-  const keys = Object.keys(value);
+  const keys = Object.keys(value).filter(key => value[key] !== undefined);
   if (!keys.length)
     return '';
   return (hasArguments ? ', ' : '') + formatObject(value);

--- a/packages/playwright-core/src/server/codegen/python.ts
+++ b/packages/playwright-core/src/server/codegen/python.ts
@@ -100,6 +100,8 @@ export class PythonLanguageGenerator implements LanguageGenerator {
         const optionsString = formatOptions(options, false);
         return `${subject}.${this._asLocator(action.selector)}.${method}(${optionsString})`;
       }
+      case 'hover':
+        return `${subject}.${this._asLocator(action.selector)}.hover(${formatOptions({ position: action.position }, false)})`;
       case 'check':
         return `${subject}.${this._asLocator(action.selector)}.check()`;
       case 'uncheck':

--- a/packages/playwright-core/src/server/recorder/recorderRunner.ts
+++ b/packages/playwright-core/src/server/recorder/recorderRunner.ts
@@ -55,6 +55,11 @@ async function performActionImpl(progress: Progress, mainFrame: Frame, actionInC
     return;
   }
 
+  if (action.name === 'hover') {
+    await mainFrame.hover(progress, selector, { position: action.position, strict: true });
+    return;
+  }
+
   if (action.name === 'press') {
     const modifiers = toKeyboardModifiers(action.modifiers);
     const shortcut = [...modifiers, action.key].join('+');

--- a/packages/recorder/src/actions.d.ts
+++ b/packages/recorder/src/actions.d.ts
@@ -19,6 +19,7 @@ type Point = { x: number, y: number };
 export type ActionName =
   'check' |
   'click' |
+  'hover' |
   'closePage' |
   'fill' |
   'navigate' |
@@ -50,6 +51,11 @@ export type ClickAction = ActionWithSelector & {
   button: 'left' | 'middle' | 'right',
   modifiers: number,
   clickCount: number,
+  position?: Point,
+};
+
+export type HoverAction = ActionWithSelector & {
+  name: 'hover',
   position?: Point,
 };
 
@@ -121,9 +127,9 @@ export type AssertSnapshotAction = ActionWithSelector & {
   ariaSnapshot: string,
 };
 
-export type Action = ClickAction | CheckAction | ClosesPageAction | OpenPageAction | UncheckAction | FillAction | NavigateAction | PressAction | SelectAction | SetInputFilesAction | AssertTextAction | AssertValueAction | AssertCheckedAction | AssertVisibleAction | AssertSnapshotAction;
+export type Action = ClickAction | HoverAction | CheckAction | ClosesPageAction | OpenPageAction | UncheckAction | FillAction | NavigateAction | PressAction | SelectAction | SetInputFilesAction | AssertTextAction | AssertValueAction | AssertCheckedAction | AssertVisibleAction | AssertSnapshotAction;
 export type AssertAction = AssertCheckedAction | AssertValueAction | AssertTextAction | AssertVisibleAction | AssertSnapshotAction;
-export type PerformOnRecordAction = ClickAction | CheckAction | UncheckAction | PressAction | SelectAction;
+export type PerformOnRecordAction = ClickAction | HoverAction | CheckAction | UncheckAction | PressAction | SelectAction;
 
 // Signals.
 


### PR DESCRIPTION
Upon right click, a list of actions appears and the page behind is dimmed. Includes click, right click, double click and hover actions for now.

Fixes #37075.

<img width="614" height="422" alt="Screenshot 2025-09-11 at 10 18 58 AM" src="https://github.com/user-attachments/assets/3a69c9a8-56a7-43bd-a1cb-21056c57e623" />
