### PR TITLE
feat(trace): Only allow zip files to be selected for upload

### DIFF
--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -39,7 +39,7 @@ pwsh bin/Debug/netX/playwright.ps1 show-trace trace.zip
 
 ### Using [trace.playwright.dev](https://trace.playwright.dev)
 
-[trace.playwright.dev](https://trace.playwright.dev) is a statically hosted variant of the Trace Viewer. You can upload trace files using drag and drop or via the `Select file(s)` button.
+[trace.playwright.dev](https://trace.playwright.dev) is a statically hosted variant of the Trace Viewer. You can upload a trace file using drag and drop or via the `Select file` button.
 
 Trace Viewer loads the trace entirely in your browser and does not transmit any data externally.
 

--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -213,9 +213,10 @@ export const WorkbenchLoader: React.FunctionComponent<{
       <button onClick={() => {
         const input = document.createElement('input');
         input.type = 'file';
+        input.accept = 'application/zip';
         input.click();
         input.addEventListener('change', e => handleFileInputChange(e));
-      }} type='button'>Select file(s)</button>
+      }} type='button'>Select file</button>
       <div style={{ maxWidth: 400 }}>Playwright Trace Viewer is a Progressive Web App, it does not send your trace anywhere,
         it opens it locally.</div>
     </div>}

--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -213,7 +213,7 @@ export const WorkbenchLoader: React.FunctionComponent<{
       <button onClick={() => {
         const input = document.createElement('input');
         input.type = 'file';
-        input.accept = 'application/zip';
+        input.accept = '.zip';
         input.click();
         input.addEventListener('change', e => handleFileInputChange(e));
       }} type='button'>Select file</button>

--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -213,7 +213,6 @@ export const WorkbenchLoader: React.FunctionComponent<{
       <button onClick={() => {
         const input = document.createElement('input');
         input.type = 'file';
-        input.accept = '.zip';
         input.click();
         input.addEventListener('change', e => handleFileInputChange(e));
       }} type='button'>Select file</button>


### PR DESCRIPTION
Reflect the change that the trace viewer only allows 1 trace at same time and let user only select zip files.

Before:
<img width="381" height="169" alt="image" src="https://github.com/user-attachments/assets/99ab7fd0-768d-4fce-acf3-1455c7f6f5f1" />


After:
<img width="367" height="162" alt="image" src="https://github.com/user-attachments/assets/509dcd26-6ba5-41b7-bc60-41397e50b283" />

Closes: #37933
