### PR TITLE
devops: npm whoami fails with OIDC workflow

### DIFF
--- a/utils/publish_all_packages.sh
+++ b/utils/publish_all_packages.sh
@@ -35,11 +35,6 @@ if ! command -v npm >/dev/null; then
   exit 1
 fi
 
-if ! npm whoami >/dev/null 2>&1; then
-  echo "ERROR: NPM is not logged in."
-  exit 1
-fi
-
 cd ..
 
 NPM_PUBLISH_TAG="next"


### PR DESCRIPTION
We don't use github token and try trusted CI instead https://docs.npmjs.com/trusted-publishers#for-github-actions. The step failed but we shouldn't need it with the new workflow.

```
+ npm whoami
+ echo 'ERROR: NPM is not logged in.'
+ exit 1
ERROR: NPM is not logged in.
```