### PR TITLE
chore: fix vscode test failure

### DIFF
--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -471,13 +471,13 @@ export class TestInfoImpl implements TestInfo {
         this._callbacks.onTestPaused!({ testId: this.testId, stepId: step.stepId, errors: this._isFailure() ? this.errors : [] }),
         this._interruptedPromise.then(() => 'interrupted' as const),
       ]);
-      step.complete({});
       if (result !== 'interrupted') {
         if (result.action === 'abort')
           this._interrupt();
         if (result.action === undefined)
           await this._interruptedPromise;
       }
+      step.complete({});
     }
     await this._onDidFinishTestFunctionCallback?.();
   }


### PR DESCRIPTION
When no reporter replies to `onTestPaused`, as with the extension, then we currently end the `Paused` step even though we're clearly still paused until there's an interrupt. The extensions's tests are asserting on `onStepEnd`, though, and are getting confused that a step end sneaks into the pause: 
<img width="1063" height="381" alt="Screenshot 2025-12-11 at 11 14 02" src="https://github.com/user-attachments/assets/5d9b8573-4fdc-418b-b6c3-29d08a7cd0b6" />

We could relax the tests, but conceptually it's wrong that the `Paused` step ends. So i'm just moving the end. There might be a little race around the `_interrupt` rejection and when exactly `step.complete` is called, but it seems fine in tests.