### PR TITLE
feat: Add pretty print toggle for request and response bodies in network details

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -19,6 +19,11 @@
   overflow: auto;
 }
 
+.network-response-toolbar {
+  border-top: 1px solid var(--vscode-panel-border);
+  border-bottom: none !important;
+}
+
 .network-request-details-tab > * {
   flex: none;
 }
@@ -68,6 +73,10 @@
 
 .network-request-details-tab .cm-wrapper {
   overflow: hidden;
+}
+
+.network-response-body {
+  height: calc(100% - 31px /* Height of bottom toolbar */);
 }
 
 .network-request-request-body {

--- a/packages/trace-viewer/src/ui/networkResourceDetails.css
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.css
@@ -76,7 +76,7 @@
 }
 
 .network-response-body {
-  height: calc(100% - 31px /* Height of bottom toolbar */);
+  flex: 1;
 }
 
 .network-request-request-body {

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -239,7 +239,7 @@ const ResponseTab: React.FunctionComponent<{
     {!resource.response.content._sha1 && <div>Response body is not available for this request.</div>}
     {responseBody && responseBody.font && <FontPreview font={responseBody.font} />}
     {responseBody && responseBody.dataUrl && <div><img draggable='false' src={responseBody.dataUrl} /></div>}
-    {responseBody && responseBody.text !== undefined && <div className='network-response-body'>
+    {responseBody && responseBody.text !== undefined && <div className='vbox network-response-body'>
       <CodeMirrorWrapper text={formatResult.text} mimeType={responseBody.mimeType} readOnly lineNumbers={true}/>
       <Toolbar noShadow={true} noMinHeight={true} className='network-response-toolbar'>
         <div style={{ margin: 'auto' }}></div>
@@ -322,7 +322,7 @@ function formatXml(xml: string, indent = '  ') {
 }
 
 function formatBody(body: string, contentType?: string): string {
-  if (!contentType)
+  if (!body.trim() || !contentType)
     return body;
 
   if (isJsonMimeType(contentType))

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -29,8 +29,10 @@ import { msToString, useAsyncMemo, useSetting } from '@web/uiUtils';
 import type { Entry } from '@trace/har';
 import { useTraceModel } from './traceModelContext';
 import { Expandable } from '@web/components/expandable';
+import { Toolbar } from '@web/components/toolbar';
 
 type RequestBody = { text: string, mimeType?: string } | null;
+type ResponseBody = { dataUrl?: string, text?: string, mimeType?: string, font?: BufferSource } | null;
 
 
 export const NetworkResourceDetails: React.FunctionComponent<{
@@ -48,9 +50,9 @@ export const NetworkResourceDetails: React.FunctionComponent<{
       const requestContentType = requestContentTypeHeader ? requestContentTypeHeader.value : '';
       if (resource.request.postData._sha1) {
         const response = await fetch(model.createRelativeUrl(`sha1/${resource.request.postData._sha1}`));
-        return { text: formatBody(await response.text(), requestContentType), mimeType: requestContentType };
+        return { text: await response.text(), mimeType: requestContentType };
       } else {
-        return { text: formatBody(resource.request.postData.text, requestContentType), mimeType: requestContentType };
+        return { text: resource.request.postData.text, mimeType: requestContentType };
       }
     } else {
       return null;
@@ -107,22 +109,37 @@ const CopyDropdown: React.FC<{
   );
 };
 
+const FormatToggleButton: React.FC<{
+  toggled: boolean;
+  error?: boolean;
+  onToggle: () => void;
+}> = ({ toggled, error, onToggle }) => {
+  return <ToolbarButton icon='json' title='Pretty print' toggled={toggled} errorBadge={error ? 'Formatting failed' : undefined} onClick={e => {
+    e.stopPropagation();
+    onToggle();
+  }}/>;
+};
+
 const ExpandableSection: React.FC<{
   title: string;
   showCount?: boolean,
   data?: { name: string, value: React.ReactNode }[],
   children?: React.ReactNode
+  titleChildren?: React.ReactNode;
   className?: string;
-}> = ({ title, data, showCount, children, className }) => {
+}> = ({ title, data, showCount, children, titleChildren, className }) => {
   const [expanded, setExpanded] = useSetting(`trace-viewer-network-details-${title.replaceAll(' ', '-')}`, true);
   return <Expandable
     expanded={expanded}
     setExpanded={setExpanded}
     expandOnTitleClick
     title={
-      <span className='network-request-details-header'>{title}
-        {showCount && <span className='network-request-details-header-count'> × {data?.length ?? 0}</span>}
-      </span>
+      <>
+        <span className='network-request-details-header'>{title}
+          {showCount && <span className='network-request-details-header-count'> × {data?.length ?? 0}</span>}
+        </span>
+        { titleChildren }
+      </>
     }
     className={className}
   >
@@ -166,11 +183,19 @@ const PayloadTab: React.FunctionComponent<{
   resource: ResourceSnapshot;
   requestBody: RequestBody,
 }> = ({ resource, requestBody }) => {
+  const [showFormatted, setShowFormatted] = useSetting('trace-viewer-network-details-show-formatted-payload', true);
+  const formatResult = useFormattedBody(requestBody, showFormatted);
+
   return <div className='vbox network-request-details-tab'>
     {resource.request.queryString.length === 0 && !requestBody && <em className='network-request-no-payload'>No payload for this request.</em>}
     {resource.request.queryString.length > 0 && <ExpandableSection title='Query String Parameters' showCount data={resource.request.queryString}/>}
-    {requestBody && <ExpandableSection title='Request Body' className='network-request-request-body'>
-      <CodeMirrorWrapper text={requestBody.text} mimeType={requestBody.mimeType} readOnly lineNumbers={true}/>
+    {requestBody && <ExpandableSection title='Request Body' className='network-request-request-body' titleChildren={
+      <>
+        <div style={{ margin: 'auto' }}></div>
+        <FormatToggleButton toggled={showFormatted} error={formatResult.error} onToggle={() => setShowFormatted(!showFormatted)} />
+      </>
+    }>
+      <CodeMirrorWrapper text={formatResult.text} mimeType={requestBody.mimeType} readOnly lineNumbers={true}/>
     </ExpandableSection>}
   </div>;
 };
@@ -179,7 +204,7 @@ const ResponseTab: React.FunctionComponent<{
   resource: ResourceSnapshot;
 }> = ({ resource }) => {
   const model = useTraceModel();
-  const [responseBody, setResponseBody] = React.useState<{ dataUrl?: string, text?: string, mimeType?: string, font?: BufferSource } | null>(null);
+  const [responseBody, setResponseBody] = React.useState<ResponseBody>(null);
 
   React.useEffect(() => {
     const readResources = async  () => {
@@ -197,8 +222,7 @@ const ResponseTab: React.FunctionComponent<{
           const font = await response.arrayBuffer();
           setResponseBody({ font });
         } else {
-          const formattedBody = formatBody(await response.text(), resource.response.content.mimeType);
-          setResponseBody({ text: formattedBody, mimeType: resource.response.content.mimeType });
+          setResponseBody({ text: await response.text(), mimeType: resource.response.content.mimeType });
         }
       } else {
         setResponseBody(null);
@@ -208,11 +232,20 @@ const ResponseTab: React.FunctionComponent<{
     readResources();
   }, [resource, model]);
 
+  const [showFormattedResponse, setShowFormattedResponse] = useSetting('trace-viewer-network-details-show-formatted-response', true);
+  const formatResult = useFormattedBody(responseBody, showFormattedResponse);
+
   return <div className='vbox network-request-details-tab'>
     {!resource.response.content._sha1 && <div>Response body is not available for this request.</div>}
     {responseBody && responseBody.font && <FontPreview font={responseBody.font} />}
     {responseBody && responseBody.dataUrl && <div><img draggable='false' src={responseBody.dataUrl} /></div>}
-    {responseBody && responseBody.text && <CodeMirrorWrapper text={responseBody.text} mimeType={responseBody.mimeType} readOnly lineNumbers={true}/>}
+    {responseBody && responseBody.text !== undefined && <div className='network-response-body'>
+      <CodeMirrorWrapper text={formatResult.text} mimeType={responseBody.mimeType} readOnly lineNumbers={true}/>
+      <Toolbar noShadow={true} noMinHeight={true} className='network-response-toolbar'>
+        <div style={{ margin: 'auto' }}></div>
+        <FormatToggleButton toggled={showFormattedResponse} error={formatResult.error} onToggle={() => setShowFormattedResponse(!showFormattedResponse)} />
+      </Toolbar>
+    </div>}
   </div>;
 };
 
@@ -288,32 +321,34 @@ function formatXml(xml: string, indent = '  ') {
   return lines.join('\n');
 }
 
-function formatBody(body: string | null, contentType: string): string {
-  if (body === null)
-    return 'Loading...';
+function formatBody(body: string, contentType?: string): string {
+  if (!contentType)
+    return body;
 
-  const bodyStr = body;
-  if (bodyStr === '')
-    return '<Empty>';
+  if (isJsonMimeType(contentType))
+    return JSON.stringify(JSON.parse(body), null, 2);
 
-  if (isJsonMimeType(contentType)) {
-    try {
-      return JSON.stringify(JSON.parse(bodyStr), null, 2);
-    } catch (err) {
-      return bodyStr;
-    }
-  }
-
-  if (isXmlMimeType(contentType)) {
-    try {
-      return formatXml(bodyStr);
-    } catch {
-      return bodyStr;
-    }
-  }
+  if (isXmlMimeType(contentType))
+    return formatXml(body);
 
   if (contentType.includes('application/x-www-form-urlencoded'))
-    return decodeURIComponent(bodyStr);
+    return decodeURIComponent(body);
 
-  return bodyStr;
+  return body;
 }
+
+const useFormattedBody = (body: RequestBody | ResponseBody, showFormatted: boolean) => {
+  return React.useMemo(() => {
+    if (body?.text === undefined)
+      return { text: '' };
+
+    if (!showFormatted)
+      return { text: body.text };
+
+    try {
+      return { text: formatBody(body.text, body.mimeType) };
+    } catch {
+      return { text: body.text, error: true };
+    }
+  }, [body, showFormatted]);
+};

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -184,11 +184,13 @@ const PayloadTab: React.FunctionComponent<{
   requestBody: RequestBody,
 }> = ({ resource, requestBody }) => {
   const [showFormatted, setShowFormatted] = useSetting('trace-viewer-network-details-show-formatted-payload', true);
+  const hasQueryString = resource.request.queryString.length > 0;
+  const hasRequestBody = !!(requestBody || resource.request.postData);
   const formatResult = useFormattedBody(requestBody, showFormatted);
 
   return <div className='vbox network-request-details-tab'>
-    {resource.request.queryString.length === 0 && !requestBody && <em className='network-request-no-payload'>No payload for this request.</em>}
-    {resource.request.queryString.length > 0 && <ExpandableSection title='Query String Parameters' showCount data={resource.request.queryString}/>}
+    {!hasQueryString && !hasRequestBody && <em className='network-request-no-payload'>No payload for this request.</em>}
+    {hasQueryString && <ExpandableSection title='Query String Parameters' showCount data={resource.request.queryString}/>}
     {requestBody && <ExpandableSection title='Request Body' className='network-request-request-body' titleChildren={
       <>
         <div style={{ margin: 'auto' }}></div>

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -469,8 +469,7 @@ export const UIModeView: React.FC<{}> = ({
           <div className='section-title'>Playwright</div>
           <ToolbarButton icon='refresh' title='Reload' onClick={() => reloadTests()} disabled={isRunningTest || isLoading}></ToolbarButton>
           <div style={{ position: 'relative' }}>
-            <ToolbarButton icon={'terminal'} title={'Toggle output — ' + (isMac ? '⌃`' : 'Ctrl + `')} toggled={isShowingOutput} onClick={() => { setIsShowingOutput(!isShowingOutput); }} />
-            {outputContainsError && <div title='Output contains error' style={{ position: 'absolute', top: 2, right: 2, width: 7, height: 7, borderRadius: '50%', backgroundColor: 'var(--vscode-notificationsErrorIcon-foreground)' }} />}
+            <ToolbarButton icon={'terminal'} title={'Toggle output — ' + (isMac ? '⌃`' : 'Ctrl + `')} toggled={isShowingOutput} errorBadge={outputContainsError ? 'Output contains error' : undefined} onClick={() => { setIsShowingOutput(!isShowingOutput); }} />
           </div>
           {!hasBrowsers && <ToolbarButton icon='lightbulb-autofix' style={{ color: 'var(--vscode-list-warningForeground)' }} title='Playwright browsers are missing' onClick={openInstallDialog} />}
         </Toolbar>

--- a/packages/web/src/components/toolbar.css
+++ b/packages/web/src/components/toolbar.css
@@ -28,7 +28,7 @@
   background-color: var(--vscode-sideBar-background);
 }
 
-.toolbar:after {
+.toolbar:not(.no-shadow):after {
   content: '';
   display: block;
   position: absolute;
@@ -39,10 +39,6 @@
   right: -2px;
   box-shadow: var(--vscode-scrollbar-shadow) 0 6px 6px -6px;
   z-index: 100;
-}
-
-.toolbar.no-shadow:after {
-  box-shadow: none;
 }
 
 .toolbar.no-min-height {

--- a/packages/web/src/components/toolbarButton.css
+++ b/packages/web/src/components/toolbarButton.css
@@ -15,6 +15,7 @@
 */
 
 .toolbar-button {
+  position: relative;
   flex: none;
   border: none;
   outline: none;
@@ -41,6 +42,16 @@
 
 .toolbar-button.toggled {
   color: var(--vscode-notificationLink-foreground);
+}
+
+.toolbar-button-error-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background-color: var(--vscode-notificationsErrorIcon-foreground);
 }
 
 .toolbar-separator {

--- a/packages/web/src/components/toolbarButton.tsx
+++ b/packages/web/src/components/toolbarButton.tsx
@@ -45,6 +45,7 @@ export const ToolbarButton = React.forwardRef<HTMLButtonElement, React.PropsWith
   ariaLabel,
   errorBadge,
 }, ref) {
+  const errorId = React.useId();
   return <button
     ref={ref}
     className={clsx(className, 'toolbar-button', icon, toggled && 'toggled')}
@@ -56,10 +57,11 @@ export const ToolbarButton = React.forwardRef<HTMLButtonElement, React.PropsWith
     style={style}
     data-testid={testId}
     aria-label={ariaLabel || title}
+    aria-describedby={errorBadge ? errorId : undefined}
   >
     {icon && <span className={`codicon codicon-${icon}`} style={children ? { marginRight: 5 } : {}}></span>}
     {children}
-    {errorBadge && <span className='toolbar-button-error-badge' title={errorBadge}></span>}
+    {errorBadge && <span id={errorId} className='toolbar-button-error-badge' title={errorBadge} aria-label={errorBadge}></span>}
   </button>;
 });
 

--- a/packages/web/src/components/toolbarButton.tsx
+++ b/packages/web/src/components/toolbarButton.tsx
@@ -29,6 +29,7 @@ export interface ToolbarButtonProps {
   testId?: string,
   className?: string,
   ariaLabel?: string,
+  errorBadge?: string,
 }
 
 export const ToolbarButton = React.forwardRef<HTMLButtonElement, React.PropsWithChildren<ToolbarButtonProps>>(function ToolbarButton({
@@ -42,6 +43,7 @@ export const ToolbarButton = React.forwardRef<HTMLButtonElement, React.PropsWith
   testId,
   className,
   ariaLabel,
+  errorBadge,
 }, ref) {
   return <button
     ref={ref}
@@ -57,6 +59,7 @@ export const ToolbarButton = React.forwardRef<HTMLButtonElement, React.PropsWith
   >
     {icon && <span className={`codicon codicon-${icon}`} style={children ? { marginRight: 5 } : {}}></span>}
     {children}
+    {errorBadge && <span className='toolbar-button-error-badge' title={errorBadge}></span>}
   </button>;
 });
 

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -143,7 +143,7 @@ test('should filter network requests by url', async ({ runUITest, server }) => {
   await expect(networkItems.getByText('font.woff2')).toBeVisible();
 });
 
-test('should format JSON request body', async ({ runUITest, server }) => {
+test('should pretty-print JSON request body', async ({ runUITest, server }) => {
   const { page } = await runUITest({
     'network-tab.test.ts': `
       import { test, expect } from '@playwright/test';
@@ -188,14 +188,14 @@ test('should format JSON request body', async ({ runUITest, server }) => {
     '}',
   ], { useInnerText: true });
 
-  // Untoggle pretty print to see original request body
+  // Toggle off pretty print to see original request body
   await payloadPanel.getByRole('button', { name: 'Pretty print', exact: true }).click();
   await expect(payloadPanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
     '{"data":{"key":"value","array":["value-1","value-2"]}}'
   ], { useInnerText: true });
 });
 
-test('should format XML request body', async ({ runUITest, server }) => {
+test('should pretty-print XML request body', async ({ runUITest, server }) => {
   const { page } = await runUITest({
     'network-tab.test.ts': `
       import { test, expect } from '@playwright/test';
@@ -220,11 +220,67 @@ test('should format XML request body', async ({ runUITest, server }) => {
     '</note>'
   ], { useInnerText: true });
 
-  // Untoggle pretty print to see original request body
+  // Toggle off pretty print to see original request body
   await payloadPanel.getByRole('button', { name: 'Pretty print', exact: true }).click();
   await expect(payloadPanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
     '<?xml version="1.0"?><note to="Alice" from="Bob"><body>Hello &amp; welcome!</body></note>'
   ], { useInnerText: true });
+});
+
+test('should pretty-print response bodies and show formatting errors', async ({ runUITest, server }) => {
+  server.setRoute('/response-json-good', (_, res) => res.setHeader('Content-Type', 'application/json').end('{"ok":true,"items":[1,2]}'));
+  server.setRoute('/response-json-bad', (_, res) => res.setHeader('Content-Type', 'application/json').end('{"ok":true,,}'));
+
+  const { page } = await runUITest({
+    'network-tab.test.ts': `
+      import { test } from '@playwright/test';
+      test('network response tab', async ({ request }) => {
+        await Promise.all([
+          request.get('${server.PREFIX}/response-json-good'),
+          request.get('${server.PREFIX}/response-json-bad'),
+        ].map(r => r.then(res => res.text())));
+      });
+    `,
+  });
+
+  await page.getByText('network response tab').dblclick();
+  await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
+  await page.getByRole('tab', { name: 'Network' }).click();
+
+  const networkList = page.getByRole('list', { name: 'Network requests' }).getByRole('listitem');
+  const responsePanel = page.getByRole('tabpanel', { name: 'Response' });
+
+  // Pretty printed by default
+  await networkList.filter({ hasText: 'response-json-good' }).click();
+  await page.getByRole('tabpanel', { name: 'Network' }).getByRole('tab', { name: 'Response' }).click();
+  await expect(responsePanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+    '{',
+    '  "ok": true,',
+    '  "items": [',
+    '    1,',
+    '    2',
+    '  ]',
+    '}',
+  ], { useInnerText: true });
+
+  // Toggle off to see original body
+  const prettyPrint = responsePanel.getByRole('button', { name: 'Pretty print', exact: true });
+  const prettyPrintError = responsePanel.getByTitle('Formatting failed');
+  await prettyPrint.click();
+  await expect(responsePanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+    '{"ok":true,"items":[1,2]}',
+  ], { useInnerText: true });
+  await expect(prettyPrintError).toBeHidden();
+
+  // Re-enable pretty print so errors are surfaced
+  await prettyPrint.click();
+
+  // Malformed JSON shows badge and preserves original text
+  await networkList.filter({ hasText: 'response-json-bad' }).click();
+  await expect(responsePanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+    '{"ok":true,,}',
+  ], { useInnerText: true });
+  await expect(prettyPrintError).toBeVisible();
 });
 
 test('should display list of query parameters (only if present)', async ({ runUITest, server }) => {

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -187,6 +187,12 @@ test('should format JSON request body', async ({ runUITest, server }) => {
     '  }',
     '}',
   ], { useInnerText: true });
+
+  // Untoggle pretty print to see original request body
+  await payloadPanel.getByRole('button', { name: 'Pretty print', exact: true }).click();
+  await expect(payloadPanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+    '{"data":{"key":"value","array":["value-1","value-2"]}}'
+  ], { useInnerText: true });
 });
 
 test('should format XML request body', async ({ runUITest, server }) => {
@@ -212,6 +218,12 @@ test('should format XML request body', async ({ runUITest, server }) => {
     '<note to="Alice" from="Bob">',
     '    <body>Hello &amp; welcome!</body>',
     '</note>'
+  ], { useInnerText: true });
+
+  // Untoggle pretty print to see original request body
+  await payloadPanel.getByRole('button', { name: 'Pretty print', exact: true }).click();
+  await expect(payloadPanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+    '<?xml version="1.0"?><note to="Alice" from="Bob"><body>Hello &amp; welcome!</body></note>'
   ], { useInnerText: true });
 });
 
@@ -380,15 +392,9 @@ test('should copy network request', async ({ runUITest, server }) => {
   await expect(async () => {
     const playwrightRequest = await page.evaluate(() => (window as any).__clipboardCall);
     expect(playwrightRequest).toContain(`await page.request.post('${server.PREFIX}/post-data-1', {`);
-    expect(playwrightRequest.replaceAll('\r\n', '\n')).toContain(`  data: \`{
-  "data": {
-    "key": "value",
-    "array": [
-      "value-1",
-      "value-2"
-    ]
-  }
-}\``);
+    expect(playwrightRequest.replaceAll('\r\n', '\n')).toContain(
+        `  data: '{"data":{"key":"value","array":["value-1","value-2"]}}'`
+    );
     expect(playwrightRequest).toContain(`'content-type': 'application/json'`);
   }).toPass();
 });


### PR DESCRIPTION
Follow up on #39405,

- Add a button to toggle formatting for:
  - Request bodies (button in section title)
  - Response bodies (button in newly added bottom toolbar)
- If the formatting fails, we show an error badge with title on the format button
  - Copied from `uiModeView.tsx` (extracted to `ToolbarButton`)
- Remember setting option (default true) in local storage
- Got rid of  `Loading...` which in most cases just causing flickering anyway (since most bodies are fetched very quickly)
- Previously, empty bodies showed `<Empty>`, but to line up with e.g. Chrome Devtools, we now just show an empty editor to avoid confusion
- Previously, copying request would copy formatted request body, now it instead uses the original request body

| Section        | On                                                                                                                                       | Off                                                                                                                                       |
|----------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
| Request body   | <img width="613" height="192" alt="image" src="https://github.com/user-attachments/assets/f85ebf51-b4e8-442f-9b32-bbc5c2a1eb3a" /> | <img width="619" height="130" alt="image" src="https://github.com/user-attachments/assets/cce1cf6a-cd29-4da3-b1b7-a5835d68eea9" /> |
| Response body  | <img width="616" height="436" alt="image" src="https://github.com/user-attachments/assets/4b53de9a-0c3a-4c8d-9411-ff2cbc84679c" /> | <img width="623" height="449" alt="image" src="https://github.com/user-attachments/assets/bef9312b-aa02-418d-8fa3-55c774852862" /> |

If formatting fails:
<img alt="image" src="https://github.com/user-attachments/assets/900d06d4-f41b-4372-8f38-624aa7081210" width=300></img>

<details><summary>Example test to showcase this new feature</summary>
<p>

```ts
it('Request API examples: JSON and XML echo', async ({ request, server }) => {
  // JSON example
  const jsonPayload = { message: 'hello from Playwright', id: 123 };
  const jsonResp = await request.post('https://postman-echo.com/post', { data: jsonPayload });
  expect(jsonResp.ok()).toBeTruthy();

  // XML example
  const xmlPayload = `
      <note>        <to>User</to>
        <from>Playwright</from>        <heading>Reminder</heading>
        <body>Hello XML world</body>      </note>`;
  const xmlResp = await request.post('https://postman-echo.com/post', {
    headers: { 'Content-Type': 'application/xml' },
    data: xmlPayload.trim(),
  });
  expect(xmlResp.ok()).toBeTruthy();

  // Malformed XML example (unclosed <body>)
  const malformedXmlPayload = `
    <note>
      <to>User</to>
      <from>Playwright</from>
      <heading>Broken</heading>
      <body>Hello XML world</body`;
  const malformedResp = await request.post('https://postman-echo.com/post', {
    headers: { 'Content-Type': 'application/xml' },
    data: malformedXmlPayload.trim(),
  });
  // postman-echo returns 200 and echoes the body even if malformed; adjust assertion if you switch to a stricter endpoint
  expect(malformedResp.ok()).toBeTruthy();

  // Malformed JSON response example: valid JSON request body, but response body is bad JSON
  server.setRoute('/malformed-json', (req, res) => {
    res.statusCode = 200;
    res.setHeader('content-type', 'application/json');
    res.end('{"foo": "bar"'); // missing closing brace -> malformed JSON
  });

  const validJsonPayload = { ping: 'pong' };
  const malformedJsonResp = await request.post(`${server.PREFIX}/malformed-json`, { data: validJsonPayload });
  expect(malformedJsonResp.ok()).toBeTruthy();
});
```

</p>
</details> 


If we want, we can extract `useFormattedBody` and its helper functions to a separate file as suggested [here](https://github.com/microsoft/playwright/pull/39405#pullrequestreview-3918322285)?

Closes: #37963