### PR TITLE
feat(trace-viewer): add WebSocket frames to network panel

### DIFF
--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -765,6 +765,20 @@ Double click on an action from your test in the actions sidebar. This will filte
 
 Use the timeline to filter actions, by clicking a start point and dragging to an ending point. The network tab will also be filtered to only show the network requests that were made during the actions selected.
 
+#### WebSocket connections
+
+The Network tab also displays WebSocket connections made during your test. WebSocket entries are shown with a "WS" method indicator and can be filtered using the type filter. Click on a WebSocket connection to see detailed information:
+
+- **Info tab**: Shows the WebSocket URL, connection status, timing information, and frame statistics (total frames, sent/received count, text/binary breakdown).
+- **Frames tab**: Displays all WebSocket frames exchanged during the connection. Each frame shows:
+  - Direction (sent ↑ or received ↓)
+  - Frame type (text or binary)
+  - Timestamp
+  - Data size
+  - Content preview
+
+Click on any frame in the list to view its full content. This is particularly useful for debugging real-time communication in applications using WebSocket-based protocols like Socket.IO or custom WebSocket implementations.
+
 ### Metadata
 
 Next to the Actions tab you will find the Metadata tab which will show you more information on your test such as the Browser, viewport size, test duration and more.

--- a/packages/playwright-core/src/utils/isomorphic/trace/entries.ts
+++ b/packages/playwright-core/src/utils/isomorphic/trace/entries.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Language } from '../locatorGenerators';
-import type { ResourceSnapshot } from '@trace/snapshot';
+import type { ResourceSnapshot, WebSocketSnapshot } from '@trace/snapshot';
 import type * as trace from '@trace/trace';
 
 // *Entry structures are used to pass the trace between the sw and the page.
@@ -35,6 +35,7 @@ export type ContextEntry = {
   options: trace.BrowserContextEventOptions;
   pages: PageEntry[];
   resources: ResourceSnapshot[];
+  websockets: WebSocketSnapshot[];
   actions: ActionEntry[];
   events: (trace.EventTraceEvent | trace.ConsoleMessageTraceEvent)[];
   stdio: trace.StdioTraceEvent[];

--- a/packages/playwright-core/src/utils/isomorphic/trace/traceLoader.ts
+++ b/packages/playwright-core/src/utils/isomorphic/trace/traceLoader.ts
@@ -148,6 +148,7 @@ function createEmptyContext(): ContextEntry {
     },
     pages: [],
     resources: [],
+    websockets: [],
     actions: [],
     events: [],
     errors: [],

--- a/packages/playwright-core/src/utils/isomorphic/trace/traceModel.ts
+++ b/packages/playwright-core/src/utils/isomorphic/trace/traceModel.ts
@@ -17,7 +17,7 @@
 import { getActionGroup } from '@isomorphic/protocolFormatter';
 
 import type { Language } from '@isomorphic/locatorGenerators';
-import type { ResourceSnapshot } from '@trace/snapshot';
+import type { ResourceSnapshot, WebSocketSnapshot } from '@trace/snapshot';
 import type * as trace from '@trace/trace';
 import type { ActionTraceEvent } from '@trace/trace';
 import type { ActionEntry, ContextEntry, PageEntry } from '@isomorphic/trace/entries';
@@ -85,6 +85,7 @@ export class TraceModel {
   readonly testIdAttributeName: string | undefined;
   readonly sources: Map<string, SourceModel>;
   resources: ResourceSnapshot[];
+  websockets: WebSocketSnapshot[];
   readonly actionCounters: Map<string, number>;
   readonly traceUrl: string;
 
@@ -114,11 +115,13 @@ export class TraceModel {
     this.hasSource = contexts.some(c => c.hasSource);
     this.hasStepData = contexts.some(context => context.origin === 'testRunner');
     this.resources = [...contexts.map(c => c.resources)].flat();
+    this.websockets = [...contexts.map(c => c.websockets)].flat();
     this.attachments = this.actions.flatMap(action => action.attachments?.map(attachment => ({ ...attachment, callId: action.callId, traceUrl })) ?? []);
     this.visibleAttachments = this.attachments.filter(attachment => !attachment.name.startsWith('_'));
 
     this.events.sort((a1, a2) => a1.time - a2.time);
     this.resources.sort((a1, a2) => a1._monotonicTime! - a2._monotonicTime!);
+    this.websockets.sort((a1, a2) => a1.createdTimestamp - a2.createdTimestamp);
     this.errorDescriptors = this.hasStepData ? this._errorDescriptorsFromTestRunner() : this._errorDescriptorsFromActions();
     this.sources = collectSources(this.actions, this.errorDescriptors);
 

--- a/packages/trace-viewer/src/ui/networkFilters.tsx
+++ b/packages/trace-viewer/src/ui/networkFilters.tsx
@@ -16,7 +16,7 @@
 
 import './networkFilters.css';
 
-const resourceTypes = ['Fetch', 'HTML', 'JS', 'CSS', 'Font', 'Image'] as const;
+const resourceTypes = ['Fetch', 'HTML', 'JS', 'CSS', 'Font', 'Image', 'WS'] as const;
 export type ResourceType = typeof resourceTypes[number];
 
 export type FilterState = {

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -152,3 +152,89 @@
 .yellow-circle::before {
   background-color: var(--vscode-charts-yellow);
 }
+
+/* WebSocket Frames Styles */
+.websocket-frames-tab {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.websocket-frames-list {
+  flex: 1 1 40%;
+  min-height: 100px;
+  overflow: auto;
+  border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.websocket-frames-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.websocket-frames-table th {
+  background-color: var(--vscode-sideBar-background);
+  padding: 6px 8px;
+  text-align: left;
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+  border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.websocket-frame-row {
+  cursor: pointer;
+}
+
+.websocket-frame-row:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.websocket-frame-row.selected {
+  background-color: var(--vscode-list-activeSelectionBackground);
+  color: var(--vscode-list-activeSelectionForeground);
+}
+
+.websocket-frame-row td {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.websocket-frame-direction {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.websocket-frame-row.sent .websocket-frame-direction .codicon {
+  color: var(--vscode-charts-green);
+}
+
+.websocket-frame-row.received .websocket-frame-direction .codicon {
+  color: var(--vscode-charts-blue);
+}
+
+.websocket-frame-preview {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--vscode-editor-font-family);
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.websocket-frame-detail {
+  flex: 1 1 300px;
+  min-height: 200px;
+  max-height: 50%;
+  overflow: auto;
+  border-top: 1px solid var(--vscode-panel-border);
+}
+
+.network-request-error {
+  color: var(--vscode-charts-red);
+  padding: 8px;
+}

--- a/packages/trace/src/snapshot.ts
+++ b/packages/trace/src/snapshot.ts
@@ -18,6 +18,23 @@ import type { Entry as HAREntry } from './har';
 
 export type ResourceSnapshot = HAREntry;
 
+export type WebSocketFrame = {
+  opcode: number; // 1 = text, 2 = binary
+  data: string;
+  timestamp: number;
+  direction: 'sent' | 'received';
+};
+
+export type WebSocketSnapshot = {
+  wsGuid: string;
+  url: string;
+  pageId?: string;
+  createdTimestamp: number;
+  closedTimestamp?: number;
+  error?: string;
+  frames: WebSocketFrame[];
+};
+
 // Text node.
 export type TextNodeSnapshot = string;
 // Subtree reference, "x snapshots ago, node #y". Could point to a text node.

--- a/packages/trace/src/trace.ts
+++ b/packages/trace/src/trace.ts
@@ -165,6 +165,36 @@ export type ErrorTraceEvent = {
   stack?: StackFrame[];
 };
 
+export type WebSocketFrameTraceEvent = {
+  type: 'websocket-frame';
+  wsGuid: string;
+  timestamp: number;
+  opcode: number; // 1 = text, 2 = binary
+  data: string;
+  direction: 'sent' | 'received';
+};
+
+export type WebSocketCreatedTraceEvent = {
+  type: 'websocket-created';
+  wsGuid: string;
+  timestamp: number;
+  url: string;
+  pageId?: string;
+};
+
+export type WebSocketClosedTraceEvent = {
+  type: 'websocket-closed';
+  wsGuid: string;
+  timestamp: number;
+};
+
+export type WebSocketErrorTraceEvent = {
+  type: 'websocket-error';
+  wsGuid: string;
+  timestamp: number;
+  error: string;
+};
+
 export type TraceEvent =
     ContextCreatedTraceEvent |
     ScreencastFrameTraceEvent |
@@ -178,4 +208,8 @@ export type TraceEvent =
     ResourceSnapshotTraceEvent |
     FrameSnapshotTraceEvent |
     StdioTraceEvent |
-    ErrorTraceEvent;
+    ErrorTraceEvent |
+    WebSocketCreatedTraceEvent |
+    WebSocketFrameTraceEvent |
+    WebSocketClosedTraceEvent |
+    WebSocketErrorTraceEvent;


### PR DESCRIPTION
This patch adds WebSocket connection tracking and frame visualization to the trace viewer's network panel.

Changes:
- Record WebSocket lifecycle events (created, frame, closed, error)
- Display WebSocket connections in network tab with 'WS' method
- Show frame details (sent/received, text/binary, timestamps)
- Add WebSocket filtering support
- Include frame statistics and content preview
- Add documentation for WebSocket tracing
- Add test for WebSocket trace recording

Fixes #10996 

<img width="1365" height="851" alt="Screenshot 2025-12-04 at 10 55 59" src="https://github.com/user-attachments/assets/9f984fd5-a2af-479f-b4a3-fa6008ae5598" />
