### PR TITLE
fix(cli): preserve leading zeros in positional string arguments

### DIFF
--- a/packages/playwright/src/mcp/terminal/program.ts
+++ b/packages/playwright/src/mcp/terminal/program.ts
@@ -494,7 +494,7 @@ export async function program(packageLocation: string) {
 
   const argv = process.argv.slice(2);
   const boolean = [...help.booleanOptions, ...booleanOptions];
-  const args: MinimistArgs = require('minimist')(argv, { boolean });
+  const args: MinimistArgs = require('minimist')(argv, { boolean, string: ['_'] });
   for (const [key, value] of Object.entries(args)) {
     if (key !== '_' && typeof value !== 'boolean')
       args[key] = String(value);

--- a/tests/mcp/cli-parsing.spec.ts
+++ b/tests/mcp/cli-parsing.spec.ts
@@ -59,3 +59,12 @@ test('wrong argument type', async ({ cli, server }) => {
   const press = await cli('press', '5');
   expect(press.exitCode).toBe(0);
 });
+
+test('should preserve leading zeros in string arguments', async ({ cli, server }) => {
+  server.setContent('/', `<input type=text>`, 'text/html');
+  await cli('open', server.PREFIX);
+  await cli('click', 'e2');
+  await cli('type', '0812345679');
+  const { snapshot } = await cli('snapshot');
+  expect(snapshot).toContain(`0812345679`);
+});


### PR DESCRIPTION
Minimist auto-converts numeric-looking positional args to numbers, stripping leading zeros (e.g. "0812345679" becomes 812345679). Pass string: ['_'] to keep positional args as strings.

Fixes https://github.com/microsoft/playwright-cli/issues/252