### PR TITLE
feat(mcp): add --config-json flag for inline JSON configuration

### DIFF
--- a/packages/playwright/src/mcp/program.ts
+++ b/packages/playwright/src/mcp/program.ts
@@ -43,6 +43,7 @@ export function decorateCommand(command: Command, version: string) {
       .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
       .option('--cdp-header <headers...>', 'CDP headers to send with the connect request, multiple can be specified.', headerParser)
       .option('--config <path>', 'path to the configuration file.')
+      .option('--config-json <json>', 'configuration as a JSON string (mutually exclusive with --config)')
       .option('--device <device>', 'device to emulate, for example: "iPhone 15"')
       .option('--executable-path <path>', 'path to the browser executable.')
       .option('--extension', 'Connect to a running browser instance (Edge/Chrome only). Requires the "Playwright MCP Bridge" browser extension to be installed.')


### PR DESCRIPTION
Add a new CLI option --config-json that accepts configuration as an inline JSON string, complementing the existing --config file-based option.

This simplifies Playwright MCP usage in environments where creating or configuring files can be complicated or not possible, such as containerized deployments, CI/CD pipelines, and scripting scenarios. It also allows providing secrets in a more secure way without storing them in a file.

Key changes:
- Add configJson field to CLIOptions type
- Update loadConfig() to parse JSON string when provided
- Add mutual exclusivity check between --config and --config-json
- Add --config-json option to CLI in program.ts
- Add tests for valid JSON, invalid JSON, and mutual exclusivity

The options are mutually exclusive - using both results in an error. Configuration priority remains: defaults → config file/JSON → env → CLI.

Fixes microsoft/playwright-mcp#1239