### PR TITLE
feat(html-reporter): preserve text filter when clicking All button

### DIFF
--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -86,13 +86,23 @@ export const GlobalFilterView: React.FC<{
   </>);
 };
 
+function getAllUrl(searchParams: URLSearchParams): string {
+  const query = searchParams.get('q') ?? '';
+  const tokens = query.split(/\s+/).filter(t => t && !t.startsWith('s:') && !t.startsWith('p:') && !t.startsWith('@') && !t.startsWith('annot:'));
+  if (tokens.length === 0)
+    return '#?';
+  const result = new URLSearchParams();
+  result.set('q', tokens.join(' '));
+  return '#?' + result.toString();
+}
+
 const StatsNavView: React.FC<{
   stats: Stats
 }> = ({ stats }) => {
   const searchParams = useSearchParams();
 
   return <nav>
-    <Link className='subnav-item' href='#?'>
+    <Link className='subnav-item' href={getAllUrl(searchParams)}>
       <span className='subnav-item-label'>All</span>
       <span className='d-inline counter'>{stats.total - stats.skipped}</span>
     </Link>


### PR DESCRIPTION
Implement text filter preservation for All button (Item #8 from issue #35212):
- All button now preserves plain text search terms when clicked
- Only removes status filters (s:), project filters (p:), tag filters (@), and annotation filters
- Allows users to clear status/project/tag filters while keeping their search text

For example, if searching for 'my test s:failed', clicking All will show 'my test' results across all statuses instead of clearing everything.