### PR TITLE
feat(html): order by duration

### DIFF
--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -165,7 +165,7 @@ export class Filter {
         if (comparison !== 0)
           return sortToken.not ? -comparison : comparison;
       }
-      return 0;
+      return this._compareTests(a, b, 'file');
     });
   }
 
@@ -176,11 +176,9 @@ export class Filter {
       return a.title.localeCompare(b.title);
     if (field === 'line')
       return a.location.line - b.location.line;
-    const searchValuesA = cacheSearchValues(a);
-    const searchValuesB = cacheSearchValues(b);
-    if (field === 'status' || field === 'file' || field === 'project')
-      return searchValuesA[field].localeCompare(searchValuesB[field]);
-    return searchValuesA.text.localeCompare(searchValuesB.text);
+    if (field !== 'status' && field !== 'file' && field !== 'project' && field !== 'text')
+      return 0;
+    return cacheSearchValues(a)[field].localeCompare(cacheSearchValues(b)[field]);
   }
 }
 

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -163,7 +163,7 @@ export class Filter {
       for (const sortToken of this.sort) {
         let comparison = 0;
         if (sortToken.name === 'duration')
-          comparison = a.duration - b.duration;
+          comparison = b.duration - a.duration;
         if (comparison !== 0)
           return sortToken.not ? -comparison : comparison;
       }

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -176,9 +176,11 @@ export class Filter {
       return a.title.localeCompare(b.title);
     if (field === 'line')
       return a.location.line - b.location.line;
+    const searchValuesA = cacheSearchValues(a);
+    const searchValuesB = cacheSearchValues(b);
     if (field === 'status' || field === 'file' || field === 'project')
-      return cacheSearchValues(a)[field].localeCompare(cacheSearchValues(b)[field]);
-    return 0;
+      return searchValuesA[field].localeCompare(searchValuesB[field]);
+    return searchValuesA.text.localeCompare(searchValuesB.text);
   }
 }
 

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -161,14 +161,24 @@ export class Filter {
 
     tests.sort((a, b) => {
       for (const sortToken of this.sort) {
-        let comparison = 0;
-        if (sortToken.name === 'duration')
-          comparison = b.duration - a.duration;
+        const comparison = this._compareTests(a, b, sortToken.name);
         if (comparison !== 0)
           return sortToken.not ? -comparison : comparison;
       }
       return 0;
     });
+  }
+
+  private _compareTests(a: TestCaseSummary, b: TestCaseSummary, field: string): number {
+    if (field === 'duration')
+      return b.duration - a.duration;
+    if (field === 'title')
+      return a.title.localeCompare(b.title);
+    if (field === 'line')
+      return a.location.line - b.location.line;
+    if (field === 'status' || field === 'file' || field === 'project')
+      return cacheSearchValues(a)[field].localeCompare(cacheSearchValues(b)[field]);
+    return 0;
   }
 }
 

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -155,11 +155,11 @@ export class Filter {
     return true;
   }
 
-  sortTests(tests: TestCaseSummary[]): TestCaseSummary[] {
+  sortTests(tests: TestCaseSummary[]): void {
     if (!this.sort.length)
-      return tests;
+      return;
 
-    return tests.slice().sort((a, b) => {
+    tests.sort((a, b) => {
       for (const sortToken of this.sort) {
         let comparison = 0;
         if (sortToken.name === 'duration')

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -37,48 +37,26 @@ export class Filter {
   }
 
   static parse(expression: string): Filter {
-    const tokens = Filter.tokenize(expression);
-    const project = new Set<FilterToken>();
-    const status = new Set<FilterToken>();
-    const text: FilterToken[] = [];
-    const labels = new Set<FilterToken>();
-    const annotations = new Set<FilterToken>();
-    const sort: FilterToken[] = [];
-    for (let token of tokens) {
+    const filter = new Filter();
+    for (let token of Filter.tokenize(expression)) {
       const not = token.startsWith('!');
       if (not)
         token = token.slice(1);
 
-      if (token.startsWith('o:')) {
-        sort.push({ name: token.slice(2), not });
-        continue;
-      }
-      if (token.startsWith('p:')) {
-        project.add({ name: token.slice(2), not });
-        continue;
-      }
-      if (token.startsWith('s:')) {
-        status.add({ name: token.slice(2), not });
-        continue;
-      }
-      if (token.startsWith('@')) {
-        labels.add({ name: token, not });
-        continue;
-      }
-      if (token.startsWith('annot:')) {
-        annotations.add({ name: token.slice('annot:'.length), not });
-        continue;
-      }
-      text.push({ name: token.toLowerCase(), not });
+      if (token.startsWith('o:'))
+        filter.sort.push({ name: token.slice(2), not });
+      else if (token.startsWith('p:'))
+        filter.project.push({ name: token.slice(2), not });
+      else if (token.startsWith('s:'))
+        filter.status.push({ name: token.slice(2), not });
+      else if (token.startsWith('@'))
+        filter.labels.push({ name: token, not });
+      else if (token.startsWith('annot:'))
+        filter.annotations.push({ name: token.slice('annot:'.length), not });
+      else
+        filter.text.push({ name: token.toLowerCase(), not });
     }
 
-    const filter = new Filter();
-    filter.text = text;
-    filter.project = [...project];
-    filter.status = [...status];
-    filter.labels = [...labels];
-    filter.annotations = [...annotations];
-    filter.sort = sort;
     return filter;
   }
 

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -214,9 +214,8 @@ function createFilesModel(report: LoadedReport | undefined, filter: Filter): Tes
     result.tests.push(...tests);
   }
 
-  filter.sortTests(result.tests);
-
   if (filter.sort.length) {
+    filter.sortTests(result.tests);
     result.files = [{
       fileId: '',
       fileName: '',
@@ -258,9 +257,8 @@ function createMergedFilesModel(report: LoadedReport | undefined, filter: Filter
   for (const group of groups)
     result.tests.push(...group.tests);
 
-  filter.sortTests(result.tests);
-
   if (filter.sort.length) {
+    filter.sortTests(result.tests);
     result.files = [{
       fileId: '',
       fileName: '',

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -206,13 +206,25 @@ function computeStats(files: TestFileSummary[], filter: Filter): FilteredStats {
 
 function createFilesModel(report: LoadedReport | undefined, filter: Filter): TestModelSummary {
   const result: TestModelSummary = { files: [], tests: [] };
+
   for (const file of report?.json().files || []) {
     const tests = file.tests.filter(t => filter.matches(t));
-    filter.sortTests(tests);
     if (tests.length)
       result.files.push({ ...file, tests });
     result.tests.push(...tests);
   }
+
+  filter.sortTests(result.tests);
+
+  if (filter.sort.length) {
+    result.files = [{
+      fileId: '',
+      fileName: '',
+      tests: result.tests,
+      stats: { total: 0, expected: 0, unexpected: 0, flaky: 0, skipped: 0, ok: true }
+    }];
+  }
+
   return result;
 }
 
@@ -242,11 +254,20 @@ function createMergedFilesModel(report: LoadedReport | undefined, filter: Filter
 
   groups.sort((a, b) => a.fileName.localeCompare(b.fileName));
 
-  for (const group of groups)
-    filter.sortTests(group.tests);
-
   const result: TestModelSummary = { files: groups, tests: [] };
   for (const group of groups)
     result.tests.push(...group.tests);
+
+  filter.sortTests(result.tests);
+
+  if (filter.sort.length) {
+    result.files = [{
+      fileId: '',
+      fileName: '',
+      tests: result.tests,
+      stats: { total: 0, expected: 0, unexpected: 0, flaky: 0, skipped: 0, ok: true }
+    }];
+  }
+
   return result;
 }

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -207,7 +207,8 @@ function computeStats(files: TestFileSummary[], filter: Filter): FilteredStats {
 function createFilesModel(report: LoadedReport | undefined, filter: Filter): TestModelSummary {
   const result: TestModelSummary = { files: [], tests: [] };
   for (const file of report?.json().files || []) {
-    const tests = filter.sortTests(file.tests.filter(t => filter.matches(t)));
+    const tests = file.tests.filter(t => filter.matches(t));
+    filter.sortTests(tests);
     if (tests.length)
       result.files.push({ ...file, tests });
     result.tests.push(...tests);
@@ -242,7 +243,7 @@ function createMergedFilesModel(report: LoadedReport | undefined, filter: Filter
   groups.sort((a, b) => a.fileName.localeCompare(b.fileName));
 
   for (const group of groups)
-    group.tests = filter.sortTests(group.tests);
+    filter.sortTests(group.tests);
 
   const result: TestModelSummary = { files: groups, tests: [] };
   for (const group of groups)

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -256,13 +256,21 @@ function createSortedNoFilesModel(report: LoadedReport | undefined, filter: Filt
   tests = tests.filter(t => filter.matches(t));
   filter.sortTests(tests);
 
-  return {
-    files: [{
-      fileId: '',
-      fileName: '',
-      tests,
+  const files: TestFileSummary[] = [];
+  const chunkSize = 100;
+
+  for (let i = 0; i < tests.length; i += chunkSize) {
+    const chunk = tests.slice(i, i + chunkSize);
+    files.push({
+      fileId: '' + i,
+      fileName: `${i} - ${i + chunkSize - 1}`,
+      tests: chunk,
       stats: { total: 0, expected: 0, unexpected: 0, flaky: 0, skipped: 0, ok: true }
-    }],
+    });
+  }
+
+  return {
+    files,
     tests
   };
 }

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -207,7 +207,7 @@ function computeStats(files: TestFileSummary[], filter: Filter): FilteredStats {
 function createFilesModel(report: LoadedReport | undefined, filter: Filter): TestModelSummary {
   const result: TestModelSummary = { files: [], tests: [] };
   for (const file of report?.json().files || []) {
-    const tests = file.tests.filter(t => filter.matches(t));
+    const tests = filter.sortTests(file.tests.filter(t => filter.matches(t)));
     if (tests.length)
       result.files.push({ ...file, tests });
     result.tests.push(...tests);
@@ -240,6 +240,9 @@ function createMergedFilesModel(report: LoadedReport | undefined, filter: Filter
   }
 
   groups.sort((a, b) => a.fileName.localeCompare(b.fileName));
+
+  for (const group of groups)
+    group.tests = filter.sortTests(group.tests);
 
   const result: TestModelSummary = { files: groups, tests: [] };
   for (const group of groups)

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3269,6 +3269,10 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
       test('very slow test', async ({}) => {
         await new Promise(resolve => setTimeout(resolve, 150));
       });
+      test('known slow', async ({}) => {
+        test.slow();
+        await new Promise(resolve => setTimeout(resolve, 75));
+      });
     `,
   }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
 
@@ -3286,28 +3290,34 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
     - region:
       - link "very fast test"
       - link "very slow test"
+      - link "known slow"
   `);
 
   await searchInput.fill('o:duration');
   await expect(page.getByRole('main')).toMatchAriaSnapshot(`
     - button [expanded]
     - region:
-      - link "very fast test"
-      - link "fast test"
-      - link "medium test"
-      - link "slow test"
       - link "very slow test"
+      - link "slow test"
+      - link "known slow"
+      - link "medium test"
+      - link "fast test"
+      - link "very fast test"
   `);
+
+  await searchInput.fill('o:duration !@slow');
+  await expect(page.getByRole('link', { name: 'known slow' })).not.toBeVisible();
 
   await searchInput.fill('!o:duration');
   await expect(page.getByRole('main')).toMatchAriaSnapshot(`
     - button [expanded]
     - region:
-      - link "very slow test"
-      - link "slow test"
-      - link "medium test"
-      - link "fast test"
       - link "very fast test"
+      - link "fast test"
+      - link "medium test"
+      - link "known slow"
+      - link "slow test"
+      - link "very slow test"
   `);
 
   await searchInput.clear();
@@ -3321,6 +3331,7 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
     - region:
       - link "very fast test"
       - link "very slow test"
+      - link "known slow"
   `);
 });
 

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3261,6 +3261,15 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
         await new Promise(resolve => setTimeout(resolve, 50));
       });
     `,
+    'b.test.js': `
+      import { test, expect } from '@playwright/test';
+      test('very fast test', async ({}) => {
+        await new Promise(resolve => setTimeout(resolve, 5));
+      });
+      test('very slow test', async ({}) => {
+        await new Promise(resolve => setTimeout(resolve, 150));
+      });
+    `,
   }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
 
   await showReport();
@@ -3268,16 +3277,16 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
   const searchInput = page.locator('.subnav-search-input');
   const testTitles = page.locator('.test-file-test .test-file-title');
 
-  await expect(testTitles).toHaveText(['fast test', 'slow test', 'medium test']);
+  await expect(testTitles).toHaveText(['fast test', 'slow test', 'medium test', 'very fast test', 'very slow test']);
 
   await searchInput.fill('o:duration');
-  await expect(testTitles).toHaveText(['fast test', 'medium test', 'slow test']);
+  await expect(testTitles).toHaveText(['very fast test', 'fast test', 'medium test', 'slow test', 'very slow test']);
 
   await searchInput.fill('!o:duration');
-  await expect(testTitles).toHaveText(['slow test', 'medium test', 'fast test']);
+  await expect(testTitles).toHaveText(['very slow test', 'slow test', 'medium test', 'fast test', 'very fast test']);
 
   await searchInput.clear();
-  await expect(testTitles).toHaveText(['fast test', 'slow test', 'medium test']);
+  await expect(testTitles).toHaveText(['fast test', 'slow test', 'medium test', 'very fast test', 'very slow test']);
 });
 
 function readAllFromStream(stream: NodeJS.ReadableStream): Promise<Buffer> {

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3305,7 +3305,7 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
       - link "very fast test"
   `);
 
-  await searchInput.fill('o:duration !@slow');
+  await searchInput.fill('o:duration !annot:slow');
   await expect(page.getByRole('link', { name: 'known slow' })).not.toBeVisible();
 
   await searchInput.fill('!o:duration');

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3277,190 +3277,50 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
   const searchInput = page.locator('.subnav-search-input');
 
   await expect(page.locator('body')).toMatchAriaSnapshot(`
-    - main:
-      - navigation:
-        - link "All5":
-          - /url: "#?"
-        - link "Passed5":
-          - /url: "#?q=s:passed"
-        - link "Failed0":
-          - /url: "#?q=s:failed"
-        - link "Flaky0":
-          - /url: "#?q=s:flaky"
-        - link "Skipped0":
-          - /url: "#?q=s:skipped"
-        - button "Settings"
-      - textbox
-      - text: "/\\\\d+\\\\/\\\\d+\\\\/\\\\d+, 1:\\\\d+:\\\\d+ PM Total time: \\\\d+[hmsp]+/"
-      - button "a.test.js" [expanded]
-      - region:
-        - link "fast test":
-          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:3":
-          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
-        - link "slow test":
-          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:6":
-          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
-        - link "medium test":
-          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:9":
-          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
-      - button "b.test.js" [expanded]
-      - region:
-        - link "very fast test":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
-        - text: /\\d+[hmsp]+/
-        - link "b.test.js:3":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
-        - link "very slow test":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
-        - text: /\\d+[hmsp]+/
-        - link "b.test.js:6":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
+    - button "a.test.js" [expanded]
+    - region:
+      - link "fast test"
+      - link "slow test"
+      - link "medium test"
+    - button "b.test.js" [expanded]
+    - region:
+      - link "very fast test"
+      - link "very slow test"
   `);
 
   await searchInput.fill('o:duration');
   await expect(page.locator('body')).toMatchAriaSnapshot(`
-    - main:
-      - navigation:
-        - link "All5":
-          - /url: "#?"
-        - link "Passed5":
-          - /url: "#?q=s:passed"
-        - link "Failed0":
-          - /url: "#?q=s:failed"
-        - link "Flaky0":
-          - /url: "#?q=s:flaky"
-        - link "Skipped0":
-          - /url: "#?q=s:skipped"
-        - button "Settings"
-      - textbox: o:duration
-      - text: "/\\\\d+\\\\/\\\\d+\\\\/\\\\d+, 1:\\\\d+:\\\\d+ PM Total time: \\\\d+[hmsp]+/"
-      - button [expanded]
-      - region:
-        - link "very fast test":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
-        - text: /\\d+[hmsp]+/
-        - link "b.test.js:3":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
-        - link "fast test":
-          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:3":
-          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
-        - link "medium test":
-          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:9":
-          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
-        - link "slow test":
-          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:6":
-          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
-        - link "very slow test":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
-        - text: /\\d+[hmsp]+/
-        - link "b.test.js:6":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
+    - button [expanded]
+    - region:
+      - link "very fast test"
+      - link "fast test"
+      - link "medium test"
+      - link "slow test"
+      - link "very slow test"
   `);
 
   await searchInput.fill('!o:duration');
   await expect(page.locator('body')).toMatchAriaSnapshot(`
-    - main:
-      - navigation:
-        - link "All5":
-          - /url: "#?"
-        - link "Passed5":
-          - /url: "#?q=s:passed"
-        - link "Failed0":
-          - /url: "#?q=s:failed"
-        - link "Flaky0":
-          - /url: "#?q=s:flaky"
-        - link "Skipped0":
-          - /url: "#?q=s:skipped"
-        - button "Settings"
-      - textbox: "!o:duration"
-      - text: "/\\\\d+\\\\/\\\\d+\\\\/\\\\d+, 1:\\\\d+:\\\\d+ PM Total time: \\\\d+[hmsp]+/"
-      - button [expanded]
-      - region:
-        - link "very slow test":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
-        - text: /\\d+[hmsp]+/
-        - link "b.test.js:6":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
-        - link "slow test":
-          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:6":
-          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
-        - link "medium test":
-          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:9":
-          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
-        - link "fast test":
-          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:3":
-          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
-        - link "very fast test":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
-        - text: /\\d+[hmsp]+/
-        - link "b.test.js:3":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
+    - button [expanded]
+    - region:
+      - link "very slow test"
+      - link "slow test"
+      - link "medium test"
+      - link "fast test"
+      - link "very fast test"
   `);
 
   await searchInput.clear();
   await expect(page.locator('body')).toMatchAriaSnapshot(`
-    - main:
-      - navigation:
-        - link "All5":
-          - /url: "#?"
-        - link "Passed5":
-          - /url: "#?q=s:passed"
-        - link "Failed0":
-          - /url: "#?q=s:failed"
-        - link "Flaky0":
-          - /url: "#?q=s:flaky"
-        - link "Skipped0":
-          - /url: "#?q=s:skipped"
-        - button "Settings"
-      - textbox
-      - text: "/\\\\d+\\\\/\\\\d+\\\\/\\\\d+, 1:\\\\d+:\\\\d+ PM Total time: \\\\d+[hmsp]+/"
-      - button "a.test.js" [expanded]
-      - region:
-        - link "fast test":
-          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:3":
-          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
-        - link "slow test":
-          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:6":
-          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
-        - link "medium test":
-          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
-        - text: /\\d+[hmsp]+/
-        - link "a.test.js:9":
-          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
-      - button "b.test.js" [expanded]
-      - region:
-        - link "very fast test":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
-        - text: /\\d+[hmsp]+/
-        - link "b.test.js:3":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
-        - link "very slow test":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
-        - text: /\\d+[hmsp]+/
-        - link "b.test.js:6":
-          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
+    - button "a.test.js" [expanded]
+    - region:
+      - link "fast test"
+      - link "slow test"
+      - link "medium test"
+    - button "b.test.js" [expanded]
+    - region:
+      - link "very fast test"
+      - link "very slow test"
   `);
 });
 

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3275,18 +3275,193 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
   await showReport();
 
   const searchInput = page.locator('.subnav-search-input');
-  const testTitles = page.locator('.test-file-test .test-file-title');
 
-  await expect(testTitles).toHaveText(['fast test', 'slow test', 'medium test', 'very fast test', 'very slow test']);
+  await expect(page.locator('body')).toMatchAriaSnapshot(`
+    - main:
+      - navigation:
+        - link "All5":
+          - /url: "#?"
+        - link "Passed5":
+          - /url: "#?q=s:passed"
+        - link "Failed0":
+          - /url: "#?q=s:failed"
+        - link "Flaky0":
+          - /url: "#?q=s:flaky"
+        - link "Skipped0":
+          - /url: "#?q=s:skipped"
+        - button "Settings"
+      - textbox
+      - text: "/\\\\d+\\\\/\\\\d+\\\\/\\\\d+, 1:\\\\d+:\\\\d+ PM Total time: \\\\d+[hmsp]+/"
+      - button "a.test.js" [expanded]
+      - region:
+        - link "fast test":
+          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:3":
+          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
+        - link "slow test":
+          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:6":
+          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
+        - link "medium test":
+          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:9":
+          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
+      - button "b.test.js" [expanded]
+      - region:
+        - link "very fast test":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
+        - text: /\\d+[hmsp]+/
+        - link "b.test.js:3":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
+        - link "very slow test":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
+        - text: /\\d+[hmsp]+/
+        - link "b.test.js:6":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
+  `);
 
   await searchInput.fill('o:duration');
-  await expect(testTitles).toHaveText(['very fast test', 'fast test', 'medium test', 'slow test', 'very slow test']);
+  await expect(page.locator('body')).toMatchAriaSnapshot(`
+    - main:
+      - navigation:
+        - link "All5":
+          - /url: "#?"
+        - link "Passed5":
+          - /url: "#?q=s:passed"
+        - link "Failed0":
+          - /url: "#?q=s:failed"
+        - link "Flaky0":
+          - /url: "#?q=s:flaky"
+        - link "Skipped0":
+          - /url: "#?q=s:skipped"
+        - button "Settings"
+      - textbox: o:duration
+      - text: "/\\\\d+\\\\/\\\\d+\\\\/\\\\d+, 1:\\\\d+:\\\\d+ PM Total time: \\\\d+[hmsp]+/"
+      - button [expanded]
+      - region:
+        - link "very fast test":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
+        - text: /\\d+[hmsp]+/
+        - link "b.test.js:3":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
+        - link "fast test":
+          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:3":
+          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
+        - link "medium test":
+          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:9":
+          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
+        - link "slow test":
+          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:6":
+          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
+        - link "very slow test":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
+        - text: /\\d+[hmsp]+/
+        - link "b.test.js:6":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
+  `);
 
   await searchInput.fill('!o:duration');
-  await expect(testTitles).toHaveText(['very slow test', 'slow test', 'medium test', 'fast test', 'very fast test']);
+  await expect(page.locator('body')).toMatchAriaSnapshot(`
+    - main:
+      - navigation:
+        - link "All5":
+          - /url: "#?"
+        - link "Passed5":
+          - /url: "#?q=s:passed"
+        - link "Failed0":
+          - /url: "#?q=s:failed"
+        - link "Flaky0":
+          - /url: "#?q=s:flaky"
+        - link "Skipped0":
+          - /url: "#?q=s:skipped"
+        - button "Settings"
+      - textbox: "!o:duration"
+      - text: "/\\\\d+\\\\/\\\\d+\\\\/\\\\d+, 1:\\\\d+:\\\\d+ PM Total time: \\\\d+[hmsp]+/"
+      - button [expanded]
+      - region:
+        - link "very slow test":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
+        - text: /\\d+[hmsp]+/
+        - link "b.test.js:6":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
+        - link "slow test":
+          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:6":
+          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
+        - link "medium test":
+          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:9":
+          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
+        - link "fast test":
+          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:3":
+          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
+        - link "very fast test":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
+        - text: /\\d+[hmsp]+/
+        - link "b.test.js:3":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
+  `);
 
   await searchInput.clear();
-  await expect(testTitles).toHaveText(['fast test', 'slow test', 'medium test', 'very fast test', 'very slow test']);
+  await expect(page.locator('body')).toMatchAriaSnapshot(`
+    - main:
+      - navigation:
+        - link "All5":
+          - /url: "#?"
+        - link "Passed5":
+          - /url: "#?q=s:passed"
+        - link "Failed0":
+          - /url: "#?q=s:failed"
+        - link "Flaky0":
+          - /url: "#?q=s:flaky"
+        - link "Skipped0":
+          - /url: "#?q=s:skipped"
+        - button "Settings"
+      - textbox
+      - text: "/\\\\d+\\\\/\\\\d+\\\\/\\\\d+, 1:\\\\d+:\\\\d+ PM Total time: \\\\d+[hmsp]+/"
+      - button "a.test.js" [expanded]
+      - region:
+        - link "fast test":
+          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:3":
+          - /url: "#?testId=17c2af56efedce05daab-64b07a38d632a2a9987c"
+        - link "slow test":
+          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:6":
+          - /url: "#?testId=17c2af56efedce05daab-3bd304b2dc4dd6f5e519"
+        - link "medium test":
+          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
+        - text: /\\d+[hmsp]+/
+        - link "a.test.js:9":
+          - /url: "#?testId=17c2af56efedce05daab-bd277126f3467d5bae5d"
+      - button "b.test.js" [expanded]
+      - region:
+        - link "very fast test":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
+        - text: /\\d+[hmsp]+/
+        - link "b.test.js:3":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-3b2a25f05f406137f27f"
+        - link "very slow test":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
+        - text: /\\d+[hmsp]+/
+        - link "b.test.js:6":
+          - /url: "#?testId=970b9ee1a59d47a8ca1c-5471a3464ee1e078930b"
+  `);
 });
 
 function readAllFromStream(stream: NodeJS.ReadableStream): Promise<Buffer> {

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3252,26 +3252,26 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
     'a.test.js': `
       import { test, expect } from '@playwright/test';
       test('fast test', async ({}) => {
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await new Promise(resolve => setTimeout(resolve, 200));
       });
       test('slow test', async ({}) => {
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await new Promise(resolve => setTimeout(resolve, 500));
       });
       test('medium test', async ({}) => {
-        await new Promise(resolve => setTimeout(resolve, 50));
+        await new Promise(resolve => setTimeout(resolve, 300));
       });
     `,
     'b.test.js': `
       import { test, expect } from '@playwright/test';
       test('very fast test', async ({}) => {
-        await new Promise(resolve => setTimeout(resolve, 5));
+        await new Promise(resolve => setTimeout(resolve, 100));
       });
       test('very slow test', async ({}) => {
-        await new Promise(resolve => setTimeout(resolve, 150));
+        await new Promise(resolve => setTimeout(resolve, 600));
       });
       test('known slow', async ({}) => {
         test.slow();
-        await new Promise(resolve => setTimeout(resolve, 75));
+        await new Promise(resolve => setTimeout(resolve, 400));
       });
     `,
   }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3276,7 +3276,7 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
 
   const searchInput = page.locator('.subnav-search-input');
 
-  await expect(page.locator('body')).toMatchAriaSnapshot(`
+  await expect(page.getByRole('main')).toMatchAriaSnapshot(`
     - button "a.test.js" [expanded]
     - region:
       - link "fast test"
@@ -3289,7 +3289,7 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
   `);
 
   await searchInput.fill('o:duration');
-  await expect(page.locator('body')).toMatchAriaSnapshot(`
+  await expect(page.getByRole('main')).toMatchAriaSnapshot(`
     - button [expanded]
     - region:
       - link "very fast test"
@@ -3300,7 +3300,7 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
   `);
 
   await searchInput.fill('!o:duration');
-  await expect(page.locator('body')).toMatchAriaSnapshot(`
+  await expect(page.getByRole('main')).toMatchAriaSnapshot(`
     - button [expanded]
     - region:
       - link "very slow test"
@@ -3311,7 +3311,7 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
   `);
 
   await searchInput.clear();
-  await expect(page.locator('body')).toMatchAriaSnapshot(`
+  await expect(page.getByRole('main')).toMatchAriaSnapshot(`
     - button "a.test.js" [expanded]
     - region:
       - link "fast test"

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3247,7 +3247,7 @@ test('should support merge files option', async ({ runInlineTest, showReport, pa
   `);
 });
 
-test('should support sorting by duration', async ({ runInlineTest, showReport, page }) => {
+test('should support sorting', async ({ runInlineTest, showReport, page }) => {
   await runInlineTest({
     'a.test.js': `
       import { test, expect } from '@playwright/test';
@@ -3318,6 +3318,30 @@ test('should support sorting by duration', async ({ runInlineTest, showReport, p
       - link "known slow"
       - link "slow test"
       - link "very slow test"
+  `);
+
+  await searchInput.fill('o:title');
+  await expect(page.getByRole('main')).toMatchAriaSnapshot(`
+    - button [expanded]
+    - region:
+      - link "fast test"
+      - link "known slow"
+      - link "medium test"
+      - link "slow test"
+      - link "very fast test"
+      - link "very slow test"
+  `);
+
+  await searchInput.fill('o:file');
+  await expect(page.getByRole('main')).toMatchAriaSnapshot(`
+    - button [expanded]
+    - region:
+      - link "fast test"
+      - link "slow test"
+      - link "medium test"
+      - link "very fast test"
+      - link "very slow test"
+      - link "known slow"
   `);
 
   await searchInput.clear();


### PR DESCRIPTION
Adds an `o:duration` filter that allows seeing the slowest tests quickly:
<img width="1394" height="912" alt="Screenshot 2025-10-15 at 13 38 45" src="https://github.com/user-attachments/assets/cebf2883-8a78-40b4-970c-d81564deafea" />

Part of https://github.com/microsoft/playwright/issues/37724.
