### PR TITLE
chore(docs): fix asymmetric matcher expressions

### DIFF
--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -91,14 +91,21 @@ Prefer [auto-retrying](#auto-retrying-assertions) assertions whenever possible. 
 | [`method: GenericAssertions.toMatchObject`] | Object contains specified properties |
 | [`method: GenericAssertions.toStrictEqual`] | Value is similar, including property types |
 | [`method: GenericAssertions.toThrow`] | Function throws an error |
-| [`method: GenericAssertions.any`] | Matches any instance of a class/primitive |
-| [`method: GenericAssertions.anything`] | Matches anything |
-| [`method: GenericAssertions.arrayContaining`] | Array contains specific elements |
-| [`method: GenericAssertions.arrayOf`] | Array contains elements of specific type |
-| [`method: GenericAssertions.closeTo`] | Number is approximately equal |
-| [`method: GenericAssertions.objectContaining`] | Object contains specific properties |
-| [`method: GenericAssertions.stringContaining`] | String contains a substring |
-| [`method: GenericAssertions.stringMatching`] | String matches a regular expression |
+
+## Asymmetric matchers
+
+These expressions can be nested in other assertions to allow more relaxed matching against a given condition.
+
+| Matcher | Description |
+| :- | :- |
+| [expect.any()](./api/class-genericassertions.md#generic-assertions-any) | Matches any instance of a class/primitive |
+| [expect.anything()](./api/class-genericassertions.md#generic-assertions-anything) | Matches anything |
+| [expect.arrayContaining()](./api/class-genericassertions.md#generic-assertions-array-containing) | Array contains specific elements |
+| [expect.arrayOf()](./api/class-genericassertions.md#generic-assertions-array-of) | Array contains elements of specific type |
+| [expect.closeTo()](./api/class-genericassertions.md#generic-assertions-close-to) | Number is approximately equal |
+| [expect.objectContaining()](./api/class-genericassertions.md#generic-assertions-object-containing) | Object contains specific properties |
+| [expect.stringContaining()](./api/class-genericassertions.md#generic-assertions-string-containing) | String contains a substring |
+| [expect.stringMatching()](./api/class-genericassertions.md#generic-assertions-string-matching) | String matches a regular expression |
 
 ## Negating matchers
 


### PR DESCRIPTION
Fixes #38082

Asymmetric matches show the wrong usage syntax in the main table of assertions due to our automatic link generation. Switch to manually created links.

Additionally, as asymmetric matchers are not directly related to assertions, separate them into their own section.