### PR TITLE
fix(mcp): handle non-deterministic contextmenu/mouseup order in right…

### DIFF
--- a/tests/mcp/mouse.spec.ts
+++ b/tests/mcp/mouse.spec.ts
@@ -78,7 +78,7 @@ test('browser_mouse_click_xy (right button)', async ({ client }) => {
     arguments: { x: 100, y: 100, button: 'right' },
   })).toHaveResponse({
     code: expect.stringContaining(`await page.mouse.click(100, 100, {\n  button: 'right'\n});`),
-    snapshot: expect.stringMatching(/mousemove 100 100.*mousedown button:2.*contextmenu button:2.*mouseup button:2/s),
+    snapshot: expect.stringMatching(/mousemove 100 100.*mousedown button:2(?=.*mouseup button:2)(?=.*contextmenu button:2)/s),
   });
 });
 


### PR DESCRIPTION
…-click test

Use lookaheads instead of sequential matching so both events are asserted regardless of which fires first.

Fixes the following sporadic error on the bots:

```
Error: expect(received).toEqual(expected) // deep equality

- Expected  -  3
+ Received  + 10

- ObjectContaining {
-   "code": StringContaining "await page.mouse.click(100, 100, {
+ Object {
+   "code": "// Click mouse at coordinates (100, 100)
+ await page.mouse.click(100, 100, {
    button: 'right'
  });",
-   "snapshot": StringMatching /mousemove 100 100.*mousedown button:2.*contextmenu button:2.*mouseup button:2/s,
+   "snapshot": "\`\`\`yaml
+ - <changed> generic [ref=e2]:
+   - generic [ref=e3]: mousemove 100 100
+   - generic [ref=e4]: mousedown button:2
+   - generic [ref=e5]: mouseup button:2
+   - generic [ref=e6]: contextmenu button:2
+ \`\`\`",
  }

```