### PR TITLE
feat(storageState): handle Float16Array values

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/utilityScriptSerializers.ts
+++ b/packages/playwright-core/src/utils/isomorphic/utilityScriptSerializers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-type TypedArrayKind = 'i8' | 'ui8' | 'ui8c' | 'i16' | 'ui16' | 'i32' | 'ui32' | 'f32' | 'f64' | 'bi64' | 'bui64';
+type TypedArrayKind = 'i8' | 'ui8' | 'ui8c' | 'i16' | 'ui16' | 'i32' | 'ui32' | 'f16' | 'f32' | 'f64' | 'bi64' | 'bui64';
 
 export type SerializedValue =
     undefined | boolean | number | string |
@@ -86,7 +86,7 @@ const typedArrayConstructors: Record<TypedArrayKind, Function> = {
   ui16: Uint16Array,
   i32: Int32Array,
   ui32: Uint32Array,
-  // TODO: add Float16Array once it's in baseline
+  f16: Float16Array,
   f32: Float32Array,
   f64: Float64Array,
   bi64: BigInt64Array,

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -103,6 +103,7 @@ it('should transfer typed arrays', async ({ page }) => {
     new Uint16Array([1, 2, 3]),
     new Int32Array([1, 2, 3]),
     new Uint32Array([1, 2, 3]),
+    new Float16Array([1.1, 2.2, 3.3]),
     new Float32Array([1.1, 2.2, 3.3]),
     new Float64Array([1.1, 2.2, 3.3]),
     new BigInt64Array([1n, 2n, 3n]),


### PR DESCRIPTION
Enables (de)serialization of Float16Array values in Storage State captures of IndexedDB records, since [it's Baseline 2025](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array#browser_compatibility)

See https://github.com/microsoft/playwright/pull/38923#issuecomment-3790562382