### PR TITLE
docs: fix another Java compilation error in Locator chaining example

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -858,7 +858,7 @@ page.getByRole(AriaRole.LISTITEM)
     .filter(new Locator.FilterOptions()
         .setHasText(Pattern.compile("Product 2")))
     .getByRole(AriaRole.BUTTON,
-               new Page.GetByRoleOptions().setName("Add to cart"))
+               new Locator.GetByRoleOptions().setName("Add to cart"))
     .click();
 ```
 


### PR DESCRIPTION
I found another instance of the same error fixed in PR #38387. This PR fixes the remaining incorrect example.