### PR TITLE
feat(test-runner): Support file-only entries in `--test-list` files

### DIFF
--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -123,6 +123,12 @@ Options `--test-list` and `--test-list-invert` accept a path to a test list file
 # This is a test list file.
 # It can include comments and empty lines.
 
+# Run ALL tests in a file:
+path/to/example.spec.ts
+
+# Run all tests in a file for a specific project:
+[chromium] › path/to/example.spec.ts
+
 # Fully qualified test with a project:
 [chromium] › path/to/example.spec.ts:3:9 › suite › nested suite › example test
 

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -129,6 +129,12 @@ path/to/example.spec.ts
 # Run all tests in a file for a specific project:
 [chromium] › path/to/example.spec.ts
 
+# Run all tests in a specific group/suite:
+path/to/example.spec.ts › suite name
+
+# Run all tests in a nested group:
+path/to/example.spec.ts › outer suite › inner suite
+
 # Fully qualified test with a project:
 [chromium] › path/to/example.spec.ts:3:9 › suite › nested suite › example test
 

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -377,7 +377,10 @@ export async function loadTestList(config: FullConfigInternal, filePath: string)
       // If no title path is specified, match ALL tests in the file
       if (d.titlePath.length === 0)
         return true;
-      return d.titlePath.length === titles.length && d.titlePath.every((_, index) => titles[index] === d.titlePath[index]);
+      // Match if test's title path starts with the specified title path (supports groups/suites)
+      if (d.titlePath.length > titles.length)
+        return false;
+      return d.titlePath.every((title, index) => titles[index] === title);
     });
   } catch (e) {
     throw errorWithFile(filePath, 'Cannot read test list file: ' + e.message);

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -374,7 +374,7 @@ export async function loadTestList(config: FullConfigInternal, filePath: string)
       const relativeFile = toPosixPath(path.relative(config.config.rootDir, test.location.file));
       if (relativeFile !== d.file)
         return false;
-      return d.titlePath.length > titles.length && d.titlePath.every((_, index) => titles[index] === d.titlePath[index]);
+      return d.titlePath.length <= titles.length && d.titlePath.every((_, index) => titles[index] === d.titlePath[index]);
     });
   } catch (e) {
     throw errorWithFile(filePath, 'Cannot read test list file: ' + e.message);

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -374,6 +374,9 @@ export async function loadTestList(config: FullConfigInternal, filePath: string)
       const relativeFile = toPosixPath(path.relative(config.config.rootDir, test.location.file));
       if (relativeFile !== d.file)
         return false;
+      // If no title path is specified, match ALL tests in the file
+      if (d.titlePath.length === 0)
+        return true;
       return d.titlePath.length === titles.length && d.titlePath.every((_, index) => titles[index] === d.titlePath[index]);
     });
   } catch (e) {

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -374,13 +374,7 @@ export async function loadTestList(config: FullConfigInternal, filePath: string)
       const relativeFile = toPosixPath(path.relative(config.config.rootDir, test.location.file));
       if (relativeFile !== d.file)
         return false;
-      // If no title path is specified, match ALL tests in the file
-      if (d.titlePath.length === 0)
-        return true;
-      // Match if test's title path starts with the specified title path (supports groups/suites)
-      if (d.titlePath.length > titles.length)
-        return false;
-      return d.titlePath.every((title, index) => titles[index] === title);
+      return d.titlePath.length > titles.length && d.titlePath.every((_, index) => titles[index] === d.titlePath[index]);
     });
   } catch (e) {
     throw errorWithFile(filePath, 'Cannot read test list file: ' + e.message);

--- a/tests/playwright-test/test-list.spec.ts
+++ b/tests/playwright-test/test-list.spec.ts
@@ -32,6 +32,19 @@ const varietyWorkspace = {
     # more comments
           dir3/c.spec.ts > test2
   `,
+  'dir/fileonly.list': `
+      # Run all tests in this file
+      dir1/a.test.ts
+  `,
+  'dir/projectfile.list': `
+      [p1] › dir1/a.test.ts
+  `,
+  'dir/mixed.list': `
+      # All tests in this file
+      dir1/a.test.ts
+      # Specific test only
+      dir3/c.spec.ts › test2
+  `,
   'empty.list': `
       # nothing to see here
   `,
@@ -127,6 +140,42 @@ test('--list output should work for --test-list', async ({ runInlineTest }) => {
     'b-test1-p2',
     'b-test2-p2',
     'c-test1-p2',
+    'c-test2-p2',
+  ]);
+});
+
+test('--test-list with file-only entries should run all tests in file', async ({ runInlineTest }) => {
+  const result = await runInlineTest(varietyWorkspace, { 'workers': 1, 'test-list': 'dir/fileonly.list' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(4); // 2 tests × 2 projects
+  expect(result.outputLines).toEqual([
+    'a-test1-p1',
+    'a-test2-p1',
+    'a-test1-p2',
+    'a-test2-p2',
+  ]);
+});
+
+test('--test-list with project-scoped file-only entry', async ({ runInlineTest }) => {
+  const result = await runInlineTest(varietyWorkspace, { 'workers': 1, 'test-list': 'dir/projectfile.list' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2); // 2 tests × 1 project
+  expect(result.outputLines).toEqual([
+    'a-test1-p1',
+    'a-test2-p1',
+  ]);
+});
+
+test('--test-list with mixed file-only and full test paths', async ({ runInlineTest }) => {
+  const result = await runInlineTest(varietyWorkspace, { 'workers': 1, 'test-list': 'dir/mixed.list' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(6); // 4 from a.test.ts + 2 from c.spec.ts test2
+  expect(result.outputLines).toEqual([
+    'a-test1-p1',
+    'a-test2-p1',
+    'c-test2-p1',
+    'a-test1-p2',
+    'a-test2-p2',
     'c-test2-p2',
   ]);
 });

--- a/tests/playwright-test/test-list.spec.ts
+++ b/tests/playwright-test/test-list.spec.ts
@@ -45,6 +45,14 @@ const varietyWorkspace = {
       # Specific test only
       dir3/c.spec.ts › test2
   `,
+  'dir/suite.list': `
+      # Run all tests in the outer group
+      dir4/d.spec.ts › outer
+  `,
+  'dir/nested-suite.list': `
+      # Run all tests in the nested group
+      dir4/d.spec.ts › outer › inner
+  `,
   'empty.list': `
       # nothing to see here
   `,
@@ -70,6 +78,15 @@ const varietyWorkspace = {
     test('test1', async () => { console.log('\\n%%c-test1-' + test.info().project.name); });
     test('test2', async () => { console.log('\\n%%c-test2-' + test.info().project.name); });
   `,
+  'tests/dir4/d.spec.ts': `
+    import { test, expect } from '@playwright/test';
+    test.describe('outer', () => {
+      test('test1', async () => { console.log('\\n%%d-test1-' + test.info().project.name); });
+      test.describe('inner', () => {
+        test('test2', async () => { console.log('\\n%%d-test2-' + test.info().project.name); });
+      });
+    });
+  `,
 };
 
 test('--test-list should work', async ({ runInlineTest }) => {
@@ -87,16 +104,20 @@ test('--test-list should work', async ({ runInlineTest }) => {
 test('--test-list-invert should work', async ({ runInlineTest }) => {
   const result = await runInlineTest(varietyWorkspace, { 'workers': 1, 'test-list-invert': 'dir/test.list' });
   expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(8);
+  expect(result.passed).toBe(12);
   expect(result.outputLines).toEqual([
     'a-test2-p1',
     'b-test1-p1',
     'b-test2-p1',
     'c-test1-p1',
+    'd-test1-p1',
+    'd-test2-p1',
     'a-test1-p2',
     'a-test2-p2',
     'b-test1-p2',
     'c-test1-p2',
+    'd-test1-p2',
+    'd-test2-p2',
   ]);
 });
 
@@ -127,7 +148,7 @@ test('--list output should work for --test-list', async ({ runInlineTest }) => {
 
   const result = await runInlineTest(varietyWorkspace, { 'workers': 1, 'test-list': 'generated.list' });
   expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(12);
+  expect(result.passed).toBe(16);
   expect(result.outputLines).toEqual([
     'a-test1-p1',
     'a-test2-p1',
@@ -135,12 +156,16 @@ test('--list output should work for --test-list', async ({ runInlineTest }) => {
     'b-test2-p1',
     'c-test1-p1',
     'c-test2-p1',
+    'd-test1-p1',
+    'd-test2-p1',
     'a-test1-p2',
     'a-test2-p2',
     'b-test1-p2',
     'b-test2-p2',
     'c-test1-p2',
     'c-test2-p2',
+    'd-test1-p2',
+    'd-test2-p2',
   ]);
 });
 
@@ -177,5 +202,27 @@ test('--test-list with mixed file-only and full test paths', async ({ runInlineT
     'a-test1-p2',
     'a-test2-p2',
     'c-test2-p2',
+  ]);
+});
+
+test('--test-list with group/suite entry should run all tests in that group', async ({ runInlineTest }) => {
+  const result = await runInlineTest(varietyWorkspace, { 'workers': 1, 'test-list': 'dir/suite.list' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(4); // 2 tests in outer × 2 projects
+  expect(result.outputLines).toEqual([
+    'd-test1-p1',
+    'd-test2-p1',
+    'd-test1-p2',
+    'd-test2-p2',
+  ]);
+});
+
+test('--test-list with nested group entry should run only tests in that nested group', async ({ runInlineTest }) => {
+  const result = await runInlineTest(varietyWorkspace, { 'workers': 1, 'test-list': 'dir/nested-suite.list' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2); // 1 test in inner × 2 projects
+  expect(result.outputLines).toEqual([
+    'd-test2-p1',
+    'd-test2-p2',
   ]);
 });


### PR DESCRIPTION
## Description

This PR adds support for **file-only entries** and **group/suite entries** in `--test-list` files, allowing users to specify just a file path (to run all tests in that file) or a partial title path (to run all tests in a describe block).

### Before this change

The `--test-list` option required a full test description including the complete title path:

```
path/to/example.spec.ts › suite › test name
```

### After this change

You can now specify:

```bash
# Run all tests in a file
path/to/example.spec.ts

# Optionally scope to a specific project
[chromium] › path/to/example.spec.ts

# Run all tests in a describe block (group/suite)
path/to/example.spec.ts › suite name

# Run all tests in a nested describe block
path/to/example.spec.ts › outer suite › inner suite

# Mix file-only, group, and specific test entries
path/to/example.spec.ts
path/to/other.spec.ts › my suite
path/to/another.spec.ts › suite › specific test
```

---

## Motivation

We run thousands of tests and need a flexible test routing system based purely on file names. Our CI infrastructure dynamically partitions test files across workers, and we don't need (or want) to specify individual test names.

### Command line length limits

Passing file lists via command line arguments (e.g., `npx playwright test $(cat files.txt)`) hits OS command line length limits:

| Platform | Max Command Line Length |
|----------|------------------------|
| Windows  | 8,191 characters (cmd.exe) or 32,767 characters (CreateProcess) |
| Linux    | ~2 MB (varies by kernel, `getconf ARG_MAX`) |
| macOS    | ~256 KB (`ARG_MAX` = 262,144) |

In practice, **CI agents often have lower effective limits** due to environment variable overhead. Azure DevOps (ADO) agents, for example, can fail with "Argument list too long" errors when passing hundreds of test files via command substitution.

With 1000+ test files averaging 250 characters per path (including deep directory structures and descriptive file names), you're looking at 250KB+ just for file paths—before accounting for the command itself and environment variables. This exceeds macOS limits and frequently fails on hosted CI agents.

### Why `--test-list` with file-only entries solves this

The `--test-list` file approach:
- **Bypasses command line limits entirely** — file paths are read from disk, not passed as arguments
- **Simple to generate programmatically** — just output file paths, one per line
- **Resilient to test name changes** — no need to update when tests are renamed within files
- **Compatible with file-based sharding** — routing systems can partition by file and output simple lists

### Current workaround is cumbersome

Without file-only support, we would need to list every single test by its full title path, which:
- Creates massive, hard-to-maintain test list files  
- Breaks whenever test names change
- Requires regenerating lists after any test modification