### PR TITLE
feat(docker): support for Red Hat Universal Base Images (UBI) w/ multi-arch & Browser support

### DIFF
--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -231,6 +231,54 @@ We currently publish images based on the following [Ubuntu](https://hub.docker.c
 
 Browser builds for Firefox and WebKit are built for the [glibc](https://en.wikipedia.org/wiki/Glibc) library. Alpine Linux and other distributions that are based on the [musl](https://en.wikipedia.org/wiki/Musl) standard library are not supported.
 
+#### Red Hat UBI
+
+For environments that require Red Hat Universal Base Images, several Dockerfiles are available for building custom images. Browser support varies by UBI version due to system library constraints:
+
+| Image | Base | Chromium | Firefox | WebKit | Notes |
+|-------|------|----------|---------|--------|-------|
+| [Dockerfile.ubi9] | `redhat/ubi9` | Supported | Supported | Not supported | Recommended for full browser support |
+| [Dockerfile.ubi9-minimal] | `redhat/ubi9-minimal` | Supported | Supported | Not supported | Smaller image with full browser support |
+| [Dockerfile.ubi8] | `redhat/ubi8` | Supported | Not supported | Not supported | Firefox needs `GLIBCXX_3.4.26+` |
+| [Dockerfile.ubi8-minimal] | `redhat/ubi8-minimal` | Supported | Not supported | Not supported | Smallest image size |
+
+:::note
+WebKit is not supported on any RHEL-based distribution.
+:::
+
+To build a UBI-based image locally:
+
+```bash
+# From the playwright repository root (requires npm install && npm run build first)
+
+# UBI9 (recommended - supports Chromium + Firefox)
+./utils/docker/build.sh --amd64 ubi9 playwright:localbuild-ubi9
+
+# UBI9-minimal (smaller image with Chromium + Firefox)
+./utils/docker/build.sh --amd64 ubi9-minimal playwright:localbuild-ubi9-minimal
+
+# UBI8
+./utils/docker/build.sh --amd64 ubi8 playwright:localbuild-ubi8
+
+# UBI8-minimal (smallest image, Chromium only)
+./utils/docker/build.sh --amd64 ubi8-minimal playwright:localbuild-ubi8-minimal
+```
+
+Run a UBI image:
+
+```bash
+# As root (for trusted e2e tests)
+docker run -it --rm --ipc=host playwright:localbuild-ubi9 /bin/bash
+
+# As pwuser with seccomp profile (for untrusted content)
+docker run -it --rm --ipc=host --user pwuser --security-opt seccomp=seccomp_profile.json playwright:localbuild-ubi9 /bin/bash
+```
+
+[Dockerfile.ubi9]: https://github.com/microsoft/playwright/blob/main/utils/docker/Dockerfile.ubi9
+[Dockerfile.ubi9-minimal]: https://github.com/microsoft/playwright/blob/main/utils/docker/Dockerfile.ubi9-minimal
+[Dockerfile.ubi8]: https://github.com/microsoft/playwright/blob/main/utils/docker/Dockerfile.ubi8
+[Dockerfile.ubi8-minimal]: https://github.com/microsoft/playwright/blob/main/utils/docker/Dockerfile.ubi8-minimal
+
 ## Using a different .NET version
 * langs: csharp
 

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -233,7 +233,7 @@ Browser builds for Firefox and WebKit are built for the [glibc](https://en.wikip
 
 #### Red Hat UBI
 
-For environments that require Red Hat Universal Base Images, several Dockerfiles are available for building custom images. Browser support varies by UBI version due to system library constraints:
+For environments that require Red Hat Universal Base Images, several Dockerfiles are available for building custom images. These images support both `amd64` and `arm64` architectures. Browser support varies by UBI version due to system library constraints:
 
 | Image | Base | Chromium | Firefox | WebKit | Notes |
 |-------|------|----------|---------|--------|-------|
@@ -253,11 +253,12 @@ To build a UBI-based image locally:
 
 # UBI9 (recommended - supports Chromium + Firefox)
 ./utils/docker/build.sh --amd64 ubi9 playwright:localbuild-ubi9
+./utils/docker/build.sh --arm64 ubi9 playwright:localbuild-ubi9  # For Apple Silicon / ARM
 
 # UBI9-minimal (smaller image with Chromium + Firefox)
 ./utils/docker/build.sh --amd64 ubi9-minimal playwright:localbuild-ubi9-minimal
 
-# UBI8
+# UBI8 (Chromium only)
 ./utils/docker/build.sh --amd64 ubi8 playwright:localbuild-ubi8
 
 # UBI8-minimal (smallest image, Chromium only)

--- a/utils/docker/Dockerfile.ubi8
+++ b/utils/docker/Dockerfile.ubi8
@@ -1,0 +1,116 @@
+FROM redhat/ubi8
+
+# Metadata
+LABEL maintainer="Microsoft Playwright Team"
+LABEL description="Playwright Docker image based on Red Hat UBI8 with Chromium"
+LABEL org.opencontainers.image.source="https://github.com/microsoft/playwright"
+
+# Build arguments
+ARG TZ=America/Los_Angeles
+ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright:v%version%-ubi8"
+ARG NODE_VERSION=20
+
+# Environment variables
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# === INSTALL Node.js AND BROWSER DEPENDENCIES ===
+# Combined into single layer to reduce image size
+# Using --setopt=install_weak_deps=False to skip unnecessary dependencies
+
+RUN dnf install -y --setopt=install_weak_deps=False \
+        # Node.js prerequisites
+        curl \
+        wget \
+        ca-certificates \
+        gnupg2 \
+        # Development tools (feature-parity with node.js base images)
+        git \
+        openssh-clients \
+        # Basic X11 libraries
+        libX11 \
+        libXcomposite \
+        libXcursor \
+        libXdamage \
+        libXext \
+        libXfixes \
+        libXi \
+        libXrandr \
+        libXrender \
+        libXtst \
+        libxcb \
+        libxkbcommon \
+        libxshmfence \
+        # GTK and rendering
+        gtk3 \
+        cairo \
+        cairo-gobject \
+        pango \
+        gdk-pixbuf2 \
+        # Audio
+        alsa-lib \
+        # NSS/NSPR (for Chromium)
+        nss \
+        nspr \
+        # DRM/GBM (for Chromium GPU)
+        libdrm \
+        mesa-libgbm \
+        # D-Bus
+        dbus-libs \
+        dbus-glib \
+        # Fonts
+        fontconfig \
+        freetype \
+        liberation-fonts-common \
+        liberation-mono-fonts \
+        dejavu-sans-fonts \
+        # Accessibility (at-spi2-atk provides libatk-bridge-2.0)
+        at-spi2-atk \
+        at-spi2-core \
+        # Other required libraries
+        cups-libs \
+        libwayland-client \
+        libwayland-egl \
+        libwayland-server \
+        libpng \
+        libjpeg-turbo \
+        harfbuzz \
+        # EGL/GL support
+        mesa-libEGL \
+        mesa-libGL \
+        # Utilities
+        which \
+    && \
+    # Install Node.js via NodeSource
+    curl -fsSL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    dnf install -y --setopt=install_weak_deps=False nodejs && \
+    npm install -g yarn && \
+    # Cleanup
+    dnf clean all && \
+    rm -rf /var/cache/dnf /var/cache/yum /tmp/* /var/tmp/*
+
+# Create non-root user for sandboxed browser execution
+RUN useradd -m -s /bin/bash pwuser
+
+# Set working directory
+WORKDIR /home/pwuser
+
+# Copy playwright-core package (built beforehand from tip-of-tree Playwright)
+COPY ./playwright-core.tar.gz /tmp/playwright-core.tar.gz
+
+# Bake browsers into image
+# LIMITATION: Only Chromium supported on UBI8
+# - Firefox requires GLIBCXX_3.4.26+ (UBI8 only has up to GLIBCXX_3.4.25)
+# - WebKit not supported on RHEL-based distributions
+# - Set 777 permissions so any user can access browsers
+RUN mkdir -p /ms-playwright /ms-playwright-agent && \
+    cd /ms-playwright-agent && \
+    npm init -y && \
+    npm i /tmp/playwright-core.tar.gz && \
+    npm exec --no -- playwright-core mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    npm exec --no -- playwright-core install chromium && \
+    # Cleanup
+    rm -f /tmp/playwright-core.tar.gz && \
+    rm -rf /ms-playwright-agent ~/.npm /tmp/* /var/tmp/* && \
+    chmod -R 777 /ms-playwright

--- a/utils/docker/Dockerfile.ubi8-minimal
+++ b/utils/docker/Dockerfile.ubi8-minimal
@@ -1,0 +1,121 @@
+FROM redhat/ubi8-minimal
+
+# Metadata
+LABEL maintainer="Microsoft Playwright Team"
+LABEL description="Playwright Docker image based on Red Hat UBI8-minimal with Chromium"
+LABEL org.opencontainers.image.source="https://github.com/microsoft/playwright"
+
+# Build arguments
+ARG TZ=America/Los_Angeles
+ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright:v%version%-ubi8-minimal"
+ARG NODE_VERSION=20
+
+# Environment variables
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# === INSTALL Node.js AND BROWSER DEPENDENCIES ===
+# Combined into single layer to reduce image size
+# Using --setopt=install_weak_deps=0 to skip unnecessary dependencies
+# Note: ubi8-minimal uses microdnf instead of dnf
+
+RUN microdnf install -y --setopt=install_weak_deps=0 \
+        # Node.js prerequisites
+        curl \
+        wget \
+        ca-certificates \
+        tar \
+        gzip \
+        findutils \
+        # Development tools (feature-parity with node.js base images)
+        git \
+        openssh-clients \
+        # Basic X11 libraries
+        libX11 \
+        libXcomposite \
+        libXcursor \
+        libXdamage \
+        libXext \
+        libXfixes \
+        libXi \
+        libXrandr \
+        libXrender \
+        libXtst \
+        libxcb \
+        libxkbcommon \
+        libxshmfence \
+        # GTK and rendering
+        gtk3 \
+        cairo \
+        cairo-gobject \
+        pango \
+        gdk-pixbuf2 \
+        # Audio
+        alsa-lib \
+        # NSS/NSPR (for Chromium)
+        nss \
+        nspr \
+        # DRM/GBM (for Chromium GPU)
+        libdrm \
+        mesa-libgbm \
+        # D-Bus
+        dbus-libs \
+        dbus-glib \
+        # Fonts
+        fontconfig \
+        freetype \
+        liberation-fonts-common \
+        liberation-mono-fonts \
+        dejavu-sans-fonts \
+        # Accessibility (at-spi2-atk provides libatk-bridge-2.0)
+        at-spi2-atk \
+        at-spi2-core \
+        # Other required libraries
+        cups-libs \
+        libwayland-client \
+        libwayland-egl \
+        libwayland-server \
+        libpng \
+        libjpeg-turbo \
+        harfbuzz \
+        # EGL/GL support
+        mesa-libEGL \
+        mesa-libGL \
+    && \
+    # Install Node.js via NodeSource
+    curl -fsSL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    microdnf install -y --setopt=install_weak_deps=0 nodejs && \
+    npm install -g yarn && \
+    # Cleanup
+    microdnf clean all && \
+    rm -rf /var/cache/yum /tmp/* /var/tmp/*
+
+# Create non-root user for sandboxed browser execution
+# Note: useradd not available in minimal, create user manually
+RUN echo "pwuser:x:1000:1000:pwuser:/home/pwuser:/bin/bash" >> /etc/passwd && \
+    echo "pwuser:x:1000:" >> /etc/group && \
+    mkdir -p /home/pwuser && \
+    chown -R 1000:1000 /home/pwuser
+
+# Set working directory
+WORKDIR /home/pwuser
+
+# Copy playwright-core package (built beforehand from tip-of-tree Playwright)
+COPY ./playwright-core.tar.gz /tmp/playwright-core.tar.gz
+
+# Bake browsers into image
+# LIMITATION: Only Chromium supported on UBI8-minimal
+# - Firefox requires GLIBCXX_3.4.26+ (UBI8 only has up to GLIBCXX_3.4.25)
+# - WebKit not supported on RHEL-based distributions
+# - Set 777 permissions so any user can access browsers
+RUN mkdir -p /ms-playwright /ms-playwright-agent && \
+    cd /ms-playwright-agent && \
+    npm init -y && \
+    npm i /tmp/playwright-core.tar.gz && \
+    npm exec --no -- playwright-core mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    npm exec --no -- playwright-core install chromium && \
+    # Cleanup
+    rm -f /tmp/playwright-core.tar.gz && \
+    rm -rf /ms-playwright-agent ~/.npm /tmp/* /var/tmp/* && \
+    chmod -R 777 /ms-playwright

--- a/utils/docker/Dockerfile.ubi9
+++ b/utils/docker/Dockerfile.ubi9
@@ -1,0 +1,115 @@
+FROM redhat/ubi9
+
+# Metadata
+LABEL maintainer="Microsoft Playwright Team"
+LABEL description="Playwright Docker image based on Red Hat UBI9 with Chromium and Firefox"
+LABEL org.opencontainers.image.source="https://github.com/microsoft/playwright"
+
+# Build arguments
+ARG TZ=America/Los_Angeles
+ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright:v%version%-ubi9"
+ARG NODE_VERSION=20
+
+# Environment variables
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# === INSTALL Node.js AND BROWSER DEPENDENCIES ===
+# Combined into single layer to reduce image size
+# Using --setopt=install_weak_deps=False to skip unnecessary dependencies
+# Note: UBI9 comes with curl-minimal pre-installed
+
+RUN dnf install -y --setopt=install_weak_deps=False \
+        # Node.js prerequisites
+        wget \
+        ca-certificates \
+        gnupg2 \
+        # Development tools (feature-parity with node.js base images)
+        git \
+        openssh-clients \
+        # Basic X11 libraries
+        libX11 \
+        libXcomposite \
+        libXcursor \
+        libXdamage \
+        libXext \
+        libXfixes \
+        libXi \
+        libXrandr \
+        libXrender \
+        libXtst \
+        libxcb \
+        libxkbcommon \
+        libxshmfence \
+        # GTK and rendering
+        gtk3 \
+        cairo \
+        cairo-gobject \
+        pango \
+        gdk-pixbuf2 \
+        # Audio
+        alsa-lib \
+        # NSS/NSPR (for Chromium)
+        nss \
+        nspr \
+        # DRM/GBM (for Chromium GPU)
+        libdrm \
+        mesa-libgbm \
+        # D-Bus
+        dbus-libs \
+        dbus-glib \
+        # Fonts
+        fontconfig \
+        freetype \
+        liberation-fonts-common \
+        liberation-mono-fonts \
+        dejavu-sans-fonts \
+        # Accessibility (at-spi2-atk provides libatk-bridge-2.0)
+        at-spi2-atk \
+        at-spi2-core \
+        # Other required libraries
+        cups-libs \
+        libwayland-client \
+        libwayland-egl \
+        libwayland-server \
+        libpng \
+        libjpeg-turbo \
+        harfbuzz \
+        # EGL/GL support
+        mesa-libEGL \
+        mesa-libGL \
+        # Utilities
+        which \
+    && \
+    # Install Node.js via NodeSource
+    curl -fsSL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    dnf install -y --setopt=install_weak_deps=False nodejs && \
+    npm install -g yarn && \
+    # Cleanup
+    dnf clean all && \
+    rm -rf /var/cache/dnf /var/cache/yum /tmp/* /var/tmp/*
+
+# Create non-root user for sandboxed browser execution
+RUN useradd -m -s /bin/bash pwuser
+
+# Set working directory
+WORKDIR /home/pwuser
+
+# Copy playwright-core package (built beforehand from tip-of-tree Playwright)
+COPY ./playwright-core.tar.gz /tmp/playwright-core.tar.gz
+
+# Bake browsers into image
+# - Chromium and Firefox supported on UBI9 (has GLIBCXX_3.4.29)
+# - WebKit not supported on RHEL-based distributions
+# - Set 777 permissions so any user can access browsers
+RUN mkdir -p /ms-playwright /ms-playwright-agent && \
+    cd /ms-playwright-agent && \
+    npm init -y && \
+    npm i /tmp/playwright-core.tar.gz && \
+    npm exec --no -- playwright-core mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    npm exec --no -- playwright-core install chromium firefox && \
+    # Cleanup
+    rm -f /tmp/playwright-core.tar.gz && \
+    rm -rf /ms-playwright-agent ~/.npm /tmp/* /var/tmp/* && \
+    chmod -R 777 /ms-playwright

--- a/utils/docker/Dockerfile.ubi9-minimal
+++ b/utils/docker/Dockerfile.ubi9-minimal
@@ -1,0 +1,119 @@
+FROM redhat/ubi9-minimal
+
+# Metadata
+LABEL maintainer="Microsoft Playwright Team"
+LABEL description="Playwright Docker image based on Red Hat UBI9-minimal with Chromium and Firefox"
+LABEL org.opencontainers.image.source="https://github.com/microsoft/playwright"
+
+# Build arguments
+ARG TZ=America/Los_Angeles
+ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright:v%version%-ubi9-minimal"
+ARG NODE_VERSION=20
+
+# Environment variables
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# === INSTALL Node.js AND BROWSER DEPENDENCIES ===
+# Combined into single layer to reduce image size
+# Using --setopt=install_weak_deps=0 to skip unnecessary dependencies
+# Note: ubi9-minimal uses microdnf instead of dnf
+
+RUN microdnf install -y --setopt=install_weak_deps=0 \
+        # Node.js prerequisites
+        wget \
+        ca-certificates \
+        tar \
+        gzip \
+        findutils \
+        # Development tools (feature-parity with node.js base images)
+        git \
+        openssh-clients \
+        # Basic X11 libraries
+        libX11 \
+        libXcomposite \
+        libXcursor \
+        libXdamage \
+        libXext \
+        libXfixes \
+        libXi \
+        libXrandr \
+        libXrender \
+        libXtst \
+        libxcb \
+        libxkbcommon \
+        libxshmfence \
+        # GTK and rendering
+        gtk3 \
+        cairo \
+        cairo-gobject \
+        pango \
+        gdk-pixbuf2 \
+        # Audio
+        alsa-lib \
+        # NSS/NSPR (for Chromium)
+        nss \
+        nspr \
+        # DRM/GBM (for Chromium GPU)
+        libdrm \
+        mesa-libgbm \
+        # D-Bus
+        dbus-libs \
+        dbus-glib \
+        # Fonts
+        fontconfig \
+        freetype \
+        liberation-fonts-common \
+        liberation-mono-fonts \
+        dejavu-sans-fonts \
+        # Accessibility (at-spi2-atk provides libatk-bridge-2.0)
+        at-spi2-atk \
+        at-spi2-core \
+        # Other required libraries
+        cups-libs \
+        libwayland-client \
+        libwayland-egl \
+        libwayland-server \
+        libpng \
+        libjpeg-turbo \
+        harfbuzz \
+        # EGL/GL support
+        mesa-libEGL \
+        mesa-libGL \
+    && \
+    # Install Node.js via NodeSource
+    curl -fsSL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    microdnf install -y --setopt=install_weak_deps=0 nodejs && \
+    npm install -g yarn && \
+    # Cleanup
+    microdnf clean all && \
+    rm -rf /var/cache/yum /tmp/* /var/tmp/*
+
+# Create non-root user for sandboxed browser execution
+# Note: useradd not available in minimal, create user manually
+RUN echo "pwuser:x:1000:1000:pwuser:/home/pwuser:/bin/bash" >> /etc/passwd && \
+    echo "pwuser:x:1000:" >> /etc/group && \
+    mkdir -p /home/pwuser && \
+    chown -R 1000:1000 /home/pwuser
+
+# Set working directory
+WORKDIR /home/pwuser
+
+# Copy playwright-core package (built beforehand from tip-of-tree Playwright)
+COPY ./playwright-core.tar.gz /tmp/playwright-core.tar.gz
+
+# Bake browsers into image
+# - Chromium and Firefox supported on UBI9-minimal (has GLIBCXX_3.4.29)
+# - WebKit not supported on RHEL-based distributions
+# - Set 777 permissions so any user can access browsers
+RUN mkdir -p /ms-playwright /ms-playwright-agent && \
+    cd /ms-playwright-agent && \
+    npm init -y && \
+    npm i /tmp/playwright-core.tar.gz && \
+    npm exec --no -- playwright-core mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    npm exec --no -- playwright-core install chromium firefox && \
+    # Cleanup
+    rm -f /tmp/playwright-core.tar.gz && \
+    rm -rf /ms-playwright-agent ~/.npm /tmp/* /var/tmp/* && \
+    chmod -R 777 /ms-playwright

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -3,7 +3,7 @@ set -e
 set +x
 
 if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
-  echo "usage: $(basename $0) {--arm64,--amd64} {jammy,noble} playwright:localbuild-noble"
+  echo "usage: $(basename $0) {--arm64,--amd64} {jammy,noble,ubi8,ubi8-minimal,ubi9,ubi9-minimal} playwright:localbuild-noble"
   echo
   echo "Build Playwright docker image and tag it as 'playwright:localbuild-noble'."
   echo "Once image is built, you can run it with"
@@ -12,6 +12,14 @@ if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
   echo ""
   echo "NOTE: this requires on Playwright dependencies to be installed with 'npm install'"
   echo "      and Playwright itself being built with 'npm run build'"
+  echo ""
+  echo "Available flavors:"
+  echo "  jammy        - Ubuntu 22.04 LTS (Jammy Jellyfish)"
+  echo "  noble        - Ubuntu 24.04 LTS (Noble Numbat)"
+  echo "  ubi8         - Red Hat Universal Base Image 8 (Chromium only)"
+  echo "  ubi8-minimal - Red Hat Universal Base Image 8 Minimal (Chromium only)"
+  echo "  ubi9         - Red Hat Universal Base Image 9 (Chromium + Firefox)"
+  echo "  ubi9-minimal - Red Hat Universal Base Image 9 Minimal (Chromium + Firefox)"
   echo ""
   exit 0
 fi

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -32,6 +32,26 @@ NOBLE_TAGS=(
   "v${PW_VERSION}-noble"
 )
 
+# Red Hat UBI 8 (Chromium only)
+UBI8_TAGS=(
+  "v${PW_VERSION}-ubi8"
+)
+
+# Red Hat UBI 8 Minimal (Chromium only)
+UBI8_MINIMAL_TAGS=(
+  "v${PW_VERSION}-ubi8-minimal"
+)
+
+# Red Hat UBI 9 (Chromium + Firefox)
+UBI9_TAGS=(
+  "v${PW_VERSION}-ubi9"
+)
+
+# Red Hat UBI 9 Minimal (Chromium + Firefox)
+UBI9_MINIMAL_TAGS=(
+  "v${PW_VERSION}-ubi9-minimal"
+)
+
 tag_and_push() {
   local source="$1"
   local target="$2"
@@ -68,8 +88,16 @@ publish_docker_images_with_arch_suffix() {
     TAGS=("${JAMMY_TAGS[@]}")
   elif [[ "$FLAVOR" == "noble" ]]; then
     TAGS=("${NOBLE_TAGS[@]}")
+  elif [[ "$FLAVOR" == "ubi8" ]]; then
+    TAGS=("${UBI8_TAGS[@]}")
+  elif [[ "$FLAVOR" == "ubi8-minimal" ]]; then
+    TAGS=("${UBI8_MINIMAL_TAGS[@]}")
+  elif [[ "$FLAVOR" == "ubi9" ]]; then
+    TAGS=("${UBI9_TAGS[@]}")
+  elif [[ "$FLAVOR" == "ubi9-minimal" ]]; then
+    TAGS=("${UBI9_MINIMAL_TAGS[@]}")
   else
-    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'jammy', or 'noble'"
+    echo "ERROR: unknown flavor - $FLAVOR. Must be one of: jammy, noble, ubi8, ubi8-minimal, ubi9, ubi9-minimal"
     exit 1
   fi
   local ARCH="$2"
@@ -94,8 +122,16 @@ publish_docker_manifest () {
     TAGS=("${JAMMY_TAGS[@]}")
   elif [[ "$FLAVOR" == "noble" ]]; then
     TAGS=("${NOBLE_TAGS[@]}")
+  elif [[ "$FLAVOR" == "ubi8" ]]; then
+    TAGS=("${UBI8_TAGS[@]}")
+  elif [[ "$FLAVOR" == "ubi8-minimal" ]]; then
+    TAGS=("${UBI8_MINIMAL_TAGS[@]}")
+  elif [[ "$FLAVOR" == "ubi9" ]]; then
+    TAGS=("${UBI9_TAGS[@]}")
+  elif [[ "$FLAVOR" == "ubi9-minimal" ]]; then
+    TAGS=("${UBI9_MINIMAL_TAGS[@]}")
   else
-    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'jammy', or 'noble'"
+    echo "ERROR: unknown flavor - $FLAVOR. Must be one of: jammy, noble, ubi8, ubi8-minimal, ubi9, ubi9-minimal"
     exit 1
   fi
 
@@ -123,3 +159,19 @@ publish_docker_manifest jammy amd64 arm64
 publish_docker_images_with_arch_suffix noble amd64
 publish_docker_images_with_arch_suffix noble arm64
 publish_docker_manifest noble amd64 arm64
+
+# Red Hat UBI 8 (amd64 only - Chromium only)
+publish_docker_images_with_arch_suffix ubi8 amd64
+publish_docker_manifest ubi8 amd64
+
+# Red Hat UBI 8 Minimal (amd64 only - Chromium only)
+publish_docker_images_with_arch_suffix ubi8-minimal amd64
+publish_docker_manifest ubi8-minimal amd64
+
+# Red Hat UBI 9 (amd64 only - Chromium + Firefox)
+publish_docker_images_with_arch_suffix ubi9 amd64
+publish_docker_manifest ubi9 amd64
+
+# Red Hat UBI 9 Minimal (amd64 only - Chromium + Firefox)
+publish_docker_images_with_arch_suffix ubi9-minimal amd64
+publish_docker_manifest ubi9-minimal amd64

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -160,18 +160,22 @@ publish_docker_images_with_arch_suffix noble amd64
 publish_docker_images_with_arch_suffix noble arm64
 publish_docker_manifest noble amd64 arm64
 
-# Red Hat UBI 8 (amd64 only - Chromium only)
+# Red Hat UBI 8 (Chromium only)
 publish_docker_images_with_arch_suffix ubi8 amd64
-publish_docker_manifest ubi8 amd64
+publish_docker_images_with_arch_suffix ubi8 arm64
+publish_docker_manifest ubi8 amd64 arm64
 
-# Red Hat UBI 8 Minimal (amd64 only - Chromium only)
+# Red Hat UBI 8 Minimal (Chromium only)
 publish_docker_images_with_arch_suffix ubi8-minimal amd64
-publish_docker_manifest ubi8-minimal amd64
+publish_docker_images_with_arch_suffix ubi8-minimal arm64
+publish_docker_manifest ubi8-minimal amd64 arm64
 
-# Red Hat UBI 9 (amd64 only - Chromium + Firefox)
+# Red Hat UBI 9 (Chromium + Firefox)
 publish_docker_images_with_arch_suffix ubi9 amd64
-publish_docker_manifest ubi9 amd64
+publish_docker_images_with_arch_suffix ubi9 arm64
+publish_docker_manifest ubi9 amd64 arm64
 
-# Red Hat UBI 9 Minimal (amd64 only - Chromium + Firefox)
+# Red Hat UBI 9 Minimal (Chromium + Firefox)
 publish_docker_images_with_arch_suffix ubi9-minimal amd64
-publish_docker_manifest ubi9-minimal amd64
+publish_docker_images_with_arch_suffix ubi9-minimal arm64
+publish_docker_manifest ubi9-minimal amd64 arm64


### PR DESCRIPTION
This PR adds support for Red Hat Universal Base Images (UBI) as an alternative to Ubuntu-based Docker images.  

This enables Playwright usage in enterprise environments that require RHEL-based containers for compliance or compatibility reasons.

All UBI images support both **amd64** and **arm64** architectures.

### New Docker Images

| Image | Base | Architectures | Browsers | Notes |
|-------|------|---------------|----------|-------|
| `Dockerfile.ubi9` | `redhat/ubi9` | amd64, arm64 | Chromium, Firefox | Recommended for full browser support |
| `Dockerfile.ubi9-minimal` | `redhat/ubi9-minimal` | amd64, arm64 | Chromium, Firefox | Smaller image with full browser support |
| `Dockerfile.ubi8` | `redhat/ubi8` | amd64, arm64 | Chromium | Firefox requires GLIBCXX_3.4.26+ |
| `Dockerfile.ubi8-minimal` | `redhat/ubi8-minimal` | amd64, arm64 | Chromium | Smallest image size |

> **Note:** WebKit is not supported on any RHEL-based distribution. UBI8 images only support Chromium due to `libstdc++` version constraints (GLIBCXX_3.4.25 vs required 3.4.26+).

### Build & Run

```bash
# Build locally (requires npm install && npm run build first)
./utils/docker/build.sh --amd64 ubi9 playwright:localbuild-ubi9
./utils/docker/build.sh --arm64 ubi9 playwright:localbuild-ubi9  # For Apple Silicon / ARM

# Run container
docker run -it --rm --ipc=host playwright:localbuild-ubi9 /bin/bash
```

### Published Tags (on release)

Multi-arch manifests supporting both amd64 and arm64:
- `mcr.microsoft.com/playwright:v{VERSION}-ubi9`
- `mcr.microsoft.com/playwright:v{VERSION}-ubi9-minimal`
- `mcr.microsoft.com/playwright:v{VERSION}-ubi8`
- `mcr.microsoft.com/playwright:v{VERSION}-ubi8-minimal`

### Testing

All images have been built and tested on both architectures:

| Image | amd64 | arm64 |
|-------|-------|-------|
| UBI9 | Chromium, Firefox | Chromium, Firefox |
| UBI9-minimal | Chromium, Firefox | Chromium, Firefox |
| UBI8 | Chromium | Chromium |
| UBI8-minimal | Chromium | Chromium |

### Image Sizes

| Image | amd64 | arm64 |
|-------|-------|-------|
| ubi8-minimal | 1.14 GB | 1.49 GB |
| ubi8 | 1.20 GB | 1.52 GB |
| ubi9-minimal | 1.63 GB | 1.92 GB |
| ubi9 | 1.66 GB | 1.96 GB |

### Dockerfile Best Practices Applied

- OCI labels for metadata (maintainer, description, source)
- Combined RUN layers to reduce image size
- `--setopt=install_weak_deps=False` to skip unnecessary dependencies
- Proper cleanup in same layer as install
- Non-root `pwuser` for sandboxed browser execution
- `WORKDIR` set for consistent working directory