### PR TITLE
chore: use flexbox size for network details

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -22,29 +22,37 @@
 }
 
 .network-request-details-url {
+  flex: none;
   white-space: normal;
   word-wrap: break-word;
   margin-left: 10px;
 }
 
 .network-request-details-headers {
+  flex: none;
   white-space: pre;
   overflow: hidden;
   margin-left: 10px;
 }
 
 .network-request-details-header {
+  flex: none;
   margin: 3px 0;
   font-weight: bold;
 }
 
 .network-request-details-general {
+  flex: none;
   white-space: pre;
   margin-left: 10px;
 }
 
 .network-request-details-tab .cm-wrapper {
   overflow: hidden;
+}
+
+.network-response-body {
+  flex: auto;
 }
 
 .network-font-preview {

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -15,8 +15,6 @@
 */
 
 .network-request-details-tab {
-  width: 100%;
-  height: 100%;
   user-select: text;
   line-height: 24px;
   margin-left: 10px;

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -21,38 +21,34 @@
   overflow: auto;
 }
 
-.network-request-details-url {
+.network-request-details-tab > * {
   flex: none;
+}
+
+.network-request-details-url {
   white-space: normal;
   word-wrap: break-word;
   margin-left: 10px;
 }
 
 .network-request-details-headers {
-  flex: none;
   white-space: pre;
   overflow: hidden;
   margin-left: 10px;
 }
 
 .network-request-details-header {
-  flex: none;
   margin: 3px 0;
   font-weight: bold;
 }
 
 .network-request-details-general {
-  flex: none;
   white-space: pre;
   margin-left: 10px;
 }
 
 .network-request-details-tab .cm-wrapper {
   overflow: hidden;
-}
-
-.network-response-body {
-  flex: auto;
 }
 
 .network-font-preview {

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -110,7 +110,7 @@ const RequestTab: React.FunctionComponent<{
   startTimeOffset: number;
   requestBody: RequestBody,
 }> = ({ resource, startTimeOffset, requestBody }) => {
-  return <div className='network-request-details-tab'>
+  return <div className='vbox network-request-details-tab'>
     <div className='network-request-details-header'>General</div>
     <div className='network-request-details-url'>{`URL: ${resource.request.url}`}</div>
     <div className='network-request-details-general'>{`Method: ${resource.request.method}`}</div>
@@ -138,7 +138,7 @@ const RequestTab: React.FunctionComponent<{
 const ResponseTab: React.FunctionComponent<{
   resource: ResourceSnapshot;
 }> = ({ resource }) => {
-  return <div className='network-request-details-tab'>
+  return <div className='vbox network-request-details-tab'>
     <div className='network-request-details-header'>Response Headers</div>
     <div className='network-request-details-headers'>{resource.response.headers.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
   </div>;
@@ -177,7 +177,7 @@ const BodyTab: React.FunctionComponent<{
     readResources();
   }, [resource, model]);
 
-  return <div className='network-request-details-tab'>
+  return <div className='network-request-details-tab network-response-body'>
     {!resource.response.content._sha1 && <div>Response body is not available for this request.</div>}
     {responseBody && responseBody.font && <FontPreview font={responseBody.font} />}
     {responseBody && responseBody.dataUrl && <img draggable='false' src={responseBody.dataUrl} />}

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -177,10 +177,10 @@ const BodyTab: React.FunctionComponent<{
     readResources();
   }, [resource, model]);
 
-  return <div className='network-request-details-tab network-response-body'>
+  return <div className='vbox network-request-details-tab'>
     {!resource.response.content._sha1 && <div>Response body is not available for this request.</div>}
     {responseBody && responseBody.font && <FontPreview font={responseBody.font} />}
-    {responseBody && responseBody.dataUrl && <img draggable='false' src={responseBody.dataUrl} />}
+    {responseBody && responseBody.dataUrl && <div><img draggable='false' src={responseBody.dataUrl} /></div>}
     {responseBody && responseBody.text && <CodeMirrorWrapper text={responseBody.text} mimeType={responseBody.mimeType} readOnly lineNumbers={true}/>}
   </div>;
 };


### PR DESCRIPTION
If the style forces the flex child width to 100% and adds a margin, it pushes classic scrollbar (e.g. on linux) partially outside the flex container.

<img width="937" height="60" alt="image" src="https://github.com/user-attachments/assets/eea7feb6-e0eb-4f47-b3a6-00c4c944c60a" />

Fixes #37835