### PR TITLE
devops: drop macos 13 runners, add macos 26 for webkit

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -52,12 +52,10 @@ jobs:
       matrix:
         # Intel: *-large
         # Arm64: *-xlarge
-        os: [macos-13-large, macos-13-xlarge, macos-14-large, macos-14-xlarge]
+        os: [macos-14-large, macos-14-xlarge, macos-15-large, macos-15-xlarge]
         browser: [chromium, firefox, webkit]
         include:
-          - os: macos-15-large
-            browser: webkit
-          - os: macos-15-xlarge
+          - os: macos-26-xlarge
             browser: webkit
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
* Our minimal supported version has been macOS 14 for a while and the webkit tests have been flaky there recently even though the webkit version is pinned.
* There is only Arm [image](https://github.com/actions/runner-images) for macOS 26.