### PR TITLE
chore(deps): bump chromium-bidi to ^9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@zip.js/zip.js": "^2.7.29",
         "ansi-styles": "^4.3.0",
         "chokidar": "^3.5.3",
-        "chromium-bidi": "^8.1.0",
+        "chromium-bidi": "^9.0.0",
         "colors": "^1.4.0",
         "concurrently": "^6.2.1",
         "cross-env": "^7.0.3",
@@ -2886,9 +2886,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-8.1.0.tgz",
-      "integrity": "sha512-tkzq2Y+sMwg3M0rtZersWIYHVR0amVXNQlYHxrwvAseO+LvSm9Z19lBsZpaA0GMwEzZx1/HJiaoyMVuy7qzOdQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-9.0.0.tgz",
+      "integrity": "sha512-CGUetd0G5Bq93BRnckGppWN1BwKYTTW7tMtaZ9PxeFF0LFj3GErytqfI60KgkmB7CcnvWIjdRDfVcFWvzErSyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@zip.js/zip.js": "^2.7.29",
     "ansi-styles": "^4.3.0",
     "chokidar": "^3.5.3",
-    "chromium-bidi": "^8.1.0",
+    "chromium-bidi": "^9.0.0",
     "colors": "^1.4.0",
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
Changelog: https://github.com/GoogleChromeLabs/chromium-bidi/blob/main/CHANGELOG.md

This release should correctly support popup pages and workers and would unblock something like https://github.com/microsoft/playwright/pull/37331.