### PR TITLE
feat(mcp): add iframe interaction tools

### DIFF
--- a/packages/playwright/src/mcp/browser/tools.ts
+++ b/packages/playwright/src/mcp/browser/tools.ts
@@ -20,6 +20,7 @@ import cookies from './tools/cookies';
 import dialogs from './tools/dialogs';
 import evaluate from './tools/evaluate';
 import files from './tools/files';
+import frame from './tools/frame';
 import form from './tools/form';
 import install from './tools/install';
 import keyboard from './tools/keyboard';
@@ -49,6 +50,7 @@ export const browserTools: Tool<any>[] = [
   ...dialogs,
   ...evaluate,
   ...files,
+  ...frame,
   ...form,
   ...install,
   ...keyboard,

--- a/packages/playwright/src/mcp/browser/tools/frame.ts
+++ b/packages/playwright/src/mcp/browser/tools/frame.ts
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'playwright-core/lib/mcpBundle';
+import { defineTabTool } from './tool';
+import { formatObject } from 'playwright-core/lib/utils';
+
+const frameElementSchema = z.object({
+  frameSelector: z.string().describe('CSS selector or attributes to locate the iframe element'),
+  element: z.string().describe('Human-readable element description inside the iframe'),
+  ref: z.string().describe('Exact target element reference from the page snapshot (inside the iframe)'),
+});
+
+const frameClick = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_frame_click',
+    title: 'Click element in iframe',
+    description: 'Perform click on an element inside an iframe',
+    inputSchema: frameElementSchema.extend({
+      doubleClick: z.boolean().optional().describe('Whether to perform a double click instead of a single click'),
+      button: z.enum(['left', 'right', 'middle']).optional().describe('Button to click, defaults to left'),
+      modifiers: z.array(z.enum(['Alt', 'Control', 'ControlOrMeta', 'Meta', 'Shift'])).optional().describe('Modifier keys to press'),
+    }),
+    type: 'input',
+  },
+
+  handle: async (tab, params, response) => {
+    response.setIncludeSnapshot();
+
+    const frameLocator = tab.page.frameLocator(params.frameSelector);
+    const locator = frameLocator.locator(`aria-ref=${params.ref}`).describe(params.element);
+    
+    const options = {
+      button: params.button,
+      modifiers: params.modifiers,
+    };
+    const formatted = formatObject(options, ' ', 'oneline');
+    const optionsAttr = formatted !== '{}' ? formatted : '';
+
+    if (params.doubleClick) {
+      response.addCode(`await page.frameLocator('${params.frameSelector}').locator('aria-ref=${params.ref}').dblclick(${optionsAttr});`);
+    } else {
+      response.addCode(`await page.frameLocator('${params.frameSelector}').locator('aria-ref=${params.ref}').click(${optionsAttr});`);
+    }
+
+    await tab.waitForCompletion(async () => {
+      if (params.doubleClick)
+        await locator.dblclick(options);
+      else
+        await locator.click(options);
+    });
+  },
+});
+
+const frameType = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_frame_type',
+    title: 'Type text in iframe',
+    description: 'Type text into an editable element inside an iframe',
+    inputSchema: frameElementSchema.extend({
+      text: z.string().describe('Text to type into the element'),
+      submit: z.boolean().optional().describe('Whether to submit entered text (press Enter after)'),
+      slowly: z.boolean().optional().describe('Whether to type one character at a time'),
+    }),
+    type: 'input',
+  },
+
+  handle: async (tab, params, response) => {
+    const frameLocator = tab.page.frameLocator(params.frameSelector);
+    const locator = frameLocator.locator(`aria-ref=${params.ref}`).describe(params.element);
+    const secret = tab.context.lookupSecret(params.text);
+
+    await tab.waitForCompletion(async () => {
+      if (params.slowly) {
+        response.setIncludeSnapshot();
+        response.addCode(`await page.frameLocator('${params.frameSelector}').locator('aria-ref=${params.ref}').pressSequentially(${secret.code});`);
+        await locator.pressSequentially(secret.value);
+      } else {
+        response.addCode(`await page.frameLocator('${params.frameSelector}').locator('aria-ref=${params.ref}').fill(${secret.code});`);
+        await locator.fill(secret.value);
+      }
+
+      if (params.submit) {
+        response.setIncludeSnapshot();
+        response.addCode(`await page.frameLocator('${params.frameSelector}').locator('aria-ref=${params.ref}').press('Enter');`);
+        await locator.press('Enter');
+      }
+    });
+  },
+});
+
+const frameFill = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_frame_fill',
+    title: 'Fill input in iframe',
+    description: 'Fill an input field inside an iframe',
+    inputSchema: frameElementSchema.extend({
+      text: z.string().describe('Text to fill into the input'),
+    }),
+    type: 'input',
+  },
+
+  handle: async (tab, params, response) => {
+    const frameLocator = tab.page.frameLocator(params.frameSelector);
+    const locator = frameLocator.locator(`aria-ref=${params.ref}`).describe(params.element);
+    const secret = tab.context.lookupSecret(params.text);
+
+    response.addCode(`await page.frameLocator('${params.frameSelector}').locator('aria-ref=${params.ref}').fill(${secret.code});`);
+
+    await tab.waitForCompletion(async () => {
+      await locator.fill(secret.value);
+    });
+  },
+});
+
+const frameHover = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_frame_hover',
+    title: 'Hover element in iframe',
+    description: 'Hover over an element inside an iframe',
+    inputSchema: frameElementSchema,
+    type: 'input',
+  },
+
+  handle: async (tab, params, response) => {
+    response.setIncludeSnapshot();
+
+    const frameLocator = tab.page.frameLocator(params.frameSelector);
+    const locator = frameLocator.locator(`aria-ref=${params.ref}`).describe(params.element);
+    
+    response.addCode(`await page.frameLocator('${params.frameSelector}').locator('aria-ref=${params.ref}').hover();`);
+
+    await tab.waitForCompletion(async () => {
+      await locator.hover();
+    });
+  },
+});
+
+const frameSelectOption = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_frame_select_option',
+    title: 'Select option in iframe',
+    description: 'Select an option in a dropdown inside an iframe',
+    inputSchema: frameElementSchema.extend({
+      values: z.array(z.string()).describe('Array of values to select'),
+    }),
+    type: 'input',
+  },
+
+  handle: async (tab, params, response) => {
+    response.setIncludeSnapshot();
+
+    const frameLocator = tab.page.frameLocator(params.frameSelector);
+    const locator = frameLocator.locator(`aria-ref=${params.ref}`).describe(params.element);
+    
+    response.addCode(`await page.frameLocator('${params.frameSelector}').locator('aria-ref=${params.ref}').selectOption(${formatObject(params.values)});`);
+
+    await tab.waitForCompletion(async () => {
+      await locator.selectOption(params.values);
+    });
+  },
+});
+
+const frameCheck = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_frame_check',
+    title: 'Check checkbox in iframe',
+    description: 'Check a checkbox or radio button inside an iframe',
+    inputSchema: frameElementSchema,
+    type: 'input',
+  },
+
+  handle: async (tab, params, response) => {
+    response.setIncludeSnapshot();
+
+    const frameLocator = tab.page.frameLocator(params.frameSelector);
+    const locator = frameLocator.locator(`aria-ref=${params.ref}`).describe(params.element);
+    
+    response.addCode(`await page.frameLocator('${params.frameSelector}').locator('aria-ref=${params.ref}').check();`);
+
+    await tab.waitForCompletion(async () => {
+      await locator.check();
+    });
+  },
+});
+
+const frameUncheck = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_frame_uncheck',
+    title: 'Uncheck checkbox in iframe',
+    description: 'Uncheck a checkbox inside an iframe',
+    inputSchema: frameElementSchema,
+    type: 'input',
+  },
+
+  handle: async (tab, params, response) => {
+    response.setIncludeSnapshot();
+
+    const frameLocator = tab.page.frameLocator(params.frameSelector);
+    const locator = frameLocator.locator(`aria-ref=${params.ref}`).describe(params.element);
+    
+    response.addCode(`await page.frameLocator('${params.frameSelector}').locator('aria-ref=${params.ref}').uncheck();`);
+
+    await tab.waitForCompletion(async () => {
+      await locator.uncheck();
+    });
+  },
+});
+
+export default [
+  frameClick,
+  frameType,
+  frameFill,
+  frameHover,
+  frameSelectOption,
+  frameCheck,
+  frameUncheck,
+];

--- a/tests/mcp/frame-tools.spec.ts
+++ b/tests/mcp/frame-tools.spec.ts
@@ -1,0 +1,354 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures';
+
+test('browser_frame_click', async ({ client, server }) => {
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <h1>Main Page</h1>
+        <iframe src="/iframe.html"></iframe>
+      </body>
+    </html>
+  `, 'text/html');
+
+  server.setContent('/iframe.html', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <button id="testBtn">Click Me</button>
+        <div id="result"></div>
+        <script>
+          document.getElementById('testBtn').addEventListener('click', () => {
+            document.getElementById('result').textContent = 'Clicked!';
+          });
+        </script>
+      </body>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  // Get snapshot to find the iframe reference
+  const snapshot = await client.callTool({
+    name: 'browser_snapshot',
+    arguments: {},
+  });
+
+  expect(await client.callTool({
+    name: 'browser_frame_click',
+    arguments: {
+      frameSelector: 'iframe',
+      element: 'Click Me button',
+      ref: 'f1e2', // This should match the ref from the snapshot
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining(`await page.frameLocator('iframe').locator('aria-ref=f1e2').click();`),
+  });
+});
+
+test('browser_frame_type', async ({ client, server }) => {
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <h1>Main Page</h1>
+        <iframe src="/iframe.html"></iframe>
+      </body>
+    </html>
+  `, 'text/html');
+
+  server.setContent('/iframe.html', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <input type="text" id="textInput" placeholder="Type here" />
+      </body>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_frame_type',
+    arguments: {
+      frameSelector: 'iframe',
+      element: 'text input',
+      ref: 'f1e2',
+      text: 'Hello World',
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining(`await page.frameLocator('iframe').locator('aria-ref=f1e2').fill('Hello World');`),
+  });
+});
+
+test('browser_frame_fill', async ({ client, server }) => {
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <iframe src="/iframe.html"></iframe>
+      </body>
+    </html>
+  `, 'text/html');
+
+  server.setContent('/iframe.html', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <input type="email" placeholder="Email" />
+      </body>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_frame_fill',
+    arguments: {
+      frameSelector: 'iframe',
+      element: 'Email input',
+      ref: 'f1e2',
+      text: 'test@example.com',
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining(`await page.frameLocator('iframe').locator('aria-ref=f1e2').fill('test@example.com');`),
+  });
+});
+
+test('browser_frame_hover', async ({ client, server }) => {
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <iframe src="/iframe.html"></iframe>
+      </body>
+    </html>
+  `, 'text/html');
+
+  server.setContent('/iframe.html', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <div id="hoverDiv" style="padding: 20px; background: blue;">Hover over me</div>
+      </body>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_frame_hover',
+    arguments: {
+      frameSelector: 'iframe',
+      element: 'hover div',
+      ref: 'f1e2',
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining(`await page.frameLocator('iframe').locator('aria-ref=f1e2').hover();`),
+  });
+});
+
+test('browser_frame_select_option', async ({ client, server }) => {
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <iframe src="/iframe.html"></iframe>
+      </body>
+    </html>
+  `, 'text/html');
+
+  server.setContent('/iframe.html', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <select id="country">
+          <option value="">Choose a country</option>
+          <option value="us">United States</option>
+          <option value="uk">United Kingdom</option>
+        </select>
+      </body>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_frame_select_option',
+    arguments: {
+      frameSelector: 'iframe',
+      element: 'country select',
+      ref: 'f1e2',
+      values: ['us'],
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining(`await page.frameLocator('iframe').locator('aria-ref=f1e2').selectOption(['us']);`),
+  });
+});
+
+test('browser_frame_check and uncheck', async ({ client, server }) => {
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <iframe src="/iframe.html"></iframe>
+      </body>
+    </html>
+  `, 'text/html');
+
+  server.setContent('/iframe.html', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <label>
+          <input type="checkbox" id="terms" />
+          I agree to terms
+        </label>
+      </body>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  // Test check
+  expect(await client.callTool({
+    name: 'browser_frame_check',
+    arguments: {
+      frameSelector: 'iframe',
+      element: 'terms checkbox',
+      ref: 'f1e3',
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining(`await page.frameLocator('iframe').locator('aria-ref=f1e3').check();`),
+  });
+
+  // Test uncheck
+  expect(await client.callTool({
+    name: 'browser_frame_uncheck',
+    arguments: {
+      frameSelector: 'iframe',
+      element: 'terms checkbox',
+      ref: 'f1e3',
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining(`await page.frameLocator('iframe').locator('aria-ref=f1e3').uncheck();`),
+  });
+});
+
+test('browser_frame_click with double click', async ({ client, server }) => {
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <iframe src="/iframe.html"></iframe>
+      </body>
+    </html>
+  `, 'text/html');
+
+  server.setContent('/iframe.html', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <button id="dblClickBtn">Double Click Me</button>
+        <div id="result"></div>
+        <script>
+          document.getElementById('dblClickBtn').addEventListener('dblclick', () => {
+            document.getElementById('result').textContent = 'Double Clicked!';
+          });
+        </script>
+      </body>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_frame_click',
+    arguments: {
+      frameSelector: 'iframe',
+      element: 'Double Click Me button',
+      ref: 'f1e2',
+      doubleClick: true,
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining(`await page.frameLocator('iframe').locator('aria-ref=f1e2').dblclick();`),
+  });
+});
+
+test('browser_frame_type with slowly and submit', async ({ client, server }) => {
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <iframe src="/iframe.html"></iframe>
+      </body>
+    </html>
+  `, 'text/html');
+
+  server.setContent('/iframe.html', `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <form>
+          <input type="text" id="searchInput" />
+        </form>
+      </body>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_frame_type',
+    arguments: {
+      frameSelector: 'iframe',
+      element: 'search input',
+      ref: 'f1e3',
+      text: 'search query',
+      slowly: true,
+      submit: true,
+    },
+  })).toHaveResponse({
+    code: expect.stringContaining(`await page.frameLocator('iframe').locator('aria-ref=f1e3').pressSequentially('search query');`),
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a new set of MCP browser tools for interacting with elements inside iframes. Currently, the MCP browser server lacks dedicated tools for iframe interactions, requiring workarounds. These tools provide a clean API for common iframe operations.

## New Tools
- **`browser_frame_click`** - Click elements in iframes (supports double-click, button selection, and modifiers)
- **`browser_frame_type`** - Type text into iframe elements (with slow typing and submit options)
- **`browser_frame_fill`** - Fill input fields in iframes
- **`browser_frame_hover`** - Hover over elements in iframes
- **`browser_frame_select_option`** - Select dropdown options in iframes
- **`browser_frame_check`** - Check checkboxes in iframes
- **`browser_frame_uncheck`** - Uncheck checkboxes in iframes

## Implementation Details
- Uses `page.frameLocator()` API for consistent iframe handling
- Supports `aria-ref` element references for reliable element targeting
- Includes proper code generation for Playwright scripts
- Handles secrets appropriately for sensitive input data

## Tests
Added comprehensive test suite (`frame-tools.spec.ts`) with 8 tests covering:
- All tool variants (click, type, fill, hover, select, check/uncheck)
- Option variations (double-click, slow typing, submit on Enter)
- All 8 tests pass in Chrome browser

## Motivation
Iframes are commonly used in modern web applications for embedded content, payment forms, authentication flows, and third-party widgets. These tools make it significantly easier to automate iframe interactions through the MCP protocol without requiring complex manual iframe handling.

## Related Issues
<!-- If there's a related issue, link it here -->
