### PR TITLE
chore: use new Browser.setContentSize protocol call

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -62,7 +62,7 @@ export interface PageDelegate {
   navigateFrame(frame: frames.Frame, url: string, referrer: string | undefined): Promise<frames.GotoResult>;
 
   updateExtraHTTPHeaders(): Promise<void>;
-  updateEmulatedViewportSize(preserveWindowBoundaries?: boolean): Promise<void>;
+  updateEmulatedViewportSize(): Promise<void>;
   updateEmulateMedia(): Promise<void>;
   updateRequestInterception(): Promise<void>;
   updateFileChooserInterception(): Promise<void>;


### PR DESCRIPTION
This one takes care of insets/infobars/etc on all platforms.

[Introduced to CPD](https://chromium-review.googlesource.com/c/chromium/src/+/6712155) in Chromium 140.

https://github.com/microsoft/playwright/issues/37273