### PR TITLE
Revert "fix(electron): pass port via switches not args"

### DIFF
--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -156,8 +156,8 @@ export class Electron extends SdkObject {
 
   async launch(progress: Progress, options: Omit<channels.ElectronLaunchParams, 'timeout'>): Promise<ElectronApplication> {
     let app: ElectronApplication | undefined = undefined;
-    // --inspect=0 must be the last playwright's argument, loader.ts relies on it.
-    let electronArguments = ['--inspect=0', ...(options.args || [])];
+    // --remote-debugging-port=0 must be the last playwright's argument, loader.ts relies on it.
+    let electronArguments = ['--inspect=0', '--remote-debugging-port=0', ...(options.args || [])];
 
     if (os.platform() === 'linux') {
       if (!options.chromiumSandbox && electronArguments.indexOf('--no-sandbox') === -1)

--- a/packages/playwright-core/src/server/electron/loader.ts
+++ b/packages/playwright-core/src/server/electron/loader.ts
@@ -21,9 +21,7 @@ const { chromiumSwitches } = require('../chromium/chromiumSwitches');
 // Always pass user arguments first, see https://github.com/microsoft/playwright/issues/16614 and
 // https://github.com/microsoft/playwright/issues/29198.
 // [Electron, -r, loader.js[, --no-sandbox>], --inspect=0, --remote-debugging-port=0, ...args]
-process.argv.splice(1, process.argv.indexOf('--inspect=0'));
-
-app.commandLine.appendSwitch('remote-debugging-port', '0');
+process.argv.splice(1, process.argv.indexOf('--remote-debugging-port=0'));
 
 for (const arg of chromiumSwitches()) {
   const match = arg.match(/--([^=]*)=?(.*)/)!;


### PR DESCRIPTION
Reverts microsoft/playwright#39012

We are actually getting 0 complaints about the behavior on 1.58, while we see it regress in new Electrons (VS Code that is using Electron 39 does not work with the new way).