### PR TITLE
chore(deps): bump body-parser from 2.2.0 to 2.2.1

### DIFF
--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -11,7 +11,7 @@ This project incorporates components from the projects listed below. The origina
 -	ajv-formats@3.0.1 (https://github.com/ajv-validator/ajv-formats)
 -	ajv@8.17.1 (https://github.com/ajv-validator/ajv)
 -	balanced-match@1.0.2 (https://github.com/juliangruber/balanced-match)
--	body-parser@2.2.0 (https://github.com/expressjs/body-parser)
+-	body-parser@2.2.1 (https://github.com/expressjs/body-parser)
 -	brace-expansion@1.1.12 (https://github.com/juliangruber/brace-expansion)
 -	buffer-crc32@0.2.13 (https://github.com/brianloveswords/buffer-crc32)
 -	bytes@3.1.2 (https://github.com/visionmedia/bytes.js)
@@ -29,6 +29,7 @@ This project incorporates components from the projects listed below. The origina
 -	cross-spawn@7.0.6 (https://github.com/moxystudio/node-cross-spawn)
 -	debug@4.3.4 (https://github.com/debug-js/debug)
 -	debug@4.4.0 (https://github.com/debug-js/debug)
+-	debug@4.4.3 (https://github.com/debug-js/debug)
 -	define-lazy-prop@2.0.0 (https://github.com/sindresorhus/define-lazy-prop)
 -	depd@2.0.0 (https://github.com/dougwilson/nodejs-depd)
 -	diff@7.0.0 (https://github.com/kpdecker/jsdiff)
@@ -59,9 +60,9 @@ This project incorporates components from the projects listed below. The origina
 -	graceful-fs@4.2.10 (https://github.com/isaacs/node-graceful-fs)
 -	has-symbols@1.1.0 (https://github.com/inspect-js/has-symbols)
 -	hasown@2.0.2 (https://github.com/inspect-js/hasOwn)
--	http-errors@2.0.0 (https://github.com/jshttp/http-errors)
+-	http-errors@2.0.1 (https://github.com/jshttp/http-errors)
 -	https-proxy-agent@7.0.6 (https://github.com/TooTallNate/proxy-agents)
--	iconv-lite@0.6.3 (https://github.com/ashtuchkin/iconv-lite)
+-	iconv-lite@0.7.0 (https://github.com/pillarjs/iconv-lite)
 -	inherits@2.0.4 (https://github.com/isaacs/inherits)
 -	ip-address@9.0.5 (https://github.com/beaugunderson/ip-address)
 -	ipaddr.js@1.9.1 (https://github.com/whitequark/ipaddr.js)
@@ -100,7 +101,7 @@ This project incorporates components from the projects listed below. The origina
 -	pump@3.0.2 (https://github.com/mafintosh/pump)
 -	qs@6.14.0 (https://github.com/ljharb/qs)
 -	range-parser@1.2.1 (https://github.com/jshttp/range-parser)
--	raw-body@3.0.0 (https://github.com/stream-utils/raw-body)
+-	raw-body@3.0.2 (https://github.com/stream-utils/raw-body)
 -	require-from-string@2.0.2 (https://github.com/floatdrop/require-from-string)
 -	retry@0.12.0 (https://github.com/tim-kos/node-retry)
 -	router@2.2.0 (https://github.com/pillarjs/router)
@@ -120,7 +121,6 @@ This project incorporates components from the projects listed below. The origina
 -	socks-proxy-agent@8.0.5 (https://github.com/TooTallNate/proxy-agents)
 -	socks@2.8.3 (https://github.com/JoshGlazebrook/socks)
 -	sprintf-js@1.1.3 (https://github.com/alexei/sprintf.js)
--	statuses@2.0.1 (https://github.com/jshttp/statuses)
 -	statuses@2.0.2 (https://github.com/jshttp/statuses)
 -	toidentifier@1.0.1 (https://github.com/component/toidentifier)
 -	type-is@2.0.1 (https://github.com/jshttp/type-is)
@@ -500,7 +500,7 @@ SOFTWARE.
 =========================================
 END OF balanced-match@1.0.2 AND INFORMATION
 
-%% body-parser@2.2.0 NOTICES AND INFORMATION BEGIN HERE
+%% body-parser@2.2.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 (The MIT License)
 
@@ -526,7 +526,7 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
-END OF body-parser@2.2.0 AND INFORMATION
+END OF body-parser@2.2.1 AND INFORMATION
 
 %% brace-expansion@1.1.12 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -973,6 +973,30 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF debug@4.4.0 AND INFORMATION
+
+%% debug@4.4.3 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+(The MIT License)
+
+Copyright (c) 2014-2017 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2018-2021 Josh Junon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the 'Software'), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF debug@4.4.3 AND INFORMATION
 
 %% define-lazy-prop@2.0.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1756,7 +1780,7 @@ SOFTWARE.
 =========================================
 END OF hasown@2.0.2 AND INFORMATION
 
-%% http-errors@2.0.0 NOTICES AND INFORMATION BEGIN HERE
+%% http-errors@2.0.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 The MIT License (MIT)
 
@@ -1781,7 +1805,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 =========================================
-END OF http-errors@2.0.0 AND INFORMATION
+END OF http-errors@2.0.1 AND INFORMATION
 
 %% https-proxy-agent@7.0.6 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1810,7 +1834,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF https-proxy-agent@7.0.6 AND INFORMATION
 
-%% iconv-lite@0.6.3 NOTICES AND INFORMATION BEGIN HERE
+%% iconv-lite@0.7.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 Copyright (c) 2011 Alexander Shtuchkin
 
@@ -1833,7 +1857,7 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
-END OF iconv-lite@0.6.3 AND INFORMATION
+END OF iconv-lite@0.7.0 AND INFORMATION
 
 %% inherits@2.0.4 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -2782,7 +2806,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF range-parser@1.2.1 AND INFORMATION
 
-%% raw-body@3.0.0 NOTICES AND INFORMATION BEGIN HERE
+%% raw-body@3.0.2 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 The MIT License (MIT)
 
@@ -2807,7 +2831,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 =========================================
-END OF raw-body@3.0.0 AND INFORMATION
+END OF raw-body@3.0.2 AND INFORMATION
 
 %% require-from-string@2.0.2 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -3275,33 +3299,6 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 =========================================
 END OF sprintf-js@1.1.3 AND INFORMATION
-
-%% statuses@2.0.1 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-The MIT License (MIT)
-
-Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
-Copyright (c) 2016 Douglas Christopher Wilson <doug@somethingdoug.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-=========================================
-END OF statuses@2.0.1 AND INFORMATION
 
 %% statuses@2.0.2 NOTICES AND INFORMATION BEGIN HERE
 =========================================

--- a/packages/playwright-core/bundles/mcp/package-lock.json
+++ b/packages/playwright-core/bundles/mcp/package-lock.json
@@ -107,23 +107,27 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
         "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bytes": {
@@ -231,9 +235,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -548,40 +552,39 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
@@ -808,18 +811,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/require-from-string": {


### PR DESCRIPTION
Verified that the `raw-body` [alias](https://github.com/microsoft/playwright/blob/99ffc10ab67d57d348ff2ea42ea0d6721acdd48e/utils/build/build.js#L283-L285) still applies and keeps the bundle size smaller.

```
$ du -sh packages/playwright-core/lib/mcpBundleImpl/*
860K	packages/playwright-core/lib/mcpBundleImpl/index.js
```

Closes https://github.com/microsoft/playwright/pull/38399