### PR TITLE
chore: drop duplicate runGlobalTeardown

### DIFF
--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -154,8 +154,6 @@ export class TestServerDispatcher implements TestServerInterface {
   }
 
   async runGlobalSetup(params: Parameters<TestServerInterface['runGlobalSetup']>[0]): ReturnType<TestServerInterface['runGlobalSetup']> {
-    await this.runGlobalTeardown();
-
     const { reporter, report } = await this._collectingReporter();
     this._globalSetupReport = report;
     const { status } = await this._testRunner.runGlobalSetup([reporter, new ListReporter()]);


### PR DESCRIPTION
this got a little wrong in #37024. there's no need to call `runGlobalTeardown` from the test server, the test runner's `runGlobalSetup` does the same thing.