### PR TITLE
test(bidi): fix large screenshot test

### DIFF
--- a/tests/bidi/expectations/moz-firefox-nightly-page.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-page.txt
@@ -140,7 +140,6 @@ page/page-route.spec.ts › should not throw if request was cancelled by the pag
 page/page-screenshot.spec.ts › page screenshot › should allow transparency [fail]
 page/page-screenshot.spec.ts › page screenshot animations › should not capture css animations in shadow DOM [flaky]
 page/page-screenshot.spec.ts › page screenshot animations › should not capture pseudo element css animation [fail]
-page/page-screenshot.spec.ts › should throw if screenshot size is too large [fail]
 page/page-set-input-files.spec.ts › should upload a folder [fail]
 page/page-wait-for-load-state.spec.ts › should wait for load state of empty url popup [timeout]
 page/wheel.spec.ts › should dispatch wheel events after popup was opened @smoke [timeout]


### PR DESCRIPTION
Note that the screenshot size limit was [recently increased in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1911583), so this could be increased [in Juggler](https://github.com/microsoft/playwright/blob/cd36dab6ecc7f4b3adeec333e55f9ac03711a9b1/browser_patches/firefox/juggler/protocol/PageHandler.js#L337) as well.