### PR TITLE
fix: strip UTF-8 BOM when parsing JSON config files

### DIFF
--- a/packages/playwright/src/cli/client/program.ts
+++ b/packages/playwright/src/cli/client/program.ts
@@ -264,7 +264,8 @@ async function ensureConfiguredBrowserInstalled() {
   if (fs.existsSync(defaultConfigFile())) {
     const { registry } = await import('playwright-core/lib/server/registry/index');
     // Config exists, ensure configured browser is installed
-    const config = JSON.parse(await fs.promises.readFile(defaultConfigFile(), 'utf-8')) as Config;
+    const data = await fs.promises.readFile(defaultConfigFile(), 'utf-8');
+    const config = JSON.parse(data.charCodeAt(0) === 0xFEFF ? data.slice(1) : data) as Config;
     const browserName = config.browser?.browserName ?? 'chromium';
     const channel = config.browser?.launchOptions?.channel;
     if (!channel || channel.startsWith('chromium')) {

--- a/packages/playwright/src/mcp/browser/config.ts
+++ b/packages/playwright/src/mcp/browser/config.ts
@@ -366,7 +366,8 @@ export async function loadConfig(configFile: string | undefined): Promise<Config
     return configFromIniFile(configFile);
 
   try {
-    return JSON.parse(await fs.promises.readFile(configFile, 'utf8'));
+    const data = await fs.promises.readFile(configFile, 'utf8');
+    return JSON.parse(data.charCodeAt(0) === 0xFEFF ? data.slice(1) : data);
   } catch {
     return configFromIniFile(configFile);
   }

--- a/tests/mcp/cli-config.spec.ts
+++ b/tests/mcp/cli-config.spec.ts
@@ -89,6 +89,21 @@ test('config-print prints merged config from file, env and cli', async ({ cli, s
   expect(config.browser.isolated).toBe(true);
 });
 
+test('context options with UTF-8 BOM', async ({ cli, server }, testInfo) => {
+  const config = {
+    browser: {
+      contextOptions: {
+        viewport: { width: 800, height: 600 },
+      },
+    },
+  };
+  // Write config with UTF-8 BOM prefix, as some Windows editors (Notepad, PowerShell) do.
+  await fs.promises.writeFile(testInfo.outputPath('.playwright', 'cli.config.json'), '\uFEFF' + JSON.stringify(config, null, 2));
+  await cli('open', server.PREFIX);
+  const { output } = await cli('eval', 'window.innerWidth + "x" + window.innerHeight');
+  expect(output).toContain('800x600');
+});
+
 test('isolated', async ({ cli, server }, testInfo) => {
   const config = {
     browser: {


### PR DESCRIPTION
JSON config files saved with a UTF-8 BOM (EF BB BF) by Windows tools such as Notepad or PowerShell were silently ignored. Strip the BOM character before calling JSON.parse in loadConfig() and ensureConfiguredBrowserInstalled().

**Some context from our friend:**

 The UTF-8 BOM (EF BB BF / \uFEFF) gets inserted by:                                                                                                
                                                            
  - Notepad (pre-Windows 10 versions) — added BOM by default for UTF-8 files; newer Notepad still offers it                                                                             
  - PowerShell — Set-Content and Out-File historically defaulted to UTF-8 with BOM; only PowerShell 6+ (Core) changed the default to BOM-less UTF-8
  - Visual Studio — can add BOM depending on project/encoding settings                                                                                                                  
  - Some older versions of VS Code when configured with "files.encoding": "utf8bom"

  The BOM was originally intended to signal UTF-16 byte order, but got reused as a UTF-8 marker on Windows even though it's technically unnecessary and discouraged by the Unicode
  standard for UTF-8. Linux/macOS tools almost never add it, which is why cross-platform projects hit this as a Windows-specific surprise.

Fixes https://github.com/microsoft/playwright-cli/issues/274