### PR TITLE
docs: fix typo in APIRequestContext multipart docs

### DIFF
--- a/docs/src/api/class-apirequestcontext.md
+++ b/docs/src/api/class-apirequestcontext.md
@@ -247,7 +247,7 @@ var data = new Dictionary<string, object>() {
 await Request.FetchAsync("https://example.com/api/createBook", new() { Method = "post", DataObject = data });
 ```
 
-The common way to send file(s) in the body of a request is to upload them as form fields with `multipart/form-data` encoding, by specifiying the `multipart` parameter:
+The common way to send file(s) in the body of a request is to upload them as form fields with `multipart/form-data` encoding, by specifying the `multipart` parameter:
 
 ```js
 const form = new FormData();

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -18295,7 +18295,7 @@ export interface APIRequestContext {
    * ```
    *
    * The common way to send file(s) in the body of a request is to upload them as form fields with `multipart/form-data`
-   * encoding, by specifiying the `multipart` parameter:
+   * encoding, by specifying the `multipart` parameter:
    *
    * ```js
    * const form = new FormData();

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -18295,7 +18295,7 @@ export interface APIRequestContext {
    * ```
    *
    * The common way to send file(s) in the body of a request is to upload them as form fields with `multipart/form-data`
-   * encoding, by specifiying the `multipart` parameter:
+   * encoding, by specifying the `multipart` parameter:
    *
    * ```js
    * const form = new FormData();


### PR DESCRIPTION
## Summary
- fix "specifiying" to "specifying" in the APIRequestContext multipart documentation

## Related issue
- N/A (minor documentation update; Playwright CONTRIBUTING exempts these from the issue requirement)

## Guideline alignment
- Follows [CONTRIBUTING.md](https://github.com/microsoft/playwright/blob/main/CONTRIBUTING.md): single-file docs-only change with no behavior impact

## Validation
- Not run (documentation-only change)
