### PR TITLE
fix(chromium): wait until workerScriptLoaded event before evaluating

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -126,6 +126,7 @@ export class BidiPage implements PageDelegate {
       const delegate = new BidiExecutionContext(this._session, realmInfo);
       const worker = new Worker(this._page, realmInfo.origin);
       this._realmToWorkerContext.set(realmInfo.realm, worker.createExecutionContext(delegate));
+      worker.workerScriptLoaded();
       this._page.addWorker(realmInfo.realm, worker);
       return;
     }

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -49,6 +49,7 @@ export class CRBrowser extends Browser {
   _serviceWorkers = new Map<string, CRServiceWorker>();
   _devtools?: CRDevTools;
   private _version = '';
+  private _majorVersion = 0;
 
   private _tracingRecording = false;
   private _tracingClient: CRSession | undefined;
@@ -68,6 +69,10 @@ export class CRBrowser extends Browser {
 
     const version = await session.send('Browser.getVersion');
     browser._version = version.product.substring(version.product.indexOf('/') + 1);
+    try {
+      browser._majorVersion = +browser._version.split('.')[0];
+    } catch {
+    }
     browser._userAgent = version.userAgent;
     // We don't trust the option as it may lie in case of connectOverCDP where remote browser
     // may have been launched with different options.
@@ -128,6 +133,10 @@ export class CRBrowser extends Browser {
 
   version(): string {
     return this._version;
+  }
+
+  majorVersion() {
+    return this._majorVersion;
   }
 
   userAgent(): string {

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -750,6 +750,10 @@ class FrameSession {
     session.once('Runtime.executionContextCreated', async event => {
       worker.createExecutionContext(new CRExecutionContext(session, event.context));
     });
+    if (this._crPage._browserContext._browser.majorVersion() >= 143)
+      session.on('Inspector.workerScriptLoaded', () => worker.workerScriptLoaded());
+    else
+      worker.workerScriptLoaded();
     // This might fail if the target is closed before we initialize.
     session._sendMayFail('Runtime.enable');
     // TODO: attribute workers to the right frame.

--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -36,6 +36,10 @@ export class CRServiceWorker extends Worker {
     session.once('Runtime.executionContextCreated', event => {
       this.createExecutionContext(new CRExecutionContext(session, event.context));
     });
+    if (this.browserContext._browser.majorVersion() >= 143)
+      session.on('Inspector.workerScriptLoaded', () => this.workerScriptLoaded());
+    else
+      this.workerScriptLoaded();
 
     if (this._networkManager && this._isNetworkInspectionEnabled()) {
       this.updateRequestInterception();

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -280,6 +280,7 @@ export class FFPage implements PageDelegate {
     this._page.addWorker(workerId, worker);
     workerSession.once('Runtime.executionContextCreated', event => {
       worker.createExecutionContext(new FFExecutionContext(workerSession, event.executionContextId));
+      worker.workerScriptLoaded();
     });
     workerSession.on('Runtime.console', event => {
       const { type, args, location } = event;

--- a/packages/playwright-core/src/server/webkit/wkWorkers.ts
+++ b/packages/playwright-core/src/server/webkit/wkWorkers.ts
@@ -49,6 +49,7 @@ export class WKWorkers {
         });
         this._workerSessions.set(event.workerId, workerSession);
         worker.createExecutionContext(new WKExecutionContext(workerSession, undefined));
+        worker.workerScriptLoaded();
         this._page.addWorker(event.workerId, worker);
         workerSession.on('Console.messageAdded', event => this._onConsoleMessage(worker, event));
         Promise.all([


### PR DESCRIPTION
This ensures we evaluate in the worker only after the initial worker script was loaded. Fixes a few flaky/crashing tests as well.

Closes #35778.