### PR TITLE
fix(trace-viewer): Keep network entry selected during test run

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/trace/traceModel.ts
+++ b/packages/playwright-core/src/utils/isomorphic/trace/traceModel.ts
@@ -42,6 +42,8 @@ export type SourceModel = {
   content: string | undefined;
 };
 
+export type ResourceEntry = ResourceSnapshot & { id: string };
+
 export type ActionTraceEventInContext = ActionEntry & {
   context: ContextEntry;
 };
@@ -84,7 +86,7 @@ export class TraceModel {
   readonly sdkLanguage: Language | undefined;
   readonly testIdAttributeName: string | undefined;
   readonly sources: Map<string, SourceModel>;
-  resources: ResourceSnapshot[];
+  resources: ResourceEntry[];
   readonly actionCounters: Map<string, number>;
   readonly traceUri: string;
 
@@ -113,7 +115,7 @@ export class TraceModel {
     this.errors = ([] as trace.ErrorTraceEvent[]).concat(...contexts.map(c => c.errors));
     this.hasSource = contexts.some(c => c.hasSource);
     this.hasStepData = contexts.some(context => context.origin === 'testRunner');
-    this.resources = [...contexts.map(c => c.resources)].flat();
+    this.resources = [...contexts.map(c => c.resources)].flat().map(entry => ({ ...entry, id: `${entry.pageref}-${entry.time}-${entry.request.url}` }));
     this.attachments = this.actions.flatMap(action => action.attachments?.map(attachment => ({ ...attachment, callId: action.callId, traceUri })) ?? []);
     this.visibleAttachments = this.attachments.filter(attachment => !attachment.name.startsWith('_'));
 

--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -72,10 +72,8 @@ export const NetworkTab: React.FunctionComponent<{
   sdkLanguage: Language,
 }> = ({ boundaries, networkModel, onResourceHovered, sdkLanguage }) => {
   const [sorting, setSorting] = React.useState<Sorting | undefined>(undefined);
-  const [selectedEntry, setSelectedEntry] = React.useState<RenderedEntry | undefined>(undefined);
+  const [selectedEntryKey, setSelectedEntryKey] = React.useState<string | undefined>(undefined);
   const [filterState, setFilterState] = React.useState(defaultFilterState);
-
-  const visibleSelectedEntry = React.useMemo(() => (selectedEntry && networkModel.resources.includes(selectedEntry.resource)) ? selectedEntry : undefined, [selectedEntry, networkModel.resources]);
 
   const { renderedEntries } = React.useMemo(() => {
     const renderedEntries = networkModel.resources.map((entry, i) => renderEntry(entry, boundaries, networkModel.contextIdMap, i)).filter(filterEntry(filterState));
@@ -84,13 +82,15 @@ export const NetworkTab: React.FunctionComponent<{
     return { renderedEntries };
   }, [networkModel.resources, networkModel.contextIdMap, filterState, sorting, boundaries]);
 
+  const visibleSelectedEntry = React.useMemo(() => (selectedEntryKey ? renderedEntries.find(entry => JSON.stringify(entry) === selectedEntryKey) : undefined), [selectedEntryKey, renderedEntries]);
+
   const [columnWidths, setColumnWidths] = React.useState<Map<ColumnName, number>>(() => {
     return new Map(allColumns().map(column => [column, columnWidth(column)]));
   });
 
   const onFilterStateChange = React.useCallback((newFilterState: FilterState) => {
     setFilterState(newFilterState);
-    setSelectedEntry(undefined);
+    setSelectedEntryKey(undefined);
   }, []);
 
   if (!networkModel.resources.length)
@@ -101,7 +101,7 @@ export const NetworkTab: React.FunctionComponent<{
     ariaLabel='Network requests'
     items={renderedEntries}
     selectedItem={visibleSelectedEntry}
-    onSelected={item => setSelectedEntry(item)}
+    onSelected={item => setSelectedEntryKey(JSON.stringify(item))}
     onHighlighted={item => onResourceHovered?.(item?.ordinal)}
     columns={visibleColumns(!!visibleSelectedEntry, renderedEntries)}
     columnTitle={columnTitle}
@@ -122,7 +122,7 @@ export const NetworkTab: React.FunctionComponent<{
         sidebarIsFirst={true}
         orientation='horizontal'
         settingName='networkResourceDetails'
-        main={<NetworkResourceDetails resource={visibleSelectedEntry.resource} sdkLanguage={sdkLanguage} startTimeOffset={visibleSelectedEntry.start} onClose={() => setSelectedEntry(undefined)} />}
+        main={<NetworkResourceDetails resource={visibleSelectedEntry.resource} sdkLanguage={sdkLanguage} startTimeOffset={visibleSelectedEntry.start} onClose={() => setSelectedEntryKey(undefined)} />}
         sidebar={grid}
       />}
   </>;

--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -72,7 +72,7 @@ export const NetworkTab: React.FunctionComponent<{
   sdkLanguage: Language,
 }> = ({ boundaries, networkModel, onResourceHovered, sdkLanguage }) => {
   const [sorting, setSorting] = React.useState<Sorting | undefined>(undefined);
-  const [selectedEntryKey, setSelectedEntryKey] = React.useState<string | undefined>(undefined);
+  const [selectedResourceKey, setSelectedResourceKey] = React.useState<string | undefined>(undefined);
   const [filterState, setFilterState] = React.useState(defaultFilterState);
 
   const { renderedEntries } = React.useMemo(() => {
@@ -82,7 +82,7 @@ export const NetworkTab: React.FunctionComponent<{
     return { renderedEntries };
   }, [networkModel.resources, networkModel.contextIdMap, filterState, sorting, boundaries]);
 
-  const visibleSelectedEntry = React.useMemo(() => (selectedEntryKey ? renderedEntries.find(entry => JSON.stringify(entry) === selectedEntryKey) : undefined), [selectedEntryKey, renderedEntries]);
+  const visibleSelectedEntry = React.useMemo(() => (selectedResourceKey ? renderedEntries.find(entry => JSON.stringify(entry.resource) === selectedResourceKey) : undefined), [selectedResourceKey, renderedEntries]);
 
   const [columnWidths, setColumnWidths] = React.useState<Map<ColumnName, number>>(() => {
     return new Map(allColumns().map(column => [column, columnWidth(column)]));
@@ -90,7 +90,7 @@ export const NetworkTab: React.FunctionComponent<{
 
   const onFilterStateChange = React.useCallback((newFilterState: FilterState) => {
     setFilterState(newFilterState);
-    setSelectedEntryKey(undefined);
+    setSelectedResourceKey(undefined);
   }, []);
 
   if (!networkModel.resources.length)
@@ -101,7 +101,7 @@ export const NetworkTab: React.FunctionComponent<{
     ariaLabel='Network requests'
     items={renderedEntries}
     selectedItem={visibleSelectedEntry}
-    onSelected={item => setSelectedEntryKey(JSON.stringify(item))}
+    onSelected={item => setSelectedResourceKey(JSON.stringify(item.resource))}
     onHighlighted={item => onResourceHovered?.(item?.ordinal)}
     columns={visibleColumns(!!visibleSelectedEntry, renderedEntries)}
     columnTitle={columnTitle}
@@ -122,7 +122,7 @@ export const NetworkTab: React.FunctionComponent<{
         sidebarIsFirst={true}
         orientation='horizontal'
         settingName='networkResourceDetails'
-        main={<NetworkResourceDetails resource={visibleSelectedEntry.resource} sdkLanguage={sdkLanguage} startTimeOffset={visibleSelectedEntry.start} onClose={() => setSelectedEntryKey(undefined)} />}
+        main={<NetworkResourceDetails resource={visibleSelectedEntry.resource} sdkLanguage={sdkLanguage} startTimeOffset={visibleSelectedEntry.start} onClose={() => setSelectedResourceKey(undefined)} />}
         sidebar={grid}
       />}
   </>;

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -374,7 +374,6 @@ test('should not preserve selection across test runs', async ({ runUITest, serve
       import { test, expect } from '@playwright/test';
       test('network tab test', async ({ page }) => {
         await page.goto('${server.PREFIX}/network-tab/network.html');
-        await page.evaluate(() => (window as any).donePromise);
       });
     `,
   });
@@ -383,11 +382,34 @@ test('should not preserve selection across test runs', async ({ runUITest, serve
   await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
 
   await page.getByRole('tab', { name: 'Network' }).click();
-  const networkItem = page.getByRole('listitem').filter({ hasText: 'network.html' });
-  await networkItem.click();
+  await page.getByRole('listitem').filter({ hasText: 'network.html' }).click();
   const headersPanel = page.getByRole('tabpanel', { name: 'Headers' });
   await expect(headersPanel).toBeVisible();
 
   await page.getByRole('treeitem', { name: 'network tab test' }).dblclick();
+  await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
   await expect(headersPanel).toBeHidden();
+});
+
+test('should preserve selection during test run', async ({ runUITest, server }, testInfo) => {
+  const { page } = await runUITest({
+    'network-tab.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('network tab test', async ({ page }) => {
+        await page.goto('${server.PREFIX}/network-tab/network.html');
+        // Keep test running to make sure that selected network entry stay open
+        await page.waitForTimeout(${testInfo.timeout});
+      });
+    `,
+  });
+
+  await page.getByRole('treeitem', { name: 'network tab test' }).dblclick();
+  await page.getByRole('tab', { name: 'Network' }).click();
+  await page.getByRole('listitem').filter({ hasText: 'network.html' }).click();
+  const headersPanel = page.getByRole('tabpanel', { name: 'Headers' });
+  await expect(headersPanel).toBeVisible();
+
+  // Wait to ensure that trace polling (every 500ms) does not close the selected entry
+  await page.waitForTimeout(1000);
+  await expect(headersPanel).toBeVisible();
 });

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -387,6 +387,7 @@ test('should not preserve selection across test runs', async ({ runUITest, serve
   await expect(headersPanel).toBeVisible();
 
   await page.getByRole('treeitem', { name: 'network tab test' }).dblclick();
+  await expect(headersPanel).toBeHidden();
   await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
   await expect(headersPanel).toBeHidden();
 });


### PR DESCRIPTION
The polling every 500s causes the `networkModel` to reset, causing the `networkModel.resources` to be a new array (with (partially) same values), so `===`-comparison will not work. Ideally the `Entry` would have a unique id-property, this `JSON.stringify` solution is not ideal. 


Closes: #39050