### PR TITLE
feat: add --no-mcp flag to init-agents command for enterprise environ…

### DIFF
--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -182,16 +182,18 @@ function addInitAgentsCommand(program: Command) {
   command.option('-c, --config <file>', `Configuration file to find a project to use for seed test`);
   command.option('--project <project>', 'Project to use for seed test');
   command.option('--prompts', 'Whether to include prompts in the agent initialization');
+  command.option('--no-mcp', 'Generate agents without MCP server dependency (for enterprise environments)');
   command.action(async opts => {
     const config = await loadConfigFromFile(opts.config);
+    const noMcp = opts.mcp === false;
     if (opts.loop === 'opencode') {
-      await OpencodeGenerator.init(config, opts.project, opts.prompts);
+      await OpencodeGenerator.init(config, opts.project, opts.prompts, noMcp);
     } else if (opts.loop === 'vscode-legacy') {
-      await VSCodeGenerator.init(config, opts.project);
+      await VSCodeGenerator.init(config, opts.project, noMcp);
     } else if (opts.loop === 'claude') {
-      await ClaudeGenerator.init(config, opts.project, opts.prompts);
+      await ClaudeGenerator.init(config, opts.project, opts.prompts, noMcp);
     } else {
-      await CopilotGenerator.init(config, opts.project, opts.prompts);
+      await CopilotGenerator.init(config, opts.project, opts.prompts, noMcp);
       return;
     }
   });

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -121,8 +121,10 @@ class ProgramStep extends Step {
   /** @override */
   async run() {
     const step = this._options;
-    console.log(`==== Running ${step.command} ${step.args.join(' ')} in ${step.cwd || process.cwd()}`);
-    const child = child_process.spawn(step.command, step.args, {
+    // Quote arguments that contain spaces when using shell
+    const args = step.shell ? step.args.map(arg => arg.includes(' ') ? `"${arg}"` : arg) : step.args;
+    console.log(`==== Running ${step.command} ${args.join(' ')} in ${step.cwd || process.cwd()}`);
+    const child = child_process.spawn(step.command, args, {
       stdio: 'inherit',
       shell: step.shell,
       env: {
@@ -138,7 +140,7 @@ class ProgramStep extends Step {
     return new Promise((resolve, reject) => {
       child.on('close', (code, signal) => {
         if (code || signal)
-          reject(new Error(`'${step.command} ${step.args.join(' ')}' exited with code ${code}, signal ${signal}`));
+          reject(new Error(`'${step.command} ${args.join(' ')}' exited with code ${code}, signal ${signal}`));
         else
           resolve({ });
       });
@@ -351,14 +353,14 @@ steps.push(new ProgramStep({
 // Build injected icons.
 steps.push(new ProgramStep({
   command: 'node',
-  args: ['utils/generate_clip_paths.js'],
+  args: [path.resolve(__dirname, '../generate_clip_paths.js')],
   shell: true,
 }));
 
 // Build injected scripts.
 steps.push(new ProgramStep({
   command: 'node',
-  args: ['utils/generate_injected.js'],
+  args: [path.resolve(__dirname, '../generate_injected.js')],
   shell: true,
 }));
 


### PR DESCRIPTION
Resolves #38703

This change allows Playwright Test agents to work in enterprise environments where MCP server installation is restricted by security policies.

Changes:
- Add --no-mcp CLI option to init-agents command
- Filter out MCP tools when noMcp flag is enabled
- Skip MCP configuration file generation in no-mcp mode
- Add NO_MCP_MODE.md documentation for manual workflows
- Fix Windows path quoting in build.js for paths with spaces

The --no-mcp flag:
- Removes playwright-test/* tools from agent definitions
- Skips .vscode/mcp.json and .mcp.json generation
- Provides clear instructions for manual test workflows
- Maintains full compatibility with normal MCP mode