### PR TITLE
test(bidi): wait for dialog to be dismissed in beforeunload test

### DIFF
--- a/tests/library/beforeunload.spec.ts
+++ b/tests/library/beforeunload.spec.ts
@@ -195,7 +195,9 @@ it('does not get stalled by beforeUnload', {
       event.preventDefault();
     });
   });
-  page.on('dialog', dialog => dialog.dismiss());
+  const dialogDismissed = new Promise<void>(resolve => {
+    page.on('dialog', dialog => dialog.dismiss().then(() => resolve()));
+  });
 
   // We have to interact with a page so that 'beforeunload' handlers
   // fire.
@@ -207,4 +209,6 @@ it('does not get stalled by beforeUnload', {
   await page.close({ runBeforeUnload: true });
 
   await page.evaluate(async () => fetch(new URL('/api', window.location.href)));
+
+  await dialogDismissed;
 });


### PR DESCRIPTION
This test throws `dialog.dismiss: Test ended.` with Firefox/Bidi on Linux (and the failure gets misattributed to another test in CI and causes other tests to be skipped).
Unlike previous attempts, this PR doesn't swallow any exceptions but waits for the dialog to be dismissed before the test ends.
