### PR TITLE
fix(trace-viewer): accept Windows ZIP MIME type for clipboard paste

### DIFF
--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -56,8 +56,9 @@ export const WorkbenchLoader: React.FunctionComponent<{
     const listener = async (e: ClipboardEvent) => {
       if (!e.clipboardData?.files.length)
         return;
+      const zipMimeTypes = ['application/zip', 'application/x-zip-compressed'];
       for (const file of e.clipboardData.files) {
-        if (file.type !== 'application/zip')
+        if (!zipMimeTypes.includes(file.type))
           return;
       }
       e.preventDefault();

--- a/packages/trace-viewer/src/ui/workbenchLoader.tsx
+++ b/packages/trace-viewer/src/ui/workbenchLoader.tsx
@@ -56,9 +56,8 @@ export const WorkbenchLoader: React.FunctionComponent<{
     const listener = async (e: ClipboardEvent) => {
       if (!e.clipboardData?.files.length)
         return;
-      const zipMimeTypes = ['application/zip', 'application/x-zip-compressed'];
       for (const file of e.clipboardData.files) {
-        if (!zipMimeTypes.includes(file.type))
+        if (file.type !== 'application/zip')
           return;
       }
       e.preventDefault();


### PR DESCRIPTION
  Windows reports ZIP files with the MIME type application/x-zip-compressed
  instead of the standard application/zip. This change accepts both MIME types
  when pasting trace files into the trace viewer. 
  
  FIXES https://github.com/microsoft/playwright/pull/37907 https://github.com/microsoft/playwright/issues/37906