### PR TITLE
docs: fix method casing error in Java locator filtering example

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -986,7 +986,7 @@ await expect(page
 assertThat(page
     .getByRole(AriaRole.LISTITEM)
     .filter(new Locator.FilterOptions()
-        .setHas(page.GetByRole(AriaRole.HEADING,
+        .setHas(page.getByRole(AriaRole.HEADING,
                                new Page.GetByRoleOptions().setName("Product 2")))))
     .hasCount(1);
 ```


### PR DESCRIPTION
### Description
Fixed a compilation error in the Java documentation snippet for Locator filtering.

### Changes
- In `docs/src/locators.md`: Changed `page.GetByRole(...)` to `page.getByRole(...)`.

### Reason
Java method names are case-sensitive and start with a lowercase letter. `GetByRole` (PascalCase) is incorrect for Java and causes a "cannot find symbol" compilation error; it should be `getByRole` (camelCase).