### PR TITLE
chore(mcp): test graceful http server shutdown on windows

### DIFF
--- a/packages/playwright/src/mcp/sdk/http.ts
+++ b/packages/playwright/src/mcp/sdk/http.ts
@@ -64,7 +64,7 @@ export async function installHttpTransport(httpServer: http.Server, serverBacken
   const streamableSessions = new Map();
   httpServer.on('request', async (req, res) => {
     const url = new URL(`http://localhost${req.url}`);
-    if (url.pathname === '/killkillkill') {
+    if (url.pathname === '/killkillkill' && req.method === 'GET') {
       res.statusCode = 200;
       res.end('Killing process');
       // Simulate Ctrl+C in a way that works on Windows too.

--- a/packages/playwright/src/mcp/sdk/http.ts
+++ b/packages/playwright/src/mcp/sdk/http.ts
@@ -64,6 +64,13 @@ export async function installHttpTransport(httpServer: http.Server, serverBacken
   const streamableSessions = new Map();
   httpServer.on('request', async (req, res) => {
     const url = new URL(`http://localhost${req.url}`);
+    if (url.pathname === '/killkillkill') {
+      res.statusCode = 200;
+      res.end('Killing process');
+      // Simulate Ctrl+C in a way that works on Windows too.
+      process.emit('SIGINT');
+      return;
+    }
     if (url.pathname.startsWith('/sse'))
       await handleSSE(serverBackendFactory, req, res, url, sseSessions);
     else


### PR DESCRIPTION
On Windows `child.kill('SIGTERM')` results in `TerminateProcess(process_handle, 1)` call which kills the process without firing any shutdown events. `Ctrl+C` in windows terminal calls `GenerateConsoleCtrlEvent` Win32 API which is ends up in a  Node.js handler added with `SetConsoleCtrlHandler` which converts the event into `process.on('SIGINT`, ...)` event and triggers our watchdog logic. The PR adds an http endpoint that simulates that even on the server end and calls it from the tests.

Reference https://github.com/microsoft/playwright-mcp/issues/1045