### PR TITLE
fix(perform): ensure proper timeouts for expect tools

### DIFF
--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -47,7 +47,12 @@ import type { ElementText, TextMatcher } from './selectorUtils';
 import type { Builtins } from './utilityScript';
 
 
-export type FrameExpectParams = Omit<channels.FrameExpectParams, 'expectedValue' | 'timeout'> & { expectedValue?: any };
+export type FrameExpectParams = Omit<channels.FrameExpectParams, 'expectedValue' | 'timeout'> & {
+  expectedValue?: any;
+  timeoutForLogs?: number;
+  explicitTimeout?: number;
+  noPreChecks?: boolean;
+};
 
 export type ElementState = 'visible' | 'hidden' | 'enabled' | 'disabled' | 'editable' | 'checked' | 'unchecked' | 'indeterminate' | 'stable';
 export type ElementStateWithoutStable = Exclude<ElementState, 'stable'>;

--- a/packages/playwright-core/src/server/agent/context.ts
+++ b/packages/playwright-core/src/server/agent/context.ts
@@ -124,7 +124,7 @@ export class Context {
         promises.push(request.response());
     }
 
-    await progress.race(promises, { timeout: 5000 });
+    await progress.race([...promises, progress.wait(5000)]);
     if (!promises.length)
       await progress.wait(500);
 

--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -266,7 +266,7 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
     let expectedValue = params.expectedValue ? parseArgument(params.expectedValue) : undefined;
     if (params.expression === 'to.match.aria' && expectedValue)
       expectedValue = parseAriaSnapshotUnsafe(yaml, expectedValue);
-    const result = await this._frame.expect(progress, params.selector, { ...params, expectedValue }, params.timeout);
+    const result = await this._frame.expect(progress, params.selector, { ...params, expectedValue, timeoutForLogs: params.timeout });
     if (result.received !== undefined)
       result.received = serializeResult(result.received);
     return result;

--- a/packages/protocol/src/progress.d.ts
+++ b/packages/protocol/src/progress.d.ts
@@ -38,8 +38,8 @@ export interface Progress {
   timeout: number;
   deadline: number;
   log(message: string): void;
-  race<T>(promise: Promise<T> | Promise<T>[], options?: { timeout?: number }): Promise<T>;
-  wait(timeout: number): Promise<void>;
+  race<T>(promise: Promise<T> | Promise<T>[]): Promise<T>;
+  wait(timeout: number): Promise<void>; // timeout = 0 here means "wait 0 ms", not forever.
   signal: AbortSignal;
   metadata: CallMetadata;
 }

--- a/tests/library/__llm_cache__/library-agent-expect-expect-timeout-during-generate.json
+++ b/tests/library/__llm_cache__/library-agent-expect-expect-timeout-during-generate.json
@@ -1,0 +1,135 @@
+{
+  "0e1e6182377f3ddc9e605d47dc0f4e5db456be40": {
+    "result": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "The assertion has been executed. The text \"hello\" is **not visible** on the page - the assertion failed as expected since the page snapshot only shows \"bye\" text. The tool has verified that \"hello\" cannot be found on the page."
+        }
+      ],
+      "stopReason": {
+        "code": "other",
+        "message": "Unexpected stop reason: end_turn"
+      }
+    },
+    "usage": {
+      "input": 1912,
+      "output": 54
+    }
+  },
+  "b4fd4ea81b4c3d84f354169c7a97dd0f708710d2": {
+    "result": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "I need to verify that the text \"hello\" is visible on the page. Based on the page snapshot, I can see there's only text \"bye\" visible, not \"hello\". However, I should still make the assertion to check for \"hello\"."
+        },
+        {
+          "type": "tool_call",
+          "name": "browser_expect_visible_text",
+          "arguments": {
+            "text": "hello",
+            "_is_done": true
+          },
+          "id": "toolu_01WePrBxxAHf7CS13nU77ay2"
+        }
+      ],
+      "stopReason": {
+        "code": "ok"
+      }
+    },
+    "usage": {
+      "input": 1694,
+      "output": 129
+    }
+  },
+  "c8a85f5c1a56b73cf3fc1b00e01b45e9a78b94be": {
+    "result": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "I'll verify that the input has the value \"hello\"."
+        },
+        {
+          "type": "tool_call",
+          "name": "browser_expect_value",
+          "arguments": {
+            "type": "textbox",
+            "element": "input",
+            "ref": "e2",
+            "value": "hello",
+            "_is_done": true
+          },
+          "id": "toolu_011Tt781hyZUbLUUQMVyhdxB"
+        }
+      ],
+      "stopReason": {
+        "code": "ok"
+      }
+    },
+    "usage": {
+      "input": 1695,
+      "output": 140
+    }
+  },
+  "e59b1ef4668b6d7d8d0fbad3fc1a0a3172d6d07b": {
+    "result": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "The assertion has been executed. The test expectation that text \"hello\" is visible has **failed** because the text \"hello\" was not found on the page. According to the page snapshot, only the text \"bye\" is present in a generic element, not \"hello\"."
+        }
+      ],
+      "stopReason": {
+        "code": "other",
+        "message": "Unexpected stop reason: end_turn"
+      }
+    },
+    "usage": {
+      "input": 1895,
+      "output": 60
+    }
+  },
+  "e94f4d28220373c8f84256201c83f8cf744ff680": {
+    "result": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "The assertion has been executed. As expected based on the page snapshot showing only \"bye\", the text \"hello\" is **not visible** on the page. The test failed because \"hello\" could not be found."
+        }
+      ],
+      "stopReason": {
+        "code": "other",
+        "message": "Unexpected stop reason: end_turn"
+      }
+    },
+    "usage": {
+      "input": 1930,
+      "output": 47
+    }
+  },
+  "ffe7d66a201de8f2a816d99550859ad43fee1ffb": {
+    "result": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "The assertion failed as expected - the text \"hello\" is not visible on the page. The page only contains the text \"bye\". The task has been completed by calling the browser_expect_visible_text tool to verify the condition."
+        }
+      ],
+      "stopReason": {
+        "code": "other",
+        "message": "Unexpected stop reason: end_turn"
+      }
+    },
+    "usage": {
+      "input": 1913,
+      "output": 51
+    }
+  }
+}

--- a/tests/library/__llm_cache__/library-agent-expect-expect-timeout-during-run.json
+++ b/tests/library/__llm_cache__/library-agent-expect-expect-timeout-during-run.json
@@ -1,0 +1,30 @@
+{
+  "3b4f08f411f9002019b8fab8f14772f4b4beb15a": {
+    "result": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "I'll verify that the submit button is visible on the page."
+        },
+        {
+          "type": "tool_call",
+          "name": "browser_expect_visible",
+          "arguments": {
+            "role": "button",
+            "accessibleName": "Submit",
+            "_is_done": true
+          },
+          "id": "toolu_01CyQoKismpKpLjmnSHrnn8M"
+        }
+      ],
+      "stopReason": {
+        "code": "ok"
+      }
+    },
+    "usage": {
+      "input": 1694,
+      "output": 107
+    }
+  }
+}

--- a/tests/library/agent-expect.spec.ts
+++ b/tests/library/agent-expect.spec.ts
@@ -16,7 +16,7 @@
 
 import { stripAnsi } from '../config/utils';
 import { browserTest as test, expect } from '../config/browserTest';
-import { setCacheObject, runAgent } from './agent-helpers';
+import { setCacheObject, runAgent, generateAgent, cacheObject } from './agent-helpers';
 
 // LOWIRE_NO_CACHE=1 to generate api caches
 // LOWIRE_FORCE_CACHE=1 to force api caches
@@ -33,16 +33,16 @@ test('expectVisible not found error', async ({ context }) => {
   });
   const { page, agent } = await runAgent(context);
   await page.setContent(`<button hidden>Submit</button>`);
-  const error = await agent.expect('submit button is visible', { timeout: 1000 }).catch(e => e);
+  const error = await agent.expect('submit button is visible').catch(e => e);
   expect(stripAnsi(error.message)).toContain(`pageAgent.expect: expect(locator).toBeVisible() failed
 
 Locator: getByRole('button')
 Expected: visible
-Timeout: 1000ms
+Timeout: 5000ms
 Error: element(s) not found
 
 Call log:
-  - Expect Visible
+  - Expect Visible with timeout 5000ms
   - waiting for getByRole('button')`);
 });
 
@@ -58,16 +58,16 @@ test('expectVisible not visible error', async ({ context }) => {
   });
   const { page, agent } = await runAgent(context);
   await page.setContent(`<button hidden>Submit</button>`);
-  const error = await agent.expect('submit button is visible', { timeout: 1000 }).catch(e => e);
+  const error = await agent.expect('submit button is visible').catch(e => e);
   expect(stripAnsi(error.message)).toContain(`pageAgent.expect: expect(locator).toBeVisible() failed
 
 Locator:  locator('button')
 Expected: visible
 Received: hidden
-Timeout:  1000ms
+Timeout:  5000ms
 
 Call log:
-  - Expect Visible
+  - Expect Visible with timeout 5000ms
   - waiting for locator('button')`);
 });
 
@@ -84,16 +84,16 @@ test('not expectVisible visible error', async ({ context }) => {
   });
   const { page, agent } = await runAgent(context);
   await page.setContent(`<button>Submit</button>`);
-  const error = await agent.expect('submit button is not visible', { timeout: 1000 }).catch(e => e);
+  const error = await agent.expect('submit button is not visible').catch(e => e);
   expect(stripAnsi(error.message)).toContain(`pageAgent.expect: expect(locator).not.toBeVisible() failed
 
 Locator:  locator('button')
 Expected: not visible
 Received: visible
-Timeout:  1000ms
+Timeout:  5000ms
 
 Call log:
-  - Expect Visible
+  - Expect Visible with timeout 5000ms
   - waiting for locator('button')`);
 });
 
@@ -111,16 +111,16 @@ test('expectChecked not checked error', async ({ context }) => {
   });
   const { page, agent } = await runAgent(context);
   await page.setContent(`<input type=checkbox>`);
-  const error = await agent.expect('checkbox is checked', { timeout: 1000 }).catch(e => e);
+  const error = await agent.expect('checkbox is checked').catch(e => e);
   expect(stripAnsi(error.message)).toContain(`pageAgent.expect: expect(locator).toBeChecked() failed
 
 Locator:  locator('input')
 Expected: checked
 Received: unchecked
-Timeout:  1000ms
+Timeout:  5000ms
 
 Call log:
-  - Expect Checked
+  - Expect Checked with timeout 5000ms
   - waiting for locator('input')`);
 });
 
@@ -138,16 +138,16 @@ test('expectValue wrong value error', async ({ context }) => {
   });
   const { page, agent } = await runAgent(context);
   await page.setContent(`<input type=text value="world">`);
-  const error = await agent.expect('input has value "hello"', { timeout: 1000 }).catch(e => e);
+  const error = await agent.expect('input has value "hello"').catch(e => e);
   expect(stripAnsi(error.message)).toContain(`pageAgent.expect: expect(locator).toHaveValue(expected) failed
 
 Locator:  locator('input')
 Expected: hello
 Received: world
-Timeout:  1000ms
+Timeout:  5000ms
 
 Call log:
-  - Expect Value
+  - Expect Value with timeout 5000ms
   - waiting for locator('input')`);
 });
 
@@ -163,7 +163,7 @@ test('expectAria wrong snapshot error', async ({ context }) => {
   });
   const { page, agent } = await runAgent(context);
   await page.setContent(`<ul><li>one</li><li style="display:none">two</li></ul>`);
-  const error = await agent.expect('two items are visible', { timeout: 1000 }).catch(e => e);
+  const error = await agent.expect('two items are visible').catch(e => e);
   const errorMessage = `pageAgent.expect: expect(locator).toMatchAriaSnapshot(expected) failed
 
 Locator:  locator('body')
@@ -174,10 +174,48 @@ Expected:
 Received:
 - list:
   - listitem: one
-Timeout:  1000ms
+Timeout:  5000ms
 
 Call log:
-  - Expect Aria Snapshot
+  - Expect Aria Snapshot with timeout 5000ms
   - waiting for locator('body')`.replace('Expected:', 'Expected: ').replace('Received:', 'Received: ');
   expect(stripAnsi(error.message)).toContain(errorMessage);
+});
+
+test('expect timeout during run', async ({ context }) => {
+  {
+    const { page, agent } = await generateAgent(context);
+    await page.setContent(`<button>Submit</button>`);
+    await agent.expect('submit button is visible');
+  }
+  expect(await cacheObject()).toEqual({
+    'submit button is visible': {
+      actions: [expect.objectContaining({ method: 'expectVisible' })],
+    },
+  });
+  {
+    const { page, agent } = await runAgent(context);
+    await page.setContent(`<button hidden>Submit</button>`);
+    const error = await agent.expect('submit button is visible', { timeout: 10000 }).catch(e => e);
+    expect(stripAnsi(error.message)).toContain(`pageAgent.expect: expect(locator).toBeVisible() failed
+
+Locator: getByRole('button', { name: 'Submit' })
+Expected: visible
+Timeout: 5000ms
+Error: element(s) not found
+
+Call log:
+  - Expect Visible with timeout 5000ms`);
+  }
+});
+
+test('expect timeout during generate', async ({ context }) => {
+  const { page, agent } = await generateAgent(context, { limits: { maxActionRetries: 0 } });
+  await page.setContent(`<input type=text value="bye">`);
+  const error = await agent.expect('input has value "hello"').catch(e => e);
+  expect(stripAnsi(error.message)).toContain(`pageAgent.expect: Agentic loop failed: Failed to perform action after 0 tool call retries
+Call log:
+  - Expect Value
+  - waiting for getByRole('textbox')`);
+  expect(stripAnsi(error.message)).toContain(`- unexpected value "bye"`);
 });


### PR DESCRIPTION
In run mode, defaults to 5000. Not configurable yet. In generate mode, timeout is zero (one-shot only), and pre-checks are disabled.