### PR TITLE
fix(selector generator): heuristic for icon fonts

### DIFF
--- a/packages/injected/src/selectorGenerator.ts
+++ b/packages/injected/src/selectorGenerator.ts
@@ -343,7 +343,8 @@ function buildTextCandidates(injectedScript: InjectedScript, element: Element, i
   const ariaRole = getAriaRole(element);
   if (ariaRole && !['none', 'presentation'].includes(ariaRole)) {
     const ariaName = getElementAccessibleName(element, false);
-    if (ariaName) {
+    // \p{Co} means "Private Use" characters - these are often used for icon fonts and make for bad locators.
+    if (ariaName && !ariaName.match(/^\p{Co}+$/u)) {
       const roleToken = { engine: 'internal:role', selector: `${ariaRole}[name=${escapeForAttributeSelector(ariaName, true)}]`, score: kRoleWithNameScoreExact };
       candidates.push([roleToken]);
       for (const alternative of suitableTextAlternatives(ariaName))

--- a/tests/library/selector-generator.spec.ts
+++ b/tests/library/selector-generator.spec.ts
@@ -661,4 +661,23 @@ it.describe('selector generator', () => {
       `internal:label=\"Toggle Todo\"i >> nth=0`,
     ]);
   });
+
+  it('should not use icon fonts aria name', async ({ page }) => {
+    await page.setContent(`
+      <style>
+        .icon-foo:before {
+          content: "\\F1D4";
+        }
+        .icon-bar:before {
+          content: "\\F0000";
+        }
+      </style>
+      <div>
+        <button><i class="icon-foo"></i></button>
+        <button><i class="icon-bar"></i></button>
+      </div>
+    `);
+    expect.soft(await generate(page, 'button:first-child')).toBe('internal:role=button >> nth=0');
+    expect.soft(await generate(page, 'button:last-child')).toBe('internal:role=button >> nth=1');
+  });
 });


### PR DESCRIPTION
A common technique used for icon fonts is to prepend a `::before { content: "..." }` pseudo with a character from a unicode private use area, and define an icon rendering for such a character.

Using such a character as accessible name in `getByRole()` is not very readable, so avoid that.

Fixes #38173.