### PR TITLE
test: add inline scripts to csp tests

### DIFF
--- a/tests/assets/csp.html
+++ b/tests/assets/csp.html
@@ -1,1 +1,2 @@
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+<script type='text/javascript'>window.__inlineScriptValue = 42;</script>";

--- a/tests/electron/electron-app.spec.ts
+++ b/tests/electron/electron-app.spec.ts
@@ -213,6 +213,7 @@ test('should bypass csp', async ({ launchElectronApp, server }) => {
   await page.goto(server.PREFIX + '/csp.html');
   await page.addScriptTag({ content: 'window["__injected"] = 42;' });
   expect(await page.evaluate('window["__injected"]')).toBe(42);
+  expect(await page.evaluate('window["__inlineScriptValue"]')).toBe(42);
 });
 
 test('should create page for browser view', async ({ launchElectronApp }) => {

--- a/tests/library/defaultbrowsercontext-1.spec.ts
+++ b/tests/library/defaultbrowsercontext-1.spec.ts
@@ -113,6 +113,7 @@ it('should support bypassCSP option', async ({ server, launchPersistent }) => {
   await page.goto(server.PREFIX + '/csp.html');
   await page.addScriptTag({ content: 'window["__injected"] = 42;' });
   expect(await page.evaluate('__injected')).toBe(42);
+  expect(await page.evaluate('window["__inlineScriptValue"]')).toBe(42);
 });
 
 it('should support javascriptEnabled option', async ({ launchPersistent, browserName }) => {


### PR DESCRIPTION
Currently the tests use solely `addScriptTag` which should work regardless of `bypassCSP` option, whereas the option should make inline scripts in the user code run without errors. Make sure we test the latter.