### PR TITLE
fix(runner): respect project workers

### DIFF
--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -71,7 +71,7 @@ export class Dispatcher {
       const projectIdWorkerLimit = this._workerLimitPerProjectId.get(job.projectId);
       if (!projectIdWorkerLimit)
         return index;
-      const runningWorkersWithSameProjectId = this._workerSlots.filter(w => w.busy && w.worker && w.worker.projectId() === job.projectId).length;
+      const runningWorkersWithSameProjectId = this._workerSlots.filter(w => w.busy && (w.jobDispatcher?.job.projectId === job.projectId || w.worker?.projectId() === job.projectId)).length;
       if (runningWorkersWithSameProjectId < projectIdWorkerLimit)
         return index;
     }


### PR DESCRIPTION
## Summary
This PR fixes a scheduling issue where `project.workers` could be exceeded during initial job dispatch.

## Problem
When multiple worker slots are scheduled synchronously, a slot may already be claimed (`busy = true`) but `WorkerHost` is not created yet.  
In that window, project-level worker counting only checked `w.worker?.projectId()`, so claimed slots were not counted and jobs from the same project could be overscheduled.

## Root Cause
In `Dispatcher._findFirstJobToRun`, running workers for a project were counted with:
- `w.busy`
- `w.worker`
- `w.worker.projectId() === job.projectId`

Because `w.worker` is assigned asynchronously, this missed newly claimed slots during initial scheduling.

## Fix
Updated project worker-limit counting to include both:
- claimed slots via `w.jobDispatcher?.job.projectId`
- started workers via `w.worker?.projectId()`

This ensures project-level limits are respected even before worker processes are fully initialized.
