### PR TITLE
chore(ct): expose fixture types for downstream use

### DIFF
--- a/packages/playwright-ct-react/index.d.ts
+++ b/packages/playwright-ct-react/index.d.ts
@@ -27,11 +27,13 @@ export interface MountResult extends Locator {
   update(component: React.JSX.Element): Promise<void>;
 }
 
-export const test: TestType<{
+export interface ComponentFixtures {
   mount<HooksConfig>(
     component: React.JSX.Element,
     options?: MountOptions<HooksConfig>
   ): Promise<MountResult>;
-}>;
+}
+
+export const test: TestType<ComponentFixtures>;
 
 export { defineConfig, PlaywrightTestConfig, expect, devices } from '@playwright/experimental-ct-core';

--- a/packages/playwright-ct-react17/index.d.ts
+++ b/packages/playwright-ct-react17/index.d.ts
@@ -25,11 +25,13 @@ export interface MountResult extends Locator {
   update(component: JSX.Element): Promise<void>;
 }
 
-export const test: TestType<{
+export interface ComponentFixtures {
   mount<HooksConfig>(
     component: JSX.Element,
     options?: MountOptions<HooksConfig>
   ): Promise<MountResult>;
-}>;
+}
+
+export const test: TestType<ComponentFixtures>;
 
 export { defineConfig, PlaywrightTestConfig, expect, devices } from '@playwright/experimental-ct-core';

--- a/packages/playwright-ct-svelte/index.d.ts
+++ b/packages/playwright-ct-svelte/index.d.ts
@@ -39,11 +39,13 @@ export interface MountResult<Component extends InteropComponent> extends Locator
   }): Promise<void>;
 }
 
-export const test: TestType<{
+export interface ComponentFixtures {
   mount<HooksConfig, Component extends InteropComponent = InteropComponent>(
     component: Component,
     options?: MountOptions<HooksConfig, Component>
   ): Promise<MountResult<Component>>;
-}>;
+}
+
+export const test: TestType<ComponentFixtures>;
 
 export { defineConfig, PlaywrightTestConfig, expect, devices } from '@playwright/experimental-ct-core';

--- a/packages/playwright-ct-vue/index.d.ts
+++ b/packages/playwright-ct-vue/index.d.ts
@@ -52,7 +52,7 @@ export interface MountResultJsx extends Locator {
   update(component: JSX.Element): Promise<void>;
 }
 
-export const test: TestType<{
+export interface ComponentFixtures {
   mount<HooksConfig>(
     component: JSX.Element,
     options?: MountOptionsJsx<HooksConfig>
@@ -61,6 +61,8 @@ export const test: TestType<{
     component: Component,
     options?: MountOptions<HooksConfig, Component>
   ): Promise<MountResult<Component>>;
-}>;
+}
+
+export const test: TestType<ComponentFixtures>;
 
 export { defineConfig, PlaywrightTestConfig, expect, devices } from '@playwright/experimental-ct-core';


### PR DESCRIPTION
Fixes #37045

It is non-trivial to extract the types of each CT frameworks' fixtures, but the work is trivial on our side. Expose these types.