### PR TITLE
chore(bidi): add support for page.requestGC() in Firefox

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -403,7 +403,13 @@ export class BidiPage implements PageDelegate {
   }
 
   async requestGC(): Promise<void> {
-    throw new Error('Method not implemented.');
+    const result = await this._session.send('script.evaluate', {
+      expression: 'TestUtils.gc()',
+      target: { context: this._session.sessionId },
+      awaitPromise: true,
+    });
+    if (result.type === 'exception')
+      throw new Error('Method not implemented.');
   }
 
   private async _onScriptMessage(event: bidi.Script.MessageParameters) {

--- a/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/firefoxPrefs.ts
@@ -265,6 +265,9 @@ function defaultProfilePreferences(
 
     // Prevent starting into safe mode after application crashes
     'toolkit.startup.max_resumed_crashes': -1,
+
+    // Enable TestUtils
+    'dom.testing.testutils.enabled': true,
   };
 
   return Object.assign(defaultPrefs, extraPrefs);

--- a/tests/bidi/expectations/moz-firefox-nightly-page.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-page.txt
@@ -137,7 +137,6 @@ page/page-request-continue.spec.ts › continue should drop content-length on re
 page/page-request-continue.spec.ts › should not throw if request was cancelled by the page [timeout]
 page/page-request-fulfill.spec.ts › should fulfill with gzip and readback [timeout]
 page/page-request-fulfill.spec.ts › should not throw if request was cancelled by the page [timeout]
-page/page-request-gc.spec.ts › should work [fail]
 page/page-request-intercept.spec.ts › request.postData is not null when fetching FormData with a Blob [fail]
 page/page-request-intercept.spec.ts › should intercept multipart/form-data request body [fail]
 page/page-route.spec.ts › should be abortable with custom error codes [fail]


### PR DESCRIPTION
This PR implements `page.requestGC()` using [`TestUtils.gc()`](https://testutils.spec.whatwg.org/#dom-testutils-gc).
Fixes the test "should work" in `page/page-request-gc.spec.ts` in Firefox.
