### PR TITLE
fix(snapshot): draw a minimum size browser window for small snapshots

### DIFF
--- a/packages/trace-viewer/src/ui/snapshotTab.css
+++ b/packages/trace-viewer/src/ui/snapshotTab.css
@@ -81,7 +81,7 @@
   height: calc(100% - var(--browser-frame-header-height));
 
   /* CSS checkerboard */
-  background: conic-gradient(#eee 25%, #aaa 0 50%, #eee 0 75%, #aaa 0) 0 0 / 40px 40px;
+  background: conic-gradient(#eee 25%, #ddd 0 50%, #eee 0 75%, #ddd 0) 0 0 / 40px 40px;
 }
 
 .snapshot-switcher {

--- a/packages/trace-viewer/src/ui/snapshotTab.css
+++ b/packages/trace-viewer/src/ui/snapshotTab.css
@@ -77,9 +77,16 @@
   box-shadow: 0 12px 28px 0 rgba(0,0,0,.2),0 2px 4px 0 rgba(0,0,0,.1);
 }
 
+.snapshot-browser-body {
+  height: calc(100% - var(--browser-frame-header-height));
+
+  /* CSS checkerboard */
+  background: conic-gradient(#eee 25%, #aaa 0 50%, #eee 0 75%, #aaa 0) 0 0 / 40px 40px;
+}
+
 .snapshot-switcher {
   width: 100%;
-  height: calc(100% - var(--browser-frame-header-height));
+  height: 100%;
   position: relative;
 }
 

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -195,23 +195,35 @@ const SnapshotWrapper: React.FunctionComponent<React.PropsWithChildren<{
   const windowHeaderHeight = 40;
   const snapshotContainerSize = {
     width: snapshotInfo.viewport.width,
-    height: snapshotInfo.viewport.height + windowHeaderHeight,
+    height: snapshotInfo.viewport.height,
   };
 
-  const scale = Math.min(measure.width / snapshotContainerSize.width, measure.height / snapshotContainerSize.height, 1);
+  const renderedBrowserFrameSize = {
+    width: Math.max(snapshotContainerSize.width, 480),
+    height: Math.max(snapshotContainerSize.height + windowHeaderHeight, 320),
+  };
+
+  const scale = Math.min(measure.width / renderedBrowserFrameSize.width, measure.height / renderedBrowserFrameSize.height, 1);
   const translate = {
-    x: (measure.width - snapshotContainerSize.width) / 2,
-    y: (measure.height - snapshotContainerSize.height) / 2,
+    x: (measure.width - renderedBrowserFrameSize.width) / 2,
+    y: (measure.height - renderedBrowserFrameSize.height) / 2,
   };
 
   return <div ref={ref} className='snapshot-wrapper'>
     <div className='snapshot-container' style={{
-      width: snapshotContainerSize.width + 'px',
-      height: snapshotContainerSize.height + 'px',
+      width: renderedBrowserFrameSize.width + 'px',
+      height: renderedBrowserFrameSize.height + 'px',
       transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
     }}>
       <BrowserFrame url={snapshotInfo.url} />
-      {children}
+      <div className='snapshot-browser-body'>
+        <div style={{
+          width: snapshotContainerSize.width + 'px',
+          height: snapshotContainerSize.height + 'px',
+        }}>
+          {children}
+        </div>
+      </div>
     </div>
   </div>;
 };


### PR DESCRIPTION
DOM snapshots can be very small, to the point that our "browser" chrome around the document no longer displays correctly. Set a minimum width and height for our "browser", marking out of bounds areas with a checkerboard pattern.

<img width="1392" height="912" alt="Screenshot 2025-09-29 at 11 13 56 AM" src="https://github.com/user-attachments/assets/a0e8a89e-62d3-4f72-959a-a168f4202fc4" />
<img width="2360" height="1451" alt="Screenshot 2025-09-29 at 11 14 01 AM" src="https://github.com/user-attachments/assets/869c0ca8-a530-4f84-aa4b-28b98d0db01e" />
<img width="2360" height="1451" alt="Screenshot 2025-09-29 at 11 14 04 AM" src="https://github.com/user-attachments/assets/2f8f3e2f-2bf0-4ebe-a7d9-179f2ee07b96" />
