### PR TITLE
Revert "chore: fix commander truncating help output (#38930)"

### DIFF
--- a/packages/playwright-core/src/utilsBundle.ts
+++ b/packages/playwright-core/src/utilsBundle.ts
@@ -39,14 +39,6 @@ export type { Range as YAMLRange, Scalar as YAMLScalar, YAMLError, YAMLMap, YAML
 export type { Command } from '../bundles/utils/node_modules/commander';
 export type { EventEmitter as WebSocketEventEmitter, RawData as WebSocketRawData, WebSocket, WebSocketServer } from '../bundles/utils/node_modules/@types/ws';
 
-program.exitOverride(err => {
-  // Calling process.exit() might truncate large stdout/stderr output.
-  // See https://github.com/nodejs/node/issues/6456.
-  // See https://github.com/nodejs/node/issues/12921
-  // eslint-disable-next-line no-restricted-properties
-  process.stdout.write('', () => process.stderr.write('', () => process.exit(err.exitCode)));
-});
-
 export function ms(ms: number): string {
   if (!isFinite(ms))
     return '-';


### PR DESCRIPTION
This reverts commit efb816e9580ea5ee418b3d38a96a2de2191bd2d0. The fix did not help.