### PR TITLE
devops: do not run tests if build failed

### DIFF
--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -161,7 +161,6 @@ jobs:
         job_name: "web-components-html-reporter"
 
     - run: npm run test-web
-      if: ${{ !cancelled() }}
       env:
         PWTEST_BOT_NAME: "web-components-web"
     - name: Upload blob report


### PR DESCRIPTION
Otherwise we get [this](https://github.com/microsoft/playwright/actions/runs/19275394825/job/55113829445?pr=38179):

```
  1) [chromium] › packages/web/src/components/codeMirrorWrapper.spec.tsx:71:5 › highlight JavaScript 

    Error: browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1200/chrome-headless-shell-linux64/chrome-headless-shell
    ╔═════════════════════════════════════════════════════════════════════════╗
    ║ Looks like Playwright Test or Playwright was just installed or updated. ║
    ║ Please run the following command to download new browsers:              ║
    ║                                                                         ║
    ║     npx playwright install                                              ║
    ║                                                                         ║
    ║ <3 Playwright Team                                                      ║
    ╚═════════════════════════════════════════════════════════════════════════╝
```