### PR TITLE
fix: use native ws module when running in Bun

### DIFF
--- a/packages/playwright-core/src/utilsBundle.ts
+++ b/packages/playwright-core/src/utilsBundle.ts
@@ -31,7 +31,10 @@ export const program: typeof import('../bundles/utils/node_modules/commander').p
 export const ProgramOption: typeof import('../bundles/utils/node_modules/commander').Option = require('./utilsBundleImpl').ProgramOption;
 export const progress: typeof import('../bundles/utils/node_modules/@types/progress') = require('./utilsBundleImpl').progress;
 export const SocksProxyAgent: typeof import('../bundles/utils/node_modules/socks-proxy-agent').SocksProxyAgent = require('./utilsBundleImpl').SocksProxyAgent;
-export const ws: typeof import('../bundles/utils/node_modules/@types/ws') = require('./utilsBundleImpl').ws;
+// Use Bun's native ws when available — Bun's HTTP client doesn't support protocol
+// upgrades, so the bundled ws (which relies on Node's http 'upgrade' event) fails.
+// See https://github.com/oven-sh/bun/issues/9911 (open since April 2024).
+export const ws: typeof import('../bundles/utils/node_modules/@types/ws') = 'Bun' in globalThis ? require('ws') : require('./utilsBundleImpl').ws;
 export const wsServer: typeof import('../bundles/utils/node_modules/@types/ws').WebSocketServer = require('./utilsBundleImpl').wsServer;
 export const wsReceiver = require('./utilsBundleImpl').wsReceiver;
 export const wsSender = require('./utilsBundleImpl').wsSender;


### PR DESCRIPTION
## Problem

`chromium.connectOverCDP()` and `browser.connect()` timeout when running Playwright in Bun. This has been broken since at least April 2024 ([oven-sh/bun#9911](https://github.com/oven-sh/bun/issues/9911)) and affects all Bun versions (1.1.x through 1.3.x).

**Root cause:** Bun's `http.ClientRequest` polyfill doesn't emit the `upgrade` event when a server responds with 101 Switching Protocols. Playwright's bundled `ws` library relies on this event to complete WebSocket handshakes — so the connection hangs until timeout.

## Why this keeps coming back

This is the third time this fix has been proposed ([#34546](https://github.com/microsoft/playwright/pull/34546) was previously closed). The reasoning was "the fix should be in Bun or ws." Two years later:

- **Bun:** [#9911](https://github.com/oven-sh/bun/issues/9911) is still open. The gap is in Bun's Zig HTTP layer — it detects 101 upgrades internally but doesn't surface them through FetchTasklet to the Node.js compat ClientRequest. I've submitted a [proper fix to Bun](https://github.com/oven-sh/bun/issues/9911) for this, but it requires their team to review and merge.
- **ws:** Can't fix it — the library correctly uses Node's `http.request()` + `upgrade` event. The bug is that Bun doesn't emit that event.
- **Playwright bundles ws** at build time, so Bun's runtime `ws` shim (which wraps `globalThis.WebSocket` and works fine) never gets used.

## Fix

One-line change in `utilsBundle.ts`: when running in Bun, use the runtime's `ws` module (which wraps Bun's native WebSocket) instead of the bundled copy:

\`\`\`typescript
export const ws = 'Bun' in globalThis ? require('ws') : require('./utilsBundleImpl').ws;
\`\`\`

## Test plan

- Verified with Bun 1.3.5, Chrome 143, Playwright chromium-1200
- `connectOverCDP()` succeeds (was timing out before)
- Node.js behavior unchanged (condition is false, uses bundled ws as before)
- Bun warnings (`ws.WebSocket 'upgrade' event is not implemented`) are cosmetic — the native WebSocket handles upgrades internally