### PR TITLE
docs: fix compilation error in locator filter example

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -910,7 +910,7 @@ expect(page.get_by_role("listitem").filter(has_not_text="Out of stock")).to_have
 
 ```csharp
 // 5 in-stock items
-await Expect(Page.getByRole(AriaRole.Listitem).Filter(new() { HasNotText = "Out of stock" }))
+await Expect(Page.GetByRole(AriaRole.Listitem).Filter(new() { HasNotText = "Out of stock" }))
     .ToHaveCountAsync(5);
 ```
 


### PR DESCRIPTION
This PR fixes a compilation error in the C# code snippet within the "Filter by not having text" section.

The example currently uses `Page.getByRole` (camelCase), which is incorrect for the .NET language binding. Playwright .NET follows PascalCase naming conventions, and the current code causes a compile-time error (CS1061).

**Change:**
- `Page.getByRole` -> `Page.GetByRole`