### PR TITLE
ci: declare explicit token permissions in workflow jobs

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -10,6 +10,9 @@ on:
       - main
       - release-*
 
+permissions:
+  contents: read
+
 env:
   ELECTRON_SKIP_BINARY_DOWNLOAD: 1
 

--- a/.github/workflows/pr_check_client_side_changes.yml
+++ b/.github/workflows/pr_check_client_side_changes.yml
@@ -9,6 +9,10 @@ on:
       - 'packages/playwright-core/src/utils/isomorphic/**/*'
       - 'packages/playwright/src/matchers/matchers.ts'
       - 'packages/protocol/src/protocol.yml'
+
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check

--- a/.github/workflows/tests_components.yml
+++ b/.github/workflows/tests_components.yml
@@ -15,6 +15,9 @@ on:
       - main
       - release-*
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
   ELECTRON_SKIP_BINARY_DOWNLOAD: 1

--- a/.github/workflows/trigger_tests.yml
+++ b/.github/workflows/trigger_tests.yml
@@ -6,6 +6,8 @@ on:
       - main
       - release-*
 
+permissions: {}
+
 jobs:
   trigger:
     name: "trigger"


### PR DESCRIPTION
## Summary
Add explicit `GITHUB_TOKEN` permissions to workflows currently relying on implicit defaults:
- `.github/workflows/infra.yml` -> `contents: read`
- `.github/workflows/tests_components.yml` -> `contents: read`
- `.github/workflows/pr_check_client_side_changes.yml` -> `contents: read`
- `.github/workflows/trigger_tests.yml` -> `permissions: {}`

## Why
These jobs either only read repository contents or use a dedicated GitHub App token for API operations. Declaring explicit scopes improves least-privilege security posture and makes required access auditable.

## Notes
- `trigger_tests.yml` does not use `GITHUB_TOKEN`; it uses `actions/create-github-app-token`, so explicit empty permissions are sufficient.
- No functional behavior changes are intended.
