### PR TITLE
fix: `exposeBinding` should work in parallel

### DIFF
--- a/tests/page/page-expose-function.spec.ts
+++ b/tests/page/page-expose-function.spec.ts
@@ -292,3 +292,14 @@ it('should fail with busted Array.prototype.toJSON', async ({ page }) => {
 
   expect.soft(await page.evaluate(() => ([] as any).toJSON())).toBe('"[]"');
 });
+
+it('exposeBinding should work in parallel', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37712' } }, async ({ page }) => {
+  await Promise.all([
+    page.exposeBinding('foo', () => 42),
+    page.exposeBinding('bar', () => 42),
+  ]);
+  await page.evaluate(() => {
+    (window as any).foo();
+    (window as any).bar();
+  });
+});


### PR DESCRIPTION
This regressed in https://github.com/microsoft/playwright/commit/d57f1946931c3c99db8ca495fa5b14883fd3dc28 - there's a race condition in `exposePlaywrightBindingIfNeeded`.

Closes https://github.com/microsoft/playwright/issues/37712.