### PR TITLE
devops: bump workers count 2->4 on CI

### DIFF
--- a/tests/bidi/playwright.config.ts
+++ b/tests/bidi/playwright.config.ts
@@ -65,7 +65,7 @@ const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeW
   maxFailures: 0,
   timeout: 15 * 1000,
   globalTimeout: 90 * 60 * 1000,
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   fullyParallel: !process.env.CI,
   forbidOnly: !!process.env.CI,
   retries: 0, // No retries even on CI for now.

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -95,7 +95,7 @@ const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeW
   maxFailures: 200,
   timeout: video ? 60000 : 30000,
   globalTimeout: 5400000,
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   fullyParallel: !process.env.CI,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 3 : 0,

--- a/tests/mcp/playwright.config.ts
+++ b/tests/mcp/playwright.config.ts
@@ -49,7 +49,7 @@ export default defineConfig<TestOptions>({
   testDir: rootTestDir,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   reporter: reporters(),
   tag: process.env.PW_TAG,
   projects: [

--- a/tests/playwright-test/playwright.config.ts
+++ b/tests/playwright-test/playwright.config.ts
@@ -34,7 +34,7 @@ const reporters = () => {
 export default defineConfig({
   timeout: 30000,
   forbidOnly: !!process.env.CI,
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   snapshotPathTemplate: '__screenshots__/{testFilePath}/{arg}{ext}',
   projects: [
     {


### PR DESCRIPTION
[Standard](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories) runners for public repositories now have 4 CPUs:


Virtual machine / container | Processor (CPU) | Memory (RAM) | Storage (SSD) | Architecture | Workflow label
-- | -- | -- | -- | -- | --
Linux | 1 | 5 GB | 14 GB | x64 | ubuntu-slim
Linux | 4 | 16 GB | 14 GB | x64 | ubuntu-latest, ubuntu-24.04, ubuntu-22.04
Windows | 4 | 16 GB | 14 GB | x64 | windows-latest, windows-2025, windows-2022
Linux | 4 | 16 GB | 14 GB | arm64 | ubuntu-24.04-arm, ubuntu-22.04-arm
Windows | 4 | 16 GB | 14 GB | arm64 | windows-11-arm
macOS | 4 | 14 GB | 14 GB | Intel | macos-13, macos-15-intel
macOS | 3 (M1) | 7 GB | 14 GB | arm64 | macos-latest, macos-14, macos-15, macos-26 (public preview)

