### PR TITLE
fix: focus contenteditable element before selecting text in fill()

### DIFF
--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -875,6 +875,7 @@ export class InjectedScript {
       textarea.focus();
       return 'done';
     }
+    (element as HTMLElement | SVGElement).focus();
     const range = element.ownerDocument.createRange();
     range.selectNodeContents(element);
     const selection = element.ownerDocument.defaultView!.getSelection();
@@ -882,7 +883,6 @@ export class InjectedScript {
       selection.removeAllRanges();
       selection.addRange(range);
     }
-    (element as HTMLElement | SVGElement).focus();
     return 'done';
   }
 

--- a/tests/page/page-fill.spec.ts
+++ b/tests/page/page-fill.spec.ts
@@ -405,7 +405,7 @@ it('fill back to back', async ({ page }) => {
   await expect(page.locator('id=two')).toHaveValue('second value');
 });
 
-it('should replace contenteditable text when focus handler collapses selection', {
+it('should fill contenteditable with focus handler that collapses selection', {
   annotation: {
     type: 'issue',
     description: 'https://github.com/microsoft/playwright/issues/39492'
@@ -413,7 +413,6 @@ it('should replace contenteditable text when focus handler collapses selection',
 }, async ({ page }) => {
   await page.setContent(`
     <div contenteditable="true">initial text</div>
-    <button>blur target</button>
     <script>
       const editor = document.querySelector('[contenteditable]');
       editor.addEventListener('focus', () => {
@@ -424,11 +423,6 @@ it('should replace contenteditable text when focus handler collapses selection',
     </script>
   `);
 
-  const editor = page.locator('[contenteditable]');
-
-  await editor.fill('old text');
-  await page.locator('button').click();
-  await editor.fill('new text');
-
-  await expect(editor).toHaveText('new text');
+  await page.fill('div[contenteditable]', 'some value');
+  expect(await page.locator('div[contenteditable]').textContent()).toBe('some value');
 });

--- a/tests/page/page-fill.spec.ts
+++ b/tests/page/page-fill.spec.ts
@@ -404,3 +404,31 @@ it('fill back to back', async ({ page }) => {
   await expect(page.locator('id=one')).toHaveValue('first value');
   await expect(page.locator('id=two')).toHaveValue('second value');
 });
+
+it('should replace contenteditable text when focus handler collapses selection', {
+  annotation: {
+    type: 'issue',
+    description: 'https://github.com/microsoft/playwright/issues/39492'
+  }
+}, async ({ page }) => {
+  await page.setContent(`
+    <div contenteditable="true">initial text</div>
+    <button>blur target</button>
+    <script>
+      const editor = document.querySelector('[contenteditable]');
+      editor.addEventListener('focus', () => {
+        const selection = window.getSelection();
+        if (selection.rangeCount > 0)
+          selection.collapseToEnd();
+      });
+    </script>
+  `);
+
+  const editor = page.locator('[contenteditable]');
+
+  await editor.fill('old text');
+  await page.locator('button').click();
+  await editor.fill('new text');
+
+  await expect(editor).toHaveText('new text');
+});


### PR DESCRIPTION
Fixes #39492

## Problem

When `fill()` is called on a contenteditable element that is **not currently focused**, the text is appended instead of replaced.

This happens because `selectText()` creates the selection range **before** calling `focus()`. When `focus()` fires, the element's focus event handlers (common in rich text editors like Jodit, CKEditor, TinyMCE, etc.) can reset the cursor/selection, causing the previously set selection to be lost. The subsequent `insertText` then appends at the cursor position instead of replacing the selection.

Reproduction test (against the public [Jodit Editor Playground](https://xdsoft.net/jodit/play.html)):

```typescript
import { test, expect } from '@playwright/test';

test('fill() should replace contenteditable text, not append', async ({ page }) => {
  await page.goto('https://xdsoft.net/jodit/play.html');

  const editor = page.locator('[contenteditable="true"]');

  await editor.fill('old text');
  await page.locator('body').click();
  await editor.fill('new text');

  await expect(editor).toHaveText('new text');
});
```

## Fix

Move `focus()` before the selection logic in `selectText()` so that focus handlers settle first, then the selection is created and remains intact for the subsequent `insertText`.

## Test results

All existing tests pass:
- `page-fill.spec.ts`: 45/45 passed
- `elementhandle-select-text.spec.ts`: 5/5 passed