### PR TITLE
chore(chromium-tip-of-tree): roll to 1389

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -17,16 +17,16 @@
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1384",
+      "revision": "1389",
       "installByDefault": false,
-      "browserVersion": "143.0.7499.25",
+      "browserVersion": "144.0.7559.3",
       "title": "Chrome Canary for Testing"
     },
     {
       "name": "chromium-tip-of-tree-headless-shell",
-      "revision": "1384",
+      "revision": "1389",
       "installByDefault": false,
-      "browserVersion": "143.0.7499.25",
+      "browserVersion": "144.0.7559.3",
       "title": "Chrome Canary Headless Shell"
     },
     {

--- a/tests/library/inspector/cli-codegen-1.spec.ts
+++ b/tests/library/inspector/cli-codegen-1.spec.ts
@@ -990,7 +990,8 @@ await page.GetByText("Click me").ClickAsync(new()
       const { x, y, width, height } = await page.locator('input').boundingBox();
       await page.mouse.move(x + width / 2, y + height / 2);
       await page.mouse.down();
-      await page.mouse.move(x + width, y + height / 2);
+      // Dragging to the exact edge is not registered as slider change, so drag close to the end.
+      await page.mouse.move(x + width - 3, y + height / 2);
       await page.mouse.up();
     };
 

--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -131,8 +131,12 @@ browserTest.describe('page screenshot', () => {
     await context.close();
   });
 
-  browserTest('should work with large size', async ({ browserName, headless, platform, contextFactory }) => {
+  browserTest('should work with large size', {
+    annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/4038' },
+  }, async ({ browserName, headless, platform, contextFactory, channel }) => {
     browserTest.fixme(browserName === 'chromium' && !headless && platform === 'linux', 'Chromium has gpu problems on linux with large screenshots');
+    // TODO: figure this out. https://github.com/microsoft/playwright/issues/38476
+    browserTest.fixme(platform === 'darwin' && channel === 'chromium-tip-of-tree', 'SwiftShader is forced on Mac, and does not render below 8192px');
     browserTest.slow(true, 'Large screenshot is slow');
 
     const context = await contextFactory();


### PR DESCRIPTION
There was a small change in behavior of the browser: dragging a slider outside of its bounds in a single mousemove does not update the value. To overcome this, we drag right to the edge, but not further.