### PR TITLE
test: unskip cookie test for firefox

### DIFF
--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -74,9 +74,7 @@ it('should get a non-session cookie', async ({ context, page, server, defaultSam
 
 it('should allow adding cookies with >400 days expiration', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37903' }
-}, async ({ context, server, browserName, channel }) => {
-  it.fixme(browserName === 'firefox' && !channel?.startsWith('moz-firefox'), 'Firefox fails to add cookies with >400 days expiration');
-
+}, async ({ context, server }) => {
   // Browsers start to cap cookies with 400 days max expires value.
   // See https://github.com/httpwg/http-extensions/pull/1732
   // Chromium patch: https://chromium.googlesource.com/chromium/src/+/aaa5d2b55478eac2ee642653dcd77a50ac3faff6


### PR DESCRIPTION
It was fixed in https://github.com/microsoft/playwright-browsers/pull/1916.

Closes #37903