### PR TITLE
docs: fix syntax error in locator filter options constructor

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -1313,7 +1313,7 @@ Consider a page with two buttons, the first invisible and the second [visible](.
   await page.locator('button').filter({ visible: true }).click();
   ```
   ```java
-  page.locator("button").filter(new Locator.FilterOptions.setVisible(true)).click();
+  page.locator("button").filter(new Locator.FilterOptions().setVisible(true)).click();
   ```
   ```python async
   await page.locator("button").filter(visible=True).click()


### PR DESCRIPTION
This PR fixes a Java syntax error in the "Matching only visible elements" section.

The example code was missing parentheses `()` when instantiating `Locator.FilterOptions`. The current code `new Locator.FilterOptions.setVisible(true)` is invalid Java syntax and causes a compilation error.

**Change:**
- `new Locator.FilterOptions.setVisible(true)` -> `new Locator.FilterOptions().setVisible(true)`