### PR TITLE
feat(mcp): add tabId support for multi-agent tab isolation

### DIFF
--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -126,6 +126,10 @@ export class Context {
     return this._tabs;
   }
 
+  tabById(tabId: string): Tab | undefined {
+    return this._tabs.find(t => t.tabId === tabId);
+  }
+
   currentTab(): Tab | undefined {
     return this._currentTab;
   }

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -90,6 +90,7 @@ type TabSnapshot = {
 };
 
 export class Tab extends EventEmitter<TabEventsInterface> {
+  readonly tabId: string;
   readonly context: Context;
   readonly page: playwright.Page;
   private _lastHeader: TabHeader = { title: 'about:blank', url: 'about:blank', current: false, console: { total: 0, warnings: 0, errors: 0 } };
@@ -108,6 +109,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
   constructor(context: Context, page: playwright.Page, onPageClose: (tab: Tab) => void) {
     super();
+    this.tabId = Math.random().toString(36).slice(2, 8);
     this.context = context;
     this.page = page;
     this._onPageClose = onPageClose;

--- a/packages/playwright-core/src/tools/backend/tabs.ts
+++ b/packages/playwright-core/src/tools/backend/tabs.ts
@@ -24,7 +24,19 @@ const browserTabs = defineTool({
   schema: {
     name: 'browser_tabs',
     title: 'Manage tabs',
-    description: 'List, create, close, or select a browser tab.',
+    description: [
+      'List, create, close, or select a browser tab.',
+      '',
+      'When opening a new tab, the response includes a `tabId` — a stable identifier for',
+      'that tab. Pass `tabId` to any other browser tool to direct its action at a specific',
+      'tab rather than whichever tab happens to be active.  This is especially useful when',
+      'multiple agents (or parallel tool calls) share the same browser session: each agent',
+      'opens its own tab, keeps its `tabId`, and never interferes with the others.',
+      '',
+      'Backward compatibility: omitting `tabId` in other tools continues to work as before,',
+      'targeting the currently active tab.',
+    ].join('
+'),
     inputSchema: z.object({
       action: z.enum(['list', 'new', 'close', 'select']).describe('Operation to perform'),
       index: z.number().optional().describe('Tab index, used for close/select. If omitted for close, current tab is closed.'),
@@ -39,8 +51,14 @@ const browserTabs = defineTool({
         break;
       }
       case 'new': {
-        await context.newTab();
-        break;
+        const tab = await context.newTab();
+        // Return the stable tabId so callers can pin subsequent tool calls to this tab.
+        response.addTextResult(`Opened new tab. tabId: ${tab.tabId}`);
+        const tabHeaders = await Promise.all(context.tabs().map(t => t.headerSnapshot()));
+        const result = renderTabsMarkdown(tabHeaders);
+        response.addTextResult(result.join('
+'));
+        return;
       }
       case 'close': {
         await context.closeTab(params.index);
@@ -55,7 +73,8 @@ const browserTabs = defineTool({
     }
     const tabHeaders = await Promise.all(context.tabs().map(tab => tab.headerSnapshot()));
     const result = renderTabsMarkdown(tabHeaders);
-    response.addTextResult(result.join('\n'));
+    response.addTextResult(result.join('
+'));
   },
 });
 

--- a/packages/playwright-core/src/tools/backend/tool.ts
+++ b/packages/playwright-core/src/tools/backend/tool.ts
@@ -71,7 +71,18 @@ export function defineTabTool<Input extends z.Schema>(tool: TabTool<Input>): Too
   return {
     ...tool,
     handle: async (context, params, response) => {
-      const tab = await context.ensureTab();
+      // If the caller provides a tabId, route to that specific tab.
+      // Otherwise fall back to the current active tab (backward compatible).
+      const tabId: string | undefined = (params as { tabId?: string }).tabId;
+      let tab: Tab;
+      if (tabId) {
+        const resolved = context.tabById(tabId);
+        if (!resolved)
+          throw new Error(`Tab "${tabId}" not found. Use browser_tabs with action "new" to open a tab and obtain its tabId.`);
+        tab = resolved;
+      } else {
+        tab = await context.ensureTab();
+      }
       const modalStates = tab.modalStates().map(state => state.type);
       if (tool.clearsModalState && !modalStates.includes(tool.clearsModalState))
         response.addError(`Error: The tool "${tool.schema.name}" can only be used when there is related modal state present.`);


### PR DESCRIPTION
## Summary

When multiple AI agents (or parallel tool calls) share a single browser session, they race for the \"current\" tab — one agent navigates while another is still reading the page, causing unpredictable failures.

This PR adds a **`tabId`** mechanism that lets each agent pin its actions to a specific tab:

```
// Agent 1 opens its own tab
const { tabId } = await browser_tabs({ action: "new" });   // returns tabId: "a3f9bc"
await browser_navigate({ tabId: "a3f9bc", url: "https://..." });

// Agent 2 works in parallel — zero interference
const { tabId: tab2 } = await browser_tabs({ action: "new" });  // tabId: "d7e201"
await browser_navigate({ tabId: "d7e201", url: "https://..." });
```

## Changes

### `packages/playwright-core/src/tools/backend/tab.ts`
- Add `readonly tabId: string` — a 6-character random alphanumeric ID generated at construction time.

### `packages/playwright-core/src/tools/backend/context.ts`
- Add `tabById(tabId: string): Tab | undefined` — look up a tab by its stable ID.

### `packages/playwright-core/src/tools/backend/tool.ts`
- Modify `defineTabTool` to read an optional `tabId` from `params`.  When present, the tool is dispatched to that tab; when absent, the existing behaviour (current active tab) is preserved.

### `packages/playwright-core/src/tools/backend/tabs.ts`
- `browser_tabs(action: "new")` now includes `tabId: <id>` in its text response so callers can capture it.
- Improve the tool description to document the multi-agent pattern.

## Backward compatibility

**Fully backward-compatible.** `tabId` is optional in every tool. Existing scripts that never pass `tabId` continue to work exactly as before — they always operate on the currently active tab.

## Related

- Closes microsoft/playwright-mcp#893
- Working implementation: https://github.com/mohammad-rj/playwright-mcp/commit/6df1b8b