### PR TITLE
fix(firefox): include icu locale header with system icu

### DIFF
--- a/browser_patches/firefox/patches/bootstrap.diff
+++ b/browser_patches/firefox/patches/bootstrap.diff
@@ -320,9 +320,9 @@ index 39a832eccf7e7c0b64b2deb1214f82e7533b249a..6bbb911f00d86340a912fe030ee87382
  #  include <unistd.h>  // for getpid()
  #endif
  
-+#if JS_HAS_INTL_API && !MOZ_SYSTEM_ICU
++#if JS_HAS_INTL_API
 +#  include "unicode/locid.h"
-+#endif /* JS_HAS_INTL_API && !MOZ_SYSTEM_ICU */
++#endif /* JS_HAS_INTL_API */
 +
 +#include "js/LocaleSensitive.h"
 +


### PR DESCRIPTION
Fixes #39472.

`bootstrap.diff` guards `#include "unicode/locid.h"` behind `!MOZ_SYSTEM_ICU`, but `SetIcuLocale()` uses `icu::Locale` unconditionally. The `JS_HAS_INTL_API` guard alone is sufficient — system ICU provides this header.