### PR TITLE
chore(bidi): add support for fetching request bodies

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -70,7 +70,7 @@ export class BidiBrowser extends Browser {
     });
 
     await browser._browserSession.send('network.addDataCollector', {
-      dataTypes: [bidi.Network.DataType.Response],
+      dataTypes: [bidi.Network.DataType.Request, bidi.Network.DataType.Response],
       maxEncodedDataSize: 20_000_000, // same default as in CDP: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/inspector/inspector_network_agent.cc;l=134;drc=4128411589187a396829a827f59a655bed876aa7
     });
 

--- a/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
+++ b/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
@@ -54,7 +54,7 @@ export class BidiNetworkManager {
     eventsHelper.removeEventListeners(this._eventListeners);
   }
 
-  private _onBeforeRequestSent(param: bidi.Network.BeforeRequestSentParameters) {
+  private async _onBeforeRequestSent(param: bidi.Network.BeforeRequestSentParameters) {
     if (param.request.url.startsWith('data:'))
       return;
     const redirectedFrom = param.redirectCount ? (this._requests.get(param.request.request) || null) : null;
@@ -79,7 +79,8 @@ export class BidiNetworkManager {
         route = new BidiRouteImpl(this._session, param.request.request);
       }
     }
-    const request = new BidiRequest(frame, redirectedFrom, param, route);
+    const requestData = await getNetworkData(this._session, param.request, bidi.Network.DataType.Request).catch(() => null);
+    const request = new BidiRequest(frame, redirectedFrom, param, route, requestData);
     this._requests.set(request._id, request);
     this._page.frameManager.requestStarted(request.request, route);
   }
@@ -88,11 +89,7 @@ export class BidiNetworkManager {
     const request = this._requests.get(params.request.request);
     if (!request)
       return;
-    const getResponseBody = async () => {
-      const { bytes } = await this._session.send('network.getData', { request: params.request.request, dataType: bidi.Network.DataType.Response });
-      const encoding = bytes.type === 'base64' ? 'base64' : 'utf8';
-      return Buffer.from(bytes.value, encoding);
-    };
+    const getResponseBody = async () => (await getNetworkData(this._session, params.request, bidi.Network.DataType.Response))!;
     const timings = params.request.timings;
     const startTime = timings.requestTime;
     function relativeToStart(time: number): number {
@@ -236,14 +233,12 @@ class BidiRequest {
   // store the first and only Route in the chain (if any).
   _originalRequestRoute: BidiRouteImpl | undefined;
 
-  constructor(frame: frames.Frame, redirectedFrom: BidiRequest | null, payload: bidi.Network.BeforeRequestSentParameters, route: BidiRouteImpl | undefined) {
+  constructor(frame: frames.Frame, redirectedFrom: BidiRequest | null, payload: bidi.Network.BeforeRequestSentParameters, route: BidiRouteImpl | undefined, postData: Buffer | null) {
     this._id = payload.request.request;
     if (redirectedFrom)
       redirectedFrom._redirectedTo = this;
-    // TODO: missing in the spec?
-    const postDataBuffer = null;
     this.request = new network.Request(frame._page.browserContext, frame, null, redirectedFrom ? redirectedFrom.request : null, payload.navigation ?? undefined, payload.request.url,
-        resourceTypeFromBidi(payload.request.destination, payload.request.initiatorType, payload.initiator?.type), payload.request.method, postDataBuffer, fromBidiHeaders(payload.request.headers));
+        resourceTypeFromBidi(payload.request.destination, payload.request.initiatorType, payload.initiator?.type), payload.request.method, postData, fromBidiHeaders(payload.request.headers));
     // "raw" headers are the same as "provisional" headers in Bidi.
     this.request.setRawRequestHeaders(null);
     this.request._setBodySize(payload.request.bodySize || 0);
@@ -389,4 +384,12 @@ function resourceTypeFromBidi(requestDestination: string, requestInitiatorType: 
       }
     default: return 'other';
   }
+}
+
+async function getNetworkData(session: BidiSession, request: bidi.Network.RequestData, dataType: bidi.Network.DataType): Promise<Buffer | null> {
+  if (dataType === 'request' && !request.bodySize)
+    return null;
+  const { bytes } = await session.send('network.getData', { request: request.request, dataType });
+  const encoding = bytes.type === 'base64' ? 'base64' : 'utf8';
+  return Buffer.from(bytes.value, encoding);
 }

--- a/packages/playwright-core/src/server/bidi/third_party/bidiProtocolCore.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiProtocolCore.ts
@@ -1383,6 +1383,7 @@ export namespace Network {
 }
 export namespace Network {
   export const enum DataType {
+    Request = 'request',
     Response = 'response',
   }
 }


### PR DESCRIPTION
Fixes the following tests in Firefox:
- `tests/library/har.spec.ts`:
  - "should include postData"
  - "should include binary postData"
  - "should include form params"
- `tests/page/network-post-data.spec.ts`:
  - "should return correct postData buffer for utf-8 body"
  - "should return post data w/o content-type"
  - "should throw on invalid JSON in post data"
  - "should return post data for PUT requests"
  - "should get post data for file/blob"
  - "should get post data for navigator.sendBeacon api calls"
- `tests/page/page-network-request.spec.ts`:
  - "should parse the data if content-type is application/x-www-form-urlencoded"
  - "should parse the data if content-type is application/x-www-form-urlencoded; charset=UTF-8"
  - "should parse the json post data"
  - "should return multipart/form-data"
  - "should return postData"
  - "should work with binary post data"
  - "should work with binary post data and interception"
- `tests/page/page-request-intercept.spec.ts`:
  - "request.postData is not null when fetching FormData with a Blob"
- `tests/page/page-route.spec.ts`:
  - "should intercept when postData is more than 1MB"
