### PR TITLE
fix(routeFromHAR, take 2): hack harRouter to merge set-cookie headers

### DIFF
--- a/tests/assets/har-fulfill.har
+++ b/tests/assets/har-fulfill.har
@@ -62,6 +62,14 @@
             {
               "name": "content-type",
               "value": "text/html"
+            },
+            {
+              "name": "Set-Cookie",
+              "value": "playwright=works;"
+            },
+            {
+              "name": "Set-Cookie",
+              "value": "with=multiple-set-cookie-headers;"
             }
           ],
           "content": {

--- a/tests/assets/har-fulfill.har
+++ b/tests/assets/har-fulfill.har
@@ -62,14 +62,6 @@
             {
               "name": "content-type",
               "value": "text/html"
-            },
-            {
-              "name": "Set-Cookie",
-              "value": "playwright=works;"
-            },
-            {
-              "name": "Set-Cookie",
-              "value": "with=multiple-set-cookie-headers;"
             }
           ],
           "content": {

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -470,13 +470,12 @@ it('should record single set-cookie headers', {
   });
 
   const harPath = testInfo.outputPath('har.zip');
-  console.log('HAR path:', harPath);
   const context1 = await contextFactory();
   await context1.routeFromHAR(harPath, { update: true });
   const page1 = await context1.newPage();
   await page1.goto(server.EMPTY_PAGE);
   const cookie1 = await page1.evaluate(() => document.cookie);
-  expect(cookie1.split('; ').sort().join('; ')).toBe('first=foo');
+  expect(cookie1).toBe('first=foo');
   await context1.close();
 
   const context2 = await contextFactory();
@@ -484,7 +483,7 @@ it('should record single set-cookie headers', {
   const page2 = await context2.newPage();
   await page2.goto(server.EMPTY_PAGE);
   const cookie2 = await page2.evaluate(() => document.cookie);
-  expect(cookie2.split('; ').sort().join('; ')).toBe('first=foo');
+  expect(cookie2).toBe('first=foo');
 });
 
 it('should record multiple set-cookie headers', {
@@ -497,7 +496,6 @@ it('should record multiple set-cookie headers', {
   });
 
   const harPath = testInfo.outputPath('har.zip');
-  console.log('HAR path:', harPath);
   const context1 = await contextFactory();
   await context1.routeFromHAR(harPath, { update: true });
   const page1 = await context1.newPage();

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -358,14 +358,6 @@ it('should record overridden requests to har', async ({ contextFactory, server }
   expect(await page2.evaluate(fetchFunction, { path: '/echo', body: '12' })).toBe('12');
 });
 
-it('should replay requests with multiple set-cookie headers properly', async ({ context, asset }) => {
-  const path = asset('har-fulfill.har');
-  await context.routeFromHAR(path);
-  const page = await context.newPage();
-  await page.goto('http://no.playwright/');
-  expect(await page.context().cookies()).toEqual([expect.objectContaining({ name: 'playwright', value: 'works' }), expect.objectContaining({ name: 'with', value: 'multiple-set-cookie-headers' })]);
-});
-
 it('should disambiguate by header', async ({ contextFactory, server }, testInfo) => {
   server.setRoute('/echo', async (req, res) => {
     res.end(req.headers['baz']);


### PR DESCRIPTION
This was previously closed in https://github.com/microsoft/playwright/pull/38255 due to inactivity. This PR has been updated with the feedback from @yury-s on the previous PR to avoid a bug with single set-cookie headers.

Following PR description is copied from the original: 

Route.fulfill currently does not support multiple headers with the same name (#37342). There are workarounds when using this API directly (merging headers, tweaking the header name casing, etc.), but this is problematic for routeFromHAR, which depends on
this API internally. This patch adds special handling for set-cookie headers within harRouter to merge them into one header. There's some precedent for treating set-cookie specially at various places in the codebase (ex:
https://github.com/microsoft/playwright/blob/f54478a23e0daa450fe524905eabc8aabf6efb07/packages/playwright-core/src/utils/isomorphic/headers.ts#L29, https://github.com/microsoft/playwright/blob/baeb065e9ea84502f347129a0b896a85d2a8dada/packages/playwright-core/src/server/chromium/crNetworkManager.ts#L675), so I think this is okay.