### PR TITLE
Skip ESM loader registration in `bun` (to avoid a hang).

### DIFF
--- a/packages/playwright/src/common/esmLoaderHost.ts
+++ b/packages/playwright/src/common/esmLoaderHost.ts
@@ -29,7 +29,7 @@ export function registerESMLoader() {
 
   // Transpilation in `bun` is not necessary, and trying to register a hook would cause issues.
   // https://github.com/oven-sh/bun/issues/8222#issuecomment-3665364677
-  if ("Bun" in globalThis)
+  if ('Bun' in globalThis)
     return true;
 
   if (loaderChannel)

--- a/packages/playwright/src/common/esmLoaderHost.ts
+++ b/packages/playwright/src/common/esmLoaderHost.ts
@@ -27,6 +27,11 @@ export function registerESMLoader() {
   if (process.env.PW_DISABLE_TS_ESM)
     return true;
 
+  // Transpilation in `bun` is not necessary, and trying to register a hook would cause issues.
+  // https://github.com/oven-sh/bun/issues/8222#issuecomment-3665364677
+  if ("Bun" in globalThis)
+    return true;
+
   if (loaderChannel)
     return true;
 


### PR DESCRIPTION
This allows the following to run successfully instead of hanging:

```shell
bun x --bun playwright test
```

See:

- https://github.com/oven-sh/bun/issues/8222#issuecomment-3665364677
- https://github.com/microsoft/playwright/issues/27139