### PR TITLE
devops: provenance data is generated by default for trusted publishers

### DIFF
--- a/utils/publish_all_packages.sh
+++ b/utils/publish_all_packages.sh
@@ -77,7 +77,7 @@ echo "==================== Publishing version ${VERSION} ================"
 node ./utils/workspace.js --ensure-consistent
 node ./utils/workspace.js --list-public-package-paths | while read package
 do
-  npm publish --access=public ${package} --tag="${NPM_PUBLISH_TAG}" --provenance
+  npm publish --access=public ${package} --tag="${NPM_PUBLISH_TAG}"
 done
 
 echo "Done."


### PR DESCRIPTION
See https://docs.npmjs.com/trusted-publishers#automatic-provenance-generation, no need to pass --provenance explicitely.

Reference: https://github.com/microsoft/playwright/issues/37495