### PR TITLE
feat(mcp): add browser_network_mock and browser_network_unmock tools

### DIFF
--- a/packages/playwright/src/mcp/browser/tools/network.ts
+++ b/packages/playwright/src/mcp/browser/tools/network.ts
@@ -73,7 +73,7 @@ const networkMock = defineTabTool({
         status: z.number().default(200).describe('HTTP status code for the mocked response'),
         contentType: z.string().default('application/json').describe('Content-Type header for the response'),
         body: z.string().describe('Response body as a string. For JSON responses, provide a JSON string.'),
-        headers: z.record(z.string()).optional().describe('Additional headers to include in the response'),
+        headers: z.record(z.string(), z.string()).optional().describe('Additional headers to include in the response'),
       }).describe('The mock response to return'),
     }),
     type: 'action',


### PR DESCRIPTION
## Summary

Fixes #38961

This PR adds two new MCP tools for mocking network responses dynamically:

### New Tools

#### `browser_network_mock`
Mock a network response for a URL pattern. When a request matches the pattern, it will be fulfilled with the provided response instead of going to the network.

**Parameters:**
- `urlPattern` - URL pattern to match (glob pattern, e.g., `**/api/users`, `https://example.com/api/**`)
- `response.status` - HTTP status code for the mocked response (default: 200)
- `response.contentType` - Content-Type header (default: `application/json`)
- `response.body` - Response body as a string
- `response.headers` - Optional additional headers

#### `browser_network_unmock`
Remove all network mocks for a URL pattern.

**Parameters:**
- `urlPattern` - URL pattern to unmock (must match the pattern used in `browser_network_mock`)

### Use Cases

1. **AI agents can test error scenarios** - Mock 500 errors, 404s, timeouts, etc.
2. **Test different API responses** - Mock different data without requiring a backend
3. **Faster automation** - No need to wait for real API calls
4. **Isolated testing** - Control exactly what data the application receives

### Example Usage

```typescript
// Set up a mock
await client.callTool({
  name: 'browser_network_mock',
  arguments: {
    urlPattern: '**/api/users',
    response: {
      status: 200,
      contentType: 'application/json',
      body: JSON.stringify([{ id: 1, name: 'John' }]),
    },
  },
});

// Remove the mock
await client.callTool({
  name: 'browser_network_unmock',
  arguments: {
    urlPattern: '**/api/users',
  },
});
```

### Tests

Added comprehensive tests in `tests/mcp/network.spec.ts`:
- `browser_network_mock - mock JSON API response`
- `browser_network_unmock - remove mock`

All tests pass on chromium and chrome.