### PR TITLE
chore(deps): bump fast-xml-parser from 5.2.5 to 5.3.4

### DIFF
--- a/utils/flakiness-dashboard/package-lock.json
+++ b/utils/flakiness-dashboard/package-lock.json
@@ -444,9 +444,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
+      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
 ## Summary
 
1. Why:
To remove CVEs:

     - [CVE-2026-25128](https://avd.aquasec.com/nvd/2026/cve-2026-25128/)

2. What:

     - Upgrade fast-xml-parser to 5.3.4 to remove [CVE-2026-25128](https://avd.aquasec.com/nvd/2026/cve-2026-25128/)
 
 ## Additional evidence
 
 Partial output from security scanner Trivy:
<img width="1089" height="70" alt="cve playwright fastxmlparser" src="https://github.com/user-attachments/assets/f3ec8d04-adc6-4059-b267-c32a073bed4a" />

 ## Categorization
 
- [x] security/CVE