### PR TITLE
fix(keyboard): support audio and media control keys

### DIFF
--- a/packages/playwright-core/src/server/firefox/ffInput.ts
+++ b/packages/playwright-core/src/server/firefox/ffInput.ts
@@ -21,6 +21,25 @@ import type { Progress } from '../progress';
 import type * as types from '../types';
 import type { FFSession } from './ffConnection';
 
+// Firefox exposes AudioVolume* as KeyboardEvent.key values, but synthesized
+// volume keys need Firefox-specific code/keyCode values (Volume* and 181-183).
+// See https://searchfox.org/firefox-main/source/dom/webidl/KeyEvent.webidl
+const kFirefoxKeyOverrides = new Map<string, Pick<input.KeyDescription, 'code' | 'keyCodeWithoutLocation'>>([
+  ['AudioVolumeMute', { code: 'VolumeMute', keyCodeWithoutLocation: 181 }],
+  ['AudioVolumeDown', { code: 'VolumeDown', keyCodeWithoutLocation: 182 }],
+  ['AudioVolumeUp', { code: 'VolumeUp', keyCodeWithoutLocation: 183 }],
+]);
+
+function toFirefoxKeyDescription(description: input.KeyDescription): input.KeyDescription {
+  const override = kFirefoxKeyOverrides.get(description.key);
+  if (!override)
+    return description;
+  return {
+    ...description,
+    ...override,
+  };
+}
+
 function toModifiersMask(modifiers: Set<types.KeyboardModifier>): number {
   let mask = 0;
   if (modifiers.has('Alt'))
@@ -63,14 +82,15 @@ export class RawKeyboardImpl implements input.RawKeyboard {
   }
 
   async keydown(progress: Progress, modifiers: Set<types.KeyboardModifier>, keyName: string, description: input.KeyDescription, autoRepeat: boolean): Promise<void> {
-    let text = description.text;
+    const keyDescription = toFirefoxKeyDescription(description);
+    let text = keyDescription.text;
     // Firefox will figure out Enter by itself
     if (text === '\r')
       text = '';
-    const { code, key, location } = description;
+    const { code, key, location } = keyDescription;
     await progress.race(this._client.send('Page.dispatchKeyEvent', {
       type: 'keydown',
-      keyCode: description.keyCodeWithoutLocation,
+      keyCode: keyDescription.keyCodeWithoutLocation,
       code,
       key,
       repeat: autoRepeat,
@@ -80,11 +100,12 @@ export class RawKeyboardImpl implements input.RawKeyboard {
   }
 
   async keyup(progress: Progress, modifiers: Set<types.KeyboardModifier>, keyName: string, description: input.KeyDescription): Promise<void> {
-    const { code, key, location } = description;
+    const keyDescription = toFirefoxKeyDescription(description);
+    const { code, key, location } = keyDescription;
     await progress.race(this._client.send('Page.dispatchKeyEvent', {
       type: 'keyup',
       key,
-      keyCode: description.keyCodeWithoutLocation,
+      keyCode: keyDescription.keyCodeWithoutLocation,
       code,
       location,
       repeat: false

--- a/packages/playwright-core/src/server/usKeyboardLayout.ts
+++ b/packages/playwright-core/src/server/usKeyboardLayout.ts
@@ -134,6 +134,14 @@ export const USKeyboardLayout: KeyboardLayout = {
   'ArrowRight': { 'keyCode': 39, 'key': 'ArrowRight' },
   'ArrowDown': { 'keyCode': 40, 'key': 'ArrowDown' },
 
+  // Media keys
+  'AudioVolumeMute': { 'keyCode': 173, 'key': 'AudioVolumeMute' },
+  'AudioVolumeDown': { 'keyCode': 174, 'key': 'AudioVolumeDown' },
+  'AudioVolumeUp': { 'keyCode': 175, 'key': 'AudioVolumeUp' },
+  'MediaTrackNext': { 'keyCode': 176, 'key': 'MediaTrackNext' },
+  'MediaTrackPrevious': { 'keyCode': 177, 'key': 'MediaTrackPrevious' },
+  'MediaPlayPause': { 'keyCode': 179, 'key': 'MediaPlayPause' },
+
   // Numpad
   'NumLock': { 'keyCode': 144, 'key': 'NumLock' },
   'NumpadDivide': { 'keyCode': 111, 'key': '/', 'location': 3 },

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -296,6 +296,27 @@ it('should press Enter', async ({ page, server }) => {
   }
 });
 
+it('should press audio and media control keys', async ({ page, browserName }) => {
+  await page.setContent('<input autofocus>');
+  await page.focus('input');
+  const lastEvent = await captureLastKeydown(page);
+  const mediaKeys = [
+    { key: 'AudioVolumeMute', code: browserName === 'firefox' ? 'VolumeMute' : 'AudioVolumeMute' },
+    { key: 'AudioVolumeDown', code: browserName === 'firefox' ? 'VolumeDown' : 'AudioVolumeDown' },
+    { key: 'AudioVolumeUp', code: browserName === 'firefox' ? 'VolumeUp' : 'AudioVolumeUp' },
+    { key: 'MediaTrackNext', code: 'MediaTrackNext' },
+    { key: 'MediaTrackPrevious', code: 'MediaTrackPrevious' },
+    { key: 'MediaPlayPause', code: 'MediaPlayPause' },
+  ];
+
+  for (const mediaKey of mediaKeys) {
+    await page.keyboard.press(mediaKey.key);
+    expect.soft(await lastEvent.evaluate(e => e.key)).toBe(mediaKey.key);
+    expect.soft(await lastEvent.evaluate(e => e.code)).toBe(mediaKey.code);
+    expect.soft(await lastEvent.evaluate(e => e.location)).toBe(0);
+  }
+});
+
 it('should throw on unknown keys', async ({ page, server }) => {
   let error = await page.keyboard.press('NotARealKey').catch(e => e);
   expect(error.message).toContain('Unknown key: "NotARealKey"');


### PR DESCRIPTION
  Add missing audio/media key definitions to the US keyboard layout
  and cover them with a page keyboard regression test.

  Fixes #39533