### PR TITLE
feat(mcp): add browser_set_checked tool

### DIFF
--- a/packages/playwright/src/mcp/browser/tools/snapshot.ts
+++ b/packages/playwright/src/mcp/browser/tools/snapshot.ts
@@ -215,6 +215,33 @@ const uncheck = defineTabTool({
   },
 });
 
+const setCheckedSchema = elementSchema.extend({
+  checked: z.boolean().describe('Whether the checkbox or radio button should be checked'),
+});
+
+const setChecked = defineTabTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_set_checked',
+    title: 'Check or uncheck',
+    description: 'Set the checked state of a checkbox or radio button',
+    inputSchema: setCheckedSchema,
+    type: 'input',
+  },
+
+  handle: async (tab, params, response) => {
+    response.setIncludeSnapshot();
+
+    const { locator, resolved } = await tab.refLocator(params);
+    response.addCode(`await page.${resolved}.setChecked(${params.checked});`);
+
+    await tab.waitForCompletion(async () => {
+      await locator.setChecked(params.checked);
+    });
+  },
+});
+
 export default [
   snapshot,
   click,
@@ -224,4 +251,5 @@ export default [
   pickLocator,
   check,
   uncheck,
+  setChecked,
 ];

--- a/tests/mcp/set-checked.spec.ts
+++ b/tests/mcp/set-checked.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures';
+
+test('browser_set_checked (checkbox)', async ({ client, server }) => {
+  server.setContent('/', `
+    <title>Checkbox Test</title>
+    <label>
+      <input type="checkbox" id="terms" />
+      Accept terms
+    </label>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  // Check the checkbox
+  expect(await client.callTool({
+    name: 'browser_set_checked',
+    arguments: {
+      element: 'Accept terms checkbox',
+      ref: 'e2',
+      checked: true,
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining('.setChecked(true)'),
+    snapshot: expect.stringContaining('[checked]'),
+  });
+
+  // Uncheck the checkbox
+  expect(await client.callTool({
+    name: 'browser_set_checked',
+    arguments: {
+      element: 'Accept terms checkbox',
+      ref: 'e2',
+      checked: false,
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining('.setChecked(false)'),
+  });
+});
+
+test('browser_set_checked (radio button)', async ({ client, server }) => {
+  server.setContent('/', `
+    <title>Radio Test</title>
+    <input type="radio" name="color" id="red" />
+    <label for="red">Red</label>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  // Select the Red radio button
+  expect(await client.callTool({
+    name: 'browser_set_checked',
+    arguments: {
+      element: 'Red radio button',
+      ref: 'e2',
+      checked: true,
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining('.setChecked(true)'),
+    snapshot: expect.stringContaining('[checked]'),
+  });
+});
+
+test('browser_set_checked (already checked)', async ({ client, server }) => {
+  server.setContent('/', `
+    <title>Pre-checked Test</title>
+    <label>
+      <input type="checkbox" id="newsletter" checked />
+      Subscribe to newsletter
+    </label>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  // Verify already checked
+  let response = await client.callTool({
+    name: 'browser_snapshot',
+    arguments: {},
+  });
+  expect(response).toHaveResponse({
+    snapshot: expect.stringContaining('[checked]'),
+  });
+
+  // Uncheck it
+  expect(await client.callTool({
+    name: 'browser_set_checked',
+    arguments: {
+      element: 'Subscribe checkbox',
+      ref: 'e2',
+      checked: false,
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining('.setChecked(false)'),
+  });
+
+  // Verify unchecked - the snapshot should not contain [checked] for this element
+  response = await client.callTool({
+    name: 'browser_snapshot',
+    arguments: {},
+  });
+  expect(response).toHaveResponse({
+    snapshot: expect.not.stringContaining('[checked]'),
+  });
+});


### PR DESCRIPTION
## Description

Adds a new `browser_set_checked` MCP tool that allows setting the checked state of checkboxes and radio buttons.

### What does this PR do?

- Adds `browser_set_checked` tool in `packages/playwright/src/mcp/browser/tools/snapshot.ts`
- The tool accepts:
  - `element`: Human-readable element description
  - `ref`: Exact target element reference from the page snapshot  
  - `checked`: Boolean to set the checked state (true/false)
- Generates Playwright code like `await page.getByRole('checkbox', { name: 'Accept' }).setChecked(true);`
- Includes snapshot in response for verification

### Why is this needed?

The existing `browser_check` and `browser_uncheck` tools are marked as `skillOnly: true` (not exposed to MCP). This new tool provides a single interface to both check and uncheck elements, which is the expected API for LLM agents interacting with forms.

### Tests

Added `tests/mcp/set-checked.spec.ts` with 3 tests:
- `browser_set_checked (checkbox)` - Tests checking and unchecking a checkbox
- `browser_set_checked (radio button)` - Tests selecting a radio button
- `browser_set_checked (already checked)` - Tests unchecking a pre-checked element

All tests pass locally with `npm run ctest-mcp`.

Fixes microsoft/playwright-mcp#1342