### PR TITLE
fix(playwright): add retainLines to preserve source line numbers

### DIFF
--- a/packages/playwright/bundles/babel/src/babelBundleImpl.ts
+++ b/packages/playwright/bundles/babel/src/babelBundleImpl.ts
@@ -112,6 +112,7 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
       ...pluginsEpilogue.map(([name, options]) => [require(name), options]),
     ],
     compact: false,
+    retainLines: true,
     sourceMaps: 'both',
   };
 }

--- a/tests/playwright-test/babel.spec.ts
+++ b/tests/playwright-test/babel.spec.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
+import { join } from 'path';
 import { test, expect } from './playwright-test-fixtures';
 
 test('should preserve source line numbers in compiled output with destructured parameters', async ({}) => {
-  const { babelTransform } = require(path.join(__dirname, '..', '..', 'packages', 'playwright', 'lib', 'transform', 'babelBundleImpl'));
+  const { babelTransform } = require(join(__dirname, '..', '..', 'packages', 'playwright', 'lib', 'transform', 'babelBundleImpl'));
 
   // TypeScript source with destructured parameters in test callbacks.
   // Lines 7, 10, 13 contain the test() calls.


### PR DESCRIPTION
## Problem

Babel's `compact: false` expands destructured parameters across multiple lines in the compiled output, causing **cumulative line drift**:

```
Source line 7:  test('first', async ({ foo, bar, baz }) => {
Source line 10: test('second', async ({ foo, bar, baz }) => {
Source line 13: test('third', async ({ foo, bar, baz }) => {

Compiled (without retainLines) — 15 source lines become 30 compiled lines:
Line 9:  test('first', async ({    → +2 drift
Line 16: test('second', async ({   → +6 drift
Line 23: test('third', async ({    → +10 drift
```

Each destructured pattern with N parameters expands from 1 line to N+2 lines. The drift grows with each pattern, compounding across the file.

### Why source maps alone don't cover this

While `sourceMapSupport` correctly resolves line numbers in the test report path (`wrapFunctionWithLocation` → `sourceMapSupport.wrapCallSite`), the **Playwright Inspector** (`PWDEBUG=1`) uses a different code path:

1. `captureRawStack()` captures `Error.stack` → `parseStackFrame()` extracts line numbers
2. Line numbers are sent as `metadata.location` to the server
3. `Recorder._updateUserSources()` uses `metadata.location.line` directly to highlight lines in the **source file**

Additionally, `retainLines: true` makes the source map trivially correct (1:1 line mapping), eliminating any potential for source map inaccuracies with complex transformations.

## Fix

One-line change: add `retainLines: true` to babel transform options. This tells babel to keep statements on their original lines, preserving line number alignment between source and compiled output.

## Test

The test calls `babelTransform()` directly and verifies that `test()` calls with destructured TypeScript parameters remain on their original source lines (7, 10, 13) in the compiled output. **This test fails without `retainLines: true`** (lines shift to 9, 16, 23).

## Related Issues

- #38578 — Wrong line numbers in reports
- #38804 — Test decorations shown in wrong position