### PR TITLE
chore(ui-mode): properly communicate file lookups over trace server connection

### DIFF
--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -192,7 +192,7 @@ async function doFetch(event: FetchEvent): Promise<Response> {
       return new Response(null, { status: 404 });
     }
 
-    // There may be no trailing slash, and we only care about the `path` query param
+    // There will be no trailing slash, and we only care about the `path` query param
     if (relativePath === '/file') {
       const path = urlInScope.searchParams.get('path')!;
       const traceViewConnection = getOrCreateServerConnection(client, undefined);


### PR DESCRIPTION
#33542 was intended to decouple the UI Mode interface from the underlying webserver, allowing it to connect to the trace server and webserver separately. The core functionality, file retrieval, appears to not have functioned as expected.

* The functionality watched for service worker connections on `/file/` (trailing slash), but these routes do not have any further content in the URL path, but have it all in a query string. So the route to hit is actually `/file` (no trailing slash), so this code never ran.
* Even if you do have the code run, it relies on a trace server connection to be active. The code as written only establishes a trace server connection object once you load a trace for the first time. This means if you load the UI and don't start running a test, you cannot retrieve any files.

This previously worked because the route we catch on the service worker (`/trace/file`) also happens to be a valid route on our webserver/trace server, with the same usage semantics. These requests were bypassing the service worker and going directly to the service.

----

This change makes all of the requests go through the service worker as expected. This has the side effect of fixing file previous in HMR mode.