### PR TITLE
chore: avoid DEP0190 warning in electron

### DIFF
--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -318,8 +318,6 @@ async function waitForLine(progress: Progress, process: childProcess.ChildProces
 }
 
 function escapeWinCmdArg(str: string): string {
-  return str.replace(/\\/g, '\\\\')
-      .replace(/"/g, '\\"')
-      .replace(/[&<>^|]/g, '^$&')
-      .replace(/%/g, '%%');
+  return str.replace(/"/g, '\\"')
+    .replace(/%([^%].)/g, '%^$1');
 }

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -198,7 +198,7 @@ export class Electron extends SdkObject {
       // On Windows, we need to quote the executable path and arguments due to shell: true.
       // We allso pass the arguments as a single string due to DEP0190,
       // see https://github.com/microsoft/playwright/issues/38278.
-      command = [command, ...electronArguments].map(arg => `"${arg}"`).join(' ');
+      command = [command, ...electronArguments].map(arg => `"${escapeWinCmdArg(arg)}"`).join(' ');
       electronArguments = [];
     }
 
@@ -315,4 +315,11 @@ async function waitForLine(progress: Progress, process: childProcess.ChildProces
   } finally {
     eventsHelper.removeEventListeners(listeners);
   }
+}
+
+function escapeWinCmdArg(str: string): string {
+  return str.replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/[&<>^|]/g, '^$&')
+      .replace(/%/g, '%%');
 }

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -318,6 +318,5 @@ async function waitForLine(progress: Progress, process: childProcess.ChildProces
 }
 
 function escapeWinCmdArg(str: string): string {
-  return str.replace(/"/g, '\\"')
-    .replace(/%([^%].)/g, '%^$1');
+  return str.replace(/"/g, '\\"').replace(/%([^%].)/g, '%^$1');
 }

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -195,10 +195,11 @@ export class Electron extends SdkObject {
       // On Windows in order to run .cmd files, shell: true is required.
       // https://github.com/nodejs/node/issues/52554
       shell = true;
-      // On Windows, we need to quote the executable path due to shell: true.
-      command = `"${command}"`;
-      // On Windows, we need to quote the arguments due to shell: true.
-      electronArguments = electronArguments.map(arg => `"${arg}"`);
+      // On Windows, we need to quote the executable path and arguments due to shell: true.
+      // We allso pass the arguments as a single string due to DEP0190,
+      // see https://github.com/microsoft/playwright/issues/38278.
+      command = [command, ...electronArguments].map(arg => `"${arg}"`).join(' ');
+      electronArguments = [];
     }
 
     // When debugging Playwright test that runs Electron, NODE_OPTIONS

--- a/tests/electron/electron-app.spec.ts
+++ b/tests/electron/electron-app.spec.ts
@@ -130,10 +130,10 @@ test('should script application', async ({ electronApp }) => {
 });
 
 test('should preserve args', async ({ launchElectronApp, isMac }) => {
-  const electronApp = await launchElectronApp('electron-app-args.js', ['foo', 'bar']);
+  const electronApp = await launchElectronApp('electron-app-args.js', ['foo', 'bar', '%PATH%', '& <>^|\\"']);
   const argv = await electronApp.evaluate(async () => globalThis.argv);
   const electronPath = isMac ? path.join('dist', 'Electron.app') : path.join('dist', 'electron');
-  expect(argv).toEqual([expect.stringContaining(electronPath), expect.stringContaining(path.join('electron', 'electron-app-args.js')), 'foo', 'bar']);
+  expect(argv).toEqual([expect.stringContaining(electronPath), expect.stringContaining(path.join('electron', 'electron-app-args.js')), 'foo', 'bar', '%^PATH%', '& <>^|\\"']);
 });
 
 test('should return windows', async ({ electronApp, newWindow }) => {

--- a/tests/electron/globalSetup.ts
+++ b/tests/electron/globalSetup.ts
@@ -18,7 +18,7 @@ import assert from 'assert';
 import { spawnAsync } from '../../packages/playwright-core/lib/server/utils/spawnAsync';
 
 export default async () => {
-  const result = await spawnAsync('npx', ['electron', require.resolve('./electron-print-chromium-version.js'), '--no-sandbox'], {
+  const result = await spawnAsync(['npx', 'electron', `"${require.resolve('./electron-print-chromium-version.js')}"`, '--no-sandbox'].join(' '), [], {
     shell: true,
   });
   const chromiumVersion = result.stdout.trim();


### PR DESCRIPTION
This is to avoid https://nodejs.org/api/deprecations.html#DEP0190.

Fixes https://github.com/microsoft/playwright/issues/38278