### PR TITLE
fix(har): don't wait for HTTP version in HAR tracer

### DIFF
--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -362,10 +362,11 @@ export class HarTracer {
     });
     this._addBarrier(page || request.serviceWorker(), promise);
 
-    this._addBarrier(page || request.serviceWorker(), response.httpVersion().then(httpVersion => {
+    // Update httpVersion but don't wait on hanging requests
+    response.httpVersion().then(httpVersion => {
       harEntry.request.httpVersion = httpVersion;
       harEntry.response.httpVersion = httpVersion;
-    }));
+    }).catch(() => {});
 
     // Response end timing is only available after the response event was received.
     const timing = response.timing();


### PR DESCRIPTION
After merging #39434 failing tests were seen. This PR was created to fix the issue however, It was already fixed in https://github.com/microsoft/playwright/pull/39501 instead