### PR TITLE
chore: bump some dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.34.0",
         "@lowire/loop": "^0.0.23",
-        "@modelcontextprotocol/sdk": "^1.17.5",
+        "@modelcontextprotocol/sdk": "^1.25.2",
         "@octokit/graphql-schema": "^15.26.0",
         "@stylistic/eslint-plugin": "^5.2.3",
         "@types/codemirror": "^5.60.7",
@@ -62,7 +62,7 @@
         "xml2js": "^0.5.0",
         "yaml": "2.6.0",
         "zod": "^3.25.76",
-        "zod-to-json-schema": "^3.24.6"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -976,6 +976,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.8.tgz",
+      "integrity": "sha512-0/g2lIOPzX8f3vzW1ggQgvG5mjtFBDBHFAzI5SFAi2DzSqS9luJwqg9T6O/gKYLi+inS7eNxBeIFkkghIPvrMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1075,12 +1088,15 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.5.tgz",
-      "integrity": "sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg==",
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
+      "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "@hono/node-server": "^1.19.7",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
@@ -1088,14 +1104,52 @@
         "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
@@ -2371,6 +2425,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -4199,6 +4295,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4757,6 +4870,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
+      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -5329,6 +5453,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5374,6 +5508,13 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6614,6 +6755,16 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8153,12 +8304,13 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "dev": true,
+      "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25 || ^4"
       }
     },
     "packages/html-reporter": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.34.0",
     "@lowire/loop": "^0.0.23",
-    "@modelcontextprotocol/sdk": "^1.17.5",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "@octokit/graphql-schema": "^15.26.0",
     "@stylistic/eslint-plugin": "^5.2.3",
     "@types/codemirror": "^5.60.7",
@@ -99,6 +99,6 @@
     "xml2js": "^0.5.0",
     "yaml": "2.6.0",
     "zod": "^3.25.76",
-    "zod-to-json-schema": "^3.24.6"
+    "zod-to-json-schema": "^3.25.1"
   }
 }

--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -4,8 +4,9 @@ THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 
 This project incorporates components from the projects listed below. The original copyright notices and the licenses under which Microsoft received such components are set forth below. Microsoft reserves all rights not expressly granted herein, whether by implication, estoppel or otherwise.
 
+-	@hono/node-server@1.19.8 (https://github.com/honojs/node-server)
 -	@lowire/loop@0.0.23 (https://github.com/pavelfeldman/lowire)
--	@modelcontextprotocol/sdk@1.24.2 (https://github.com/modelcontextprotocol/typescript-sdk)
+-	@modelcontextprotocol/sdk@1.25.2 (https://github.com/modelcontextprotocol/typescript-sdk)
 -	accepts@2.0.0 (https://github.com/jshttp/accepts)
 -	agent-base@7.1.4 (https://github.com/TooTallNate/proxy-agents)
 -	ajv-formats@3.0.1 (https://github.com/ajv-validator/ajv-formats)
@@ -60,6 +61,7 @@ This project incorporates components from the projects listed below. The origina
 -	graceful-fs@4.2.10 (https://github.com/isaacs/node-graceful-fs)
 -	has-symbols@1.1.0 (https://github.com/inspect-js/has-symbols)
 -	hasown@2.0.2 (https://github.com/inspect-js/hasOwn)
+-	hono@4.11.3 (https://github.com/honojs/hono)
 -	http-errors@2.0.1 (https://github.com/jshttp/http-errors)
 -	https-proxy-agent@7.0.6 (https://github.com/TooTallNate/proxy-agents)
 -	iconv-lite@0.7.0 (https://github.com/pillarjs/iconv-lite)
@@ -74,6 +76,7 @@ This project incorporates components from the projects listed below. The origina
 -	jpeg-js@0.4.4 (https://github.com/eugeneware/jpeg-js)
 -	jsbn@1.1.0 (https://github.com/andyperlitch/jsbn)
 -	json-schema-traverse@1.0.0 (https://github.com/epoberezkin/json-schema-traverse)
+-	json-schema-typed@8.0.2 (https://github.com/RemyRylan/json-schema-typed)
 -	math-intrinsics@1.1.0 (https://github.com/es-shims/math-intrinsics)
 -	media-typer@1.1.0 (https://github.com/jshttp/media-typer)
 -	merge-descriptors@2.0.0 (https://github.com/sindresorhus/merge-descriptors)
@@ -99,7 +102,7 @@ This project incorporates components from the projects listed below. The origina
 -	proxy-addr@2.0.7 (https://github.com/jshttp/proxy-addr)
 -	proxy-from-env@1.1.0 (https://github.com/Rob--W/proxy-from-env)
 -	pump@3.0.2 (https://github.com/mafintosh/pump)
--	qs@6.14.0 (https://github.com/ljharb/qs)
+-	qs@6.14.1 (https://github.com/ljharb/qs)
 -	range-parser@1.2.1 (https://github.com/jshttp/range-parser)
 -	raw-body@3.0.2 (https://github.com/stream-utils/raw-body)
 -	require-from-string@2.0.2 (https://github.com/floatdrop/require-from-string)
@@ -132,8 +135,370 @@ This project incorporates components from the projects listed below. The origina
 -	yaml@2.6.0 (https://github.com/eemeli/yaml)
 -	yauzl@3.2.0 (https://github.com/thejoshwolfe/yauzl)
 -	yazl@2.5.1 (https://github.com/thejoshwolfe/yazl)
--	zod-to-json-schema@3.25.0 (https://github.com/StefanTerdell/zod-to-json-schema)
+-	zod-to-json-schema@3.25.1 (https://github.com/StefanTerdell/zod-to-json-schema)
 -	zod@3.25.76 (https://github.com/colinhacks/zod)
+
+%% @hono/node-server@1.19.8 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+# Node.js Adapter for Hono
+
+This adapter `@hono/node-server` allows you to run your Hono application on Node.js.
+Initially, Hono wasn't designed for Node.js, but with this adapter, you can now use Hono on Node.js.
+It utilizes web standard APIs implemented in Node.js version 18 or higher.
+
+## Benchmarks
+
+Hono is 3.5 times faster than Express.
+
+Express:
+
+```txt
+$ bombardier -d 10s --fasthttp http://localhost:3000/
+
+Statistics        Avg      Stdev        Max
+  Reqs/sec     16438.94    1603.39   19155.47
+  Latency        7.60ms     7.51ms   559.89ms
+  HTTP codes:
+    1xx - 0, 2xx - 164494, 3xx - 0, 4xx - 0, 5xx - 0
+    others - 0
+  Throughput:     4.55MB/s
+```
+
+Hono + `@hono/node-server`:
+
+```txt
+$ bombardier -d 10s --fasthttp http://localhost:3000/
+
+Statistics        Avg      Stdev        Max
+  Reqs/sec     58296.56    5512.74   74403.56
+  Latency        2.14ms     1.46ms   190.92ms
+  HTTP codes:
+    1xx - 0, 2xx - 583059, 3xx - 0, 4xx - 0, 5xx - 0
+    others - 0
+  Throughput:    12.56MB/s
+```
+
+## Requirements
+
+It works on Node.js versions greater than 18.x. The specific required Node.js versions are as follows:
+
+- 18.x => 18.14.1+
+- 19.x => 19.7.0+
+- 20.x => 20.0.0+
+
+Essentially, you can simply use the latest version of each major release.
+
+## Installation
+
+You can install it from the npm registry with `npm` command:
+
+```sh
+npm install @hono/node-server
+```
+
+Or use `yarn`:
+
+```sh
+yarn add @hono/node-server
+```
+
+## Usage
+
+Just import `@hono/node-server` at the top and write the code as usual.
+The same code that runs on Cloudflare Workers, Deno, and Bun will work.
+
+```ts
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+
+const app = new Hono()
+app.get('/', (c) => c.text('Hono meets Node.js'))
+
+serve(app, (info) => {
+  console.log(`Listening on http://localhost:${info.port}`) // Listening on http://localhost:3000
+})
+```
+
+For example, run it using `ts-node`. Then an HTTP server will be launched. The default port is `3000`.
+
+```sh
+ts-node ./index.ts
+```
+
+Open `http://localhost:3000` with your browser.
+
+## Options
+
+### `port`
+
+```ts
+serve({
+  fetch: app.fetch,
+  port: 8787, // Port number, default is 3000
+})
+```
+
+### `createServer`
+
+```ts
+import { createServer } from 'node:https'
+import fs from 'node:fs'
+
+//...
+
+serve({
+  fetch: app.fetch,
+  createServer: createServer,
+  serverOptions: {
+    key: fs.readFileSync('test/fixtures/keys/agent1-key.pem'),
+    cert: fs.readFileSync('test/fixtures/keys/agent1-cert.pem'),
+  },
+})
+```
+
+### `overrideGlobalObjects`
+
+The default value is `true`. The Node.js Adapter rewrites the global Request/Response and uses a lightweight Request/Response to improve performance. If you don't want to do that, set `false`.
+
+```ts
+serve({
+  fetch: app.fetch,
+  overrideGlobalObjects: false,
+})
+```
+
+### `autoCleanupIncoming`
+
+The default value is `true`. The Node.js Adapter automatically cleans up (explicitly call `destroy()` method) if application is not finished to consume the incoming request. If you don't want to do that, set `false`.
+
+If the application accepts connections from arbitrary clients, this cleanup must be done otherwise incomplete requests from clients may cause the application to stop responding. If your application only accepts connections from trusted clients, such as in a reverse proxy environment and there is no process that returns a response without reading the body of the POST request all the way through, you can improve performance by setting it to `false`.
+
+```ts
+serve({
+  fetch: app.fetch,
+  autoCleanupIncoming: false,
+})
+```
+
+## Middleware
+
+Most built-in middleware also works with Node.js.
+Read [the documentation](https://hono.dev/middleware/builtin/basic-auth) and use the Middleware of your liking.
+
+```ts
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+import { prettyJSON } from 'hono/pretty-json'
+
+const app = new Hono()
+
+app.get('*', prettyJSON())
+app.get('/', (c) => c.json({ 'Hono meets': 'Node.js' }))
+
+serve(app)
+```
+
+## Serve Static Middleware
+
+Use Serve Static Middleware that has been created for Node.js.
+
+```ts
+import { serveStatic } from '@hono/node-server/serve-static'
+
+//...
+
+app.use('/static/*', serveStatic({ root: './' }))
+```
+
+If using a relative path, `root` will be relative to the current working directory from which the app was started.
+
+This can cause confusion when running your application locally.
+
+Imagine your project structure is:
+
+```
+my-hono-project/
+  src/
+    index.ts
+  static/
+    index.html
+```
+
+Typically, you would run your app from the project's root directory (`my-hono-project`),
+so you would need the following code to serve the `static` folder:
+
+```ts
+app.use('/static/*', serveStatic({ root: './static' }))
+```
+
+Notice that `root` here is not relative to `src/index.ts`, rather to `my-hono-project`.
+
+### Options
+
+#### `rewriteRequestPath`
+
+If you want to serve files in `./.foojs` with the request path `/__foo/*`, you can write like the following.
+
+```ts
+app.use(
+  '/__foo/*',
+  serveStatic({
+    root: './.foojs/',
+    rewriteRequestPath: (path: string) => path.replace(/^\/__foo/, ''),
+  })
+)
+```
+
+#### `onFound`
+
+You can specify handling when the requested file is found with `onFound`.
+
+```ts
+app.use(
+  '/static/*',
+  serveStatic({
+    // ...
+    onFound: (_path, c) => {
+      c.header('Cache-Control', `public, immutable, max-age=31536000`)
+    },
+  })
+)
+```
+
+#### `onNotFound`
+
+The `onNotFound` is useful for debugging. You can write a handle for when a file is not found.
+
+```ts
+app.use(
+  '/static/*',
+  serveStatic({
+    root: './non-existent-dir',
+    onNotFound: (path, c) => {
+      console.log(`${path} is not found, request to ${c.req.path}`)
+    },
+  })
+)
+```
+
+#### `precompressed`
+
+The `precompressed` option checks if files with extensions like `.br` or `.gz` are available and serves them based on the `Accept-Encoding` header. It prioritizes Brotli, then Zstd, and Gzip. If none are available, it serves the original file.
+
+```ts
+app.use(
+  '/static/*',
+  serveStatic({
+    precompressed: true,
+  })
+)
+```
+
+## ConnInfo Helper
+
+You can use the [ConnInfo Helper](https://hono.dev/docs/helpers/conninfo) by importing `getConnInfo` from `@hono/node-server/conninfo`.
+
+```ts
+import { getConnInfo } from '@hono/node-server/conninfo'
+
+app.get('/', (c) => {
+  const info = getConnInfo(c) // info is `ConnInfo`
+  return c.text(`Your remote address is ${info.remote.address}`)
+})
+```
+
+## Accessing Node.js API
+
+You can access the Node.js API from `c.env` in Node.js. For example, if you want to specify a type, you can write the following.
+
+```ts
+import { serve } from '@hono/node-server'
+import type { HttpBindings } from '@hono/node-server'
+import { Hono } from 'hono'
+
+const app = new Hono<{ Bindings: HttpBindings }>()
+
+app.get('/', (c) => {
+  return c.json({
+    remoteAddress: c.env.incoming.socket.remoteAddress,
+  })
+})
+
+serve(app)
+```
+
+The APIs that you can get from `c.env` are as follows.
+
+```ts
+type HttpBindings = {
+  incoming: IncomingMessage
+  outgoing: ServerResponse
+}
+
+type Http2Bindings = {
+  incoming: Http2ServerRequest
+  outgoing: Http2ServerResponse
+}
+```
+
+## Direct response from Node.js API
+
+You can directly respond to the client from the Node.js API.
+In that case, the response from Hono should be ignored, so return `RESPONSE_ALREADY_SENT`.
+
+> [!NOTE]
+> This feature can be used when migrating existing Node.js applications to Hono, but we recommend using Hono's API for new applications.
+
+```ts
+import { serve } from '@hono/node-server'
+import type { HttpBindings } from '@hono/node-server'
+import { RESPONSE_ALREADY_SENT } from '@hono/node-server/utils/response'
+import { Hono } from 'hono'
+
+const app = new Hono<{ Bindings: HttpBindings }>()
+
+app.get('/', (c) => {
+  const { outgoing } = c.env
+  outgoing.writeHead(200, { 'Content-Type': 'text/plain' })
+  outgoing.end('Hello World\n')
+
+  return RESPONSE_ALREADY_SENT
+})
+
+serve(app)
+```
+
+## Listen to a UNIX domain socket
+
+You can configure the HTTP server to listen to a UNIX domain socket instead of a TCP port.
+
+```ts
+import { createAdaptorServer } from '@hono/node-server'
+
+// ...
+
+const socketPath ='/tmp/example.sock'
+
+const server = createAdaptorServer(app)
+server.listen(socketPath, () => {
+  console.log(`Listening on ${socketPath}`)
+})
+```
+
+## Related projects
+
+- Hono - <https://hono.dev>
+- Hono GitHub repository - <https://github.com/honojs/hono>
+
+## Author
+
+Yusuke Wada <https://github.com/yusukebe>
+
+## License
+
+MIT
+=========================================
+END OF @hono/node-server@1.19.8 AND INFORMATION
 
 %% @lowire/loop@0.0.23 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -341,7 +706,7 @@ Apache License
 =========================================
 END OF @lowire/loop@0.0.23 AND INFORMATION
 
-%% @modelcontextprotocol/sdk@1.24.2 NOTICES AND INFORMATION BEGIN HERE
+%% @modelcontextprotocol/sdk@1.25.2 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 MIT License
 
@@ -365,7 +730,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 =========================================
-END OF @modelcontextprotocol/sdk@1.24.2 AND INFORMATION
+END OF @modelcontextprotocol/sdk@1.25.2 AND INFORMATION
 
 %% accepts@2.0.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1780,6 +2145,32 @@ SOFTWARE.
 =========================================
 END OF hasown@2.0.2 AND INFORMATION
 
+%% hono@4.11.3 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+MIT License
+
+Copyright (c) 2021 - present, Yusuke Wada and Hono contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF hono@4.11.3 AND INFORMATION
+
 %% http-errors@2.0.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 The MIT License (MIT)
@@ -2125,6 +2516,68 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 =========================================
 END OF json-schema-traverse@1.0.0 AND INFORMATION
+
+%% json-schema-typed@8.0.2 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+BSD 2-Clause License
+
+Original source code is copyright (c) 2019-2025 Remy Rylan
+<https://github.com/RemyRylan>
+
+All JSON Schema documentation and descriptions are copyright (c):
+
+2009 [draft-0] IETF Trust <https://www.ietf.org/>, Kris Zyp <kris@sitepen.com>,
+and SitePen (USA) <https://www.sitepen.com/>.
+
+2009 [draft-1] IETF Trust <https://www.ietf.org/>, Kris Zyp <kris@sitepen.com>,
+and SitePen (USA) <https://www.sitepen.com/>.
+
+2010 [draft-2] IETF Trust <https://www.ietf.org/>, Kris Zyp <kris@sitepen.com>,
+and SitePen (USA) <https://www.sitepen.com/>.
+
+2010 [draft-3] IETF Trust <https://www.ietf.org/>, Kris Zyp <kris@sitepen.com>,
+Gary Court <gary.court@gmail.com>, and SitePen (USA) <https://www.sitepen.com/>.
+
+2013 [draft-4] IETF Trust <https://www.ietf.org/>), Francis Galiegue
+<fgaliegue@gmail.com>, Kris Zyp <kris@sitepen.com>, Gary Court
+<gary.court@gmail.com>, and SitePen (USA) <https://www.sitepen.com/>.
+
+2018 [draft-7] IETF Trust <https://www.ietf.org/>, Austin Wright <aaa@bzfx.net>,
+Henry Andrews <henry@cloudflare.com>, Geraint Luff <luffgd@gmail.com>, and
+Cloudflare, Inc. <https://www.cloudflare.com/>.
+
+2019 [draft-2019-09] IETF Trust <https://www.ietf.org/>, Austin Wright
+<aaa@bzfx.net>, Henry Andrews <andrews_henry@yahoo.com>, Ben Hutton
+<bh7@sanger.ac.uk>, and Greg Dennis <gregsdennis@yahoo.com>.
+
+2020 [draft-2020-12] IETF Trust <https://www.ietf.org/>, Austin Wright
+<aaa@bzfx.net>, Henry Andrews <andrews_henry@yahoo.com>, Ben Hutton
+<ben@jsonschema.dev>, and Greg Dennis <gregsdennis@yahoo.com>.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+=========================================
+END OF json-schema-typed@8.0.2 AND INFORMATION
 
 %% math-intrinsics@1.1.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -2744,7 +3197,7 @@ THE SOFTWARE.
 =========================================
 END OF pump@3.0.2 AND INFORMATION
 
-%% qs@6.14.0 NOTICES AND INFORMATION BEGIN HERE
+%% qs@6.14.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 BSD 3-Clause License
 
@@ -2776,7 +3229,7 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 =========================================
-END OF qs@6.14.0 AND INFORMATION
+END OF qs@6.14.1 AND INFORMATION
 
 %% range-parser@1.2.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -3570,7 +4023,7 @@ SOFTWARE.
 =========================================
 END OF yazl@2.5.1 AND INFORMATION
 
-%% zod-to-json-schema@3.25.0 NOTICES AND INFORMATION BEGIN HERE
+%% zod-to-json-schema@3.25.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 ISC License
 
@@ -3588,7 +4041,7 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 =========================================
-END OF zod-to-json-schema@3.25.0 AND INFORMATION
+END OF zod-to-json-schema@3.25.1 AND INFORMATION
 
 %% zod@3.25.76 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -3618,6 +4071,6 @@ END OF zod@3.25.76 AND INFORMATION
 
 SUMMARY BEGIN HERE
 =========================================
-Total Packages: 130
+Total Packages: 133
 =========================================
 END OF SUMMARY

--- a/packages/playwright-core/bundles/mcp/package-lock.json
+++ b/packages/playwright-core/bundles/mcp/package-lock.json
@@ -9,9 +9,21 @@
       "version": "0.0.1",
       "dependencies": {
         "@lowire/loop": "^0.0.23",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.25.2",
         "zod": "^3.25.76",
-        "zod-to-json-schema": "^3.24.6"
+        "zod-to-json-schema": "^3.25.1"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.8.tgz",
+      "integrity": "sha512-0/g2lIOPzX8f3vzW1ggQgvG5mjtFBDBHFAzI5SFAi2DzSqS9luJwqg9T6O/gKYLi+inS7eNxBeIFkkghIPvrMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@lowire/loop": {
@@ -24,11 +36,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.2.tgz",
-      "integrity": "sha512-hS/kzSfchqzvUeJUsdiDHi84/kNhLIZaZ6coGQVwbYIelOBbcAwUohUfaQTLa1MvFOK/jbTnGFzraHSFwB7pjQ==",
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
+      "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -39,6 +52,7 @@
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "jose": "^6.1.1",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
@@ -551,6 +565,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
+      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -628,6 +652,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -787,9 +817,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1093,9 +1123,9 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
-      "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"

--- a/packages/playwright-core/bundles/mcp/package.json
+++ b/packages/playwright-core/bundles/mcp/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "dependencies": {
     "@lowire/loop": "^0.0.23",
-    "@modelcontextprotocol/sdk": "^1.24.0",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "zod": "^3.25.76",
-    "zod-to-json-schema": "^3.24.6"
+    "zod-to-json-schema": "^3.25.1"
   }
 }

--- a/packages/playwright-core/src/mcpBundle.ts
+++ b/packages/playwright-core/src/mcpBundle.ts
@@ -17,7 +17,7 @@
 // @ts-ignore
 import * as bundle from './mcpBundleImpl';
 
-const zodToJsonSchema: typeof import('zod-to-json-schema').zodToJsonSchema = bundle.zodToJsonSchema;
+const zodToJsonSchema: (schema: any, options?: any) => any = bundle.zodToJsonSchema;
 const Client: typeof import('@modelcontextprotocol/sdk/client/index.js').Client = bundle.Client;
 const Server: typeof import('@modelcontextprotocol/sdk/server/index.js').Server = bundle.Server;
 const SSEClientTransport: typeof import('@modelcontextprotocol/sdk/client/sse.js').SSEClientTransport = bundle.SSEClientTransport;

--- a/tests/mcp/wait.spec.ts
+++ b/tests/mcp/wait.spec.ts
@@ -49,7 +49,6 @@ test('browser_wait_for(text)', async ({ client, server }) => {
   await client.callTool({
     name: 'browser_wait_for',
     arguments: { text: 'Text to appear' },
-    code: `await page.getByText("Text to appear").first().waitFor({ state: 'visible' });`,
   });
 
   expect(await client.callTool({
@@ -92,7 +91,6 @@ test('browser_wait_for(textGone)', async ({ client, server }) => {
   await client.callTool({
     name: 'browser_wait_for',
     arguments: { textGone: 'Text to disappear' },
-    code: `await page.getByText("Text to disappear").first().waitFor({ state: 'hidden' });`,
   });
 
   expect(await client.callTool({


### PR DESCRIPTION
Resolves some audits/alerts.

- `@modelcontextprotocol/sdk` to `1.25.2`;
- `zod-to-json-schema` to `3.25.1`;
- `qs` to `6.14.1`.

Unfortunately, re-exporting `zodToJsonSchema` type from the bundle now results in `error TS2589: Type instantiation is excessively deep and possibly infinite.` errors in some places. I removed the exact type, since the result is always immediately type-casted everywhere.

Also fix some type issues found after version bumps.