### PR TITLE
chore(bidi): Improve object previews

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -287,7 +287,7 @@ export class BidiPage implements PageDelegate {
 
     const callFrame = params.stackTrace?.callFrames[0];
     const location = callFrame ?? { url: '', lineNumber: 1, columnNumber: 1 };
-    this._page.addConsoleMessage(null, entry.method, entry.args.map(arg => createHandle(context, arg)), location, params.text || undefined);
+    this._page.addConsoleMessage(null, entry.method, entry.args.map(arg => createHandle(context, arg)), location);
   }
 
   private async _onFileDialogOpened(params: bidi.Input.FileDialogInfo) {


### PR DESCRIPTION
With this PR, the object previews rendered by Playwright/BiDi are closer to those that Playwright provides with other protocols and Playwright/BiDi always renders its own preview for console messages instead of using the browser-supplied one, making them more consistent across browsers and protocols.

There are some differences in the previews due to BiDi limitations:
- Functions are rendered simply as `Function`
- WeakMap/WeakSet are rendered as `WeakMap`/`WeakSet` (i.e. without a size)
- Symbol('foo') is rendered as `Symbol()`
- Typed arrays are rendered as `TypedArray`

Fixes the following tests:
- `tests/page/jshandle-to-string.spec.ts`:
  - "should work for complicated objects"
  - "should work with different subtypes"
  - "should work with previewable subtypes"
- `tests/page/page-event-console.spec.ts`:
  - "should not fail for window object"
  - "should use object previews for arrays and objects"
