### PR TITLE
chore: update xterm dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@stylistic/eslint-plugin": "^5.2.3",
         "@types/codemirror": "^5.60.7",
         "@types/formidable": "^2.0.4",
-        "@types/immutable": "^3.8.7",
         "@types/node": "18.19.76",
         "@types/react": "^18.0.12",
         "@types/react-dom": "^18.0.5",
@@ -1781,16 +1780,6 @@
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true
     },
-    "node_modules/@types/immutable": {
-      "version": "3.8.7",
-      "resolved": "https://registry.npmjs.org/@types/immutable/-/immutable-3.8.7.tgz",
-      "integrity": "sha512-nsHFDX48Tl3RaP4BF47HHe5njx40Pcp+0a8CIqzJata80Fp7JzkcuGB7UhZBGjH9aA1fMEahIqvPQQNmro5YLg==",
-      "deprecated": "This is a stub types definition for Facebook's Immutable (https://github.com/facebook/immutable-js). Facebook's Immutable provides its own type definitions, so you don't need @types/immutable installed!",
-      "dev": true,
-      "dependencies": {
-        "immutable": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2279,6 +2268,21 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.21.tgz",
       "integrity": "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==",
       "peer": true
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
     },
     "node_modules/@zip.js/zip.js": {
       "version": "2.7.73",
@@ -8043,21 +8047,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/xterm": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead."
-    },
-    "node_modules/xterm-addon-fit": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz",
-      "integrity": "sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==",
-      "deprecated": "This package is now deprecated. Move to @xterm/addon-fit instead.",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8391,9 +8380,9 @@
     "packages/web": {
       "version": "0.0.0",
       "dependencies": {
-        "codemirror": "5.65.18",
-        "xterm": "^5.1.0",
-        "xterm-addon-fit": "^0.7.0"
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
+        "codemirror": "5.65.18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@stylistic/eslint-plugin": "^5.2.3",
     "@types/codemirror": "^5.60.7",
     "@types/formidable": "^2.0.4",
-    "@types/immutable": "^3.8.7",
     "@types/node": "18.19.76",
     "@types/react": "^18.0.12",
     "@types/react-dom": "^18.0.5",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "dependencies": {
     "codemirror": "5.65.18",
-    "xterm": "^5.1.0",
-    "xterm-addon-fit": "^0.7.0"
+    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-fit": "^0.10.0"
   }
 }

--- a/packages/web/src/components/xtermModule.tsx
+++ b/packages/web/src/components/xtermModule.tsx
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';

--- a/packages/web/src/components/xtermModule.tsx
+++ b/packages/web/src/components/xtermModule.tsx
@@ -16,8 +16,8 @@
 
 import 'xterm/css/xterm.css';
 
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
 
 export type XtermModule = {
   Terminal: typeof Terminal;

--- a/packages/web/src/components/xtermWrapper.tsx
+++ b/packages/web/src/components/xtermWrapper.tsx
@@ -16,8 +16,8 @@
 
 import * as React from 'react';
 import './xtermWrapper.css';
-import type { ITheme, Terminal } from 'xterm';
-import type { FitAddon } from 'xterm-addon-fit';
+import type { ITheme, Terminal } from '@xterm/xterm';
+import type { FitAddon } from '@xterm/addon-fit';
 import type { XtermModule } from './xtermModule';
 import { currentTheme, addThemeListener, removeThemeListener } from '../theme';
 import { useMeasure } from '../uiUtils';


### PR DESCRIPTION
Fixes the following warnings:
```
npm warn deprecated @types/immutable@3.8.7: This is a stub types definition for Facebook's Immutable (https://github.com/facebook/immutable-js). Facebook's Immutable provides its own type definitions, so you don't need @types/immutable installed!
npm warn deprecated xterm-addon-fit@0.7.0: This package is now deprecated. Move to @xterm/addon-fit instead.
npm warn deprecated xterm@5.3.0: This package is now deprecated. Move to @xterm/xterm instead.
```