### PR TITLE
Fix streamable-http session management with minimal change

### DIFF
--- a/packages/playwright/src/mcp/sdk/http.ts
+++ b/packages/playwright/src/mcp/sdk/http.ts
@@ -163,8 +163,12 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
     transport.onclose = () => {
       if (!transport.sessionId)
         return;
-      sessions.delete(transport.sessionId);
-      testDebug(`delete http session: ${transport.sessionId}`);
+      const sessionId = transport.sessionId;
+      // Delay cleanup to allow multi-step operations to complete
+      setTimeout(() => {
+        sessions.delete(sessionId);
+        testDebug(`delete http session: ${sessionId}`);
+      }, 5000);
     };
 
     await transport.handleRequest(req, res);


### PR DESCRIPTION
Replace immediate session cleanup with 5-second delayed cleanup to prevent 'Session not found' errors during multi-step browser automation operations.

This is the minimal fix that resolves the core issue around streamable-http transport support.

When combined with the playwright-mcp PR, these two changes will fix the "navigate to google, type banana into the search bar, click search and take a screen shot of the result" scenario without a session being dropped when using it in a pod.