### PR TITLE
feat: Make `reportSlowTests` operate on tests, not test files

### DIFF
--- a/docs/src/test-api/class-fullconfig.md
+++ b/docs/src/test-api/class-fullconfig.md
@@ -93,8 +93,8 @@ See [`property: TestConfig.reporter`].
 ## property: FullConfig.reportSlowTests
 * since: v1.10
 - type: <[null]|[Object]>
-  - `max` <[int]> The maximum number of slow test files to report.
-  - `threshold` <[float]> Test file duration in milliseconds that is considered slow.
+  - `max` <[int]> The maximum number of slow tests to report.
+  - `threshold` <[float]> Test duration in milliseconds that is considered slow.
 
 See [`property: TestConfig.reportSlowTests`].
 

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -471,12 +471,12 @@ export default defineConfig({
 ```
 
 ## property: TestConfig.reportSlowTests
-* since: v1.10
+* since: v1.57
 - type: ?<[null]|[Object]>
-  - `max` <[int]> The maximum number of slow test files to report. Defaults to `5`.
-  - `threshold` <[float]> Test file duration in milliseconds that is considered slow. Defaults to 5 minutes.
+  - `max` <[int]> The maximum number of slow tests to report. Defaults to `5`.
+  - `threshold` <[float]> Test duration in milliseconds that is considered slow. Defaults to 5 minutes.
 
-Whether to report slow test files. Pass `null` to disable this feature.
+Whether to report slow tests. Pass `null` to disable this feature.
 
 **Usage**
 
@@ -490,7 +490,11 @@ export default defineConfig({
 
 **Details**
 
-Test files that took more than `threshold` milliseconds are considered slow, and the slowest ones are reported, no more than `max` number of them. Passing zero as `max` reports all test files that exceed the threshold.
+Tests that took more than `threshold` milliseconds are considered slow, and the slowest ones are reported, no more than `max` number of them. Passing zero as `max` reports all tests that exceed the threshold.
+
+:::note
+In versions prior to 1.57, this config was about reporting slow test *files*, as opposed to slow tests.
+:::
 
 ## property: TestConfig.respectGitIgnore
 * since: v1.45

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1528,7 +1528,7 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
   repeatEach?: number;
 
   /**
-   * Whether to report slow test files. Pass `null` to disable this feature.
+   * Whether to report slow tests. Pass `null` to disable this feature.
    *
    * **Usage**
    *
@@ -1543,17 +1543,20 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    *
    * **Details**
    *
-   * Test files that took more than `threshold` milliseconds are considered slow, and the slowest ones are reported, no
-   * more than `max` number of them. Passing zero as `max` reports all test files that exceed the threshold.
+   * Tests that took more than `threshold` milliseconds are considered slow, and the slowest ones are reported, no more
+   * than `max` number of them. Passing zero as `max` reports all tests that exceed the threshold.
+   *
+   * **NOTE** In versions prior to 1.57, this config was about reporting slow test *files*, as opposed to slow tests.
+   *
    */
   reportSlowTests?: null|{
     /**
-     * The maximum number of slow test files to report. Defaults to `5`.
+     * The maximum number of slow tests to report. Defaults to `5`.
      */
     max: number;
 
     /**
-     * Test file duration in milliseconds that is considered slow. Defaults to 5 minutes.
+     * Test duration in milliseconds that is considered slow. Defaults to 5 minutes.
      */
     threshold: number;
   };
@@ -2005,12 +2008,12 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
    */
   reportSlowTests: null|{
     /**
-     * The maximum number of slow test files to report.
+     * The maximum number of slow tests to report.
      */
     max: number;
 
     /**
-     * Test file duration in milliseconds that is considered slow.
+     * Test duration in milliseconds that is considered slow.
      */
     threshold: number;
   };

--- a/tests/playwright-test/reporter-github.spec.ts
+++ b/tests/playwright-test/reporter-github.spec.ts
@@ -74,7 +74,7 @@ for (const useIntermediateMergeReport of [false, true] as const) {
         `
       }, { retries: 3, reporter: 'github' }, { GITHUB_WORKSPACE: '' });
       const text = result.output;
-      expect(text).toContain('::warning title=Slow Test,file=a.test.js::a.test.js took');
+      expect(text).toContain('::warning title=Slow Test,file=a.test.js:3:15 › slow test::a.test.js:3:15 › slow test took ');
       expect(text).toContain('::notice title=🎭 Playwright Run Summary::  1 passed');
       expect(result.exitCode).toBe(0);
     });


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/37724.
The current implementation of `reportSlowTests`, contrary to what the name implies, operates on test *files* and is from a time when `fullyParallel` wasn't yet a thing. Today, it does't really work when multiple workers and `fullyParallel` are used, which makes it useless for pretty much anybody.

To bring the feature in line with its name, this PR replaces the implementation so that it operates on tests. This is technically a breaking change, but it's OK to break broken things.