### PR TITLE
feat(mcp): store console events to per-tab log file

### DIFF
--- a/packages/playwright/src/mcp/browser/browserServerBackend.ts
+++ b/packages/playwright/src/mcp/browser/browserServerBackend.ts
@@ -68,7 +68,7 @@ export class BrowserServerBackend implements ServerBackend {
     const parsedArguments = tool.schema.inputSchema.parse(rawArguments || {}) as any;
     const cwd = rawArguments?._meta && typeof rawArguments?._meta === 'object' && (rawArguments._meta as any)?.cwd;
     const context = this._context!;
-    const response = Response.create(context, name, parsedArguments, cwd);
+    const response = new Response(context, name, parsedArguments, cwd);
     context.setRunningTool(name);
     let responseObject: mcpServer.CallToolResult;
     try {

--- a/packages/playwright/src/mcp/browser/response.ts
+++ b/packages/playwright/src/mcp/browser/response.ts
@@ -215,18 +215,18 @@ export class Response {
     }
 
     // Handle tab log
+    const text: string[] = [];
+    if (tabSnapshot?.logChunk) {
+      const logFilePath = this._computRelativeTo(tabSnapshot.logChunk.file);
+      const entryWord = tabSnapshot.logChunk.entryCount === 1 ? 'entry' : 'entries';
+      const lineRange = tabSnapshot.logChunk.fromLine === tabSnapshot.logChunk.toLine
+        ? `#L${tabSnapshot.logChunk.fromLine}`
+        : `#L${tabSnapshot.logChunk.fromLine}-L${tabSnapshot.logChunk.toLine}`;
+      text.push(`- ${tabSnapshot.logChunk.entryCount} new console ${entryWord} in "${logFilePath}${lineRange}"`);
+    }
     if (tabSnapshot?.events.filter(event => event.type !== 'request').length) {
-      const text: string[] = [];
-      if (tabSnapshot.consoleLog) {
-        const logFilePath = this._computRelativeTo(tabSnapshot.consoleLog.file);
-        const entryWord = tabSnapshot.consoleLog.newEntryCount === 1 ? 'entry' : 'entries';
-        const lineRange = tabSnapshot.consoleLog.firstNewLine === tabSnapshot.consoleLog.lastNewLine
-          ? `line ${tabSnapshot.consoleLog.firstNewLine}`
-          : `lines ${tabSnapshot.consoleLog.firstNewLine}-${tabSnapshot.consoleLog.lastNewLine}`;
-        text.push(`- ${tabSnapshot.consoleLog.newEntryCount} new console ${entryWord} in ${logFilePath}, ${lineRange}`);
-      }
       for (const event of tabSnapshot.events) {
-        if (event.type === 'console' && !tabSnapshot.consoleLog) {
+        if (event.type === 'console' && !tabSnapshot.logChunk) {
           if (shouldIncludeMessage(this._context.config.console.level, event.message.type))
             text.push(`- ${trimMiddle(event.message.toString(), 100)}`);
         } else if (event.type === 'download-start') {
@@ -236,8 +236,8 @@ export class Response {
           text.push(`- Downloaded file ${event.download.download.suggestedFilename()} to "${this._computRelativeTo(event.download.outputFile)}"`);
         }
       }
-      addSection('Events', text);
     }
+    addSection('Events', text);
     return sections;
   }
 }

--- a/packages/playwright/src/mcp/browser/response.ts
+++ b/packages/playwright/src/mcp/browser/response.ts
@@ -221,8 +221,8 @@ export class Response {
         const logFilePath = this._computRelativeTo(tabSnapshot.consoleLog.file);
         const entryWord = tabSnapshot.consoleLog.newEntryCount === 1 ? 'entry' : 'entries';
         const lineRange = tabSnapshot.consoleLog.firstNewLine === tabSnapshot.consoleLog.lastNewLine
-            ? `line ${tabSnapshot.consoleLog.firstNewLine}`
-            : `lines ${tabSnapshot.consoleLog.firstNewLine}-${tabSnapshot.consoleLog.lastNewLine}`;
+          ? `line ${tabSnapshot.consoleLog.firstNewLine}`
+          : `lines ${tabSnapshot.consoleLog.firstNewLine}-${tabSnapshot.consoleLog.lastNewLine}`;
         text.push(`- ${tabSnapshot.consoleLog.newEntryCount} new console ${entryWord} in ${logFilePath}, ${lineRange}`);
       }
       for (const event of tabSnapshot.events) {

--- a/packages/playwright/src/mcp/browser/tab.ts
+++ b/packages/playwright/src/mcp/browser/tab.ts
@@ -112,7 +112,7 @@ class LogFile {
     this._entryCount = 0;
   }
 
-  append(text: string) {
+  appendLine(text: string) {
     this._writeChain = (this._writeChain ?? Promise.resolve()).then(() => this._write(text));
     this._writeChain.catch(logUnhandledError);
   }
@@ -130,8 +130,8 @@ class LogFile {
   private async _write(text: string) {
     if (!this._file)
       this._file = await this._createFile();
-    await fs.promises.appendFile(this._file, text);
-    const lineCount = text.split('\n').length - 1;
+    await fs.promises.appendFile(this._file, text + '\n');
+    const lineCount = text.split('\n').length;
     this._lastLine += lineCount;
     this._entryCount++;
     return {
@@ -283,8 +283,8 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       return;
 
     const relativeTime = wallTime - this._consoleLog.startTime;
-    const logLine = `[${String(relativeTime).padStart(8, ' ')}ms] [${message.type.toUpperCase()}] ${message.toString()}\n`;
-    this._consoleLog.append(logLine);
+    const logLine = `[${String(relativeTime).padStart(8, ' ')}ms] [${message.type.toUpperCase()}] ${message.toString()}`;
+    this._consoleLog.appendLine(logLine);
   }
 
   private _addLogEntry(entry: EventEntry) {

--- a/packages/playwright/src/mcp/browser/tab.ts
+++ b/packages/playwright/src/mcp/browser/tab.ts
@@ -117,13 +117,11 @@ class LogFile {
     this._writeChain.catch(logUnhandledError);
   }
 
-  async flush() : Promise<LogState|undefined> {
-    if (this._writeChain)
-      return await this._writeChain;
-    return undefined;
+  async flush(): Promise<LogState|undefined> {
+    return await this._writeChain;
   }
 
-  private async _createFile() : Promise<string> {
+  private async _createFile(): Promise<string> {
     return await this._context.outputFile(dateAsFileName('console', 'log', new Date(this.startTime)), { origin: 'code', title: 'Console log' });
   }
 
@@ -138,7 +136,7 @@ class LogFile {
       file: this._file,
       lastLine: this._lastLine,
       entryCount: this._entryCount,
-    }
+    };
   }
 }
 

--- a/packages/playwright/src/mcp/browser/tab.ts
+++ b/packages/playwright/src/mcp/browser/tab.ts
@@ -98,18 +98,18 @@ type LogState = {
 };
 
 class LogFile {
+  readonly startTime: number;
+  private _context: Context;
   private _file: string | undefined;
-  private _startTime: number;
   private _lastLine: number;
   private _entryCount: number;
-  private _context: Context;
   private _writeChain: Promise<LogState> | undefined;
 
   constructor(startTime: number, context: Context) {
-    this._startTime = startTime;
+    this.startTime = startTime;
+    this._context = context;
     this._lastLine = 0;
     this._entryCount = 0;
-    this._context = context;
   }
 
   append(text: string) {
@@ -124,7 +124,7 @@ class LogFile {
   }
 
   private async _createFile() : Promise<string> {
-    return await this._context.outputFile(dateAsFileName('console', 'log', new Date(this._startTime)), { origin: 'code', title: 'Console log' });
+    return await this._context.outputFile(dateAsFileName('console', 'log', new Date(this.startTime)), { origin: 'code', title: 'Console log' });
   }
 
   private async _write(text: string) {
@@ -282,7 +282,8 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     if (!this._consoleLog)
       return;
 
-    const logLine = `[${String(wallTime).padStart(10, ' ')}ms] [${message.type.toUpperCase()}] ${message.toString()}\n`;
+    const relativeTime = wallTime - this._consoleLog.startTime;
+    const logLine = `[${String(relativeTime).padStart(8, ' ')}ms] [${message.type.toUpperCase()}] ${message.toString()}\n`;
     this._consoleLog.append(logLine);
   }
 

--- a/packages/playwright/src/mcp/browser/tools/utils.ts
+++ b/packages/playwright/src/mcp/browser/tools/utils.ts
@@ -59,8 +59,8 @@ export async function callOnPageNoTrace<T>(page: playwright.Page, callback: (pag
   return await (page as any)._wrapApiCall(() => callback(page), { internal: true });
 }
 
-export function dateAsFileName(prefix: string, extension: string): string {
-  const date = new Date();
+export function dateAsFileName(prefix: string, extension: string, date?: Date): string {
+  date = date ?? new Date();
   return `${prefix}-${date.toISOString().replace(/[:.]/g, '-')}.${extension}`;
 }
 

--- a/tests/mcp/console.spec.ts
+++ b/tests/mcp/console.spec.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+import path from 'path';
 import { test, expect, parseResponse } from './fixtures';
 
 test('browser_console_messages', async ({ client, server }) => {
@@ -191,4 +193,258 @@ test('browser_console_messages errors only', async ({ client, server }) => {
   expect.soft(response.result).toContain('404');
   expect.soft(response.result).not.toContain('console.log');
   expect.soft(response.result).not.toContain('console.warn');
+});
+
+test('console log file is created on snapshot', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir, outputMode: 'file' },
+  });
+
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <script>
+        console.log("Hello from console");
+        console.error("Error message");
+      </script>
+    </html>
+  `, 'text/html');
+
+  const response = parseResponse(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  }));
+
+  // Check events section mentions the log file with line range
+  expect(response.events).toMatch(/\d+ new console entr(y|ies) in .+\.log, lines? \d+(-\d+)?/);
+
+  // Verify log file exists and contains the messages
+  const files = await fs.promises.readdir(outputDir);
+  const logFile = files.find(f => f.startsWith('console-') && f.endsWith('.log'));
+  expect(logFile).toBeTruthy();
+
+  const logContent = await fs.promises.readFile(path.join(outputDir, logFile!), 'utf-8');
+  expect(logContent).toContain('Hello from console');
+  expect(logContent).toContain('Error message');
+});
+
+test('console log file shows correct entry count', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir, outputMode: 'file' },
+  });
+
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <script>
+        console.log("Message 1");
+        console.log("Message 2");
+        console.log("Message 3");
+      </script>
+    </html>
+  `, 'text/html');
+
+  const response = parseResponse(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  }));
+
+  expect(response.events).toContain('3 new console entries');
+});
+
+test('console log file shows singular entry', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir, outputMode: 'file' },
+  });
+
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <script>
+        console.log("Single message");
+      </script>
+    </html>
+  `, 'text/html');
+
+  const response = parseResponse(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  }));
+
+  expect(response.events).toContain('1 new console entry');
+});
+
+test('new console log file after navigation', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir, outputMode: 'file' },
+  });
+
+  server.setContent('/page1', `
+    <!DOCTYPE html>
+    <html>
+      <script>console.log("Page 1 message");</script>
+    </html>
+  `, 'text/html');
+
+  server.setContent('/page2', `
+    <!DOCTYPE html>
+    <html>
+      <script>console.log("Page 2 message");</script>
+    </html>
+  `, 'text/html');
+
+  // Navigate to first page
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX + '/page1' },
+  });
+
+  // Navigate to second page (should create new log file)
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX + '/page2' },
+  });
+
+  // Verify two log files exist
+  const files = await fs.promises.readdir(outputDir);
+  const logFiles = files.filter(f => f.startsWith('console-') && f.endsWith('.log'));
+  expect(logFiles.length).toBe(2);
+
+  // Each file should have only its own message
+  const contents = await Promise.all(
+      logFiles.map(f => fs.promises.readFile(path.join(outputDir, f), 'utf-8'))
+  );
+  const allContent = contents.join('\n');
+  expect(allContent).toContain('Page 1 message');
+  expect(allContent).toContain('Page 2 message');
+});
+
+test('console log file appends on multiple snapshots', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir, outputMode: 'file' },
+  });
+
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <button onclick="console.log('Button clicked');">Click me</button>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  // Click button to generate console message
+  await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'Click me', ref: 'e2' },
+  });
+
+  // Click again
+  await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'Click me', ref: 'e2' },
+  });
+
+  // Verify only one log file exists (same page, appended)
+  const files = await fs.promises.readdir(outputDir);
+  const logFiles = files.filter(f => f.startsWith('console-') && f.endsWith('.log'));
+  expect(logFiles.length).toBe(1);
+
+  // File should contain both click messages
+  const logContent = await fs.promises.readFile(path.join(outputDir, logFiles[0]), 'utf-8');
+  const matches = logContent.match(/Button clicked/g);
+  expect(matches?.length).toBe(2);
+});
+
+test('console log file stores message type and content', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir, outputMode: 'file' },
+  });
+
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <script>
+        console.log("Log message");
+        console.warn("Warning message");
+        console.error("Error message");
+        console.info("Info message");
+        console.debug("Debug message");
+      </script>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const files = await fs.promises.readdir(outputDir);
+  const logFile = files.find(f => f.startsWith('console-') && f.endsWith('.log'));
+  expect(logFile).toBeTruthy();
+
+  const logContent = await fs.promises.readFile(path.join(outputDir, logFile!), 'utf-8');
+
+  // Check that message types are stored
+  expect(logContent).toContain('[LOG] Log message');
+  expect(logContent).toContain('[WARNING] Warning message');
+  expect(logContent).toContain('[ERROR] Error message');
+  expect(logContent).toContain('[INFO] Info message');
+  expect(logContent).toContain('[DEBUG] Debug message');
+
+  // Check that source location is stored
+  expect(logContent).toMatch(/@ http:\/\/localhost:\d+\/:5/);  // console.log line
+  expect(logContent).toMatch(/@ http:\/\/localhost:\d+\/:6/);  // console.warn line
+  expect(logContent).toMatch(/@ http:\/\/localhost:\d+\/:7/);  // console.error line
+});
+
+test('console log is updated without taking snapshots', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir, outputMode: 'file' },
+  });
+
+  // Navigate to the page (this takes a snapshot)
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.EMPTY_PAGE },
+  });
+
+  async function getLogContent() {
+    const files = await fs.promises.readdir(outputDir);
+    const logFile = files.find(f => f.startsWith('console-') && f.endsWith('.log'));
+    if (!logFile)
+      return '<no log file>';
+    return await fs.promises.readFile(path.join(outputDir, logFile!), 'utf-8');
+  }
+
+  // Use browser_evaluate to trigger console messages without taking a snapshot
+  await client.callTool({
+    name: 'browser_evaluate',
+    arguments: {
+      function: `() => {
+        for (let i = 0; i < 5; i++) {
+          console.log('Evaluated message ' + i);
+        }
+      }`,
+    },
+  });
+
+  // Verify log file contains the evaluated messages without needing another snapshot
+  await expect.poll(async () => await getLogContent()).toContain('Evaluated message 4');
+
+  const logContent = await getLogContent();
+  expect(logContent).toContain('Evaluated message 0');
+  expect(logContent).toContain('Evaluated message 1');
+  expect(logContent).toContain('Evaluated message 2');
+  expect(logContent).toContain('Evaluated message 3');
 });

--- a/tests/mcp/console.spec.ts
+++ b/tests/mcp/console.spec.ts
@@ -217,7 +217,7 @@ test('console log file is created on snapshot', async ({ startClient, server }, 
   }));
 
   // Check events section mentions the log file with line range
-  expect(response.events).toMatch(/\d+ new console entr(y|ies) in .+\.log, lines? \d+(-\d+)?/);
+  expect(response.events).toMatch(/\d+ new console entr(y|ies) in ".+\.log#L\d+(-L\d+)?"/);
 
   // Verify log file exists and contains the messages
   const files = await fs.promises.readdir(outputDir);


### PR DESCRIPTION
When output mode is 'file', console events are now written to a timestamped log file (e.g., console-2026-01-29T12-00-00-000Z.log).