### PR TITLE
feat: store video artifacts under per-session output directory

### DIFF
--- a/packages/playwright/src/mcp/browser/config.ts
+++ b/packages/playwright/src/mcp/browser/config.ts
@@ -331,9 +331,12 @@ function tmpDir(): string {
 
 export function outputDir(config: FullConfig, clientInfo: ClientInfo): string {
   const rootPath = firstRootPath(clientInfo);
-  return config.outputDir
+  const baseDir = config.outputDir
     ?? (rootPath ? path.join(rootPath, '.playwright-mcp') : undefined)
     ?? path.join(tmpDir(), String(clientInfo.timestamp));
+  if (clientInfo.sessionId)
+    return path.join(baseDir, clientInfo.sessionId);
+  return baseDir;
 }
 
 export async function outputFile(config: FullConfig, clientInfo: ClientInfo, fileName: string, options: { origin: 'code' | 'llm' | 'web', reason: string }): Promise<string> {

--- a/packages/playwright/src/mcp/browser/sessionLog.ts
+++ b/packages/playwright/src/mcp/browser/sessionLog.ts
@@ -53,7 +53,7 @@ export class SessionLog {
   }
 
   static async create(config: FullConfig, clientInfo: mcpServer.ClientInfo): Promise<SessionLog> {
-    const sessionFolder = await outputFile(config, clientInfo, `session-${Date.now()}`, { origin: 'code', reason: 'Saving session' });
+    const sessionFolder = await outputFile(config, clientInfo, '', { origin: 'code', reason: 'Saving session' });
     await fs.promises.mkdir(sessionFolder, { recursive: true });
     // eslint-disable-next-line no-console
     console.error(`Session: ${sessionFolder}`);

--- a/packages/playwright/src/mcp/sdk/http.ts
+++ b/packages/playwright/src/mcp/sdk/http.ts
@@ -114,7 +114,7 @@ async function handleSSE(serverBackendFactory: ServerBackendFactory, req: http.I
     const transport = new mcpBundle.SSEServerTransport('/sse', res);
     sessions.set(transport.sessionId, transport);
     testDebug(`create SSE session: ${transport.sessionId}`);
-    await mcpServer.connect(serverBackendFactory, transport, false);
+    await mcpServer.connect(serverBackendFactory, transport, false, transport.sessionId);
     res.on('close', () => {
       testDebug(`delete SSE session: ${transport.sessionId}`);
       sessions.delete(transport.sessionId);
@@ -142,8 +142,8 @@ async function handleStreamable(serverBackendFactory: ServerBackendFactory, req:
     const transport = new mcpBundle.StreamableHTTPServerTransport({
       sessionIdGenerator: () => crypto.randomUUID(),
       onsessioninitialized: async sessionId => {
-        testDebug(`create http session: ${transport.sessionId}`);
-        await mcpServer.connect(serverBackendFactory, transport, true);
+        testDebug(`create http session: ${sessionId}`);
+        await mcpServer.connect(serverBackendFactory, transport, true, sessionId);
         sessions.set(sessionId, transport);
       }
     });


### PR DESCRIPTION
## Description

### Problem

When running multiple MCP sessions (HTTP or SSE) with `--save-video`, video artifacts are currently written into a shared output directory.
This leads to:

* Collisions between concurrent sessions
* Difficulty mapping a recorded video back to the originating MCP session
* Flaky behavior in environments where multiple test runs or agents execute in parallel (e.g. AI-driven test runners, CI, Kubernetes)

The MCP protocol already assigns a unique `sessionId`, but this identifier was not previously reflected in the artifact layout.

---

### Solution

This change stores video artifacts under a **per-session output directory**, keyed by the MCP `sessionId`.

New layout:

```
outputDir/
  <mcp-session-id>/
    page-<timestamp>.webm
```

This applies consistently to:

* Streamable HTTP (`/mcp`)
* SSE (`/sse`)
* Isolated and persistent browser contexts

---

### Implementation Details

* `recordVideo.dir` is now derived from `outputDir(config, clientInfo)`, ensuring all video artifacts are scoped to the active MCP session.
* The session identifier is propagated through existing `ClientInfo`, without changing the public MCP API.
* MCP video tests were updated to validate the new directory structure while preserving existing coverage.

---

### Why this approach

* Avoids introducing new CLI flags or configuration surface
* Uses existing MCP session semantics
* Scales naturally to concurrent and long-running MCP servers
* Aligns video artifact handling with other session-scoped outputs (e.g. traces)

---

### Tests

* Updated and ran:

  ```
  npx playwright test -c tests/mcp/playwright.config.ts tests/mcp/video.spec.ts --project=chromium
  ```
* Verified behavior manually for both `/mcp` and `/sse` transports.
