### PR TITLE
devops: fix bidi tests

### DIFF
--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -45,6 +45,8 @@ jobs:
         node-version: 20
     - run: npm ci
     - run: npm run build
+    # Needed for video tests
+    - run: npx playwright install ffmpeg
     - run: npx playwright install --with-deps chromium
       if: matrix.channel == 'bidi-chromium'
     - if: matrix.channel == 'moz-firefox-nightly'

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -23,8 +23,6 @@ import { registry } from '../../packages/playwright-core/lib/server';
 import { expect, browserTest as it } from '../config/browserTest';
 import { parseTraceRaw } from '../config/utils';
 
-const ffmpeg = registry.findExecutable('ffmpeg')!.executablePathOrDie('javascript');
-
 export class VideoPlayer {
   fileName: string;
   output: string;
@@ -36,6 +34,7 @@ export class VideoPlayer {
 
   constructor(fileName: string) {
     this.fileName = fileName;
+    const ffmpeg = registry.findExecutable('ffmpeg')!.executablePathOrDie('javascript');
     // Force output frame rate to 25 fps as otherwise it would produce one image per timebase unit
     // which is 1 / (25 * 1000).
     this.output = spawnSync(ffmpeg, ['-i', this.fileName, '-r', '25', `${this.fileName}-%03d.png`]).stderr.toString();


### PR DESCRIPTION
Since https://github.com/microsoft/playwright/issues/37382 video tests throw if there is no ffmpeg.

Instead of throwing on the require level, I think its better to throw to when we actually need it.

Also install ffmpeg in the bidi tests, should be helpful for the future once we have screencast support.

Fixes https://github.com/microsoft/playwright/pull/37390#issuecomment-3280395930