### PR TITLE
chore(ui): fix TreeView tree role

### DIFF
--- a/packages/web/src/components/treeView.tsx
+++ b/packages/web/src/components/treeView.tsx
@@ -126,9 +126,10 @@ export function TreeView<T extends TreeItem>({
     setTreeState({ ...treeState });
   }, [treeItems, treeState, setTreeState]);
 
-  return <div className={clsx(`tree-view vbox`, name + '-tree-view')} role={'tree'} data-testid={dataTestId || (name + '-tree')}>
+  return <div className={clsx(`tree-view vbox`, name + '-tree-view')} data-testid={dataTestId || (name + '-tree')}>
     <div
       className={clsx('tree-view-content')}
+      role={treeItems.size > 0 ? 'tree' : undefined}
       tabIndex={0}
       onKeyDown={event => {
         if (selectedItem && event.key === 'Enter') {


### PR DESCRIPTION
`role="tree"` should only be present on the direct parent of `treeitem`/`group`. It should also not be present if there are no children.