### PR TITLE
chore: remove bidi-chromium from default downloads

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiChromium.ts
+++ b/packages/playwright-core/src/server/bidi/bidiChromium.ts
@@ -154,6 +154,22 @@ export class BidiChromium extends BrowserType {
     chromeArguments.push(...args);
     return chromeArguments;
   }
+
+  override getExecutableName(options: types.LaunchOptions): string {
+    switch (options.channel) {
+      case 'bidi-chromium':
+        return 'chromium';
+      case 'bidi-chrome':
+        return 'chrome';
+      case 'bidi-chrome-beta':
+        return 'chrome-beta';
+      case 'bidi-chrome-dev':
+        return 'chrome-dev';
+      case 'bidi-chrome-canary':
+        return 'chrome-canary';
+    }
+    throw new Error(`Unsupported Bidi Chromium channel: ${options.channel}`);
+  }
 }
 
 const kBidiOverCdpWrapper = Symbol('kBidiConnectionWrapper');

--- a/tests/bidi/playwright.config.ts
+++ b/tests/bidi/playwright.config.ts
@@ -83,7 +83,7 @@ const getExecutablePath = (browserName: BrowserName) => {
 };
 
 const browserToChannels = {
-  'chromium': ['bidi-chromium', 'bidi-chrome-canary', 'bidi-chrome-stable'],
+  'chromium': ['bidi-chromium', 'bidi-chrome-canary', 'bidi-chrome'],
   'firefox': ['moz-firefox', 'moz-firefox-beta', 'moz-firefox-nightly'],
 };
 


### PR DESCRIPTION
Currently it is listed in the help of install:

<img width="763" height="73" alt="image" src="https://github.com/user-attachments/assets/2b66627e-f705-476d-ab15-62bf9728d839" />


Closes https://github.com/microsoft/playwright/pull/39065