### PR TITLE
feat(ui): add isStriped prop to TreeView component (#36649)

### DIFF
--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -106,6 +106,7 @@ export const ActionList: React.FC<ActionListProps> = ({
       isError={isError}
       isVisible={isVisible}
       render={render}
+      isStriped={true}
     />
   </div>;
 };

--- a/packages/web/src/components/treeView.css
+++ b/packages/web/src/components/treeView.css
@@ -86,11 +86,6 @@
   background-color: var(--vscode-inputValidation-errorBackground);
 }
 
-.tree-view-entry.warning {
-  color: var(--vscode-list-warningForeground);
-  background-color: var(--vscode-inputValidation-warningBackground);
-}
-
-.tree-view-entry.info {
-  background-color: var(--vscode-inputValidation-infoBackground);
+.tree-view-striped > [role="treeitem"]:nth-child(odd) {
+  background-color: var(--vscode-tree-tableOddRowsBackground);
 }

--- a/packages/web/src/components/treeView.tsx
+++ b/packages/web/src/components/treeView.tsx
@@ -35,6 +35,7 @@ export type TreeViewProps<T> = {
   title?: (item: T) => string,
   icon?: (item: T) => string | undefined,
   isError?: (item: T) => boolean,
+  isStriped?: boolean,
   isVisible?: (item: T) => boolean,
   selectedItem?: T,
   onAccepted?: (item: T) => void,
@@ -56,6 +57,7 @@ export function TreeView<T extends TreeItem>({
   title,
   icon,
   isError,
+  isStriped,
   isVisible,
   selectedItem,
   onAccepted,
@@ -128,7 +130,7 @@ export function TreeView<T extends TreeItem>({
 
   return <div className={clsx(`tree-view vbox`, name + '-tree-view')} data-testid={dataTestId || (name + '-tree')}>
     <div
-      className={clsx('tree-view-content')}
+      className={clsx('tree-view-content', isStriped && 'tree-view-striped')}
       role={treeItems.size > 0 ? 'tree' : undefined}
       tabIndex={0}
       onKeyDown={event => {

--- a/tests/playwright-test/ui-mode-test-tree.spec.ts
+++ b/tests/playwright-test/ui-mode-test-tree.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect, retries, dumpTestTree } from './ui-mode-fixtures';
+import { dumpTestTree, expect, retries, test } from './ui-mode-fixtures';
 
 test.describe.configure({ mode: 'parallel', retries });
 
@@ -630,4 +630,27 @@ test('should merge files', async ({ runUITest }) => {
           - treeitem "[icon-circle-outline] second"
           - treeitem "[icon-circle-outline] fifth"
   `);
+});
+
+test('should apply striped background to actions tree but not test tree', async ({ runUITest }) => {
+  const { page } = await runUITest({
+    'test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('Striped test', async ({ page }) => {
+        await page.goto('about:blank');
+        await page.click('body');
+      });
+    `,
+  });
+
+  await page.getByTitle('Run all').click();
+  await expect(page.getByTestId('status-line')).toHaveText('1/1 passed (100%)');
+
+  const actionsTree = page.getByTestId('actions-tree');
+  const actionsTreeContent = actionsTree.locator('.tree-view-content');
+  await expect(actionsTreeContent).toHaveClass(/tree-view-striped/);
+
+  const testTree = page.getByTestId('test-tree');
+  const testTreeContent = testTree.locator('.tree-view-content');
+  await expect(testTreeContent).not.toHaveClass(/tree-view-striped/);
 });


### PR DESCRIPTION
## Description

This PR adds an optional `isStriped` prop to the `TreeView` component that enables alternating background colors for tree items, improving readability when items span multiple lines or can be expanded/collapsed.

## Problem

As described in the feature request, the actions list in UI mode can be difficult to scan because:
- Some actions (like timeouts) are only one line
- Other actions span two lines (e.g., `getByText('Heute')`)
- Without visual separation, it's hard to distinguish between adjacent items

## Solution

- Added `isStriped?: boolean` prop to `TreeViewProps`
- Applied `tree-view-striped` CSS class conditionally when `isStriped={true}`
- Updated CSS to use `--vscode-tree-tableOddRowsBackground` for theme-aware alternating backgrounds
- Enabled striped background for the actions tree in trace viewer
- Keep it flexible so the Tests overview has the old styling

## Points of interest

- I removed unused styling in the treeview.css (.tree-view-entry.info and tree-view-entry.warning)

## Screenshots
Old:
<img width="237" height="440" alt="image" src="https://github.com/user-attachments/assets/53b8e3cd-756b-4d8a-893e-20dc28e98b25" />

New:
<img width="247" height="409" alt="image" src="https://github.com/user-attachments/assets/23a88b90-bf4b-4538-8901-587d91f9f098" />
<img width="253" height="444" alt="image" src="https://github.com/user-attachments/assets/1c21d96a-225e-4418-8139-2535ac805b61" />

With errors and expanded tree items:
<img width="377" height="471" alt="image" src="https://github.com/user-attachments/assets/9d70a130-e564-450a-abdf-422b9ee9b2fa" />






Fixes [#36649](https://github.com/microsoft/playwright/issues/36649)