### PR TITLE
chore(ci): skip non-bidi workflows on bidi-only changes

### DIFF
--- a/.github/workflows/tests_components.yml
+++ b/.github/workflows/tests_components.yml
@@ -9,7 +9,9 @@ on:
     paths-ignore:
       - 'browser_patches/**'
       - 'docs/**'
+      - 'packages/playwright-core/src/server/bidi/**'
       - 'packages/playwright-core/src/tools/**'
+      - 'tests/bidi/**'
       - 'tests/mcp/**'
     branches:
       - main

--- a/.github/workflows/tests_mcp.yml
+++ b/.github/workflows/tests_mcp.yml
@@ -9,6 +9,8 @@ on:
     paths-ignore:
       - 'browser_patches/**'
       - 'docs/**'
+      - 'packages/playwright-core/src/server/bidi/**'
+      - 'tests/bidi/**'
     branches:
       - main
       - release-*

--- a/.github/workflows/tests_others.yml
+++ b/.github/workflows/tests_others.yml
@@ -9,6 +9,8 @@ on:
     paths-ignore:
       - 'browser_patches/**'
       - 'docs/**'
+      - 'packages/playwright-core/src/server/bidi/**'
+      - 'tests/bidi/**'
     types: [ labeled ]
     branches:
       - main

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -9,7 +9,9 @@ on:
     paths-ignore:
       - 'browser_patches/**'
       - 'docs/**'
+      - 'packages/playwright-core/src/server/bidi/**'
       - 'packages/playwright-core/src/tools/**'
+      - 'tests/bidi/**'
       - 'tests/mcp/**'
     branches:
       - main

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -9,6 +9,8 @@ on:
     paths-ignore:
       - 'browser_patches/**'
       - 'docs/**'
+      - 'packages/playwright-core/src/server/bidi/**'
+      - 'tests/bidi/**'
     types: [ labeled ]
     branches:
       - main


### PR DESCRIPTION
## Summary
- Add `packages/playwright-core/src/server/bidi/**` and `tests/bidi/**` to `paths-ignore` in all test workflows (`tests 1`, `tests 2`, `tests others`, `MCP`, `components`) so they don't run on PRs that only touch bidi code