### PR TITLE
feat: allow declare field

### DIFF
--- a/packages/playwright/bundles/babel/src/babelBundleImpl.ts
+++ b/packages/playwright/bundles/babel/src/babelBundleImpl.ts
@@ -28,6 +28,11 @@ export { declare } from '@babel/helper-plugin-utils';
 export { types } from '@babel/core';
 export const traverse = traverseFunction;
 
+const typescriptTransformOptions = {
+  onlyRemoveTypeImports: false,
+  allowDeclareFields: true,
+};
+
 function babelTransformOptions(isTypeScript: boolean, isModule: boolean, pluginsPrologue: [string, any?][], pluginsEpilogue: [string, any?][]): TransformOptions {
   const plugins = [
     [require('@babel/plugin-syntax-import-attributes'), { deprecatedAssertSyntax: true }],
@@ -35,6 +40,9 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
 
   if (isTypeScript) {
     plugins.push(
+        // This is redundant with the preset, but we need this plugin
+        // to run before others.
+        [require('@babel/plugin-transform-typescript'), typescriptTransformOptions],
         [require('@babel/plugin-proposal-decorators'), { version: '2023-05' }],
         [require('@babel/plugin-transform-explicit-resource-management')],
         [require('@babel/plugin-transform-class-properties')],
@@ -102,7 +110,7 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
       setPublicClassFields: true,
     },
     presets: isTypeScript ? [
-      [require('@babel/preset-typescript'), { onlyRemoveTypeImports: false }],
+      [require('@babel/preset-typescript'), typescriptTransformOptions],
     ] : [],
     plugins: [
       ...pluginsPrologue.map(([name, options]) => [require(name), options]),

--- a/packages/playwright/bundles/babel/src/babelBundleImpl.ts
+++ b/packages/playwright/bundles/babel/src/babelBundleImpl.ts
@@ -40,9 +40,7 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
 
   if (isTypeScript) {
     plugins.push(
-        // This is redundant with the preset, but we need this plugin
-        // to run before others.
-        [require('@babel/plugin-transform-typescript'), typescriptTransformOptions],
+        [require('@babel/plugin-transform-typescript'), typescriptTransformOptions], // This is redundant with the preset, but we need this plugin to run before others.
         [require('@babel/plugin-proposal-decorators'), { version: '2023-05' }],
         [require('@babel/plugin-transform-explicit-resource-management')],
         [require('@babel/plugin-transform-class-properties')],

--- a/tests/playwright-test/babel.spec.ts
+++ b/tests/playwright-test/babel.spec.ts
@@ -156,6 +156,24 @@ test('should not transform external', async ({ runInlineTest }) => {
   expect(result.output).toMatch(/(SyntaxError: Unexpected token ':')|(SyntaxError: TypeScript enum is not supported)/);
 });
 
+test('should support declare field', async ({ runInlineTest }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/38586' });
+  const result = await runInlineTest({
+    'example.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      class Example {
+        declare field: number;
+      }
+      test('works', () => {
+        new Example();
+      })
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
+
 for (const type of ['module', undefined]) {
   test(`should support import assertions with type=${type} in the package.json`, {
     annotation: {


### PR DESCRIPTION
We have to insert @babel/plugin-transform-typescript explicitly into the list of plugins to avoid this error:

```
TypeScript 'declare' fields must first be transformed by @babel/plugin-transform-typescript.
If you have already enabled that plugin (or '@babel/preset-typescript'), make sure that it runs before any plugin related to additional class features:
 - @babel/plugin-transform-class-properties
 - @babel/plugin-transform-private-methods
 - @babel/plugin-proposal-decorators

```

Fixes https://github.com/microsoft/playwright/issues/38586