### PR TITLE
chore: remove server dependencies from serverRegistry

### DIFF
--- a/packages/devtools/src/grid.tsx
+++ b/packages/devtools/src/grid.tsx
@@ -91,7 +91,7 @@ export const Grid: React.FC<{ model: SessionModel }> = ({ model }) => {
               </div>
               {isExpanded && (
                 <div className='session-chips'>
-                  {entries.map(session => <SessionChip key={session.browserDescriptor.guid} descriptor={session.browserDescriptor} wsUrl={session.wsUrl} visible={isExpanded} model={model} />)}
+                  {entries.map(session => <SessionChip key={session.guid} descriptor={session.browserDescriptor} wsUrl={session.wsUrl} visible={isExpanded} model={model} />)}
                 </div>
               )}
             </div>
@@ -103,7 +103,7 @@ export const Grid: React.FC<{ model: SessionModel }> = ({ model }) => {
 };
 
 const SessionChip: React.FC<{ descriptor: BrowserDescriptor; wsUrl: string | undefined; visible: boolean; model: SessionModel }> = ({ descriptor, wsUrl, visible, model }) => {
-  const href = '#session=' + encodeURIComponent(descriptor.guid);
+  const href = '#session=' + encodeURIComponent(descriptor.browser.guid);
 
   const channel = React.useMemo(() => {
     if (!wsUrl || !visible)

--- a/packages/devtools/src/sessionModel.ts
+++ b/packages/devtools/src/sessionModel.ts
@@ -18,10 +18,10 @@ import type { ClientInfo } from '../../playwright-core/src/cli/client/registry';
 import type { BrowserDescriptor } from '../../playwright-core/src/serverRegistry';
 
 export type SessionStatus = {
+  guid: string;
   browserDescriptor: BrowserDescriptor;
   wsUrl?: string;
 };
-
 
 type Listener = () => void;
 
@@ -67,7 +67,7 @@ export class SessionModel {
   }
 
   sessionByGuid(guid: string): SessionStatus | undefined {
-    return this.sessions.find(s => s.browserDescriptor.guid === guid);
+    return this.sessions.find(s => s.browserDescriptor.browser.guid === guid);
   }
 
   private async _fetchSessions() {
@@ -103,7 +103,7 @@ export class SessionModel {
     await fetch('/api/sessions/close', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ sessionGuid: descriptor.guid }),
+      body: JSON.stringify({ guid: descriptor.browser.guid }),
     });
     await this._fetchSessions();
   }
@@ -112,7 +112,7 @@ export class SessionModel {
     await fetch('/api/sessions/delete-data', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ sessionGuid: descriptor.guid }),
+      body: JSON.stringify({ guid: descriptor.browser.guid }),
     });
     await this._fetchSessions();
   }

--- a/packages/playwright-core/src/devtools/devtoolsApp.ts
+++ b/packages/playwright-core/src/devtools/devtoolsApp.ts
@@ -48,11 +48,11 @@ function readBody(request: http.IncomingMessage): Promise<any> {
   });
 }
 
-async function parseRequest(request: http.IncomingMessage): Promise<{ sessionGuid: string }> {
+async function parseRequest(request: http.IncomingMessage): Promise<{ guid: string }> {
   const body = await readBody(request);
-  if (!body.sessionGuid)
+  if (!body.guid)
     throw new Error('Dashboard app is too old, please close it and open again');
-  return { sessionGuid: body.sessionGuid };
+  return { guid: body.guid };
 }
 
 function sendJSON(response: http.ServerResponse, data: any, statusCode = 200) {
@@ -62,17 +62,17 @@ function sendJSON(response: http.ServerResponse, data: any, statusCode = 200) {
 }
 
 async function loadBrowserDescriptorSessions(wsPath: string): Promise<SessionStatus[]> {
-  const servers = await serverRegistry.list();
+  const entriesByWorkspace = await serverRegistry.list();
   const sessions: SessionStatus[] = [];
-  for (const [, browsers] of servers) {
-    for (const browser of browsers) {
+  for (const [, entries] of entriesByWorkspace) {
+    for (const entry of entries) {
       let wsUrl: string | undefined;
-      if (browser.canConnect) {
+      if (entry.canConnect) {
         const url = new URL(wsPath, 'http://localhost');
-        url.searchParams.set('sessionGuid', browser.guid);
+        url.searchParams.set('guid', entry.browser.guid);
         wsUrl = url.pathname + url.search;
       }
-      sessions.push({ browserDescriptor: browser, wsUrl });
+      sessions.push({ guid: entry.browser.guid, browserDescriptor: entry, wsUrl });
     }
   }
   return sessions;
@@ -91,10 +91,10 @@ async function handleApiRequest(httpServer: HttpServer, request: http.IncomingMe
   }
 
   if (apiPath === '/api/sessions/close' && request.method === 'POST') {
-    const { sessionGuid } = await parseRequest(request);
+    const { guid } = await parseRequest(request);
     let browser: api.Browser;
     try {
-      const browserDescriptor = serverRegistry.readDescriptor(sessionGuid);
+      const browserDescriptor = serverRegistry.readDescriptor(guid);
       browser = await connectToBrowserAcrossVersions(browserDescriptor);
     } catch (e) {
       sendJSON(response, { error: 'Failed to connect to browser socket: ' + e.message }, 500);
@@ -112,9 +112,9 @@ async function handleApiRequest(httpServer: HttpServer, request: http.IncomingMe
   }
 
   if (apiPath === '/api/sessions/delete-data' && request.method === 'POST') {
-    const { sessionGuid } = await parseRequest(request);
+    const { guid } = await parseRequest(request);
     try {
-      await serverRegistry.deleteUserData(sessionGuid);
+      await serverRegistry.deleteUserData(guid);
     } catch (e) {
       sendJSON(response, { error: 'Failed to delete session data: ' + e.message }, 500);
       return;
@@ -141,16 +141,16 @@ async function openDevToolsApp(): Promise<api.Page> {
   });
 
   httpServer.createWebSocket(url => {
-    const sessionGuid = url.searchParams.get('sessionGuid');
-    if (!sessionGuid)
+    const guid = url.searchParams.get('guid');
+    if (!guid)
       throw new Error('Unsupported WebSocket URL: ' + url.toString());
-    const browserDescriptor = serverRegistry.readDescriptor(sessionGuid);
+    const browserDescriptor = serverRegistry.readDescriptor(guid);
 
     const cdpPageId = url.searchParams.get('cdpPageId');
     if (cdpPageId) {
-      const connection = browserGuidToDevToolsConnection.get(sessionGuid);
+      const connection = browserGuidToDevToolsConnection.get(guid);
       if (!connection)
-        throw new Error('CDP connection not found for session: ' + sessionGuid);
+        throw new Error('CDP connection not found for session: ' + guid);
       const page = connection.pageForId(cdpPageId);
       if (!page)
         throw new Error('Page not found for page ID: ' + cdpPageId);
@@ -159,9 +159,9 @@ async function openDevToolsApp(): Promise<api.Page> {
 
     const cdpUrl = new URL(httpServer.urlPrefix('human-readable'));
     cdpUrl.pathname = httpServer.wsGuid()!;
-    cdpUrl.searchParams.set('sessionGuid', sessionGuid);
-    const connection = new DevToolsConnection(browserDescriptor, cdpUrl, () => browserGuidToDevToolsConnection.delete(sessionGuid));
-    browserGuidToDevToolsConnection.set(sessionGuid, connection);
+    cdpUrl.searchParams.set('guid', guid);
+    const connection = new DevToolsConnection(browserDescriptor, cdpUrl, () => browserGuidToDevToolsConnection.delete(guid));
+    browserGuidToDevToolsConnection.set(guid, connection);
     return connection;
   });
 

--- a/packages/playwright-core/src/devtools/devtoolsController.ts
+++ b/packages/playwright-core/src/devtools/devtoolsController.ts
@@ -259,7 +259,7 @@ export class DevToolsConnection implements Transport, DevToolsChannel {
   }
 
   private async _devtoolsUrl(page: api.Page) {
-    const cdpPort = this._browserDescriptor.browser.launchOptions.cdpPort;
+    const cdpPort = (this._browserDescriptor.browser.launchOptions as any).cdpPort;
     if (cdpPort)
       return new URL(`http://localhost:${cdpPort}/devtools/`);
 

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -26,7 +26,7 @@ import { Page } from './page';
 import { ClientCertificatesProxy } from './socksClientCertificatesInterceptor';
 import { PlaywrightPipeServer } from '../remote/playwrightPipeServer';
 import { PlaywrightWebSocketServer } from '../remote/playwrightWebSocketServer';
-import { serverRegistry } from '../serverRegistry';
+import { BrowserInfo, serverRegistry } from '../serverRegistry';
 
 import type * as types from './types';
 import type { ProxySettings } from './types';
@@ -35,6 +35,7 @@ import type * as channels from '@protocol/channels';
 import type { ChildProcess } from 'child_process';
 import type { Language } from '../utils';
 import type { Progress } from './progress';
+import type * as playwright from '../..';
 
 export interface BrowserProcess {
   onclose?: ((exitCode: number | null, signal: string | null) => void);
@@ -213,7 +214,6 @@ export class BrowserServer {
   private _wsServer?: PlaywrightWebSocketServer;
   private _pipeSocketPath?: string;
   private _isStarted = false;
-  private _sessionGuid?: string;
 
   constructor(browser: Browser) {
     this._browser = browser;
@@ -236,7 +236,13 @@ export class BrowserServer {
       result.wsEndpoint = await this._wsServer.listen(0, 'localhost', path);
     }
 
-    this._sessionGuid = await serverRegistry.create(this._browser, {
+    const browserInfo: BrowserInfo = {
+      guid: this._browser.guid,
+      browserName: this._browser.options.browserType,
+      launchOptions: asClientLaunchOptions(this._browser.options.originalLaunchOptions),
+      userDataDir: this._browser.options.userDataDir,
+    };
+    await serverRegistry.create(browserInfo, {
       title,
       wsEndpoint: result.wsEndpoint,
       pipeName: result.pipeName,
@@ -246,9 +252,8 @@ export class BrowserServer {
   }
 
   async stop() {
-    if (this._sessionGuid)
-      await serverRegistry.delete(this._browser, this._sessionGuid);
-    this._sessionGuid = undefined;
+    if (!this._browser.options.userDataDir)
+      await serverRegistry.delete(this._browser.guid);
     if (this._pipeSocketPath && process.platform !== 'win32')
       await fs.promises.unlink(this._pipeSocketPath).catch(() => {});
     await this._pipeServer?.close();
@@ -266,4 +271,11 @@ export class BrowserServer {
     await fs.promises.mkdir(socketsDir, { recursive: true });
     return path.join(socketsDir, socketName);
   }
+}
+
+function asClientLaunchOptions(serverOptions: types.LaunchOptions): playwright.LaunchOptions {
+  return {
+    ...serverOptions,
+    env: serverOptions.env ? Object.fromEntries(serverOptions.env.map(({ name, value }) => [name, value])) : undefined,
+  };
 }

--- a/packages/playwright-core/src/serverRegistry.ts
+++ b/packages/playwright-core/src/serverRegistry.ts
@@ -18,30 +18,30 @@ import fs from 'fs';
 import net from 'net';
 import path from 'path';
 import os from 'os';
-import crypto from 'crypto';
 
-import type { Browser } from './server/browser';
-import type { LaunchOptions } from './server/types';
-import type { BrowserName } from './server/registry/index';
+// Only client depenencies with backward compatibility guarantees should be imported here.
+import type { LaunchOptions } from '../types/types';
 
 const packageVersion = require('../package.json').version;
 
 export type BrowserInfo = {
+  guid: string;
+  browserName: 'chromium' | 'firefox' | 'webkit';
+  userDataDir?: string;
+  launchOptions: LaunchOptions;
+};
+
+export type EndpointInfo = {
   title: string;
   wsEndpoint?: string;
   pipeName?: string;
   workspaceDir?: string;
 };
 
-export type BrowserDescriptor = BrowserInfo & {
-  guid: string;
+export type BrowserDescriptor = EndpointInfo & {
   playwrightVersion: string;
   playwrightLib: string;
-  browser: {
-    browserName: BrowserName;
-    launchOptions: LaunchOptions;
-    userDataDir?: string;
-  };
+  browser: BrowserInfo;
 };
 
 export type BrowserStatus = BrowserDescriptor & { canConnect: boolean };
@@ -85,37 +85,28 @@ class ServerRegistry {
     return resolvedResult;
   }
 
-  async create(browser: Browser, info: BrowserInfo): Promise<string> {
-    const guid = createGuid();
-    const file = path.join(this._browsersDir(), guid);
+  async create(browser: BrowserInfo, endpoint: EndpointInfo) {
+    const file = path.join(this._browsersDir(), browser.guid);
     await fs.promises.mkdir(this._browsersDir(), { recursive: true });
     const descriptor: BrowserDescriptor = {
-      guid,
       playwrightVersion: packageVersion,
       playwrightLib: require.resolve('..'),
-      title: info.title,
-      browser: {
-        browserName: browser.options.browserType,
-        launchOptions: browser.options.originalLaunchOptions,
-        userDataDir: browser.options.userDataDir,
-      },
-      wsEndpoint: info.wsEndpoint,
-      pipeName: info.pipeName,
-      workspaceDir: info.workspaceDir,
+      title: endpoint.title,
+      browser,
+      wsEndpoint: endpoint.wsEndpoint,
+      pipeName: endpoint.pipeName,
+      workspaceDir: endpoint.workspaceDir,
     };
     await fs.promises.writeFile(file, JSON.stringify(descriptor), 'utf-8');
-    return guid;
   }
 
-  async delete(browser: Browser, sessionGuid: string): Promise<void> {
-    if (browser.options.userDataDir)
-      return;
-    const file = path.join(this._browsersDir(), sessionGuid);
+  async delete(guid: string): Promise<void> {
+    const file = path.join(this._browsersDir(), guid);
     await fs.promises.unlink(file).catch(() => {});
   }
 
-  async deleteUserData(sessionGuid: string): Promise<void> {
-    const filePath = path.join(this._browsersDir(), sessionGuid);
+  async deleteUserData(guid: string): Promise<void> {
+    const filePath = path.join(this._browsersDir(), guid);
     const content = await fs.promises.readFile(filePath, 'utf-8');
     const descriptor: BrowserDescriptor = JSON.parse(content);
     if (descriptor.browser.userDataDir)
@@ -123,8 +114,8 @@ class ServerRegistry {
     await fs.promises.unlink(filePath);
   }
 
-  readDescriptor(sessionGuid: string): BrowserDescriptor {
-    const filePath = path.join(this._browsersDir(), sessionGuid);
+  readDescriptor(guid: string): BrowserDescriptor {
+    const filePath = path.join(this._browsersDir(), guid);
     const content = fs.readFileSync(filePath, 'utf-8');
     const descriptor: BrowserDescriptor = JSON.parse(content);
     return descriptor;
@@ -144,10 +135,6 @@ class ServerRegistry {
   private _browsersDir() {
     return process.env.PLAYWRIGHT_SERVER_REGISTRY || registryDirectory;
   }
-}
-
-function createGuid(): string {
-  return crypto.randomBytes(16).toString('hex');
 }
 
 async function canConnect(descriptor: BrowserDescriptor): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Decouple `serverRegistry` from server-side types (`Browser`, server `LaunchOptions`, `BrowserName`) so it only imports client types with backward compatibility guarantees
- Move browser info construction to the call site (`BrowserServer`) and pass plain data objects to the registry
- Rename `sessionGuid` to `guid` throughout devtools app and session model for consistency