### PR TITLE
docs: fix incorrect time format in Java input example

### DIFF
--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -33,7 +33,7 @@ page.getByRole(AriaRole.TEXTBOX).fill("Peter");
 page.getByLabel("Birth date").fill("2020-02-02");
 
 // Time input
-page.getByLabel("Appointment time").fill("13-15");
+page.getByLabel("Appointment time").fill("13:15");
 
 // Local datetime input
 page.getByLabel("Local time").fill("2020-03-02T05:15");


### PR DESCRIPTION
### Description
Fixed a typo in the Java documentation snippet for filling a time input.

### Changes
- In `docs/src/input.md` (or the relevant file): Changed `.fill("13-15")` to `.fill("13:15")`.

### Reason
HTML `<input type="time">` elements expect the value to be in `HH:mm` format (ISO 8601). The previous value `"13-15"` is invalid and would be rejected by the browser, causing the input to remain empty or throw an error.