### PR TITLE
fix(trace-viewer): Keep showing source when test is scheduled

### DIFF
--- a/packages/trace-viewer/src/ui/sourceTab.tsx
+++ b/packages/trace-viewer/src/ui/sourceTab.tsx
@@ -56,7 +56,7 @@ function useSources(stack: StackFrame[] | undefined, selectedFrame: number, sour
       const sha1 = await calculateSha1(file);
       try {
         let response = model ? await fetch(model.createRelativeUrl(`sha1/src@${sha1}.txt`)) : undefined;
-        if (!response || response.status === 404)
+        if (!response || response.status >= 400)
           response = await fetch(`file?path=${encodeURIComponent(file)}`);
         if (response.status >= 400)
           source.content = `<Unable to read "${file}">`;

--- a/packages/trace-viewer/src/ui/uiModeTraceView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeTraceView.tsx
@@ -58,7 +58,7 @@ export const TraceView: React.FC<{
       return;
     }
 
-    if (!outputDir || item.treeItem?.status === 'scheduled') {
+    if (!outputDir) {
       setModel(undefined);
       return;
     }

--- a/packages/trace-viewer/src/ui/uiModeTraceView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeTraceView.tsx
@@ -58,7 +58,7 @@ export const TraceView: React.FC<{
       return;
     }
 
-    if (!outputDir) {
+    if (!outputDir || item.treeItem?.status === 'scheduled') {
       setModel(undefined);
       return;
     }


### PR DESCRIPTION
Currently after 500ms the trace file would be fetched (`loadSingleTraceFile`), this however fails since the test is still (likely) to be scheduled at that point in time. This causes the model to be reset to a new empty one. Since there now is a model, `useSources` will instead try to fetch the source file from `sha1/src`, but with an empty trace URL. The SW doesn't like this empty trace URL and throws an error `Error: File not found`, and returns status code 505 (not 400, so it's not retried via `file` endpoint).

Fix: Prevent polling the model if we know that test is still scheduled. We do need `setModel(undefined);` to immediately clear the old steps in the UI, else when re-running a test, the old steps will remain visible until the test has started.

Side note: There are still quite a lot of console errors when running a test in UI mode.

Closes: #38359