### PR TITLE
fix: address TypeScript 6.0 deprecations

### DIFF
--- a/docs/src/test-typescript-js.md
+++ b/docs/src/test-typescript-js.md
@@ -54,9 +54,8 @@ Here is an example `tsconfig.json` that works with Playwright:
 ```json title="tsconfig.json"
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@myhelper/*": ["packages/myhelper/*"] // This mapping is relative to "baseUrl".
+      "@myhelper/*": ["packages/myhelper/*"] // This mapping is relative to the tsconfig.
     }
   }
 }

--- a/docs/src/test-typescript-js.md
+++ b/docs/src/test-typescript-js.md
@@ -47,7 +47,7 @@ playwright.config.ts
 
 ### tsconfig path mapping
 
-Playwright supports [path mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) declared in the `tsconfig.json`. Make sure that `baseUrl` is also set.
+Playwright supports [path mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) declared in the `tsconfig.json`.
 
 Here is an example `tsconfig.json` that works with Playwright:
 

--- a/packages/html-reporter/tsconfig.json
+++ b/packages/html-reporter/tsconfig.json
@@ -14,7 +14,6 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "useUnknownInCatchVariables": false,
     "paths": {
       "@protocol/*": ["../protocol/src/*"],

--- a/packages/playwright-core/src/server/chromium/protocol.d.ts
+++ b/packages/playwright-core/src/server/chromium/protocol.d.ts
@@ -1,7 +1,7 @@
 // This is generated from /utils/protocol-types-generator/index.js
 type binary = string;
-export module Protocol {
-  export module Accessibility {
+export namespace Protocol {
+  export namespace Accessibility {
     /**
      * Unique accessibility node identifier.
      */
@@ -341,7 +341,7 @@ including nodes that are ignored for accessibility.
     }
   }
   
-  export module Animation {
+  export namespace Animation {
     /**
      * Animation instance.
      */
@@ -667,7 +667,7 @@ percentage [0 - 100] for scroll driven animations
   /**
    * Audits domain allows investigation of page violations and possible improvements.
    */
-  export module Audits {
+  export namespace Audits {
     /**
      * Information about a cookie that is affected by an inspector issue.
      */
@@ -1242,7 +1242,7 @@ using Audits.issueAdded event.
   /**
    * Defines commands and events for Autofill.
    */
-  export module Autofill {
+  export namespace Autofill {
     export interface CreditCard {
       /**
        * 16-digit credit card number.
@@ -1409,7 +1409,7 @@ If the field and related form cannot be autofilled, returns an error.
   /**
    * Defines events for background web platform features.
    */
-  export module BackgroundService {
+  export namespace BackgroundService {
     /**
      * The Background Service that will be associated with the commands/events.
 Every Background Service operates independently, but they share the same
@@ -1512,7 +1512,7 @@ events afterwards if enabled and recording.
    * This domain allows configuring virtual Bluetooth devices to test
 the web-bluetooth API.
    */
-  export module BluetoothEmulation {
+  export namespace BluetoothEmulation {
     /**
      * Indicates the various states of Central.
      */
@@ -1797,7 +1797,7 @@ by |characteristicId|.
   /**
    * The Browser domain defines methods and events for browser managing.
    */
-  export module Browser {
+  export namespace Browser {
     export type BrowserContextID = string;
     export type WindowID = number;
     /**
@@ -2284,7 +2284,7 @@ CSS objects can be loaded using the `get*ForNode()` calls (which accept a DOM no
 can also keep track of stylesheets via the `styleSheetAdded`/`styleSheetRemoved` events and
 subsequently load the required stylesheet contents using the `getStyleSheet[Text]()` methods.
    */
-  export module CSS {
+  export namespace CSS {
     /**
      * Stylesheet type: "injected" for stylesheets injected via extension, "user-agent" for user-agent
 stylesheets, "inspector" for stylesheets created by the inspector (i.e. those holding the "via
@@ -3870,7 +3870,7 @@ instrumentation).
     }
   }
   
-  export module CacheStorage {
+  export namespace CacheStorage {
     /**
      * Unique identifier of the Cache object.
      */
@@ -4067,7 +4067,7 @@ is the count of all entries from this storage.
    * A domain for interacting with Cast, Presentation API, and Remote Playback API
 functionalities.
    */
-  export module Cast {
+  export namespace Cast {
     export interface Sink {
       name: string;
       id: string;
@@ -4156,7 +4156,7 @@ and never sends the same node twice. It is client's responsibility to collect in
 the nodes that were sent to the client. Note that `iframe` owner elements will return
 corresponding document elements as their child nodes.
    */
-  export module DOM {
+  export namespace DOM {
     /**
      * Unique DOM node identifier.
      */
@@ -5619,7 +5619,7 @@ popover if it was previously force-opened.
    * DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript
 execution will stop on these operations as if there was a regular breakpoint set.
    */
-  export module DOMDebugger {
+  export namespace DOMDebugger {
     /**
      * DOM breakpoint type.
      */
@@ -5821,7 +5821,7 @@ EventTarget.
   /**
    * This domain facilitates obtaining document snapshots with DOM, layout, and style information.
    */
-  export module DOMSnapshot {
+  export namespace DOMSnapshot {
     /**
      * A Node in the DOM tree.
      */
@@ -6359,7 +6359,7 @@ The final text color opacity is computed based on the opacity of all overlapping
   /**
    * Query and modify DOM storage.
    */
-  export module DOMStorage {
+  export namespace DOMStorage {
     export type SerializedStorageKey = string;
     /**
      * DOM Storage identifier.
@@ -6442,7 +6442,7 @@ The final text color opacity is computed based on the opacity of all overlapping
     }
   }
   
-  export module DeviceAccess {
+  export namespace DeviceAccess {
     /**
      * Device request id.
      */
@@ -6504,7 +6504,7 @@ selectPrompt or cancelPrompt command.
     }
   }
   
-  export module DeviceOrientation {
+  export namespace DeviceOrientation {
     
     
     /**
@@ -6538,7 +6538,7 @@ selectPrompt or cancelPrompt command.
   /**
    * This domain emulates different environments for the page.
    */
-  export module Emulation {
+  export namespace Emulation {
     export interface SafeAreaInsets {
       /**
        * Overrides safe-area-inset-top.
@@ -7435,7 +7435,7 @@ of size 100lvh.
 occurring in native code invoked from JavaScript. Once breakpoint is hit, it is
 reported through Debugger domain, similarly to regular breakpoints being hit.
    */
-  export module EventBreakpoints {
+  export namespace EventBreakpoints {
     
     
     /**
@@ -7472,7 +7472,7 @@ reported through Debugger domain, similarly to regular breakpoints being hit.
   /**
    * Defines commands and events for browser extensions.
    */
-  export module Extensions {
+  export namespace Extensions {
     /**
      * Storage areas.
      */
@@ -7591,7 +7591,7 @@ will be merged with existing values in the storage area.
   /**
    * This domain allows interacting with the FedCM dialog.
    */
-  export module FedCm {
+  export namespace FedCm {
     /**
      * Whether this is a sign-up or sign-in action for this account, i.e.
 whether this account has ever been used to sign in to this RP before.
@@ -7699,7 +7699,7 @@ a dialog even if one was recently dismissed by the user.
   /**
    * A domain for letting clients substitute browser's network layer with client code.
    */
-  export module Fetch {
+  export namespace Fetch {
     /**
      * Unique request identifier.
 Note that this does not identify individual HTTP requests that are part of
@@ -8070,7 +8070,7 @@ domain before body is received results in an undefined behavior.
     }
   }
   
-  export module FileSystem {
+  export namespace FileSystem {
     export interface File {
       name: string;
       /**
@@ -8121,7 +8121,7 @@ domain before body is received results in an undefined behavior.
   /**
    * This domain provides experimental commands only supported in headless mode.
    */
-  export module HeadlessExperimental {
+  export namespace HeadlessExperimental {
     /**
      * Encoding options for a screenshot.
      */
@@ -8201,7 +8201,7 @@ display. Reported for diagnostic uses, may be removed in the future.
   /**
    * Input/Output operations for streams produced by DevTools.
    */
-  export module IO {
+  export namespace IO {
     /**
      * This is either obtained from another method or specified as `blob:<uuid>` where
 `<uuid>` is an UUID of a Blob.
@@ -8269,7 +8269,7 @@ following the last read). Some types of streams may only support sequential read
     }
   }
   
-  export module IndexedDB {
+  export namespace IndexedDB {
     /**
      * Database with an array of object stores.
      */
@@ -8648,7 +8648,7 @@ Security origin.
     }
   }
   
-  export module Input {
+  export namespace Input {
     export interface TouchPoint {
       /**
        * X coordinate of the event relative to the main frame's viewport in CSS pixels.
@@ -9171,7 +9171,7 @@ for the preferred input type).
     }
   }
   
-  export module Inspector {
+  export namespace Inspector {
     
     /**
      * Fired when remote debugging connection is about to be terminated. Contains detach reason.
@@ -9211,7 +9211,7 @@ for the preferred input type).
     }
   }
   
-  export module LayerTree {
+  export namespace LayerTree {
     /**
      * Unique Layer identifier.
      */
@@ -9508,7 +9508,7 @@ transform/scrolling purposes only.
   /**
    * Provides access to log entries.
    */
-  export module Log {
+  export namespace Log {
     /**
      * Log entry.
      */
@@ -9624,7 +9624,7 @@ transform/scrolling purposes only.
   /**
    * This domain allows detailed inspection of media elements.
    */
-  export module Media {
+  export namespace Media {
     /**
      * Players will get an ID that is unique within the agent context.
      */
@@ -9755,7 +9755,7 @@ event for each active player.
     }
   }
   
-  export module Memory {
+  export namespace Memory {
     /**
      * Memory pressure level.
      */
@@ -9935,7 +9935,7 @@ collected since browser process startup.
    * Network domain allows tracking network activities of the page. It exposes information about http,
 file, data and other requests and responses, their headers, bodies, timing, etc.
    */
-  export module Network {
+  export namespace Network {
     /**
      * Resource type as it was perceived by the rendering engine.
      */
@@ -12597,7 +12597,7 @@ Page reload is required before the new cookie behavior will be observed
   /**
    * This domain provides various functionality related to drawing atop the inspected page.
    */
-  export module Overlay {
+  export namespace Overlay {
     /**
      * Configuration data for drawing the source order of an elements children.
      */
@@ -13423,7 +13423,7 @@ Backend then generates 'inspectNodeRequested' event upon element selection.
   /**
    * This domain allows interacting with the browser to control PWAs.
    */
-  export module PWA {
+  export namespace PWA {
     /**
      * The following types are the replica of
 https://crsrc.org/c/chrome/browser/web_applications/proto/web_app_os_integration_state.proto;drc=9910d3be894c8f142c977ba1023f30a656bc13fc;l=67
@@ -13594,7 +13594,7 @@ supported yet.
   /**
    * Actions and events related to the inspected page belong to the page domain.
    */
-  export module Page {
+  export namespace Page {
     /**
      * Unique frame identifier.
      */
@@ -15714,7 +15714,7 @@ components/optimization_guide/proto/features/common_quality_data.proto
     }
   }
   
-  export module Performance {
+  export namespace Performance {
     /**
      * Run-time execution metric.
      */
@@ -15791,7 +15791,7 @@ this method while metrics collection is enabled returns an error.
    * Reporting of performance timeline events, as specified in
 https://w3c.github.io/performance-timeline/#dom-performanceobserver.
    */
-  export module PerformanceTimeline {
+  export namespace PerformanceTimeline {
     /**
      * See https://github.com/WICG/LargestContentfulPaint and largest_contentful_paint.idl
      */
@@ -15880,7 +15880,7 @@ Note that not all types exposed to the web platform are currently supported.
     }
   }
   
-  export module Preload {
+  export namespace Preload {
     /**
      * Unique id
      */
@@ -16072,7 +16072,7 @@ that is incompatible with prerender and has caused the cancellation of the attem
     }
   }
   
-  export module Security {
+  export namespace Security {
     /**
      * An internal certificate ID value.
      */
@@ -16377,7 +16377,7 @@ be handled by the DevTools client and should be answered with `handleCertificate
     }
   }
   
-  export module ServiceWorker {
+  export namespace ServiceWorker {
     export type RegistrationID = string;
     /**
      * ServiceWorker registration.
@@ -16499,7 +16499,7 @@ For cached script it is the last time the cache entry was validated.
     }
   }
   
-  export module Storage {
+  export namespace Storage {
     export type SerializedStorageKey = string;
     /**
      * Enum of possible storage types.
@@ -17604,7 +17604,7 @@ party URL, only the first-party URL is returned in the array.
   /**
    * The SystemInfo domain defines methods and events for querying low-level system information.
    */
-  export module SystemInfo {
+  export namespace SystemInfo {
     /**
      * Describes a single graphics processor (GPU).
      */
@@ -17802,7 +17802,7 @@ supported.
   /**
    * Supports additional targets discovery and allows to attach to them.
    */
-  export module Target {
+  export namespace Target {
     export type TargetID = string;
     /**
      * Unique identifier of attached debugging session.
@@ -18317,7 +18317,7 @@ and performance.
   /**
    * The Tethering domain defines methods and events for browser port binding.
    */
-  export module Tethering {
+  export namespace Tethering {
     
     /**
      * Informs that port was successfully bound and got a specified connection id.
@@ -18357,7 +18357,7 @@ and performance.
     }
   }
   
-  export module Tracing {
+  export namespace Tracing {
     /**
      * Configuration for memory dump. Used only when "memory-infra" category is enabled.
      */
@@ -18575,7 +18575,7 @@ are ignored.
    * This domain allows inspection of Web Audio API.
 https://webaudio.github.io/web-audio-api/
    */
-  export module WebAudio {
+  export namespace WebAudio {
     /**
      * An unique ID for a graph object (AudioContext, AudioNode, AudioParam) in Web Audio API
      */
@@ -18812,7 +18812,7 @@ capacity and glitch may occur.
    * This domain allows configuring virtual authenticators to test the WebAuthn
 API.
    */
-  export module WebAuthn {
+  export namespace WebAuthn {
     export type AuthenticatorId = string;
     export type AuthenticatorProtocol = "u2f"|"ctap2";
     export type Ctap2Version = "ctap2_0"|"ctap2_1";
@@ -19109,7 +19109,7 @@ https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties
   /**
    * This domain is deprecated - use Runtime or Log instead.
    */
-  export module Console {
+  export namespace Console {
     /**
      * Console message.
      */
@@ -19178,7 +19178,7 @@ https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties
    * Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing
 breakpoints, stepping through execution, exploring stack traces, etc.
    */
-  export module Debugger {
+  export namespace Debugger {
     /**
      * Breakpoint identifier.
      */
@@ -20205,7 +20205,7 @@ before next pause.
     }
   }
   
-  export module HeapProfiler {
+  export namespace HeapProfiler {
     /**
      * Heap snapshot object id.
      */
@@ -20434,7 +20434,7 @@ Deprecated in favor of `exposeInternals`.
     }
   }
   
-  export module Profiler {
+  export namespace Profiler {
     /**
      * Profile node. Holds callsite information, execution statistics and child nodes.
      */
@@ -20704,7 +20704,7 @@ and unique identifier that can be used for further object reference. Original ob
 maintained in memory unless they are either explicitly released or are released along with the
 other objects in their object group.
    */
-  export module Runtime {
+  export namespace Runtime {
     /**
      * Unique script identifier.
      */
@@ -21763,7 +21763,7 @@ Error was thrown.
   /**
    * This domain is deprecated.
    */
-  export module Schema {
+  export namespace Schema {
     /**
      * Description of the protocol domain.
      */

--- a/packages/playwright-core/src/server/firefox/protocol.d.ts
+++ b/packages/playwright-core/src/server/firefox/protocol.d.ts
@@ -1,7 +1,7 @@
 // This is generated from /utils/protocol-types-generator/index.js
-export module Protocol {
+export namespace Protocol {
 
-  export module Browser {
+  export namespace Browser {
     export type TargetInfo = {
       type: ("page");
       targetId: string;
@@ -320,12 +320,12 @@ export module Protocol {
     };
     export type cancelDownloadReturnValue = void;
   }
-  export module Heap {
+  export namespace Heap {
     export type collectGarbageParameters = {
     };
     export type collectGarbageReturnValue = void;
   }
-  export module Page {
+  export namespace Page {
     export type DOMPoint = {
       x: number;
       y: number;
@@ -732,7 +732,7 @@ export module Protocol {
     export type stopScreencastParameters = void;
     export type stopScreencastReturnValue = void;
   }
-  export module Runtime {
+  export namespace Runtime {
     export type RemoteObject = {
       type?: ("object"|"function"|"undefined"|"string"|"number"|"boolean"|"symbol"|"bigint");
       subtype?: ("array"|"null"|"node"|"regexp"|"date"|"map"|"set"|"weakmap"|"weakset"|"error"|"proxy"|"promise"|"typedarray");
@@ -862,7 +862,7 @@ export module Protocol {
       }[];
     };
   }
-  export module Network {
+  export namespace Network {
     export type HTTPHeader = {
       name: string;
       value: string;

--- a/packages/playwright-core/src/server/webkit/protocol.d.ts
+++ b/packages/playwright-core/src/server/webkit/protocol.d.ts
@@ -1,10 +1,10 @@
 // This is generated from /utils/protocol-types-generator/index.js
 type binary = string;
-export module Protocol {
+export namespace Protocol {
   /**
    * Domain for tracking/modifying Web Animations, as well as CSS (declarative) animations and transitions.
    */
-  export module Animation {
+  export namespace Animation {
     /**
      * Unique Web Animation identifier.
      */
@@ -200,7 +200,7 @@ export module Protocol {
     }
   }
   
-  export module Audit {
+  export namespace Audit {
     
     
     /**
@@ -249,7 +249,7 @@ export module Protocol {
   /**
    * The Browser domain contains commands and events related to getting information about the browser 
    */
-  export module Browser {
+  export namespace Browser {
     /**
      * Unique extension identifier.
      */
@@ -300,7 +300,7 @@ export module Protocol {
   /**
    * CPUProfiler domain exposes cpu usage tracking.
    */
-  export module CPUProfiler {
+  export namespace CPUProfiler {
     /**
      * CPU usage for an individual thread.
      */
@@ -372,7 +372,7 @@ export module Protocol {
   /**
    * This domain exposes CSS read/write operations. All CSS objects, like stylesheets, rules, and styles, have an associated <code>id</code> used in subsequent operations on the related object. Each object type has a specific <code>id</code> structure, and those are not interchangeable between objects of different kinds. CSS objects can be loaded using the <code>get*ForNode()</code> calls (which accept a DOM node id). Alternatively, a client can discover all the existing stylesheets with the <code>getAllStyleSheets()</code> method and subsequently load the required stylesheet contents using the <code>getStyleSheet[Text]()</code> methods.
    */
-  export module CSS {
+  export namespace CSS {
     export type StyleSheetId = string;
     /**
      * This object identifies a CSS style in a unique way.
@@ -1095,7 +1095,7 @@ export module Protocol {
   /**
    * Canvas domain allows tracking of canvases that have an associated graphics context. Tracks canvases in the DOM and CSS canvases created with -webkit-canvas.
    */
-  export module Canvas {
+  export namespace Canvas {
     /**
      * Unique canvas identifier.
      */
@@ -1432,7 +1432,7 @@ export module Protocol {
   /**
    * Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.
    */
-  export module Console {
+  export namespace Console {
     /**
      * Channels for different types of log messages.
      */
@@ -1652,7 +1652,7 @@ export module Protocol {
   /**
    * This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object that has an <code>id</code>. This <code>id</code> can be used to get additional information on the Node, resolve it into the JavaScript object wrapper, etc. It is important that client receives DOM events only for the nodes that are known to the client. Backend keeps track of the nodes that were sent to the client and never sends the same node twice. It is client's responsibility to collect information about the nodes that were sent to the client.<p>Note that <code>iframe</code> owner elements will return corresponding document elements as their child nodes.</p>
    */
-  export module DOM {
+  export namespace DOM {
     /**
      * Unique DOM node identifier.
      */
@@ -3351,7 +3351,7 @@ might return multiple quads for inline nodes.
   /**
    * DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript execution will stop on these operations as if there was a regular breakpoint set.
    */
-  export module DOMDebugger {
+  export namespace DOMDebugger {
     /**
      * DOM breakpoint type.
      */
@@ -3479,7 +3479,7 @@ might return multiple quads for inline nodes.
   /**
    * Query and modify DOM storage.
    */
-  export module DOMStorage {
+  export namespace DOMStorage {
     /**
      * DOM Storage identifier.
      */
@@ -3560,7 +3560,7 @@ might return multiple quads for inline nodes.
   /**
    * Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.
    */
-  export module Debugger {
+  export namespace Debugger {
     /**
      * Breakpoint identifier.
      */
@@ -4323,7 +4323,7 @@ might return multiple quads for inline nodes.
   /**
    * Actions and events related to alert boxes.
    */
-  export module Dialog {
+  export namespace Dialog {
     
     /**
      * Fired when a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload) is about to open.
@@ -4374,7 +4374,7 @@ might return multiple quads for inline nodes.
     }
   }
   
-  export module Emulation {
+  export namespace Emulation {
     
     
     /**
@@ -4443,7 +4443,7 @@ might return multiple quads for inline nodes.
   /**
    * Exposes generic types to be used by any domain.
    */
-  export module GenericTypes {
+  export namespace GenericTypes {
     /**
      * Search match in a resource.
      */
@@ -4464,7 +4464,7 @@ might return multiple quads for inline nodes.
   /**
    * Heap domain exposes JavaScript heap attributes and capabilities.
    */
-  export module Heap {
+  export namespace Heap {
     /**
      * Information about a garbage collection.
      */
@@ -4596,7 +4596,7 @@ might return multiple quads for inline nodes.
     }
   }
   
-  export module IndexedDB {
+  export namespace IndexedDB {
     /**
      * Database with an array of object stores.
      */
@@ -4850,7 +4850,7 @@ might return multiple quads for inline nodes.
     }
   }
   
-  export module Input {
+  export namespace Input {
     /**
      * UTC time in seconds, counted from January 1, 1970.
      */
@@ -5050,7 +5050,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     }
   }
   
-  export module Inspector {
+  export namespace Inspector {
     
     export type evaluateForTestInFrontendPayload = {
       script: string;
@@ -5083,7 +5083,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     }
   }
   
-  export module LayerTree {
+  export namespace LayerTree {
     /**
      * Unique RenderLayer identifier.
      */
@@ -5339,7 +5339,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
   /**
    * Memory domain exposes page memory tracking.
    */
-  export module Memory {
+  export namespace Memory {
     export interface Event {
       timestamp: number;
       /**
@@ -5420,7 +5420,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
   /**
    * Network domain allows tracking network activities of the page. It exposes information about http, file, data and other requests and responses, their headers, bodies, timing, etc.
    */
-  export module Network {
+  export namespace Network {
     /**
      * Unique loader identifier.
      */
@@ -6344,7 +6344,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
   /**
    * Actions and events related to the inspected page belong to the page domain.
    */
-  export module Page {
+  export namespace Page {
     /**
      * List of settings able to be overridden by WebInspector.
      */
@@ -7076,7 +7076,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     }
   }
   
-  export module Playwright {
+  export namespace Playwright {
     /**
      * Id of Browser context.
      */
@@ -7557,7 +7557,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
   /**
    * General types used for recordings of actions performed in the inspected page.
    */
-  export module Recording {
+  export namespace Recording {
     /**
      * The type of the recording.
      */
@@ -7624,7 +7624,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
   /**
    * Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.
    */
-  export module Runtime {
+  export namespace Runtime {
     /**
      * Unique object identifier.
      */
@@ -8430,7 +8430,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     }
   }
   
-  export module Screencast {
+  export namespace Screencast {
     /**
      * Unique identifier of the screencast.
      */
@@ -8506,7 +8506,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
   /**
    * Profiler domain exposes JavaScript evaluation timing and profiling.
    */
-  export module ScriptProfiler {
+  export namespace ScriptProfiler {
     export type EventType = "API"|"Microtask"|"Other";
     export interface Event {
       startTime: number;
@@ -8600,7 +8600,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
   /**
    * Security domain allows the frontend to query for information relating to the security of the page (e.g. HTTPS info, TLS info, user activity, etc.).
    */
-  export module Security {
+  export namespace Security {
     /**
      * Information about a SSL connection to display in the frontend.
      */
@@ -8638,7 +8638,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
   /**
    * Actions and events related to the inspected service worker.
    */
-  export module ServiceWorker {
+  export namespace ServiceWorker {
     /**
      * ServiceWorker metadata and initial state.
      */
@@ -8666,7 +8666,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     }
   }
   
-  export module Target {
+  export namespace Target {
     /**
      * Description of a target.
      */
@@ -8767,7 +8767,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
   /**
    * Timeline provides its clients with instrumentation records that are generated during the page runtime. Timeline instrumentation can be started and stopped using corresponding commands. While timeline is started, it is generating timeline event records.
    */
-  export module Timeline {
+  export namespace Timeline {
     /**
      * Timeline record type.
      */
@@ -8882,7 +8882,7 @@ the top of the viewport and Y increases as it proceeds towards the bottom of the
     }
   }
   
-  export module Worker {
+  export namespace Worker {
     
     export type workerCreatedPayload = {
       workerId: string;

--- a/packages/playwright-core/types/protocol.d.ts
+++ b/packages/playwright-core/types/protocol.d.ts
@@ -171,7 +171,7 @@ export namespace Protocol {
        */
       frameId?: Page.FrameId;
     }
-
+    
     /**
      * The loadComplete event mirrors the load complete event sent by the browser to assistive
 technology when the web page has finished loading.
@@ -191,7 +191,7 @@ technology when the web page has finished loading.
        */
       nodes: AXNode[];
     }
-
+    
     /**
      * Disables the accessibility domain.
      */
@@ -340,7 +340,7 @@ including nodes that are ignored for accessibility.
       nodes: AXNode[];
     }
   }
-
+  
   export namespace Animation {
     /**
      * Animation instance.
@@ -498,7 +498,7 @@ percentage [0 - 100] for scroll driven animations
        */
       easing: string;
     }
-
+    
     /**
      * Event for when an animation has been cancelled.
      */
@@ -535,7 +535,7 @@ percentage [0 - 100] for scroll driven animations
        */
       animation: Animation;
     }
-
+    
     /**
      * Disables animation domain notifications.
      */
@@ -663,7 +663,7 @@ percentage [0 - 100] for scroll driven animations
     export type setTimingReturnValue = {
     }
   }
-
+  
   /**
    * Audits domain allows investigation of page violations and possible improvements.
    */
@@ -1160,11 +1160,11 @@ exception, CDP message, etc.) is referencing this issue.
        */
       issueId?: IssueId;
     }
-
+    
     export type issueAddedPayload = {
       issue: InspectorIssue;
     }
-
+    
     /**
      * Returns the response body and size if it were re-encoded with the specified settings. Only
 applies to images.
@@ -1238,7 +1238,7 @@ using Audits.issueAdded event.
       formIssues: GenericIssueDetails[];
     }
   }
-
+  
   /**
    * Defines commands and events for Autofill.
    */
@@ -1342,7 +1342,7 @@ Munich 81456
        */
       fieldId: DOM.BackendNodeId;
     }
-
+    
     /**
      * Emitted when an address form is filled.
      */
@@ -1357,7 +1357,7 @@ Consists of a 2D array where each child represents an address/profile line.
        */
       addressUi: AddressUI;
     }
-
+    
     /**
      * Trigger autofill on a form identified by the fieldId.
 If the field and related form cannot be autofilled, returns an error.
@@ -1405,7 +1405,7 @@ If the field and related form cannot be autofilled, returns an error.
     export type enableReturnValue = {
     }
   }
-
+  
   /**
    * Defines events for background web platform features.
    */
@@ -1457,7 +1457,7 @@ API.
        */
       storageKey: string;
     }
-
+    
     /**
      * Called when the recording state for the service has been updated.
      */
@@ -1472,7 +1472,7 @@ events afterwards if enabled and recording.
     export type backgroundServiceEventReceivedPayload = {
       backgroundServiceEvent: BackgroundServiceEvent;
     }
-
+    
     /**
      * Enables event updates for the service.
      */
@@ -1507,7 +1507,7 @@ events afterwards if enabled and recording.
     export type clearEventsReturnValue = {
     }
   }
-
+  
   /**
    * This domain allows configuring virtual Bluetooth devices to test
 the web-bluetooth API.
@@ -1590,7 +1590,7 @@ Specification BT 4.2 Vol 3 Part G 3.3.1. Characteristic Properties.
       authenticatedSignedWrites?: boolean;
       extendedProperties?: boolean;
     }
-
+    
     /**
      * Event for when a GATT operation of |type| to the peripheral with |address|
 happened.
@@ -1620,7 +1620,7 @@ respresented by |descriptorId| happened. |data| is expected to exist when
       type: DescriptorOperationType;
       data?: binary;
     }
-
+    
     /**
      * Enable the BluetoothEmulation domain.
      */
@@ -1793,7 +1793,7 @@ by |characteristicId|.
     export type simulateGATTDisconnectionReturnValue = {
     }
   }
-
+  
   /**
    * The Browser domain defines methods and events for browser managing.
    */
@@ -1906,7 +1906,7 @@ Note that userVisibleOnly = true is the only currently supported type.
       buckets: Bucket[];
     }
     export type PrivacySandboxAPI = "BiddingAndAuctionServices"|"TrustedKeyValue";
-
+    
     /**
      * Fired when page is about to start a download.
      */
@@ -1955,7 +1955,7 @@ is guaranteed to exist.
        */
       filePath?: string;
     }
-
+    
     /**
      * Set permission settings for given embedding and embedded origins.
      */
@@ -2275,7 +2275,7 @@ context is used.
     export type addPrivacySandboxCoordinatorKeyConfigReturnValue = {
     }
   }
-
+  
   /**
    * This domain exposes CSS read/write operations. All CSS objects (stylesheets, rules, and styles)
 have an associated `id` used in subsequent operations on the related object. Each object type has
@@ -3237,7 +3237,7 @@ stylesheet rules) this rule came from.
        */
       text: string;
     }
-
+    
     /**
      * Fires whenever a web font is updated.  A non-empty font parameter indicates a successfully loaded
 web font.
@@ -3283,7 +3283,7 @@ resized.) The current implementation considers only viewport-dependent media fea
        */
       nodeId: DOM.NodeId;
     }
-
+    
     /**
      * Inserts a new rule with the given `ruleText` in a stylesheet with given `styleSheetId`, at the
 position specified by `location`.
@@ -3869,7 +3869,7 @@ instrumentation).
     export type setLocalFontsEnabledReturnValue = {
     }
   }
-
+  
   export namespace CacheStorage {
     /**
      * Unique identifier of the Cache object.
@@ -3954,8 +3954,8 @@ instrumentation).
        */
       body: binary;
     }
-
-
+    
+    
     /**
      * Deletes a cache.
      */
@@ -4062,7 +4062,7 @@ is the count of all entries from this storage.
       returnCount: number;
     }
   }
-
+  
   /**
    * A domain for interacting with Cast, Presentation API, and Remote Playback API
 functionalities.
@@ -4077,7 +4077,7 @@ session on the sink.
        */
       session?: string;
     }
-
+    
     /**
      * This is fired whenever the list of available sinks changes. A sink is a
 device or a software surface that you can cast to.
@@ -4092,7 +4092,7 @@ device or a software surface that you can cast to.
     export type issueUpdatedPayload = {
       issueMessage: string;
     }
-
+    
     /**
      * Starts observing for sinks that can be used for tab mirroring, and if set,
 sinks compatible with |presentationUrl| as well. When sinks are found, a
@@ -4146,7 +4146,7 @@ sink via Presentation API, Remote Playback API, or Cast SDK.
     export type stopCastingReturnValue = {
     }
   }
-
+  
   /**
    * This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object
 that has an `id`. This `id` can be used to get additional information on the Node, resolve it into
@@ -4453,7 +4453,7 @@ The property is always undefined now.
        */
       value: string;
     }
-
+    
     /**
      * Fired when `Element`'s attribute is modified.
      */
@@ -4675,7 +4675,7 @@ most of the calls requesting node ids.
        */
       root: Node;
     }
-
+    
     /**
      * Collects class names for the node with given id and all of it's child nodes.
      */
@@ -5614,7 +5614,7 @@ popover if it was previously force-opened.
       nodeIds: NodeId[];
     }
   }
-
+  
   /**
    * DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript
 execution will stop on these operations as if there was a regular breakpoint set.
@@ -5673,8 +5673,8 @@ execution will stop on these operations as if there was a regular breakpoint set
        */
       backendNodeId?: DOM.BackendNodeId;
     }
-
-
+    
+    
     /**
      * Returns event listeners of the given object.
      */
@@ -5817,7 +5817,7 @@ EventTarget.
     export type setXHRBreakpointReturnValue = {
     }
   }
-
+  
   /**
    * This domain facilitates obtaining document snapshots with DOM, layout, and style information.
    */
@@ -6258,8 +6258,8 @@ represented as a surrogate pair in UTF-16 have length 2.
        */
       length: number[];
     }
-
-
+    
+    
     /**
      * Disables DOM snapshot agent for the given page.
      */
@@ -6355,7 +6355,7 @@ The final text color opacity is computed based on the opacity of all overlapping
       strings: string[];
     }
   }
-
+  
   /**
    * Query and modify DOM storage.
    */
@@ -6382,7 +6382,7 @@ The final text color opacity is computed based on the opacity of all overlapping
      * DOM Storage item.
      */
     export type Item = string[];
-
+    
     export type domStorageItemAddedPayload = {
       storageId: StorageId;
       key: string;
@@ -6401,7 +6401,7 @@ The final text color opacity is computed based on the opacity of all overlapping
     export type domStorageItemsClearedPayload = {
       storageId: StorageId;
     }
-
+    
     export type clearParameters = {
       storageId: StorageId;
     }
@@ -6441,7 +6441,7 @@ The final text color opacity is computed based on the opacity of all overlapping
     export type setDOMStorageItemReturnValue = {
     }
   }
-
+  
   export namespace DeviceAccess {
     /**
      * Device request id.
@@ -6461,7 +6461,7 @@ The final text color opacity is computed based on the opacity of all overlapping
        */
       name: string;
     }
-
+    
     /**
      * A device request opened a user prompt to select a device. Respond with the
 selectPrompt or cancelPrompt command.
@@ -6470,7 +6470,7 @@ selectPrompt or cancelPrompt command.
       id: RequestId;
       devices: PromptDevice[];
     }
-
+    
     /**
      * Enable events in this domain.
      */
@@ -6503,10 +6503,10 @@ selectPrompt or cancelPrompt command.
     export type cancelPromptReturnValue = {
     }
   }
-
+  
   export namespace DeviceOrientation {
-
-
+    
+    
     /**
      * Clears the overridden Device Orientation.
      */
@@ -6534,7 +6534,7 @@ selectPrompt or cancelPrompt command.
     export type setDeviceOrientationOverrideReturnValue = {
     }
   }
-
+  
   /**
    * This domain emulates different environments for the page.
    */
@@ -6781,12 +6781,12 @@ see https://w3c.github.io/window-management/#screendetailed.
      * Enum of image types that can be disabled.
      */
     export type DisabledImageType = "avif"|"webp";
-
+    
     /**
      * Notification sent after the virtual time budget for the current VirtualTimePolicy has run out.
      */
     export type virtualTimeBudgetExpiredPayload = void;
-
+    
     /**
      * Tells whether emulation is supported.
      */
@@ -7429,15 +7429,15 @@ of size 100lvh.
     export type removeScreenReturnValue = {
     }
   }
-
+  
   /**
    * EventBreakpoints permits setting JavaScript breakpoints on operations and events
 occurring in native code invoked from JavaScript. Once breakpoint is hit, it is
 reported through Debugger domain, similarly to regular breakpoints being hit.
    */
   export namespace EventBreakpoints {
-
-
+    
+    
     /**
      * Sets breakpoint on particular native event.
      */
@@ -7468,7 +7468,7 @@ reported through Debugger domain, similarly to regular breakpoints being hit.
     export type disableReturnValue = {
     }
   }
-
+  
   /**
    * Defines commands and events for browser extensions.
    */
@@ -7477,8 +7477,8 @@ reported through Debugger domain, similarly to regular breakpoints being hit.
      * Storage areas.
      */
     export type StorageArea = "session"|"local"|"sync"|"managed";
-
-
+    
+    
     /**
      * Installs an unpacked extension from the filesystem similar to
 --load-extension CLI flags. Returns extension ID once the extension
@@ -7587,7 +7587,7 @@ will be merged with existing values in the storage area.
     export type setStorageItemsReturnValue = {
     }
   }
-
+  
   /**
    * This domain allows interacting with the FedCM dialog.
    */
@@ -7627,7 +7627,7 @@ whether this account has ever been used to sign in to this RP before.
       termsOfServiceUrl?: string;
       privacyPolicyUrl?: string;
     }
-
+    
     export type dialogShownPayload = {
       dialogId: string;
       dialogType: DialogType;
@@ -7646,7 +7646,7 @@ or a command below.
     export type dialogClosedPayload = {
       dialogId: string;
     }
-
+    
     export type enableParameters = {
       /**
        * Allows callers to disable the promise rejection delay that would
@@ -7695,7 +7695,7 @@ a dialog even if one was recently dismissed by the user.
     export type resetCooldownReturnValue = {
     }
   }
-
+  
   /**
    * A domain for letting clients substitute browser's network layer with client code.
    */
@@ -7776,7 +7776,7 @@ ProvideCredentials.
        */
       password?: string;
     }
-
+    
     /**
      * Issued when the domain is enabled and the request URL matches the
 specified filter. The request is paused until the client responds
@@ -7862,7 +7862,7 @@ contains AuthChallengeResponse.
        */
       authChallenge: AuthChallenge;
     }
-
+    
     /**
      * Disables the fetch domain.
      */
@@ -8069,7 +8069,7 @@ domain before body is received results in an undefined behavior.
       stream: IO.StreamHandle;
     }
   }
-
+  
   export namespace FileSystem {
     export interface File {
       name: string;
@@ -8105,8 +8105,8 @@ domain before body is received results in an undefined behavior.
        */
       pathComponents: string[];
     }
-
-
+    
+    
     export type getDirectoryParameters = {
       bucketFileSystemLocator: BucketFileSystemLocator;
     }
@@ -8117,7 +8117,7 @@ domain before body is received results in an undefined behavior.
       directory: Directory;
     }
   }
-
+  
   /**
    * This domain provides experimental commands only supported in headless mode.
    */
@@ -8139,8 +8139,8 @@ domain before body is received results in an undefined behavior.
        */
       optimizeForSpeed?: boolean;
     }
-
-
+    
+    
     /**
      * Sends a BeginFrame to the target and returns when the frame was completed. Optionally captures a
 screenshot from the resulting frame. Requires that the target was created with enabled
@@ -8197,7 +8197,7 @@ display. Reported for diagnostic uses, may be removed in the future.
     export type enableReturnValue = {
     }
   }
-
+  
   /**
    * Input/Output operations for streams produced by DevTools.
    */
@@ -8207,8 +8207,8 @@ display. Reported for diagnostic uses, may be removed in the future.
 `<uuid>` is an UUID of a Blob.
      */
     export type StreamHandle = string;
-
-
+    
+    
     /**
      * Close the stream, discard any temporary backing storage.
      */
@@ -8268,7 +8268,7 @@ following the last read). Some types of streams may only support sequential read
       uuid: string;
     }
   }
-
+  
   export namespace IndexedDB {
     /**
      * Database with an array of object stores.
@@ -8410,8 +8410,8 @@ requires the version number to be 'unsigned long long')
        */
       array?: string[];
     }
-
-
+    
+    
     /**
      * Clears all entries from an object store.
      */
@@ -8647,7 +8647,7 @@ Security origin.
       databaseNames: string[];
     }
   }
-
+  
   export namespace Input {
     export interface TouchPoint {
       /**
@@ -8733,7 +8733,7 @@ text, HTML markup or any other data.
        */
       dragOperationsMask: number;
     }
-
+    
     /**
      * Emitted only when `Input.setInterceptDrags` is enabled. Use this data with `Input.dispatchDragEvent` to
 restore normal drag and drop behavior.
@@ -8741,7 +8741,7 @@ restore normal drag and drop behavior.
     export type dragInterceptedPayload = {
       data: DragData;
     }
-
+    
     /**
      * Dispatches a drag event into the page.
      */
@@ -9170,9 +9170,9 @@ for the preferred input type).
     export type synthesizeTapGestureReturnValue = {
     }
   }
-
+  
   export namespace Inspector {
-
+    
     /**
      * Fired when remote debugging connection is about to be terminated. Contains detach reason.
      */
@@ -9194,7 +9194,7 @@ for the preferred input type).
      * Fired on worker targets when main worker script and any imported scripts have been evaluated.
      */
     export type workerScriptLoadedPayload = void;
-
+    
     /**
      * Disables inspector domain notifications.
      */
@@ -9210,7 +9210,7 @@ for the preferred input type).
     export type enableReturnValue = {
     }
   }
-
+  
   export namespace LayerTree {
     /**
      * Unique Layer identifier.
@@ -9345,7 +9345,7 @@ transform/scrolling purposes only.
      * Array of timings, one per paint step.
      */
     export type PaintProfile = number[];
-
+    
     export type layerPaintedPayload = {
       /**
        * The id of the painted layer.
@@ -9362,7 +9362,7 @@ transform/scrolling purposes only.
        */
       layers?: Layer[];
     }
-
+    
     /**
      * Provides the reasons why the given layer was composited.
      */
@@ -9504,7 +9504,7 @@ transform/scrolling purposes only.
       commandLog: { [key: string]: string }[];
     }
   }
-
+  
   /**
    * Provides access to log entries.
    */
@@ -9568,7 +9568,7 @@ transform/scrolling purposes only.
        */
       threshold: number;
     }
-
+    
     /**
      * Issued when new message was logged.
      */
@@ -9578,7 +9578,7 @@ transform/scrolling purposes only.
        */
       entry: LogEntry;
     }
-
+    
     /**
      * Clears the log.
      */
@@ -9620,7 +9620,7 @@ transform/scrolling purposes only.
     export type stopViolationsReportReturnValue = {
     }
   }
-
+  
   /**
    * This domain allows detailed inspection of media elements.
    */
@@ -9699,7 +9699,7 @@ caused by an WindowsError
       playerId: PlayerId;
       domNodeId?: DOM.BackendNodeId;
     }
-
+    
     /**
      * This can be called multiple times, and can be used to set / override /
 remove player properties. A null propValue indicates removal.
@@ -9738,7 +9738,7 @@ event for each active player.
     export type playerCreatedPayload = {
       player: Player;
     }
-
+    
     /**
      * Enables the Media domain
      */
@@ -9754,7 +9754,7 @@ event for each active player.
     export type disableReturnValue = {
     }
   }
-
+  
   export namespace Memory {
     /**
      * Memory pressure level.
@@ -9820,8 +9820,8 @@ the returned names to be consistent across runs.
        */
       count: number;
     }
-
-
+    
+    
     /**
      * Retruns current DOM object counters.
      */
@@ -9930,7 +9930,7 @@ collected since browser process startup.
       profile: SamplingProfile;
     }
   }
-
+  
   /**
    * Network domain allows tracking network activities of the page. It exposes information about http,
 file, data and other requests and responses, their headers, bodies, timing, etc.
@@ -11176,7 +11176,7 @@ CORB and streaming.
       disableCache: boolean;
       includeCredentials: boolean;
     }
-
+    
     /**
      * Fired when data chunk was received over the network.
      */
@@ -11918,7 +11918,7 @@ And after 'enableReportingApi' for all existing reports.
       origin: string;
       endpoints: ReportingApiEndpoint[];
     }
-
+    
     /**
      * Sets a list of content encodings that will be accepted. Empty list means no encoding is accepted.
      */
@@ -12593,7 +12593,7 @@ Page reload is required before the new cookie behavior will be observed
     export type setCookieControlsReturnValue = {
     }
   }
-
+  
   /**
    * This domain provides various functionality related to drawing atop the inspected page.
    */
@@ -12989,7 +12989,7 @@ Page reload is required before the new cookie behavior will be observed
       maskColor?: DOM.RGBA;
     }
     export type InspectMode = "searchForNode"|"searchForUAShadowDOM"|"captureAreaScreenshot"|"none";
-
+    
     /**
      * Fired when the node should be inspected. This happens after call to `setInspectMode` or when
 user manually inspects an element.
@@ -13019,7 +13019,7 @@ user manually inspects an element.
      * Fired when user cancels the inspect mode.
      */
     export type inspectModeCanceledPayload = void;
-
+    
     /**
      * Disables domain notifications.
      */
@@ -13419,7 +13419,7 @@ Backend then generates 'inspectNodeRequested' event upon element selection.
     export type setShowWindowControlsOverlayReturnValue = {
     }
   }
-
+  
   /**
    * This domain allows interacting with the browser to control PWAs.
    */
@@ -13445,8 +13445,8 @@ https://www.iana.org/assignments/media-types/media-types.xhtml
      * If user prefers opening the app in browser or an app window.
      */
     export type DisplayMode = "standalone"|"browser";
-
-
+    
+    
     /**
      * Returns the following OS state for the given manifest id.
      */
@@ -13590,7 +13590,7 @@ supported yet.
     export type changeAppUserSettingsReturnValue = {
     }
   }
-
+  
   /**
    * Actions and events related to the inspected page belong to the page domain.
    */
@@ -14313,7 +14313,7 @@ dependent on the reason:
        */
       children: BackForwardCacheNotRestoredExplanationTree[];
     }
-
+    
     export type domContentEventFiredPayload = {
       timestamp: Network.MonotonicTime;
     }
@@ -14709,7 +14709,7 @@ etc.
        */
       data: binary;
     }
-
+    
     /**
      * Deprecated, please use addScriptToEvaluateOnNewDocument instead.
      */
@@ -15713,7 +15713,7 @@ components/optimization_guide/proto/features/common_quality_data.proto
       content: binary;
     }
   }
-
+  
   export namespace Performance {
     /**
      * Run-time execution metric.
@@ -15728,7 +15728,7 @@ components/optimization_guide/proto/features/common_quality_data.proto
        */
       value: number;
     }
-
+    
     /**
      * Current values of the metrics.
      */
@@ -15742,7 +15742,7 @@ components/optimization_guide/proto/features/common_quality_data.proto
        */
       title: string;
     }
-
+    
     /**
      * Disable collecting and reporting metrics.
      */
@@ -15786,7 +15786,7 @@ this method while metrics collection is enabled returns an error.
       metrics: Metric[];
     }
   }
-
+  
   /**
    * Reporting of performance timeline events, as specified in
 https://w3c.github.io/performance-timeline/#dom-performanceobserver.
@@ -15854,14 +15854,14 @@ This determines which of the optional "details" fields is present.
       lcpDetails?: LargestContentfulPaint;
       layoutShiftDetails?: LayoutShift;
     }
-
+    
     /**
      * Sent when a performance timeline event is added. See reportPerformanceTimeline method.
      */
     export type timelineEventAddedPayload = {
       event: TimelineEvent;
     }
-
+    
     /**
      * Previously buffered events would be reported before method returns.
 See also: timelineEventAdded
@@ -15879,7 +15879,7 @@ Note that not all types exposed to the web platform are currently supported.
     export type enableReturnValue = {
     }
   }
-
+  
   export namespace Preload {
     /**
      * Unique id
@@ -16004,7 +16004,7 @@ filter out the ones that aren't necessary to the developers.
       initialValue?: string;
       activationValue?: string;
     }
-
+    
     /**
      * Upsert. Currently, it is only emitted when a rule set added.
      */
@@ -16061,7 +16061,7 @@ that is incompatible with prerender and has caused the cancellation of the attem
       loaderId: Network.LoaderId;
       preloadingAttemptSources: PreloadingAttemptSource[];
     }
-
+    
     export type enableParameters = {
     }
     export type enableReturnValue = {
@@ -16071,7 +16071,7 @@ that is incompatible with prerender and has caused the cancellation of the attem
     export type disableReturnValue = {
     }
   }
-
+  
   export namespace Security {
     /**
      * An internal certificate ID value.
@@ -16266,7 +16266,7 @@ https://www.w3.org/TR/mixed-content/#categories
 request and cancel will cancel the request.
      */
     export type CertificateErrorAction = "continue"|"cancel";
-
+    
     /**
      * There is a certificate error. If overriding certificate errors is enabled, then it should be
 handled with the `handleCertificateError` command. Note: this event does not fire if the
@@ -16322,7 +16322,7 @@ empty.
        */
       summary?: string;
     }
-
+    
     /**
      * Disables tracking security state changes.
      */
@@ -16376,7 +16376,7 @@ be handled by the DevTools client and should be answered with `handleCertificate
     export type setOverrideCertificateErrorsReturnValue = {
     }
   }
-
+  
   export namespace ServiceWorker {
     export type RegistrationID = string;
     /**
@@ -16422,7 +16422,7 @@ For cached script it is the last time the cache entry was validated.
       lineNumber: number;
       columnNumber: number;
     }
-
+    
     export type workerErrorReportedPayload = {
       errorMessage: ServiceWorkerErrorMessage;
     }
@@ -16432,7 +16432,7 @@ For cached script it is the last time the cache entry was validated.
     export type workerVersionUpdatedPayload = {
       versions: ServiceWorkerVersion[];
     }
-
+    
     export type deliverPushMessageParameters = {
       origin: string;
       registrationId: RegistrationID;
@@ -16498,7 +16498,7 @@ For cached script it is the last time the cache entry was validated.
     export type updateRegistrationReturnValue = {
     }
   }
-
+  
   export namespace Storage {
     export type SerializedStorageKey = string;
     /**
@@ -16914,7 +16914,7 @@ int
        */
       serviceSites: string[];
     }
-
+    
     /**
      * A cache's contents have been modified.
      */
@@ -17156,7 +17156,7 @@ associated shared storage worklet.
       netErrorName?: string;
       httpStatusCode?: number;
     }
-
+    
     /**
      * Returns a storage key given a frame id.
 Deprecated. Please use Storage.getStorageKey instead.
@@ -17600,7 +17600,7 @@ party URL, only the first-party URL is returned in the array.
     export type setProtectedAudienceKAnonymityReturnValue = {
     }
   }
-
+  
   /**
    * The SystemInfo domain defines methods and events for querying low-level system information.
    */
@@ -17749,8 +17749,8 @@ process since the process start.
        */
       cpuTime: number;
     }
-
-
+    
+    
     /**
      * Returns information about the system.
      */
@@ -17798,7 +17798,7 @@ supported.
       processInfo: ProcessInfo[];
     }
   }
-
+  
   /**
    * Supports additional targets discovery and allows to attach to them.
    */
@@ -17873,7 +17873,7 @@ If filter is not specified, the one assumed is
      * The state of the target window.
      */
     export type WindowState = "normal"|"minimized"|"maximized"|"fullscreen";
-
+    
     /**
      * Issued when attached to target because of auto-attach or `attachToTarget` command.
      */
@@ -17947,7 +17947,7 @@ issued multiple times per target if multiple sessions have been attached to it.
     export type targetInfoChangedPayload = {
       targetInfo: TargetInfo;
     }
-
+    
     /**
      * Activates (focuses) the target.
      */
@@ -18313,12 +18313,12 @@ and performance.
       targetId: TargetID;
     }
   }
-
+  
   /**
    * The Tethering domain defines methods and events for browser port binding.
    */
   export namespace Tethering {
-
+    
     /**
      * Informs that port was successfully bound and got a specified connection id.
      */
@@ -18332,7 +18332,7 @@ and performance.
        */
       connectionId: string;
     }
-
+    
     /**
      * Request browser port binding.
      */
@@ -18356,7 +18356,7 @@ and performance.
     export type unbindReturnValue = {
     }
   }
-
+  
   export namespace Tracing {
     /**
      * Configuration for memory dump. Used only when "memory-infra" category is enabled.
@@ -18424,7 +18424,7 @@ supported on Chrome OS and uses the Perfetto system tracing service.
 specifies at least one non-Chrome data source; otherwise uses `chrome`.
      */
     export type TracingBackend = "auto"|"chrome"|"system";
-
+    
     export type bufferUsagePayload = {
       /**
        * A number in range [0..1] that indicates the used size of event buffer as a fraction of its
@@ -18471,7 +18471,7 @@ buffer wrapped around.
        */
       streamCompression?: StreamCompression;
     }
-
+    
     /**
      * Stop trace events collection.
      */
@@ -18570,7 +18570,7 @@ are ignored.
     export type startReturnValue = {
     }
   }
-
+  
   /**
    * This domain allows inspection of Web Audio API.
 https://webaudio.github.io/web-audio-api/
@@ -18685,7 +18685,7 @@ capacity and glitch may occur.
       minValue: number;
       maxValue: number;
     }
-
+    
     /**
      * Notifies that a new BaseAudioContext has been created.
      */
@@ -18782,7 +18782,7 @@ capacity and glitch may occur.
       destinationId: GraphObjectId;
       sourceOutputIndex?: number;
     }
-
+    
     /**
      * Enables the WebAudio domain and starts sending context lifetime events.
      */
@@ -18807,7 +18807,7 @@ capacity and glitch may occur.
       realtimeData: ContextRealtimeData;
     }
   }
-
+  
   /**
    * This domain allows configuring virtual authenticators to test the WebAuthn
 API.
@@ -18931,7 +18931,7 @@ https://w3c.github.io/webauthn/#dom-publickeycredentialuserentity-displayname
        */
       userDisplayName?: string;
     }
-
+    
     /**
      * Triggered when a credential is added to an authenticator.
      */
@@ -18962,7 +18962,7 @@ PublicKeyCredential.signalCurrentUserDetails().
       authenticatorId: AuthenticatorId;
       credential: Credential;
     }
-
+    
     /**
      * Enable the WebAuthn domain and start intercepting credential storage and
 retrieval with a virtual authenticator.
@@ -19105,7 +19105,7 @@ https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties
     export type setCredentialPropertiesReturnValue = {
     }
   }
-
+  
   /**
    * This domain is deprecated - use Runtime or Log instead.
    */
@@ -19139,7 +19139,7 @@ https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties
        */
       column?: number;
     }
-
+    
     /**
      * Issued when new console message is added.
      */
@@ -19149,7 +19149,7 @@ https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties
        */
       message: ConsoleMessage;
     }
-
+    
     /**
      * Does nothing.
      */
@@ -19173,7 +19173,7 @@ https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties
     export type enableReturnValue = {
     }
   }
-
+  
   /**
    * Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing
 breakpoints, stepping through execution, exploring stack traces, etc.
@@ -19354,7 +19354,7 @@ variables as its properties.
        */
       location: Location;
     }
-
+    
     /**
      * Fired when breakpoint is resolved to an actual script and location.
 Deprecated in favor of `resolvedBreakpoints` in the `scriptParsed` event.
@@ -19575,7 +19575,7 @@ matches this script's URL or hash. Clients that use this list can ignore the
        */
       resolvedBreakpoints?: ResolvedBreakpoint[];
     }
-
+    
     /**
      * Continues execution until specific location is reached.
      */
@@ -20204,7 +20204,7 @@ before next pause.
     export type stepOverReturnValue = {
     }
   }
-
+  
   export namespace HeapProfiler {
     /**
      * Heap snapshot object id.
@@ -20256,7 +20256,7 @@ between startSampling and stopSampling.
       head: SamplingHeapProfileNode;
       samples: SamplingHeapProfileSample[];
     }
-
+    
     export type addHeapSnapshotChunkPayload = {
       chunk: string;
     }
@@ -20286,7 +20286,7 @@ then one or more heapStatsUpdate events will be sent before a new lastSeenObject
       finished?: boolean;
     }
     export type resetProfilesPayload = void;
-
+    
     /**
      * Enables console to refer to the node with given id via $x (see Command Line API for more details
 $x functions).
@@ -20433,7 +20433,7 @@ Deprecated in favor of `exposeInternals`.
     export type takeHeapSnapshotReturnValue = {
     }
   }
-
+  
   export namespace Profiler {
     /**
      * Profile node. Holds callsite information, execution statistics and child nodes.
@@ -20555,7 +20555,7 @@ profile startTime.
        */
       functions: FunctionCoverage[];
     }
-
+    
     export type consoleProfileFinishedPayload = {
       id: string;
       /**
@@ -20602,7 +20602,7 @@ trigger collection of coverage data immediately at a certain point in time.
        */
       result: ScriptCoverage[];
     }
-
+    
     export type disableParameters = {
     }
     export type disableReturnValue = {
@@ -20696,7 +20696,7 @@ coverage needs to have started.
       timestamp: number;
     }
   }
-
+  
   /**
    * Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects.
 Evaluation results are returned as mirror object that expose object type, string representation
@@ -21117,7 +21117,7 @@ allows to track cross-debugger calls. See `Runtime.StackTrace` and `Debugger.pau
       id: string;
       debuggerId?: UniqueDebuggerId;
     }
-
+    
     /**
      * Notification is issued every time when binding is called.
      */
@@ -21223,7 +21223,7 @@ call).
        */
       executionContextId?: ExecutionContextId;
     }
-
+    
     /**
      * Add handler to promise with given promise object id.
      */
@@ -21759,7 +21759,7 @@ Error was thrown.
       exceptionDetails?: ExceptionDetails;
     }
   }
-
+  
   /**
    * This domain is deprecated.
    */
@@ -21777,8 +21777,8 @@ Error was thrown.
        */
       version: string;
     }
-
-
+    
+    
     /**
      * Returns supported domains.
      */
@@ -21791,7 +21791,7 @@ Error was thrown.
       domains: Domain[];
     }
   }
-
+  
   export type Events = {
     "Accessibility.loadComplete": Accessibility.loadCompletePayload;
     "Accessibility.nodesUpdated": Accessibility.nodesUpdatedPayload;

--- a/packages/playwright-core/types/protocol.d.ts
+++ b/packages/playwright-core/types/protocol.d.ts
@@ -1,7 +1,7 @@
 // This is generated from /utils/protocol-types-generator/index.js
 type binary = string;
-export module Protocol {
-  export module Accessibility {
+export namespace Protocol {
+  export namespace Accessibility {
     /**
      * Unique accessibility node identifier.
      */
@@ -171,7 +171,7 @@ export module Protocol {
        */
       frameId?: Page.FrameId;
     }
-    
+
     /**
      * The loadComplete event mirrors the load complete event sent by the browser to assistive
 technology when the web page has finished loading.
@@ -191,7 +191,7 @@ technology when the web page has finished loading.
        */
       nodes: AXNode[];
     }
-    
+
     /**
      * Disables the accessibility domain.
      */
@@ -340,8 +340,8 @@ including nodes that are ignored for accessibility.
       nodes: AXNode[];
     }
   }
-  
-  export module Animation {
+
+  export namespace Animation {
     /**
      * Animation instance.
      */
@@ -498,7 +498,7 @@ percentage [0 - 100] for scroll driven animations
        */
       easing: string;
     }
-    
+
     /**
      * Event for when an animation has been cancelled.
      */
@@ -535,7 +535,7 @@ percentage [0 - 100] for scroll driven animations
        */
       animation: Animation;
     }
-    
+
     /**
      * Disables animation domain notifications.
      */
@@ -663,11 +663,11 @@ percentage [0 - 100] for scroll driven animations
     export type setTimingReturnValue = {
     }
   }
-  
+
   /**
    * Audits domain allows investigation of page violations and possible improvements.
    */
-  export module Audits {
+  export namespace Audits {
     /**
      * Information about a cookie that is affected by an inspector issue.
      */
@@ -1160,11 +1160,11 @@ exception, CDP message, etc.) is referencing this issue.
        */
       issueId?: IssueId;
     }
-    
+
     export type issueAddedPayload = {
       issue: InspectorIssue;
     }
-    
+
     /**
      * Returns the response body and size if it were re-encoded with the specified settings. Only
 applies to images.
@@ -1238,11 +1238,11 @@ using Audits.issueAdded event.
       formIssues: GenericIssueDetails[];
     }
   }
-  
+
   /**
    * Defines commands and events for Autofill.
    */
-  export module Autofill {
+  export namespace Autofill {
     export interface CreditCard {
       /**
        * 16-digit credit card number.
@@ -1342,7 +1342,7 @@ Munich 81456
        */
       fieldId: DOM.BackendNodeId;
     }
-    
+
     /**
      * Emitted when an address form is filled.
      */
@@ -1357,7 +1357,7 @@ Consists of a 2D array where each child represents an address/profile line.
        */
       addressUi: AddressUI;
     }
-    
+
     /**
      * Trigger autofill on a form identified by the fieldId.
 If the field and related form cannot be autofilled, returns an error.
@@ -1405,11 +1405,11 @@ If the field and related form cannot be autofilled, returns an error.
     export type enableReturnValue = {
     }
   }
-  
+
   /**
    * Defines events for background web platform features.
    */
-  export module BackgroundService {
+  export namespace BackgroundService {
     /**
      * The Background Service that will be associated with the commands/events.
 Every Background Service operates independently, but they share the same
@@ -1457,7 +1457,7 @@ API.
        */
       storageKey: string;
     }
-    
+
     /**
      * Called when the recording state for the service has been updated.
      */
@@ -1472,7 +1472,7 @@ events afterwards if enabled and recording.
     export type backgroundServiceEventReceivedPayload = {
       backgroundServiceEvent: BackgroundServiceEvent;
     }
-    
+
     /**
      * Enables event updates for the service.
      */
@@ -1507,12 +1507,12 @@ events afterwards if enabled and recording.
     export type clearEventsReturnValue = {
     }
   }
-  
+
   /**
    * This domain allows configuring virtual Bluetooth devices to test
 the web-bluetooth API.
    */
-  export module BluetoothEmulation {
+  export namespace BluetoothEmulation {
     /**
      * Indicates the various states of Central.
      */
@@ -1590,7 +1590,7 @@ Specification BT 4.2 Vol 3 Part G 3.3.1. Characteristic Properties.
       authenticatedSignedWrites?: boolean;
       extendedProperties?: boolean;
     }
-    
+
     /**
      * Event for when a GATT operation of |type| to the peripheral with |address|
 happened.
@@ -1620,7 +1620,7 @@ respresented by |descriptorId| happened. |data| is expected to exist when
       type: DescriptorOperationType;
       data?: binary;
     }
-    
+
     /**
      * Enable the BluetoothEmulation domain.
      */
@@ -1793,11 +1793,11 @@ by |characteristicId|.
     export type simulateGATTDisconnectionReturnValue = {
     }
   }
-  
+
   /**
    * The Browser domain defines methods and events for browser managing.
    */
-  export module Browser {
+  export namespace Browser {
     export type BrowserContextID = string;
     export type WindowID = number;
     /**
@@ -1906,7 +1906,7 @@ Note that userVisibleOnly = true is the only currently supported type.
       buckets: Bucket[];
     }
     export type PrivacySandboxAPI = "BiddingAndAuctionServices"|"TrustedKeyValue";
-    
+
     /**
      * Fired when page is about to start a download.
      */
@@ -1955,7 +1955,7 @@ is guaranteed to exist.
        */
       filePath?: string;
     }
-    
+
     /**
      * Set permission settings for given embedding and embedded origins.
      */
@@ -2275,7 +2275,7 @@ context is used.
     export type addPrivacySandboxCoordinatorKeyConfigReturnValue = {
     }
   }
-  
+
   /**
    * This domain exposes CSS read/write operations. All CSS objects (stylesheets, rules, and styles)
 have an associated `id` used in subsequent operations on the related object. Each object type has
@@ -2284,7 +2284,7 @@ CSS objects can be loaded using the `get*ForNode()` calls (which accept a DOM no
 can also keep track of stylesheets via the `styleSheetAdded`/`styleSheetRemoved` events and
 subsequently load the required stylesheet contents using the `getStyleSheet[Text]()` methods.
    */
-  export module CSS {
+  export namespace CSS {
     /**
      * Stylesheet type: "injected" for stylesheets injected via extension, "user-agent" for user-agent
 stylesheets, "inspector" for stylesheets created by the inspector (i.e. those holding the "via
@@ -3237,7 +3237,7 @@ stylesheet rules) this rule came from.
        */
       text: string;
     }
-    
+
     /**
      * Fires whenever a web font is updated.  A non-empty font parameter indicates a successfully loaded
 web font.
@@ -3283,7 +3283,7 @@ resized.) The current implementation considers only viewport-dependent media fea
        */
       nodeId: DOM.NodeId;
     }
-    
+
     /**
      * Inserts a new rule with the given `ruleText` in a stylesheet with given `styleSheetId`, at the
 position specified by `location`.
@@ -3869,8 +3869,8 @@ instrumentation).
     export type setLocalFontsEnabledReturnValue = {
     }
   }
-  
-  export module CacheStorage {
+
+  export namespace CacheStorage {
     /**
      * Unique identifier of the Cache object.
      */
@@ -3954,8 +3954,8 @@ instrumentation).
        */
       body: binary;
     }
-    
-    
+
+
     /**
      * Deletes a cache.
      */
@@ -4062,12 +4062,12 @@ is the count of all entries from this storage.
       returnCount: number;
     }
   }
-  
+
   /**
    * A domain for interacting with Cast, Presentation API, and Remote Playback API
 functionalities.
    */
-  export module Cast {
+  export namespace Cast {
     export interface Sink {
       name: string;
       id: string;
@@ -4077,7 +4077,7 @@ session on the sink.
        */
       session?: string;
     }
-    
+
     /**
      * This is fired whenever the list of available sinks changes. A sink is a
 device or a software surface that you can cast to.
@@ -4092,7 +4092,7 @@ device or a software surface that you can cast to.
     export type issueUpdatedPayload = {
       issueMessage: string;
     }
-    
+
     /**
      * Starts observing for sinks that can be used for tab mirroring, and if set,
 sinks compatible with |presentationUrl| as well. When sinks are found, a
@@ -4146,7 +4146,7 @@ sink via Presentation API, Remote Playback API, or Cast SDK.
     export type stopCastingReturnValue = {
     }
   }
-  
+
   /**
    * This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object
 that has an `id`. This `id` can be used to get additional information on the Node, resolve it into
@@ -4156,7 +4156,7 @@ and never sends the same node twice. It is client's responsibility to collect in
 the nodes that were sent to the client. Note that `iframe` owner elements will return
 corresponding document elements as their child nodes.
    */
-  export module DOM {
+  export namespace DOM {
     /**
      * Unique DOM node identifier.
      */
@@ -4453,7 +4453,7 @@ The property is always undefined now.
        */
       value: string;
     }
-    
+
     /**
      * Fired when `Element`'s attribute is modified.
      */
@@ -4675,7 +4675,7 @@ most of the calls requesting node ids.
        */
       root: Node;
     }
-    
+
     /**
      * Collects class names for the node with given id and all of it's child nodes.
      */
@@ -5614,12 +5614,12 @@ popover if it was previously force-opened.
       nodeIds: NodeId[];
     }
   }
-  
+
   /**
    * DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript
 execution will stop on these operations as if there was a regular breakpoint set.
    */
-  export module DOMDebugger {
+  export namespace DOMDebugger {
     /**
      * DOM breakpoint type.
      */
@@ -5673,8 +5673,8 @@ execution will stop on these operations as if there was a regular breakpoint set
        */
       backendNodeId?: DOM.BackendNodeId;
     }
-    
-    
+
+
     /**
      * Returns event listeners of the given object.
      */
@@ -5817,11 +5817,11 @@ EventTarget.
     export type setXHRBreakpointReturnValue = {
     }
   }
-  
+
   /**
    * This domain facilitates obtaining document snapshots with DOM, layout, and style information.
    */
-  export module DOMSnapshot {
+  export namespace DOMSnapshot {
     /**
      * A Node in the DOM tree.
      */
@@ -6258,8 +6258,8 @@ represented as a surrogate pair in UTF-16 have length 2.
        */
       length: number[];
     }
-    
-    
+
+
     /**
      * Disables DOM snapshot agent for the given page.
      */
@@ -6355,11 +6355,11 @@ The final text color opacity is computed based on the opacity of all overlapping
       strings: string[];
     }
   }
-  
+
   /**
    * Query and modify DOM storage.
    */
-  export module DOMStorage {
+  export namespace DOMStorage {
     export type SerializedStorageKey = string;
     /**
      * DOM Storage identifier.
@@ -6382,7 +6382,7 @@ The final text color opacity is computed based on the opacity of all overlapping
      * DOM Storage item.
      */
     export type Item = string[];
-    
+
     export type domStorageItemAddedPayload = {
       storageId: StorageId;
       key: string;
@@ -6401,7 +6401,7 @@ The final text color opacity is computed based on the opacity of all overlapping
     export type domStorageItemsClearedPayload = {
       storageId: StorageId;
     }
-    
+
     export type clearParameters = {
       storageId: StorageId;
     }
@@ -6441,8 +6441,8 @@ The final text color opacity is computed based on the opacity of all overlapping
     export type setDOMStorageItemReturnValue = {
     }
   }
-  
-  export module DeviceAccess {
+
+  export namespace DeviceAccess {
     /**
      * Device request id.
      */
@@ -6461,7 +6461,7 @@ The final text color opacity is computed based on the opacity of all overlapping
        */
       name: string;
     }
-    
+
     /**
      * A device request opened a user prompt to select a device. Respond with the
 selectPrompt or cancelPrompt command.
@@ -6470,7 +6470,7 @@ selectPrompt or cancelPrompt command.
       id: RequestId;
       devices: PromptDevice[];
     }
-    
+
     /**
      * Enable events in this domain.
      */
@@ -6503,10 +6503,10 @@ selectPrompt or cancelPrompt command.
     export type cancelPromptReturnValue = {
     }
   }
-  
-  export module DeviceOrientation {
-    
-    
+
+  export namespace DeviceOrientation {
+
+
     /**
      * Clears the overridden Device Orientation.
      */
@@ -6534,11 +6534,11 @@ selectPrompt or cancelPrompt command.
     export type setDeviceOrientationOverrideReturnValue = {
     }
   }
-  
+
   /**
    * This domain emulates different environments for the page.
    */
-  export module Emulation {
+  export namespace Emulation {
     export interface SafeAreaInsets {
       /**
        * Overrides safe-area-inset-top.
@@ -6781,12 +6781,12 @@ see https://w3c.github.io/window-management/#screendetailed.
      * Enum of image types that can be disabled.
      */
     export type DisabledImageType = "avif"|"webp";
-    
+
     /**
      * Notification sent after the virtual time budget for the current VirtualTimePolicy has run out.
      */
     export type virtualTimeBudgetExpiredPayload = void;
-    
+
     /**
      * Tells whether emulation is supported.
      */
@@ -7429,15 +7429,15 @@ of size 100lvh.
     export type removeScreenReturnValue = {
     }
   }
-  
+
   /**
    * EventBreakpoints permits setting JavaScript breakpoints on operations and events
 occurring in native code invoked from JavaScript. Once breakpoint is hit, it is
 reported through Debugger domain, similarly to regular breakpoints being hit.
    */
-  export module EventBreakpoints {
-    
-    
+  export namespace EventBreakpoints {
+
+
     /**
      * Sets breakpoint on particular native event.
      */
@@ -7468,17 +7468,17 @@ reported through Debugger domain, similarly to regular breakpoints being hit.
     export type disableReturnValue = {
     }
   }
-  
+
   /**
    * Defines commands and events for browser extensions.
    */
-  export module Extensions {
+  export namespace Extensions {
     /**
      * Storage areas.
      */
     export type StorageArea = "session"|"local"|"sync"|"managed";
-    
-    
+
+
     /**
      * Installs an unpacked extension from the filesystem similar to
 --load-extension CLI flags. Returns extension ID once the extension
@@ -7587,11 +7587,11 @@ will be merged with existing values in the storage area.
     export type setStorageItemsReturnValue = {
     }
   }
-  
+
   /**
    * This domain allows interacting with the FedCM dialog.
    */
-  export module FedCm {
+  export namespace FedCm {
     /**
      * Whether this is a sign-up or sign-in action for this account, i.e.
 whether this account has ever been used to sign in to this RP before.
@@ -7627,7 +7627,7 @@ whether this account has ever been used to sign in to this RP before.
       termsOfServiceUrl?: string;
       privacyPolicyUrl?: string;
     }
-    
+
     export type dialogShownPayload = {
       dialogId: string;
       dialogType: DialogType;
@@ -7646,7 +7646,7 @@ or a command below.
     export type dialogClosedPayload = {
       dialogId: string;
     }
-    
+
     export type enableParameters = {
       /**
        * Allows callers to disable the promise rejection delay that would
@@ -7695,11 +7695,11 @@ a dialog even if one was recently dismissed by the user.
     export type resetCooldownReturnValue = {
     }
   }
-  
+
   /**
    * A domain for letting clients substitute browser's network layer with client code.
    */
-  export module Fetch {
+  export namespace Fetch {
     /**
      * Unique request identifier.
 Note that this does not identify individual HTTP requests that are part of
@@ -7776,7 +7776,7 @@ ProvideCredentials.
        */
       password?: string;
     }
-    
+
     /**
      * Issued when the domain is enabled and the request URL matches the
 specified filter. The request is paused until the client responds
@@ -7862,7 +7862,7 @@ contains AuthChallengeResponse.
        */
       authChallenge: AuthChallenge;
     }
-    
+
     /**
      * Disables the fetch domain.
      */
@@ -8069,8 +8069,8 @@ domain before body is received results in an undefined behavior.
       stream: IO.StreamHandle;
     }
   }
-  
-  export module FileSystem {
+
+  export namespace FileSystem {
     export interface File {
       name: string;
       /**
@@ -8105,8 +8105,8 @@ domain before body is received results in an undefined behavior.
        */
       pathComponents: string[];
     }
-    
-    
+
+
     export type getDirectoryParameters = {
       bucketFileSystemLocator: BucketFileSystemLocator;
     }
@@ -8117,11 +8117,11 @@ domain before body is received results in an undefined behavior.
       directory: Directory;
     }
   }
-  
+
   /**
    * This domain provides experimental commands only supported in headless mode.
    */
-  export module HeadlessExperimental {
+  export namespace HeadlessExperimental {
     /**
      * Encoding options for a screenshot.
      */
@@ -8139,8 +8139,8 @@ domain before body is received results in an undefined behavior.
        */
       optimizeForSpeed?: boolean;
     }
-    
-    
+
+
     /**
      * Sends a BeginFrame to the target and returns when the frame was completed. Optionally captures a
 screenshot from the resulting frame. Requires that the target was created with enabled
@@ -8197,18 +8197,18 @@ display. Reported for diagnostic uses, may be removed in the future.
     export type enableReturnValue = {
     }
   }
-  
+
   /**
    * Input/Output operations for streams produced by DevTools.
    */
-  export module IO {
+  export namespace IO {
     /**
      * This is either obtained from another method or specified as `blob:<uuid>` where
 `<uuid>` is an UUID of a Blob.
      */
     export type StreamHandle = string;
-    
-    
+
+
     /**
      * Close the stream, discard any temporary backing storage.
      */
@@ -8268,8 +8268,8 @@ following the last read). Some types of streams may only support sequential read
       uuid: string;
     }
   }
-  
-  export module IndexedDB {
+
+  export namespace IndexedDB {
     /**
      * Database with an array of object stores.
      */
@@ -8410,8 +8410,8 @@ requires the version number to be 'unsigned long long')
        */
       array?: string[];
     }
-    
-    
+
+
     /**
      * Clears all entries from an object store.
      */
@@ -8647,8 +8647,8 @@ Security origin.
       databaseNames: string[];
     }
   }
-  
-  export module Input {
+
+  export namespace Input {
     export interface TouchPoint {
       /**
        * X coordinate of the event relative to the main frame's viewport in CSS pixels.
@@ -8733,7 +8733,7 @@ text, HTML markup or any other data.
        */
       dragOperationsMask: number;
     }
-    
+
     /**
      * Emitted only when `Input.setInterceptDrags` is enabled. Use this data with `Input.dispatchDragEvent` to
 restore normal drag and drop behavior.
@@ -8741,7 +8741,7 @@ restore normal drag and drop behavior.
     export type dragInterceptedPayload = {
       data: DragData;
     }
-    
+
     /**
      * Dispatches a drag event into the page.
      */
@@ -9170,9 +9170,9 @@ for the preferred input type).
     export type synthesizeTapGestureReturnValue = {
     }
   }
-  
-  export module Inspector {
-    
+
+  export namespace Inspector {
+
     /**
      * Fired when remote debugging connection is about to be terminated. Contains detach reason.
      */
@@ -9194,7 +9194,7 @@ for the preferred input type).
      * Fired on worker targets when main worker script and any imported scripts have been evaluated.
      */
     export type workerScriptLoadedPayload = void;
-    
+
     /**
      * Disables inspector domain notifications.
      */
@@ -9210,8 +9210,8 @@ for the preferred input type).
     export type enableReturnValue = {
     }
   }
-  
-  export module LayerTree {
+
+  export namespace LayerTree {
     /**
      * Unique Layer identifier.
      */
@@ -9345,7 +9345,7 @@ transform/scrolling purposes only.
      * Array of timings, one per paint step.
      */
     export type PaintProfile = number[];
-    
+
     export type layerPaintedPayload = {
       /**
        * The id of the painted layer.
@@ -9362,7 +9362,7 @@ transform/scrolling purposes only.
        */
       layers?: Layer[];
     }
-    
+
     /**
      * Provides the reasons why the given layer was composited.
      */
@@ -9504,11 +9504,11 @@ transform/scrolling purposes only.
       commandLog: { [key: string]: string }[];
     }
   }
-  
+
   /**
    * Provides access to log entries.
    */
-  export module Log {
+  export namespace Log {
     /**
      * Log entry.
      */
@@ -9568,7 +9568,7 @@ transform/scrolling purposes only.
        */
       threshold: number;
     }
-    
+
     /**
      * Issued when new message was logged.
      */
@@ -9578,7 +9578,7 @@ transform/scrolling purposes only.
        */
       entry: LogEntry;
     }
-    
+
     /**
      * Clears the log.
      */
@@ -9620,11 +9620,11 @@ transform/scrolling purposes only.
     export type stopViolationsReportReturnValue = {
     }
   }
-  
+
   /**
    * This domain allows detailed inspection of media elements.
    */
-  export module Media {
+  export namespace Media {
     /**
      * Players will get an ID that is unique within the agent context.
      */
@@ -9699,7 +9699,7 @@ caused by an WindowsError
       playerId: PlayerId;
       domNodeId?: DOM.BackendNodeId;
     }
-    
+
     /**
      * This can be called multiple times, and can be used to set / override /
 remove player properties. A null propValue indicates removal.
@@ -9738,7 +9738,7 @@ event for each active player.
     export type playerCreatedPayload = {
       player: Player;
     }
-    
+
     /**
      * Enables the Media domain
      */
@@ -9754,8 +9754,8 @@ event for each active player.
     export type disableReturnValue = {
     }
   }
-  
-  export module Memory {
+
+  export namespace Memory {
     /**
      * Memory pressure level.
      */
@@ -9820,8 +9820,8 @@ the returned names to be consistent across runs.
        */
       count: number;
     }
-    
-    
+
+
     /**
      * Retruns current DOM object counters.
      */
@@ -9930,12 +9930,12 @@ collected since browser process startup.
       profile: SamplingProfile;
     }
   }
-  
+
   /**
    * Network domain allows tracking network activities of the page. It exposes information about http,
 file, data and other requests and responses, their headers, bodies, timing, etc.
    */
-  export module Network {
+  export namespace Network {
     /**
      * Resource type as it was perceived by the rendering engine.
      */
@@ -11176,7 +11176,7 @@ CORB and streaming.
       disableCache: boolean;
       includeCredentials: boolean;
     }
-    
+
     /**
      * Fired when data chunk was received over the network.
      */
@@ -11918,7 +11918,7 @@ And after 'enableReportingApi' for all existing reports.
       origin: string;
       endpoints: ReportingApiEndpoint[];
     }
-    
+
     /**
      * Sets a list of content encodings that will be accepted. Empty list means no encoding is accepted.
      */
@@ -12593,11 +12593,11 @@ Page reload is required before the new cookie behavior will be observed
     export type setCookieControlsReturnValue = {
     }
   }
-  
+
   /**
    * This domain provides various functionality related to drawing atop the inspected page.
    */
-  export module Overlay {
+  export namespace Overlay {
     /**
      * Configuration data for drawing the source order of an elements children.
      */
@@ -12989,7 +12989,7 @@ Page reload is required before the new cookie behavior will be observed
       maskColor?: DOM.RGBA;
     }
     export type InspectMode = "searchForNode"|"searchForUAShadowDOM"|"captureAreaScreenshot"|"none";
-    
+
     /**
      * Fired when the node should be inspected. This happens after call to `setInspectMode` or when
 user manually inspects an element.
@@ -13019,7 +13019,7 @@ user manually inspects an element.
      * Fired when user cancels the inspect mode.
      */
     export type inspectModeCanceledPayload = void;
-    
+
     /**
      * Disables domain notifications.
      */
@@ -13419,11 +13419,11 @@ Backend then generates 'inspectNodeRequested' event upon element selection.
     export type setShowWindowControlsOverlayReturnValue = {
     }
   }
-  
+
   /**
    * This domain allows interacting with the browser to control PWAs.
    */
-  export module PWA {
+  export namespace PWA {
     /**
      * The following types are the replica of
 https://crsrc.org/c/chrome/browser/web_applications/proto/web_app_os_integration_state.proto;drc=9910d3be894c8f142c977ba1023f30a656bc13fc;l=67
@@ -13445,8 +13445,8 @@ https://www.iana.org/assignments/media-types/media-types.xhtml
      * If user prefers opening the app in browser or an app window.
      */
     export type DisplayMode = "standalone"|"browser";
-    
-    
+
+
     /**
      * Returns the following OS state for the given manifest id.
      */
@@ -13590,11 +13590,11 @@ supported yet.
     export type changeAppUserSettingsReturnValue = {
     }
   }
-  
+
   /**
    * Actions and events related to the inspected page belong to the page domain.
    */
-  export module Page {
+  export namespace Page {
     /**
      * Unique frame identifier.
      */
@@ -14313,7 +14313,7 @@ dependent on the reason:
        */
       children: BackForwardCacheNotRestoredExplanationTree[];
     }
-    
+
     export type domContentEventFiredPayload = {
       timestamp: Network.MonotonicTime;
     }
@@ -14709,7 +14709,7 @@ etc.
        */
       data: binary;
     }
-    
+
     /**
      * Deprecated, please use addScriptToEvaluateOnNewDocument instead.
      */
@@ -15713,8 +15713,8 @@ components/optimization_guide/proto/features/common_quality_data.proto
       content: binary;
     }
   }
-  
-  export module Performance {
+
+  export namespace Performance {
     /**
      * Run-time execution metric.
      */
@@ -15728,7 +15728,7 @@ components/optimization_guide/proto/features/common_quality_data.proto
        */
       value: number;
     }
-    
+
     /**
      * Current values of the metrics.
      */
@@ -15742,7 +15742,7 @@ components/optimization_guide/proto/features/common_quality_data.proto
        */
       title: string;
     }
-    
+
     /**
      * Disable collecting and reporting metrics.
      */
@@ -15786,12 +15786,12 @@ this method while metrics collection is enabled returns an error.
       metrics: Metric[];
     }
   }
-  
+
   /**
    * Reporting of performance timeline events, as specified in
 https://w3c.github.io/performance-timeline/#dom-performanceobserver.
    */
-  export module PerformanceTimeline {
+  export namespace PerformanceTimeline {
     /**
      * See https://github.com/WICG/LargestContentfulPaint and largest_contentful_paint.idl
      */
@@ -15854,14 +15854,14 @@ This determines which of the optional "details" fields is present.
       lcpDetails?: LargestContentfulPaint;
       layoutShiftDetails?: LayoutShift;
     }
-    
+
     /**
      * Sent when a performance timeline event is added. See reportPerformanceTimeline method.
      */
     export type timelineEventAddedPayload = {
       event: TimelineEvent;
     }
-    
+
     /**
      * Previously buffered events would be reported before method returns.
 See also: timelineEventAdded
@@ -15879,8 +15879,8 @@ Note that not all types exposed to the web platform are currently supported.
     export type enableReturnValue = {
     }
   }
-  
-  export module Preload {
+
+  export namespace Preload {
     /**
      * Unique id
      */
@@ -16004,7 +16004,7 @@ filter out the ones that aren't necessary to the developers.
       initialValue?: string;
       activationValue?: string;
     }
-    
+
     /**
      * Upsert. Currently, it is only emitted when a rule set added.
      */
@@ -16061,7 +16061,7 @@ that is incompatible with prerender and has caused the cancellation of the attem
       loaderId: Network.LoaderId;
       preloadingAttemptSources: PreloadingAttemptSource[];
     }
-    
+
     export type enableParameters = {
     }
     export type enableReturnValue = {
@@ -16071,8 +16071,8 @@ that is incompatible with prerender and has caused the cancellation of the attem
     export type disableReturnValue = {
     }
   }
-  
-  export module Security {
+
+  export namespace Security {
     /**
      * An internal certificate ID value.
      */
@@ -16266,7 +16266,7 @@ https://www.w3.org/TR/mixed-content/#categories
 request and cancel will cancel the request.
      */
     export type CertificateErrorAction = "continue"|"cancel";
-    
+
     /**
      * There is a certificate error. If overriding certificate errors is enabled, then it should be
 handled with the `handleCertificateError` command. Note: this event does not fire if the
@@ -16322,7 +16322,7 @@ empty.
        */
       summary?: string;
     }
-    
+
     /**
      * Disables tracking security state changes.
      */
@@ -16376,8 +16376,8 @@ be handled by the DevTools client and should be answered with `handleCertificate
     export type setOverrideCertificateErrorsReturnValue = {
     }
   }
-  
-  export module ServiceWorker {
+
+  export namespace ServiceWorker {
     export type RegistrationID = string;
     /**
      * ServiceWorker registration.
@@ -16422,7 +16422,7 @@ For cached script it is the last time the cache entry was validated.
       lineNumber: number;
       columnNumber: number;
     }
-    
+
     export type workerErrorReportedPayload = {
       errorMessage: ServiceWorkerErrorMessage;
     }
@@ -16432,7 +16432,7 @@ For cached script it is the last time the cache entry was validated.
     export type workerVersionUpdatedPayload = {
       versions: ServiceWorkerVersion[];
     }
-    
+
     export type deliverPushMessageParameters = {
       origin: string;
       registrationId: RegistrationID;
@@ -16498,8 +16498,8 @@ For cached script it is the last time the cache entry was validated.
     export type updateRegistrationReturnValue = {
     }
   }
-  
-  export module Storage {
+
+  export namespace Storage {
     export type SerializedStorageKey = string;
     /**
      * Enum of possible storage types.
@@ -16914,7 +16914,7 @@ int
        */
       serviceSites: string[];
     }
-    
+
     /**
      * A cache's contents have been modified.
      */
@@ -17156,7 +17156,7 @@ associated shared storage worklet.
       netErrorName?: string;
       httpStatusCode?: number;
     }
-    
+
     /**
      * Returns a storage key given a frame id.
 Deprecated. Please use Storage.getStorageKey instead.
@@ -17600,11 +17600,11 @@ party URL, only the first-party URL is returned in the array.
     export type setProtectedAudienceKAnonymityReturnValue = {
     }
   }
-  
+
   /**
    * The SystemInfo domain defines methods and events for querying low-level system information.
    */
-  export module SystemInfo {
+  export namespace SystemInfo {
     /**
      * Describes a single graphics processor (GPU).
      */
@@ -17749,8 +17749,8 @@ process since the process start.
        */
       cpuTime: number;
     }
-    
-    
+
+
     /**
      * Returns information about the system.
      */
@@ -17798,11 +17798,11 @@ supported.
       processInfo: ProcessInfo[];
     }
   }
-  
+
   /**
    * Supports additional targets discovery and allows to attach to them.
    */
-  export module Target {
+  export namespace Target {
     export type TargetID = string;
     /**
      * Unique identifier of attached debugging session.
@@ -17873,7 +17873,7 @@ If filter is not specified, the one assumed is
      * The state of the target window.
      */
     export type WindowState = "normal"|"minimized"|"maximized"|"fullscreen";
-    
+
     /**
      * Issued when attached to target because of auto-attach or `attachToTarget` command.
      */
@@ -17947,7 +17947,7 @@ issued multiple times per target if multiple sessions have been attached to it.
     export type targetInfoChangedPayload = {
       targetInfo: TargetInfo;
     }
-    
+
     /**
      * Activates (focuses) the target.
      */
@@ -18313,12 +18313,12 @@ and performance.
       targetId: TargetID;
     }
   }
-  
+
   /**
    * The Tethering domain defines methods and events for browser port binding.
    */
-  export module Tethering {
-    
+  export namespace Tethering {
+
     /**
      * Informs that port was successfully bound and got a specified connection id.
      */
@@ -18332,7 +18332,7 @@ and performance.
        */
       connectionId: string;
     }
-    
+
     /**
      * Request browser port binding.
      */
@@ -18356,8 +18356,8 @@ and performance.
     export type unbindReturnValue = {
     }
   }
-  
-  export module Tracing {
+
+  export namespace Tracing {
     /**
      * Configuration for memory dump. Used only when "memory-infra" category is enabled.
      */
@@ -18424,7 +18424,7 @@ supported on Chrome OS and uses the Perfetto system tracing service.
 specifies at least one non-Chrome data source; otherwise uses `chrome`.
      */
     export type TracingBackend = "auto"|"chrome"|"system";
-    
+
     export type bufferUsagePayload = {
       /**
        * A number in range [0..1] that indicates the used size of event buffer as a fraction of its
@@ -18471,7 +18471,7 @@ buffer wrapped around.
        */
       streamCompression?: StreamCompression;
     }
-    
+
     /**
      * Stop trace events collection.
      */
@@ -18570,12 +18570,12 @@ are ignored.
     export type startReturnValue = {
     }
   }
-  
+
   /**
    * This domain allows inspection of Web Audio API.
 https://webaudio.github.io/web-audio-api/
    */
-  export module WebAudio {
+  export namespace WebAudio {
     /**
      * An unique ID for a graph object (AudioContext, AudioNode, AudioParam) in Web Audio API
      */
@@ -18685,7 +18685,7 @@ capacity and glitch may occur.
       minValue: number;
       maxValue: number;
     }
-    
+
     /**
      * Notifies that a new BaseAudioContext has been created.
      */
@@ -18782,7 +18782,7 @@ capacity and glitch may occur.
       destinationId: GraphObjectId;
       sourceOutputIndex?: number;
     }
-    
+
     /**
      * Enables the WebAudio domain and starts sending context lifetime events.
      */
@@ -18807,12 +18807,12 @@ capacity and glitch may occur.
       realtimeData: ContextRealtimeData;
     }
   }
-  
+
   /**
    * This domain allows configuring virtual authenticators to test the WebAuthn
 API.
    */
-  export module WebAuthn {
+  export namespace WebAuthn {
     export type AuthenticatorId = string;
     export type AuthenticatorProtocol = "u2f"|"ctap2";
     export type Ctap2Version = "ctap2_0"|"ctap2_1";
@@ -18931,7 +18931,7 @@ https://w3c.github.io/webauthn/#dom-publickeycredentialuserentity-displayname
        */
       userDisplayName?: string;
     }
-    
+
     /**
      * Triggered when a credential is added to an authenticator.
      */
@@ -18962,7 +18962,7 @@ PublicKeyCredential.signalCurrentUserDetails().
       authenticatorId: AuthenticatorId;
       credential: Credential;
     }
-    
+
     /**
      * Enable the WebAuthn domain and start intercepting credential storage and
 retrieval with a virtual authenticator.
@@ -19105,11 +19105,11 @@ https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties
     export type setCredentialPropertiesReturnValue = {
     }
   }
-  
+
   /**
    * This domain is deprecated - use Runtime or Log instead.
    */
-  export module Console {
+  export namespace Console {
     /**
      * Console message.
      */
@@ -19139,7 +19139,7 @@ https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties
        */
       column?: number;
     }
-    
+
     /**
      * Issued when new console message is added.
      */
@@ -19149,7 +19149,7 @@ https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties
        */
       message: ConsoleMessage;
     }
-    
+
     /**
      * Does nothing.
      */
@@ -19173,12 +19173,12 @@ https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties
     export type enableReturnValue = {
     }
   }
-  
+
   /**
    * Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing
 breakpoints, stepping through execution, exploring stack traces, etc.
    */
-  export module Debugger {
+  export namespace Debugger {
     /**
      * Breakpoint identifier.
      */
@@ -19354,7 +19354,7 @@ variables as its properties.
        */
       location: Location;
     }
-    
+
     /**
      * Fired when breakpoint is resolved to an actual script and location.
 Deprecated in favor of `resolvedBreakpoints` in the `scriptParsed` event.
@@ -19575,7 +19575,7 @@ matches this script's URL or hash. Clients that use this list can ignore the
        */
       resolvedBreakpoints?: ResolvedBreakpoint[];
     }
-    
+
     /**
      * Continues execution until specific location is reached.
      */
@@ -20204,8 +20204,8 @@ before next pause.
     export type stepOverReturnValue = {
     }
   }
-  
-  export module HeapProfiler {
+
+  export namespace HeapProfiler {
     /**
      * Heap snapshot object id.
      */
@@ -20256,7 +20256,7 @@ between startSampling and stopSampling.
       head: SamplingHeapProfileNode;
       samples: SamplingHeapProfileSample[];
     }
-    
+
     export type addHeapSnapshotChunkPayload = {
       chunk: string;
     }
@@ -20286,7 +20286,7 @@ then one or more heapStatsUpdate events will be sent before a new lastSeenObject
       finished?: boolean;
     }
     export type resetProfilesPayload = void;
-    
+
     /**
      * Enables console to refer to the node with given id via $x (see Command Line API for more details
 $x functions).
@@ -20433,8 +20433,8 @@ Deprecated in favor of `exposeInternals`.
     export type takeHeapSnapshotReturnValue = {
     }
   }
-  
-  export module Profiler {
+
+  export namespace Profiler {
     /**
      * Profile node. Holds callsite information, execution statistics and child nodes.
      */
@@ -20555,7 +20555,7 @@ profile startTime.
        */
       functions: FunctionCoverage[];
     }
-    
+
     export type consoleProfileFinishedPayload = {
       id: string;
       /**
@@ -20602,7 +20602,7 @@ trigger collection of coverage data immediately at a certain point in time.
        */
       result: ScriptCoverage[];
     }
-    
+
     export type disableParameters = {
     }
     export type disableReturnValue = {
@@ -20696,7 +20696,7 @@ coverage needs to have started.
       timestamp: number;
     }
   }
-  
+
   /**
    * Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects.
 Evaluation results are returned as mirror object that expose object type, string representation
@@ -20704,7 +20704,7 @@ and unique identifier that can be used for further object reference. Original ob
 maintained in memory unless they are either explicitly released or are released along with the
 other objects in their object group.
    */
-  export module Runtime {
+  export namespace Runtime {
     /**
      * Unique script identifier.
      */
@@ -21117,7 +21117,7 @@ allows to track cross-debugger calls. See `Runtime.StackTrace` and `Debugger.pau
       id: string;
       debuggerId?: UniqueDebuggerId;
     }
-    
+
     /**
      * Notification is issued every time when binding is called.
      */
@@ -21223,7 +21223,7 @@ call).
        */
       executionContextId?: ExecutionContextId;
     }
-    
+
     /**
      * Add handler to promise with given promise object id.
      */
@@ -21759,11 +21759,11 @@ Error was thrown.
       exceptionDetails?: ExceptionDetails;
     }
   }
-  
+
   /**
    * This domain is deprecated.
    */
-  export module Schema {
+  export namespace Schema {
     /**
      * Description of the protocol domain.
      */
@@ -21777,8 +21777,8 @@ Error was thrown.
        */
       version: string;
     }
-    
-    
+
+
     /**
      * Returns supported domains.
      */
@@ -21791,7 +21791,7 @@ Error was thrown.
       domains: Domain[];
     }
   }
-  
+
   export type Events = {
     "Accessibility.loadComplete": Accessibility.loadCompletePayload;
     "Accessibility.nodesUpdated": Accessibility.nodesUpdatedPayload;

--- a/packages/playwright/src/common/validators.ts
+++ b/packages/playwright/src/common/validators.ts
@@ -16,7 +16,7 @@
 
 import { zod } from 'playwright-core/lib/utilsBundle';
 
-import type { TestAnnotation, TestDetailsAnnotation } from 'packages/playwright/types/test';
+import type { TestAnnotation, TestDetailsAnnotation } from '../../types/test';
 import type { Location } from '../../types/testReporter';
 import type { ZodError } from 'zod';
 

--- a/packages/recorder/tsconfig.json
+++ b/packages/recorder/tsconfig.json
@@ -14,7 +14,6 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "useUnknownInCatchVariables": false,
     "paths": {
       "@isomorphic/*": ["../playwright-core/src/utils/isomorphic/*"],

--- a/packages/trace-viewer/tsconfig.json
+++ b/packages/trace-viewer/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": true,
     "skipLibCheck": false,
-    "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "module": "ESNext",
@@ -14,7 +13,6 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "@injected/*": ["../injected/src/*"],
       "@isomorphic/*": ["../playwright-core/src/utils/isomorphic/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ES2019",
     "module": "commonjs",
     "lib": ["esnext", "dom", "DOM.Iterable"],
-    "baseUrl": ".",
     "paths": {
       /*
         The following two serve different purposes:

--- a/utils/protocol-types-generator/index.js
+++ b/utils/protocol-types-generator/index.js
@@ -40,11 +40,11 @@ const conditionFilter = command => command.condition !== 'defined(WTF_PLATFORM_I
 function jsonToTS(json) {
   return `// This is generated from /utils/protocol-types-generator/index.js
 type binary = string;
-export module Protocol {${json.domains.map(domain => `${domain.description ? `
+export namespace Protocol {${json.domains.map(domain => `${domain.description ? `
   /**
    * ${domain.description}
    */` : ''}
-  export module ${domain.domain} {${(domain.types || []).map(type => `${type.description ? `
+  export namespace ${domain.domain} {${(domain.types || []).map(type => `${type.description ? `
     /**
      * ${type.description}
      */` : ''}${type.properties ? `
@@ -180,9 +180,9 @@ async function generateFirefoxProtocol(executablePath) {
 function firefoxJSONToTS(json) {
   const domains = Object.entries(json.domains);
   return `// This is generated from /utils/protocol-types-generator/index.js
-export module Protocol {
+export namespace Protocol {
 ${domains.map(([domainName, domain]) => `
-  export module ${domainName} {${Object.entries(domain.types).map(([typeName, type]) => `
+  export namespace ${domainName} {${Object.entries(domain.types).map(([typeName, type]) => `
     export type ${typeName} = ${firefoxTypeToString(type, '    ')};`).join('')}${(Object.entries(domain.events)).map(([eventName, event]) => `
     export type ${eventName}Payload = ${firefoxTypeToString(event)}`).join('')}${(Object.entries(domain.methods)).map(([commandName, command]) => `
     export type ${commandName}Parameters = ${firefoxTypeToString(command.params)};


### PR DESCRIPTION
TypeScript 6.0 is deprecating a few old features used by Playwright, that being:
- `baseUrl` is being removed. `paths` has not needed `baseUrl` to be set for a while and it appears that it was indeed only set for `paths`.
- `module x` will now need to be `namespace x`. Note that this has been the recommendation for many years. This does _not_ effect the similar seeming `declare module "foo"`. This is what inspired me to open this PR since dependents on TypeScript 6.0 will get errors from `playwright-core`.
- `esModuleInterop` can no longer be set to `false`. Given the usage of Vite in the only package that set this (`trace-viewer`) I don't anticipate this to cause any issues.

See https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/#deprecation-compatibility for more information.