### PR TITLE
chore: rename --no-sandbox to --no-chromium-sandbox

### DIFF
--- a/packages/playwright/src/mcp/browser/config.ts
+++ b/packages/playwright/src/mcp/browser/config.ts
@@ -41,6 +41,7 @@ export type CLIOptions = {
   cdpEndpoint?: string;
   cdpHeader?: Record<string, string>;
   cdpTimeout?: number;
+  chromiumSandbox?: boolean;
   codegen?: 'typescript' | 'none';
   config?: string;
   consoleLevel?: 'error' | 'warning' | 'info' | 'debug';
@@ -56,7 +57,6 @@ export type CLIOptions = {
   initPage?: string[];
   isolated?: boolean;
   imageResponses?: 'allow' | 'omit';
-  sandbox?: boolean;
   outputDir?: string;
   outputMode?: 'file' | 'stdout';
   port?: number;
@@ -240,10 +240,10 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config & { configF
     headless: cliOptions.headless,
   };
 
-  // --sandbox was passed, enable the sandbox
-  // --no-sandbox was passed, disable the sandbox
-  if (cliOptions.sandbox !== undefined)
-    launchOptions.chromiumSandbox = cliOptions.sandbox;
+  // --chromium-sandbox was passed, enable the chromium sandbox
+  // --no-chromium-sandbox was passed, disable the chromium sandbox
+  if (cliOptions.chromiumSandbox !== undefined)
+    launchOptions.chromiumSandbox = cliOptions.chromiumSandbox;
 
   if (cliOptions.proxyServer) {
     launchOptions.proxy = {
@@ -355,7 +355,7 @@ function configFromEnv(): Config & { configFile?: string } {
   options.isolated = envToBoolean(process.env.PLAYWRIGHT_MCP_ISOLATED);
   if (process.env.PLAYWRIGHT_MCP_IMAGE_RESPONSES)
     options.imageResponses = enumParser<'allow' | 'omit'>('--image-responses', ['allow', 'omit'], process.env.PLAYWRIGHT_MCP_IMAGE_RESPONSES);
-  options.sandbox = envToBoolean(process.env.PLAYWRIGHT_MCP_SANDBOX);
+  options.chromiumSandbox = envToBoolean(process.env.PLAYWRIGHT_MCP_CHROMIUM_SANDBOX);
   options.outputDir = envToString(process.env.PLAYWRIGHT_MCP_OUTPUT_DIR);
   options.port = numberParser(process.env.PLAYWRIGHT_MCP_PORT);
   options.proxyBypass = envToString(process.env.PLAYWRIGHT_MCP_PROXY_BYPASS);

--- a/packages/playwright/src/mcp/program.ts
+++ b/packages/playwright/src/mcp/program.ts
@@ -43,7 +43,7 @@ export function decorateCommand(command: Command, version: string) {
       .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
       .option('--cdp-header <headers...>', 'CDP headers to send with the connect request, multiple can be specified.', headerParser)
       .option('--cdp-timeout <timeout>', 'timeout in milliseconds for connecting to CDP endpoint, defaults to 30000ms', numberParser)
-      .option('--chromium-sandbox', 'enable the chromium sandbox. on by default, disable with --no-chromium-sandbox.')
+      .option('--chromium-sandbox', 'enable the chromium sandbox. disable with --no-chromium-sandbox.')
       .option('--no-chromium-sandbox', 'disable the chromium sandbox.')
       .option('--codegen <lang>', 'specify the language to use for code generation, possible values: "typescript", "none". Default is "typescript".', enumParser.bind(null, '--codegen', ['none', 'typescript']))
       .option('--config <path>', 'path to the configuration file.')
@@ -81,7 +81,7 @@ export function decorateCommand(command: Command, version: string) {
       .addOption(new ProgramOption('--daemon-session <path>', 'path to the daemon config.').hideHelp())
       .action(async options => {
 
-        // normalize the --no-sandbox option: sandbox = true => nothing was passed, sandbox = false => --no-sandbox was passed.
+        // normalize the --no-chromium-sandbox option: chromiumSandbox = true => nothing was passed, chromiumSandbox = false => --no-chromium-sandbox was passed.
         options.chromiumSandbox = options.chromiumSandbox === true ? undefined : false;
 
         setupExitWatchdog();

--- a/packages/playwright/src/mcp/program.ts
+++ b/packages/playwright/src/mcp/program.ts
@@ -43,6 +43,8 @@ export function decorateCommand(command: Command, version: string) {
       .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
       .option('--cdp-header <headers...>', 'CDP headers to send with the connect request, multiple can be specified.', headerParser)
       .option('--cdp-timeout <timeout>', 'timeout in milliseconds for connecting to CDP endpoint, defaults to 30000ms', numberParser)
+      .option('--chromium-sandbox', 'enable the chromium sandbox. on by default, disable with --no-chromium-sandbox.')
+      .option('--no-chromium-sandbox', 'disable the chromium sandbox.')
       .option('--codegen <lang>', 'specify the language to use for code generation, possible values: "typescript", "none". Default is "typescript".', enumParser.bind(null, '--codegen', ['none', 'typescript']))
       .option('--config <path>', 'path to the configuration file.')
       .option('--console-level <level>', 'level of console messages to return: "error", "warning", "info", "debug". Each level includes the messages of more severe levels.', enumParser.bind(null, '--console-level', ['error', 'warning', 'info', 'debug']))
@@ -57,13 +59,11 @@ export function decorateCommand(command: Command, version: string) {
       .option('--init-script <path...>', 'path to JavaScript file to add as an initialization script. The script will be evaluated in every page before any of the page\'s scripts. Can be specified multiple times.')
       .option('--isolated', 'keep the browser profile in memory, do not save it to disk.')
       .option('--image-responses <mode>', 'whether to send image responses to the client. Can be "allow" or "omit", Defaults to "allow".', enumParser.bind(null, '--image-responses', ['allow', 'omit']))
-      .option('--no-sandbox', 'disable the sandbox for all process types that are normally sandboxed.')
       .option('--output-dir <path>', 'path to the directory for output files.')
       .option('--output-mode <mode>', 'whether to save snapshots, console messages, network logs to a file or to the standard output. Can be "file" or "stdout". Default is "stdout".', enumParser.bind(null, '--output-mode', ['file', 'stdout']))
       .option('--port <port>', 'port to listen on for SSE transport.')
       .option('--proxy-bypass <bypass>', 'comma-separated domains to bypass proxy, for example ".com,chromium.org,.domain.com"')
       .option('--proxy-server <proxy>', 'specify proxy server, for example "http://myproxy:3128" or "socks5://myproxy:8080"')
-      .option('--sandbox', 'enable the sandbox for all process types that are normally not sandboxed.')
       .option('--save-session', 'Whether to save the Playwright MCP session into the output directory.')
       .option('--save-trace', 'Whether to save the Playwright Trace of the session into the output directory.')
       .option('--save-video <size>', 'Whether to save the video of the session into the output directory. For example "--save-video=800x600"', resolutionParser.bind(null, '--save-video'))
@@ -82,7 +82,7 @@ export function decorateCommand(command: Command, version: string) {
       .action(async options => {
 
         // normalize the --no-sandbox option: sandbox = true => nothing was passed, sandbox = false => --no-sandbox was passed.
-        options.sandbox = options.sandbox === true ? undefined : false;
+        options.chromiumSandbox = options.chromiumSandbox === true ? undefined : false;
 
         setupExitWatchdog();
 

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -78,15 +78,15 @@ test.describe(() => {
   });
 });
 
-async function sandboxOption(cli: any) {
-  const config: any = await resolveCLIConfig(cli);
-  return config.browser.launchOptions.chromiumSandbox;
-}
+test('test chromiumSandbox configuration', async ({}) => {
+  async function sandboxOption(cli: any) {
+    const config: any = await resolveCLIConfig(cli);
+    return config.browser.launchOptions.chromiumSandbox;
+  }
 
-test('test sandbox configuration', async ({}) => {
   expect(await sandboxOption({ browser: 'chromium' })).toBe(process.platform !== 'linux');
-  expect(await sandboxOption({ browser: 'chromium', sandbox: true })).toBe(true);
-  expect(await sandboxOption({ browser: 'chrome', sandbox: false })).toBe(false);
+  expect(await sandboxOption({ browser: 'chromium', chromiumSandbox: true })).toBe(true);
+  expect(await sandboxOption({ browser: 'chrome', chromiumSandbox: false })).toBe(false);
   expect(await sandboxOption({ browser: 'chrome' })).toBe(true);
   expect(await sandboxOption({ browser: 'msedge' })).toBe(true);
 });


### PR DESCRIPTION
In the context of MCP, `--sandbox` sounds like an agent sandbox which it isn't.