### PR TITLE
fix(chromium): make video recording duration close to real duration of the test run

### DIFF
--- a/packages/playwright-core/src/server/chromium/videoRecorder.ts
+++ b/packages/playwright-core/src/server/chromium/videoRecorder.ts
@@ -26,6 +26,7 @@ const fps = 25;
 export class VideoRecorder {
   private _process: ChildProcess | null = null;
   private _gracefullyClose: (() => Promise<void>) | null = null;
+  private _launchTimestamp: number = 0;
   private _lastWritePromise: Promise<void> = Promise.resolve();
   private _lastFrameTimestamp: number = 0;
   private _lastFrameBuffer: Buffer | null = null;
@@ -115,6 +116,7 @@ export class VideoRecorder {
     });
     this._process = launchedProcess;
     this._gracefullyClose = gracefullyClose;
+    this._launchTimestamp = monotonicTime();
   }
 
   writeFrame(frame: Buffer, timestamp: number) {
@@ -134,10 +136,11 @@ export class VideoRecorder {
         this._frameQueue.push(this._lastFrameBuffer);
       this._lastWritePromise = this._lastWritePromise.then(() => this._sendFrames());
       this._lastFrameTimestamp += repeatCount / fps;
+    } else {
+      this._lastFrameTimestamp = timestamp - (monotonicTime() - this._launchTimestamp) / 1000;
     }
 
     this._lastFrameBuffer = frame;
-    this._lastFrameTimestamp = timestamp;
     this._lastWriteTimestamp = monotonicTime();
   }
 

--- a/packages/playwright-core/src/server/chromium/videoRecorder.ts
+++ b/packages/playwright-core/src/server/chromium/videoRecorder.ts
@@ -122,6 +122,11 @@ export class VideoRecorder {
     if (this._isStopped)
       return;
 
+    if (timestamp - this._lastFrameTimestamp < 1 / fps) {
+      this._lastFrameBuffer = frame;
+      return;
+    }
+
     if (this._lastFrameBuffer) {
       const durationSec = timestamp - this._lastFrameTimestamp;
       const repeatCount = Math.max(1, Math.round(fps * durationSec));

--- a/packages/playwright-core/src/server/chromium/videoRecorder.ts
+++ b/packages/playwright-core/src/server/chromium/videoRecorder.ts
@@ -133,6 +133,7 @@ export class VideoRecorder {
       for (let i = 0; i < repeatCount; ++i)
         this._frameQueue.push(this._lastFrameBuffer);
       this._lastWritePromise = this._lastWritePromise.then(() => this._sendFrames());
+      this._lastFrameTimestamp += repeatCount / fps;
     }
 
     this._lastFrameBuffer = frame;


### PR DESCRIPTION
Videos recorded with playwright using chromium engine are shorter or longer than what could be expected by measuring execution time. Causes:

- with fast updating web pages, chromium can generate frames faster than playwright expects; all sent frames are pushed to ffmpeg, which sometimes exceeds the hardcoded frame rate (25 fps); in the effect video get too long; frame throttler does not help much with it because it was designed for different purpouse,
- timestamp of last added frame is taken from timestamp reported by browser which is not in 1/fps intervals; this leads to rounding errors and video files shorter than real execution time,
- the first screencast frame is send by browser with slight delay from the start of screencast; this causes drift between audio and video recording start times rendering them out of sync.

Fixes #9611 #35776 #38219