### PR TITLE
feat(trace-viewer): add action filtering functionality

### DIFF
--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -686,7 +686,9 @@ public class WithTestNameAttribute : BeforeAfterTestAttribute
 ## Trace Viewer features
 ### Actions
 
-In the Actions tab you can see what locator was used for every action and how long each one took to run. Hover over each action of your test and visually see the change in the DOM snapshot. Go back and forward in time and click an action to inspect and debug. Use the Before and After tabs to visually see what happened before and after the action.
+In the Actions tab you can see what locator was used for every action and how long each one took to run. Use the **Filter actions** search field at the top of the list to filter the action hierarchy by text; only actions whose title matches the search (and their parent actions) are shown. Clear the filter to show all actions again; expanded nodes are preserved when the filter is removed.
+
+Hover over each action of your test and visually see the change in the DOM snapshot. Go back and forward in time and click an action to inspect and debug. Use the Before and After tabs to visually see what happened before and after the action.
 
 <img src="https://github.com/microsoft/playwright/assets/13063165/948b65cd-f0fd-4c7f-8e53-2c632b5a07f1" alt="actions tab in trace viewer" width="3598" height="2218" />
 

--- a/packages/trace-viewer/src/ui/workbench.css
+++ b/packages/trace-viewer/src/ui/workbench.css
@@ -44,3 +44,32 @@
   user-select: none;
   color: var(--vscode-editorCodeLens-foreground);
 }
+
+.workbench-action-filter {
+  flex: none;
+  padding: 4px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.workbench-action-filter input[type=search] {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 4px 8px;
+  line-height: 20px;
+  outline: none;
+  border: 1px solid var(--vscode-input-border);
+  border-radius: 2px;
+  color: var(--vscode-input-foreground);
+  background-color: var(--vscode-input-background);
+}
+
+.workbench-action-filter input[type=search]:focus {
+  border-color: var(--vscode-focusBorder);
+}
+
+.action-list-container {
+  min-height: 0;
+  flex: auto;
+  display: flex;
+  flex-direction: column;
+}

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -88,6 +88,7 @@ const PartitionedWorkbench: React.FunctionComponent<WorkbenchProps & { partition
   const [revealedAttachmentCallId, setRevealedAttachmentCallId] = usePartitionedState<{ callId: string } | undefined>('revealedAttachmentCallId');
   const [highlightedResourceKey, setHighlightedResourceKey] = usePartitionedState<string | undefined>('highlightedResourceKey');
   const [treeState, setTreeState] = usePartitionedState<TreeState>('treeState', { expandedItems: new Map() });
+  const [actionFilterText, setActionFilterText] = React.useState('');
 
   togglePartition(partition);
 
@@ -321,6 +322,16 @@ const PartitionedWorkbench: React.FunctionComponent<WorkbenchProps & { partition
         <div className='spacer'></div>
         <div className='workbench-run-duration'>{time ? msToString(time) : ''}</div>
       </div>}
+      <div className='workbench-action-filter'>
+        <input
+          type='search'
+          placeholder='Filter actions'
+          aria-label='Filter actions'
+          spellCheck={false}
+          value={actionFilterText}
+          onChange={e => setActionFilterText(e.target.value)}
+        />
+      </div>
       <ActionList
         sdkLanguage={sdkLanguage}
         actions={actions || []}
@@ -334,6 +345,7 @@ const PartitionedWorkbench: React.FunctionComponent<WorkbenchProps & { partition
         revealActionAttachment={revealActionAttachment}
         revealConsole={() => selectPropertiesTab('console')}
         isLive={isLive}
+        actionFilterText={actionFilterText}
       />
     </div>
   };

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -191,6 +191,20 @@ test('should open simple trace viewer', async ({ showTraceViewer }) => {
   ]);
 });
 
+test('should filter actions by text', async ({ showTraceViewer }) => {
+  const traceViewer = await showTraceViewer(traceFile);
+  const filterInput = traceViewer.page.getByRole('searchbox', { name: 'Filter actions' });
+  await expect(filterInput).toBeVisible();
+
+  const fullCount = await traceViewer.actionTitles.count();
+  await filterInput.fill('Click');
+  await expect(traceViewer.actionTitles.filter({ hasText: 'Click' }).first()).toBeVisible();
+  expect(await traceViewer.actionTitles.count()).toBeLessThan(fullCount);
+
+  await filterInput.fill('');
+  await expect(traceViewer.actionTitles).toHaveCount(fullCount);
+});
+
 test('should open uncompressed trace directory', async ({ showTraceViewer }) => {
   const traceDir = test.info().outputPath('unzipped-trace');
   await extractZip(traceFile, { dir: traceDir });

--- a/tests/playwright-test/ui-mode-test-filters.spec.ts
+++ b/tests/playwright-test/ui-mode-test-filters.spec.ts
@@ -37,7 +37,7 @@ const basicTestTree = {
 
 test('should filter by title', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree);
-  await page.getByPlaceholder('Filter').fill('inner');
+  await page.getByPlaceholder('Filter (e.g. text, @tag)').fill('inner');
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ◯ a.test.ts
       ▼ ◯ suite
@@ -48,7 +48,7 @@ test('should filter by title', async ({ runUITest }) => {
 
 test('should filter by explicit tags', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree);
-  await page.getByPlaceholder('Filter').fill('@smoke inner');
+  await page.getByPlaceholder('Filter (e.g. text, @tag)').fill('@smoke inner');
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ◯ a.test.ts
       ▼ ◯ suite
@@ -65,7 +65,7 @@ test('should display native tags and filter by them on click', async ({ runUITes
   `,
   });
   await page.locator('.ui-mode-tree-item-title').getByText('smoke').click();
-  await expect(page.getByPlaceholder('Filter')).toHaveValue('@smoke');
+  await expect(page.getByPlaceholder('Filter (e.g. text, @tag)')).toHaveValue('@smoke');
   await expect.poll(dumpTestTree(page)).toBe(`
     ▼ ◯ a.test.ts
         ◯ pwt


### PR DESCRIPTION
Split from https://github.com/microsoft/playwright/pull/39334 with a more clean code (I hope) and the trace viewer only, if code is ok I'll write the same feature for the html reporter.

## Without filter (default state)
<img width="1392" height="912" alt="Screenshot 2026-02-25 alle 18 38 28" src="https://github.com/user-attachments/assets/187a8277-7bd6-4c99-ad62-839e519cce92" />

## With filter
<img width="1392" height="912" alt="Screenshot 2026-02-25 alle 18 38 20" src="https://github.com/user-attachments/assets/92384341-65bb-4e36-bca2-44eb33d25d09" />