### PR TITLE
Revert "chore(chromium): reenable RenderDocument (#38890)"

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -40,6 +40,8 @@ const disabledFeatures = (assistantMode?: boolean) => [
   'Translate',
   // See https://issues.chromium.org/u/1/issues/435410220
   'AutoDeElevate',
+  // See https://github.com/microsoft/playwright/issues/37714
+  'RenderDocument',
   // Prevents downloading optimization hints on startup.
   'OptimizationHints',
   assistantMode ? 'AutomationControlled' : '',


### PR DESCRIPTION
This reverts commit 7041c29d51ad4930ed1cb1b04c66797e96eb69e6.

References #37714.