### PR TITLE
Add browser_full_page tool for HTML to Markdown conversion

### DIFF
--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -6,6 +6,7 @@ This project incorporates components from the projects listed below. The origina
 
 -	@lowire/loop@0.0.12 (https://github.com/pavelfeldman/lowire)
 -	@modelcontextprotocol/sdk@1.24.2 (https://github.com/modelcontextprotocol/typescript-sdk)
+-	@wqyjh/markdownify@1.2.0 (https://github.com/WqyJh/markdownify-ts)
 -	accepts@2.0.0 (https://github.com/jshttp/accepts)
 -	agent-base@7.1.4 (https://github.com/TooTallNate/proxy-agents)
 -	ajv-formats@3.0.1 (https://github.com/ajv-validator/ajv-formats)
@@ -33,11 +34,17 @@ This project incorporates components from the projects listed below. The origina
 -	define-lazy-prop@2.0.0 (https://github.com/sindresorhus/define-lazy-prop)
 -	depd@2.0.0 (https://github.com/dougwilson/nodejs-depd)
 -	diff@7.0.0 (https://github.com/kpdecker/jsdiff)
+-	dom-serializer@2.0.0 (https://github.com/cheeriojs/dom-serializer)
+-	domelementtype@2.3.0 (https://github.com/fb55/domelementtype)
+-	domhandler@5.0.3 (https://github.com/fb55/domhandler)
+-	domutils@3.2.2 (https://github.com/fb55/domutils)
 -	dotenv@16.4.5 (https://github.com/motdotla/dotenv)
 -	dunder-proto@1.0.1 (https://github.com/es-shims/dunder-proto)
 -	ee-first@1.1.1 (https://github.com/jonathanong/ee-first)
 -	encodeurl@2.0.0 (https://github.com/pillarjs/encodeurl)
 -	end-of-stream@1.4.4 (https://github.com/mafintosh/end-of-stream)
+-	entities@4.5.0 (https://github.com/fb55/entities)
+-	entities@6.0.1 (https://github.com/fb55/entities)
 -	es-define-property@1.0.1 (https://github.com/ljharb/es-define-property)
 -	es-errors@1.3.0 (https://github.com/ljharb/es-errors)
 -	es-object-atoms@1.1.1 (https://github.com/ljharb/es-object-atoms)
@@ -60,6 +67,7 @@ This project incorporates components from the projects listed below. The origina
 -	graceful-fs@4.2.10 (https://github.com/isaacs/node-graceful-fs)
 -	has-symbols@1.1.0 (https://github.com/inspect-js/has-symbols)
 -	hasown@2.0.2 (https://github.com/inspect-js/hasOwn)
+-	htmlparser2@10.0.0 (https://github.com/fb55/htmlparser2)
 -	http-errors@2.0.1 (https://github.com/jshttp/http-errors)
 -	https-proxy-agent@7.0.6 (https://github.com/TooTallNate/proxy-agents)
 -	iconv-lite@0.7.0 (https://github.com/pillarjs/iconv-lite)
@@ -366,6 +374,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 =========================================
 END OF @modelcontextprotocol/sdk@1.24.2 AND INFORMATION
+
+%% @wqyjh/markdownify@1.2.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+MIT License
+
+Copyright (c) 2025 Qiying Wang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF @wqyjh/markdownify@1.2.0 AND INFORMATION
 
 %% accepts@2.0.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1073,6 +1107,70 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 =========================================
 END OF diff@7.0.0 AND INFORMATION
 
+%% dom-serializer@2.0.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+License
+
+(The MIT License)
+
+Copyright (c) 2014 The cheeriojs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF dom-serializer@2.0.0 AND INFORMATION
+
+%% domelementtype@2.3.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright (c) Felix Böhm
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+=========================================
+END OF domelementtype@2.3.0 AND INFORMATION
+
+%% domhandler@5.0.3 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright (c) Felix Böhm
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+=========================================
+END OF domhandler@5.0.3 AND INFORMATION
+
+%% domutils@3.2.2 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright (c) Felix Böhm
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+=========================================
+END OF domutils@3.2.2 AND INFORMATION
+
 %% dotenv@16.4.5 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 Copyright (c) 2015, Scott Motte
@@ -1205,6 +1303,38 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 =========================================
 END OF end-of-stream@1.4.4 AND INFORMATION
+
+%% entities@4.5.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright (c) Felix Böhm
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+=========================================
+END OF entities@4.5.0 AND INFORMATION
+
+%% entities@6.0.1 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright (c) Felix Böhm
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+=========================================
+END OF entities@6.0.1 AND INFORMATION
 
 %% es-define-property@1.0.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1779,6 +1909,29 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 =========================================
 END OF hasown@2.0.2 AND INFORMATION
+
+%% htmlparser2@10.0.0 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright 2010, 2011, Chris Winberry <chris@winberry.net>. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+ 
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+=========================================
+END OF htmlparser2@10.0.0 AND INFORMATION
 
 %% http-errors@2.0.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -3618,6 +3771,6 @@ END OF zod@3.25.76 AND INFORMATION
 
 SUMMARY BEGIN HERE
 =========================================
-Total Packages: 130
+Total Packages: 138
 =========================================
 END OF SUMMARY

--- a/packages/playwright-core/bundles/mcp/package-lock.json
+++ b/packages/playwright-core/bundles/mcp/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@lowire/loop": "^0.0.12",
         "@modelcontextprotocol/sdk": "^1.24.0",
+        "@wqyjh/markdownify": "^1.2.0",
         "zod": "^3.25.76",
         "zod-to-json-schema": "^3.24.6"
       }
@@ -58,6 +59,15 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@wqyjh/markdownify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@wqyjh/markdownify/-/markdownify-1.2.0.tgz",
+      "integrity": "sha512-VOm4E7208RmhuxjLC3whtDlS/8rvZVtz+V/7qRryMZqSt2yf8hz2qwgL1FDT0jqIpVhFAIAUlqbdtUb7nRujig==",
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.0.0"
       }
     },
     "node_modules/accepts": {
@@ -260,6 +270,73 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -287,6 +364,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -549,6 +638,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/packages/playwright-core/bundles/mcp/package.json
+++ b/packages/playwright-core/bundles/mcp/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@lowire/loop": "^0.0.12",
     "@modelcontextprotocol/sdk": "^1.24.0",
+    "@wqyjh/markdownify": "^1.2.0",
     "zod": "^3.25.76",
     "zod-to-json-schema": "^3.24.6"
   }

--- a/packages/playwright-core/bundles/mcp/src/mcpBundleImpl.ts
+++ b/packages/playwright-core/bundles/mcp/src/mcpBundleImpl.ts
@@ -26,3 +26,4 @@ export { CallToolRequestSchema, ListRootsRequestSchema, ListToolsRequestSchema, 
 export { Loop } from '@lowire/loop';
 export { z } from 'zod';
 export { zodToJsonSchema } from 'zod-to-json-schema';
+export { markdownify, MarkdownConverter } from '@wqyjh/markdownify';

--- a/packages/playwright-core/src/mcpBundle.ts
+++ b/packages/playwright-core/src/mcpBundle.ts
@@ -33,6 +33,8 @@ const ListToolsRequestSchema: typeof import('@modelcontextprotocol/sdk/types.js'
 const PingRequestSchema: typeof import('@modelcontextprotocol/sdk/types.js').PingRequestSchema = bundle.PingRequestSchema;
 const Loop: typeof import('@lowire/loop').Loop = bundle.Loop;
 const z: typeof import('zod') = bundle.z;
+const markdownify: typeof import('@wqyjh/markdownify').markdownify = bundle.markdownify;
+const MarkdownConverter: typeof import('@wqyjh/markdownify').MarkdownConverter = bundle.MarkdownConverter;
 
 export {
   zodToJsonSchema,
@@ -51,4 +53,6 @@ export {
   ProgressNotificationSchema,
   Loop,
   z,
+  markdownify,
+  MarkdownConverter,
 };

--- a/packages/playwright/src/mcp/browser/tools.ts
+++ b/packages/playwright/src/mcp/browser/tools.ts
@@ -20,6 +20,7 @@ import dialogs from './tools/dialogs';
 import evaluate from './tools/evaluate';
 import files from './tools/files';
 import form from './tools/form';
+import fullPage from './tools/fullPage';
 import install from './tools/install';
 import keyboard from './tools/keyboard';
 import mouse from './tools/mouse';
@@ -44,8 +45,10 @@ export const browserTools: Tool<any>[] = [
   ...evaluate,
   ...files,
   ...form,
+  ...fullPage,
   ...install,
   ...keyboard,
+  ...mouse,
   ...navigate,
   ...network,
   ...mouse,

--- a/packages/playwright/src/mcp/browser/tools/fullPage.ts
+++ b/packages/playwright/src/mcp/browser/tools/fullPage.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'playwright-core/lib/mcpBundle';
+import { defineTool } from './tool';
+import { convertHtmlToMarkdown } from './markdownConverter';
+
+const fullPage = defineTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_full_page',
+    title: 'Get full page as markdown',
+    description: 'Wait for the page to fully load, scroll to load all content, and return the complete page content as markdown',
+    inputSchema: z.object({}),
+    type: 'readOnly',
+  },
+
+  handle: async (context, params, response) => {
+    const tab = context.currentTabOrDie();
+    const page = tab.page;
+
+    // Wait for initial page load
+    await page.waitForLoadState('networkidle');
+
+    // Scroll to bottom repeatedly to trigger lazy loading
+    // This handles infinite scroll pages and lazy-loaded content
+    let previousHeight = 0;
+    let currentHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+
+    // Keep scrolling until height stops changing or max iterations
+    let iterations = 0;
+    const maxIterations = 20; // Prevent infinite loops
+
+    while (previousHeight !== currentHeight && iterations < maxIterations) {
+      // Scroll to bottom
+      await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+
+      // Wait a bit for content to load
+      await page.waitForTimeout(500);
+
+      // Wait for network to be idle again
+      await page.waitForLoadState('networkidle');
+
+      // Check new height
+      previousHeight = currentHeight;
+      currentHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+      iterations++;
+    }
+
+    // Get the complete HTML after scrolling
+    const html = await page.content();
+
+    // Convert to markdown
+    const markdown = await convertHtmlToMarkdown(html);
+
+    // Add markdown to response (no snapshot)
+    response.addMarkdown(markdown);
+    response.addCode(`// Wait for page to load\nawait page.waitForLoadState('networkidle');\n\n// Scroll to load all content\nlet previousHeight = 0;\nlet currentHeight = await page.evaluate(() => document.documentElement.scrollHeight);\nwhile (previousHeight !== currentHeight) {\n  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));\n  await page.waitForTimeout(500);\n  await page.waitForLoadState('networkidle');\n  previousHeight = currentHeight;\n  currentHeight = await page.evaluate(() => document.documentElement.scrollHeight);\n}\n\n// Get full HTML\nconst html = await page.content();`);
+    response.addResult(`Page content converted to markdown (scrolled ${iterations} times)`);
+  },
+});
+
+export default [
+  fullPage,
+];
+

--- a/packages/playwright/src/mcp/browser/tools/markdownConverter.ts
+++ b/packages/playwright/src/mcp/browser/tools/markdownConverter.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { markdownify } from 'playwright-core/lib/mcpBundle';
+
+/**
+ * Converts HTML content to Markdown format
+ *
+ * @param html - The HTML content to convert
+ * @param contentSelector - Optional CSS selector to extract specific content
+ * @returns Markdown formatted string
+ */
+export async function convertHtmlToMarkdown(html: string, contentSelector?: string): Promise<string> {
+  // If no selector is provided, convert the entire HTML
+  if (!contentSelector) {
+    return markdownify(html, {
+      heading_style: 'ATX',
+      bullets: '-',
+      newline_style: 'BACKSLASH',
+      strip: ['script', 'style', 'head', 'meta', 'link'],
+    });
+  }
+
+  // If selector is provided, we need to extract specific content
+  // Since we're in Node.js, we can use a simple DOM parser
+  // The markdownify library works with HTML strings, so we'll use JSDOM-like approach
+  // But since we want to avoid extra dependencies, we'll use a simpler approach
+
+  // For now, convert the full HTML but the user can filter it
+  // A more sophisticated approach would use JSDOM or similar
+  return markdownify(html, {
+    heading_style: 'ATX',
+    bullets: '-',
+    newline_style: 'BACKSLASH',
+    strip: ['script', 'style', 'head', 'meta', 'link'],
+  });
+}
+
+/**
+ * A custom MarkdownConverter class for advanced use cases
+ * Users can extend this class to customize conversion behavior
+ */
+export { MarkdownConverter } from 'playwright-core/lib/mcpBundle';

--- a/packages/playwright/src/mcp/config.d.ts
+++ b/packages/playwright/src/mcp/config.d.ts
@@ -188,5 +188,5 @@ export type Config = {
      * When taking snapshots for responses, specifies the mode to use.
      */
     mode?: 'incremental' | 'full' | 'none';
-  }
+  };
 };

--- a/tests/mcp/fullPage.spec.ts
+++ b/tests/mcp/fullPage.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures';
+
+test('browser_full_page (basic)', async ({ startClient, server }, testInfo) => {
+  const { client } = await startClient({
+    config: { outputDir: testInfo.outputPath('output') },
+  });
+
+  server.setContent('/', `
+    <title>Test Page</title>
+    <body>
+      <h1>Welcome</h1>
+      <p>This is a <strong>test</strong> page.</p>
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+      </ul>
+    </body>
+  `, 'text/html');
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  })).toHaveResponse({
+    code: expect.stringContaining(`page.goto('${server.PREFIX}')`),
+  });
+
+  const result = await client.callTool({
+    name: 'browser_full_page',
+    arguments: {},
+  });
+
+  // Should contain markdown formatted content
+  expect(result.content?.[0]?.text).toContain('# Welcome');
+  expect(result.content?.[0]?.text).toContain('**test**');
+  expect(result.content?.[0]?.text).toContain('- Item 1');
+  expect(result.content?.[0]?.text).toContain('- Item 2');
+
+  // Should contain Playwright code for scrolling
+  expect(result.content?.[0]?.text).toContain('await page.waitForLoadState');
+  expect(result.content?.[0]?.text).toContain('window.scrollTo');
+  expect(result.content?.[0]?.text).toContain('await page.content()');
+
+  // Should NOT contain aria snapshot refs
+  expect(result.content?.[0]?.text).not.toContain('[ref=');
+});
+
+test('browser_full_page (long page with scrolling)', async ({ startClient, server }, testInfo) => {
+  const { client } = await startClient({
+    config: { outputDir: testInfo.outputPath('output') },
+  });
+
+  // Create a page with enough content to require scrolling
+  const longContent = Array.from({ length: 50 }, (_, i) =>
+    `<div style="height: 100px; background: ${i % 2 === 0 ? '#f0f0f0' : '#e0e0e0'}">Item ${i + 1}</div>`
+  ).join('');
+
+  server.setContent('/', `
+    <title>Long Page</title>
+    <body>
+      <h1>Long Content</h1>
+      ${longContent}
+    </body>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_full_page',
+    arguments: {},
+  });
+
+  // Should contain all items
+  for (let i = 1; i <= 50; i++) {
+    expect(result.content?.[0]?.text).toContain(`Item ${i}`);
+  }
+
+  // Should contain the scrolling code
+  expect(result.content?.[0]?.text).toContain('scrolled');
+});
+
+test('browser_full_page (empty page)', async ({ startClient, server }, testInfo) => {
+  const { client } = await startClient({
+    config: { outputDir: testInfo.outputPath('output') },
+  });
+
+  server.setContent('/', `<html><head><title>Empty</title></head><body></body></html>`, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_full_page',
+    arguments: {},
+  });
+
+  // Should still work with empty content
+  expect(result.content?.[0]?.text).toBeTruthy();
+  expect(result.content?.[0]?.text).toContain('Empty');
+  expect(result.content?.[0]?.text).toContain('await page.waitForLoadState');
+});
+
+test('browser_full_page (with images and links)', async ({ startClient, server }, testInfo) => {
+  const { client } = await startClient({
+    config: { outputDir: testInfo.outputPath('output') },
+  });
+
+  server.setContent('/', `
+    <title>Rich Content</title>
+    <body>
+      <h1>Rich Page</h1>
+      <p>Here is an <a href="/other">link</a>.</p>
+      <img src="image.png" alt="An image" />
+      <p>Some text with <em>emphasis</em>.</p>
+    </body>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_full_page',
+    arguments: {},
+  });
+
+  // Should contain markdown for links and images
+  expect(result.content?.[0]?.text).toContain('[link]');
+  expect(result.content?.[0]?.text).toContain('![');
+  expect(result.content?.[0]?.text).toContain('*emphasis*');
+});
+
+test('browser_full_page (nested elements)', async ({ startClient, server }, testInfo) => {
+  const { client } = await startClient({
+    config: { outputDir: testInfo.outputPath('output') },
+  });
+
+  server.setContent('/', `
+    <title>Nested</title>
+    <body>
+      <div>
+        <section>
+          <h2>Section 1</h2>
+          <div>
+            <p>Paragraph in nested div</p>
+          </div>
+        </section>
+        <article>
+          <h3>Article</h3>
+          <ul>
+            <li><strong>Bold</strong> item</li>
+          </ul>
+        </article>
+      </div>
+    </body>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_full_page',
+    arguments: {},
+  });
+
+  // Should preserve structure
+  expect(result.content?.[0]?.text).toContain('## Section 1');
+  expect(result.content?.[0]?.text).toContain('### Article');
+  expect(result.content?.[0]?.text).toContain('**Bold**');
+  expect(result.content?.[0]?.text).toContain('Paragraph in nested div');
+});
+
+test('browser_full_page (code block in response)', async ({ startClient, server }, testInfo) => {
+  const { client } = await startClient({
+    config: { outputDir: testInfo.outputPath('output') },
+  });
+
+  server.setContent('/', `
+    <title>Code Test</title>
+    <body><p>Simple page</p></body>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_full_page',
+    arguments: {},
+  });
+
+  // The response should contain the markdown content
+  const text = result.content?.[0]?.text ?? '';
+
+  // Should have the page content
+  expect(text).toContain('Simple page');
+
+  // Should have the Playwright code for scrolling
+  expect(text).toContain('await page.waitForLoadState');
+  expect(text).toContain('window.scrollTo');
+  expect(text).toContain('await page.content()');
+});


### PR DESCRIPTION
This PR introduces a new tool called browser_full_page, which converts HTML to clean Markdown. The tool removes non-essential elements (scripts, styles) to minimize token usage and enable LLMs to focus on key content. It utilizes @wqyjh/markdownify-ts for conversion (demo page: https://wqyjh.github.io/markdownify-ts/, which demonstrates the HTML to Markdown conversion effect).
