### PR TITLE
chore(bidi): don't set Accept-Language header for a locale override

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -226,7 +226,7 @@ export class BidiBrowserContext extends BrowserContext {
         userContexts: [this._userContextId()],
       }));
     }
-    if (this._options.extraHTTPHeaders || this._options.locale)
+    if (this._options.extraHTTPHeaders)
       promises.push(this.doUpdateExtraHTTPHeaders());
     await Promise.all(promises);
   }
@@ -326,9 +326,7 @@ export class BidiBrowserContext extends BrowserContext {
   }
 
   async doUpdateExtraHTTPHeaders(): Promise<void> {
-    let allHeaders = this._options.extraHTTPHeaders || [];
-    if (this._options.locale)
-      allHeaders = network.mergeHeaders([allHeaders, network.singleHeader('Accept-Language', this._options.locale)]);
+    const allHeaders = this._options.extraHTTPHeaders || [];
     await this._browser._browserSession.send('network.setExtraHeaders', {
       headers: allHeaders.map(({ name, value }) => ({ name, value: { type: 'string', value } })),
       userContexts: [this._userContextId()],

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -298,11 +298,9 @@ export class BidiPage implements PageDelegate {
   }
 
   async updateExtraHTTPHeaders(): Promise<void> {
-    const locale = this._browserContext._options.locale;
     const allHeaders = network.mergeHeaders([
       this._browserContext._options.extraHTTPHeaders,
       this._page.extraHTTPHeaders(),
-      locale ? network.singleHeader('Accept-Language', locale) : undefined,
     ]);
     await this._session.send('network.setExtraHeaders', {
       headers: allHeaders.map(({ name, value }) => ({ name, value: { type: 'string', value } })),


### PR DESCRIPTION
Follow-up to #38079: The spec is [being updated](https://github.com/whatwg/fetch/pull/1869) so that browsers should automatically change the Accept-Language header when a locale override is set. This is now implemented in both [Chrome](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3863) and [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1995691), so let's remove the workaround I initially added.
