### PR TITLE
fix(test_setup_page): escape locations when passing to test runner

### DIFF
--- a/packages/playwright/src/mcp/test/testTools.ts
+++ b/packages/playwright/src/mcp/test/testTools.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { noColors } from 'playwright-core/lib/utils';
+import { noColors, escapeRegExp } from 'playwright-core/lib/utils';
 
 import { z } from '../sdk/bundle';
 import { terminalScreen } from '../../reporters/base';
@@ -169,7 +169,7 @@ ${seedFileContent}
 
     const result = await testRunner.runTests(reporter, {
       headed: !context.options?.headless,
-      locations: [seedFile],
+      locations: ['/' + escapeRegExp(seedFile) + '/'],
       projects: params.project ? [params.project] : undefined,
       timeout: 0,
       workers: 1,


### PR DESCRIPTION
Test runner treats them as regular expressions, not as file paths.
This is especially broken on Windows, where backslashes are common.