### PR TITLE
chore(chromium): allow AcceptCHFrame feature

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -18,8 +18,6 @@
 // No dependencies as it is used from the Electron loader.
 
 const disabledFeatures = (assistantMode?: boolean) => [
-  // See https://github.com/microsoft/playwright/pull/10380
-  'AcceptCHFrame',
   // See https://github.com/microsoft/playwright/issues/14047
   'AvoidUnnecessaryBeforeUnloadCheckSync',
   'DestroyProfileOnBrowserClose',


### PR DESCRIPTION
This feature was disabled by #10380. See [this comment](https://github.com/microsoft/playwright/issues/10376#issuecomment-993034701) for investigation notes.

While the network request restart is still present in CDP, #27429 fixed the similar problem in `CRNetworkManager`. I assume it has also fixed #10376, because the issue does not reproduce today.

References #10376.