### PR TITLE
chore(mcp): fix file download test flake

### DIFF
--- a/tests/mcp/files.spec.ts
+++ b/tests/mcp/files.spec.ts
@@ -146,6 +146,6 @@ test('navigating to download link emits download', async ({ startClient, server,
       url: server.PREFIX + '/download',
     },
   })).toHaveResponse({
-    downloads: expect.stringContaining(`- Downloaded file test.txt to`),
+    downloads: expect.stringMatching(`- Downloaded file test\.txt to|- Downloading file test\.txt`),
   });
 });


### PR DESCRIPTION
Fix a racing MCP test condition where a download may not have finished by the time a navigation snapshot is taken.