### PR TITLE
test(mouse): disable click steps test on headed

### DIFF
--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -1288,8 +1288,9 @@ it('should click shadow root button', { annotation: { type: 'issue', description
   await page.locator('my-button').click();
 });
 
-it('should click with tweened mouse movement', async ({ page, browserName, isAndroid }) => {
+it('should click with tweened mouse movement', async ({ page, browserName, isAndroid, headless }) => {
   it.skip(isAndroid, 'Bad rounding');
+  it.skip(!headless, 'System cursor tends to interfere with this test');
 
   await page.setContent(`
     <body style="margin: 0; padding: 0; height: 500px; width: 500px;">


### PR DESCRIPTION
The click move `steps` change (#38036) introduced a test that is flaky when headed. This is nearly identical to the existing `Mouse.move` test, so it's likely a timing issue. Disable the test when headed for now.