### PR TITLE
test: update fill color expectation for wk win

### DIFF
--- a/tests/page/page-fill.spec.ts
+++ b/tests/page/page-fill.spec.ts
@@ -73,10 +73,13 @@ it('should fill color input', async ({ page }) => {
   expect(await page.$eval('input', input => input.value)).toBe('#aaaaaa');
 });
 
-it('should fill color input case insensitive', async ({ page }) => {
+it('should fill color input case insensitive', async ({ page, browserName, isWindows }) => {
   await page.setContent('<input type=color value="#e66465">');
   await page.fill('input', '#AbCd00');
-  expect(await page.$eval('input', input => input.value)).toBe('#abcd00');
+  if (browserName === 'webkit' && isWindows)
+    expect(await page.$eval('input', input => input.value)).toBe('#AbCd00');
+  else
+    expect(await page.$eval('input', input => input.value)).toBe('#abcd00');
 });
 
 it('should throw on incorrect color value', async ({ page, browserName, isWindows }) => {


### PR DESCRIPTION
WebKit Windows doesn't normalize the value:

```
Error: expect(received).toBe(expected) // Object.is equality

Expected: "#abcd00"
Received: "#AbCd00"
    at D:\a\playwright\playwright\tests\page\page-fill.spec.ts:79:59
```