### PR TITLE
chore(mcp): let browser_run_code support helper scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@stylistic/eslint-plugin": "^5.2.3",
         "@types/codemirror": "^5.60.7",
         "@types/formidable": "^2.0.4",
-        "@types/node": "18.19.76",
+        "@types/node": "25.0.3",
         "@types/react": "^19.2.1",
         "@types/react-dom": "^19.2.1",
         "@types/ws": "^8.5.3",
@@ -1811,12 +1811,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.19.76",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.76.tgz",
-      "integrity": "sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==",
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
@@ -7667,10 +7668,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@stylistic/eslint-plugin": "^5.2.3",
     "@types/codemirror": "^5.60.7",
     "@types/formidable": "^2.0.4",
-    "@types/node": "18.19.76",
+    "@types/node": "25.0.3",
     "@types/react": "^19.2.1",
     "@types/react-dom": "^19.2.1",
     "@types/ws": "^8.5.3",

--- a/packages/playwright/src/mcp/browser/tools/runCode.ts
+++ b/packages/playwright/src/mcp/browser/tools/runCode.ts
@@ -53,7 +53,9 @@ const runCode = defineTabTool({
           __end__.reject(e);
         }
       })()`;
-      await vm.runInContext(snippet, context);
+      await vm.runInContext(snippet, context, {
+        importModuleDynamically: vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+      });
       const result = await __end__;
       if (typeof result === 'string')
         response.addResult(result);

--- a/packages/playwright/src/mcp/browser/tools/runCode.ts
+++ b/packages/playwright/src/mcp/browser/tools/runCode.ts
@@ -54,7 +54,7 @@ const runCode = defineTabTool({
         }
       })()`;
       await vm.runInContext(snippet, context, {
-        importModuleDynamically: vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+        importModuleDynamically: vm.constants?.USE_MAIN_CONTEXT_DEFAULT_LOADER,
       });
       const result = await __end__;
       if (typeof result === 'string')

--- a/tests/mcp/run-code.spec.ts
+++ b/tests/mcp/run-code.spec.ts
@@ -166,3 +166,34 @@ test('browser_run_code return value', async ({ client, server }) => {
     result: '{"message":"Hello, world!"}',
   });
 });
+
+test('browser_run_code dynamic import', async ({ client, server }) => {
+  server.setContent('/', `
+    <button onclick="console.log('Submit')">Submit</button>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const scriptPath = test.info().outputPath('helper.mjs');
+  await fs.writeFile(scriptPath, `
+export async function clickSubmit(page) {
+  await page.getByRole("button", { name: "Submit" }).click();
+}
+`);
+
+  const code = `async (page) => {
+  const { clickSubmit } = await import(${JSON.stringify(scriptPath)});
+  await clickSubmit(page);
+}`;
+  expect(await client.callTool({
+    name: 'browser_run_code',
+    arguments: {
+      code,
+    },
+  })).toHaveResponse({
+    code: `await (${code})(page);`,
+    consoleMessages: expect.stringContaining('- [LOG] Submit'),
+  });
+});


### PR DESCRIPTION
https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#provide-utility-scripts

```md
[... skill ...]

# Example: Simulating Perfect Circle Movement

```javascript
async (page) => {
  const { runCircle } = await import('./run-circle.js'); // helper to generate circle points
  await runCircle(page, {
    center: { latitude: 52.5234, longitude: 13.4014 },
    radius: 50, // in meters
    steps: 30,
    duration: 15 * 60 * 1000,
  });
}
``
```

This API is experimental, though. https://nodejs.org/api/vm.html#support-of-dynamic-import-in-compilation-apis