### PR TITLE
fix(route): don't get stalled by "runBeforeUnload"

### DIFF
--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -634,7 +634,8 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
 
   async close(options: { runBeforeUnload?: boolean, reason?: string } = {}) {
     this._closeReason = options.reason;
-    this._closeWasCalled = true;
+    if (!options.runBeforeUnload)
+      this._closeWasCalled = true;
     try {
       if (this._ownedContext)
         await this._ownedContext.close();

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -1070,7 +1070,7 @@ it('should be able to intercept every navigation to a page controlled by service
   expect(interceptions).toBe(2);
 });
 
-it('does not get stalled by beforeUnload', async ({ page, server }) => {
+it('does not get stalled by beforeUnload', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/38731' }}, async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
 
   await page.evaluate(() => {

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -1070,7 +1070,7 @@ it('should be able to intercept every navigation to a page controlled by service
   expect(interceptions).toBe(2);
 });
 
-it('does not get stalled by beforeUnload', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/38731' }}, async ({ page, server }) => {
+it('does not get stalled by beforeUnload', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/38731' } }, async ({ page, server }) => {
   await page.goto(server.HELLO_WORLD);
 
   await page.evaluate(() => {

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -1071,7 +1071,7 @@ it('should be able to intercept every navigation to a page controlled by service
 });
 
 it('does not get stalled by beforeUnload', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/38731' }}, async ({ page, server }) => {
-  await page.goto(server.EMPTY_PAGE);
+  await page.goto(server.HELLO_WORLD);
 
   await page.evaluate(() => {
     window.addEventListener('beforeunload', event => {
@@ -1079,6 +1079,10 @@ it('does not get stalled by beforeUnload', { annotation: { type: 'issue', descri
     });
   });
   page.on('dialog', dialog => dialog.dismiss());
+
+  // We have to interact with a page so that 'beforeunload' handlers
+  // fire.
+  await page.click('body');
 
   await page.route('**/api', route => route.fulfill({ status: 200, body: 'ok' }));
   await page.evaluate(async () => fetch(new URL('/api', window.location.href)));


### PR DESCRIPTION
This condition is stalling routes after `page.close(runBeforeUnload: true)`:

https://github.com/microsoft/playwright/blob/7c03101540a5d847319471f7c6e6d6d972c57b6b/packages/playwright-core/src/client/page.ts#L197-L199

It was added in https://github.com/microsoft/playwright/pull/28414/changes#diff-b2b8e731138f178e6972c51b45f112fc60aff0eec1072e9899b3a5df2cf1133a, and I can't quite spot why. We can also remove that condition entirely.

Closes https://github.com/microsoft/playwright/issues/38731