### PR TITLE
chore: fix lint warning about useEffect

### DIFF
--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -49,11 +49,11 @@ export const GlobalFilterView: React.FC<{
   setFilterText: (filterText: string) => void,
 }> = ({ stats, filterText, setFilterText }) => {
   const searchParams = useSearchParams();
+  const query = searchParams.get('q');
   React.useEffect(() => {
     // Add an extra space such that users can easily add to query
-    const query = searchParams.get('q');
     setFilterText(query ? `${query.trim()} ` : '');
-  }, [searchParams.toString(), setFilterText]);
+  }, [query, setFilterText]);
 
   return (<>
     <div className='pt-3'>


### PR DESCRIPTION
```ts
packages/html-reporter/src/headerView.tsx
  56:6  warning  React Hook React.useEffect has a missing dependency: 'searchParams'. Either include it or remove the dependency array                           react-hooks/exhaustive-deps
  56:7  warning  React Hook React.useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked  react-hooks/exhaustive-deps
```