### PR TITLE
docs: fix typo in debug.md

### DIFF
--- a/docs/src/debug.md
+++ b/docs/src/debug.md
@@ -28,7 +28,7 @@ You can also edit the locators in VS Code and Playwright will show you the chang
 
 ### Picking a Locator
 
-Pick a [locator](./locators.md) and copy it into your test file by clicking the **Pick locator** button form the testing sidebar. Then in the browser click the element you require and it will now show up in the **Pick locator** box in VS Code. Press 'enter' on your keyboard to copy the locator into the clipboard and then paste anywhere in your code. Or press 'escape' if you want to cancel.
+Pick a [locator](./locators.md) and copy it into your test file by clicking the **Pick locator** button from the testing sidebar. Then in the browser click the element you require and it will now show up in the **Pick locator** box in VS Code. Press 'enter' on your keyboard to copy the locator into the clipboard and then paste anywhere in your code. Or press 'escape' if you want to cancel.
 
 <img width="1394" alt="Pick locators" src="https://user-images.githubusercontent.com/13063165/212741666-6479a702-2517-44a3-9eca-e719e13b379c.png" />
 


### PR DESCRIPTION
## Summary

Fixes a typo in the debugging documentation.

## Changes

- Fixed: `button form the testing sidebar` → `button from the testing sidebar`

## Location

`docs/src/debug.md` - Picking a Locator section