### PR TITLE
fix(aria): respect ElementInternals for aria analysis

### DIFF
--- a/packages/injected/src/domUtils.ts
+++ b/packages/injected/src/domUtils.ts
@@ -173,3 +173,9 @@ export function endDOMCaches() {
     cacheStyleAfter = undefined;
   }
 }
+
+export function elementInternals(element: Element): ElementInternals | null {
+  // eslint-disable-next-line no-restricted-globals
+  return ((globalThis as unknown as { __playwrightElementInternalsMap?: WeakMap<Element, ElementInternals> })
+      .__playwrightElementInternalsMap)?.get(element) ?? null;
+}


### PR DESCRIPTION
This PR adds support for interpreting the ElementInternals configuration for custom elements.

Closes #34264

Due to the nature of `HTMLElement.attachInternals()` there is and will be no way to access that information, if not exposed by the custom element author. Due to this, this solution adds a monkey-patch to intercept the creation and store it in a WeakMap, which can be accessed by playwright.
This script is currently injected via init script. Maybe there is a better place to do that and I am open to suggestions.