### PR TITLE
fix(cli): correct mousewheel delta mapping

### DIFF
--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -212,11 +212,11 @@ const mouseWheel = declareCommand({
   description: 'Scroll mouse wheel',
   category: 'mouse',
   args: z.object({
-    dx: numberArg.describe('Y delta'),
-    dy: numberArg.describe('X delta'),
+    dx: numberArg.describe('X delta'),
+    dy: numberArg.describe('Y delta'),
   }),
   toolName: 'browser_mouse_wheel',
-  toolParams: ({ dx: deltaY, dy: deltaX }) => ({ deltaY, deltaX }),
+  toolParams: ({ dx: deltaX, dy: deltaY }) => ({ deltaX, deltaY }),
 });
 
 // Core

--- a/tests/mcp/cli-mouse.spec.ts
+++ b/tests/mcp/cli-mouse.spec.ts
@@ -45,5 +45,5 @@ test('mousewheel', async ({ cli, server }) => {
 
   await cli('mousewheel', '10', '5');
 
-  await expect.poll(() => cli('snapshot').then(result => result.snapshot)).toContain('wheel 5 10');
+  await expect.poll(() => cli('snapshot').then(result => result.snapshot)).toContain('wheel 10 5');
 });


### PR DESCRIPTION
## Summary
- correct 'playwright-cli mousewheel dx dy' 
- align CLI behavior with 'page.mouse.wheel(deltaX, deltaY)'yep

Fixed #39715