### PR TITLE
feat(mcp): add --disable-http-cache flag to disable HTTP cache

### DIFF
--- a/packages/playwright/src/mcp/browser/config.ts
+++ b/packages/playwright/src/mcp/browser/config.ts
@@ -27,6 +27,7 @@ export type CLIOptions = {
   allowedOrigins?: string[];
   blockedOrigins?: string[];
   blockServiceWorkers?: boolean;
+  disableHttpCache?: boolean;
   browser?: string;
   caps?: string[];
   cdpEndpoint?: string;
@@ -200,6 +201,7 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config {
     network: {
       allowedOrigins: cliOptions.allowedOrigins,
       blockedOrigins: cliOptions.blockedOrigins,
+      disableHttpCache: cliOptions.disableHttpCache,
     },
     saveSession: cliOptions.saveSession,
     saveTrace: cliOptions.saveTrace,
@@ -220,6 +222,7 @@ function configFromEnv(): Config {
   options.allowedOrigins = semicolonSeparatedList(process.env.PLAYWRIGHT_MCP_ALLOWED_ORIGINS);
   options.blockedOrigins = semicolonSeparatedList(process.env.PLAYWRIGHT_MCP_BLOCKED_ORIGINS);
   options.blockServiceWorkers = envToBoolean(process.env.PLAYWRIGHT_MCP_BLOCK_SERVICE_WORKERS);
+  options.disableHttpCache = envToBoolean(process.env.PLAYWRIGHT_MCP_DISABLE_HTTP_CACHE);
   options.browser = envToString(process.env.PLAYWRIGHT_MCP_BROWSER);
   options.caps = commaSeparatedList(process.env.PLAYWRIGHT_MCP_CAPS);
   options.cdpEndpoint = envToString(process.env.PLAYWRIGHT_MCP_CDP_ENDPOINT);

--- a/packages/playwright/src/mcp/browser/context.ts
+++ b/packages/playwright/src/mcp/browser/context.ts
@@ -173,6 +173,12 @@ export class Context {
   }
 
   private async _setupRequestInterception(context: playwright.BrowserContext) {
+    // Disable HTTP cache if requested
+    // As per Playwright docs: "Enabling routing disables http cache"
+    if (this.config.network?.disableHttpCache) {
+      await context.route('**', route => route.continue());
+    }
+
     if (this.config.network?.allowedOrigins?.length) {
       await context.route('**', route => route.abort('blockedbyclient'));
 

--- a/packages/playwright/src/mcp/browser/context.ts
+++ b/packages/playwright/src/mcp/browser/context.ts
@@ -175,9 +175,8 @@ export class Context {
   private async _setupRequestInterception(context: playwright.BrowserContext) {
     // Disable HTTP cache if requested
     // As per Playwright docs: "Enabling routing disables http cache"
-    if (this.config.network?.disableHttpCache) {
+    if (this.config.network?.disableHttpCache)
       await context.route('**', route => route.continue());
-    }
 
     if (this.config.network?.allowedOrigins?.length) {
       await context.route('**', route => route.abort('blockedbyclient'));

--- a/packages/playwright/src/mcp/config.d.ts
+++ b/packages/playwright/src/mcp/config.d.ts
@@ -122,6 +122,11 @@ export type Config = {
      * List of origins to block the browser to request. Origins matching both `allowedOrigins` and `blockedOrigins` will be blocked.
      */
     blockedOrigins?: string[];
+
+    /**
+     * Disable HTTP cache by enabling request routing. When enabled, all requests are intercepted which automatically disables HTTP cache.
+     */
+    disableHttpCache?: boolean;
   };
 
   timeouts?: {

--- a/packages/playwright/src/mcp/program.ts
+++ b/packages/playwright/src/mcp/program.ts
@@ -31,6 +31,7 @@ export function decorateCommand(command: Command, version: string) {
   command.option('--allowed-origins <origins>', 'semicolon-separated list of origins to allow the browser to request. Default is to allow all.', semicolonSeparatedList)
       .option('--blocked-origins <origins>', 'semicolon-separated list of origins to block the browser from requesting. Blocklist is evaluated before allowlist. If used without the allowlist, requests not matching the blocklist are still allowed.', semicolonSeparatedList)
       .option('--block-service-workers', 'block service workers')
+      .option('--disable-http-cache', 'disable HTTP cache by enabling request routing')
       .option('--browser <browser>', 'browser or chrome channel to use, possible values: chrome, firefox, webkit, msedge.')
       .option('--caps <caps>', 'comma-separated list of additional capabilities to enable, possible values: vision, pdf.', commaSeparatedList)
       .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')


### PR DESCRIPTION
## Summary

Adds `--disable-http-cache` CLI flag and `PLAYWRIGHT_MCP_DISABLE_HTTP_CACHE` environment variable to disable HTTP cache in MCP Playwright server.

## Real-World Problem & Use Case

**This issue severely impacts modern AI-assisted development workflows**, particularly when using Claude Code with MCP Playwright for iterative frontend development.

### My Development Scenario
I'm using Claude Code to make frontend changes to a web application, with Playwright MCP providing browser automation for testing and verification. The typical workflow is:
1. Claude Code modifies JavaScript/CSS files 
2. Uses Playwright MCP to open the page and verify changes
3. Iterates quickly based on visual feedback

### The Critical Blocker
**HTTP cache completely breaks this workflow.** When Claude Code makes changes to frontend files, Playwright serves stale cached versions instead of fresh files. This means:
- ❌ Changes appear to "not work" when they actually do
- ❌ Impossible to verify if modifications are correct
- ❌ Development feedback loop is broken
- ❌ Must manually clear cache or restart browsers constantly
- ❌ AI-assisted development becomes frustratingly slow

### Failed Attempt: Custom Chrome Extension
I attempted to solve this by configuring Playwright to use Chrome with a cache-disabling extension, but **MCP Playwright cannot be configured to load custom Chrome profiles/extensions reliably**. This approach failed because:
- Extension loading isn't supported in MCP context
- Profile configuration is limited
- Chrome flags don't affect HTTP cache in Playwright's automation context

### Why This Matters for Modern Development
**AI-powered development tools like Claude Code are increasingly common**, and they rely heavily on rapid iteration cycles. When cache prevents immediate feedback, it breaks the entire development experience. Frontend development **requires** the ability to see changes instantly.

## Problem

Currently, there is **no way** to disable HTTP cache when using MCP Playwright for development, causing developers to see stale JavaScript/CSS files instead of fresh changes. This is a critical issue for development workflows where immediate feedback is essential.

## Attempted Workarounds (All Failed)

We extensively tested all possible approaches before creating this PR:

### ❌ Chrome Browser Flags
```bash
PLAYWRIGHT_BROWSER_ARGS=--disable-application-cache --disk-cache-size=0 --aggressive-cache-discard --incognito
```
**Result**: HTTP cache remains active in MCP context

### ❌ Service Worker Blocking
```bash
PLAYWRIGHT_BLOCK_SERVICE_WORKERS=true
```  
**Result**: Cache still works, only blocks service workers

### ❌ Browser Isolation
```bash
PLAYWRIGHT_ISOLATED=true
```
**Result**: Creates fresh context but cache still active within session

### ❌ Custom Chrome Extensions
Attempted to load cache-disabling Chrome extensions but MCP doesn't support custom profile/extension configuration reliably.

### ❌ DevTools Cache Disable
Manual browser DevTools cache disabling cannot be automated in MCP context

### ❌ Hard Refresh Methods
Keyboard shortcuts and forced refresh don't work reliably in automated context

## Root Cause Analysis

The fundamental issue is that **MCP Playwright doesn't set up request routing by default**. According to Playwright documentation: "Enabling routing disables http cache."

Without `context.route()` being called, HTTP cache remains active regardless of browser flags, environment variables, or other settings. The cache operates at the Chromium level before these other mechanisms can intercept requests.

## Solution

This PR implements the only viable solution: using Playwright's documented routing approach. When `--disable-http-cache` is enabled, we call `context.route('**', route => route.continue())` which automatically disables HTTP cache.

## Changes

- **CLI flag**: `--disable-http-cache` - disable HTTP cache by enabling request routing
- **Environment variable**: `PLAYWRIGHT_MCP_DISABLE_HTTP_CACHE=true` - same functionality via env var
- **Implementation**: Sets up routing in `_setupRequestInterception()` when flag is enabled
- **Configuration**: Added `disableHttpCache` option to config types

## Files Modified

- `packages/playwright/src/mcp/program.ts` - Added CLI flag
- `packages/playwright/src/mcp/browser/config.ts` - Added config mapping and env var support
- `packages/playwright/src/mcp/config.d.ts` - Added type definition
- `packages/playwright/src/mcp/browser/context.ts` - Implemented cache disabling logic

## Testing Methodology

**Test Setup**: Created JavaScript file with timestamp logging to detect cache behavior:
```javascript
console.log("🔥 CACHE TEST - main.js loaded at:", new Date().toLocaleTimeString());
```

**Verification Process**:
1. Modified JavaScript file with new console.log timestamp
2. Refreshed page in Playwright browser
3. Checked console for fresh vs cached messages
4. **Cache disabled**: New timestamp appears immediately
5. **Cache enabled**: Old cached timestamp persists

**Results**:
- ✅ **With our flag**: Fresh files served, new timestamps appear
- ❌ **Without flag**: Cached files served, old timestamps persist
- ❌ **With Chrome flags only**: Cache still active
- ❌ **With other workarounds**: Cache still active

## Usage

```bash
# Via CLI flag
mcp-server-playwright --disable-http-cache

# Via environment variable  
PLAYWRIGHT_MCP_DISABLE_HTTP_CACHE=true mcp-server-playwright
```

## Why This Change Is Critical

This PR addresses a **fundamental gap** that blocks modern AI-assisted development workflows. As tools like Claude Code, GitHub Copilot, and other AI development assistants become standard, the need for immediate feedback loops becomes essential. 

Currently, MCP Playwright is **unsuitable for frontend development** because developers cannot see their changes. This change enables:
- ✅ Rapid iteration with AI coding assistants
- ✅ Immediate visual feedback on frontend changes  
- ✅ Proper testing of JavaScript/CSS modifications
- ✅ Seamless integration with modern development workflows

The implementation follows Playwright's documented patterns and adds minimal overhead when disabled (default behavior unchanged).

🤖 Generated with [Claude Code](https://claude.ai/code)