### PR TITLE
chore(flakiness-dashboard): use ManagedIdentityCredential instead of DefaultAzureCredential

### DIFF
--- a/utils/flakiness-dashboard/processing/utils.js
+++ b/utils/flakiness-dashboard/processing/utils.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 // @ts-check
-const { DefaultAzureCredential } = require('@azure/identity');
+const { ManagedIdentityCredential } = require('@azure/identity');
 const { BlobServiceClient } = require('@azure/storage-blob');
-const defaultAzureCredential = new DefaultAzureCredential();
+const defaultAzureCredential = new ManagedIdentityCredential();
 const zlib = require('zlib');
 const util = require('util');
 


### PR DESCRIPTION
Switch to ManagedIdentityCredential to satisfy CodeQL rule [SM05138] and avoid the warning about DefaultAzureCredential in production.

Function App runs with a system-assigned managed identity, so this credential is functionally equivalent and avoids fallback to dev-only sources (Azure CLI, VS Code, etc.).