### PR TITLE
chore(bidi): add support for emulation.setScreenSettingsOverride

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -337,7 +337,7 @@ export class BidiBrowserContext extends BrowserContext {
   async doUpdateExtraHTTPHeaders(): Promise<void> {
     const allHeaders = this._options.extraHTTPHeaders || [];
     await this._browser._browserSession.send('network.setExtraHeaders', {
-      headers: allHeaders.map(({ name, value }) => ({ name, value: { type: 'string', value } })),
+      headers: allHeaders.map(({ name, value }) => ({ name, value: { type: 'string' as 'string', value } })),
       userContexts: [this._userContextId()],
     });
   }
@@ -395,19 +395,29 @@ export class BidiBrowserContext extends BrowserContext {
   }
 
   override async doUpdateDefaultViewport() {
-    if (!this._options.viewport)
+    if (!this._options.viewport && !this._options.screen)
       return;
+
+    const screenSize = (this._options.screen || this._options.viewport)!;
+    const viewportSize = (this._options.viewport || this._options.screen)!;
     await Promise.all([
       this._browser._browserSession.send('browsingContext.setViewport', {
         viewport: {
-          width: this._options.viewport.width,
-          height: this._options.viewport.height
+          width: viewportSize.width,
+          height: viewportSize.height
         },
         devicePixelRatio: this._options.deviceScaleFactor || 1,
         userContexts: [this._userContextId()],
       }),
       this._browser._browserSession.send('emulation.setScreenOrientationOverride', {
-        screenOrientation: getScreenOrientation(!!this._options.isMobile, this._options.viewport),
+        screenOrientation: getScreenOrientation(!!this._options.isMobile, screenSize),
+        userContexts: [this._userContextId()],
+      }),
+      this._browser._browserSession.send('emulation.setScreenSettingsOverride', {
+        screenArea: {
+          width: screenSize.width,
+          height: screenSize.height,
+        },
         userContexts: [this._userContextId()],
       })
     ]);

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -315,7 +315,7 @@ export class BidiPage implements PageDelegate {
       this._page.extraHTTPHeaders(),
     ]);
     await this._session.send('network.setExtraHeaders', {
-      headers: allHeaders.map(({ name, value }) => ({ name, value: { type: 'string', value } })),
+      headers: allHeaders.map(({ name, value }) => ({ name, value: { type: 'string' as 'string', value } })),
       contexts: [this._session.sessionId],
     });
   }
@@ -337,6 +337,7 @@ export class BidiPage implements PageDelegate {
     const emulatedSize = this._page.emulatedSize();
     if (!emulatedSize)
       return;
+    const screenSize = emulatedSize.screen;
     const viewportSize = emulatedSize.viewport;
     await Promise.all([
       this._session.send('browsingContext.setViewport', {
@@ -349,7 +350,14 @@ export class BidiPage implements PageDelegate {
       }),
       this._session.send('emulation.setScreenOrientationOverride', {
         contexts: [this._session.sessionId],
-        screenOrientation: getScreenOrientation(!!options.isMobile, viewportSize)
+        screenOrientation: getScreenOrientation(!!options.isMobile, screenSize)
+      }),
+      this._session.send('emulation.setScreenSettingsOverride', {
+        contexts: [this._session.sessionId],
+        screenArea: {
+          width: screenSize.width,
+          height: screenSize.height,
+        }
       })
     ]);
   }

--- a/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiCommands.d.ts
@@ -117,6 +117,10 @@ export interface Commands {
     params: Bidi.Emulation.SetGeolocationOverrideParameters;
     returnType: Bidi.EmptyResult;
   };
+  'emulation.setScreenSettingsOverride': {
+    params: Bidi.Emulation.SetScreenSettingsOverrideParameters;
+    returnType: Bidi.SetScreenSettingsOverrideResult;
+  };
   'emulation.setScreenOrientationOverride': {
     params: Bidi.Emulation.SetScreenOrientationOverrideParameters;
     returnType: Bidi.EmptyResult;

--- a/packages/playwright-core/src/server/bidi/third_party/bidiProtocolCore.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiProtocolCore.ts
@@ -212,7 +212,7 @@ export namespace Session {
   export type Subscription = string;
 }
 export namespace Session {
-  export type SubscriptionRequest = {
+  export type SubscribeParameters = {
     events: [string, ...string[]];
     contexts?: [
       BrowsingContext.BrowsingContext,
@@ -282,7 +282,7 @@ export namespace Session {
 export namespace Session {
   export type Subscribe = {
     method: 'session.subscribe';
-    params: Session.SubscriptionRequest;
+    params: Session.SubscribeParameters;
   };
 }
 export namespace Session {
@@ -1052,6 +1052,7 @@ export type EmulationCommand =
   | Emulation.SetForcedColorsModeThemeOverride
   | Emulation.SetGeolocationOverride
   | Emulation.SetLocaleOverride
+  | Emulation.SetNetworkConditions
   | Emulation.SetScreenOrientationOverride
   | Emulation.SetScriptingEnabled
   | Emulation.SetTimezoneOverride
@@ -1177,6 +1178,58 @@ export namespace Emulation {
 }
 export namespace Emulation {
   export type SetLocaleOverrideResult = EmptyResult;
+}
+export namespace Emulation {
+  export type SetNetworkConditions = {
+    method: 'emulation.setNetworkConditions';
+    params: Emulation.SetNetworkConditionsParameters;
+  };
+}
+export namespace Emulation {
+  export type SetNetworkConditionsParameters = {
+    networkConditions: Emulation.NetworkConditions | null;
+    contexts?: [
+      BrowsingContext.BrowsingContext,
+      ...BrowsingContext.BrowsingContext[],
+    ];
+    userContexts?: [Browser.UserContext, ...Browser.UserContext[]];
+  };
+}
+export namespace Emulation {
+  export type NetworkConditions = Emulation.NetworkConditionsOffline;
+}
+export namespace Emulation {
+  export type NetworkConditionsOffline = {
+    type: 'offline';
+  };
+}
+export namespace Emulation {
+  export type SetNetworkConditionsResult = EmptyResult;
+}
+export namespace Emulation {
+  export type SetScreenSettingsOverride = {
+    method: 'emulation.setScreenSettingsOverride';
+    params: Emulation.SetScreenSettingsOverrideParameters;
+  };
+}
+export namespace Emulation {
+  export type ScreenArea = {
+    width: JsUint;
+    height: JsUint;
+  };
+}
+export namespace Emulation {
+  export type SetScreenSettingsOverrideParameters = {
+    screenArea: Emulation.ScreenArea | null;
+    contexts?: [
+      BrowsingContext.BrowsingContext,
+      ...BrowsingContext.BrowsingContext[],
+    ];
+    userContexts?: [Browser.UserContext, ...Browser.UserContext[]];
+  };
+}
+export namespace Emulation {
+  export type SetScreenSettingsOverrideResult = EmptyResult;
 }
 export namespace Emulation {
   export type SetScreenOrientationOverride = {
@@ -1383,6 +1436,7 @@ export namespace Network {
 }
 export namespace Network {
   export const enum DataType {
+    Request = 'request',
     Response = 'response',
   }
 }

--- a/tests/library/browsercontext-viewport.spec.ts
+++ b/tests/library/browsercontext-viewport.spec.ts
@@ -128,8 +128,8 @@ browserTest('should support touch with null viewport', async ({ browser, server 
   await context.close();
 });
 
-it('should set both screen and viewport options', async ({ contextFactory, browserName }) => {
-  it.fail(browserName === 'firefox', 'Screen size is reset to viewport');
+it('should set both screen and viewport options', async ({ contextFactory, browserName, channel }) => {
+  it.fail(browserName === 'firefox' && !channel?.startsWith('moz-firefox'), 'Screen size is reset to viewport');
   const context = await contextFactory({
     screen: { 'width': 1280, 'height': 720 },
     viewport: { 'width': 1000, 'height': 600 },


### PR DESCRIPTION
Fixes #38448 and the following tests:
- `tests/library/browsercontext-device.spec.ts`:
  - "should emulate viewport and screen size"
  - "should emulate viewport without screen size"
- `tests/library/browsercontext-viewport.spec.ts`:
  - "should emulate device width"
  - "should emulate device height"
  - "should emulate availWidth and availHeight"
  - "should set both screen and viewport options"