### PR TITLE
test(bidi): fix beforeunload test

### DIFF
--- a/tests/library/beforeunload.spec.ts
+++ b/tests/library/beforeunload.spec.ts
@@ -195,7 +195,7 @@ it('does not get stalled by beforeUnload', {
       event.preventDefault();
     });
   });
-  page.on('dialog', dialog => dialog.dismiss());
+  page.on('dialog', dialog => dialog.dismiss().catch(() => {}));
 
   // We have to interact with a page so that 'beforeunload' handlers
   // fire.


### PR DESCRIPTION
This test throws `dialog.dismiss: Test ended.` with Firefox/Bidi on Linux (and the failure gets misattributed to another test in CI).