### PR TITLE
chore: disable RenderDocument feature

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -40,6 +40,8 @@ const disabledFeatures = (assistantMode?: boolean) => [
   'Translate',
   // See https://issues.chromium.org/u/1/issues/435410220
   'AutoDeElevate',
+  // See https://github.com/microsoft/playwright/issues/37714
+  'RenderDocument',
   assistantMode ? 'AutomationControlled' : '',
 ].filter(Boolean);
 


### PR DESCRIPTION
See #37714.

This should fix `chrome-beta` failures that happen when RenderDocument is enabled via fieldtrials on the particular bot, and unblock `chromium-tip-of-tree` rolls.