### PR TITLE
test(bidi): Enable pref for dismissing file pickers

### DIFF
--- a/tests/bidi/playwright.config.ts
+++ b/tests/bidi/playwright.config.ts
@@ -30,6 +30,7 @@ function firefoxUserPrefs() {
   const defaultPrefs = {
     'network.proxy.allow_hijacking_localhost': true,
     'network.proxy.testing_localhost_is_secure_when_hijacked': true,
+    'remote.bidi.dismiss_file_pickers.enabled': true,
   };
   const prefsString = process.env.PWTEST_FIREFOX_USER_PREFS;
   if (!prefsString)


### PR DESCRIPTION
We had to put some of our file picker logic behind a pref because it caused regressions in non-BiDi test sessions.
In the future this will be enabled by `unhandledPromptBehavior.file` but until then we want to enable the pref in the Playwright tests.

Fixes the following tests in Firefox:
- `tests/library/capabilities.spec.ts`:
  - "should not crash when clicking a label with a \<input type="file"/\>"
- `tests/page/page-filechooser.spec.ts`:
  - "should upload multiple large files"
  - "should emit event once"
  - "should emit event via prepend"
  - "should emit event on/off"
  - "should emit event addListener/removeListener"
  - "should work when file input is attached to DOM"
  - "should work when file input is not attached to DOM"
  - "should not throw when filechooser belongs to iframe"
  - "should not throw when frame is detached immediately"
  - "should work with no timeout"
  - "should return the same file chooser when there are many watchdogs simultaneously"
  - "should accept single file"
  - "should be able to read selected file"
  - "should work for single file pick"
  - "should work for "multiple""
  - "should work for "webkitdirectory""
  - "should emit event after navigation"
  - "should trigger listener added before navigation"
