### PR TITLE
docs: add docker node version upgrade to v1.57 release notes

### DIFF
--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -116,6 +116,10 @@ After 3 years of being deprecated, we removed `page.accessibility` from our API.
 - Network requests issued by [Service Workers](./service-workers.md#network-events-and-routing) are now reported and can be routed through the [BrowserContext](./api/class-browsercontext.md), only in Chromium. You can opt out using the `PLAYWRIGHT_DISABLE_SERVICE_WORKER_NETWORK` environment variable.
 - Console messages from Service Workers are dispatched through [`event: Worker.console`]. You can opt out of this using the `PLAYWRIGHT_DISABLE_SERVICE_WORKER_CONSOLE` environment variable.
 
+### Miscellaneous
+
+- Playwright docker images switched from Node.js v22 to Node.js v24 LTS.
+
 ### Browser Versions
 
 - Chromium 143.0.7499.4


### PR DESCRIPTION
Closes #39286 

Other release notes had some mentions of older Docker updates, but not the previous (20 -> 22 LTS); if they should be updated as well, I can amend the PR.