### PR TITLE
feat(mcp): add --cdp-timeout CLI option for CDP connection timeout

### DIFF
--- a/packages/playwright/src/mcp/browser/config.ts
+++ b/packages/playwright/src/mcp/browser/config.ts
@@ -40,6 +40,7 @@ export type CLIOptions = {
   caps?: string[];
   cdpEndpoint?: string;
   cdpHeader?: Record<string, string>;
+  cdpTimeout?: number;
   codegen?: 'typescript' | 'none';
   config?: string;
   consoleLevel?: 'error' | 'warning' | 'info' | 'debug';
@@ -273,6 +274,7 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config & { configF
       contextOptions,
       cdpEndpoint: cliOptions.cdpEndpoint,
       cdpHeaders: cliOptions.cdpHeader,
+      cdpTimeout: cliOptions.cdpTimeout,
       initPage: cliOptions.initPage,
       initScript: cliOptions.initScript,
     },
@@ -322,6 +324,7 @@ function configFromEnv(): Config & { configFile?: string } {
   options.caps = commaSeparatedList(process.env.PLAYWRIGHT_MCP_CAPS);
   options.cdpEndpoint = envToString(process.env.PLAYWRIGHT_MCP_CDP_ENDPOINT);
   options.cdpHeader = headerParser(process.env.PLAYWRIGHT_MCP_CDP_HEADERS, {});
+  options.cdpTimeout = numberParser(process.env.PLAYWRIGHT_MCP_CDP_TIMEOUT);
   options.config = envToString(process.env.PLAYWRIGHT_MCP_CONFIG);
   if (process.env.PLAYWRIGHT_MCP_CONSOLE_LEVEL)
     options.consoleLevel = enumParser<'error' | 'warning' | 'info' | 'debug'>('--console-level', ['error', 'warning', 'info', 'debug'], process.env.PLAYWRIGHT_MCP_CONSOLE_LEVEL);

--- a/packages/playwright/src/mcp/program.ts
+++ b/packages/playwright/src/mcp/program.ts
@@ -42,6 +42,7 @@ export function decorateCommand(command: Command, version: string) {
       .option('--caps <caps>', 'comma-separated list of additional capabilities to enable, possible values: vision, pdf, devtools.', commaSeparatedList)
       .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
       .option('--cdp-header <headers...>', 'CDP headers to send with the connect request, multiple can be specified.', headerParser)
+      .option('--cdp-timeout <timeout>', 'timeout in milliseconds for connecting to CDP endpoint, defaults to 30000ms', numberParser)
       .option('--codegen <lang>', 'specify the language to use for code generation, possible values: "typescript", "none". Default is "typescript".', enumParser.bind(null, '--codegen', ['none', 'typescript']))
       .option('--config <path>', 'path to the configuration file.')
       .option('--console-level <level>', 'level of console messages to return: "error", "warning", "info", "debug". Each level includes the messages of more severe levels.', enumParser.bind(null, '--console-level', ['error', 'warning', 'info', 'debug']))


### PR DESCRIPTION
This PR adds the --cdp-timeout CLI option to complement the browser.cdpTimeout config file option added in #38746.

## Changes
- Added --cdp-timeout <timeout> CLI option in program.ts
- Added cdpTimeout to CLIOptions type in config.ts
- Added mapping from CLI option to config in configFromCLIOptions()
- Added PLAYWRIGHT_MCP_CDP_TIMEOUT environment variable support
## Usage
`npx @playwright/mcp --cdp-endpoint ws://... --cdp-timeout 120000`

or via environment variable:

`PLAYWRIGHT_MCP_CDP_TIMEOUT=120000 npx @playwright/mcp --cdp-endpoint ws://...`

## Related
- Implements CLI portion of #38741
- Complements #38746