### PR TITLE
fix(html-reporter): Prevent duplicate query parameters in artifact URLs

### DIFF
--- a/packages/html-reporter/src/utils.ts
+++ b/packages/html-reporter/src/utils.ts
@@ -59,7 +59,7 @@ export function formatUrl(url: string | undefined): string | undefined {
     const parsed = new URL(url, window.location.href);
     if (parsed.origin === window.location.origin) {
       for (const [key, value] of new URLSearchParams(window.location.search))
-        parsed.searchParams.append(key, value);
+        parsed.searchParams.set(key, value);
       return parsed.toString();
     }
     return url;


### PR DESCRIPTION
This PR fixes a bug where artifact URLs in the HTML report could fail with a 403 error when using authentication tokens in the
query string (like SAS tokens).

The issue was caused by URLSearchParams.append() creating duplicate authentication parameters. This has been changed to URLSearchParams.set() to ensure URLs are generated correctly.

Fixes #39529.