### PR TITLE
chore(bidi): add support for emulation.setScreenOrientationOverride

### DIFF
--- a/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
@@ -117,6 +117,10 @@ export interface Commands {
     params: Bidi.Emulation.SetGeolocationOverrideParameters;
     returnType: Bidi.EmptyResult;
   };
+  'emulation.setScreenOrientationOverride': {
+    params: Bidi.Emulation.SetScreenOrientationOverrideParameters;
+    returnType: Bidi.EmptyResult;
+  };
   'emulation.setTimezoneOverride': {
     params: Bidi.Emulation.SetTimezoneOverrideParameters;
     returnType: Bidi.EmptyResult;


### PR DESCRIPTION
Fixes #37334 and the following tests:
- `tests/library/browsercontext-viewport-mobile.spec.ts`:
  - "should fire orientationchange event"
- `tests/library/browsercontext-viewport.spec.ts`:
  - "should set window.screen.orientation.type for mobile devices"
