### PR TITLE
chore(role): should not stop at shadow slots

### DIFF
--- a/packages/injected/src/roleSelectorEngine.ts
+++ b/packages/injected/src/roleSelectorEngine.ts
@@ -164,13 +164,17 @@ function queryRole(scope: SelectorRoot, options: RoleEngineOptions, internal: bo
   };
 
   const query = (root: Element | ShadowRoot | Document) => {
-    const shadows: ShadowRoot[] = [];
+    const shadows: (ShadowRoot | Element)[] = [];
     if ((root as Element).shadowRoot)
       shadows.push((root as Element).shadowRoot!);
+    if ((root as HTMLSlotElement).assignedElements)
+      shadows.push(...(root as HTMLSlotElement).assignedElements());
     for (const element of root.querySelectorAll('*')) {
       match(element);
       if (element.shadowRoot)
         shadows.push(element.shadowRoot);
+      if ((element as HTMLSlotElement).assignedElements)
+        shadows.push(...(element as HTMLSlotElement).assignedElements());
     }
     shadows.forEach(query);
   };

--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -1288,6 +1288,19 @@ it('should click shadow root button', { annotation: { type: 'issue', description
   await page.locator('my-button').click();
 });
 
+it('should click into shadow root dialog with slotted div', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/38166' } }, async ({ page }) => {
+  await page.setContent(`
+    <my-dialog>
+      <template shadowrootmode="open">
+        <dialog open><slot></slot></dialog>
+      </template>
+      <div><button>Foo</button></div>
+    </my-dialog>
+  `);
+
+  await page.getByRole('dialog').getByRole('button', { name: 'Foo' }).click();
+});
+
 it('should click with tweened mouse movement', async ({ page, browserName, isAndroid, headless }) => {
   it.skip(isAndroid, 'Bad rounding');
   it.skip(!headless, 'System cursor tends to interfere with this test');


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/38166. The role engine doesn't currently discover elements in shadow slots when going through all child elements.