### PR TITLE
fix: add missing path mappings to devtools tsconfig for watch mode

### DIFF
--- a/packages/devtools/tsconfig.json
+++ b/packages/devtools/tsconfig.json
@@ -4,7 +4,7 @@
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": true,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
@@ -16,9 +16,14 @@
     "jsx": "react-jsx",
     "useUnknownInCatchVariables": false,
     "paths": {
+      "@devtools/*": ["./src/*"],
+      "@injected/*": ["../injected/src/*"],
       "@isomorphic/*": ["../playwright-core/src/utils/isomorphic/*"],
       "@protocol/*": ["../protocol/src/*"],
+      "@recorder/*": ["../recorder/src/*"],
+      "@trace/*": ["../trace/src/*"],
       "@web/*": ["../web/src/*"],
+      "playwright-core/lib/*": ["../playwright-core/src/*"],
     }
   },
   "include": ["src"],


### PR DESCRIPTION
The 6d35c8b168768a1f6dbc19eb414b2373bd6de8a9 commit introduced relative imports from devtools into the playwright package, pulling in transitive dependencies that require playwright-core/lib/*, @recorder/*, @trace/*, and @injected/* path mappings. These were missing from the devtools tsconfig, causing 112 errors in watch mode (tsc -w -p packages/devtools).