### PR TITLE
chore: support 'chrome-for-testing' channel

### DIFF
--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -177,8 +177,7 @@ program
           throw new Error(`Only one of --dry-run and --list can be specified`);
         if (options.dryRun) {
           for (const executable of executables) {
-            const version = executable.browserVersion ? `version ` + executable.browserVersion : '';
-            console.log(`browser: ${executable.name}${version ? ' ' + version : ''}`);
+            console.log(registry.calculateDownloadTitle(executable));
             console.log(`  Install location:    ${executable.directory ?? '<system>'}`);
             if (executable.downloadURLs?.length) {
               const [url, ...fallbacks] = executable.downloadURLs;

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -361,6 +361,8 @@ export class Chromium extends BrowserType {
   }
 
   override getExecutableName(options: types.LaunchOptions): string {
+    if (options.channel && registry.isChromiumAlias(options.channel))
+      return 'chromium';
     if (options.channel)
       return options.channel;
     return options.headless ? 'chromium-headless-shell' : 'chromium';

--- a/tests/installation/playwright-cli-install-should-work.spec.ts
+++ b/tests/installation/playwright-cli-install-should-work.spec.ts
@@ -155,7 +155,7 @@ test('should be able to remove browsers', async ({ exec, checkInstalledSoftwareO
   await exec('npx playwright install chromium');
   await checkInstalledSoftwareOnDisk(['chromium', 'chromium-headless-shell', 'ffmpeg', ...extraInstalledSoftware]);
   await exec('npx playwright uninstall');
-  await checkInstalledSoftwareOnDisk([...extraInstalledSoftware]);
+  await checkInstalledSoftwareOnDisk([]);
 });
 
 test('should print the right install command without browsers', async ({ exec }) => {


### PR DESCRIPTION
Also turns 'bidi-chromium' into a chromium alias.
Also cleans up wrong executable names, types, etc. Also makes `install --dry-run` consistent with `install`.