### PR TITLE
chore(bidi): ignore fileDialogOpened event from detached frame

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiConnection.ts
+++ b/packages/playwright-core/src/server/bidi/bidiConnection.ts
@@ -224,6 +224,7 @@ export class BidiSession extends EventEmitter {
     this._browsingContexts.clear();
     for (const callback of this._callbacks.values()) {
       callback.error.type = this._crashed ? 'crashed' : 'closed';
+      callback.error.setMessage(`Internal server error, session ${callback.error.type}.`);
       callback.error.logs = this.connection._browserDisconnectedLogs;
       callback.reject(callback.error);
     }

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -297,8 +297,10 @@ export class BidiPage implements PageDelegate {
     if (!frame)
       return;
     const executionContext = await frame._mainContext();
-    const handle = await toBidiExecutionContext(executionContext).remoteObjectForNodeId(executionContext, { sharedId: params.element.sharedId });
-    await this._page._onFileChooserOpened(handle as dom.ElementHandle);
+    try {
+      const handle = await toBidiExecutionContext(executionContext).remoteObjectForNodeId(executionContext, { sharedId: params.element.sharedId });
+      await this._page._onFileChooserOpened(handle as dom.ElementHandle);
+    } catch {}
   }
 
   async navigateFrame(frame: frames.Frame, url: string, referrer: string | undefined): Promise<frames.GotoResult> {


### PR DESCRIPTION
The test "should not throw when frame is detached immediately" in `tests/page/page-filechooser.spec.ts` is failing because `remoteObjectForNodeId()` fails if the node (in this case the file input) is in a detached frame.
(Note that with Firefox `remoteObjectForNodeId()` hangs until it is rejected when the test is finished and then the error is misattributed in CI to the next test "should respect timeout").
