### PR TITLE
devops: build html report with PR's code

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
     - uses: actions/setup-node@v6
       with:
         node-version: 20


### PR DESCRIPTION
When a PR touches the HTML reporter, it'd be neat if its own test results use its own changes for review purposes. Currently, we're using `main`, with this change we're using the PR's code.