### PR TITLE
feat(api): add Page.clearConsoleMessages method

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2722,6 +2722,11 @@ Returns whether the element is [visible](../actionability.md#visible). [`param: 
 - type: <[Keyboard]>
 
 
+## async method: Page.clearConsoleMessages
+* since: v1.59
+
+Clears all stored console messages from this page. Subsequent calls to [`method: Page.consoleMessages`] will only return messages logged after the clear.
+
 ## async method: Page.consoleMessages
 * since: v1.56
 - returns: <[Array]<[ConsoleMessage]>>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -2257,6 +2257,13 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * Clears all stored console messages from this page. Subsequent calls to
+   * [page.consoleMessages()](https://playwright.dev/docs/api/class-page#page-console-messages) will only return
+   * messages logged after the clear.
+   */
+  clearConsoleMessages(): Promise<void>;
+
+  /**
    * **NOTE** Use locator-based [locator.click([options])](https://playwright.dev/docs/api/class-locator#locator-click) instead.
    * Read more about [locators](https://playwright.dev/docs/locators).
    *

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -655,6 +655,10 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     return await this._mainFrame.fill(selector, value, options);
   }
 
+  async clearConsoleMessages(): Promise<void> {
+    await this._channel.clearConsoleMessages();
+  }
+
   async consoleMessages(): Promise<ConsoleMessage[]> {
     const { messages } = await this._channel.consoleMessages();
     return messages.map(message => new ConsoleMessage(this._platform, message, this, null));

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1230,6 +1230,8 @@ scheme.PageCloseParams = tObject({
   reason: tOptional(tString),
 });
 scheme.PageCloseResult = tOptional(tObject({}));
+scheme.PageClearConsoleMessagesParams = tOptional(tObject({}));
+scheme.PageClearConsoleMessagesResult = tOptional(tObject({}));
 scheme.PageConsoleMessagesParams = tOptional(tObject({}));
 scheme.PageConsoleMessagesResult = tObject({
   messages: tArray(tObject({

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -272,6 +272,10 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     await this._page.keyboard.press(progress, params.key, params);
   }
 
+  async clearConsoleMessages(params: channels.PageClearConsoleMessagesParams, progress: Progress): Promise<channels.PageClearConsoleMessagesResult> {
+    this._page.clearConsoleMessages();
+  }
+
   async consoleMessages(params: channels.PageConsoleMessagesParams, progress: Progress): Promise<channels.PageConsoleMessagesResult> {
     // Send all future console messages to the client, so that it can reliably receive all of them.
     // Otherwise, if subscription is added in a different task from this call (either before or after),

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -400,6 +400,10 @@ export class Page extends SdkObject<PageEventMap> {
       this.emitOnContext(BrowserContext.Events.Console, message);
   }
 
+  clearConsoleMessages() {
+    this._consoleMessages.length = 0;
+  }
+
   consoleMessages() {
     return this._consoleMessages;
   }

--- a/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
+++ b/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
@@ -106,6 +106,7 @@ export const methodMetainfo = new Map<string, { internal?: boolean, title?: stri
   ['BrowserContext.devtoolsStop', { internal: true, }],
   ['Page.addInitScript', { title: 'Add init script', group: 'configuration', }],
   ['Page.close', { title: 'Close page', pausesBeforeAction: true, }],
+  ['Page.clearConsoleMessages', { title: 'Clear console messages', }],
   ['Page.consoleMessages', { title: 'Get console messages', group: 'getter', }],
   ['Page.emulateMedia', { title: 'Emulate media', snapshot: true, pausesBeforeAction: true, }],
   ['Page.exposeBinding', { title: 'Expose binding', group: 'configuration', }],

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2257,6 +2257,13 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * Clears all stored console messages from this page. Subsequent calls to
+   * [page.consoleMessages()](https://playwright.dev/docs/api/class-page#page-console-messages) will only return
+   * messages logged after the clear.
+   */
+  clearConsoleMessages(): Promise<void>;
+
+  /**
    * **NOTE** Use locator-based [locator.click([options])](https://playwright.dev/docs/api/class-locator#locator-click) instead.
    * Read more about [locators](https://playwright.dev/docs/locators).
    *

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -2088,6 +2088,7 @@ export interface PageChannel extends PageEventTarget, EventTargetChannel {
   _type_Page: boolean;
   addInitScript(params: PageAddInitScriptParams, progress?: Progress): Promise<PageAddInitScriptResult>;
   close(params: PageCloseParams, progress?: Progress): Promise<PageCloseResult>;
+  clearConsoleMessages(params?: PageClearConsoleMessagesParams, progress?: Progress): Promise<PageClearConsoleMessagesResult>;
   consoleMessages(params?: PageConsoleMessagesParams, progress?: Progress): Promise<PageConsoleMessagesResult>;
   emulateMedia(params: PageEmulateMediaParams, progress?: Progress): Promise<PageEmulateMediaResult>;
   exposeBinding(params: PageExposeBindingParams, progress?: Progress): Promise<PageExposeBindingResult>;
@@ -2187,6 +2188,9 @@ export type PageCloseOptions = {
   reason?: string,
 };
 export type PageCloseResult = void;
+export type PageClearConsoleMessagesParams = {};
+export type PageClearConsoleMessagesOptions = {};
+export type PageClearConsoleMessagesResult = void;
 export type PageConsoleMessagesParams = {};
 export type PageConsoleMessagesOptions = {};
 export type PageConsoleMessagesResult = {

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1589,6 +1589,9 @@ Page:
       flags:
         pausesBeforeAction: true
 
+    clearConsoleMessages:
+      title: Clear console messages
+
     consoleMessages:
       title: Get console messages
       group: getter

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -275,3 +275,24 @@ it('consoleMessages should work', async ({ page }) => {
   expect(objects.length, 'should be at least 100 messages').toBeGreaterThanOrEqual(100);
   expect(objects.slice(objects.length - expected.length), 'should return last messages').toEqual(expected);
 });
+
+it('clearConsoleMessages should work', async ({ page }) => {
+  await page.evaluate(() => {
+    console.log('message1');
+    console.log('message2');
+  });
+
+  let messages = await page.consoleMessages();
+  expect(messages.map(m => m.text())).toContain('message1');
+  expect(messages.map(m => m.text())).toContain('message2');
+
+  await page.clearConsoleMessages();
+
+  messages = await page.consoleMessages();
+  expect(messages).toEqual([]);
+
+  await page.evaluate(() => console.log('message3'));
+  messages = await page.consoleMessages();
+  expect(messages.length).toBe(1);
+  expect(messages[0].text()).toBe('message3');
+});


### PR DESCRIPTION
Adds a method to clear stored console messages from a page, so that subsequent calls to consoleMessages() only return messages logged after the clear.