### PR TITLE
fix(trace): respect dark mode in blank snapshot

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/playwright-core/src/utils/isomorphic/trace/snapshotRenderer.ts
@@ -345,7 +345,7 @@ function snapshotScript(viewport: ViewportSize, ...targetIds: (string | undefine
           frameBoundingRectsInfo.frames.set(iframe, { boundingRect, scrollLeft: 0, scrollTop: 0 });
         const src = iframe.getAttribute('__playwright_src__');
         if (!src) {
-          iframe.setAttribute('src', 'data:text/html,<body style="background: #ddd"></body>');
+          iframe.setAttribute('src', blankSnapshotUrl);
         } else {
           // Retain query parameters to inherit name=, time=, pointX=, pointY= and other values from parent.
           const url = new URL(win.location.href);
@@ -639,3 +639,5 @@ function escapeURLsInStyleSheet(text: string): string {
   };
   return text.replace(urlToEscapeRegex1, replacer).replace(urlToEscapeRegex2, replacer);
 }
+
+export const blankSnapshotUrl = 'data:text/html;base64,' + btoa(`<body></body><style>body { color-scheme: light dark; background: light-dark(white, #333) }</style>`);

--- a/packages/trace-viewer/src/ui/snapshotTab.css
+++ b/packages/trace-viewer/src/ui/snapshotTab.css
@@ -97,7 +97,7 @@ iframe[name=snapshot] {
   width: 100%;
   height: 100%;
   border: none;
-  background: white;
+  background: light-dark(white, #333);
   visibility: hidden;
 }
 

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -25,6 +25,7 @@ import { clsx, useMeasure, useSetting } from '@web/uiUtils';
 import { InjectedScript } from '@injected/injectedScript';
 import { Recorder } from '@injected/recorder/recorder';
 import { asLocator } from '@isomorphic/locatorGenerators';
+import { blankSnapshotUrl } from '@isomorphic/trace/snapshotRenderer';
 import type { Language } from '@isomorphic/locatorGenerators';
 import { locatorOrSelectorAsSelector } from '@isomorphic/locatorParser';
 import { TabbedPaneTab } from '@web/components/tabbedPane';
@@ -133,7 +134,7 @@ export const SnapshotView: React.FunctionComponent<{
           iframe.addEventListener('error', loadedCallback);
 
           // Try preventing history entry from being created.
-          const snapshotUrl = snapshotUrls?.snapshotUrl || kBlankSnapshotUrl;
+          const snapshotUrl = snapshotUrls?.snapshotUrl || blankSnapshotUrl;
           if (iframe.contentWindow)
             iframe.contentWindow.location.replace(snapshotUrl);
           else
@@ -457,4 +458,3 @@ export async function fetchSnapshotInfo(snapshotInfoUrl: string | undefined) {
 }
 
 export const kDefaultViewport = { width: 1280, height: 720 };
-const kBlankSnapshotUrl = 'data:text/html,<body style="background: #ddd"></body>';


### PR DESCRIPTION
closes https://github.com/microsoft/playwright/issues/39201

before: <img width="1392" height="912" alt="Screenshot 2026-02-10 at 10 34 47" src="https://github.com/user-attachments/assets/adf231d8-342c-4161-a89b-b7dcbf75411f" />
after: <img width="1392" height="912" alt="Screenshot 2026-02-10 at 10 34 18" src="https://github.com/user-attachments/assets/7046b692-3dc6-4973-a3ac-ecba0d4b5cb6" />
