### PR TITLE
feat: add browser zoom support via page.setZoom()

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -4198,6 +4198,51 @@ Page width in pixels.
 
 Page height in pixels.
 
+## async method: Page.setZoom
+* since: v1.59
+
+Sets the browser zoom level for the page. A zoom factor of `1` represents 100% (default). Values greater
+than `1` zoom in, and values less than `1` zoom out.
+
+This is useful for testing zoom-dependent layouts and accessibility scenarios, such as verifying that
+content remains usable at 200% zoom per WCAG guidelines.
+
+**Usage**
+
+```js
+// Set zoom to 150%
+await page.setZoom(1.5);
+
+// Reset zoom to 100%
+await page.setZoom(1);
+```
+
+```java
+// Set zoom to 150%
+page.setZoom(1.5);
+```
+
+```python async
+# Set zoom to 150%
+await page.set_zoom(1.5)
+```
+
+```python sync
+# Set zoom to 150%
+page.set_zoom(1.5)
+```
+
+```csharp
+// Set zoom to 150%
+await page.SetZoomAsync(1.5);
+```
+
+### param: Page.setZoom.zoomFactor
+* since: v1.59
+- `zoomFactor` <[float]>
+
+Zoom factor, where `1` is 100%. Must be a positive number.
+
 ## async method: Page.tap
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.tap`] instead. Read more about [locators](../locators.md).

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -485,6 +485,10 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     await this._channel.setViewportSize({ viewportSize });
   }
 
+  async setZoom(zoomFactor: number) {
+    await this._channel.setZoom({ zoomFactor });
+  }
+
   viewportSize(): Size | null {
     return this._viewportSize || null;
   }

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1378,6 +1378,10 @@ scheme.PageSetViewportSizeParams = tObject({
   }),
 });
 scheme.PageSetViewportSizeResult = tOptional(tObject({}));
+scheme.PageSetZoomParams = tObject({
+  zoomFactor: tFloat,
+});
+scheme.PageSetZoomResult = tOptional(tObject({}));
 scheme.PageKeyboardDownParams = tObject({
   key: tString,
 });

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -373,6 +373,10 @@ export class BidiPage implements PageDelegate {
     ]);
   }
 
+  async setZoom(zoomFactor: number): Promise<void> {
+    throw new Error('Zoom is not supported in BiDi mode');
+  }
+
   async updateRequestInterception(): Promise<void> {
     await this._networkManager.setRequestInterception(this._page.requestInterceptors.length > 0);
   }

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -177,6 +177,10 @@ export class CRPage implements PageDelegate {
     await this._mainFrameSession._updateViewport(preserveWindowBoundaries);
   }
 
+  async setZoom(zoomFactor: number): Promise<void> {
+    await this._mainFrameSession._client.send('Emulation.setPageScaleFactor', { pageScaleFactor: zoomFactor });
+  }
+
   async bringToFront(): Promise<void> {
     await this._mainFrameSession._client.send('Page.bringToFront');
   }

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -187,6 +187,10 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     await this._page.setViewportSize(progress, params.viewportSize);
   }
 
+  async setZoom(params: channels.PageSetZoomParams, progress: Progress): Promise<void> {
+    await this._page.setZoom(progress, params.zoomFactor);
+  }
+
   async addInitScript(params: channels.PageAddInitScriptParams, progress: Progress): Promise<void> {
     this._initScripts.push(await this._page.addInitScript(progress, params.source));
   }

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -335,6 +335,10 @@ export class FFPage implements PageDelegate {
     await this._session.send('Page.setViewportSize', { viewportSize });
   }
 
+  async setZoom(zoomFactor: number): Promise<void> {
+    await this._session.send('Page.setZoom', { zoom: zoomFactor });
+  }
+
   async bringToFront(): Promise<void> {
     await this._session.send('Page.bringToFront', {});
   }

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -65,6 +65,7 @@ export interface PageDelegate {
 
   updateExtraHTTPHeaders(): Promise<void>;
   updateEmulatedViewportSize(preserveWindowBoundaries?: boolean): Promise<void>;
+  setZoom(zoomFactor: number): Promise<void>;
   updateEmulateMedia(): Promise<void>;
   updateRequestInterception(): Promise<void>;
   updateFileChooserInterception(): Promise<void>;
@@ -605,6 +606,10 @@ export class Page extends SdkObject<PageEventMap> {
       this.delegate.updateEmulatedViewportSize().catch(() => {});
       throw error;
     }
+  }
+
+  async setZoom(progress: Progress, zoomFactor: number) {
+    await progress.race(this.delegate.setZoom(zoomFactor));
   }
 
   setEmulatedSizeFromWindowOpen(emulatedSize: EmulatedSize) {

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -688,6 +688,11 @@ export class WKPage implements PageDelegate {
     await this._updateViewport();
   }
 
+  async setZoom(zoomFactor: number): Promise<void> {
+    const pageProxyId = this._pageProxySession.sessionId;
+    await this._pageProxySession.connection.browserSession.send('Playwright.setPageZoomFactor', { pageProxyId, zoomFactor });
+  }
+
   async updateUserAgent(): Promise<void> {
     const contextOptions = this._browserContext._options;
     this._updateState('Page.overrideUserAgent', { value: contextOptions.userAgent });

--- a/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
+++ b/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
@@ -123,6 +123,7 @@ export const methodMetainfo = new Map<string, { internal?: boolean, title?: stri
   ['Page.setNetworkInterceptionPatterns', { title: 'Route requests', group: 'route', }],
   ['Page.setWebSocketInterceptionPatterns', { title: 'Route WebSockets', group: 'route', }],
   ['Page.setViewportSize', { title: 'Set viewport size', snapshot: true, pausesBeforeAction: true, }],
+  ['Page.setZoom', { title: 'Set zoom level', snapshot: true, pausesBeforeAction: true, }],
   ['Page.keyboardDown', { title: 'Key down "{key}"', slowMo: true, snapshot: true, pausesBeforeAction: true, }],
   ['Page.keyboardUp', { title: 'Key up "{key}"', slowMo: true, snapshot: true, pausesBeforeAction: true, }],
   ['Page.keyboardInsertText', { title: 'Insert "{text}"', slowMo: true, snapshot: true, pausesBeforeAction: true, }],

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -4565,6 +4565,28 @@ export interface Page {
     height: number;
   }): Promise<void>;
 
+
+  /**
+   * Sets the browser zoom level. A zoom factor of `1` represents 100% (default). Values greater
+   * than `1` zoom in, and values less than `1` zoom out. For example, a value of `1.5` represents
+   * 150% zoom.
+   *
+   * This is useful for testing zoom-dependent layouts and accessibility scenarios, such as
+   * verifying that content remains usable at 200% zoom per WCAG guidelines.
+   *
+   * **Usage**
+   *
+   * ```js
+   * // Set zoom to 150%
+   * await page.setZoom(1.5);
+   *
+   * // Reset zoom to 100%
+   * await page.setZoom(1);
+   * ```
+   *
+   * @param zoomFactor Zoom factor, where `1` is 100%. Must be a positive number.
+   */
+  setZoom(zoomFactor: number): Promise<void>;
   /**
    * **NOTE** Use locator-based [locator.tap([options])](https://playwright.dev/docs/api/class-locator#locator-tap) instead. Read
    * more about [locators](https://playwright.dev/docs/locators).

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -2098,6 +2098,7 @@ export interface PageChannel extends PageEventTarget, EventTargetChannel {
   setNetworkInterceptionPatterns(params: PageSetNetworkInterceptionPatternsParams, progress?: Progress): Promise<PageSetNetworkInterceptionPatternsResult>;
   setWebSocketInterceptionPatterns(params: PageSetWebSocketInterceptionPatternsParams, progress?: Progress): Promise<PageSetWebSocketInterceptionPatternsResult>;
   setViewportSize(params: PageSetViewportSizeParams, progress?: Progress): Promise<PageSetViewportSizeResult>;
+  setZoom(params: PageSetZoomParams, progress?: Progress): Promise<PageSetZoomResult>;
   keyboardDown(params: PageKeyboardDownParams, progress?: Progress): Promise<PageKeyboardDownResult>;
   keyboardUp(params: PageKeyboardUpParams, progress?: Progress): Promise<PageKeyboardUpResult>;
   keyboardInsertText(params: PageKeyboardInsertTextParams, progress?: Progress): Promise<PageKeyboardInsertTextResult>;
@@ -2414,6 +2415,13 @@ export type PageSetViewportSizeOptions = {
 
 };
 export type PageSetViewportSizeResult = void;
+export type PageSetZoomParams = {
+  zoomFactor: number,
+};
+export type PageSetZoomOptions = {
+
+};
+export type PageSetZoomResult = void;
 export type PageKeyboardDownParams = {
   key: string,
 };

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1802,6 +1802,14 @@ Page:
         snapshot: true
         pausesBeforeAction: true
 
+    setZoom:
+      title: Set zoom level
+      parameters:
+        zoomFactor: float
+      flags:
+        snapshot: true
+        pausesBeforeAction: true
+
     keyboardDown:
       title: Key down "{key}"
       parameters:

--- a/tests/page/page-set-zoom.spec.ts
+++ b/tests/page/page-set-zoom.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test as it, expect } from './pageTest';
+
+it('should set zoom to 200%', async ({ page, server }) => {
+  await page.goto(server.PREFIX + '/grid.html');
+  await page.setZoom(2);
+  // At 200% zoom, the visual viewport should be smaller.
+  const innerWidth = await page.evaluate(() => window.innerWidth);
+  const viewportSize = page.viewportSize()!;
+  // At 2x zoom, the innerWidth should be roughly half the viewport width.
+  expect(innerWidth).toBeLessThanOrEqual(viewportSize.width / 1.5);
+});
+
+it('should set zoom to 50%', async ({ page, server }) => {
+  await page.goto(server.PREFIX + '/grid.html');
+  await page.setZoom(0.5);
+  // At 50% zoom, the visual viewport should be larger.
+  const innerWidth = await page.evaluate(() => window.innerWidth);
+  const viewportSize = page.viewportSize()!;
+  // At 0.5x zoom, the innerWidth should be roughly double the viewport width.
+  expect(innerWidth).toBeGreaterThanOrEqual(viewportSize.width * 1.5);
+});
+
+it('should reset zoom to default', async ({ page, server }) => {
+  await page.goto(server.PREFIX + '/grid.html');
+  const originalWidth = await page.evaluate(() => window.innerWidth);
+  await page.setZoom(2);
+  await page.setZoom(1);
+  const resetWidth = await page.evaluate(() => window.innerWidth);
+  expect(resetWidth).toBe(originalWidth);
+});
+
+it('should affect layout at 150% zoom', async ({ page, server }) => {
+  await page.setViewportSize({ width: 800, height: 600 });
+  await page.goto(server.PREFIX + '/grid.html');
+  const originalWidth = await page.evaluate(() => window.innerWidth);
+  await page.setZoom(1.5);
+  const zoomedWidth = await page.evaluate(() => window.innerWidth);
+  // Zooming in shrinks the effective viewport.
+  expect(zoomedWidth).toBeLessThan(originalWidth);
+});


### PR DESCRIPTION
Adds a `page.setZoom(zoomFactor)` API for controlling browser zoom level programmatically. Been wanting this for accessibility testing -- specifically verifying content works at 200% zoom per WCAG guidelines.

The API is straightforward:
```js
await page.setZoom(1.5); // 150% zoom
await page.setZoom(1);   // back to default
```

Each browser backend uses its native protocol command:
- **Chromium**: `Emulation.setPageScaleFactor`
- **Firefox**: `Page.setZoom`  
- **WebKit**: `Playwright.setPageZoomFactor`

Changes span the full stack -- protocol definition, channel types, server PageDelegate interface, all four browser implementations (Chromium, Firefox, WebKit, BiDi), dispatcher, client API, public types, docs, and tests.

BiDi currently throws since the protocol doesn't have zoom support yet.

Closes #2497