### PR TITLE
docs(config): remove reference to HTML reporter in metadata object

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -287,7 +287,7 @@ export default defineConfig({
 * since: v1.10
 - type: ?<[Metadata]>
 
-Metadata contains key-value pairs to be included in the report. For example, HTML report will display it as key-value pairs, and JSON report will include metadata serialized as json.
+Metadata contains key-value pairs to be included in the report. For example, the JSON report will include metadata serialized as JSON.
 
 **Usage**
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1388,8 +1388,8 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
   maxFailures?: number;
 
   /**
-   * Metadata contains key-value pairs to be included in the report. For example, HTML report will display it as
-   * key-value pairs, and JSON report will include metadata serialized as json.
+   * Metadata contains key-value pairs to be included in the report. For example, the JSON report will include metadata
+   * serialized as JSON.
    *
    * **Usage**
    *


### PR DESCRIPTION
As a result of #35001, user-defined metadata key-value pairs no longer appear by default in HTML reports. Update the docs to reflect this.