### PR TITLE
chore: update proxy-from-env to not use deprecated url.parse anymore

### DIFF
--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -102,7 +102,7 @@ This project incorporates components from the projects listed below. The origina
 -	pngjs@6.0.0 (https://github.com/lukeapage/pngjs)
 -	progress@2.0.3 (https://github.com/visionmedia/node-progress)
 -	proxy-addr@2.0.7 (https://github.com/jshttp/proxy-addr)
--	proxy-from-env@1.1.0 (https://github.com/Rob--W/proxy-from-env)
+-	proxy-from-env@2.0.0 (https://github.com/Rob--W/proxy-from-env)
 -	pump@3.0.2 (https://github.com/mafintosh/pump)
 -	qs@6.14.1 (https://github.com/ljharb/qs)
 -	range-parser@1.2.1 (https://github.com/jshttp/range-parser)
@@ -3191,7 +3191,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF proxy-addr@2.0.7 AND INFORMATION
 
-%% proxy-from-env@1.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% proxy-from-env@2.0.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 The MIT License
 
@@ -3214,7 +3214,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
-END OF proxy-from-env@1.1.0 AND INFORMATION
+END OF proxy-from-env@2.0.0 AND INFORMATION
 
 %% pump@3.0.2 NOTICES AND INFORMATION BEGIN HERE
 =========================================

--- a/packages/playwright-core/bundles/utils/package-lock.json
+++ b/packages/playwright-core/bundles/utils/package-lock.json
@@ -22,7 +22,7 @@
         "open": "8.4.0",
         "pngjs": "6.0.0",
         "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
+        "proxy-from-env": "2.0.0",
         "retry": "0.12.0",
         "signal-exit": "3.0.7",
         "socks-proxy-agent": "8.0.5",
@@ -371,9 +371,10 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.0.0.tgz",
+      "integrity": "sha512-h2lD3OfRraP3R51rNFKIE8nX+qoLr1mE74X91YhVxtDbt+OD6ntoNZv56+JgI4RCdtwQ5eexsOk1KdOQDfvPCQ==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.12.0",

--- a/packages/playwright-core/bundles/utils/package.json
+++ b/packages/playwright-core/bundles/utils/package.json
@@ -17,7 +17,7 @@
     "open": "8.4.0",
     "pngjs": "6.0.0",
     "progress": "2.0.3",
-    "proxy-from-env": "1.1.0",
+    "proxy-from-env": "2.0.0",
     "retry": "0.12.0",
     "signal-exit": "3.0.7",
     "socks-proxy-agent": "8.0.5",


### PR DESCRIPTION
Supercedes https://github.com/microsoft/playwright/pull/39226 and closes https://github.com/microsoft/playwright/issues/38469.

By upgrading proxy-from-env, we remove the last `url.parse` call, but also drop support for `npm_config_*`-inferred proxies. As per https://github.com/Rob--W/proxy-from-env/issues/13#issuecomment-3150256653, these are obsolete since NPM 6 so that's fine.