### PR TITLE
fix(api): make Tracing.group return Disposable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ When creating or moving files, update the relevant `DEPS.list` to declare allowe
 
 ## Commit Convention
 
+Before committing, run `npm run flint` and fix errors.
+
 Semantic commit messages: `label(scope): description`
 
 Labels: `fix`, `feat`, `chore`, `docs`, `test`, `devops`

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -305,6 +305,7 @@ To specify the final trace zip file name, you need to pass `path` option to
 
 ## async method: Tracing.group
 * since: v1.49
+- returns: <[Disposable]>
 
 :::caution
 Use `test.step` instead when available.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -21957,7 +21957,7 @@ export interface Tracing {
 
       column?: number;
     };
-  }): Promise<void>;
+  }): Promise<Disposable>;
 
   /**
    * Closes the last group created by

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -16,6 +16,7 @@
 
 import { Artifact } from './artifact';
 import { ChannelOwner } from './channelOwner';
+import { DisposableStub } from './disposable';
 
 import type * as api from '../../types/types';
 import type * as channels from '@protocol/channels';
@@ -62,6 +63,7 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
     if (options.location)
       this._additionalSources.add(options.location.file);
     await this._channel.tracingGroup({ name, location: options.location });
+    return new DisposableStub(() => this.groupEnd());
   }
 
   async groupEnd() {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -21957,7 +21957,7 @@ export interface Tracing {
 
       column?: number;
     };
-  }): Promise<void>;
+  }): Promise<Disposable>;
 
   /**
    * Closes the last group created by

--- a/tests/library/screencast.spec.ts
+++ b/tests/library/screencast.spec.ts
@@ -97,9 +97,9 @@ test('screencast.start dispose stops screencast', async ({ browser, server, trac
   const page = await context.newPage();
 
   const frames: { data: Buffer }[] = [];
-  page.screencast().on('screencastframe', frame => frames.push(frame));
+  page.screencast.on('screencastframe', frame => frames.push(frame));
 
-  const disposable = await page.screencast().start({ maxSize: { width: 500, height: 400 } });
+  const disposable = await page.screencast.start({ maxSize: { width: 500, height: 400 } });
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => document.body.style.backgroundColor = 'red');
   await rafraf(page, 100);


### PR DESCRIPTION
## Summary
- `Tracing.group()` now returns a `Disposable` that calls `groupEnd()` on dispose
- Enables `await using` pattern for automatic group cleanup