### PR TITLE
docs(api): add fourth item to toContainText example

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -1195,6 +1195,7 @@ For example, consider the following list:
   <li>Item Text 1</li>
   <li>Item Text 2</li>
   <li>Item Text 3</li>
+  <li>Item Text 4</li>
 </ul>
 ```
 

--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -1203,7 +1203,7 @@ Let's see how we can use the assertion:
 
 ```js
 // ✓ Contains the right items in the right order
-await expect(page.locator('ul > li')).toContainText(['Text 1', 'Text 3']);
+await expect(page.locator('ul > li')).toContainText(['Text 1', 'Text 3', 'Text 4']);
 
 // ✖ Wrong order
 await expect(page.locator('ul > li')).toContainText(['Text 3', 'Text 2']);


### PR DESCRIPTION
## Fix toContainText documentation example

### Context

The HTML example in `toContainText` documentation was missing the fourth list item, but all code examples except JavaScript (Java, Python, C#) were referencing `"Text 4"`. This made the example misleading since it appeared to demonstrate incorrect behavior.

### Changes

Added `<li>Item Text 4</li>` to the HTML example to match the code examples. This correctly demonstrates the subset matching behavior where `["Text 1", "Text 3", "Text 4"]` matches items 1, 3, and 4 in order, skipping item 2.

<table>
  <tr>
    <th>AsIs</th>
    <th>ToBe</th>
  </tr>
  <tr>
    <td>
      <img
        width="450"
        alt="AsIs"
        src="https://github.com/user-attachments/assets/a3239f0e-26ec-4ec4-92ad-4269518e7f07"
      />
    </td>
    <td>
      <img
        width="450"
        alt="ToBe"
        src="https://github.com/user-attachments/assets/6d9d4b59-0441-4fb8-ab6f-6f780964e98d"
      />
    </td>
  </tr>
</table>



Fixes #38823
