### PR TITLE
docs: fix compilation errors in locator filtering code snippet

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -942,10 +942,10 @@ await page
 ```java
 page.getByRole(AriaRole.LISTITEM)
     .filter(new Locator.FilterOptions()
-        .setHas(page.GetByRole(AriaRole.HEADING, new Page.GetByRoleOptions()
+        .setHas(page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions()
         .setName("Product 2"))))
     .getByRole(AriaRole.BUTTON,
-               new Page.GetByRoleOptions().setName("Add to cart"))
+               new Locator.GetByRoleOptions().setName("Add to cart"))
     .click();
 ```
 


### PR DESCRIPTION
### Description

This PR fixes multiple compilation errors in the Java documentation code snippet.

1.  **Case Sensitivity:** Replaced `page.GetByRole` (PascalCase) with `page.getByRole` (camelCase) to comply with Java naming conventions.
2.  **Type Mismatch:** The chained `.getByRole(...)` method is called on a `Locator`, so it requires `new Locator.GetByRoleOptions()` instead of `new Page.GetByRoleOptions()`.

### Changes

- Fixed method name casing.
- Fixed incorrect Options class type for Locator chaining.