### PR TITLE
feat: Enable search functionality for CodeMirror editor

### DIFF
--- a/packages/web/src/components/codeMirrorModule.tsx
+++ b/packages/web/src/components/codeMirrorModule.tsx
@@ -28,6 +28,11 @@ import 'codemirror/addon/display/placeholder';
 import 'codemirror/addon/mode/simple';
 import 'codemirror/addon/edit/matchbrackets';
 import 'codemirror/addon/edit/closebrackets';
+import 'codemirror/addon/search/search';
+import 'codemirror/addon/search/searchcursor';
+import 'codemirror/addon/search/jump-to-line';
+import 'codemirror/addon/dialog/dialog';
+import 'codemirror/addon/dialog/dialog.css';
 
 export type CodeMirror = typeof codemirrorType;
 export default codemirror;

--- a/packages/web/src/components/codeMirrorWrapper.css
+++ b/packages/web/src/components/codeMirrorWrapper.css
@@ -185,3 +185,7 @@
 .CodeMirror-placeholder {
   color: var(--vscode-input-placeholderForeground) !important;
 }
+
+.CodeMirror-dialog-top {
+  padding-top: 8px !important;
+}

--- a/packages/web/src/components/codeMirrorWrapper.tsx
+++ b/packages/web/src/components/codeMirrorWrapper.tsx
@@ -108,6 +108,10 @@ export const CodeMirrorWrapper: React.FC<SourceProps> = ({
         placeholder,
         matchBrackets: true,
         autoCloseBrackets: true,
+        extraKeys: {
+          'Ctrl-F': 'findPersistent',
+          'Cmd-F': 'findPersistent'
+        }
       });
       codemirrorRef.current = { cm };
       if (isFocused)


### PR DESCRIPTION
Unfortunately I have not added a `enableSearch` prop to CodeMirror component to dynamically allow search. It is doable via custom key maps, but I found this extra complexity not worth it. So search is now also enabled in the Locator editors, which is not ideal, up for discussion.

(It is probably easier to implement in CodeMirror v6)

Trace viewer
<img width="514" height="182" alt="image" src="https://github.com/user-attachments/assets/e22b7362-2444-4144-b48a-6eb81a5b5ef0" />
<img width="496" height="103" alt="image" src="https://github.com/user-attachments/assets/e0e50d60-dfb5-4876-b41e-63f1b98d71a4" />
<img width="638" height="206" alt="image" src="https://github.com/user-attachments/assets/304abb11-e071-4d2a-a9a4-3234f1bff9d2" />
<img width="585" height="135" alt="image" src="https://github.com/user-attachments/assets/9a16b075-e30e-46ce-b2ed-fc6ff74f2c6c" />


Codegen:
<img width="620" height="145" alt="image" src="https://github.com/user-attachments/assets/97ad7284-fd58-43b3-b473-131473a144cd" />
<img width="624" height="76" alt="image" src="https://github.com/user-attachments/assets/3072bf0b-e880-43d2-bf9a-b48997629d95" />
<img width="619" height="67" alt="image" src="https://github.com/user-attachments/assets/279362ee-5d7b-45eb-bf77-ab8d109cf384" />



Closes: #37978