### PR TITLE
chore(bidi): add support for network.setExtraHeaders

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -222,6 +222,8 @@ export class BidiBrowserContext extends BrowserContext {
         userContexts: [this._userContextId()],
       }));
     }
+    if (this._options.extraHTTPHeaders || this._options.locale)
+      promises.push(this.doUpdateExtraHTTPHeaders());
     await Promise.all(promises);
   }
 
@@ -320,6 +322,13 @@ export class BidiBrowserContext extends BrowserContext {
   }
 
   async doUpdateExtraHTTPHeaders(): Promise<void> {
+    let allHeaders = this._options.extraHTTPHeaders || [];
+    if (this._options.locale)
+      allHeaders = network.mergeHeaders([allHeaders, network.singleHeader('Accept-Language', this._options.locale)]);
+    await this._browser._browserSession.send('network.setExtraHeaders', {
+      headers: allHeaders.map(({ name, value }) => ({ name, value: { type: 'string', value } })),
+      userContexts: [this._userContextId()],
+    });
   }
 
   async setUserAgent(userAgent: string | undefined): Promise<void> {

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -26,6 +26,7 @@ import { BidiNetworkManager } from './bidiNetworkManager';
 import { BidiPDF } from './bidiPdf';
 import * as bidi from './third_party/bidiProtocol';
 
+import * as network from '../network';
 import type { RegisteredListener } from '../utils/eventsHelper';
 import type * as accessibility from '../accessibility';
 import type * as frames from '../frames';
@@ -297,6 +298,16 @@ export class BidiPage implements PageDelegate {
   }
 
   async updateExtraHTTPHeaders(): Promise<void> {
+    const locale = this._browserContext._options.locale;
+    const allHeaders = network.mergeHeaders([
+      this._browserContext._options.extraHTTPHeaders,
+      this._page.extraHTTPHeaders(),
+      locale ? network.singleHeader('Accept-Language', locale) : undefined,
+    ]);
+    await this._session.send('network.setExtraHeaders', {
+      headers: allHeaders.map(({ name, value }) => ({ name, value: { type: 'string', value } })),
+      contexts: [this._session.sessionId],
+    });
   }
 
   async updateEmulateMedia(): Promise<void> {

--- a/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
@@ -178,6 +178,10 @@ export interface Commands {
     returnType: Bidi.Storage.SetCookieParameters;
   };
 
+  'network.setExtraHeaders': {
+    params: Bidi.Network.SetExtraHeadersParameters;
+    returnType: Bidi.Network.SetExtraHeadersResult;
+  };
   'network.addDataCollector': {
     params: Bidi.Network.AddDataCollectorParameters;
     returnType: Bidi.Network.AddDataCollectorResult;


### PR DESCRIPTION
Fixes #38060 and the following tests:
- `tests/library/browsercontext-locale.spec.ts`:
  - "should affect accept-language header"
- `tests/library/browsercontext-set-extra-http-headers.spec.ts`:
  - "should override extra headers from browser context"
- `tests/library/defaultbrowsercontext-2.spec.ts`:
  - "should support extraHTTPHeaders option"
- `tests/library/popup.spec.ts`:
  - "should inherit extra headers from browser context"
- `tests/page/page-route.spec.ts`:
  - "should show custom HTTP headers"
  - "should work with custom referer headers"
  - "should send referer"
- `tests/page/page-set-extra-http-headers.spec.ts`:
  - "should work"
  - "should work with redirects"
  - "should work with extra headers from browser context"
  - "should not duplicate referer header"
