### PR TITLE
test(bidi): wait for utility contexts

### DIFF
--- a/tests/page/frame-evaluate.spec.ts
+++ b/tests/page/frame-evaluate.spec.ts
@@ -35,11 +35,12 @@ it('should have correct execution contexts @smoke', async ({ page, server }) => 
   expect(await page.frames()[1].evaluate(() => document.body.textContent.trim())).toBe(`Hi, I'm frame`);
 });
 
-function expectContexts(pageImpl, count, browserName) {
+async function expectContexts(page, count, toImpl, browserName) {
+  await Promise.all(page.frames().map(frame => toImpl(frame)._context('utility')));
   if (browserName === 'chromium')
-    expect(pageImpl.delegate._mainFrameSession._contextIdToContext.size).toBe(count);
+    expect(toImpl(page).delegate._mainFrameSession._contextIdToContext.size).toBe(count);
   else
-    expect(pageImpl.delegate._contextIdToContext.size).toBe(count);
+    expect(toImpl(page).delegate._contextIdToContext.size).toBe(count);
 }
 
 it('should dispose context on navigation', async ({ page, server, toImpl, browserName, isElectron }) => {
@@ -47,9 +48,9 @@ it('should dispose context on navigation', async ({ page, server, toImpl, browse
 
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(page.frames().length).toBe(2);
-  expectContexts(toImpl(page), 4, browserName);
+  await expectContexts(page, 4, toImpl, browserName);
   await page.goto(server.EMPTY_PAGE);
-  expectContexts(toImpl(page), 2, browserName);
+  await expectContexts(page, 2, toImpl, browserName);
 });
 
 it('should dispose context on cross-origin navigation', async ({ page, server, toImpl, browserName, isElectron }) => {
@@ -57,9 +58,9 @@ it('should dispose context on cross-origin navigation', async ({ page, server, t
 
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(page.frames().length).toBe(2);
-  expectContexts(toImpl(page), 4, browserName);
+  await expectContexts(page, 4, toImpl, browserName);
   await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
-  expectContexts(toImpl(page), 2, browserName);
+  await expectContexts(page, 2, toImpl, browserName);
 });
 
 it('should execute after cross-site navigation', async ({ page, server }) => {


### PR DESCRIPTION
These tests are racy with Bidi because the utility contexts are created asynchronously. Note that with this fix they are still racy with Bidi because `page.goto()` currently can't wait for the page to be loaded and `expect(page.frames().length).toBe(2)` sometimes fails (see https://github.com/w3c/webdriver-bidi/issues/832#issuecomment-3298427309).