### PR TITLE
feat(trace-viewer): Show version on trace viewer home screen

### DIFF
--- a/packages/trace-viewer/src/ui/workbenchLoader.css
+++ b/packages/trace-viewer/src/ui/workbenchLoader.css
@@ -44,6 +44,11 @@ body .drop-target {
   margin-bottom: 30px;
 }
 
+.drop-target .info {
+  max-width: 400px;
+  text-align: center;
+}
+
 .drop-target .processing-error {
   font-size: 24px;
   color: #e74c3c;
@@ -63,6 +68,11 @@ body .drop-target {
   border: none;
   margin: 30px 0;
   cursor: pointer;
+}
+
+.drop-target .version {
+  color: var(--vscode-disabledForeground);
+  margin-top: 8px;
 }
 
 .progress-dialog {

--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -216,8 +216,9 @@ export const WorkbenchLoader: React.FunctionComponent<{
         input.click();
         input.addEventListener('change', e => handleFileInputChange(e));
       }} type='button'>Select file</button>
-      <div style={{ maxWidth: 400 }}>Playwright Trace Viewer is a Progressive Web App, it does not send your trace anywhere,
+      <div className='info'>Playwright Trace Viewer is a Progressive Web App, it does not send your trace anywhere,
         it opens it locally.</div>
+      <div className='version'>Playwright v{__APP_VERSION__}</div>
     </div>}
     {isServer && !traceURL && <div className='drop-target'>
       <div className='title'>Select test to see the trace</div>

--- a/packages/trace-viewer/src/vite-env.d.ts
+++ b/packages/trace-viewer/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/packages/trace-viewer/vite.config.ts
+++ b/packages/trace-viewer/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
   ],
   define: {
     'process.env': {},
+    '__APP_VERSION__': JSON.stringify(process.env.npm_package_version),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Before:
<img width="509" height="383" alt="image" src="https://github.com/user-attachments/assets/025c48bd-dcbb-40b5-b363-2c36900f8e7e" />


After (show version and also centers the text):
<img width="497" height="353" alt="image" src="https://github.com/user-attachments/assets/b8c99c83-aa62-440b-ab80-f8846b1f701c" />



refs: #37955