### PR TITLE
feat(mcp): add tabId support for multi-agent tab isolation

### DIFF
--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -126,6 +126,10 @@ export class Context {
     return this._tabs;
   }
 
+  tabById(tabId: string): Tab | undefined {
+    return this._tabs.find(t => t.tabId === tabId);
+  }
+
   currentTab(): Tab | undefined {
     return this._currentTab;
   }

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -90,6 +90,7 @@ type TabSnapshot = {
 };
 
 export class Tab extends EventEmitter<TabEventsInterface> {
+  readonly tabId: string;
   readonly context: Context;
   readonly page: playwright.Page;
   private _lastHeader: TabHeader = { title: 'about:blank', url: 'about:blank', current: false, console: { total: 0, warnings: 0, errors: 0 } };
@@ -108,6 +109,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
   constructor(context: Context, page: playwright.Page, onPageClose: (tab: Tab) => void) {
     super();
+    this.tabId = Math.random().toString(36).slice(2, 8);
     this.context = context;
     this.page = page;
     this._onPageClose = onPageClose;

--- a/packages/playwright-core/src/tools/backend/tabs.ts
+++ b/packages/playwright-core/src/tools/backend/tabs.ts
@@ -39,7 +39,8 @@ const browserTabs = defineTool({
         break;
       }
       case 'new': {
-        await context.newTab();
+        const tab = await context.newTab();
+        response.addTextResult(`tabId: ${tab.tabId}`);
         break;
       }
       case 'close': {

--- a/packages/playwright-core/src/tools/backend/tool.ts
+++ b/packages/playwright-core/src/tools/backend/tool.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { z } from 'zod';
+import { z } from '../../mcpBundle';
 import type { Context } from './context';
 import type * as playwright from '../../..';
 import type { Tab } from './tab';
@@ -67,11 +67,24 @@ export type TabTool<Input extends z.Schema = z.Schema> = {
   handle: (tab: Tab, params: z.output<Input>, response: Response) => Promise<void>;
 };
 
-export function defineTabTool<Input extends z.Schema>(tool: TabTool<Input>): Tool<Input> {
+const tabIdSchema = z.string().optional().describe('Tab ID to target a specific tab, obtained from browser_tabs({ action: "new" }).');
+
+export function defineTabTool<Input extends z.ZodObject<z.ZodRawShape>>(tool: TabTool<Input>): Tool<Input> {
+  const inputSchema = tool.schema.inputSchema.extend({ tabId: tabIdSchema }) as unknown as Input;
   return {
     ...tool,
+    schema: { ...tool.schema, inputSchema },
     handle: async (context, params, response) => {
-      const tab = await context.ensureTab();
+      const tabId = (params as { tabId?: string }).tabId;
+      let tab: Tab;
+      if (tabId) {
+        const found = context.tabById(tabId);
+        if (!found)
+          throw new Error(`Tab "${tabId}" not found`);
+        tab = found;
+      } else {
+        tab = await context.ensureTab();
+      }
       const modalStates = tab.modalStates().map(state => state.type);
       if (tool.clearsModalState && !modalStates.includes(tool.clearsModalState))
         response.addError(`Error: The tool "${tool.schema.name}" can only be used when there is related modal state present.`);

--- a/tests/mcp/tabs.spec.ts
+++ b/tests/mcp/tabs.spec.ts
@@ -127,6 +127,66 @@ test('close tab', async ({ client }) => {
   });
 });
 
+test('new tab action returns tabId', async ({ client }) => {
+  const result = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'new' },
+  });
+  const text = result.content[0].text;
+  expect(text).toMatch(/tabId: [a-z0-9]+/);
+});
+
+test('route tool call to specific tab using tabId', async ({ client }) => {
+  // Open tab A, navigate to page A
+  const tabAResult = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'new' },
+  });
+  const tabAId = tabAResult.content[0].text.match(/tabId: ([a-z0-9]+)/)?.[1]!;
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: 'data:text/html,<title>Tab A</title>' },
+  });
+
+  // Open tab B, navigate to page B (tab B is now current)
+  const tabBResult = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'new' },
+  });
+  const tabBId = tabBResult.content[0].text.match(/tabId: ([a-z0-9]+)/)?.[1]!;
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: 'data:text/html,<title>Tab B</title>' },
+  });
+
+  // Evaluate on tab A using its tabId — current tab is still tab B
+  const evalResult = await client.callTool({
+    name: 'browser_evaluate',
+    arguments: { expression: 'document.title', tabId: tabAId },
+  });
+  expect(evalResult.content[0].text).toContain('Tab A');
+
+  // Evaluate on tab B using its tabId
+  const evalResultB = await client.callTool({
+    name: 'browser_evaluate',
+    arguments: { expression: 'document.title', tabId: tabBId },
+  });
+  expect(evalResultB.content[0].text).toContain('Tab B');
+});
+
+test('error on unknown tabId', async ({ client }) => {
+  await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'new' },
+  });
+  const result = await client.callTool({
+    name: 'browser_evaluate',
+    arguments: { expression: 'document.title', tabId: 'notexist' },
+  });
+  expect(result.isError).toBe(true);
+  expect(result.content[0].text).toContain('Tab "notexist" not found');
+});
+
 test('reuse first tab when navigating', async ({ startClient, cdpServer, server }) => {
   const browserContext = await cdpServer.start();
   const pages = browserContext.pages();


### PR DESCRIPTION
## Problem

When multiple AI agents (e.g. separate Claude Code tabs) share one Playwright MCP server, they can accidentally interfere with each other — one agent's `browser_navigate` affects the tab another agent is working on.

## Solution

Add a `tabId` to each tab, returned when creating a new tab via `browser_tabs`. All tab-aware tools accept an optional `tabId` parameter to route the action to a specific tab.

**Use case:** One shared Chrome session (shared cookies, history, single process) with multiple agents each owning a dedicated tab — vs. running two separate browser processes.

### How it works

- `Tab` gets a readonly `tabId: string` (6-char random, e.g. `"a3f7k2"`)
- `browser_tabs({ action: "new" })` returns `tabId: <id>`
- All tab-aware tools accept optional `tabId` — if omitted, falls back to `context.ensureTab()` (existing behaviour, no breaking change)
- `Context.tabById()` routes the call to the correct tab

## Changes

- `tab.ts` — add `readonly tabId: string`
- `context.ts` — add `tabById(id)` method
- `tabs.ts` — return `tabId` on `new` action
- `tool.ts` — route via `tabId` in `defineTabTool` when provided
- `tests/mcp/tabs.spec.ts` — tests for tabId creation and routing

## Backwards compatibility

Fully backwards compatible — `tabId` is optional. Existing single-agent usage is unaffected.