### PR TITLE
docs(ci): use origin/ prefix with --only-changed in GitHub Actions snippet

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -440,7 +440,7 @@ jobs:
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
     - name: Run changed Playwright tests
-      run: npx playwright test --only-changed=$GITHUB_BASE_REF
+      run: npx playwright test --only-changed=origin/$GITHUB_BASE_REF
       if: github.event_name == 'pull_request'
     - name: Run Playwright tests
       run: npx playwright test


### PR DESCRIPTION
In pull_request workflows, `actions/checkout` creates remote-tracking branches (e.g. `origin/main`) rather than local branch refs, even with `fetch-depth: 0`. Using `--only-changed=$GITHUB_BASE_REF` fails with:

```
Error: The repository is a shallow clone and does not have 'main' available locally.
```

This updates the snippet to use `origin/$GITHUB_BASE_REF` which correctly resolves the remote-tracking branch.

Fixes https://github.com/microsoft/playwright/issues/39555