### PR TITLE
chore(ct): add further checks to prevent React injection

### DIFF
--- a/packages/playwright-ct-core/src/viteUtils.ts
+++ b/packages/playwright-ct-core/src/viteUtils.ts
@@ -166,11 +166,13 @@ export function hasJSComponents(components: ImportInfo[]): boolean {
 
 const importReactRE = /(^|\n|;)import\s+(\*\s+as\s+)?React(,|\s+)/;
 const compiledReactRE = /(const|var)\s+React\s*=/;
+const runtimeImportRequire = /import\(['"`]react['"`]\)|require\(['"`]react['"`]\)/i;
 
 export function transformIndexFile(id: string, content: string, templateDir: string, registerSource: string, importInfos: Map<string, ImportInfo>): TransformResult  | null {
   // Vite React plugin will do this for .jsx files, but not .js files.
   // `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` check is to avoid modifying React itself (such as react.development.js)
-  if (id.endsWith('.js') && content.includes('React.createElement') && !content.includes('__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED') && !content.match(importReactRE) && !content.match(compiledReactRE)) {
+  if (id.endsWith('.js') && content.includes('React.createElement') && !content.includes('__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED') && !content.match(importReactRE)
+    && !content.match(compiledReactRE) && !content.match(runtimeImportRequire)) {
     const code = `import React from 'react';\n${content}`;
     return { code, map: { mappings: '' } };
   }


### PR DESCRIPTION
Some libraries apparently wrap their definition in a function that takes a `React` argument and passes `require('react')` directly to that function. I believe we can safely assume that any `import('react')` or `require('react')` in a file means we do not need to inject an import ourselves.