### PR TITLE
Revert "fix: do not force swiftshader on chromium mac (#39129)"

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiChromium.ts
+++ b/packages/playwright-core/src/server/bidi/bidiChromium.ts
@@ -23,7 +23,6 @@ import { kBrowserCloseMessageId } from './bidiConnection';
 import { chromiumSwitches } from '../chromium/chromiumSwitches';
 import { RecentLogsCollector } from '../utils/debugLogger';
 import { waitForReadyState } from '../chromium/chromium';
-import { hasGpuMac } from '../utils/hostPlatform';
 
 import type { BrowserOptions } from '../browser';
 import type { SdkObject } from '../instrumentation';
@@ -115,7 +114,7 @@ export class BidiChromium extends BrowserType {
       throw new Error('Arguments can not specify page to be opened');
     const chromeArguments = [...chromiumSwitches(options.assistantMode)];
 
-    if (os.platform() !== 'darwin' || !hasGpuMac()) {
+    if (os.platform() === 'darwin') {
       // See https://issues.chromium.org/issues/40277080
       chromeArguments.push('--enable-unsafe-swiftshader');
     }

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -22,7 +22,7 @@ import path from 'path';
 import { chromiumSwitches } from './chromiumSwitches';
 import { CRBrowser } from './crBrowser';
 import { kBrowserCloseMessageId } from './crConnection';
-import { debugMode, hasGpuMac, headersArrayToObject, headersObjectToArray } from '../../utils';
+import { debugMode, headersArrayToObject, headersObjectToArray, } from '../../utils';
 import { wrapInASCIIBox } from '../utils/ascii';
 import { RecentLogsCollector } from '../utils/debugLogger';
 import { ManualPromise } from '../../utils/isomorphic/manualPromise';
@@ -319,10 +319,8 @@ export class Chromium extends BrowserType {
       throw new Error('Arguments can not specify page to be opened');
     const chromeArguments = [...chromiumSwitches(options.assistantMode, options.channel)];
 
-    if (os.platform() !== 'darwin' || !hasGpuMac()) {
-      // See https://issues.chromium.org/issues/40277080
-      chromeArguments.push('--enable-unsafe-swiftshader');
-    }
+    // See https://issues.chromium.org/issues/40277080
+    chromeArguments.push('--enable-unsafe-swiftshader');
 
     if (options.headless) {
       chromeArguments.push('--headless');

--- a/packages/playwright-core/src/server/utils/hostPlatform.ts
+++ b/packages/playwright-core/src/server/utils/hostPlatform.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { execSync } from 'child_process';
 import os from 'os';
 
 import { getLinuxDistributionInfoSync } from './linuxUtils';
@@ -134,17 +133,3 @@ function toShortPlatform(hostPlatform: HostPlatform): ShortPlatform {
 }
 
 export const shortPlatform = toShortPlatform(hostPlatform);
-
-let hasGpuMacValue: boolean | undefined;
-
-export function hasGpuMac() {
-  try {
-    if (hasGpuMacValue === undefined) {
-      const output = execSync('system_profiler SPDisplaysDataType', { stdio: ['ignore', 'pipe', 'ignore'] }).toString();
-      hasGpuMacValue = output.includes('Metal: Supported') || output.includes('Metal Support: Metal');
-    }
-    return hasGpuMacValue;
-  } catch (e) {
-    return false;
-  }
-}


### PR DESCRIPTION
This reverts commit 6a6719eecd0909b1cf63d90aa6f2154d67f90991.

The fix is now available in the latest chromium roll. Closes #38476.