### PR TITLE
devops: use node 20 instead of 18 on CI

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
       with:
-        node-version: 18
+        node-version: 20
     - run: npm ci
       env:
         ELECTRON_SKIP_BINARY_DOWNLOAD: 1

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
       with:
-        node-version: 18
+        node-version: 20
     - run: npm ci
     - run: npm run build
     - run: npx playwright install --with-deps
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
       with:
-        node-version: 18
+        node-version: 20
     - uses: actions/setup-python@v6
       with:
         python-version: '3.11'

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
       with:
-        node-version: 18
+        node-version: 20
         registry-url: 'https://registry.npmjs.org'
     # Ensure npm 11.5.1 or later is installed (for OIDC npm publishing)
     - name: Update npm
@@ -74,7 +74,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
       with:
-        node-version: 18
+        node-version: 20
     - uses: actions/create-github-app-token@v2
       id: app-token
       with:

--- a/.github/workflows/publish_release_docker.yml
+++ b/.github/workflows/publish_release_docker.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
       with:
-        node-version: 18
+        node-version: 20
         registry-url: 'https://registry.npmjs.org'
     - name: Set up Docker QEMU for arm64 docker builds
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
       with:
-        node-version: 18
+        node-version: 20
     - run: npm ci
     - run: npm run build
     - name: Install dependencies

--- a/.github/workflows/roll_driver_nodejs.yml
+++ b/.github/workflows/roll_driver_nodejs.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 20
       - run: node utils/build/update-playwright-driver-version.mjs
       - name: Prepare branch
         id: prepare-branch

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -146,7 +146,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
       with:
-        node-version: 18
+        node-version: 20
     - run: npm ci
     - run: npm run build
 
@@ -182,7 +182,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
       with:
-        node-version: 18
+        node-version: 20
     - run: npm ci
       env:
         DEBUG: pw:install

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -299,7 +299,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v5
       with:
-        node-version: 18
+        node-version: 20
     - run: npm ci
     - run: npm run build
     - run: utils/build/build-playwright-driver.sh


### PR DESCRIPTION
20 is the current Maintenance LTS.

Fixing the following error after https://github.com/microsoft/playwright/pull/37563:
```
Run npm install -g npm@latest
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: npm@11.6.1
npm error notsup Not compatible with your version of node/npm: npm@11.6.1
npm error notsup Required: {"node":"^20.17.0 || >=22.9.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v18.20.8"}
```