### PR TITLE
fix: H-scroll positions after restore

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/playwright-core/src/utils/isomorphic/trace/snapshotRenderer.ts
@@ -404,7 +404,7 @@ function snapshotScript(viewport: ViewportSize, ...targetIds: (string | undefine
         element.scrollLeft = +element.getAttribute('__playwright_scroll_left_')!;
         element.removeAttribute('__playwright_scroll_left_');
         if (frameBoundingRectsInfo.frames.has(element))
-          frameBoundingRectsInfo.frames.get(element)!.scrollLeft = element.scrollTop;
+          frameBoundingRectsInfo.frames.get(element)!.scrollLeft = element.scrollLeft;
       }
 
       win.document.styleSheets[0].disabled = true;


### PR DESCRIPTION
Copy-paste error?

assigns element.scrollTop to scrollLeft property. This will cause horizontal scroll positions to be restored incorrectly in snapshot rendering.