### PR TITLE
fix(tele receiver): make sure to resolve "." and ".." in relative paths

### DIFF
--- a/packages/playwright/src/reporters/merge.ts
+++ b/packages/playwright/src/reporters/merge.ts
@@ -58,10 +58,15 @@ export async function createMergedReport(config: FullConfigInternal, dir: string
   const eventData = await mergeEvents(dir, shardFiles, stringPool, printStatus, rootDirOverride);
   // If explicit config is provided, use platform path separator, otherwise use the one from the report (if any).
   const pathSeparator = rootDirOverride ? path.sep : (eventData.pathSeparatorFromMetadata ?? path.sep);
+  const pathPackage = pathSeparator === '/' ? path.posix : path.win32;
   const receiver = new TeleReporterReceiver(multiplexer, {
     mergeProjects: false,
     mergeTestCases: false,
-    resolvePath: (rootDir, relativePath) => stringPool.internString(rootDir + pathSeparator + relativePath),
+    // When merging on a different OS, an absolute path like `C:\foo\bar` from win may look like
+    // a relative path on posix, and vice versa.
+    // Therefore, we cannot use `path.resolve()` here - it will resolve relative-looking paths
+    // against `process.cwd()`, while we just want to normalize ".." and "." segments.
+    resolvePath: (rootDir, relativePath) => stringPool.internString(pathPackage.normalize(pathPackage.join(rootDir, relativePath))),
     configOverrides: config.config,
   });
   printStatus(`processing test events`);


### PR DESCRIPTION
We report all paths relative to `rootDir`. When some file is outside of the `rootDir`, we must resolve "." and ".." properly. 

Many things break if we don't:
- reading sources through `file/?` fetch;
- predicting `tracesDir` for live trace viewing;
- `runTest({ locations })` that are treated as a regular expression.

Fixes #38367.