### PR TITLE
feat(mcp): introduces quiet mode to reduce context polution

### DIFF
--- a/packages/playwright/src/mcp/browser/config.ts
+++ b/packages/playwright/src/mcp/browser/config.ts
@@ -44,6 +44,7 @@ export type CLIOptions = {
   port?: number;
   proxyBypass?: string;
   proxyServer?: string;
+  quietMode?: boolean;
   saveSession?: boolean;
   saveTrace?: boolean;
   secrets?: Record<string, string>;
@@ -201,6 +202,7 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config {
       allowedOrigins: cliOptions.allowedOrigins,
       blockedOrigins: cliOptions.blockedOrigins,
     },
+    quietMode: cliOptions.quietMode,
     saveSession: cliOptions.saveSession,
     saveTrace: cliOptions.saveTrace,
     secrets: cliOptions.secrets,
@@ -238,6 +240,7 @@ function configFromEnv(): Config {
   options.port = numberParser(process.env.PLAYWRIGHT_MCP_PORT);
   options.proxyBypass = envToString(process.env.PLAYWRIGHT_MCP_PROXY_BYPASS);
   options.proxyServer = envToString(process.env.PLAYWRIGHT_MCP_PROXY_SERVER);
+  options.quietMode = envToBoolean(process.env.PLAYWRIGHT_MCP_QUIET_MODE);
   options.saveTrace = envToBoolean(process.env.PLAYWRIGHT_MCP_SAVE_TRACE);
   options.secrets = dotenvFileLoader(process.env.PLAYWRIGHT_MCP_SECRETS_FILE);
   options.storageState = envToString(process.env.PLAYWRIGHT_MCP_STORAGE_STATE);

--- a/packages/playwright/src/mcp/browser/response.ts
+++ b/packages/playwright/src/mcp/browser/response.ts
@@ -76,6 +76,11 @@ export class Response {
     this._includeSnapshot = true;
   }
 
+  setMaybeIncludeSnapshot() {
+    if (!this._context.config.quietMode)
+      this._includeSnapshot = true;
+  }
+
   setIncludeTabs() {
     this._includeTabs = true;
   }

--- a/packages/playwright/src/mcp/browser/tools/dialogs.ts
+++ b/packages/playwright/src/mcp/browser/tools/dialogs.ts
@@ -32,7 +32,7 @@ const handleDialog = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    response.setIncludeSnapshot();
+    response.setMaybeIncludeSnapshot();
 
     const dialogState = tab.modalStates().find(state => state.type === 'dialog');
     if (!dialogState)

--- a/packages/playwright/src/mcp/browser/tools/evaluate.ts
+++ b/packages/playwright/src/mcp/browser/tools/evaluate.ts
@@ -38,7 +38,7 @@ const evaluate = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    response.setIncludeSnapshot();
+    response.setMaybeIncludeSnapshot();
 
     let locator: playwright.Locator | undefined;
     if (params.ref && params.element) {

--- a/packages/playwright/src/mcp/browser/tools/files.ts
+++ b/packages/playwright/src/mcp/browser/tools/files.ts
@@ -31,7 +31,7 @@ const uploadFile = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    response.setIncludeSnapshot();
+    response.setMaybeIncludeSnapshot();
 
     const modalState = tab.modalStates().find(state => state.type === 'fileChooser');
     if (!modalState)

--- a/packages/playwright/src/mcp/browser/tools/keyboard.ts
+++ b/packages/playwright/src/mcp/browser/tools/keyboard.ts
@@ -33,7 +33,7 @@ const pressKey = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    response.setIncludeSnapshot();
+    response.setMaybeIncludeSnapshot();
     response.addCode(`// Press ${params.key}`);
     response.addCode(`await page.keyboard.press('${params.key}');`);
 
@@ -65,7 +65,7 @@ const type = defineTabTool({
 
     await tab.waitForCompletion(async () => {
       if (params.slowly) {
-        response.setIncludeSnapshot();
+        response.setMaybeIncludeSnapshot();
         response.addCode(`await page.${await generateLocator(locator)}.pressSequentially(${secret.code});`);
         await locator.pressSequentially(secret.value);
       } else {
@@ -74,7 +74,7 @@ const type = defineTabTool({
       }
 
       if (params.submit) {
-        response.setIncludeSnapshot();
+        response.setMaybeIncludeSnapshot();
         response.addCode(`await page.${await generateLocator(locator)}.press('Enter');`);
         await locator.press('Enter');
       }

--- a/packages/playwright/src/mcp/browser/tools/mouse.ts
+++ b/packages/playwright/src/mcp/browser/tools/mouse.ts
@@ -58,7 +58,7 @@ const mouseClick = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    response.setIncludeSnapshot();
+    response.setMaybeIncludeSnapshot();
 
     response.addCode(`// Click mouse at coordinates (${params.x}, ${params.y})`);
     response.addCode(`await page.mouse.move(${params.x}, ${params.y});`);
@@ -89,7 +89,7 @@ const mouseDrag = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    response.setIncludeSnapshot();
+    response.setMaybeIncludeSnapshot();
 
     response.addCode(`// Drag mouse from (${params.startX}, ${params.startY}) to (${params.endX}, ${params.endY})`);
     response.addCode(`await page.mouse.move(${params.startX}, ${params.startY});`);

--- a/packages/playwright/src/mcp/config.d.ts
+++ b/packages/playwright/src/mcp/config.d.ts
@@ -101,6 +101,12 @@ export type Config = {
   saveTrace?: boolean;
 
   /**
+   * When enabled, reduces verbosity by omitting automatic snapshots after certain tool actions.
+   * Snapshots will still be included for tools that explicitly require them.
+   */
+  quietMode?: boolean;
+
+  /**
    * Secrets are used to prevent LLM from getting sensitive data while
    * automating scenarios such as authentication.
    * Prefer the browser.contextOptions.storageState over secrets file as a more secure alternative.

--- a/packages/playwright/src/mcp/program.ts
+++ b/packages/playwright/src/mcp/program.ts
@@ -49,6 +49,7 @@ export function decorateCommand(command: Command, version: string) {
       .option('--port <port>', 'port to listen on for SSE transport.')
       .option('--proxy-bypass <bypass>', 'comma-separated domains to bypass proxy, for example ".com,chromium.org,.domain.com"')
       .option('--proxy-server <proxy>', 'specify proxy server, for example "http://myproxy:3128" or "socks5://myproxy:8080"')
+      .option('--quiet-mode', 'reduce verbosity by omitting automatic snapshots after certain tool actions')
       .option('--save-session', 'Whether to save the Playwright MCP session into the output directory.')
       .option('--save-trace', 'Whether to save the Playwright Trace of the session into the output directory.')
       .option('--secrets <path>', 'path to a file containing secrets in the dotenv format', dotenvFileLoader)


### PR DESCRIPTION
Initially I opened this https://github.com/microsoft/playwright-mcp/issues/1040 to talk about possible approaches to this problem.

Here I am suggesting a potential solution that I have been using in my own fork, the rationale is that the MCP client can and will call for a new snapshot when needed. Another option I see is going more extreme and never returning an snapshot but rather keep the most up to date snapshot in a file and let the client read the file when it needs.

My open questions with the proposed approach are mostly about what are the tools that should or should not return the snapshot in quiet mode?