### PR TITLE
chore: disable infobars in Chromium

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -82,4 +82,7 @@ export const chromiumSwitches = (assistantMode?: boolean, channel?: string) => [
   // Edge can potentially restart on Windows (msRelaunchNoCompatLayer) which looses its file descriptors (stdout/stderr) and CDP (3/4). Disable until fixed upstream.
   '--edge-skip-compat-layer-relaunch',
   assistantMode ? '' : '--enable-automation',
+  // This disables Chrome for Testing infobar that is visible in the persistent context.
+  // The switch is ignored everywhere else, including Chromium/Chrome/Edge.
+  '--disable-infobars',
 ].filter(Boolean);


### PR DESCRIPTION
This is to get rid of the Chrome for Testing infobar that's visible for the persistent context.