### PR TITLE
fix(test-runner): fix RangeError when running thousands of tests

### DIFF
--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -184,8 +184,7 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
     for (const projectSuite of rootSuite.suites) {
       // Split beforeAll-grouped tests into "config.shard.total" groups when needed.
       // Later on, we'll re-split them between workers by using "config.workers" instead.
-      const testGroups = createTestGroups(projectSuite, config.config.shard.total);
-      for (const group of testGroups)
+      for (const group of createTestGroups(projectSuite, config.config.shard.total))
         testGroups.push(group);
     }
 

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -184,7 +184,10 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
     for (const projectSuite of rootSuite.suites) {
       // Split beforeAll-grouped tests into "config.shard.total" groups when needed.
       // Later on, we'll re-split them between workers by using "config.workers" instead.
-      testGroups.push(...createTestGroups(projectSuite, config.config.shard.total));
+      const testGroups = createTestGroups(projectSuite, config.config.shard.total);
+      for (const group of testGroups) {
+        testGroups.push(group);
+      }
     }
 
     // Shard test groups.

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -185,9 +185,8 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
       // Split beforeAll-grouped tests into "config.shard.total" groups when needed.
       // Later on, we'll re-split them between workers by using "config.workers" instead.
       const testGroups = createTestGroups(projectSuite, config.config.shard.total);
-      for (const group of testGroups) {
+      for (const group of testGroups)
         testGroups.push(group);
-      }
     }
 
     // Shard test groups.


### PR DESCRIPTION
At my workplace we run a stress test pipeline so run all of our tests to be repeated many times. When we reached a certain number of tests, our pipeline failed since we ran into a RangeError.

Similar to #37767
Max:
<img width="788" height="85" alt="Screenshot 2025-10-21 at 14 38 49" src="https://github.com/user-attachments/assets/45bf6399-ebc2-4b7a-864d-011a56a4d70d" />

Over limit:
<img width="794" height="62" alt="Screenshot 2025-10-21 at 14 38 17" src="https://github.com/user-attachments/assets/daeaab5a-64a5-47c2-aec4-638cf08a1d49" />
<img width="691" height="209" alt="Screenshot 2025-10-21 at 14 47 16" src="https://github.com/user-attachments/assets/668d160e-dc48-45fd-8af2-79996f725665" />

`DEBUG=*`
<img width="914" height="216" alt="Screenshot 2025-10-21 at 09 55 03" src="https://github.com/user-attachments/assets/6b2c9e0c-2d67-4859-a95a-3f7fd9508d56" />

