### PR TITLE
chore(mcp): run relay server on 127.0.0.1 only

### DIFF
--- a/.github/workflows/tests_mcp.yml
+++ b/.github/workflows/tests_mcp.yml
@@ -23,7 +23,7 @@ env:
   # Force terminal colors. @see https://www.npmjs.com/package/colors
   FORCE_COLOR: 1
   ELECTRON_SKIP_BINARY_DOWNLOAD: 1
-  PWDEBUGIMPL=1
+  PWDEBUGIMPL: 1
   DEBUG: pw:mcp:error
 
 jobs:

--- a/packages/playwright-core/src/server/utils/httpServer.ts
+++ b/packages/playwright-core/src/server/utils/httpServer.ts
@@ -21,7 +21,7 @@ import { mime, wsServer } from '../../utilsBundle';
 import { createGuid } from './crypto';
 import { assert } from '../../utils/isomorphic/assert';
 import { ManualPromise } from '../../utils/isomorphic/manualPromise';
-import { createHttpServer } from './network';
+import { createHttpServer, tryStartHttpServer } from './network';
 
 import type http from 'http';
 
@@ -110,17 +110,17 @@ export class HttpServer {
     assert(!this._started, 'server already started');
     this._started = true;
 
-    const host = options.host || 'localhost';
+    const host = options.host;
     if (options.preferredPort) {
       try {
-        await this._tryStart(options.preferredPort, host);
+        await tryStartHttpServer(this._server, { port: options.preferredPort, host });
       } catch (e) {
         if (!e || !e.message || !e.message.includes('EADDRINUSE'))
           throw e;
-        await this._tryStart(undefined, host);
+        await tryStartHttpServer(this._server, { host });
       }
     } else {
-      await this._tryStart(options.port, host);
+      await tryStartHttpServer(this._server, { port: options.port, host });
     }
 
     const address = this._server.address();

--- a/packages/playwright-core/src/server/utils/httpServer.ts
+++ b/packages/playwright-core/src/server/utils/httpServer.ts
@@ -64,22 +64,6 @@ export class HttpServer {
     return this._port;
   }
 
-  private async _tryStart(port: number | undefined, host: string) {
-    const errorPromise = new ManualPromise();
-    const errorListener = (error: Error) => errorPromise.reject(error);
-    this._server.on('error', errorListener);
-
-    try {
-      this._server.listen(port, host);
-      await Promise.race([
-        new Promise(cb => this._server!.once('listening', cb)),
-        errorPromise,
-      ]);
-    } finally {
-      this._server.removeListener('error', errorListener);
-    }
-  }
-
   createWebSocket(transport: Transport, guid?: string) {
     assert(!this._wsGuid, 'can only create one main websocket transport per server');
     this._wsGuid = guid || createGuid();

--- a/packages/playwright-core/src/server/utils/httpServer.ts
+++ b/packages/playwright-core/src/server/utils/httpServer.ts
@@ -142,7 +142,7 @@ export class HttpServer {
     }
   }
 
-  _serveFile(response: http.ServerResponse, absoluteFilePath: string) {
+  private _serveFile(response: http.ServerResponse, absoluteFilePath: string) {
     const content = fs.readFileSync(absoluteFilePath);
     response.statusCode = 200;
     const contentType = mime.getType(path.extname(absoluteFilePath)) || 'application/octet-stream';
@@ -151,7 +151,7 @@ export class HttpServer {
     response.end(content);
   }
 
-  _serveRangeFile(request: http.IncomingMessage, response: http.ServerResponse, absoluteFilePath: string) {
+  private _serveRangeFile(request: http.IncomingMessage, response: http.ServerResponse, absoluteFilePath: string) {
     const range = request.headers.range;
     if (!range || !range.startsWith('bytes=') || range.includes(', ') || [...range].filter(char => char === '-').length !== 1) {
       response.statusCode = 400;

--- a/packages/playwright-core/src/server/utils/httpServer.ts
+++ b/packages/playwright-core/src/server/utils/httpServer.ts
@@ -20,8 +20,7 @@ import path from 'path';
 import { mime, wsServer } from '../../utilsBundle';
 import { createGuid } from './crypto';
 import { assert } from '../../utils/isomorphic/assert';
-import { ManualPromise } from '../../utils/isomorphic/manualPromise';
-import { createHttpServer, tryStartHttpServer } from './network';
+import { createHttpServer, startHttpServer } from './network';
 
 import type http from 'http';
 
@@ -97,14 +96,14 @@ export class HttpServer {
     const host = options.host;
     if (options.preferredPort) {
       try {
-        await tryStartHttpServer(this._server, { port: options.preferredPort, host });
+        await startHttpServer(this._server, { port: options.preferredPort, host });
       } catch (e) {
         if (!e || !e.message || !e.message.includes('EADDRINUSE'))
           throw e;
-        await tryStartHttpServer(this._server, { host });
+        await startHttpServer(this._server, { host });
       }
     } else {
-      await tryStartHttpServer(this._server, { port: options.port, host });
+      await startHttpServer(this._server, { port: options.port, host });
     }
 
     const address = this._server.address();

--- a/packages/playwright-core/src/server/utils/network.ts
+++ b/packages/playwright-core/src/server/utils/network.ts
@@ -193,13 +193,11 @@ export function createHttp2Server(...args: any[]): http2.Http2SecureServer {
   return server;
 }
 
-export async function tryStartHttpServer(server: http.Server, options: { host?: string, port?: number }) {
+export async function startHttpServer(server: http.Server, options: { host?: string, port?: number }) {
   const { host = 'localhost', port = 0 } = options;
-
   const errorPromise = new ManualPromise();
   const errorListener = (error: Error) => errorPromise.reject(error);
   server.on('error', errorListener);
-
   try {
     server.listen(port, host);
     await Promise.race([

--- a/packages/playwright/src/mcp/extension/cdpRelay.ts
+++ b/packages/playwright/src/mcp/extension/cdpRelay.ts
@@ -29,7 +29,7 @@ import { debug, ws, wsServer } from 'playwright-core/lib/utilsBundle';
 import { registry } from 'playwright-core/lib/server/registry/index';
 import { ManualPromise } from 'playwright-core/lib/utils';
 
-import { httpAddressToString } from '../sdk/http';
+import { addressToString } from '../sdk/http';
 import { logUnhandledError } from '../log';
 import * as protocol from './protocol';
 
@@ -76,7 +76,7 @@ export class CDPRelayServer {
   private _extensionConnectionPromise!: ManualPromise<void>;
 
   constructor(server: http.Server, browserChannel: string, userDataDir?: string, executablePath?: string) {
-    this._wsHost = httpAddressToString(server.address()).replace(/^http/, 'ws');
+    this._wsHost = addressToString(server.address(), { protocol: 'ws' });
     this._browserChannel = browserChannel;
     this._userDataDir = userDataDir;
     this._executablePath = executablePath;

--- a/packages/playwright/src/mcp/extension/cdpRelay.ts
+++ b/packages/playwright/src/mcp/extension/cdpRelay.ts
@@ -77,7 +77,6 @@ export class CDPRelayServer {
 
   constructor(server: http.Server, browserChannel: string, userDataDir?: string, executablePath?: string) {
     this._wsHost = httpAddressToString(server.address()).replace(/^http/, 'ws');
-    assert(this._wsHost.startsWith('ws://127.0.0.1'), 'CDPRelayServer only supports loopback connections');
     this._browserChannel = browserChannel;
     this._userDataDir = userDataDir;
     this._executablePath = executablePath;

--- a/packages/playwright/src/mcp/extension/cdpRelay.ts
+++ b/packages/playwright/src/mcp/extension/cdpRelay.ts
@@ -27,7 +27,7 @@ import http from 'http';
 
 import { debug, ws, wsServer } from 'playwright-core/lib/utilsBundle';
 import { registry } from 'playwright-core/lib/server/registry/index';
-import { ManualPromise } from 'playwright-core/lib/utils';
+import { assert, ManualPromise } from 'playwright-core/lib/utils';
 
 import { httpAddressToString } from '../sdk/http';
 import { logUnhandledError } from '../log';
@@ -77,6 +77,7 @@ export class CDPRelayServer {
 
   constructor(server: http.Server, browserChannel: string, userDataDir?: string, executablePath?: string) {
     this._wsHost = httpAddressToString(server.address()).replace(/^http/, 'ws');
+    assert(this._wsHost.startsWith('ws://127.0.0.1'), 'CDPRelayServer only supports loopback connections');
     this._browserChannel = browserChannel;
     this._userDataDir = userDataDir;
     this._executablePath = executablePath;

--- a/packages/playwright/src/mcp/extension/cdpRelay.ts
+++ b/packages/playwright/src/mcp/extension/cdpRelay.ts
@@ -27,7 +27,7 @@ import http from 'http';
 
 import { debug, ws, wsServer } from 'playwright-core/lib/utilsBundle';
 import { registry } from 'playwright-core/lib/server/registry/index';
-import { assert, ManualPromise } from 'playwright-core/lib/utils';
+import { ManualPromise } from 'playwright-core/lib/utils';
 
 import { httpAddressToString } from '../sdk/http';
 import { logUnhandledError } from '../log';

--- a/packages/playwright/src/mcp/extension/extensionContextFactory.ts
+++ b/packages/playwright/src/mcp/extension/extensionContextFactory.ts
@@ -16,8 +16,8 @@
 
 import * as playwright from 'playwright-core';
 import { debug } from 'playwright-core/lib/utilsBundle';
+import { createHttpServer, tryStartHttpServer } from 'playwright-core/lib/utils';
 
-import { startHttpServer } from '../sdk/http';
 import { CDPRelayServer } from './cdpRelay';
 
 import type { BrowserContextFactory } from '../browser/browserContextFactory';
@@ -54,12 +54,10 @@ export class ExtensionContextFactory implements BrowserContextFactory {
   }
 
   private async _startRelay(abortSignal: AbortSignal) {
+    const httpServer = createHttpServer();
     // Listen to the loopback interface only. The extension will disallow
     // connections to other hosts anyway.
-    const httpServer = await startHttpServer({
-      host: '127.0.0.1',
-      port: 0,
-    });
+    await tryStartHttpServer(httpServer, { host: '127.0.0.1' });
     if (abortSignal.aborted) {
       httpServer.close();
       throw new Error(abortSignal.reason);

--- a/packages/playwright/src/mcp/extension/extensionContextFactory.ts
+++ b/packages/playwright/src/mcp/extension/extensionContextFactory.ts
@@ -54,7 +54,12 @@ export class ExtensionContextFactory implements BrowserContextFactory {
   }
 
   private async _startRelay(abortSignal: AbortSignal) {
-    const httpServer = await startHttpServer({});
+    // Listen to the loopback interface only. The extension will disallow
+    // connections to other hosts anyway.
+    const httpServer = await startHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+    });
     if (abortSignal.aborted) {
       httpServer.close();
       throw new Error(abortSignal.reason);

--- a/packages/playwright/src/mcp/extension/extensionContextFactory.ts
+++ b/packages/playwright/src/mcp/extension/extensionContextFactory.ts
@@ -16,7 +16,7 @@
 
 import * as playwright from 'playwright-core';
 import { debug } from 'playwright-core/lib/utilsBundle';
-import { createHttpServer, tryStartHttpServer } from 'playwright-core/lib/utils';
+import { createHttpServer, startHttpServer } from 'playwright-core/lib/utils';
 
 import { CDPRelayServer } from './cdpRelay';
 
@@ -57,7 +57,7 @@ export class ExtensionContextFactory implements BrowserContextFactory {
     const httpServer = createHttpServer();
     // Listen to the loopback interface only. The extension will disallow
     // connections to other hosts anyway.
-    await tryStartHttpServer(httpServer, { host: '127.0.0.1' });
+    await startHttpServer(httpServer, {});
     if (abortSignal.aborted) {
       httpServer.close();
       throw new Error(abortSignal.reason);

--- a/packages/playwright/src/mcp/sdk/server.ts
+++ b/packages/playwright/src/mcp/sdk/server.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from 'url';
 import { debug } from 'playwright-core/lib/utilsBundle';
 import * as mcpBundle from 'playwright-core/lib/mcpBundle';
 
-import { startHttpServer } from './http';
+import { startMcpHttpServer } from './http';
 import { InProcessTransport } from './inProcessTransport';
 
 import type { Tool, CallToolResult, CallToolRequest, Root } from '@modelcontextprotocol/sdk/types.js';
@@ -178,7 +178,7 @@ export async function start(serverBackendFactory: ServerBackendFactory, options:
     return;
   }
 
-  const url = await startHttpServer(options, serverBackendFactory, options.allowedHosts);
+  const url = await startMcpHttpServer(options, serverBackendFactory, options.allowedHosts);
 
   const mcpConfig: any = { mcpServers: { } };
   mcpConfig.mcpServers[serverBackendFactory.nameInConfig] = {

--- a/packages/playwright/src/mcp/sdk/server.ts
+++ b/packages/playwright/src/mcp/sdk/server.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from 'url';
 import { debug } from 'playwright-core/lib/utilsBundle';
 import * as mcpBundle from 'playwright-core/lib/mcpBundle';
 
-import { installHttpTransport, startHttpServer } from './http';
+import { startHttpServer } from './http';
 import { InProcessTransport } from './inProcessTransport';
 
 import type { Tool, CallToolResult, CallToolRequest, Root } from '@modelcontextprotocol/sdk/types.js';
@@ -178,8 +178,7 @@ export async function start(serverBackendFactory: ServerBackendFactory, options:
     return;
   }
 
-  const httpServer = await startHttpServer(options);
-  const url = await installHttpTransport(httpServer, serverBackendFactory, false, options.allowedHosts);
+  const url = await startHttpServer(options, serverBackendFactory, options.allowedHosts);
 
   const mcpConfig: any = { mcpServers: { } };
   mcpConfig.mcpServers[serverBackendFactory.nameInConfig] = {

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -260,8 +260,8 @@ async function runTests(args: string[], opts: { [key: string]: any }) {
 }
 
 async function runTestServer(opts: { [key: string]: any }) {
-  const host = opts.host || 'localhost';
-  const port = opts.port ? +opts.port : 0;
+  const host = opts.host;
+  const port = opts.port ? +opts.port : undefined;
   const status = await testServer.runTestServer(opts.config, { }, { host, port });
   const exitCode = status === 'interrupted' ? 130 : (status === 'passed' ? 0 : 1);
   gracefullyProcessExitDoNotHang(exitCode);

--- a/tests/mcp/http.spec.ts
+++ b/tests/mcp/http.spec.ts
@@ -16,6 +16,7 @@
 
 import fs from 'fs';
 import net from 'net';
+import dns from 'dns';
 
 import { ChildProcess, spawn } from 'child_process';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
@@ -61,6 +62,19 @@ const test = baseTest.extend<{ serverEndpoint: (options?: { args?: string[], noP
     cp?.kill('SIGTERM');
   },
 });
+
+async function resolveToIp(address: string) {
+  const resolvedIp = await new Promise<{ address: string, family: number }>((resolve, reject) => {
+    dns.lookup('localhost', (err, address, family) => {
+      if (err)
+        return reject(err);
+      resolve({ address, family }); // ::1 6  OR  127.0.0.1 4
+    });
+  });
+  if (resolvedIp.family === 6)
+    return `[${resolvedIp.address}]`;
+  return resolvedIp.address;
+}
 
 test('http transport', async ({ serverEndpoint }) => {
   const { url } = await serverEndpoint();
@@ -351,10 +365,12 @@ test('client should receive list roots request', async ({ serverEndpoint, server
 });
 
 test('should not allow rebinding to localhost', async ({ serverEndpoint }) => {
-  const { url } = await serverEndpoint();
-  const response = await fetch(url.href.replace('localhost', '127.0.0.1'));
-  expect(response.status).toBe(403);
-  expect(await response.text()).toContain('Access is only allowed at localhost');
+  const { url, stderr } = await serverEndpoint();
+  const ip = await resolveToIp('localhost');
+  const response = await fetch(url.href.replace('localhost', ip));
+  console.log('logs:', stderr());
+  expect.soft(response.status).toBe(403);
+  expect.soft(await response.text()).toContain('Access is only allowed at localhost');
 });
 
 test('should respect allowed hosts (negative)', async ({ serverEndpoint }) => {


### PR DESCRIPTION
We don't bother with ::1 for ipv6, as in practice it vanishingly rare on desktops/servers to have ipv6-only configuration.