### PR TITLE
fix(mcp): propagate abort signal to stop test execution

### DIFF
--- a/packages/playwright/src/mcp/sdk/server.ts
+++ b/packages/playwright/src/mcp/sdk/server.ts
@@ -45,7 +45,7 @@ export type ProgressCallback = (params: ProgressParams) => void;
 export interface ServerBackend {
   initialize?(clientInfo: ClientInfo): Promise<void>;
   listTools(): Promise<Tool[]>;
-  callTool(name: string, args: CallToolRequest['params']['arguments'], progress: ProgressCallback): Promise<CallToolResult>;
+  callTool(name: string, args: CallToolRequest['params']['arguments'], progress: ProgressCallback, signal?: AbortSignal): Promise<CallToolResult>;
   serverClosed?(server: Server): void;
   onBrowserContextClosed?: (() => void) | undefined;
 }
@@ -112,7 +112,7 @@ export function createServer(name: string, version: string, backend: ServerBacke
       if (!initializePromise)
         initializePromise = initializeServer(server, backend, runHeartbeat);
       await initializePromise;
-      const toolResult = await backend.callTool(request.params.name, request.params.arguments || {}, progress);
+      const toolResult = await backend.callTool(request.params.name, request.params.arguments || {}, progress, extra.signal);
       const mergedResult = mergeTextParts(toolResult);
       serverDebugResponse('callResult', mergedResult);
       return mergedResult;

--- a/packages/playwright/src/mcp/test/generatorTools.ts
+++ b/packages/playwright/src/mcp/test/generatorTools.ts
@@ -34,10 +34,10 @@ export const setupPage = defineTestTool({
     type: 'readOnly',
   },
 
-  handle: async (context, params) => {
+  handle: async (context, params, signal) => {
     const seed = await context.getOrCreateSeedFile(params.seedFile, params.project);
     context.generatorJournal = new GeneratorJournal(context.rootPath, params.plan, seed);
-    const { output, status } = await context.runSeedTest(seed.file, seed.projectName);
+    const { output, status } = await context.runSeedTest(seed.file, seed.projectName, signal);
     return { content: [{ type: 'text', text: output }], isError: status !== 'paused' };
   },
 });

--- a/packages/playwright/src/mcp/test/plannerTools.ts
+++ b/packages/playwright/src/mcp/test/plannerTools.ts
@@ -32,9 +32,9 @@ export const setupPage = defineTestTool({
     type: 'readOnly',
   },
 
-  handle: async (context, params) => {
+  handle: async (context, params, signal) => {
     const seed = await context.getOrCreateSeedFile(params.seedFile, params.project);
-    const { output, status } = await context.runSeedTest(seed.file, seed.projectName);
+    const { output, status } = await context.runSeedTest(seed.file, seed.projectName, signal);
     return { content: [{ type: 'text', text: output }], isError: status !== 'paused' };
   },
 });

--- a/packages/playwright/src/mcp/test/testBackend.ts
+++ b/packages/playwright/src/mcp/test/testBackend.ts
@@ -58,12 +58,12 @@ export class TestServerBackend implements mcp.ServerBackend {
     return this._tools.map(tool => mcp.toMcpTool(tool.schema));
   }
 
-  async callTool(name: string, args: mcp.CallToolRequest['params']['arguments']): Promise<mcp.CallToolResult> {
+  async callTool(name: string, args: mcp.CallToolRequest['params']['arguments'], _progress: mcp.ProgressCallback, signal: AbortSignal): Promise<mcp.CallToolResult> {
     const tool = this._tools.find(tool => tool.schema.name === name);
     if (!tool)
       throw new Error(`Tool not found: ${name}. Available tools: ${this._tools.map(tool => tool.schema.name).join(', ')}`);
     try {
-      return await tool.handle(this._context!, tool.schema.inputSchema.parse(args || {}));
+      return await tool.handle(this._context!, tool.schema.inputSchema.parse(args || {}), signal);
     } catch (e) {
       return { content: [{ type: 'text', text: String(e) }], isError: true };
     }

--- a/packages/playwright/src/mcp/test/testTool.ts
+++ b/packages/playwright/src/mcp/test/testTool.ts
@@ -21,7 +21,7 @@ import type { ToolSchema } from '../sdk/tool.js';
 
 export type TestTool<Input extends z.Schema = z.Schema> = {
   schema: ToolSchema<Input>;
-  handle: (context: TestContext, params: z.output<Input>) => Promise<CallToolResult>;
+  handle: (context: TestContext, params: z.output<Input>, signal: AbortSignal) => Promise<CallToolResult>;
 };
 
 export function defineTestTool<Input extends z.Schema>(tool: TestTool<Input>): TestTool<Input> {

--- a/packages/playwright/src/mcp/test/testTools.ts
+++ b/packages/playwright/src/mcp/test/testTools.ts
@@ -47,12 +47,12 @@ export const runTests = defineTestTool({
     type: 'readOnly',
   },
 
-  handle: async (context, params) => {
+  handle: async (context, params, signal) => {
     const { output } = await context.runTestsWithGlobalSetupAndPossiblePause({
       locations: params.locations ?? [],
       projects: params.projects,
       disableConfigReporters: true,
-    });
+    }, signal);
     return { content: [{ type: 'text', text: output }] };
   },
 });
@@ -71,7 +71,7 @@ export const debugTest = defineTestTool({
     type: 'readOnly',
   },
 
-  handle: async (context, params) => {
+  handle: async (context, params, signal) => {
     const { output, status } = await context.runTestsWithGlobalSetupAndPossiblePause({
       headed: context.computedHeaded,
       locations: [], // we can make this faster by passing the test's location, so we don't need to scan all tests to find the ID
@@ -82,7 +82,7 @@ export const debugTest = defineTestTool({
       pauseOnError: true,
       disableConfigReporters: true,
       actionTimeout: 5000,
-    });
+    }, signal);
     return { content: [{ type: 'text', text: output }], isError: status !== 'paused' && status !== 'passed' };
   },
 });


### PR DESCRIPTION
When an MCP tool call is aborted (e.g., user cancels in Claude Code or another MCP client), the abort signal from the MCP SDK was not being propagated to the test runner, causing tests to continue running even after the call was cancelled.

This change:
- Adds `signal: AbortSignal` parameter to `ServerBackend.callTool`
- Passes `extra.signal` from MCP SDK request handler to backends
- Listens for abort signal in `runTestsWithGlobalSetupAndPossiblePause` and calls `testRunner.stopTests()` when aborted
- Updates all test tool handlers to accept and pass the signal

Fixes https://github.com/microsoft/playwright/issues/38937