### PR TITLE
chore(webkit): make sure npx command is used from the wsl container

### DIFF
--- a/packages/playwright-core/bin/install_webkit_wsl.ps1
+++ b/packages/playwright-core/bin/install_webkit_wsl.ps1
@@ -23,7 +23,7 @@ if [ ! -f "/home/$Username/node/bin/node" ]; then
   mkdir -p /home/$Username/node
   curl -fsSL https://nodejs.org/dist/v22.17.0/node-v22.17.0-linux-x64.tar.xz -o /home/$Username/node/node-v22.17.0-linux-x64.tar.xz
   tar -xJf /home/$Username/node/node-v22.17.0-linux-x64.tar.xz -C /home/$Username/node --strip-components=1
-  echo 'export PATH=/home/$Username/node/bin:$PATH' >> /home/$Username/.profile
+  sudo -u $Username echo 'export PATH=/home/$Username/node/bin:\`$PATH' >> /home/$Username/.profile
 fi
 /home/$Username/node/bin/node cli.js install-deps webkit
 sudo -u $Username PLAYWRIGHT_SKIP_BROWSER_GC=1 /home/$Username/node/bin/node cli.js install webkit

--- a/packages/playwright-core/bin/install_webkit_wsl.ps1
+++ b/packages/playwright-core/bin/install_webkit_wsl.ps1
@@ -23,7 +23,7 @@ if [ ! -f "/home/$Username/node/bin/node" ]; then
   mkdir -p /home/$Username/node
   curl -fsSL https://nodejs.org/dist/v22.17.0/node-v22.17.0-linux-x64.tar.xz -o /home/$Username/node/node-v22.17.0-linux-x64.tar.xz
   tar -xJf /home/$Username/node/node-v22.17.0-linux-x64.tar.xz -C /home/$Username/node --strip-components=1
-  echo 'export PATH=/home/$Username/node/bin:$PATH' >> /home/$Username/.bashrc
+  echo 'export PATH=/home/$Username/node/bin:$PATH' >> /home/$Username/.profile
 fi
 /home/$Username/node/bin/node cli.js install-deps webkit
 sudo -u $Username PLAYWRIGHT_SKIP_BROWSER_GC=1 /home/$Username/node/bin/node cli.js install webkit

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -83,7 +83,6 @@ if (channel === 'webkit-wsl') {
   webServer = {
     command: 'wsl.exe -d playwright -- bash -lc \'/home/pwuser/node/bin/npx playwright run-server --port=3777\'',
     url: 'http://localhost:3777',
-    reuseExistingServer: !process.env.CI,
   };
 }
 

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -81,7 +81,7 @@ if (mode === 'service2') {
 if (channel === 'webkit-wsl') {
   connectOptions = { wsEndpoint: 'ws://localhost:3777/' };
   webServer = {
-    command: 'wsl -d playwright -- npx playwright run-server --port=3777',
+    command: 'wsl.exe -d playwright -- bash -lc \'/home/pwuser/node/bin/npx playwright run-server --port=3777\'',
     url: 'http://localhost:3777',
     reuseExistingServer: !process.env.CI,
   };


### PR DESCRIPTION
* Add custom node to path in .profile, so that it is picked up in non-interactive shells too
* Run the `npx playwright` command inside bash login shell, so that it has proper PATH configured with node and npx in it
* `$` sign in `$PATH` parameter to `bash -c` requires double escaping:
  - `$ for powershell
  - `\$` for bash

Reference https://github.com/microsoft/playwright/issues/37036