### PR TITLE
docs(api): fix spelling in APIRequestContext docs

### DIFF
--- a/docs/src/api/class-apirequestcontext.md
+++ b/docs/src/api/class-apirequestcontext.md
@@ -247,7 +247,7 @@ var data = new Dictionary<string, object>() {
 await Request.FetchAsync("https://example.com/api/createBook", new() { Method = "post", DataObject = data });
 ```
 
-The common way to send file(s) in the body of a request is to upload them as form fields with `multipart/form-data` encoding, by specifiying the `multipart` parameter:
+The common way to send file(s) in the body of a request is to upload them as form fields with `multipart/form-data` encoding, by specifying the `multipart` parameter:
 
 ```js
 const form = new FormData();


### PR DESCRIPTION
## Summary\n- Fix a spelling typo in the APIRequestContext docs.\n\n## Related issue\n- N/A (minor documentation update)\n\n## Guideline alignment\n- https://github.com/microsoft/playwright/blob/main/CONTRIBUTING.md\n\n## Validation/testing\n- Not run (docs-only).