### PR TITLE
docs(dotnet): update installation instruction for xUnit v3

### DIFF
--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -48,7 +48,7 @@ cd PlaywrightTests
 <TabItem value="xunit-v3">
 
 ```bash
-dotnet new xunit -n PlaywrightTests
+dotnet new xunit3 -n PlaywrightTests
 cd PlaywrightTests
 ```
 


### PR DESCRIPTION
The installation instructions for xUnit v3 uses `dotnet new xunit -n PlaywrightTests` to create a project.  
`dotnet new xunit` is for v2, using this together with `Microsoft.Playwright.Xunit.v3` package causes a CS0433 build error: 
```
The type 'FactAttribute' exists in both 'xunit.core, Version=2.9.2.0, Culture=neutral, PublicKeyToken=' and 'xunit.v3.core, Version=1.0.1.0, Culture=neutral, PublicKeyToken='
```
