### PR TITLE
chore(cli): display init-agents help by default

### DIFF
--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -187,6 +187,8 @@ function addInitAgentsCommand(program: Command) {
       await initVSCodeRepo();
     else if (opts.loop === 'claude')
       await initClaudeCodeRepo();
+    else
+      command.help();
   });
 }
 


### PR DESCRIPTION
```
➜  npx playwright init-agents
Usage: npx playwright init-agents [options]

Initialize repository agents for the Claude Code

Options:
  --loop <loop>  Agentic loop provider (choices: "code", "claude", "opencode")
  -h, --help     display help for command
```