### PR TITLE
feat(api): add Response.httpVersion() method

### DIFF
--- a/docs/src/api/class-response.md
+++ b/docs/src/api/class-response.md
@@ -80,6 +80,12 @@ Returns all values of the headers matching the name, for example `set-cookie`. T
 
 Name of the header.
 
+## async method: Response.httpVersion
+* since: v1.59
+- returns: <[string]>
+
+Returns the http version used by the response.
+
 ## async method: Response.json
 * since: v1.8
 * langs: js, python

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -21156,6 +21156,11 @@ export interface Response {
   headerValues(name: string): Promise<Array<string>>;
 
   /**
+   * Returns the http version used by the response.
+   */
+  httpVersion(): Promise<string>;
+
+  /**
    * Returns the JSON representation of response body.
    *
    * This method will throw if the response body is not parsable via `JSON.parse`.

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -743,9 +743,7 @@ export class Response extends ChannelOwner<channels.ResponseChannel> implements 
   }
 
   async httpVersion(): Promise<string> {
-    return this._wrapApiCall(async () => {
-      return (await this._channel.httpVersion()).value;
-    }, { internal: true });
+    return (await this._channel.httpVersion()).value;
   }
 }
 

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -741,6 +741,12 @@ export class Response extends ChannelOwner<channels.ResponseChannel> implements 
   async securityDetails(): Promise<SecurityDetails|null> {
     return (await this._channel.securityDetails()).value || null;
   }
+
+  async httpVersion(): Promise<string> {
+    return this._wrapApiCall(async () => {
+      return (await this._channel.httpVersion()).value;
+    }, { internal: true });
+  }
 }
 
 export class WebSocket extends ChannelOwner<channels.WebSocketChannel> implements api.WebSocket {

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -2416,6 +2416,10 @@ scheme.ResponseRawResponseHeadersParams = tOptional(tObject({}));
 scheme.ResponseRawResponseHeadersResult = tObject({
   headers: tArray(tType('NameValue')),
 });
+scheme.ResponseHttpVersionParams = tOptional(tObject({}));
+scheme.ResponseHttpVersionResult = tObject({
+  value: tString,
+});
 scheme.ResponseSizesParams = tOptional(tObject({}));
 scheme.ResponseSizesResult = tObject({
   sizes: tType('RequestSizes'),

--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -426,7 +426,8 @@ export class CRNetworkManager {
         responseStart: -1,
       };
     }
-    const response = new network.Response(request.request, responsePayload.status, responsePayload.statusText, headersObjectToArray(responsePayload.headers), timing, getResponseBody, !!responsePayload.fromServiceWorker, responsePayload.protocol);
+    const response = new network.Response(request.request, responsePayload.status, responsePayload.statusText, headersObjectToArray(responsePayload.headers), timing, getResponseBody, !!responsePayload.fromServiceWorker);
+    response._setHttpVersion(responsePayload?.protocol ?? null);
     if (responsePayload?.remoteIPAddress && typeof responsePayload?.remotePort === 'number') {
       response._serverAddrFinished({
         ipAddress: responsePayload.remoteIPAddress,

--- a/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
+++ b/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
@@ -117,6 +117,10 @@ export class ResponseDispatcher extends Dispatcher<Response, channels.ResponseCh
     return { headers: await progress.race(this._object.rawResponseHeaders()) };
   }
 
+  async httpVersion(params: channels.ResponseHttpVersionParams, progress: Progress): Promise<channels.ResponseHttpVersionResult> {
+    return { value: await progress.race(this._object.httpVersion()) };
+  }
+
   async sizes(params: channels.ResponseSizesParams, progress: Progress): Promise<channels.ResponseSizesResult> {
     return { sizes: await progress.race(this._object.sizes()) };
   }

--- a/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
+++ b/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
@@ -144,8 +144,7 @@ export class FFNetworkManager {
       this._requests.delete(request._id);
       response._requestFinished(responseEndTime);
     }
-    if (event.protocolVersion)
-      response._setHttpVersion(event.protocolVersion);
+    response._setHttpVersion(event.protocolVersion ?? null);
     this._page.frameManager.reportRequestFinished(request.request, response);
   }
 

--- a/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
+++ b/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
@@ -158,6 +158,7 @@ export class FFNetworkManager {
       response.setTransferSize(null);
       response.setEncodedBodySize(null);
       response._requestFinished(-1);
+      response._setHttpVersion(null);
     }
     request.request._setFailureText(event.errorCode);
     this._page.frameManager.requestFailed(request.request, event.errorCode === 'NS_BINDING_ABORTED');

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -442,7 +442,7 @@ export class HarTracer {
     }
   }
 
-  private async _onResponse(response: network.Response) {
+  private _onResponse(response: network.Response) {
     const harEntry = this._entryForRequest(response.request());
     if (!harEntry)
       return;

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -323,9 +323,10 @@ export class HarTracer {
       }));
     }
 
-    const httpVersion = await response.httpVersion();
-    harEntry.request.httpVersion = httpVersion;
-    harEntry.response.httpVersion = httpVersion;
+    this._addBarrier(page || request.serviceWorker(), response.httpVersion().then(httpVersion => {
+      harEntry.request.httpVersion = httpVersion;
+      harEntry.response.httpVersion = httpVersion;
+    }));
 
     const compressionCalculationBarrier = this._options.omitSizes ? undefined : {
       _encodedBodySize: -1,
@@ -452,7 +453,7 @@ export class HarTracer {
     harEntry.response = {
       status: response.status(),
       statusText: response.statusText(),
-      httpVersion: await response.httpVersion(),
+      httpVersion: FALLBACK_HTTP_VERSION,
       // These are bad values that will be overwritten below.
       cookies: [],
       headers: [],
@@ -465,6 +466,10 @@ export class HarTracer {
       redirectURL: '',
       _transferSize: this._options.omitSizes ? undefined : -1
     };
+
+    this._addBarrier(page || request.serviceWorker(), response.httpVersion().then(httpVersion => {
+      harEntry.response.httpVersion = httpVersion;
+    }));
 
     if (!this._options.omitTiming) {
       const startDateTime = pageEntry ? ((pageEntry as any)[startedDateSymbol] as Date).valueOf() : 0;

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -323,7 +323,7 @@ export class HarTracer {
       }));
     }
 
-    const httpVersion = response.httpVersion();
+    const httpVersion = await response.httpVersion();
     harEntry.request.httpVersion = httpVersion;
     harEntry.response.httpVersion = httpVersion;
 
@@ -441,7 +441,7 @@ export class HarTracer {
     }
   }
 
-  private _onResponse(response: network.Response) {
+  private async _onResponse(response: network.Response) {
     const harEntry = this._entryForRequest(response.request());
     if (!harEntry)
       return;
@@ -452,7 +452,7 @@ export class HarTracer {
     harEntry.response = {
       status: response.status(),
       statusText: response.statusText(),
-      httpVersion: response.httpVersion(),
+      httpVersion: await response.httpVersion(),
       // These are bad values that will be overwritten below.
       cookies: [],
       headers: [],

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -323,11 +323,6 @@ export class HarTracer {
       }));
     }
 
-    this._addBarrier(page || request.serviceWorker(), response.httpVersion().then(httpVersion => {
-      harEntry.request.httpVersion = httpVersion;
-      harEntry.response.httpVersion = httpVersion;
-    }));
-
     const compressionCalculationBarrier = this._options.omitSizes ? undefined : {
       _encodedBodySize: -1,
       _decodedBodySize: -1,
@@ -468,6 +463,7 @@ export class HarTracer {
     };
 
     this._addBarrier(page || request.serviceWorker(), response.httpVersion().then(httpVersion => {
+      harEntry.request.httpVersion = httpVersion;
       harEntry.response.httpVersion = httpVersion;
     }));
 

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -508,13 +508,13 @@ export class Response extends SdkObject {
   private _serverAddrPromise = new ManualPromise<RemoteAddr | undefined>();
   private _securityDetailsPromise = new ManualPromise<SecurityDetails | undefined>();
   private _rawResponseHeadersPromise = new ManualPromise<HeadersArray>();
-  private _httpVersionPromise = new ManualPromise<string | undefined>();
+  private _httpVersionPromise = new ManualPromise<string | null>();
   private _fromServiceWorker: boolean;
   private _encodedBodySizePromise = new ManualPromise<number | null>();
   private _transferSizePromise = new ManualPromise<number | null>();
   private _responseHeadersSizePromise = new ManualPromise<number | null>();
 
-  constructor(request: Request, status: number, statusText: string, headers: HeadersArray, timing: ResourceTiming, getResponseBodyCallback: GetResponseBodyCallback, fromServiceWorker: boolean, httpVersion?: string) {
+  constructor(request: Request, status: number, statusText: string, headers: HeadersArray, timing: ResourceTiming, getResponseBodyCallback: GetResponseBodyCallback, fromServiceWorker: boolean) {
     super(request.frame() || request._context, 'response');
     this._request = request;
     this._timing = timing;
@@ -526,8 +526,6 @@ export class Response extends SdkObject {
       this._headersMap.set(name.toLowerCase(), value);
     this._getResponseBodyCallback = getResponseBodyCallback;
     this._request._setResponse(this);
-    if (httpVersion)
-      this._httpVersionPromise.resolve(httpVersion);
     this._fromServiceWorker = fromServiceWorker;
   }
 
@@ -547,7 +545,7 @@ export class Response extends SdkObject {
     this._finishedPromise.resolve();
   }
 
-  _setHttpVersion(httpVersion: string) {
+  _setHttpVersion(httpVersion: string | null) {
     this._httpVersionPromise.resolve(httpVersion);
   }
 
@@ -640,8 +638,6 @@ export class Response extends SdkObject {
       return 'HTTP/1.1';
     if (httpVersion === 'h2')
       return 'HTTP/2.0';
-    if (httpVersion === 'h3')
-      return 'HTTP/3.0';
     return httpVersion;
   }
 

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -1161,8 +1161,7 @@ export class WKPage implements PageDelegate {
         validFrom: responseReceivedPayload?.response.security?.certificate?.validFrom,
         validTo: responseReceivedPayload?.response.security?.certificate?.validUntil,
       });
-      if (event.metrics?.protocol)
-        response._setHttpVersion(event.metrics.protocol);
+      response._setHttpVersion(event.metrics?.protocol ?? null);
       response.setEncodedBodySize(event.metrics?.responseBodyBytesReceived ?? null);
       response.setResponseHeadersSize(event.metrics?.responseHeaderBytesReceived ?? null);
 

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -1195,6 +1195,7 @@ export class WKPage implements PageDelegate {
     if (response) {
       response._serverAddrFinished();
       response._securityDetailsFinished();
+      response._setHttpVersion(null);
       response.setResponseHeadersSize(null);
       response.setEncodedBodySize(null);
       response._requestFinished(helper.secondsToRoundishMillis(event.timestamp - request._timestamp));

--- a/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
+++ b/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
@@ -263,6 +263,7 @@ export const methodMetainfo = new Map<string, { internal?: boolean, title?: stri
   ['Response.securityDetails', { internal: true, }],
   ['Response.serverAddr', { internal: true, }],
   ['Response.rawResponseHeaders', { internal: true, }],
+  ['Response.httpVersion', { internal: true, }],
   ['Response.sizes', { internal: true, }],
   ['BindingCall.reject', { internal: true, }],
   ['BindingCall.resolve', { internal: true, }],

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21156,6 +21156,11 @@ export interface Response {
   headerValues(name: string): Promise<Array<string>>;
 
   /**
+   * Returns the http version used by the response.
+   */
+  httpVersion(): Promise<string>;
+
+  /**
    * Returns the JSON representation of response body.
    *
    * This method will throw if the response body is not parsable via `JSON.parse`.

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -4136,6 +4136,7 @@ export interface ResponseChannel extends ResponseEventTarget, Channel {
   securityDetails(params?: ResponseSecurityDetailsParams, progress?: Progress): Promise<ResponseSecurityDetailsResult>;
   serverAddr(params?: ResponseServerAddrParams, progress?: Progress): Promise<ResponseServerAddrResult>;
   rawResponseHeaders(params?: ResponseRawResponseHeadersParams, progress?: Progress): Promise<ResponseRawResponseHeadersResult>;
+  httpVersion(params?: ResponseHttpVersionParams, progress?: Progress): Promise<ResponseHttpVersionResult>;
   sizes(params?: ResponseSizesParams, progress?: Progress): Promise<ResponseSizesResult>;
 }
 export type ResponseBodyParams = {};
@@ -4157,6 +4158,11 @@ export type ResponseRawResponseHeadersParams = {};
 export type ResponseRawResponseHeadersOptions = {};
 export type ResponseRawResponseHeadersResult = {
   headers: NameValue[],
+};
+export type ResponseHttpVersionParams = {};
+export type ResponseHttpVersionOptions = {};
+export type ResponseHttpVersionResult = {
+  value: string,
 };
 export type ResponseSizesParams = {};
 export type ResponseSizesOptions = {};

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -3656,6 +3656,11 @@ Response:
           type: array
           items: NameValue
 
+    httpVersion:
+      internal: true
+      returns:
+        value: string
+
     sizes:
       internal: true
       returns:

--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -17,7 +17,11 @@
 
 import fs from 'fs';
 import url from 'url';
+import type { AddressInfo } from 'net';
 import { expect, test as it } from './pageTest';
+import { TestServer } from '../config/testserver';
+
+const { createHttp2Server } = require('../../packages/playwright-core/lib/utils');
 
 it('should work @smoke', async ({ page, server }) => {
   server.setRoute('/empty.html', (req, res) => {
@@ -420,4 +424,9 @@ it('request.existingResponse should return the response after it is received', a
   const response = await page.goto(server.EMPTY_PAGE);
   const request = response.request();
   expect(request.existingResponse()).toBe(response);
+});
+
+it('should return http version', async ({ page, server }) => {
+  const response = await page.goto(server.EMPTY_PAGE);
+  expect(await response.httpVersion()).toBe('HTTP/1.1');
 });

--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -17,11 +17,7 @@
 
 import fs from 'fs';
 import url from 'url';
-import type { AddressInfo } from 'net';
 import { expect, test as it } from './pageTest';
-import { TestServer } from '../config/testserver';
-
-const { createHttp2Server } = require('../../packages/playwright-core/lib/utils');
 
 it('should work @smoke', async ({ page, server }) => {
   server.setRoute('/empty.html', (req, res) => {


### PR DESCRIPTION
Adds `Response.httpVersion()` to get the http version of a given response.
Issue: https://github.com/microsoft/playwright/issues/39310

Previous PR #39309 was closed out with some comments. I've addressed the comments and opened a this new PR. This feature would be extremely useful to reduce bloat/boilerplate for our test suite.