### PR TITLE
chore(bidi): fix finding the opener for popups

### DIFF
--- a/tests/page/page-event-popup.spec.ts
+++ b/tests/page/page-event-popup.spec.ts
@@ -148,7 +148,7 @@ it('should work with clicking target=_blank and rel=noopener', async ({ page, se
 
 it('should report popup opened from iframes', async ({ page, server, browserName }) => {
   await page.goto(server.PREFIX + '/frames/two-frames.html');
-  const frame = page.frame('uno');
+  const frame = page.frames()[1];
   expect(frame).toBeTruthy();
   const [popup] = await Promise.all([
     page.waitForEvent('popup'),


### PR DESCRIPTION
Fixes the following test:
- `tests/page/page-event-popup.spec.ts`:
  - "should report popup opened from iframes"
