### PR TITLE
fix(html): preserve rounded corners when hovering bottom of chip

### DIFF
--- a/packages/html-reporter/src/chip.css
+++ b/packages/html-reporter/src/chip.css
@@ -50,6 +50,7 @@
   border-bottom-right-radius: 6px;
   padding: 16px;
   margin-bottom: 12px;
+  overflow: hidden;
 }
 
 .chip-body-no-insets {


### PR DESCRIPTION
Hovering over the bottom item of a chip would occlude the rounded border corners. Prevent this from occurring.

### After

<img width="1509" height="127" alt="Screenshot 2025-11-14 at 7 38 27 AM" src="https://github.com/user-attachments/assets/26c186b9-38e2-47b0-a41b-c0fb80d5a3d6" />

### Before

<img width="1506" height="122" alt="Screenshot 2025-11-14 at 7 38 11 AM" src="https://github.com/user-attachments/assets/c27b1977-d1d2-47e9-84fd-535d2cd08b11" />
