### PR TITLE
chore(chromium): request swift shader on all platforms

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -316,10 +316,8 @@ export class Chromium extends BrowserType {
       throw new Error('Arguments can not specify page to be opened');
     const chromeArguments = [...chromiumSwitches(options.assistantMode, options.channel)];
 
-    if (os.platform() === 'darwin') {
-      // See https://issues.chromium.org/issues/40277080
-      chromeArguments.push('--enable-unsafe-swiftshader');
-    }
+    // See https://issues.chromium.org/issues/40277080
+    chromeArguments.push('--enable-unsafe-swiftshader');
 
     if (options.headless) {
       chromeArguments.push('--headless');


### PR DESCRIPTION
Swift shader is being progressively put behind a flag.
Recent change: https://chromium-review.googlesource.com/c/chromium/src/+/7128438.
Tracking issue: https://issues.chromium.org/u/1/issues/40277080.

See failing roll #38437.