### PR TITLE
feat(api): add Response.httpVersion() method

### DIFF
--- a/docs/src/api/class-response.md
+++ b/docs/src/api/class-response.md
@@ -80,6 +80,12 @@ Returns all values of the headers matching the name, for example `set-cookie`. T
 
 Name of the header.
 
+## async method: Response.httpVersion
+* since: v1.59
+- returns: <[string]>
+
+Returns the http version used by the response.
+
 ## async method: Response.json
 * since: v1.8
 * langs: js, python

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -21156,6 +21156,11 @@ export interface Response {
   headerValues(name: string): Promise<Array<string>>;
 
   /**
+   * Returns the http version used by the response.
+   */
+  httpVersion(): Promise<string>;
+
+  /**
    * Returns the JSON representation of response body.
    *
    * This method will throw if the response body is not parsable via `JSON.parse`.

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -741,6 +741,12 @@ export class Response extends ChannelOwner<channels.ResponseChannel> implements 
   async securityDetails(): Promise<SecurityDetails|null> {
     return (await this._channel.securityDetails()).value || null;
   }
+
+  async httpVersion(): Promise<string> {
+    return this._wrapApiCall(async () => {
+      return (await this._channel.httpVersion()).value;
+    }, { internal: true });
+  }
 }
 
 export class WebSocket extends ChannelOwner<channels.WebSocketChannel> implements api.WebSocket {

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -2416,6 +2416,10 @@ scheme.ResponseRawResponseHeadersParams = tOptional(tObject({}));
 scheme.ResponseRawResponseHeadersResult = tObject({
   headers: tArray(tType('NameValue')),
 });
+scheme.ResponseHttpVersionParams = tOptional(tObject({}));
+scheme.ResponseHttpVersionResult = tObject({
+  value: tString,
+});
 scheme.ResponseSizesParams = tOptional(tObject({}));
 scheme.ResponseSizesResult = tObject({
   sizes: tType('RequestSizes'),

--- a/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
+++ b/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
@@ -117,6 +117,10 @@ export class ResponseDispatcher extends Dispatcher<Response, channels.ResponseCh
     return { headers: await progress.race(this._object.rawResponseHeaders()) };
   }
 
+  async httpVersion(params: channels.ResponseHttpVersionParams, progress: Progress): Promise<channels.ResponseHttpVersionResult> {
+    return { value: await progress.race(this._object.httpVersion()) };
+  }
+
   async sizes(params: channels.ResponseSizesParams, progress: Progress): Promise<channels.ResponseSizesResult> {
     return { sizes: await progress.race(this._object.sizes()) };
   }

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -323,7 +323,7 @@ export class HarTracer {
       }));
     }
 
-    const httpVersion = response.httpVersion();
+    const httpVersion = await response.httpVersion();
     harEntry.request.httpVersion = httpVersion;
     harEntry.response.httpVersion = httpVersion;
 
@@ -441,7 +441,7 @@ export class HarTracer {
     }
   }
 
-  private _onResponse(response: network.Response) {
+  private async _onResponse(response: network.Response) {
     const harEntry = this._entryForRequest(response.request());
     if (!harEntry)
       return;
@@ -452,7 +452,7 @@ export class HarTracer {
     harEntry.response = {
       status: response.status(),
       statusText: response.statusText(),
-      httpVersion: response.httpVersion(),
+      httpVersion: await response.httpVersion(),
       // These are bad values that will be overwritten below.
       cookies: [],
       headers: [],

--- a/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
+++ b/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
@@ -263,6 +263,7 @@ export const methodMetainfo = new Map<string, { internal?: boolean, title?: stri
   ['Response.securityDetails', { internal: true, }],
   ['Response.serverAddr', { internal: true, }],
   ['Response.rawResponseHeaders', { internal: true, }],
+  ['Response.httpVersion', { internal: true, }],
   ['Response.sizes', { internal: true, }],
   ['BindingCall.reject', { internal: true, }],
   ['BindingCall.resolve', { internal: true, }],

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21156,6 +21156,11 @@ export interface Response {
   headerValues(name: string): Promise<Array<string>>;
 
   /**
+   * Returns the http version used by the response.
+   */
+  httpVersion(): Promise<string>;
+
+  /**
    * Returns the JSON representation of response body.
    *
    * This method will throw if the response body is not parsable via `JSON.parse`.

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -4136,6 +4136,7 @@ export interface ResponseChannel extends ResponseEventTarget, Channel {
   securityDetails(params?: ResponseSecurityDetailsParams, progress?: Progress): Promise<ResponseSecurityDetailsResult>;
   serverAddr(params?: ResponseServerAddrParams, progress?: Progress): Promise<ResponseServerAddrResult>;
   rawResponseHeaders(params?: ResponseRawResponseHeadersParams, progress?: Progress): Promise<ResponseRawResponseHeadersResult>;
+  httpVersion(params?: ResponseHttpVersionParams, progress?: Progress): Promise<ResponseHttpVersionResult>;
   sizes(params?: ResponseSizesParams, progress?: Progress): Promise<ResponseSizesResult>;
 }
 export type ResponseBodyParams = {};
@@ -4157,6 +4158,11 @@ export type ResponseRawResponseHeadersParams = {};
 export type ResponseRawResponseHeadersOptions = {};
 export type ResponseRawResponseHeadersResult = {
   headers: NameValue[],
+};
+export type ResponseHttpVersionParams = {};
+export type ResponseHttpVersionOptions = {};
+export type ResponseHttpVersionResult = {
+  value: string,
 };
 export type ResponseSizesParams = {};
 export type ResponseSizesOptions = {};

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -3656,6 +3656,11 @@ Response:
           type: array
           items: NameValue
 
+    httpVersion:
+      internal: true
+      returns:
+        value: string
+
     sizes:
       internal: true
       returns:


### PR DESCRIPTION
Adds `Response.httpVersion()` to get the http version of a given response
Issue: https://github.com/microsoft/playwright/issues/39310