### PR TITLE
feat(ui-mode): add accept snapshots button

### DIFF
--- a/docs/src/test-ui-mode-js.md
+++ b/docs/src/test-ui-mode-js.md
@@ -99,6 +99,10 @@ The "Attachments" tab allows you to explore attachments. If you're doing [visual
 
 ![ui mode with attachments](https://github.com/microsoft/playwright/assets/13063165/bb83b406-84ed-4380-a96c-0e62d1388093)
 
+### Accepting snapshots
+
+When a test has snapshot failures, you can accept the new snapshots directly from UI mode. Click the "Accept Snapshots" button that appears when a test has snapshot errors. This will copy the actual snapshots to replace the expected snapshots, similar to running tests with the `--update-snapshots` flag. A status message will confirm how many snapshots were accepted.
+
 ## Metadata
 
 Next to the Actions tab you will find the Metadata tab which will show you more information on your test such as the Browser, viewport size, test duration and more.

--- a/packages/playwright/src/isomorphic/testServerConnection.ts
+++ b/packages/playwright/src/isomorphic/testServerConnection.ts
@@ -240,6 +240,10 @@ export class TestServerConnection implements TestServerInterface, TestServerInte
     return await this._sendMessage('runTests', params);
   }
 
+  async acceptSnapshots(params: Parameters<TestServerInterface['acceptSnapshots']>[0]): ReturnType<TestServerInterface['acceptSnapshots']> {
+    return await this._sendMessage('acceptSnapshots', params);
+  }
+
   async findRelatedTestFiles(params: Parameters<TestServerInterface['findRelatedTestFiles']>[0]): ReturnType<TestServerInterface['findRelatedTestFiles']> {
     return await this._sendMessage('findRelatedTestFiles', params);
   }

--- a/packages/playwright/src/isomorphic/testServerInterface.ts
+++ b/packages/playwright/src/isomorphic/testServerInterface.ts
@@ -109,6 +109,16 @@ export interface TestServerInterface {
     status: reporterTypes.FullResult['status'];
   }>;
 
+  /**
+   * Accepts snapshot updates by copying actual snapshots to expected locations.
+   */
+  acceptSnapshots(param: { paths: [string, string][]}): Promise<{
+    status: boolean;
+    accepted: number;
+    failed: number;
+    errors?: string[];
+  }>;
+
   findRelatedTestFiles(params: {
     files: string[];
   }): Promise<{ testFiles: string[]; errors?: reporterTypes.TestError[]; }>;

--- a/packages/trace-viewer/src/ui/uiModeView.css
+++ b/packages/trace-viewer/src/ui/uiModeView.css
@@ -83,14 +83,27 @@
 }
 
 .status-line {
-  flex: auto;
+  flex: none;
   white-space: nowrap;
-  line-height: 22px;
-  padding-left: 10px;
+  line-height: 16px;
+  padding: 4px 8px;
   display: flex;
   flex-direction: row;
   align-items: center;
-  height: 30px;
+  height: auto;
+  min-height: 20px;
+  font-size: 11px;
+}
+
+@keyframes slideInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .status-line > div {

--- a/tests/playwright-test/ui-mode-test-snapshots.spec.ts
+++ b/tests/playwright-test/ui-mode-test-snapshots.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, retries } from './ui-mode-fixtures';
+
+test.describe.configure({ mode: 'parallel', retries });
+
+test('should show accept snapshots button when snapshot fails', async ({ runUITest }, testInfo) => {
+  const { page } = await runUITest({
+    'snapshot.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('snapshot test', async ({ page }) => {
+        await page.setContent('<div>Hello World</div>');
+        await expect(page.locator('div')).toHaveScreenshot('snapshot.png');
+      });
+    `,
+  });
+
+  // Run the test - will fail on first run (missing snapshot)
+  await page.getByTitle('Run all').click();
+
+  // Wait for test to complete
+  await expect(page.getByTestId('status-line')).toContainText('/1');
+
+  // Accept snapshots button should be visible
+  const testItem = page.locator('.ui-mode-tree-item:has-text("snapshot test")');
+  const acceptButton = testItem.getByTitle('Accept snapshots');
+  await expect(acceptButton).toBeVisible();
+});
+
+test('should hide accept snapshots button when no snapshot errors', async ({ runUITest }, testInfo) => {
+  const { page } = await runUITest({
+    'passing.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('passing test', async () => {
+        expect(1 + 1).toBe(2);
+      });
+    `,
+  });
+
+  // Run the test
+  await page.getByTitle('Run all').click();
+
+  // Wait for test to complete
+  await expect(page.getByTestId('status-line')).toContainText('/1');
+
+  // Accept snapshots button should not be visible
+  const testItem = page.locator('.ui-mode-tree-item:has-text("passing test")');
+  const acceptButton = testItem.getByTitle('Accept snapshots');
+  await expect(acceptButton).toBeHidden();
+});
+
+test('should show accept all snapshots button in toolbar when snapshots fail', async ({ runUITest }, testInfo) => {
+  const { page } = await runUITest({
+    'snapshot.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('snapshot test', async ({ page }) => {
+        await page.setContent('<div>Hello World</div>');
+        await expect(page.locator('div')).toHaveScreenshot('snapshot.png');
+      });
+    `,
+  });
+
+  // Run the test - will fail on first run (missing snapshot)
+  await page.getByTitle('Run all').click();
+
+  // Wait for test to complete
+  await expect(page.getByTestId('status-line')).toContainText('/1');
+
+  // Accept all snapshots button should be visible in toolbar
+  const acceptAllButton = page.getByTitle('Accept all snapshots');
+  await expect(acceptAllButton).toBeVisible();
+});
+
+test('should hide accept all snapshots button when no snapshot errors', async ({ runUITest }, testInfo) => {
+  const { page } = await runUITest({
+    'passing.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('passing test', async () => {
+        expect(1 + 1).toBe(2);
+      });
+    `,
+  });
+
+  // Run the test
+  await page.getByTitle('Run all').click();
+
+  // Wait for test to complete
+  await expect(page.getByTestId('status-line')).toContainText('/1');
+
+  // Accept all snapshots button should not be visible in toolbar
+  const acceptAllButton = page.getByTitle('Accept all snapshots');
+  await expect(acceptAllButton).toBeHidden();
+});


### PR DESCRIPTION
> **Note:** this patch in its original form has been lingering on my disk for about a year and has been successfully used in my work projects. To make it PR-ready, I've used Claude Code's assistance to add tests and do a general review and clean up. I've made every effort to re-review the code manually and I think it's in good shape; nevertheless, I consider this PR a discussion starter. It works for me, but as always, there are probably things that have been overlooked and need correcting.

### Summary

This PR adds snapshot acceptance functionality to UI Mode, allowing developers to accept snapshot updates directly from the UI without switching to the command line and running `--update-snapshots`.

### Features

- **Per-test/file/directory buttons**: Accept snapshots for specific scope
- **Global "Accept all" button**: Accept all failing snapshots at once
- **Smart visibility**: Buttons only appear when snapshot errors exist
- **Immediate feedback**: Toast notification with acceptance status
- **Works while tests run**: Snapshots can be accepted even during test execution

### Screenshot

<img width="762" height="221" alt="image" src="https://github.com/user-attachments/assets/aa588933-9ee6-4aad-857a-4b6e2cf628a0" />

### Related Issues

Fixes #24310 