### PR TITLE
test(bidi): set channel option in showTraceViewer() fixture

### DIFF
--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -171,7 +171,7 @@ export const traceViewerFixtures: Fixtures<TraceViewerFixtures, {}, BaseTestFixt
       const cp = childProcess({ command });
       await cp.waitForOutput('Listening on');
       const browser = await playwright.chromium.launch({
-        channel: 'chrome',
+        channel: 'chromium',
         executablePath: process.env.CRPATH, // without this, setting FFPATH makes us launch Firefox with Chromium args
       });
       browsers.push(browser);

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -153,7 +153,7 @@ class TraceViewerPage {
 }
 
 export const traceViewerFixtures: Fixtures<TraceViewerFixtures, {}, BaseTestFixtures, BaseWorkerFixtures> = {
-  showTraceViewer: async ({ playwright, childProcess }, use) => {
+  showTraceViewer: async ({ playwright, childProcess, browserName }, use) => {
     const browsers: Browser[] = [];
     await use(async (trace: string | undefined, { host, port, stdin } = {}) => {
       const command = [
@@ -171,7 +171,7 @@ export const traceViewerFixtures: Fixtures<TraceViewerFixtures, {}, BaseTestFixt
       const cp = childProcess({ command });
       await cp.waitForOutput('Listening on');
       const browser = await playwright.chromium.launch({
-        ...(browserName === 'chromium' ? {} : { channel: 'chromium' })
+        ...(browserName === 'chromium' ? {} : { channel: 'chromium' }),
         executablePath: process.env.CRPATH, // without this, setting FFPATH makes us launch Firefox with Chromium args
       });
       browsers.push(browser);

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -171,7 +171,7 @@ export const traceViewerFixtures: Fixtures<TraceViewerFixtures, {}, BaseTestFixt
       const cp = childProcess({ command });
       await cp.waitForOutput('Listening on');
       const browser = await playwright.chromium.launch({
-        channel: 'chromium',
+        ...(browserName === 'chromium' ? {} : { channel: 'chromium' })
         executablePath: process.env.CRPATH, // without this, setting FFPATH makes us launch Firefox with Chromium args
       });
       browsers.push(browser);

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -171,6 +171,7 @@ export const traceViewerFixtures: Fixtures<TraceViewerFixtures, {}, BaseTestFixt
       const cp = childProcess({ command });
       await cp.waitForOutput('Listening on');
       const browser = await playwright.chromium.launch({
+        channel: 'chrome',
         executablePath: process.env.CRPATH, // without this, setting FFPATH makes us launch Firefox with Chromium args
       });
       browsers.push(browser);


### PR DESCRIPTION
After #39209 the trace-viewer tests are failing in Firefox Bidi test runs because the defaultLaunchOptions contain `channel: 'moz-firefox-nightly-library'` and therefore `playwright.chromium.launch()` throws.