### PR TITLE
test(bidi): always install chromium in CI

### DIFF
--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -53,7 +53,6 @@ jobs:
     # Needed for video tests
     - run: npx playwright install ffmpeg
     - run: npx playwright install --with-deps chromium
-      if: matrix.channel == 'bidi-chromium'
     - if: matrix.channel == 'moz-firefox-nightly'
       run: |
         echo "BIDI_FFPATH=$(npx -y @puppeteer/browsers install firefox@nightly | tail -n1 | sed 's/^[^ ]* *//')" >> "$GITHUB_ENV"


### PR DESCRIPTION
The trace-viewer tests are still failing for Firefox in CI because they need Chromium to be installed.