### PR TITLE
chore: update pixelmatch to 7.1.0

### DIFF
--- a/packages/playwright-core/src/third_party/pixelmatch.js
+++ b/packages/playwright-core/src/third_party/pixelmatch.js
@@ -2,7 +2,7 @@
  * 
  * ISC License
  *
- * Copyright (c) 2019, Mapbox
+ * Copyright (c) 2025, Mapbox
 
  * Permission to use, copy, modify, and/or distribute this software for any purpose
  * with or without fee is hereby granted, provided that the above copyright notice
@@ -17,21 +17,34 @@
  * THIS SOFTWARE.
  */
 
-'use strict';
-
-module.exports = pixelmatch;
-
-const defaultOptions = {
-    threshold: 0.1,         // matching threshold (0 to 1); smaller is more sensitive
-    includeAA: false,       // whether to skip anti-aliasing detection
-    alpha: 0.1,             // opacity of original image in diff output
-    aaColor: [255, 255, 0], // color of anti-aliased pixels in diff output
-    diffColor: [255, 0, 0], // color of different pixels in diff output
-    diffColorAlt: null,     // whether to detect dark on light differences between img1 and img2 and set an alternative color to differentiate between the two
-    diffMask: false         // draw the diff over a transparent background (a mask)
-};
-
-function pixelmatch(img1, img2, output, width, height, options) {
+/**
+ * Compare two equally sized images, pixel by pixel.
+ *
+ * @param {Uint8Array | Uint8ClampedArray} img1 First image data.
+ * @param {Uint8Array | Uint8ClampedArray} img2 Second image data.
+ * @param {Uint8Array | Uint8ClampedArray | void} output Image data to write the diff to, if provided.
+ * @param {number} width Input images width.
+ * @param {number} height Input images height.
+ *
+ * @param {Object} [options]
+ * @param {number} [options.threshold=0.1] Matching threshold (0 to 1); smaller is more sensitive.
+ * @param {boolean} [options.includeAA=false] Whether to skip anti-aliasing detection.
+ * @param {number} [options.alpha=0.1] Opacity of original image in diff output.
+ * @param {[number, number, number]} [options.aaColor=[255, 255, 0]] Color of anti-aliased pixels in diff output.
+ * @param {[number, number, number]} [options.diffColor=[255, 0, 0]] Color of different pixels in diff output.
+ * @param {[number, number, number]} [options.diffColorAlt=options.diffColor] Whether to detect dark on light differences between img1 and img2 and set an alternative color to differentiate between the two.
+ * @param {boolean} [options.diffMask=false] Draw the diff over a transparent background (a mask).
+ *
+ * @return {number} The number of mismatched pixels.
+ */
+export default function pixelmatch(img1, img2, output, width, height, options = {}) {
+    const {
+        threshold = 0.1,
+        alpha = 0.1,
+        aaColor = [255, 255, 0],
+        diffColor = [255, 0, 0],
+        includeAA, diffColorAlt, diffMask
+    } = options;
 
     if (!isPixelData(img1) || !isPixelData(img2) || (output && !isPixelData(output)))
         throw new Error('Image data: Uint8Array, Uint8ClampedArray or Buffer expected.');
@@ -40,8 +53,6 @@ function pixelmatch(img1, img2, output, width, height, options) {
         throw new Error('Image sizes do not match.');
 
     if (img1.length !== width * height * 4) throw new Error('Image data size does not match width/height.');
-
-    options = Object.assign({}, defaultOptions, options);
 
     // check if images are identical
     const len = width * height;
@@ -53,46 +64,54 @@ function pixelmatch(img1, img2, output, width, height, options) {
         if (a32[i] !== b32[i]) { identical = false; break; }
     }
     if (identical) { // fast path if identical
-        if (output && !options.diffMask) {
-            for (let i = 0; i < len; i++) drawGrayPixel(img1, 4 * i, options.alpha, output);
+        if (output && !diffMask) {
+            for (let i = 0; i < len; i++) drawGrayPixel(img1, 4 * i, alpha, output);
         }
         return 0;
     }
 
     // maximum acceptable square distance between two colors;
     // 35215 is the maximum possible value for the YIQ difference metric
-    const maxDelta = 35215 * options.threshold * options.threshold;
+    const maxDelta = 35215 * threshold * threshold;
+    const [aaR, aaG, aaB] = aaColor;
+    const [diffR, diffG, diffB] = diffColor;
+    const [altR, altG, altB] = diffColorAlt || diffColor;
     let diff = 0;
 
     // compare each pixel of one image against the other one
     for (let y = 0; y < height; y++) {
         for (let x = 0; x < width; x++) {
 
-            const pos = (y * width + x) * 4;
+            const i = y * width + x;
+            const pos = i * 4;
 
             // squared YUV distance between colors at this pixel position, negative if the img2 pixel is darker
-            const delta = colorDelta(img1, img2, pos, pos);
+            const delta = a32[i] === b32[i] ? 0 : colorDelta(img1, img2, pos, pos, false);
 
             // the color difference is above the threshold
             if (Math.abs(delta) > maxDelta) {
                 // check it's a real rendering difference or just anti-aliasing
-                if (!options.includeAA && (antialiased(img1, x, y, width, height, img2) ||
-                                           antialiased(img2, x, y, width, height, img1))) {
+                const isAA = antialiased(img1, x, y, width, height, a32, b32) || antialiased(img2, x, y, width, height, b32, a32);
+                if (!includeAA && isAA) {
                     // one of the pixels is anti-aliasing; draw as yellow and do not count as difference
                     // note that we do not include such pixels in a mask
-                    if (output && !options.diffMask) drawPixel(output, pos, ...options.aaColor);
+                    if (output && !diffMask) drawPixel(output, pos, aaR, aaG, aaB);
 
                 } else {
                     // found substantial difference not caused by anti-aliasing; draw it as such
                     if (output) {
-                        drawPixel(output, pos, ...(delta < 0 && options.diffColorAlt || options.diffColor));
+                        if (delta < 0) {
+                            drawPixel(output, pos, altR, altG, altB);
+                        } else {
+                            drawPixel(output, pos, diffR, diffG, diffB);
+                        }
                     }
                     diff++;
                 }
 
-            } else if (output) {
+            } else if (output && !diffMask) {
                 // pixels are similar; draw background as grayscale image blended with white
-                if (!options.diffMask) drawGrayPixel(img1, pos, options.alpha, output);
+                drawGrayPixel(img1, pos, alpha, output);
             }
         }
     }
@@ -101,24 +120,36 @@ function pixelmatch(img1, img2, output, width, height, options) {
     return diff;
 }
 
+/** @param {Uint8Array | Uint8ClampedArray} arr */
 function isPixelData(arr) {
     // work around instanceof Uint8Array not working properly in some Jest environments
-    return ArrayBuffer.isView(arr) && arr.constructor.BYTES_PER_ELEMENT === 1;
+    return ArrayBuffer.isView(arr) && arr.BYTES_PER_ELEMENT === 1;
 }
 
-// check if a pixel is likely a part of anti-aliasing;
-// based on "Anti-aliased Pixel and Intensity Slope Detector" paper by V. Vysniauskas, 2009
-
-function antialiased(img, x1, y1, width, height, img2) {
+/**
+ * Check if a pixel is likely a part of anti-aliasing;
+ * based on "Anti-aliased Pixel and Intensity Slope Detector" paper by V. Vysniauskas, 2009
+ * @param {Uint8Array | Uint8ClampedArray} img
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} width
+ * @param {number} height
+ * @param {Uint32Array} a32
+ * @param {Uint32Array} b32
+ */
+function antialiased(img, x1, y1, width, height, a32, b32) {
     const x0 = Math.max(x1 - 1, 0);
     const y0 = Math.max(y1 - 1, 0);
     const x2 = Math.min(x1 + 1, width - 1);
     const y2 = Math.min(y1 + 1, height - 1);
-    const pos = (y1 * width + x1) * 4;
+    const pos = y1 * width + x1;
     let zeroes = x1 === x0 || x1 === x2 || y1 === y0 || y1 === y2 ? 1 : 0;
     let min = 0;
     let max = 0;
-    let minX, minY, maxX, maxY;
+    let minX = 0;
+    let minY = 0;
+    let maxX = 0;
+    let maxY = 0;
 
     // go through 8 adjacent pixels
     for (let x = x0; x <= x2; x++) {
@@ -126,7 +157,7 @@ function antialiased(img, x1, y1, width, height, img2) {
             if (x === x1 && y === y1) continue;
 
             // brightness delta between the center pixel and adjacent one
-            const delta = colorDelta(img, img, pos, (y * width + x) * 4, true);
+            const delta = colorDelta(img, img, pos * 4, (y * width + x) * 4, true);
 
             // count the number of equal, darker and brighter adjacent pixels
             if (delta === 0) {
@@ -154,91 +185,92 @@ function antialiased(img, x1, y1, width, height, img2) {
 
     // if either the darkest or the brightest pixel has 3+ equal siblings in both images
     // (definitely not anti-aliased), this pixel is anti-aliased
-    return (hasManySiblings(img, minX, minY, width, height) && hasManySiblings(img2, minX, minY, width, height)) ||
-           (hasManySiblings(img, maxX, maxY, width, height) && hasManySiblings(img2, maxX, maxY, width, height));
+    return (hasManySiblings(a32, minX, minY, width, height) && hasManySiblings(b32, minX, minY, width, height)) ||
+           (hasManySiblings(a32, maxX, maxY, width, height) && hasManySiblings(b32, maxX, maxY, width, height));
 }
 
-// check if a pixel has 3+ adjacent pixels of the same color.
+/**
+ * Check if a pixel has 3+ adjacent pixels of the same color.
+ * @param {Uint32Array} img
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} width
+ * @param {number} height
+ */
 function hasManySiblings(img, x1, y1, width, height) {
     const x0 = Math.max(x1 - 1, 0);
     const y0 = Math.max(y1 - 1, 0);
     const x2 = Math.min(x1 + 1, width - 1);
     const y2 = Math.min(y1 + 1, height - 1);
-    const pos = (y1 * width + x1) * 4;
+    const val = img[y1 * width + x1];
     let zeroes = x1 === x0 || x1 === x2 || y1 === y0 || y1 === y2 ? 1 : 0;
 
     // go through 8 adjacent pixels
     for (let x = x0; x <= x2; x++) {
         for (let y = y0; y <= y2; y++) {
             if (x === x1 && y === y1) continue;
-
-            const pos2 = (y * width + x) * 4;
-            if (img[pos] === img[pos2] &&
-                img[pos + 1] === img[pos2 + 1] &&
-                img[pos + 2] === img[pos2 + 2] &&
-                img[pos + 3] === img[pos2 + 3]) zeroes++;
-
+            zeroes += +(val === img[y * width + x]);
             if (zeroes > 2) return true;
         }
     }
-
     return false;
 }
 
-// calculate color difference according to the paper "Measuring perceived color difference
-// using YIQ NTSC transmission color space in mobile applications" by Y. Kotsarenko and F. Ramos
-
+/**
+ * Calculate color difference according to the paper "Measuring perceived color difference
+ * using YIQ NTSC transmission color space in mobile applications" by Y. Kotsarenko and F. Ramos
+ * @param {Uint8Array | Uint8ClampedArray} img1
+ * @param {Uint8Array | Uint8ClampedArray} img2
+ * @param {number} k
+ * @param {number} m
+ * @param {boolean} yOnly
+ */
 function colorDelta(img1, img2, k, m, yOnly) {
-    let r1 = img1[k + 0];
-    let g1 = img1[k + 1];
-    let b1 = img1[k + 2];
-    let a1 = img1[k + 3];
+    const r1 = img1[k];
+    const g1 = img1[k + 1];
+    const b1 = img1[k + 2];
+    const a1 = img1[k + 3];
+    const r2 = img2[m];
+    const g2 = img2[m + 1];
+    const b2 = img2[m + 2];
+    const a2 = img2[m + 3];
 
-    let r2 = img2[m + 0];
-    let g2 = img2[m + 1];
-    let b2 = img2[m + 2];
-    let a2 = img2[m + 3];
+    let dr = r1 - r2;
+    let dg = g1 - g2;
+    let db = b1 - b2;
+    const da = a1 - a2;
 
-    if (a1 === a2 && r1 === r2 && g1 === g2 && b1 === b2) return 0;
+    if (!dr && !dg && !db && !da) return 0;
 
-    if (a1 < 255) {
-        a1 /= 255;
-        r1 = blend(r1, a1);
-        g1 = blend(g1, a1);
-        b1 = blend(b1, a1);
+    if (a1 < 255 || a2 < 255) { // blend pixels with background
+        const rb = 48 + 159 * (k % 2);
+        const gb = 48 + 159 * ((k / 1.618033988749895 | 0) % 2);
+        const bb = 48 + 159 * ((k / 2.618033988749895 | 0) % 2);
+        dr = (r1 * a1 - r2 * a2 - rb * da) / 255;
+        dg = (g1 * a1 - g2 * a2 - gb * da) / 255;
+        db = (b1 * a1 - b2 * a2 - bb * da) / 255;
     }
 
-    if (a2 < 255) {
-        a2 /= 255;
-        r2 = blend(r2, a2);
-        g2 = blend(g2, a2);
-        b2 = blend(b2, a2);
-    }
-
-    const y1 = rgb2y(r1, g1, b1);
-    const y2 = rgb2y(r2, g2, b2);
-    const y = y1 - y2;
+    const y = dr * 0.29889531 + dg * 0.58662247 + db * 0.11448223;
 
     if (yOnly) return y; // brightness difference only
 
-    const i = rgb2i(r1, g1, b1) - rgb2i(r2, g2, b2);
-    const q = rgb2q(r1, g1, b1) - rgb2q(r2, g2, b2);
+    const i = dr * 0.59597799 - dg * 0.27417610 - db * 0.32180189;
+    const q = dr * 0.21147017 - dg * 0.52261711 + db * 0.31114694;
 
     const delta = 0.5053 * y * y + 0.299 * i * i + 0.1957 * q * q;
 
     // encode whether the pixel lightens or darkens in the sign
-    return y1 > y2 ? -delta : delta;
+    return y > 0 ? -delta : delta;
 }
 
-function rgb2y(r, g, b) { return r * 0.29889531 + g * 0.58662247 + b * 0.11448223; }
-function rgb2i(r, g, b) { return r * 0.59597799 - g * 0.27417610 - b * 0.32180189; }
-function rgb2q(r, g, b) { return r * 0.21147017 - g * 0.52261711 + b * 0.31114694; }
-
-// blend semi-transparent color with white
-function blend(c, a) {
-    return 255 + (c - 255) * a;
-}
-
+/**
+ * @param {Uint8Array | Uint8ClampedArray} output
+ * @param {number} pos
+ * @param {number} r
+ * @param {number} g
+ * @param {number} b
+ */
 function drawPixel(output, pos, r, g, b) {
     output[pos + 0] = r;
     output[pos + 1] = g;
@@ -246,10 +278,13 @@ function drawPixel(output, pos, r, g, b) {
     output[pos + 3] = 255;
 }
 
+/**
+ * @param {Uint8Array | Uint8ClampedArray} img
+ * @param {number} i
+ * @param {number} alpha
+ * @param {Uint8Array | Uint8ClampedArray} output
+ */
 function drawGrayPixel(img, i, alpha, output) {
-    const r = img[i + 0];
-    const g = img[i + 1];
-    const b = img[i + 2];
-    const val = blend(rgb2y(r, g, b), alpha * img[i + 3] / 255);
+    const val = 255 + (img[i] * 0.29889531 + img[i + 1] * 0.58662247 + img[i + 2] * 0.11448223 - 255) * alpha * img[i + 3] / 255;
     drawPixel(output, i, val, val, val);
 }

--- a/tests/playwright-test/to-have-screenshot.spec.ts
+++ b/tests/playwright-test/to-have-screenshot.spec.ts
@@ -1191,7 +1191,7 @@ test('should attach expected/actual/diff when sizes are different', async ({ run
   expect(result.exitCode).toBe(1);
   const outputText = result.output;
   expect(outputText).toContain('Expected an image 2px by 2px, received 1280px by 720px.');
-  expect(outputText).toContain('4 pixels (ratio 0.01 of all image pixels) are different.');
+  expect(outputText).toContain('921600 pixels (ratio 1.00 of all image pixels) are different.');
   const attachments = outputText.split('\n').filter(l => l.startsWith('## ')).map(l => l.substring(3)).map(l => JSON.parse(l))[0];
   for (const attachment of attachments)
     attachment.path = attachment.path.replace(testInfo.outputDir, '').substring(1).replace(/\\/g, '/');


### PR DESCRIPTION
The pixelmatch version used in Playwright seems to be from 2020 (2b03b635cffb9525bcefee4cc7329f98e375cff5, after 5.2.1)

Several improvements seem worthy:
- optimize diff drawing, close #105
- add first-class TypeScript types
- Faster anti-aliasing detection (~22% faster matching) (#150)

The "Improve differentiation of semitransparent pixels" from pixelmatch broke a test in tests/playwright-test/to-have-screenshot.spec.ts My understanding is that it happens because the way diff pixels are handled, then counted.