### PR TITLE
fix(skill): run-code example needs to be function

### DIFF
--- a/packages/playwright/src/mcp/terminal/SKILL.md
+++ b/packages/playwright/src/mcp/terminal/SKILL.md
@@ -100,7 +100,7 @@ playwright-cli tab-select 0
 playwright-cli console
 playwright-cli console warning
 playwright-cli network
-playwright-cli run-code "await page.waitForTimeout(1000)"
+playwright-cli run-code "async page => await page.waitForTimeout(1000)"
 playwright-cli tracing-start
 playwright-cli tracing-stop
 ```

--- a/packages/playwright/src/mcp/terminal/SKILL.md
+++ b/packages/playwright/src/mcp/terminal/SKILL.md
@@ -100,7 +100,7 @@ playwright-cli tab-select 0
 playwright-cli console
 playwright-cli console warning
 playwright-cli network
-playwright-cli run-code "async page => await page.waitForTimeout(1000)"
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
 playwright-cli tracing-start
 playwright-cli tracing-stop
 ```


### PR DESCRIPTION
Current example yields "TypeError: (intermediate value) is not a function"