### PR TITLE
docs: improve testing library migration docs for within

### DIFF
--- a/docs/src/testing-library-js.md
+++ b/docs/src/testing-library-js.md
@@ -119,7 +119,7 @@ You can create a locator inside another locator with [`method: Locator.locator`]
 
 ```js
 // Testing Library
-const messages = document.getElementById('messages');
+const messages = screen.getByTestId('messages');
 const helloMessage = within(messages).getByText('hello');
 
 // Playwright


### PR DESCRIPTION
Really love playwright's component testing DX, some really nice improvements here, ty!!

I read the [testing library migration part](https://playwright.dev/docs/testing-library#replacing-within) of the docs and thought that this change would be a more realistic (and accurate?) representation of what testing-lib users would do to query by test id. I think technically it makes sense if the element you're querying actually has an `id` property of `messages`, but I don't think the code comparison from TL -> Playwright here is 1-1.