### PR TITLE
feat(html): show the list of runs from the same worker

### DIFF
--- a/packages/html-reporter/src/chip.tsx
+++ b/packages/html-reporter/src/chip.tsx
@@ -28,9 +28,10 @@ export const Chip: React.FC<{
   expanded?: boolean,
   noInsets?: boolean,
   setExpanded?: (expanded: boolean) => void,
-  children?: any,
+  children?: React.ReactNode,
+  body?: () => React.ReactNode | undefined,
   dataTestId?: string,
-}> = ({ header, footer, expanded, setExpanded, children, noInsets, dataTestId }) => {
+}> = ({ header, footer, expanded, setExpanded, children, noInsets, body, dataTestId }) => {
   const id = React.useId();
   return <div className='chip' data-testid={dataTestId}>
     <div
@@ -45,6 +46,7 @@ export const Chip: React.FC<{
     </div>
     {(!setExpanded || expanded) && <div id={id} role='region' className={clsx('chip-body', noInsets && 'chip-body-no-insets')}>
       {children}
+      {body && body()}
       {footer && <div className='chip-footer'>{footer}</div>}
     </div>}
   </div>;
@@ -54,10 +56,11 @@ export const AutoChip: React.FC<{
   header: React.JSX.Element | string,
   initialExpanded?: boolean,
   noInsets?: boolean,
-  children?: any,
+  children?: React.ReactNode,
+  body?: () => React.ReactNode | undefined,
   dataTestId?: string,
   revealOnAnchorId?: AnchorID,
-}> = ({ header, initialExpanded, noInsets, children, dataTestId, revealOnAnchorId }) => {
+}> = ({ header, initialExpanded, noInsets, children, body, dataTestId, revealOnAnchorId }) => {
   const [expanded, setExpanded] = React.useState(initialExpanded ?? true);
   const onReveal = React.useCallback(() => setExpanded(true), []);
   useAnchor(revealOnAnchorId, onReveal);
@@ -66,6 +69,7 @@ export const AutoChip: React.FC<{
     expanded={expanded}
     setExpanded={setExpanded}
     noInsets={noInsets}
+    body={body}
     dataTestId={dataTestId}
   >
     {children}

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -193,12 +193,9 @@ const TestCaseViewLoader: React.FC<{
     </div>;
   }
 
-  const { projectNames, metadata, options } = report.json();
   return <div className='test-case-column'>
     <TestCaseView
-      projectNames={projectNames}
-      testRunMetadata={metadata}
-      options={options}
+      report={report}
       next={next}
       prev={prev}
       test={test}

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -15,7 +15,7 @@
 */
 
 import type { TestAnnotation } from '@playwright/test';
-import type { HTMLReportOptions, TestCase, TestCaseSummary } from './types';
+import type { TestCase, TestCaseSummary } from './types';
 import * as React from 'react';
 import { TabbedPane } from './tabbedPane';
 import { AutoChip } from './chip';
@@ -29,18 +29,16 @@ import { msToString } from './utils';
 import { clsx } from '@web/uiUtils';
 import { CopyToClipboardContainer } from './copyToClipboard';
 import { HeaderView } from './headerView';
-import type { MetadataWithCommitInfo } from '@playwright/isomorphic/types';
 import { ProjectAndTagLabelsView } from './labels';
+import type { LoadedReport } from './loadedReport';
 
 export const TestCaseView: React.FC<{
-  projectNames: string[],
+  report: LoadedReport,
   test: TestCase,
-  testRunMetadata: MetadataWithCommitInfo | undefined,
   next: TestCaseSummary | undefined,
   prev: TestCaseSummary | undefined,
   run: number,
-  options?: HTMLReportOptions,
-}> = ({ projectNames, test, testRunMetadata, run, next, prev, options }) => {
+}> = ({ report, test, run, next, prev }) => {
   const [selectedResultIndex, setSelectedResultIndex] = React.useState(run);
   const searchParams = useSearchParams();
 
@@ -66,7 +64,7 @@ export const TestCaseView: React.FC<{
       <TraceLink test={test} trailingSeparator={true} />
       <div className='test-case-duration'>{msToString(test.duration)}</div>
     </div>
-    <ProjectAndTagLabelsView style={{ marginLeft: '6px' }} projectNames={projectNames} activeProjectName={test.projectName} otherLabels={test.tags} />
+    <ProjectAndTagLabelsView style={{ marginLeft: '6px' }} projectNames={report.json().projectNames} activeProjectName={test.projectName} otherLabels={test.tags} />
     {/* If there are no results, display test annotations. Otherwise test annotations will be displayed alongside runtime annotations in individual result pane */}
     {test.results.length === 0 && visibleTestAnnotations.length !== 0 && <AutoChip header='Annotations' dataTestId='test-case-annotations'>
       {visibleTestAnnotations.map((annotation, index) => <TestCaseAnnotationView key={index} annotation={annotation} />)}
@@ -84,7 +82,7 @@ export const TestCaseView: React.FC<{
             {!!visibleAnnotations.length && <AutoChip header='Annotations' dataTestId='test-case-annotations'>
               {visibleAnnotations.map((annotation, index) => <TestCaseAnnotationView key={index} annotation={annotation} />)}
             </AutoChip>}
-            <TestResultView test={test!} result={result} testRunMetadata={testRunMetadata} options={options} />
+            <TestResultView test={test!} result={result} report={report} />
           </>;
         },
       })) || []} selectedTab={String(selectedResultIndex)} setSelectedTab={id => setSelectedResultIndex(+id)} />

--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -22,7 +22,7 @@
   text-overflow: ellipsis;
 }
 
-.test-file-test:hover {
+.test-file-test-selected, .test-file-test:hover {
   background-color: var(--color-canvas-subtle);
 }
 

--- a/packages/html-reporter/src/types.d.ts
+++ b/packages/html-reporter/src/types.d.ts
@@ -88,6 +88,8 @@ export type TestCaseSummary = {
 
 export type TestResultSummary = {
   attachments: { name: string, contentType: string, path?: string }[];
+  startTime: string;
+  workerIndex: number;
 };
 
 export type TestCase = Omit<TestCaseSummary, 'results'> & {
@@ -110,6 +112,7 @@ export type TestResult = {
   attachments: TestAttachment[];
   status: 'passed' | 'failed' | 'timedOut' | 'skipped' | 'interrupted';
   annotations: TestAnnotation[];
+  workerIndex: number;
 };
 
 export type TestStep = {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -443,7 +443,11 @@ class HtmlBuilder {
         path,
         ok: test.outcome() === 'expected' || test.outcome() === 'flaky',
         results: results.map(result => {
-          return { attachments: result.attachments.map(a => ({ name: a.name, contentType: a.contentType, path: a.path })) };
+          return {
+            attachments: result.attachments.map(a => ({ name: a.name, contentType: a.contentType, path: a.path })),
+            startTime: result.startTime,
+            workerIndex: result.workerIndex,
+          };
         }),
       },
     };
@@ -552,6 +556,7 @@ class HtmlBuilder {
         ...result.attachments,
         ...result.stdout.map(m => stdioAttachment(m, 'stdout')),
         ...result.stderr.map(m => stdioAttachment(m, 'stderr'))]),
+      workerIndex: result.workerIndex,
     };
   }
 

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -2326,3 +2326,39 @@ test('should populate projects in config when merging reports', async ({ runInli
   const projectNames = JSON.parse(outputLines[0]);
   expect(projectNames).toEqual(['setup', 'p1', 'setup', 'p2']);
 });
+
+test('workerIndex is rebased', async ({ runInlineTest, writeFiles, showReport, page, mergeReports }) => {
+  const reportDir = test.info().outputPath('blob-reports');
+  await writeFiles({
+    'playwright.config.ts': `
+      module.exports = {
+        fullyParallel: true,
+        reporter: [['blob', { outputDir: '${reportDir.replace(/\\/g, '/')}' }]]
+      };
+    `,
+    'a.test.js': `
+      import { test, expect } from '@playwright/test';
+      test('test-one', async () => {});
+      test('test-two', async () => {});
+    `,
+  });
+
+  await runInlineTest({}, { shard: '1/2', workers: '1' }, { PWTEST_BLOB_DO_NOT_REMOVE: '1' });
+  await runInlineTest({}, { shard: '2/2', workers: '1' }, { PWTEST_BLOB_DO_NOT_REMOVE: '1' });
+
+  const { exitCode } = await mergeReports(reportDir, { 'PLAYWRIGHT_HTML_OPEN': 'never' }, { additionalArgs: ['--reporter', 'html'] });
+  expect(exitCode).toBe(0);
+  await showReport();
+
+  await page.getByRole('link', { name: 'test-two', exact: true }).click();
+
+  await page.getByRole('button', { name: 'Executed in Worker #1' }).click();
+  await expect(page.getByTestId('worker-test-list')).toMatchAriaSnapshot(`
+    - 'button "Executed in Worker #1" [expanded]'
+    - region:
+      - list:
+        - listitem:
+          - link "test-two"
+          - link "a.test.js:4"
+  `);
+});


### PR DESCRIPTION
The list is shown at the bottom of a test run, collapsed by default.

<img width="1006" height="367" alt="Screenshot 2026-02-03 at 11 02 44 AM" src="https://github.com/user-attachments/assets/8a40ca31-986f-4875-bc4f-ad0a62e73957" />
