### PR TITLE
fix(test-runner): tighten tag regex to avoid false positives from @ in test titles

### DIFF
--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -302,7 +302,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
     const path: string[] = [];
     this.parent._collectTagTitlePath(path);
     path.push(this.title);
-    const titleTags = path.join(' ').match(/@[\S]+/g) || [];
+    const titleTags = path.join(' ').match(/(?<!\w)@[\w-]+/g) || [];
     return [
       ...titleTags,
       ...this._tags,

--- a/tests/playwright-test/test-tag.spec.ts
+++ b/tests/playwright-test/test-tag.spec.ts
@@ -91,6 +91,50 @@ test('should have correct tags', async ({ runInlineTest }) => {
   ]);
 });
 
+test('should not extract false positive tags from @ in test data', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': `
+      export default class Reporter {
+        onBegin(config, suite) {
+          const visit = suite => {
+            for (const test of suite.tests || [])
+              console.log('\\n%%title=' + test.title + ', tags=' + test.tags.join(','));
+            for (const child of suite.suites || [])
+              visit(child);
+          };
+          visit(suite);
+        }
+        onError(error) {
+          console.log(error);
+        }
+      }
+    `,
+    'playwright.config.ts': `
+      module.exports = {
+        reporter: './reporter',
+      };
+    `,
+    'stdio.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('email user@example.com test', () => {
+      });
+      test('special chars @#$%^&* test', () => {
+      });
+      test('valid @smoke tag', () => {
+      });
+      test('mixed valid@invalid and @real-tag', () => {
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    `title=email user@example.com test, tags=`,
+    `title=special chars @#$%^&* test, tags=`,
+    `title=valid @smoke tag, tags=@smoke`,
+    `title=mixed valid@invalid and @real-tag, tags=@real-tag`,
+  ]);
+});
+
 test('config.grep should work', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
## Summary

The `tags` getter in `TestCase` used `/@[\S]+/g` to extract inline tags from test titles. This matched any `@` followed by non-whitespace characters, producing false positives when test titles contained `@` as part of test data (e.g., email addresses, special character strings like `@#$%^&*`).

Changed to `(?<!\w)@[\w-]+` which requires:
1. `@` is not preceded by a word character (prevents matching mid-word like `user@example`)
2. Only word characters and hyphens follow `@` (prevents matching `@#$%^&*`)

## Changes

- `packages/playwright/src/common/test.ts` - tightened regex from `/@[\S]+/g` to `/(?<!\w)@[\w-]+/g`
- `tests/playwright-test/test-tag.spec.ts` - added test verifying emails, special chars, and valid tags

## Testing

- All 9 existing tag tests pass
- New test verifies: `user@example.com` (no false positive), `@#$%^&*` (no match), `@smoke` (valid tag matched), `valid@invalid` (no false positive due to lookbehind)
- `npm run flint` passes

Fixes https://github.com/microsoft/playwright/issues/39677

This contribution was developed with AI assistance (Claude Code).