### PR TITLE
docs: fix webServer.wait.stdout example to use raw regex

### DIFF
--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -41,7 +41,7 @@ export default defineConfig({
   webServer: {
     command: 'npm run start',
     wait: {
-      stdout: '/Listening on port (?<my_server_port>\\d+)/'
+      stdout: /Listening on port (?<my_server_port>\d+)/
     },
   },
 });

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -797,7 +797,7 @@ export default defineConfig({
   webServer: {
     command: 'npm run start',
     wait: {
-      stdout: '/Listening on port (?<my_server_port>\\d+)/'
+      stdout: /Listening on port (?<my_server_port>\d+)/
     },
   },
 });

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -714,8 +714,8 @@ export default defineConfig({
   - `stderr` ?<["pipe"|"ignore"]> Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`.
   - `stdout` ?<["pipe"|"ignore"]> If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`.
   - `wait` ?<[Object]> Consider command started only when given output has been produced.
-    - `stdout` ?<[RegExp]> Regular expression to wait for in the `stdout` of the command output. Named capture groups are stored in the environment, for example `/Listening on port (?<my_server_port>\\d+)/` will store the port number in `process.env['MY_SERVER_PORT']`.
-    - `stderr` ?<[RegExp]> Regular expression to wait for in the `stderr` of the command output. Named capture groups are stored in the environment, for example `/Listening on port (?<my_server_port>\\d+)/` will store the port number in `process.env['MY_SERVER_PORT']`.
+    - `stdout` ?<[RegExp]> Regular expression to wait for in the `stdout` of the command output. Named capture groups are stored in the environment, for example `/Listening on port (?<my_server_port>\d+)/` will store the port number in `process.env['MY_SERVER_PORT']`.
+    - `stderr` ?<[RegExp]> Regular expression to wait for in the `stderr` of the command output. Named capture groups are stored in the environment, for example `/Listening on port (?<my_server_port>\d+)/` will store the port number in `process.env['MY_SERVER_PORT']`.
   - `timeout` ?<[int]> How long to wait for the process to start up and be available in milliseconds. Defaults to 60000.
   - `url` ?<[string]> The url on your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Redirects (3xx status codes) are being followed and the new location is checked. Either `port` or `url` should be specified.
 

--- a/docs/src/test-webserver-js.md
+++ b/docs/src/test-webserver-js.md
@@ -41,7 +41,7 @@ export default defineConfig({
 | `stdout` | If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`. |
 | `timeout` | How long to wait for the process to start up and be available in milliseconds. Defaults to 60000. |
 | `url`| URL of your http server that is expected to return a 2xx, 3xx, 400, 401, 402, or 403 status code when the server is ready to accept connections. Either `port` or `url` should be specified. |
-| `wait` | Consider command started only when given output has been produced. Takes an object with optional `stdout` and/or `stderr` regular expressions. Named capture groups in the regex are stored in the environment, for example `/Listening on port (?<my_server_port>\\d+)/` will store the port number in `process.env['MY_SERVER_PORT']`. |
+| `wait` | Consider command started only when given output has been produced. Takes an object with optional `stdout` and/or `stderr` regular expressions. Named capture groups in the regex are stored in the environment, for example `/Listening on port (?<my_server_port>\d+)/` will store the port number in `process.env['MY_SERVER_PORT']`. |
 
 ## Adding a server timeout
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1001,7 +1001,7 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    *   webServer: {
    *     command: 'npm run start',
    *     wait: {
-   *       stdout: '/Listening on port (?<my_server_port>\\d+)/'
+   *       stdout: /Listening on port (?<my_server_port>\d+)/
    *     },
    *   },
    * });
@@ -10251,14 +10251,14 @@ interface TestConfigWebServer {
   wait?: {
     /**
      * Regular expression to wait for in the `stdout` of the command output. Named capture groups are stored in the
-     * environment, for example `/Listening on port (?<my_server_port>\\d+)/` will store the port number in
+     * environment, for example `/Listening on port (?<my_server_port>\d+)/` will store the port number in
      * `process.env['MY_SERVER_PORT']`.
      */
     stdout?: RegExp;
 
     /**
      * Regular expression to wait for in the `stderr` of the command output. Named capture groups are stored in the
-     * environment, for example `/Listening on port (?<my_server_port>\\d+)/` will store the port number in
+     * environment, for example `/Listening on port (?<my_server_port>\d+)/` will store the port number in
      * `process.env['MY_SERVER_PORT']`.
      */
     stderr?: RegExp;


### PR DESCRIPTION
The code example showed `stdout` as a string literal instead of a raw JavaScript regex.

Using a string causes a TypeScript error since `wait.stdout` expects `RegExp`:

```
error TS2769: No overload matches this call.
  Type 'string' is not assignable to type 'RegExp'.
```