### PR TITLE
chore: deprecate reportSlowTests

### DIFF
--- a/docs/src/test-api/class-fullconfig.md
+++ b/docs/src/test-api/class-fullconfig.md
@@ -92,6 +92,7 @@ See [`property: TestConfig.reporter`].
 
 ## property: FullConfig.reportSlowTests
 * since: v1.10
+* deprecated: This feature is discouraged and will be removed in the future. Its detection is incomplete.
 - type: <[null]|[Object]>
   - `max` <[int]> The maximum number of slow test files to report.
   - `threshold` <[float]> Test file duration in milliseconds that is considered slow.

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -472,6 +472,7 @@ export default defineConfig({
 
 ## property: TestConfig.reportSlowTests
 * since: v1.10
+* deprecated: This feature is discouraged and will be removed in the future. Its detection is incomplete.
 - type: ?<[null]|[Object]>
   - `max` <[int]> The maximum number of slow test files to report. Defaults to `5`.
   - `threshold` <[float]> Test file duration in milliseconds that is considered slow. Defaults to 5 minutes.

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1545,6 +1545,7 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    *
    * Test files that took more than `threshold` milliseconds are considered slow, and the slowest ones are reported, no
    * more than `max` number of them. Passing zero as `max` reports all test files that exceed the threshold.
+   * @deprecated This feature is discouraged and will be removed in the future. Its detection is incomplete.
    */
   reportSlowTests?: null|{
     /**
@@ -2022,6 +2023,7 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
 
   /**
    * See [testConfig.reportSlowTests](https://playwright.dev/docs/api/class-testconfig#test-config-report-slow-tests).
+   * @deprecated This feature is discouraged and will be removed in the future. Its detection is incomplete.
    */
   reportSlowTests: null|{
     /**


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/37724. Due to https://github.com/microsoft/TypeScript/issues/60442, this won't be surfaced to our users very well though:

<img width="514" height="474" alt="Screenshot 2025-11-11 at 16 39 09" src="https://github.com/user-attachments/assets/c64602ae-376b-428a-9292-44ead6f152ea" />

It'll be visible in the docs though, see https://playwright.dev/docs/api/class-locator#locator-type for an example.