### PR TITLE
docs: document promise unwrapping

### DIFF
--- a/docs/src/api/class-genericassertions.md
+++ b/docs/src/api/class-genericassertions.md
@@ -28,6 +28,34 @@ const value = 1;
 expect(value).not.toBe(2);
 ```
 
+## property: GenericAssertions.resolves
+* since: v1.9
+- returns: <[GenericAssertions]>
+
+Use `resolves` to unwrap the value of a fulfilled promise so any other matcher can be chained. If the promise is rejected the assertion fails.
+
+For example, this code tests that the promise resolves and that the resulting value is `'lemon'`:
+
+```js
+test('resolves to lemon', async () => {
+  await expect(Promise.resolve('lemon')).resolves.toBe('lemon');
+});
+```
+
+## property: GenericAssertions.rejects
+* since: v1.9
+- returns: <[GenericAssertions]>
+
+Use `.rejects` to unwrap the reason of a rejected promise so any other matcher can be chained. If the promise is fulfilled the assertion fails.
+
+For example, this code tests that the promise rejects with reason `'octopus'`:
+
+```js
+test('rejects to octopus', async () => {
+  await expect(Promise.reject(new Error('octopus'))).rejects.toThrow('octopus');
+});
+```
+
 
 ## method: GenericAssertions.toBe
 * since: v1.9

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -7916,6 +7916,34 @@ interface GenericAssertions<R> {
    */
   not: GenericAssertions<R>;
   /**
+   * Use `resolves` to unwrap the value of a fulfilled promise so any other matcher can be chained. If the promise is
+   * rejected the assertion fails.
+   *
+   * For example, this code tests that the promise resolves and that the resulting value is `'lemon'`:
+   *
+   * ```js
+   * test('resolves to lemon', async () => {
+   *   await expect(Promise.resolve('lemon')).resolves.toBe('lemon');
+   * });
+   * ```
+   *
+   */
+  resolves: GenericAssertions<R>;
+  /**
+   * Use `.rejects` to unwrap the reason of a rejected promise so any other matcher can be chained. If the promise is
+   * fulfilled the assertion fails.
+   *
+   * For example, this code tests that the promise rejects with reason `'octopus'`:
+   *
+   * ```js
+   * test('rejects to octopus', async () => {
+   *   await expect(Promise.reject(new Error('octopus'))).rejects.toThrow('octopus');
+   * });
+   * ```
+   *
+   */
+  rejects: GenericAssertions<R>;
+  /**
    * Compares value with
    * [`expected`](https://playwright.dev/docs/api/class-genericassertions#generic-assertions-to-be-option-expected) by
    * calling `Object.is`. This method compares objects by reference instead of their contents, similarly to the strict

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -332,6 +332,8 @@ interface AsymmetricMatchers {
 
 interface GenericAssertions<R> {
   not: GenericAssertions<R>;
+  resolves: GenericAssertions<R>;
+  rejects: GenericAssertions<R>;
   toBe(expected: unknown): R;
   toBeCloseTo(expected: number, numDigits?: number): R;
   toBeDefined(): R;


### PR DESCRIPTION
fixes #39027

Inspired by similar Jest's modifiers [`.resolves`](https://jestjs.io/docs/expect#resolves)/[`.rejects`](https://jestjs.io/docs/expect#rejects).

- [x] Double check proper version
- [x] Double check return type
- [x] Maybe a guide like Jest  ["Testing Asynchronous Code - `.resolves`/`.rejects`"](https://jestjs.io/docs/asynchronous#resolves--rejects) guide would be desireable as well