### PR TITLE
feat(mcp): support wildcard port in allowedOrigins and blockedOrigins

### DIFF
--- a/packages/playwright/src/mcp/browser/context.ts
+++ b/packages/playwright/src/mcp/browser/context.ts
@@ -277,11 +277,9 @@ function allRootPaths(clientInfo: ClientInfo): string[] {
 
 function originOrHostGlob(originOrHost: string) {
   // Support wildcard port patterns like "http://localhost:*" or "https://example.com:*"
-  const wildcardPortMatch = originOrHost.match(/^(https?):\/\/([^/:]+):\*$/);
-  if (wildcardPortMatch) {
-    const [, protocol, hostname] = wildcardPortMatch;
-    return `${protocol}://${hostname}:*/**`;
-  }
+  const wildcardPortMatch = originOrHost.match(/^(https?:\/\/[^/:]+):\*$/);
+  if (wildcardPortMatch)
+    return `${wildcardPortMatch[1]}:*/**`;
 
   try {
     const url = new URL(originOrHost);

--- a/packages/playwright/src/mcp/browser/context.ts
+++ b/packages/playwright/src/mcp/browser/context.ts
@@ -276,6 +276,13 @@ function allRootPaths(clientInfo: ClientInfo): string[] {
 
 
 function originOrHostGlob(originOrHost: string) {
+  // Support wildcard port patterns like "http://localhost:*" or "https://example.com:*"
+  const wildcardPortMatch = originOrHost.match(/^(https?):\/\/([^/:]+):\*$/);
+  if (wildcardPortMatch) {
+    const [, protocol, hostname] = wildcardPortMatch;
+    return `${protocol}://${hostname}:*/**`;
+  }
+
   try {
     const url = new URL(originOrHost);
     // localhost:1234 will parse as protocol 'localhost:' and 'null' origin.

--- a/packages/playwright/src/mcp/config.d.ts
+++ b/packages/playwright/src/mcp/config.d.ts
@@ -172,11 +172,21 @@ export type Config = {
   network?: {
     /**
      * List of origins to allow the browser to request. Default is to allow all. Origins matching both `allowedOrigins` and `blockedOrigins` will be blocked.
+     *
+     * Supported formats:
+     * - Full origin: `https://example.com` - matches only that origin
+     * - Hostname only: `example.com` - matches any protocol on that host
+     * - Wildcard port: `http://localhost:*` - matches any port on localhost with http protocol
      */
     allowedOrigins?: string[];
 
     /**
      * List of origins to block the browser to request. Origins matching both `allowedOrigins` and `blockedOrigins` will be blocked.
+     *
+     * Supported formats:
+     * - Full origin: `https://example.com` - matches only that origin
+     * - Hostname only: `example.com` - matches any protocol on that host
+     * - Wildcard port: `http://localhost:*` - matches any port on localhost with http protocol
      */
     blockedOrigins?: string[];
   };

--- a/packages/playwright/src/mcp/config.d.ts
+++ b/packages/playwright/src/mcp/config.d.ts
@@ -174,8 +174,7 @@ export type Config = {
      * List of origins to allow the browser to request. Default is to allow all. Origins matching both `allowedOrigins` and `blockedOrigins` will be blocked.
      *
      * Supported formats:
-     * - Full origin: `https://example.com` - matches only that origin
-     * - Hostname only: `example.com` - matches any protocol on that host
+     * - Full origin: `https://example.com:8080` - matches only that origin
      * - Wildcard port: `http://localhost:*` - matches any port on localhost with http protocol
      */
     allowedOrigins?: string[];
@@ -184,8 +183,7 @@ export type Config = {
      * List of origins to block the browser to request. Origins matching both `allowedOrigins` and `blockedOrigins` will be blocked.
      *
      * Supported formats:
-     * - Full origin: `https://example.com` - matches only that origin
-     * - Hostname only: `example.com` - matches any protocol on that host
+     * - Full origin: `https://example.com:8080` - matches only that origin
      * - Wildcard port: `http://localhost:*` - matches any port on localhost with http protocol
      */
     blockedOrigins?: string[];


### PR DESCRIPTION
## Summary

Add support for wildcard port syntax like `http://localhost:*` in the `network.allowedOrigins` and `network.blockedOrigins` config options. This allows restricting browser requests to a specific protocol and hostname while accepting any port number.

Fixes microsoft/playwright-mcp#1337

## Changes

- **`packages/playwright/src/mcp/browser/context.ts`**: Update `originOrHostGlob()` to detect wildcard port patterns and generate the correct glob pattern
- **`packages/playwright/src/mcp/config.d.ts`**: Document supported origin formats in JSDoc
- **`tests/mcp/request-blocking.spec.ts`**: Add 4 tests for wildcard port functionality

## Problem

Previously, patterns like `http://localhost:*` would fail to parse as a valid URL, causing the code to fall through to legacy host-only mode and generate an invalid glob pattern like `*://http://localhost:*/**` which never matches anything.

## Solution

Detect wildcard port patterns with regex before attempting URL parsing:

```typescript
const wildcardPortMatch = originOrHost.match(/^(https?):\/\/([^/:]+):\*$/);
if (wildcardPortMatch) {
  const [, protocol, hostname] = wildcardPortMatch;
  return `${protocol}://${hostname}:*/**`;
}
```

| Input | Previous Output | New Output |
|-------|----------------|------------|
| `http://localhost:*` | `*://http://localhost:*/**` ❌ | `http://localhost:*/**` ✅ |
| `https://example.com:*` | `*://https://example.com:*/**` ❌ | `https://example.com:*/**` ✅ |
| `http://localhost:8000` | `http://localhost:8000/**` | (unchanged) |
| `localhost` | `*://localhost/**` | (unchanged) |

## Use Case

This is useful when you want to:
- Allow only HTTP (not HTTPS) traffic to localhost
- Allow localhost on any port while blocking other hosts
- Have more granular control over protocol while keeping port flexibility