### PR TITLE
fix(library): don't dirty page state when calling page.close()

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -755,12 +755,7 @@ export class Page extends SdkObject {
     if (options.reason)
       this.closeReason = options.reason;
     const runBeforeUnload = !!options.runBeforeUnload;
-    if (this._closedState !== 'closing') {
-      this._closedState = 'closing';
-      // This might throw if the browser context containing the page closes
-      // while we are trying to close the page.
-      await this.delegate.closePage(runBeforeUnload).catch(e => debugLogger.log('error', e));
-    }
+    await this.delegate.closePage(runBeforeUnload).catch(e => debugLogger.log('error', e));
     if (!runBeforeUnload)
       await this._closedPromise;
   }

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -755,7 +755,14 @@ export class Page extends SdkObject {
     if (options.reason)
       this.closeReason = options.reason;
     const runBeforeUnload = !!options.runBeforeUnload;
-    await this.delegate.closePage(runBeforeUnload).catch(e => debugLogger.log('error', e));
+    if (this._closedState !== 'closing') {
+      // If runBeforeUnload is true, we don't know if we will close, so don't modify the state
+      if (!runBeforeUnload)
+        this._closedState = 'closing';
+      // This might throw if the browser context containing the page closes
+      // while we are trying to close the page.
+      await this.delegate.closePage(runBeforeUnload).catch(e => debugLogger.log('error', e));
+    }
     if (!runBeforeUnload)
       await this._closedPromise;
   }

--- a/tests/library/beforeunload.spec.ts
+++ b/tests/library/beforeunload.spec.ts
@@ -128,11 +128,11 @@ it('should not stall on click when dismissing beforeunload', async ({ page, serv
 });
 
 it('should support dismissing the dialog multiple times', async ({ page, server }) => {
-  await page.goto(server.EMPTY_PAGE);
+  await page.goto(server.PREFIX + '/beforeunload.html');
 
-  await page.evaluate(() => {
-    window.onbeforeunload = () => true;
-  });
+  // We have to interact with a page so that 'beforeunload' handlers
+  // fire (in Firefox).
+  await page.click('body');
 
   const [dialog] = await Promise.all([
     page.waitForEvent('dialog'),
@@ -150,11 +150,11 @@ it('should support dismissing the dialog multiple times', async ({ page, server 
 });
 
 it('should support closing the page after a previous dismiss', async ({ page, server }) => {
-  await page.goto(server.EMPTY_PAGE);
+  await page.goto(server.PREFIX + '/beforeunload.html');
 
-  await page.evaluate(() => {
-    window.onbeforeunload = () => true;
-  });
+  // We have to interact with a page so that 'beforeunload' handlers
+  // fire (in Firefox).
+  await page.click('body');
 
   const [dialog] = await Promise.all([
     page.waitForEvent('dialog'),
@@ -168,11 +168,11 @@ it('should support closing the page after a previous dismiss', async ({ page, se
 });
 
 it('should support closing the page via a subsequent onbeforeunload dialog', async ({ page, server }) => {
-  await page.goto(server.EMPTY_PAGE);
+  await page.goto(server.PREFIX + '/beforeunload.html');
 
-  await page.evaluate(() => {
-    window.onbeforeunload = () => true;
-  });
+  // We have to interact with a page so that 'beforeunload' handlers
+  // fire (in Firefox).
+  await page.click('body');
 
   const [dialog] = await Promise.all([
     page.waitForEvent('dialog'),

--- a/tests/library/beforeunload.spec.ts
+++ b/tests/library/beforeunload.spec.ts
@@ -126,3 +126,61 @@ it('should not stall on click when dismissing beforeunload', async ({ page, serv
   await page.getByRole('link').click({ timeout: 5000 });
   await expect(page).toHaveURL(server.PREFIX + '/frames/one-frame.html');
 });
+
+it('should support dismissing the dialog multiple times', async ({ page, server }) => {
+  await page.goto(server.EMPTY_PAGE);
+
+  await page.evaluate(() => {
+    window.onbeforeunload = () => true;
+  });
+
+  const [dialog] = await Promise.all([
+    page.waitForEvent('dialog'),
+    page.close({ runBeforeUnload: true })
+  ]);
+
+  await dialog.dismiss();
+
+  const [dialog2] = await Promise.all([
+    page.waitForEvent('dialog'),
+    page.close({ runBeforeUnload: true })
+  ]);
+
+  await dialog2.dismiss();
+});
+
+it('should support closing the page after a previous dismiss', async ({ page, server }) => {
+  await page.goto(server.EMPTY_PAGE);
+
+  await page.evaluate(() => {
+    window.onbeforeunload = () => true;
+  });
+
+  const [dialog] = await Promise.all([
+    page.waitForEvent('dialog'),
+    page.close({ runBeforeUnload: true })
+  ]);
+
+  await dialog.dismiss();
+
+  await page.close();
+  await expect(page.isClosed()).toBe(true);
+});
+
+it('should support closing the page via a subsequent onbeforeunload dialog', async ({ page, server }) => {
+  await page.goto(server.EMPTY_PAGE);
+
+  await page.evaluate(() => {
+    window.onbeforeunload = () => true;
+  });
+
+  const [dialog] = await Promise.all([
+    page.waitForEvent('dialog'),
+    page.close({ runBeforeUnload: true })
+  ]);
+
+  await dialog.accept();
+
+  await page.waitForEvent('close');
+  await expect(page.isClosed()).toBe(true);
+});


### PR DESCRIPTION
Fixes #37597.

When `page.close()` is called, a `closing` state is currently assigned to the page, preventing any subsequent delegate calls to `close` on that page. This prevents both opening subsequent dialogs as well as actual page closes. This check is used solely for preventing double close.