### PR TITLE
docs: fix Java compilation error in Locator chaining example

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -1,6 +1,6 @@
 ---
 id: locators
-title: "Locators"<img width="1507" height="626" alt="image" src="https://github.com/user-attachments/assets/b586c19f-25c1-4bae-ab84-34e641422449" />
+title: "Locators"
 
 ---
 

--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -1,7 +1,6 @@
 ---
 id: locators
 title: "Locators"
-
 ---
 
 ## Introduction

--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -1,6 +1,7 @@
 ---
 id: locators
-title: "Locators"
+title: "Locators"<img width="1507" height="626" alt="image" src="https://github.com/user-attachments/assets/b586c19f-25c1-4bae-ab84-34e641422449" />
+
 ---
 
 ## Introduction
@@ -819,7 +820,7 @@ await page
 page.getByRole(AriaRole.LISTITEM)
     .filter(new Locator.FilterOptions().setHasText("Product 2"))
     .getByRole(AriaRole.BUTTON,
-               new Page.GetByRoleOptions().setName("Add to cart"))
+               new Locator.GetByRoleOptions().setName("Add to cart"))
     .click();
 ```
 


### PR DESCRIPTION
hanged Page.GetByRoleOptions to Locator.GetByRoleOptions because Locator.getByRole expects Locator options.