### PR TITLE
docs: fix multiple syntax errors in locator filters example

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -1031,9 +1031,9 @@ await expect(page
 assertThat(page
     .getByRole(AriaRole.LISTITEM)
     .filter(new Locator.FilterOptions()
-        .setHas(page.GetByRole(AriaRole.LIST)
-                    .GetByRole(AriaRole.HEADING,
-                               new Page.GetByRoleOptions().setName("Product 2")))))
+        .setHas(page.getByRole(AriaRole.LIST)
+                    .getByRole(AriaRole.HEADING,
+                               new Locator.GetByRoleOptions().setName("Product 2")))))
     .hasCount(1);
 ```
 


### PR DESCRIPTION
### **What does this PR do?** 
This PR fixes compilation errors in the Java code snippet for locator filters. Fixed issues:
1. Method Naming: Changed GetByRole (PascalCase) to getByRole (camelCase) to comply with Java syntax.
2. Type Mismatch: Changed new Page.GetByRoleOptions() to new Locator.GetByRoleOptions(). Since the method is chained on a Locator, it requires Locator.GetByRoleOptions. The previous code caused a compilation error due to incompatible types. 
### **Note:** 
The logic itself remains "wrong" intentionally (as per the example's purpose), but the code is now syntactically valid Java.