### PR TITLE
chore(cli): shutdown on launch failure

### DIFF
--- a/packages/playwright/src/mcp/browser/browserServerBackend.ts
+++ b/packages/playwright/src/mcp/browser/browserServerBackend.ts
@@ -52,7 +52,7 @@ export class BrowserServerBackend implements ServerBackend {
       clientInfo,
     });
     this._context.onBrowserContextClosed = () => this.onBrowserContextClosed?.();
-    this._context.onBrowserLaunchFailed = (error) => this.onBrowserLaunchFailed?.(error);
+    this._context.onBrowserLaunchFailed = error => this.onBrowserLaunchFailed?.(error);
   }
 
   async listTools(): Promise<mcpServer.Tool[]> {

--- a/packages/playwright/src/mcp/browser/browserServerBackend.ts
+++ b/packages/playwright/src/mcp/browser/browserServerBackend.ts
@@ -35,6 +35,7 @@ export class BrowserServerBackend implements ServerBackend {
   private _browserContextFactory: BrowserContextFactory;
 
   onBrowserContextClosed: (() => void) | undefined;
+  onBrowserLaunchFailed: ((error: Error) => void) | undefined;
 
   constructor(config: FullConfig, factory: BrowserContextFactory, options: { allTools?: boolean, structuredOutput?: boolean } = {}) {
     this._config = config;
@@ -51,6 +52,7 @@ export class BrowserServerBackend implements ServerBackend {
       clientInfo,
     });
     this._context.onBrowserContextClosed = () => this.onBrowserContextClosed?.();
+    this._context.onBrowserLaunchFailed = (error) => this.onBrowserLaunchFailed?.(error);
   }
 
   async listTools(): Promise<mcpServer.Tool[]> {

--- a/packages/playwright/src/mcp/browser/context.ts
+++ b/packages/playwright/src/mcp/browser/context.ts
@@ -202,7 +202,7 @@ export class Context {
       return this._browserContextPromise;
 
     this._browserContextPromise = this._setupBrowserContext();
-    this._browserContextPromise.catch((error) => {
+    this._browserContextPromise.catch(error => {
       this._browserContextPromise = undefined;
       this.onBrowserLaunchFailed?.(error);
     });

--- a/packages/playwright/src/mcp/browser/context.ts
+++ b/packages/playwright/src/mcp/browser/context.ts
@@ -56,6 +56,7 @@ export class Context {
   private _abortController = new AbortController();
 
   onBrowserContextClosed: (() => void) | undefined;
+  onBrowserLaunchFailed: ((error: Error) => void) | undefined;
 
   constructor(options: ContextOptions) {
     this.config = options.config;
@@ -201,8 +202,9 @@ export class Context {
       return this._browserContextPromise;
 
     this._browserContextPromise = this._setupBrowserContext();
-    this._browserContextPromise.catch(() => {
+    this._browserContextPromise.catch((error) => {
       this._browserContextPromise = undefined;
+      this.onBrowserLaunchFailed?.(error);
     });
     return this._browserContextPromise;
   }

--- a/packages/playwright/src/mcp/sdk/server.ts
+++ b/packages/playwright/src/mcp/sdk/server.ts
@@ -48,6 +48,7 @@ export interface ServerBackend {
   callTool(name: string, args: CallToolRequest['params']['arguments'], progress: ProgressCallback): Promise<CallToolResult>;
   serverClosed?(server: Server): void;
   onBrowserContextClosed?: (() => void) | undefined;
+  onBrowserLaunchFailed?: ((error: Error) => void) | undefined;
 }
 
 export type ServerBackendFactory = {

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -56,7 +56,7 @@ export const test = baseTest.extend<{
   },
 });
 
-async function runCli(childProcess: CommonFixtures['childProcess'], args: string[], cliOptions: { cwd?: string }, options: { mcpBrowser: string, mcpHeadless: boolean }, sessions: { name: string, pid: number }[]) {
+async function runCli(childProcess: CommonFixtures['childProcess'], args: string[], cliOptions: { cwd?: string, env?: Record<string, string> }, options: { mcpBrowser: string, mcpHeadless: boolean }, sessions: { name: string, pid: number }[]) {
   const stepTitle = `cli ${args.join(' ')}`;
   return await test.step(stepTitle, async () => {
     const testInfo = test.info();
@@ -70,6 +70,7 @@ async function runCli(childProcess: CommonFixtures['childProcess'], args: string
         PLAYWRIGHT_DAEMON_SOCKETS_DIR: path.join(testInfo.project.outputDir, 'daemon-sockets'),
         PLAYWRIGHT_MCP_BROWSER: options.mcpBrowser,
         PLAYWRIGHT_MCP_HEADLESS: String(options.mcpHeadless),
+        ...cliOptions.env,
       },
     });
     await cli.exited.finally(async () => {

--- a/tests/mcp/cli.spec.ts
+++ b/tests/mcp/cli.spec.ts
@@ -615,3 +615,14 @@ test.describe('isolated', () => {
     expect(listOutput).toContain('default (live)');
   });
 });
+
+test.describe('browser launch failure', () => {
+  test('daemon shuts down on browser launch failure', async ({ cli, server }) => {
+    const first = await cli('open', server.PREFIX, { env: { PLAYWRIGHT_MCP_EXECUTABLE_PATH: '/nonexistent/browser/path' } });
+    expect(first.output).toContain('Failed to launch');
+
+    const second = await cli('open', server.PREFIX);
+    expect(second.exitCode).toBe(0);
+    expect(second.output).toContain('Page URL');
+  });
+});


### PR DESCRIPTION
Currently, when a daemon is spawned with faulty config that can't launch a browser, it keeps running and every subsequent call, even if it provides correct config, will reuse the faulty config and error.

This PR makes the daemon shutdown after a browser launch failure, so that a new daemon with correct config gets a chance to live. Closes https://github.com/microsoft/playwright-cli/issues/222.