### PR TITLE
fix(mcp): persistent context is always shared

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ EOF
 )"
 ```
 
+Never add Co-Authored-By agents in commit message.
 Branch naming for issue fixes: `fix-<issue-number>`
 
 ## Development Guides

--- a/packages/playwright-core/src/mcp/config.d.ts
+++ b/packages/playwright-core/src/mcp/config.d.ts
@@ -138,11 +138,6 @@ export type Config = {
   saveSession?: boolean;
 
   /**
-   * Reuse the same browser context between all connected HTTP clients.
-   */
-  sharedBrowserContext?: boolean;
-
-  /**
    * Secrets are used to prevent LLM from getting sensitive data while
    * automating scenarios such as authentication.
    * Prefer the browser.contextOptions.storageState over secrets file as a more secure alternative.

--- a/packages/playwright-core/src/mcp/config.ts
+++ b/packages/playwright-core/src/mcp/config.ts
@@ -64,7 +64,6 @@ export type CLIOptions = {
   proxyServer?: string;
   saveSession?: boolean;
   secrets?: Record<string, string>;
-  sharedBrowserContext?: boolean;
   snapshotMode?: 'incremental' | 'full' | 'none';
   storageState?: string;
   testIdAttribute?: string;
@@ -253,7 +252,6 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config & { configF
     codegen: cliOptions.codegen,
     saveSession: cliOptions.saveSession,
     secrets: cliOptions.secrets,
-    sharedBrowserContext: cliOptions.sharedBrowserContext,
     snapshot: cliOptions.snapshotMode ? { mode: cliOptions.snapshotMode } : undefined,
     outputMode: cliOptions.outputMode,
     outputDir: cliOptions.outputDir,

--- a/packages/playwright-core/src/mcp/configIni.ts
+++ b/packages/playwright-core/src/mcp/configIni.ts
@@ -160,7 +160,6 @@ const longhandTypes: Record<string, LonghandType> = {
   'saveSession': 'boolean',
   'saveTrace': 'boolean',
   'saveVideo': 'size',
-  'sharedBrowserContext': 'boolean',
   'outputDir': 'string',
   'outputMode': 'string',
   'imageResponses': 'string',

--- a/packages/playwright-core/src/mcp/program.ts
+++ b/packages/playwright-core/src/mcp/program.ts
@@ -26,6 +26,7 @@ import { testDebug } from './log';
 
 import type { Command } from '../utilsBundle';
 import type { ClientInfo } from './sdk/server';
+import type * as playwright from '../..';
 
 export function decorateMCPCommand(command: Command, version: string) {
   command
@@ -62,7 +63,6 @@ export function decorateMCPCommand(command: Command, version: string) {
       .option('--sandbox', 'enable the sandbox for all process types that are normally not sandboxed.')
       .option('--save-session', 'Whether to save the Playwright MCP session into the output directory.')
       .option('--secrets <path>', 'path to a file containing secrets in the dotenv format', dotenvFileLoader)
-      .option('--shared-browser-context', 'reuse the same browser context between all connected HTTP clients.')
       .option('--snapshot-mode <mode>', 'when taking snapshots for responses, specifies the mode to use. Can be "incremental", "full", or "none". Default is incremental.')
       .option('--storage-state <path>', 'path to the storage state file for isolated sessions.')
       .option('--test-id-attribute <attribute>', 'specify the attribute to use for test ids, defaults to "data-testid"')
@@ -107,14 +107,18 @@ export function decorateMCPCommand(command: Command, version: string) {
           return;
         }
 
-        const sharedBrowser = config.sharedBrowserContext ? await createBrowser(config, { cwd: process.cwd() }) : undefined;
+        const useSharedBrowser = !!config.browser.userDataDir;
+        let sharedBrowser: playwright.Browser | undefined;
         let clientCount = 0;
+
         const factory: mcpServer.ServerBackendFactory = {
           name: 'Playwright',
           nameInConfig: 'playwright',
           version,
           toolSchemas: tools.map(tool => tool.schema),
           create: async (clientInfo: ClientInfo) => {
+            if (useSharedBrowser && clientCount === 0)
+              sharedBrowser = await createBrowser(config, clientInfo);
             clientCount++;
             const browser = sharedBrowser || await createBrowser(config, clientInfo);
             const browserContext = config.browser.isolated ? await browser.newContext(config.browser.contextOptions) : browser.contexts()[0];
@@ -126,6 +130,7 @@ export function decorateMCPCommand(command: Command, version: string) {
               return;
 
             testDebug('close browser');
+            sharedBrowser = undefined;
             const browserContext = (backend as BrowserServerBackend).browserContext;
             await browserContext.close().catch(() => { });
             await browserContext.browser()!.close().catch(() => { });

--- a/tests/mcp/http.spec.ts
+++ b/tests/mcp/http.spec.ts
@@ -236,33 +236,8 @@ test('http transport browser lifecycle (persistent)', async ({ serverEndpoint, s
   });
 });
 
-test('http transport browser lifecycle (persistent, multiclient)', async ({ serverEndpoint, server }) => {
-  const { url } = await serverEndpoint();
-
-  const transport1 = new StreamableHTTPClientTransport(new URL('/mcp', url));
-  const client1 = new Client({ name: 'test', version: '1.0.0' });
-  await client1.connect(transport1);
-  await client1.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.HELLO_WORLD },
-  });
-
-  const transport2 = new StreamableHTTPClientTransport(new URL('/mcp', url));
-  const client2 = new Client({ name: 'test', version: '1.0.0' });
-  await client2.connect(transport2);
-  const response = await client2.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.HELLO_WORLD },
-  });
-  expect(response.isError).toBe(true);
-  expect(response.content?.[0].text).toContain('use --isolated to run multiple instances of the same browser');
-
-  await client1.close();
-  await client2.close();
-});
-
 test('http transport shared context', async ({ serverEndpoint, server }) => {
-  const { url, stderr } = await serverEndpoint({ args: ['--shared-browser-context'] });
+  const { url, stderr } = await serverEndpoint();
 
   // Create first client and navigate
   const transport1 = new StreamableHTTPClientTransport(new URL('/mcp', url));

--- a/tests/mcp/sse.spec.ts
+++ b/tests/mcp/sse.spec.ts
@@ -185,33 +185,8 @@ test('sse transport browser lifecycle (persistent)', async ({ serverEndpoint, se
   });
 });
 
-test('sse transport browser lifecycle (persistent, multiclient)', async ({ serverEndpoint, server }) => {
-  const { url } = await serverEndpoint();
-
-  const transport1 = new SSEClientTransport(new URL('/sse', url));
-  const client1 = new Client({ name: 'test', version: '1.0.0' });
-  await client1.connect(transport1);
-  await client1.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.HELLO_WORLD },
-  });
-
-  const transport2 = new SSEClientTransport(new URL('/sse', url));
-  const client2 = new Client({ name: 'test', version: '1.0.0' });
-  await client2.connect(transport2);
-  const response = await client2.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.HELLO_WORLD },
-  });
-  expect(response.isError).toBe(true);
-  expect(response.content?.[0].text).toContain('use --isolated to run multiple instances of the same browser');
-
-  await client1.close();
-  await client2.close();
-});
-
 test('sse transport shared context', async ({ serverEndpoint, server }) => {
-  const { url, stderr } = await serverEndpoint({ args: ['--shared-browser-context'] });
+  const { url, stderr } = await serverEndpoint();
 
   // Create first client and navigate
   const transport1 = new SSEClientTransport(new URL('/sse', url));


### PR DESCRIPTION
## Summary
- Remove the `--shared-browser-context` CLI flag and `sharedBrowserContext` config option
- When using a persistent browser context (`userDataDir`), automatically share it across HTTP clients
- Lazily create the shared browser on first client connection and clean up when the last client disconnects
