### PR TITLE
docs: fix outdated tocList text in POM page object model example

### DIFF
--- a/docs/src/pom.md
+++ b/docs/src/pom.md
@@ -95,13 +95,13 @@ test('getting started should contain table of contents', async ({ page }) => {
   await playwrightDev.getStarted();
   await expect(playwrightDev.tocList).toHaveText([
     `How to install Playwright`,
-    `What's Installed`,
+    `What's installed`,
     `How to run the example test`,
     `How to open the HTML test report`,
-    `Write tests using web first assertions, page fixtures and locators`,
-    `Run single test, multiple tests, headed mode`,
+    `Write tests using web-first assertions, fixtures and locators`,
+    `Run single or multiple tests; headed mode`,
     `Generate tests with Codegen`,
-    `See a trace of your tests`
+    `View a trace of your tests`,
   ]);
 });
 
@@ -122,13 +122,13 @@ await playwrightDev.goto();
 await playwrightDev.getStarted();
 await expect(playwrightDev.tocList).toHaveText([
   `How to install Playwright`,
-  `What's Installed`,
+  `What's installed`,
   `How to run the example test`,
   `How to open the HTML test report`,
-  `Write tests using web first assertions, page fixtures and locators`,
-  `Run single test, multiple tests, headed mode`,
+  `Write tests using web-first assertions, fixtures and locators`,
+  `Run single or multiple tests; headed mode`,
   `Generate tests with Codegen`,
-  `See a trace of your tests`
+  `View a trace of your tests`,
 ]);
 ```
 


### PR DESCRIPTION
The `toHaveText` assertions in the `example.spec.ts` snippet on the [Page Object Models](https://playwright.dev/docs/pom) docs page no longer match the current text on playwright.dev, which would cause the example test to fail if run as-is.

**Changes:**

| Before | After |
|---|---|
| `What's Installed` | `What's installed` |
| `Write tests using web first assertions, page fixtures and locators` | `Write tests using web-first assertions, fixtures and locators` |
| `Run single test, multiple tests, headed mode` | `Run single or multiple tests; headed mode` |
| `See a trace of your tests` | `View a trace of your tests` |

Verified against the current playwright.dev site.