### PR TITLE
chore(docker): add Finch build helper script

### DIFF
--- a/utils/docker/build_finch.sh
+++ b/utils/docker/build_finch.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -e
+set +x
+
+if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
+  echo "usage: $(basename $0) {--arm64,--amd64} {jammy,noble} playwright:localbuild-noble"
+  echo
+  echo "Build Playwright Finch image and tag it as 'playwright:localbuild-noble'."
+  echo "Once image is built, you can run it with"
+  echo ""
+  echo "  finch run --rm -it playwright:localbuild-noble /bin/bash"
+  echo ""
+  echo "NOTE: this requires Playwright dependencies to be installed with 'npm install'"
+  echo "      and Playwright itself being built with 'npm run build'"
+  echo ""
+  exit 0
+fi
+
+function cleanup() {
+  rm -f "playwright-core.tar.gz"
+}
+
+trap "cleanup; cd $(pwd -P)" EXIT
+cd "$(dirname "$0")"
+
+# We rely on `./playwright-core.tar.gz` to download browsers into the container
+# image.
+node ../../utils/pack_package.js playwright-core ./playwright-core.tar.gz
+
+PLATFORM=""
+if [[ "$1" == "--arm64" ]]; then
+  PLATFORM="linux/arm64";
+elif [[ "$1" == "--amd64" ]]; then
+  PLATFORM="linux/amd64"
+else
+  echo "ERROR: unknown platform specifier - $1. Only --arm64 or --amd64 is supported"
+  exit 1
+fi
+
+finch build --platform "${PLATFORM}" -t "$3" -f "Dockerfile.$2" .


### PR DESCRIPTION
## Summary

Add `utils/docker/build_finch.sh` as a Finch equivalent of `utils/docker/build.sh` for local contributor workflows.

This script mirrors the existing Docker helper:
- same arguments: `{--arm64,--amd64} {jammy,noble} <tag>`
- same packaging step (`pack_package.js` -> `playwright-core.tar.gz`)
- same Dockerfiles (`utils/docker/Dockerfile.jammy|noble`)
- only runtime invocation differs (`finch build` vs `docker build`)

## Why

Some contributor environments use Finch instead of Docker CLI.
This helper provides a minimal, explicit path to build the same local Playwright image with Finch.

## Scope / Non-goals

- No change to published image pipeline
- No CI changes
- No user-facing docs changes
- No new dependencies

## Validation (macOS arm64, Finch v1.15.1)

### 1) Script usage/help

```bash
$ ./utils/docker/build_finch.sh -h
usage: build_finch.sh {--arm64,--amd64} {jammy,noble} playwright:localbuild-noble
...
```

### 2) Noble build + runtime + Playwright docker marker

```bash
$ ./utils/docker/build_finch.sh --arm64 noble playwright:localbuild-noble
/Users/.../utils/docker/playwright-core.tar.gz
...
#9 naming to docker.io/library/playwright:localbuild-noble done
#9 unpacking to docker.io/library/playwright:localbuild-noble done
#9 DONE 0.0s

$ finch run --rm playwright:localbuild-noble /bin/bash -lc 'node -v && npm -v && cat /etc/os-release | head -n 2 && cat /ms-playwright/.docker-info'
v24.14.0
11.9.0
PRETTY_NAME="Ubuntu 24.04.4 LTS"
NAME="Ubuntu"
{
  "driverVersion": "1.59.0-next",
  "dockerImageName": "mcr.microsoft.com/playwright:v1.59.0-next-noble"
}
```

### 3) Jammy build + runtime + Playwright docker marker

```bash
$ ./utils/docker/build_finch.sh --arm64 jammy playwright:localbuild-jammy
/Users/.../utils/docker/playwright-core.tar.gz
...
#9 naming to docker.io/library/playwright:localbuild-jammy done
#9 unpacking to docker.io/library/playwright:localbuild-jammy done
#9 DONE 0.0s

$ finch run --rm playwright:localbuild-jammy /bin/bash -lc 'node -v && npm -v && cat /etc/os-release | head -n 2 && cat /ms-playwright/.docker-info'
v24.14.0
11.9.0
PRETTY_NAME="Ubuntu 22.04.5 LTS"
NAME="Ubuntu"
{
  "driverVersion": "1.59.0-next",
  "dockerImageName": "mcr.microsoft.com/playwright:v1.59.0-next-jammy"
}
```
