### PR TITLE
chore: migrate proxy handling to WHATWG URL

### DIFF
--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -136,8 +136,8 @@ function shouldBypassProxy(url: URL, bypass?: string): boolean {
 }
 
 function normalizeProxyURL(proxy: string): URL {
-  // Browsers allow to specify proxy without a protocol, defaulting to http.
   proxy = proxy.trim();
+  // Browsers allow to specify proxy without a protocol, defaulting to http.
   if (!/^\w+:\/\//.test(proxy))
     proxy = 'http://' + proxy;
   return new URL(proxy);

--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -172,7 +172,7 @@ export function createProxyAgent(proxy?: ProxySettings, forUrl?: URL) {
     return new HttpsProxyAgent(proxyURL);
   }
 
-  // TODO: This branch should be different from above. We should use HttpProxyAgent conditional on proxyOpts.protocol instead of always using CONNECT method.
+  // TODO: This branch should be different from above. We should use HttpProxyAgent conditional on proxyURL.protocol instead of always using CONNECT method.
   return new HttpsProxyAgent(proxyURL);
 }
 

--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -52,17 +52,17 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
 
   const proxyURL = getProxyForUrl(params.url);
   if (proxyURL) {
-    const parsedProxyURL = normalizeProxyURL(proxyURL);
     if (params.url.startsWith('http:')) {
+      const parsedProxyURL = url.parse(proxyURL);
       options = {
         path: parsedUrl.href,
         host: parsedProxyURL.hostname,
-        port: parsedProxyURL.port || undefined,
+        port: parsedProxyURL.port,
         headers: options.headers,
         method: options.method
       };
     } else {
-      options.agent = new HttpsProxyAgent(parsedProxyURL);
+      options.agent = new HttpsProxyAgent(normalizeProxyURL(proxyURL));
       options.rejectUnauthorized = false;
     }
   }


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/playwright/pull/37713, part of https://github.com/microsoft/playwright/issues/37676.

There's two main behaviour changes in WHATWG:

**Invalid URLs throw an exception:** When a proxy URL is missing protocols, we default it to HTTP. WHATWG by default throws an exception. To prevent that, i've extended our defaulting to the `httpRequest` routine. Picking HTTP as the default protocol is inline with our previous behaviour - the prior version of  https-proxy-agent [picked the protocol based on `secureProxy`](https://github.com/TooTallNate/node-http-proxy-agent/blob/5368fa899134a9b0d7d49cc6917c1eecabe7aeb0/src/agent.ts#L122C7-L122C18), and [we chose `false`](https://github.com/microsoft/playwright/pull/37713/files/0dcffb6a5849a25b26a66d85444000012c25a944#diff-8412192264b8fb9b391f707d0ddc8ef97b812b9a67c4f9e6c75cdf53b28822eeR65) when there's no protocol defined. We also have lots of coverage on this in `proxy.spec.ts`.
**Unspecified or default segments are represented as empty string**: I'm assuming that `https-proxy-agent` knows how to handle that, so I haven't made any further changes.

I also had my Copilot double-check the code and verify the behaviour changes.

<details>
<summary>
Prompt
</summary>

```
look at my diff. i've updated the httpsproxyagent library and it now supports WHATWG
URL, so i'd like to transition there. There's a couple of behaviour differences
between WHATWG URL and url.parse and I want to ensure we don't regress. please
carefully examine my diff and counter-check the behaviour of the two APIs to ensure
we're not regressing.
```

</details>