### PR TITLE
feat(test-server): add acceptSnapshots API endpoint

### DIFF
--- a/packages/playwright/src/isomorphic/testServerConnection.ts
+++ b/packages/playwright/src/isomorphic/testServerConnection.ts
@@ -240,6 +240,10 @@ export class TestServerConnection implements TestServerInterface, TestServerInte
     return await this._sendMessage('runTests', params);
   }
 
+  async acceptSnapshots(params: Parameters<TestServerInterface['acceptSnapshots']>[0]): ReturnType<TestServerInterface['acceptSnapshots']> {
+    return await this._sendMessage('acceptSnapshots', params);
+  }
+
   async findRelatedTestFiles(params: Parameters<TestServerInterface['findRelatedTestFiles']>[0]): ReturnType<TestServerInterface['findRelatedTestFiles']> {
     return await this._sendMessage('findRelatedTestFiles', params);
   }

--- a/packages/playwright/src/isomorphic/testServerInterface.ts
+++ b/packages/playwright/src/isomorphic/testServerInterface.ts
@@ -109,6 +109,16 @@ export interface TestServerInterface {
     status: reporterTypes.FullResult['status'];
   }>;
 
+  /**
+   * Accepts snapshot updates by copying actual snapshots to expected locations.
+   */
+  acceptSnapshots(param: { paths: [string, string][]}): Promise<{
+    status: boolean;
+    accepted: number;
+    failed: number;
+    errors?: string[];
+  }>;
+
   findRelatedTestFiles(params: {
     files: string[];
   }): Promise<{ testFiles: string[]; errors?: reporterTypes.TestError[]; }>;


### PR DESCRIPTION
## Summary

Add server-side API to accept snapshot updates by copying actual snapshots to expected locations:

- Add `acceptSnapshots()` method to `TestServerInterface`
- Implement handler in `TestServerDispatcher` that copies files and creates destination directories
- Add connection method in `TestServerConnection`
- Add test coverage for success and error cases

This is a backend-only change that adds the infrastructure for accepting snapshot updates. No UI changes included.

## Context

Split out from #38321 per reviewer feedback requesting smaller, incremental changes.

This PR contains only the backend API. Frontend changes will follow in a separate PR once this is merged.