### PR TITLE
fix(mcp): use protocol blocklist instead of allowlist

### DIFF
--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -79,7 +79,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
   private _closeReason: string | undefined;
   private _harRouters: HarRouter[] = [];
   private _onRecorderEventSink: RecorderEventSink | undefined;
-  private _allowedProtocols: string[] | undefined;
+  private _disallowedProtocols: string[] | undefined;
   private _allowedDirectories: string[] | undefined;
 
   static from(context: channels.BrowserContextChannel): BrowserContext {
@@ -555,12 +555,12 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     await this._channel.exposeConsoleApi();
   }
 
-  _setAllowedProtocols(protocols: string[]) {
-    this._allowedProtocols = protocols;
+  _setDisallowedProtocols(protocols: string[]) {
+    this._disallowedProtocols = protocols;
   }
 
   _checkUrlAllowed(url: string) {
-    if (!this._allowedProtocols)
+    if (!this._disallowedProtocols)
       return;
     let parsedURL;
     try {
@@ -568,8 +568,8 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     } catch (e) {
       throw new Error(`Access to ${url} is blocked. Invalid URL: ${e.message}`);
     }
-    if (!this._allowedProtocols.includes(parsedURL.protocol))
-      throw new Error(`Access to "${parsedURL.protocol}" URL is blocked. Allowed protocols: ${this._allowedProtocols.join(', ')}. Attempted URL: ${url}`);
+    if (this._disallowedProtocols.includes(parsedURL.protocol))
+      throw new Error(`Access to "${parsedURL.protocol}" protocol is blocked. Attempted URL: "${url}"`);
   }
 
   _setAllowedDirectories(rootDirectories: string[]) {

--- a/packages/playwright-core/src/tools/context.ts
+++ b/packages/playwright-core/src/tools/context.ts
@@ -287,7 +287,7 @@ export class Context {
       selectors.setTestIdAttribute(this.config.testIdAttribute);
     const browserContext = this._rawBrowserContext;
     if (!this.config.allowUnrestrictedFileAccess) {
-      (browserContext as any)._setAllowedProtocols(['http:', 'https:', 'about:', 'data:']);
+      (browserContext as any)._setDisallowedProtocols(['file:']);
       (browserContext as any)._setAllowedDirectories([this.options.cwd]);
     }
     await this._setupRequestInterception(browserContext);

--- a/tests/mcp/core.spec.ts
+++ b/tests/mcp/core.spec.ts
@@ -37,7 +37,7 @@ test('browser_navigate blocks file:// URLs by default', async ({ client }) => {
     name: 'browser_navigate',
     arguments: { url: 'file:///etc/passwd' },
   })).toHaveResponse({
-    error: expect.stringContaining('Error: Access to "file:" URL is blocked. Allowed protocols: http:, https:, about:, data:. Attempted URL: file:///etc/passwd'),
+    error: expect.stringContaining('Error: Access to "file:" protocol is blocked. Attempted URL: "file:///etc/passwd"'),
     isError: true,
   });
 });

--- a/tests/mcp/run-code.spec.ts
+++ b/tests/mcp/run-code.spec.ts
@@ -90,7 +90,7 @@ test('browser_run_code blocks fetch of file:// URLs by default', async ({ client
       code: `async (page) => { await page.request.get('file:///etc/passwd'); }`,
     },
   })).toHaveResponse({
-    error: expect.stringContaining('Error: apiRequestContext.get: Access to "file:" URL is blocked. Allowed protocols: http:, https:, about:, data:. Attempted URL: file:///etc/passwd'),
+    error: expect.stringContaining('Error: apiRequestContext.get: Access to "file:" protocol is blocked. Attempted URL: "file:///etc/passwd"'),
     isError: true,
   });
 });


### PR DESCRIPTION
## Summary
- Switch from an allowlist (`_allowedProtocols: ['http:', 'https:', 'about:', 'data:']`) to a blocklist (`_disallowedProtocols: ['file:']`) for URL protocol checks in MCP context
- This unblocks `chrome-extension://` and other non-file protocols without requiring `allowUnrestrictedFileAccess: true`

Fixes https://github.com/microsoft/playwright/issues/39569