### PR TITLE
fix(trace-viewer): Add line height to title of filmstrip hover

### DIFF
--- a/packages/trace-viewer/src/ui/filmStrip.css
+++ b/packages/trace-viewer/src/ui/filmStrip.css
@@ -58,4 +58,5 @@
   display: flex;
   align-items: center;
   overflow: hidden;
+  line-height: 28px;
 }


### PR DESCRIPTION
When hovering over actions in the timeline, the locator is not quite readable. Apply the same line height here as done in the actions list.

Before:
<img width="249" height="197" alt="image" src="https://github.com/user-attachments/assets/a4a44130-8e08-42a5-ab2a-1c4fe921114e" />

After:
<img width="205" height="196" alt="image" src="https://github.com/user-attachments/assets/aba21087-93d6-4c2b-a0cc-3da56e341e71" />
