### PR TITLE
fix(ui): Wait with polling if test is still scheduled

### DIFF
--- a/packages/trace-viewer/src/ui/uiModeTraceView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeTraceView.tsx
@@ -46,7 +46,7 @@ export const TraceView: React.FC<{
       clearTimeout(pollTimer.current);
 
     const result = item.testCase?.results[0];
-    if (!result) {
+    if (!result || item.treeItem?.status === 'scheduled') {
       setModel(undefined);
       return;
     }

--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -160,6 +160,11 @@ test('should run on double click', async ({ runUITest }) => {
             - button "Watch"
           - treeitem "[icon-circle-outline] fails"
   `);
+
+  const allMessages = await page.consoleMessages();
+  const messages = allMessages.filter(m => !m.location().url.includes('trace/sha1/src'));
+  expect(messages).toHaveLength(0);
+  expect(await page.pageErrors()).toHaveLength(0);
 });
 
 test('should run on Enter', async ({ runUITest }) => {

--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -160,11 +160,6 @@ test('should run on double click', async ({ runUITest }) => {
             - button "Watch"
           - treeitem "[icon-circle-outline] fails"
   `);
-
-  const allMessages = await page.consoleMessages();
-  const messages = allMessages.filter(m => !m.location().url.includes('trace/sha1/src'));
-  expect(messages).toHaveLength(0);
-  expect(await page.pageErrors()).toHaveLength(0);
 });
 
 test('should run on Enter', async ({ runUITest }) => {


### PR DESCRIPTION
Don't poll if the selected test is still selected. Wait for a response from the websocket instead that the test has started (that updates `item` prop). This polling fetch would fail (sw errors), causing the model to be set to a new `TraceModel` with an empty `traceURI`, which in case would make the source call fail (the original issue).

Added assertions to existing test. 
> Tried instead adding following assertions in `runUITest` fixture:
>```
> expect.soft((page && !page.isClosed()) ? await page.consoleMessages() : []).toHaveLength(0);
> expect.soft((page && !page.isClosed()) ? await page.pageErrors() : []).toHaveLength(0);
>```
>
>However many would then fail:
>`snapshot action must have a pageId` (10+ ui-mode tests; e.g. `should not duplicate network entries from beforeAll`)
>`Failed to load resource: the server responded with a status of 404 (Not Found)`  (`should run folder` / `should merge trace events` / `should merge web assertion events` / `should show request source context id`)


Closes: #38359