### PR TITLE
chore: suppress verbose review body in Copilot PR reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,3 +7,4 @@ When reviewing pull requests:
 - Keep each comment short — one or two sentences maximum.
 - Do not write long descriptions or summaries of what the code does.
 - Do not suggest refactors or improvements unrelated to the PR's stated goal.
+- Do not produce a review body or top-level summary. Leave the review body empty; put findings only in inline comments.


### PR DESCRIPTION
## Summary
- Adds an instruction to `.github/copilot-instructions.md` telling Copilot not to generate a top-level review body/summary (the "Pull request overview" block with the file table). Findings should go only in inline comments.

Fixes the pattern seen in https://github.com/microsoft/playwright/pull/39760#pullrequestreview-3972963901