### PR TITLE
test(bidi): fix the csv reporter

### DIFF
--- a/tests/bidi/csvReporter.ts
+++ b/tests/bidi/csvReporter.ts
@@ -58,8 +58,16 @@ class CsvReporter implements Reporter {
             row.push('fixme' + (fixme.description ? `: ${fixme.description}` : ''));
           } else {
             const result = test.results.find(r => r.error);
-            const errorMessage = stripAnsi(result?.error?.message.replace(/\s+/g, ' ').trim().substring(0, 1024));
-            row.push(csvEscape(errorMessage ?? ''));
+            if (result) {
+              const errorMessage = stripAnsi(result.error?.message.replace(/\s+/g, ' ').trim().substring(0, 1024) ?? '');
+              row.push(csvEscape(errorMessage));
+            } else {
+              const fail = test.annotations.find(a => a.type === 'fail');
+              if (fail)
+                row.push(csvEscape(`Should have failed: ${fail.description}`));
+              else
+                row.push('');
+            }
           }
           rows.push(row);
         }


### PR DESCRIPTION
The csv reporter currently fails if a passing test was annotated with `test.fail()`.