### PR TITLE
fix(test): use relative path in error-context location

### DIFF
--- a/packages/playwright/src/errorContext.ts
+++ b/packages/playwright/src/errorContext.ts
@@ -19,6 +19,8 @@ import path from 'path';
 
 import { parseErrorStack, stripAnsiEscapes } from 'playwright-core/lib/utils';
 
+import { relativeFilePath } from './util';
+
 import type { TestInfoError } from '../types/test';
 
 const fixTestInstructions = `# Instructions
@@ -46,7 +48,7 @@ export function buildErrorContext(options: {
     '# Test info',
     '',
     `- Name: ${titlePath.join(' >> ')}`,
-    `- Location: ${location.file}:${location.line}:${location.column}`,
+    `- Location: ${relativeFilePath(location.file)}:${location.line}:${location.column}`,
   ];
 
   if (meaningfulErrors.length) {

--- a/tests/playwright-test/playwright.artifacts.spec.ts
+++ b/tests/playwright-test/playwright.artifacts.spec.ts
@@ -572,6 +572,27 @@ test('should work with trace: retain-on-failure-and-retries', async ({ runInline
   ]);
 });
 
+test('error-context should use relative path in location', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('fail', async ({ page }) => {
+        expect(1).toBe(2);
+      });
+    `,
+  }, { workers: 1 });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+
+  const errorContextPath = testInfo.outputPath('test-results', 'a-fail', 'error-context.md');
+  const content = fs.readFileSync(errorContextPath, 'utf8');
+  const locationLine = content.split('\n').find(line => line.startsWith('- Location:'))!;
+  expect(locationLine).toBeTruthy();
+  // Location should be a relative path, not absolute.
+  expect(locationLine).toContain('- Location: a.spec.ts:');
+});
+
 test('should take screenshot when page is closed in afterEach', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
## Summary
- Error-context.md was using absolute paths in the `Location:` field
- Use `relativeFilePath()` (same helper used by reporters) to make it relative to cwd
- Add test verifying the location is a relative path