### PR TITLE
fix(trace-viewer): Prevent dropping non-files

### DIFF
--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -174,7 +174,11 @@ export const WorkbenchLoader: React.FunctionComponent<{
 
   const showFileUploadDropArea = !!(!isServer && !dragOver && !fileForLocalModeError && (!traceURL || processingErrorMessage));
 
-  return <div className='vbox workbench-loader' onDragOver={event => { event.preventDefault(); setDragOver(true); }}>
+  return <div className='vbox workbench-loader' onDragOver={event => {
+    event.preventDefault();
+    if (event.dataTransfer.types.includes('Files'))
+      setDragOver(true);
+  }}>
     <div className='hbox header' {...(showFileUploadDropArea ? { inert: true } : {})}>
       <div className='logo'>
         <img src='playwright-logo.svg' alt='Playwright logo' />


### PR DESCRIPTION
Do not show drop target when [not dragging files](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/types#:~:text=If%20any%20files%20are%20included%20in%20the%20drag%20operation%2C%20then%20one%20of%20the%20types%20will%20be%20the%20string%20Files%2E) (e.g. text)

![Recording 2025-11-29 112829](https://github.com/user-attachments/assets/53b6e500-2f4f-4a7c-be80-24cd0e63a85d)

Closes: #38361