### PR TITLE
chore: freeze webkit version on macos 14

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -48,6 +48,8 @@
       "revision": "2251",
       "installByDefault": true,
       "revisionOverrides": {
+        "mac14": "2251",
+        "mac14-arm64": "2251",
         "debian11-x64": "2105",
         "debian11-arm64": "2105",
         "ubuntu20.04-x64": "2092",


### PR DESCRIPTION
Apple no longer keeps it compiling on mac 14: https://webkit.slack.com/archives/CU64U6FDW/p1769465785071029