### PR TITLE
chore(bidi): fix header overrides for intercepted redirects

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
+++ b/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
@@ -68,8 +68,16 @@ export class BidiNetworkManager {
       // We do not support intercepting redirects.
       if (redirectedFrom) {
         let params = {};
-        if (redirectedFrom._originalRequestRoute?._alreadyContinuedHeaders)
-          params = toBidiRequestHeaders(redirectedFrom._originalRequestRoute._alreadyContinuedHeaders ?? []);
+        if (redirectedFrom._originalRequestRoute?._alreadyContinuedHeaders) {
+          const { headers } = toBidiRequestHeaders(redirectedFrom._originalRequestRoute._alreadyContinuedHeaders ?? []);
+          const hostHeader = headers.find(header => header.name.toLowerCase() === 'host');
+          if (hostHeader) {
+            const requestHostHeader = param.request.headers.find(header => header.name.toLowerCase() === 'host');
+            if (requestHostHeader)
+              hostHeader.value = requestHostHeader.value;
+          }
+          params = { headers };
+        }
 
         this._session.sendMayFail('network.continueRequest', {
           request: param.request.request,

--- a/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
+++ b/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
@@ -225,6 +225,8 @@ class FFRouteImpl implements network.RouteDelegate {
   private _request: InterceptableRequest;
   private _session: FFSession;
 
+  readonly removeHostHeaderFromOverrides = true;
+
   constructor(session: FFSession, request: InterceptableRequest) {
     this._session = session;
     this._request = request;

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -358,10 +358,10 @@ export class Route extends SdkObject {
         throw new Error('New URL must have same protocol as overridden URL');
     }
     if (overrides.headers) {
-      overrides.headers = overrides.headers?.filter(header => {
-        const headerName = header.name.toLowerCase();
-        return headerName !== 'cookie' && headerName !== 'host';
-      });
+      const headersToRemove = ['cookie'];
+      if (this._delegate.removeHostHeaderFromOverrides)
+        headersToRemove.push('host');
+      overrides.headers = overrides.headers.filter(header => !headersToRemove.includes(header.name));
     }
     overrides = this._request._applyOverrides(overrides);
 
@@ -668,6 +668,7 @@ export class WebSocket extends SdkObject {
 }
 
 export interface RouteDelegate {
+  readonly removeHostHeaderFromOverrides?: boolean;
   abort(errorCode: string): Promise<void>;
   fulfill(response: types.NormalizedFulfillResponse): Promise<void>;
   continue(overrides: types.NormalizedContinueOverrides): Promise<void>;

--- a/packages/playwright-core/src/server/webkit/wkInterceptableRequest.ts
+++ b/packages/playwright-core/src/server/webkit/wkInterceptableRequest.ts
@@ -107,6 +107,8 @@ export class WKRouteImpl implements network.RouteDelegate {
   private readonly _session: WKSession;
   private readonly _requestId: string;
 
+  readonly removeHostHeaderFromOverrides = true;
+
   constructor(session: WKSession, requestId: string) {
     this._session = session;
     this._requestId = requestId;


### PR DESCRIPTION
#36932 filters the host header from overrides to fix intercepted redirects in Firefox/Juggler (#36719).
This broke network intercepts in Firefox/BiDi because Firefox expects the host header to be present in overrides.
With this PR:
- the host header is only filtered for Firefox/Juggler and Safari (the latter only to maintain the behavior documented [here](https://github.com/microsoft/playwright/blob/232ea015fa2ba45caf84a452910aca09aa857e60/tests/page/page-request-continue.spec.ts#L63-L67) - we could also update the test expectation instead)
- for BiDi, the host header override is updated with the value from the redirected request so that Firefox/BiDi doesn't run into the same issue that Firefox/Juggler had

Fixes the following tests in Firefox:
- `tests/page/page-network-request.spec.ts`:
  - "should override post data content type"
- `tests/page/page-request-continue.spec.ts`:
  - "should amend HTTP headers"
  - "should delete header with undefined value"
  - "post data > should compute content-length from post data"
  - "should delete the origin header"
  - "should continue preload link requests"
  - "redirect after continue should be able to delete cookie"
  - "continue should propagate headers to redirects"
  - "continue should delete headers on redirects"
  - "propagate headers cross origin redirect after interception"
  - "should not forward Host header on cross-origin redirect"
- `tests/page/page-request-fallback.spec.ts`:
  - "should amend HTTP headers"
  - "should delete header with undefined value"
- `tests/page/page-request-fulfill.spec.ts`:
  - "should not modify the headers sent to the server"
- `tests/page/page-route.spec.ts`:
  - "should be able to remove headers"
