### PR TITLE
fix(build): handle workspace paths with spaces on Windows

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -121,8 +121,10 @@ class ProgramStep extends Step {
   /** @override */
   async run() {
     const step = this._options;
-    console.log(`==== Running ${step.command} ${step.args.join(' ')} in ${step.cwd || process.cwd()}`);
-    const child = child_process.spawn(step.command, step.args, {
+    // Quote arguments that contain spaces when using shell
+    const args = step.shell ? step.args.map(arg => arg.includes(' ') ? `"${arg}"` : arg) : step.args;
+    console.log(`==== Running ${step.command} ${args.join(' ')} in ${step.cwd || process.cwd()}`);
+    const child = child_process.spawn(step.command, args, {
       stdio: 'inherit',
       shell: step.shell,
       env: {


### PR DESCRIPTION
Fix build script to properly handle Windows workspace paths that contain spaces:
- Quote arguments containing spaces when using shell mode
- Prevents shell parsing errors on Windows with paths like 'C:\\Program Files\\...'
- Only applies quoting when shell mode is enabled to avoid breaking non-shell commands

This ensures the build process works correctly regardless of workspace location.