### PR TITLE
chore: Remove duplicate eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -147,7 +147,6 @@ export const baseRules = {
   "space-in-parens": [2, "never"],
   "array-bracket-spacing": [2, "never"],
   "comma-spacing": [2, { before: false, after: true }],
-  "keyword-spacing": [2, "always"],
   "space-before-function-paren": [
     2,
     {


### PR DESCRIPTION
`keyword-spacing` rule is defined twice, removed first occurrence 