### PR TITLE
feat(mcp): add cookie management tools

### DIFF
--- a/packages/playwright/src/mcp/browser/tools.ts
+++ b/packages/playwright/src/mcp/browser/tools.ts
@@ -16,6 +16,7 @@
 
 import common from './tools/common';
 import console from './tools/console';
+import cookies from './tools/cookies';
 import dialogs from './tools/dialogs';
 import evaluate from './tools/evaluate';
 import files from './tools/files';
@@ -40,6 +41,7 @@ import type { FullConfig } from './config';
 export const browserTools: Tool<any>[] = [
   ...common,
   ...console,
+  ...cookies,
   ...dialogs,
   ...evaluate,
   ...files,

--- a/packages/playwright/src/mcp/browser/tools/cookies.ts
+++ b/packages/playwright/src/mcp/browser/tools/cookies.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'playwright-core/lib/mcpBundle';
+import { defineTool } from './tool';
+
+const cookieSchema = z.object({
+  name: z.string().describe('Cookie name'),
+  value: z.string().describe('Cookie value'),
+  domain: z.string().describe('Cookie domain'),
+  path: z.string().optional().describe('Cookie path, defaults to "/"'),
+  expires: z.number().optional().describe('Unix timestamp in seconds when cookie expires'),
+  httpOnly: z.boolean().optional().describe('Whether cookie is httpOnly'),
+  secure: z.boolean().optional().describe('Whether cookie is secure'),
+  sameSite: z.enum(['Strict', 'Lax', 'None']).optional().describe('Cookie sameSite attribute'),
+});
+
+const addCookies = defineTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_add_cookies',
+    title: 'Add cookies',
+    description: 'Add cookies to the browser context. Useful for setting authentication tokens, session cookies, or any other cookies needed for the session.',
+    inputSchema: z.object({
+      cookies: z.array(cookieSchema).describe('Array of cookies to add to the browser context'),
+    }),
+    type: 'action',
+  },
+
+  handle: async (context, params, response) => {
+    const tab = await context.ensureTab();
+    const browserContext = tab.page.context();
+    await browserContext.addCookies(params.cookies);
+
+    response.addCode(`await context.addCookies(${JSON.stringify(params.cookies, null, 2)});`);
+    response.addLog(`Added ${params.cookies.length} cookie(s) to the browser context`);
+  },
+});
+
+const getCookies = defineTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_get_cookies',
+    title: 'Get cookies',
+    description: 'Get cookies from the browser context. Returns all cookies or cookies for specific URLs.',
+    inputSchema: z.object({
+      urls: z.array(z.string()).optional().describe('Optional list of URLs to get cookies for. If not specified, returns all cookies.'),
+    }),
+    type: 'readOnly',
+  },
+
+  handle: async (context, params, response) => {
+    const tab = await context.ensureTab();
+    const browserContext = tab.page.context();
+    const cookies = await browserContext.cookies(params.urls);
+
+    if (params.urls) {
+      response.addCode(`await context.cookies(${JSON.stringify(params.urls)});`);
+    } else {
+      response.addCode(`await context.cookies();`);
+    }
+    response.addLog(JSON.stringify(cookies, null, 2));
+  },
+});
+
+const clearCookies = defineTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_clear_cookies',
+    title: 'Clear cookies',
+    description: 'Clear cookies from the browser context. Can clear all cookies or filter by name, domain, and path.',
+    inputSchema: z.object({
+      name: z.string().optional().describe('Optional cookie name pattern to clear'),
+      domain: z.string().optional().describe('Optional domain pattern to clear cookies for'),
+      path: z.string().optional().describe('Optional path pattern to clear cookies for'),
+    }),
+    type: 'action',
+  },
+
+  handle: async (context, params, response) => {
+    const tab = await context.ensureTab();
+    const browserContext = tab.page.context();
+    
+    const hasFilters = params.name || params.domain || params.path;
+    const filterOptions: { name?: string; domain?: string; path?: string } = {};
+    if (params.name) filterOptions.name = params.name;
+    if (params.domain) filterOptions.domain = params.domain;
+    if (params.path) filterOptions.path = params.path;
+
+    if (hasFilters) {
+      await browserContext.clearCookies(filterOptions);
+      response.addCode(`await context.clearCookies(${JSON.stringify(filterOptions)});`);
+      response.addLog(`Cleared cookies matching: ${JSON.stringify(filterOptions)}`);
+    } else {
+      await browserContext.clearCookies();
+      response.addCode(`await context.clearCookies();`);
+      response.addLog('Cleared all cookies');
+    }
+  },
+});
+
+export default [
+  addCookies,
+  getCookies,
+  clearCookies,
+];

--- a/tests/mcp/cookies.spec.ts
+++ b/tests/mcp/cookies.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures';
+
+test('browser_add_cookies should add cookies to context', async ({ client, server }) => {
+  server.setContent('/', '<html><body>Hello</body></html>', 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_add_cookies',
+    arguments: {
+      cookies: [
+        {
+          name: 'session_token',
+          value: 'abc123',
+          domain: 'localhost',
+          path: '/',
+        },
+      ],
+    },
+  });
+
+  expect(result).toHaveResponse({ result: expect.stringContaining('Added 1 cookie(s)') });
+});
+
+test('browser_add_cookies should add multiple cookies', async ({ client, server }) => {
+  server.setContent('/', '<html><body>Hello</body></html>', 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_add_cookies',
+    arguments: {
+      cookies: [
+        { name: 'cookie1', value: 'value1', domain: 'localhost' },
+        { name: 'cookie2', value: 'value2', domain: 'localhost' },
+      ],
+    },
+  });
+
+  expect(result).toHaveResponse({ result: expect.stringContaining('Added 2 cookie(s)') });
+});
+
+test('browser_get_cookies should return added cookies', async ({ client, server }) => {
+  server.setContent('/', '<html><body>Hello</body></html>', 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  await client.callTool({
+    name: 'browser_add_cookies',
+    arguments: {
+      cookies: [
+        { name: 'test_cookie', value: 'test_value', domain: 'localhost' },
+      ],
+    },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_cookies',
+    arguments: {},
+  });
+
+  expect(result).toHaveResponse({ result: expect.stringContaining('test_cookie') });
+  expect(result).toHaveResponse({ result: expect.stringContaining('test_value') });
+});
+
+test('browser_clear_cookies should clear all cookies', async ({ client, server }) => {
+  server.setContent('/', '<html><body>Hello</body></html>', 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  await client.callTool({
+    name: 'browser_add_cookies',
+    arguments: {
+      cookies: [
+        { name: 'cookie1', value: 'value1', domain: 'localhost' },
+      ],
+    },
+  });
+
+  const clearResult = await client.callTool({
+    name: 'browser_clear_cookies',
+    arguments: {},
+  });
+
+  expect(clearResult).toHaveResponse({ result: expect.stringContaining('Cleared all cookies') });
+
+  const getCookiesResult = await client.callTool({
+    name: 'browser_get_cookies',
+    arguments: {},
+  });
+
+  expect(getCookiesResult).toHaveResponse({ result: expect.stringContaining('[]') });
+});
+
+test('browser_clear_cookies should clear cookies by name', async ({ client, server }) => {
+  server.setContent('/', '<html><body>Hello</body></html>', 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  await client.callTool({
+    name: 'browser_add_cookies',
+    arguments: {
+      cookies: [
+        { name: 'keep_me', value: 'value1', domain: 'localhost' },
+        { name: 'delete_me', value: 'value2', domain: 'localhost' },
+      ],
+    },
+  });
+
+  await client.callTool({
+    name: 'browser_clear_cookies',
+    arguments: { name: 'delete_me' },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_cookies',
+    arguments: {},
+  });
+
+  expect(result).toHaveResponse({ result: expect.stringContaining('keep_me') });
+  expect(result).not.toHaveResponse({ result: expect.stringContaining('delete_me') });
+});


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2>
<p>This PR adds three new MCP tools for cookie management:</p>
<ul>
<li><code>browser_add_cookies</code> - Add cookies to the browser context</li>
<li><code>browser_get_cookies</code> - Get cookies from the browser context</li>
<li><code>browser_clear_cookies</code> - Clear cookies from the browser context</li>
</ul>
<h2>Motivation</h2>
<p>While Playwright MCP already supports <code>--storage-state</code> for initial state and <code>browser_run_code</code> for arbitrary code execution, there's no dedicated, discoverable tool for runtime cookie management. This is a common use case for:</p>
<ol>
<li><strong>Corporate/Enterprise apps</strong> - Injecting session cookies or auth tokens obtained through external authentication flows</li>
<li><strong>Testing authenticated flows</strong> - Adding cookies without going through login flows</li>
<li><strong>Session management</strong> - Dynamically adding/removing cookies during a session</li>
</ol>
<h3>Current workarounds and their limitations</h3>

Workaround | Limitation
-- | --
--storage-state | Only works at startup, cannot add cookies at runtime
--init-page | Requires external TypeScript file, not dynamic
browser_run_code | Not discoverable, requires knowing Playwright internals


<p>A dedicated tool makes this functionality discoverable and provides a better developer experience.</p>
<h2>New Tools</h2>
<h3>browser_add_cookies</h3>
<p>Add cookies to the browser context. Supports all cookie attributes including <code>httpOnly</code>, <code>secure</code>, and <code>sameSite</code>.</p>
<h3>browser_get_cookies</h3>
<p>Get cookies from the browser context. Can return all cookies or filter by URLs.</p>
<h3>browser_clear_cookies</h3>
<p>Clear cookies from the browser context. Can clear all cookies or filter by name, domain, and path.</p>
<h2>Example Usage</h2>
<pre><code class="language-javascript">// Navigate to establish context
await mcp.callTool('browser_navigate', { url: 'https://myapp.com' });

// Add authentication cookies
await mcp.callTool('browser_add_cookies', {
  cookies: [{
    name: 'session_id',
    value: 'abc123xyz',
    domain: 'myapp.com',
    httpOnly: true,
    secure: true
  }]
});

// Navigate to authenticated page
await mcp.callTool('browser_navigate', { url: 'https://myapp.com/dashboard' });
</code></pre>
<h2>Implementation</h2>
<ul>
<li>Uses existing Playwright <code>BrowserContext</code> API (<code>addCookies</code>, <code>cookies</code>, <code>clearCookies</code>)</li>
<li>Follows existing tool patterns in the codebase</li>
<li>Includes tests</li>
</ul></body></html>