### PR TITLE
feat(webkit): roll to r2230

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "webkit",
-      "revision": "2229",
+      "revision": "2230",
       "installByDefault": true,
       "revisionOverrides": {
         "debian11-x64": "2105",

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -468,7 +468,10 @@ it('should not auto play audio', {
     });
   });
   await page.goto('http://127.0.0.1/audio.html');
-  await expect(page.locator('#log')).toHaveText('State: interrupted');
+  if (browserName === 'webkit')
+    await expect(page.locator('#log')).toHaveText('State: interrupted');
+  else
+    await expect(page.locator('#log')).toHaveText('State: suspended');
 });
 
 it('should not crash on feature detection for PublicKeyCredential', {

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -468,7 +468,7 @@ it('should not auto play audio', {
     });
   });
   await page.goto('http://127.0.0.1/audio.html');
-  await expect(page.locator('#log')).toHaveText('State: suspended');
+  await expect(page.locator('#log')).toHaveText('State: interrupted');
 });
 
 it('should not crash on feature detection for PublicKeyCredential', {


### PR DESCRIPTION
The roll https://github.com/microsoft/playwright-browsers/pull/1957

The status in audio test changed across the platforms after https://github.com/WebKit/WebKit/pull/53698. The new expectation is consistent with WebKit behavior without Playwright.