### PR TITLE
test(bidi): update test expectations

### DIFF
--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -69,7 +69,6 @@ it('should respect CSP @smoke', async ({ page, server }) => {
 
 it('should play video @smoke', async ({ page, asset, browserName, isWindows, isLinux, mode }) => {
   it.skip(browserName === 'webkit' && isWindows, 'passes locally but fails on GitHub Action bot, apparently due to a Media Pack issue in the Windows Server');
-  it.fixme(browserName === 'firefox' && isLinux, 'https://github.com/microsoft/playwright/issues/5721');
   it.skip(mode.startsWith('service'));
 
   // Safari only plays mp4 so we test WebKit with an .mp4 clip.

--- a/tests/library/download.spec.ts
+++ b/tests/library/download.spec.ts
@@ -624,8 +624,9 @@ it('should be able to download a inline PDF file via response interception', asy
   await page.close();
 });
 
-it('should be able to download a inline PDF file via navigation', async ({ browser, server, asset, browserName, isHeadlessShell }) => {
+it('should be able to download a inline PDF file via navigation', async ({ browser, server, asset, browserName, isHeadlessShell, isBidi }) => {
   it.skip(browserName === 'chromium' && !isHeadlessShell, 'We expect PDF Viewer to open up in headed Chromium');
+  it.skip(browserName === 'firefox' && isBidi, 'We expect PDF Viewer to open up in Firefox with Bidi');
 
   const page = await browser.newPage();
   await page.goto(server.EMPTY_PAGE);

--- a/tests/page/page-focus.spec.ts
+++ b/tests/page/page-focus.spec.ts
@@ -109,7 +109,7 @@ it('should traverse only form elements', async function({ page, browserName, pla
 });
 
 it('clicking checkbox should activate it', async ({ page, browserName, headless, platform }) => {
-  it.fixme(browserName !== 'chromium');
+  it.fixme(browserName === 'webkit');
 
   await page.setContent(`<input type=checkbox></input>`);
   await page.click('input');

--- a/tests/page/page-wait-for-load-state.spec.ts
+++ b/tests/page/page-wait-for-load-state.spec.ts
@@ -70,7 +70,7 @@ it('should work with pages that have loaded before being connected to', async ({
   expect(popup.url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should wait for load state of empty url popup', async ({ page, browserName }) => {
+it('should wait for load state of empty url popup', async ({ page, browserName, isBidi }) => {
   const [popup, readyState] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => {
@@ -79,8 +79,8 @@ it('should wait for load state of empty url popup', async ({ page, browserName }
     }),
   ]);
   await popup.waitForLoadState();
-  expect(readyState).toBe(browserName === 'firefox' ? 'uninitialized' : 'complete');
-  expect(await popup.evaluate(() => document.readyState)).toBe(browserName === 'firefox' ? 'uninitialized' : 'complete');
+  expect(readyState).toBe(browserName === 'firefox' && !isBidi ? 'uninitialized' : 'complete');
+  expect(await popup.evaluate(() => document.readyState)).toBe(browserName === 'firefox' && !isBidi ? 'uninitialized' : 'complete');
 });
 
 it('should wait for load state of about:blank popup ', async ({ page }) => {


### PR DESCRIPTION
Fixes the following tests:
- `library/permissions.spec.ts`:
  - "should deny permission when not listed" (with BiDi, permissions that were not granted remain in 'prompt' state instead of changing to 'denied')
  - "should fail when bad permission is given" (the error message is different with BiDi)
  - "should trigger permission onchange" (with BiDi, permissions that were not granted remain in 'prompt' state instead of changing to 'denied')
  - "should isolate permissions between browser contexts" (with BiDi, permissions that were not granted remain in 'prompt' state instead of changing to 'denied')
- `page/page-wait-for-load-state.spec.ts`:
  - "should wait for load state of empty url popup" (Firefox/BiDi behaves like other browsers, unlike Firefox/Juggler)

Skips the following tests:
- `library/download.spec.ts`:
  - "should be able to download a inline PDF file via navigation" (like headed Chromium, the file is shown in the PDF viewer instead of being downloaded)

Unskips the following tests:
- `library/capabilities.spec.ts`:
  - "should play video" (the Firefox issue seems to have been fixed)
- `page/page-focus.spec.ts`:
  - "clicking checkbox should activate it" (the test fails only in Safari)
