### PR TITLE
fix(trace-viewer): make Call tab Time rendering consistent, with copy buttons

### DIFF
--- a/packages/trace-viewer/src/ui/callTab.css
+++ b/packages/trace-viewer/src/ui/callTab.css
@@ -89,6 +89,7 @@ a.call-value:hover {
 
 .call-value.datetime,
 .call-value.string,
+.call-value.literal,
 .call-value.locator {
   color: var(--vscode-charts-orange);
 }

--- a/packages/trace-viewer/src/ui/callTab.tsx
+++ b/packages/trace-viewer/src/ui/callTab.tsx
@@ -44,8 +44,8 @@ export const CallTab: React.FunctionComponent<{
     <div className='call-tab'>
       <div className='call-line'>{action.title}</div>
       <div className='call-section'>Time</div>
-      <DateTimeCallLine name='start:' value={startTime} />
-      <DateTimeCallLine name='duration:' value={renderDuration(action)} />
+      {renderProperty({ name: 'start', type: 'literal', text: startTime })}
+      {renderProperty({ name: 'duration', type: 'literal', text: renderDuration(action) })}
       {
         !!paramKeys.length && <>
           <div className='call-section'>Parameters</div>
@@ -64,11 +64,9 @@ export const CallTab: React.FunctionComponent<{
   );
 };
 
-const DateTimeCallLine: React.FC<{ name: string, value: string }> = ({ name, value }) => <div className='call-line'>{name}<span className='call-value datetime' title={value}>{value}</span></div>;
-
 type Property = {
   name: string;
-  type: 'string' | 'number' | 'object' | 'locator' | 'handle' | 'bigint' | 'boolean' | 'symbol' | 'undefined' | 'function';
+  type: 'literal' | 'string' | 'number' | 'object' | 'locator' | 'handle' | 'bigint' | 'boolean' | 'symbol' | 'undefined' | 'function';
   text: string;
 };
 
@@ -88,7 +86,7 @@ function renderProperty(property: Property) {
   return (
     <div key={property.name} className='call-line'>
       {property.name}:<span className={clsx('call-value', property.type)} title={property.text}>{text}</span>
-      { ['string', 'number', 'object', 'locator'].includes(property.type) &&
+      { ['literal', 'string', 'number', 'object', 'locator'].includes(property.type) &&
         <CopyToClipboard value={property.text} />
       }
     </div>


### PR DESCRIPTION
Keep rendering the same as all other items.

<img width="228" height="92" alt="Screenshot 2025-10-17 at 10 38 48 AM" src="https://github.com/user-attachments/assets/506b5ca1-8107-4687-b549-c7b9adeee187" />