### PR TITLE
test(junit): rename misleading 'unexpected' tests

### DIFF
--- a/tests/playwright-test/reporter-junit.spec.ts
+++ b/tests/playwright-test/reporter-junit.spec.ts
@@ -50,7 +50,7 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(result.exitCode).toBe(0);
     });
 
-    test('should render unexpected', async ({ runInlineTest }) => {
+    test('should render assertion failure', async ({ runInlineTest }) => {
       const result = await runInlineTest({
         'a.test.js': `
           import { test, expect } from '@playwright/test';
@@ -70,7 +70,7 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(result.exitCode).toBe(1);
     });
 
-    test('should render unexpected after retry', async ({ runInlineTest }) => {
+    test('should render assertion failure after retry', async ({ runInlineTest }) => {
       const result = await runInlineTest({
         'a.test.js': `
           import { test, expect } from '@playwright/test';


### PR DESCRIPTION
The tests named "should render unexpected" exercise expect() assertion failures (JUnit <failure>),
not unexpected runtime errors (<error>).

Renaming improves clarity and avoids confusion when working on JUnit error vs failure reporting.
