### PR TITLE
devops: dont skip blob upload

### DIFF
--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -40,5 +40,7 @@ runs:
     - name: Unzip artifacts
       shell: bash
       run: |
-        unzip -n '${{ inputs.path }}/artifacts/*.zip' -d ${{ inputs.path }}
+        if ls '${{ inputs.path }}/artifacts'/*.zip 1>/dev/null 2>&1; then
+          unzip -n '${{ inputs.path }}/artifacts/*.zip' -d ${{ inputs.path }}
+        fi
         rm -rf '${{ inputs.path }}/artifacts'

--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -86,6 +86,7 @@ runs:
       if: ${{ !cancelled() }}
       shell: bash
     - name: Upload blob report
+      if: ${{ !cancelled() }}
       uses: ./.github/actions/upload-blob-report
       with:
         report_dir: blob-report

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -182,6 +182,7 @@ jobs:
       env:
         PW_TAG: "@vscode-extension"
     - name: Upload blob report
+      if: ${{ !cancelled() }}
       uses: ./.github/actions/upload-blob-report
       with:
         report_dir: playwright-vscode/blob-report


### PR DESCRIPTION
I accidentally removed the `if: ${{ !cancelled() }}` directive, which means the step is skipped if any previous step failed, so it's currently skipping the upload of any failing job.