### PR TITLE
fix(routeFromHAR): hack harRouter to merge set-cookie headers

### DIFF
--- a/tests/assets/har-fulfill.har
+++ b/tests/assets/har-fulfill.har
@@ -62,6 +62,14 @@
             {
               "name": "content-type",
               "value": "text/html"
+            },
+            {
+              "name": "Set-Cookie",
+              "value": "playwright=works;"
+            },
+            {
+              "name": "Set-Cookie",
+              "value": "with=multiple-set-cookie-headers;"
             }
           ],
           "content": {

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -358,6 +358,14 @@ it('should record overridden requests to har', async ({ contextFactory, server }
   expect(await page2.evaluate(fetchFunction, { path: '/echo', body: '12' })).toBe('12');
 });
 
+it('should replay requests with multiple set-cookie headers properly', async ({ context, asset }) => {
+  const path = asset('har-fulfill.har');
+  await context.routeFromHAR(path);
+  const page = await context.newPage();
+  await page.goto('http://no.playwright/');
+  expect(await page.context().cookies()).toEqual([expect.objectContaining({ name: 'playwright', value: 'works' }), expect.objectContaining({ name: 'with', value: 'multiple-set-cookie-headers' })]);
+});
+
 it('should disambiguate by header', async ({ contextFactory, server }, testInfo) => {
   server.setRoute('/echo', async (req, res) => {
     res.end(req.headers['baz']);


### PR DESCRIPTION
Route.fulfill currently does not support multiple headers with the same name (#37342). There are workarounds when using this API directly (merging headers, tweaking the header name casing, etc.), but this is problematic for routeFromHAR, which depends on
this API internally. This patch adds special handling for set-cookie headers within harRouter to merge them into one header. There's some precedent for treating set-cookie specially at various places in the codebase:

https://github.com/microsoft/playwright/blob/f54478a23e0daa450fe524905eabc8aabf6efb07/packages/playwright-core/src/utils/isomorphic/headers.ts#L29

https://github.com/microsoft/playwright/blob/baeb065e9ea84502f347129a0b896a85d2a8dada/packages/playwright-core/src/server/chromium/crNetworkManager.ts#L675

so I think this is okay.