### PR TITLE
docs(ci): use origin/ with --only-changed

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -440,7 +440,7 @@ jobs:
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
     - name: Run changed Playwright tests
-      run: npx playwright test --only-changed=$GITHUB_BASE_REF
+      run: npx playwright test --only-changed=origin/$GITHUB_BASE_REF
       if: github.event_name == 'pull_request'
     - name: Run Playwright tests
       run: npx playwright test


### PR DESCRIPTION
Fixes #39555\n\nThe GitHub Actions CI snippet used:\n\n`npx playwright test --only-changed=`\n\nIn pull_request workflows, the base ref is typically available as a remote-tracking branch (e.g. `origin/main`) rather than a checked out local branch name, so this can fail with:\n\n`The repository is a shallow clone and does not have 'main' available locally.`\n\nThis updates the snippet to:\n\n`npx playwright test --only-changed=origin/`\n\nwhich matches the branch naming present in the checkout context.