### PR TITLE
docs(test): fix typo in test sharding guide

### DIFF
--- a/docs/src/test-sharding-js.md
+++ b/docs/src/test-sharding-js.md
@@ -166,7 +166,7 @@ You can now see the reports have been merged and a combined HTML report is avail
 
 ## Merging reports from multiple environments
 
-If you want to run the same tests in multiple environments, as opposed to shard your tests onto multiple machines, you need to differentiate these enviroments.
+If you want to run the same tests in multiple environments, as opposed to shard your tests onto multiple machines, you need to differentiate these environments.
 
 In this case, it is useful to specify the [`property: TestConfig.tag`] property, to tag all tests with the environment name. This tag will be automatically picked up by the blob report and later on by the merge tool.
 


### PR DESCRIPTION
## Summary
- fix typo in docs/src/test-sharding-js.md
- change "enviroments" to "environments"

## Why
- improves clarity in the multi-environment sharding section