### PR TITLE
fix(trace-viewer): restore displaying selected call title in call tab

### DIFF
--- a/packages/trace-viewer/src/ui/callTab.tsx
+++ b/packages/trace-viewer/src/ui/callTab.tsx
@@ -24,6 +24,7 @@ import { asLocator } from '@isomorphic/locatorGenerators';
 import type { Language } from '@isomorphic/locatorGenerators';
 import { PlaceholderPanel } from './placeholderPanel';
 import type { ActionTraceEventInContext } from './modelUtil';
+import { renderTitleForCall } from './actionList';
 
 export const CallTab: React.FunctionComponent<{
   action: ActionTraceEventInContext | undefined,
@@ -40,9 +41,11 @@ export const CallTab: React.FunctionComponent<{
   const startTimeMillis = action.startTime - startTimeOffset;
   const startTime = msToString(startTimeMillis);
 
+  const { title } = renderTitleForCall(action);
+
   return (
     <div className='call-tab'>
-      <div className='call-line'>{action.title}</div>
+      <div className='call-line'>{title}</div>
       <div className='call-section'>Time</div>
       <DateTimeCallLine name='start:' value={startTime} />
       <DateTimeCallLine name='duration:' value={renderDuration(action)} />

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -303,7 +303,7 @@ test('should show params and return value', async ({ showTraceViewer }) => {
   const traceViewer = await showTraceViewer(traceFile);
   await traceViewer.selectAction('Evaluate');
   await expect(traceViewer.callLines).toHaveText([
-    '',
+    /Evaluate/,
     /start:[\d\.]+m?s/,
     /duration:[\d]+ms/,
     /expression:"\({↵    a↵  }\) => {↵    console\.log\(\'Info\'\);↵    console\.warn\(\'Warning\'\);↵    console/,
@@ -329,7 +329,7 @@ test('should show null as a param', async ({ showTraceViewer, browserName }) => 
   const traceViewer = await showTraceViewer(traceFile);
   await traceViewer.selectAction('Evaluate', 1);
   await expect(traceViewer.callLines).toHaveText([
-    '',
+    /Evaluate/,
     /start:[\d\.]+m?s/,
     /duration:[\d]+ms/,
     'expression:"() => 1 + 1"',


### PR DESCRIPTION
In the refactoring of `apiName` metadata, the display of the call `apiName` was lost from the top of the Call Tab for everything but legacy traces. Consume the same title generation logic as the actions list and continue displaying at the top of the list.

**NOTE:** I could also see this being the `apiName` equivalent (`class.method`), but that wouldn't match the actions list.

<img width="350" height="595" alt="Screenshot 2025-10-17 at 6 35 43 AM" src="https://github.com/user-attachments/assets/d46a641d-4ff9-4121-9136-3f8d83b86ee8" />