### PR TITLE
fix: don't parse file names for tags

### DIFF
--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -143,10 +143,10 @@ export class Suite extends Base {
   }
 
   _collectTagTitlePath(path: string[]) {
+    this.parent?._collectTagTitlePath(path);
     // Only collect titles from describe blocks for tag extraction.
-    // Skip file/project/root titles to avoid parsing file names as tags.
-    if (this.parent?._type === 'describe')
-      this.parent._collectTagTitlePath(path);
+    // Skip root/project/file titles to avoid parsing file names as tags.
+    // Note that file suite may have explicit global tags as well.
     if (this._type === 'describe')
       path.push(this.title);
     path.push(...this._tags);
@@ -299,12 +299,10 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   }
 
   get tags(): string[] {
-    // Only extract inline tags from describe blocks and test title, not from file/project/root titles.
     const path: string[] = [];
     this.parent._collectTagTitlePath(path);
     path.push(this.title);
     const titleTags = path.join(' ').match(/@[\S]+/g) || [];
-
     return [
       ...titleTags,
       ...this._tags,

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -142,6 +142,16 @@ export class Suite extends Base {
     path.push(...this._tags);
   }
 
+  _collectTagTitlePath(path: string[]) {
+    // Only collect titles from describe blocks for tag extraction.
+    // Skip file/project/root titles to avoid parsing file names as tags.
+    if (this.parent?._type === 'describe')
+      this.parent._collectTagTitlePath(path);
+    if (this._type === 'describe')
+      path.push(this.title);
+    path.push(...this._tags);
+  }
+
   _getOnlyItems(): (TestCase | Suite)[] {
     const items: (TestCase | Suite)[] = [];
     if (this._only)
@@ -289,7 +299,11 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   }
 
   get tags(): string[] {
-    const titleTags = this._grepBaseTitlePath().join(' ').match(/@[\S]+/g) || [];
+    // Only extract inline tags from describe blocks and test title, not from file/project/root titles.
+    const path: string[] = [];
+    this.parent._collectTagTitlePath(path);
+    path.push(this.title);
+    const titleTags = path.join(' ').match(/@[\S]+/g) || [];
 
     return [
       ...titleTags,


### PR DESCRIPTION
File names containing @ symbols (e.g., @sample.test.ts) were incorrectly being treated as tags. Now only extract inline tags from describe block titles and test titles, not from file/project/root suite titles.

Fixes #38946