### PR TITLE
feat(trace-viewer): Collapse sections inside network request

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -17,7 +17,7 @@
 .network-request-details-tab {
   user-select: text;
   line-height: 24px;
-  margin-left: 10px;
+  margin-left: 12px;
   overflow: auto;
 }
 
@@ -40,6 +40,8 @@
 .network-request-details-header {
   margin: 3px 0;
   font-weight: bold;
+  user-select: none;
+  cursor: pointer;
 }
 
 .network-request-details-general {

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -58,11 +58,11 @@
   overflow: hidden;
 }
 
-.expandable:has(.cm-wrapper) {
+.network-request-request-body {
   max-height: 100%;
 }
 
-.expandable-content:has(.cm-wrapper) {
+.network-request-request-body .expandable-content {
   height: 100%;
 }
 

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -35,13 +35,14 @@
   margin-left: 10px;
 }
 
-.expandable-title {
+.network-request-details-tab .expandable-title {
   padding-left: 3px;
 }
 
-.expandable-content {
+.network-request-details-tab .expandable-content {
   margin-left: 0;
   padding-left: 28px;
+  line-height: 24px;
 }
 
 .network-request-details-header {
@@ -64,10 +65,6 @@
 
 .network-request-request-body .expandable-content {
   height: 100%;
-}
-
-.expandable-content {
-  line-height: 24px;
 }
 
 .network-font-preview {

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -16,8 +16,6 @@
 
 .network-request-details-tab {
   user-select: text;
-  line-height: 24px;
-  margin-left: 12px;
   overflow: auto;
 }
 
@@ -37,11 +35,18 @@
   margin-left: 10px;
 }
 
+.expandable-title {
+  padding-left: 3px;
+}
+
+.expandable-content {
+  margin-left: 0;
+  padding-left: 28px;
+}
+
 .network-request-details-header {
-  margin: 3px 0;
+  margin: 3px 0 3px 14px;
   font-weight: bold;
-  user-select: none;
-  cursor: pointer;
 }
 
 .network-request-details-general {
@@ -51,6 +56,18 @@
 
 .network-request-details-tab .cm-wrapper {
   overflow: hidden;
+}
+
+.expandable:has(.cm-wrapper) {
+  max-height: 100%;
+}
+
+.expandable-content:has(.cm-wrapper) {
+  height: 100%;
+}
+
+.expandable-content {
+  line-height: 24px;
 }
 
 .network-font-preview {

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -27,6 +27,7 @@ import type { Language } from '@isomorphic/locatorGenerators';
 import { msToString, useAsyncMemo, useSetting } from '@web/uiUtils';
 import type { Entry } from '@trace/har';
 import { useTraceModel } from './traceModelContext';
+import { Expandable } from '@web/components/expandable';
 
 type RequestBody = { text: string, mimeType?: string } | null;
 
@@ -105,23 +106,19 @@ const CopyDropdown: React.FC<{
   );
 };
 
-const DetailsSection: React.FC<{
+const ExpandableSection: React.FC<{
   title: string;
   children?: React.ReactNode
 }> = ({ title, children }) => {
-  const [isOpen, setIsOpen] = useSetting(`trace-viewer-network-details-${title.replaceAll(' ', '-')}`, true);
-
-  return (
-    <details className='network-request-details-section' open={isOpen} aria-label={title}>
-      <summary className='network-request-details-header' onClick={event => {
-        event.preventDefault();
-        setIsOpen(!isOpen);
-      }}>
-        {title}
-      </summary>
-      {children}
-    </details>
-  );
+  const [expanded, setExpanded] = useSetting(`trace-viewer-network-details-${title.replaceAll(' ', '-')}`, true);
+  return <Expandable
+    expanded={expanded}
+    setExpanded={setExpanded}
+    expandOnTitleClick
+    title={<span className='network-request-details-header'>{title}</span>}
+  >
+    {children}
+  </Expandable>;
 };
 
 const RequestTab: React.FunctionComponent<{
@@ -130,35 +127,35 @@ const RequestTab: React.FunctionComponent<{
   requestBody: RequestBody,
 }> = ({ resource, startTimeOffset, requestBody }) => {
   return <div className='vbox network-request-details-tab'>
-    <DetailsSection title='General'>
+    <ExpandableSection title='General'>
       <div className='network-request-details-url'>{`URL: ${resource.request.url}`}</div>
       <div className='network-request-details-general'>{`Method: ${resource.request.method}`}</div>
       {resource.response.status !== -1 && <div className='network-request-details-general' style={{ display: 'flex' }}>
         Status Code: <span className={statusClass(resource.response.status)} style={{ display: 'inline-flex' }}>
           {`${resource.response.status} ${resource.response.statusText}`}
         </span></div>}
-    </DetailsSection>
+    </ExpandableSection>
 
     {resource.request.queryString.length ?
-      <DetailsSection title='Query String Parameters'>
+      <ExpandableSection title='Query String Parameters'>
         <div className='network-request-details-headers'>
           {resource.request.queryString.map(param => `${param.name}: ${param.value}`).join('\n')}
         </div>
-      </DetailsSection>
+      </ExpandableSection>
       : null}
 
-    <DetailsSection title='Request Headers'>
+    <ExpandableSection title='Request Headers'>
       <div className='network-request-details-headers'>{resource.request.headers.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
-    </DetailsSection>
+    </ExpandableSection>
 
-    <DetailsSection title='Time'>
+    <ExpandableSection title='Time'>
       <div className='network-request-details-general'>{`Start: ${msToString(startTimeOffset)}`}</div>
       <div className='network-request-details-general'>{`Duration: ${msToString(resource.time)}`}</div>
-    </DetailsSection>
+    </ExpandableSection>
 
-    {requestBody && <DetailsSection title='Request Body'>
+    {requestBody && <ExpandableSection title='Request Body'>
       <CodeMirrorWrapper text={requestBody.text} mimeType={requestBody.mimeType} readOnly lineNumbers={true}/>
-    </DetailsSection>}
+    </ExpandableSection>}
   </div>;
 };
 
@@ -166,9 +163,9 @@ const ResponseTab: React.FunctionComponent<{
   resource: ResourceSnapshot;
 }> = ({ resource }) => {
   return <div className='vbox network-request-details-tab'>
-    <DetailsSection title='Response Headers'>
+    <ExpandableSection title='Response Headers'>
       <div className='network-request-details-headers'>{resource.response.headers.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
-    </DetailsSection>
+    </ExpandableSection>
   </div>;
 };
 

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -24,7 +24,7 @@ import { generateCurlCommand, generateFetchCall } from '../third_party/devtools'
 import { CopyToClipboardTextButton } from './copyToClipboard';
 import { getAPIRequestCodeGen } from './codegen';
 import type { Language } from '@isomorphic/locatorGenerators';
-import { msToString, useAsyncMemo } from '@web/uiUtils';
+import { msToString, useAsyncMemo, useSetting } from '@web/uiUtils';
 import type { Entry } from '@trace/har';
 import { useTraceModel } from './traceModelContext';
 
@@ -105,33 +105,60 @@ const CopyDropdown: React.FC<{
   );
 };
 
+const DetailsSection: React.FC<{
+  title: string;
+  children?: React.ReactNode
+}> = ({ title, children }) => {
+  const [isOpen, setIsOpen] = useSetting(`trace-viewer-network-details-${title.replaceAll(' ', '-')}`, true);
+
+  return (
+    <details className='network-request-details-section' open={isOpen} aria-label={title}>
+      <summary className='network-request-details-header' onClick={event => {
+        event.preventDefault();
+        setIsOpen(!isOpen);
+      }}>
+        {title}
+      </summary>
+      {children}
+    </details>
+  );
+};
+
 const RequestTab: React.FunctionComponent<{
   resource: ResourceSnapshot;
   startTimeOffset: number;
   requestBody: RequestBody,
 }> = ({ resource, startTimeOffset, requestBody }) => {
   return <div className='vbox network-request-details-tab'>
-    <div className='network-request-details-header'>General</div>
-    <div className='network-request-details-url'>{`URL: ${resource.request.url}`}</div>
-    <div className='network-request-details-general'>{`Method: ${resource.request.method}`}</div>
-    {resource.response.status !== -1 && <div className='network-request-details-general' style={{ display: 'flex' }}>
-      Status Code: <span className={statusClass(resource.response.status)} style={{ display: 'inline-flex' }}>
-        {`${resource.response.status} ${resource.response.statusText}`}
-      </span></div>}
-    {resource.request.queryString.length ? <>
-      <div className='network-request-details-header'>Query String Parameters</div>
-      <div className='network-request-details-headers'>
-        {resource.request.queryString.map(param => `${param.name}: ${param.value}`).join('\n')}
-      </div>
-    </> : null}
-    <div className='network-request-details-header'>Request Headers</div>
-    <div className='network-request-details-headers'>{resource.request.headers.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
-    <div className='network-request-details-header'>Time</div>
-    <div className='network-request-details-general'>{`Start: ${msToString(startTimeOffset)}`}</div>
-    <div className='network-request-details-general'>{`Duration: ${msToString(resource.time)}`}</div>
+    <DetailsSection title='General'>
+      <div className='network-request-details-url'>{`URL: ${resource.request.url}`}</div>
+      <div className='network-request-details-general'>{`Method: ${resource.request.method}`}</div>
+      {resource.response.status !== -1 && <div className='network-request-details-general' style={{ display: 'flex' }}>
+        Status Code: <span className={statusClass(resource.response.status)} style={{ display: 'inline-flex' }}>
+          {`${resource.response.status} ${resource.response.statusText}`}
+        </span></div>}
+    </DetailsSection>
 
-    {requestBody && <div className='network-request-details-header'>Request Body</div>}
-    {requestBody && <CodeMirrorWrapper text={requestBody.text} mimeType={requestBody.mimeType} readOnly lineNumbers={true}/>}
+    {resource.request.queryString.length ?
+      <DetailsSection title='Query String Parameters'>
+        <div className='network-request-details-headers'>
+          {resource.request.queryString.map(param => `${param.name}: ${param.value}`).join('\n')}
+        </div>
+      </DetailsSection>
+      : null}
+
+    <DetailsSection title='Request Headers'>
+      <div className='network-request-details-headers'>{resource.request.headers.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
+    </DetailsSection>
+
+    <DetailsSection title='Time'>
+      <div className='network-request-details-general'>{`Start: ${msToString(startTimeOffset)}`}</div>
+      <div className='network-request-details-general'>{`Duration: ${msToString(resource.time)}`}</div>
+    </DetailsSection>
+
+    {requestBody && <DetailsSection title='Request Body'>
+      <CodeMirrorWrapper text={requestBody.text} mimeType={requestBody.mimeType} readOnly lineNumbers={true}/>
+    </DetailsSection>}
   </div>;
 };
 
@@ -139,8 +166,9 @@ const ResponseTab: React.FunctionComponent<{
   resource: ResourceSnapshot;
 }> = ({ resource }) => {
   return <div className='vbox network-request-details-tab'>
-    <div className='network-request-details-header'>Response Headers</div>
-    <div className='network-request-details-headers'>{resource.response.headers.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
+    <DetailsSection title='Response Headers'>
+      <div className='network-request-details-headers'>{resource.response.headers.map(pair => `${pair.name}: ${pair.value}`).join('\n')}</div>
+    </DetailsSection>
   </div>;
 };
 

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -109,13 +109,15 @@ const CopyDropdown: React.FC<{
 const ExpandableSection: React.FC<{
   title: string;
   children?: React.ReactNode
-}> = ({ title, children }) => {
+  className?: string;
+}> = ({ title, children, className }) => {
   const [expanded, setExpanded] = useSetting(`trace-viewer-network-details-${title.replaceAll(' ', '-')}`, true);
   return <Expandable
     expanded={expanded}
     setExpanded={setExpanded}
     expandOnTitleClick
     title={<span className='network-request-details-header'>{title}</span>}
+    className={className}
   >
     {children}
   </Expandable>;
@@ -153,7 +155,7 @@ const RequestTab: React.FunctionComponent<{
       <div className='network-request-details-general'>{`Duration: ${msToString(resource.time)}`}</div>
     </ExpandableSection>
 
-    {requestBody && <ExpandableSection title='Request Body'>
+    {requestBody && <ExpandableSection title='Request Body' className='network-request-request-body'>
       <CodeMirrorWrapper text={requestBody.text} mimeType={requestBody.mimeType} readOnly lineNumbers={true}/>
     </ExpandableSection>}
   </div>;

--- a/packages/web/src/components/expandable.css
+++ b/packages/web/src/components/expandable.css
@@ -29,3 +29,7 @@
   user-select: none;
   cursor: pointer;
 }
+
+.expandable-content {
+  margin-left: 25px;
+}

--- a/packages/web/src/components/expandable.tsx
+++ b/packages/web/src/components/expandable.tsx
@@ -24,7 +24,8 @@ export const Expandable: React.FunctionComponent<React.PropsWithChildren<{
   expanded: boolean,
   expandOnTitleClick?: boolean,
 }>> = ({ title, children, setExpanded, expanded, expandOnTitleClick }) => {
-  const id = React.useId();
+  const titleId = React.useId();
+  const regionId = React.useId();
 
   const onClick = React.useCallback(() => setExpanded(!expanded), [expanded, setExpanded]);
 
@@ -36,9 +37,10 @@ export const Expandable: React.FunctionComponent<React.PropsWithChildren<{
   return <div className={clsx('expandable', expanded && 'expanded')}>
     {expandOnTitleClick ?
       <div
+        id={titleId}
         role='button'
         aria-expanded={expanded}
-        aria-controls={id}
+        aria-controls={regionId}
         className='expandable-title'
         onClick={onClick}>
         {chevron}
@@ -48,6 +50,6 @@ export const Expandable: React.FunctionComponent<React.PropsWithChildren<{
         {chevron}
         {title}
       </div>}
-    {expanded && <div id={id} role='region' style={{ marginLeft: 25 }}>{children}</div>}
+    {expanded && <div id={regionId} aria-labelledby={titleId} role='region' className='expandable-content'>{children}</div>}
   </div>;
 };

--- a/packages/web/src/components/expandable.tsx
+++ b/packages/web/src/components/expandable.tsx
@@ -23,7 +23,8 @@ export const Expandable: React.FunctionComponent<React.PropsWithChildren<{
   setExpanded: (expanded: boolean) => void,
   expanded: boolean,
   expandOnTitleClick?: boolean,
-}>> = ({ title, children, setExpanded, expanded, expandOnTitleClick }) => {
+  className?: string;
+}>> = ({ title, children, setExpanded, expanded, expandOnTitleClick, className }) => {
   const titleId = React.useId();
   const regionId = React.useId();
 
@@ -34,7 +35,7 @@ export const Expandable: React.FunctionComponent<React.PropsWithChildren<{
     style={{ cursor: 'pointer', color: 'var(--vscode-foreground)', marginLeft: '5px' }}
     onClick={!expandOnTitleClick ? onClick : undefined} />;
 
-  return <div className={clsx('expandable', expanded && 'expanded')}>
+  return <div className={clsx('expandable', expanded && 'expanded', className)}>
     {expandOnTitleClick ?
       <div
         id={titleId}

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -196,14 +196,14 @@ test('should display list of query parameters (only if present)', async ({ runUI
 
   await page.getByText('call-with-query-params').click();
 
-  const group = page.getByRole('group', { name: 'Query String Parameters' });
-  await expect(group.getByText('param1: value1')).toBeVisible();
-  await expect(group.getByText('param1: value2')).toBeVisible();
-  await expect(group.getByText('param2: value2')).toBeVisible();
+  const region = page.getByRole('region', { name: 'Query String Parameters' });
+  await expect(region.getByText('param1: value1')).toBeVisible();
+  await expect(region.getByText('param1: value2')).toBeVisible();
+  await expect(region.getByText('param2: value2')).toBeVisible();
 
   await page.getByText('endpoint').click();
 
-  await expect(group).toBeHidden();
+  await expect(region).toBeHidden();
 });
 
 test('should not duplicate network entries from beforeAll', {
@@ -258,22 +258,21 @@ test('should toggle sections inside network details', async ({ runUITest, server
   await page.getByRole('listitem').filter({ hasText: 'post-data-1' }).click();
   const requestPanel = page.getByRole('tabpanel', { name: 'Request' });
 
-  // Make sure to assert with useInnerText, because .textContent always includes text even if details is collapsed
-  await requestPanel.getByText('Request Headers').click();
-  await expect(requestPanel.getByRole('group', { name: 'Request Headers' })).toHaveText('Request Headers', { useInnerText: true });
-  await expect(requestPanel.getByRole('group', { name: 'Time' })).toHaveText(/Time\nStart: .+\nDuration: \d+ms/,  { useInnerText: true });
+  await requestPanel.getByRole('button', { name: 'Request Headers' }).click();
+  await expect(requestPanel.getByRole('region', { name: 'Request Headers' })).toBeHidden();
+  await expect(requestPanel.getByRole('region', { name: 'Time' })).toHaveText(/Start: .+Duration: \d+ms/);
 
-  await requestPanel.getByText('Time').click();
-  await expect(requestPanel.getByRole('group', { name: 'Request Headers' })).toHaveText('Request Headers', { useInnerText: true });
-  await expect(requestPanel.getByRole('group', { name: 'Time' })).toHaveText('Time', { useInnerText: true });
+  await requestPanel.getByRole('button', { name: 'Time' }).click();
+  await expect(requestPanel.getByRole('region', { name: 'Request Headers' })).toBeHidden();
+  await expect(requestPanel.getByRole('region', { name: 'Time' })).toBeHidden();
 
-  await requestPanel.getByText('Time').click();
-  await expect(requestPanel.getByRole('group', { name: 'Request Headers' })).toHaveText('Request Headers', { useInnerText: true });
-  await expect(requestPanel.getByRole('group', { name: 'Time' })).toHaveText(/Time\nStart: .+\nDuration: \d+ms/, { useInnerText: true });
+  await requestPanel.getByRole('button', { name: 'Time' }).click();
+  await expect(requestPanel.getByRole('region', { name: 'Request Headers' })).toBeHidden();
+  await expect(requestPanel.getByRole('region', { name: 'Time' })).toHaveText(/Start: .+Duration: \d+ms/);
 
   // Re-opening should preserve open state
   await page.getByRole('tabpanel', { name: 'Network' }).getByRole('button', { name: 'Close' }).click();
   await page.getByRole('listitem').filter({ hasText: 'post-data-1' }).click();
-  await expect(requestPanel.getByRole('group', { name: 'Request Headers' })).toHaveText('Request Headers', { useInnerText: true });
-  await expect(requestPanel.getByRole('group', { name: 'Time' })).toHaveText(/Time\nStart: .+\nDuration: \d+ms/, { useInnerText: true });
+  await expect(requestPanel.getByRole('region', { name: 'Request Headers' })).toBeHidden();
+  await expect(requestPanel.getByRole('region', { name: 'Time' })).toHaveText(/Start: .+Duration: \d+ms/);
 });


### PR DESCRIPTION
- Made sections collapsible
- Store the collapsed state in local storage
- Aligned chevrons with 'x' icon and aligned section's with 'Request' tab name
- Added test


Before:
<img width="445" height="255" alt="image" src="https://github.com/user-attachments/assets/2706c352-9e48-4528-87f5-9266c33add71" />

After:
<img width="380" height="251" alt="image" src="https://github.com/user-attachments/assets/cd8676c4-6c93-4be9-9b2d-1115b2cd6b9e" />
<img width="399" height="276" alt="image" src="https://github.com/user-attachments/assets/d2fdb125-9d2d-4a66-b5fa-76acf415a4ab" />


references: #35214