### PR TITLE
test: dont flake on weight recommendations

### DIFF
--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3357,7 +3357,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
           - text: Use shard weights to
           - link "rebalance your shards":
             - /url: https://playwright.dev/docs/test-sharding#rebalancing-shards
-          - text: ": @linux: npx playwright test --shard-weights=67:33:0 @mac: npx playwright test --shard-weights=67:33"
+          - text: /@linux. npx playwright test --shard-weights=\\d+:\\d+:\\d+ @mac. npx playwright test --shard-weights=\\d+:\\d+/
       `);
     });
   });


### PR DESCRIPTION
The recommendations depend on exact millisecond timings which are flaky.