### PR TITLE
test: unflake some tests

### DIFF
--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -1991,7 +1991,6 @@ test('should load trace from HTTP with progress indicator', async ({ showTraceVi
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Length', file.byteLength);
   res.writeHead(200);
-  await expect(dialog).not.toBeVisible({ timeout: 100 });
   // Should become visible after ~200ms
   await expect(dialog).toBeVisible();
 

--- a/tests/page/page-event-pageerror.spec.ts
+++ b/tests/page/page-event-pageerror.spec.ts
@@ -155,7 +155,7 @@ it('pageErrors should work', async ({ page }) => {
   await page.evaluate(async () => {
     for (let i = 0; i < 301; i++)
       window.builtins.setTimeout(() => { throw new Error('error' + i); }, 0);
-    await new Promise(f => window.builtins.setTimeout(f, 100));
+    await new Promise(f => window.builtins.setTimeout(f, 2000));
   });
 
   const errors = await page.pageErrors();


### PR DESCRIPTION
- `should load trace from HTTP with progress indicator`
- `pageErrors should work`
    
100/200ms is not a reasonable timeout on the bots.