### PR TITLE
test(bidi): hide scrollbars in screenshot tests in Firefox

### DIFF
--- a/tests/assets/grid.html
+++ b/tests/assets/grid.html
@@ -50,6 +50,10 @@ body {
     display: none;
 }
 
+html {
+    scrollbar-width: none;
+}
+
 @keyframes move {
     from { left: -500px; background-color: cyan; }
     to { left: 0; background-color: rgb(255, 210, 204); }


### PR DESCRIPTION
`grid.html` already contains `::-webkit-scrollbar { display: none; }` to hide scrollbars in browsers other than Firefox, `html { scrollbar-width: none; }` will also hide them in Firefox.

Fixes the following tests:
- `tests/library/emulation-focus.spec.ts`:
  - "should not affect screenshots"
- `page/elementhandle-bounding-box.spec.ts`:
  - "should work"
- `page/locator-misc-2.spec.ts`:
  - "should return bounding box"
- `page/page-add-locator-handler.spec.ts`
  - "should work with toHaveScreenshot"
- `page/page-screenshot.spec.ts`
  - "page screenshot › mask option › should hide elements based on attr"
  - "page screenshot › mask option › should mask in parallel"
  - "page screenshot › mask option › should mask inside iframe"
  - "page screenshot › mask option › should mask multiple elements"
  - "page screenshot › mask option › should remove elements based on attr"
  - "page screenshot › mask option › should work"
  - "page screenshot › mask option › should work when mask color is not pink #F0F"
  - "page screenshot › mask option › should work with elementhandle"
  - "page screenshot › mask option › should work with locator"
  - "page screenshot › path option should create subdirectories"
  - "page screenshot › path option should work"
  - "page screenshot › should clip elements to the viewport"
  - "page screenshot › should clip rect"
  - "page screenshot › should clip rect with fullPage"
  - "page screenshot › should take fullPage screenshots"
  - "page screenshot › should take fullPage screenshots and mask elements outside of it"
  - "page screenshot › should work smoke"
  - "page screenshot › should work with Array deleted"
  - "page screenshot › should work with iframe in shadow"
