### PR TITLE
chore(bidi): don't accept page in firefox launch arguments

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiFirefox.ts
+++ b/packages/playwright-core/src/server/bidi/bidiFirefox.ts
@@ -97,6 +97,8 @@ export class BidiFirefox extends BrowserType {
     const userDataDirArg = args.find(arg => arg.startsWith('-profile') || arg.startsWith('--profile'));
     if (userDataDirArg)
       throw this._createUserDataDirArgMisuseError('--profile');
+    if (args.find(arg => !arg.startsWith('-')))
+      throw new Error('Arguments can not specify page to be opened');
     const firefoxArguments = ['--remote-debugging-port=0'];
     if (headless)
       firefoxArguments.push('--headless');


### PR DESCRIPTION
Fixes the following tests in Firefox:
- `tests/library/browsertype-launch.spec.ts`:
  - "should throw if page argument is passed"
- `tests/library/defaultbrowsercontext-2.spec.ts`:
  - "should throw if page argument is passed"
