### PR TITLE
fix: step id not found error log

### DIFF
--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -459,18 +459,18 @@ export class TestInfoImpl implements TestInfo {
     });
     this._attach(
         await normalizeAndSaveAttachment(this.outputPath(), name, options),
-        step.group ? undefined : step.stepId
+        step.stepId
     );
     step.complete({});
   }
 
   _attach(attachment: TestInfo['attachments'][0], stepId: string | undefined) {
     const index = this._attachmentsPush(attachment) - 1;
-    let internal = false;
     if (stepId) {
       const step = this._stepMap.get(stepId)!;
       step.attachmentIndices.push(index);
-      internal = step.group !== undefined;
+      if (!!step.group)
+        stepId = undefined;
     } else {
       const stepId = `attach@${createGuid()}`;
       this._tracing.appendBeforeActionForStep({ stepId, title: `Attach ${escapeWithQuotes(attachment.name, '"')}`, category: 'test.attach', stack: [] });
@@ -483,7 +483,7 @@ export class TestInfoImpl implements TestInfo {
       contentType: attachment.contentType,
       path: attachment.path,
       body: attachment.body?.toString('base64'),
-      stepId: internal ? undefined : stepId,
+      stepId,
     });
   }
 

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -466,8 +466,11 @@ export class TestInfoImpl implements TestInfo {
 
   _attach(attachment: TestInfo['attachments'][0], stepId: string | undefined) {
     const index = this._attachmentsPush(attachment) - 1;
+    let internal = false;
     if (stepId) {
-      this._stepMap.get(stepId)!.attachmentIndices.push(index);
+      const step = this._stepMap.get(stepId)!;
+      step.attachmentIndices.push(index);
+      internal = step.group !== undefined;
     } else {
       const stepId = `attach@${createGuid()}`;
       this._tracing.appendBeforeActionForStep({ stepId, title: `Attach ${escapeWithQuotes(attachment.name, '"')}`, category: 'test.attach', stack: [] });
@@ -480,7 +483,7 @@ export class TestInfoImpl implements TestInfo {
       contentType: attachment.contentType,
       path: attachment.path,
       body: attachment.body?.toString('base64'),
-      stepId,
+      stepId: internal ? undefined : stepId,
     });
   }
 

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -466,11 +466,13 @@ export class TestInfoImpl implements TestInfo {
 
   _attach(attachment: TestInfo['attachments'][0], stepId: string | undefined) {
     const index = this._attachmentsPush(attachment) - 1;
-    if (stepId) {
-      const step = this._stepMap.get(stepId)!;
+
+    let step = stepId ? this._stepMap.get(stepId) : undefined;
+    if (!!step?.group)
+      step = undefined;
+
+    if (step) {
       step.attachmentIndices.push(index);
-      if (!!step.group)
-        stepId = undefined;
     } else {
       const stepId = `attach@${createGuid()}`;
       this._tracing.appendBeforeActionForStep({ stepId, title: `Attach ${escapeWithQuotes(attachment.name, '"')}`, category: 'test.attach', stack: [] });
@@ -483,7 +485,7 @@ export class TestInfoImpl implements TestInfo {
       contentType: attachment.contentType,
       path: attachment.path,
       body: attachment.body?.toString('base64'),
-      stepId,
+      stepId: step?.stepId,
     });
   }
 


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/37747

This is the second report about this error line, both weren't pointing to underlying bugs. Maybe we should remove the log line instead?