### PR TITLE
docs: update demo trace URL

### DIFF
--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -68,7 +68,7 @@ pwsh bin/Debug/netX/playwright.ps1 show-trace https://example.com/trace.zip
 When using [trace.playwright.dev](https://trace.playwright.dev), you can also pass the URL of your uploaded trace at some accessible storage (e.g. inside your CI) as a query parameter. CORS (Cross-Origin Resource Sharing) rules might apply.
 
 ```txt
-https://trace.playwright.dev/?trace=https://demo.playwright.dev/reports/todomvc/data/fa874b0d59cdedec675521c21124e93161d66533.zip
+https://trace.playwright.dev/?trace=https://demo.playwright.dev/reports/todomvc/data/e6099cadf79aa753d5500aa9508f9d1dbd87b5ee.zip
 ```
 
 ## Recording a trace


### PR DESCRIPTION
Updates to a 1.56 trace, see https://github.com/microsoft/playwright/issues/37734. 