### PR TITLE
fix: Remove link prefix when picking snapshots

### DIFF
--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -202,7 +202,9 @@ export function generateAriaTree(rootElement: Element, publicOptions: AriaTreeOp
 
     if (ariaNode.role === 'link' && element.hasAttribute('href')) {
       const href = element.getAttribute('href')!;
-      ariaNode.props['url'] = href;
+      // Remove link prefix added in trace viewer snapshots
+      const linkPrefix = 'link://';
+      ariaNode.props['url'] = href.startsWith(linkPrefix) ? href.slice(linkPrefix.length) : href;
     }
 
     if (ariaNode.role === 'textbox' && element.hasAttribute('placeholder') && element.getAttribute('placeholder') !== ariaNode.name) {

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -1194,6 +1194,20 @@ test('should pick locator', async ({ page, runAndTrace, server }) => {
   await expect(traceViewer.page.locator('.cm-wrapper').last()).toContainText(`- button "Submit"`);
 });
 
+test('should generate aria snapshot with unaltered urls', async ({ page, runAndTrace, server }) => {
+  const traceViewer = await runAndTrace(async () => {
+    await page.goto(server.EMPTY_PAGE);
+    await page.setContent('<a href="https://example.com">Example link</a>');
+  });
+  const snapshot = await traceViewer.snapshotFrame('Set content');
+  await traceViewer.page.getByTitle('Pick locator').click();
+  await snapshot.getByRole('link').click();
+  await expect(traceViewer.page.locator('.cm-wrapper').last()).toContainText(`
+    - link "Example link":
+      - /url: https://example.com
+  `);
+});
+
 test('should update highlight when typing locator', async ({ page, runAndTrace, server }) => {
   const traceViewer = await runAndTrace(async () => {
     await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
- Remove `link` scheme from links, added here:
https://github.com/microsoft/playwright/blob/14212c8728458334847c7620860156a239fb0ab8/packages/trace-viewer/src/sw/snapshotRenderer.ts#L132

- `link` is not an official [URI scheme](https://en.wikipedia.org/wiki/List_of_URI_schemes), so should be fine if we always remove it (regardless if we are in trace viewer or not)

Closes: #38288