### PR TITLE
chore(bidi): add support for fetching request bodies

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -74,7 +74,7 @@ export class BidiBrowser extends Browser {
     });
 
     await browser._browserSession.send('network.addDataCollector', {
-      dataTypes: [bidi.Network.DataType.Response],
+      dataTypes: [bidi.Network.DataType.Request, bidi.Network.DataType.Response],
       maxEncodedDataSize: 20_000_000, // same default as in CDP: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/inspector/inspector_network_agent.cc;l=134;drc=4128411589187a396829a827f59a655bed876aa7
     });
 

--- a/packages/playwright-core/src/server/bidi/third_party/bidiProtocolCore.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiProtocolCore.ts
@@ -1383,6 +1383,7 @@ export namespace Network {
 }
 export namespace Network {
   export const enum DataType {
+    Request = 'request',
     Response = 'response',
   }
 }

--- a/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
+++ b/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
@@ -67,7 +67,7 @@ export class RequestDispatcher extends Dispatcher<Request, channels.RequestChann
   }
 
   async body(params: channels.RequestBodyParams, progress: Progress): Promise<channels.RequestBodyResult> {
-    const postData = this._object.postDataBuffer();
+    const postData = await this._object.body();
     return { body: postData === null ? undefined : postData };
   }
 

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -342,7 +342,7 @@ it('should record overridden requests to har', async ({ contextFactory, server }
   await page1.route('**/echo_redir', async route => {
     await route.fallback({
       url: server.PREFIX + '/echo',
-      postData: +route.request().postData() + 10,
+      postData: +(await route.request().body()) + 10,
     });
   });
   expect(await page1.evaluate(fetchFunction, { path: '/echo_redir', body: '1' })).toBe('11');

--- a/tests/library/browsercontext-route.spec.ts
+++ b/tests/library/browsercontext-route.spec.ts
@@ -21,13 +21,13 @@ import type { Route } from '@playwright/test';
 it('should intercept', async ({ browser, server }) => {
   const context = await browser.newContext();
   let intercepted = false;
-  await context.route('**/empty.html', route => {
+  await context.route('**/empty.html', async route => {
     intercepted = true;
     const request = route.request();
     expect(request.url()).toContain('empty.html');
     expect(request.headers()['user-agent']).toBeTruthy();
     expect(request.method()).toBe('GET');
-    expect(request.postData()).toBe(null);
+    expect(await request.body()).toBe(null);
     expect(request.isNavigationRequest()).toBe(true);
     expect(request.resourceType()).toBe('document');
     expect(request.frame() === page.mainFrame()).toBe(true);

--- a/tests/page/network-post-data.spec.ts
+++ b/tests/page/network-post-data.spec.ts
@@ -16,7 +16,9 @@
 
 import { test as it, expect } from './pageTest';
 
-it('should return correct postData buffer for utf-8 body', async ({ page, server }) => {
+it.skip(({ channel }) => channel?.startsWith('bidi-chrom') || channel?.startsWith('moz-firefox'), 'request.postData is not supported with BiDi');
+
+it('should return correct postData buffer for utf-8 body', async ({ page, server, channel }) => {
   await page.goto(server.EMPTY_PAGE);
   const value = 'baẞ';
   const [request] = await Promise.all([
@@ -34,7 +36,7 @@ it('should return correct postData buffer for utf-8 body', async ({ page, server
   expect(request.postDataJSON()).toBe(value);
 });
 
-it('should return post data w/o content-type @smoke', async ({ page, server }) => {
+it('should return post data w/o content-type @smoke', async ({ page, server, channel }) => {
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     page.waitForRequest('**'),
@@ -50,7 +52,7 @@ it('should return post data w/o content-type @smoke', async ({ page, server }) =
   expect(request.postDataJSON()).toEqual({ value: 42 });
 });
 
-it('should throw on invalid JSON in post data', async ({ page, server }) => {
+it('should throw on invalid JSON in post data', async ({ page, server, channel }) => {
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     page.waitForRequest('**'),
@@ -71,7 +73,7 @@ it('should throw on invalid JSON in post data', async ({ page, server }) => {
   expect(error.message).toContain('POST data is not a valid JSON object: <not a json>');
 });
 
-it('should return post data for PUT requests', async ({ page, server }) => {
+it('should return post data for PUT requests', async ({ page, server, channel }) => {
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
     page.waitForRequest('**'),
@@ -86,7 +88,7 @@ it('should return post data for PUT requests', async ({ page, server }) => {
   expect(request.postDataJSON()).toEqual({ value: 42 });
 });
 
-it('should get post data for file/blob', async ({ page, server, browserName }) => {
+it('should get post data for file/blob', async ({ page, server, browserName, channel }) => {
   it.fail(browserName === 'webkit' || browserName === 'chromium');
   await page.goto(server.EMPTY_PAGE);
   const [request] = await Promise.all([
@@ -106,7 +108,7 @@ it('should get post data for file/blob', async ({ page, server, browserName }) =
   expect(request.postData()).toBe('file-contents');
 });
 
-it('should get post data for navigator.sendBeacon api calls', async ({ page, server, browserName }) => {
+it('should get post data for navigator.sendBeacon api calls', async ({ page, server, browserName, channel }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/12231' });
   it.fail(browserName === 'chromium', 'postData is empty');
   it.fail(browserName === 'webkit', 'postData is empty');

--- a/tests/page/page-request-intercept.spec.ts
+++ b/tests/page/page-request-intercept.spec.ts
@@ -191,7 +191,7 @@ it('should intercept multipart/form-data request body', async ({ page, server, a
     page.click('input[type=submit]', { noWaitAfter: true })
   ]);
   expect(request.method()).toBe('POST');
-  expect(request.postData()).toContain(fs.readFileSync(filePath, 'utf8'));
+  expect(await request.body()).toContain(fs.readFileSync(filePath, 'utf8'));
 });
 
 it('should fulfill intercepted response using alias', async ({ page, server, isElectron, electronMajorVersion, isAndroid }) => {
@@ -307,7 +307,7 @@ it('request.postData is not null when fetching FormData with a Blob', {
   const postDataPromise = new Promise<string>(resolve => resolvePostData = resolve);
   await page.route(server.PREFIX + '/upload', async (route, request) => {
     expect(request.method()).toBe('POST');
-    resolvePostData(await request.postData());
+    resolvePostData(await request.body());
     await route.fulfill({
       status: 200,
       body: 'ok',

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -20,12 +20,12 @@ import { test as it, expect } from './pageTest';
 
 it('should intercept @smoke', async ({ page, server }) => {
   let intercepted = false;
-  await page.route('**/empty.html', (route, request) => {
+  await page.route('**/empty.html', async (route, request) => {
     expect(route.request()).toBe(request);
     expect(request.url()).toContain('empty.html');
     expect(request.headers()['user-agent']).toBeTruthy();
     expect(request.method()).toBe('GET');
-    expect(request.postData()).toBe(null);
+    expect(await request.body()).toBe(null);
     expect(request.isNavigationRequest()).toBe(true);
     expect(request.resourceType()).toBe('document');
     expect(request.frame() === page.mainFrame()).toBe(true);
@@ -1044,7 +1044,7 @@ it('should intercept when postData is more than 1MB', async ({ page, server }) =
   const POST_BODY = '0'.repeat(2 * 1024 * 1024); // 2MB
   await page.route('**/404.html', async route => {
     await route.abort();
-    interceptionCallback(route.request().postData());
+    interceptionCallback(await route.request().body());
   });
   await page.evaluate(POST_BODY => fetch('/404.html', {
     method: 'POST',


### PR DESCRIPTION
I have also updated the tests to use `request.body*` instead of `request.postData*` except for the following:
- I changed the tests in `tests/page/network-post-data.spec.ts` to be skipped for BiDi because these tests are mirrored by those in `tests/page/network-request-body.spec.ts`
- I didn't change `tests/page/page-request-fallback.spec.ts` because it only tests overridden request bodies which are always available synchronously

Fixes the following tests in Firefox:
- `tests/page/network-request-body.spec.ts`:
  - "should return correct request body buffer for utf-8 body"
  - "should return request body w/o content-type"
  - "should throw on invalid JSON in post data"
  - "should return body for PUT requests"
  - "should get request body for file/blob"
  - "should get request body for navigator.sendBeacon api calls"
- `tests/page/page-network-request.spec.ts`:
  - "should parse the data if content-type is application/x-www-form-urlencoded"
  - "should parse the data if content-type is application/x-www-form-urlencoded; charset=UTF-8"
  - "should parse the json post data"
  - "should return multipart/form-data"
  - "should return postData"
  - "should work with binary post data"
  - "should work with binary post data and interception"
- `tests/page/page-request-intercept.spec.ts`:
  - "request.postData is not null when fetching FormData with a Blob"
  - "should intercept multipart/form-data request body"
- `tests/page/page-route.spec.ts`:
  - "should intercept when postData is more than 1MB"
