### PR TITLE
fix(Typescript) Add optional property to Location interface …

### DIFF
--- a/docs/src/test-api/class-location.md
+++ b/docs/src/test-api/class-location.md
@@ -21,3 +21,8 @@ Line number in the source file.
 - type: <[int]>
 
 Column number in the source file.
+
+## property: Location.function
+- type: <[string]>
+
+Qualified name of the function.

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -9772,6 +9772,11 @@ export interface Location {
    * Line number in the source file.
    */
   line: number;
+
+  /**
+   * Qualified name of the function.
+   */
+  function?: string;
 }
 
 /**


### PR DESCRIPTION
Add optional property to Location interface to match isomorphic type StackFrame.

The source of this data is the isomporphic utility. The `function` property was added to the StackFrame type in this commit:
https://github.com/microsoft/playwright/commit/8b28e637c8ca117aa225889f2afd2bf8c0d3cb7c#diff-27c1f1c695e7913344be9ed8453aada352203f36d76aeb938de35adaf07a6388R24

(Found this while working on a custom reporter and I wanted to filter some test steps using this function name.)