### PR TITLE
feat: install --skills also copies to .agents/skills/ directory

### DIFF
--- a/packages/playwright/src/cli/client/program.ts
+++ b/packages/playwright/src/cli/client/program.ts
@@ -219,15 +219,17 @@ async function install(args: MinimistArgs) {
 
   if (args.skills) {
     const skillSourceDir = path.join(__dirname, '../../skill');
-    const skillDestDir = path.join(cwd, '.claude', 'skills', 'playwright-cli');
 
     if (!fs.existsSync(skillSourceDir)) {
       console.error('❌ Skills source directory not found:', skillSourceDir);
       process.exit(1);
     }
 
-    await fs.promises.cp(skillSourceDir, skillDestDir, { recursive: true });
-    console.log(`✅ Skills installed to \`${path.relative(cwd, skillDestDir)}\`.`);
+    for (const baseDir of ['.claude', '.agents']) {
+      const skillDestDir = path.join(cwd, baseDir, 'skills', 'playwright-cli');
+      await fs.promises.cp(skillSourceDir, skillDestDir, { recursive: true });
+      console.log(`✅ Skills installed to \`${path.relative(cwd, skillDestDir)}\`.`);
+    }
   }
 
   await ensureConfiguredBrowserInstalled();

--- a/tests/mcp/cli-misc.spec.ts
+++ b/tests/mcp/cli-misc.spec.ts
@@ -43,6 +43,7 @@ test('install workspace', async ({ cli }, testInfo) => {
 test('install workspace w/skills', async ({ cli }, testInfo) => {
   const { output } = await cli('install', '--skills');
   expect(output).toContain(`Skills installed to \`.claude${path.sep}skills${path.sep}playwright-cli\`.`);
+  expect(output).toContain(`Skills installed to \`.agents${path.sep}skills${path.sep}playwright-cli\`.`);
 
   const skillFile = testInfo.outputPath('.claude', 'skills', 'playwright-cli', 'SKILL.md');
   expect(fs.existsSync(skillFile)).toBe(true);
@@ -50,6 +51,13 @@ test('install workspace w/skills', async ({ cli }, testInfo) => {
   const referencesDir = testInfo.outputPath('.claude', 'skills', 'playwright-cli', 'references');
   const references = await fs.promises.readdir(referencesDir);
   expect(references.length).toBeGreaterThan(0);
+
+  const agentsSkillFile = testInfo.outputPath('.agents', 'skills', 'playwright-cli', 'SKILL.md');
+  expect(fs.existsSync(agentsSkillFile)).toBe(true);
+
+  const agentsReferencesDir = testInfo.outputPath('.agents', 'skills', 'playwright-cli', 'references');
+  const agentsReferences = await fs.promises.readdir(agentsReferencesDir);
+  expect(agentsReferences.length).toBeGreaterThan(0);
 });
 
 test('install handles browser detection', async ({ cli }) => {


### PR DESCRIPTION
## Summary

When running `playwright-cli install --skills`, skill files are now copied to both `.claude/skills/playwright-cli/` (existing behavior) and `.agents/skills/playwright-cli/` (new) to support the emerging `.agents` standard directory for agent skill discovery.

Fixes #39317

## Changes

### `packages/playwright/src/cli/client/program.ts`
- Added a second `fs.promises.cp()` call in the `install()` function to also copy skills to `.agents/skills/playwright-cli/`
- Added corresponding console output message

### `tests/mcp/cli-misc.spec.ts`
- Extended the `install workspace w/skills` test to verify:
  - Console output mentions the `.agents` path
  - `.agents/skills/playwright-cli/SKILL.md` exists
  - `.agents/skills/playwright-cli/references/` directory exists and is non-empty

## Motivation

The `.agents` directory is emerging as a standard location for agent-related configuration and skills across multiple tools. By also writing to `.agents/skills/`, Playwright is forward-compatible with tooling that adopts this convention, while maintaining full backward compatibility with the existing `.claude/skills/` location.

The [Aspire CLI](https://github.com/dotnet/aspire) (`aspire agent init` / `aspire init`) installs Playwright with user permission and wants to ensure skill files are in the standard discovery location.