### PR TITLE
chore: mark page.agent as js-only

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -711,6 +711,7 @@ Raw CSS content to be injected into frame.
 
 ## async method: Page.agent
 * since: v1.58
+* langs: js
 - returns: <[PageAgent]>
 
 Initialize page agent with the llm provider and cache.

--- a/docs/src/api/class-pageagent.md
+++ b/docs/src/api/class-pageagent.md
@@ -1,5 +1,6 @@
 # class: PageAgent
 * since: v1.58
+* langs: js
 
 ## event: PageAgent.turn
 * since: v1.58


### PR DESCRIPTION
This unblocks rolling docs to playwright.dev, until we figure out `z.ZodSchema` for languages.