### PR TITLE
docs(browsers): improve opt-in wording for browser cache path

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -1090,7 +1090,7 @@ dotnet test
 Playwright keeps track of packages that need those browsers and will garbage collect them as you update Playwright to the newer versions.
 
 :::note
-Developers can opt-in in this mode via exporting `PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers` in their `.bashrc`.
+Developers can opt into this mode by exporting `PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers` in their `.bashrc`.
 :::
 
 ### Hermetic install


### PR DESCRIPTION
## Summary
- fix docs wording in `docs/src/browsers.md`
- change `opt-in in this mode` to `opt into this mode`

## Notes
Minor documentation update; no related issue required per contribution guidelines.
