### PR TITLE
fix(agents): use cmd /c npx on Windows for init-agents MCP config

### DIFF
--- a/docs/src/test-agents-js.md
+++ b/docs/src/test-agents-js.md
@@ -47,7 +47,7 @@ npx playwright init-agents --loop=opencode
 VS Code v1.105 (released October 9, 2025) is needed for the agentic experience to function properly in VS Code.
 :::
 
-Once the agents have been generated, you can use your AI tool of choice to command these agents to build Playwright Tests. 
+Once the agents have been generated, you can use your AI tool of choice to command these agents to build Playwright Tests.
 
 
 ## 🎭 Planner

--- a/docs/src/test-agents-js.md
+++ b/docs/src/test-agents-js.md
@@ -47,7 +47,7 @@ npx playwright init-agents --loop=opencode
 VS Code v1.105 (released October 9, 2025) is needed for the agentic experience to function properly in VS Code.
 :::
 
-Once the agents have been generated, you can use your AI tool of choice to command these agents to build Playwright Tests.
+Once the agents have been generated, you can use your AI tool of choice to command these agents to build Playwright Tests. 
 
 
 ## 🎭 Planner

--- a/packages/playwright/src/agents/generateAgents.ts
+++ b/packages/playwright/src/agents/generateAgents.ts
@@ -262,12 +262,10 @@ export class VSCodeGenerator {
     if (!mcpJson.servers)
       mcpJson.servers = {};
 
-    const mcpServer = process.platform === 'win32'
-        ? { command: 'cmd', args: ['/c', 'npx', 'playwright', 'run-test-mcp-server'] }
-        : { command: 'npx', args: ['playwright', 'run-test-mcp-server'] };
     mcpJson.servers['playwright-test'] = {
       type: 'stdio',
-      ...mcpServer,
+      command: 'npx',
+      args: ['playwright', 'run-test-mcp-server'],
     };
     await writeFile(mcpJsonPath, JSON.stringify(mcpJson, null, 2), '🔧', 'mcp configuration');
   }

--- a/packages/playwright/src/agents/generateAgents.ts
+++ b/packages/playwright/src/agents/generateAgents.ts
@@ -45,9 +45,11 @@ export class ClaudeGenerator {
     for (const agent of agents)
       await writeFile(`.claude/agents/${agent.name}.md`, ClaudeGenerator.agentSpec(agent), '🤖', 'agent definition');
 
+    // On Windows, npx resolves to npx.cmd which cannot be executed without shell: true.
+    // See: https://code.claude.com/docs/en/mcp#dynamic-tool-updates
     const mcpServer = process.platform === 'win32'
-        ? { command: 'cmd', args: ['/c', 'npx', 'playwright', 'run-test-mcp-server'] }
-        : { command: 'npx', args: ['playwright', 'run-test-mcp-server'] };
+      ? { command: 'cmd', args: ['/c', 'npx', 'playwright', 'run-test-mcp-server'] }
+      : { command: 'npx', args: ['playwright', 'run-test-mcp-server'] };
     await writeFile('.mcp.json', JSON.stringify({
       mcpServers: {
         'playwright-test': mcpServer,

--- a/tests/mcp/init-agents.spec.ts
+++ b/tests/mcp/init-agents.spec.ts
@@ -90,19 +90,3 @@ test('claude generates correct mcp config', async ({  }) => {
   }
 });
 
-test('vscode generates correct mcp config', async ({  }) => {
-  const baseDir = await writeFiles({
-    'playwright.config.ts': `module.exports = {};`,
-  });
-
-  await runInitAgents({ cwd: baseDir, args: ['--loop', 'vscode'] });
-
-  const mcpJson = JSON.parse(fs.readFileSync(path.join(baseDir, '.vscode', 'mcp.json'), 'utf-8'));
-  if (process.platform === 'win32') {
-    expect(mcpJson.servers['playwright-test'].command).toBe('cmd');
-    expect(mcpJson.servers['playwright-test'].args).toEqual(['/c', 'npx', 'playwright', 'run-test-mcp-server']);
-  } else {
-    expect(mcpJson.servers['playwright-test'].command).toBe('npx');
-    expect(mcpJson.servers['playwright-test'].args).toEqual(['playwright', 'run-test-mcp-server']);
-  }
-});

--- a/tests/mcp/init-agents.spec.ts
+++ b/tests/mcp/init-agents.spec.ts
@@ -72,3 +72,44 @@ test('create seed file with --config', async ({  }) => {
   });
   expect(fs.existsSync(path.join(baseDir, 'custom', 'bar', 'e2e', 'seed.spec.ts'))).toBe(true);
 });
+
+const isWindows = process.platform === 'win32';
+const expectedCommand = isWindows ? 'cmd' : 'npx';
+const expectedArgs = isWindows
+    ? ['/c', 'npx', 'playwright', 'run-test-mcp-server']
+    : ['playwright', 'run-test-mcp-server'];
+
+test('claude generates correct mcp config', async ({  }) => {
+  const baseDir = await writeFiles({
+    'playwright.config.ts': `module.exports = {};`,
+  });
+
+  await runInitAgents({ cwd: baseDir, args: ['--loop', 'claude'] });
+
+  const mcpJson = JSON.parse(fs.readFileSync(path.join(baseDir, '.mcp.json'), 'utf-8'));
+  expect(mcpJson.mcpServers['playwright-test'].command).toBe(expectedCommand);
+  expect(mcpJson.mcpServers['playwright-test'].args).toEqual(expectedArgs);
+});
+
+test('vscode generates correct mcp config', async ({  }) => {
+  const baseDir = await writeFiles({
+    'playwright.config.ts': `module.exports = {};`,
+  });
+
+  await runInitAgents({ cwd: baseDir, args: ['--loop', 'vscode'] });
+
+  const mcpJson = JSON.parse(fs.readFileSync(path.join(baseDir, '.vscode', 'mcp.json'), 'utf-8'));
+  expect(mcpJson.servers['playwright-test'].command).toBe(expectedCommand);
+  expect(mcpJson.servers['playwright-test'].args).toEqual(expectedArgs);
+});
+
+test('opencode generates correct mcp config', async ({  }) => {
+  const baseDir = await writeFiles({
+    'playwright.config.ts': `module.exports = {};`,
+  });
+
+  await runInitAgents({ cwd: baseDir, args: ['--loop', 'opencode'] });
+
+  const opencodeJson = JSON.parse(fs.readFileSync(path.join(baseDir, 'opencode.json'), 'utf-8'));
+  expect(opencodeJson.mcp['playwright-test'].command).toEqual([expectedCommand, ...expectedArgs]);
+});

--- a/tests/mcp/init-agents.spec.ts
+++ b/tests/mcp/init-agents.spec.ts
@@ -89,4 +89,3 @@ test('claude generates correct mcp config', async ({  }) => {
     expect(mcpJson.mcpServers['playwright-test'].args).toEqual(['playwright', 'run-test-mcp-server']);
   }
 });
-


### PR DESCRIPTION
## Summary

- On Windows, `npx` resolves to `npx.cmd` (a batch file) which cannot be executed by MCP clients using `child_process.spawn()` without `shell: true`
- Added platform detection in `generateAgents.ts` for **Claude** generator to use `cmd /c npx` on Windows
- Other generators unchanged: VS Code handles `.cmd` resolution internally, Copilot runs on GitHub cloud, Opencode spawns a shell

## Changes

- `ClaudeGenerator.init()`: generates `.mcp.json` with `cmd /c npx` on Windows
- Added 1 test in `tests/mcp/init-agents.spec.ts` verifying MCP config output for claude generator

## Test plan

- [x] Build passes
- [x] All 4 init-agents tests pass
- [x] Verified VS Code works with plain `npx` on Windows (no `cmd /c` needed)
- [x] Test uses `if/else` platform branching, validated across CI environments (ubuntu, macos, windows)