### PR TITLE
fix(webkit): prepare for frame (OOPIF) targets

### DIFF
--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -308,6 +308,9 @@ export class WKPage implements PageDelegate {
         session.dispatchMessage({ id: message.id, error: { message: e.message } });
       });
     });
+    // TODO: support OOPIFs.
+    if (targetInfo.type === 'frame' as any)
+      return;
     assert(targetInfo.type === 'page', 'Only page targets are expected in WebKit, received: ' + targetInfo.type);
 
     if (!targetInfo.isProvisional) {


### PR DESCRIPTION
Frame targets were introduced upstream in https://github.com/WebKit/WebKit/pull/50623 and cause some test failures on the recent roll https://github.com/microsoft/playwright-browsers/pull/1875. Ignore those targets for now to make the tests pass.