### PR TITLE
fix(mcp): use PLAYWRIGHT_MCP_CONFIG env var to load config file

### DIFF
--- a/packages/playwright/src/mcp/browser/config.ts
+++ b/packages/playwright/src/mcp/browser/config.ts
@@ -153,7 +153,8 @@ export async function resolveConfig(config: Config): Promise<FullConfig> {
 }
 
 export async function resolveCLIConfig(cliOptions: CLIOptions): Promise<FullConfig> {
-  const configInFile = await loadConfig(cliOptions.config);
+  const configPath = cliOptions.config || process.env.PLAYWRIGHT_MCP_CONFIG;
+  const configInFile = await loadConfig(configPath);
   const envOverrides = configFromEnv();
   const cliOverrides = configFromCLIOptions(cliOptions);
   let result = cliOptions.daemon ? defaultDaemonConfig(cliOptions) : defaultConfig;


### PR DESCRIPTION
## Summary
- The `PLAYWRIGHT_MCP_CONFIG` environment variable is documented and read by `configFromEnv()` but was never used to actually load the config file
- This fix adds a fallback in `resolveCLIConfig()` to use the env var when `--config` CLI option is not provided

## Test plan
- [x] Set `PLAYWRIGHT_MCP_CONFIG=/path/to/config.json` environment variable
- [x] Verify config file is loaded (tested with `contextOptions.extraHTTPHeaders` and `contextOptions.userAgent`)
- [x] Verify `--config` CLI flag still takes precedence over env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)