### PR TITLE
chore: follow up for httpVersion()

### DIFF
--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -362,6 +362,11 @@ export class HarTracer {
     });
     this._addBarrier(page || request.serviceWorker(), promise);
 
+    this._addBarrier(page || request.serviceWorker(), response.httpVersion().then(httpVersion => {
+      harEntry.request.httpVersion = httpVersion;
+      harEntry.response.httpVersion = httpVersion;
+    }));
+
     // Response end timing is only available after the response event was received.
     const timing = response.timing();
     harEntry.timings.receive = response.request()._responseEndTiming !== -1 ? helper.millisToRoundishMillis(response.request()._responseEndTiming - timing.responseStart) : -1;
@@ -461,11 +466,6 @@ export class HarTracer {
       redirectURL: '',
       _transferSize: this._options.omitSizes ? undefined : -1
     };
-
-    this._addBarrier(page || request.serviceWorker(), response.httpVersion().then(httpVersion => {
-      harEntry.request.httpVersion = httpVersion;
-      harEntry.response.httpVersion = httpVersion;
-    }));
 
     if (!this._options.omitTiming) {
       const startDateTime = pageEntry ? ((pageEntry as any)[startedDateSymbol] as Date).valueOf() : 0;

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -1094,6 +1094,7 @@ export class WKPage implements PageDelegate {
 
   private _handleRequestRedirect(request: WKInterceptableRequest, requestId: string, responsePayload: Protocol.Network.Response, timestamp: number) {
     const response = request.createResponse(responsePayload);
+    response._setHttpVersion(null);
     response._securityDetailsFinished();
     response._serverAddrFinished();
     response.setResponseHeadersSize(null);


### PR DESCRIPTION
Fixes stalling har tracer and httpVersion for redirects. Covered by existing failing tests.