### PR TITLE
fix(ui mode): filter dialog positioning

### DIFF
--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -123,21 +123,24 @@ const SettingsButton: React.FC = () => {
   const [darkMode, setDarkMode] = useDarkModeSetting();
   const [mergeFiles, setMergeFiles] = useSetting('mergeFiles', false);
 
-  return <div
-    role='button'
-    ref={settingsRef}
-    style={{ cursor: 'pointer' }}
-    className='subnav-item'
-    title='Settings'
-    onClick={e => {
-      setSettingsOpen(!settingsOpen);
-      e.preventDefault();
-    }}
-    onMouseDown={preventDefault}>
+  return <>
+    <div
+      role='button'
+      ref={settingsRef}
+      style={{ cursor: 'pointer' }}
+      className='subnav-item'
+      title='Settings'
+      onClick={e => {
+        setSettingsOpen(!settingsOpen);
+        e.preventDefault();
+      }}
+      onMouseDown={preventDefault}>
+      {icons.settings()}
+    </div>
     <Dialog
       open={settingsOpen}
-      width={150}
-      verticalOffset={8}
+      minWidth={150}
+      verticalOffset={4}
       requestClose={() => setSettingsOpen(false)}
       anchor={settingsRef}
       dataTestId='settings-dialog'
@@ -151,8 +154,7 @@ const SettingsButton: React.FC = () => {
         Merge files
       </label>
     </Dialog>
-    {icons.settings()}
-  </div>;
+  </>;
 };
 
 const preventDefault = (e: any) => {

--- a/packages/injected/src/highlight.ts
+++ b/packages/injected/src/highlight.ts
@@ -215,6 +215,7 @@ export class Highlight {
     };
   }
 
+  // Note: there is a copy of this method in dialog.tsx. Please fix bugs in both places.
   tooltipPosition(box: DOMRect, tooltipElement: HTMLElement) {
     const tooltipWidth = tooltipElement.offsetWidth;
     const tooltipHeight = tooltipElement.offsetHeight;

--- a/packages/recorder/src/recorder.tsx
+++ b/packages/recorder/src/recorder.tsx
@@ -198,7 +198,6 @@ export const Recorder: React.FC<RecorderProps> = ({
       <Dialog
         style={{ padding: '4px 8px' }}
         open={settingsOpen}
-        width={200}
         verticalOffset={8}
         requestClose={() => setSettingsOpen(false)}
         anchor={settingsButtonRef}

--- a/packages/web/src/components/dialogToolbarButton.tsx
+++ b/packages/web/src/components/dialogToolbarButton.tsx
@@ -41,7 +41,6 @@ export const DialogToolbarButton: React.FC<React.PropsWithChildren<DialogToolbar
           padding: '4px 8px'
         }}
         open={open}
-        width={200}
         // TODO: Temporary spacing until design of toolbar buttons is revisited
         verticalOffset={8}
         requestClose={() => setOpen(false)}


### PR DESCRIPTION
Dialog position logic did not account for the viewport size. To fix this, copy logic from highlight.ts that does it for tooltips.
This issue was [reported here](https://github.com/microsoft/playwright/pull/37554#issuecomment-3339907649).

Dirve-by: make dialog measure its width instead of hardcoding 200, make `useMeasure()` return the full rect, not just size.