### PR TITLE
chore: update electron to v38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "concurrently": "^6.2.1",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
-        "electron": "^30.1.2",
+        "electron": "^35.7.5",
         "esbuild": "^0.25.0",
         "eslint": "^9.34.0",
         "eslint-plugin-import": "^2.32.0",
@@ -3345,14 +3345,15 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "30.5.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.5.1.tgz",
-      "integrity": "sha512-AhL7+mZ8Lg14iaNfoYTkXQ2qee8mmsQyllKdqxlpv/zrKgfxz6jNVtcRRbQtLxtF8yzcImWdfTQROpYiPumdbw==",
+      "version": "35.7.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-35.7.5.tgz",
+      "integrity": "sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -3368,10 +3369,11 @@
       "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q=="
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "20.19.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
-      "integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
+      "version": "22.18.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+      "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3380,7 +3382,8 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "concurrently": "^6.2.1",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
-        "electron": "^35.7.5",
+        "electron": "^38.1.0",
         "esbuild": "^0.25.0",
         "eslint": "^9.34.0",
         "eslint-plugin-import": "^2.32.0",
@@ -3345,9 +3345,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "35.7.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.7.5.tgz",
-      "integrity": "sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==",
+      "version": "38.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.1.0.tgz",
+      "integrity": "sha512-ypA8GF8RU4HD5pA1sa0/2U8k+92EPP2c7pX+3XbgB760F7OmqrFXtYkOilVw6HfV4+lk88XxqigmsUKTACQYoQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",
-    "electron": "^30.1.2",
+    "electron": "^35.7.5",
     "esbuild": "^0.25.0",
     "eslint": "^9.34.0",
     "eslint-plugin-import": "^2.32.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",
-    "electron": "^35.7.5",
+    "electron": "^38.1.0",
     "esbuild": "^0.25.0",
     "eslint": "^9.34.0",
     "eslint-plugin-import": "^2.32.0",

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -55,12 +55,7 @@ it('should not allow to override unsafe HTTP headers', async ({ page, server, br
       trailer: 'baz',
     }
   }).catch(e => e);
-  if (isElectron) {
-    // Electron doesn't send the request if the host header is overridden,
-    // but doesn't throw an error either.
-    expect(error).toBeFalsy();
-    serverRequestPromise.catch(() => {});
-  } else if (browserName === 'chromium') {
+  if (browserName === 'chromium' || isElectron) {
     expect(error.message).toContain('Unsafe header');
     serverRequestPromise.catch(() => {});
   } else {


### PR DESCRIPTION
v38 is the latest stable version (see https://www.electronjs.org/docs/latest/tutorial/electron-timelines).

v35 is the oldest supported version at the moment, but it comes with `Electron has ASAR Integrity Bypass via resource modification - https://github.com/advisories/GHSA-vmqv-hx8q-j7mg`
