### PR TITLE
chore(cli): "info" method that returns the version

### DIFF
--- a/packages/playwright/src/cli/client/registry.ts
+++ b/packages/playwright/src/cli/client/registry.ts
@@ -28,6 +28,10 @@ export type ClientInfo = {
   workspaceDir: string | undefined;
 };
 
+export type ServerInfo = {
+  version: string;
+};
+
 export type SessionConfig = {
   name: string;
   version: string;

--- a/packages/playwright/src/cli/client/session.ts
+++ b/packages/playwright/src/cli/client/session.ts
@@ -173,7 +173,7 @@ to restart the browser session.`);
     if (!socket)
       socket = await this._startDaemon();
 
-    this._connection = new SocketConnection(socket, this.config.version);
+    this._connection = new SocketConnection(socket);
     this._connection.onmessage = message => this._onMessage(message);
     this._connection.onclose = () => this.disconnect();
     return this._connection;

--- a/packages/playwright/src/cli/client/socketConnection.ts
+++ b/packages/playwright/src/cli/client/socketConnection.ts
@@ -19,15 +19,12 @@ import net from 'net';
 export class SocketConnection {
   private _socket: net.Socket;
   private _pendingBuffers: Buffer[] = [];
-  private _version: string;
 
   onclose?: () => void;
   onmessage?: (message: any) => void;
-  onversionerror?: (id: number, versions: { expected: string, received: string }) => boolean;
 
-  constructor(socket: net.Socket, version: string) {
+  constructor(socket: net.Socket) {
     this._socket = socket;
-    this._version = version;
     socket.on('data', buffer => this._onData(buffer));
     socket.on('close', () => {
       this.onclose?.();
@@ -39,7 +36,7 @@ export class SocketConnection {
 
   async send(message: { id: number, error?: string, result?: any }) {
     await new Promise((resolve, reject) => {
-      this._socket.write(`${JSON.stringify({ ...message, version: this._version })}\n`, error => {
+      this._socket.write(`${JSON.stringify(message)}\n`, error => {
         if (error)
           reject(error);
         else
@@ -76,10 +73,6 @@ export class SocketConnection {
   private _dispatchMessage(message: string) {
     try {
       const parsedMessage = JSON.parse(message);
-      if (parsedMessage.version !== this._version) {
-        if (this.onversionerror?.(parsedMessage.id, { expected: this._version, received: parsedMessage.version }))
-          return;
-      }
       this.onmessage?.(parsedMessage);
     } catch (e) {
       // eslint-disable-next-line no-console

--- a/packages/playwright/src/mcp/browser/config.ts
+++ b/packages/playwright/src/mcp/browser/config.ts
@@ -28,7 +28,6 @@ import { firstRootPath } from '../sdk/server';
 import type * as playwright from '../../../types/test';
 import type { Config, ToolCapability } from '../config';
 import type { ClientInfo } from '../sdk/server';
-import type { SessionConfig } from '../../cli/client/registry';
 
 type ViewportSize = { width: number; height: number };
 
@@ -134,7 +133,6 @@ export type FullConfig = Config & {
   },
   skillMode?: boolean;
   configFile?: string;
-  sessionConfig?: SessionConfig;
 };
 
 export async function resolveConfig(config: Config): Promise<FullConfig> {


### PR DESCRIPTION
This will be used for compatibility checks later on.

Drive-by: remove `sessionConfig` from the mcp config, leave it only for the cli daemon.
Drive-by: remove version handling from `SocketConnection`, as it is unused.