### PR TITLE
fix(shadow dom): follow assigned slot when hit-testing

### DIFF
--- a/packages/injected/src/domUtils.ts
+++ b/packages/injected/src/domUtils.ts
@@ -41,8 +41,6 @@ export function enclosingElement(node: Node) {
 }
 
 export function parentElementOrShadowHost(element: Element): Element | undefined {
-  if (element.assignedSlot)
-    return element.assignedSlot;
   if (element.parentElement)
     return element.parentElement;
   if (!element.parentNode)

--- a/packages/injected/src/domUtils.ts
+++ b/packages/injected/src/domUtils.ts
@@ -41,6 +41,8 @@ export function enclosingElement(node: Node) {
 }
 
 export function parentElementOrShadowHost(element: Element): Element | undefined {
+  if (element.assignedSlot)
+    return element.assignedSlot;
   if (element.parentElement)
     return element.parentElement;
   if (!element.parentNode)

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -989,6 +989,8 @@ export class InjectedScript {
     const hitParents: Element[] = [];
     while (hitElement && hitElement !== targetElement) {
       hitParents.push(hitElement);
+      // Prefer the composed tree over the light-dom tree, as browser performs hit testing on the composed tree.
+      // Note that we will still eventually climb to the light-dom parent, as any element distributed to a slot is a direct child of the shadow host that contains the slot.
       hitElement = hitElement.assignedSlot ?? parentElementOrShadowHost(hitElement);
     }
     if (hitElement === targetElement)

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -989,7 +989,7 @@ export class InjectedScript {
     const hitParents: Element[] = [];
     while (hitElement && hitElement !== targetElement) {
       hitParents.push(hitElement);
-      hitElement = parentElementOrShadowHost(hitElement);
+      hitElement = hitElement.assignedSlot ?? parentElementOrShadowHost(hitElement);
     }
     if (hitElement === targetElement)
       return 'done';

--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -1274,3 +1274,16 @@ it('should click into shadow root with slotted div', { annotation: { type: 'issu
 
   await page.getByRole('button', { name: 'Foo' }).click();
 });
+
+it('should click shadow root button', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37768' } }, async ({ page }) => {
+  await page.setContent(`
+    <my-button>
+      <template shadowrootmode="open">
+        <button><slot></slot></button>
+      </template>
+      <div>Foo</div>
+    </my-button>
+  `);
+
+  await page.locator('my-button').click();
+});

--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -1261,3 +1261,16 @@ it('should set PointerEvent.pressure on pointermove', async ({ page, isLinux, he
     [0, 50, 50],
   ]);
 });
+
+it('should click into shadow root with slotted div', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37768' } }, async ({ page }) => {
+  await page.setContent(`
+    <my-button>
+      <template shadowrootmode="open">
+        <button><slot></slot></button>
+      </template>
+      <div>Foo</div>
+    </my-button>
+  `);
+
+  await page.getByRole('button', { name: 'Foo' }).click();
+});

--- a/tests/page/selectors-css.spec.ts
+++ b/tests/page/selectors-css.spec.ts
@@ -468,3 +468,16 @@ it('css on the handle should be relative', async ({ page }) => {
   expect(await div.$eval(`.find-me`, e => e.id)).toBe('target2');
   expect(await page.$eval(`div >> .find-me`, e => e.id)).toBe('target2');
 });
+
+it('should use light DOM structure for child combinator with slotted content', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37768' } }, async ({ page }) => {
+  await page.setContent(`
+    <my-button>
+      <template shadowrootmode="open">
+        <button><slot></slot></button>
+      </template>
+      <div class="content">Foo</div>
+    </my-button>
+  `);
+  expect(await page.$eval(`my-button > div`, e => e.className)).toBe('content');
+  expect(await page.$eval(`my-button > .content`, e => e.textContent)).toBe('Foo');
+});


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/37768. When we perform hit testing, we traverse up from the hit element to see if it's a descendant of the target element.
In the reported case, we went from `<div>Foo</div>` straight up to `<my-button>`, because that's its position in the light DOM. In shadow DOM however, it's logically inside the target `<button>` element. We should follow this positioning for hit testing.