### PR TITLE
chore(mcp): merge refLocator and generateSelector

### DIFF
--- a/packages/playwright/src/mcp/browser/tools/evaluate.ts
+++ b/packages/playwright/src/mcp/browser/tools/evaluate.ts
@@ -17,9 +17,8 @@
 import { z } from '../../sdk/bundle';
 import { defineTabTool } from './tool';
 import * as javascript from '../codegen';
-import { generateLocator } from './utils';
 
-import type * as playwright from 'playwright-core';
+import type { Tab } from '../tab';
 
 const evaluateSchema = z.object({
   function: z.string().describe('() => { /* code */ } or (element) => { /* code */ } when element is provided'),
@@ -40,16 +39,16 @@ const evaluate = defineTabTool({
   handle: async (tab, params, response) => {
     response.setIncludeSnapshot();
 
-    let locator: playwright.Locator | undefined;
+    let locator: Awaited<ReturnType<Tab['refLocator']>> | undefined;
     if (params.ref && params.element) {
       locator = await tab.refLocator({ ref: params.ref, element: params.element });
-      response.addCode(`await page.${await generateLocator(locator)}.evaluate(${javascript.quote(params.function)});`);
+      response.addCode(`await page.${locator.resolved}.evaluate(${javascript.quote(params.function)});`);
     } else {
       response.addCode(`await page.evaluate(${javascript.quote(params.function)});`);
     }
 
     await tab.waitForCompletion(async () => {
-      const receiver = locator ?? tab.page as any;
+      const receiver = locator?.locator ?? tab.page;
       const result = await receiver._evaluateFunction(params.function);
       response.addResult(JSON.stringify(result, null, 2) || 'undefined');
     });

--- a/packages/playwright/src/mcp/browser/tools/form.ts
+++ b/packages/playwright/src/mcp/browser/tools/form.ts
@@ -16,7 +16,6 @@
 
 import { z } from '../../sdk/bundle';
 import { defineTabTool } from './tool';
-import { generateLocator } from './utils';
 import * as codegen from '../codegen';
 
 const fillForm = defineTabTool({
@@ -39,8 +38,8 @@ const fillForm = defineTabTool({
 
   handle: async (tab, params, response) => {
     for (const field of params.fields) {
-      const locator = await tab.refLocator({ element: field.name, ref: field.ref });
-      const locatorSource = `await page.${await generateLocator(locator)}`;
+      const { locator, resolved } = await tab.refLocator({ element: field.name, ref: field.ref });
+      const locatorSource = `await page.${resolved}`;
       if (field.type === 'textbox' || field.type === 'slider') {
         const secret = tab.context.lookupSecret(field.value);
         await locator.fill(secret.value);

--- a/packages/playwright/src/mcp/browser/tools/keyboard.ts
+++ b/packages/playwright/src/mcp/browser/tools/keyboard.ts
@@ -17,7 +17,6 @@
 import { z } from '../../sdk/bundle';
 import { defineTabTool } from './tool';
 import { elementSchema } from './snapshot';
-import { generateLocator } from './utils';
 
 const pressKey = defineTabTool({
   capability: 'core',
@@ -60,22 +59,22 @@ const type = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    const locator = await tab.refLocator(params);
+    const { locator, resolved } = await tab.refLocator(params);
     const secret = tab.context.lookupSecret(params.text);
 
     await tab.waitForCompletion(async () => {
       if (params.slowly) {
         response.setIncludeSnapshot();
-        response.addCode(`await page.${await generateLocator(locator)}.pressSequentially(${secret.code});`);
+        response.addCode(`await page.${resolved}.pressSequentially(${secret.code});`);
         await locator.pressSequentially(secret.value);
       } else {
-        response.addCode(`await page.${await generateLocator(locator)}.fill(${secret.code});`);
+        response.addCode(`await page.${resolved}.fill(${secret.code});`);
         await locator.fill(secret.value);
       }
 
       if (params.submit) {
         response.setIncludeSnapshot();
-        response.addCode(`await page.${await generateLocator(locator)}.press('Enter');`);
+        response.addCode(`await page.${resolved}.press('Enter');`);
         await locator.press('Enter');
       }
     });

--- a/packages/playwright/src/mcp/browser/tools/screenshot.ts
+++ b/packages/playwright/src/mcp/browser/tools/screenshot.ts
@@ -17,7 +17,7 @@
 import { z } from '../../sdk/bundle';
 import { defineTabTool } from './tool';
 import * as javascript from '../codegen';
-import { generateLocator, dateAsFileName } from './utils';
+import { dateAsFileName } from './utils';
 
 import type * as playwright from 'playwright-core';
 
@@ -60,14 +60,14 @@ const screenshot = defineTabTool({
     response.addCode(`// Screenshot ${screenshotTarget} and save it as ${fileName}`);
 
     // Only get snapshot when element screenshot is needed
-    const locator = params.ref ? await tab.refLocator({ element: params.element || '', ref: params.ref }) : null;
+    const ref = params.ref ? await tab.refLocator({ element: params.element || '', ref: params.ref }) : null;
 
-    if (locator)
-      response.addCode(`await page.${await generateLocator(locator)}.screenshot(${javascript.formatObject(options)});`);
+    if (ref)
+      response.addCode(`await page.${ref.resolved}.screenshot(${javascript.formatObject(options)});`);
     else
       response.addCode(`await page.screenshot(${javascript.formatObject(options)});`);
 
-    const buffer = locator ? await locator.screenshot(options) : await tab.page.screenshot(options);
+    const buffer = ref ? await ref.locator.screenshot(options) : await tab.page.screenshot(options);
     response.addResult(`Took the ${screenshotTarget} screenshot and saved it as ${fileName}`);
 
     // https://github.com/microsoft/playwright-mcp/issues/817

--- a/packages/playwright/src/mcp/browser/tools/utils.ts
+++ b/packages/playwright/src/mcp/browser/tools/utils.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { asLocator } from 'playwright-core/lib/utils';
-
 import type * as playwright from 'playwright-core';
 import type { Tab } from '../tab';
 
@@ -71,15 +69,6 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
     return result;
   } finally {
     dispose();
-  }
-}
-
-export async function generateLocator(locator: playwright.Locator): Promise<string> {
-  try {
-    const { resolvedSelector } = await (locator as any)._resolveSelector();
-    return asLocator('javascript', resolvedSelector);
-  } catch (e) {
-    throw new Error('Ref not found, likely because element was removed. Use browser_snapshot to see what elements are currently on the page.');
   }
 }
 

--- a/packages/playwright/src/mcp/browser/tools/verify.ts
+++ b/packages/playwright/src/mcp/browser/tools/verify.ts
@@ -17,7 +17,6 @@
 import { z } from '../../sdk/bundle';
 import { defineTabTool } from './tool';
 import * as javascript from '../codegen';
-import { generateLocator } from './utils';
 
 const verifyElement = defineTabTool({
   capability: 'testing',
@@ -83,7 +82,7 @@ const verifyList = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    const locator = await tab.refLocator({ ref: params.ref, element: params.element });
+    const { locator } = await tab.refLocator({ ref: params.ref, element: params.element });
     const itemTexts: string[] = [];
     for (const item of params.items) {
       const itemLocator = locator.getByText(item);
@@ -118,8 +117,8 @@ const verifyValue = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    const locator = await tab.refLocator({ ref: params.ref, element: params.element });
-    const locatorSource = `page.${await generateLocator(locator)}`;
+    const { locator, resolved } = await tab.refLocator({ ref: params.ref, element: params.element });
+    const locatorSource = `page.${resolved}`;
     if (params.type === 'textbox' || params.type === 'slider' || params.type === 'combobox') {
       const value = await locator.inputValue();
       if (value !== params.value) {


### PR DESCRIPTION
These two are always used together. The change avoids unnecessary `_snapshotForAI()` call, which will come handy for incremental snapshots.