### PR TITLE
Website Documentation: Add info for using noVNC web view for Codespaces and Docker

### DIFF
--- a/docs/src/codegen.md
+++ b/docs/src/codegen.md
@@ -155,25 +155,6 @@ You can generate [locators](/locators.md) with the test generator.
 
 ![picking a locator](https://github.com/microsoft/playwright/assets/13063165/1478f56f-422f-4276-9696-0674041f11dc)
 
-## Docker DevContainers & GitHub Codespaces
-
-For Docker and GitHub Codespaces environments, you can generate tests using the `noVNC` viewer built into the Playwright Docker image. In order for the VNC webviewer to be accessible outside of the container, you can enable the `desktop-lite` feature and specify the `webPort` in your `.devcontainer/devcontainer.json` file: 
-
-```json
-{
-  "image": "mcr.microsoft.com/playwright:v1.57.0",
-  "forwardPorts": [6080],
-  "features": {
-    "desktop-lite": {
-      "webPort": "6080"
-    }
-  }
-}
-```
-
-Once this is enabled you can open the port specified in a new browser tab and you will have access to the `noVNC` web viewer, and will be able to record tests and use codegen directly on your container.
-
-
 ## Emulation
 
 You can use the test generator to generate tests using emulation so as to generate a test for a specific viewport, device, color scheme, as well as emulate the geolocation, language or timezone. The test generator can also generate a test while preserving authenticated state.

--- a/docs/src/codegen.md
+++ b/docs/src/codegen.md
@@ -155,6 +155,25 @@ You can generate [locators](/locators.md) with the test generator.
 
 ![picking a locator](https://github.com/microsoft/playwright/assets/13063165/1478f56f-422f-4276-9696-0674041f11dc)
 
+## Docker DevContainers & GitHub Codespaces
+
+For Docker and GitHub Codespaces environments, you can generate tests using the `noVNC` viewer built into the Playwright Docker image. In order for the VNC webviewer to be accessible outside of the container, you can enable the `desktop-lite` feature and specify the `webPort` in your `.devcontainer/devcontainer.json` file: 
+
+```json
+{
+  "image": "mcr.microsoft.com/playwright:v1.57.0",
+  "forwardPorts": [6080],
+  "features": {
+    "desktop-lite": {
+      "webPort": "6080"
+    }
+  }
+}
+```
+
+Once this is enabled you can open the port specified in a new browser tab and you will have access to the `noVNC` web viewer, and will be able to record tests and use codegen directly on your container.
+
+
 ## Emulation
 
 You can use the test generator to generate tests using emulation so as to generate a test for a specific viewport, device, color scheme, as well as emulate the geolocation, language or timezone. The test generator can also generate a test while preserving authenticated state.

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -190,6 +190,24 @@ This makes `hostmachine` point to the host's localhost. Your tests should use `h
 When running tests remotely, ensure the Playwright version in your tests matches the version running in the Docker container.
 :::
 
+### Connecting using noVNC and GitHub Codespaces
+
+For Docker and GitHub Codespaces environments, you can view and generate tests using the `noVNC` viewer built into the Docker image. In order for the VNC webviewer to be accessible outside of the container, you can enable the `desktop-lite` feature and specify the `webPort` in your `.devcontainer/devcontainer.json` file: 
+
+```json
+{
+  "image": "mcr.microsoft.com/playwright:v1.57.0",
+  "forwardPorts": [6080],
+  "features": {
+    "desktop-lite": {
+      "webPort": "6080"
+    }
+  }
+}
+```
+
+Once this is enabled you can open the port specified in a new browser tab and you will have access to the `noVNC` web viewer. This will enable you to record tests, pick selectors, and use codegen directly on your container.
+
 ## Image tags
 
 See [all available image tags].

--- a/docs/src/test-ui-mode-js.md
+++ b/docs/src/test-ui-mode-js.md
@@ -128,5 +128,5 @@ npx playwright test --ui-port=8080 --ui-host=0.0.0.0
 ```
 
 :::note
-Be aware that when specifying the `--ui-host=0.0.0.0` flag, UI Mode with your traces, the passwords and secrets is accessible from other machines inside your network. In the case of GitHub Codespaces, the ports are only accessible from your account by default.
+Be aware that when specifying the `--ui-host=0.0.0.0` flag, UI Mode with your traces, the passwords and secrets are accessible from other machines inside your network. In the case of GitHub Codespaces, the ports are only accessible from your account by default.
 :::


### PR DESCRIPTION
Adds info about how to use noVNC on GitHub Codespaces which is very useful, but isn't currently documented.

Also fixes a grammatical typo on `docs/src/test-ui-mode-js.md`