### PR TITLE
fix(test runner): do not print config.tag at the end of each test

### DIFF
--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -502,7 +502,7 @@ function formatTestTitle(screen: Screen, config: FullConfig, test: TestCase, ste
   const projectLabel = options.includeTestId ? `project=` : '';
   const projectTitle = projectName ? `[${projectLabel}${projectName}] › ` : '';
   const testTitle = `${testId}${projectTitle}${location} › ${titles.join(' › ')}`;
-  const extraTags = test.tags.filter(t => !testTitle.includes(t));
+  const extraTags = test.tags.filter(t => !testTitle.includes(t) && !config.tags.includes(t));
   return `${testTitle}${stepSuffix(step)}${extraTags.length ? ' ' + extraTags.join(' ') : ''}`;
 }
 

--- a/tests/playwright-test/reporter-line.spec.ts
+++ b/tests/playwright-test/reporter-line.spec.ts
@@ -207,5 +207,21 @@ for (const useIntermediateMergeReport of [false, true] as const) {
         expect(text).toContain(`Error Context: ${path.join('test-results', 'a-one', 'error-context.md')}`);
       expect(result.exitCode).toBe(1);
     });
+
+    test('should not include global tag in the title', async ({ runInlineTest }) => {
+      const result = await runInlineTest({
+        'playwright.config.ts': `
+          export default { tag: '@global' };
+        `,
+        'a.test.ts': `
+          import { test, expect } from '@playwright/test';
+          test('passes', async ({}) => {
+          });
+        `,
+      }, { reporter: 'line' });
+      expect(result.output).toContain('[1/1] a.test.ts:3:15 › passes\n');
+      expect(result.output).not.toContain('@global');
+      expect(result.exitCode).toBe(0);
+    });
   });
 }


### PR DESCRIPTION
Before:
<img width="1049" height="97" alt="Screenshot 2025-11-26 at 2 06 17 PM" src="https://github.com/user-attachments/assets/aa1fcc41-678e-4dd6-8a0f-6b65e6451f15" />


After:
<img width="989" height="114" alt="Screenshot 2025-11-26 at 2 05 52 PM" src="https://github.com/user-attachments/assets/fcbcd805-8dd2-42f7-8ee7-71099f636e81" />
