### PR TITLE
Revert "chore: update xterm dependency (#37412)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@stylistic/eslint-plugin": "^5.2.3",
         "@types/codemirror": "^5.60.7",
         "@types/formidable": "^2.0.4",
+        "@types/immutable": "^3.8.7",
         "@types/node": "18.19.76",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
@@ -1780,6 +1781,16 @@
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true
     },
+    "node_modules/@types/immutable": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@types/immutable/-/immutable-3.8.7.tgz",
+      "integrity": "sha512-nsHFDX48Tl3RaP4BF47HHe5njx40Pcp+0a8CIqzJata80Fp7JzkcuGB7UhZBGjH9aA1fMEahIqvPQQNmro5YLg==",
+      "deprecated": "This is a stub types definition for Facebook's Immutable (https://github.com/facebook/immutable-js). Facebook's Immutable provides its own type definitions, so you don't need @types/immutable installed!",
+      "dev": true,
+      "dependencies": {
+        "immutable": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2263,21 +2274,6 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.21.tgz",
       "integrity": "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==",
       "peer": true
-    },
-    "node_modules/@xterm/addon-fit": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
-      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@xterm/xterm": "^5.0.0"
-      }
-    },
-    "node_modules/@xterm/xterm": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
-      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
     },
     "node_modules/@zip.js/zip.js": {
       "version": "2.7.73",
@@ -8047,6 +8043,21 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/xterm": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
+      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead."
+    },
+    "node_modules/xterm-addon-fit": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz",
+      "integrity": "sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==",
+      "deprecated": "This package is now deprecated. Move to @xterm/addon-fit instead.",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8381,9 +8392,9 @@
     "packages/web": {
       "version": "0.0.0",
       "dependencies": {
-        "@xterm/addon-fit": "^0.10.0",
-        "@xterm/xterm": "^5.5.0",
-        "codemirror": "5.65.18"
+        "codemirror": "5.65.18",
+        "xterm": "^5.1.0",
+        "xterm-addon-fit": "^0.7.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@stylistic/eslint-plugin": "^5.2.3",
         "@types/codemirror": "^5.60.7",
         "@types/formidable": "^2.0.4",
-        "@types/immutable": "^3.8.7",
         "@types/node": "18.19.76",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
@@ -1780,16 +1779,6 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true
-    },
-    "node_modules/@types/immutable": {
-      "version": "3.8.7",
-      "resolved": "https://registry.npmjs.org/@types/immutable/-/immutable-3.8.7.tgz",
-      "integrity": "sha512-nsHFDX48Tl3RaP4BF47HHe5njx40Pcp+0a8CIqzJata80Fp7JzkcuGB7UhZBGjH9aA1fMEahIqvPQQNmro5YLg==",
-      "deprecated": "This is a stub types definition for Facebook's Immutable (https://github.com/facebook/immutable-js). Facebook's Immutable provides its own type definitions, so you don't need @types/immutable installed!",
-      "dev": true,
-      "dependencies": {
-        "immutable": "*"
-      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@stylistic/eslint-plugin": "^5.2.3",
     "@types/codemirror": "^5.60.7",
     "@types/formidable": "^2.0.4",
+    "@types/immutable": "^3.8.7",
     "@types/node": "18.19.76",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@stylistic/eslint-plugin": "^5.2.3",
     "@types/codemirror": "^5.60.7",
     "@types/formidable": "^2.0.4",
-    "@types/immutable": "^3.8.7",
     "@types/node": "18.19.76",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "dependencies": {
     "codemirror": "5.65.18",
-    "@xterm/xterm": "^5.5.0",
-    "@xterm/addon-fit": "^0.10.0"
+    "xterm": "^5.1.0",
+    "xterm-addon-fit": "^0.7.0"
   }
 }

--- a/packages/web/src/components/xtermModule.tsx
+++ b/packages/web/src/components/xtermModule.tsx
@@ -14,10 +14,10 @@
   limitations under the License.
 */
 
-import '@xterm/xterm/css/xterm.css';
+import 'xterm/css/xterm.css';
 
-import { Terminal } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
 
 export type XtermModule = {
   Terminal: typeof Terminal;

--- a/packages/web/src/components/xtermWrapper.tsx
+++ b/packages/web/src/components/xtermWrapper.tsx
@@ -16,8 +16,8 @@
 
 import * as React from 'react';
 import './xtermWrapper.css';
-import type { ITheme, Terminal } from '@xterm/xterm';
-import type { FitAddon } from '@xterm/addon-fit';
+import type { ITheme, Terminal } from 'xterm';
+import type { FitAddon } from 'xterm-addon-fit';
 import type { XtermModule } from './xtermModule';
 import { currentTheme, addThemeListener, removeThemeListener } from '../theme';
 import { useMeasure } from '../uiUtils';


### PR DESCRIPTION
This reverts commit 98c0d8935a716cffa5257bb711f088b0542fdb79.

The text looks ugly with the new xterm package:

<img width="896" height="428" alt="image" src="https://github.com/user-attachments/assets/d991525c-81b2-4960-8e06-2027dc5b1290" />


Filed upstream report: https://github.com/xtermjs/xterm.js/issues/5409