### PR TITLE
docs: fix typo in TestStep.category JSDoc

### DIFF
--- a/docs/src/test-reporter-api/class-teststep.md
+++ b/docs/src/test-reporter-api/class-teststep.md
@@ -14,7 +14,7 @@ Step category to differentiate steps with different origin and verbosity. Built-
 * `hook` for hooks initialization and teardown
 * `pw:api` for Playwright API calls.
 * `test.step` for test.step API calls.
-* `test.attach` for test attachmen calls.
+* `test.attach` for testInfo.attach API calls.
 
 
 ## property: TestStep.duration

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -773,7 +773,7 @@ export interface TestStep {
    * - `hook` for hooks initialization and teardown
    * - `pw:api` for Playwright API calls.
    * - `test.step` for test.step API calls.
-   * - `test.attach` for test attachmen calls.
+   * - `test.attach` for testInfo.attach API calls.
    */
   category: string;
 


### PR DESCRIPTION
Remove the `attachmen` mis-spelling and additionally clarify that `attach` is called on `testInfo`.