### PR TITLE
fix(test-mcp): handle dependent projects in tools

### DIFF
--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -224,7 +224,7 @@ export class Dispatcher {
       extraEnv: this._extraEnvByProjectId.get(testGroup.projectId) || {},
       outputDir,
       pauseOnError: this._failureTracker.pauseOnError(),
-      pauseAtEnd: this._failureTracker.pauseAtEnd(),
+      pauseAtEnd: this._failureTracker.pauseAtEnd(projectConfig),
     });
     const handleOutput = (params: TestOutputPayload) => {
       const chunk = chunkFromParams(params);

--- a/packages/playwright/src/runner/failureTracker.ts
+++ b/packages/playwright/src/runner/failureTracker.ts
@@ -15,13 +15,14 @@
  */
 
 import type { TestResult } from '../../types/testReporter';
-import type { FullConfigInternal } from '../common/config';
+import type { FullConfigInternal, FullProjectInternal } from '../common/config';
 import type { Suite, TestCase } from '../common/test';
 
 export class FailureTracker {
   private _failureCount = 0;
   private _hasWorkerErrors = false;
   private _rootSuite: Suite | undefined;
+  private _topLevelProjects: FullProjectInternal[] = [];
   private _pauseOnError: boolean;
   private _pauseAtEnd: boolean;
 
@@ -30,8 +31,9 @@ export class FailureTracker {
     this._pauseAtEnd = options?.pauseAtEnd ?? false;
   }
 
-  onRootSuite(rootSuite: Suite) {
+  onRootSuite(rootSuite: Suite, topLevelProjects: FullProjectInternal[]) {
     this._rootSuite = rootSuite;
+    this._topLevelProjects = topLevelProjects;
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
@@ -48,8 +50,8 @@ export class FailureTracker {
     return this._pauseOnError;
   }
 
-  pauseAtEnd(): boolean {
-    return this._pauseAtEnd;
+  pauseAtEnd(inProject: FullProjectInternal): boolean {
+    return this._pauseAtEnd && this._topLevelProjects.includes(inProject);
   }
 
   hasReachedMaxFailures() {

--- a/packages/playwright/src/runner/projectUtils.ts
+++ b/packages/playwright/src/runner/projectUtils.ts
@@ -23,7 +23,7 @@ import { minimatch } from 'playwright-core/lib/utilsBundle';
 
 import { createFileMatcher } from '../util';
 
-import type { FullProjectInternal } from '../common/config';
+import type { FullConfigInternal, FullProjectInternal } from '../common/config';
 
 
 const readFileAsync = promisify(fs.readFile);
@@ -113,6 +113,11 @@ export function buildProjectsClosure(projects: FullProjectInternal[], hasTests?:
   for (const p of projects)
     visit(0, p);
   return result;
+}
+
+export function findTopLevelProjects(config: FullConfigInternal): FullProjectInternal[] {
+  const closure = buildProjectsClosure(config.projects);
+  return [...closure].filter(entry => entry[1] === 'top-level').map(entry => entry[0]);
 }
 
 export function buildDependentProjects(forProjects: FullProjectInternal[], projects: FullProjectInternal[]): Set<FullProjectInternal> {

--- a/packages/playwright/src/runner/testRunner.ts
+++ b/packages/playwright/src/runner/testRunner.ts
@@ -73,6 +73,8 @@ export type RunTestsParams = {
   connectWsEndpoint?: string;
   pauseOnError?: boolean;
   pauseAtEnd?: boolean;
+  doNotRunDepsOutsideProjectFilter?: boolean;
+  disableConfigReporters?: boolean;
 };
 
 type FullResultStatus = reporterTypes.FullResult['status'];
@@ -337,12 +339,12 @@ export class TestRunner extends EventEmitter<TestRunnerEventMap> {
       config.preOnlyTestFilters.push(test => testIdSet.has(test.id));
     }
 
-    const configReporters = await createReporters(config, 'test', true);
+    const configReporters = params.disableConfigReporters ? [] : await createReporters(config, 'test', true);
     const reporter = new InternalReporter([...configReporters, userReporter]);
     const stop = new ManualPromise();
     const tasks = [
       createApplyRebaselinesTask(),
-      createLoadTask('out-of-process', { filterOnly: true, failOnLoadErrors: false, doNotRunDepsOutsideProjectFilter: true }),
+      createLoadTask('out-of-process', { filterOnly: true, failOnLoadErrors: false, doNotRunDepsOutsideProjectFilter: params.doNotRunDepsOutsideProjectFilter }),
       ...createRunTestsTasks(config),
     ];
     const testRun = new TestRun(config, reporter, { pauseOnError: params.pauseOnError, pauseAtEnd: params.pauseAtEnd });

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -200,7 +200,10 @@ export class TestServerDispatcher implements TestServerInterface {
 
   async runTests(params: Parameters<TestServerInterface['runTests']>[0]): ReturnType<TestServerInterface['runTests']> {
     const wireReporter = await this._wireReporter(e => this._dispatchEvent('report', e));
-    const { status } = await this._testRunner.runTests(wireReporter, params);
+    const { status } = await this._testRunner.runTests(wireReporter, {
+      ...params,
+      doNotRunDepsOutsideProjectFilter: true,
+    });
     return { status };
   }
 


### PR DESCRIPTION
- `test_run` should run dependencies, like a normal test run would, to perform authentication and other setup.
- `test_setup_page` should choose a top-level project, run setup and top-level test, and only stop at the end of the top-level test.