### PR TITLE
fix(html): don't include extra spacing in metadata section

### DIFF
--- a/packages/html-reporter/src/metadataView.tsx
+++ b/packages/html-reporter/src/metadataView.tsx
@@ -65,21 +65,23 @@ const InnerMetadataView: React.FC<{ metadata: Metadata }> = params => {
   return <div className='metadata-view'>
     {commitInfo.ci && !commitInfo.gitCommit && <CiInfoView info={commitInfo.ci}/>}
     {commitInfo.gitCommit && <GitCommitInfoView ci={commitInfo.ci} commit={commitInfo.gitCommit}/>}
-    {otherEntries.length > 0 && (commitInfo.gitCommit || commitInfo.ci) && <div className='metadata-separator' />}
-    <div className='metadata-section metadata-properties' role='list'>
-      {otherEntries.map(([propertyName, value]) => {
-        const valueString = typeof value !== 'object' || value === null || value === undefined ? String(value) : JSON.stringify(value);
-        const trimmedValue = valueString.length > 1000 ? valueString.slice(0, 1000) + '\u2026' : valueString;
-        return (
-          <div key={propertyName} className='copyable-property' role='listitem'>
-            <CopyToClipboardContainer value={valueString}>
-              <span style={{ fontWeight: 'bold' }} title={propertyName}>{propertyName}</span>
-              : <span title={trimmedValue}>{linkifyText(trimmedValue)}</span>
-            </CopyToClipboardContainer>
-          </div>
-        );
-      })}
-    </div>
+    {otherEntries.length > 0 && <>
+      {(commitInfo.gitCommit || commitInfo.ci) && <div className='metadata-separator' />}
+      <div className='metadata-section metadata-properties' role='list'>
+        {otherEntries.map(([propertyName, value]) => {
+          const valueString = typeof value !== 'object' || value === null || value === undefined ? String(value) : JSON.stringify(value);
+          const trimmedValue = valueString.length > 1000 ? valueString.slice(0, 1000) + '\u2026' : valueString;
+          return (
+            <div key={propertyName} className='copyable-property' role='listitem'>
+              <CopyToClipboardContainer value={valueString}>
+                <span style={{ fontWeight: 'bold' }} title={propertyName}>{propertyName}</span>
+                : <span title={trimmedValue}>{linkifyText(trimmedValue)}</span>
+              </CopyToClipboardContainer>
+            </div>
+          );
+        })}
+      </div>
+    </>}
   </div>;
 };
 


### PR DESCRIPTION
The metadata section is incorrectly spaced for all users who are not using the query param to enable extra metadata display (most users). Properly gate on activation of that feature.

### After

<img width="991" height="224" alt="Screenshot 2025-09-12 at 9 20 48 AM" src="https://github.com/user-attachments/assets/50ab6071-ad77-456d-8e90-c04bba8207f4" />

<img width="1013" height="369" alt="Screenshot 2025-09-12 at 9 20 56 AM" src="https://github.com/user-attachments/assets/5d3e07e5-8e83-4884-a975-c31c203faa77" />

### Before

<img width="1005" height="192" alt="Screenshot 2025-09-12 at 6 20 55 AM" src="https://github.com/user-attachments/assets/c2b5d79a-c461-4ce1-8d5c-3b69f9e89025" />