### PR TITLE
fix(mcp): guard toWellFormed() for Node 18 compatibility

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -276,7 +276,9 @@ function trimMiddle(text: string, maxLength: number) {
  * Replaces lone surrogates with U+FFFD using String.prototype.toWellFormed().
  */
 function sanitizeUnicode(text: string): string {
-  return text.toWellFormed();
+  if ((String.prototype as any).toWellFormed)
+    return text.toWellFormed();
+  return text;
 }
 
 function parseSections(text: string): Map<string, string> {


### PR DESCRIPTION
## Summary
- `String.prototype.toWellFormed()` is only available in Node 20+. Guard the call in `sanitizeUnicode` so it's a no-op on Node 18 instead of crashing.

Follows the same pattern already used in `driver.ts`.