### PR TITLE
feat(android): include `chrome_devtools_remote` socket in the webview discovery

### DIFF
--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -405,14 +405,15 @@ export class AndroidDevice extends SdkObject {
   }
 
   private async _refreshWebViews() {
-    // possible socketName, eg: webview_devtools_remote_32327, webview_devtools_remote_32327_zeus, webview_devtools_remote_zeus
-    const sockets = (await this._backend.runCommand(`shell:cat /proc/net/unix | grep webview_devtools_remote`)).toString().split('\n');
+    // possible socketName, eg: chrome_devtools_remote, webview_devtools_remote_32327,
+    // webview_devtools_remote_32327_zeus, webview_devtools_remote_zeus
+    const sockets = (await this._backend.runCommand(`shell:cat /proc/net/unix | grep devtools_remote`)).toString().split('\n');
     if (this._isClosed)
       return;
 
     const socketNames = new Set<string>();
     for (const line of sockets) {
-      const matchSocketName = line.match(/[^@]+@(.*?webview_devtools_remote_?.*)/);
+      const matchSocketName = line.match(/[^@]+@((?:chrome|webview)_devtools_remote_?.*)/);
       if (!matchSocketName)
         continue;
 
@@ -423,7 +424,7 @@ export class AndroidDevice extends SdkObject {
 
       // possible line: 0000000000000000: 00000002 00000000 00010000 0001 01 5841881 @webview_devtools_remote_zeus
       // the result: match[1] = ''
-      const match = line.match(/[^@]+@.*?webview_devtools_remote_?(\d*)/);
+      const match = line.match(/[^@]+@.*?(?:chrome|webview)_devtools_remote_?(\d*)/);
       let pid = -1;
       if (match && match[1])
         pid = +match[1];


### PR DESCRIPTION
While apps usually use webview to embed a web page, many apps use a full Chrome instance for login pages like the following:
<img width="359" height="724" alt="Screenshot 2026-03-16 at 2 10 19 AM" src="https://github.com/user-attachments/assets/d0070d7e-324f-4a0e-bac7-4cf3a6d452b7" />


In such cases, we see a socket name with `chrome_devtools_remote` instead of one prefixed with `webview_devtools_remote` as the current code assumes. Example:
```bash
$ cat /proc/net/unix | grep devtools
0000000000000000: 00000002 00000000 00010000 0001 01 501922846 @chrome_devtools_remote
0000000000000000: 00000002 00000000 00010000 0001 01 501905275 @webview_devtools_remote_40812
```

This change makes the webview discovery mechanism cover those cases as well by letting users make the server attach to `chrome_devtools_remote`.

We've manually tested this change locally as well as in @limrun-inc emulators.