### PR TITLE
chore: remove the wrong heap test

### DIFF
--- a/tests/stress/heap.spec.ts
+++ b/tests/stress/heap.spec.ts
@@ -81,18 +81,6 @@ test('should not leak dispatchers after closing page', async ({ context, server 
   expect(await queryObjectCount(require('../../packages/playwright-core/lib/client/network').Response)).toBe(0);
 });
 
-test('should not leak requests over 100', async ({ context, server }) => {
-  const page = await context.newPage();
-  await page.goto(server.PREFIX + '/title.html');
-  for (let i = 0; i < 100; ++i)
-    await page.evaluate(url => fetch(url), server.EMPTY_PAGE);
-  await page.requests();
-  for (let i = 0; i < 200; ++i)
-    await page.evaluate(url => fetch(url), server.EMPTY_PAGE);
-  await page.requests();
-  expect(await queryObjectCount(require('../../packages/playwright-core/lib/server/dispatchers/networkDispatchers').RequestDispatcher)).toBeLessThanOrEqual(100);
-});
-
 test.describe(() => {
   test.beforeEach(() => {
     require('../../packages/playwright-core/lib/server/dispatchers/dispatcher').setMaxDispatchersForTest(100);


### PR DESCRIPTION
The behavior has been changed in #37612, so the test is not needed anymore.