### PR TITLE
chore(deps): bump chromium-bidi to ^11.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "@zip.js/zip.js": "^2.7.29",
         "chokidar": "^3.5.3",
-        "chromium-bidi": "^9.0.0",
+        "chromium-bidi": "^11.0.0",
         "colors": "^1.4.0",
         "concurrently": "^6.2.1",
         "cross-env": "^7.0.3",
@@ -2883,9 +2883,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-9.0.0.tgz",
-      "integrity": "sha512-CGUetd0G5Bq93BRnckGppWN1BwKYTTW7tMtaZ9PxeFF0LFj3GErytqfI60KgkmB7CcnvWIjdRDfVcFWvzErSyQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-11.0.0.tgz",
+      "integrity": "sha512-cM3DI+OOb89T3wO8cpPSro80Q9eKYJ7hGVXoGS3GkDPxnYSqiv+6xwpIf6XERyJ9Tdsl09hmNmY94BkgZdVekw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "@zip.js/zip.js": "^2.7.29",
     "chokidar": "^3.5.3",
-    "chromium-bidi": "^9.0.0",
+    "chromium-bidi": "^11.0.0",
     "colors": "^1.4.0",
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",

--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -50,12 +50,16 @@ export class BidiBrowser extends Browser {
     browser._bidiSessionInfo = await browser._browserSession.send('session.new', {
       capabilities: {
         alwaysMatch: {
-          acceptInsecureCerts: options.persistent?.internalIgnoreHTTPSErrors || options.persistent?.ignoreHTTPSErrors,
-          proxy: getProxyConfiguration(options.originalLaunchOptions.proxyOverride ?? options.proxy),
-          unhandledPromptBehavior: {
+          'acceptInsecureCerts': options.persistent?.internalIgnoreHTTPSErrors || options.persistent?.ignoreHTTPSErrors,
+          'proxy': getProxyConfiguration(options.originalLaunchOptions.proxyOverride ?? options.proxy),
+          'unhandledPromptBehavior': {
             default: bidi.Session.UserPromptHandlerType.Ignore,
           },
-          webSocketUrl: true
+          'webSocketUrl': true,
+          // Chrome with WebDriver BiDi does not support prerendering
+          // yet because WebDriver BiDi behavior is not specified. See
+          // https://github.com/w3c/webdriver-bidi/issues/321.
+          'goog:prerenderingDisabled': true,
         },
       }
     });


### PR DESCRIPTION
Changelog: https://github.com/GoogleChromeLabs/chromium-bidi/blob/main/CHANGELOG.md

Adds `goog:prerenderingDisabled` to turn off pre-rendering that is not supported by WebDriver BiDi spec yet.