### PR TITLE
fix(trace): convert file path to URI in StdinServer._loadTrace

### DIFF
--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -244,9 +244,10 @@ class StdinServer implements Transport {
   close?: () => void;
 
   private _loadTrace(traceUrl: string) {
-    this._traceUrl = traceUrl;
+    const validatedUrl = validateTraceUrl(traceUrl);
+    this._traceUrl = validatedUrl;
     clearTimeout(this._pollTimer);
-    this.sendEvent?.('loadTraceRequested', { traceUrl });
+    this.sendEvent?.('loadTraceRequested', { traceUrl: validatedUrl });
   }
 
   private _pollLoadTrace(url: string) {


### PR DESCRIPTION
## Summary

Fix trace viewer failing when receiving trace paths via stdin (used by VS Code extension for live trace).

- `StdinServer._loadTrace()` now calls `validateTraceUrl()` to convert file paths to `file?path=` URI format
- This makes stdin path handling consistent with `runTraceViewerApp()` and `runTraceInBrowser()`

## Problem

After #38566, the trace viewer expects trace URIs in `file?path=...` format, but `StdinServer._loadTrace()` was still sending raw file paths. This caused the Service Worker to attempt fetching the raw path directly, resulting in:

```
Not allowed to load local resource: file:///C:/Users/.../traces/xxx.json
```

## Root Cause

In commit 185bfb7d4, `validateTraceUrl()` was updated to convert file paths to URI format, but `StdinServer._loadTrace()` was not updated to use this function.

## Fix

```diff
  private _loadTrace(traceUrl: string) {
-   this._traceUrl = traceUrl;
+   const validatedUrl = validateTraceUrl(traceUrl);
+   this._traceUrl = validatedUrl;
    clearTimeout(this._pollTimer);
-   this.sendEvent?.('loadTraceRequested', { traceUrl });
+   this.sendEvent?.('loadTraceRequested', { traceUrl: validatedUrl });
  }
```

## Test Plan

- [x] Verified VS Code extension (v1.1.17) live trace now works with this fix
- [ ] Existing trace viewer tests should pass

Fixes #39096