### PR TITLE
Add IDE selection dropdown in trace viewer (VS Code, Cursor, WebStorm, Visual Studio, Notepad++)

### DIFF
--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -16,16 +16,13 @@
 
 import fs from 'fs';
 import path from 'path';
-
-import { gracefullyProcessExitDoNotHang } from '../../../utils';
-import { isUnderTest } from '../../../utils';
+import { spawn, spawnSync } from 'child_process';
+import { gracefullyProcessExitDoNotHang, isUnderTest } from '../../../utils';
 import { HttpServer } from '../../utils/httpServer';
 import { open } from '../../../utilsBundle';
-import { syncLocalStorageWithSettings } from '../../launchApp';
-import { launchApp } from '../../launchApp';
+import { launchApp, syncLocalStorageWithSettings } from '../../launchApp';
 import { createPlaywright } from '../../playwright';
 import { ProgressController } from '../../progress';
-
 import type { Transport } from '../../utils/httpServer';
 import type { BrowserType } from '../../browserType';
 import type { Page } from '../../page';
@@ -56,11 +53,15 @@ function validateTraceUrl(traceUrl: string | undefined) {
   if (!traceUrl)
     return;
   let traceFile = traceUrl;
-  // If .json is requested, we'll synthesize it.
   if (traceUrl.endsWith('.json'))
     traceFile = traceUrl.substring(0, traceUrl.length - '.json'.length);
 
-  if (!traceUrl.startsWith('http://') && !traceUrl.startsWith('https://') && !fs.existsSync(traceFile) && !fs.existsSync(traceFile + '.trace'))
+  if (
+    !traceUrl.startsWith('http://') &&
+    !traceUrl.startsWith('https://') &&
+    !fs.existsSync(traceFile) &&
+    !fs.existsSync(traceFile + '.trace')
+  )
     throw new Error(`Trace file ${traceUrl} does not exist!`);
 }
 
@@ -69,13 +70,140 @@ export async function startTraceViewerServer(options?: TraceViewerServerOptions)
   server.routePrefix('/trace', (request, response) => {
     const url = new URL('http://localhost' + request.url!);
     const relativePath = url.pathname.slice('/trace'.length);
+
+    // --- Enhanced: open-in-ide endpoint for VS Code, Cursor, WebStorm, Visual Studio, Notepad++ ---
+    if (relativePath.startsWith('/open-in-ide')) {
+      try {
+        const ide = url.searchParams.get('ide');
+        const file = url.searchParams.get('file');
+        const line = url.searchParams.get('line');
+
+        // --- IDE availability check handler ---
+        if (url.searchParams.get('check') === '1') {
+          const isWin = process.platform === 'win32';
+          let exists = false;
+
+          if (ide === 'vscode') {
+            exists = true; // assume protocol handler exists
+          } else if (ide === 'cursor') {
+            const check = spawnSync('which', ['cursor']);
+            exists = check.status === 0;
+          } else if (ide === 'webstorm') {
+            const check = spawnSync('which', ['webstorm']);
+            exists = check.status === 0;
+          } else if (ide === 'visualstudio' && isWin) {
+            exists = true;
+          } else if (ide === 'notepadpp' && isWin) {
+            exists = true;
+          }
+
+          response.statusCode = exists ? 200 : 404;
+          response.end();
+          return true;
+        }
+
+        if (!file) {
+          response.statusCode = 400;
+          response.end('Missing file parameter');
+          return true;
+        }
+
+        // ---- VS Code ----
+        if (ide === 'vscode') {
+          const vscodeUrl = `vscode://file//${file}${line ? `:${line}` : ''}`;
+          response.statusCode = 200;
+          response.setHeader('Content-Type', 'application/json');
+          response.end(JSON.stringify({ url: vscodeUrl }));
+          return true;
+        }
+
+        // ---- Cursor ----
+        if (ide === 'cursor') {
+          const cursorUrl = `cursor://file//${file}${line ? `:${line}` : ''}`;
+          response.statusCode = 200;
+          response.setHeader('Content-Type', 'application/json');
+          response.end(JSON.stringify({ url: cursorUrl }));
+          return true;
+        }
+
+        // ---- WebStorm ----
+        if (ide === 'webstorm') {
+          const args: string[] = [];
+          if (line)
+            args.push('--line', line);
+          args.push(file);
+          try {
+            spawn('webstorm', args, { detached: true, stdio: 'ignore' });
+          } catch (err) {
+            console.error('Failed to launch WebStorm:', err);
+          }
+          response.statusCode = 200;
+          response.end('ok');
+          return true;
+        }
+
+        // ---- Visual Studio (Windows only) ----
+        if (ide === 'visualstudio') {
+          if (process.platform !== 'win32') {
+            response.statusCode = 400;
+            response.end('Visual Studio is only supported on Windows');
+            return true;
+          }
+          const args: string[] = [];
+          if (line)
+            args.push('/Edit', file, '/Command', `Edit.Goto ${line}`);
+          else
+            args.push('/Edit', file);
+          try {
+            spawn('devenv', args, { detached: true, stdio: 'ignore' });
+          } catch (err) {
+            console.error('Failed to launch Visual Studio:', err);
+          }
+          response.statusCode = 200;
+          response.end('ok');
+          return true;
+        }
+
+        // ---- Notepad++ (Windows only) ----
+        if (ide === 'notepadpp') {
+          if (process.platform !== 'win32') {
+            response.statusCode = 400;
+            response.end('Notepad++ is only supported on Windows');
+            return true;
+          }
+          const args: string[] = [];
+          if (line)
+            args.push(`-n${line}`);
+          args.push(file);
+          try {
+            spawn('notepad++', args, { detached: true, stdio: 'ignore' });
+          } catch (err) {
+            console.error('Failed to launch Notepad++:', err);
+          }
+          response.statusCode = 200;
+          response.end('ok');
+          return true;
+        }
+
+        // ---- Unknown IDE ----
+        response.statusCode = 400;
+        response.end('Unknown IDE');
+        return true;
+      } catch (e) {
+        console.error('Failed to open IDE:', e);
+        response.statusCode = 500;
+        response.end('Failed to open IDE');
+        return true;
+      }
+    }
+    // ---------------------------------------------------------------
+
     if (relativePath.startsWith('/file')) {
       try {
         const filePath = url.searchParams.get('path')!;
         if (fs.existsSync(filePath))
           return server.serveFile(request, response, url.searchParams.get('path')!);
 
-        // If .json is requested, we'll synthesize it for zip-less operation.
         if (filePath.endsWith('.json')) {
           const traceName = filePath.substring(0, filePath.length - '.json'.length);
           response.statusCode = 200;
@@ -83,12 +211,12 @@ export async function startTraceViewerServer(options?: TraceViewerServerOptions)
           response.end(JSON.stringify(traceDescriptor(traceName)));
           return true;
         }
-      } catch (e) {
-      }
+      } catch (e) {}
       response.statusCode = 404;
       response.end();
       return true;
     }
+
     const absolutePath = path.join(__dirname, '..', '..', '..', 'vite', 'traceViewer', ...relativePath.split('/'));
     return server.serveFile(request, response, absolutePath);
   });
@@ -125,7 +253,7 @@ export async function installRootRedirect(server: HttpServer, traceUrl: string |
   for (const reporter of options.reporter || [])
     params.append('reporter', reporter);
 
-  const urlPath  = `./trace/${options.webApp || 'index.html'}?${params.toString()}`;
+  const urlPath = `./trace/${options.webApp || 'index.html'}?${params.toString()}`;
   server.routePath('/', (_, response) => {
     response.statusCode = 302;
     response.setHeader('Location', urlPath);
@@ -210,19 +338,12 @@ class StdinServer implements Transport {
     process.stdin.on('close', () => gracefullyProcessExitDoNotHang(0));
   }
 
-  onconnect() {
-  }
-
+  onconnect() {}
   async dispatch(method: string, params: any) {
-    if (method === 'initialize') {
-      if (this._traceUrl)
-        this._loadTrace(this._traceUrl);
-    }
+    if (method === 'initialize' && this._traceUrl)
+      this._loadTrace(this._traceUrl);
   }
-
-  onclose() {
-  }
-
+  onclose() {}
   sendEvent?: (method: string, params: any) => void;
   close?: () => void;
 
@@ -234,24 +355,18 @@ class StdinServer implements Transport {
 
   private _pollLoadTrace(url: string) {
     this._loadTrace(url);
-    this._pollTimer = setTimeout(() => {
-      this._pollLoadTrace(url);
-    }, 500);
+    this._pollTimer = setTimeout(() => this._pollLoadTrace(url), 500);
   }
 }
 
 function traceDescriptor(traceName: string) {
-  const result: { entries: { name: string, path: string }[] } = {
-    entries: []
-  };
-
+  const result: { entries: { name: string; path: string }[] } = { entries: [] };
   const traceDir = path.dirname(traceName);
   const traceFile = path.basename(traceName);
   for (const name of fs.readdirSync(traceDir)) {
     if (name.startsWith(traceFile))
       result.entries.push({ name, path: path.join(traceDir, name) });
   }
-
   const resourcesDir = path.join(traceDir, 'resources');
   if (fs.existsSync(resourcesDir)) {
     for (const name of fs.readdirSync(resourcesDir))

--- a/packages/trace-viewer/src/ui/sourceTab.css
+++ b/packages/trace-viewer/src/ui/sourceTab.css
@@ -35,3 +35,14 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.ide-dropdown {
+  margin-right: 8px;
+  background: var(--vscode-dropdown-background, #2a2a2a);
+  color: var(--vscode-foreground, #fff);
+  border: 1px solid var(--vscode-dropdown-border, #555);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 12px;
+  max-width: 200px;
+}


### PR DESCRIPTION
This change enhances the **trace viewer SourceTab** by allowing users to open source files in their preferred IDE instead of being limited to VS Code.

#### **Key changes**

* Added a dropdown in the trace viewer toolbar to select the preferred IDE.
* Supported IDEs:

  * VS Code *(default)*
  * Cursor
  * WebStorm
  * Visual Studio *(Windows only)*
  * Notepad++ *(Windows only)*
* IDE availability is dynamically detected based on the user platform and backend support (`/trace/open-in-ide?check=1`).
* Persisted the user’s IDE preference in `localStorage` under `pw.ui.ide.selection`.
* Kept backward compatibility — default behavior still opens VS Code if no preference is stored.
* No layout or visual regressions; existing toolbar behavior is unchanged.

close #22158
