### PR TITLE
fix(perform): reuse param-based rendering in trace for performed actions

### DIFF
--- a/packages/playwright-core/src/server/agent/actionRunner.ts
+++ b/packages/playwright-core/src/server/agent/actionRunner.ts
@@ -172,7 +172,7 @@ export function performActionTimeout(action: actions.Action): number {
   }
 }
 
-export function traceParamsForAction(action: actions.Action): { method: string, title: string, params: any } {
+export function traceParamsForAction(action: actions.Action): { method: string, type: string, params: any, title?: string } {
   const timeout = generateActionTimeout(action);
   switch (action.method) {
     case 'navigate': {
@@ -180,7 +180,7 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
         url: action.url,
         timeout,
       };
-      return { method: 'goto', title: 'Navigate', params };
+      return { type: 'Frame', method: 'goto', params };
     }
     case 'click': {
       const params: channels.FrameClickParams = {
@@ -191,7 +191,7 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
         clickCount: action.clickCount,
         timeout,
       };
-      return { method: 'click', title: 'Click', params };
+      return { type: 'Frame', method: 'click', params };
     }
     case 'drag': {
       const params: channels.FrameDragAndDropParams = {
@@ -199,7 +199,7 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
         target: action.targetSelector,
         timeout,
       };
-      return { method: 'dragAndDrop', title: 'Drag and Drop', params };
+      return { type: 'Frame', method: 'dragAndDrop', params };
     }
     case 'hover': {
       const params: channels.FrameHoverParams = {
@@ -207,13 +207,13 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
         modifiers: action.modifiers,
         timeout,
       };
-      return { method: 'hover', title: 'Hover', params };
+      return { type: 'Frame', method: 'hover', params };
     }
     case 'pressKey': {
       const params: channels.PageKeyboardPressParams = {
         key: action.key,
       };
-      return { method: 'press', title: 'Press', params };
+      return { type: 'Page', method: 'keyboardPress', params };
     }
     case 'pressSequentially': {
       const params: channels.FrameTypeParams = {
@@ -221,7 +221,7 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
         text: action.text,
         timeout,
       };
-      return { method: 'type', title: 'Type', params };
+      return { type: 'Frame', method: 'type', params };
     }
     case 'fill': {
       const params: channels.FrameFillParams = {
@@ -230,7 +230,7 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
         value: action.text,
         timeout,
       };
-      return { method: 'fill', title: 'Fill', params };
+      return { type: 'Frame', method: 'fill', params };
     }
     case 'setChecked': {
       if (action.checked) {
@@ -239,14 +239,14 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
           strict: true,
           timeout,
         };
-        return { method: 'check', title: 'Check', params };
+        return { type: 'Frame', method: 'check', params };
       } else {
         const params: channels.FrameUncheckParams = {
           selector: action.selector,
           strict: true,
           timeout,
         };
-        return { method: 'uncheck', title: 'Uncheck', params };
+        return { type: 'Frame', method: 'uncheck', params };
       }
     }
     case 'selectOption': {
@@ -256,7 +256,7 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
         options: action.labels.map(label => ({ label })),
         timeout,
       };
-      return { method: 'selectOption', title: 'Select Option', params };
+      return { type: 'Frame', method: 'selectOption', params };
     }
     case 'expectValue': {
       if (action.type === 'textbox' || action.type === 'combobox' || action.type === 'slider') {
@@ -268,7 +268,7 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
           isNot: !!action.isNot,
           timeout: kDefaultTimeout,
         };
-        return { method: 'expect', title: 'Expect Value', params };
+        return { type: 'Frame', method: 'expect', title: 'Expect Value', params };
       } else if (action.type === 'checkbox' || action.type === 'radio') {
         // TODO: provide serialized expected value
         const params: channels.FrameExpectParams = {
@@ -277,7 +277,7 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
           isNot: !!action.isNot,
           timeout: kDefaultTimeout,
         };
-        return { method: 'expect', title: 'Expect Checked', params };
+        return { type: 'Frame', method: 'expect', title: 'Expect Checked', params };
       } else {
         throw new Error(`Unsupported element type: ${action.type}`);
       }
@@ -289,7 +289,7 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
         isNot: !!action.isNot,
         timeout: kDefaultTimeout,
       };
-      return { method: 'expect', title: 'Expect Visible', params };
+      return { type: 'Frame', method: 'expect', title: 'Expect Visible', params };
     }
     case 'expectAria': {
       // TODO: provide serialized expected value
@@ -300,13 +300,13 @@ export function traceParamsForAction(action: actions.Action): { method: string, 
         isNot: !!action.isNot,
         timeout: kDefaultTimeout,
       };
-      return { method: 'expect', title: 'Expect Aria Snapshot', params };
+      return { type: 'Frame', method: 'expect', title: 'Expect Aria Snapshot', params };
     }
   }
 }
 
 function callMetadataForAction(frame: Frame, action: actions.Action): CallMetadata {
-  const { method, title, params } = traceParamsForAction(action);
+  const { method, type, params, title } = traceParamsForAction(action);
 
   const callMetadata: CallMetadata = {
     id: `call@${createGuid()}`,
@@ -315,7 +315,7 @@ function callMetadataForAction(frame: Frame, action: actions.Action): CallMetada
     frameId: frame.guid,
     startTime: monotonicTime(),
     endTime: 0,
-    type: 'Frame',
+    type,
     method,
     params,
     title,


### PR DESCRIPTION
This way we get titles like `Press "Enter"` instead of just `Press`, based on the standard formatting defined in `protocol.yml`.

<img width="366" height="164" alt="Screenshot 2026-01-14 at 4 09 02 PM" src="https://github.com/user-attachments/assets/99f996ef-ea96-4a88-b1b5-67d1423f9fcc" />
