### PR TITLE
chore: pass isUnderTest to wsl

### DIFF
--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -73,6 +73,7 @@ const test = playwrightTest.extend<ExtraFixtures>({
 
 test.slow(true, 'All connect tests are slow');
 test.skip(({ mode }) => mode.startsWith('service'));
+test.skip(({ mode }) => mode === 'wsl');
 
 for (const kind of ['launchServer', 'run-server'] as const) {
   test.describe(kind, () => {

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -81,7 +81,7 @@ if (mode === 'service2') {
 if (channel === 'webkit-wsl') {
   connectOptions = { wsEndpoint: 'ws://localhost:3777/' };
   webServer = {
-    command: 'wsl.exe -d playwright -u pwuser -- bash -lc \'/home/pwuser/node/bin/npx playwright run-server --port=3777\'',
+    command: 'set PWTEST_UNDER_TEST=1 && set WSLENV=PWTEST_UNDER_TEST && wsl.exe -d playwright -u pwuser -- bash -lc \'/home/pwuser/node/bin/npx playwright run-server --port=3777\'',
     url: 'http://localhost:3777',
   };
 }

--- a/tests/library/signals.spec.ts
+++ b/tests/library/signals.spec.ts
@@ -22,7 +22,8 @@ import os from 'os';
 
 test.slow();
 
-test('should close the browser when the node process closes', async ({ startRemoteServer, isWindows, server }) => {
+test('should close the browser when the node process closes', async ({ startRemoteServer, isWindows, server, mode }) => {
+  test.skip(mode === 'wsl', 'Remove server cannot start on Windows with WebKit WSL params');
   const remoteServer = await startRemoteServer('launchServer', { url: server.EMPTY_PAGE });
   try {
     if (isWindows)


### PR DESCRIPTION
* WSL forwards only explicitly allowed user env variables
* Skip connect tests in wsl mode as the server tries to start on the host system with wsl params

https://github.com/microsoft/playwright/issues/37036