### PR TITLE
Reapply "Revert "test: make trace-viewer tests e2e (#39174)"

### DIFF
--- a/packages/playwright-core/src/server/index.ts
+++ b/packages/playwright-core/src/server/index.ts
@@ -28,4 +28,4 @@ export { createPlaywright } from './playwright';
 
 export type { DispatcherScope } from './dispatchers/dispatcher';
 export type { Playwright } from './playwright';
-export { installRootRedirect, openTraceInBrowser, openTraceViewerApp, runTraceViewerApp, startTraceViewerServer } from './trace/viewer/traceViewer';
+export { installRootRedirect, openTraceInBrowser, openTraceViewerApp, startTraceViewerServer } from './trace/viewer/traceViewer';

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -171,7 +171,7 @@ export const traceViewerFixtures: Fixtures<TraceViewerFixtures, {}, BaseTestFixt
       const cp = childProcess({ command });
       await cp.waitForOutput('Listening on');
       const browser = await playwright.chromium.launch({
-        executablePath: process.env.CRPATH,
+        executablePath: process.env.CRPATH, // without this, setting FFPATH makes us launch Firefox with Chromium args
       });
       browsers.push(browser);
       const page = await browser.newPage();

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -170,7 +170,9 @@ export const traceViewerFixtures: Fixtures<TraceViewerFixtures, {}, BaseTestFixt
         command.push(trace);
       const cp = childProcess({ command });
       await cp.waitForOutput('Listening on');
-      const browser = await playwright.chromium.launch();
+      const browser = await playwright.chromium.launch({
+        executablePath: process.env.CRPATH,
+      });
       browsers.push(browser);
       const page = await browser.newPage();
       const url = cp.output.match(/Listening on (http:\/\/[^\s]+)/)![1];


### PR DESCRIPTION
relands, but without the bug reported in https://github.com/microsoft/playwright/issues/39202.