### PR TITLE
feat: show locator for expect steps in report

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -268,8 +268,8 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
           // and connect it to the existing expect step.
           if (zone.apiName)
             data.apiName = zone.apiName;
-          if (zone.title)
-            data.title = zone.title;
+          if (zone.shortTitle || zone.title)
+            data.title = zone.shortTitle ?? zone.title;
           data.stepId = zone.stepId;
           return;
         }

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -37,6 +37,7 @@ export type TestStepCategory = 'expect' | 'fixture' | 'hook' | 'pw:api' | 'test.
 
 interface TestStepData {
   title: string;
+  shortTitle?: string;
   category: TestStepCategory;
   location?: Location;
   apiName?: string;
@@ -374,7 +375,7 @@ export class TestInfoImpl implements TestInfo {
       this._tracing.appendBeforeActionForStep({
         stepId,
         parentId: parentStep?.stepId,
-        title: step.title,
+        title: step.shortTitle ?? step.title,
         category: step.category,
         params: step.params,
         stack: step.location ? [step.location] : [],

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -534,7 +534,7 @@ test('should nest steps based on zones', async ({ runInlineTest }) => {
             }),
             test.step('parent2', async () => {
               await test.step('child2', async () => {
-                await expect(page.locator('body')).toBeVisible();
+                await expect(page.locator('body').describe('main element')).toBeVisible();
               });
             }),
           ]);
@@ -562,7 +562,7 @@ test.step |    child1 @ a.test.ts:23
 pw:api    |      Click locator('body') @ a.test.ts:24
 test.step |  parent2 @ a.test.ts:27
 test.step |    child2 @ a.test.ts:28
-expect    |      Expect "toBeVisible" @ a.test.ts:29
+expect    |      Expect "toBeVisible" main element @ a.test.ts:29
 hook      |After Hooks
 hook      |  afterEach hook @ a.test.ts:15
 test.step |    in afterEach @ a.test.ts:16
@@ -892,7 +892,7 @@ pw:api    |    Create context
 fixture   |  Fixture "page"
 pw:api    |    Create page
 pw:api    |Set content @ a.test.ts:4
-expect    |Checking color @ a.test.ts:6
+expect    |Checking color locator('div') @ a.test.ts:6
 hook      |After Hooks
 fixture   |  Fixture "page"
 fixture   |  Fixture "context"
@@ -1087,14 +1087,14 @@ fixture   |  Fixture "page"
 pw:api    |    Create page
 pw:api    |Set content @ a.test.ts:4
 expect    |Expect "poll toBe" @ a.test.ts:13
-expect    |  Expect "toHaveText" @ a.test.ts:7
+expect    |  Expect "toHaveText" locator('div') @ a.test.ts:7
 test.step |  iteration 1 @ a.test.ts:9
-expect    |    Expect "toBeVisible" @ a.test.ts:10
+expect    |    Expect "toBeVisible" locator('div') @ a.test.ts:10
 expect    |  Expect "toBe" @ a.test.ts:6
 expect    |  ↪ error: Error: expect(received).toBe(expected) // Object.is equality
-expect    |  Expect "toHaveText" @ a.test.ts:7
+expect    |  Expect "toHaveText" locator('div') @ a.test.ts:7
 test.step |  iteration 2 @ a.test.ts:9
-expect    |    Expect "toBeVisible" @ a.test.ts:10
+expect    |    Expect "toBeVisible" locator('div') @ a.test.ts:10
 expect    |  Expect "toBe" @ a.test.ts:6
 hook      |After Hooks
 fixture   |  Fixture "page"
@@ -1451,7 +1451,7 @@ pw:api    |  Wait for event "response" @ a.test.ts:7
 pw:api    |  Click locator('div') @ a.test.ts:14
 pw:api    |  Get content @ a.test.ts:8
 pw:api    |  Get content @ a.test.ts:9
-expect    |  Expect "toContainText" @ a.test.ts:10
+expect    |  Expect "toContainText" locator('div') @ a.test.ts:10
 expect    |Expect "toBe" @ a.test.ts:18
 hook      |After Hooks
 fixture   |  Fixture "page"
@@ -1745,7 +1745,7 @@ pw:api    |    Create context
 fixture   |  Fixture "page"
 pw:api    |    Create page
 pw:api    |Set content @ a.test.ts:16
-expect    |Expect "toBeInvisible" @ a.test.ts:17
+expect    |Expect "toBeInvisible" locator('div') @ a.test.ts:17
 expect    |  Expect "poll toBe" @ a.test.ts:7
 pw:api    |    Query count locator('div').filter({ visible: true }) @ a.test.ts:7
 expect    |    Expect "toBe" @ a.test.ts:7
@@ -1829,7 +1829,7 @@ pw:api    |      Navigate to "data:" @ a.test.ts:16
 pw:api    |  Set content @ a.test.ts:22
 test.step |  inner step @ a.test.ts:23
 pw:api    |    Navigate to "data:" @ a.test.ts:24
-expect    |Expect "toBeVisible" @ a.test.ts:32
+expect    |Expect "toBeVisible" locator('body') @ a.test.ts:32
 expect    |Expect "toBe" @ a.test.ts:33
 expect    |Expect "toBe" @ a.test.ts:34
 expect    |Expect "toBe" @ a.test.ts:35


### PR DESCRIPTION
Before: `Expect "toBeVisible"`
After: `Expect "toBeVisible" getByRole('button')`

<img width="991" height="271" alt="Screenshot 2025-11-14 at 1 01 05 AM" src="https://github.com/user-attachments/assets/b2a0164a-7e42-45c9-b263-8f33cdd95145" />

Fixes #36312.