### PR TITLE
docs: standardize date format pattern to 'yyyy' in Java clock example

### DIFF
--- a/docs/src/clock.md
+++ b/docs/src/clock.md
@@ -84,7 +84,7 @@ expect(page.get_by_test_id("current-time")).to_have_text("2/2/2024, 10:30:00 AM"
 ```
 
 ```java
-SimpleDateFormat format = new SimpleDateFormat("yyy-MM-dd'T'HH:mm:ss");
+SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 page.clock().setFixedTime(format.parse("2024-02-02T10:00:00"));
 page.navigate("http://localhost:3333");
 Locator locator = page.getByTestId("current-time");
@@ -178,7 +178,7 @@ expect(page.get_by_test_id("current-time")).to_have_text("2/2/2024, 10:30:00 AM"
 ```java
 // Initialize clock with some time before the test time and let the page load
 // naturally. `Date.now` will progress as the timers fire.
-SimpleDateFormat format = new SimpleDateFormat("yyy-MM-dd'T'HH:mm:ss");
+SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 page.clock().install(new Clock.InstallOptions().setTime(format.parse("2024-02-02T08:00:00")));
 page.navigate("http://localhost:3333");
 Locator locator = page.getByTestId("current-time");
@@ -396,7 +396,7 @@ expect(locator).to_have_text("2/2/2024, 10:00:02 AM")
 ```
 
 ```java
-SimpleDateFormat format = new SimpleDateFormat("yyy-MM-dd'T'HH:mm:ss");
+SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 // Initialize clock with a specific time, let the page load naturally.
 page.clock().install(new Clock.InstallOptions()
     .setTime(format.parse("2024-02-02T08:00:00")));


### PR DESCRIPTION
Changed the SimpleDateFormat pattern from yyy to yyyy. Although yyy works for parsing 4-digit years due to lenient parsing rules, yyyy is the standard ISO 8601 convention and is less confusing for developers using the documentation as a reference.