### PR TITLE
feat: Add global config option for `/children` property of aria snapshots

### DIFF
--- a/docs/src/aria-snapshots.md
+++ b/docs/src/aria-snapshots.md
@@ -307,6 +307,25 @@ Following snapshot will fail due to Feature C not being in the template:
   - listitem: Feature B
 ```
 
+#### Setting `children` mode globally
+
+Instead of adding a `/children` property to every snapshot, you can set the default children matching mode for all
+`toMatchAriaSnapshot` calls in the configuration file:
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  expect: {
+    toMatchAriaSnapshot: {
+      children: 'equal',
+    },
+  },
+});
+```
+
+Individual snapshots can still override the global setting by including an explicit `/children` property in the template.
+
 ### Matching with regular expressions
 
 Regular expressions allow flexible matching for elements with dynamic or variable text. Accessible names and text can

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -83,6 +83,7 @@ The structure of the git commit metadata is subject to change.
     - `pathTemplate` ?<[string]> A template controlling location of the screenshots. See [`property: TestConfig.snapshotPathTemplate`] for details.
   - `toMatchAriaSnapshot` ?<[Object]> Configuration for the [`method: LocatorAssertions.toMatchAriaSnapshot#2`] method.
     - `pathTemplate` ?<[string]> A template controlling location of the aria snapshots. See [`property: TestConfig.snapshotPathTemplate`] for details.
+    - `children` ?<["contain" | "equal" | "deep-equal"]> Controls how children of the snapshot root are matched against the actual accessibility tree. This is equivalent to adding a `/children` property at the top of every aria snapshot template. Individual snapshots can override this by including an explicit `/children` property.
   - `toMatchSnapshot` ?<[Object]> Configuration for the [`method: SnapshotAssertions.toMatchSnapshot#1`] method.
     - `maxDiffPixels` ?<[int]> An acceptable amount of pixels that could be different, unset by default.
     - `maxDiffPixelRatio` ?<[float]> An acceptable ratio of pixels that are different to the total amount of pixels, between `0` and `1` , unset by default.

--- a/docs/src/test-api/class-testproject.md
+++ b/docs/src/test-api/class-testproject.md
@@ -101,6 +101,7 @@ export default defineConfig({
     - `pathTemplate` ?<[string]> A template controlling location of the screenshots. See [`property: TestProject.snapshotPathTemplate`] for details.
   - `toMatchAriaSnapshot` ?<[Object]> Configuration for the [`method: LocatorAssertions.toMatchAriaSnapshot#2`] method.
     - `pathTemplate` ?<[string]> A template controlling location of the aria snapshots. See [`property: TestProject.snapshotPathTemplate`] for details.
+    - `children` ?<["contain" | "equal" | "deep-equal"]> Controls how children of the snapshot root are matched against the actual accessibility tree. This is equivalent to adding a `/children` property at the top of every aria snapshot template. Individual snapshots can override this by including an explicit `/children` property.
   - `toMatchSnapshot` ?<[Object]> Configuration for the [`method: SnapshotAssertions.toMatchSnapshot#1`] method.
     - `threshold` ?<[float]> an acceptable perceived color difference between the same pixel in compared images, ranging from `0` (strict) and `1` (lax). `"pixelmatch"` comparator computes color difference in [YIQ color space](https://en.wikipedia.org/wiki/YIQ) and defaults `threshold` value to `0.2`.
     - `maxDiffPixels` ?<[int]> an acceptable amount of pixels that could be different, unset by default.

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -80,6 +80,11 @@ export async function toMatchAriaSnapshot(
   }
 
   expected = unshift(expected);
+
+  const globalChildren = testInfo._projectInternal.expect?.toMatchAriaSnapshot?.children;
+  if (globalChildren)
+    expected = `- /children: ${globalChildren}\n` + expected;
+
   const { matches: pass, received, log, timedOut, errorMessage } = await locator._expect('to.match.aria', { expectedValue: expected, isNot: this.isNot, timeout });
   const typedReceived = received as MatcherReceived;
 

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -82,7 +82,7 @@ export async function toMatchAriaSnapshot(
   expected = unshift(expected);
 
   const globalChildren = testInfo._projectInternal.expect?.toMatchAriaSnapshot?.children;
-  if (globalChildren)
+  if (globalChildren && !expected.match(/^- \/children:\s/m))
     expected = `- /children: ${globalChildren}\n` + expected;
 
   const { matches: pass, received, log, timedOut, errorMessage } = await locator._expect('to.match.aria', { expectedValue: expected, isNot: this.isNot, timeout });

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -82,7 +82,7 @@ export async function toMatchAriaSnapshot(
   expected = unshift(expected);
 
   const globalChildren = testInfo._projectInternal.expect?.toMatchAriaSnapshot?.children;
-  if (globalChildren && !expected.match(/^- \/children:\s/m))
+  if (globalChildren && !expected.match(/^- \/children:/m))
     expected = `- /children: ${globalChildren}\n` + expected;
 
   const { matches: pass, received, log, timedOut, errorMessage } = await locator._expect('to.match.aria', { expectedValue: expected, isNot: this.isNot, timeout });

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -250,6 +250,13 @@ interface TestProject<TestArgs = {}, WorkerArgs = {}> {
        * for details.
        */
       pathTemplate?: string;
+
+      /**
+       * Controls how children of the snapshot root are matched against the actual accessibility tree. This is equivalent to
+       * adding a `/children` property at the top of every aria snapshot template. Individual snapshots can override this by
+       * including an explicit `/children` property.
+       */
+      children?: "contain"|"equal"|"deep-equal";
     };
 
     /**
@@ -1181,6 +1188,13 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
        * for details.
        */
       pathTemplate?: string;
+
+      /**
+       * Controls how children of the snapshot root are matched against the actual accessibility tree. This is equivalent to
+       * adding a `/children` property at the top of every aria snapshot template. Individual snapshots can override this by
+       * including an explicit `/children` property.
+       */
+      children?: "contain"|"equal"|"deep-equal";
     };
 
     /**

--- a/tests/playwright-test/aria-snapshot-file.spec.ts
+++ b/tests/playwright-test/aria-snapshot-file.spec.ts
@@ -336,7 +336,7 @@ test('should respect config.expect.toMatchAriaSnapshot.children=deep-equal', asy
   expect(result.output).toContain('+       - listitem: "1.2"');
 });
 
-test('inline /children: directive should override global children config', async ({ runInlineTest }) => {
+test('inline /children property should override global children config', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
       export default {
@@ -360,6 +360,7 @@ test('inline /children: directive should override global children config', async
       });
     `
   });
+
   expect(result.exitCode).toBe(0);
 });
 
@@ -395,8 +396,37 @@ test('should respect project-level expect.toMatchAriaSnapshot.children=equal', a
       });
     `
   });
+
   expect(result.exitCode).toBe(1);
   expect(result.passed).toBe(1);
   expect(result.failed).toBe(1);
   expect(result.output).toContain('+ - paragraph: Paragraph');
+});
+
+
+test('top-level equal should overwrite deep-equal children config', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      export default {
+        expect: {
+          toMatchAriaSnapshot: {
+            children: 'deep-equal',
+          },
+        },
+      };
+    `,
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('equal matches part of tree', async ({ page }) => {
+        await page.setContent(\`<ul><li>One</li><li>Two</li></ul>\`);
+        await expect(page.locator('body')).toMatchAriaSnapshot(\`
+          - /children: equal
+          - list:
+            - listitem: "One"
+        \`);
+      });
+    `
+  });
+
+  expect(result.exitCode).toBe(0);
 });


### PR DESCRIPTION
Simply prepend `- /children: <mode>` to the excepted aria snapshot. But only when it doesn't contain a root `children` property already.

This does mean that the aria diffs will also include this property, but that might actually come in useful for #38833.

Closes: #39345