### PR TITLE
feat(aria): trim snapshot diff to only include changed chunks

### DIFF
--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -300,18 +300,22 @@ export class InjectedScript {
     return new Set<Element>(result.map(r => r.element));
   }
 
-  ariaSnapshot(node: Node, options: AriaTreeOptions & { track?: string, incremental?: boolean }): string {
+  ariaSnapshot(node: Node, options: AriaTreeOptions): string {
+    return this.incrementalAriaSnapshot(node, options).snapshot;
+  }
+
+  incrementalAriaSnapshot(node: Node, options: AriaTreeOptions & { track?: string, incremental?: boolean }): { snapshot: string, iframeRefs: string[], isIncremental: boolean } {
     if (node.nodeType !== Node.ELEMENT_NODE)
       throw this.createStacklessError('Can only capture aria snapshot of Element nodes.');
     const ariaSnapshot = generateAriaTree(node as Element, options);
     let previous: AriaSnapshot | undefined;
-    if (options.incremental)
-      previous = options.track ? this._lastAriaSnapshotForTrack.get(options.track) : undefined;
-    const result = renderAriaTree(ariaSnapshot, options, previous);
+    if (options.incremental && options.track)
+      previous = this._lastAriaSnapshotForTrack.get(options.track);
+    const snapshot = renderAriaTree(ariaSnapshot, options, previous);
     if (options.track)
       this._lastAriaSnapshotForTrack.set(options.track, ariaSnapshot);
     this._lastAriaSnapshotForQuery = ariaSnapshot;
-    return result;
+    return { snapshot, iframeRefs: ariaSnapshot.iframeRefs, isIncremental: !!previous };
   }
 
   ariaSnapshotForRecorder(): { ariaSnapshot: string, refs: Map<Element, string> } {

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -860,7 +860,7 @@ export class Page extends SdkObject {
 
   async snapshotForAI(progress: Progress, options: { track?: string, mode?: 'full' | 'incremental' }): Promise<string> {
     const snapshot = await snapshotFrameForAI(progress, this.mainFrame(), options);
-    return snapshot.join('\n');
+    return snapshot.lines.join('\n');
   }
 }
 
@@ -1035,9 +1035,22 @@ class FrameThrottler {
   }
 }
 
-async function snapshotFrameForAI(progress: Progress, frame: frames.Frame, options: { track?: string, mode?: 'full' | 'incremental' }): Promise<string[]> {
+async function snapshotFrameRefForAI(progress: Progress, parentFrame: frames.Frame, frameRef: string, options: { track?: string, mode?: 'full' | 'incremental' }): Promise<{ lines: string[], isIncremental: boolean }> {
+  const frameSelector = `aria-ref=${frameRef} >> internal:control=enter-frame`;
+  const frameBodySelector = `${frameSelector} >> body`;
+  const child = await progress.race(parentFrame.selectors.resolveFrameForSelector(frameBodySelector, { strict: true }));
+  if (!child)
+    return { lines: [], isIncremental: false };
+  try {
+    return await snapshotFrameForAI(progress, child.frame, options);
+  } catch {
+    return { lines: [], isIncremental: false };
+  }
+}
+
+async function snapshotFrameForAI(progress: Progress, frame: frames.Frame, options: { track?: string, mode?: 'full' | 'incremental' }): Promise<{ lines: string[], isIncremental: boolean }> {
   // Only await the topmost navigations, inner frames will be empty when racing.
-  const snapshot = await frame.retryWithProgressAndTimeouts(progress, [1000, 2000, 4000, 8000], async continuePolling => {
+  const { snapshot, iframeRefs, isIncremental } = await frame.retryWithProgressAndTimeouts(progress, [1000, 2000, 4000, 8000], async continuePolling => {
     try {
       const context = await progress.race(frame._utilityContext());
       const injectedScript = await progress.race(context.injectedScript());
@@ -1045,7 +1058,7 @@ async function snapshotFrameForAI(progress: Progress, frame: frames.Frame, optio
         const node = injected.document.body;
         if (!node)
           return true;
-        return injected.ariaSnapshot(node, { mode: 'ai', ...options });
+        return injected.incrementalAriaSnapshot(node, { mode: 'ai', ...options });
       }, { refPrefix: frame.seq ? 'f' + frame.seq : '', incremental: options.mode === 'incremental', track: options.track }));
       if (snapshotOrRetry === true)
         return continuePolling;
@@ -1059,6 +1072,21 @@ async function snapshotFrameForAI(progress: Progress, frame: frames.Frame, optio
 
   const lines = snapshot.split('\n');
   const result = [];
+
+  if (isIncremental) {
+    result.push(...lines);
+    for (const ref of iframeRefs) {
+      const childSnapshot = await snapshotFrameRefForAI(progress, frame, ref, options);
+      if (!childSnapshot.lines.length)
+        continue;
+      if (childSnapshot.isIncremental)
+        result.push(...childSnapshot.lines);
+      else
+        result.push('- <changed> iframe [ref=' + ref + ']', ...childSnapshot.lines.map(l => '  ' + l));
+    }
+    return { lines: result, isIncremental };
+  }
+
   for (const line of lines) {
     const match = line.match(/^(\s*)- iframe (?:\[active\] )?\[ref=([^\]]*)\]/);
     if (!match) {
@@ -1068,21 +1096,11 @@ async function snapshotFrameForAI(progress: Progress, frame: frames.Frame, optio
 
     const leadingSpace = match[1];
     const ref = match[2];
-    const frameSelector = `aria-ref=${ref} >> internal:control=enter-frame`;
-    const frameBodySelector = `${frameSelector} >> body`;
-    const child = await progress.race(frame.selectors.resolveFrameForSelector(frameBodySelector, { strict: true }));
-    if (!child) {
-      result.push(line);
-      continue;
-    }
-    try {
-      const childSnapshot = await snapshotFrameForAI(progress, child.frame, options);
-      result.push(line + ':', ...childSnapshot.map(l => leadingSpace + '  ' + l));
-    } catch {
-      result.push(line);
-    }
+    const childSnapshot = await snapshotFrameRefForAI(progress, frame, ref, options);
+    result.push(childSnapshot.lines.length ? line + ':' : line);
+    result.push(...childSnapshot.lines.map(l => leadingSpace + '  ' + l));
   }
-  return result;
+  return { lines: result, isIncremental };
 }
 
 function ensureArrayLimit<T>(array: T[], limit: number): T[] {

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -1082,7 +1082,7 @@ async function snapshotFrameForAI(progress: Progress, frame: frames.Frame, optio
       if (childSnapshot.isIncremental)
         result.push(...childSnapshot.lines);
       else
-        result.push('- <changed> iframe [ref=' + ref + ']', ...childSnapshot.lines.map(l => '  ' + l));
+        result.push('- <changed> iframe [ref=' + ref + ']:', ...childSnapshot.lines.map(l => '  ' + l));
     }
     return { lines: result, isIncremental };
   }

--- a/packages/playwright-core/src/utils/isomorphic/ariaSnapshot.ts
+++ b/packages/playwright-core/src/utils/isomorphic/ariaSnapshot.ts
@@ -24,6 +24,7 @@ export type AriaRole = 'alert' | 'alertdialog' | 'application' | 'article' | 'ba
   'spinbutton' | 'status' | 'strong' | 'subscript' | 'superscript' | 'switch' | 'tab' | 'table' | 'tablist' | 'tabpanel' | 'term' | 'textbox' | 'time' | 'timer' |
   'toolbar' | 'tooltip' | 'tree' | 'treegrid' | 'treeitem';
 
+// Note: please keep in sync with ariaPropsEqual() below.
 export type AriaProps = {
   checked?: boolean | 'mixed';
   disabled?: boolean;
@@ -33,6 +34,10 @@ export type AriaProps = {
   pressed?: boolean | 'mixed';
   selected?: boolean;
 };
+
+export function ariaPropsEqual(a: AriaProps, b: AriaProps): boolean {
+  return a.active === b.active && a.checked === b.checked && a.disabled === b.disabled && a.expanded === b.expanded && a.selected === b.selected && a.level === b.level && a.pressed === b.pressed;
+}
 
 // We pass parsed template between worlds using JSON, make it easy.
 export type AriaRegex = { pattern: string };

--- a/packages/playwright/src/mcp/browser/response.ts
+++ b/packages/playwright/src/mcp/browser/response.ts
@@ -192,7 +192,8 @@ function renderTabSnapshot(tabSnapshot: TabSnapshot, options: { omitSnapshot?: b
   lines.push(`- Page Title: ${tabSnapshot.title}`);
   lines.push(`- Page Snapshot:`);
   lines.push('```yaml');
-  lines.push(options.omitSnapshot ? '<snapshot>' : tabSnapshot.ariaSnapshot);
+  // TODO: perhaps not render page state when there are no changes?
+  lines.push(options.omitSnapshot ? '<snapshot>' : (tabSnapshot.ariaSnapshot || '<no changes>'));
   lines.push('```');
 
   return lines.join('\n');

--- a/tests/mcp/click.spec.ts
+++ b/tests/mcp/click.spec.ts
@@ -41,7 +41,7 @@ test('browser_click', async ({ client, server }) => {
     },
   })).toHaveResponse({
     code: `await page.getByRole('button', { name: 'Submit' }).click();`,
-    pageState: expect.stringContaining(`- button "Submit" [active] [ref=e2]`),
+    pageState: expect.stringContaining(`button "Submit" [active] [ref=e2]`),
   });
 });
 
@@ -70,7 +70,7 @@ test('browser_click (double)', async ({ client, server }) => {
     },
   })).toHaveResponse({
     code: `await page.getByRole('heading', { name: 'Click me' }).dblclick();`,
-    pageState: expect.stringContaining(`- heading "Double clicked" [level=1] [ref=e3]`),
+    pageState: expect.stringContaining(`heading "Double clicked" [level=1] [ref=e3]`),
   });
 });
 
@@ -100,7 +100,7 @@ test('browser_click (right)', async ({ client, server }) => {
   });
   expect(result).toHaveResponse({
     code: `await page.getByRole('button', { name: 'Menu' }).click({ button: 'right' });`,
-    pageState: expect.stringContaining(`- button "Right clicked"`),
+    pageState: expect.stringContaining(`button "Right clicked"`),
   });
 });
 
@@ -156,7 +156,7 @@ test('browser_click (modifiers)', async ({ client, server, mcpBrowser }) => {
     },
   })).toHaveResponse({
     code: `await page.getByRole('button', { name: 'Submit' }).click({ modifiers: ['Shift', 'Alt'] });`,
-    pageState: expect.stringContaining(`- generic [ref=e3]: ctrlKey:false metaKey:false shiftKey:true altKey:true`),
+    pageState: expect.stringContaining(`generic [ref=e3]: ctrlKey:false metaKey:false shiftKey:true altKey:true`),
   });
 });
 

--- a/tests/mcp/core.spec.ts
+++ b/tests/mcp/core.spec.ts
@@ -58,7 +58,7 @@ test('browser_select_option', async ({ client, server }) => {
 - Page Title: Title
 - Page Snapshot:
 \`\`\`yaml
-- combobox [ref=e2]:
+- <changed> combobox [ref=e2]:
   - option "Foo"
   - option "Bar" [selected]
 \`\`\``,
@@ -90,8 +90,8 @@ test('browser_select_option (multiple)', async ({ client, server }) => {
   })).toHaveResponse({
     code: `await page.getByRole('listbox').selectOption(['bar', 'baz']);`,
     pageState: expect.stringContaining(`
-  - option "Bar" [selected] [ref=e4]
-  - option "Baz" [selected] [ref=e5]`),
+- <changed> option "Bar" [selected] [ref=e4]
+- <changed> option "Baz" [selected] [ref=e5]`),
   });
 });
 

--- a/tests/mcp/dialogs.spec.ts
+++ b/tests/mcp/dialogs.spec.ts
@@ -139,7 +139,7 @@ test('confirm dialog (true)', async ({ client, server }) => {
     },
   })).toHaveResponse({
     modalState: undefined,
-    pageState: expect.stringContaining(`- generic [active] [ref=e1]: "true"`),
+    pageState: expect.stringContaining(`generic [active] [ref=e1]: "true"`),
   });
 });
 
@@ -175,7 +175,7 @@ test('confirm dialog (false)', async ({ client, server }) => {
     },
   })).toHaveResponse({
     modalState: undefined,
-    pageState: expect.stringContaining(`- generic [active] [ref=e1]: "false"`),
+    pageState: expect.stringContaining(`generic [active] [ref=e1]: "false"`),
   });
 });
 
@@ -213,7 +213,7 @@ test('prompt dialog', async ({ client, server }) => {
   });
 
   expect(result).toHaveResponse({
-    pageState: expect.stringContaining(`- generic [active] [ref=e1]: Answer`),
+    pageState: expect.stringContaining(`generic [active] [ref=e1]: Answer`),
   });
 });
 

--- a/tests/mcp/secrets.spec.ts
+++ b/tests/mcp/secrets.spec.ts
@@ -53,7 +53,7 @@ test('browser_type', async ({ startClient, server }) => {
     expect(response).toHaveResponse({
       code: `await page.getByRole('textbox').fill(process.env['X-PASSWORD']);
 await page.getByRole('textbox').press('Enter');`,
-      pageState: expect.stringContaining(`- textbox`),
+      pageState: expect.stringMatching(/textbox (\[active\] )?\[ref=e2\]: <secret>X-PASSWORD<\/secret>/),
     });
   }
 

--- a/tests/mcp/snapshot-diff.spec.ts
+++ b/tests/mcp/snapshot-diff.spec.ts
@@ -65,7 +65,7 @@ test('should return aria snapshot diff', async ({ client, server }) => {
   })).toHaveResponse({
     pageState: expect.stringContaining(`Page Snapshot:
 \`\`\`yaml
-- ref=e1 [unchanged]
+<no changes>
 \`\`\``),
   });
 
@@ -78,7 +78,7 @@ test('should return aria snapshot diff', async ({ client, server }) => {
   })).toHaveResponse({
     pageState: expect.stringContaining(`Page Snapshot:
 \`\`\`yaml
-- generic [ref=e1]:
+- <changed> generic [ref=e1]:
   - button "Button 1" [active] [ref=e2]
   - button "Button 2new text" [ref=e105]
   - ref=e4 [unchanged]

--- a/tests/mcp/type.spec.ts
+++ b/tests/mcp/type.spec.ts
@@ -44,7 +44,7 @@ test('browser_type', async ({ client, server }) => {
     expect(response).toHaveResponse({
       code: `await page.getByRole('textbox').fill('Hi!');
 await page.getByRole('textbox').press('Enter');`,
-      pageState: expect.stringContaining(`- textbox`),
+      pageState: expect.stringMatching(/textbox (\[active\] )?\[ref=e2\]: Hi!/),
     });
   }
 
@@ -79,7 +79,7 @@ test('browser_type (slowly)', async ({ client, server }) => {
 
     expect(response).toHaveResponse({
       code: `await page.getByRole('textbox').pressSequentially('Hi!');`,
-      pageState: expect.stringContaining(`- textbox`),
+      pageState: expect.stringMatching(/textbox (\[active\] )?\[ref=e2\]: Hi!/),
     });
   }
   const response = await client.callTool({

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -696,3 +696,24 @@ it('should not create incremental snapshots without tracks', async ({ page }) =>
       - listitem [ref=e5]: a span
   `);
 });
+
+it('should create incremental snapshot for children swap', async ({ page }) => {
+  await page.setContent(`
+    <ul>
+      <li>item 1</li>
+      <li>item 2</li>
+    </ul>
+  `);
+  expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
+    - list [ref=e2]:
+      - listitem [ref=e3]: item 1
+      - listitem [ref=e4]: item 2
+  `);
+
+  await page.evaluate(() => document.querySelector('ul').appendChild(document.querySelector('li')));
+  expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
+    - <changed> list [ref=e2]:
+      - ref=e4 [unchanged]
+      - ref=e3 [unchanged]
+  `);
+});

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -717,3 +717,33 @@ it('should create incremental snapshot for children swap', async ({ page }) => {
       - ref=e3 [unchanged]
   `);
 });
+
+it('should create incremental snapshot with iframes', async ({ page }) => {
+  await page.setContent(`
+    <iframe srcdoc="
+      <li>
+        <span style='display:none'>outer text</span>
+        <button>a button</button>
+        <iframe src='data:text/html,<li>inner text</li>' style='display:none'></iframe>
+      </li>
+    "></iframe>
+  `);
+  expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
+    - iframe [ref=e2]:
+      - listitem [ref=f1e2]:
+        - button "a button" [ref=f1e3]
+  `);
+
+  await page.frames()[1].evaluate(() => {
+    document.querySelector('span').style.display = 'block';
+    document.querySelector('iframe').style.display = 'block';
+  });
+  expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
+    - <changed> listitem [ref=f1e2]:
+      - generic [ref=f1e4]: outer text
+      - ref=f1e3 [unchanged]
+      - iframe [ref=f1e5]
+    - <changed> iframe [ref=f1e5]:
+      - listitem [ref=f2e2]: inner text
+  `);
+});

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -510,7 +510,6 @@ it('should create incremental snapshots on multiple tracks', async ({ page }) =>
       - listitem [ref=e5]: a span
   `);
   expect(await snapshotForAI(page, { track: 'first', mode: 'incremental' })).toContainYaml(`
-    - ref=e2 [unchanged]
   `);
 
   await page.evaluate(() => {
@@ -518,7 +517,7 @@ it('should create incremental snapshots on multiple tracks', async ({ page }) =>
     document.getElementById('hidden-li').style.display = 'inline';
   });
   expect(await snapshotForAI(page, { track: 'first', mode: 'incremental' })).toContainYaml(`
-    - list [ref=e2]:
+    - <changed> list [ref=e2]:
       - ref=e3 [unchanged]
       - listitem [ref=e5]: changed span
       - listitem [ref=e6]: some text
@@ -529,12 +528,11 @@ it('should create incremental snapshots on multiple tracks', async ({ page }) =>
     document.getElementById('hidden-li').style.display = 'none';
   });
   expect(await snapshotForAI(page, { track: 'first', mode: 'incremental' })).toContainYaml(`
-    - list [ref=e2]:
+    - <changed> list [ref=e2]:
       - ref=e3 [unchanged]
       - listitem [ref=e5]: a span
   `);
   expect(await snapshotForAI(page, { track: 'second', mode: 'incremental' })).toContainYaml(`
-    - ref=e2 [unchanged]
   `);
 
   expect(await snapshotForAI(page, { track: 'second', mode: 'full' })).toContainYaml(`
@@ -554,7 +552,7 @@ it('should create incremental snapshot for attribute change', async ({ page }) =
 
   await page.evaluate(() => document.querySelector('button').blur());
   expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
-    - button "a button" [ref=e2]
+    - <changed> button "a button" [ref=e2]
   `);
 });
 
@@ -568,7 +566,7 @@ it('should create incremental snapshot for child removal', async ({ page }) => {
 
   await page.evaluate(() => document.querySelector('span').remove());
   expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
-    - listitem [ref=e2]:
+    - <changed> listitem [ref=e2]:
       - ref=e3 [unchanged]
   `);
 });
@@ -582,7 +580,7 @@ it('should create incremental snapshot for child addition', async ({ page }) => 
 
   await page.evaluate(() => document.querySelector('span').style.display = 'inline');
   expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
-    - listitem [ref=e2]:
+    - <changed> listitem [ref=e2]:
       - ref=e3 [unchanged]
       - text: some text
   `);
@@ -597,7 +595,7 @@ it('should create incremental snapshot for prop change', async ({ page }) => {
 
   await page.evaluate(() => document.querySelector('a').setAttribute('href', 'https://playwright.dev'));
   expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
-    - link "a link" [ref=e2] [cursor=pointer]:
+    - <changed> link "a link" [ref=e2] [cursor=pointer]:
       - /url: https://playwright.dev
   `);
 });
@@ -611,7 +609,7 @@ it('should create incremental snapshot for cursor change', async ({ page }) => {
 
   await page.evaluate(() => document.querySelector('a').style.cursor = 'default');
   expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
-    - link "a link" [ref=e2]:
+    - <changed> link "a link" [ref=e2]:
       - /url: about:blank
   `);
 });
@@ -624,7 +622,7 @@ it('should create incremental snapshot for name change', async ({ page }) => {
 
   await page.evaluate(() => document.querySelector('span').textContent = 'new button');
   expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
-    - button "new button" [ref=e3]
+    - <changed> button "new button" [ref=e3]
   `);
 });
 
@@ -636,21 +634,49 @@ it('should create incremental snapshot for text change', async ({ page }) => {
 
   await page.evaluate(() => document.querySelector('span').textContent = 'new text');
   expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
-    - listitem [ref=e2]: new text
+    - <changed> listitem [ref=e2]: new text
   `);
 });
 
-it('should not produce incremental snapshot for iframes', async ({ page }) => {
+it('should create multiple chunks in incremental snapshot', async ({ page }) => {
   await page.setContent(`
-    <iframe srcdoc="<h1>hello</h1>"></iframe>
+    <ul>
+      <li><span>item1</span></li>
+      <li><span>item2</span></li>
+      <li><div role=group><span>item3</span></div></li>
+      <ul>
+        <li id=to-remove>to be removed</li>
+        <li>one more</li>
+      </ul>
+    </ul>
   `);
   expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
-    - iframe [ref=e2]:
-      - heading "hello" [level=1] [ref=f1e2]
+    - list [ref=e2]:
+      - listitem [ref=e3]: item1
+      - listitem [ref=e4]: item2
+      - listitem [ref=e5]:
+        - group [ref=e6]: item3
+      - list [ref=e7]:
+        - listitem [ref=e8]: to be removed
+        - listitem [ref=e9]: one more
   `);
+
+  await page.evaluate(() => {
+    const spans = document.querySelectorAll('span');
+    spans[0].textContent = 'new item1';
+    spans[2].textContent = 'new item3';
+    const button = document.createElement('button');
+    button.textContent = 'button';
+    spans[2].parentElement.appendChild(button);
+    document.querySelector('#to-remove').remove();
+  });
   expect(await snapshotForAI(page, { track: 'track', mode: 'incremental' })).toContainYaml(`
-    - iframe [ref=e2]:
-      - ref=f1e2 [unchanged]
+    - <changed> listitem [ref=e3]: new item1
+    - <changed> group [ref=e6]:
+      - text: new item3
+      - button "button" [ref=e10]
+    - <changed> list [ref=e7]:
+      - ref=e9 [unchanged]
   `);
 });
 


### PR DESCRIPTION
Example diff with 3 chunks:
```yaml
  - <changed> listitem [ref=e3]: new item1
  - <changed> group [ref=e6]:
    - text: new item3
    - button "button" [ref=e10]
  - <changed> list [ref=e7]:
    - ref=e9 [unchanged]
```

MCP reports `<no changes>` when no chunks are reported. We can follow up to remove page state in this case entirely.