### PR TITLE
feat(mcp): add delay options to browser_mouse_click_xy (#39368)

### DIFF
--- a/packages/playwright-core/src/mcp/browser/tools/mouse.ts
+++ b/packages/playwright-core/src/mcp/browser/tools/mouse.ts
@@ -118,6 +118,7 @@ const mouseClick = defineTabTool({
       y: z.number().describe('Y coordinate'),
       button: z.enum(['left', 'right', 'middle']).optional().describe('Button to click, defaults to left'),
       clickCount: z.number().optional().describe('Number of clicks, defaults to 1'),
+      delay: z.number().optional().describe('Time to wait between mouse down and mouse up in milliseconds, defaults to 0'),
     }),
     type: 'input',
   },
@@ -128,6 +129,7 @@ const mouseClick = defineTabTool({
     const options = {
       button: params.button,
       clickCount: params.clickCount,
+      delay: params.delay,
     };
     const formatted = formatObjectOrVoid(options);
     const optionsArg = formatted ? `, ${formatted}` : '';

--- a/tests/mcp/mouse.spec.ts
+++ b/tests/mcp/mouse.spec.ts
@@ -34,11 +34,15 @@ const eventsPage = `<!DOCTYPE html>
       document.body.addEventListener('mousemove', (event) => {
         log('mousemove', event.clientX, event.clientY);
       });
+      let downPressTime = undefined;
       document.body.addEventListener('mousedown', (event) => {
+        downPressTime = performance.now();
         log('mousedown', 'button:' + event.button);
       });
       document.body.addEventListener('mouseup', (event) => {
         log('mouseup', 'button:' + event.button);
+        if (downPressTime !== undefined)
+          log('delta', Math.round(performance.now() - downPressTime));
       });
       document.body.addEventListener('click', (event) => {
         log('click', 'button:' + event.button);
@@ -99,5 +103,15 @@ test('browser_mouse_click_xy (double click)', async ({ client }) => {
   })).toHaveResponse({
     code: expect.stringContaining(`await page.mouse.click(100, 100, {\n  clickCount: 2\n});`),
     snapshot: expect.stringMatching(/mousemove 100 100.*mousedown button:0.*mouseup button:0.*dblclick button:0/s),
+  });
+});
+
+test('browser_mouse_click_xy (delay)', async ({ client }) => {
+  expect(await client.callTool({
+    name: 'browser_mouse_click_xy',
+    arguments: { x: 100, y: 100, delay: 20 },
+  })).toHaveResponse({
+    code: expect.stringContaining(`await page.mouse.click(100, 100, {\n  delay: 20\n});`),
+    snapshot: expect.stringMatching(/mousemove 100 100.*mousedown button:0.*mouseup button:0.*delta (?:[2-9]\d|\d{3,})/s),
   });
 });


### PR DESCRIPTION
seems for [39368](https://github.com/microsoft/playwright/pull/39368) we missed **delay** option that helps to have more human like clicks. Can we add it?
