### PR TITLE
fix(trace-viewer): decode + quote report path in fallback “Copy Command” (file://) 

### DIFF
--- a/packages/trace-viewer/index.html
+++ b/packages/trace-viewer/index.html
@@ -16,37 +16,65 @@
 <!DOCTYPE html>
 <html lang="en" translate="no">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="/playwright-logo.svg" type="image/svg+xml">
-    <link rel="manifest" href="/manifest.webmanifest">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/playwright-logo.svg" type="image/svg+xml" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <title>Playwright Trace Viewer</title>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
     <dialog id="fallback-error">
-      <p>The Playwright Trace Viewer must be loaded over the <code>http://</code> or <code>https://</code> protocols.</p>
-      <p>For more information, please see the <a href="https://aka.ms/playwright/trace-viewer-file-protocol">docs</a>.</p>
+      <p>
+        The Playwright Trace Viewer must be loaded over the
+        <code>http://</code> or <code>https://</code> protocols.
+      </p>
+      <p>
+        For more information, please see the
+        <a href="https://aka.ms/playwright/trace-viewer-file-protocol">docs</a>.
+      </p>
     </dialog>
     <script>
       if (!/^https?:/.test(window.location.protocol)) {
-        const fallbackErrorDialog = document.getElementById('fallback-error');
-        const isTraceViewerInsidePlaywrightReport = window.location.protocol === 'file:' && window.location.pathname.endsWith('/trace/index.html');
-        // Best-effort to show the report path in the dialog.
+        const fallbackErrorDialog = document.getElementById("fallback-error");
+
+        const isTraceViewerInsidePlaywrightReport =
+          window.location.protocol === "file:" &&
+          decodeURIComponent(window.location.pathname).endsWith(
+            "/trace/index.html"
+          );
+
         if (isTraceViewerInsidePlaywrightReport) {
+          const basePathname = decodeURIComponent(window.location.pathname);
+          const base = basePathname.replace(/\/trace\/index\.html$/, "");
+
           const reportPath = (() => {
-            const base = window.location.pathname.replace(/\/trace\/index\.html$/, '');
-            if (navigator.platform === 'Win32')
-              return base.replace(/^\//, '').replace(/\//g, '\\\\');
+            if (navigator.platform === "Win32") {
+              return base.replace(/^\//, "").replace(/\//g, "\\");
+            }
             return base;
           })();
-          const reportLink = document.createElement('div');
-          const command = `npx playwright show-report ${reportPath}`;
-          reportLink.innerHTML = `You can open the report via <code>${command}</code> from your Playwright project. <button type="button">Copy Command</button>`;
-          fallbackErrorDialog.insertBefore(reportLink, fallbackErrorDialog.children[1]);
-          reportLink.querySelector('button').addEventListener('click', () => navigator.clipboard.writeText(command));
+
+          const command = `npx playwright show-report "${reportPath}"`;
+
+          const reportLink = document.createElement("div");
+          reportLink.innerHTML =
+            `You can open the report via <code>${command}</code> from your Playwright project. ` +
+            `<button type="button">Copy Command</button>`;
+          fallbackErrorDialog.insertBefore(
+            reportLink,
+            fallbackErrorDialog.children[1]
+          );
+
+          const copyBtn = reportLink.querySelector("button");
+          if (copyBtn) {
+            copyBtn.addEventListener("click", () =>
+              navigator.clipboard.writeText(command)
+            );
+          }
         }
+
         fallbackErrorDialog.show();
       }
     </script>

--- a/packages/trace-viewer/index.html
+++ b/packages/trace-viewer/index.html
@@ -16,65 +16,37 @@
 <!DOCTYPE html>
 <html lang="en" translate="no">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="/playwright-logo.svg" type="image/svg+xml" />
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="/playwright-logo.svg" type="image/svg+xml">
+    <link rel="manifest" href="/manifest.webmanifest">
     <title>Playwright Trace Viewer</title>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
     <dialog id="fallback-error">
-      <p>
-        The Playwright Trace Viewer must be loaded over the
-        <code>http://</code> or <code>https://</code> protocols.
-      </p>
-      <p>
-        For more information, please see the
-        <a href="https://aka.ms/playwright/trace-viewer-file-protocol">docs</a>.
-      </p>
+      <p>The Playwright Trace Viewer must be loaded over the <code>http://</code> or <code>https://</code> protocols.</p>
+      <p>For more information, please see the <a href="https://aka.ms/playwright/trace-viewer-file-protocol">docs</a>.</p>
     </dialog>
     <script>
       if (!/^https?:/.test(window.location.protocol)) {
-        const fallbackErrorDialog = document.getElementById("fallback-error");
-
-        const isTraceViewerInsidePlaywrightReport =
-          window.location.protocol === "file:" &&
-          decodeURIComponent(window.location.pathname).endsWith(
-            "/trace/index.html"
-          );
-
+        const fallbackErrorDialog = document.getElementById('fallback-error');
+        const isTraceViewerInsidePlaywrightReport = window.location.protocol === 'file:' && window.location.pathname.endsWith('/trace/index.html');
+        // Best-effort to show the report path in the dialog.
         if (isTraceViewerInsidePlaywrightReport) {
-          const basePathname = decodeURIComponent(window.location.pathname);
-          const base = basePathname.replace(/\/trace\/index\.html$/, "");
-
           const reportPath = (() => {
-            if (navigator.platform === "Win32") {
-              return base.replace(/^\//, "").replace(/\//g, "\\");
-            }
+            const base = decodeURIComponent(window.location.pathname).replace(/\/trace\/index\.html$/, '');
+            if (navigator.platform === 'Win32')
+              return base.replace(/^\//, '').replace(/\//g, '\\\\');
             return base;
           })();
-
+          const reportLink = document.createElement('div');
           const command = `npx playwright show-report "${reportPath}"`;
-
-          const reportLink = document.createElement("div");
-          reportLink.innerHTML =
-            `You can open the report via <code>${command}</code> from your Playwright project. ` +
-            `<button type="button">Copy Command</button>`;
-          fallbackErrorDialog.insertBefore(
-            reportLink,
-            fallbackErrorDialog.children[1]
-          );
-
-          const copyBtn = reportLink.querySelector("button");
-          if (copyBtn) {
-            copyBtn.addEventListener("click", () =>
-              navigator.clipboard.writeText(command)
-            );
-          }
+          reportLink.innerHTML = `You can open the report via <code>${command}</code> from your Playwright project. <button type="button">Copy Command</button>`;
+          fallbackErrorDialog.insertBefore(reportLink, fallbackErrorDialog.children[1]);
+          reportLink.querySelector('button').addEventListener('click', () => navigator.clipboard.writeText(command));
         }
-
         fallbackErrorDialog.show();
       }
     </script>

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -17,6 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 import url from 'url';
+import process from 'process';
 import { test as baseTest, expect as baseExpect, createImage } from './playwright-test-fixtures';
 import type { HttpServer } from '../../packages/playwright-core/lib/server/utils/httpServer';
 import { startHtmlReportServer } from '../../packages/playwright/lib/reporters/html';
@@ -2943,9 +2944,13 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.locator('.test-case-path')).toHaveText('Root describe');
     });
 
-    test('should print a user-friendly warning when opening a trace via file:// protocol', async ({ runInlineTest, showReport, page }) => {
-      await runInlineTest({
-        'playwright.config.ts': `
+    test('should print a user-friendly warning when opening a trace via file:// protocol', async ({
+      runInlineTest,
+      page,
+    }) => {
+      await runInlineTest(
+          {
+            'playwright.config.ts': `
           module.exports = {
             projects: [{
               name: 'chromium',
@@ -2956,18 +2961,35 @@ for (const useIntermediateMergeReport of [true, false] as const) {
             }]
           };
         `,
-        'a.test.js': `
+            'a.test.js': `
           import { test } from '@playwright/test';
           test('passes', ({ page }) => {});
         `,
-      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+          },
+          { reporter: 'dot,html' },
+          { PLAYWRIGHT_HTML_OPEN: 'never' }
+      );
 
       const reportPath = path.join(test.info().outputPath(), 'playwright-report');
-      await page.goto(url.pathToFileURL(path.join(reportPath, 'index.html')).toString());
+
+      await page.goto(
+          url.pathToFileURL(path.join(reportPath, 'index.html')).toString()
+      );
       await page.getByRole('link', { name: 'View trace' }).click();
-      await expect(page.locator('#fallback-error')).toContainText('The Playwright Trace Viewer must be loaded over the http:// or https:// protocols.');
-      await expect(page.locator('#fallback-error')).toContainText(`npx playwright show-report ${reportPath.replace(/\\/g, '\\\\')}`);
+
+      await expect(page.locator('#fallback-error')).toContainText(
+          'The Playwright Trace Viewer must be loaded over the http:// or https:// protocols.'
+      );
+
+      const expectedPath =
+        process.platform === 'win32'
+          ? reportPath.replace(/\\/g, '\\\\')
+          : reportPath;
+
+      const expectedCmd = `npx playwright show-report "${expectedPath}"`;
+      await expect(page.locator('#fallback-error')).toContainText(expectedCmd);
     });
+
 
     test('should not collate identical file names in different project directories', async ({ runInlineTest, page }) => {
       await runInlineTest({

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2981,12 +2981,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
           'The Playwright Trace Viewer must be loaded over the http:// or https:// protocols.'
       );
 
-      const expectedPath =
-        process.platform === 'win32'
-          ? reportPath.replace(/\\/g, '\\\\')
-          : reportPath;
-
-      const expectedCmd = `npx playwright show-report "${expectedPath}"`;
+      const expectedCmd = `npx playwright show-report "${reportPath}"`;
       await expect(page.locator('#fallback-error')).toContainText(expectedCmd);
     });
 

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2966,8 +2966,13 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       const reportPath = path.join(test.info().outputPath(), 'playwright-report');
       await page.goto(url.pathToFileURL(path.join(reportPath, 'index.html')).toString());
       await page.getByRole('link', { name: 'View trace' }).click();
-      await expect(page.locator('#fallback-error')).toContainText('The Playwright Trace Viewer must be loaded over the http:// or https:// protocols.');
-      await expect(page.locator('#fallback-error')).toContainText(`npx playwright show-report "${reportPath}"`);
+      await expect(page.locator('#fallback-error')).toContainText(
+          'The Playwright Trace Viewer must be loaded over the http:// or https:// protocols.'
+      );
+      const expectedReportPath = reportPath.replace(/\\/g, '\\\\');
+      await expect(page.locator('#fallback-error')).toContainText(
+          `npx playwright show-report "${expectedReportPath}"`
+      );
     });
 
 


### PR DESCRIPTION
Fixes #37709.
Updates the Trace Viewer fallback dialog (when opened via `file://`) to produce a **working** “Copy Command.”
It now **decodes** the URL path and **quotes** it (and normalizes slashes on Windows), so paths with spaces or special characters open correctly via `npx playwright show-report`.
