### PR TITLE
feat(trace-viewer): Format XML bodies in network tab

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/mimeType.ts
+++ b/packages/playwright-core/src/utils/isomorphic/mimeType.ts
@@ -18,6 +18,10 @@ export function isJsonMimeType(mimeType: string) {
   return !!mimeType.match(/^(application\/json|application\/.*?\+json|text\/(x-)?json)(;\s*charset=.*)?$/);
 }
 
+export function isXmlMimeType(mimeType: string) {
+  return !!mimeType.match(/^(application\/xml|application\/.*?\+xml|text\/xml)(;\s*charset=.*)?$/);
+}
+
 export function isTextualMimeType(mimeType: string) {
   return !!mimeType.match(/^(text\/.*?|application\/(json|(x-)?javascript|xml.*?|ecmascript|graphql|x-www-form-urlencoded)|image\/svg(\+xml)?|application\/.*?(\+json|\+xml))(;\s*charset=.*)?$/);
 }

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -263,15 +263,9 @@ function statusClass(statusCode: number): string {
 const kInlineTagPattern = /<[^>]+>[^<]*<\//;
 
 function formatXml(xml: string, indent = '  ') {
-  const doc = new DOMParser().parseFromString(xml, 'application/xml');
-  if (doc.querySelector('parsererror'))
-    throw new Error('Invalid XML');
-
   let depth = 0;
   const lines: string[] = [];
-
-  const raw = new XMLSerializer().serializeToString(doc);
-  const tokens = raw.replace(/>\s*</g, '>\n<').split('\n');
+  const tokens = xml.replace(/>\s*</g, '>\n<').split('\n');
 
   for (const token of tokens) {
     const trimmed = token.trim();
@@ -279,7 +273,7 @@ function formatXml(xml: string, indent = '  ') {
       continue;
 
     if (trimmed.startsWith('</')) {
-      depth--;
+      depth = Math.max(depth - 1, 0);
       lines.push(indent.repeat(depth) + trimmed);
     } else if (trimmed.endsWith('/>') || trimmed.startsWith('<?') || kInlineTagPattern.test(trimmed)) {
       lines.push(indent.repeat(depth) + trimmed);

--- a/tests/assets/network-tab/network.html
+++ b/tests/assets/network-tab/network.html
@@ -32,6 +32,11 @@
           headers: { 'Content-Type': 'application/json' },
           body,
         }),
+        fetch('/post-xml-data', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/xml' },
+          body: `<?xml version="1.0"?><note to="Alice" from="Bob"><body>Hello &amp; welcome!</body></note>`,
+        }),
       ];
       window.donePromise = Promise.all(fetches.map(f => f.then(r => r.body()).then(() => null).catch(e => {})));
     </script>

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -464,7 +464,7 @@ test('should filter network requests by multiple resource types', async ({ page,
   await expect(networkRequests.getByText('image.png')).toBeVisible();
 
   await traceViewer.page.getByText('All', { exact: true }).click();
-  await expect(networkRequests).toHaveCount(9);
+  await expect(networkRequests).toHaveCount(10);
 });
 
 test('should show font preview', async ({ page, runAndTrace, server }) => {

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -189,6 +189,32 @@ test('should format JSON request body', async ({ runUITest, server }) => {
   ], { useInnerText: true });
 });
 
+test('should format XML request body', async ({ runUITest, server }) => {
+  const { page } = await runUITest({
+    'network-tab.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('network tab test', async ({ page }) => {
+        await page.goto('${server.PREFIX}/network-tab/network.html');
+        await page.evaluate(() => (window as any).donePromise);
+      });
+    `,
+  });
+
+  await page.getByText('network tab test').dblclick();
+  await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
+
+  await page.getByText('Network', { exact: true }).click();
+  await page.getByText('post-xml-data').click();
+  await page.getByRole('tabpanel', { name: 'Network' }).getByRole('tab', { name: 'Payload' }).click();
+  const payloadPanel = page.getByRole('tabpanel', { name: 'Payload' });
+  await expect(payloadPanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+    '<?xml version="1.0"?>',
+    '<note to="Alice" from="Bob">',
+    '    <body>Hello &amp; welcome!</body>',
+    '</note>'
+  ], { useInnerText: true });
+});
+
 test('should display list of query parameters (only if present)', async ({ runUITest, server }) => {
   const { page } = await runUITest({
     'network-tab.test.ts': `

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -80,7 +80,7 @@ test('should filter network requests by multiple resource types', async ({ runUI
   await page.getByText('Network', { exact: true }).click();
 
   const networkItems = page.getByRole('list', { name: 'Network requests' }).getByRole('listitem');
-  await expect(networkItems).toHaveCount(9);
+  await expect(networkItems).toHaveCount(10);
 
   await page.getByText('JS', { exact: true }).click();
   await expect(networkItems).toHaveCount(1);
@@ -101,7 +101,7 @@ test('should filter network requests by multiple resource types', async ({ runUI
   await expect(networkItems.getByText('image.png')).toBeVisible();
 
   await page.getByText('All', { exact: true }).click();
-  await expect(networkItems).toHaveCount(9);
+  await expect(networkItems).toHaveCount(10);
 });
 
 test('should filter network requests by url', async ({ runUITest, server }) => {


### PR DESCRIPTION
Best effort attempt to format XML bodies without making it too complex. It isn't perfect in all cases, but probably best we can do without introducing external formatting libraries.

Next (last) step for this story would be to add a toggle for this pretty printing.

Example from the ticket (note that we don't have the Codemirror xml formatter installed):
<img width="869" height="229" alt="image" src="https://github.com/user-attachments/assets/e82e6862-b6ae-41d5-af0c-5962218eb556" />


References: #37963