### PR TITLE
fix(test-runner): do not run afterEach hooks after dynamically skipped test

### DIFF
--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -417,6 +417,11 @@ export class WorkerMain extends ProcessRunner {
     // Update duration, so it is available in fixture teardown and afterEach hooks.
     testInfo.duration = testInfo._timeoutManager.defaultSlot().elapsed | 0;
 
+    // If the test was dynamically skipped (e.g. test.skip() called inside the test body),
+    // do not run afterEach hooks.
+    if (testInfo.status === 'skipped')
+      shouldRunAfterEachHooks = false;
+
     // No skips in after hooks.
     testInfo._allowSkips = true;
 

--- a/tests/playwright-test/hooks.spec.ts
+++ b/tests/playwright-test/hooks.spec.ts
@@ -863,7 +863,22 @@ test('afterAll should run if last test was skipped 2', async ({ runInlineTest })
   expect(result.output).toContain('after-all');
 });
 
-test('afterEach timeout after skipped test should be reported', async ({ runInlineTest }) => {
+test('afterEach should not run after dynamically skipped test', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      import { test, expect } from '@playwright/test';
+      test.afterEach(() => {
+        console.log('\\n%%afterEach');
+      });
+      test('skipped', () => { test.skip(); });
+    `,
+  }, { timeout: 2000 });
+  expect(result.exitCode).toBe(0);
+  expect(result.skipped).toBe(1);
+  expect(result.output).not.toContain('afterEach');
+});
+
+test('afterEach timeout after dynamically skipped test should not be reported', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
       import { test, expect } from '@playwright/test';
@@ -873,12 +888,12 @@ test('afterEach timeout after skipped test should be reported', async ({ runInli
       test('skipped', () => { test.skip(); });
     `,
   }, { timeout: 2000 });
-  expect(result.exitCode).toBe(1);
-  expect(result.failed).toBe(1);
-  expect(result.output).toContain('Test timeout of 2000ms exceeded while running "afterEach" hook.');
+  expect(result.exitCode).toBe(0);
+  expect(result.skipped).toBe(1);
+  expect(result.output).not.toContain('afterEach');
 });
 
-test('afterEach exception after skipped test should be reported', async ({ runInlineTest }) => {
+test('afterEach exception after dynamically skipped test should not be reported', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
       import { test, expect } from '@playwright/test';
@@ -888,9 +903,9 @@ test('afterEach exception after skipped test should be reported', async ({ runIn
       test('skipped', () => { test.skip(); });
     `,
   }, { timeout: 2000 });
-  expect(result.exitCode).toBe(1);
-  expect(result.failed).toBe(1);
-  expect(result.output).toContain('Error: oh my!');
+  expect(result.exitCode).toBe(0);
+  expect(result.skipped).toBe(1);
+  expect(result.output).not.toContain('Error: oh my!');
 });
 
 test('afterAll should be run for test.skip', async ({ runInlineTest }) => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/30570