### PR TITLE
docs: fix compilation error by using assertThat in checkboxes example

### DIFF
--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -101,7 +101,7 @@ await page.getByLabel('XL').check();
 page.getByLabel("I agree to the terms above").check();
 
 // Assert the checked state
-assertTrue(page.getByLabel("Subscribe to newsletter")).isChecked();
+assertThat(page.getByLabel("Subscribe to newsletter")).isChecked();
 
 // Select the radio button
 page.getByLabel("XL").check();


### PR DESCRIPTION
Fixed a syntax error in the Java checkboxes example by replacing the broken assertTrue call with the correct assertThat assertion.

The original code assertTrue(page.getByLabel(...)).isChecked(); does not compile because:

assertTrue expects a boolean argument, not a Locator.

.isChecked() cannot be chained after assertTrue.

Switching to assertThat(locator).isChecked() fixes the compilation error and ensures the assertion works as intended using Playwright's test assertions.