### PR TITLE
chore: re-introduce PLAYWRIGHT_SKIP_NAVIGATION_CHECK env var

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -489,6 +489,12 @@ export class Page extends SdkObject {
   }
 
   private async _performWaitForNavigationCheck(progress: Progress) {
+    // Allow skipping navigation checks for applications that manage navigation non-standardly.
+    // Some downstream users rely on this for scenarios like Electron apps with custom request
+    // interception and multi-window navigation handling.
+    if (process.env.PLAYWRIGHT_SKIP_NAVIGATION_CHECK)
+      return;
+
     const mainFrame = this.frameManager.mainFrame();
     if (!mainFrame || !mainFrame.pendingDocument())
       return;


### PR DESCRIPTION
As stated in the comment, some Electron applications (including ours) rely on PLAYWRIGHT_SKIP_NAVIGATION_CHECK, which was removed in #36283.

The issue is that we intercept certain requests and open them in a separate Electron window. When this happens, Playwright loses context and waits indefinitely for the page to load, even though it never will since the request was intercepted.

This PR re-introduces the environment variable as a means of providing an escape hatch for applications with non-standard navigation handling. 

🙏 