### PR TITLE
fix(trace-viewer): properly size copy button to prevent bounce

### DIFF
--- a/packages/trace-viewer/src/ui/callTab.css
+++ b/packages/trace-viewer/src/ui/callTab.css
@@ -69,6 +69,12 @@
   margin-bottom: -2px;
 }
 
+.call-line .toolbar-button.check {
+  margin-left: 5px;
+  margin-top: -2px;
+  margin-bottom: -2px;
+}
+
 .call-value {
   margin-left: 2px;
   text-overflow: ellipsis;

--- a/packages/trace-viewer/src/ui/copyToClipboard.tsx
+++ b/packages/trace-viewer/src/ui/copyToClipboard.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { ToolbarButton } from '@web/components/toolbarButton';
 import './copyToClipboard.css';
 
+// TODO: This should be deduplicated with packages/html-reporter/src/copyToClipboard.tsx
 export const CopyToClipboard: React.FunctionComponent<{
   value: string | (() => Promise<string>),
   description?: string,


### PR DESCRIPTION
The copy button in the Call information tab in Trace Viewer causes the row to bounce when clicked. Match the existing non-ideal styling for the clicked state.

Ideally in the future this is deduplicated against the implementation in HTML Reporter and doesn't require positioning hacks.

<img width="294" height="84" alt="Screenshot 2025-10-17 at 8 27 53 AM" src="https://github.com/user-attachments/assets/2ee2fbae-e71f-4397-8368-86963250588a" />
