### PR TITLE
docs(locators): Fix wrong python api usage

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -1207,10 +1207,10 @@ const button = page.getByRole('button').and(page.getByTitle('Subscribe'));
 Locator button = page.getByRole(AriaRole.BUTTON).and(page.getByTitle("Subscribe"));
 ```
 ```python async
-button = page.get_by_role("button").and_(page.getByTitle("Subscribe"))
+button = page.get_by_role("button").and_(page.get_by_title("Subscribe"))
 ```
 ```python sync
-button = page.get_by_role("button").and_(page.getByTitle("Subscribe"))
+button = page.get_by_role("button").and_(page.get_by_title("Subscribe"))
 ```
 ```csharp
 var button = page.GetByRole(AriaRole.Button).And(page.GetByTitle("Subscribe"));


### PR DESCRIPTION
There is no `getByTitle` in `Locator`, it should be `get_by_title` instead.

<https://playwright.dev/python/docs/api/class-locator#locator-get-by-title>