### PR TITLE
fix(trace-viewer): don't show loading view when in error state

### DIFF
--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -169,7 +169,7 @@ export const WorkbenchLoader: React.FunctionComponent<{
     })();
   }, [isServer, traceURLs, uploadedTraceNames]);
 
-  const showLoading = progress.done !== progress.total && progress.total !== 0;
+  const showLoading = progress.done !== progress.total && progress.total !== 0 && !processingErrorMessage;
 
   React.useEffect(() => {
     if (showLoading) {


### PR DESCRIPTION
Fixes #37604