### PR TITLE
docs: Improve `not` property sections

### DIFF
--- a/docs/src/api/class-apiresponseassertions.md
+++ b/docs/src/api/class-apiresponseassertions.md
@@ -51,7 +51,11 @@ def test_navigates_to_login_page(page: Page) -> None:
 * langs: java, js, csharp
 - returns: <[APIResponseAssertions]>
 
-Makes the assertion check for the opposite condition. For example, this code tests that the response status is not successful:
+Makes the assertion check for the opposite condition.
+
+**Usage**
+
+For example, this code tests that the response status is not successful:
 
 ```js
 await expect(response).not.toBeOK();

--- a/docs/src/api/class-genericassertions.md
+++ b/docs/src/api/class-genericassertions.md
@@ -17,7 +17,11 @@ test('assert a value', async ({ page }) => {
 * since: v1.9
 - returns: <[GenericAssertions]>
 
-Makes the assertion check for the opposite condition. For example, the following code passes:
+Makes the assertion check for the opposite condition.
+
+**Usage**
+
+For example, the following code passes:
 
 ```js
 const value = 1;

--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -70,7 +70,11 @@ public class ExampleTests : PageTest
 * langs: java, js, csharp
 - returns: <[LocatorAssertions]>
 
-Makes the assertion check for the opposite condition. For example, this code tests that the Locator doesn't contain text `"error"`:
+Makes the assertion check for the opposite condition.
+
+**Usage**
+
+For example, this code tests that the Locator doesn't contain text `"error"`:
 
 ```js
 await expect(locator).not.toContainText('error');

--- a/docs/src/api/class-pageassertions.md
+++ b/docs/src/api/class-pageassertions.md
@@ -72,7 +72,11 @@ public class ExampleTests : PageTest
 * langs: java, js, csharp
 - returns: <[PageAssertions]>
 
-Makes the assertion check for the opposite condition. For example, this code tests that the page URL doesn't contain `"error"`:
+Makes the assertion check for the opposite condition.
+
+**Usage**
+
+For example, this code tests that the page URL doesn't contain `"error"`:
 
 ```js
 await expect(page).not.toHaveURL('error');

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -7921,7 +7921,11 @@ interface AsymmetricMatchers {
  */
 interface GenericAssertions<R> {
   /**
-   * Makes the assertion check for the opposite condition. For example, the following code passes:
+   * Makes the assertion check for the opposite condition.
+   *
+   * **Usage**
+   *
+   * For example, the following code passes:
    *
    * ```js
    * const value = 1;
@@ -9432,8 +9436,11 @@ interface LocatorAssertions {
   }): Promise<void>;
 
   /**
-   * Makes the assertion check for the opposite condition. For example, this code tests that the Locator doesn't contain
-   * text `"error"`:
+   * Makes the assertion check for the opposite condition.
+   *
+   * **Usage**
+   *
+   * For example, this code tests that the Locator doesn't contain text `"error"`:
    *
    * ```js
    * await expect(locator).not.toContainText('error');
@@ -9630,8 +9637,11 @@ interface APIResponseAssertions {
   toBeOK(): Promise<void>;
 
   /**
-   * Makes the assertion check for the opposite condition. For example, this code tests that the response status is not
-   * successful:
+   * Makes the assertion check for the opposite condition.
+   *
+   * **Usage**
+   *
+   * For example, this code tests that the response status is not successful:
    *
    * ```js
    * await expect(response).not.toBeOK();
@@ -9750,8 +9760,11 @@ interface PageAssertions {
   }): Promise<void>;
 
   /**
-   * Makes the assertion check for the opposite condition. For example, this code tests that the page URL doesn't
-   * contain `"error"`:
+   * Makes the assertion check for the opposite condition.
+   *
+   * **Usage**
+   *
+   * For example, this code tests that the page URL doesn't contain `"error"`:
    *
    * ```js
    * await expect(page).not.toHaveURL('error');


### PR DESCRIPTION
`not` properties have two code blocks [[auto-generated](https://github.com/microsoft/playwright.dev/blob/862be2e3d58ee1458587d4702cbc9a06f408f3b1/src/generator.js#L304)], reduce it to one


Example before:
<img width="990" height="461" alt="image" src="https://github.com/user-attachments/assets/875a912a-cfe5-4943-aa8d-4314e7e55314" />

After:

<img width="996" height="452" alt="image" src="https://github.com/user-attachments/assets/6587ddff-d4ce-4152-8ff8-76a57caffec6" />

