### PR TITLE
fix(windows): hide console window when spawning browser processes

### DIFF
--- a/packages/playwright-core/src/server/utils/processLauncher.ts
+++ b/packages/playwright-core/src/server/utils/processLauncher.ts
@@ -136,6 +136,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     // process group, making it possible to kill child process tree with `.kill(-pid)` command.
     // @see https://nodejs.org/api/child_process.html#child_process_options_detached
     detached: process.platform !== 'win32',
+    windowsHide: true,
     env: options.env,
     cwd: options.cwd,
     shell: options.shell,
@@ -233,7 +234,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
       // Force kill the browser.
       try {
         if (process.platform === 'win32') {
-          const taskkillProcess = childProcess.spawnSync(`taskkill /pid ${spawnedProcess.pid} /T /F`, { shell: true });
+          const taskkillProcess = childProcess.spawnSync(`taskkill /pid ${spawnedProcess.pid} /T /F`, { shell: true, windowsHide: true });
           const [stdout, stderr] = [taskkillProcess.stdout.toString(), taskkillProcess.stderr.toString()];
           if (stdout)
             options.log(`[pid=${spawnedProcess.pid}] taskkill stdout: ${stdout}`);


### PR DESCRIPTION
  Description:
  ## Problem
  On Windows, running Playwright in headless mode shows a visible console window for `chrome-headless-shell.exe`. Additionally, when closing the browser, a `taskkill` command window briefly flashes.

  This happens because `child_process.spawn()` and `spawnSync()` don't set `windowsHide: true`.

  ## Solution
  Add `windowsHide: true` to:
  1. `spawnOptions` in `launchProcess()` - hides the browser console window
  2. `taskkill` spawnSync call - hides the kill command window

  ## Testing
  Tested on Windows 11 with Playwright 1.57.0 running chromium in headless mode.

  Before: Console window visible during entire browser session
  After: No console window appears


Fixes: https://github.com/microsoft/playwright/issues/39335