### PR TITLE
chore(bidi): rename BidiPage._realmToContext

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -464,7 +464,7 @@ export class BidiBrowserContext extends BrowserContext {
       userContexts: [this._userContextId()],
     }));
     promises.push(...this._bidiPages().map(page => {
-      const realms = [...page._realmToContext].filter(([realm, context]) => context.world === 'main').map(([realm, context]) => realm);
+      const realms = [...page._contextIdToContext].filter(([realm, context]) => context.world === 'main').map(([realm, context]) => realm);
       return Promise.all(realms.map(realm => {
         return page._session.send('script.callFunction', {
           functionDeclaration,

--- a/tests/bidi/expectations/moz-firefox-nightly-page.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-page.txt
@@ -12,8 +12,6 @@ page/elementhandle-scroll-into-view.spec.ts › should wait for nested display:n
 page/elementhandle-scroll-into-view.spec.ts › should work @smoke [fail]
 page/expect-misc.spec.ts › strict mode violation error format [fail]
 page/frame-evaluate.spec.ts › should allow cross-frame element handles [fail]
-page/frame-evaluate.spec.ts › should dispose context on cross-origin navigation [fail]
-page/frame-evaluate.spec.ts › should dispose context on navigation [fail]
 page/frame-evaluate.spec.ts › should not allow cross-frame element handles when frames do not script each other [fail]
 page/frame-goto.spec.ts › should continue after client redirect [flaky]
 page/frame-hierarchy.spec.ts › should support framesets [fail]


### PR DESCRIPTION
Fixes the following tests in `page/frame-evaluate.spec.ts` (which access the renamed Map to verify that execution contexts are cleaned up):
- "should dispose context on navigation"
- "should dispose context on cross-origin navigation"
