### PR TITLE
feat(uimode): add pick locator button to inspector tab

### DIFF
--- a/packages/trace-viewer/src/ui/inspectorTab.tsx
+++ b/packages/trace-viewer/src/ui/inspectorTab.tsx
@@ -27,10 +27,11 @@ import type { Language } from '@isomorphic/locatorGenerators';
 
 export const InspectorTab: React.FunctionComponent<{
   sdkLanguage: Language,
+  isInspecting: boolean,
   setIsInspecting: (isInspecting: boolean) => void,
   highlightedElement: HighlightedElement,
   setHighlightedElement: (element: HighlightedElement) => void,
-}> = ({ sdkLanguage, setIsInspecting, highlightedElement, setHighlightedElement }) => {
+}> = ({ sdkLanguage, isInspecting, setIsInspecting, highlightedElement, setHighlightedElement }) => {
   const [ariaSnapshotErrors, setAriaSnapshotErrors] = React.useState<SourceHighlight[]>();
   const onAriaEditorChange = React.useCallback((ariaSnapshot: string) => {
     const { errors } = parseAriaSnapshot(yaml, ariaSnapshot, { prettyErrors: false });
@@ -50,7 +51,9 @@ export const InspectorTab: React.FunctionComponent<{
 
   return <div style={{ flex: 'auto', backgroundColor: 'var(--vscode-sideBar-background)', padding: '0 10px 10px 10px', overflow: 'auto' }}>
     <div className='hbox' style={{ lineHeight: '28px', color: 'var(--vscode-editorCodeLens-foreground)' }}>
-      <div style={{ flex: 'auto'  }}>Locator</div>
+      <div>Locator</div>
+      <ToolbarButton style={{ margin: '0 4px' }} title='Pick locator' icon='target' toggled={isInspecting} onClick={() => setIsInspecting(!isInspecting)} />
+      <div style={{ flex: 'auto'  }}></div>
       <ToolbarButton icon='files' title='Copy locator' onClick={() => {
         copy(highlightedElement.locator || '');
       }}></ToolbarButton>

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -181,6 +181,7 @@ export const Workbench: React.FunctionComponent<{
     title: 'Locator',
     render: () => <InspectorTab
       sdkLanguage={sdkLanguage}
+      isInspecting={isInspecting}
       setIsInspecting={setIsInspecting}
       highlightedElement={highlightedElement}
       setHighlightedElement={setHighlightedElement} />,


### PR DESCRIPTION
Duplicate the existing "Pick locator" button in the snapshot toolbar to also appear next to the locator in the Inspector tab to aid in discoverability.

<img width="1392" height="912" alt="Screenshot 2025-10-07 at 8 13 15 AM" src="https://github.com/user-attachments/assets/5772b12c-03c2-452b-9136-67db33045c78" />
