### PR TITLE
fix(install): --force should work for downloadable browsers

### DIFF
--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -142,7 +142,7 @@ program
     .option('--with-deps', 'install system dependencies for browsers')
     .option('--dry-run', 'do not execute installation, only print information')
     .option('--list', 'prints list of browsers from all playwright installations')
-    .option('--force', 'force reinstall of stable browser channels')
+    .option('--force', 'force reinstall of already installed browsers')
     .option('--only-shell', 'only install headless shell when installing chromium')
     .option('--no-shell', 'do not install chromium headless shell')
     .action(async function(args: string[], options: { withDeps?: boolean, force?: boolean, dryRun?: boolean, list?: boolean, shell?: boolean, noShell?: boolean, onlyShell?: boolean }) {
@@ -191,8 +191,7 @@ program
           const browsers = await registry.listInstalledBrowsers();
           printGroupedByPlaywrightVersion(browsers);
         } else {
-          const force = args.length === 0 ? false : !!options.force;
-          await registry.install(executables, { force });
+          await registry.install(executables, { force: options.force });
           await registry.validateHostRequirementsForExecutablesIfNeeded(executables, process.env.PW_LANG_NAME || 'javascript').catch((e: Error) => {
             e.name = 'Playwright Host validation warning';
             console.error(e);

--- a/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
+++ b/packages/playwright-core/src/server/registry/oopDownloadBrowserMain.ts
@@ -20,6 +20,7 @@ import path from 'path';
 import { ManualPromise } from '../../utils/isomorphic/manualPromise';
 import { httpRequest } from '../utils/network';
 import { extract } from '../../zipBundle';
+import { removeFolders } from '../utils/fileUtils';
 
 export type DownloadParams = {
   title: string;
@@ -113,6 +114,8 @@ function downloadFile(options: DownloadParams): Promise<void> {
 async function main(options: DownloadParams) {
   await downloadFile(options);
   log(`SUCCESS downloading ${options.title}`);
+  log(`removing existing browser directory if any`);
+  await removeFolders([options.browserDirectory]);
   log(`extracting archive`);
   await extract(options.zipPath, { dir: options.browserDirectory });
   if (options.executablePath) {


### PR DESCRIPTION
Drive-by: switch to `removeFolders` helper to avoid Node.js warning.

```
(node:59808) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

References #38689.