### PR TITLE
docs: clarify shared browser path wording

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -1028,7 +1028,7 @@ $Env:PLAYWRIGHT_BROWSERS_PATH="$Env:USERPROFILE\pw-browsers"
 pwsh bin/Debug/netX/playwright.ps1 install
 ```
 
-When running Playwright scripts, ask it to search for browsers in a shared location.
+When running Playwright scripts, ask Playwright to search for browsers in a shared location.
 
 ```bash tab=bash-bash lang=js
 PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers npx playwright test


### PR DESCRIPTION
## Summary
- clarify wording in `docs/src/browsers.md` for shared browser-path usage

## Guideline alignment
- guideline reference: https://github.com/microsoft/playwright/blob/main/CONTRIBUTING.md
- Playwright requires an issue except for minor documentation updates; this PR is a minor documentation wording update
- no functional changes

## Validation
- docs-only change
