### PR TITLE
chore: update video api and implementation

### DIFF
--- a/docs/src/api/class-video.md
+++ b/docs/src/api/class-video.md
@@ -28,31 +28,36 @@ Alternatively, you can use [`method: Video.start`] and [`method: Video.stop`] to
 ```js
 await page.video().start();
 // ... perform actions ...
-await page.video().stop({ path: 'video.webm' });
+await page.video().stop();
+await page.video().saveAs('video.webm');
 ```
 
 ```java
 page.video().start();
 // ... perform actions ...
-page.video().stop(new Video.StopOptions().setPath(Paths.get("video.webm")));
+page.video().stop();
+page.video().saveAs(Paths.get("video.webm"));
 ```
 
 ```python async
 await page.video.start()
 # ... perform actions ...
-await page.video.stop(path="video.webm")
+await page.video.stop()
+await page.video.save_as("video.webm")
 ```
 
 ```python sync
 page.video.start()
 # ... perform actions ...
-page.video.stop(path="video.webm")
+page.video.stop()
+page.video.save_as("video.webm")
 ```
 
 ```csharp
 await page.Video.StartAsync();
 // ... perform actions ...
-await page.Video.StopAsync(new() { Path = "video.webm" });
+await page.Video.StopAsync();
+await page.Video.SaveAsAsync("video.webm");
 ```
 
 ## async method: Video.delete
@@ -140,10 +145,4 @@ Optional dimensions of the recorded video. If not specified the size will be equ
 ## async method: Video.stop
 * since: v1.59
 
-Stops video recording started with [`method: Video.start`] and either saves or discards the video file.
-
-### option: Video.stop.path
-* since: v1.59
-- `path` <[path]>
-
-Path where the video should be saved.
+Stops video recording started with [`method: Video.start`]. Use [`method: Video.path`] or [`method: Video.saveAs`] methods to access the video file.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -4808,8 +4808,8 @@ export interface Page {
   /**
    * Video object associated with this page. Can be used to control video recording with
    * [video.start([options])](https://playwright.dev/docs/api/class-video#video-start) and
-   * [video.stop([options])](https://playwright.dev/docs/api/class-video#video-stop), or to access the video file when
-   * using the `recordVideo` context option.
+   * [video.stop()](https://playwright.dev/docs/api/class-video#video-stop), or to access the video file when using the
+   * `recordVideo` context option.
    */
   video(): Video;
 
@@ -21835,13 +21835,14 @@ export interface Tracing {
  * ```
  *
  * Alternatively, you can use [video.start([options])](https://playwright.dev/docs/api/class-video#video-start) and
- * [video.stop([options])](https://playwright.dev/docs/api/class-video#video-stop) to record video manually. This
- * approach is mutually exclusive with the `recordVideo` option.
+ * [video.stop()](https://playwright.dev/docs/api/class-video#video-stop) to record video manually. This approach is
+ * mutually exclusive with the `recordVideo` option.
  *
  * ```js
  * await page.video().start();
  * // ... perform actions ...
- * await page.video().stop({ path: 'video.webm' });
+ * await page.video().stop();
+ * await page.video().saveAs('video.webm');
  * ```
  *
  */
@@ -21897,16 +21898,11 @@ export interface Video {
 
   /**
    * Stops video recording started with
-   * [video.start([options])](https://playwright.dev/docs/api/class-video#video-start) and either saves or discards the
-   * video file.
-   * @param options
+   * [video.start([options])](https://playwright.dev/docs/api/class-video#video-start). Use
+   * [video.path()](https://playwright.dev/docs/api/class-video#video-path) or
+   * [video.saveAs(path)](https://playwright.dev/docs/api/class-video#video-save-as) methods to access the video file.
    */
-  stop(options?: {
-    /**
-     * Path where the video should be saved.
-     */
-    path?: string;
-  }): Promise<void>;
+  stop(): Promise<void>;
 }
 
 /**

--- a/packages/playwright-core/src/client/video.ts
+++ b/packages/playwright-core/src/client/video.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { ManualPromise } from '../utils/isomorphic/manualPromise';
 import { Artifact } from './artifact';
 
 import type { Connection } from './connection';
@@ -22,26 +21,19 @@ import type { Page } from './page';
 import type * as api from '../../types/types';
 
 export class Video implements api.Video {
-  private _artifact: Promise<Artifact | undefined> | undefined;
-  private _artifactReadyPromise: ManualPromise<Artifact>;
+  private _artifact: Artifact | undefined;
   private _isRemote = false;
   private _page: Page;
 
-  constructor(page: Page, connection: Connection) {
+  constructor(page: Page, connection: Connection, artifact: Artifact | undefined) {
     this._page = page;
     this._isRemote = connection.isRemote();
-    this._artifactReadyPromise = new ManualPromise<Artifact>();
-    this._artifact = page._closedOrCrashedScope.safeRace(this._artifactReadyPromise);
-  }
-
-  _artifactReady(artifact: Artifact) {
-    this._artifactReadyPromise.resolve(artifact);
+    this._artifact = artifact;
   }
 
   async start(options: { size?: { width: number, height: number } } = {}): Promise<void> {
-    await this._page._channel.videoStart(options);
-    this._artifactReadyPromise = new ManualPromise<Artifact>();
-    this._artifact = this._page._closedOrCrashedScope.safeRace(this._artifactReadyPromise);
+    const result = await this._page._channel.videoStart(options);
+    this._artifact = Artifact.from(result.artifact);
   }
 
   async stop(): Promise<void> {
@@ -51,23 +43,19 @@ export class Video implements api.Video {
   async path(): Promise<string> {
     if (this._isRemote)
       throw new Error(`Path is not available when connecting remotely. Use saveAs() to save a local copy.`);
-
-    const artifact = await this._artifact;
-    if (!artifact)
-      throw new Error('Page did not produce any video frames');
-    return artifact._initializer.absolutePath;
+    if (!this._artifact)
+      throw new Error('Video recording has not been started.');
+    return this._artifact._initializer.absolutePath;
   }
 
   async saveAs(path: string): Promise<void> {
-    const artifact = await this._artifact;
-    if (!artifact)
-      throw new Error('Page did not produce any video frames');
-    return await artifact.saveAs(path);
+    if (!this._artifact)
+      throw new Error('Video recording has not been started.');
+    return await this._artifact.saveAs(path);
   }
 
   async delete(): Promise<void> {
-    const artifact = await this._artifact;
-    if (artifact)
-      await artifact.delete();
+    if (this._artifact)
+      await this._artifact.delete();
   }
 }

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1509,9 +1509,7 @@ scheme.PageVideoStartParams = tObject({
     height: tInt,
   })),
 });
-scheme.PageVideoStartResult = tObject({
-  path: tString,
-});
+scheme.PageVideoStartResult = tOptional(tObject({}));
 scheme.PageVideoStopParams = tOptional(tObject({}));
 scheme.PageVideoStopResult = tOptional(tObject({}));
 scheme.PageUpdateSubscriptionParams = tObject({

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -928,9 +928,6 @@ scheme.BrowserContextRouteEvent = tObject({
 scheme.BrowserContextWebSocketRouteEvent = tObject({
   webSocketRoute: tChannel(['WebSocketRoute']),
 });
-scheme.BrowserContextVideoEvent = tObject({
-  artifact: tChannel(['Artifact']),
-});
 scheme.BrowserContextServiceWorkerEvent = tObject({
   worker: tChannel(['Worker']),
 });
@@ -1167,6 +1164,7 @@ scheme.PageInitializer = tObject({
   })),
   isClosed: tBoolean,
   opener: tOptional(tChannel(['Page'])),
+  video: tOptional(tChannel(['Artifact'])),
 });
 scheme.PageBindingCallEvent = tObject({
   binding: tChannel(['BindingCall']),
@@ -1202,9 +1200,6 @@ scheme.PageRouteEvent = tObject({
 });
 scheme.PageWebSocketRouteEvent = tObject({
   webSocketRoute: tChannel(['WebSocketRoute']),
-});
-scheme.PageVideoEvent = tObject({
-  artifact: tChannel(['Artifact']),
 });
 scheme.PageWebSocketEvent = tObject({
   webSocket: tChannel(['WebSocket']),
@@ -1509,7 +1504,9 @@ scheme.PageVideoStartParams = tObject({
     height: tInt,
   })),
 });
-scheme.PageVideoStartResult = tOptional(tObject({}));
+scheme.PageVideoStartResult = tObject({
+  artifact: tChannel(['Artifact']),
+});
 scheme.PageVideoStopParams = tOptional(tObject({}));
 scheme.PageVideoStopResult = tOptional(tObject({}));
 scheme.PageUpdateSubscriptionParams = tObject({

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -151,16 +151,11 @@ export abstract class Browser extends SdkObject {
     this._downloads.delete(uuid);
   }
 
-  _videoStarted(context: BrowserContext, videoId: string, path: string, pageOrError: Promise<Page | Error>) {
-    const artifact = new Artifact(context, path);
-    this._idToVideo.set(videoId, { context, artifact });
-    pageOrError.then(page => {
-      if (page instanceof Page) {
-        page.video = artifact;
-        page.emitOnContext(BrowserContext.Events.VideoStarted, artifact);
-        page.emit(Page.Events.Video, artifact);
-      }
-    });
+  _videoStarted(page: Page, videoId: string, path: string) {
+    const artifact = new Artifact(page.browserContext, path);
+    page.video = artifact;
+    this._idToVideo.set(videoId, { context: page.browserContext, artifact });
+    return artifact;
   }
 
   _takeVideo(videoId: string): Artifact | undefined {

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -63,7 +63,6 @@ const BrowserContextEvent = {
   RequestFulfilled: 'requestfulfilled',
   RequestContinued: 'requestcontinued',
   BeforeClose: 'beforeclose',
-  VideoStarted: 'videostarted',
   RecorderEvent: 'recorderevent',
 } as const;
 
@@ -80,7 +79,6 @@ export type BrowserContextEventMap = {
   [BrowserContextEvent.RequestFulfilled]: [request: network.Request];
   [BrowserContextEvent.RequestContinued]: [request: network.Request];
   [BrowserContextEvent.BeforeClose]: [];
-  [BrowserContextEvent.VideoStarted]: [artifact: Artifact];
   [BrowserContextEvent.RecorderEvent]: [event: { event: 'actionAdded' | 'actionUpdated' | 'signalAdded', data: any, page: Page, code: string }];
 };
 

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -438,7 +438,7 @@ class FrameSession {
     }
 
     let videoOptions: types.VideoOptions | undefined;
-    if (!this._page.isStorageStatePage && this._isMainFrame() && hasUIWindow)
+    if (this._isMainFrame() && hasUIWindow)
       videoOptions = this._crPage._page.screencast.launchAutomaticVideoRecorder();
 
     let lifecycleEventsEnabled: Promise<any>;

--- a/packages/playwright-core/src/server/dispatchers/artifactDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/artifactDispatcher.ts
@@ -32,7 +32,7 @@ export class ArtifactDispatcher extends Dispatcher<Artifact, channels.ArtifactCh
     return ArtifactDispatcher.fromNullable(parentScope, artifact)!;
   }
 
-  static fromNullable(parentScope: DispatcherScope, artifact: Artifact): ArtifactDispatcher | undefined {
+  static fromNullable(parentScope: DispatcherScope, artifact: Artifact | undefined): ArtifactDispatcher | undefined {
     if (!artifact)
       return undefined;
     const result = parentScope.connection.existingDispatcher<ArtifactDispatcher>(artifact);

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -37,7 +37,6 @@ import { RecorderApp } from '../recorder/recorderApp';
 import { ElementHandleDispatcher } from './elementHandlerDispatcher';
 import { JSHandleDispatcher } from './jsHandleDispatcher';
 
-import type { Artifact } from '../artifact';
 import type { ConsoleMessage } from '../console';
 import type { Dialog } from '../dialog';
 import type { Request, Response, RouteHandler } from '../network';
@@ -96,18 +95,6 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     this._context = context;
     // Note: when launching persistent context, or connecting to an existing browser,
     // dispatcher is created very late, so we can already have pages, videos and everything else.
-
-    const onVideo = (artifact: Artifact) => {
-      // Note: Video must outlive Page and BrowserContext, so that client can saveAs it
-      // after closing the context. We use |scope| for it.
-      const artifactDispatcher = ArtifactDispatcher.from(parentScope, artifact);
-      this._dispatchEvent('video', { artifact: artifactDispatcher });
-    };
-    this.addObjectListener(BrowserContext.Events.VideoStarted, onVideo);
-    for (const video of context._browser._idToVideo.values()) {
-      if (video.context === context)
-        onVideo(video.artifact);
-    }
 
     for (const page of context.pages())
       this._dispatchEvent('page', { page: PageDispatcher.from(this, page) });

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -18,7 +18,6 @@
 import { assert } from '../../utils';
 import { Browser } from '../browser';
 import { BrowserContext, verifyGeolocation } from '../browserContext';
-import { TargetClosedError } from '../errors';
 import * as network from '../network';
 import { ConnectionEvents, FFConnection  } from './ffConnection';
 import { FFPage } from './ffPage';
@@ -142,7 +141,7 @@ export class FFBrowser extends Browser {
     if (!originPage) {
       // Resume the page creation with an error. The page will automatically close right
       // after the download begins.
-      ffPage._markAsError(new Error('Starting new page download'));
+      ffPage._reportAsNew(new Error('Starting new page download'));
       if (ffPage._opener)
         originPage = ffPage._opener._page.initializedOrUndefined();
     }
@@ -157,9 +156,6 @@ export class FFBrowser extends Browser {
   }
 
   _onDisconnect() {
-    for (const video of this._idToVideo.values())
-      video.artifact.reportFinished(new TargetClosedError(this.closeReason()));
-    this._idToVideo.clear();
     for (const ffPage of this._ffPages.values())
       ffPage.didClose();
     this._ffPages.clear();

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -130,7 +130,6 @@ const PageEvent = {
   InternalFrameNavigatedToNewDocument: 'internalframenavigatedtonewdocument',
   LocatorHandlerTriggered: 'locatorhandlertriggered',
   ScreencastFrame: 'screencastframe',
-  Video: 'video',
   WebSocket: 'websocket',
   Worker: 'worker',
 } as const;
@@ -146,7 +145,6 @@ export type PageEventMap = {
   [PageEvent.InternalFrameNavigatedToNewDocument]: [frame: frames.Frame];
   [PageEvent.LocatorHandlerTriggered]: [uid: number];
   [PageEvent.ScreencastFrame]: [frame: types.ScreencastFrame];
-  [PageEvent.Video]: [artifact: Artifact];
   [PageEvent.WebSocket]: [webSocket: network.WebSocket];
   [PageEvent.Worker]: [worker: Worker];
 };
@@ -179,7 +177,7 @@ export class Page extends SdkObject<PageEventMap> {
   readonly pdf: ((options: channels.PagePdfParams) => Promise<Buffer>) | undefined;
   readonly coverage: any;
   readonly requestInterceptors: network.RouteHandler[] = [];
-  video: Artifact | null = null;
+  video: Artifact | undefined;
   private _opener: Page | undefined;
   readonly isStorageStatePage: boolean;
   private _locatorHandlers = new Map<number, { selector: string, noWaitAfter?: boolean, resolved?: ManualPromise<void> }>();

--- a/packages/playwright-core/src/server/screencast.ts
+++ b/packages/playwright-core/src/server/screencast.ts
@@ -128,7 +128,6 @@ export class Screencast {
     const size = validateVideoSize(options.size, this._page.emulatedSize()?.viewport);
     const videoOptions = this._launchVideoRecorder(this._page.browserContext._browser.options.artifactsDir, size);
     await this.startVideoRecording(videoOptions);
-    return { path: videoOptions.outputFile };
   }
 
   async stopExplicitVideoRecording() {

--- a/packages/playwright-core/src/server/screencast.ts
+++ b/packages/playwright-core/src/server/screencast.ts
@@ -61,7 +61,7 @@ export class Screencast {
   // and it is equally important to send Screencast.startScreencast before sending Target.resume.
   launchAutomaticVideoRecorder(): types.VideoOptions | undefined {
     const recordVideo = this._page.browserContext._options.recordVideo;
-    if (!recordVideo)
+    if (!recordVideo || this._page.isStorageStatePage)
       return;
     // validateBrowserContextOptions ensures correct video size.
     return this._launchVideoRecorder(recordVideo.dir, recordVideo.size!);
@@ -92,16 +92,12 @@ export class Screencast {
     const videoId = this._videoId;
     assert(videoId);
     this._page.once(Page.Events.Close, () => this.stopVideoRecording().catch(() => {}));
-    const gotFirstFrame = new Promise(f => this._page.once(Page.Events.ScreencastFrame, f));
     await this._startScreencast(this._videoRecorder, {
       quality: 90,
       width: options.width,
       height: options.height,
     });
-    // Wait for the first frame before reporting video to the client.
-    gotFirstFrame.then(() => {
-      this._page.browserContext._browser._videoStarted(this._page.browserContext, videoId, options.outputFile, this._page.waitForInitializedOrError());
-    });
+    return this._page.browserContext._browser._videoStarted(this._page, videoId, options.outputFile);
   }
 
   async stopVideoRecording(): Promise<void> {
@@ -127,7 +123,7 @@ export class Screencast {
       throw new Error('Video is already being recorded');
     const size = validateVideoSize(options.size, this._page.emulatedSize()?.viewport);
     const videoOptions = this._launchVideoRecorder(this._page.browserContext._browser.options.artifactsDir, size);
-    await this.startVideoRecording(videoOptions);
+    return await this.startVideoRecording(videoOptions);
   }
 
   async stopExplicitVideoRecording() {

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -21,7 +21,6 @@ import { BrowserContext, verifyGeolocation } from '../browserContext';
 import * as network from '../network';
 import { WKConnection, WKSession, kPageProxyMessageReceived } from './wkConnection';
 import { WKPage } from './wkPage';
-import { TargetClosedError } from '../errors';
 import { translatePathToWSL } from './webkit';
 
 import type { BrowserOptions } from '../browser';
@@ -76,9 +75,6 @@ export class WKBrowser extends Browser {
     for (const wkPage of this._wkPages.values())
       wkPage.didClose();
     this._wkPages.clear();
-    for (const video of this._idToVideo.values())
-      video.artifact.reportFinished(new TargetClosedError(this.closeReason()));
-    this._idToVideo.clear();
     this._didClose();
   }
 

--- a/packages/playwright-core/src/utils/isomorphic/manualPromise.ts
+++ b/packages/playwright-core/src/utils/isomorphic/manualPromise.ts
@@ -88,7 +88,9 @@ export class LongStandingScope {
     return this._race(Array.isArray(promise) ? promise : [promise], false) as Promise<T>;
   }
 
-  async safeRace<T>(promise: Promise<T>, defaultValue?: T): Promise<T> {
+  async safeRace<T>(promise: Promise<T>, defaultValue: T): Promise<T>;
+  async safeRace<T>(promise: Promise<T>): Promise<T | undefined>;
+  async safeRace<T>(promise: Promise<T>, defaultValue?: T): Promise<T | undefined> {
     return this._race([promise], true, defaultValue);
   }
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -4808,8 +4808,8 @@ export interface Page {
   /**
    * Video object associated with this page. Can be used to control video recording with
    * [video.start([options])](https://playwright.dev/docs/api/class-video#video-start) and
-   * [video.stop([options])](https://playwright.dev/docs/api/class-video#video-stop), or to access the video file when
-   * using the `recordVideo` context option.
+   * [video.stop()](https://playwright.dev/docs/api/class-video#video-stop), or to access the video file when using the
+   * `recordVideo` context option.
    */
   video(): Video;
 
@@ -21835,13 +21835,14 @@ export interface Tracing {
  * ```
  *
  * Alternatively, you can use [video.start([options])](https://playwright.dev/docs/api/class-video#video-start) and
- * [video.stop([options])](https://playwright.dev/docs/api/class-video#video-stop) to record video manually. This
- * approach is mutually exclusive with the `recordVideo` option.
+ * [video.stop()](https://playwright.dev/docs/api/class-video#video-stop) to record video manually. This approach is
+ * mutually exclusive with the `recordVideo` option.
  *
  * ```js
  * await page.video().start();
  * // ... perform actions ...
- * await page.video().stop({ path: 'video.webm' });
+ * await page.video().stop();
+ * await page.video().saveAs('video.webm');
  * ```
  *
  */
@@ -21897,16 +21898,11 @@ export interface Video {
 
   /**
    * Stops video recording started with
-   * [video.start([options])](https://playwright.dev/docs/api/class-video#video-start) and either saves or discards the
-   * video file.
-   * @param options
+   * [video.start([options])](https://playwright.dev/docs/api/class-video#video-start). Use
+   * [video.path()](https://playwright.dev/docs/api/class-video#video-path) or
+   * [video.saveAs(path)](https://playwright.dev/docs/api/class-video#video-save-as) methods to access the video file.
    */
-  stop(options?: {
-    /**
-     * Path where the video should be saved.
-     */
-    path?: string;
-  }): Promise<void>;
+  stop(): Promise<void>;
 }
 
 /**

--- a/packages/playwright/src/mcp/browser/tools/video.ts
+++ b/packages/playwright/src/mcp/browser/tools/video.ts
@@ -54,7 +54,8 @@ const stopVideo = defineTabTool({
 
   handle: async (tab, params, response) => {
     const resolvedFile = await response.resolveFile({ prefix: 'video', ext: 'webm', suggestedFilename: params.filename }, 'Video');
-    await tab.page.video().stop({ path: resolvedFile.fileName });
+    await tab.page.video().stop();
+    await tab.page.video().saveAs(resolvedFile.fileName);
     await response.addFileResult(resolvedFile, null);
   },
 });

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -1580,7 +1580,6 @@ export interface BrowserContextEventTarget {
   on(event: 'pageError', callback: (params: BrowserContextPageErrorEvent) => void): this;
   on(event: 'route', callback: (params: BrowserContextRouteEvent) => void): this;
   on(event: 'webSocketRoute', callback: (params: BrowserContextWebSocketRouteEvent) => void): this;
-  on(event: 'video', callback: (params: BrowserContextVideoEvent) => void): this;
   on(event: 'serviceWorker', callback: (params: BrowserContextServiceWorkerEvent) => void): this;
   on(event: 'request', callback: (params: BrowserContextRequestEvent) => void): this;
   on(event: 'requestFailed', callback: (params: BrowserContextRequestFailedEvent) => void): this;
@@ -1657,9 +1656,6 @@ export type BrowserContextRouteEvent = {
 };
 export type BrowserContextWebSocketRouteEvent = {
   webSocketRoute: WebSocketRouteChannel,
-};
-export type BrowserContextVideoEvent = {
-  artifact: ArtifactChannel,
 };
 export type BrowserContextServiceWorkerEvent = {
   worker: WorkerChannel,
@@ -2029,7 +2025,6 @@ export interface BrowserContextEvents {
   'pageError': BrowserContextPageErrorEvent;
   'route': BrowserContextRouteEvent;
   'webSocketRoute': BrowserContextWebSocketRouteEvent;
-  'video': BrowserContextVideoEvent;
   'serviceWorker': BrowserContextServiceWorkerEvent;
   'request': BrowserContextRequestEvent;
   'requestFailed': BrowserContextRequestFailedEvent;
@@ -2047,6 +2042,7 @@ export type PageInitializer = {
   },
   isClosed: boolean,
   opener?: PageChannel,
+  video?: ArtifactChannel,
 };
 export interface PageEventTarget {
   on(event: 'bindingCall', callback: (params: PageBindingCallEvent) => void): this;
@@ -2060,7 +2056,6 @@ export interface PageEventTarget {
   on(event: 'locatorHandlerTriggered', callback: (params: PageLocatorHandlerTriggeredEvent) => void): this;
   on(event: 'route', callback: (params: PageRouteEvent) => void): this;
   on(event: 'webSocketRoute', callback: (params: PageWebSocketRouteEvent) => void): this;
-  on(event: 'video', callback: (params: PageVideoEvent) => void): this;
   on(event: 'webSocket', callback: (params: PageWebSocketEvent) => void): this;
   on(event: 'worker', callback: (params: PageWorkerEvent) => void): this;
 }
@@ -2143,9 +2138,6 @@ export type PageRouteEvent = {
 };
 export type PageWebSocketRouteEvent = {
   webSocketRoute: WebSocketRouteChannel,
-};
-export type PageVideoEvent = {
-  artifact: ArtifactChannel,
 };
 export type PageWebSocketEvent = {
   webSocket: WebSocketChannel,
@@ -2617,7 +2609,9 @@ export type PageVideoStartOptions = {
     height: number,
   },
 };
-export type PageVideoStartResult = void;
+export type PageVideoStartResult = {
+  artifact: ArtifactChannel,
+};
 export type PageVideoStopParams = {};
 export type PageVideoStopOptions = {};
 export type PageVideoStopResult = void;
@@ -2677,7 +2671,6 @@ export interface PageEvents {
   'locatorHandlerTriggered': PageLocatorHandlerTriggeredEvent;
   'route': PageRouteEvent;
   'webSocketRoute': PageWebSocketRouteEvent;
-  'video': PageVideoEvent;
   'webSocket': PageWebSocketEvent;
   'worker': PageWorkerEvent;
 }

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -2617,9 +2617,7 @@ export type PageVideoStartOptions = {
     height: number,
   },
 };
-export type PageVideoStartResult = {
-  path: string,
-};
+export type PageVideoStartResult = void;
 export type PageVideoStopParams = {};
 export type PageVideoStopOptions = {};
 export type PageVideoStopResult = void;

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -2038,8 +2038,6 @@ Page:
           properties:
             width: int
             height: int
-      returns:
-        path: string
 
     videoStop:
       title: Stop video recording

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1500,10 +1500,6 @@ BrowserContext:
       parameters:
         webSocketRoute: WebSocketRoute
 
-    video:
-      parameters:
-        artifact: Artifact
-
     serviceWorker:
       parameters:
         worker: Worker
@@ -1558,6 +1554,7 @@ Page:
         height: int
     isClosed: boolean
     opener: Page?
+    video: Artifact?
 
   commands:
 
@@ -2038,6 +2035,8 @@ Page:
           properties:
             width: int
             height: int
+      returns:
+        artifact: Artifact
 
     videoStop:
       title: Stop video recording
@@ -2128,10 +2127,6 @@ Page:
     webSocketRoute:
       parameters:
         webSocketRoute: WebSocketRoute
-
-    video:
-      parameters:
-        artifact: Artifact
 
     webSocket:
       parameters:


### PR DESCRIPTION
- `page.video()` is always available.
- `video.path()` is available right away upon recording, and throws when no video is being recorded.
- No `path` option when stopping, use `saveAs()` instead.
- No `page did not produce any video frames` error anymore - add a single white frame instead.
- More tests around edge cases.
- Simplify plumbing.