### PR TITLE
fix(mcp): route custom screenshot filenames through outputFile

### DIFF
--- a/packages/playwright/src/mcp/browser/response.ts
+++ b/packages/playwright/src/mcp/browser/response.ts
@@ -69,7 +69,7 @@ export class Response {
   async resolveClientFile(template: FilenameTemplate, title: string): Promise<ResolvedFile> {
     let fileName: string;
     if (template.suggestedFilename)
-      fileName = await this._context.workspaceFile(template.suggestedFilename, this._clientWorkspace);
+      fileName = await this._context.outputFile(template, { origin: 'llm' });
     else
       fileName = await this._context.outputFile(template, { origin: 'llm' });
     const relativeName = this._computRelativeTo(fileName);


### PR DESCRIPTION
Custom filenames passed to `browser_take_screenshot` (and `browser_pdf_save`) are resolved via `workspaceFile()` instead of `outputFile()` in `resolveClientFile()`. This means they save to the workspace root, bypassing `--output-dir`.

Auto-generated filenames (when no filename is provided) already correctly route through `outputFile()`. This one-line fix makes custom filenames use the same path.

## Reproduction

1. Start MCP with `--output-dir /tmp/playwright-mcp`
2. `browser_take_screenshot()` without filename → saves to `/tmp/playwright-mcp/page-{timestamp}.png` ✅
3. `browser_take_screenshot(filename: "test.png")` → saves to `{workspace}/test.png` ❌ (should go to `/tmp/playwright-mcp/test.png`)

## Fix

In `packages/playwright/src/mcp/browser/response.ts`, `resolveClientFile()` line 72:

```diff
  if (template.suggestedFilename)
-   fileName = await this._context.workspaceFile(template.suggestedFilename, this._clientWorkspace);
+   fileName = await this._context.outputFile(template, { origin: 'llm' });
```

`context.outputFile()` already handles `suggestedFilename` — it uses it as the basename and resolves against `outputDir`. The `checkFile()` security validation still applies.

References microsoft/playwright-mcp#1390, microsoft/playwright-mcp#1253, microsoft/playwright-mcp#1002