### PR TITLE
chore(ui): Speedboard UI improvements

### DIFF
--- a/packages/html-reporter/src/chip.css
+++ b/packages/html-reporter/src/chip.css
@@ -58,7 +58,6 @@
 
 .chip-footer {
   border-top: 1px solid var(--color-border-default);
-  padding: 8px 0px;
 }
 
 @media only screen and (max-width: 600px) {

--- a/packages/html-reporter/src/chip.css
+++ b/packages/html-reporter/src/chip.css
@@ -58,7 +58,7 @@
 
 .chip-footer {
   border-top: 1px solid var(--color-border-default);
-  padding: 8px;
+  padding: 8px 0px;
 }
 
 @media only screen and (max-width: 600px) {

--- a/packages/html-reporter/src/chip.tsx
+++ b/packages/html-reporter/src/chip.tsx
@@ -42,6 +42,7 @@ export const Chip: React.FC<{
       title={typeof header === 'string' ? header : undefined}>
       {setExpanded && !!expanded && icons.downArrow()}
       {setExpanded && !expanded && icons.rightArrow()}
+      {!setExpanded && <span className='octicon' style={{ width: 16, height: 16 }} />}
       {header}
     </div>
     {(!setExpanded || expanded) && <div id={id} role='region' className={clsx('chip-body', noInsets && 'chip-body-no-insets')}>

--- a/packages/html-reporter/src/chip.tsx
+++ b/packages/html-reporter/src/chip.tsx
@@ -40,9 +40,7 @@ export const Chip: React.FC<{
       className={clsx('chip-header', setExpanded && ' expanded-' + expanded)}
       onClick={() => setExpanded?.(!expanded)}
       title={typeof header === 'string' ? header : undefined}>
-      {setExpanded && !!expanded && <icons.downArrow />}
-      {setExpanded && !expanded && <icons.rightArrow />}
-      {!setExpanded && <icons.spacer />}
+      {setExpanded ? (expanded ? <icons.downArrow /> : <icons.rightArrow />) : <icons.spacer />}
       {header}
     </div>
     {(!setExpanded || expanded) && <div id={id} role='region' className={clsx('chip-body', noInsets && 'chip-body-no-insets')}>

--- a/packages/html-reporter/src/chip.tsx
+++ b/packages/html-reporter/src/chip.tsx
@@ -40,9 +40,9 @@ export const Chip: React.FC<{
       className={clsx('chip-header', setExpanded && ' expanded-' + expanded)}
       onClick={() => setExpanded?.(!expanded)}
       title={typeof header === 'string' ? header : undefined}>
-      {setExpanded && !!expanded && icons.downArrow()}
-      {setExpanded && !expanded && icons.rightArrow()}
-      {!setExpanded && <span className='octicon' style={{ width: 16, height: 16 }} />}
+      {setExpanded && !!expanded && <icons.downArrow />}
+      {setExpanded && !expanded && <icons.rightArrow />}
+      {!setExpanded && <icons.spacer />}
       {header}
     </div>
     {(!setExpanded || expanded) && <div id={id} role='region' className={clsx('chip-body', noInsets && 'chip-body-no-insets')}>

--- a/packages/html-reporter/src/common.css
+++ b/packages/html-reporter/src/common.css
@@ -216,7 +216,7 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
 }
 
 .subnav-item[aria-selected="true"] {
-  background: var(--color-canvas-subtle);
+  background: var(--color-control-transparent-bg-hover);
 }
 
 .subnav-item:first-child {

--- a/packages/html-reporter/src/common.css
+++ b/packages/html-reporter/src/common.css
@@ -215,6 +215,10 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   background-color: var(--color-canvas-subtle);
 }
 
+.subnav-item[aria-selected="true"] {
+  background: var(--color-canvas-subtle);
+}
+
 .subnav-item:first-child {
   border-top-left-radius: 6px;
   border-bottom-left-radius: 6px;

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -214,9 +214,11 @@ function cacheSearchValues(test: TestCaseSummary & { [searchValuesSymbol]?: Sear
 const SEARCH_PARAM_GROUP_REGEX = /("[^"]*"|"[^"]*$|\S+)/g;
 
 export function filterWithQuery(searchParams: URLSearchParams, token: string, append: boolean): string {
-  const result = new URLSearchParams(searchParams);
+  const result = new URLSearchParams();
+  if (searchParams.has('speedboard'))
+    result.set('speedboard', '');
 
-  const existingQuery = result.get('q') ?? '';
+  const existingQuery = searchParams.get('q') ?? '';
   const tokens = [...existingQuery.matchAll(SEARCH_PARAM_GROUP_REGEX)].map(m => {
     const rawValue = m[0];
     return rawValue.startsWith('"') && rawValue.endsWith('"') && rawValue.length > 1 ? rawValue.slice(1, rawValue.length - 1) : rawValue;

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -214,13 +214,17 @@ function cacheSearchValues(test: TestCaseSummary & { [searchValuesSymbol]?: Sear
 const SEARCH_PARAM_GROUP_REGEX = /("[^"]*"|"[^"]*$|\S+)/g;
 
 export function filterWithQuery(searchParams: URLSearchParams, token: string, append: boolean): string {
-  const existingQuery = searchParams.get('q') ?? '';
+  const result = new URLSearchParams(searchParams);
+
+  const existingQuery = result.get('q') ?? '';
   const tokens = [...existingQuery.matchAll(SEARCH_PARAM_GROUP_REGEX)].map(m => {
     const rawValue = m[0];
     return rawValue.startsWith('"') && rawValue.endsWith('"') && rawValue.length > 1 ? rawValue.slice(1, rawValue.length - 1) : rawValue;
   });
-  if (append)
-    return '#?q=' + joinTokens(!tokens.includes(token) ? [...tokens, token] : tokens.filter(t => t !== token));
+  if (append) {
+    result.set('q', joinTokens(!tokens.includes(token) ? [...tokens, token] : tokens.filter(t => t !== token)));
+    return '#?' + result;
+  }
 
   // if metaKey or ctrlKey is not pressed, replace existing token with new token
   let prefix: 's:' | 'p:' | '@';
@@ -233,7 +237,9 @@ export function filterWithQuery(searchParams: URLSearchParams, token: string, ap
 
   const newTokens = tokens.filter(t => !t.startsWith(prefix));
   newTokens.push(token);
-  return '#?q=' + joinTokens(newTokens);
+
+  result.set('q', joinTokens(newTokens));
+  return '#?' + result;
 }
 
 function joinTokens(tokens: string[]): string {

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -214,10 +214,7 @@ function cacheSearchValues(test: TestCaseSummary & { [searchValuesSymbol]?: Sear
 const SEARCH_PARAM_GROUP_REGEX = /("[^"]*"|"[^"]*$|\S+)/g;
 
 export function filterWithQuery(searchParams: URLSearchParams, token: string, append: boolean): string {
-  const result = new URLSearchParams();
-  if (searchParams.has('speedboard'))
-    result.set('speedboard', '');
-
+  const result = new URLSearchParams(searchParams);
   const existingQuery = searchParams.get('q') ?? '';
   const tokens = [...existingQuery.matchAll(SEARCH_PARAM_GROUP_REGEX)].map(m => {
     const rawValue = m[0];

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -113,6 +113,7 @@ const NavLink: React.FC<{
 }> = ({ token, count }) => {
   const searchParams = new URLSearchParams(React.useContext(SearchParamsContext));
   searchParams.delete('speedboard');
+  searchParams.delete('testId');
 
   const queryToken = `s:${token}`;
 

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -27,7 +27,6 @@ import { linkifyText } from '@web/renderUtils';
 import { Dialog } from '@web/shared/dialog';
 import { useDarkModeSetting } from '@web/theme';
 import { useSetting } from '@web/uiUtils';
-import { speedboardRoutePredicate } from './reportView';
 
 export const HeaderView: React.FC<{
   title: string | undefined,
@@ -91,7 +90,6 @@ const StatsNavView: React.FC<{
   stats: Stats
 }> = ({ stats }) => {
   const searchParams = React.useContext(SearchParamsContext);
-  const speedboardActive = speedboardRoutePredicate(searchParams);
 
   return <nav>
     <Link className='subnav-item' href='#?'>
@@ -102,7 +100,7 @@ const StatsNavView: React.FC<{
     <NavLink token='failed' count={stats.unexpected} />
     <NavLink token='flaky' count={stats.flaky} />
     <NavLink token='skipped' count={stats.skipped} />
-    <Link className='subnav-item' href='#?speedboard' title='Speedboard' aria-selected={speedboardActive}>
+    <Link className='subnav-item' href='#?speedboard' title='Speedboard' aria-selected={searchParams.has('speedboard')}>
       {icons.clock()}
     </Link>
     <SettingsButton />

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -115,7 +115,7 @@ const NavLink: React.FC<{
   searchParams.delete('speedboard');
 
   const queryToken = `s:${token}`;
-  
+
   const clickUrl = filterWithQuery(searchParams, queryToken, false);
   const ctrlClickUrl = filterWithQuery(searchParams, queryToken, true);
 

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -27,6 +27,7 @@ import { linkifyText } from '@web/renderUtils';
 import { Dialog } from '@web/shared/dialog';
 import { useDarkModeSetting } from '@web/theme';
 import { useSetting } from '@web/uiUtils';
+import { speedboardRoutePredicate } from './reportView';
 
 export const HeaderView: React.FC<{
   title: string | undefined,
@@ -89,6 +90,9 @@ export const GlobalFilterView: React.FC<{
 const StatsNavView: React.FC<{
   stats: Stats
 }> = ({ stats }) => {
+  const searchParams = React.useContext(SearchParamsContext);
+  const speedboardActive = speedboardRoutePredicate(searchParams);
+
   return <nav>
     <Link className='subnav-item' href='#?'>
       <span className='subnav-item-label'>All</span>
@@ -98,7 +102,7 @@ const StatsNavView: React.FC<{
     <NavLink token='failed' count={stats.unexpected} />
     <NavLink token='flaky' count={stats.flaky} />
     <NavLink token='skipped' count={stats.skipped} />
-    <Link className='subnav-item' href='#?speedboard' title='Speedboard'>
+    <Link className='subnav-item' href='#?speedboard' title='Speedboard' aria-selected={speedboardActive}>
       {icons.clock()}
     </Link>
     <SettingsButton />
@@ -109,9 +113,11 @@ const NavLink: React.FC<{
   token: string,
   count: number,
 }> = ({ token, count }) => {
-  const searchParams = React.useContext(SearchParamsContext);
-  const queryToken = `s:${token}`;
+  const searchParams = new URLSearchParams(React.useContext(SearchParamsContext));
+  searchParams.delete('speedboard');
 
+  const queryToken = `s:${token}`;
+  
   const clickUrl = filterWithQuery(searchParams, queryToken, false);
   const ctrlClickUrl = filterWithQuery(searchParams, queryToken, true);
 

--- a/packages/html-reporter/src/icons.tsx
+++ b/packages/html-reporter/src/icons.tsx
@@ -17,6 +17,10 @@
 import './colors.css';
 import './common.css';
 
+export const spacer = () => {
+  return <span className='octicon' style={{ width: 16, height: 16 }} />;
+};
+
 export const search = () => {
   return <svg aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16' data-view-component='true' className='octicon subnav-search-icon'>
     <path fillRule='evenodd' d='M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z'></path>

--- a/packages/html-reporter/src/labels.tsx
+++ b/packages/html-reporter/src/labels.tsx
@@ -41,15 +41,14 @@ export const ProjectAndTagLabelsView: React.FC<{
   projectNames: string[],
   activeProjectName: string,
   otherLabels: string[],
-  useLinks?: boolean,
   style?: React.CSSProperties,
-}> = ({ projectNames, activeProjectName, otherLabels, useLinks, style }) => {
+}> = ({ projectNames, activeProjectName, otherLabels, style }) => {
   // We can have an empty project name if we have no projects specified in the config
   const hasProjectNames = projectNames.length > 0 && !!activeProjectName;
 
   return (hasProjectNames || otherLabels.length > 0) && <span className='label-row' style={style ?? {}}>
     <ProjectLink projectNames={projectNames} projectName={activeProjectName} />
-    {!!useLinks ? <LabelsLinkView labels={otherLabels} /> : <LabelsClickView labels={otherLabels} />}
+    <LabelsClickView labels={otherLabels} />
   </span>;
 };
 

--- a/packages/html-reporter/src/labels.tsx
+++ b/packages/html-reporter/src/labels.tsx
@@ -66,9 +66,3 @@ const LabelsClickView: React.FC<{
     {labels.map(label => <Label key={label} label={label} trimAtSymbolPrefix={true} onClick={onClickHandle} />)}
   </>;
 };
-
-const LabelsLinkView: React.FC<{
-  labels: string[],
-}> = ({ labels }) => <>
-  {labels.map((label, index) => <Label key={index} label={label} trimAtSymbolPrefix={true} href={`#?q=${label}`} />)}
-</>;

--- a/packages/html-reporter/src/labels.tsx
+++ b/packages/html-reporter/src/labels.tsx
@@ -59,6 +59,9 @@ const LabelsClickView: React.FC<{
 
   const onClickHandle = React.useCallback((e: React.MouseEvent, label: string) => {
     e.preventDefault();
+    if (searchParams.has('testId'))
+      searchParams.delete('speedboard');
+    searchParams.delete('testId');
     navigate(filterWithQuery(searchParams, label, e.metaKey || e.ctrlKey));
   }, [searchParams]);
 

--- a/packages/html-reporter/src/links.css
+++ b/packages/html-reporter/src/links.css
@@ -57,6 +57,15 @@
   fill: var(--color-fg-muted);
 }
 
+.fullwidth-link {
+  width: 100%;
+  text-align: left;
+}
+
+.fullwidth-link:hover {
+  background-color: var(--color-canvas-subtle);
+}
+
 .trace-link {
   /* Trace link button has 1px border and 4px padding, so we need 3px right margin to match content on the other side of divider */
   margin-right: 3px;

--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -214,8 +214,8 @@ export function Anchor({ id, children }: React.PropsWithChildren<{ id: AnchorID 
   return <div ref={ref}>{children}</div>;
 }
 
-export function testResultHref({ test, result, anchor }: { test?: TestCase | TestCaseSummary, result?: TestResult | TestResultSummary, anchor?: string }) {
-  const params = new URLSearchParams();
+export function testResultHref({ test, result, anchor }: { test?: TestCase | TestCaseSummary, result?: TestResult | TestResultSummary, anchor?: string }, searchParams: URLSearchParams) {
+  const params = new URLSearchParams(searchParams);
   if (test)
     params.set('testId', test.testId);
   if (test && result)

--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -65,6 +65,9 @@ export const ProjectLink: React.FunctionComponent<{
   projectName: string,
 }> = ({  projectNames, projectName }) => {
   const searchParams = React.useContext(SearchParamsContext);
+  if (searchParams.has('testId'))
+    searchParams.delete('speedboard');
+  searchParams.delete('testId');
   return <Link click={filterWithQuery(searchParams, `p:${projectName}`, false)} ctrlClick={filterWithQuery(searchParams, `p:${projectName}`, true)}>
     <Label label={projectName} colorIndex={projectNames.indexOf(projectName) % 6} />
   </Link>;

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -97,10 +97,14 @@ export const ReportView: React.FC<{
           break;
         case 'p':
           event.preventDefault();
+          searchParams.delete('testId');
+          searchParams.delete('speedboard');
           navigate(filterWithQuery(searchParams, 's:passed', false));
           break;
         case 'f':
           event.preventDefault();
+          searchParams.delete('testId');
+          searchParams.delete('speedboard');
           navigate(filterWithQuery(searchParams, 's:failed', false));
           break;
         case 'ArrowLeft':

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -106,13 +106,13 @@ export const ReportView: React.FC<{
         case 'ArrowLeft':
           if (prev) {
             event.preventDefault();
-            navigate(testResultHref({ test: prev }) + filterParam);
+            navigate(testResultHref({ test: prev }, searchParams) + filterParam);
           }
           break;
         case 'ArrowRight':
           if (next) {
             event.preventDefault();
-            navigate(testResultHref({ test: next }) + filterParam);
+            navigate(testResultHref({ test: next }, searchParams) + filterParam);
           }
           break;
       }

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -146,7 +146,7 @@ export const ReportView: React.FC<{
       </Route>
       <Route predicate={speedboardRoutePredicate}>
         <TestFilesHeader report={report?.json()} filteredStats={filteredStats} metadataVisible={metadataVisible} toggleMetadataVisible={() => setMetadataVisible(visible => !visible)}/>
-        {report && <Speedboard filter={filter} report={report} />}
+        {report && <Speedboard report={report} tests={testModel.tests} />}
       </Route>
       <Route predicate={testCaseRoutePredicate}>
         {report && <TestCaseViewLoader report={report} next={next} prev={prev} testId={testId} testIdToFileIdMap={testIdToFileIdMap} />}

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -74,9 +74,6 @@ export const ReportView: React.FC<{
   }, [report, filter, mergeFiles, speedboard]);
 
   const { prev, next } = React.useMemo(() => {
-    if (!testId)
-      return { prev: undefined, next: undefined };
-
     const index = testModel.tests.findIndex(t => t.testId === testId);
     const prev = index > 0 ? testModel.tests[index - 1] : undefined;
     const next = index < testModel.tests.length - 1 ? testModel.tests[index + 1] : undefined;

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -38,7 +38,7 @@ declare global {
 // These are extracted to preserve the function identity between renders to avoid re-triggering effects.
 const testFilesRoutePredicate = (params: URLSearchParams) => !params.has('testId') && !params.has('speedboard');
 const testCaseRoutePredicate = (params: URLSearchParams) => params.has('testId');
-const speedboardRoutePredicate = (params: URLSearchParams) => params.has('speedboard');
+const speedboardRoutePredicate = (params: URLSearchParams) => params.has('speedboard') && !params.has('testId');
 
 type TestModelSummary = {
   files: TestFileSummary[];

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -106,12 +106,14 @@ export const ReportView: React.FC<{
         case 'ArrowLeft':
           if (prev) {
             event.preventDefault();
+            searchParams.delete('testId');
             navigate(testResultHref({ test: prev }, searchParams) + filterParam);
           }
           break;
         case 'ArrowRight':
           if (next) {
             event.preventDefault();
+            searchParams.delete('testId');
             navigate(testResultHref({ test: next }, searchParams) + filterParam);
           }
           break;

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -38,7 +38,7 @@ declare global {
 // These are extracted to preserve the function identity between renders to avoid re-triggering effects.
 const testFilesRoutePredicate = (params: URLSearchParams) => !params.has('testId') && !params.has('speedboard');
 const testCaseRoutePredicate = (params: URLSearchParams) => params.has('testId');
-const speedboardRoutePredicate = (params: URLSearchParams) => params.has('speedboard');
+export const speedboardRoutePredicate = (params: URLSearchParams) => params.has('speedboard');
 
 type TestModelSummary = {
   files: TestFileSummary[];

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -260,5 +260,5 @@ function createSpeedboardFilesModel(report: LoadedReport | undefined, filter: Fi
   return {
     files: [],
     tests,
-  }
+  };
 }

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -35,11 +35,6 @@ declare global {
   }
 }
 
-// These are extracted to preserve the function identity between renders to avoid re-triggering effects.
-const testFilesRoutePredicate = (params: URLSearchParams) => !params.has('testId') && !params.has('speedboard');
-const testCaseRoutePredicate = (params: URLSearchParams) => params.has('testId');
-const speedboardRoutePredicate = (params: URLSearchParams) => params.has('speedboard') && !params.has('testId');
-
 type TestModelSummary = {
   files: TestFileSummary[];
   tests: TestCaseSummary[];
@@ -135,7 +130,7 @@ export const ReportView: React.FC<{
   return <div className='htmlreport vbox px-4 pb-4'>
     <main>
       {report && <GlobalFilterView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText} />}
-      <Route predicate={testFilesRoutePredicate}>
+      <Route predicate={React.useCallback(params => !params.has('testId') && !params.has('speedboard'), [])}>
         <TestFilesHeader report={report?.json()} filteredStats={filteredStats} metadataVisible={metadataVisible} toggleMetadataVisible={() => setMetadataVisible(visible => !visible)}/>
         <TestFilesView
           files={testModel.files}
@@ -144,11 +139,11 @@ export const ReportView: React.FC<{
           projectNames={report?.json().projectNames || []}
         />
       </Route>
-      <Route predicate={speedboardRoutePredicate}>
+      <Route predicate={React.useCallback(params => params.has('speedboard') && !params.has('testId'), [])}>
         <TestFilesHeader report={report?.json()} filteredStats={filteredStats} metadataVisible={metadataVisible} toggleMetadataVisible={() => setMetadataVisible(visible => !visible)}/>
         {report && <Speedboard report={report} tests={testModel.tests} />}
       </Route>
-      <Route predicate={testCaseRoutePredicate}>
+      <Route predicate={React.useCallback(params => params.has('testId'), [])}>
         {report && <TestCaseViewLoader report={report} next={next} prev={prev} testId={testId} testIdToFileIdMap={testIdToFileIdMap} />}
       </Route>
     </main>

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -35,6 +35,11 @@ declare global {
   }
 }
 
+// These are extracted to preserve the function identity between renders to avoid re-triggering effects.
+const testFilesRoutePredicate = (params: URLSearchParams) => !params.has('testId') && !params.has('speedboard');
+const testCaseRoutePredicate = (params: URLSearchParams) => params.has('testId');
+const speedboardRoutePredicate = (params: URLSearchParams) => params.has('speedboard');
+
 type TestModelSummary = {
   files: TestFileSummary[];
   tests: TestCaseSummary[];
@@ -127,7 +132,7 @@ export const ReportView: React.FC<{
   return <div className='htmlreport vbox px-4 pb-4'>
     <main>
       {report && <GlobalFilterView stats={report.json().stats} filterText={filterText} setFilterText={setFilterText} />}
-      <Route predicate={React.useCallback(params => !params.has('testId') && !params.has('speedboard'), [])}>
+      <Route predicate={testFilesRoutePredicate}>
         <TestFilesHeader report={report?.json()} filteredStats={filteredStats} metadataVisible={metadataVisible} toggleMetadataVisible={() => setMetadataVisible(visible => !visible)}/>
         <TestFilesView
           files={testModel.files}
@@ -136,11 +141,11 @@ export const ReportView: React.FC<{
           projectNames={report?.json().projectNames || []}
         />
       </Route>
-      <Route predicate={React.useCallback(params => params.has('speedboard') && !params.has('testId'), [])}>
+      <Route predicate={speedboardRoutePredicate}>
         <TestFilesHeader report={report?.json()} filteredStats={filteredStats} metadataVisible={metadataVisible} toggleMetadataVisible={() => setMetadataVisible(visible => !visible)}/>
         {report && <Speedboard report={report} tests={testModel.tests} />}
       </Route>
-      <Route predicate={React.useCallback(params => params.has('testId'), [])}>
+      <Route predicate={testCaseRoutePredicate}>
         {report && <TestCaseViewLoader report={report} next={next} prev={prev} testId={testId} testIdToFileIdMap={testIdToFileIdMap} />}
       </Route>
     </main>

--- a/packages/html-reporter/src/speedboard.tsx
+++ b/packages/html-reporter/src/speedboard.tsx
@@ -27,7 +27,7 @@ export function Speedboard({ filter, report }: { filter: Filter, report: LoadedR
 }
 
 export function SlowestTests({ filter, report }: { filter: Filter, report: LoadedReport}) {
-  const [length, setLength] = React.useState(10);
+  const [length, setLength] = React.useState(50);
   const slowestTests = React.useMemo(() => {
     const tests = report.json().files.flatMap(file => file.tests).filter(t => filter.matches(t));
     return tests.sort((a, b) => b.duration - a.duration);
@@ -42,9 +42,9 @@ export function SlowestTests({ filter, report }: { filter: Filter, report: Loade
     projectNames={report.json().projectNames}
     footer={
       length < slowestTests.length
-        ? <button className='link-badge' onClick={() => setLength(l => l + 10)}>
+        ? <button className='link-badge' onClick={() => setLength(l => l + 50)}>
           {icons.downArrow()}
-          Show more
+          Show 50 more
         </button>
         : undefined
     }

--- a/packages/html-reporter/src/speedboard.tsx
+++ b/packages/html-reporter/src/speedboard.tsx
@@ -38,7 +38,7 @@ export function SlowestTests({ report, tests }: { report: LoadedReport, tests: T
     projectNames={report.json().projectNames}
     footer={
       length < tests.length
-        ? <button className='link-badge' onClick={() => setLength(l => l + 50)}>
+        ? <button className='link-badge fullwidth-link' style={{ padding: '8px 5px' }} onClick={() => setLength(l => l + 50)}>
           {icons.downArrow()}
           Show 50 more
         </button>

--- a/packages/html-reporter/src/speedboard.tsx
+++ b/packages/html-reporter/src/speedboard.tsx
@@ -15,33 +15,29 @@
  */
 
 import React from 'react';
-import { Filter } from './filter';
 import { LoadedReport } from './loadedReport';
 import { TestFileView } from './testFileView';
 import * as icons from './icons';
+import { TestCaseSummary } from './types';
 
-export function Speedboard({ filter, report }: { filter: Filter, report: LoadedReport}) {
+export function Speedboard({ report, tests }: { report: LoadedReport, tests: TestCaseSummary[] }) {
   return <>
-    <SlowestTests filter={filter} report={report} />
+    <SlowestTests report={report} tests={tests} />
   </>;
 }
 
-export function SlowestTests({ filter, report }: { filter: Filter, report: LoadedReport}) {
+export function SlowestTests({ report, tests }: { report: LoadedReport, tests: TestCaseSummary[] }) {
   const [length, setLength] = React.useState(50);
-  const slowestTests = React.useMemo(() => {
-    const tests = report.json().files.flatMap(file => file.tests).filter(t => filter.matches(t));
-    return tests.sort((a, b) => b.duration - a.duration);
-  }, [report, filter]);
   return <TestFileView
     file={{
       fileId: 'slowest',
       fileName: 'Slowest Tests',
-      tests: slowestTests.slice(0, length),
+      tests: tests.slice(0, length),
       stats: null as any,
     }}
     projectNames={report.json().projectNames}
     footer={
-      length < slowestTests.length
+      length < tests.length
         ? <button className='link-badge' onClick={() => setLength(l => l + 50)}>
           {icons.downArrow()}
           Show 50 more

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -52,9 +52,9 @@ export const TestCaseView: React.FC<{
       title={test.title}
       leftSuperHeader={<div className='test-case-path'>{test.path.join(' › ')}</div>}
       rightSuperHeader={<>
-        <div className={clsx(!prev && 'hidden')}><Link href={testResultHref({ test: prev }) + filterParam}>« previous</Link></div>
+        <div className={clsx(!prev && 'hidden')}><Link href={testResultHref({ test: prev }, searchParams) + filterParam}>« previous</Link></div>
         <div style={{ width: 10 }}></div>
-        <div className={clsx(!next && 'hidden')}><Link href={testResultHref({ test: next }) + filterParam}>next »</Link></div>
+        <div className={clsx(!next && 'hidden')}><Link href={testResultHref({ test: next }, searchParams) + filterParam}>next »</Link></div>
       </>}
     />
     <div className='hbox' style={{ lineHeight: '24px' }}>

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -47,14 +47,18 @@ export const TestCaseView: React.FC<{
   const filterParam = searchParams.has('q') ? '&q=' + searchParams.get('q') : '';
   const visibleTestAnnotations = test.annotations.filter(a => !a.type.startsWith('_')) ?? [];
 
+  searchParams.delete('testId');
+  const previousLink = testResultHref({ test: prev }, searchParams) + filterParam;
+  const nextLink = testResultHref({ test: next }, searchParams) + filterParam;
+
   return <>
     <HeaderView
       title={test.title}
       leftSuperHeader={<div className='test-case-path'>{test.path.join(' › ')}</div>}
       rightSuperHeader={<>
-        <div className={clsx(!prev && 'hidden')}><Link href={testResultHref({ test: prev }, searchParams) + filterParam}>« previous</Link></div>
+        <div className={clsx(!prev && 'hidden')}><Link href={previousLink}>« previous</Link></div>
         <div style={{ width: 10 }}></div>
-        <div className={clsx(!next && 'hidden')}><Link href={testResultHref({ test: next }, searchParams) + filterParam}>next »</Link></div>
+        <div className={clsx(!next && 'hidden')}><Link href={nextLink}>next »</Link></div>
       </>}
     />
     <div className='hbox' style={{ lineHeight: '24px' }}>

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -44,21 +44,16 @@ export const TestCaseView: React.FC<{
   const [selectedResultIndex, setSelectedResultIndex] = React.useState(run);
   const searchParams = React.useContext(SearchParamsContext);
 
-  const filterParam = searchParams.has('q') ? '&q=' + searchParams.get('q') : '';
   const visibleTestAnnotations = test.annotations.filter(a => !a.type.startsWith('_')) ?? [];
-
-  searchParams.delete('testId');
-  const previousLink = testResultHref({ test: prev }, searchParams) + filterParam;
-  const nextLink = testResultHref({ test: next }, searchParams) + filterParam;
 
   return <>
     <HeaderView
       title={test.title}
       leftSuperHeader={<div className='test-case-path'>{test.path.join(' › ')}</div>}
       rightSuperHeader={<>
-        <div className={clsx(!prev && 'hidden')}><Link href={previousLink}>« previous</Link></div>
+        <div className={clsx(!prev && 'hidden')}><Link href={testResultHref({ test: prev }, searchParams)}>« previous</Link></div>
         <div style={{ width: 10 }}></div>
-        <div className={clsx(!next && 'hidden')}><Link href={nextLink}>next »</Link></div>
+        <div className={clsx(!next && 'hidden')}><Link href={testResultHref({ test: next }, searchParams)}>next »</Link></div>
       </>}
     />
     <div className='hbox' style={{ lineHeight: '24px' }}>

--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -33,7 +33,12 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
   footer?: React.JSX.Element | string;
 }>> = ({ file, projectNames, isFileExpanded, setFileExpanded, footer }) => {
   const searchParams = React.useContext(SearchParamsContext);
-  const filterParam = searchParams.has('q') ? '&q=' + searchParams.get('q') : '';
+  const linkedSearchParams = new URLSearchParams();
+  if (searchParams.has('q'))
+    linkedSearchParams.set('q', searchParams.get('q')!);
+  if (searchParams.has('speedboard'))
+    linkedSearchParams.set('speedboard', '');
+  const filterParam = linkedSearchParams.size ? '&' + linkedSearchParams : '';
   return <Chip
     expanded={isFileExpanded ? isFileExpanded(file.fileId) : undefined}
     noInsets={true}

--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -56,7 +56,7 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
               {statusIcon(test.outcome)}
             </span>
             <span>
-              <Link href={testResultHref({ test }) + filterParam} title={[...test.path, test.title].join(' › ')}>
+              <Link href={testResultHref({ test }, searchParams) + filterParam} title={[...test.path, test.title].join(' › ')}>
                 <span className='test-file-title'>{[...test.path, test.title].join(' › ')}</span>
               </Link>
               <ProjectAndTagLabelsView style={{ marginLeft: '6px' }} projectNames={projectNames} activeProjectName={test.projectName} otherLabels={test.tags} />
@@ -66,11 +66,11 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
         </div>
         <div className='test-file-details-row'>
           <div className='test-file-details-row-items'>
-            <Link href={testResultHref({ test })} title={[...test.path, test.title].join(' › ')} className='test-file-path-link'>
+            <Link href={testResultHref({ test }, searchParams)} title={[...test.path, test.title].join(' › ')} className='test-file-path-link'>
               <span className='test-file-path'>{test.location.file}:{test.location.line}</span>
             </Link>
-            {imageDiffBadge(test)}
-            {videoBadge(test)}
+            <ImageDiffBadge test={test} />
+            <VideoBadge test={test} />
             <TraceLink test={test} dim={true} />
           </div>
         </div>
@@ -79,16 +79,18 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
   </Chip>;
 };
 
-function imageDiffBadge(test: TestCaseSummary): React.JSX.Element | undefined {
+function ImageDiffBadge({ test }: { test: TestCaseSummary }) {
+  const searchParams = React.useContext(SearchParamsContext);
   for (const result of test.results) {
     for (const attachment of result.attachments) {
       if (attachment.contentType.startsWith('image/') && !!attachment.name.match(/-(expected|actual|diff)/))
-        return <LinkBadge href={testResultHref({ test, result, anchor: `attachment-${result.attachments.indexOf(attachment)}` })} title='View images' dim={true}>{image()}</LinkBadge>;
+        return <LinkBadge href={testResultHref({ test, result, anchor: `attachment-${result.attachments.indexOf(attachment)}` }, searchParams)} title='View images' dim={true}>{image()}</LinkBadge>;
     }
   }
 }
 
-function videoBadge(test: TestCaseSummary): React.JSX.Element | undefined {
+function VideoBadge({ test }: { test: TestCaseSummary }) {
+  const searchParams = React.useContext(SearchParamsContext);
   const resultWithVideo = test.results.find(result => result.attachments.some(attachment => attachment.name === 'video'));
-  return resultWithVideo ? <LinkBadge href={testResultHref({ test, result: resultWithVideo, anchor: 'attachment-video' })} title='View video' dim={true}>{video()}</LinkBadge> : undefined;
+  return resultWithVideo ? <LinkBadge href={testResultHref({ test, result: resultWithVideo, anchor: 'attachment-video' }, searchParams)} title='View video' dim={true}>{video()}</LinkBadge> : undefined;
 }

--- a/packages/html-reporter/src/testFileView.tsx
+++ b/packages/html-reporter/src/testFileView.tsx
@@ -33,12 +33,6 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
   footer?: React.JSX.Element | string;
 }>> = ({ file, projectNames, isFileExpanded, setFileExpanded, footer }) => {
   const searchParams = React.useContext(SearchParamsContext);
-  const linkedSearchParams = new URLSearchParams();
-  if (searchParams.has('q'))
-    linkedSearchParams.set('q', searchParams.get('q')!);
-  if (searchParams.has('speedboard'))
-    linkedSearchParams.set('speedboard', '');
-  const filterParam = linkedSearchParams.size ? '&' + linkedSearchParams : '';
   return <Chip
     expanded={isFileExpanded ? isFileExpanded(file.fileId) : undefined}
     noInsets={true}
@@ -56,7 +50,7 @@ export const TestFileView: React.FC<React.PropsWithChildren<{
               {statusIcon(test.outcome)}
             </span>
             <span>
-              <Link href={testResultHref({ test }, searchParams) + filterParam} title={[...test.path, test.title].join(' › ')}>
+              <Link href={testResultHref({ test }, searchParams)} title={[...test.path, test.title].join(' › ')}>
                 <span className='test-file-title'>{[...test.path, test.title].join(' › ')}</span>
               </Link>
               <ProjectAndTagLabelsView style={{ marginLeft: '6px' }} projectNames={projectNames} activeProjectName={test.projectName} otherLabels={test.tags} />

--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -20,7 +20,7 @@ import { TreeItem } from './treeItem';
 import { formatUrl, msToString } from './utils';
 import { AutoChip } from './chip';
 import { traceImage } from './images';
-import { Anchor, AttachmentLink, generateTraceUrl, testResultHref } from './links';
+import { Anchor, AttachmentLink, generateTraceUrl, SearchParamsContext, testResultHref } from './links';
 import { statusIcon } from './statusIcon';
 import type { ImageDiff } from '@web/shared/imageDiffView';
 import { ImageDiffView } from '@web/shared/imageDiffView';
@@ -193,12 +193,13 @@ const StepTreeItem: React.FC<{
   step: TestStep;
   depth: number,
 }> = ({ test, step, result, depth }) => {
+  const searchParams = React.useContext(SearchParamsContext);
   return <TreeItem title={<span aria-label={step.title}>
     <span style={{ float: 'right' }}>{msToString(step.duration)}</span>
     {step.attachments.length > 0 && <a
       style={{ float: 'right' }}
       title={`reveal attachment`}
-      href={formatUrl(testResultHref({ test, result, anchor: `attachment-${step.attachments[0]}` }))}
+      href={formatUrl(testResultHref({ test, result, anchor: `attachment-${step.attachments[0]}` }, searchParams))}
       onClick={evt => { evt.stopPropagation(); }}>
       {icons.attachment()}
     </a>}

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3210,7 +3210,6 @@ for (const useIntermediateMergeReport of [true, false] as const) {
 
     test.describe('speedboard', () => {
       test('clicking on label should not exit speedboard', async ({ runInlineTest, showReport, page }) => {
-        test.setTimeout(10000);
         await runInlineTest({
           'playwright.config.ts': `
           module.exports = {

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2007,21 +2007,21 @@ for (const useIntermediateMergeReport of [true, false] as const) {
 
         const smokeLabelButton = page.locator('.test-file-test', { has: page.getByText('@smoke fails', { exact: true }) }).locator('.label', { hasText: 'smoke' });
         await smokeLabelButton.click();
-        await expect(page).toHaveURL(/@smoke/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@smoke');
         await expect(searchInput).toHaveValue('@smoke ');
         await searchInput.clear();
         await page.keyboard.press('Enter');
         await expect(searchInput).toHaveValue('');
-        await expect(page).not.toHaveURL(/@smoke/);
+        await expect(page).not.toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@smoke');
 
         const regressionLabelButton = page.locator('.test-file-test', { has: page.getByText('@regression passes', { exact: true }) }).locator('.label', { hasText: 'regression' });
         await regressionLabelButton.click();
-        await expect(page).toHaveURL(/@regression/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression');
         await expect(searchInput).toHaveValue('@regression ');
         await searchInput.clear();
         await page.keyboard.press('Enter');
         await expect(searchInput).toHaveValue('');
-        await expect(page).not.toHaveURL(/@regression/);
+        await expect(page).not.toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression');
       });
 
       test('filter should update stats', async ({ runInlineTest, showReport, page }) => {
@@ -2146,7 +2146,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
         await expect(page.locator('.test-file-test .test-file-title')).toHaveText('@smoke fails');
         await expect(searchInput).toHaveValue('s:failed @smoke ');
-        await expect(page).toHaveURL(/s:failed%20@smoke/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === 's:failed @smoke');
 
         await passedNavMenu.click();
         await smokeLabelButton.click({ modifiers: [process.platform === 'darwin' ? 'Meta' : 'Control'] });
@@ -2156,7 +2156,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(0);
         await expect(page.locator('.test-file-test .test-file-title')).toHaveText('@regression passes');
         await expect(searchInput).toHaveValue('s:passed @regression ');
-        await expect(page).toHaveURL(/s:passed%20@regression/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === 's:passed @regression');
 
         await allNavMenu.click();
         await regressionLabelButton.click();
@@ -2165,7 +2165,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
         await expect(page.locator('.test-file-test .test-file-title')).toHaveCount(2);
         await expect(searchInput).toHaveValue('@regression ');
-        await expect(page).toHaveURL(/@regression/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression');
       });
 
       test('tests should be filtered by label input in search field', async ({ runInlineTest, showReport, page }) => {
@@ -2348,7 +2348,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await smokeButton.click();
 
         await expect(searchInput).toHaveValue('@smoke ');
-        await expect(page).toHaveURL(/@smoke/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@smoke');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
@@ -2357,7 +2357,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await regressionButton.click();
 
         await expect(searchInput).toHaveValue('@smoke @regression ');
-        await expect(page).toHaveURL(/@smoke%20@regression/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@smoke @regression');
         await expect(page.locator('.chip')).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(0);
@@ -2366,7 +2366,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await smokeButton.click();
 
         await expect(searchInput).toHaveValue('@regression ');
-        await expect(page).toHaveURL(/@regression/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(0);
@@ -2375,7 +2375,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await flakyButton.click();
 
         await expect(searchInput).toHaveValue('@regression @flaky ');
-        await expect(page).toHaveURL(/@regression%20@flaky/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression @flaky');
         await expect(page.locator('.chip')).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(0);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(0);
@@ -2384,7 +2384,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await regressionButton.click();
 
         await expect(searchInput).toHaveValue('@flaky ');
-        await expect(page).toHaveURL(/@flaky/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@flaky');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(0);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
@@ -2393,7 +2393,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await flakyButton.click();
 
         await expect(searchInput).toHaveValue('');
-        await expect(page).not.toHaveURL(/@/);
+        await expect(page).not.toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q').includes('@'));
         await expect(page.locator('.chip')).toHaveCount(3);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
@@ -2403,7 +2403,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await smokeButton.click();
 
         await expect(searchInput).toHaveValue('@smoke ');
-        await expect(page).toHaveURL(/@smoke/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@smoke');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
@@ -2412,7 +2412,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await regressionButton.click();
 
         await expect(searchInput).toHaveValue('@regression ');
-        await expect(page).toHaveURL(/@regression/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(0);
@@ -2421,7 +2421,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await flakyButton.click();
 
         await expect(searchInput).toHaveValue('@flaky ');
-        await expect(page).toHaveURL(/@flaky/);
+        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@flaky');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(0);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3240,6 +3240,8 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await page.getByRole('link', { name: 'Speedboard' }).click();
         await expect(page.getByRole('link', { name: 'Speedboard' })).toHaveAttribute('aria-selected', 'true');
 
+        await page.pause();
+
         await expect(page.getByRole('main')).toMatchAriaSnapshot(`
           - button "Slowest Tests"
           - region:

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3236,7 +3236,11 @@ for (const useIntermediateMergeReport of [true, false] as const) {
           `,
         }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
         await showReport();
+
+        await expect(page.getByRole('link', { name: 'Speedboard' })).toHaveAttribute('aria-selected', 'false');
         await page.getByRole('link', { name: 'Speedboard' }).click();
+        await expect(page.getByRole('link', { name: 'Speedboard' })).toHaveAttribute('aria-selected', 'true');
+
         await expect(page.getByRole('main')).toMatchAriaSnapshot(`
           - button "Slowest Tests"
           - region:
@@ -3257,6 +3261,9 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(page.getByRole('main')).toMatchAriaSnapshot(`
           - button "Slowest Tests"
         `);
+
+        await page.getByRole('link', { name: 'Failed' }).click();
+        await expect(page.getByRole('main')).toContainText('No tests found');
       });
     })
   });

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2007,21 +2007,21 @@ for (const useIntermediateMergeReport of [true, false] as const) {
 
         const smokeLabelButton = page.locator('.test-file-test', { has: page.getByText('@smoke fails', { exact: true }) }).locator('.label', { hasText: 'smoke' });
         await smokeLabelButton.click();
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@smoke');
+        await expect(page).toHaveURL(url => getFilter(url) === '@smoke');
         await expect(searchInput).toHaveValue('@smoke ');
         await searchInput.clear();
         await page.keyboard.press('Enter');
         await expect(searchInput).toHaveValue('');
-        await expect(page).not.toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@smoke');
+        await expect(page).not.toHaveURL(url => getFilter(url) === '@smoke');
 
         const regressionLabelButton = page.locator('.test-file-test', { has: page.getByText('@regression passes', { exact: true }) }).locator('.label', { hasText: 'regression' });
         await regressionLabelButton.click();
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression');
+        await expect(page).toHaveURL(url => getFilter(url) === '@regression');
         await expect(searchInput).toHaveValue('@regression ');
         await searchInput.clear();
         await page.keyboard.press('Enter');
         await expect(searchInput).toHaveValue('');
-        await expect(page).not.toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression');
+        await expect(page).not.toHaveURL(url => getFilter(url) === '@regression');
       });
 
       test('filter should update stats', async ({ runInlineTest, showReport, page }) => {
@@ -2146,7 +2146,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
         await expect(page.locator('.test-file-test .test-file-title')).toHaveText('@smoke fails');
         await expect(searchInput).toHaveValue('s:failed @smoke ');
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === 's:failed @smoke');
+        await expect(page).toHaveURL(url => getFilter(url) === 's:failed @smoke');
 
         await passedNavMenu.click();
         await smokeLabelButton.click({ modifiers: [process.platform === 'darwin' ? 'Meta' : 'Control'] });
@@ -2156,7 +2156,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(0);
         await expect(page.locator('.test-file-test .test-file-title')).toHaveText('@regression passes');
         await expect(searchInput).toHaveValue('s:passed @regression ');
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === 's:passed @regression');
+        await expect(page).toHaveURL(url => getFilter(url) === 's:passed @regression');
 
         await allNavMenu.click();
         await regressionLabelButton.click();
@@ -2165,7 +2165,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
         await expect(page.locator('.test-file-test .test-file-title')).toHaveCount(2);
         await expect(searchInput).toHaveValue('@regression ');
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression');
+        await expect(page).toHaveURL(url => getFilter(url) === '@regression');
       });
 
       test('tests should be filtered by label input in search field', async ({ runInlineTest, showReport, page }) => {
@@ -2348,7 +2348,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await smokeButton.click();
 
         await expect(searchInput).toHaveValue('@smoke ');
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@smoke');
+        await expect(page).toHaveURL(url => getFilter(url) === '@smoke');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
@@ -2357,7 +2357,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await regressionButton.click();
 
         await expect(searchInput).toHaveValue('@smoke @regression ');
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@smoke @regression');
+        await expect(page).toHaveURL(url => getFilter(url) === '@smoke @regression');
         await expect(page.locator('.chip')).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(0);
@@ -2366,7 +2366,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await smokeButton.click();
 
         await expect(searchInput).toHaveValue('@regression ');
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression');
+        await expect(page).toHaveURL(url => getFilter(url) === '@regression');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(0);
@@ -2375,7 +2375,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await flakyButton.click();
 
         await expect(searchInput).toHaveValue('@regression @flaky ');
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression @flaky');
+        await expect(page).toHaveURL(url => getFilter(url) === '@regression @flaky');
         await expect(page.locator('.chip')).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(0);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(0);
@@ -2384,7 +2384,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await regressionButton.click();
 
         await expect(searchInput).toHaveValue('@flaky ');
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@flaky');
+        await expect(page).toHaveURL(url => getFilter(url) === '@flaky');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(0);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
@@ -2393,7 +2393,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await flakyButton.click();
 
         await expect(searchInput).toHaveValue('');
-        await expect(page).not.toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q').includes('@'));
+        await expect(page).not.toHaveURL(url => getFilter(url).includes('@'));
         await expect(page.locator('.chip')).toHaveCount(3);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
@@ -2403,7 +2403,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await smokeButton.click();
 
         await expect(searchInput).toHaveValue('@smoke ');
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@smoke');
+        await expect(page).toHaveURL(url => getFilter(url) === '@smoke');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
@@ -2412,7 +2412,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await regressionButton.click();
 
         await expect(searchInput).toHaveValue('@regression ');
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@regression');
+        await expect(page).toHaveURL(url => getFilter(url) === '@regression');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(1);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(0);
@@ -2421,7 +2421,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await flakyButton.click();
 
         await expect(searchInput).toHaveValue('@flaky ');
-        await expect(page).toHaveURL(url => new URLSearchParams(url.hash.slice(1)).get('q') === '@flaky');
+        await expect(page).toHaveURL(url => getFilter(url) === '@flaky');
         await expect(page.locator('.chip')).toHaveCount(2);
         await expect(page.locator('.chip', { hasText: 'a.test.js' })).toHaveCount(0);
         await expect(page.locator('.chip', { hasText: 'b.test.js' })).toHaveCount(1);
@@ -3390,4 +3390,8 @@ async function ghaPullRequestEnv(baseDir: string) {
     GITHUB_RUN_ID: 'example-run-id',
     GITHUB_EVENT_PATH: eventPath,
   };
+}
+
+function getFilter(url: URL): string {
+  return new URLSearchParams(url.hash.slice(1)).get('q');
 }

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3293,15 +3293,19 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(page.getByRole('link', { name: 'previous' })).not.toBeVisible();
 
         await page.getByRole('link', { name: 'next' }).click();
-        await expect(page.locator('.test-file-title').getByText('two')).toBeVisible();
+        await expect(page.getByText('two')).toBeVisible();
         await expect(page.getByRole('link', { name: 'Speedboard' })).toHaveAttribute('aria-selected', 'true');
 
         await page.getByRole('link', { name: 'next' }).click();
-        await expect(page.locator('.test-file-title').getByText('three')).toBeVisible();
+        await expect(page.getByText('one')).toBeVisible();
         await expect(page.getByRole('link', { name: 'next' })).not.toBeVisible();
 
         await page.getByRole('link', { name: 'previous' }).click();
-        await expect(page.locator('.test-file-title').getByText('two')).toBeVisible();
+        await expect(page.getByText('two')).toBeVisible();
+
+        await page.getByRole('link', { name: 'previous' }).click();
+        await expect(page.getByText('three')).toBeVisible();
+        await expect(page.getByRole('link', { name: 'previous' })).not.toBeVisible();
       });
     });
   });

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3291,16 +3291,17 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(page.getByRole('link', { name: 'previous' })).not.toBeVisible();
 
         await page.getByRole('link', { name: 'next' }).click();
-        await expect(page.getByText('two')).toBeVisible();
+        await expect(page.locator('.test-file-title').getByText('two')).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Speedboard' })).toHaveAttribute('aria-selected', 'true');
 
         await page.getByRole('link', { name: 'next' }).click();
-        await expect(page.getByText('three')).toBeVisible();
+        await expect(page.locator('.test-file-title').getByText('three')).toBeVisible();
         await expect(page.getByRole('link', { name: 'next' })).not.toBeVisible();
 
         await page.getByRole('link', { name: 'previous' }).click();
-        await expect(page.getByText('two')).toBeVisible();
+        await expect(page.locator('.test-file-title').getByText('two')).toBeVisible();
       });
-    })
+    });
   });
 }
 

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3240,8 +3240,6 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await page.getByRole('link', { name: 'Speedboard' }).click();
         await expect(page.getByRole('link', { name: 'Speedboard' })).toHaveAttribute('aria-selected', 'true');
 
-        await page.pause();
-
         await expect(page.getByRole('main')).toMatchAriaSnapshot(`
           - button "Slowest Tests"
           - region:


### PR DESCRIPTION
Implements UI feedback from API review. I didn't implement the "url could be #/speedboard?q=evaluate" change, that would be a bigger lift. Don't want to block the release on that.