### PR TITLE
feat(ui-mode): Add filter option to only show changed files

### DIFF
--- a/packages/playwright/src/isomorphic/testServerInterface.ts
+++ b/packages/playwright/src/isomorphic/testServerInterface.ts
@@ -83,6 +83,7 @@ export interface TestServerInterface {
     locations?: string[];
     grep?: string;
     grepInvert?: string;
+    onlyChanged?: string;
   }): Promise<{
     report: ReportEntry[],
     status: reporterTypes.FullResult['status']

--- a/packages/playwright/src/runner/testRunner.ts
+++ b/packages/playwright/src/runner/testRunner.ts
@@ -56,6 +56,7 @@ export type ListTestsParams = {
   locations?: string[];
   grep?: string;
   grepInvert?: string;
+  onlyChanged?: string;
 };
 
 export type RunTestsParams = {
@@ -271,6 +272,7 @@ export class TestRunner extends EventEmitter<TestRunnerEventMap> {
     config.cliGrep = params.grep;
     config.cliGrepInvert = params.grepInvert;
     config.cliProjectFilter = params.projects?.length ? params.projects : undefined;
+    config.cliOnlyChanged = params.onlyChanged;
     config.cliListOnly = true;
 
     const status = await runTasks(new TestRun(config, reporter), [

--- a/packages/trace-viewer/src/ui/uiModeFiltersView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeFiltersView.tsx
@@ -29,9 +29,11 @@ export const FiltersView: React.FC<{
   setStatusFilters: (filters: Map<string, boolean>) => void;
   projectFilters: Map<string, boolean>;
   setProjectFilters: (filters: Map<string, boolean>) => void;
+  onlyChanged: boolean;
+  setOnlyChanged: (value: boolean) => void;
   testModel: TeleSuiteUpdaterTestModel | undefined,
   runTests: () => void;
-}> = ({ filterText, setFilterText, statusFilters, setStatusFilters, projectFilters, setProjectFilters, testModel, runTests }) => {
+}> = ({ filterText, setFilterText, statusFilters, setStatusFilters, projectFilters, setProjectFilters, onlyChanged, setOnlyChanged, testModel, runTests }) => {
   const [expanded, setExpanded] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
   React.useEffect(() => {
@@ -53,42 +55,51 @@ export const FiltersView: React.FC<{
             runTests();
         }} />}>
     </Expandable>
-    <div className='filter-summary' title={'Status: ' + statusLine + '\nProjects: ' + projectsLine} onClick={() => setExpanded(!expanded)}>
+    <div className='filter-summary' title={'Status: ' + statusLine + '\nProjects: ' + projectsLine + (onlyChanged ? '\nOnly changed' : '')} onClick={() => setExpanded(!expanded)}>
       <span className='filter-label'>Status:</span> {statusLine}
       <span className='filter-label'>Projects:</span> {projectsLine}
+      {onlyChanged && <><span className='filter-label'>Only changed</span></>}
     </div>
-    {expanded && <div className='hbox' style={{ marginLeft: 14, maxHeight: 200, overflowY: 'auto' }}>
-      <div className='filter-list' role='list' data-testid='status-filters'>
-        {[...statusFilters.entries()].map(([status, value]) => {
-          return <div className='filter-entry' key={status} role='listitem'>
-            <label>
-              <input type='checkbox' checked={value} onChange={() => {
-                const copy = new Map(statusFilters);
-                copy.set(status, !copy.get(status));
-                setStatusFilters(copy);
-              }}/>
-              <div>{status}</div>
-            </label>
-          </div>;
-        })}
+    {expanded && <>
+      <div className='hbox' style={{ marginLeft: 14, maxHeight: 200, overflowY: 'auto' }}>
+        <div className='filter-list' role='list' data-testid='status-filters'>
+          {[...statusFilters.entries()].map(([status, value]) => {
+            return <div className='filter-entry' key={status} role='listitem'>
+              <label>
+                <input type='checkbox' checked={value} onChange={() => {
+                  const copy = new Map(statusFilters);
+                  copy.set(status, !copy.get(status));
+                  setStatusFilters(copy);
+                }}/>
+                <div>{status}</div>
+              </label>
+            </div>;
+          })}
+        </div>
+        <div className='filter-list' role='list' data-testid='project-filters'>
+          {[...projectFilters.entries()].map(([projectName, value]) => {
+            return <div className='filter-entry' key={projectName}  role='listitem'>
+              <label>
+                <input type='checkbox' checked={value} onChange={() => {
+                  const copy = new Map(projectFilters);
+                  copy.set(projectName, !copy.get(projectName));
+                  setProjectFilters(copy);
+                  const configFile = testModel?.config?.configFile;
+                  if (configFile)
+                    settings.setObject(configFile + ':projects', [...copy.entries()].filter(([_, v]) => v).map(([k]) => k));
+                }}/>
+                <div>{projectName || 'untitled'}</div>
+              </label>
+            </div>;
+          })}
+        </div>
       </div>
-      <div className='filter-list' role='list' data-testid='project-filters'>
-        {[...projectFilters.entries()].map(([projectName, value]) => {
-          return <div className='filter-entry' key={projectName}  role='listitem'>
-            <label>
-              <input type='checkbox' checked={value} onChange={() => {
-                const copy = new Map(projectFilters);
-                copy.set(projectName, !copy.get(projectName));
-                setProjectFilters(copy);
-                const configFile = testModel?.config?.configFile;
-                if (configFile)
-                  settings.setObject(configFile + ':projects', [...copy.entries()].filter(([_, v]) => v).map(([k]) => k));
-              }}/>
-              <div>{projectName || 'untitled'}</div>
-            </label>
-          </div>;
-        })}
+      <div className='filter-entry' style={{ marginLeft: 24 }}>
+        <label>
+          <input type='checkbox' checked={onlyChanged} onChange={() => setOnlyChanged(!onlyChanged)}/>
+          <div>Show only changed files</div>
+        </label>
       </div>
-    </div>}
+    </>}
   </div>;
 };

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -109,6 +109,7 @@ export const UIModeView: React.FC<{}> = ({
 
   const [singleWorker, setSingleWorker] = useSetting<boolean>('single-worker', false);
   const [updateSnapshots, setUpdateSnapshots] = useSetting<reporterTypes.FullConfig['updateSnapshots']>('updateSnapshots', 'missing');
+  const [onlyChanged, setOnlyChanged] = useSetting<boolean>('only-changed', false);
   const [mergeFiles] = useSetting('mergeFiles', false);
 
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -197,7 +198,7 @@ export const UIModeView: React.FC<{}> = ({
         if (status !== 'passed')
           return;
 
-        const result = await testServerConnection.listTests({ projects: queryParams.projects, locations: queryParams.args, grep: queryParams.grep, grepInvert: queryParams.grepInvert });
+        const result = await testServerConnection.listTests({ projects: queryParams.projects, locations: queryParams.args, grep: queryParams.grep, grepInvert: queryParams.grepInvert, onlyChanged: onlyChanged ? 'HEAD' : undefined });
         teleSuiteUpdater.processListReport(result.report);
 
         testServerConnection.onReport(params => {
@@ -213,7 +214,7 @@ export const UIModeView: React.FC<{}> = ({
     return () => {
       clearTimeout(throttleTimer);
     };
-  }, [testServerConnection]);
+  }, [onlyChanged, testServerConnection]);
 
   // Update project filter default values.
   React.useEffect(() => {
@@ -321,7 +322,7 @@ export const UIModeView: React.FC<{}> = ({
       commandQueue.current = commandQueue.current.then(async () => {
         setIsLoading(true);
         try {
-          const result = await testServerConnection.listTests({ projects: queryParams.projects, locations: queryParams.args, grep: queryParams.grep, grepInvert: queryParams.grepInvert });
+          const result = await testServerConnection.listTests({ projects: queryParams.projects, locations: queryParams.args, grep: queryParams.grep, grepInvert: queryParams.grepInvert, onlyChanged: onlyChanged ? 'HEAD' : undefined });
           teleSuiteUpdater.processListReport(result.report);
         } catch (e) {
           // eslint-disable-next-line no-console
@@ -375,7 +376,7 @@ export const UIModeView: React.FC<{}> = ({
       runTests('queue-if-busy', { locations, testIds });
     });
     return () => disposable.dispose();
-  }, [runTests, testServerConnection, watchAll, watchedTreeIds, teleSuiteUpdater, projectFilters, mergeFiles]);
+  }, [runTests, testServerConnection, watchAll, watchedTreeIds, teleSuiteUpdater, projectFilters, mergeFiles, onlyChanged]);
 
   // Shortcuts.
   React.useEffect(() => {
@@ -480,6 +481,8 @@ export const UIModeView: React.FC<{}> = ({
           setStatusFilters={setStatusFilters}
           projectFilters={projectFilters}
           setProjectFilters={setProjectFilters}
+          onlyChanged={onlyChanged}
+          setOnlyChanged={setOnlyChanged}
           testModel={testModel}
           runTests={runVisibleTests} />
         <Toolbar className='section-toolbar' noMinHeight={true}>

--- a/tests/playwright-test/only-changed.spec.ts
+++ b/tests/playwright-test/only-changed.spec.ts
@@ -14,23 +14,7 @@
  * limitations under the License.
  */
 
-import { test as baseTest, expect, playwrightCtConfigText } from './playwright-test-fixtures';
-import { execSync } from 'node:child_process';
-
-const test = baseTest.extend<{ git(command: string): void }>({
-  git: async ({}, use, testInfo) => {
-    const baseDir = testInfo.outputPath();
-
-    const git = (command: string) => execSync(`git ${command}`, { cwd: baseDir, stdio: process.env.PWTEST_DEBUG ? 'inherit' : 'ignore' });
-
-    git(`init --initial-branch=main`);
-    git(`config --local user.name "Robert Botman"`);
-    git(`config --local user.email "botty@mcbotface.com"`);
-    git(`config --local core.autocrlf false`);
-
-    await use((command: string) => git(command));
-  },
-});
+import { test, expect, playwrightCtConfigText } from './playwright-test-fixtures';
 
 test.slow();
 

--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -18,6 +18,7 @@ import type { JSONReport, JSONReportSpec, JSONReportSuite, JSONReportTest, JSONR
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { execSync } from 'node:child_process';
 import { PNG } from 'playwright-core/lib/utilsBundle';
 import type { CommonFixtures, CommonWorkerFixtures, TestChildProcess } from '../config/commonFixtures';
 import { commonFixtures } from '../config/commonFixtures';
@@ -252,6 +253,7 @@ export type RunOptions = {
 type Fixtures = {
   writeFiles: (files: Files) => Promise<string>;
   deleteFile: (file: string) => Promise<void>;
+  git: (command: string) => void;
   runInlineTest: (files: Files, params?: Params, env?: NodeJS.ProcessEnv, options?: RunOptions) => Promise<RunResult>;
   runCLICommand: (files: Files, command: string, args?: string[]) => Promise<{ stdout: string, stderr: string, exitCode: number }>;
   startCLICommand: (files: Files, command: string, args?: string[], options?: RunOptions, env?: NodeJS.ProcessEnv) => Promise<TestChildProcess>;
@@ -276,6 +278,16 @@ export const test = base
           const baseDir = testInfo.outputPath();
           await fs.promises.unlink(path.join(baseDir, file));
         });
+      },
+
+      git: async ({}, use, testInfo) => {
+        const baseDir = testInfo.outputPath();
+        const git = (command: string) => execSync(`git ${command}`, { cwd: baseDir, stdio: process.env.PWTEST_DEBUG ? 'inherit' : 'ignore' });
+        git(`init --initial-branch=main`);
+        git(`config --local user.name "Robert Botman"`);
+        git(`config --local user.email "botty@mcbotface.com"`);
+        git(`config --local core.autocrlf false`);
+        await use((command: string) => git(command));
       },
 
       runInlineTest: async ({ childProcess, mergeReports, useIntermediateMergeReport }, use, testInfo: TestInfo) => {

--- a/tests/playwright-test/ui-mode-test-filters.spec.ts
+++ b/tests/playwright-test/ui-mode-test-filters.spec.ts
@@ -245,3 +245,33 @@ test('should not show tests filtered with --grep-invert', async ({ runUITest }) 
   await expect.poll(dumpTestTree(page)).toContain('passes');
   await expect.poll(dumpTestTree(page)).not.toContain('fails');
 });
+
+test('should filter by only changed files', async ({ runUITest, git, writeFiles }) => {
+  const committedFiles = {
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('committed test', () => {});
+    `,
+  };
+
+  await writeFiles(committedFiles);
+  git(`add .`);
+  git(`commit -m init`);
+
+  const { page } = await runUITest({
+    ...committedFiles,
+    'b.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('new untracked test', () => {});
+    `,
+  });
+
+  await expect.poll(dumpTestTree(page)).toContain('a.test.ts');
+  await expect.poll(dumpTestTree(page)).toContain('b.test.ts');
+
+  await page.getByText('Status:').click();
+  await page.getByLabel('Show only changed files').setChecked(true);
+
+  await expect.poll(dumpTestTree(page)).toContain('b.test.ts');
+  await expect.poll(dumpTestTree(page)).not.toContain('a.test.ts');
+});


### PR DESCRIPTION
| State           | Expanded                                                                                                                                                                                                                                    | Collpased                                                                                                                                                                                                   |
|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| **Filter inactive** | <img width="429" height="218" alt="Filter inactive main UI" src="https://github.com/user-attachments/assets/f36f40f3-a6e5-4be9-9a34-22135ac885ec" /> | <img width="358" height="86" alt="Filter inactive bar" src="https://github.com/user-attachments/assets/c838083e-c303-4cf6-88b3-af1a3a86c233" />         |
| **Filter active**   | <img width="432" height="217" alt="Filter active main UI" src="https://github.com/user-attachments/assets/ccfadecb-6850-48b3-a30b-84ec73d8eb4d" />    | <img width="355" height="87" alt="Filter active bar" src="https://github.com/user-attachments/assets/32e06b70-d6b7-45d9-bbd0-9efc5966ff11" />              |


- Moved `git` fixture for reuse


Closes: #39344