### PR TITLE
fix(reporter): properly record result annotations when all tests are skipped

### DIFF
--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -68,6 +68,7 @@ export const TestCaseView: React.FC<{
       <div className='test-case-duration'>{msToString(test.duration)}</div>
     </div>
     <ProjectAndTagLabelsView style={{ marginLeft: '6px' }} projectNames={projectNames} activeProjectName={test.projectName} otherLabels={test.tags} />
+    {/* If there are no results, display test annotations. Otherwise test annotations will be displayed alongside runtime annotations in individual result pane */}
     {test.results.length === 0 && visibleTestAnnotations.length !== 0 && <AutoChip header='Annotations' dataTestId='test-case-annotations'>
       {visibleTestAnnotations.map((annotation, index) => <TestCaseAnnotationView key={index} annotation={annotation} />)}
     </AutoChip>}

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -601,6 +601,8 @@ class JobDispatcher {
         const result = test._appendTestResult();
         this._reporter.onTestBegin?.(test, result);
         result.status = 'skipped';
+        // This must mirror _onTestEnd() above
+        result.annotations = [...test.annotations];
         this._reportTestEnd(test, result);
       }
       return true;


### PR DESCRIPTION
Addresses #38197

HTML Reporter expects annotations to exist in the test result if there is a result, but we were not copying the static annotations over if all tests were skipped at compile time (and thus no worker was spawned). Copy those annotations over and document how the HTML Reporter renders in those scenarios.