### PR TITLE
docs: Add explanation about `/url` property for links

### DIFF
--- a/docs/src/aria-snapshots.md
+++ b/docs/src/aria-snapshots.md
@@ -14,7 +14,9 @@ await expect(page.getByRole('banner')).toMatchAriaSnapshot(`
   - banner:
     - heading /Playwright enables reliable end-to-end/ [level=1]
     - link "Get started"
+      - /url: /docs/intro
     - link "Star microsoft/playwright on GitHub"
+      - /url: https://github.com/microsoft/playwright
     - link /[\\d]+k\\+ stargazers on GitHub/
 `);
 ```
@@ -25,7 +27,9 @@ expect(page.query_selector('banner')).to_match_aria_snapshot("""
   - banner:
     - heading /Playwright enables reliable end-to-end/ [level=1]
     - link "Get started"
+      - /url: /docs/intro
     - link "Star microsoft/playwright on GitHub"
+      - /url: https://github.com/microsoft/playwright
     - link /[\\d]+k\\+ stargazers on GitHub/
 """)
 ```
@@ -36,7 +40,9 @@ await expect(page.query_selector('banner')).to_match_aria_snapshot("""
   - banner:
     - heading /Playwright enables reliable end-to-end/ [level=1]
     - link "Get started"
+      - /url: /docs/intro
     - link "Star microsoft/playwright on GitHub"
+      - /url: https://github.com/microsoft/playwright
     - link /[\\d]+k\\+ stargazers on GitHub/
 """)
 ```
@@ -47,7 +53,9 @@ assertThat(page.locator("banner")).matchesAriaSnapshot("""
   - banner:
     - heading /Playwright enables reliable end-to-end/ [level=1]
     - link "Get started"
+      - /url: /docs/intro
     - link "Star microsoft/playwright on GitHub"
+      - /url: https://github.com/microsoft/playwright
     - link /[\\d]+k\\+ stargazers on GitHub/
 """);
 ```
@@ -58,7 +66,9 @@ await Expect(page.Locator("banner")).ToMatchAriaSnapshotAsync(@"
   - banner:
     - heading ""Playwright enables reliable end-to-end testing for modern web apps."" [level=1]
     - link ""Get started""
+      - /url: /docs/intro
     - link ""Star microsoft/playwright on GitHub""
+      - /url: https://github.com/microsoft/playwright
     - link /[\\d]+k\\+ stargazers on GitHub/
 ");
 ```
@@ -215,9 +225,7 @@ attributes.
 <button>Submit</button>
 ```
 
-*aria snapshot*
-
-```yaml
+```yaml title="aria snapshot"
 - button
 ```
 
@@ -233,9 +241,7 @@ focusing solely on role and hierarchy.
 <input type="checkbox" checked>
 ```
 
-*aria snapshot for partial match*
-
-```yaml
+```yaml title="aria snapshot (partial match)"
 - checkbox
 ```
 
@@ -253,9 +259,7 @@ Similarly, you can partially match children in lists or groups by omitting speci
 </ul>
 ```
 
-*aria snapshot for partial match*
-
-```yaml
+```yaml title="aria snapshot (partial match)"
 - list
   - listitem: Feature B
 ```
@@ -275,9 +279,7 @@ By default, a template containing the subset of children will be matched:
 </ul>
 ```
 
-*aria snapshot for partial match*
-
-```yaml
+```yaml title="aria snapshot (partial match)"
 - list
   - listitem: Feature B
 ```
@@ -296,9 +298,9 @@ The `/children` property can be used to control how child elements are matched:
 </ul>
 ```
 
-*aria snapshot will fail due to Feature C not being in the template*
+Following snapshot will fail due to Feature C not being in the template:
 
-```yaml
+```yaml title="aria snapshot"
 - list
   - /children: equal
   - listitem: Feature A
@@ -314,9 +316,7 @@ support regex patterns.
 <h1>Issues 12</h1>
 ```
 
-*aria snapshot with regular expression*
-
-```yaml
+```yaml title="aria snapshot"
 - heading /Issues \d+/
 ```
 
@@ -445,9 +445,7 @@ Headings can include a `level` attribute indicating their heading level.
 <h2>Subtitle</h2>
 ```
 
-*aria snapshot*
-
-```yaml
+```yaml title="aria snapshot"
 - heading "Title" [level=1]
 - heading "Subtitle" [level=2]
 ```
@@ -460,9 +458,7 @@ Standalone or descriptive text elements appear as text nodes.
 <div>Sample accessible name</div>
 ```
 
-*aria snapshot*
-
-```yaml
+```yaml title="aria snapshot"
 - text: Sample accessible name
 ```
 
@@ -474,24 +470,35 @@ Multiline text, such as paragraphs, is normalized in the aria snapshot.
 <p>Line 1<br>Line 2</p>
 ```
 
-*aria snapshot*
-
-```yaml
+```yaml title="aria snapshot"
 - paragraph: Line 1 Line 2
 ```
 
 ### Links
 
-Links display their text or composed content from pseudo-elements.
+Links display their text or composed content from pseudo-elements. The link’s destination may be matched using the
+`/url` property.
 
 ```html
 <a href="#more-info">Read more about Accessibility</a>
 ```
 
-*aria snapshot*
+```yaml title="aria snapshot"
+- link "Read more about Accessibility":
+    - /url: "#more-info"
+```
 
-```yaml
-- link "Read more about Accessibility"
+<hr/>
+
+The value of `/url` may also be a regular expression:
+
+```html
+<a href="https://www.youtube.com/channel/UC46Zj8pDH5tDosqm1gd7WTg">YouTube channel</a>
+```
+
+```yaml title="aria snapshot"
+- link:
+  - /url: /https://www.youtube.com/channel/.*/
 ```
 
 ### Text boxes
@@ -502,9 +509,7 @@ Input elements of type `text` show their `value` attribute content.
 <input type="text" value="Enter your name">
 ```
 
-*aria snapshot*
-
-```yaml
+```yaml title="aria snapshot"
 - textbox: Enter your name
 ```
 
@@ -519,9 +524,7 @@ Ordered and unordered lists include their list items.
 </ul>
 ```
 
-*aria snapshot*
-
-```yaml
+```yaml title="aria snapshot"
 - list "Main Features":
   - listitem: Feature 1
   - listitem: Feature 2
@@ -538,9 +541,7 @@ Groups capture nested elements, such as `<details>` elements with summary conten
 </details>
 ```
 
-*aria snapshot*
-
-```yaml
+```yaml title="aria snapshot"
 - group: Summary
 ```
 
@@ -555,9 +556,7 @@ control states.
 <input type="checkbox" checked>
 ```
 
-*aria snapshot*
-
-```yaml
+```yaml title="aria snapshot"
 - checkbox [checked]
 ```
 
@@ -567,8 +566,6 @@ control states.
 <button aria-pressed="true">Toggle</button>
 ```
 
-*aria snapshot*
-
-```yaml
+```yaml title="aria snapshot"
 - button "Toggle" [pressed=true]
 ```

--- a/docs/src/aria-snapshots.md
+++ b/docs/src/aria-snapshots.md
@@ -13,9 +13,9 @@ await page.goto('https://playwright.dev/');
 await expect(page.getByRole('banner')).toMatchAriaSnapshot(`
   - banner:
     - heading /Playwright enables reliable end-to-end/ [level=1]
-    - link "Get started"
+    - link "Get started":
       - /url: /docs/intro
-    - link "Star microsoft/playwright on GitHub"
+    - link "Star microsoft/playwright on GitHub":
       - /url: https://github.com/microsoft/playwright
     - link /[\\d]+k\\+ stargazers on GitHub/
 `);
@@ -26,9 +26,9 @@ page.goto('https://playwright.dev/')
 expect(page.query_selector('banner')).to_match_aria_snapshot("""
   - banner:
     - heading /Playwright enables reliable end-to-end/ [level=1]
-    - link "Get started"
+    - link "Get started":
       - /url: /docs/intro
-    - link "Star microsoft/playwright on GitHub"
+    - link "Star microsoft/playwright on GitHub":
       - /url: https://github.com/microsoft/playwright
     - link /[\\d]+k\\+ stargazers on GitHub/
 """)
@@ -39,9 +39,9 @@ await page.goto('https://playwright.dev/')
 await expect(page.query_selector('banner')).to_match_aria_snapshot("""
   - banner:
     - heading /Playwright enables reliable end-to-end/ [level=1]
-    - link "Get started"
+    - link "Get started":
       - /url: /docs/intro
-    - link "Star microsoft/playwright on GitHub"
+    - link "Star microsoft/playwright on GitHub":
       - /url: https://github.com/microsoft/playwright
     - link /[\\d]+k\\+ stargazers on GitHub/
 """)
@@ -52,9 +52,9 @@ page.navigate("https://playwright.dev/");
 assertThat(page.locator("banner")).matchesAriaSnapshot("""
   - banner:
     - heading /Playwright enables reliable end-to-end/ [level=1]
-    - link "Get started"
+    - link "Get started":
       - /url: /docs/intro
-    - link "Star microsoft/playwright on GitHub"
+    - link "Star microsoft/playwright on GitHub":
       - /url: https://github.com/microsoft/playwright
     - link /[\\d]+k\\+ stargazers on GitHub/
 """);
@@ -65,9 +65,9 @@ await page.GotoAsync("https://playwright.dev/");
 await Expect(page.Locator("banner")).ToMatchAriaSnapshotAsync(@"
   - banner:
     - heading ""Playwright enables reliable end-to-end testing for modern web apps."" [level=1]
-    - link ""Get started""
+    - link ""Get started"":
       - /url: /docs/intro
-    - link ""Star microsoft/playwright on GitHub""
+    - link ""Star microsoft/playwright on GitHub"":
       - /url: https://github.com/microsoft/playwright
     - link /[\\d]+k\\+ stargazers on GitHub/
 ");
@@ -487,8 +487,6 @@ Links display their text or composed content from pseudo-elements. The link’s 
 - link "Read more about Accessibility":
     - /url: "#more-info"
 ```
-
-<hr/>
 
 The value of `/url` may also be a regular expression:
 

--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -177,7 +177,7 @@ This version was also tested against the following stable channels:
     await Expect(Page.GetByRole(AriaRole.Listitem, new() { Name = "Ship v1.52" })).ToContainClassAsync("done");
   ```
 
-- [Aria Snapshots](./aria-snapshots.md) got two new properties: [`/children`](./aria-snapshots.md#strict-matching) for strict matching and `/url` for links.
+- [Aria Snapshots](./aria-snapshots.md) got two new properties: [`/children`](./aria-snapshots.md#strict-matching) for strict matching and [`/url`](./aria-snapshots.md#links) for links.
 
   ```csharp
   await Expect(locator).ToMatchAriaSnapshotAsync(@"

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -175,7 +175,7 @@ This version was also tested against the following stable channels:
     assertThat(page.getByRole(AriaRole.LISTITEM, new Page.GetByRoleOptions().setName("Ship v1.52"))).containsClass("done");
   ```
 
-- [Aria Snapshots](./aria-snapshots.md) got two new properties: [`/children`](./aria-snapshots.md#strict-matching) for strict matching and `/url` for links.
+- [Aria Snapshots](./aria-snapshots.md) got two new properties: [`/children`](./aria-snapshots.md#strict-matching) for strict matching and [`/url`](./aria-snapshots.md#links) for links.
 
   ```java
   assertThat(locator).toMatchAriaSnapshot("""

--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -301,7 +301,7 @@ This version was also tested against the following stable channels:
   await expect(page.getByRole('listitem', { name: 'Ship v1.52' })).toContainClass('done');
   ```
 
-- [Aria Snapshots](./aria-snapshots.md) got two new properties: [`/children`](./aria-snapshots.md#strict-matching) for strict matching and `/url` for links.
+- [Aria Snapshots](./aria-snapshots.md) got two new properties: [`/children`](./aria-snapshots.md#strict-matching) for strict matching and [`/url`](./aria-snapshots.md#links) for links.
 
   ```ts
   await expect(locator).toMatchAriaSnapshot(`

--- a/docs/src/release-notes-python.md
+++ b/docs/src/release-notes-python.md
@@ -177,7 +177,7 @@ This version was also tested against the following stable channels:
     expect(page.get_by_role('listitem', name='Ship v1.52')).to_contain_class('done')
   ```
 
-- [Aria Snapshots](./aria-snapshots.md) got two new properties: [`/children`](./aria-snapshots.md#strict-matching) for strict matching and `/url` for links.
+- [Aria Snapshots](./aria-snapshots.md) got two new properties: [`/children`](./aria-snapshots.md#strict-matching) for strict matching and [`/url`](./aria-snapshots.md#links) for links.
 
   ```python
   expect(locator).to_match_aria_snapshot("""


### PR DESCRIPTION
This feature was added in #35134, but some documentation was still missing.
- Moved `*aria snapshot*` text to title of code block for better readability

<img width="978" height="607" alt="image" src="https://github.com/user-attachments/assets/5289a091-1f95-4705-9c48-a834c5a565f1" />


Closes: #38834