### PR TITLE
chore(mcp): do not mark test run result as error

### DIFF
--- a/packages/playwright/src/mcp/test/testTools.ts
+++ b/packages/playwright/src/mcp/test/testTools.ts
@@ -66,7 +66,7 @@ export const runTests = defineTestTool({
     const configDir = context.configLocation.configDir;
     const reporter = new ListReporter({ configDir, screen, includeTestId: true });
     const testRunner = await context.createTestRunner();
-    const result = await testRunner.runTests(reporter, {
+    await testRunner.runTests(reporter, {
       locations: params.locations,
       projects: params.projects,
       disableConfigReporters: true,
@@ -76,8 +76,7 @@ export const runTests = defineTestTool({
     return {
       content: [
         { type: 'text', text },
-      ],
-      isError: result.status !== 'passed',
+      ]
     };
   },
 });

--- a/tests/mcp/test-tools.spec.ts
+++ b/tests/mcp/test-tools.spec.ts
@@ -96,6 +96,26 @@ test('test_run', async ({ startClient }) => {
   expect(text).not.toContain(`../../test-results`);
 });
 
+test('test_run for a failed tests is not an error', async ({ startClient }) => {
+  await writeFiles({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('fails', () => { expect(1).toBe(2); });
+    `,
+  });
+
+  const { client } = await startClient();
+  const response = await client.callTool({
+    name: 'test_run',
+  });
+
+  const text = response.content[0].text;
+  // The tool run has succeeded, even though the test has failed.
+  expect(response.isError).toBeFalsy();
+
+  expect(text).toContain(`1 failed`);
+});
+
 test('test_run filters', async ({ startClient }) => {
   await writeFiles({
     'playwright.config.ts': `


### PR DESCRIPTION
Otherwise it highlights the tool call as failed in the chat while the tool did its job