### PR TITLE
fix(tracing): resourceOverrides issues

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/playwright-core/src/utils/isomorphic/trace/snapshotRenderer.ts
@@ -193,20 +193,24 @@ export class SnapshotRenderer {
     let result = sameFrameResource ?? otherFrameResource;
     if (result && method.toUpperCase() === 'GET') {
       // Patch override if necessary.
-      for (const o of snapshot.resourceOverrides) {
-        if (url === o.url && o.sha1) {
-          result = {
-            ...result,
-            response: {
-              ...result.response,
-              content: {
-                ...result.response.content,
-                _sha1: o.sha1,
-              }
-            },
-          };
-          break;
-        }
+      let override = snapshot.resourceOverrides.find(o => o.url === url);
+      if (override?.ref) {
+        // "ref" means use the same content as "ref" snapshots ago.
+        const index = this._index - override.ref;
+        if (index >= 0 && index < this._snapshots.length)
+          override = this._snapshots[index].resourceOverrides.find(o => o.url === url);
+      }
+      if (override?.sha1) {
+        result = {
+          ...result,
+          response: {
+            ...result.response,
+            content: {
+              ...result.response.content,
+              _sha1: override.sha1,
+            }
+          },
+        };
       }
     }
 

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -2178,6 +2178,8 @@ test('should respect CSSOM changes', async ({ runAndTrace, page, server }) => {
     await page.goto(server.EMPTY_PAGE);
     await page.setContent('<link rel="stylesheet" href="style.css"><button>Hello</button>');
     await page.evaluate(() => { (document.styleSheets[0].cssRules[0] as any).style.color = 'blue'; });
+    await page.evaluate(() => '1 + 1');
+    await page.evaluate(() => { document.styleSheets[0].disabled = true; });
   });
 
   const frame1 = await traceViewer.snapshotFrame('Set content', 0);
@@ -2196,6 +2198,11 @@ test('should respect CSSOM changes', async ({ runAndTrace, page, server }) => {
   await expect(frame6.locator('button')).toHaveCSS('color', 'rgb(255, 0, 0)');
   const frame7 = await traceViewer.snapshotFrame('Evaluate', 4);
   await expect(frame7.locator('button')).toHaveCSS('color', 'rgb(0, 0, 255)');
+  const frame8 = await traceViewer.snapshotFrame('Evaluate', 5);
+  await traceViewer.page.waitForTimeout(1000); // give it time to render wrong color
+  await expect(frame8.locator('button')).toHaveCSS('color', 'rgb(0, 0, 255)');
+  const frame9 = await traceViewer.snapshotFrame('Evaluate', 6);
+  await expect(frame9.locator('button')).toHaveCSS('color', 'rgb(0, 0, 0)');
 });
 
 test('should preserve custom doctype', async ({ runAndTrace, page }) => {


### PR DESCRIPTION
- For resource overrides with a `ref`, meaning they have not changed the value, actually follow the ref.
- Always report CSSOM-touched stylesheets in the overrides, to avoid rendering non-edited content when there were no recent changes in the stylesheet.
- Honor the value of `styleSheet.disabled`.
- Invalidate upon `styleSheet.disabled` assignment.