### PR TITLE
fix: allow screenshot capture when filename is an empty string

### DIFF
--- a/packages/playwright/src/mcp/browser/tools/screenshot.ts
+++ b/packages/playwright/src/mcp/browser/tools/screenshot.ts
@@ -24,9 +24,7 @@ import type * as playwright from 'playwright-core';
 const screenshotSchema = z.object({
   type: z.enum(['png', 'jpeg']).default('png').describe('Image format for the screenshot. Default is png.'),
   filename: z.preprocess((v) => {
-    if (v === '') {
-      return null;
-    }
+    if (v === '') return null;
     return v;
   }, z.string().nullable()).optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.'),

--- a/packages/playwright/src/mcp/browser/tools/screenshot.ts
+++ b/packages/playwright/src/mcp/browser/tools/screenshot.ts
@@ -23,8 +23,10 @@ import type * as playwright from 'playwright-core';
 
 const screenshotSchema = z.object({
   type: z.enum(['png', 'jpeg']).default('png').describe('Image format for the screenshot. Default is png.'),
-  filename: z.preprocess((v) => {
-    if (v === '') return null;
+  filename: z.preprocess(v => {
+    if (v === '')
+      return null;
+
     return v;
   }, z.string().nullable()).optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.'),

--- a/packages/playwright/src/mcp/browser/tools/screenshot.ts
+++ b/packages/playwright/src/mcp/browser/tools/screenshot.ts
@@ -23,7 +23,12 @@ import type * as playwright from 'playwright-core';
 
 const screenshotSchema = z.object({
   type: z.enum(['png', 'jpeg']).default('png').describe('Image format for the screenshot. Default is png.'),
-  filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
+  filename: z.preprocess((v) => {
+    if (v === '') {
+      return null;
+    }
+    return v;
+  }, z.string().nullable()).optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.'),
   ref: z.string().optional().describe('Exact target element reference from the page snapshot. If not provided, the screenshot will be taken of viewport. If ref is provided, element must be provided too.'),
   fullPage: z.boolean().optional().describe('When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.'),

--- a/packages/playwright/src/mcp/browser/tools/screenshot.ts
+++ b/packages/playwright/src/mcp/browser/tools/screenshot.ts
@@ -23,12 +23,7 @@ import type * as playwright from 'playwright-core';
 
 const screenshotSchema = z.object({
   type: z.enum(['png', 'jpeg']).default('png').describe('Image format for the screenshot. Default is png.'),
-  filename: z.preprocess(v => {
-    if (v === '')
-      return null;
-
-    return v;
-  }, z.string().nullable()).optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
+  filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.'),
   ref: z.string().optional().describe('Exact target element reference from the page snapshot. If not provided, the screenshot will be taken of viewport. If ref is provided, element must be provided too.'),
   fullPage: z.boolean().optional().describe('When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.'),
@@ -51,7 +46,7 @@ const screenshot = defineTabTool({
       throw new Error('fullPage cannot be used with element screenshots.');
 
     const fileType = params.type || 'png';
-    const fileName = await tab.context.outputFile(params.filename ?? dateAsFileName(fileType), { origin: 'llm', reason: 'Saving screenshot' });
+    const fileName = await tab.context.outputFile(params.filename || dateAsFileName(fileType), { origin: 'llm', reason: 'Saving screenshot' });
     const options: playwright.PageScreenshotOptions = {
       type: fileType,
       quality: fileType === 'png' ? undefined : 90,

--- a/tests/mcp/screenshot.spec.ts
+++ b/tests/mcp/screenshot.spec.ts
@@ -17,7 +17,6 @@
 import fs from 'fs';
 
 import { test, expect } from './fixtures';
-import { text } from 'stream/consumers';
 
 test('browser_take_screenshot (viewport)', async ({ startClient, server }, testInfo) => {
   const { client } = await startClient({

--- a/tests/mcp/screenshot.spec.ts
+++ b/tests/mcp/screenshot.spec.ts
@@ -196,7 +196,7 @@ test('browser_take_screenshot (filename is empty string)', async ({ startClient,
     content: [
       {
         text: expect.stringMatching(
-          new RegExp(`page-\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}\\-\\d{3}Z\\.png`)
+            new RegExp(`page-\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}\\-\\d{3}Z\\.png`)
         ),
         type: 'text',
       },

--- a/tests/mcp/screenshot.spec.ts
+++ b/tests/mcp/screenshot.spec.ts
@@ -17,6 +17,7 @@
 import fs from 'fs';
 
 import { test, expect } from './fixtures';
+import { text } from 'stream/consumers';
 
 test('browser_take_screenshot (viewport)', async ({ startClient, server }, testInfo) => {
   const { client } = await startClient({
@@ -174,6 +175,49 @@ test('browser_take_screenshot (default type should be png)', async ({ startClien
   expect(files).toHaveLength(1);
   expect(files[0]).toMatch(/^page-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.png$/);
 });
+
+test('browser_take_screenshot (filename is empty string)', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir },
+  });
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    code: expect.stringContaining(`page.goto('http://localhost`),
+  });
+
+  expect(await client.callTool({
+    name: 'browser_take_screenshot',
+    arguments: {
+      filename: '',
+    },
+  })).toEqual({
+    content: [
+      {
+        text: expect.stringMatching(
+          new RegExp(`page-\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}\\-\\d{3}Z\\.png`)
+        ),
+        type: 'text',
+      },
+      {
+        data: expect.any(String),
+        mimeType: 'image/png',
+        type: 'image',
+      },
+    ],
+  });
+
+  const files = [...fs.readdirSync(outputDir)].filter(f => f.endsWith('.png'));
+
+  expect(fs.existsSync(outputDir)).toBeTruthy();
+  expect(files).toHaveLength(1);
+  expect(files[0]).toMatch(
+      new RegExp(`^page-\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}-\\d{3}Z\\.png$`)
+  );
+});
+
 
 test('browser_take_screenshot (filename: "output.png")', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');


### PR DESCRIPTION
## Problem
- Screenshot saving failed when an empty string ("") was passed as the filename.
- The resolver treated the empty string as a path to a directory end and incorrectly flagged it as `file path for  is outside` returning an error response instead of an image.

<img width="1055" height="516" alt="image" src="https://github.com/user-attachments/assets/7c5f059a-8f85-41bc-b57d-c53950a2a504" alt="Failing test screenshot" />

## Root Cause
- The logic for assigning a default filename handled cases where the parameter was omitted, but it did not account for cases where an empty string was explicitly provided.

## Fix
- Treat empty filename as null.
- Let the existing defaulting path assign the default filename (e.g., `page-YYYY-MM-DDTHH-mm-ss-SSSZ.png`) in the output directory.

## Behavior Changes
- Before: empty string → error response.
- After: empty string → screenshot is saved with a default filename, normal success payload.