### PR TITLE
chore(mcp): do not render page state when snapshot has not changed

### DIFF
--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -847,9 +847,8 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     return result.pdf;
   }
 
-  async _snapshotForAI(options: TimeoutOptions & { track?: string, mode?: 'full' | 'incremental' } = {}): Promise<string> {
-    const result = await this._channel.snapshotForAI({ timeout: this._timeoutSettings.timeout(options), track: options.track, mode: options.mode });
-    return result.snapshot;
+  async _snapshotForAI(options: TimeoutOptions & { track?: string } = {}): Promise<{ full: string, incremental?: string }> {
+    return await this._channel.snapshotForAI({ timeout: this._timeoutSettings.timeout(options), track: options.track });
   }
 }
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1466,11 +1466,11 @@ scheme.PageRequestsResult = tObject({
 });
 scheme.PageSnapshotForAIParams = tObject({
   track: tOptional(tString),
-  mode: tOptional(tEnum(['full', 'incremental'])),
   timeout: tFloat,
 });
 scheme.PageSnapshotForAIResult = tObject({
-  snapshot: tString,
+  full: tString,
+  incremental: tOptional(tString),
 });
 scheme.PageStartJSCoverageParams = tObject({
   resetOnNavigation: tOptional(tBoolean),

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -352,7 +352,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
   }
 
   async snapshotForAI(params: channels.PageSnapshotForAIParams, progress: Progress): Promise<channels.PageSnapshotForAIResult> {
-    return { snapshot: await this._page.snapshotForAI(progress, params) };
+    return await this._page.snapshotForAI(progress, params);
   }
 
   async bringToFront(params: channels.PageBringToFrontParams, progress: Progress): Promise<void> {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -681,7 +681,7 @@ class ArtifactsRecorder {
     try {
       // TODO: maybe capture snapshot when the error is created, so it's from the right page and right time
       await page._wrapApiCall(async () => {
-        this._pageSnapshot = await page._snapshotForAI({ timeout: 5000 });
+        this._pageSnapshot = (await page._snapshotForAI({ timeout: 5000 })).full;
       }, { internal: true });
     } catch {}
   }

--- a/packages/playwright/src/mcp/test/browserBackend.ts
+++ b/packages/playwright/src/mcp/test/browserBackend.ts
@@ -61,7 +61,7 @@ export async function runBrowserBackendAtEnd(context: playwright.BrowserContext,
     lines.push(
         `- Page Snapshot:`,
         '```yaml',
-        await (page as Page)._snapshotForAI(),
+        (await (page as Page)._snapshotForAI()).full,
         '```',
     );
   }

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -2549,15 +2549,14 @@ export type PageRequestsResult = {
 };
 export type PageSnapshotForAIParams = {
   track?: string,
-  mode?: 'full' | 'incremental',
   timeout: number,
 };
 export type PageSnapshotForAIOptions = {
   track?: string,
-  mode?: 'full' | 'incremental',
 };
 export type PageSnapshotForAIResult = {
-  snapshot: string,
+  full: string,
+  incremental?: string,
 };
 export type PageStartJSCoverageParams = {
   resetOnNavigation?: boolean,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1977,16 +1977,12 @@ Page:
     snapshotForAI:
       internal: true
       parameters:
+        # When track is present, an incremental snapshot is returned when possible.
         track: string?
-        mode:
-          # defaults to "full"
-          type: enum?
-          literals:
-          - full
-          - incremental
         timeout: float
       returns:
-        snapshot: string
+        full: string
+        incremental: string?
 
     startJSCoverage:
       title: Start JS coverage

--- a/tests/mcp/session-log.spec.ts
+++ b/tests/mcp/session-log.spec.ts
@@ -42,7 +42,6 @@ test('session log should record tool calls', async ({ startClient, server }, tes
     },
   })).toHaveResponse({
     code: `await page.getByRole('button', { name: 'Submit' }).click();`,
-    pageState: expect.stringContaining(`Page Title: Title`),
   });
 
   const output = stderr().split('\n').filter(line => line.startsWith('Session: '))[0];

--- a/tests/mcp/snapshot-diff.spec.ts
+++ b/tests/mcp/snapshot-diff.spec.ts
@@ -63,10 +63,7 @@ test('should return aria snapshot diff', async ({ client, server }) => {
       ref: 'e3',
     },
   })).toHaveResponse({
-    pageState: expect.stringContaining(`Page Snapshot:
-\`\`\`yaml
-<no changes>
-\`\`\``),
+    pageState: expect.not.stringContaining(`Page Snapshot`),
   });
 
   expect(await client.callTool({


### PR DESCRIPTION
Drive-by: return both full and incremental snapshot from `_snapshotForAI`.