### PR TITLE
fix(ct): detect React import after closing brace in minified code

### DIFF
--- a/packages/playwright-ct-core/src/viteUtils.ts
+++ b/packages/playwright-ct-core/src/viteUtils.ts
@@ -164,7 +164,7 @@ export function hasJSComponents(components: ImportInfo[]): boolean {
   return false;
 }
 
-const importReactRE = /(^|\n|;)import\s+(\*\s+as\s+)?React(,|\s+)/;
+const importReactRE = /(^|[\n;}\])])import\s+(\*\s+as\s+)?React(,|\s+)/;
 const compiledReactRE = /(const|var)\s+React\s*=/;
 const runtimeImportRequire = /import\(['"`]react['"`]\)|require\(['"`]react['"`]\)/i;
 


### PR DESCRIPTION
The importReactRE regex now matches import statements preceded by }, ], or ) in addition to start of file, newline, or semicolon. This fixes builds with minified libraries like react-tabs that have patterns like `}import React from"react"`.

Fixes #38906