### PR TITLE
fix(emulation): sync navigator.platform with custom user agent across all browsers

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -821,10 +821,6 @@ export function normalizeProxySettings(proxy: types.ProxySettings): types.ProxyS
   return { ...proxy, server, bypass };
 }
 
-// Computes user-agent emulation parameters from BrowserContextOptions.
-// Returns userAgentMetadata (Chromium CDP struct) and navigatorPlatform for
-// syncing navigator.platform with the emulated user agent across all three browsers.
-// Set PLAYWRIGHT_NO_UA_PLATFORM=1 to opt out of the platform sync.
 // Chromium reference: https://source.chromium.org/chromium/chromium/src/+/main:components/embedder_support/user_agent_utils.cc;l=434
 export function calculateUserAgentEmulation(options: types.BrowserContextOptions): {
   navigatorPlatform: string | undefined;
@@ -880,7 +876,7 @@ export function calculateUserAgentEmulation(options: types.BrowserContextOptions
     userAgentMetadata.architecture = 'arm';
 
   let navigatorPlatform: string | undefined;
-  if (!process.env['PLAYWRIGHT_NO_UA_PLATFORM']) {
+  if (!process.env.PLAYWRIGHT_NO_UA_PLATFORM) {
     switch (userAgentMetadata.platform) {
       case 'Android': navigatorPlatform = userAgentMetadata.architecture === 'arm' ? 'Linux armv8l' : 'Linux x86_64'; break;
       case 'iOS': navigatorPlatform = ua.includes('iPad') ? 'iPad' : 'iPhone'; break;

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -821,25 +821,76 @@ export function normalizeProxySettings(proxy: types.ProxySettings): types.ProxyS
   return { ...proxy, server, bypass };
 }
 
-// Maps a user agent string to the corresponding navigator.platform value.
-// Used by Firefox and WebKit; Chromium uses its own navigatorPlatform()
-// in crPage.ts which operates on already-parsed UserAgentMetadata.
-export function navigatorPlatformFromUA(ua: string): string | undefined {
+// Computes user-agent emulation parameters from BrowserContextOptions.
+// Returns userAgentMetadata (Chromium CDP struct) and navigatorPlatform for
+// syncing navigator.platform with the emulated user agent across all three browsers.
+// Set PLAYWRIGHT_NO_UA_PLATFORM=1 to opt out of the platform sync.
+// Chromium reference: https://source.chromium.org/chromium/chromium/src/+/main:components/embedder_support/user_agent_utils.cc;l=434
+export function calculateUserAgentEmulation(options: types.BrowserContextOptions): {
+  navigatorPlatform: string | undefined;
+  userAgentMetadata: {
+    mobile: boolean;
+    model: string;
+    architecture: string;
+    platform: string;
+    platformVersion: string;
+  } | undefined;
+} {
+  const ua = options.userAgent;
   if (!ua)
-    return undefined;
-  if (ua.includes('Android'))
-    return ua.includes('x86') ? 'Linux x86_64' : 'Linux armv8l';
-  if (ua.includes('iPhone OS'))
-    return 'iPhone';
-  if (ua.includes('iPad'))
-    return 'iPad';
-  if (ua.includes('Mac OS X'))
-    return 'MacIntel';
-  if (ua.includes('Windows'))
-    return 'Win32';
-  if (ua.toLowerCase().includes('linux'))
-    return ua.includes('aarch64') ? 'Linux aarch64' : 'Linux x86_64';
-  return undefined;
+    return { navigatorPlatform: undefined, userAgentMetadata: undefined };
+
+  const userAgentMetadata = {
+    mobile: !!options.isMobile,
+    model: '',
+    architecture: 'x86',
+    platform: 'Windows',
+    platformVersion: '',
+  };
+
+  const androidMatch = ua.match(/Android (\d+(\.\d+)?(\.\d+)?)/);
+  const iPhoneMatch = ua.match(/iPhone OS (\d+(_\d+)?)/);
+  const iPadMatch = ua.match(/iPad; CPU OS (\d+(_\d+)?)/);
+  const macOSMatch = ua.match(/Mac OS X (\d+(_\d+)?(_\d+)?)/);
+  const windowsMatch = ua.match(/Windows\D+(\d+(\.\d+)?(\.\d+)?)/);
+  if (androidMatch) {
+    userAgentMetadata.platform = 'Android';
+    userAgentMetadata.platformVersion = androidMatch[1];
+    userAgentMetadata.architecture = 'arm';
+  } else if (iPhoneMatch) {
+    userAgentMetadata.platform = 'iOS';
+    userAgentMetadata.platformVersion = iPhoneMatch[1];
+    userAgentMetadata.architecture = 'arm';
+  } else if (iPadMatch) {
+    userAgentMetadata.platform = 'iOS';
+    userAgentMetadata.platformVersion = iPadMatch[1];
+    userAgentMetadata.architecture = 'arm';
+  } else if (macOSMatch) {
+    userAgentMetadata.platform = 'macOS';
+    userAgentMetadata.platformVersion = macOSMatch[1];
+    if (!ua.includes('Intel'))
+      userAgentMetadata.architecture = 'arm';
+  } else if (windowsMatch) {
+    userAgentMetadata.platform = 'Windows';
+    userAgentMetadata.platformVersion = windowsMatch[1];
+  } else if (ua.toLowerCase().includes('linux')) {
+    userAgentMetadata.platform = 'Linux';
+  }
+  if (ua.includes('ARM') || ua.includes('aarch64'))
+    userAgentMetadata.architecture = 'arm';
+
+  let navigatorPlatform: string | undefined;
+  if (!process.env['PLAYWRIGHT_NO_UA_PLATFORM']) {
+    switch (userAgentMetadata.platform) {
+      case 'Android': navigatorPlatform = userAgentMetadata.architecture === 'arm' ? 'Linux armv8l' : 'Linux x86_64'; break;
+      case 'iOS': navigatorPlatform = ua.includes('iPad') ? 'iPad' : 'iPhone'; break;
+      case 'macOS': navigatorPlatform = 'MacIntel'; break;
+      case 'Linux': navigatorPlatform = userAgentMetadata.architecture === 'arm' ? 'Linux aarch64' : 'Linux x86_64'; break;
+      case 'Windows': navigatorPlatform = 'Win32'; break;
+    }
+  }
+
+  return { navigatorPlatform, userAgentMetadata };
 }
 
 const paramsThatAllowContextReuse: (keyof channels.BrowserNewContextForReuseParams)[] = [

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -855,15 +855,15 @@ export function calculateUserAgentEmulation(options: types.BrowserContextOptions
     userAgentMetadata.architecture = 'arm';
   } else if (iPhoneMatch) {
     userAgentMetadata.platform = 'iOS';
-    userAgentMetadata.platformVersion = iPhoneMatch[1];
+    userAgentMetadata.platformVersion = iPhoneMatch[1].replace(/_/g, '.');
     userAgentMetadata.architecture = 'arm';
   } else if (iPadMatch) {
     userAgentMetadata.platform = 'iOS';
-    userAgentMetadata.platformVersion = iPadMatch[1];
+    userAgentMetadata.platformVersion = iPadMatch[1].replace(/_/g, '.');
     userAgentMetadata.architecture = 'arm';
   } else if (macOSMatch) {
     userAgentMetadata.platform = 'macOS';
-    userAgentMetadata.platformVersion = macOSMatch[1];
+    userAgentMetadata.platformVersion = macOSMatch[1].replace(/_/g, '.');
     if (!ua.includes('Intel'))
       userAgentMetadata.architecture = 'arm';
   } else if (windowsMatch) {

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -821,6 +821,27 @@ export function normalizeProxySettings(proxy: types.ProxySettings): types.ProxyS
   return { ...proxy, server, bypass };
 }
 
+// Maps a user agent string to the corresponding navigator.platform value.
+// Used by Firefox and WebKit; Chromium uses its own navigatorPlatform()
+// in crPage.ts which operates on already-parsed UserAgentMetadata.
+export function navigatorPlatformFromUA(ua: string): string | undefined {
+  if (!ua)
+    return undefined;
+  if (ua.includes('Android'))
+    return ua.includes('x86') ? 'Linux x86_64' : 'Linux armv8l';
+  if (ua.includes('iPhone OS'))
+    return 'iPhone';
+  if (ua.includes('iPad'))
+    return 'iPad';
+  if (ua.includes('Mac OS X'))
+    return 'MacIntel';
+  if (ua.includes('Windows'))
+    return 'Win32';
+  if (ua.toLowerCase().includes('linux'))
+    return ua.includes('aarch64') ? 'Linux aarch64' : 'Linux x86_64';
+  return undefined;
+}
+
 const paramsThatAllowContextReuse: (keyof channels.BrowserNewContextForReuseParams)[] = [
   'colorScheme',
   'forcedColors',

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -988,10 +988,13 @@ class FrameSession {
 
   async _updateUserAgent(): Promise<void> {
     const options = this._crPage._browserContext._options;
+    const userAgentMetadata = calculateUserAgentMetadata(options);
+    const emulateUAPlatform = !process.env.PLAYWRIGHT_NO_UA_PLATFORM;
     await this._client.send('Emulation.setUserAgentOverride', {
       userAgent: options.userAgent || '',
       acceptLanguage: options.locale,
-      userAgentMetadata: calculateUserAgentMetadata(options),
+      platform: emulateUAPlatform && userAgentMetadata ? navigatorPlatform(userAgentMetadata, options.userAgent || '') : undefined,
+      userAgentMetadata,
     });
   }
 
@@ -1199,7 +1202,18 @@ function calculateUserAgentMetadata(options: types.BrowserContextOptions) {
   } else if (ua.toLowerCase().includes('linux')) {
     metadata.platform = 'Linux';
   }
-  if (ua.includes('ARM'))
+  if (ua.includes('ARM') || ua.includes('aarch64'))
     metadata.architecture = 'arm';
   return metadata;
+}
+
+function navigatorPlatform(metadata: Protocol.Emulation.UserAgentMetadata, ua: string): string {
+  switch (metadata.platform) {
+    case 'Android': return metadata.architecture === 'arm' ? 'Linux armv8l' : 'Linux x86_64';
+    case 'iOS': return ua.includes('iPad') ? 'iPad' : 'iPhone';
+    case 'macOS': return 'MacIntel';
+    case 'Linux': return metadata.architecture === 'arm' ? 'Linux aarch64' : 'Linux x86_64';
+    case 'Windows': return 'Win32';
+    default: return metadata.platform;
+  }
 }

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -24,6 +24,7 @@ import * as frames from '../frames';
 import { helper } from '../helper';
 import * as network from '../network';
 import { Page, PageBinding, Worker } from '../page';
+import { calculateUserAgentEmulation } from '../browserContext';
 import { CRBrowserContext } from './crBrowser';
 import { CRCoverage } from './crCoverage';
 import { DragManager } from './crDragDrop';
@@ -988,12 +989,11 @@ class FrameSession {
 
   async _updateUserAgent(): Promise<void> {
     const options = this._crPage._browserContext._options;
-    const userAgentMetadata = calculateUserAgentMetadata(options);
-    const emulateUAPlatform = !process.env.PLAYWRIGHT_NO_UA_PLATFORM;
+    const { navigatorPlatform, userAgentMetadata } = calculateUserAgentEmulation(options);
     await this._client.send('Emulation.setUserAgentOverride', {
       userAgent: options.userAgent || '',
       acceptLanguage: options.locale,
-      platform: emulateUAPlatform && userAgentMetadata ? navigatorPlatform(userAgentMetadata, options.userAgent || '') : undefined,
+      platform: navigatorPlatform,
       userAgentMetadata,
     });
   }
@@ -1159,61 +1159,5 @@ async function emulateTimezone(session: CRSession, timezoneId: string) {
     if (exception.message.includes('Invalid timezone'))
       throw new Error(`Invalid timezone ID: ${timezoneId}`);
     throw exception;
-  }
-}
-
-// Chromium reference: https://source.chromium.org/chromium/chromium/src/+/main:components/embedder_support/user_agent_utils.cc;l=434;drc=70a6711e08e9f9e0d8e4c48e9ba5cab62eb010c2
-function calculateUserAgentMetadata(options: types.BrowserContextOptions) {
-  const ua = options.userAgent;
-  if (!ua)
-    return undefined;
-  const metadata: Protocol.Emulation.UserAgentMetadata = {
-    mobile: !!options.isMobile,
-    model: '',
-    architecture: 'x86',
-    platform: 'Windows',
-    platformVersion: '',
-  };
-  const androidMatch = ua.match(/Android (\d+(\.\d+)?(\.\d+)?)/);
-  const iPhoneMatch = ua.match(/iPhone OS (\d+(_\d+)?)/);
-  const iPadMatch = ua.match(/iPad; CPU OS (\d+(_\d+)?)/);
-  const macOSMatch = ua.match(/Mac OS X (\d+(_\d+)?(_\d+)?)/);
-  const windowsMatch = ua.match(/Windows\D+(\d+(\.\d+)?(\.\d+)?)/);
-  if (androidMatch) {
-    metadata.platform = 'Android';
-    metadata.platformVersion = androidMatch[1];
-    metadata.architecture = 'arm';
-  } else if (iPhoneMatch) {
-    metadata.platform = 'iOS';
-    metadata.platformVersion = iPhoneMatch[1];
-    metadata.architecture = 'arm';
-  } else if (iPadMatch) {
-    metadata.platform = 'iOS';
-    metadata.platformVersion = iPadMatch[1];
-    metadata.architecture = 'arm';
-  } else if (macOSMatch) {
-    metadata.platform = 'macOS';
-    metadata.platformVersion = macOSMatch[1];
-    if (!ua.includes('Intel'))
-      metadata.architecture = 'arm';
-  } else if (windowsMatch) {
-    metadata.platform = 'Windows';
-    metadata.platformVersion = windowsMatch[1];
-  } else if (ua.toLowerCase().includes('linux')) {
-    metadata.platform = 'Linux';
-  }
-  if (ua.includes('ARM') || ua.includes('aarch64'))
-    metadata.architecture = 'arm';
-  return metadata;
-}
-
-function navigatorPlatform(metadata: Protocol.Emulation.UserAgentMetadata, ua: string): string {
-  switch (metadata.platform) {
-    case 'Android': return metadata.architecture === 'arm' ? 'Linux armv8l' : 'Linux x86_64';
-    case 'iOS': return ua.includes('iPad') ? 'iPad' : 'iPhone';
-    case 'macOS': return 'MacIntel';
-    case 'Linux': return metadata.architecture === 'arm' ? 'Linux aarch64' : 'Linux x86_64';
-    case 'Windows': return 'Win32';
-    default: return metadata.platform;
   }
 }

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -17,7 +17,7 @@
 
 import { assert } from '../../utils';
 import { Browser } from '../browser';
-import { BrowserContext, verifyGeolocation } from '../browserContext';
+import { BrowserContext, navigatorPlatformFromUA, verifyGeolocation } from '../browserContext';
 import * as network from '../network';
 import { ConnectionEvents, FFConnection  } from './ffConnection';
 import { FFPage } from './ffPage';
@@ -191,6 +191,10 @@ export class FFBrowserContext extends BrowserContext {
       promises.push(this._browser.session.send('Browser.setTouchOverride', { browserContextId, hasTouch: true }));
     if (this._options.userAgent)
       promises.push(this._browser.session.send('Browser.setUserAgentOverride', { browserContextId, userAgent: this._options.userAgent }));
+    if (this._options.userAgent && !process.env.PLAYWRIGHT_NO_UA_PLATFORM) {
+      const platform = navigatorPlatformFromUA(this._options.userAgent);
+      promises.push(this._browser.session.send('Browser.setPlatformOverride', { browserContextId, platform: platform || null }));
+    }
     if (this._options.bypassCSP)
       promises.push(this._browser.session.send('Browser.setBypassCSP', { browserContextId, bypassCSP: true }));
     if (this._options.ignoreHTTPSErrors || this._options.internalIgnoreHTTPSErrors)
@@ -325,6 +329,8 @@ export class FFBrowserContext extends BrowserContext {
 
   async setUserAgent(userAgent: string | undefined): Promise<void> {
     await this._browser.session.send('Browser.setUserAgentOverride', { browserContextId: this._browserContextId, userAgent: userAgent || null });
+    const platform = userAgent && !process.env.PLAYWRIGHT_NO_UA_PLATFORM ? navigatorPlatformFromUA(userAgent) : null;
+    await this._browser.session.send('Browser.setPlatformOverride', { browserContextId: this._browserContextId, platform: platform || null });
   }
 
   async doUpdateOffline(): Promise<void> {

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -17,7 +17,7 @@
 
 import { assert } from '../../utils';
 import { Browser } from '../browser';
-import { BrowserContext, navigatorPlatformFromUA, verifyGeolocation } from '../browserContext';
+import { BrowserContext, calculateUserAgentEmulation, verifyGeolocation } from '../browserContext';
 import * as network from '../network';
 import { ConnectionEvents, FFConnection  } from './ffConnection';
 import { FFPage } from './ffPage';
@@ -189,11 +189,10 @@ export class FFBrowserContext extends BrowserContext {
     promises.push(this.doUpdateDefaultViewport());
     if (this._options.hasTouch)
       promises.push(this._browser.session.send('Browser.setTouchOverride', { browserContextId, hasTouch: true }));
-    if (this._options.userAgent)
+    if (this._options.userAgent) {
       promises.push(this._browser.session.send('Browser.setUserAgentOverride', { browserContextId, userAgent: this._options.userAgent }));
-    if (this._options.userAgent && !process.env.PLAYWRIGHT_NO_UA_PLATFORM) {
-      const platform = navigatorPlatformFromUA(this._options.userAgent);
-      promises.push(this._browser.session.send('Browser.setPlatformOverride', { browserContextId, platform: platform || null }));
+      const { navigatorPlatform } = calculateUserAgentEmulation(this._options);
+      promises.push(this._browser.session.send('Browser.setPlatformOverride', { browserContextId, platform: navigatorPlatform || null }));
     }
     if (this._options.bypassCSP)
       promises.push(this._browser.session.send('Browser.setBypassCSP', { browserContextId, bypassCSP: true }));
@@ -329,8 +328,8 @@ export class FFBrowserContext extends BrowserContext {
 
   async setUserAgent(userAgent: string | undefined): Promise<void> {
     await this._browser.session.send('Browser.setUserAgentOverride', { browserContextId: this._browserContextId, userAgent: userAgent || null });
-    const platform = userAgent && !process.env.PLAYWRIGHT_NO_UA_PLATFORM ? navigatorPlatformFromUA(userAgent) : null;
-    await this._browser.session.send('Browser.setPlatformOverride', { browserContextId: this._browserContextId, platform: platform || null });
+    const { navigatorPlatform } = calculateUserAgentEmulation({ userAgent });
+    await this._browser.session.send('Browser.setPlatformOverride', { browserContextId: this._browserContextId, platform: navigatorPlatform || null });
   }
 
   async doUpdateOffline(): Promise<void> {

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -21,7 +21,7 @@ import { eventsHelper } from '../utils/eventsHelper';
 import { hostPlatform } from '../utils/hostPlatform';
 import { splitErrorMessage } from '../../utils/isomorphic/stackTrace';
 import { PNG, jpegjs } from '../../utilsBundle';
-import { navigatorPlatformFromUA } from '../browserContext';
+import { calculateUserAgentEmulation } from '../browserContext';
 import * as dialog from '../dialog';
 import * as dom from '../dom';
 import { TargetClosedError } from '../errors';
@@ -692,12 +692,8 @@ export class WKPage implements PageDelegate {
   async updateUserAgent(): Promise<void> {
     const contextOptions = this._browserContext._options;
     this._updateState('Page.overrideUserAgent', { value: contextOptions.userAgent });
-    if (contextOptions.userAgent && !process.env.PLAYWRIGHT_NO_UA_PLATFORM) {
-      const platform = navigatorPlatformFromUA(contextOptions.userAgent);
-      this._updateState('Page.overridePlatform', platform ? { value: platform } : { });
-    } else {
-      this._updateState('Page.overridePlatform', { });
-    }
+    const { navigatorPlatform } = calculateUserAgentEmulation(contextOptions);
+    this._updateState('Page.overridePlatform', navigatorPlatform ? { value: navigatorPlatform } : { });
   }
 
   async bringToFront(): Promise<void> {

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -21,6 +21,7 @@ import { eventsHelper } from '../utils/eventsHelper';
 import { hostPlatform } from '../utils/hostPlatform';
 import { splitErrorMessage } from '../../utils/isomorphic/stackTrace';
 import { PNG, jpegjs } from '../../utilsBundle';
+import { navigatorPlatformFromUA } from '../browserContext';
 import * as dialog from '../dialog';
 import * as dom from '../dom';
 import { TargetClosedError } from '../errors';
@@ -691,6 +692,12 @@ export class WKPage implements PageDelegate {
   async updateUserAgent(): Promise<void> {
     const contextOptions = this._browserContext._options;
     this._updateState('Page.overrideUserAgent', { value: contextOptions.userAgent });
+    if (contextOptions.userAgent && !process.env.PLAYWRIGHT_NO_UA_PLATFORM) {
+      const platform = navigatorPlatformFromUA(contextOptions.userAgent);
+      this._updateState('Page.overridePlatform', platform ? { value: platform } : { });
+    } else {
+      this._updateState('Page.overridePlatform', { });
+    }
   }
 
   async bringToFront(): Promise<void> {

--- a/tests/library/browsercontext-user-agent.spec.ts
+++ b/tests/library/browsercontext-user-agent.spec.ts
@@ -107,6 +107,38 @@ it('custom user agent for download', async ({ server, contextFactory, browserVer
   expect(req.headers['user-agent']).toBe('MyCustomUA');
 });
 
+it('should override navigator.platform to match custom user agent', async ({ browser, server }) => {
+  {
+    const context = await browser.newContext({
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    });
+    const page = await context.newPage();
+    await page.goto(server.EMPTY_PAGE);
+    expect.soft(await page.evaluate(() => navigator.platform)).toBe('Win32');
+    await context.close();
+  }
+
+  {
+    const context = await browser.newContext({
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    });
+    const page = await context.newPage();
+    await page.goto(server.EMPTY_PAGE);
+    expect.soft(await page.evaluate(() => navigator.platform)).toBe('MacIntel');
+    await context.close();
+  }
+
+  {
+    const context = await browser.newContext({
+      userAgent: 'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+    });
+    const page = await context.newPage();
+    await page.goto(server.EMPTY_PAGE);
+    expect.soft(await page.evaluate(() => navigator.platform)).toBe('Linux armv8l');
+    await context.close();
+  }
+});
+
 it('should work for navigator.userAgentData and sec-ch-ua headers', async ({ playwright, browserName, browser, server }) => {
   it.skip(browserName !== 'chromium', 'This API is Chromium-only');
 
@@ -139,6 +171,35 @@ it('should work for navigator.userAgentData and sec-ch-ua headers', async ({ pla
     expect.soft(await page.evaluate(() => (window.navigator as any).userAgentData.toJSON())).toEqual(
         expect.objectContaining({ mobile: true, platform: 'Android' })
     );
+    expect.soft(await page.evaluate(() => navigator.platform)).toBe('Linux armv8l');
+    await context.close();
+  }
+
+  {
+    const context = await browser.newContext(playwright.devices['Desktop Chrome']);
+    const page = await context.newPage();
+    const [request] = await Promise.all([
+      server.waitForRequest('/empty.html'),
+      page.goto(server.EMPTY_PAGE),
+    ]);
+    expect.soft(request.headers['sec-ch-ua-platform']).toBe(`"Windows"`);
+    expect.soft(await page.evaluate(() => (window.navigator as any).userAgentData.toJSON())).toEqual(
+        expect.objectContaining({ mobile: false, platform: 'Windows' })
+    );
+    expect.soft(await page.evaluate(() => navigator.platform)).toBe('Win32');
+    await context.close();
+  }
+
+  {
+    const context = await browser.newContext({
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    });
+    const page = await context.newPage();
+    await page.goto(server.EMPTY_PAGE);
+    expect.soft(await page.evaluate(() => (window.navigator as any).userAgentData.toJSON())).toEqual(
+        expect.objectContaining({ platform: 'macOS' })
+    );
+    expect.soft(await page.evaluate(() => navigator.platform)).toBe('MacIntel');
     await context.close();
   }
 });


### PR DESCRIPTION
When a custom `userAgent` is configured (e.g. via device presets like `Desktop Chrome`),
`navigator.platform` leaks the host OS instead of matching the emulated user agent:

- `navigator.userAgentData.platform` → `"Windows"` (from the preset UA)
- `navigator.platform` → `"MacIntel"` (host OS leaked)

Libraries like React Aria check `userAgentData.platform` first, get `"Windows"`, and
then expect Windows keyboard behavior — breaking tests that use `ControlOrMeta`.

## Changes

Per @dgozman's request, unified into a single `calculateUserAgentEmulation(options: BrowserContextOptions)` in `browserContext.ts` that returns:
- `navigatorPlatform: string | undefined`
- `userAgentMetadata: { mobile, model, architecture, platform, platformVersion } | undefined`

The `PLAYWRIGHT_NO_UA_PLATFORM` check lives inside this function (not duplicated across call sites).

**Chromium** (`crPage.ts`): passes `platform` in `Emulation.setUserAgentOverride` via `userAgentMetadata`
**Firefox** (`ffBrowser.ts`): calls `Browser.setPlatformOverride` alongside `Browser.setUserAgentOverride`
**WebKit** (`wkPage.ts`): calls `Page.overridePlatform` alongside `Page.overrideUserAgent`

`platformVersion` is normalized: UA strings encode iOS/macOS versions with underscores (`16_6`) but Client Hints expect dots (`16.6`).

When no custom user agent is set, behavior is unchanged. Set `PLAYWRIGHT_NO_UA_PLATFORM=1` to opt out.

Fixes https://github.com/microsoft/playwright/issues/39568