### PR TITLE
feat(ui-mode): support opening test source in arbitrary editor

### DIFF
--- a/packages/playwright/ThirdPartyNotices.txt
+++ b/packages/playwright/ThirdPartyNotices.txt
@@ -161,6 +161,7 @@ This project incorporates components from the projects listed below. The origina
 -	jsesc@3.1.0 (https://github.com/mathiasbynens/jsesc)
 -	json-schema-traverse@0.4.1 (https://github.com/epoberezkin/json-schema-traverse)
 -	json5@2.2.3 (https://github.com/json5/json5)
+-	launch-editor@2.11.1 (https://github.com/yyx990803/launch-editor)
 -	lru-cache@5.1.1 (https://github.com/isaacs/node-lru-cache)
 -	math-intrinsics@1.1.0 (https://github.com/es-shims/math-intrinsics)
 -	media-typer@1.1.0 (https://github.com/jshttp/media-typer)
@@ -200,6 +201,7 @@ This project incorporates components from the projects listed below. The origina
 -	setprototypeof@1.2.0 (https://github.com/wesleytodd/setprototypeof)
 -	shebang-command@2.0.0 (https://github.com/kevva/shebang-command)
 -	shebang-regex@3.0.0 (https://github.com/sindresorhus/shebang-regex)
+-	shell-quote@1.8.3 (https://github.com/ljharb/shell-quote)
 -	side-channel-list@1.0.0 (https://github.com/ljharb/side-channel-list)
 -	side-channel-map@1.0.1 (https://github.com/ljharb/side-channel-map)
 -	side-channel-weakmap@1.0.2 (https://github.com/ljharb/side-channel-weakmap)
@@ -4692,6 +4694,32 @@ SOFTWARE.
 =========================================
 END OF json5@2.2.3 AND INFORMATION
 
+%% launch-editor@2.11.1 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) 2017-present, Yuxi (Evan) You
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+=========================================
+END OF launch-editor@2.11.1 AND INFORMATION
+
 %% lru-cache@5.1.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 The ISC License
@@ -5653,6 +5681,35 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 =========================================
 END OF shebang-regex@3.0.0 AND INFORMATION
 
+%% shell-quote@1.8.3 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License
+
+Copyright (c) 2013 James Halliday (mail@substack.net)
+
+Permission is hereby granted, free of charge, 
+to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to 
+deal in the Software without restriction, including 
+without limitation the rights to use, copy, modify, 
+merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom 
+the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice 
+shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF shell-quote@1.8.3 AND INFORMATION
+
 %% side-channel-list@1.0.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 MIT License
@@ -6272,6 +6329,6 @@ END OF zod@3.25.76 AND INFORMATION
 
 SUMMARY BEGIN HERE
 =========================================
-Total Packages: 222
+Total Packages: 224
 =========================================
 END OF SUMMARY

--- a/packages/playwright/bundles/utils/package-lock.json
+++ b/packages/playwright/bundles/utils/package-lock.json
@@ -12,6 +12,7 @@
         "enquirer": "2.3.6",
         "get-east-asian-width": "1.3.0",
         "json5": "2.2.3",
+        "launch-editor": "2.11.1",
         "source-map-support": "0.5.21",
         "stoppable": "1.1.0"
       },
@@ -218,6 +219,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/launch-editor": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
+      "integrity": "sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.3"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -225,6 +236,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -246,6 +263,18 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/source-map": {
@@ -424,10 +453,24 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
+    "launch-editor": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
+      "integrity": "sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==",
+      "requires": {
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.3"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
+    "picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -441,6 +484,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/packages/playwright/bundles/utils/package.json
+++ b/packages/playwright/bundles/utils/package.json
@@ -7,6 +7,7 @@
     "enquirer": "2.3.6",
     "get-east-asian-width": "1.3.0",
     "json5": "2.2.3",
+    "launch-editor": "2.11.1",
     "source-map-support": "0.5.21",
     "stoppable": "1.1.0"
   },

--- a/packages/playwright/bundles/utils/src/utilsBundleImpl.ts
+++ b/packages/playwright/bundles/utils/src/utilsBundleImpl.ts
@@ -31,3 +31,6 @@ export const chokidar = chokidarLibrary;
 
 import * as getEastAsianWidthLibrary from 'get-east-asian-width';
 export const getEastAsianWidth = getEastAsianWidthLibrary;
+
+import launchEditorLibrary from 'launch-editor';
+export const launchEditor = launchEditorLibrary;

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -136,9 +136,9 @@ export class TestServerDispatcher implements TestServerInterface {
   async open(params: Parameters<TestServerInterface['open']>[0]): ReturnType<TestServerInterface['open']> {
     if (isUnderTest())
       return;
-    // Prevent opening CLI editors
-    process.env.EDITOR = undefined;
-    process.env.VISUAL = undefined;
+    // Prevent opening any configured CLI editors and fallback to VSCode automatically (opening it if installed and closed)
+    process.env.EDITOR = 'code';
+    delete process.env.VISUAL;
     // eslint-disable-next-line no-console
     launchEditor(`${params.location.file}:${params.location.line}:${params.location.column}`, undefined, (_, e) => console.error('Failed to launch editor: ' + e));
   }

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -18,7 +18,7 @@ import util from 'util';
 
 import { installRootRedirect, openTraceInBrowser, openTraceViewerApp, startTraceViewerServer } from 'playwright-core/lib/server';
 import { ManualPromise, gracefullyProcessExitDoNotHang, isUnderTest } from 'playwright-core/lib/utils';
-import { debug } from 'playwright-core/lib/utilsBundle';
+import { debug, open } from 'playwright-core/lib/utilsBundle';
 
 import { loadConfig, resolveConfigLocation } from '../common/configLoader';
 import ListReporter from '../reporters/list';
@@ -137,10 +137,12 @@ export class TestServerDispatcher implements TestServerInterface {
     if (isUnderTest())
       return;
     // Prevent opening any configured CLI editors and fallback to VSCode automatically (opening it if installed and closed)
-    process.env.EDITOR = 'code';
+    delete process.env.EDITOR;
     delete process.env.VISUAL;
-    // eslint-disable-next-line no-console
-    launchEditor(`${params.location.file}:${params.location.line}:${params.location.column}`, undefined, (_, e) => console.error('Failed to launch editor: ' + e));
+    launchEditor(`${params.location.file}:${params.location.line}:${params.location.column}`, undefined, (_, e) => {
+      // eslint-disable-next-line no-console
+      open(`vscode://file/${params.location.file}:${params.location.line}`).catch(e => console.error(e));
+    });
   }
 
   async resizeTerminal(params: Parameters<TestServerInterface['resizeTerminal']>[0]): ReturnType<TestServerInterface['resizeTerminal']> {

--- a/packages/playwright/src/utilsBundle.ts
+++ b/packages/playwright/src/utilsBundle.ts
@@ -20,4 +20,5 @@ export const stoppable: typeof import('../bundles/utils/node_modules/@types/stop
 export const enquirer: typeof import('../bundles/utils/node_modules/enquirer') = require('./utilsBundleImpl').enquirer;
 export const chokidar: typeof import('../bundles/utils/node_modules/chokidar') = require('./utilsBundleImpl').chokidar;
 export const getEastAsianWidth: typeof import('../bundles/utils/node_modules/get-east-asian-width') = require('./utilsBundleImpl').getEastAsianWidth;
+export const launchEditor: typeof import('../bundles/utils/node_modules/launch-editor') = require('./utilsBundleImpl').launchEditor;
 export type { RawSourceMap } from '../bundles/utils/node_modules/source-map';

--- a/packages/trace-viewer/src/ui/sourceTab.tsx
+++ b/packages/trace-viewer/src/ui/sourceTab.tsx
@@ -112,7 +112,7 @@ export const SourceTab: React.FunctionComponent<{
           <div>{shortFileName}</div>
         </div>
         <CopyToClipboard description='Copy filename' value={shortFileName}/>
-        {location && <ToolbarButton icon='link-external' title='Open in VS Code' onClick={openExternally}></ToolbarButton>}
+        {location && <ToolbarButton icon='link-external' title='Open in editor' onClick={openExternally}></ToolbarButton>}
       </Toolbar> }
       <CodeMirrorWrapper text={source.content || ''} highlighter='javascript' highlight={highlight} revealLine={targetLine} readOnly={true} lineNumbers={true} dataTestId='source-code-mirror'/>
     </div>}

--- a/tests/playwright-test/ui-mode-test-update.spec.ts
+++ b/tests/playwright-test/ui-mode-test-update.spec.ts
@@ -218,7 +218,7 @@ test('should update test locations', async ({ runUITest, writeFiles }) => {
   const passesItemLocator = page.getByRole('treeitem', { name: 'passes' });
   await passesItemLocator.hover();
   await passesItemLocator.getByTitle('Show source').click();
-  await page.getByTitle('Open in VS Code').click();
+  await page.getByTitle('Open in editor').click();
 
   expect(messages).toEqual([{
     method: 'open',
@@ -249,7 +249,7 @@ test('should update test locations', async ({ runUITest, writeFiles }) => {
   messages.length = 0;
   await passesItemLocator.hover();
   await passesItemLocator.getByTitle('Show source').click();
-  await page.getByTitle('Open in VS Code').click();
+  await page.getByTitle('Open in editor').click();
 
   expect(messages).toEqual([{
     method: 'open',


### PR DESCRIPTION
Closes #22158

Allow users to open test source in an editor of their choice, using Evan You's lightweight package for detecting running editors. If the user has an editor open when the "View in editor" button is pressed, we will attempt to use that editor. Otherwise an error will be printed to the UI Mode console (which is the same behavior as we currently have if VSCode isn't installed).