### PR TITLE
feat(devices): add Native device descriptors with platform-aware user agents

### DIFF
--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -23565,12 +23565,18 @@ type Devices = {
   "Moto G4": DeviceDescriptor;
   "Moto G4 landscape": DeviceDescriptor;
   "Desktop Chrome HiDPI": DeviceDescriptor;
+  "Desktop Chrome HiDPI Native": DeviceDescriptor;
   "Desktop Edge HiDPI": DeviceDescriptor;
+  "Desktop Edge HiDPI Native": DeviceDescriptor;
   "Desktop Firefox HiDPI": DeviceDescriptor;
+  "Desktop Firefox HiDPI Native": DeviceDescriptor;
   "Desktop Safari": DeviceDescriptor;
   "Desktop Chrome": DeviceDescriptor;
+  "Desktop Chrome Native": DeviceDescriptor;
   "Desktop Edge": DeviceDescriptor;
+  "Desktop Edge Native": DeviceDescriptor;
   "Desktop Firefox": DeviceDescriptor;
+  "Desktop Firefox Native": DeviceDescriptor;
   [key: string]: DeviceDescriptor;
 }
 

--- a/packages/playwright-core/src/server/deviceDescriptors.ts
+++ b/packages/playwright-core/src/server/deviceDescriptors.ts
@@ -19,5 +19,24 @@ import deviceDescriptorsSource from './deviceDescriptorsSource.json';
 
 import type { Devices } from './types';
 
+function platformTag(): string {
+  switch (process.platform) {
+    case 'darwin': return 'Macintosh; Intel Mac OS X 10_15_7';
+    case 'linux': return 'X11; Linux x86_64';
+    default: return 'Windows NT 10.0; Win64; x64';
+  }
+}
 
-export const deviceDescriptors = deviceDescriptorsSource as Devices;
+function resolveDescriptors(source: Devices): Devices {
+  const platform = platformTag();
+  const result: Devices = {};
+  for (const [name, descriptor] of Object.entries(source)) {
+    if (descriptor.userAgent.includes('{{platform}}'))
+      result[name] = { ...descriptor, userAgent: descriptor.userAgent.replace('{{platform}}', platform) };
+    else
+      result[name] = descriptor;
+  }
+  return result;
+}
+
+export const deviceDescriptors = resolveDescriptors(deviceDescriptorsSource as Devices);

--- a/packages/playwright-core/src/server/deviceDescriptorsSource.json
+++ b/packages/playwright-core/src/server/deviceDescriptorsSource.json
@@ -1686,6 +1686,21 @@
     "hasTouch": false,
     "defaultBrowserType": "chromium"
   },
+  "Desktop Chrome HiDPI Native": {
+    "userAgent": "Mozilla/5.0 ({{platform}}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7680.31 Safari/537.36",
+    "screen": {
+      "width": 1792,
+      "height": 1120
+    },
+    "viewport": {
+      "width": 1280,
+      "height": 720
+    },
+    "deviceScaleFactor": 2,
+    "isMobile": false,
+    "hasTouch": false,
+    "defaultBrowserType": "chromium"
+  },
   "Desktop Edge HiDPI": {
     "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7680.31 Safari/537.36 Edg/146.0.7680.31",
     "screen": {
@@ -1701,8 +1716,38 @@
     "hasTouch": false,
     "defaultBrowserType": "chromium"
   },
+  "Desktop Edge HiDPI Native": {
+    "userAgent": "Mozilla/5.0 ({{platform}}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7680.31 Safari/537.36 Edg/146.0.7680.31",
+    "screen": {
+      "width": 1792,
+      "height": 1120
+    },
+    "viewport": {
+      "width": 1280,
+      "height": 720
+    },
+    "deviceScaleFactor": 2,
+    "isMobile": false,
+    "hasTouch": false,
+    "defaultBrowserType": "chromium"
+  },
   "Desktop Firefox HiDPI": {
     "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:148.0.2) Gecko/20100101 Firefox/148.0.2",
+    "screen": {
+      "width": 1792,
+      "height": 1120
+    },
+    "viewport": {
+      "width": 1280,
+      "height": 720
+    },
+    "deviceScaleFactor": 2,
+    "isMobile": false,
+    "hasTouch": false,
+    "defaultBrowserType": "firefox"
+  },
+  "Desktop Firefox HiDPI Native": {
+    "userAgent": "Mozilla/5.0 ({{platform}}; rv:148.0.2) Gecko/20100101 Firefox/148.0.2",
     "screen": {
       "width": 1792,
       "height": 1120
@@ -1746,6 +1791,21 @@
     "hasTouch": false,
     "defaultBrowserType": "chromium"
   },
+  "Desktop Chrome Native": {
+    "userAgent": "Mozilla/5.0 ({{platform}}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7680.31 Safari/537.36",
+    "screen": {
+      "width": 1920,
+      "height": 1080
+    },
+    "viewport": {
+      "width": 1280,
+      "height": 720
+    },
+    "deviceScaleFactor": 1,
+    "isMobile": false,
+    "hasTouch": false,
+    "defaultBrowserType": "chromium"
+  },
   "Desktop Edge": {
     "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7680.31 Safari/537.36 Edg/146.0.7680.31",
     "screen": {
@@ -1761,8 +1821,38 @@
     "hasTouch": false,
     "defaultBrowserType": "chromium"
   },
+  "Desktop Edge Native": {
+    "userAgent": "Mozilla/5.0 ({{platform}}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7680.31 Safari/537.36 Edg/146.0.7680.31",
+    "screen": {
+      "width": 1920,
+      "height": 1080
+    },
+    "viewport": {
+      "width": 1280,
+      "height": 720
+    },
+    "deviceScaleFactor": 1,
+    "isMobile": false,
+    "hasTouch": false,
+    "defaultBrowserType": "chromium"
+  },
   "Desktop Firefox": {
     "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:148.0.2) Gecko/20100101 Firefox/148.0.2",
+    "screen": {
+      "width": 1920,
+      "height": 1080
+    },
+    "viewport": {
+      "width": 1280,
+      "height": 720
+    },
+    "deviceScaleFactor": 1,
+    "isMobile": false,
+    "hasTouch": false,
+    "defaultBrowserType": "firefox"
+  },
+  "Desktop Firefox Native": {
+    "userAgent": "Mozilla/5.0 ({{platform}}; rv:148.0.2) Gecko/20100101 Firefox/148.0.2",
     "screen": {
       "width": 1920,
       "height": 1080

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -23565,12 +23565,18 @@ type Devices = {
   "Moto G4": DeviceDescriptor;
   "Moto G4 landscape": DeviceDescriptor;
   "Desktop Chrome HiDPI": DeviceDescriptor;
+  "Desktop Chrome HiDPI Native": DeviceDescriptor;
   "Desktop Edge HiDPI": DeviceDescriptor;
+  "Desktop Edge HiDPI Native": DeviceDescriptor;
   "Desktop Firefox HiDPI": DeviceDescriptor;
+  "Desktop Firefox HiDPI Native": DeviceDescriptor;
   "Desktop Safari": DeviceDescriptor;
   "Desktop Chrome": DeviceDescriptor;
+  "Desktop Chrome Native": DeviceDescriptor;
   "Desktop Edge": DeviceDescriptor;
+  "Desktop Edge Native": DeviceDescriptor;
   "Desktop Firefox": DeviceDescriptor;
+  "Desktop Firefox Native": DeviceDescriptor;
   [key: string]: DeviceDescriptor;
 }
 

--- a/tests/library/browsercontext-device.spec.ts
+++ b/tests/library/browsercontext-device.spec.ts
@@ -104,6 +104,25 @@ it.describe('device', () => {
     await context.close();
   });
 
+  it('should resolve native device user agent to current platform', async ({ playwright, browser, server }) => {
+    const device = playwright.devices['Desktop Chrome Native'];
+    expect(device.userAgent).not.toContain('{{platform}}');
+    const expectedPlatform = {
+      'darwin': 'Macintosh; Intel Mac OS X 10_15_7',
+      'linux': 'X11; Linux x86_64',
+      'win32': 'Windows NT 10.0; Win64; x64',
+    }[process.platform] ?? 'Windows NT 10.0; Win64; x64';
+    expect(device.userAgent).toContain(expectedPlatform);
+
+    const context = await browser.newContext({ ...device });
+    const page = await context.newPage();
+    await page.goto(server.PREFIX + '/mobile.html');
+    const userAgent = await page.evaluate(() => navigator.userAgent);
+    expect(userAgent).toContain(expectedPlatform);
+    expect(userAgent).not.toContain('{{platform}}');
+    await context.close();
+  });
+
   it('should emulate viewport and screen size', async ({ contextFactory, playwright }) => {
     const device = playwright.devices['iPhone 12'];
     const context = await contextFactory(device);


### PR DESCRIPTION
## Summary
- Add "Native" variants of Desktop Chrome, Edge, and Firefox device descriptors (both standard and HiDPI) that use `{{platform}}` template in the user agent string
