### PR TITLE
chore: update skill

### DIFF
--- a/packages/playwright-cli-stub/playwright-cli-stub.js
+++ b/packages/playwright-cli-stub/playwright-cli-stub.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const { program } = require('playwright/lib/cli/client/program');
+const { program } = require('playwright-core/lib/cli/client/program');
 
 program().catch(e => {
   console.error(e.message);

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -24,6 +24,7 @@
     "./package.json": "./package.json",
     "./lib/outofprocess": "./lib/outofprocess.js",
     "./lib/cli/program": "./lib/cli/program.js",
+    "./lib/cli/client/program": "./lib/cli/client/program.js",
     "./lib/mcpBundle": "./lib/mcpBundle.js",
     "./lib/mcp/exports": "./lib/mcp/exports.js",
     "./lib/remote/playwrightServer": "./lib/remote/playwrightServer.js",

--- a/packages/playwright-core/src/skill/SKILL.md
+++ b/packages/playwright-core/src/skill/SKILL.md
@@ -219,7 +219,7 @@ playwright-cli kill-all
 If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
 
 ```bash
-npx playwright-cli --version
+npx --no-install playwright-cli --version
 ```
 
 When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:


### PR DESCRIPTION
Use `npx --no-install` to check whether `playwright-cli` is installed locally.
Drive-by: update `playwright-cli-stub`.