### PR TITLE
chore: a few fixes for vscode agents

### DIFF
--- a/packages/playwright/src/agents/generateAgents.ts
+++ b/packages/playwright/src/agents/generateAgents.ts
@@ -216,22 +216,38 @@ const vscodeToolMap = new Map<string, string[]>([
   ['edit', ['editFiles']],
   ['write', ['createFile', 'createDirectory']],
 ]);
+const vscodeToolsOrder = ['createFile', 'createDirectory', 'editFiles', 'fileSearch', 'textSearch', 'listDirectory', 'readFile'];
+const vscodeToolPrefix = 'test_'; // FIXME: this is ugly, fix VSCode!
 function saveAsVSCodeChatmode(agent: Agent): string {
   function asVscodeTool(tool: string): string | string[] {
     const [first, second] = tool.split('/');
     if (second)
-      return second;
+      return second.startsWith('browser_') ? vscodeToolPrefix + second : second;
     return vscodeToolMap.get(first) || first;
   }
-  const tools = agent.header.tools.map(asVscodeTool).flat().map(tool => `'${tool}'`).join(', ');
+  const tools = agent.header.tools.map(asVscodeTool).flat().sort((a, b) => {
+    // VSCode insisits on the specific tools order when editing agent config.
+    const indexA = vscodeToolsOrder.indexOf(a);
+    const indexB = vscodeToolsOrder.indexOf(b);
+    if (indexA === -1 && indexB === -1)
+      return a.localeCompare(b);
+    if (indexA === -1)
+      return 1;
+    if (indexB === -1)
+      return -1;
+    return indexA - indexB;
+  }).map(tool => `'${tool}'`).join(', ');
 
   const lines: string[] = [];
   lines.push(`---`);
-  lines.push(`description: ${agent.header.description}. Examples: ${agent.examples.map(example => `<example>${example}</example>`).join('')}`);
+  lines.push(`description: ${agent.header.description}.`);
   lines.push(`tools: [${tools}]`);
   lines.push(`---`);
   lines.push('');
   lines.push(agent.instructions);
+  for (const example of agent.examples)
+    lines.push(`<example>${example}</example>`);
+
   return lines.join('\n');
 }
 
@@ -261,6 +277,7 @@ export async function initVSCodeRepo() {
     type: 'stdio',
     command: commonMcpServers.playwrightTest.command,
     args: commonMcpServers.playwrightTest.args,
+    env: { 'PLAYWRIGHT_MCP_TOOL_PREFIX': vscodeToolPrefix },
   };
   await writeFile(mcpJsonPath, JSON.stringify(mcpJson, null, 2));
 }

--- a/packages/playwright/src/mcp/browser/tools.ts
+++ b/packages/playwright/src/mcp/browser/tools.ts
@@ -57,6 +57,13 @@ export const browserTools: Tool<any>[] = [
   ...verify,
 ];
 
+// FIXME: this is ugly, fix VSCode!
+const customPrefix = process.env.PLAYWRIGHT_MCP_TOOL_PREFIX;
+if (customPrefix) {
+  for (const tool of browserTools)
+    tool.schema.name = customPrefix + tool.schema.name;
+}
+
 export function filteredTools(config: FullConfig) {
   return browserTools.filter(tool => tool.capability.startsWith('core') || config.capabilities?.includes(tool.capability));
 }


### PR DESCRIPTION
- Move examples from description to instructions.
- Sort tools in the same way as VSCode does to avoid diffs.
- Prefix tools to avoid name collision.