### PR TITLE
Fix bidi screenshot quality=0 being treated as 80%

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -480,7 +480,7 @@ export class BidiPage implements PageDelegate {
       context: this._session.sessionId,
       format: {
         type: `image/${format === 'png' ? 'png' : 'jpeg'}`,
-        quality: quality ? quality / 100 : 0.8,
+        quality: quality !== undefined ? quality / 100 : undefined,
       },
       origin: documentRect ? 'document' : 'viewport',
       clip: {

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -394,6 +394,13 @@ it.describe('page screenshot', () => {
     expect(error.message).toContain('options.quality is unsupported for the png');
   });
 
+  it('quality option should work for jpeg', async ({ page, server }) => {
+    await page.goto(server.PREFIX + '/grid.html');
+    const zeroQuality = await page.screenshot({ type: 'jpeg', quality: 0 });
+    const highQuality = await page.screenshot({ type: 'jpeg', quality: 100 });
+    expect(zeroQuality.byteLength).toBeLessThan(highQuality.byteLength);
+  });
+
   it('should prefer type over extension', async ({ page }, testInfo) => {
     const outputPath = testInfo.outputPath('file.png');
     const buffer = await page.screenshot({ path: outputPath, type: 'jpeg' });


### PR DESCRIPTION
## Summary

`bidiPage.ts` uses a truthy check (`quality ? quality / 100 : 0.8`) to convert the screenshot quality parameter from 0–100 scale to 0–1 scale for the BiDi protocol. When `quality === 0`, the check fails (0 is falsy) and the value becomes `0.8` (80%) instead of `0.0`.

- **Root cause**: PR #22966 added `quality ?? 80` as the default in `screenshotter.ts`, but the bidi implementation was not updated to match — it still uses its own `0.8` fallback via a truthy check.
- **Chromium/Firefox**: pass `quality` through directly, so `0` works correctly.
- **Fix**: `quality !== undefined ? quality / 100 : undefined`
  - Correctly handles `quality === 0`
  - Removes the redundant `0.8` fallback (already handled upstream by `?? 80`)
  - Omits `quality` for PNG screenshots (`quality` is optional in the BiDi protocol)

## Test plan

- Added test: `quality option should work for jpeg` — verifies `quality: 0` produces a smaller file than `quality: 100`
- Existing screenshot tests continue to pass