### PR TITLE
devops: render-release-notes link to github

### DIFF
--- a/utils/doclint/linkUtils.js
+++ b/utils/doclint/linkUtils.js
@@ -149,10 +149,16 @@ function renderJSSignature(args) {
  * @param {string} content
  * @param {string} languagePath
  * @param {string} relativePath
+ * @param {boolean} releaseNotesMode
  * @returns {string}
  */
-function renderPlaywrightDevLinks(content, languagePath, relativePath) {
+function renderPlaywrightDevLinks(content, languagePath, relativePath, releaseNotesMode = false) {
   return content.replace(/\[([^\]]+)\]\((\.[^\)]+)\)/g, (match, p1, p2) => {
+    if (releaseNotesMode && p2.includes('/images/')) {
+      const url = new URL(p2, `https://github.com/microsoft/playwright/blob/main/docs/src/`);
+      url.searchParams.set('raw', 'true');
+      return `[${p1}](${url.toString()})`;
+    }
     return `[${p1}](${new URL(p2.replace('.md', ''), `https://playwright.dev${languagePath}/docs${relativePath}/`).toString()})`;
   });
 }

--- a/utils/render_release_notes.mjs
+++ b/utils/render_release_notes.mjs
@@ -72,5 +72,5 @@ documentation.renderLinksInNodes(nodes);
     throw new Error(`Could not find version ${version} in release notes.\nUsage: node ${path.basename(process.argv[1])} <language> <version>\n\nWhere <version> is a version tag without v prefix, e.g. 1.45`);
 }
 
-const output = renderPlaywrightDevLinks(md.render(nodes), languageToRelativeDocsPath(language), '');
+const output = renderPlaywrightDevLinks(md.render(nodes), languageToRelativeDocsPath(language), '', true);
 process.stdout.write(output);


### PR DESCRIPTION
Without this, `node utils/render_release_notes.mjs js 1.58` outputs a broken image link.