### PR TITLE
todomvc-test: fix dotenv dependency and verbosity

### DIFF
--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.38.0"
+    "@playwright/test": "^1.38.0",
+    "dotenv": "^17.2.3"
   }
 }

--- a/examples/todomvc/playwright.config.ts
+++ b/examples/todomvc/playwright.config.ts
@@ -3,7 +3,7 @@
 import { defineConfig, devices } from '@playwright/test';
 import dotenv from 'dotenv';
 
-dotenv.config();
+dotenv.config({ quiet: true });
 
 /**
  * See https://playwright.dev/docs/test-configuration.


### PR DESCRIPTION
This patch adds missing dotenv dependency to todomvc-test, and sets `quiet: true` when loading dotenv config, otherwise dotenv spams the terminal with emojis and tips that completely destroys the list reporter.