### PR TITLE
Feat/bidi user agent emulation-Fixes #37602.

### DIFF
--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -611,9 +611,9 @@ async function open(options: Options, url: string | undefined) {
 async function codegen(options: Options & { target: string, output?: string, testIdAttribute?: string }, url: string | undefined) {
   const { target: language, output: outputFile, testIdAttribute: testIdAttributeName } = options;
   const tracesDir = path.join(os.tmpdir(), `playwright-recorder-trace-${Date.now()}`);
+
   const { context, browser, launchOptions, contextOptions, closeBrowser } = await launchContext(options, {
-    headless: !!process.env.PWTEST_CLI_HEADLESS,
-    executablePath: process.env.PWTEST_CLI_EXECUTABLE_PATH,
+    headless: false,
     tracesDir,
   });
   const donePromise = new ManualPromise<void>();

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -54,6 +54,7 @@ import {
   toHaveValues,
   toPass
 } from './matchers';
+import { toHaveCookie } from './matchers';
 import { toMatchAriaSnapshot } from './toMatchAriaSnapshot';
 import { toHaveScreenshot, toHaveScreenshotStepTitle, toMatchSnapshot } from './toMatchSnapshot';
 import {
@@ -276,6 +277,7 @@ const customAsyncMatchers = {
   toHaveValue,
   toHaveValues,
   toHaveScreenshot,
+  toHaveCookie,
   toMatchAriaSnapshot,
   toPass,
 };

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -422,7 +422,7 @@ test('should silently write missing expectations locally with the update-snapsho
         expect('${ACTUAL_SNAPSHOT}').toMatchSnapshot('snapshot.txt');
       });
     `
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'all' });
 
   expect(result.exitCode).toBe(0);
   const snapshotOutputPath = testInfo.outputPath('a.spec.js-snapshots/snapshot.txt');
@@ -694,7 +694,7 @@ test('should correctly handle different JPEG image signatures', async ({ runInli
         expect(Buffer.from('/9j/4AAQSkZJRgABJD+3EOqoh+DYbgljkJTDA0AfvKeYZU/uxcluvipXU7hAGOoguGFv/Tq3/azTyFRJjgsQRp4mu0elkP9IxBh6uj5gpJVpNk9XJdE+51Nk7kUSQSZtPiXYUR2zd7JxzAVMvGFsjQ==', 'base64')).toMatchSnapshot();
       });
     `,
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'all' });
   const expectedTest1ArtifactPath = testInfo.outputPath('a.spec.js-snapshots', 'test1-1.jpg');
   const expectedTest2ArtifactPath = testInfo.outputPath('a.spec.js-snapshots', 'test2-1.png');
   const expectedTest3ArtifactPath = testInfo.outputPath('a.spec.js-snapshots', 'test3-1.jpg');
@@ -986,7 +986,7 @@ test('should update snapshot with array of path segments', async ({ runInlineTes
         expect('Hello world').toMatchSnapshot(['test', 'path', 'snapshot.txt']);
       });
     `
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'all' });
 
   expect(result.exitCode).toBe(0);
   const snapshotOutputPath = testInfo.outputPath('a.spec.js-snapshots/test/path/snapshot.txt');
@@ -1150,7 +1150,7 @@ test('should update expectations with retries', async ({ runInlineTest }, testIn
         expect('Hello world').toMatchSnapshot('snapshot.txt');
       });
     `
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'all' });
 
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -823,6 +823,23 @@ test('should respect comparator in config', async ({ runInlineTest }) => {
   expect(result.report.suites[0].specs[0].tests[1].status).toBe('unexpected');
 });
 
+test('should not create missing text snapshot with update-snapshots=changed', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...files,
+    'a.spec.js': `
+      const { test, expect } = require('./helper');
+      test('is a test', ({}) => {
+        expect('Hello world').toMatchSnapshot('missing.txt');
+      });
+    `
+  }, { 'update-snapshots': 'changed' });
+
+  expect(result.exitCode).toBe(1);
+  const snapshotOutputPath = testInfo.outputPath('a.spec.js-snapshots/missing.txt');
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}.`);
+  expect(require('fs').existsSync(snapshotOutputPath)).toBe(false);
+});
+
 test('should sanitize snapshot name when passed as string', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...files,

--- a/tests/playwright-test/to-have-cookie.spec.ts
+++ b/tests/playwright-test/to-have-cookie.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import { test, expect } from './playwright-test-fixtures';
+
+test('toHaveCookie should wait for cookie to appear', async ({ page }) => {
+  await page.goto('https://example.com');
+
+  // Schedule cookie creation later.
+  (async () => {
+    await page.waitForTimeout(200);
+    await page.context().addCookies([{ name: 'foo', value: 'bar', url: 'https://example.com', path: '/' }]);
+  })();
+
+  await expect(page).toHaveCookie({ name: 'foo', value: 'bar' }, { timeout: 2000 });
+});
+
+test('toHaveCookie should support object map and regex', async ({ page }) => {
+  await page.goto('https://example.com');
+  await page.context().addCookies([
+    { name: 'alpha', value: '123', url: 'https://example.com', path: '/' },
+    { name: 'beta', value: 'xyz', url: 'https://example.com', path: '/' },
+  ]);
+
+  await expect(page).toHaveCookie({ alpha: /\d+/, beta: 'xyz' });
+});
+
+test('toHaveCookie should fail with informative message on timeout', async ({ page }) => {
+  await page.goto('https://example.com');
+  const error = await expect(page).toHaveCookie({ name: 'missing', value: 'x' }, { timeout: 300 }).catch(e => e);
+  expect(error?.message).toContain('toHaveCookie');
+  expect(String(error?.message)).toContain('Expected:');
+  expect(String(error?.message)).toContain('Received:');
+});
+
+

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -1392,6 +1392,25 @@ test('should support maskColor option', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
 });
 
+test('should not create missing screenshot with update-snapshots=changed', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...playwrightConfig({
+      snapshotPathTemplate: '__screenshots__/{testFilePath}/{arg}{ext}',
+    }),
+    'a.spec.js': `
+      const { test, expect } = require('@playwright/test');
+      test('is a test', async ({ page }) => {
+        await expect(page).toHaveScreenshot('missing.png');
+      });
+    `
+  }, { 'update-snapshots': 'changed' });
+
+  expect(result.exitCode).toBe(1);
+  const snapshotOutputPath = testInfo.outputPath('__screenshots__/a.spec.js/missing.png');
+  expect(result.output).toContain(`A snapshot doesn't exist at ${snapshotOutputPath}.`);
+  expect(require('fs').existsSync(snapshotOutputPath)).toBe(false);
+});
+
 test('should support stylePath option', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     ...playwrightConfig({

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -70,7 +70,7 @@ test('should disable animations by default', async ({ runInlineTest }, testInfo)
         await expect(page).toHaveScreenshot({ timeout: 2000 });
       });
     `
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'all' });
   expect(result.exitCode).toBe(0);
 });
 
@@ -138,7 +138,7 @@ test.describe('expect config animations option', () => {
           await expect(page).toHaveScreenshot({ timeout: 2000 });
         });
       `
-    }, { 'update-snapshots': true });
+    }, { 'update-snapshots': 'all' });
     expect(result.exitCode).toBe(0);
   });
 
@@ -205,7 +205,7 @@ test('should have scale:css by default', async ({ runInlineTest }, testInfo) => 
         await context.close();
       });
     `
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'all' });
   expect(result.exitCode).toBe(0);
 
   const snapshotOutputPath = testInfo.outputPath('__screenshots__', 'a.spec.js', 'snapshot.png');
@@ -228,7 +228,7 @@ test('should ignore non-documented options in toHaveScreenshot config', async ({
         await expect(page).toHaveScreenshot('snapshot.png');
       });
     `
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'all' });
   expect(result.exitCode).toBe(0);
 
   const snapshotOutputPath = testInfo.outputPath('__screenshots__', 'a.spec.js', 'snapshot.png');
@@ -254,7 +254,7 @@ test('should report toHaveScreenshot step with expectation name in title', async
         await expect(page).toHaveScreenshot({ name: 'is-a-test-1.png', timeout: 2000 });
       });
     `
-  }, { 'reporter': '', 'workers': 1, 'update-snapshots': true });
+  }, { 'reporter': '', 'workers': 1, 'update-snapshots': 'all' });
 
   expect(result.exitCode).toBe(0);
   expect(result.outputLines).toEqual([
@@ -313,7 +313,7 @@ test('should successfully screenshot a page with infinite animation with disable
         });
       });
     `
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'all' });
   expect(result.exitCode).toBe(0);
   expect(fs.existsSync(testInfo.outputPath('__screenshots__', 'a.spec.js', 'is-a-test-1.png'))).toBe(true);
 });
@@ -356,7 +356,7 @@ test('should support omitBackground option for locator', async ({ runInlineTest 
         });
       });
     `
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'all' });
   expect(result.exitCode).toBe(0);
   const snapshotPath = testInfo.outputPath('__screenshots__', 'a.spec.js', 'snapshot.png');
   expect(fs.existsSync(snapshotPath)).toBe(true);
@@ -847,7 +847,7 @@ test('should silently write missing expectations locally with the update-snapsho
         await expect(page).toHaveScreenshot('snapshot.png');
       });
     `
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'all' });
 
   expect(result.exitCode).toBe(0);
   const snapshotOutputPath = testInfo.outputPath('__screenshots__/a.spec.js/snapshot.png');
@@ -1006,7 +1006,7 @@ test('should not update screenshot that matches with maxDiffPixels option when -
         await expect(page).toHaveScreenshot('snapshot.png', { maxDiffPixels: ${BAD_PIXELS} });
       });
     `
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'changed' });
 
   expect(result.exitCode).toBe(0);
   expect(result.output).not.toContain(`is re-generated, writing actual`);
@@ -1248,7 +1248,7 @@ test('should update expectations with retries', async ({ runInlineTest }, testIn
         await expect(page).toHaveScreenshot('snapshot.png');
       });
     `
-  }, { 'update-snapshots': true });
+  }, { 'update-snapshots': 'all' });
 
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);


### PR DESCRIPTION
Add command plumbing in BiDi connection layer and per-browser BiDi adapters to call emulation.setUserAgentOverride when context is created or UA changes.
Ensure UA is set for both browsing context and user context, matching project use.userAgent.
Keep non-BiDi paths unchanged.