### PR TITLE
feat(web): Add `matchBrackets` and `autoCloseBrackets` to CodeMirror

### DIFF
--- a/packages/web/src/components/codeMirrorModule.tsx
+++ b/packages/web/src/components/codeMirrorModule.tsx
@@ -24,7 +24,6 @@ import 'codemirror/mode/javascript/javascript';
 import 'codemirror/mode/python/python';
 import 'codemirror/mode/clike/clike';
 import 'codemirror/mode/markdown/markdown';
-import 'codemirror/mode/yaml/yaml';
 import 'codemirror/addon/display/placeholder';
 import 'codemirror/addon/mode/simple';
 import 'codemirror/addon/edit/matchbrackets';

--- a/packages/web/src/components/codeMirrorModule.tsx
+++ b/packages/web/src/components/codeMirrorModule.tsx
@@ -24,9 +24,11 @@ import 'codemirror/mode/javascript/javascript';
 import 'codemirror/mode/python/python';
 import 'codemirror/mode/clike/clike';
 import 'codemirror/mode/markdown/markdown';
+import 'codemirror/mode/yaml/yaml';
 import 'codemirror/addon/display/placeholder';
 import 'codemirror/addon/mode/simple';
-import 'codemirror/mode/yaml/yaml';
+import 'codemirror/addon/edit/matchbrackets';
+import 'codemirror/addon/edit/closebrackets';
 
 export type CodeMirror = typeof codemirrorType;
 export default codemirror;

--- a/packages/web/src/components/codeMirrorWrapper.tsx
+++ b/packages/web/src/components/codeMirrorWrapper.tsx
@@ -106,6 +106,8 @@ export const CodeMirrorWrapper: React.FC<SourceProps> = ({
         lineNumbers,
         lineWrapping: wrapLines,
         placeholder,
+        matchBrackets: true,
+        autoCloseBrackets: true,
       });
       codemirrorRef.current = { cm };
       if (isFocused)

--- a/tests/library/inspector/cli-codegen-aria.spec.ts
+++ b/tests/library/inspector/cli-codegen-aria.spec.ts
@@ -137,8 +137,8 @@ test.describe(() => {
 
     await recorder.recorderPage.locator('.tab-aria .CodeMirror').click();
     await recorder.recorderPage.keyboard.press('Backspace');
-    // 3 highlighted tokens.
-    await expect(recorder.recorderPage.locator('.source-line-error-underline')).toHaveCount(3);
+    // 1 highlighted token
+    await expect(recorder.recorderPage.locator('.source-line-error-underline')).toHaveCount(1);
   });
 
   test('should generate valid javascript with multiline snapshot assertion', async ({ openRecorder }) => {

--- a/tests/playwright-test/ui-mode-test-attachments.spec.ts
+++ b/tests/playwright-test/ui-mode-test-attachments.spec.ts
@@ -142,7 +142,7 @@ test('should linkify string attachments', async ({ runUITest, server }) => {
     await attachmentsPane.getByLabel('Third').click();
     const url = server.PREFIX + '/three.html';
     const promise = page.waitForEvent('popup');
-    await attachmentsPane.getByText('[markdown link]').click();
+    await attachmentsPane.getByText('markdown link').dblclick();
     const popup = await promise;
     await expect(popup).toHaveURL(url);
   }


### PR DESCRIPTION
For example when editing locator, brackets are now auto closed and matching brackets visualized.
![Locator editor example](https://github.com/user-attachments/assets/273ef234-dd28-437c-aa27-8cb144d701af)

references: #37711