### PR TITLE
fix(ct): Don't bloat metainfo.json file when # or ? is present in id

### DIFF
--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -291,7 +291,7 @@ function vitePlugin(registerSource: string, templateDir: string, buildInfo: Buil
 function collectViteModuleDependencies(context: PluginContext, id: string, deps: Set<string>) {
   if (!path.isAbsolute(id))
     return;
-  const normalizedId = path.normalize(id);
+  const normalizedId = path.normalize(id).split(/\?|#/)[0];
   if (deps.has(normalizedId))
     return;
   deps.add(normalizedId);

--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -294,6 +294,8 @@ function collectViteModuleDependencies(context: PluginContext, id: string, deps:
   const normalizedId = path.normalize(cleanedId);
   if (!path.isAbsolute(normalizedId))
     return;
+  if (deps.has(normalizedId))
+    return;
   deps.add(normalizedId);
   const module = context.getModuleInfo(id);
   for (const importedId of module?.importedIds || [])

--- a/packages/playwright-ct-core/src/vitePlugin.ts
+++ b/packages/playwright-ct-core/src/vitePlugin.ts
@@ -289,10 +289,10 @@ function vitePlugin(registerSource: string, templateDir: string, buildInfo: Buil
 }
 
 function collectViteModuleDependencies(context: PluginContext, id: string, deps: Set<string>) {
-  if (!path.isAbsolute(id))
-    return;
-  const normalizedId = path.normalize(id).split(/\?|#/)[0];
-  if (deps.has(normalizedId))
+  // Example: "src/Component.tsx?raw" or "src/Component.tsx?import" should resolve to the file path.
+  const cleanedId = id.split(/[?#]/)[0];
+  const normalizedId = path.normalize(cleanedId);
+  if (!path.isAbsolute(normalizedId))
     return;
   deps.add(normalizedId);
   const module = context.getModuleInfo(id);


### PR DESCRIPTION
## Proposal

Remove the `?` or `#` part from dependencies in the `metainfo.json` file.

## Description

`@playwright/experimental-ct-core` generates a `metainfo.json` file used for caching and other optimizations performed by Playwright under the hood.

The current implementation relies on a Vite plugin to generate this file. However, Vite prohibits the usage of `#` and `?` in file names, meaning there is no reason to store them in the `metainfo.json` file.

> Both # and ? are reserved for compatibility with browser URLs.
>
> -- <cite><a href="https://github.com/vitejs/vite/issues/11784#issuecomment-1798854088">patak-dev</a></cite>

We experienced two major issues with the current behavior:

- Our `metainfo.json` file exceeded 512MB, which is the hard limit for the `JSON.parse()` method, resulting in unexpected crashes

- This data was serialized and deserialized each time tests ran, resulting in a 4x slowdown of tests in our project

<img width="1627" height="561" alt="80% performance improvement with proposed fix" src="https://github.com/user-attachments/assets/e8987ecd-f56d-4539-8796-247d8cb80062" />

## Example

Metainfo.json file is reduced from 1.4M to 4.0K in provided example

```
1.4M    current/playwright/.cache/metainfo.json
4.0K    patched/playwright/.cache/metainfo.json
```
https://github.com/mikstime/playwright
