### PR TITLE
test: fix codegen tests

### DIFF
--- a/tests/library/browsercontext-timezone-id.spec.ts
+++ b/tests/library/browsercontext-timezone-id.spec.ts
@@ -18,29 +18,31 @@
 import { browserTest as it, expect } from '../config/browserTest';
 
 it('should work @smoke', async ({ browser, browserName }) => {
+  // Note: timezone names are rendered differently between browsers and platforms,
+  // so we only check the GMT offset.
   const func = () => new Date(1479579154987).toString();
   {
     const context = await browser.newContext({ locale: 'en-US', timezoneId: 'America/Jamaica' });
     const page = await context.newPage();
-    expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 13:12:34 GMT-0500 (Eastern Standard Time)');
+    expect(await page.evaluate(func)).toContain('Sat Nov 19 2016 13:12:34 GMT-0500');
     await context.close();
   }
   {
     const context = await browser.newContext({ locale: 'en-US', timezoneId: 'Pacific/Honolulu' });
     const page = await context.newPage();
-    expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 08:12:34 GMT-1000 (Hawaii-Aleutian Standard Time)');
+    expect(await page.evaluate(func)).toContain('Sat Nov 19 2016 08:12:34 GMT-1000');
     await context.close();
   }
   {
     const context = await browser.newContext({ locale: 'en-US', timezoneId: browserName === 'firefox' ? 'America/Argentina/Buenos_Aires' : 'America/Buenos_Aires' });
     const page = await context.newPage();
-    expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 15:12:34 GMT-0300 (Argentina Standard Time)');
+    expect(await page.evaluate(func)).toContain('Sat Nov 19 2016 15:12:34 GMT-0300');
     await context.close();
   }
   {
     const context = await browser.newContext({ locale: 'en-US', timezoneId: 'Europe/Berlin' });
     const page = await context.newPage();
-    expect(await page.evaluate(func)).toBe('Sat Nov 19 2016 19:12:34 GMT+0100 (Central European Standard Time)');
+    expect(await page.evaluate(func)).toContain('Sat Nov 19 2016 19:12:34 GMT+0100');
     await context.close();
   }
 });

--- a/tests/library/inspector/cli-codegen-1.spec.ts
+++ b/tests/library/inspector/cli-codegen-1.spec.ts
@@ -91,10 +91,8 @@ await page.GetByRole(AriaRole.Button, new() { Name = "Submit" }).DblClickAsync()
     ]);
   });
 
-  test('should click twice', async ({ openRecorder, headless }) => {
-    test.skip(!headless, 'real mouse moves sneak between two clicks, moving away from the button');
-
-    const { page, recorder } = await openRecorder();
+  test('should click twice', async ({ openRecorder }) => {
+    const { recorder } = await openRecorder();
 
     await recorder.setContentAndWait(`<button onclick="console.log('click')">Submit</button>`);
 
@@ -104,14 +102,13 @@ await page.GetByRole(AriaRole.Button, new() { Name = "Submit" }).DblClickAsync()
     await Promise.all([
       recorder.waitForOutput('JavaScript', 'click'),
       recorder.trustedClick(),
+      recorder.waitForActionPerformed(),
     ]);
-
-    // Do not trigger double click.
-    await page.waitForTimeout(3000);
 
     const [sources] = await Promise.all([
       recorder.waitForOutput('JavaScript', `click();\n  await`),
       recorder.trustedClick(),
+      recorder.waitForActionPerformed(),
     ]);
 
     expect(sources.get('JavaScript')!.text).toContain(`
@@ -129,14 +126,13 @@ await page.GetByRole(AriaRole.Button, new() { Name = "Submit" }).DblClickAsync()
     await Promise.all([
       recorder.waitForOutput('JavaScript', 'click'),
       recorder.trustedClick(),
+      recorder.waitForActionPerformed(),
     ]);
-
-    // Do not trigger double click.
-    await page.waitForTimeout(3000);
 
     await Promise.all([
       recorder.waitForOutput('JavaScript', `click();\n  await`),
       recorder.trustedClick(),
+      recorder.waitForActionPerformed(),
     ]);
 
     await page.keyboard.type('bar');
@@ -1061,8 +1057,9 @@ await page.GetByRole(AriaRole.Button, new() { Name = "Submit" }).ClickAsync();`)
     await Promise.all([
       recorder.waitForOutput('JavaScript', 'click'),
       page.locator('button').click(),
+      recorder.waitForActionPerformed(),
     ]);
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(600);  // See "signalThreshold" is signal processor.
     await page.goto(server.PREFIX + `/empty.html`);
     await recorder.waitForOutput('JavaScript', `await page.goto('${server.PREFIX}/empty.html');`);
   });
@@ -1073,8 +1070,9 @@ await page.GetByRole(AriaRole.Button, new() { Name = "Submit" }).ClickAsync();`)
     await Promise.all([
       recorder.waitForOutput('JavaScript', 'fill'),
       page.locator('textarea').fill('Hello world'),
+      recorder.waitForActionPerformed(),
     ]);
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(600);  // See "signalThreshold" is signal processor.
     await page.goto(server.PREFIX + `/empty.html`);
     await recorder.waitForOutput('JavaScript', `await page.goto('${server.PREFIX}/empty.html');`);
   });

--- a/tests/library/inspector/cli-codegen-2.spec.ts
+++ b/tests/library/inspector/cli-codegen-2.spec.ts
@@ -17,8 +17,6 @@
 import { test, expect } from './inspectorTest';
 
 test.describe('cli codegen', () => {
-  test.skip(({ mode }) => mode !== 'default');
-
   test('should contain open page', async ({ openRecorder }) => {
     const { recorder } = await openRecorder();
 
@@ -412,7 +410,7 @@ await page1.GotoAsync("about:blank?foo");`);
   });
 
   test('should update active model on action', async ({ openRecorder, browserName, headless }) => {
-    test.fixme(browserName === 'webkit');
+    test.skip(browserName === 'webkit', 'webkit does not actually focus the input after click');
 
     const { page, recorder } = await openRecorder();
     await recorder.setContentAndWait(`<input id="checkbox" type="checkbox" name="accept" onchange="checkbox.name='updated'"></input>`);

--- a/tests/library/inspector/cli-codegen-3.spec.ts
+++ b/tests/library/inspector/cli-codegen-3.spec.ts
@@ -20,8 +20,6 @@ import { test, expect } from './inspectorTest';
 import type { Page } from '@playwright/test';
 
 test.describe('cli codegen', () => {
-  test.skip(({ mode }) => mode !== 'default');
-
   test('should click locator.first', async ({ openRecorder }) => {
     const { page, recorder } = await openRecorder();
 
@@ -803,7 +801,7 @@ await page.GetByTestId("testid").HoverAsync();`);
   });
 
   test('should assert value on disabled input', async ({ openRecorder, browserName }) => {
-    test.fixme(browserName === 'firefox', 'pointerup event is not dispatched on a disabled input');
+    test.skip(browserName === 'firefox', 'pointerup event is not dispatched on a disabled input');
 
     const { recorder } = await openRecorder();
 

--- a/tests/library/inspector/cli-codegen-aria.spec.ts
+++ b/tests/library/inspector/cli-codegen-aria.spec.ts
@@ -18,8 +18,6 @@ import { test, expect } from './inspectorTest';
 import { roundBox } from '../../config/utils';
 
 test.describe(() => {
-  test.skip(({ mode }) => mode !== 'default');
-
   test('should generate aria snapshot', async ({ openRecorder }) => {
     const { recorder } = await openRecorder();
     await recorder.setContentAndWait(`<main><button>Submit</button></main>`);

--- a/tests/library/inspector/cli-codegen-pick-locator.spec.ts
+++ b/tests/library/inspector/cli-codegen-pick-locator.spec.ts
@@ -18,8 +18,6 @@ import { test, expect } from './inspectorTest';
 import { roundBox } from '../../config/utils';
 
 test.describe(() => {
-  test.skip(({ mode }) => mode !== 'default');
-
   test('should inspect locator', async ({ openRecorder }) => {
     const { recorder } = await openRecorder();
     await recorder.setContentAndWait(`<main><button>Submit</button></main>`);

--- a/tests/library/inspector/console-api.spec.ts
+++ b/tests/library/inspector/console-api.spec.ts
@@ -16,8 +16,6 @@
 
 import { test as it, expect } from './inspectorTest';
 
-it.skip(({ mode }) => mode !== 'default');
-
 let scriptPromise: Promise<void>;
 
 it.beforeEach(async ({ page, recorderPageGetter }) => {

--- a/tests/library/inspector/inspectorTest.ts
+++ b/tests/library/inspector/inspectorTest.ts
@@ -50,8 +50,9 @@ const codegenLangId2lang = new Map([...codegenLang2Id.entries()].map(([lang, lan
 const playwrightToAutomateInspector = require('../../../packages/playwright-core/lib/inProcessFactory').createInProcessPlaywright(nodePlatform);
 
 export const test = contextTest.extend<CLITestArgs>({
-  recorderPageGetter: async ({ context, toImpl, mode }, run, testInfo) => {
-    testInfo.skip(mode.startsWith('service'));
+  recorderPageGetter: async ({ context, toImpl, mode, headless }, run, testInfo) => {
+    testInfo.skip(mode !== 'default');
+    testInfo.skip(!headless, 'real mouse moves mess up with recording');
     await run(async () => {
       while (!toImpl(context).recorderAppForTest)
         await new Promise(f => setTimeout(f, 100));

--- a/tests/library/inspector/pause.spec.ts
+++ b/tests/library/inspector/pause.spec.ts
@@ -21,8 +21,6 @@ import type { BoundingBox } from '../../config/utils';
 import { pauseHelper } from './pause-helper';
 
 it('should resume when closing inspector', async ({ page, recorderPageGetter, closeRecorder, mode }) => {
-  it.skip(mode !== 'default');
-
   const scriptPromise = (async () => {
     // @ts-ignore
     await page.pause({ __testHookKeepTestTimeout: true });
@@ -62,8 +60,6 @@ world`);
 });
 
 it.describe('pause', () => {
-  it.skip(({ mode }) => mode !== 'default');
-
   it.afterEach(async ({ recorderPageGetter }, testInfo) => {
     if (testInfo.status === 'skipped')
       return;


### PR DESCRIPTION
- Disable them in headed. All attempts to combat spurious mouse moves have failed.
- Wait for performed/recorded action to be done before proceeding.
- Drive-by: update timezone test expectations for webkit.