### PR TITLE
fix(ct): don't modify React core in Node development mode

### DIFF
--- a/packages/playwright-ct-core/src/viteUtils.ts
+++ b/packages/playwright-ct-core/src/viteUtils.ts
@@ -169,7 +169,8 @@ const compiledReactRE = /(const|var)\s+React\s*=/;
 
 export function transformIndexFile(id: string, content: string, templateDir: string, registerSource: string, importInfos: Map<string, ImportInfo>): TransformResult  | null {
   // Vite React plugin will do this for .jsx files, but not .js files.
-  if (id.endsWith('.js') && content.includes('React.createElement') && !content.match(importReactRE) && !content.match(compiledReactRE)) {
+  // `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` check is to avoid modifying React itself (such as react.development.js)
+  if (id.endsWith('.js') && content.includes('React.createElement') && !content.includes('__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED') && !content.match(importReactRE) && !content.match(compiledReactRE)) {
     const code = `import React from 'react';\n${content}`;
     return { code, map: { mappings: '' } };
   }


### PR DESCRIPTION
Fixes #37434

The loose React detection heuristics in our CT Vite plugin are able to match `react.development.js`; the version of React that is included when using `NODE_ENV=development`. This stacks two issues on top of each other by having React import itself and inserting an `import` statement into a CJS file.

Apply an additional heuristic that will almost always only target React internals itself and never user code as a way to disable this behavior.