### PR TITLE
feat(trace-viewer): Re-arrange network tabs

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -23,6 +23,10 @@
   flex: none;
 }
 
+.network-request-no-payload {
+  margin-left: 14px;
+}
+
 .network-request-details-tab .expandable-title {
   padding-left: 3px;
   background-color: var(--vscode-sideBar-background);

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -154,9 +154,9 @@ const HeadersTab: React.FunctionComponent<{
   [resource, startTimeOffset]);
 
   return <div className='vbox network-request-details-tab'>
-    <ExpandableSection title='General' data={generalData}/>
+    <ExpandableSection title='General' data={generalData} />
+    <ExpandableSection title='Request Headers' showCount data={resource.request.headers} />
     <ExpandableSection title='Response Headers' showCount data={resource.response.headers} />
-    <ExpandableSection title='Request Headers' showCount data={resource.request.headers}/>
   </div>;
 };
 

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -38,7 +38,7 @@ export const NetworkResourceDetails: React.FunctionComponent<{
   startTimeOffset: number;
   onClose: () => void;
 }> = ({ resource, sdkLanguage, startTimeOffset, onClose }) => {
-  const [selectedTab, setSelectedTab] = React.useState('request');
+  const [selectedTab, setSelectedTab] = React.useState('headers');
   const model = useTraceModel();
 
   const requestBody = useAsyncMemo<RequestBody>(async () => {
@@ -57,24 +57,23 @@ export const NetworkResourceDetails: React.FunctionComponent<{
   }, [resource], null);
 
   return <TabbedPane
-    dataTestId='network-request-details'
     leftToolbar={[<ToolbarButton key='close' icon='close' title='Close' onClick={onClose} />]}
     rightToolbar={[<CopyDropdown key='dropdown' requestBody={requestBody} resource={resource} sdkLanguage={sdkLanguage} />]}
     tabs={[
       {
-        id: 'request',
-        title: 'Request',
-        render: () => <RequestTab resource={resource} startTimeOffset={startTimeOffset} requestBody={requestBody} />,
+        id: 'headers',
+        title: 'Headers',
+        render: () => <HeadersTab resource={resource} startTimeOffset={startTimeOffset} />,
+      },
+      {
+        id: 'payload',
+        title: 'Payload',
+        render: () => <PayloadTab resource={resource} requestBody={requestBody} />,
       },
       {
         id: 'response',
         title: 'Response',
-        render: () => <ResponseTab resource={resource}/>,
-      },
-      {
-        id: 'body',
-        title: 'Body',
-        render: () => <BodyTab resource={resource}/>,
+        render: () => <ResponseTab resource={resource} />,
       },
     ]}
     selectedTab={selectedTab}
@@ -140,31 +139,34 @@ const ExpandableSection: React.FC<{
   </Expandable>;
 };
 
-const RequestTab: React.FunctionComponent<{
+const HeadersTab: React.FunctionComponent<{
   resource: ResourceSnapshot;
   startTimeOffset: number;
-  requestBody: RequestBody,
-}> = ({ resource, startTimeOffset, requestBody }) => {
+}> = ({ resource, startTimeOffset }) => {
   const generalData = React.useMemo(() =>
     Object.entries({
       'URL': resource.request.url,
       'Method': resource.request.method,
       'Status Code': resource.response.status !== -1 && <span className={statusClass(resource.response.status)}> {resource.response.status} {resource.response.statusText}</span>,
-    }).map(([name, value]) => ({ name, value })),
-  [resource]);
-
-  const timeData = React.useMemo(() =>
-    Object.entries({
       'Start': msToString(startTimeOffset),
       'Duration': msToString(resource.time),
     }).map(([name, value]) => ({ name, value })),
-  [startTimeOffset, resource]);
+  [resource, startTimeOffset]);
 
   return <div className='vbox network-request-details-tab'>
     <ExpandableSection title='General' data={generalData}/>
-    {resource.request.queryString.length > 0 && <ExpandableSection title='Query String Parameters' showCount data={resource.request.queryString}/>}
+    <ExpandableSection title='Response Headers' showCount data={resource.response.headers} />
     <ExpandableSection title='Request Headers' showCount data={resource.request.headers}/>
-    <ExpandableSection title='Time' data={timeData}/>
+  </div>;
+};
+
+const PayloadTab: React.FunctionComponent<{
+  resource: ResourceSnapshot;
+  requestBody: RequestBody,
+}> = ({ resource, requestBody }) => {
+  return <div className='vbox network-request-details-tab'>
+    {resource.request.queryString.length === 0 && !requestBody && <em className='network-request-no-payload'>No payload for this request.</em>}
+    {resource.request.queryString.length > 0 && <ExpandableSection title='Query String Parameters' showCount data={resource.request.queryString}/>}
     {requestBody && <ExpandableSection title='Request Body' className='network-request-request-body'>
       <CodeMirrorWrapper text={requestBody.text} mimeType={requestBody.mimeType} readOnly lineNumbers={true}/>
     </ExpandableSection>}
@@ -172,14 +174,6 @@ const RequestTab: React.FunctionComponent<{
 };
 
 const ResponseTab: React.FunctionComponent<{
-  resource: ResourceSnapshot;
-}> = ({ resource }) => {
-  return <div className='vbox network-request-details-tab'>
-    <ExpandableSection title='Response Headers' showCount data={resource.response.headers} />
-  </div>;
-};
-
-const BodyTab: React.FunctionComponent<{
   resource: ResourceSnapshot;
 }> = ({ resource }) => {
   const model = useTraceModel();

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -47,6 +47,7 @@ class TraceViewerPage {
   metadataTab: Locator;
   snapshotContainer: Locator;
   sourceCodeTab: Locator;
+  networkTab: Locator;
 
   settingsDialog: Locator;
   themeSetting: Locator;
@@ -65,6 +66,7 @@ class TraceViewerPage {
     this.snapshotContainer = page.locator('.snapshot-container iframe.snapshot-visible[name=snapshot]');
     this.metadataTab = page.getByRole('tabpanel', { name: 'Metadata' });
     this.sourceCodeTab = page.getByRole('tabpanel', { name: 'Source' });
+    this.networkTab = page.getByRole('tabpanel', { name: 'Network' });
 
     this.settingsDialog = page.getByTestId('settings-toolbar-dialog');
     this.themeSetting = this.settingsDialog.getByRole('combobox', { name: 'Theme' });

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -478,8 +478,8 @@ test('should show font preview', async ({ page, runAndTrace, server }) => {
   await traceViewer.page.getByText('Font', { exact: true }).click();
   await expect(traceViewer.networkRequests).toHaveCount(1);
   await traceViewer.networkRequests.getByText('font.woff2').click();
-  await traceViewer.page.getByTestId('network-request-details').getByTitle('Body').click();
-  await expect(traceViewer.page.locator('.network-request-details-tab')).toContainText('ABCDEF');
+  await traceViewer.networkTab.getByRole('tab', { name: 'Response' }).click();
+  await expect(traceViewer.networkTab.getByRole('tabpanel', { name: 'Response' })).toContainText('ABCDEF');
 });
 
 test('should syntax highlight body', async ({ page, runAndTrace, server }) => {
@@ -493,8 +493,8 @@ test('should syntax highlight body', async ({ page, runAndTrace, server }) => {
   await traceViewer.page.getByText('HTML', { exact: true }).click();
   await expect(traceViewer.networkRequests).toHaveCount(1);
   await traceViewer.networkRequests.getByText('network.html').click();
-  await traceViewer.page.getByTestId('network-request-details').getByTitle('Body').click();
-  const keyword = traceViewer.page.locator('.network-request-details-tab').getByText('const').first();
+  await traceViewer.networkTab.getByRole('tab', { name: 'Response' }).click();
+  const keyword = traceViewer.networkTab.getByRole('tabpanel', { name: 'Response' }).getByText('const').first();
   await expect(keyword).toHaveClass('cm-keyword');
 });
 

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -152,8 +152,9 @@ test('should format JSON request body', async ({ runUITest, server }) => {
   await page.getByText('Network', { exact: true }).click();
 
   await page.getByText('post-data-1').click();
-
-  await expect(page.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+  await page.getByRole('tabpanel', { name: 'Network' }).getByRole('tab', { name: 'Payload' }).click();
+  const payloadPanel = page.getByRole('tabpanel', { name: 'Payload' });
+  await expect(payloadPanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
     '{',
     '  "data": {',
     '    "key": "value",',
@@ -167,7 +168,7 @@ test('should format JSON request body', async ({ runUITest, server }) => {
 
   await page.getByText('post-data-2').click();
 
-  await expect(page.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+  await expect(payloadPanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
     '{',
     '  "data": {',
     '    "key": "value",',
@@ -195,8 +196,9 @@ test('should display list of query parameters (only if present)', async ({ runUI
   await page.getByText('Network', { exact: true }).click();
 
   await page.getByText('call-with-query-params').click();
-
-  const region = page.getByRole('region', { name: 'Query String Parameters × 3' });
+  await page.getByRole('tabpanel', { name: 'Network' }).getByRole('tab', { name: 'Payload' }).click();
+  const payloadPanel = page.getByRole('tabpanel', { name: 'Payload' });
+  const region = payloadPanel.getByRole('region', { name: 'Query String Parameters × 3' });
   await expect(region).toMatchAriaSnapshot(
       `- table:
          - rowgroup:
@@ -261,23 +263,23 @@ test('should toggle sections inside network details', async ({ runUITest, server
   await page.getByRole('treeitem', { name: 'network tab test' }).dblclick();
   await page.getByRole('tab', { name: 'Network' }).click();
   await page.getByRole('listitem').filter({ hasText: 'post-data-1' }).click();
-  const requestPanel = page.getByRole('tabpanel', { name: 'Request' });
+  const headersPanel = page.getByRole('tabpanel', { name: 'Headers' });
 
-  await requestPanel.getByRole('button', { name: 'Request Headers × 16' }).click();
-  await expect(requestPanel.getByRole('region', { name: 'Request Headers × 16' })).toBeHidden();
-  await expect(requestPanel.getByRole('region', { name: 'Time' })).toHaveText(/Start.+Duration\d+ms/);
+  await headersPanel.getByRole('button', { name: 'Request Headers × 16' }).click();
+  await expect(headersPanel.getByRole('region', { name: 'Request Headers × 16' })).toBeHidden();
+  await expect(headersPanel.getByRole('region', { name: 'General' })).toContainText(/Start.+Duration\d+ms/);
 
-  await requestPanel.getByRole('button', { name: 'Time' }).click();
-  await expect(requestPanel.getByRole('region', { name: 'Request Headers × 16' })).toBeHidden();
-  await expect(requestPanel.getByRole('region', { name: 'Time' })).toBeHidden();
+  await headersPanel.getByRole('button', { name: 'General' }).click();
+  await expect(headersPanel.getByRole('region', { name: 'Request Headers × 16' })).toBeHidden();
+  await expect(headersPanel.getByRole('region', { name: 'General' })).toBeHidden();
 
-  await requestPanel.getByRole('button', { name: 'Time' }).click();
-  await expect(requestPanel.getByRole('region', { name: 'Request Headers × 16' })).toBeHidden();
-  await expect(requestPanel.getByRole('region', { name: 'Time' })).toHaveText(/Start.+Duration\d+ms/);
+  await headersPanel.getByRole('button', { name: 'General' }).click();
+  await expect(headersPanel.getByRole('region', { name: 'Request Headers × 16' })).toBeHidden();
+  await expect(headersPanel.getByRole('region', { name: 'General' })).toContainText(/Start.+Duration\d+ms/);
 
   // Re-opening should preserve open state
   await page.getByRole('tabpanel', { name: 'Network' }).getByRole('button', { name: 'Close' }).click();
   await page.getByRole('listitem').filter({ hasText: 'post-data-1' }).click();
-  await expect(requestPanel.getByRole('region', { name: 'Request Headers × 16' })).toBeHidden();
-  await expect(requestPanel.getByRole('region', { name: 'Time' })).toHaveText(/Start.+Duration\d+ms/);
+  await expect(headersPanel.getByRole('region', { name: 'Request Headers × 16' })).toBeHidden();
+  await expect(headersPanel.getByRole('region', { name: 'General' })).toContainText(/Start.+Duration\d+ms/);
 });


### PR DESCRIPTION
This is the last of the improvements I would like to make to the trace viewer network tab.

See screenshots for new order:
<img width="332" height="426" alt="image" src="https://github.com/user-attachments/assets/a782e3cb-4180-443c-b72c-58bafe05c4fb" />

<img width="252" height="71" alt="image" src="https://github.com/user-attachments/assets/10e09432-6019-4432-9c62-2eb3b54788b7" />
<img width="278" height="145" alt="image" src="https://github.com/user-attachments/assets/f96a7758-d502-44c6-9f90-5ae7f8a34917" />
<img width="244" height="139" alt="image" src="https://github.com/user-attachments/assets/9b1fdbb2-ef52-47e5-8023-79b39f2cd4f4" />

<img width="261" height="116" alt="image" src="https://github.com/user-attachments/assets/fd168617-a370-4622-870f-523fbd2ada3b" />



Closes: #35214