### PR TITLE
feat(firefox-beta): roll to r1505

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -38,9 +38,9 @@
     },
     {
       "name": "firefox-beta",
-      "revision": "1504",
+      "revision": "1505",
       "installByDefault": false,
-      "browserVersion": "146.0b8",
+      "browserVersion": "148.0b9",
       "title": "Firefox Beta"
     },
     {

--- a/tests/library/popup.spec.ts
+++ b/tests/library/popup.spec.ts
@@ -99,7 +99,8 @@ it('should inherit http credentials from browser context', async function({ brow
   await context.close();
 });
 
-it('should inherit touch support from browser context', async function({ browser, server }) {
+it('should inherit touch support from browser context', async function({ browser, server, browserName, browserMajorVersion }) {
+  it.fixme(browserName === 'firefox' && browserMajorVersion >= 148, 'https://bugzilla.mozilla.org/show_bug.cgi?id=2014330');
   const context = await browser.newContext({
     viewport: { width: 400, height: 500 },
     hasTouch: true

--- a/tests/page/page-wait-for-load-state.spec.ts
+++ b/tests/page/page-wait-for-load-state.spec.ts
@@ -70,7 +70,7 @@ it('should work with pages that have loaded before being connected to', async ({
   expect(popup.url()).toBe(server.EMPTY_PAGE);
 });
 
-it('should wait for load state of empty url popup', async ({ page, browserName, isBidi }) => {
+it('should wait for load state of empty url popup', async ({ page, browserName, isBidi, browserMajorVersion }) => {
   const [popup, readyState] = await Promise.all([
     page.waitForEvent('popup'),
     page.evaluate(() => {
@@ -79,8 +79,9 @@ it('should wait for load state of empty url popup', async ({ page, browserName, 
     }),
   ]);
   await popup.waitForLoadState();
-  expect(readyState).toBe(browserName === 'firefox' && !isBidi ? 'uninitialized' : 'complete');
-  expect(await popup.evaluate(() => document.readyState)).toBe(browserName === 'firefox' && !isBidi ? 'uninitialized' : 'complete');
+  const isOldFirefox = browserName === 'firefox' && browserMajorVersion < 148;
+  expect(readyState).toBe(isOldFirefox && !isBidi ? 'uninitialized' : 'complete');
+  expect(await popup.evaluate(() => document.readyState)).toBe(isOldFirefox && !isBidi ? 'uninitialized' : 'complete');
 });
 
 it('should wait for load state of about:blank popup ', async ({ page }) => {


### PR DESCRIPTION
Note: this disables one of the tests due to an upstream regression:
https://bugzilla.mozilla.org/show_bug.cgi?id=2014330
