### PR TITLE
chore(mcp): close extension tab on disconnect

### DIFF
--- a/packages/playwright/src/mcp/browser/browserContextFactory.ts
+++ b/packages/playwright/src/mcp/browser/browserContextFactory.ts
@@ -45,6 +45,7 @@ export function contextFactory(config: FullConfig): BrowserContextFactory {
 export type BrowserContextFactoryResult = {
   browserContext: playwright.BrowserContext;
   close: (afterClose: () => Promise<void>) => Promise<void>;
+  closeCurrentTabBeforeClose?: boolean;
 };
 
 export interface BrowserContextFactory {

--- a/packages/playwright/src/mcp/browser/browserServerBackend.ts
+++ b/packages/playwright/src/mcp/browser/browserServerBackend.ts
@@ -26,6 +26,7 @@ import type { Tool } from './tools/tool';
 import type { BrowserContextFactory } from './browserContextFactory';
 import type * as mcpServer from '../sdk/server';
 import type { ServerBackend } from '../sdk/server';
+import type * as playwright from 'playwright';
 
 export class BrowserServerBackend implements ServerBackend {
   private _tools: Tool[];
@@ -33,11 +34,13 @@ export class BrowserServerBackend implements ServerBackend {
   private _sessionLog: SessionLog | undefined;
   private _config: FullConfig;
   private _browserContextFactory: BrowserContextFactory;
+  private _closePageOverride?: (page: playwright.Page) => Promise<void>;
 
-  constructor(config: FullConfig, factory: BrowserContextFactory) {
+  constructor(config: FullConfig, factory: BrowserContextFactory, closePageOverride?: (page: playwright.Page) => Promise<void>) {
     this._config = config;
     this._browserContextFactory = factory;
     this._tools = filteredTools(config);
+    this._closePageOverride = closePageOverride;
   }
 
   async initialize(server: mcpServer.Server, clientInfo: mcpServer.ClientInfo): Promise<void> {
@@ -47,6 +50,7 @@ export class BrowserServerBackend implements ServerBackend {
       browserContextFactory: this._browserContextFactory,
       sessionLog: this._sessionLog,
       clientInfo,
+      closePageOverride: this._closePageOverride,
     });
   }
 

--- a/packages/playwright/src/mcp/extension/cdpRelay.ts
+++ b/packages/playwright/src/mcp/extension/cdpRelay.ts
@@ -98,11 +98,11 @@ export class CDPRelayServer {
     return `${this._wsHost}${this._extensionPath}`;
   }
 
-  async ensureExtensionConnectionForMCPContext(clientInfo: ClientInfo, abortSignal: AbortSignal, toolName: string | undefined) {
+  async ensureExtensionConnectionForMCPContext(clientInfo: ClientInfo, abortSignal: AbortSignal, createNewTab: boolean) {
     debugLogger('Ensuring extension connection for MCP context');
     if (this._extensionConnection)
       return;
-    this._connectBrowser(clientInfo, toolName);
+    this._connectBrowser(clientInfo, createNewTab);
     debugLogger('Waiting for incoming extension connection');
     await Promise.race([
       this._extensionConnectionPromise,
@@ -114,7 +114,7 @@ export class CDPRelayServer {
     debugLogger('Extension connection established');
   }
 
-  private _connectBrowser(clientInfo: ClientInfo, toolName: string | undefined) {
+  private _connectBrowser(clientInfo: ClientInfo, createNewTab: boolean) {
     const mcpRelayEndpoint = `${this._wsHost}${this._extensionPath}`;
     // Need to specify "key" in the manifest.json to make the id stable when loading from file.
     const url = new URL('chrome-extension://jakfalbnbhgkpmoaakfflhflbfpkailf/connect.html');
@@ -125,8 +125,8 @@ export class CDPRelayServer {
     };
     url.searchParams.set('client', JSON.stringify(client));
     url.searchParams.set('protocolVersion', process.env.PWMCP_TEST_PROTOCOL_VERSION ?? protocol.VERSION.toString());
-    if (toolName)
-      url.searchParams.set('newTab', String(toolName === 'browser_navigate'));
+    if (createNewTab)
+      url.searchParams.set('newTab', String(createNewTab));
     const token = process.env.PLAYWRIGHT_MCP_EXTENSION_TOKEN;
     if (token)
       url.searchParams.set('token', token);

--- a/packages/playwright/src/mcp/index.ts
+++ b/packages/playwright/src/mcp/index.ts
@@ -21,7 +21,7 @@ import * as mcpServer from './sdk/server';
 
 import type { Config } from './config';
 import type { BrowserContext } from 'playwright';
-import type { BrowserContextFactory } from './browser/browserContextFactory';
+import type { BrowserContextFactory, BrowserContextFactoryResult } from './browser/browserContextFactory';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 
 const packageJSON = require('../../package.json');
@@ -42,7 +42,7 @@ class SimpleBrowserContextFactory implements BrowserContextFactory {
     this._contextGetter = contextGetter;
   }
 
-  async createContext(): Promise<{ browserContext: BrowserContext, close: () => Promise<void> }> {
+  async createContext(): Promise<BrowserContextFactoryResult> {
     const browserContext = await this._contextGetter();
     return {
       browserContext,

--- a/packages/playwright/src/mcp/program.ts
+++ b/packages/playwright/src/mcp/program.ts
@@ -21,7 +21,7 @@ import { setupExitWatchdog } from './browser/watchdog';
 import { contextFactory } from './browser/browserContextFactory';
 import { ProxyBackend } from './sdk/proxyBackend';
 import { BrowserServerBackend } from './browser/browserServerBackend';
-import { ExtensionContextFactory } from './extension/extensionContextFactory';
+import { closePageUsingEvaluate, ExtensionContextFactory } from './extension/extensionContextFactory';
 
 import type { Command } from 'playwright-core/lib/utilsBundle';
 import type { MCPProvider } from './sdk/proxyBackend';
@@ -83,7 +83,7 @@ export function decorateCommand(command: Command, version: string) {
             name: 'Playwright w/ extension',
             nameInConfig: 'playwright-extension',
             version,
-            create: () => new BrowserServerBackend(config, extensionContextFactory)
+            create: () => new BrowserServerBackend(config, extensionContextFactory, closePageUsingEvaluate)
           };
           await mcpServer.start(serverBackendFactory, config.server);
           return;
@@ -99,7 +99,7 @@ export function decorateCommand(command: Command, version: string) {
             {
               name: 'extension',
               description: 'Connect to a browser using the Playwright MCP extension',
-              connect: () => mcpServer.wrapInProcess(new BrowserServerBackend(config, extensionContextFactory)),
+              connect: () => mcpServer.wrapInProcess(new BrowserServerBackend(config, extensionContextFactory, closePageUsingEvaluate)),
             },
           ];
           const factory: mcpServer.ServerBackendFactory = {

--- a/packages/playwright/src/mcp/test/browserBackend.ts
+++ b/packages/playwright/src/mcp/test/browserBackend.ts
@@ -24,7 +24,6 @@ import { Tab } from '../browser/tab';
 import type * as playwright from '../../../index';
 import type { Page } from '../../../../playwright-core/src/client/page';
 import type { BrowserContextFactory } from '../browser/browserContextFactory';
-import type { ClientInfo } from '../sdk/server';
 
 export async function runBrowserBackendAtEnd(context: playwright.BrowserContext, errorMessage?: string) {
   const testInfo = currentTestInfo();
@@ -80,7 +79,7 @@ export async function runBrowserBackendAtEnd(context: playwright.BrowserContext,
 
 function identityFactory(browserContext: playwright.BrowserContext): BrowserContextFactory {
   return {
-    createContext: async (clientInfo: ClientInfo, abortSignal: AbortSignal, toolName: string | undefined) => {
+    createContext: async () => {
       return {
         browserContext,
         close: async () => {}


### PR DESCRIPTION
Extensions are not allowed to call `Target.closeTarget` over CDP, but they can close the tab using `window.close()`.

Reference https://github.com/microsoft/playwright-mcp/issues/1111