### PR TITLE
fix(trace-viewer): filter down resources properly on timeline selection

### DIFF
--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -57,7 +57,13 @@ export function useNetworkTabModel(model: TraceModel | undefined, selectedTime: 
     const filtered = resources.filter(resource => {
       if (!selectedTime)
         return true;
-      return !!resource._monotonicTime && (resource._monotonicTime >= selectedTime.minimum && resource._monotonicTime <= selectedTime.maximum);
+      return !!resource._monotonicTime && (
+        // the resource overlaps with the selection iff
+        // - the start time is before the end of the selection
+        // AND
+        // - the end time is after the start of the selection
+        resource._monotonicTime <= selectedTime.maximum && (resource._monotonicTime + resource.time) >= selectedTime.minimum
+      )
     });
     return filtered;
   }, [model, selectedTime]);


### PR DESCRIPTION
Previously, selecting a time interval would filter network requests down to requests that started within a time interval. This would mean that one would not see requests that started before the selection, but would overlap it. 

This change instead filters down network requests in the network tab to any request that overlaps with the selection. This means that you can, for example, select an area near the end of a long-running request and have it appear in the network tab, instead of hunting for its start point.

Notice this selection from with this change applied (bit hard to see): I can inspect a request that starts before  my selection, but ends within my selection. So you can see (for example) what requests _ended_ around where something happened.

<img width="260" height="134" alt="image" src="https://github.com/user-attachments/assets/1f95366a-cf18-448a-9b20-061fbc3eea17" />

