### PR TITLE
fix(npm): include JSON and skill markdown files in bundle

### DIFF
--- a/packages/playwright-core/.npmignore
+++ b/packages/playwright-core/.npmignore
@@ -10,6 +10,8 @@
 !lib/**/*.png
 !lib/**/*.svg
 !lib/**/*.ttf
+!lib/**/*.json
+!lib/skill/**/*.md
 !lib/utilsBundleImpl/xdg-open
 !lib/**/manifest.webmanifest
 # Exclude injected files. A preprocessed version of these is included via lib/generated.
@@ -37,6 +39,4 @@ lib/**/injected/
 !NOTICE
 # Include browser descriptors.
 !browsers.json
-# Include generated devices descriptors
-!deviceDescriptorsSource.json
 !ThirdPartyNotices.txt


### PR DESCRIPTION
## Summary
- Add `!lib/**/*.json` to `.npmignore` so `help.json` (and other generated JSON) is included in the published package
- Add `!lib/skill/**/*.md` so skill definition markdown files are included
- Remove redundant `deviceDescriptorsSource.json` exception (now covered by the `*.json` glob)