### PR TITLE
fix(glob): do not treat custom schema as special

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/urlMatch.ts
+++ b/packages/playwright-core/src/utils/isomorphic/urlMatch.ts
@@ -132,8 +132,13 @@ function resolveGlobBase(baseURL: string | undefined, match: string): string {
         return token;
       // Handle special case of http*://, note that the new schema has to be
       // a web schema so that slashes are properly inserted after domain.
-      if (index === 0 && token.endsWith(':'))
-        return mapToken(token, 'http:');
+      if (index === 0 && token.endsWith(':')) {
+        // Replace any pattern with http:
+        if (token.indexOf('*') !== -1 || token.indexOf('{') !== -1)
+          return mapToken(token, 'http:');
+        // Preserve explicit schema as is as it may affect trailing slashes after domain.
+        return token;
+      }
       const questionIndex = token.indexOf('?');
       if (questionIndex === -1)
         return mapToken(token, `$_${index}_$`);

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -127,6 +127,12 @@ it('should work with glob', async () => {
   expect(urlMatches(undefined, 'https://localhost:3000/?a=b', '**?a=b')).toBeTruthy();
   expect(urlMatches(undefined, 'https://localhost:3000/?a=b', '**=b')).toBeTruthy();
 
+  // Custom schema.
+  expect(urlMatches(undefined, 'my.custom.protocol://foo', 'my.custom.protocol://**')).toBeTruthy();
+  expect(urlMatches(undefined, 'my.p://foo', 'my.{p,y}://**')).toBeFalsy();
+  expect(urlMatches(undefined, 'my.p://foo/', 'my.{p,y}://**')).toBeTruthy();
+  expect(urlMatches(undefined, 'file:///foo/', 'f*e://**')).toBeTruthy();
+
   // This is not supported, we treat ? as a query separator.
   expect(globToRegex('http://localhost:8080/?imple/path.js').test('http://localhost:8080/Simple/path.js')).toBeFalsy();
   expect(urlMatches(undefined, 'http://playwright.dev/', 'http://playwright.?ev')).toBeFalsy();


### PR DESCRIPTION
`new URL()` adds / after the domain if:
- the scheme is a [special scheme](https://url.spec.whatwg.org/#special-scheme) per WHATWG spec: http, https, ftp, file, ws, wss, and
- no explicit path was provided.

Aftter this PR: preserve explicit scheme to avoid inadvertent slash. Treat any scheme pattern as a special scheme for the slash resolution.

Fixes https://github.com/microsoft/playwright/issues/37821