### PR TITLE
test: unflake/fix/delete some tests

### DIFF
--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -24,7 +24,12 @@ it('SharedArrayBuffer should work @smoke', async function({ contextFactory, http
   httpsServer.setRoute('/sharedarraybuffer', (req, res) => {
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
     res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
-    res.end();
+    // Note: without 'onload', Firefox sometimes does not fire the load event
+    // over the protocol. The reason is unclear.
+    res.end(`
+      <div>Hello there!</div>
+      <script>window.onload = () => console.log('onload')</script>
+    `);
   });
   await page.goto(httpsServer.PREFIX + '/sharedarraybuffer');
   expect(await page.evaluate(() => typeof SharedArrayBuffer)).toBe('function');

--- a/tests/page/page-emulate-media.spec.ts
+++ b/tests/page/page-emulate-media.spec.ts
@@ -156,7 +156,12 @@ it('should keep reduced motion and color emulation after reload', async ({ page,
   // Force CanonicalBrowsingContext replacement in Firefox.
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-    res.end();
+    // Note: without 'onload', Firefox sometimes does not fire the load event
+    // over the protocol. The reason is unclear.
+    res.end(`
+      <div>Hello there!</div>
+      <script>window.onload = () => console.log('onload')</script>
+    `);
   });
   await page.goto(server.EMPTY_PAGE);
 

--- a/tests/page/page-goto.spec.ts
+++ b/tests/page/page-goto.spec.ts
@@ -119,7 +119,12 @@ it('should work with Cross-Origin-Opener-Policy', async ({ page, server }) => {
 it('should work with Cross-Origin-Opener-Policy and interception', async ({ page, server }) => {
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-    res.end();
+    // Note: without 'onload', Firefox sometimes does not fire the load event
+    // over the protocol. The reason is unclear.
+    res.end(`
+      <div>Hello there!</div>
+      <script>window.onload = () => console.log('onload')</script>
+    `);
   });
   const requests = new Set();
   const events = [];
@@ -155,7 +160,12 @@ it('should work with Cross-Origin-Opener-Policy after redirect', async ({ page, 
   server.setRedirect('/redirect', '/empty.html');
   server.setRoute('/empty.html', (req, res) => {
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-    res.end();
+    // Note: without 'onload', Firefox sometimes does not fire the load event
+    // over the protocol. The reason is unclear.
+    res.end(`
+      <div>Hello there!</div>
+      <script>window.onload = () => console.log('onload')</script>
+    `);
   });
   const requests = new Set();
   const events = [];

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -299,7 +299,12 @@ it('should work with Cross-Origin-Opener-Policy', async ({ page, server, browser
     serverRequests.push(req.url);
     serverHeaders ??= req.headers;
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-    res.end();
+    // Note: without 'onload', Firefox sometimes does not fire the load event
+    // over the protocol. The reason is unclear.
+    res.end(`
+      <div>Hello there!</div>
+      <script>window.onload = () => console.log('onload')</script>
+    `);
   });
 
   const intercepted = [];

--- a/tests/page/wheel.spec.ts
+++ b/tests/page/wheel.spec.ts
@@ -67,37 +67,6 @@ it('should dispatch wheel events @smoke', async ({ page, server }) => {
   });
 });
 
-it('should dispatch wheel events after context menu was opened', async ({ page, browserName, isWindows, channel }) => {
-  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/20823' });
-  it.fixme(browserName === 'firefox' && !channel?.startsWith('moz-firefox'));
-  it.skip(browserName === 'chromium' && isWindows, 'context menu support is best-effort for Linux and MacOS');
-
-  await page.setContent(`<div style="width: 5000px; height: 5000px;"></div>`);
-  await page.mouse.move(50, 60);
-  await page.evaluate(() => {
-    window['contextMenuPromise'] = new Promise(x => {
-      window.addEventListener('contextmenu', x, false);
-    });
-  });
-  await page.mouse.down({ button: 'right' });
-  await page.evaluate(() => window['contextMenuPromise']);
-
-  await listenForWheelEvents(page, 'div');
-  await page.mouse.wheel(0, 100);
-  await page.waitForFunction('window.scrollY === 100');
-  await expectEvent(page, {
-    deltaX: 0,
-    deltaY: 100,
-    clientX: 50,
-    clientY: 60,
-    deltaMode: 0,
-    ctrlKey: false,
-    shiftKey: false,
-    altKey: false,
-    metaKey: false,
-  });
-});
-
 it('should dispatch wheel events after popup was opened @smoke', async ({ page, server }) => {
   await page.setContent(`
     <div style="width: 5000px; height: 5000px;"></div>


### PR DESCRIPTION
The test `should dispatch wheel events after context menu was opened` was added in #21081, and it tests a "best-effort" edge case as stated in the test itself. Given that it's flaky, we are better off without the test.