### PR TITLE
chore: playwright-cli stub for local development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6377,6 +6377,10 @@
       "resolved": "packages/playwright-chromium",
       "link": true
     },
+    "node_modules/playwright-cli-stub": {
+      "resolved": "packages/playwright-cli-stub",
+      "link": true
+    },
     "node_modules/playwright-core": {
       "resolved": "packages/playwright-core",
       "link": true
@@ -8263,6 +8267,12 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/playwright-cli-stub": {
+      "version": "0.0.0",
+      "bin": {
+        "playwright-cli": "playwright-cli-stub.js"
       }
     },
     "packages/playwright-client": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "check-deps": "node utils/check_deps.js",
     "build-android-driver": "./utils/build_android_driver.sh",
     "innerloop": "playwright run-server --reuse-browser",
-    "playwright-cli": "node packages/playwright/lib/cli/client/cli.js",
     "test-playwright-cli": "playwright test --config=tests/mcp/playwright.config.ts --project=chrome cli-",
     "playwright-cli-readme": "node utils/generate_cli_help.js --readme"
   },

--- a/packages/playwright-cli-stub/package.json
+++ b/packages/playwright-cli-stub/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "playwright-cli-stub",
+  "version": "0.0.0",
+  "private": true,
+  "bin": {
+    "playwright-cli": "playwright-cli-stub.js"
+  }
+}

--- a/packages/playwright-cli-stub/playwright-cli-stub.js
+++ b/packages/playwright-cli-stub/playwright-cli-stub.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { program } = require('playwright/lib/cli/client/program');
+
+program().catch(e => {
+  console.error(e.message);
+  process.exit(1);
+});

--- a/packages/playwright/src/skill/SKILL.md
+++ b/packages/playwright/src/skill/SKILL.md
@@ -216,19 +216,16 @@ playwright-cli kill-all
 
 ## Installation
 
-If `playwright-cli` is not available, install it globally:
+If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
+
+```bash
+npx playwright-cli --version
+```
+
+When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:
 
 ```bash
 npm install -g @playwright/cli@latest
-```
-
-Once installed, `playwright-cli` will be available as a global command.
-
-Alternatively, install the package locally and use `npx` to run without a global install. This is useful for hermetic environments, but adds a slight `npx` overhead on each command execution:
-
-```bash
-npx playwright-cli open https://example.com
-npx playwright-cli click e1
 ```
 
 ## Example: Form submission


### PR DESCRIPTION
Makes `npx playwright-cli` work in our repo.
Also updates the skill to try local version before installing.