### PR TITLE
fix: teleEmit onExit

### DIFF
--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -157,6 +157,10 @@ export class TeleReporterEmitter implements ReporterV2 {
     });
   }
 
+  async onExit() {
+    this._messageSink({ method: 'onExit', params: undefined });
+  }
+
   printsToStdio() {
     return false;
   }

--- a/tests/playwright-test/test-server.spec.ts
+++ b/tests/playwright-test/test-server.spec.ts
@@ -104,7 +104,7 @@ test('file watching', async ({ startTestServer, writeFiles }, testInfo) => {
 
   const testServerConnection = await startTestServer();
   const tests = await testServerConnection.listTests({});
-  expect(tests.report.map(e => e.method)).toEqual(['onConfigure', 'onProject', 'onBegin', 'onEnd']);
+  expect(tests.report.map(e => e.method)).toEqual(['onConfigure', 'onProject', 'onBegin', 'onEnd', 'onExit']);
 
   await testServerConnection.watch({ fileNames: [testInfo.outputPath('a.test.ts')] });
 


### PR DESCRIPTION
Discovered through https://github.com/microsoft/playwright-vscode/pull/702. We have code for receiving `onExit`, but not for emitting.