### PR TITLE
fix(ui): collapse multiline log entries

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/protocolFormatter.ts
+++ b/packages/playwright-core/src/utils/isomorphic/protocolFormatter.ts
@@ -17,32 +17,36 @@
 import { methodMetainfo } from './protocolMetainfo';
 
 export function formatProtocolParam(params: Record<string, string> | undefined, alternatives: string): string | undefined {
-  if (!params)
-    return undefined;
+  function format() {
+    if (!params)
+      return undefined;
 
-  for (const name of alternatives.split('|')) {
-    if (name === 'url') {
-      try {
-        const urlObject = new URL(params[name]);
-        if (urlObject.protocol === 'data:')
-          return urlObject.protocol;
-        if (urlObject.protocol === 'about:')
-          return params[name];
-        return urlObject.pathname + urlObject.search;
-      } catch (error) {
-        if (params[name] !== undefined)
-          return params[name];
+    for (const name of alternatives.split('|')) {
+      if (name === 'url') {
+        try {
+          const urlObject = new URL(params[name]);
+          if (urlObject.protocol === 'data:')
+            return urlObject.protocol;
+          if (urlObject.protocol === 'about:')
+            return params[name];
+          return urlObject.pathname + urlObject.search;
+        } catch (error) {
+          if (params[name] !== undefined)
+            return params[name];
+        }
       }
-    }
-    if (name === 'timeNumber' && params[name] !== undefined) {
-      // eslint-disable-next-line no-restricted-globals
-      return new Date(params[name]).toString();
-    }
+      if (name === 'timeNumber' && params[name] !== undefined) {
+        // eslint-disable-next-line no-restricted-globals
+        return new Date(params[name]).toString();
+      }
 
-    const value = deepParam(params, name);
-    if (value !== undefined)
-      return value;
+      const value = deepParam(params, name);
+      if (value !== undefined)
+        return value;
+    }
   }
+
+  return format()?.replaceAll('\n', '\\n');
 }
 
 function deepParam(params: Record<string, any>, name: string): string | undefined {

--- a/packages/playwright-core/src/utils/isomorphic/protocolFormatter.ts
+++ b/packages/playwright-core/src/utils/isomorphic/protocolFormatter.ts
@@ -17,36 +17,36 @@
 import { methodMetainfo } from './protocolMetainfo';
 
 export function formatProtocolParam(params: Record<string, string> | undefined, alternatives: string): string | undefined {
-  function format() {
-    if (!params)
-      return undefined;
+  return _formatProtocolParam(params, alternatives)?.replaceAll('\n', '\\n');
+}
 
-    for (const name of alternatives.split('|')) {
-      if (name === 'url') {
-        try {
-          const urlObject = new URL(params[name]);
-          if (urlObject.protocol === 'data:')
-            return urlObject.protocol;
-          if (urlObject.protocol === 'about:')
-            return params[name];
-          return urlObject.pathname + urlObject.search;
-        } catch (error) {
-          if (params[name] !== undefined)
-            return params[name];
-        }
-      }
-      if (name === 'timeNumber' && params[name] !== undefined) {
-        // eslint-disable-next-line no-restricted-globals
-        return new Date(params[name]).toString();
-      }
+function _formatProtocolParam(params: Record<string, string> | undefined, alternatives: string): string | undefined {
+  if (!params)
+    return undefined;
 
-      const value = deepParam(params, name);
-      if (value !== undefined)
-        return value;
+  for (const name of alternatives.split('|')) {
+    if (name === 'url') {
+      try {
+        const urlObject = new URL(params[name]);
+        if (urlObject.protocol === 'data:')
+          return urlObject.protocol;
+        if (urlObject.protocol === 'about:')
+          return params[name];
+        return urlObject.pathname + urlObject.search;
+      } catch (error) {
+        if (params[name] !== undefined)
+          return params[name];
+      }
     }
-  }
+    if (name === 'timeNumber' && params[name] !== undefined) {
+      // eslint-disable-next-line no-restricted-globals
+      return new Date(params[name]).toString();
+    }
 
-  return format()?.replaceAll('\n', '\\n');
+    const value = deepParam(params, name);
+    if (value !== undefined)
+      return value;
+  }
 }
 
 function deepParam(params: Record<string, any>, name: string): string | undefined {

--- a/packages/recorder/src/callLog.tsx
+++ b/packages/recorder/src/callLog.tsx
@@ -41,7 +41,7 @@ export const CallLogView: React.FC<CallLogProps> = ({
       const expandOverride = expandOverrides.get(callLog.id);
       const isExpanded = typeof expandOverride === 'boolean' ? expandOverride : callLog.status !== 'done';
       const locator = callLog.params.selector ? asLocator(language, callLog.params.selector) : null;
-      let titlePrefix = callLog.title.replaceAll('\n', '\\n');
+      let titlePrefix = callLog.title;
       let titleSuffix = '';
       if (callLog.title.startsWith('expect.to') || callLog.title.startsWith('expect.not.to')) {
         titlePrefix = 'expect(';

--- a/packages/recorder/src/callLog.tsx
+++ b/packages/recorder/src/callLog.tsx
@@ -41,7 +41,7 @@ export const CallLogView: React.FC<CallLogProps> = ({
       const expandOverride = expandOverrides.get(callLog.id);
       const isExpanded = typeof expandOverride === 'boolean' ? expandOverride : callLog.status !== 'done';
       const locator = callLog.params.selector ? asLocator(language, callLog.params.selector) : null;
-      let titlePrefix = callLog.title;
+      let titlePrefix = callLog.title.replaceAll('\n', '\\n');
       let titleSuffix = '';
       if (callLog.title.startsWith('expect.to') || callLog.title.startsWith('expect.not.to')) {
         titlePrefix = 'expect(';

--- a/tests/library/inspector/pause.spec.ts
+++ b/tests/library/inspector/pause.spec.ts
@@ -48,6 +48,20 @@ it('should not reset timeouts', async ({ page, recorderPageGetter, closeRecorder
   expect(error.message).toContain('page.goto: Timeout 1000ms exceeded.');
 });
 
+it('should collapse log entries to a single line', async ({ page, recorderPageGetter }) => {
+  const scriptPromise = (async () => {
+    // @ts-ignore
+    await page.pause({ __testHookKeepTestTimeout: true });
+    await page.keyboard.type(`Hello
+world`);
+  })();
+
+  const recorderPage = await recorderPageGetter();
+  await recorderPage.click('[title="Resume (F8)"]');
+  await expect(recorderPage.locator('.call-log-call').nth(1)).toContainText('Type "Hello\\nworld"');
+  await scriptPromise;
+});
+
 it.describe('pause', () => {
   it.skip(({ mode }) => mode !== 'default');
 

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -480,6 +480,28 @@ test('should show custom fixture titles in actions tree', async ({ runUITest }) 
   ]);
 });
 
+test('should collapse log entries to a single line', async ({ runUITest }) => {
+  const { page } = await runUITest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+
+      test('multiline test', async ({ page }) => {
+        await page.keyboard.type(\`line1
+line2\`);
+      });
+    `,
+  });
+
+  await page.getByText('multiline test').dblclick();
+  const listItem = page.getByTestId('actions-tree').getByRole('treeitem');
+  await expect(listItem, 'action list').toHaveText([
+    /Before Hooks[\d.]+m?s/,
+    /Type "line1\\nline2"[\d.]+m?s/,
+    /After Hooks[\d.]+m?s/,
+  ]);
+});
+
+
 test('should hide boxed fixtures and contents, reveal upon show all actions setting', async ({ runUITest }) => {
   const { page } = await runUITest({
     'a.test.ts': `


### PR DESCRIPTION
Collapse multiline log entries in `--debug`, UI mode, and various logging that displays call actions. Prevent breaking our UI in unexpected ways.

## After

<img width="375" height="203" alt="Screenshot 2025-10-14 at 10 50 04 AM" src="https://github.com/user-attachments/assets/e81adb0b-ebad-43b6-84b0-13acf3a6475e" />

<img width="233" height="270" alt="Screenshot 2025-10-14 at 11 57 32 AM" src="https://github.com/user-attachments/assets/7d5b630b-6d9a-474c-98d3-3b9c8454c8df" />


## Before

<img width="454" height="200" alt="Screenshot 2025-10-14 at 10 51 11 AM" src="https://github.com/user-attachments/assets/99952994-6756-40a0-8b87-00718e01ff48" />

<img width="230" height="333" alt="Screenshot 2025-10-14 at 11 57 56 AM" src="https://github.com/user-attachments/assets/f5a3059e-f8bc-4857-bad8-da094c6d3e4d" />
