### PR TITLE
chore: hide run-server command

### DIFF
--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -292,7 +292,7 @@ program
     });
 
 program
-    .command('run-server')
+    .command('run-server', { hidden: true })
     .option('--port <port>', 'Server port')
     .option('--host <host>', 'Server host')
     .option('--path <path>', 'Endpoint Path', '/')


### PR DESCRIPTION
This is an internal command which shouldn't appear in the help output.

Fixes https://github.com/microsoft/playwright/issues/38234