### PR TITLE
chore(html): show empty state when all tests are filtered out

### DIFF
--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -85,3 +85,16 @@
   flex-basis: 100%;
   height: 0;
 }
+
+.no-test-files {
+  margin-top: 12px;
+
+  color: var(--color-fg-muted);
+  background-color: unset;
+
+  font-weight: unset;
+
+  border: 1px solid var(--color-border-default);
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+}

--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -86,7 +86,7 @@
   height: 0;
 }
 
-.no-test-files {
+.test-file-no-files {
   margin-top: 12px;
 
   color: var(--color-fg-muted);

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -62,7 +62,7 @@ export const TestFilesView: React.FC<{
           }}>
         </TestFileView>;
       })
-      : <div className='chip-header no-test-files'>No tests found</div>}
+      : <div className='chip-header test-file-no-files'>No tests found</div>}
   </>;
 };
 

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -18,6 +18,7 @@ import type { FilteredStats, HTMLReport, TestFileSummary } from './types';
 import * as React from 'react';
 import { TestFileView } from './testFileView';
 import './testFileView.css';
+import './chip.css';
 import { msToString } from './utils';
 import { AutoChip } from './chip';
 import { CodeSnippet } from './testErrorView';
@@ -42,24 +43,26 @@ export const TestFilesView: React.FC<{
     return result;
   }, [tests]);
   return <>
-    {filteredFiles.map(({ file, defaultExpanded }) => {
-      return <TestFileView
-        key={`file-${file.fileId}`}
-        file={file}
-        projectNames={projectNames}
-        isFileExpanded={fileId => {
-          const value = expandedFiles.get(fileId);
-          if (value === undefined)
-            return defaultExpanded;
-          return !!value;
-        }}
-        setFileExpanded={(fileId, expanded) => {
-          const newExpanded = new Map(expandedFiles);
-          newExpanded.set(fileId, expanded);
-          setExpandedFiles(newExpanded);
-        }}>
-      </TestFileView>;
-    })}
+    {filteredFiles.length > 0 ?
+      filteredFiles.map(({ file, defaultExpanded }) => {
+        return <TestFileView
+          key={`file-${file.fileId}`}
+          file={file}
+          projectNames={projectNames}
+          isFileExpanded={fileId => {
+            const value = expandedFiles.get(fileId);
+            if (value === undefined)
+              return defaultExpanded;
+            return !!value;
+          }}
+          setFileExpanded={(fileId, expanded) => {
+            const newExpanded = new Map(expandedFiles);
+            newExpanded.set(fileId, expanded);
+            setExpandedFiles(newExpanded);
+          }}>
+        </TestFileView>;
+      })
+      : <div className='chip-header no-test-files'>No tests found</div>}
   </>;
 };
 


### PR DESCRIPTION
Currently when the user filters down to no tests, the layout has nothing to pull your eye to indicate what happened. Add a specific "No tests found" message in the same general style as the chips to properly convey there's no additional information.

<img width="188" height="135" alt="Screenshot 2025-09-29 at 10 08 08 AM" src="https://github.com/user-attachments/assets/7ea55709-9336-4cee-96de-261eddca1668" />

<img width="168" height="148" alt="Screenshot 2025-09-29 at 10 07 20 AM" src="https://github.com/user-attachments/assets/7c8a1c90-229e-471e-999f-9378dc7df8bb" />
