### PR TITLE
fix(trace): Show vertical scrollbar fully in network request details tab

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -15,7 +15,6 @@
 */
 
 .network-request-details-tab {
-  width: 100%;
   height: 100%;
   user-select: text;
   line-height: 24px;


### PR DESCRIPTION
Currently:
<img width="493" height="238" alt="image" src="https://github.com/user-attachments/assets/1d158a58-d566-4411-9705-19bfa7211209" />

With this PR:
<img width="480" height="238" alt="image" src="https://github.com/user-attachments/assets/6c6a862c-21eb-4d34-b362-c2d2762128b3" />

