### PR TITLE
chore(trace-viewer): fix actions header alignment

### DIFF
--- a/packages/trace-viewer/src/ui/workbench.css
+++ b/packages/trace-viewer/src/ui/workbench.css
@@ -16,7 +16,7 @@
 
 .workbench-run-status {
   height: 30px;
-  padding: 4px;
+  padding: 4px 4px 4px 5px;
   flex: none;
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## After

<img width="854" height="712" alt="Screenshot 2025-10-16 at 10 52 47 AM" src="https://github.com/user-attachments/assets/1ea3b388-6607-4899-836b-b17561cfb042" />

## Before

<img width="1048" height="833" alt="Screenshot 2025-10-16 at 10 33 15 AM" src="https://github.com/user-attachments/assets/6b54e577-2d9e-4d5c-b713-7a0dbf7f990f" />
