### PR TITLE
chore: custom title for browser downloads

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -5,37 +5,43 @@
       "name": "chromium",
       "revision": "1202",
       "installByDefault": true,
-      "browserVersion": "143.0.7499.25"
+      "browserVersion": "143.0.7499.25",
+      "title": "Chrome for Testing"
     },
     {
       "name": "chromium-headless-shell",
       "revision": "1202",
       "installByDefault": true,
-      "browserVersion": "143.0.7499.25"
+      "browserVersion": "143.0.7499.25",
+      "title": "Chrome Headless Shell"
     },
     {
       "name": "chromium-tip-of-tree",
       "revision": "1384",
       "installByDefault": false,
-      "browserVersion": "143.0.7499.25"
+      "browserVersion": "143.0.7499.25",
+      "title": "Chrome Canary for Testing"
     },
     {
       "name": "chromium-tip-of-tree-headless-shell",
       "revision": "1384",
       "installByDefault": false,
-      "browserVersion": "143.0.7499.25"
+      "browserVersion": "143.0.7499.25",
+      "title": "Chrome Canary Headless Shell"
     },
     {
       "name": "firefox",
       "revision": "1497",
       "installByDefault": true,
-      "browserVersion": "144.0.2"
+      "browserVersion": "144.0.2",
+      "title": "Firefox"
     },
     {
       "name": "firefox-beta",
       "revision": "1493",
       "installByDefault": false,
-      "browserVersion": "145.0b10"
+      "browserVersion": "145.0b10",
+      "title": "Firefox Beta"
     },
     {
       "name": "webkit",
@@ -55,7 +61,8 @@
         "ubuntu20.04-x64": "2092",
         "ubuntu20.04-arm64": "2092"
       },
-      "browserVersion": "26.0"
+      "browserVersion": "26.0",
+      "title": "WebKit"
     },
     {
       "name": "ffmpeg",

--- a/tests/installation/npmTest.ts
+++ b/tests/installation/npmTest.ts
@@ -38,7 +38,7 @@ const expect = _expect.extend({
     const downloaded = new Set();
     let index = 0;
     while (true) {
-      const match = received.substring(index).match(/(chromium|chromium headless shell|firefox|webkit|winldd|ffmpeg)[\s\d\.]+\(?playwright build v\d+\)? downloaded/im);
+      const match = received.substring(index).match(/\(playwright (chromium|chromium-headless-shell|firefox|webkit|winldd|ffmpeg) v\d+\) downloaded/im);
       if (!match)
         break;
       downloaded.add(match[1].replace(/\s/g, '-').toLowerCase());

--- a/tests/installation/playwright-cdn.spec.ts
+++ b/tests/installation/playwright-cdn.spec.ts
@@ -24,7 +24,7 @@ const CDNS = [
   'https://cdn.playwright.dev',
 ];
 
-const DL_STAT_BLOCK = /^.*from url: (.*)$\n^.*to location: (.*)$\n^.*response status code: (.*)$\n^.*is chunked: (.*)$\n^.*total bytes: (\d+)$\n^.*download complete, size: (\d+)$\n^.*SUCCESS downloading (\w+) .*$/gm;
+const DL_STAT_BLOCK = /^.*from url: (.*)$\n^.*to location: (.*)$\n^.*response status code: (.*)$\n^.*is chunked: (.*)$\n^.*total bytes: (\d+)$\n^.*download complete, size: (\d+)$\n^.*SUCCESS downloading.*\(playwright ([a-zA-Z-]+) v\d+\).*$/gm;
 
 const parsedDownloads = (rawLogs: string) => {
   const out: { url: string, status: number, name: string }[] = [];
@@ -123,7 +123,7 @@ test(`playwright cdn should not timeout on redirect`, {
       expectToExitWithError: true
     });
     // Steps after the extraction will fail, but the download should succeed without timeouts.
-    expect(result).toContain(`pw:install SUCCESS downloading Chromium`);
+    expect(result).toContain(`pw:install SUCCESS downloading Chrome`);
     expect(result).not.toContain(`timed out after 1000ms`);
   } finally {
     await new Promise(resolve => server.close(resolve));


### PR DESCRIPTION
- `Chrome for Testing`
- `Chrome Headless Shell`
- `Firefox`
- `Firefox Beta`
- `WebKit`

Example output:
```
Downloading Chrome for Testing 143.0.7499.25 (playwright chromium v1202) from https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1202/chromium-mac-arm64.zip
160 MiB [====================] 100% 0.0s
Chrome for Testing 143.0.7499.25 (playwright chromium v1202) downloaded to /Users/dgozman/Library/Caches/ms-playwright/chromium-1202
```

Closes #38333.