### PR TITLE
fix(build): handle paths with spaces on Windows

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -121,8 +121,9 @@ class ProgramStep extends Step {
   /** @override */
   async run() {
     const step = this._options;
-    console.log(`==== Running ${step.command} ${step.args.join(' ')} in ${step.cwd || process.cwd()}`);
-    const child = child_process.spawn(step.command, step.args, {
+    const args = step.shell ? step.args.map(a => a.includes(' ') ? `"${a}"` : a) : step.args;
+    console.log(`==== Running ${step.command} ${args.join(' ')} in ${step.cwd || process.cwd()}`);
+    const child = child_process.spawn(step.command, args, {
       stdio: 'inherit',
       shell: step.shell,
       env: {
@@ -138,7 +139,7 @@ class ProgramStep extends Step {
     return new Promise((resolve, reject) => {
       child.on('close', (code, signal) => {
         if (code || signal)
-          reject(new Error(`'${step.command} ${step.args.join(' ')}' exited with code ${code}, signal ${signal}`));
+          reject(new Error(`'${step.command} ${args.join(' ')}' exited with code ${code}, signal ${signal}`));
         else
           resolve({ });
       });
@@ -151,7 +152,7 @@ class ProgramStep extends Step {
  */
 async function runOnChangeStep(onChange) {
   const step = ('script' in onChange)
-    ? new ProgramStep({ command: 'node', args: [filePath(onChange.script)], shell: false })
+    ? new ProgramStep({ command: 'node', args: [filePath(onChange.script)], shell: true })
     : new ProgramStep({ command: onChange.command, args: onChange.args || [], shell: true, cwd: onChange.cwd });
   await step.run();
 }

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -121,7 +121,7 @@ class ProgramStep extends Step {
   /** @override */
   async run() {
     const step = this._options;
-    const args = step.shell ? step.args.map(a => a.includes(' ') ? `"${a}"` : a) : step.args;
+    const args = (step.shell && process.platform === 'win32') ? step.args.map(a => a.includes(' ') ? `"${a}"` : a) : step.args;
     console.log(`==== Running ${step.command} ${args.join(' ')} in ${step.cwd || process.cwd()}`);
     const child = child_process.spawn(step.command, args, {
       stdio: 'inherit',


### PR DESCRIPTION
This PR fixes a build failure on Windows that occurs when the Playwright repository is located in a directory path containing spaces (e.g., `C:\Users\User\My Projects\playwright`).

### Problem
In [utils/build/build.js](cci:7://file:///C:/Users/harih/Documents/Open%20Source%20Contribution/playwright/utils/build/build.js:0:0-0:0), the `ProgramStep.run` method and [runOnChangeStep](cci:1://file:///C:/Users/harih/Documents/Open%20Source%20Contribution/playwright/utils/build/build.js:149:0-157:1) function spawn child processes using `child_process.spawn` with `shell: true`. On Windows, the shell incorrectly splits the command-line arguments at the first space if the path is not quoted, leading to `MODULE_NOT_FOUND` errors like:
`Error: Cannot find module 'C:\Users\User\My'`

### Changes
1.  **Platform-Specific Quoting**: Modified `ProgramStep.run` to automatically wrap arguments in quotes if they contain spaces, but **only when running on Windows** (`process.platform === 'win32'`). This ensures the fix is applied where needed without changing behavior on macOS or Linux shells.
2.  **Consistent Shell Usage**: Updated [runOnChangeStep](cci:1://file:///C:/Users/harih/Documents/Open%20Source%20Contribution/playwright/utils/build/build.js:149:0-157:1) to consistently use `shell: true` when executing Node scripts, ensuring that the quoting logic is applied during all relevant build steps (like `generate_third_party_notice.js`).

### Validation
- **Windows Verification**: Verified that `npm run build` now completes successfully on a Windows machine with spaces in the project path.
- **Standards**: Verified that `npm run lint` passes.
- **Safety**: The logic is restricted to the `win32` platform to prevent regressions on other operating systems.

Fixes #39591
