### PR TITLE
feat(mcp): Add console log filtering by levels

### DIFF
--- a/packages/playwright/src/mcp/browser/tab.ts
+++ b/packages/playwright/src/mcp/browser/tab.ts
@@ -163,8 +163,18 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   }
 
   private _handleConsoleMessage(message: ConsoleMessage) {
+    if (!this._shouldCaptureConsoleMessage(message.type))
+      return;
     this._consoleMessages.push(message);
     this._recentConsoleMessages.push(message);
+  }
+
+  private _shouldCaptureConsoleMessage(type: ConsoleMessage['type']): boolean {
+    if (!this.context.config.console?.logLevels)
+      return true;
+    if (type === undefined)
+      return false;
+    return this.context.config.console.logLevels.includes(type);
   }
 
   private _onClose() {

--- a/packages/playwright/src/mcp/config.d.ts
+++ b/packages/playwright/src/mcp/config.d.ts
@@ -181,5 +181,14 @@ export type Config = {
      * When taking snapshots for responses, specifies the mode to use.
      */
     mode?: 'incremental' | 'full' | 'none';
-  }
+  };
+
+  console?: {
+    /**
+     * List of console message levels to return to the client.
+     * Use an empty array to disable forwarding console messages.
+     * If not specified, all levels are forwarded.
+     */
+    logLevels?: string[];
+  };
 };

--- a/packages/playwright/src/mcp/program.ts
+++ b/packages/playwright/src/mcp/program.ts
@@ -72,6 +72,7 @@ export function decorateCommand(command: Command, version: string) {
       .option('--user-agent <ua string>', 'specify user agent string')
       .option('--user-data-dir <path>', 'path to the user data directory. If not specified, a temporary directory will be created.')
       .option('--viewport-size <size>', 'specify browser viewport size in pixels, for example "1280x720"', resolutionParser.bind(null, '--viewport-size'))
+      .option('--console-log-levels <levels...>', 'comma-separated list of browser console levels to forward to the client. Use "none" to disable forwarding. If not specified all levels are forwarded.', commaSeparatedList)
       .addOption(new ProgramOption('--connect-tool', 'Allow to switch between different browser connection methods.').hideHelp())
       .addOption(new ProgramOption('--vision', 'Legacy option, use --caps=vision instead').hideHelp())
       .action(async options => {

--- a/tests/mcp/log-levels.spec.ts
+++ b/tests/mcp/log-levels.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures';
+import type { StartClient } from './fixtures';
+import type { TestServer } from '../config/testserver';
+
+const PAGE = `
+  <title>Console messages</title>
+  <script>
+    console.log('log entry');
+    console.warn('warn entry');
+    console.error('error entry');
+  </script>
+`;
+
+async function navigateAndReadConsole(startClient: StartClient, server: TestServer, path: string, args?: string[]) {
+  const { client } = await startClient({ args });
+  const url = `${server.PREFIX}${path}`;
+
+  const navigateResponse = await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url },
+  });
+  const consoleResponse = await client.callTool({
+    name: 'browser_console_messages',
+    arguments: {},
+  });
+
+  return { navigateResponse, consoleResponse };
+}
+
+test('forwards all console messages by default', async ({ startClient, server }) => {
+  const path = '/console-log-levels-default';
+  server.setContent(path, PAGE, 'text/html');
+
+  const { navigateResponse, consoleResponse } = await navigateAndReadConsole(startClient, server, path);
+
+  expect(navigateResponse).toHaveResponse({
+    consoleMessages: expect.stringContaining('[LOG] log entry'),
+  });
+  expect(navigateResponse).toHaveResponse({
+    consoleMessages: expect.stringContaining('[WARNING] warn entry'),
+  });
+  expect(navigateResponse).toHaveResponse({
+    consoleMessages: expect.stringContaining('[ERROR] error entry'),
+  });
+
+  expect(consoleResponse).toHaveResponse({
+    result: expect.stringContaining('[LOG] log entry'),
+  });
+  expect(consoleResponse).toHaveResponse({
+    result: expect.stringContaining('[WARNING] warn entry'),
+  });
+  expect(consoleResponse).toHaveResponse({
+    result: expect.stringContaining('[ERROR] error entry'),
+  });
+});
+
+test('filters console messages by configured levels', async ({ startClient, server }) => {
+  const path = '/console-log-levels-filtered';
+  server.setContent(path, PAGE, 'text/html');
+
+  const { navigateResponse, consoleResponse } = await navigateAndReadConsole(
+      startClient,
+      server,
+      path,
+      ['--console-log-levels=warning,error'],
+  );
+
+  expect(navigateResponse).not.toHaveResponse({
+    consoleMessages: expect.stringContaining('[LOG] log entry'),
+  });
+  expect(navigateResponse).toHaveResponse({
+    consoleMessages: expect.stringContaining('[WARNING] warn entry'),
+  });
+  expect(navigateResponse).toHaveResponse({
+    consoleMessages: expect.stringContaining('[ERROR] error entry'),
+  });
+
+  expect(consoleResponse).not.toHaveResponse({
+    result: expect.stringContaining('[LOG] log entry'),
+  });
+  expect(consoleResponse).toHaveResponse({
+    result: expect.stringContaining('[WARNING] warn entry'),
+  });
+  expect(consoleResponse).toHaveResponse({
+    result: expect.stringContaining('[ERROR] error entry'),
+  });
+});
+
+test('disables console message forwarding when set to none', async ({ startClient, server }) => {
+  const path = '/console-log-levels-none';
+  server.setContent(path, PAGE, 'text/html');
+
+  const { navigateResponse, consoleResponse } = await navigateAndReadConsole(
+      startClient,
+      server,
+      path,
+      ['--console-log-levels=none'],
+  );
+
+  expect(navigateResponse).toHaveResponse({
+    consoleMessages: undefined,
+  });
+  expect(consoleResponse).toHaveResponse({
+    result: undefined,
+  });
+});


### PR DESCRIPTION
This commit adds CLI parameter --console-log-levels=<levels...> to restrict console logs output to client.
This could be helpful in cases if web page is too verbose in console and this consumes a lot of tokens of LLM.
Example: `--console-log-levels=warning,error` enables only warning and error logs.
Setting `--console-log-levels=none` disables all console logs.
If option is not set, then all logs are enabled by default.