### PR TITLE
feat(api): add filter option to Page.consoleMessages()

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2760,6 +2760,14 @@ Clears all stored page errors from this page. Subsequent calls to [`method: Page
 
 Returns up to (currently) 200 last console messages from this page. See [`event: Page.console`] for more details.
 
+### option: Page.consoleMessages.filter
+* since: v1.59
+- `filter` <[ConsoleMessagesFilter]<"all"|"sinceNavigation">>
+
+Controls which messages are returned:
+- `'all'` (default) — returns all stored console messages.
+- `'sinceNavigation'` — returns only messages logged after the last committed main-frame navigation.
+
 
 ## async method: Page.pageErrors
 * since: v1.56

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2765,8 +2765,8 @@ Returns up to (currently) 200 last console messages from this page. See [`event:
 - `filter` <[ConsoleMessagesFilter]<"all"|"sinceNavigation">>
 
 Controls which messages are returned:
-- `'all'` (default) — returns all stored console messages.
-- `'sinceNavigation'` — returns only messages logged after the last committed main-frame navigation.
+- `'sinceNavigation'` (default) — returns only messages logged after the last committed main-frame navigation.
+- `'all'` — returns all stored console messages.
 
 
 ## async method: Page.pageErrors

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2783,6 +2783,15 @@ Returns up to (currently) 200 last page errors from this page. See [`event: Page
 
 Returns up to (currently) 200 last page errors from this page. See [`event: Page.pageError`] for more details.
 
+### option: Page.pageErrors.filter
+* since: v1.59
+* langs: js
+- `filter` <[PageErrorsFilter]<"all"|"sinceNavigation">>
+
+Controls which errors are returned:
+- `'sinceNavigation'` (default) — returns only errors thrown after the last committed main-frame navigation.
+- `'all'` — returns all stored page errors.
+
 
 ## method: Page.locator
 * since: v1.14

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -2265,8 +2265,8 @@ export interface Page {
 
   /**
    * Clears all stored page errors from this page. Subsequent calls to
-   * [page.pageErrors()](https://playwright.dev/docs/api/class-page#page-page-errors) will only return errors thrown
-   * after the clear.
+   * [page.pageErrors([options])](https://playwright.dev/docs/api/class-page#page-page-errors) will only return errors
+   * thrown after the clear.
    */
   clearPageErrors(): Promise<void>;
 
@@ -3745,8 +3745,14 @@ export interface Page {
   /**
    * Returns up to (currently) 200 last page errors from this page. See
    * [page.on('pageerror')](https://playwright.dev/docs/api/class-page#page-event-page-error) for more details.
+   * @param options
    */
-  pageErrors(): Promise<Array<Error>>;
+  pageErrors(options?: {
+    /**
+     * Controls which errors are returned:
+     */
+    filter?: "all"|"sinceNavigation";
+  }): Promise<Array<Error>>;
 
   /**
    * Pauses script execution. Playwright will stop executing the script and wait for the user to either press the

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -2258,8 +2258,8 @@ export interface Page {
 
   /**
    * Clears all stored console messages from this page. Subsequent calls to
-   * [page.consoleMessages()](https://playwright.dev/docs/api/class-page#page-console-messages) will only return
-   * messages logged after the clear.
+   * [page.consoleMessages([options])](https://playwright.dev/docs/api/class-page#page-console-messages) will only
+   * return messages logged after the clear.
    */
   clearConsoleMessages(): Promise<void>;
 
@@ -2395,8 +2395,14 @@ export interface Page {
   /**
    * Returns up to (currently) 200 last console messages from this page. See
    * [page.on('console')](https://playwright.dev/docs/api/class-page#page-event-console) for more details.
+   * @param options
    */
-  consoleMessages(): Promise<Array<ConsoleMessage>>;
+  consoleMessages(options?: {
+    /**
+     * Controls which messages are returned:
+     */
+    filter?: "all"|"sinceNavigation";
+  }): Promise<Array<ConsoleMessage>>;
 
   /**
    * Gets the full HTML contents of the page, including the doctype.

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -679,8 +679,8 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     await this._channel.clearPageErrors();
   }
 
-  async pageErrors(): Promise<Error[]> {
-    const { errors } = await this._channel.pageErrors();
+  async pageErrors(options?: { filter?: 'all' | 'sinceNavigation' }): Promise<Error[]> {
+    const { errors } = await this._channel.pageErrors({ filter: options?.filter });
     return errors.map(error => parseError(error));
   }
 

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -670,8 +670,8 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     await this._channel.clearConsoleMessages();
   }
 
-  async consoleMessages(): Promise<ConsoleMessage[]> {
-    const { messages } = await this._channel.consoleMessages();
+  async consoleMessages(options?: { filter?: 'all' | 'sinceNavigation' }): Promise<ConsoleMessage[]> {
+    const { messages } = await this._channel.consoleMessages({ filter: options?.filter });
     return messages.map(message => new ConsoleMessage(this._platform, message, this, null));
   }
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1460,7 +1460,9 @@ scheme.PageTouchscreenTapParams = tObject({
 scheme.PageTouchscreenTapResult = tOptional(tObject({}));
 scheme.PageClearPageErrorsParams = tOptional(tObject({}));
 scheme.PageClearPageErrorsResult = tOptional(tObject({}));
-scheme.PagePageErrorsParams = tOptional(tObject({}));
+scheme.PagePageErrorsParams = tObject({
+  filter: tOptional(tType('ConsoleMessagesFilter')),
+});
 scheme.PagePageErrorsResult = tObject({
   errors: tArray(tType('SerializedError')),
 });

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -252,6 +252,7 @@ scheme.APIResponse = tObject({
   headers: tArray(tType('NameValue')),
 });
 scheme.LifecycleEvent = tEnum(['load', 'domcontentloaded', 'networkidle', 'commit']);
+scheme.ConsoleMessagesFilter = tEnum(['all', 'sinceNavigation']);
 scheme.LocalUtilsInitializer = tObject({
   deviceDescriptors: tArray(tObject({
     name: tString,
@@ -1249,7 +1250,9 @@ scheme.PageCloseParams = tObject({
 scheme.PageCloseResult = tOptional(tObject({}));
 scheme.PageClearConsoleMessagesParams = tOptional(tObject({}));
 scheme.PageClearConsoleMessagesResult = tOptional(tObject({}));
-scheme.PageConsoleMessagesParams = tOptional(tObject({}));
+scheme.PageConsoleMessagesParams = tObject({
+  filter: tOptional(tType('ConsoleMessagesFilter')),
+});
 scheme.PageConsoleMessagesResult = tObject({
   messages: tArray(tObject({
     type: tString,

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -290,7 +290,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     // Otherwise, if subscription is added in a different task from this call (either before or after),
     // there is a chance for a duplicate or a lost console message.
     this._subscriptions.add('console');
-    return { messages: this._page.consoleMessages().map(message => this.parentScope().serializeConsoleMessage(message, this)) };
+    return { messages: this._page.consoleMessages(params.filter).map(message => this.parentScope().serializeConsoleMessage(message, this)) };
   }
 
   async clearPageErrors(params: channels.PageClearPageErrorsParams, progress: Progress): Promise<channels.PageClearPageErrorsResult> {

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -298,7 +298,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
   }
 
   async pageErrors(params: channels.PagePageErrorsParams, progress: Progress): Promise<channels.PagePageErrorsResult> {
-    return { errors: this._page.pageErrors().map(error => serializeError(error)) };
+    return { errors: this._page.pageErrors(params.filter).map(error => serializeError(error)) };
   }
 
   async mouseMove(params: channels.PageMouseMoveParams, progress: Progress): Promise<void> {

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -406,7 +406,7 @@ export class Page extends SdkObject<PageEventMap> {
   }
 
   consoleMessages(filter?: 'all' | 'sinceNavigation') {
-    if (filter !== 'sinceNavigation')
+    if (filter === 'all')
       return this._consoleMessages;
     const marked = this._consoleMessages.findLastIndex(m => (m as any)[navigationMarkSymbol]);
     return marked === -1 ? this._consoleMessages : this._consoleMessages.slice(marked + 1);

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -427,8 +427,11 @@ export class Page extends SdkObject<PageEventMap> {
     this._pageErrors.length = 0;
   }
 
-  pageErrors() {
-    return this._pageErrors;
+  pageErrors(filter?: 'all' | 'sinceNavigation') {
+    if (filter === 'all')
+      return this._pageErrors;
+    const marked = this._pageErrors.findLastIndex(e => (e as any)[navigationMarkSymbol]);
+    return marked === -1 ? this._pageErrors : this._pageErrors.slice(marked + 1);
   }
 
   async reload(progress: Progress, options: types.NavigateOptions): Promise<network.Response | null> {
@@ -847,8 +850,12 @@ export class Page extends SdkObject<PageEventMap> {
     const origin = frame.origin();
     if (origin)
       this.browserContext.addVisitedOrigin(origin);
-    if (frame === this.mainFrame() && this._consoleMessages.length > 0)
-      (this._consoleMessages[this._consoleMessages.length - 1] as any)[navigationMarkSymbol] = true;
+    if (frame === this.mainFrame()) {
+      if (this._consoleMessages.length > 0)
+        (this._consoleMessages[this._consoleMessages.length - 1] as any)[navigationMarkSymbol] = true;
+      if (this._pageErrors.length > 0)
+        (this._pageErrors[this._pageErrors.length - 1] as any)[navigationMarkSymbol] = true;
+    }
   }
 
   allInitScripts() {

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -149,6 +149,8 @@ export type PageEventMap = {
   [PageEvent.Worker]: [worker: Worker];
 };
 
+const navigationMarkSymbol = Symbol('navigationMark');
+
 export class Page extends SdkObject<PageEventMap> {
   static Events = PageEvent;
 
@@ -403,8 +405,11 @@ export class Page extends SdkObject<PageEventMap> {
     this._consoleMessages.length = 0;
   }
 
-  consoleMessages() {
-    return this._consoleMessages;
+  consoleMessages(filter?: 'all' | 'sinceNavigation') {
+    if (filter !== 'sinceNavigation')
+      return this._consoleMessages;
+    const marked = this._consoleMessages.findLastIndex(m => (m as any)[navigationMarkSymbol]);
+    return marked === -1 ? this._consoleMessages : this._consoleMessages.slice(marked + 1);
   }
 
   addPageError(pageError: Error) {
@@ -842,6 +847,8 @@ export class Page extends SdkObject<PageEventMap> {
     const origin = frame.origin();
     if (origin)
       this.browserContext.addVisitedOrigin(origin);
+    if (frame === this.mainFrame() && this._consoleMessages.length > 0)
+      (this._consoleMessages[this._consoleMessages.length - 1] as any)[navigationMarkSymbol] = true;
   }
 
   allInitScripts() {

--- a/packages/playwright-core/src/tools/console.ts
+++ b/packages/playwright-core/src/tools/console.ts
@@ -25,6 +25,7 @@ const console = defineTabTool({
     description: 'Returns all console messages',
     inputSchema: z.object({
       level: z.enum(['error', 'warning', 'info', 'debug']).default('info').describe('Level of the console messages to return. Each level includes the messages of more severe levels. Defaults to "info".'),
+      all: z.boolean().optional().describe('Return all console messages since the beginning of the session, not just since the last navigation. Defaults to false.'),
       filename: z.string().optional().describe('Filename to save the console messages to. If not provided, messages are returned as text.'),
     }),
     type: 'readOnly',
@@ -32,7 +33,7 @@ const console = defineTabTool({
   handle: async (tab, params, response) => {
     const count = await tab.consoleMessageCount();
     const header = [`Total messages: ${count.total} (Errors: ${count.errors}, Warnings: ${count.warnings})`];
-    const messages = await tab.consoleMessages(params.level);
+    const messages = await tab.consoleMessages(params.level, params.all);
     if (messages.length !== count.total)
       header.push(`Returning ${messages.length} messages for level "${params.level}"`);
     const text = [...header, '', ...messages.map(message => message.toString())].join('\n');

--- a/packages/playwright-core/src/tools/tab.ts
+++ b/packages/playwright-core/src/tools/tab.ts
@@ -340,10 +340,10 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     return { total: messages.length + pageErrors.length, errors, warnings };
   }
 
-  async consoleMessages(level: ConsoleMessageLevel): Promise<ConsoleMessage[]> {
+  async consoleMessages(level: ConsoleMessageLevel, all?: boolean): Promise<ConsoleMessage[]> {
     await this._initializedPromise;
     const result: ConsoleMessage[] = [];
-    const messages = await this.page.consoleMessages({ filter: 'sinceNavigation' });
+    const messages = await this.page.consoleMessages({ filter: all ? 'all' : 'sinceNavigation' });
     for (const message of messages) {
       const cm = messageToConsoleMessage(message);
       if (shouldIncludeMessage(level, cm.type))

--- a/packages/playwright-core/src/tools/tab.ts
+++ b/packages/playwright-core/src/tools/tab.ts
@@ -298,7 +298,6 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   async navigate(url: string) {
     await this._initializedPromise;
 
-    await this.page.clearPageErrors();
     this._clearCollectedArtifacts();
 
     const { promise: downloadEvent, abort: abortDownloadEvent } = eventWaiter<playwright.Download>(this.page, 'download', 3000);
@@ -328,7 +327,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   async consoleMessageCount(): Promise<{ total: number, errors: number, warnings: number }> {
     await this._initializedPromise;
     const messages = await this.page.consoleMessages({ filter: 'sinceNavigation' });
-    const pageErrors = await this.page.pageErrors();
+    const pageErrors = await this.page.pageErrors({ filter: 'sinceNavigation' });
     let errors = pageErrors.length;
     let warnings = 0;
     for (const message of messages) {
@@ -350,7 +349,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
         result.push(cm);
     }
     if (shouldIncludeMessage(level, 'error')) {
-      const errors = await this.page.pageErrors();
+      const errors = await this.page.pageErrors({ filter: all ? 'all' : 'sinceNavigation' });
       for (const error of errors)
         result.push(pageErrorToConsoleMessage(error));
     }

--- a/packages/playwright-core/src/tools/tab.ts
+++ b/packages/playwright-core/src/tools/tab.ts
@@ -298,7 +298,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   async navigate(url: string) {
     await this._initializedPromise;
 
-    await this.clearConsoleMessages();
+    await this.page.clearPageErrors();
     this._clearCollectedArtifacts();
 
     const { promise: downloadEvent, abort: abortDownloadEvent } = eventWaiter<playwright.Download>(this.page, 'download', 3000);
@@ -327,7 +327,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
   async consoleMessageCount(): Promise<{ total: number, errors: number, warnings: number }> {
     await this._initializedPromise;
-    const messages = await this.page.consoleMessages();
+    const messages = await this.page.consoleMessages({ filter: 'sinceNavigation' });
     const pageErrors = await this.page.pageErrors();
     let errors = pageErrors.length;
     let warnings = 0;
@@ -343,7 +343,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   async consoleMessages(level: ConsoleMessageLevel): Promise<ConsoleMessage[]> {
     await this._initializedPromise;
     const result: ConsoleMessage[] = [];
-    const messages = await this.page.consoleMessages();
+    const messages = await this.page.consoleMessages({ filter: 'sinceNavigation' });
     for (const message of messages) {
       const cm = messageToConsoleMessage(message);
       if (shouldIncludeMessage(level, cm.type))

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2265,8 +2265,8 @@ export interface Page {
 
   /**
    * Clears all stored page errors from this page. Subsequent calls to
-   * [page.pageErrors()](https://playwright.dev/docs/api/class-page#page-page-errors) will only return errors thrown
-   * after the clear.
+   * [page.pageErrors([options])](https://playwright.dev/docs/api/class-page#page-page-errors) will only return errors
+   * thrown after the clear.
    */
   clearPageErrors(): Promise<void>;
 
@@ -3745,8 +3745,14 @@ export interface Page {
   /**
    * Returns up to (currently) 200 last page errors from this page. See
    * [page.on('pageerror')](https://playwright.dev/docs/api/class-page#page-event-page-error) for more details.
+   * @param options
    */
-  pageErrors(): Promise<Array<Error>>;
+  pageErrors(options?: {
+    /**
+     * Controls which errors are returned:
+     */
+    filter?: "all"|"sinceNavigation";
+  }): Promise<Array<Error>>;
 
   /**
    * Pauses script execution. Playwright will stop executing the script and wait for the user to either press the

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2258,8 +2258,8 @@ export interface Page {
 
   /**
    * Clears all stored console messages from this page. Subsequent calls to
-   * [page.consoleMessages()](https://playwright.dev/docs/api/class-page#page-console-messages) will only return
-   * messages logged after the clear.
+   * [page.consoleMessages([options])](https://playwright.dev/docs/api/class-page#page-console-messages) will only
+   * return messages logged after the clear.
    */
   clearConsoleMessages(): Promise<void>;
 
@@ -2395,8 +2395,14 @@ export interface Page {
   /**
    * Returns up to (currently) 200 last console messages from this page. See
    * [page.on('console')](https://playwright.dev/docs/api/class-page#page-event-console) for more details.
+   * @param options
    */
-  consoleMessages(): Promise<Array<ConsoleMessage>>;
+  consoleMessages(options?: {
+    /**
+     * Controls which messages are returned:
+     */
+    filter?: "all"|"sinceNavigation";
+  }): Promise<Array<ConsoleMessage>>;
 
   /**
    * Gets the full HTML contents of the page, including the doctype.

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -438,6 +438,7 @@ export type APIResponse = {
 };
 
 export type LifecycleEvent = 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
+export type ConsoleMessagesFilter = 'all' | 'sinceNavigation';
 // ----------- LocalUtils -----------
 export type LocalUtilsInitializer = {
   deviceDescriptors: {
@@ -2108,7 +2109,7 @@ export interface PageChannel extends PageEventTarget, EventTargetChannel {
   addInitScript(params: PageAddInitScriptParams, progress?: Progress): Promise<PageAddInitScriptResult>;
   close(params: PageCloseParams, progress?: Progress): Promise<PageCloseResult>;
   clearConsoleMessages(params?: PageClearConsoleMessagesParams, progress?: Progress): Promise<PageClearConsoleMessagesResult>;
-  consoleMessages(params?: PageConsoleMessagesParams, progress?: Progress): Promise<PageConsoleMessagesResult>;
+  consoleMessages(params: PageConsoleMessagesParams, progress?: Progress): Promise<PageConsoleMessagesResult>;
   emulateMedia(params: PageEmulateMediaParams, progress?: Progress): Promise<PageEmulateMediaResult>;
   exposeBinding(params: PageExposeBindingParams, progress?: Progress): Promise<PageExposeBindingResult>;
   goBack(params: PageGoBackParams, progress?: Progress): Promise<PageGoBackResult>;
@@ -2220,8 +2221,12 @@ export type PageCloseResult = void;
 export type PageClearConsoleMessagesParams = {};
 export type PageClearConsoleMessagesOptions = {};
 export type PageClearConsoleMessagesResult = void;
-export type PageConsoleMessagesParams = {};
-export type PageConsoleMessagesOptions = {};
+export type PageConsoleMessagesParams = {
+  filter?: ConsoleMessagesFilter,
+};
+export type PageConsoleMessagesOptions = {
+  filter?: ConsoleMessagesFilter,
+};
 export type PageConsoleMessagesResult = {
   messages: {
     type: string,

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -2137,7 +2137,7 @@ export interface PageChannel extends PageEventTarget, EventTargetChannel {
   mouseWheel(params: PageMouseWheelParams, progress?: Progress): Promise<PageMouseWheelResult>;
   touchscreenTap(params: PageTouchscreenTapParams, progress?: Progress): Promise<PageTouchscreenTapResult>;
   clearPageErrors(params?: PageClearPageErrorsParams, progress?: Progress): Promise<PageClearPageErrorsResult>;
-  pageErrors(params?: PagePageErrorsParams, progress?: Progress): Promise<PagePageErrorsResult>;
+  pageErrors(params: PagePageErrorsParams, progress?: Progress): Promise<PagePageErrorsResult>;
   pdf(params: PagePdfParams, progress?: Progress): Promise<PagePdfResult>;
   requests(params?: PageRequestsParams, progress?: Progress): Promise<PageRequestsResult>;
   snapshotForAI(params: PageSnapshotForAIParams, progress?: Progress): Promise<PageSnapshotForAIResult>;
@@ -2552,8 +2552,12 @@ export type PageTouchscreenTapResult = void;
 export type PageClearPageErrorsParams = {};
 export type PageClearPageErrorsOptions = {};
 export type PageClearPageErrorsResult = void;
-export type PagePageErrorsParams = {};
-export type PagePageErrorsOptions = {};
+export type PagePageErrorsParams = {
+  filter?: ConsoleMessagesFilter,
+};
+export type PagePageErrorsOptions = {
+  filter?: ConsoleMessagesFilter,
+};
 export type PagePageErrorsResult = {
   errors: SerializedError[],
 };

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -429,6 +429,12 @@ LifecycleEvent:
   - networkidle
   - commit
 
+ConsoleMessagesFilter:
+  type: enum
+  literals:
+  - all
+  - sinceNavigation
+
 CommonScreenshotOptions:
   type: mixin
   properties:
@@ -1615,6 +1621,8 @@ Page:
     consoleMessages:
       title: Get console messages
       group: getter
+      parameters:
+        filter: ConsoleMessagesFilter?
       returns:
         messages:
           type: array

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1967,6 +1967,8 @@ Page:
     pageErrors:
       title: Get page errors
       group: getter
+      parameters:
+        filter: ConsoleMessagesFilter?
       returns:
         errors:
           type: array

--- a/tests/mcp/console.spec.ts
+++ b/tests/mcp/console.spec.ts
@@ -430,6 +430,25 @@ test('browser_console_messages all option', async ({ client, server }) => {
   expect(allResponse.result).toContain('page2 message');
 });
 
+test('browser_console_messages all option for page errors', async ({ client, server }) => {
+  server.setContent('/page1', `<html><script>throw new Error('page1 error');</script></html>`, 'text/html');
+  server.setContent('/page2', `<html><script>throw new Error('page2 error');</script></html>`, 'text/html');
+
+  await client.callTool({ name: 'browser_navigate', arguments: { url: server.PREFIX + '/page1' } });
+  await client.callTool({ name: 'browser_navigate', arguments: { url: server.PREFIX + '/page2' } });
+
+  const defaultResponse = parseResponse(await client.callTool({ name: 'browser_console_messages' }));
+  expect(defaultResponse.result).toContain('page2 error');
+  expect(defaultResponse.result).not.toContain('page1 error');
+
+  const allResponse = parseResponse(await client.callTool({
+    name: 'browser_console_messages',
+    arguments: { all: true },
+  }));
+  expect(allResponse.result).toContain('page1 error');
+  expect(allResponse.result).toContain('page2 error');
+});
+
 test('console log is updated without taking snapshots', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const { client } = await startClient({

--- a/tests/mcp/console.spec.ts
+++ b/tests/mcp/console.spec.ts
@@ -406,6 +406,30 @@ test('console log file stores message type and content', async ({ startClient, s
   expect(logContent).toMatch(/@ http:\/\/localhost:\d+\/:\d/);
 });
 
+test('browser_console_messages all option', async ({ client, server }) => {
+  server.setContent('/page1', `
+    <html><script>console.log("page1 message");</script></html>
+  `, 'text/html');
+
+  server.setContent('/page2', `
+    <html><script>console.log("page2 message");</script></html>
+  `, 'text/html');
+
+  await client.callTool({ name: 'browser_navigate', arguments: { url: server.PREFIX + '/page1' } });
+  await client.callTool({ name: 'browser_navigate', arguments: { url: server.PREFIX + '/page2' } });
+
+  const defaultResponse = parseResponse(await client.callTool({ name: 'browser_console_messages' }));
+  expect(defaultResponse.result).toContain('page2 message');
+  expect(defaultResponse.result).not.toContain('page1 message');
+
+  const allResponse = parseResponse(await client.callTool({
+    name: 'browser_console_messages',
+    arguments: { all: true },
+  }));
+  expect(allResponse.result).toContain('page1 message');
+  expect(allResponse.result).toContain('page2 message');
+});
+
 test('console log is updated without taking snapshots', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const { client } = await startClient({

--- a/tests/mcp/init-script.spec.ts
+++ b/tests/mcp/init-script.spec.ts
@@ -19,7 +19,7 @@ import fs from 'fs';
 
 
 for (const context of ['isolated', 'persistent']) {
-  test(`--init-script option loads and executes script (${context})`, async ({ startClient, server }, testInfo) => {
+  test(`--init-script option loads and executes script (${context})`, async ({ startClient, server, mcpBrowser }, testInfo) => {
     // Create a temporary init script
     const initScriptPath = testInfo.outputPath('init-script1.js');
     const initScriptContent1 = `window.testInitScriptExecuted = true;`;
@@ -55,6 +55,9 @@ for (const context of ['isolated', 'persistent']) {
 
     expect(await client.callTool({
       name: 'browser_console_messages',
+      // FIXME: in firefox commit event comes after console messages from the init script.
+      // See https://github.com/microsoft/playwright/issues/39624.
+      arguments: { all: mcpBrowser === 'firefox' }
     })).toHaveResponse({
       result: expect.stringMatching(/Init script executed successfully.*Custom log/ms),
     });

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -306,11 +306,12 @@ it('consoleMessages sinceNavigation filter should work', async ({ page, server }
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => console.log('after navigation'));
 
-  const all = await page.consoleMessages();
+  const all = await page.consoleMessages({ filter: 'all' });
   expect(all.map(m => m.text())).toContain('before navigation');
   expect(all.map(m => m.text())).toContain('after navigation');
 
-  const sinceNav = await page.consoleMessages({ filter: 'sinceNavigation' });
+  // sinceNavigation is the default
+  const sinceNav = await page.consoleMessages();
   expect(sinceNav.map(m => m.text())).not.toContain('before navigation');
   expect(sinceNav.map(m => m.text())).toContain('after navigation');
 });

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -315,3 +315,20 @@ it('consoleMessages sinceNavigation filter should work', async ({ page, server }
   expect(sinceNav.map(m => m.text())).not.toContain('before navigation');
   expect(sinceNav.map(m => m.text())).toContain('after navigation');
 });
+
+it('pageErrors sinceNavigation filter should work', async ({ page, server }) => {
+  server.setContent('/page1', `<script>throw new Error('page1 error');</script>`, 'text/html');
+  server.setContent('/page2', `<script>throw new Error('page2 error');</script>`, 'text/html');
+
+  await page.goto(server.PREFIX + '/page1');
+  await page.goto(server.PREFIX + '/page2');
+
+  const all = await page.pageErrors({ filter: 'all' });
+  expect(all.map(e => e.message)).toContain('page1 error');
+  expect(all.map(e => e.message)).toContain('page2 error');
+
+  // sinceNavigation is the default
+  const sinceNav = await page.pageErrors();
+  expect(sinceNav.map(e => e.message)).not.toContain('page1 error');
+  expect(sinceNav.map(e => e.message)).toContain('page2 error');
+});

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -300,3 +300,17 @@ it('clearConsoleMessages should work', async ({ page }) => {
   expect(messages.length).toBe(1);
   expect(messages[0].text()).toBe('message3');
 });
+
+it('consoleMessages sinceNavigation filter should work', async ({ page, server }) => {
+  await page.evaluate(() => console.log('before navigation'));
+  await page.goto(server.EMPTY_PAGE);
+  await page.evaluate(() => console.log('after navigation'));
+
+  const all = await page.consoleMessages();
+  expect(all.map(m => m.text())).toContain('before navigation');
+  expect(all.map(m => m.text())).toContain('after navigation');
+
+  const sinceNav = await page.consoleMessages({ filter: 'sinceNavigation' });
+  expect(sinceNav.map(m => m.text())).not.toContain('before navigation');
+  expect(sinceNav.map(m => m.text())).toContain('after navigation');
+});


### PR DESCRIPTION
Adds a `filter` option ('all' | 'sinceNavigation') to `Page.consoleMessages()`. When 'sinceNavigation' is passed, only messages logged after the last committed main-frame navigation are returned. The last pre-navigation message is marked with a symbol in the shared array — no separate array needed.