### PR TITLE
docs: fix compilation errors in Java locator screenshot example

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -1611,7 +1611,7 @@ rowLocator
         .setHas(page.getByRole(
             AriaRole.BUTTON,
             new Page.GetByRoleOptions().setName("Say goodbye"))))
-    .screenshot(new Page.ScreenshotOptions().setPath("screenshot.png"));
+    .screenshot(new Locator.ScreenshotOptions().setPath(Paths.get("screenshot.png")));
 ```
 
 ```csharp


### PR DESCRIPTION
### Description
Fixed compilation errors in the Java documentation snippet for `Locator.filter()`.

### Changes
- In `docs/src/locators.md`:
  - Changed `new Page.ScreenshotOptions()` to `new Locator.ScreenshotOptions()` because `Locator.screenshot()` requires Locator options.
  - Changed `.setPath("screenshot.png")` to `.setPath(Paths.get("screenshot.png"))` to strictly match the Java `Path` parameter requirement.

### Reason
The provided example code fails to compile due to incompatible option types (`Page` vs `Locator`) and incorrect string argument for `setPath` (requires `java.nio.file.Path`).