### PR TITLE
fix: skip test registrations from ESM preflight imports

### DIFF
--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -73,6 +73,12 @@ export class TestTypeImpl {
   }
 
   private _currentSuite(location: Location, title: string): Suite | undefined {
+    // Skip registrations from ESM preflight imports. This can happen when external
+    // ESM loaders (like tsx/esm) intercept Playwright's .esm.preflight requests
+    // and execute the actual test file content instead of returning empty content.
+    if (location.file?.endsWith('.esm.preflight'))
+      return undefined;
+
     const suite = currentlyLoadingFileSuite();
     if (!suite) {
       throw new Error([


### PR DESCRIPTION
## Problem

When external ESM loaders like `tsx/esm` are used alongside Playwright (via `import 'tsx/esm'` in config), they intercept Playwright's `.esm.preflight` import requests and execute the actual test file content instead of returning empty content. This causes:

- `test()` calls to run twice (once during preflight, once during actual import)
- "duplicate test title" errors

Reproduction: https://github.com/Abhinegi2/playwright-issue

## Solution

Check if the registration location file path ends with `.esm.preflight` in `_currentSuite()` and return `undefined` to skip registration. This ensures tests registered during external loader's preflight phase are silently ignored.

## Testing

Verified the fix works by:
1. Setting up reproduction case with tsx/esm
2. Confirming error reproduces without fix
3. Applying fix and confirming tests run correctly (1 test listed, passes)

## Related

Fixes #39172