### PR TITLE
chore: fix wrong size due to infobar in chromium

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -62,7 +62,7 @@ export interface PageDelegate {
   navigateFrame(frame: frames.Frame, url: string, referrer: string | undefined): Promise<frames.GotoResult>;
 
   updateExtraHTTPHeaders(): Promise<void>;
-  updateEmulatedViewportSize(preserveWindowBoundaries?: boolean): Promise<void>;
+  updateEmulatedViewportSize(): Promise<void>;
   updateEmulateMedia(): Promise<void>;
   updateRequestInterception(): Promise<void>;
   updateFileChooserInterception(): Promise<void>;


### PR DESCRIPTION
Fixes the flaky `should click bottom row w/ infobar in OOPIF` test.

https://github.com/microsoft/playwright/issues/37273