### PR TITLE
chore(html): display test skipped message in result body

### DIFF
--- a/packages/html-reporter/src/chip.css
+++ b/packages/html-reporter/src/chip.css
@@ -61,6 +61,17 @@
   padding: 8px;
 }
 
+.chip-no-data {
+  color: var(--color-fg-muted);
+  background-color: unset;
+
+  font-weight: unset;
+
+  border: 1px solid var(--color-border-default);
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
 @media only screen and (max-width: 600px) {
   .chip-header {
     border-radius: 0;

--- a/packages/html-reporter/src/chip.tsx
+++ b/packages/html-reporter/src/chip.tsx
@@ -72,3 +72,5 @@ export const AutoChip: React.FC<{
     {children}
   </Chip>;
 };
+
+export const NoDataChip: React.FC<React.PropsWithChildren<{}>> = ({ children }) => <div className='chip-header chip-no-data'>{children}</div>;

--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -85,16 +85,3 @@
   flex-basis: 100%;
   height: 0;
 }
-
-.test-file-no-files {
-  margin-top: 12px;
-
-  color: var(--color-fg-muted);
-  background-color: unset;
-
-  font-weight: unset;
-
-  border: 1px solid var(--color-border-default);
-  border-bottom-left-radius: 6px;
-  border-bottom-right-radius: 6px;
-}

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -20,7 +20,7 @@ import { TestFileView } from './testFileView';
 import './testFileView.css';
 import './chip.css';
 import { msToString } from './utils';
-import { AutoChip } from './chip';
+import { AutoChip, NoDataChip } from './chip';
 import { CodeSnippet } from './testErrorView';
 import * as icons from './icons';
 import { isMetadataEmpty, MetadataView } from './metadataView';
@@ -62,7 +62,7 @@ export const TestFilesView: React.FC<{
           }}>
         </TestFileView>;
       })
-      : <div className='chip-header test-file-no-files'>No tests found</div>}
+      : <NoDataChip>No tests found</NoDataChip>}
   </>;
 };
 

--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -178,7 +178,7 @@ export const TestResultView: React.FC<{
       )}
     </AutoChip>}
 
-    {result.status === 'skipped' && <NoDataChip>Test skipped</NoDataChip>}
+    {result.status === 'skipped' && <NoDataChip>Test run skipped</NoDataChip>}
   </div>;
 };
 

--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -18,7 +18,7 @@ import type { HTMLReportOptions, TestAttachment, TestCase, TestResult, TestStep 
 import * as React from 'react';
 import { TreeItem } from './treeItem';
 import { formatUrl, msToString } from './utils';
-import { AutoChip } from './chip';
+import { AutoChip, NoDataChip } from './chip';
 import { traceImage } from './images';
 import { Anchor, AttachmentLink, generateTraceUrl, testResultHref } from './links';
 import { statusIcon } from './statusIcon';
@@ -177,6 +177,8 @@ export const TestResultView: React.FC<{
         </Anchor>
       )}
     </AutoChip>}
+
+    {result.status === 'skipped' && <NoDataChip>Test skipped</NoDataChip>}
   </div>;
 };
 


### PR DESCRIPTION
When a test run is skipped, the body of the run in the HTML Report simply lacks information like steps, with no message indicating why. Following the pattern of the test list, indicate that this run was skipped.

### No annotations

<img width="1008" height="275" alt="Screenshot 2025-11-13 at 8 42 56 AM" src="https://github.com/user-attachments/assets/fcac8f44-84b6-4904-84b4-62cf47382342" />

### With annotations

<img width="1003" height="453" alt="Screenshot 2025-11-13 at 8 42 40 AM" src="https://github.com/user-attachments/assets/91f42b78-12c5-4082-85b6-a0f989817497" />

----

As an example, this is what the empty test list looks like. We use the same styling as the empty test list

<img width="991" height="137" alt="Screenshot 2025-11-13 at 8 23 32 AM" src="https://github.com/user-attachments/assets/b834dcd1-1b67-4514-8f15-b766602ee181" />
