### PR TITLE
test: unflake mcp cli tests

### DIFF
--- a/tests/config/commonFixtures.ts
+++ b/tests/config/commonFixtures.ts
@@ -208,9 +208,9 @@ export class TestChildProcess {
   async cleanExit() {
     const r = await this.exited;
     if (r.exitCode)
-      throw new Error(`Process failed with exit code ${r.exitCode}`);
+      throw new Error(`Process failed with exit code ${r.exitCode}. Output:\n${this.output}`);
     if (r.signal)
-      throw new Error(`Process received signal: ${r.signal}`);
+      throw new Error(`Process received signal: ${r.signal}. Output:\n${this.output}`);
   }
 
   async waitForOutput(substring: string, count = 1) {

--- a/tests/mcp/cli.spec.ts
+++ b/tests/mcp/cli.spec.ts
@@ -19,19 +19,19 @@ import { test, expect, eventsPage } from './cli-fixtures';
 test.skip(({}) => process.platform === 'win32');
 
 test.describe('help', () => {
-  test('prints help by default', async ({ cli }) => {
-    const { output } = await cli('--help');
+  test('prints help by default', async ({ cliNoDaemon }) => {
+    const output = await cliNoDaemon('--help');
     expect(output).toContain('Usage: playwright-cli <command>');
   });
 
-  test('prints command help', async ({ cli }) => {
-    const { output } = await cli('click', '--help');
+  test('prints command help', async ({ cliNoDaemon }) => {
+    const output = await cliNoDaemon('click', '--help');
     expect(output).toContain('playwright-cli click <ref> [button]');
   });
 });
 
 test.describe('core', () => {
-  test('open', async ({ cli, daemon, server }) => {
+  test('open', async ({ cli, server }) => {
     const { output, snapshot } = await cli('open', server.HELLO_WORLD);
     expect(output).toContain(`### Page
 - Page URL: ${server.HELLO_WORLD}
@@ -40,13 +40,13 @@ test.describe('core', () => {
     expect(snapshot).toContain(`- generic [active] [ref=e1]: Hello, world!`);
   });
 
-  test('close', async ({ cli, daemon, server }) => {
+  test('close', async ({ cli, server }) => {
     await cli('open', server.HELLO_WORLD);
     const { output } = await cli('close');
     expect(output).toContain(`No open tabs. Navigate to a URL to create one.`);
   });
 
-  test('click button', async ({ cli, daemon, server }) => {
+  test('click button', async ({ cli, server }) => {
     server.setContent('/', `<button>Submit</button>`, 'text/html');
 
     const { snapshot } = await cli('open', server.PREFIX);
@@ -56,7 +56,7 @@ test.describe('core', () => {
     expect(clickSnapshot).toBeTruthy();
   });
 
-  test('click link', async ({ cli, daemon, server }) => {
+  test('click link', async ({ cli, server }) => {
     server.setContent('/', `<a href="/hello-world">Hello, world!</a>`, 'text/html');
 
     const { snapshot } = await cli('open', server.PREFIX);
@@ -69,14 +69,14 @@ test.describe('core', () => {
     expect(clickSnapshot).toContain('Hello, world!');
   });
 
-  test('dblclick', async ({ cli, daemon, server }) => {
+  test('dblclick', async ({ cli, server }) => {
     server.setContent('/', eventsPage, 'text/html');
     await cli('open', server.PREFIX);
     const { snapshot } = await cli('dblclick', 'e2');
     expect(snapshot).toContain('dblclick 0');
   });
 
-  test('type', async ({ cli, daemon, server }) => {
+  test('type', async ({ cli, server }) => {
     server.setContent('/', `<input type=text>`, 'text/html');
     const { snapshot } = await cli('open', server.PREFIX);
     expect(snapshot).toContain(`- textbox [ref=e2]`);
@@ -85,7 +85,7 @@ test.describe('core', () => {
     expect(typeSnapshot).toBe(`- textbox [ref=e2]`);
   });
 
-  test('fill', async ({ cli, daemon, server }) => {
+  test('fill', async ({ cli, server }) => {
     server.setContent('/', `<input type=text>`, 'text/html');
     const { snapshot } = await cli('open', server.PREFIX);
     expect(snapshot).toContain(`- textbox [ref=e2]`);
@@ -94,7 +94,7 @@ test.describe('core', () => {
     expect(fillSnapshot).toBe(`- textbox [active] [ref=e2]: Hello, world!`);
   });
 
-  test('hover', async ({ cli, daemon, server }) => {
+  test('hover', async ({ cli, server }) => {
     server.setContent('/', eventsPage, 'text/html');
     await cli('open', server.PREFIX);
     await cli('hover', 'e2');
@@ -102,7 +102,7 @@ test.describe('core', () => {
     expect(snapshot).toContain('mouse move 50 50');
   });
 
-  test('select', async ({ cli, daemon, server }) => {
+  test('select', async ({ cli, server }) => {
     server.setContent('/', `<select><option value="1">One</option><option value="2">Two</option></select>`, 'text/html');
     await cli('open', server.PREFIX);
     await cli('select', 'e2', 'Two');
@@ -110,7 +110,7 @@ test.describe('core', () => {
     expect(snapshot).toContain('- option "Two" [selected]');
   });
 
-  test('check', async ({ cli, daemon, server }) => {
+  test('check', async ({ cli, server }) => {
     server.setContent('/', `<input type="checkbox">`, 'text/html');
     await cli('open', server.PREFIX);
     await cli('check', 'e2');
@@ -118,7 +118,7 @@ test.describe('core', () => {
     expect(snapshot).toContain('- checkbox [checked] [active] [ref=e2]');
   });
 
-  test('uncheck', async ({ cli, daemon, server }) => {
+  test('uncheck', async ({ cli, server }) => {
     server.setContent('/', `<input type="checkbox" checked>`, 'text/html');
     await cli('open', server.PREFIX);
     await cli('uncheck', 'e2');
@@ -126,20 +126,20 @@ test.describe('core', () => {
     expect(snapshot).toContain('- checkbox [active] [ref=e2]');
   });
 
-  test('eval', async ({ cli, daemon, server }) => {
+  test('eval', async ({ cli, server }) => {
     await cli('open', server.HELLO_WORLD);
     const { output } = await cli('eval', '() => document.title');
     expect(output).toContain('"Title"');
   });
 
-  test('eval <ref>', async ({ cli, daemon, server }) => {
+  test('eval <ref>', async ({ cli, server }) => {
     server.setContent('/', `<button>Submit</button>`, 'text/html');
     await cli('open', server.PREFIX);
     const { output } = await cli('eval', 'element => element.nodeName', 'e2');
     expect(output).toContain('"BUTTON"');
   });
 
-  test('dialog-accept', async ({ cli, daemon, server }) => {
+  test('dialog-accept', async ({ cli, server }) => {
     server.setContent('/', `<button onclick="alert('MyAlert')">Button</button>`, 'text/html');
     await cli('open', server.PREFIX);
     const { output } = await cli('click', 'e2');
@@ -149,7 +149,7 @@ test.describe('core', () => {
     expect(snapshot).not.toContain('MyAlert');
   });
 
-  test('dialog-dismiss', async ({ cli, daemon, server }) => {
+  test('dialog-dismiss', async ({ cli, server }) => {
     server.setContent('/', `<button onclick="alert('MyAlert')">Button</button>`, 'text/html');
     await cli('open', server.PREFIX);
     const { output } = await cli('click', 'e2');
@@ -159,7 +159,7 @@ test.describe('core', () => {
     expect(snapshot).not.toContain('MyAlert');
   });
 
-  test('dialog-accept <prompt>', async ({ cli, daemon, server }) => {
+  test('dialog-accept <prompt>', async ({ cli, server }) => {
     server.setContent('/', `<button onclick="document.body.textContent = prompt('MyAlert')">Button</button>`, 'text/html');
     await cli('open', server.PREFIX);
     await cli('click', 'e2');
@@ -168,7 +168,7 @@ test.describe('core', () => {
     expect(snapshot).toContain('my reply');
   });
 
-  test('resize', async ({ cli, daemon, server }) => {
+  test('resize', async ({ cli, server }) => {
     await cli('open', server.PREFIX);
     await cli('resize', '480', '320');
     const { output } = await cli('eval', '() => window.innerWidth + "x" + window.innerHeight');
@@ -177,7 +177,7 @@ test.describe('core', () => {
 });
 
 test.describe('navigation', () => {
-  test('go-back', async ({ cli, daemon, server }) => {
+  test('go-back', async ({ cli, server }) => {
     await cli('open', server.HELLO_WORLD);
     await cli('open', server.PREFIX);
     const { output } = await cli('go-back');
@@ -186,7 +186,7 @@ test.describe('navigation', () => {
 - Page Title: Title`);
   });
 
-  test('go-forward', async ({ cli, daemon, server }) => {
+  test('go-forward', async ({ cli, server }) => {
     await cli('open', server.PREFIX);
     await cli('open', server.HELLO_WORLD);
     await cli('go-back');
@@ -198,7 +198,7 @@ test.describe('navigation', () => {
 });
 
 test.describe('keyboard', () => {
-  test('key-press', async ({ cli, daemon, server }) => {
+  test('key-press', async ({ cli, server }) => {
     server.setContent('/', `<input type=text>`, 'text/html');
     await cli('open', server.PREFIX);
     await cli('click', 'e2');
@@ -207,7 +207,7 @@ test.describe('keyboard', () => {
     expect(snapshot).toBe(`- textbox [active] [ref=e2]: h`);
   });
 
-  test('key-down key-up', async ({ cli, daemon, server }) => {
+  test('key-down key-up', async ({ cli, server }) => {
     server.setContent('/', `<input type=text>`, 'text/html');
     await cli('open', server.PREFIX);
     await cli('click', 'e2');
@@ -219,7 +219,7 @@ test.describe('keyboard', () => {
 });
 
 test.describe('mouse', () => {
-  test('mouse-move', async ({ cli, daemon, server }) => {
+  test('mouse-move', async ({ cli, server }) => {
     server.setContent('/', eventsPage, 'text/html');
     await cli('open', server.PREFIX);
     await cli('mouse-move', '45', '35');
@@ -227,7 +227,7 @@ test.describe('mouse', () => {
     expect(snapshot).toContain('mouse move 45 35');
   });
 
-  test('mouse-down mouse-up', async ({ cli, daemon, server }) => {
+  test('mouse-down mouse-up', async ({ cli, server }) => {
     server.setContent('/', eventsPage, 'text/html');
     await cli('open', server.PREFIX);
     await cli('mouse-move', '45', '35');
@@ -238,7 +238,7 @@ test.describe('mouse', () => {
     expect(snapshot).toContain('mouse up');
   });
 
-  test('mouse-wheel', async ({ cli, daemon, server }) => {
+  test('mouse-wheel', async ({ cli, server }) => {
     server.setContent('/', eventsPage, 'text/html');
     await cli('open', server.PREFIX);
     await cli('mouse-wheel', '10', '5');
@@ -249,14 +249,14 @@ test.describe('mouse', () => {
 
 
 test.describe('save as', () => {
-  test('screenshot', async ({ cli, daemon, server, mcpBrowser }) => {
+  test('screenshot', async ({ cli, server, mcpBrowser }) => {
     await cli('open', server.HELLO_WORLD);
     const { attachments } = await cli('screenshot');
     expect(attachments[0].name).toEqual('Screenshot of viewport');
     expect(attachments[0].data).toEqual(expect.any(Buffer));
   });
 
-  test('screenshot <ref>', async ({ cli, daemon, server, mcpBrowser }) => {
+  test('screenshot <ref>', async ({ cli, server, mcpBrowser }) => {
     server.setContent('/', `<div id="square" style="width: 100px; height: 100px; background-color: red;"></div>`, 'text/html');
     await cli('open', server.PREFIX);
     const { attachments } = await cli('screenshot', 'e2');
@@ -264,14 +264,14 @@ test.describe('save as', () => {
     expect(attachments[0].data).toEqual(expect.any(Buffer));
   });
 
-  test('screenshot --full-page', async ({ cli, daemon, server, mcpBrowser }) => {
+  test('screenshot --full-page', async ({ cli, server, mcpBrowser }) => {
     await cli('open', server.HELLO_WORLD);
     const { attachments } = await cli('screenshot', '--full-page');
     expect(attachments[0].name).toEqual('Screenshot of full page');
     expect(attachments[0].data).toEqual(expect.any(Buffer));
   });
 
-  test('pdf', async ({ cli, daemon, server, mcpBrowser }) => {
+  test('pdf', async ({ cli, server, mcpBrowser }) => {
     test.skip(mcpBrowser !== 'chromium' && mcpBrowser !== 'chrome', 'PDF is only supported in Chromium and Chrome');
     await cli('open', server.HELLO_WORLD);
     const { attachments } = await cli('pdf');
@@ -281,7 +281,7 @@ test.describe('save as', () => {
 });
 
 test.describe('devtools', () => {
-  test('console', async ({ cli, daemon, server }) => {
+  test('console', async ({ cli, server }) => {
     await cli('open', server.PREFIX);
     await cli('eval', 'console.log("Hello, world!")');
     const { attachments } = await cli('console');
@@ -289,7 +289,7 @@ test.describe('devtools', () => {
     expect(attachments[0].data.toString()).toContain('Hello, world!');
   });
 
-  test('console error', async ({ cli, daemon, server }) => {
+  test('console error', async ({ cli, server }) => {
     await cli('open', server.PREFIX);
     await cli('eval', 'console.log("log-level")');
     await cli('eval', 'console.error("error-level")');
@@ -299,7 +299,7 @@ test.describe('devtools', () => {
     expect(attachments[0].data.toString()).toContain('error-level');
   });
 
-  test('console --clear', async ({ cli, daemon, server }) => {
+  test('console --clear', async ({ cli, server }) => {
     await cli('open', server.PREFIX);
     await cli('eval', 'console.log("log-level")');
     await cli('console', '--clear');
@@ -308,7 +308,7 @@ test.describe('devtools', () => {
     expect(attachments[0].data.toString()).not.toContain('log-level');
   });
 
-  test('network', async ({ cli, daemon, server }) => {
+  test('network', async ({ cli, server }) => {
     await cli('open', server.PREFIX);
     await cli('eval', '() => fetch("/hello-world")');
     const { attachments } = await cli('network');
@@ -317,14 +317,14 @@ test.describe('devtools', () => {
     expect(attachments[0].data.toString()).toContain(`[GET] ${`${server.PREFIX}/hello-world`} => [200] OK`);
   });
 
-  test('network --static', async ({ cli, daemon, server }) => {
+  test('network --static', async ({ cli, server }) => {
     await cli('open', server.PREFIX);
     const { attachments } = await cli('network', '--static');
     expect(attachments[0].name).toEqual('Network');
     expect(attachments[0].data.toString()).toContain(`[GET] ${`${server.PREFIX}/`} => [200] OK`);
   });
 
-  test('network --clear', async ({ cli, daemon, server }) => {
+  test('network --clear', async ({ cli, server }) => {
     await cli('open', server.PREFIX);
     await cli('eval', '() => fetch("/hello-world")');
     await cli('network', '--clear');
@@ -333,13 +333,13 @@ test.describe('devtools', () => {
     expect(attachments[0].data.toString()).not.toContain(`[GET] ${`${server.PREFIX}/hello-world`} => [200] OK`);
   });
 
-  test('run-code', async ({ cli, daemon, server }) => {
+  test('run-code', async ({ cli, server }) => {
     await cli('open', server.HELLO_WORLD);
     const { output } = await cli('run-code', '() => page.title()');
     expect(output).toContain('"Title"');
   });
 
-  test('tracing-start-stop', async ({ cli, daemon, server }) => {
+  test('tracing-start-stop', async ({ cli, server }) => {
     await cli('open', server.HELLO_WORLD);
     const { output } = await cli('tracing-start');
     expect(output).toContain('Tracing started, saving to');

--- a/tests/mcp/fixtures.ts
+++ b/tests/mcp/fixtures.ts
@@ -26,7 +26,9 @@ import { ListRootsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { TestServer } from '../config/testserver';
 import { serverFixtures } from '../config/serverFixtures';
 import { parseResponse } from '../../packages/playwright/lib/mcp/browser/response';
+import { commonFixtures } from '../config/commonFixtures';
 
+import type { CommonFixtures, CommonWorkerFixtures } from '../config/commonFixtures';
 import type { Config } from '../../packages/playwright/src/mcp/config';
 import type { BrowserContext } from 'playwright';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
@@ -74,7 +76,9 @@ type WorkerFixtures = {
   _workerServers: { server: TestServer, httpsServer: TestServer };
 };
 
-export const serverTest = baseTest.extend<ServerFixtures, ServerWorkerOptions>(serverFixtures);
+export const serverTest = baseTest
+    .extend<CommonFixtures, CommonWorkerFixtures>(commonFixtures)
+    .extend<ServerFixtures, ServerWorkerOptions>(serverFixtures);
 
 export const test = serverTest.extend<TestFixtures & TestOptions, WorkerFixtures>({
   mcpArgs: [undefined, { option: true }],


### PR DESCRIPTION
- Make `cli` depend on `daemon`.
- Use `childProcess` fixture to avoid zombies.