### PR TITLE
devops(report): switch HTML report URLs to Azure Front Door endpoint

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -35,7 +35,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NODE_OPTIONS: --max-old-space-size=8192
-        HTML_REPORT_URL: 'https://mspwblobreport.z1.web.core.windows.net/run-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}-${{ github.sha }}/index.html'
+        HTML_REPORT_URL: 'https://mspwblobreport-apgjhvh7fpfwdebw.b01.azurefd.net/run-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}-${{ github.sha }}/index.html'
 
     - name: Azure Login
       uses: azure/login@v2
@@ -48,6 +48,6 @@ jobs:
       run: |
         REPORT_DIR='run-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}-${{ github.sha }}'
         azcopy cp --recursive "./playwright-report/*" "https://mspwblobreport.blob.core.windows.net/\$web/$REPORT_DIR"
-        echo "Report url: https://mspwblobreport.z1.web.core.windows.net/$REPORT_DIR/index.html"
+        echo "Report url: https://mspwblobreport-apgjhvh7fpfwdebw.b01.azurefd.net/$REPORT_DIR/index.html"
       env:
         AZCOPY_AUTO_LOGIN_TYPE: AZCLI


### PR DESCRIPTION
Serve Playwright test reports through our Azure Front Door profile instead of the static-website endpoint.

Why:
* The static-website endpoint (`*.web.core.windows.net`) requires anonymous blob access
* Front Door sits in front of the same `$web` container but authenticates with a managed identity, so we can disable `allowBlobPublicAccess` on the storage account and stay compliant.
* Using the CDN edge also gives us global caching and a stable URL.
* [Example report](https://mspwblobreport-apgjhvh7fpfwdebw.b01.azurefd.net/run-17814534021-1-cde6c43868be94f1ee31e468c0cd06e200eff5c3/index.html)

Workflow now publishes and prints the Front Door URL: https://mspwblobreport-apgjhvh7fpfwdebw.b01.azurefd.net/…