### PR TITLE
chore: get rid of url.parse

### DIFF
--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -49,12 +49,12 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
 
   const proxyURL = getProxyForUrl(params.url);
   if (proxyURL) {
+    const parsedProxyURL = normalizeProxyURL(proxyURL);
     if (params.url.startsWith('http:')) {
-      const parsedProxyURL = normalizeProxyURL(proxyURL);
       parsedProxyURL.pathname = url.toString();
       url = parsedProxyURL;
     } else {
-      options.agent = new HttpsProxyAgent(normalizeProxyURL(proxyURL));
+      options.agent = new HttpsProxyAgent(parsedProxyURL);
       options.rejectUnauthorized = false;
     }
   }

--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -18,7 +18,6 @@
 import http from 'http';
 import http2 from 'http2';
 import https from 'https';
-import url from 'url';
 
 import { HttpsProxyAgent, SocksProxyAgent, getProxyForUrl } from '../../utilsBundle';
 import { httpHappyEyeballsAgent, httpsHappyEyeballsAgent } from './happyEyeballs';
@@ -40,10 +39,8 @@ export type HTTPRequestParams = {
 export const NET_DEFAULT_TIMEOUT = 30_000;
 
 export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.IncomingMessage) => void, onError: (error: Error) => void): { cancel(error: Error | undefined): void } {
-  const parsedUrl = url.parse(params.url);
-  let options: https.RequestOptions = {
-    ...parsedUrl,
-    agent: parsedUrl.protocol === 'https:' ? httpsHappyEyeballsAgent : httpHappyEyeballsAgent,
+  let url = new URL(params.url);
+  const options: https.RequestOptions = {
     method: params.method || 'GET',
     headers: params.headers,
   };
@@ -53,20 +50,16 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
   const proxyURL = getProxyForUrl(params.url);
   if (proxyURL) {
     if (params.url.startsWith('http:')) {
-      const parsedProxyURL = url.parse(proxyURL);
-      options = {
-        path: parsedUrl.href,
-        host: parsedProxyURL.hostname,
-        port: parsedProxyURL.port,
-        protocol: parsedProxyURL.protocol || 'http:',
-        headers: options.headers,
-        method: options.method
-      };
+      const parsedProxyURL = normalizeProxyURL(proxyURL);
+      parsedProxyURL.pathname = url.toString();
+      url = parsedProxyURL;
     } else {
       options.agent = new HttpsProxyAgent(normalizeProxyURL(proxyURL));
       options.rejectUnauthorized = false;
     }
   }
+
+  options.agent ??= url.protocol === 'https:' ? httpsHappyEyeballsAgent : httpHappyEyeballsAgent;
 
   let cancelRequest: (e: Error | undefined) => void;
   const requestCallback = (res: http.IncomingMessage) => {
@@ -80,9 +73,9 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
       onResponse(res);
     }
   };
-  const request = options.protocol === 'https:' ?
-    https.request(options, requestCallback) :
-    http.request(options, requestCallback);
+  const request = url.protocol === 'https:' ?
+    https.request(url, options, requestCallback) :
+    http.request(url, options, requestCallback);
   request.on('error', onError);
   if (params.socketTimeout !== undefined) {
     request.setTimeout(params.socketTimeout, () =>  {

--- a/tests/library/inspector/cli-codegen-2.spec.ts
+++ b/tests/library/inspector/cli-codegen-2.spec.ts
@@ -15,7 +15,6 @@
  */
 
 import { test, expect } from './inspectorTest';
-import * as url from 'url';
 import fs from 'fs';
 
 test.describe('cli codegen', () => {
@@ -200,7 +199,7 @@ await page.GetByRole(AriaRole.Button, new() { Name = "Choose File" }).SetInputFi
     const { page, recorder } = await openRecorder();
 
     server.setRoute('/download', (req, res) => {
-      const pathName = url.parse(req.url!).path;
+      const pathName = new URL(req.url, 'http://localhost').pathname;
       if (pathName === '/download') {
         res.setHeader('Content-Type', 'application/octet-stream');
         res.setHeader('Content-Disposition', 'attachment; filename=file.txt');

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -17,7 +17,6 @@
 import * as fs from 'fs';
 import type { PlaywrightTestConfig } from '@playwright/test';
 import path from 'path';
-import url from 'url';
 import type { HttpServer } from '../../packages/playwright-core/lib/server/utils/httpServer';
 import { startHtmlReportServer } from '../../packages/playwright/lib/reporters/html';
 import { expect as baseExpect, test as baseTest, stripAnsi } from './playwright-test-fixtures';
@@ -684,7 +683,7 @@ test('generate html with attachment urls', async ({ runInlineTest, mergeReports,
 
   const oldServeFile = server.serveFile;
   server.serveFile = async (req, res) => {
-    const pathName = url.parse(req.url!).pathname!;
+    const pathName = new URL(req.url, 'http://localhost').pathname!;
     const filePath = path.join(reportDir, pathName.substring(1));
     return oldServeFile.call(server, req, res, filePath);
   };


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/38469#issuecomment-3626374147. In DotNet, the Playwright binary is in a `driver/` folder, not in `node_modules`, so the warning about `url.parse` gets printed.