### PR TITLE
feat(mcp): add browser_get_content tool for direct page content extraction

### DIFF
--- a/packages/playwright-core/src/tools/getContent.ts
+++ b/packages/playwright-core/src/tools/getContent.ts
@@ -1,0 +1,265 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from '../mcpBundle';
+import { defineTabTool } from './tool';
+
+const getContentSchema = z.object({
+  selector: z.string().optional().describe('CSS selector to filter content to specific elements'),
+  viewportOnly: z.boolean().optional().describe('Only extract content currently visible in viewport (default: false)'),
+  includeLinks: z.boolean().optional().describe('Format links as markdown (default: true)'),
+  format: z.enum(['text', 'markdown', 'html']).optional().describe('Output format (default: "markdown")'),
+});
+
+function isVisibleInViewport(element: Element, viewportHeight: number): boolean {
+  const rect = element.getBoundingClientRect();
+  return rect.top >= 0 && rect.top < viewportHeight;
+}
+
+function extractContent(element: Element, options: {
+  format: 'text' | 'markdown' | 'html';
+  includeLinks: boolean;
+  viewportOnly: boolean;
+  viewportHeight: number;
+}): string {
+  const { format, includeLinks, viewportOnly, viewportHeight } = options;
+
+  if (format === 'html') {
+    return element.innerHTML;
+  }
+
+  // For text and markdown, we need to traverse the element tree
+  let result = '';
+
+  function traverse(node: Node, insideLink: boolean = false): void {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent || '';
+      // Skip whitespace-only text nodes that aren't significant
+      if (text.trim() || result.length > 0) {
+        result += text;
+      }
+      return;
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE)
+      return;
+
+    const element = node as Element;
+    const tagName = element.tagName.toLowerCase();
+
+    // Skip scripts and styles
+    if (tagName === 'script' || tagName === 'style' || tagName === 'noscript')
+      return;
+
+    // Check visibility for viewport-only mode
+    if (viewportOnly && !isVisibleInViewport(element, viewportHeight))
+      return;
+
+    // Handle block elements - add newlines
+    const isBlock = ['p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'tr', 'br', 'hr', 'thead', 'tbody', 'tfoot', 'th', 'td'].includes(tagName);
+    if (isBlock && result.length > 0 && !result.endsWith('\n'))
+      result += '\n';
+
+    // Handle links for markdown format
+    if (tagName === 'a' && format === 'markdown' && includeLinks) {
+      const href = element.getAttribute('href');
+      if (href) {
+        const linkText = element.textContent || '';
+        result += `[${linkText}](${href})`;
+        return;
+      }
+    }
+
+    // Handle list items for text format
+    if (tagName === 'li' && format === 'text' && result.length > 0) {
+      const lastNewline = result.lastIndexOf('\n');
+      if (lastNewline === -1 || result.substring(lastNewline).trim().length > 0)
+        result += '\n';
+      result += '• ';
+    }
+
+    // Handle breaks
+    if (tagName === 'br')
+      result += '\n';
+
+    // Traverse children
+    let previousChild = null;
+    for (const child of Array.from(element.childNodes)) {
+      traverse(child, tagName === 'a' || insideLink);
+      previousChild = child;
+    }
+
+    // Add trailing newline for block elements
+    if (isBlock && format === 'markdown') {
+      if (!result.endsWith('\n'))
+        result += '\n';
+    }
+  }
+
+  traverse(element);
+
+  // Clean up excessive whitespace
+  result = result.replace(/[ \t]+/g, ' ');
+  result = result.replace(/\n{3,}/g, '\n\n');
+  result = result.trim();
+
+  return result;
+}
+
+const getContent = defineTabTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_get_content',
+    title: 'Get page content',
+    description: 'Extract text or structured content from the current page without writing JavaScript code',
+    inputSchema: getContentSchema,
+    type: 'readOnly',
+  },
+
+  handle: async (tab, params, response) => {
+    const format = params.format || 'markdown';
+    const includeLinks = params.includeLinks !== false;
+    const viewportOnly = params.viewportOnly || false;
+
+    await tab.waitForCompletion(async () => {
+      const result = await tab.page.evaluate((options) => {
+        const { selector, format, includeLinks, viewportOnly } = options;
+
+        // Get the root element to extract from
+        let rootElement: Element | null = null;
+        if (selector) {
+          rootElement = document.querySelector(selector);
+          if (!rootElement)
+            return { error: `No element found matching selector: "${selector}"` };
+        } else {
+          rootElement = document.body;
+        }
+
+        if (!rootElement)
+          return { error: 'No content found on page' };
+
+        const viewportHeight = window.innerHeight;
+
+        // Helper function to check visibility
+        function isVisibleInViewport(element: Element): boolean {
+          const rect = element.getBoundingClientRect();
+          return rect.top >= 0 && rect.top < viewportHeight;
+        }
+
+        // Extract content based on format
+        if (format === 'html') {
+          return { content: rootElement.innerHTML, format: 'html' };
+        }
+
+        // For text and markdown, traverse the element tree
+        let result = '';
+        const INVISIBLE = 'playwright-invisible';
+
+        function traverse(node: Node, insideLink: boolean = false): void {
+          if (node.nodeType === Node.TEXT_NODE) {
+            const text = node.textContent || '';
+            if (text.trim() || result.length > 0) {
+              result += text;
+            }
+            return;
+          }
+
+          if (node.nodeType !== Node.ELEMENT_NODE)
+            return;
+
+          const element = node as Element;
+          const tagName = element.tagName.toLowerCase();
+
+          // Skip scripts, styles, and hidden elements
+          if (tagName === 'script' || tagName === 'style' || tagName === 'noscript')
+            return;
+
+          // Check visibility for viewport-only mode
+          if (viewportOnly && !isVisibleInViewport(element))
+            return;
+
+          // Handle block elements
+          const isBlock = ['p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'tr', 'br', 'hr', 'thead', 'tbody', 'tfoot', 'th', 'td', 'ul', 'ol', 'blockquote', 'pre', 'article', 'section', 'header', 'footer', 'main', 'nav', 'aside'].includes(tagName);
+          if (isBlock && result.length > 0 && !result.endsWith('\n'))
+            result += '\n';
+
+          // Handle links for markdown format
+          if (tagName === 'a' && format === 'markdown' && includeLinks) {
+            const href = element.getAttribute('href');
+            if (href) {
+              const linkText = element.textContent || '';
+              result += `[${linkText}](${href})`;
+              return;
+            }
+          }
+
+          // Handle list items for text format
+          if (tagName === 'li' && format === 'text' && result.length > 0) {
+            const lastNewline = result.lastIndexOf('\n');
+            if (lastNewline === -1 || result.substring(lastNewline).trim().length > 0)
+              result += '\n';
+            result += '• ';
+          }
+
+          // Handle breaks
+          if (tagName === 'br')
+            result += '\n';
+
+          // Handle headings in markdown
+          if (format === 'markdown' && ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(tagName)) {
+            const level = parseInt(tagName.charAt(1));
+            result += '\n' + '#'.repeat(level) + ' ';
+          }
+
+          // Traverse children
+          for (const child of Array.from(element.childNodes)) {
+            traverse(child, tagName === 'a' || insideLink);
+          }
+
+          // Add trailing newline for block elements in markdown
+          if (isBlock && format === 'markdown') {
+            if (!result.endsWith('\n'))
+              result += '\n';
+          }
+        }
+
+        traverse(rootElement);
+
+        // Clean up excessive whitespace
+        result = result.replace(/[ \t]+/g, ' ');
+        result = result.replace(/\n{3,}/g, '\n\n');
+        result = result.trim();
+
+        return { content: result, format };
+      }, {
+        selector: params.selector || null,
+        format,
+        includeLinks,
+        viewportOnly,
+      });
+
+      if ('error' in result) {
+        response.addError(result.error);
+      } else {
+        response.addTextResult(result.content);
+      }
+    });
+  },
+});
+
+export default [
+  getContent,
+];

--- a/packages/playwright-core/src/tools/tools.ts
+++ b/packages/playwright-core/src/tools/tools.ts
@@ -21,6 +21,7 @@ import cookies from './cookies';
 import devtools from './devtools';
 import dialogs from './dialogs';
 import evaluate from './evaluate';
+import getContent from './getContent';
 import files from './files';
 import form from './form';
 import keyboard from './keyboard';
@@ -51,6 +52,7 @@ export const browserTools: Tool<any>[] = [
   ...devtools,
   ...dialogs,
   ...evaluate,
+  ...getContent,
   ...files,
   ...form,
   ...keyboard,

--- a/tests/mcp/get-content.spec.ts
+++ b/tests/mcp/get-content.spec.ts
@@ -1,0 +1,341 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures';
+
+test('browser_get_content basic', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <body>
+        <h1>Hello World</h1>
+        <p>This is a test page</p>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {},
+  });
+
+  expect(result.content?.[0]?.text).toContain('Hello World');
+  expect(result.content?.[0]?.text).toContain('This is a test page');
+});
+
+test('browser_get_content with selector', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <body>
+        <div id="main">
+          <h1>Main Content</h1>
+        </div>
+        <div id="sidebar">
+          <h1>Sidebar</h1>
+        </div>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {
+      selector: '#main',
+    },
+  });
+
+  expect(result.content?.[0]?.text).toContain('Main Content');
+  expect(result.content?.[0]?.text).not.toContain('Sidebar');
+});
+
+test('browser_get_content with links', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <body>
+        <p>Check out <a href="https://example.com">Example</a> for more info.</p>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {
+      format: 'markdown',
+    },
+  });
+
+  expect(result.content?.[0]?.text).toContain('[Example](https://example.com)');
+});
+
+test('browser_get_content without links', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <body>
+        <p>Check out <a href="https://example.com">Example</a> for more info.</p>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {
+      format: 'markdown',
+      includeLinks: false,
+    },
+  });
+
+  expect(result.content?.[0]?.text).not.toContain('[Example]');
+  expect(result.content?.[0]?.text).toContain('Example');
+});
+
+test('browser_get_content text format', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <body>
+        <h1>Title</h1>
+        <p>Paragraph 1</p>
+        <p>Paragraph 2</p>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {
+      format: 'text',
+    },
+  });
+
+  expect(result.content?.[0]?.text).toContain('Title');
+  expect(result.content?.[0]?.text).toContain('Paragraph 1');
+  expect(result.content?.[0]?.text).toContain('Paragraph 2');
+});
+
+test('browser_get_content html format', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <body>
+        <div class="content">
+          <p>HTML content</p>
+        </div>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {
+      format: 'html',
+    },
+  });
+
+  expect(result.content?.[0]?.text).toContain('<div class="content">');
+  expect(result.content?.[0]?.text).toContain('<p>HTML content</p>');
+});
+
+test('browser_get_content invalid selector', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <body>
+        <h1>Hello</h1>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {
+      selector: '#nonexistent',
+    },
+  });
+
+  expect(result.isError).toBe(true);
+  expect(result.content?.[0]?.text).toContain('No element found matching selector');
+});
+
+test('browser_get_content with list items', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <body>
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+        </ul>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {
+      format: 'markdown',
+    },
+  });
+
+  expect(result.content?.[0]?.text).toContain('Item 1');
+  expect(result.content?.[0]?.text).toContain('Item 2');
+  expect(result.content?.[0]?.text).toContain('Item 3');
+});
+
+test('browser_get_content with headings', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <body>
+        <h1>Main Title</h1>
+        <h2>Subtitle</h2>
+        <p>Content</p>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {
+      format: 'markdown',
+    },
+  });
+
+  expect(result.content?.[0]?.text).toContain('# Main Title');
+  expect(result.content?.[0]?.text).toContain('## Subtitle');
+});
+
+test('browser_get_content skip scripts and styles', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <head>
+        <style>.hidden { display: none; }</style>
+      </head>
+      <body>
+        <h1>Visible Content</h1>
+        <script>console.log('hidden');</script>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {},
+  });
+
+  expect(result.content?.[0]?.text).toContain('Visible Content');
+  expect(result.content?.[0]?.text).not.toContain('display: none');
+  expect(result.content?.[0]?.text).not.toContain('console.log');
+});
+
+test('browser_get_content empty page', async ({ client, server }) => {
+  server.setContent('/', `<html><body></body></html>`, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {},
+  });
+
+  // Should not error, just return empty content
+  expect(result.isError).toBe(false);
+});
+
+test('browser_get_content multiple links', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <body>
+        <p>Visit <a href="/page1">Page 1</a> or <a href="/page2">Page 2</a></p>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {
+      format: 'markdown',
+    },
+  });
+
+  expect(result.content?.[0]?.text).toContain('[Page 1](/page1)');
+  expect(result.content?.[0]?.text).toContain('[Page 2](/page2)');
+});
+
+test('browser_get_content with nested elements', async ({ client, server }) => {
+  server.setContent('/', `
+    <html>
+      <body>
+        <div>
+          <p>Nested <strong>bold</strong> text</p>
+        </div>
+      </body>
+    </html>
+  `, 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_get_content',
+    arguments: {
+      format: 'text',
+    },
+  });
+
+  expect(result.content?.[0]?.text).toContain('Nested bold text');
+});


### PR DESCRIPTION
## Summary

- Add `browser_get_content` tool for direct page content extraction
- Supports CSS selector filtering with `selector` parameter
- Supports viewport-only extraction with `viewportOnly` parameter  
- Supports multiple output formats: `text`, `markdown`, `html`
- Supports link formatting in markdown with `includeLinks` parameter

## Details

This implementation addresses the feature request in [playwright-mcp#1455](https://github.com/microsoft/playwright-mcp/issues/1455) by adding a convenient API for content extraction without requiring users to write JavaScript code. The new tool complements the existing powerful `browser_run_code` tool for advanced scenarios.

### Files Changed

- `packages/playwright-core/src/tools/getContent.ts` - New tool implementation
- `packages/playwright-core/src/tools/tools.ts` - Register the new tool
- `tests/mcp/get-content.spec.ts` - Comprehensive test suite

### API

```typescript
browser_get_content: {
  selector?: string;      // CSS selector to filter content
  viewportOnly?: boolean; // Only extract visible content in viewport
  includeLinks?: boolean; // Format links as markdown (default: true)
  format?: 'text' | 'markdown' | 'html'; // Output format (default: 'markdown')
}
```

References https://github.com/microsoft/playwright-mcp/issues/1455