### PR TITLE
fix: clamp setTimeout value to prevent negative timeout crash

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/timeoutRunner.ts
+++ b/packages/playwright-core/src/utils/isomorphic/timeoutRunner.ts
@@ -31,9 +31,7 @@ export async function raceAgainstDeadline<T>(cb: () => Promise<T>, deadline: num
     new Promise<{ timedOut: true }>(resolve => {
       if (!deadline)
         return;
-      const kMaxDeadline = 2147483647; // 2^31-1
-      const timeout = deadline - monotonicTime();
-      timer = setTimeout(() => resolve({ timedOut: true }), Math.min(timeout, kMaxDeadline));
+      timer = setTimeout(() => resolve({ timedOut: true }), deadline - monotonicTime());
     }),
   ]).finally(() => {
     clearTimeout(timer);

--- a/packages/playwright-core/src/utils/isomorphic/timeoutRunner.ts
+++ b/packages/playwright-core/src/utils/isomorphic/timeoutRunner.ts
@@ -29,9 +29,11 @@ export async function raceAgainstDeadline<T>(cb: () => Promise<T>, deadline: num
       return { result, timedOut: false };
     }),
     new Promise<{ timedOut: true }>(resolve => {
+      if (!deadline)
+        return;
       const kMaxDeadline = 2147483647; // 2^31-1
-      const timeout = (deadline || kMaxDeadline) - monotonicTime();
-      timer = setTimeout(() => resolve({ timedOut: true }), timeout);
+      const timeout = deadline - monotonicTime();
+      timer = setTimeout(() => resolve({ timedOut: true }), Math.min(timeout, kMaxDeadline));
     }),
   ]).finally(() => {
     clearTimeout(timer);


### PR DESCRIPTION
## Problem

When a Node.js process has been running for more than ~24.8 days (2^31-1 milliseconds), `monotonicTime()` exceeds the max signed 32-bit integer. In `raceAgainstDeadline()`, the timeout is computed as:

```js
const timeout = (deadline || kMaxDeadline) - monotonicTime();
```

When `monotonicTime()` exceeds `kMaxDeadline` (e.g. no explicit timeout was set, so `deadline` is `0` and falls back to `kMaxDeadline`), this produces a negative value. Node.js then coerces it to 1ms and fires the timer immediately, causing operations like `browserType.connect()` to fail with:

```
browserType.connect: Timeout undefinedms exceeded
```

## Fix

Clamp the computed timeout to `[0, kMaxDeadline]`:
- Lower bound of `0` prevents negative values that Node.js coerces to 1ms
- Upper bound of `kMaxDeadline` (2^31-1) keeps it within setTimeout's valid range

## How I verified this

Reproduced the issue by overriding `performance.now` to return a value > 2^31-1, confirming `connect()` fails before the fix and succeeds after.

Fixes #39166