### PR TITLE
chore(trace-viewer): restore missing CSS for snapshot sizing

### DIFF
--- a/packages/trace-viewer/src/ui/snapshotTab.css
+++ b/packages/trace-viewer/src/ui/snapshotTab.css
@@ -72,6 +72,12 @@
   --browser-frame-header-height: 40px;
 }
 
+.snapshot-content-measure {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
 .snapshot-container {
   display: block;
   box-shadow: 0 12px 28px 0 rgba(0,0,0,.2),0 2px 4px 0 rgba(0,0,0,.1);


### PR DESCRIPTION
Adds CSS that was missing from the PR #38048.