### PR TITLE
fix(trace-viewer): prevent browser snapshot from moving out of bounds on host resize

### DIFF
--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -187,33 +187,45 @@ export const SnapshotView: React.FunctionComponent<{
   </div>;
 };
 
+const SNAPSHOT_WRAPPER_PADDING = 10 * 2;
+const WINDOW_HEADER_HEIGHT = 40;
+const MIN_BROWSER_FRAME_SCALED_WIDTH = 100;
+const MIN_BROWSER_FRAME_SCALED_HEIGHT = 80 - SNAPSHOT_WRAPPER_PADDING;
+
 const SnapshotWrapper: React.FunctionComponent<React.PropsWithChildren<{
   snapshotInfo: SnapshotInfo,
 }>> = ({ snapshotInfo, children }) => {
   const [measure, ref] = useMeasure<HTMLDivElement>();
 
-  const windowHeaderHeight = 40;
   const snapshotContainerSize = {
     width: snapshotInfo.viewport.width,
     height: snapshotInfo.viewport.height,
   };
 
-  const renderedBrowserFrameSize = {
+  const renderedBrowserExpectedFrameSize = {
     width: Math.max(snapshotContainerSize.width, 480),
-    height: Math.max(snapshotContainerSize.height + windowHeaderHeight, 320),
+    height: Math.max(snapshotContainerSize.height + WINDOW_HEADER_HEIGHT, 320),
   };
 
-  const scale = Math.min(measure.width / renderedBrowserFrameSize.width, measure.height / renderedBrowserFrameSize.height, 1);
+  const actualMeasuredHeight = Math.max(measure.height - SNAPSHOT_WRAPPER_PADDING, 0);
+  // Calculate ideal size for the snapshot size (including browser frame) to fit within the bounds
+  const idealScale = Math.min(measure.width / renderedBrowserExpectedFrameSize.width, actualMeasuredHeight / renderedBrowserExpectedFrameSize.height, 1);
+  // Prevent window from scaling below a minimum size
+  const actualWidth = Math.max(idealScale * renderedBrowserExpectedFrameSize.width, MIN_BROWSER_FRAME_SCALED_WIDTH);
+  const actualHeight = Math.max(idealScale * renderedBrowserExpectedFrameSize.height, MIN_BROWSER_FRAME_SCALED_HEIGHT);
+  // Using new minimum sizes, calculate the final scale
+  const actualScale = Math.min(actualWidth / renderedBrowserExpectedFrameSize.width, actualHeight / renderedBrowserExpectedFrameSize.height);
   const translate = {
-    x: (measure.width - renderedBrowserFrameSize.width) / 2,
-    y: (measure.height - renderedBrowserFrameSize.height) / 2,
+    // Don't let the browser clip out of bounds when it's at the min size
+    x: (Math.max(measure.width, MIN_BROWSER_FRAME_SCALED_WIDTH) - renderedBrowserExpectedFrameSize.width) / 2,
+    y: (Math.max(actualMeasuredHeight, MIN_BROWSER_FRAME_SCALED_HEIGHT) - renderedBrowserExpectedFrameSize.height) / 2,
   };
 
   return <div ref={ref} className='snapshot-wrapper'>
     <div className='snapshot-container' style={{
-      width: renderedBrowserFrameSize.width + 'px',
-      height: renderedBrowserFrameSize.height + 'px',
-      transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
+      width: renderedBrowserExpectedFrameSize.width + 'px',
+      height: renderedBrowserExpectedFrameSize.height + 'px',
+      transform: `translate(${translate.x}px, ${translate.y}px) scale(${actualScale})`,
     }}>
       <BrowserFrame url={snapshotInfo.url} />
       <div className='snapshot-browser-body'>

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -187,10 +187,9 @@ export const SnapshotView: React.FunctionComponent<{
   </div>;
 };
 
-const SNAPSHOT_WRAPPER_PADDING = 10 * 2;
-const WINDOW_HEADER_HEIGHT = 40;
-const MIN_BROWSER_FRAME_SCALED_WIDTH = 100;
-const MIN_BROWSER_FRAME_SCALED_HEIGHT = 80 - SNAPSHOT_WRAPPER_PADDING;
+const kWindowHeaderHeight = 40;
+const kMinBrowserFrameScaledWidth = 100;
+const kMinBrowserFrameScaledHeight = 60;
 
 const SnapshotWrapper: React.FunctionComponent<React.PropsWithChildren<{
   snapshotInfo: SnapshotInfo,
@@ -204,36 +203,37 @@ const SnapshotWrapper: React.FunctionComponent<React.PropsWithChildren<{
 
   const renderedBrowserExpectedFrameSize = {
     width: Math.max(snapshotContainerSize.width, 480),
-    height: Math.max(snapshotContainerSize.height + WINDOW_HEADER_HEIGHT, 320),
+    height: Math.max(snapshotContainerSize.height + kWindowHeaderHeight, 320),
   };
 
-  const actualMeasuredHeight = Math.max(measure.height - SNAPSHOT_WRAPPER_PADDING, 0);
   // Calculate ideal size for the snapshot size (including browser frame) to fit within the bounds
-  const idealScale = Math.min(measure.width / renderedBrowserExpectedFrameSize.width, actualMeasuredHeight / renderedBrowserExpectedFrameSize.height, 1);
+  const idealScale = Math.min(measure.width / renderedBrowserExpectedFrameSize.width, measure.height / renderedBrowserExpectedFrameSize.height, 1);
   // Prevent window from scaling below a minimum size
-  const actualWidth = Math.max(idealScale * renderedBrowserExpectedFrameSize.width, MIN_BROWSER_FRAME_SCALED_WIDTH);
-  const actualHeight = Math.max(idealScale * renderedBrowserExpectedFrameSize.height, MIN_BROWSER_FRAME_SCALED_HEIGHT);
+  const actualWidth = Math.max(idealScale * renderedBrowserExpectedFrameSize.width, kMinBrowserFrameScaledWidth);
+  const actualHeight = Math.max(idealScale * renderedBrowserExpectedFrameSize.height, kMinBrowserFrameScaledHeight);
   // Using new minimum sizes, calculate the final scale
   const actualScale = Math.min(actualWidth / renderedBrowserExpectedFrameSize.width, actualHeight / renderedBrowserExpectedFrameSize.height);
   const translate = {
     // Don't let the browser clip out of bounds when it's at the min size
-    x: (Math.max(measure.width, MIN_BROWSER_FRAME_SCALED_WIDTH) - renderedBrowserExpectedFrameSize.width) / 2,
-    y: (Math.max(actualMeasuredHeight, MIN_BROWSER_FRAME_SCALED_HEIGHT) - renderedBrowserExpectedFrameSize.height) / 2,
+    x: (Math.max(measure.width, kMinBrowserFrameScaledWidth) - renderedBrowserExpectedFrameSize.width) / 2,
+    y: (Math.max(measure.height, kMinBrowserFrameScaledHeight) - renderedBrowserExpectedFrameSize.height) / 2,
   };
 
-  return <div ref={ref} className='snapshot-wrapper'>
-    <div className='snapshot-container' style={{
-      width: renderedBrowserExpectedFrameSize.width + 'px',
-      height: renderedBrowserExpectedFrameSize.height + 'px',
-      transform: `translate(${translate.x}px, ${translate.y}px) scale(${actualScale})`,
-    }}>
-      <BrowserFrame url={snapshotInfo.url} />
-      <div className='snapshot-browser-body'>
-        <div style={{
-          width: snapshotContainerSize.width + 'px',
-          height: snapshotContainerSize.height + 'px',
-        }}>
-          {children}
+  return <div className='snapshot-wrapper'>
+    <div ref={ref} className='snapshot-content-measure'>
+      <div className='snapshot-container' style={{
+        width: renderedBrowserExpectedFrameSize.width + 'px',
+        height: renderedBrowserExpectedFrameSize.height + 'px',
+        transform: `translate(${translate.x}px, ${translate.y}px) scale(${actualScale})`,
+      }}>
+        <BrowserFrame url={snapshotInfo.url} />
+        <div className='snapshot-browser-body'>
+          <div style={{
+            width: snapshotContainerSize.width + 'px',
+            height: snapshotContainerSize.height + 'px',
+          }}>
+            {children}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #38024

Ensure browser snapshots never move out of bounds in the negative X and Y directions. Additionally prevents the browser from collapsing into an infinitely small box; at the absolute min size, it will overflow offscreen to the positive X, Y.

<img width="671" height="610" alt="Screenshot 2025-10-29 at 7 46 46 AM" src="https://github.com/user-attachments/assets/ed314070-b380-4ee8-89e8-542bf77cd383" />
