### PR TITLE
feat(html-reporter): add state filter toggle functionality

### DIFF
--- a/packages/html-reporter/src/common.css
+++ b/packages/html-reporter/src/common.css
@@ -215,7 +215,8 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   background-color: var(--color-canvas-subtle);
 }
 
-.subnav-item[aria-selected="true"] {
+.subnav-item[aria-selected="true"],
+.subnav-item[aria-pressed="true"] {
   background: var(--color-control-transparent-bg-hover);
 }
 

--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -225,17 +225,26 @@ export function filterWithQuery(searchParams: URLSearchParams, token: string, ap
     return '#?' + result;
   }
 
-  // if metaKey or ctrlKey is not pressed, replace existing token with new token
-  let prefix: 's:' | 'p:' | '@';
+  // if metaKey or ctrlKey is not pressed, toggle or replace existing token with new token
+  let prefix: 's:' | 'p:' | '@' | undefined;
   if (token.startsWith('s:'))
     prefix = 's:';
-  if (token.startsWith('p:'))
+  else if (token.startsWith('p:'))
     prefix = 'p:';
-  if (token.startsWith('@'))
+  else if (token.startsWith('@'))
     prefix = '@';
 
-  const newTokens = tokens.filter(t => !t.startsWith(prefix));
-  newTokens.push(token);
+  // Toggle behavior: if token already exists, remove it; otherwise add it
+  const hasToken = tokens.includes(token);
+  let newTokens: string[];
+  if (hasToken) {
+    // Remove the token (toggle off)
+    newTokens = tokens.filter(t => t !== token);
+  } else {
+    // Add the token, removing other tokens with same prefix
+    newTokens = tokens.filter(t => !prefix || !t.startsWith(prefix));
+    newTokens.push(token);
+  }
 
   result.set('q', joinTokens(newTokens));
   return '#?' + result;

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -116,13 +116,15 @@ const NavLink: React.FC<{
   searchParams.delete('testId');
 
   const queryToken = `s:${token}`;
+  const query = searchParams.get('q') ?? '';
+  const isActive = query.includes(queryToken);
 
   const clickUrl = filterWithQuery(searchParams, queryToken, false);
   const ctrlClickUrl = filterWithQuery(searchParams, queryToken, true);
 
   const label = token.charAt(0).toUpperCase() + token.slice(1);
 
-  return <Link className='subnav-item' href={clickUrl} click={clickUrl} ctrlClick={ctrlClickUrl}>
+  return <Link className='subnav-item' href={clickUrl} click={clickUrl} ctrlClick={ctrlClickUrl} role='button' aria-pressed={isActive}>
     {count > 0 && statusIcon(token as any)}
     <span className='subnav-item-label'>{label}</span>
     <span className='d-inline counter'>{count}</span>


### PR DESCRIPTION
Implement toggle behavior for state filter buttons (Item #1 from issue #35212):
- Add aria-pressed attribute to state filter buttons for accessibility
- Add visual feedback with aria-pressed styling in CSS
- Clicking an active filter now toggles it off instead of keeping it active
- Clicking an inactive filter toggles other filters of same type off

This improves UX by making filters behave like expected toggle buttons.