### PR TITLE
Revert "feat(toHaveCss) Overload toHaveCSS matcher to accept React.CSSProperties (#38617)"

### DIFF
--- a/docs/src/actionability.md
+++ b/docs/src/actionability.md
@@ -66,7 +66,7 @@ Playwright includes auto-retrying assertions that remove flakiness by waiting un
 | [`method: LocatorAssertions.toHaveAttribute`] | Element has a DOM attribute |
 | [`method: LocatorAssertions.toHaveClass`] | Element has a class property |
 | [`method: LocatorAssertions.toHaveCount`] | List has exact number of children |
-| [`method: LocatorAssertions.toHaveCSS#1`] | Element has CSS property |
+| [`method: LocatorAssertions.toHaveCSS`] | Element has CSS property |
 | [`method: LocatorAssertions.toHaveId`] | Element has an ID |
 | [`method: LocatorAssertions.toHaveJSProperty`] | Element has a JavaScript property |
 | [`method: LocatorAssertions.toHaveText`] | Element matches text |

--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -351,7 +351,7 @@ Expected count.
 * since: v1.20
 * langs: python
 
-The opposite of [`method: LocatorAssertions.toHaveCSS#1`].
+The opposite of [`method: LocatorAssertions.toHaveCSS`].
 
 ### param: LocatorAssertions.NotToHaveCSS.name
 * since: v1.18
@@ -1694,7 +1694,7 @@ Expected count.
 ### option: LocatorAssertions.toHaveCount.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
-## async method: LocatorAssertions.toHaveCSS#1
+## async method: LocatorAssertions.toHaveCSS
 * since: v1.20
 * langs:
   - alias-java: hasCSS
@@ -1731,52 +1731,23 @@ var locator = Page.GetByRole(AriaRole.Button);
 await Expect(locator).ToHaveCSSAsync("display", "flex");
 ```
 
-### param: LocatorAssertions.toHaveCSS#1.name
+### param: LocatorAssertions.toHaveCSS.name
 * since: v1.18
 - `name` <[string]>
 
 CSS property name.
 
-### param: LocatorAssertions.toHaveCSS#1.value
+### param: LocatorAssertions.toHaveCSS.value
 * since: v1.18
 - `value` <[string]|[RegExp]>
 
 CSS property value.
 
-### option: LocatorAssertions.toHaveCSS#1.timeout = %%-js-assertions-timeout-%%
+### option: LocatorAssertions.toHaveCSS.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
-### option: LocatorAssertions.toHaveCSS#1.timeout = %%-csharp-java-python-assertions-timeout-%%
+### option: LocatorAssertions.toHaveCSS.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
-
-## async method: LocatorAssertions.toHaveCSS#2
-* since: v1.58
-* langs: js
-
-Ensures the [Locator] resolves to an element with the given computed CSS properties.
-
-:::note
-The `CSSProperties` object parameter for toHaveCSS requires `react` to be installed for type checking.
-:::
-
-**Usage**
-
-```js
-const locator = page.getByRole('button');
-await expect(locator).toHaveCSS({
-  display: 'flex',
-  backgroundColor: 'rgb(255, 0, 0)'
-});
-```
-
-### param: LocatorAssertions.toHaveCSS#2.styles
-* since: v1.58
-- `styles` <[CSSProperties]>
-
-CSS properties object.
-
-### option: LocatorAssertions.toHaveCSS#2.timeout = %%-js-assertions-timeout-%%
-* since: v1.58
 
 ## async method: LocatorAssertions.toHaveId
 * since: v1.20

--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -3154,7 +3154,7 @@ List of all new assertions:
 - [`expect(locator).toHaveAttribute(name, value)`](./api/class-locatorassertions#locator-assertions-to-have-attribute)
 - [`expect(locator).toHaveClass(expected)`](./api/class-locatorassertions#locator-assertions-to-have-class)
 - [`expect(locator).toHaveCount(count)`](./api/class-locatorassertions#locator-assertions-to-have-count)
-- [`expect(locator).toHaveCSS(name, value)`](./api/class-locatorassertions#locator-assertions-to-have-css-1)
+- [`expect(locator).toHaveCSS(name, value)`](./api/class-locatorassertions#locator-assertions-to-have-css)
 - [`expect(locator).toHaveId(id)`](./api/class-locatorassertions#locator-assertions-to-have-id)
 - [`expect(locator).toHaveJSProperty(name, value)`](./api/class-locatorassertions#locator-assertions-to-have-js-property)
 - [`expect(locator).toHaveText(expected, options)`](./api/class-locatorassertions#locator-assertions-to-have-text)

--- a/docs/src/test-assertions-csharp-java-python.md
+++ b/docs/src/test-assertions-csharp-java-python.md
@@ -24,7 +24,7 @@ title: "Assertions"
 | [`method: LocatorAssertions.toHaveAttribute`] | Element has a DOM attribute |
 | [`method: LocatorAssertions.toHaveClass`] | Element has a class property |
 | [`method: LocatorAssertions.toHaveCount`] | List has exact number of children |
-| [`method: LocatorAssertions.toHaveCSS#1`] | Element has CSS property |
+| [`method: LocatorAssertions.toHaveCSS`] | Element has CSS property |
 | [`method: LocatorAssertions.toHaveId`] | Element has an ID |
 | [`method: LocatorAssertions.toHaveJSProperty`] | Element has a JavaScript property |
 | [`method: LocatorAssertions.toHaveRole`] | Element has a specific [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles) |

--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -46,7 +46,7 @@ Note that retrying assertions are async, so you must `await` them.
 | [await expect(locator).toHaveAttribute()](./api/class-locatorassertions.md#locator-assertions-to-have-attribute) | Element has a DOM attribute |
 | [await expect(locator).toHaveClass()](./api/class-locatorassertions.md#locator-assertions-to-have-class) | Element has specified CSS class property |
 | [await expect(locator).toHaveCount()](./api/class-locatorassertions.md#locator-assertions-to-have-count) | List has exact number of children |
-| [await expect(locator).toHaveCSS()](./api/class-locatorassertions.md#locator-assertions-to-have-css-1) | Element has CSS property |
+| [await expect(locator).toHaveCSS()](./api/class-locatorassertions.md#locator-assertions-to-have-css) | Element has CSS property |
 | [await expect(locator).toHaveId()](./api/class-locatorassertions.md#locator-assertions-to-have-id) | Element has an ID |
 | [await expect(locator).toHaveJSProperty()](./api/class-locatorassertions.md#locator-assertions-to-have-js-property) | Element has a JavaScript property |
 | [await expect(locator).toHaveRole()](./api/class-locatorassertions.md#locator-assertions-to-have-role) | Element has a specific [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles) |

--- a/packages/playwright-core/src/utils/isomorphic/stringUtils.ts
+++ b/packages/playwright-core/src/utils/isomorphic/stringUtils.ts
@@ -47,11 +47,6 @@ export function toSnakeCase(name: string): string {
   return name.replace(/([a-z0-9])([A-Z])/g, '$1_$2').replace(/([A-Z])([A-Z][a-z])/g, '$1_$2').toLowerCase();
 }
 
-export function toKebabCase(name: string): string {
-  // E.g. backgroundColor => background-color.
-  return name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').replace(/([A-Z])([A-Z][a-z])/g, '$1-$2').toLowerCase();
-}
-
 export function formatObject(value: any, indent = '  ', mode: 'multiline' | 'oneline' = 'multiline'): string {
   if (typeof value === 'string')
     return escapeWithQuotes(value, '\'');

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -18,10 +18,6 @@
 import type { APIRequestContext, Browser, BrowserContext, BrowserContextOptions, Page, PageAgent, LaunchOptions, ViewportSize, Geolocation, HTTPCredentials, Locator, APIResponse, PageScreenshotOptions } from 'playwright-core';
 export * from 'playwright-core';
 
-// @ts-ignore ReactCSSProperties will be any if react is not installed
-type ReactCSSProperties = import('react').CSSProperties;
-export type CSSProperties = keyof ReactCSSProperties extends string ? ReactCSSProperties : never;
-
 export type BlobReporterOptions = { outputDir?: string, fileName?: string };
 export type ListReporterOptions = { printSteps?: boolean };
 export type JUnitReporterOptions = { outputFile?: string, stripANSIControlSequences?: boolean, includeProjectInTestName?: boolean };
@@ -9178,32 +9174,6 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveCSS(name: string, value: string|RegExp, options?: {
-    /**
-     * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
-     */
-    timeout?: number;
-  }): Promise<void>;
-
-  /**
-   * Ensures the [Locator](https://playwright.dev/docs/api/class-locator) resolves to an element with the given computed
-   * CSS properties.
-   *
-   * **NOTE** The `CSSProperties` object parameter for toHaveCSS requires `react` to be installed for type checking.
-   *
-   * **Usage**
-   *
-   * ```js
-   * const locator = page.getByRole('button');
-   * await expect(locator).toHaveCSS({
-   *   display: 'flex',
-   *   backgroundColor: 'rgb(255, 0, 0)'
-   * });
-   * ```
-   *
-   * @param styles CSS properties object.
-   * @param options
-   */
-  toHaveCSS(styles: CSSProperties, options?: {
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */

--- a/tests/page/expect-misc.spec.ts
+++ b/tests/page/expect-misc.spec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { CSSProperties } from 'packages/playwright-test';
 import { stripAnsi } from '../config/utils';
 import { test, expect } from './pageTest';
 
@@ -508,43 +507,16 @@ Timeout: 1000ms`);
 });
 
 test.describe('toHaveCSS', () => {
-  test('pass with css property', async ({ page }) => {
+  test('pass', async ({ page }) => {
     await page.setContent('<div id=node style="color: rgb(255, 0, 0)">Text content</div>');
     const locator = page.locator('#node');
     await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
   });
 
-  test('pass with custom css property', async ({ page }) => {
+  test('custom css properties', async ({ page }) => {
     await page.setContent('<div id=node style="--custom-color-property:#FF00FF;">Text content</div>');
     const locator = page.locator('#node');
     await expect(locator).toHaveCSS('--custom-color-property', '#FF00FF');
-  });
-
-  test('pass with CSSPProperties object', async ({ page }) => {
-    await page.setContent('<div id=node style="color: rgb(255, 0, 0); display: flex;">Text content</div>');
-    const locator = page.locator('#node');
-    await expect(locator).toHaveCSS({ 'color': 'rgb(255, 0, 0)', 'display': 'flex' });
-  });
-
-  test('pass with CSSPProperties object with camelCased properties', async ({ page }) => {
-    await page.setContent('<div id=node style="background-color: red">Text content</div>');
-    const locator = page.locator('#node');
-    await expect(locator).toHaveCSS({ 'backgroundColor': 'rgb(255, 0, 0)' });
-  });
-
-  test('pass with CSSPProperties object with vendor-prefixed properties', async ({ page, browserName }) => {
-    await page.setContent('<div id=node style="-webkit-transform: rotate(45deg);-moz-transform: rotate(45deg);">Text content</div>');
-    const locator = page.locator('#node');
-    if (browserName === 'firefox')
-      await expect(locator).toHaveCSS({ 'MozTransform': 'matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0)' });
-    else
-      await expect(locator).toHaveCSS({ 'WebkitTransform': 'matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0)' });
-  });
-
-  test('pass with CSSPProperties object with custom properties', async ({ page }) => {
-    await page.setContent('<div id=node style="--my-color: blue;">Text content</div>');
-    const locator = page.locator('#node');
-    await expect(locator).toHaveCSS({ '--my-color': 'blue' } as CSSProperties);
   });
 });
 

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -17,10 +17,6 @@
 import type { APIRequestContext, Browser, BrowserContext, BrowserContextOptions, Page, PageAgent, LaunchOptions, ViewportSize, Geolocation, HTTPCredentials, Locator, APIResponse, PageScreenshotOptions } from 'playwright-core';
 export * from 'playwright-core';
 
-// @ts-ignore ReactCSSProperties will be any if react is not installed
-type ReactCSSProperties = import('react').CSSProperties;
-export type CSSProperties = keyof ReactCSSProperties extends string ? ReactCSSProperties : never;
-
 export type BlobReporterOptions = { outputDir?: string, fileName?: string };
 export type ListReporterOptions = { printSteps?: boolean };
 export type JUnitReporterOptions = { outputFile?: string, stripANSIControlSequences?: boolean, includeProjectInTestName?: boolean };


### PR DESCRIPTION


This reverts commit 5a071b80a64a5b539fbe772ffc4d28c33dc0bc60.