### PR TITLE
fix(test runner): export _baseTest when imported as an esmodule

### DIFF
--- a/packages/playwright/test.mjs
+++ b/packages/playwright/test.mjs
@@ -25,6 +25,7 @@ export const errors = playwright.errors;
 export const request = playwright.request;
 export const _electron = playwright._electron;
 export const _android = playwright._android;
+export const _baseTest = playwright._baseTest;
 export const test = playwright.test;
 export const expect = playwright.expect;
 export const defineConfig = playwright.defineConfig;


### PR DESCRIPTION
The commonjs and typescript types already export `_baseTest`, which lets you use folio as a test runner without the default playwright fixtures. But it was missing from the esmodule exports. There are a few other things missing (`_channel`, `on`, `off`, etc), but they were never exported in the types and I don't know what anyone would use them for so I didn't add them here.