### PR TITLE
feat(locator): extend mouse movement steps to dragTo

### DIFF
--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -482,6 +482,9 @@ Optional event-specific initialization properties.
 ### option: Frame.dragAndDrop.targetPosition = %%-input-target-position-%%
 * since: v1.14
 
+### option: Frame.dragAndDrop.steps = %%-input-drag-steps-%%
+* since: v1.57
+
 ## async method: Frame.evalOnSelector
 * since: v1.9
 * discouraged: This method does not wait for the element to pass the actionability

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -875,6 +875,9 @@ Locator of the element to drag to.
 ### option: Locator.dragTo.targetPosition = %%-input-target-position-%%
 * since: v1.18
 
+### option: Locator.dragTo.steps = %%-input-drag-steps-%%
+* since: v1.57
+
 ## async method: Locator.elementHandle
 * since: v1.14
 * discouraged: Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1102,6 +1102,9 @@ await Page.DragAndDropAsync("#source", "#target", new()
 ### option: Page.dragAndDrop.targetPosition = %%-input-target-position-%%
 * since: v1.14
 
+### option: Page.dragAndDrop.steps = %%-input-drag-steps-%%
+* since: v1.57
+
 ## async method: Page.emulateMedia
 * since: v1.8
 

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -108,6 +108,11 @@ element.
 
 Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor position and the provided destination. When set to 1, emits a single `mousemove` event at the destination location.
 
+## input-drag-steps
+- `steps` <[int]>
+
+Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between the `mousedown` and `mouseup` of the drag. When set to 1, emits a single `mousemove` event at the destination location.
+
 ## input-modifiers
 - `modifiers` <[Array]<[KeyboardModifier]<"Alt"|"Control"|"ControlOrMeta"|"Meta"|"Shift">>>
 

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -2497,6 +2497,12 @@ export interface Page {
     };
 
     /**
+     * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between the `mousedown` and `mouseup`
+     * of the drag. When set to 1, emits a single `mousemove` event at the destination location.
+     */
+    steps?: number;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6399,6 +6405,12 @@ export interface Frame {
 
       y: number;
     };
+
+    /**
+     * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between the `mousedown` and `mouseup`
+     * of the drag. When set to 1, emits a single `mousemove` event at the destination location.
+     */
+    steps?: number;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -13072,6 +13084,12 @@ export interface Locator {
 
       y: number;
     };
+
+    /**
+     * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between the `mousedown` and `mouseup`
+     * of the drag. When set to 1, emits a single `mousemove` event at the destination location.
+     */
+    steps?: number;
 
     /**
      * Drops on the target element at this point relative to the top-left corner of the element's padding box. If not

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1582,6 +1582,7 @@ scheme.FrameDragAndDropParams = tObject({
   sourcePosition: tOptional(tType('Point')),
   targetPosition: tOptional(tType('Point')),
   strict: tOptional(tBoolean),
+  steps: tOptional(tInt),
 });
 scheme.FrameDragAndDropResult = tOptional(tObject({}));
 scheme.FrameDblclickParams = tObject({

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1168,7 +1168,7 @@ export class Frame extends SdkObject {
     // Note: do not perform locator handlers checkpoint to avoid moving the mouse in the middle of a drag operation.
     dom.assertDone(await this._retryWithProgressIfNotConnected(progress, target, options.strict, false /* performActionPreChecks */, async handle => {
       return handle._retryPointerAction(progress, 'move and up', false, async point => {
-        await this._page.mouse.move(progress, point.x, point.y);
+        await this._page.mouse.move(progress, point.x, point.y, { steps: options.steps });
         await this._page.mouse.up(progress);
       }, {
         ...options,

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -113,6 +113,7 @@ export type PointerActionOptions = {
 export type DragActionOptions = {
   sourcePosition?: Point;
   targetPosition?: Point;
+  steps?: number;
 };
 
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2497,6 +2497,12 @@ export interface Page {
     };
 
     /**
+     * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between the `mousedown` and `mouseup`
+     * of the drag. When set to 1, emits a single `mousemove` event at the destination location.
+     */
+    steps?: number;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6399,6 +6405,12 @@ export interface Frame {
 
       y: number;
     };
+
+    /**
+     * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between the `mousedown` and `mouseup`
+     * of the drag. When set to 1, emits a single `mousemove` event at the destination location.
+     */
+    steps?: number;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -13072,6 +13084,12 @@ export interface Locator {
 
       y: number;
     };
+
+    /**
+     * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between the `mousedown` and `mouseup`
+     * of the drag. When set to 1, emits a single `mousemove` event at the destination location.
+     */
+    steps?: number;
 
     /**
      * Drops on the target element at this point relative to the top-left corner of the element's padding box. If not

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -2789,6 +2789,7 @@ export type FrameDragAndDropParams = {
   sourcePosition?: Point,
   targetPosition?: Point,
   strict?: boolean,
+  steps?: number,
 };
 export type FrameDragAndDropOptions = {
   force?: boolean,
@@ -2796,6 +2797,7 @@ export type FrameDragAndDropOptions = {
   sourcePosition?: Point,
   targetPosition?: Point,
   strict?: boolean,
+  steps?: number,
 };
 export type FrameDragAndDropResult = void;
 export type FrameDblclickParams = {

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -2224,6 +2224,7 @@ Frame:
         sourcePosition: Point?
         targetPosition: Point?
         strict: boolean?
+        steps: int?
       flags:
         slowMo: true
         snapshot: true

--- a/tests/page/page-drag.spec.ts
+++ b/tests/page/page-drag.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ElementHandle, Route } from 'playwright-core';
+import type { ElementHandle, Page, Route } from 'playwright-core';
 import { test as it, expect } from './pageTest';
 import { attachFrame } from '../config/utils';
 
@@ -291,6 +291,68 @@ it.describe('Drag and drop', () => {
     await page.goto(server.PREFIX + '/drag-n-drop.html');
     await page.dragAndDrop('#source', '#target');
     expect(await page.$eval('#target', target => target.contains(document.querySelector('#source')))).toBe(true); // could not find source in target
+  });
+
+  [{
+    title: 'dragAndDrop',
+    drag: (page: Page, steps?: number) => page.dragAndDrop('#red', '#blue', { steps }),
+  }, {
+    title: 'dragTo',
+    drag: (page: Page, steps?: number) => page.locator('#red').dragTo(page.locator('#blue'), { steps }),
+  }].forEach(({ title, drag }) => {
+    it(`should ${title} with tweened mouse movement`, async ({ page }) => {
+      await page.setContent(`
+        <body style="margin: 0; padding: 0;">
+          <div style="width:100px;height:100px;background:red;" id="red"></div>
+          <div style="width:300px;height:100px;background:blue;" id="blue"></div>
+        </body>
+      `);
+      const eventsHandle = await page.evaluateHandle(() => {
+        const events = [];
+        document.addEventListener('mousedown', event => {
+          events.push({
+            type: 'mousedown',
+            x: event.pageX,
+            y: event.pageY,
+          });
+        });
+        document.addEventListener('mouseup', event => {
+          events.push({
+            type: 'mouseup',
+            x: event.pageX,
+            y: event.pageY,
+          });
+        });
+        document.addEventListener('mousemove', event => {
+          events.push({
+            type: 'mousemove',
+            x: event.pageX,
+            y: event.pageY,
+          });
+        });
+        return events;
+      });
+      await drag(page);
+      const steplessEvents = [
+        { type: 'mousemove', x: 50, y: 50 },
+        { type: 'mousedown', x: 50, y: 50 },
+        { type: 'mousemove', x: 150, y: 150 },
+        { type: 'mouseup', x: 150, y: 150 },
+      ];
+      expect(await eventsHandle.jsonValue()).toEqual(steplessEvents);
+
+      await drag(page, 4);
+      expect(await eventsHandle.jsonValue()).toEqual([
+        ...steplessEvents,
+        { type: 'mousemove', x: 50, y: 50 },
+        { type: 'mousedown', x: 50, y: 50 },
+        { type: 'mousemove', x: 75, y: 75 },
+        { type: 'mousemove', x: 100, y: 100 },
+        { type: 'mousemove', x: 125, y: 125 },
+        { type: 'mousemove', x: 150, y: 150 },
+        { type: 'mouseup', x: 150, y: 150 },
+      ]);
+    });
   });
 
   it('should allow specifying the position', async ({ page, server }) => {

--- a/tests/page/page-drag.spec.ts
+++ b/tests/page/page-drag.spec.ts
@@ -342,7 +342,7 @@ it.describe('Drag and drop', () => {
       expect(await eventsHandle.jsonValue()).toEqual(steplessEvents);
 
       await drag(page, 4);
-      expect(await eventsHandle.jsonValue()).toEqual([
+      await expect.poll(() => eventsHandle.jsonValue()).toEqual([
         ...steplessEvents,
         { type: 'mousemove', x: 50, y: 50 },
         { type: 'mousedown', x: 50, y: 50 },

--- a/tests/page/page-drag.spec.ts
+++ b/tests/page/page-drag.spec.ts
@@ -332,18 +332,8 @@ it.describe('Drag and drop', () => {
         });
         return events;
       });
-      await drag(page);
-      const steplessEvents = [
-        { type: 'mousemove', x: 50, y: 50 },
-        { type: 'mousedown', x: 50, y: 50 },
-        { type: 'mousemove', x: 150, y: 150 },
-        { type: 'mouseup', x: 150, y: 150 },
-      ];
-      expect(await eventsHandle.jsonValue()).toEqual(steplessEvents);
-
       await drag(page, 4);
       await expect.poll(() => eventsHandle.jsonValue()).toEqual([
-        ...steplessEvents,
         { type: 'mousemove', x: 50, y: 50 },
         { type: 'mousedown', x: 50, y: 50 },
         { type: 'mousemove', x: 75, y: 75 },


### PR DESCRIPTION
Continuation of #38036. Adds `steps` to `Locator.dragTo` and `Frame.dragAndDrop`.