### PR TITLE
test(bidi): update test expectations for Firefox BiDi

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -423,6 +423,8 @@ export class BidiPage implements PageDelegate {
   }
 
   async setBackgroundColor(color?: { r: number; g: number; b: number; a: number; }): Promise<void> {
+    if (color)
+      throw new Error('Not implemented');
   }
 
   async takeScreenshot(progress: Progress, format: string, documentRect: types.Rect | undefined, viewportRect: types.Rect | undefined, quality: number | undefined, fitsViewport: boolean, scale: 'css' | 'device'): Promise<Buffer> {

--- a/tests/library/browsercontext-page-event.spec.ts
+++ b/tests/library/browsercontext-page-event.spec.ts
@@ -170,7 +170,7 @@ it('should work with Shift-clicking', async ({ browser, server, browserName }) =
   await context.close();
 });
 
-it('should work with Ctrl-clicking', async ({ browser, server, browserName }) => {
+it('should work with Ctrl-clicking', async ({ browser, server, browserName, channel }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -179,6 +179,6 @@ it('should work with Ctrl-clicking', async ({ browser, server, browserName }) =>
     context.waitForEvent('page'),
     page.click('a', { modifiers: ['ControlOrMeta'] }),
   ]);
-  expect(await popup.opener()).toBe(browserName === 'firefox' ? page : null);
+  expect(await popup.opener()).toBe(browserName === 'firefox' && !channel?.startsWith('moz-firefox') ? page : null);
   await context.close();
 });

--- a/tests/library/browsercontext-proxy.spec.ts
+++ b/tests/library/browsercontext-proxy.spec.ts
@@ -173,7 +173,7 @@ it.describe('should proxy local network requests', () => {
 
 
 it('should use ipv6 proxy', async ({ contextFactory, server, proxyServer, browserName, channel }) => {
-  it.fail(browserName === 'firefox', 'page.goto: NS_ERROR_UNKNOWN_HOST');
+  it.fail(browserName === 'firefox' && !channel?.startsWith('moz-firefox'), 'page.goto: NS_ERROR_UNKNOWN_HOST');
   it.fail(channel === 'webkit-wsl', 'WebKit on WSL does not support IPv6: https://github.com/microsoft/WSL/issues/10803');
   proxyServer.forwardTo(server.PORT);
   const context = await contextFactory({

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -859,7 +859,7 @@ it('should include redirects from API request', async ({ contextFactory, server 
   expect(json.timings).toBeDefined();
 });
 
-it('should not hang on resources served from cache', async ({ contextFactory, server, browserName }, testInfo) => {
+it('should not hang on resources served from cache', async ({ contextFactory, server, browserName, channel }, testInfo) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/11435' });
   server.setRoute('/one-style.css', (req, res) => {
     res.writeHead(200, {
@@ -874,7 +874,7 @@ it('should not hang on resources served from cache', async ({ contextFactory, se
   const log = await getLog();
   const entries = log.entries.filter(e => e.request.url.endsWith('one-style.css'));
   // In firefox no request events are fired for cached resources.
-  if (browserName === 'firefox')
+  if (browserName === 'firefox' && !channel?.startsWith('moz-firefox'))
     expect(entries.length).toBe(1);
   else
     expect(entries.length).toBe(2);

--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -110,7 +110,7 @@ browserTest.describe('page screenshot', () => {
     await context.close();
   });
 
-  browserTest('should throw if screenshot size is too large with device scale factor', async ({ browser, browserName, isMac }) => {
+  browserTest('should throw if screenshot size is too large with device scale factor', async ({ browser, browserName, isMac, channel }) => {
     browserTest.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/16727' });
     const context = await browser.newContext({ viewport: { width: 500, height: 500 }, deviceScaleFactor: 2 });
     const page = await context.newPage();
@@ -122,7 +122,7 @@ browserTest.describe('page screenshot', () => {
     {
       await page.setContent(`<style>body {margin: 0; padding: 0;}</style><div style='min-height: 16384px; background: red;'></div>`);
       const exception = await page.screenshot({ fullPage: true }).catch(e => e);
-      if (browserName === 'firefox' || (browserName === 'webkit' && !isMac))
+      if ((browserName === 'firefox' && !channel?.startsWith('moz-firefox')) || (browserName === 'webkit' && !isMac))
         expect(exception.message).toContain('Cannot take screenshot larger than 32767');
 
       const image = await page.screenshot({ fullPage: true, scale: 'css' });

--- a/tests/page/page-add-init-script.spec.ts
+++ b/tests/page/page-add-init-script.spec.ts
@@ -84,7 +84,7 @@ it('should work after a cross origin navigation', async ({ page, server }) => {
   expect(await page.evaluate(() => window['result'])).toBe(123);
 });
 
-it('init script should run only once in iframe', async ({ page, server, browserName }) => {
+it('init script should run only once in iframe', async ({ page, server, browserName, channel }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/26992' });
   const messages = [];
   page.on('console', event => {
@@ -95,6 +95,6 @@ it('init script should run only once in iframe', async ({ page, server, browserN
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(messages).toEqual([
     'init script: /frames/one-frame.html',
-    'init script: ' + (browserName === 'firefox' ? 'no url yet' : '/frames/frame.html'),
+    'init script: ' + (browserName === 'firefox' && !channel?.startsWith('moz-firefox') ? 'no url yet' : '/frames/frame.html'),
   ]);
 });

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -453,7 +453,7 @@ it('should disable timeout when its set to 0', async ({ page, server }) => {
   expect(loaded).toBe(true);
 });
 
-it('should fail when replaced by another navigation', async ({ page, server, browserName }) => {
+it('should fail when replaced by another navigation', async ({ page, server, browserName, channel }) => {
   let anotherPromise;
   server.setRoute('/empty.html', (req, res) => {
     anotherPromise = page.goto(server.PREFIX + '/one-style.html');
@@ -466,8 +466,11 @@ it('should fail when replaced by another navigation', async ({ page, server, bro
   } else if (browserName === 'webkit') {
     expect(error.message).toContain(`page.goto: Navigation to "${server.PREFIX + '/empty.html'}" is interrupted by another navigation to "${server.PREFIX + '/one-style.html'}"`);
   } else if (browserName === 'firefox') {
-    // Firefox might yield either NS_BINDING_ABORTED or 'navigation interrupted by another one'
-    expect(error.message.includes(`page.goto: Navigation to "${server.PREFIX + '/empty.html'}" is interrupted by another navigation to "${server.PREFIX + '/one-style.html'}"`) || error.message.includes('NS_BINDING_ABORTED')).toBe(true);
+    if (channel?.startsWith('moz-firefox'))
+      expect(error.message).toContain('page.goto: Protocol error (browsingContext.navigate): unknown error');
+    else
+      // Firefox might yield either NS_BINDING_ABORTED or 'navigation interrupted by another one'
+      expect(error.message.includes(`page.goto: Navigation to "${server.PREFIX + '/empty.html'}" is interrupted by another navigation to "${server.PREFIX + '/one-style.html'}"`) || error.message.includes('NS_BINDING_ABORTED')).toBe(true);
   }
 });
 

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -240,8 +240,8 @@ it.describe('page screenshot', () => {
     await verifyViewport(page, 500, 500);
   });
 
-  it('should allow transparency', async ({ page, browserName, platform, headless }) => {
-    it.fail(browserName === 'firefox');
+  it('should allow transparency', async ({ page, browserName, channel }) => {
+    it.fail(browserName === 'firefox' || channel?.startsWith('bidi-chrom'));
 
     await page.setViewportSize({ width: 300, height: 300 });
     await page.setContent(`


### PR DESCRIPTION
These tests have Firefox-specific expectations that were originally added for Juggler but now are getting applied to BiDi as well (since #37696).