### PR TITLE
fix(html-reporter): make test case path a clickable link back to test list

### DIFF
--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -43,11 +43,18 @@ export const TestCaseView: React.FC<{
   const searchParams = useSearchParams();
 
   const visibleTestAnnotations = test.annotations.filter(a => !a.type.startsWith('_')) ?? [];
+  const allTestsHref = React.useMemo(() => {
+    const params = new URLSearchParams(searchParams);
+    params.delete('testId');
+    params.delete('run');
+    params.delete('anchor');
+    return '#?' + params;
+  }, [searchParams]);
 
   return <>
     <HeaderView
       title={test.title}
-      leftSuperHeader={<div className='test-case-path'>{test.path.join(' › ')}</div>}
+      leftSuperHeader={<div className='test-case-path'><Link href={allTestsHref}>{test.path.join(' › ')}</Link></div>}
       rightSuperHeader={<>
         <div className={clsx(!prev && 'hidden')}><Link href={testResultHref({ test: prev }, searchParams)}>« previous</Link></div>
         <div style={{ width: 10 }}></div>


### PR DESCRIPTION
## Summary

When viewing an individual test case in the HTML reporter, the breadcrumb path (e.g. "dashboard-page") is rendered as plain text. There is no way to navigate back to the test list without using the browser back button.

This wraps the path in a `Link` component that navigates back to the test list view, preserving any active search filter query. The path already sits in the header row alongside the `previous` / `next` links, so making it clickable is consistent with user expectations.

## Changes

- `packages/html-reporter/src/testCaseView.tsx` -- wrap `test.path.join()` in a `Link` that strips `testId`, `run`, and `anchor` params from the URL
- `tests/playwright-test/reporter-html.spec.ts` -- two integration tests: basic back navigation and filter preservation

## Test plan

- [x] Added integration test: clicking path link navigates back to test list
- [x] Added integration test: search filter is preserved when navigating back
- [ ] Existing tests asserting `.test-case-path` text content are unaffected (text is unchanged, only wrapped in a link)