### PR TITLE
fix: httpRequest for http url via https proxy

### DIFF
--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -58,6 +58,7 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
         path: parsedUrl.href,
         host: parsedProxyURL.hostname,
         port: parsedProxyURL.port,
+        protocol: parsedProxyURL.protocol || 'http:',
         headers: options.headers,
         method: options.method
       };


### PR DESCRIPTION
While going through this code, I spotted a bug in `httpRequest`. When `getProxyForUrl` returns a HTTPS address, but `params.url` is HTTP, we delete `options.protocol` which means we'll be picking the wrong HTTP library in L83. I don't think this has ever been reported, and the only way of triggering it I could find involved the `ALL_PROXY` env var that's not super common. We currently use `httpRequest` for the following:

- browser downloads (official sources are always HTTP)
- contacting selenium grid (experimental)
- `urlToWSEndpoint`
- liveness checking in webserver and vite

I don't think any of these usecases will ever run into this specific bug. But it's a bug! Is it worth fixing?