### PR TITLE
fix(ui-mode): restore console character spacing

### DIFF
--- a/packages/web/src/components/xtermWrapper.tsx
+++ b/packages/web/src/components/xtermWrapper.tsx
@@ -64,7 +64,7 @@ export const XtermWrapper: React.FC<{ source: XtermDataSource }> = ({
         convertEol: true,
         fontSize: 13,
         scrollback: 10000,
-        fontFamily: 'var(--vscode-editor-font-family)',
+        fontFamily: 'monospace',
         theme: terminalTheme,
       });
 


### PR DESCRIPTION
The newest version of `xterm.js` isn't able to properly calculate the size of the used font when a CSS variable is used. Since we are not likely to ever change this value and we never provided any web fonts, hardcode it to `monospace`, which is the font we always were using anyway.

<img width="1353" height="920" alt="Screenshot 2025-09-23 at 12 01 46 PM" src="https://github.com/user-attachments/assets/37c2410a-f698-4f55-88dd-d1c34ff88cf9" />
