### PR TITLE
chore: page.agent timeouts sorted

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -722,6 +722,11 @@ Initialize page agent with the llm provider and cache.
   - `cacheFile` ?<[string]> Cache file to use/generate code for performed actions into. Cache is not used if not specified (default).
   - `cacheOutFile` ?<[string]> When specified, generated entries are written into the `cacheOutFile` instead of updating the `cacheFile`.
 
+### option: Page.agent.expect
+* since: v1.58
+- `expect` <[Object]>
+  - `timeout` ?<[int]> Default timeout for expect calls in milliseconds, defaults to 5000ms.
+
 ### option: Page.agent.limits
 * since: v1.58
 - `limits` <[Object]>

--- a/docs/src/api/class-pageagent.md
+++ b/docs/src/api/class-pageagent.md
@@ -35,6 +35,12 @@ await agent.expect('"0 items" to be reported');
 
 Expectation to assert.
 
+### option: PageAgent.expect.timeout
+* since: v1.58
+- `timeout` <[float]>
+
+Expect timeout in milliseconds. Defaults to `5000`. The default value can be changed via `expect.timeout` option in the config, or by specifying the `expect` property of the [`option: Page.agent.expect`] option. Pass `0` to disable timeout.
+
 ### option: PageAgent.expect.-inline- = %%-page-agent-call-options-v1.58-%%
 * since: v1.58
 
@@ -68,6 +74,13 @@ Task to perform using agentic loop.
 * since: v1.58
 - `schema` <[z.ZodSchema]>
 
+### option: PageAgent.extract.timeout
+* since: v1.58
+- `timeout` <[float]>
+
+Extract timeout in milliseconds. Defaults to `5000`. The default value can be changed via `actionTimeout` option in the config, or by using the [`method: BrowserContext.setDefaultTimeout`] or
+[`method: Page.setDefaultTimeout`] methods. Pass `0` to disable timeout.
+
 ### option: PageAgent.extract.-inline- = %%-page-agent-call-options-v1.58-%%
 * since: v1.58
 
@@ -93,6 +106,13 @@ await agent.perform('Click submit button');
 - `task` <[string]>
 
 Task to perform using agentic loop.
+
+### option: PageAgent.perform.timeout
+* since: v1.58
+- `timeout` <[float]>
+
+Perform timeout in milliseconds. Defaults to `5000`. The default value can be changed via `actionTimeout` option in the config, or by using the [`method: BrowserContext.setDefaultTimeout`] or
+[`method: Page.setDefaultTimeout`] methods. Pass `0` to disable timeout.
 
 ### option: PageAgent.perform.-inline- = %%-page-agent-call-options-v1.58-%%
 * since: v1.58

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -396,18 +396,11 @@ Maximum number of agentic actions to generate, defaults to context-wide value sp
 
 Maximum number of retries when generating each action, defaults to context-wide value specified in `agent` property.
 
-## page-agent-timeout
-* since: v1.58
-- `timeout` <[int]>
-
-Request timeout in milliseconds. Defaults to action timeout. Pass `0` to disable timeout.
-
 ## page-agent-call-options-v1.58
 - %%-page-agent-cache-key-%%
 - %%-page-agent-max-tokens-%%
 - %%-page-agent-max-actions-%%
 - %%-page-agent-max-action-retries-%%
-- %%-page-agent-timeout-%%
 
 ## fetch-param-url
 - `url` <[string]>

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -50,8 +50,7 @@ import type { Builtins } from './utilityScript';
 export type FrameExpectParams = Omit<channels.FrameExpectParams, 'expectedValue' | 'timeout'> & {
   expectedValue?: any;
   timeoutForLogs?: number;
-  explicitTimeout?: number;
-  noPreChecks?: boolean;
+  noAutoWaiting?: boolean;
 };
 
 export type ElementState = 'visible' | 'hidden' | 'enabled' | 'disabled' | 'editable' | 'checked' | 'unchecked' | 'indeterminate' | 'stable';

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -2112,6 +2112,13 @@ export interface Page {
       cacheOutFile?: string;
     };
 
+    expect?: {
+      /**
+       * Default timeout for expect calls in milliseconds, defaults to 5000ms.
+       */
+      timeout?: number;
+    };
+
     /**
      * Limits to use for the agentic loop.
      */
@@ -5440,7 +5447,10 @@ export interface PageAgent {
     maxTokens?: number;
 
     /**
-     * Request timeout in milliseconds. Defaults to action timeout. Pass `0` to disable timeout.
+     * Expect timeout in milliseconds. Defaults to `5000`. The default value can be changed via `expect.timeout` option in
+     * the config, or by specifying the `expect` property of the
+     * [`expect`](https://playwright.dev/docs/api/class-page#page-agent-option-expect) option. Pass `0` to disable
+     * timeout.
      */
     timeout?: number;
   }): Promise<void>;
@@ -5482,7 +5492,11 @@ export interface PageAgent {
     maxTokens?: number;
 
     /**
-     * Request timeout in milliseconds. Defaults to action timeout. Pass `0` to disable timeout.
+     * Perform timeout in milliseconds. Defaults to `5000`. The default value can be changed via `actionTimeout` option in
+     * the config, or by using the
+     * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
+     * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout) methods.
+     * Pass `0` to disable timeout.
      */
     timeout?: number;
   }): Promise<{

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -865,7 +865,9 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
       systemPrompt: options.systemPrompt,
     };
     const { agent } = await this._channel.agent(params);
-    return PageAgent.from(agent);
+    const pageAgent = PageAgent.from(agent);
+    pageAgent._expectTimeout = options?.expect?.timeout;
+    return pageAgent;
   }
 
   async _snapshotForAI(options: TimeoutOptions & { track?: string } = {}): Promise<{ full: string, incremental?: string }> {

--- a/packages/playwright-core/src/server/agent/pageAgent.ts
+++ b/packages/playwright-core/src/server/agent/pageAgent.ts
@@ -50,7 +50,7 @@ export async function pageAgentPerform(progress: Progress, context: Context, use
 ### Task
 ${userTask}
 `;
-
+  progress.disableTimeout();
   await runLoop(progress, context, performTools, task, undefined, callParams);
   await updateCache(context, cacheKey);
 }
@@ -68,7 +68,7 @@ export async function pageAgentExpect(progress: Progress, context: Context, expe
 ### Expectation
 ${expectation}
 `;
-
+  progress.disableTimeout();
   await runLoop(progress, context, expectTools, task, undefined, callParams);
   await updateCache(context, cacheKey);
 }
@@ -101,7 +101,7 @@ async function runLoop(progress: Progress, context: Context, toolDefinitions: To
 
   const apiCacheTextBefore = context.agentParams.apiCacheFile ?
     await fs.promises.readFile(context.agentParams.apiCacheFile, 'utf-8').catch(() => '{}') : '{}';
-  const apiCacheBefore = JSON.parse(apiCacheTextBefore);
+  const apiCacheBefore = JSON.parse(apiCacheTextBefore || '{}');
 
   const loop = new Loop({
     api: context.agentParams.api as any,

--- a/packages/playwright-core/src/server/progress.ts
+++ b/packages/playwright-core/src/server/progress.ts
@@ -61,10 +61,14 @@ export class ProgressController {
     const deadline = timeout ? monotonicTime() + timeout : 0;
     assert(this._state === 'before');
     this._state = 'running';
+    let timer: NodeJS.Timeout | undefined;
 
     const progress: Progress = {
       timeout: timeout ?? 0,
       deadline,
+      disableTimeout: () => {
+        clearTimeout(timer);
+      },
       log: message => {
         if (this._state === 'running')
           this.metadata.log.push(message);
@@ -87,10 +91,10 @@ export class ProgressController {
       signal: this._controller.signal,
     };
 
-    let timer: NodeJS.Timeout | undefined;
     if (deadline) {
       const timeoutError = new TimeoutError(`Timeout ${timeout}ms exceeded.`);
       timer = setTimeout(() => {
+        // TODO: migrate this to "progress.disableTimeout()".
         if (this.metadata.pauseStartTime && !this.metadata.pauseEndTime)
           return;
         if (this._state === 'running') {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2112,6 +2112,13 @@ export interface Page {
       cacheOutFile?: string;
     };
 
+    expect?: {
+      /**
+       * Default timeout for expect calls in milliseconds, defaults to 5000ms.
+       */
+      timeout?: number;
+    };
+
     /**
      * Limits to use for the agentic loop.
      */
@@ -5440,7 +5447,10 @@ export interface PageAgent {
     maxTokens?: number;
 
     /**
-     * Request timeout in milliseconds. Defaults to action timeout. Pass `0` to disable timeout.
+     * Expect timeout in milliseconds. Defaults to `5000`. The default value can be changed via `expect.timeout` option in
+     * the config, or by specifying the `expect` property of the
+     * [`expect`](https://playwright.dev/docs/api/class-page#page-agent-option-expect) option. Pass `0` to disable
+     * timeout.
      */
     timeout?: number;
   }): Promise<void>;
@@ -5482,7 +5492,11 @@ export interface PageAgent {
     maxTokens?: number;
 
     /**
-     * Request timeout in milliseconds. Defaults to action timeout. Pass `0` to disable timeout.
+     * Perform timeout in milliseconds. Defaults to `5000`. The default value can be changed via `actionTimeout` option in
+     * the config, or by using the
+     * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
+     * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout) methods.
+     * Pass `0` to disable timeout.
      */
     timeout?: number;
   }): Promise<{

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -477,6 +477,9 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
       limits: agentOptions?.limits,
       secrets: agentOptions?.secrets,
       systemPrompt: agentOptions?.systemPrompt,
+      expect: {
+        timeout: testInfoImpl._projectInternal.expect?.timeout,
+      },
     });
 
     await use(agent);

--- a/packages/protocol/src/progress.d.ts
+++ b/packages/protocol/src/progress.d.ts
@@ -37,6 +37,7 @@ import type { CallMetadata } from './callMetadata';
 export interface Progress {
   timeout: number;
   deadline: number;
+  disableTimeout(): void;
   log(message: string): void;
   race<T>(promise: Promise<T> | Promise<T>[]): Promise<T>;
   wait(timeout: number): Promise<void>; // timeout = 0 here means "wait 0 ms", not forever.

--- a/tests/library/__llm_cache__/library-agent-expect-expect-timeout-during-run-from-agent-options.json
+++ b/tests/library/__llm_cache__/library-agent-expect-expect-timeout-during-run-from-agent-options.json
@@ -1,0 +1,30 @@
+{
+  "44bfbaa6fe0cb038adf37547ecb000d4f39e243f": {
+    "result": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "I'll verify that the submit button is visible on the page."
+        },
+        {
+          "type": "tool_call",
+          "name": "browser_expect_visible",
+          "arguments": {
+            "role": "button",
+            "accessibleName": "Submit",
+            "_is_done": true
+          },
+          "id": "toolu_012RgUS8buCjrQRgt4w2sYFf"
+        }
+      ],
+      "stopReason": {
+        "code": "ok"
+      }
+    },
+    "usage": {
+      "input": 2203,
+      "output": 107
+    }
+  }
+}

--- a/tests/library/__llm_cache__/library-agent-expect-expectTitle-success.json
+++ b/tests/library/__llm_cache__/library-agent-expect-expectTitle-success.json
@@ -5,7 +5,7 @@
       "content": [
         {
           "type": "text",
-          "text": "I need to verify that the page title is \"My Page Title\". I'll use the browser_expect_title tool to assert this condition."
+          "text": "I need to verify that the page title is \"My Page Title\". I'll use the browser_expect_title tool to check this."
         },
         {
           "type": "tool_call",
@@ -14,7 +14,7 @@
             "title": "My Page Title",
             "_is_done": true
           },
-          "id": "toolu_01VvWdf4VVFNQuDaEtTsAu3K"
+          "id": "toolu_01R1QyAwfxk2KSz3tsAx9RCA"
         }
       ],
       "stopReason": {
@@ -23,7 +23,7 @@
     },
     "usage": {
       "input": 2195,
-      "output": 106
+      "output": 105
     }
   }
 }

--- a/tests/library/__llm_cache__/library-agent-expect-expectTitle-wrong-title-error.json
+++ b/tests/library/__llm_cache__/library-agent-expect-expectTitle-wrong-title-error.json
@@ -5,7 +5,7 @@
       "content": [
         {
           "type": "text",
-          "text": "I'll verify that the page title is \"Other Title\" using the browser_expect_title tool."
+          "text": "I need to verify that the page title is \"Other Title\" using one of the browser_expect_* tools."
         },
         {
           "type": "tool_call",
@@ -14,7 +14,7 @@
             "title": "Other Title",
             "_is_done": true
           },
-          "id": "toolu_017UT5LEe8JRoB53R1YGKrYD"
+          "id": "toolu_017ZvXqNbcab9Uyjzw3VuByK"
         }
       ],
       "stopReason": {
@@ -23,7 +23,7 @@
     },
     "usage": {
       "input": 2194,
-      "output": 97
+      "output": 100
     }
   }
 }

--- a/tests/library/__llm_cache__/library-agent-expect-expectURL-success.json
+++ b/tests/library/__llm_cache__/library-agent-expect-expectURL-success.json
@@ -5,7 +5,7 @@
       "content": [
         {
           "type": "text",
-          "text": "I'll verify that the page URL is /counter.html using the browser_expect_url tool."
+          "text": "I'll verify that the page URL is /counter.html."
         },
         {
           "type": "tool_call",
@@ -14,7 +14,7 @@
             "url": "/counter.html",
             "_is_done": true
           },
-          "id": "toolu_017jkU3FcrQpAVJgtjrzYovK"
+          "id": "toolu_01PkjsZaM5eEGtjLtMixyJUk"
         }
       ],
       "stopReason": {
@@ -23,25 +23,25 @@
     },
     "usage": {
       "input": 2240,
-      "output": 99
+      "output": 91
     }
   },
-  "f6d9bc80fd5bad48f6a886d7ec77c8d5889521b1": {
+  "71a7a4f51b3994a200f239eda9b505454825a79f": {
     "result": {
       "role": "assistant",
       "content": [
         {
           "type": "text",
-          "text": "I see the issue - the actual URL includes a server prefix. Let me use a regex pattern to match the URL ending with /counter.html."
+          "text": "I need to use a regex pattern to match the URL since it includes a server prefix. Let me update the expectation to match the actual URL pattern."
         },
         {
           "type": "tool_call",
           "name": "browser_expect_url",
           "arguments": {
-            "regex": "/counter\\.html$/",
+            "regex": "/\\/counter\\.html$/",
             "_is_done": true
           },
-          "id": "toolu_01JQuC1CJR7W6LiwAnvjaiDX"
+          "id": "toolu_01Wwq7Pbe2DthqpmskgGfCzk"
         }
       ],
       "stopReason": {
@@ -49,8 +49,8 @@
       }
     },
     "usage": {
-      "input": 2441,
-      "output": 109
+      "input": 2433,
+      "output": 111
     }
   }
 }

--- a/tests/library/__llm_cache__/library-agent-expect-expectURL-with-regex-error.json
+++ b/tests/library/__llm_cache__/library-agent-expect-expectURL-with-regex-error.json
@@ -5,7 +5,7 @@
       "content": [
         {
           "type": "text",
-          "text": "I'll verify that the page URL matches the `/counter` pattern using the browser_expect_url tool with a regex pattern."
+          "text": "I'll verify that the page URL matches the /counter pattern using the browser_expect_url tool with a regex pattern."
         },
         {
           "type": "tool_call",
@@ -14,7 +14,7 @@
             "regex": "/counter/",
             "_is_done": true
           },
-          "id": "toolu_01J38E1DkiNA7JsvQtGx3otW"
+          "id": "toolu_01JxsK661QmxpScYeTMCfWTZ"
         }
       ],
       "stopReason": {
@@ -23,7 +23,7 @@
     },
     "usage": {
       "input": 2239,
-      "output": 103
+      "output": 102
     }
   }
 }

--- a/tests/library/__llm_cache__/library-agent-expect-expectURL-with-regex.json
+++ b/tests/library/__llm_cache__/library-agent-expect-expectURL-with-regex.json
@@ -14,7 +14,7 @@
             "regex": "/counter/",
             "_is_done": true
           },
-          "id": "toolu_01Qen21mVwEVb2JsEVavTWbf"
+          "id": "toolu_01YVkbby1j3FBXk2o5Bi4cjP"
         }
       ],
       "stopReason": {

--- a/tests/library/__llm_cache__/library-agent-expect-expectURL-wrong-URL-error.json
+++ b/tests/library/__llm_cache__/library-agent-expect-expectURL-wrong-URL-error.json
@@ -14,7 +14,7 @@
             "url": "/counter.html",
             "_is_done": true
           },
-          "id": "toolu_01B3LSMGJoDrDfCZKwa3neZ9"
+          "id": "toolu_01BrgLhGzD2dYWeu75KGgxKv"
         }
       ],
       "stopReason": {
@@ -26,22 +26,22 @@
       "output": 99
     }
   },
-  "99f45f7c71e64f612bfc0bcb148faf235ccfe006": {
+  "8315bc81a0dfc915cb8be72ad00102f627e370dd": {
     "result": {
       "role": "assistant",
       "content": [
         {
           "type": "text",
-          "text": "I see the issue. The actual URL includes the server prefix. Let me use a regex pattern to match the URL ending with /counter.html."
+          "text": "I see the issue. The actual URL includes the server portion. Let me use a regex pattern to match the URL ending with /counter.html."
         },
         {
           "type": "tool_call",
           "name": "browser_expect_url",
           "arguments": {
-            "regex": "/counter\\.html$/",
+            "regex": "/\\/counter\\.html$/",
             "_is_done": true
           },
-          "id": "toolu_01Ufux7hKwV9Djp9jT1JgYwJ"
+          "id": "toolu_01KtWVz2EdJjx2V9viYeqs71"
         }
       ],
       "stopReason": {
@@ -50,7 +50,7 @@
     },
     "usage": {
       "input": 2441,
-      "output": 109
+      "output": 110
     }
   }
 }

--- a/tests/library/__llm_cache__/library-agent-perform-perform-run-timeout-inherited-from-page.json
+++ b/tests/library/__llm_cache__/library-agent-perform-perform-run-timeout-inherited-from-page.json
@@ -1,0 +1,30 @@
+{
+  "554366043f6477d30a36655c10cbb4ec0eaa21d4": {
+    "result": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "I'll click the Fox button for you."
+        },
+        {
+          "type": "tool_call",
+          "name": "browser_click",
+          "arguments": {
+            "element": "Fox button",
+            "ref": "e3",
+            "_is_done": true
+          },
+          "id": "toolu_01TBMe2oPqGUpNuPnFnDeZJe"
+        }
+      ],
+      "stopReason": {
+        "code": "ok"
+      }
+    },
+    "usage": {
+      "input": 3066,
+      "output": 101
+    }
+  }
+}

--- a/tests/library/agent-expect.spec.ts
+++ b/tests/library/agent-expect.spec.ts
@@ -196,16 +196,36 @@ test('expect timeout during run', async ({ context }) => {
   {
     const { page, agent } = await runAgent(context);
     await page.setContent(`<button hidden>Submit</button>`);
-    const error = await agent.expect('submit button is visible', { timeout: 10000 }).catch(e => e);
+    const error = await agent.expect('submit button is visible', { timeout: 3000 }).catch(e => e);
     expect(stripAnsi(error.message)).toContain(`pageAgent.expect: expect(locator).toBeVisible() failed
 
 Locator: getByRole('button', { name: 'Submit' })
 Expected: visible
-Timeout: 5000ms
+Timeout: 3000ms
 Error: element(s) not found
 
 Call log:
-  - Expect Visible with timeout 5000ms`);
+  - Expect Visible with timeout 3000ms`);
+  }
+});
+
+test('expect timeout during run from agent options', async ({ context }) => {
+  {
+    const { page, agent } = await generateAgent(context);
+    await page.setContent(`<button>Submit</button>`);
+    await agent.expect('submit button is visible');
+  }
+  expect(await cacheObject()).toEqual({
+    'submit button is visible': {
+      actions: [expect.objectContaining({ method: 'expectVisible' })],
+    },
+  });
+  {
+    const { page, agent } = await runAgent(context, { expect: { timeout: 3000 } });
+    await page.setContent(`<button hidden>Submit</button>`);
+    const error = await agent.expect('submit button is visible').catch(e => e);
+    expect(stripAnsi(error.message)).toContain(`pageAgent.expect: expect(locator).toBeVisible() failed`);
+    expect(stripAnsi(error.message)).toContain(`Expect Visible with timeout 3000ms`);
   }
 });
 

--- a/tests/library/agent-helpers.ts
+++ b/tests/library/agent-helpers.ts
@@ -55,9 +55,10 @@ export async function generateAgent(context: BrowserContext, options: AgentOptio
   return { page, agent };
 }
 
-export async function runAgent(context: BrowserContext, options: { secrets?: Record<string, string> } = {}) {
+export async function runAgent(context: BrowserContext, options: AgentOptions = {}) {
   const page = await context.newPage();
   const agent = await page.agent({
+    ...options,
     cache: { cacheFile: cacheFile() },
     ...{ _doNotRenderActive: true },
   });

--- a/tests/library/agent-perform.spec.ts
+++ b/tests/library/agent-perform.spec.ts
@@ -174,6 +174,28 @@ test('perform run timeout', async ({ context }) => {
   }
 });
 
+test('perform run timeout inherited from page', async ({ context }) => {
+  {
+    const { page, agent } = await generateAgent(context);
+    await page.setContent(`
+      <button>Wolf</button>
+      <button>Fox</button>
+    `);
+    await agent.perform('click the Fox button');
+  }
+  {
+    const { page, agent } = await runAgent(context);
+    await page.setContent(`
+      <button>Wolf</button>
+      <button>Rabbit</button>
+    `);
+    page.setDefaultTimeout(3000);
+    const error = await agent.perform('click the Fox button').catch(e => e);
+    expect(error.message).toContain('Timeout 3000ms exceeded.');
+    expect(error.message).toContain(`waiting for getByRole('button', { name: 'Fox' })`);
+  }
+});
+
 test('invalid cache file throws error', async ({ context }) => {
   await setCacheObject({
     'some key': {


### PR DESCRIPTION
For all agent calls, timeout limits the outer `agent.xyz()` call, not individual actions inside.

When running the loop for generation, timeout is disabled entirely. This means, generation is only limited by the test timeout.

When generating, all individual actions inside are run as a one-shot, with all auto-waiting disabled. This effectively makes them instant, so timeout has no effect on actions. Instead, timeout effectively limits the model processing time.

For `agent.perform()` and `agent.extract()`, timeout is taken from the first defined:
- `timeout` option for the call;
- `page.setDefaultTimeout()` or `browserContext.setDefaultTimeout()`;
- `config.actionTimeout`;
- 0 (no timeout) if nothing above is defined.

For `agent.expect()`, timeout is taken from the first defined:
- `timeout` option for the call;
- `page.agent({ expect: { timeout } })` option for the agent;
- `config.expect.timeout`;
- 5000 if nothing above is defined.