### PR TITLE
docs: fix docs roll

### DIFF
--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -705,8 +705,8 @@ export default defineConfig({
   - `stderr` ?<["pipe"|"ignore"]> Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`.
   - `stdout` ?<["pipe"|"ignore"]> If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`.
   - `wait` ?<[Object]> Consider command started only when given output has been produced.
-    - `stdout` ?<[RegExp]> Regular expression to wait for in the `stdout` of the command output. Named capture groups are stored in the environment, for example /Listening on port (?<my_server_port>\\d+)/ will store the port number in `process.env['MY_SERVER_PORT']`.
-    - `stderr` ?<[RegExp]> Regular expression to wait for in the `stderr` of the command output. Named capture groups are stored in the environment, for example /Listening on port (?<my_server_port>\\d+)/ will store the port number in `process.env['MY_SERVER_PORT']`.
+    - `stdout` ?<[RegExp]> Regular expression to wait for in the `stdout` of the command output. Named capture groups are stored in the environment, for example `/Listening on port (?<my_server_port>\\d+)/` will store the port number in `process.env['MY_SERVER_PORT']`.
+    - `stderr` ?<[RegExp]> Regular expression to wait for in the `stderr` of the command output. Named capture groups are stored in the environment, for example `/Listening on port (?<my_server_port>\\d+)/` will store the port number in `process.env['MY_SERVER_PORT']`.
     - `time` ?<[int]>
   - `timeout` ?<[int]> How long to wait for the process to start up and be available in milliseconds. Defaults to 60000.
   - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is checked. Either `port` or `url` should be specified.

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -10198,14 +10198,14 @@ interface TestConfigWebServer {
   wait?: {
     /**
      * Regular expression to wait for in the `stdout` of the command output. Named capture groups are stored in the
-     * environment, for example /Listening on port (?<my_server_port>\\d+)/ will store the port number in
+     * environment, for example `/Listening on port (?<my_server_port>\\d+)/` will store the port number in
      * `process.env['MY_SERVER_PORT']`.
      */
     stdout?: RegExp;
 
     /**
      * Regular expression to wait for in the `stderr` of the command output. Named capture groups are stored in the
-     * environment, for example /Listening on port (?<my_server_port>\\d+)/ will store the port number in
+     * environment, for example `/Listening on port (?<my_server_port>\\d+)/` will store the port number in
      * `process.env['MY_SERVER_PORT']`.
      */
     stderr?: RegExp;


### PR DESCRIPTION
```
Expected a closing tag for `<my_server_port>` (1113:162-1113:178) before the end of `paragraph`
```

https://github.com/microsoft/playwright.dev/pulls/1919