### PR TITLE
fix(fixtures): prevent a fixture named "then" from being awaited

### DIFF
--- a/packages/playwright/src/worker/fixtureRunner.ts
+++ b/packages/playwright/src/worker/fixtureRunner.ts
@@ -228,7 +228,7 @@ export class FixtureRunner {
       throw firstError;
   }
 
-  async resolveParametersForFunction(fn: Function, testInfo: TestInfoImpl, autoFixtures: 'worker' | 'test' | 'all-hooks-only', runnable: RunnableDescription): Promise<object | null> {
+  async resolveParametersForFunction(fn: Function, testInfo: TestInfoImpl, autoFixtures: 'worker' | 'test' | 'all-hooks-only', runnable: RunnableDescription): Promise<{ result: object } | null> {
     const collector = new Set<FixtureRegistration>();
 
     // Collect automatic fixtures.
@@ -264,7 +264,8 @@ export class FixtureRunner {
         return null;
       params[name] = fixture.value;
     }
-    return params;
+    // Wrap in an object to avoid returning a thenable if a fixture is named 'then'.
+    return { result: params };
   }
 
   async resolveParametersAndRunFunction(fn: Function, testInfo: TestInfoImpl, autoFixtures: 'worker' | 'test' | 'all-hooks-only', runnable: RunnableDescription) {
@@ -273,7 +274,7 @@ export class FixtureRunner {
       // Do not run the function when fixture setup has already failed.
       return null;
     }
-    await testInfo._runWithTimeout(runnable, () => fn(params, testInfo));
+    await testInfo._runWithTimeout(runnable, () => fn(params.result, testInfo));
   }
 
   private async _setupFixtureForRegistration(registration: FixtureRegistration, testInfo: TestInfoImpl, runnable: RunnableDescription): Promise<Fixture> {

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -391,7 +391,10 @@ export class WorkerMain extends ProcessRunner {
         await this._runEachHooksForSuites(suites, 'beforeEach', testInfo);
 
         // Setup fixtures required by the test.
-        testFunctionParams = await this._fixtureRunner.resolveParametersForFunction(test.fn, testInfo, 'test', { type: 'test' });
+        const params = await this._fixtureRunner.resolveParametersForFunction(test.fn, testInfo, 'test', { type: 'test' });
+        if (params !== null)
+          testFunctionParams = params.result;
+
       });
 
       if (testFunctionParams === null) {

--- a/tests/playwright-test/fixtures.spec.ts
+++ b/tests/playwright-test/fixtures.spec.ts
@@ -834,3 +834,19 @@ test('should error if use is not called', async ({ runInlineTest }) => {
   expect(result.failed).toBe(1);
   expect(result.output).toContain(`use() was not called in fixture "fixture"`);
 });
+
+test('should not treat fixtures as thenable promise', async ({ runInlineTest }) => {
+  const { results } = await runInlineTest({
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        then: async ({}, use) => await use(() => 'test-function'),
+      });
+
+      test('should not treat fixtures as thenable promise', async ({ then }) => {
+        expect(typeof then).toBe('function');
+      });
+    `,
+  });
+  expect(results[0].status).toBe('passed');
+});


### PR DESCRIPTION
Fixes an issue where a fixture named `then` with a function value would make the entire test parameters object be incorrectly treated as a Promise by async/await, causing unexpected behaviour of the test runner.

The fix changes the internal representation of test parameters (the resolved fixtures) from a plain object to a Map, which is converted to an object only when passed to the test function. This prevents the name and type of fixtures from having any impact on the test runner's behaviour.

Fixes #38828 