### PR TITLE
fix(chromium): unflake oopifs upon connect

### DIFF
--- a/tests/library/chromium/oopif.spec.ts
+++ b/tests/library/chromium/oopif.spec.ts
@@ -383,8 +383,6 @@ it('should allow to re-connect to OOPIFs with CDP when iframes were there alread
 
   const browser = await browserType.connectOverCDP(`http://localhost:${cdpPort}`);
   const page = browser.contexts()[0].pages()[0];
-  // can be fixed by reloading first
-  // await page.reload();
   expect(page.frames().length).toBe(2);
   await assertOOPIFCount(browser, 1);
   expect(await page.frames()[1].evaluate(() => '' + location.href)).toBe(server.CROSS_PROCESS_PREFIX + '/grid.html');


### PR DESCRIPTION
When `Target.autoAttachedToTarget` arrives before the response to `Page.getFrameTree`, which is possible due to browser/renderer race, we cannot insert the OOPIF target into the non-existent frame tree yet.

The solution is to buffer attached events for a short time, until the frame tree arrives.

Already covered by a flaky test "should allow to re-connect to OOPIFs with CDP when iframes were there already".
References #17656.