### PR TITLE
docs(api): fix multipart parameter typo

### DIFF
--- a/docs/src/api/class-apirequestcontext.md
+++ b/docs/src/api/class-apirequestcontext.md
@@ -247,7 +247,7 @@ var data = new Dictionary<string, object>() {
 await Request.FetchAsync("https://example.com/api/createBook", new() { Method = "post", DataObject = data });
 ```
 
-The common way to send file(s) in the body of a request is to upload them as form fields with `multipart/form-data` encoding, by specifiying the `multipart` parameter:
+The common way to send file(s) in the body of a request is to upload them as form fields with `multipart/form-data` encoding, by specifying the `multipart` parameter:
 
 ```js
 const form = new FormData();


### PR DESCRIPTION
## Summary

- Fixes a typo in the `APIRequestContext` docs by changing `specifiying` to `specifying` in the multipart upload description.

## Related issue

- N/A (minor documentation update; `CONTRIBUTING.md` exempts minor documentation updates from the issue requirement)

## Guideline alignment

- https://github.com/microsoft/playwright/blob/main/CONTRIBUTING.md

## Validation

- `git diff --check`
- No tests added; documentation-only change.
