### PR TITLE
test(mcp): enabled passing storage tests in webkit

### DIFF
--- a/tests/mcp/cli-storage.spec.ts
+++ b/tests/mcp/cli-storage.spec.ts
@@ -59,8 +59,6 @@ test('state-save saves to custom filename', async ({ cli, server }, testInfo) =>
 });
 
 test('state-load restores storage state from file', async ({ cli, server, mcpBrowser }, testInfo) => {
-  test.fixme(mcpBrowser === 'webkit', 'setStorageState is failing');
-
   const config = { capabilities: ['storage'] };
   await fs.promises.writeFile(testInfo.outputPath('playwright-cli.json'), JSON.stringify(config, null, 2));
 
@@ -103,8 +101,6 @@ test('state-load restores storage state from file', async ({ cli, server, mcpBro
 });
 
 test('state-save and state-load roundtrip', async ({ cli, server, mcpBrowser }, testInfo) => {
-  test.fixme(mcpBrowser === 'webkit', 'setStorageState is failing');
-
   const config = { capabilities: ['storage'] };
   await fs.promises.writeFile(testInfo.outputPath('playwright-cli.json'), JSON.stringify(config, null, 2));
 

--- a/tests/mcp/storage.spec.ts
+++ b/tests/mcp/storage.spec.ts
@@ -107,8 +107,6 @@ test('browser_storage_state saves to custom filename', async ({ startClient, ser
 });
 
 test('browser_set_storage_state restores storage state from file', async ({ startClient, server, mcpBrowser }, testInfo) => {
-  test.fixme(mcpBrowser === 'webkit', 'setStorageState is failing');
-
   const outputDir = testInfo.outputPath('output');
   await fs.promises.mkdir(outputDir, { recursive: true });
 
@@ -174,8 +172,6 @@ test('browser_set_storage_state restores storage state from file', async ({ star
 });
 
 test('browser_storage_state and browser_set_storage_state roundtrip', async ({ startClient, server, mcpBrowser }, testInfo) => {
-  test.fixme(mcpBrowser === 'webkit', 'setStorageState is failing');
-
   const outputDir = testInfo.outputPath('output');
 
   const { client } = await startClient({


### PR DESCRIPTION
Underlying issue was fixed in https://github.com/microsoft/playwright-browsers/pull/2061