### PR TITLE
chore(ui-mode): match select style to input

### DIFF
--- a/packages/trace-viewer/src/ui/uiModeView.css
+++ b/packages/trace-viewer/src/ui/uiModeView.css
@@ -27,10 +27,6 @@
   margin: 0 0 8px 23px;
 }
 
-.ui-mode-sidebar input[type=search] {
-  flex: auto;
-}
-
 .ui-mode-sidebar .toolbar-button:not([disabled]) .codicon-play {
   color: var(--vscode-debugIcon-restartForeground);
 }
@@ -108,6 +104,17 @@
   line-height: 24px;
   outline: none;
   margin: 0 4px;
+  border: none;
+  color: var(--vscode-input-foreground);
+  background-color: var(--vscode-input-background);
+}
+
+.ui-mode-sidebar select {
+  flex: auto;
+  padding: 0 5px;
+  height: 24px;
+  line-height: 24px;
+  outline: none;
   border: none;
   color: var(--vscode-input-foreground);
   background-color: var(--vscode-input-background);


### PR DESCRIPTION
Tweak `select` styling to match the existing filter UI in the sidebar.

<img width="1392" height="912" alt="Screenshot 2025-09-24 at 5 47 29 AM" src="https://github.com/user-attachments/assets/24bdb605-257c-4eaa-b4ff-d6b616e9a75f" />
