### PR TITLE
chore(mcp): remove unused install-browser command

### DIFF
--- a/packages/playwright-core/src/tools/mcp/cli-stub.ts
+++ b/packages/playwright-core/src/tools/mcp/cli-stub.ts
@@ -15,14 +15,9 @@
  */
 
 import { program } from '../../utilsBundle';
-import { decorateMCPCommand, decorateMCPInstallBrowserCommand } from './program';
+import { decorateMCPCommand } from './program';
 
 const packageJSON = require('../../../package.json');
 const p = program.version('Version ' + packageJSON.version).name('Playwright MCP');
 decorateMCPCommand(p);
-
-const installBrowserCommand = p.command('install-browser');
-installBrowserCommand.description('Install browser for Playwright MCP');
-decorateMCPInstallBrowserCommand(installBrowserCommand);
-
 void program.parseAsync(process.argv);

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -142,19 +142,3 @@ export function decorateMCPCommand(command: Command) {
         await mcpServer.start(factory, config.server);
       });
 }
-
-export function decorateMCPInstallBrowserCommand(command: Command) {
-  command
-      .description('ensure browsers necessary for this version of Playwright are installed')
-      .option('--with-deps', 'install system dependencies for browsers')
-      .option('--dry-run', 'do not execute installation, only print information')
-      .option('--list', 'prints list of browsers from all playwright installations')
-      .option('--force', 'force reinstall of already installed browsers')
-      .option('--only-shell', 'only install headless shell when installing chromium')
-      .option('--no-shell', 'do not install chromium headless shell')
-      .action(async options => {
-        const argv = process.argv.map(arg => arg === 'install-browser' ? 'install' : arg);
-        const { program: mainProgram } = await import('../../cli/program');
-        mainProgram.parse(argv);
-      });
-}


### PR DESCRIPTION
## Summary
- Remove `decorateMCPInstallBrowserCommand` export and the `install-browser` CLI subcommand from MCP — no longer used.