### PR TITLE
fix(codegen): auxclick vs contextmenu on various browsers/platforms

### DIFF
--- a/tests/library/inspector/cli-codegen-3.spec.ts
+++ b/tests/library/inspector/cli-codegen-3.spec.ts
@@ -669,7 +669,7 @@ await page.GetByRole(AriaRole.Textbox, new() { Name = \"Coun\\\"try\" }).ClickAs
     ]);
   });
 
-  test('should consume contextmenu events, despite a custom context menu', async ({ openRecorder }) => {
+  test('should consume contextmenu events, despite a custom context menu', async ({ openRecorder, browserName, isWindows }) => {
     const { page, recorder } = await openRecorder();
 
     await recorder.setContentAndWait(`
@@ -712,7 +712,7 @@ await page.GetByRole(AriaRole.Textbox, new() { Name = \"Coun\\\"try\" }).ClickAs
       action(),
     ]);
     expect(message.text()).toBe('right-clicked');
-    expect(await page.evaluate('log')).toEqual(['button: contextmenu']);
+    expect(await page.evaluate('log')).toEqual((isWindows && browserName === 'chromium') ? ['button: auxclick', 'button: contextmenu'] : ['button: contextmenu']);
   });
 
   test('should generate hover action', async ({ openRecorder }) => {


### PR DESCRIPTION
The sequence of events for context menu works differently between browsers and platforms.

This PR fixes two issues:
- consumes builtin context menu upon right click, because we show the dialog instead;
- updates test expectations.

References #37075.