### PR TITLE
chore: fix flaky codegen test by not recording x-pw- actions

### DIFF
--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -378,6 +378,8 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   async onBeforeCall(sdkObject: SdkObject, metadata: CallMetadata) {
+    if (isUnderTest() && metadata.params.selector && metadata.params.selector.startsWith('x-pw'))
+      return;
     if (this._omitCallTracking || this._isRecording())
       return;
     this._debugLog('onBeforeCall', metadata.method, metadata.params);
@@ -391,6 +393,8 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   async onAfterCall(sdkObject: SdkObject, metadata: CallMetadata) {
+    if (isUnderTest() && metadata.params.selector && metadata.params.selector.startsWith('x-pw'))
+      return;
     if (this._omitCallTracking || this._isRecording())
       return;
     this._debugLog('onAfterCall', metadata.method, metadata.params);

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -378,8 +378,6 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   async onBeforeCall(sdkObject: SdkObject, metadata: CallMetadata) {
-    if (isUnderTest() && metadata.params.selector && metadata.params.selector.startsWith('x-pw'))
-      return;
     if (this._omitCallTracking || this._isRecording())
       return;
     this._debugLog('onBeforeCall', metadata.method, metadata.params);
@@ -393,8 +391,6 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   async onAfterCall(sdkObject: SdkObject, metadata: CallMetadata) {
-    if (isUnderTest() && metadata.params.selector && metadata.params.selector.startsWith('x-pw'))
-      return;
     if (this._omitCallTracking || this._isRecording())
       return;
     this._debugLog('onAfterCall', metadata.method, metadata.params);

--- a/tests/library/inspector/inspectorTest.ts
+++ b/tests/library/inspector/inspectorTest.ts
@@ -92,6 +92,7 @@ export const test = contextTest.extend<CLITestArgs>({
     await use(async options => {
       await (context as any)._enableRecorder({
         mode: 'recording',
+        omitCallTracking: true,
         ...options
       });
       const page = await context.newPage();


### PR DESCRIPTION
In a flaky run of `should update locator highlight`, i saw this log:

```
387291.345 setHighlightedSelector getByRole('button', { name: 'Cancel' })
387302.543 onBeforeCall expect { selector: 'x-pw-highlight', ... }
387309.533 __pw_recorderState { ... actionSelector: 'x-pw-highlight' ... }
```

here's the green next run:
```
405409.758 setHighlightedSelector getByRole('button', { name: 'Cancel' })
405416.736 __pw_recorderState { ... actionSelector: 'internal:role=button[name="Cancel"i]' ... }
405422.924 onBeforeCall expect { selector: 'x-pw-highlight', ... }
405445.428 onAfterCall expect { ... }
```

`expect` reaches the recorder and sets `actionSelector` to `x-pw-highlight`, making `x-pw-highlight` close in the process. I'm fixing it by making the recorder ignore all actions.

https://github.com/microsoft/playwright/blob/19bb594fea68580be49653a076fd42d6e32955fb/tests/library/inspector/cli-codegen-pick-locator.spec.ts#L62
