### PR TITLE
test: gardening some tests failing on WebKit

### DIFF
--- a/tests/library/browsercontext-timezone-id.spec.ts
+++ b/tests/library/browsercontext-timezone-id.spec.ts
@@ -24,25 +24,25 @@ it('should work @smoke', async ({ browser, browserName }) => {
   {
     const context = await browser.newContext({ locale: 'en-US', timezoneId: 'America/Jamaica' });
     const page = await context.newPage();
-    expect(await page.evaluate(func)).toContain('Sat Nov 19 2016 13:12:34 GMT-0500');
+    expect.soft(await page.evaluate(func)).toContain('Sat Nov 19 2016 13:12:34 GMT-0500');
     await context.close();
   }
   {
     const context = await browser.newContext({ locale: 'en-US', timezoneId: 'Pacific/Honolulu' });
     const page = await context.newPage();
-    expect(await page.evaluate(func)).toContain('Sat Nov 19 2016 08:12:34 GMT-1000');
+    expect.soft(await page.evaluate(func)).toContain('Sat Nov 19 2016 08:12:34 GMT-1000');
     await context.close();
   }
   {
     const context = await browser.newContext({ locale: 'en-US', timezoneId: browserName === 'firefox' ? 'America/Argentina/Buenos_Aires' : 'America/Buenos_Aires' });
     const page = await context.newPage();
-    expect(await page.evaluate(func)).toContain('Sat Nov 19 2016 15:12:34 GMT-0300');
+    expect.soft(await page.evaluate(func)).toContain('Sat Nov 19 2016 15:12:34 GMT-0300');
     await context.close();
   }
   {
     const context = await browser.newContext({ locale: 'en-US', timezoneId: 'Europe/Berlin' });
     const page = await context.newPage();
-    expect(await page.evaluate(func)).toContain('Sat Nov 19 2016 19:12:34 GMT+0100');
+    expect.soft(await page.evaluate(func)).toContain('Sat Nov 19 2016 19:12:34 GMT+0100');
     await context.close();
   }
 });

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -247,7 +247,9 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       expect(request.headers['foo']).toBe('bar');
     });
 
-    test('should send default User-Agent and X-Playwright-Browser headers with connect request', async ({ connect, browserName, server }) => {
+    test('should send default User-Agent and X-Playwright-Browser headers with connect request', async ({ connect, browserName, server, isMac, macVersion }) => {
+      test.skip(browserName === 'webkit' && isMac && macVersion <= 14, 'WebKit on macOS-14 is frozen');
+
       const [request] = await Promise.all([
         server.waitForWebSocketConnectionRequest(),
         connect(`ws://localhost:${server.PORT}/ws`, {

--- a/tests/library/popup.spec.ts
+++ b/tests/library/popup.spec.ts
@@ -17,7 +17,9 @@
 import { browserTest as it, expect } from '../config/browserTest';
 import type { Page } from 'playwright-core';
 
-it('should inherit user agent from browser context @smoke', async function({ browser, server }) {
+it('should inherit user agent from browser context @smoke', async function({ browser, server, browserName, isMac, macVersion }) {
+  it.skip(browserName === 'webkit' && isMac && macVersion <= 14, 'WebKit on macOS-14 is frozen');
+
   const context = await browser.newContext({
     userAgent: 'hey'
   });


### PR DESCRIPTION
* The timezone tests started failing on the mac bots recently and not reproducible locally.
* The other two tests are flaky on mac14 only and WebKit is frozen there.