### PR TITLE
feat(test runner): each worker fixture gets a separate timeout

### DIFF
--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -354,6 +354,8 @@ Playwright Test uses [worker processes](./test-parallel.md) to run test files. S
 
 Below we'll create an `account` fixture that will be shared by all tests in the same worker, and override the `page` fixture to log in to this account for each test. To generate unique accounts, we'll use the [`property: WorkerInfo.workerIndex`] that is available to any test or fixture. Note the tuple-like syntax for the worker fixture - we have to pass `{scope: 'worker'}` so that test runner sets this fixture up once per worker.
 
+In addition to only being run once per worker, worker-scoped fixtures also get a separate timeout equal to the default test timeout. You can change it by passing the `timeout` option. See [fixture timeout](#fixture-timeout) for more details.
+
 ```js title="my-test.ts"
 import { test as base } from '@playwright/test';
 
@@ -434,7 +436,7 @@ export { expect } from '@playwright/test';
 
 ## Fixture timeout
 
-By default, the fixture inherits the timeout value of the test. However, for slow fixtures, especially [worker-scoped](#worker-scoped-fixtures) ones, it is convenient to have a separate timeout. This way you can keep the overall test timeout small, and give the slow fixture more time.
+Fixture is considered to be a part of a test, and so its setup and teardown running time counts towards the test timeout. Therefore, a slow fixture may cause test timeouts. You can set a separate larger timeout for such a fixture, and keep the overall test timeout small.
 
 ```js
 import { test as base, expect } from '@playwright/test';
@@ -451,6 +453,7 @@ test('example test', async ({ slowFixture }) => {
 });
 ```
 
+Unlike regular test-scoped fixtures, each [worker-scoped](#worker-scoped-fixtures) fixture has its own timeout, equal to the test timeout. You can change the timeout for a worker-scoped fixture in the same way.
 
 ## Fixtures-options
 

--- a/packages/playwright/src/worker/fixtureRunner.ts
+++ b/packages/playwright/src/worker/fixtureRunner.ts
@@ -55,10 +55,13 @@ class Fixture {
       title,
       phase: 'setup',
       location,
-      slot: this.registration.timeout === undefined ? undefined : {
+      slot: this.registration.timeout !== undefined ? {
         timeout: this.registration.timeout,
         elapsed: 0,
-      }
+      } : this.registration.scope === 'worker' ? {
+        timeout: this.runner.workerFixtureTimeout,
+        elapsed: 0,
+      } : undefined,
     };
     this._teardownDescription = { ...this._setupDescription, phase: 'teardown' };
   }
@@ -179,6 +182,7 @@ export class FixtureRunner {
   private testScopeClean = true;
   pool: FixturePool | undefined;
   instanceForId = new Map<string, Fixture>();
+  workerFixtureTimeout = 0;
 
   setPool(pool: FixturePool) {
     if (!this.testScopeClean)

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -212,6 +212,7 @@ export class WorkerMain extends ProcessRunner {
     this._config = config;
     this._project = project;
     this._poolBuilder = PoolBuilder.createForWorker(this._project);
+    this._fixtureRunner.workerFixtureTimeout = this._project.project.timeout;
   }
 
   async runTestGroup(runPayload: ipc.RunPayload) {

--- a/tests/playwright-test/fixture-errors.spec.ts
+++ b/tests/playwright-test/fixture-errors.spec.ts
@@ -46,18 +46,18 @@ test('should handle worker fixture timeout', async ({ runInlineTest }) => {
     'a.spec.ts': `
       import { test as base, expect } from '@playwright/test';
       const test = base.extend({
-        timeout: [async ({}, runTest) => {
+        slowFixture: [async ({}, runTest) => {
           await runTest();
           await new Promise(f => setTimeout(f, 100000));
         }, { scope: 'worker' }]
       });
 
-      test('fails', async ({timeout}) => {
+      test('fails', async ({ slowFixture }) => {
       });
     `
   }, { timeout: 500 });
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('Worker teardown timeout of 500ms exceeded while tearing down "timeout".');
+  expect(result.output).toContain('Fixture "slowFixture" timeout of 500ms exceeded during teardown.');
 });
 
 test('should handle worker fixture error', async ({ runInlineTest }) => {
@@ -607,7 +607,7 @@ test('should report worker fixture teardown with debug info', async ({ runInline
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(20);
   expect(result.output).toContain([
-    'Worker teardown timeout of 1000ms exceeded while tearing down "fixture".',
+    'Fixture "fixture" timeout of 1000ms exceeded during teardown.',
     '',
     'Failed worker ran 20 tests, last 10 tests were:',
     'a.spec.ts:10:9 › good10',


### PR DESCRIPTION
References #38690.