### PR TITLE
feat(trace): Pin copy address button to the right in the address bar

### DIFF
--- a/packages/trace-viewer/src/ui/browserFrame.css
+++ b/packages/trace-viewer/src/ui/browserFrame.css
@@ -34,7 +34,7 @@
   height: 28px;
 
   .browser-frame-address {
-    flex: 1;
+    flex: auto;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/trace-viewer/src/ui/browserFrame.css
+++ b/packages/trace-viewer/src/ui/browserFrame.css
@@ -32,13 +32,13 @@
   display: flex;
   align-items: center;
   height: 28px;
+}
 
-  .browser-frame-address {
-    flex: auto;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+.browser-frame-address {
+  flex: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .browser-frame-menu-bar {

--- a/packages/trace-viewer/src/ui/browserFrame.css
+++ b/packages/trace-viewer/src/ui/browserFrame.css
@@ -29,20 +29,16 @@
   font: 400 16px Arial,sans-serif;
   margin: 0 16px 0 8px;
   padding: 5px 15px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   display: flex;
   align-items: center;
   height: 28px;
-}
 
-.browser-frame-address-bar > button {
-  visibility: hidden;
-}
-
-.browser-frame-address-bar:hover > button {
-  visibility: visible;
+  .browser-frame-address {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .browser-frame-menu-bar {

--- a/packages/trace-viewer/src/ui/browserFrame.tsx
+++ b/packages/trace-viewer/src/ui/browserFrame.tsx
@@ -31,7 +31,7 @@ export const BrowserFrame: React.FunctionComponent<{
       className='browser-frame-address-bar'
       title={url || 'about:blank'}
     >
-      {url || 'about:blank'}
+      <span className='browser-frame-address'>{url || 'about:blank'}</span>
       {url && (
         <CopyToClipboard value={url} />
       )}

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -473,20 +473,17 @@ test('should have network request overrides 2', async ({ page, server, runAndTra
   await expect.soft(traceViewer.networkRequests).toContainText([/script.jsGET200application\/javascript.*continued/]);
 });
 
-test('should show snapshot URL', async ({ page, runAndTrace, server }) => {
+test('should show snapshot URL and copy button', async ({ page, runAndTrace, server }) => {
   const traceViewer = await runAndTrace(async () => {
     await page.goto(server.EMPTY_PAGE);
     await page.evaluate('2+2');
   });
   await traceViewer.snapshotFrame('Evaluate');
-  const browserFrameAddressBarLocator = traceViewer.page.locator('.browser-frame-address-bar');
-  await expect(browserFrameAddressBarLocator).toHaveText(server.EMPTY_PAGE);
-  const copySelectorLocator = browserFrameAddressBarLocator.getByRole('button', { name: 'Copy' });
-  await expect(copySelectorLocator).toBeHidden();
-  await browserFrameAddressBarLocator.hover();
-  await expect(copySelectorLocator).toBeVisible();
+  const addressBar = traceViewer.page.locator('.browser-frame-address-bar');
+  await expect(addressBar).toHaveText(server.EMPTY_PAGE);
+
   await traceViewer.page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
-  await copySelectorLocator.click();
+  await addressBar.getByRole('button', { name: 'Copy' }).click();
   expect(await traceViewer.page.evaluate(() => navigator.clipboard.readText())).toBe(server.EMPTY_PAGE);
 });
 


### PR DESCRIPTION
Old (on hover):
<img width="1315" height="63" alt="image" src="https://github.com/user-attachments/assets/204a1c63-ecee-4ccb-9a6e-0efa47e9a13e" />
<img width="1307" height="53" alt="image" src="https://github.com/user-attachments/assets/df039d81-d526-4ebd-8c02-28228d38ebc0" />



New (no hover, pinned to right, dotted when overflow):
<img width="1308" height="72" alt="image" src="https://github.com/user-attachments/assets/6ef07b84-4846-4592-a135-bc4e45332179" />
<img width="1303" height="59" alt="image" src="https://github.com/user-attachments/assets/0465450a-3f91-4187-b251-b564826ca8d6" />



fixes: #37801