### PR TITLE
chore(deps): bump chromium-bidi to ^12.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "@zip.js/zip.js": "^2.7.29",
         "chokidar": "^3.5.3",
-        "chromium-bidi": "^11.0.0",
+        "chromium-bidi": "^12.0.0",
         "colors": "^1.4.0",
         "concurrently": "^6.2.1",
         "cross-env": "^7.0.3",
@@ -2894,9 +2894,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-11.0.0.tgz",
-      "integrity": "sha512-cM3DI+OOb89T3wO8cpPSro80Q9eKYJ7hGVXoGS3GkDPxnYSqiv+6xwpIf6XERyJ9Tdsl09hmNmY94BkgZdVekw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-12.0.0.tgz",
+      "integrity": "sha512-z703oisqO+hrSTwivCpV5Sg8ymizTQ70f6P8vRFcKcjbbOZ7t5D4VfNOOvXx/S/iomWkrMUTFwkCNBDE+w+oBg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "@zip.js/zip.js": "^2.7.29",
     "chokidar": "^3.5.3",
-    "chromium-bidi": "^11.0.0",
+    "chromium-bidi": "^12.0.0",
     "colors": "^1.4.0",
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
Required, as Playwright relies on `emulation.setScreenSettingsOverride`, which is implemented in `12.0.0`.