### PR TITLE
fix(mcp): resolve init-page/init-script paths relative to config file

### DIFF
--- a/tests/mcp/cli-config.spec.ts
+++ b/tests/mcp/cli-config.spec.ts
@@ -99,3 +99,39 @@ test('isolated', async ({ cli, server }, testInfo) => {
   await cli('open', server.PREFIX);
   expect(fs.existsSync(testInfo.outputPath('daemon', 'default-user-data'))).toBe(false);
 });
+
+
+test('init-page path is resolved relative to config file', async ({ cli }, testInfo) => {
+  const config = {
+    browser: {
+      initPage: ['./init-page.cjs'],
+    },
+  };
+  await fs.promises.writeFile(testInfo.outputPath('.playwright', 'cli.config.json'), JSON.stringify(config, null, 2));
+  await fs.promises.writeFile(testInfo.outputPath('.playwright', 'init-page.cjs'), `
+    module.exports = {
+      default: async ({ page }) => {
+        await page.setContent('<div>relative-init-page-loaded</div>');
+      },
+    };
+  `);
+
+  await cli('open');
+  const { output } = await cli('eval', 'document.body.textContent');
+  expect(output).toContain('relative-init-page-loaded');
+});
+
+test('init-script path is resolved relative to config file', async ({ cli }, testInfo) => {
+  const config = {
+    browser: {
+      initScript: ['./init-script.js'],
+    },
+  };
+  await fs.promises.writeFile(testInfo.outputPath('.playwright', 'cli.config.json'), JSON.stringify(config, null, 2));
+  await fs.promises.writeFile(testInfo.outputPath('.playwright', 'init-script.js'), 'window.__relativeInitScriptLoaded = true;');
+
+  await cli('open');
+  await cli('goto', 'data:text/html,<body>ok</body>');
+  const { output } = await cli('eval', 'window.__relativeInitScriptLoaded === true');
+  expect(output).toContain('true');
+});


### PR DESCRIPTION
## Summary
- Resolve `browser.initPage` and `browser.initScript` paths relative to the config file location when loading MCP/CLI config.
- Keep support for absolute paths unchanged.
- Add CLI config tests proving relative `initPage` and `initScript` paths work.

Fixes https://github.com/microsoft/playwright-cli/issues/290.

## Why
I was using Playwright CLI with a coding agent and wanted to keep `.playwright/cli.config.json` portable. Relative init paths currently fail unless converted to absolute paths, which makes shared configs harder to use across machines.

## Testing
- `npx playwright test --config=tests/mcp/playwright.config.ts --project=chrome tests/mcp/cli-config.spec.ts tests/mcp/init-page.spec.ts`