### PR TITLE
chore(deps): bump hono from 4.11.8 to 4.12.2

### DIFF
--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -61,7 +61,7 @@ This project incorporates components from the projects listed below. The origina
 -	graceful-fs@4.2.10 (https://github.com/isaacs/node-graceful-fs)
 -	has-symbols@1.1.0 (https://github.com/inspect-js/has-symbols)
 -	hasown@2.0.2 (https://github.com/inspect-js/hasOwn)
--	hono@4.11.8 (https://github.com/honojs/hono)
+-	hono@4.12.2 (https://github.com/honojs/hono)
 -	http-errors@2.0.1 (https://github.com/jshttp/http-errors)
 -	https-proxy-agent@7.0.6 (https://github.com/TooTallNate/proxy-agents)
 -	iconv-lite@0.7.2 (https://github.com/pillarjs/iconv-lite)
@@ -2146,7 +2146,7 @@ SOFTWARE.
 =========================================
 END OF hasown@2.0.2 AND INFORMATION
 
-%% hono@4.11.8 NOTICES AND INFORMATION BEGIN HERE
+%% hono@4.12.2 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 MIT License
 
@@ -2170,7 +2170,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 =========================================
-END OF hono@4.11.8 AND INFORMATION
+END OF hono@4.12.2 AND INFORMATION
 
 %% http-errors@2.0.1 NOTICES AND INFORMATION BEGIN HERE
 =========================================

--- a/packages/playwright-core/bundles/mcp/package-lock.json
+++ b/packages/playwright-core/bundles/mcp/package-lock.json
@@ -576,9 +576,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.8.tgz",
-      "integrity": "sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
+      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
 ## Summary
 
1. Why:
To remove CVEs:

     - [GHSA-gq3j-xvxp-8hrf](https://github.com/advisories/GHSA-gq3j-xvxp-8hrf)

2. What:

     - Upgrade hono to 4.12.2 to remove [GHSA-gq3j-xvxp-8hrf](https://github.com/advisories/GHSA-gq3j-xvxp-8hrf)
 
 ## Additional evidence
 
 Partial output from security scanner Trivy:
<img width="1532" height="97" alt="image" src="https://github.com/user-attachments/assets/8dbded88-a078-4eab-9ea2-f0b9de2b6523" />

 ## Categorization
 
- [x] security/CVE