### PR TITLE
chore(mcp): align MCP output mode, centralize secret redaction

### DIFF
--- a/packages/playwright-core/src/tools/backend/evaluate.ts
+++ b/packages/playwright-core/src/tools/backend/evaluate.ts
@@ -26,6 +26,7 @@ const evaluateSchema = z.object({
   element: z.string().optional().describe('Human-readable element description used to obtain permission to interact with the element'),
   ref: z.string().optional().describe('Exact target element reference from the page snapshot'),
   selector: z.string().optional().describe('CSS or role selector for the target element, when "ref" is not available.'),
+  filename: z.string().optional().describe('Filename to save the result to. If not provided, result is returned as text.'),
 });
 
 const evaluate = defineTabTool({
@@ -55,7 +56,7 @@ const evaluate = defineTabTool({
       func.toString = () => params.function;
       const result = locator?.locator ? await locator?.locator.evaluate(func) : await tab.page.evaluate(func);
       const text = JSON.stringify(result, null, 2) || 'undefined';
-      response.addTextResult(text);
+      await response.addResult('Evaluation result', text, { prefix: 'result', ext: 'json', suggestedFilename: params.filename });
     });
   },
 });

--- a/packages/playwright-core/src/tools/backend/logFile.ts
+++ b/packages/playwright-core/src/tools/backend/logFile.ts
@@ -52,7 +52,7 @@ export class LogFile {
     this._title = title;
   }
 
-  appendLine(wallTime: number, text: () => string) {
+  appendLine(wallTime: number, text: string) {
     this._writeChain = this._writeChain.then(() => this._write(wallTime, text)).catch(e => debug('pw:tools:error')(e));
   }
 
@@ -87,12 +87,12 @@ export class LogFile {
     return chunk;
   }
 
-  private async _write(wallTime: number, text: () => string) {
+  private async _write(wallTime: number, text: string) {
     if (this._stopped)
       return;
     this._file ??= await this._context.outputFile({ prefix: this._filePrefix, ext: 'log', date: new Date(this._startTime) }, { origin: 'code' });
     const relativeTime = Math.round(wallTime - this._startTime);
-    const logLine = `[${String(relativeTime).padStart(8, ' ')}ms] ${text()}\n`;
+    const logLine = `[${String(relativeTime).padStart(8, ' ')}ms] ${text}\n`;
     await fs.promises.appendFile(this._file, logLine);
 
     const lineCount = logLine.split('\n').length - 1;

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -18,7 +18,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { debug } from '../../utilsBundle';
-import { renderModalStates, shouldIncludeMessage } from './tab';
+import { renderModalStates } from './tab';
 import { scaleImageToFitMessage } from './screenshot';
 
 import type { TabHeader } from './tab';
@@ -45,7 +45,7 @@ export class Response {
   private _errors: string[] = [];
   private _code: string[] = [];
   private _context: Context;
-  private _includeSnapshot: 'none' | 'full' | 'incremental' = 'none';
+  private _includeSnapshot: 'none' | 'full' | 'incremental' | 'explicit' = 'none';
   private _includeSnapshotFileName: string | undefined;
   private _includeSnapshotSelector: string | undefined;
   private _includeSnapshotDepth: number | undefined;
@@ -87,7 +87,7 @@ export class Response {
   }
 
   async addResult(title: string, data: Buffer | string, file: FilenameTemplate) {
-    if (this._context.config.outputMode === 'file' || file.suggestedFilename || typeof data !== 'string') {
+    if (file.suggestedFilename || typeof data !== 'string') {
       const resolvedFile = await this.resolveClientFile(file, title);
       await this.addFileResult(resolvedFile, data);
     } else {
@@ -95,11 +95,15 @@ export class Response {
     }
   }
 
-  async addFileResult(resolvedFile: ResolvedFile, data: Buffer | string | null) {
+  private async _writeFile(resolvedFile: ResolvedFile, data: Buffer | string | null) {
     if (typeof data === 'string')
-      await fs.promises.writeFile(resolvedFile.fileName, data, 'utf-8');
+      await fs.promises.writeFile(resolvedFile.fileName, this._redactSecrets(data), 'utf-8');
     else if (data)
       await fs.promises.writeFile(resolvedFile.fileName, data);
+  }
+
+  async addFileResult(resolvedFile: ResolvedFile, data: Buffer | string | null) {
+    await this._writeFile(resolvedFile, data);
     this.addTextResult(resolvedFile.printableLink);
   }
 
@@ -129,19 +133,20 @@ export class Response {
   }
 
   setIncludeFullSnapshot(includeSnapshotFileName?: string, selector?: string, depth?: number) {
-    this._includeSnapshot = 'full';
+    this._includeSnapshot = 'explicit';
     this._includeSnapshotFileName = includeSnapshotFileName;
     this._includeSnapshotDepth = depth;
     this._includeSnapshotSelector = selector;
   }
 
-  async serialize(): Promise<CallToolResult> {
-    const redactText = (text: string): string => {
-      for (const [secretName, secretValue] of Object.entries(this._context.config.secrets ?? {}))
-        text = text.replaceAll(secretValue, `<secret>${secretName}</secret>`);
-      return text;
-    };
+  private _redactSecrets(text: string): string {
+    for (const [secretName, secretValue] of Object.entries(this._context.config.secrets ?? {}))
+      text = text.replaceAll(secretValue, `<secret>${secretName}</secret>`);
+    return text;
+  }
 
+
+  async serialize(): Promise<CallToolResult> {
     const sections = await this._build();
 
     const text: string[] = [];
@@ -159,7 +164,7 @@ export class Response {
     const content: (TextContent | ImageContent)[] = [
       {
         type: 'text',
-        text: sanitizeUnicode(redactText(text.join('\n'))),
+        text: sanitizeUnicode(this._redactSecrets(text.join('\n'))),
       }
     ];
 
@@ -213,13 +218,13 @@ export class Response {
 
     // Handle tab snapshot
     if (tabSnapshot && this._includeSnapshot !== 'none') {
-      const snapshot = tabSnapshot.ariaSnapshot;
-      if (this._context.config.outputMode === 'file' || this._includeSnapshotFileName) {
-        const resolvedFile = await this.resolveClientFile({ prefix: 'page', ext: 'yml', suggestedFilename: this._includeSnapshotFileName }, 'Snapshot');
-        await fs.promises.writeFile(resolvedFile.fileName, snapshot, 'utf-8');
+      if (this._includeSnapshot !== 'explicit' || this._includeSnapshotFileName) {
+        const suggestedFilename = this._includeSnapshotFileName === '<auto>' ? undefined : this._includeSnapshotFileName;
+        const resolvedFile = await this.resolveClientFile({ prefix: 'page', ext: 'yml', suggestedFilename }, 'Snapshot');
+        await this._writeFile(resolvedFile, tabSnapshot.ariaSnapshot);
         addSection('Snapshot', [resolvedFile.printableLink]);
       } else {
-        addSection('Snapshot', [snapshot], 'yaml');
+        addSection('Snapshot', [tabSnapshot.ariaSnapshot], 'yaml');
       }
     }
 
@@ -229,14 +234,10 @@ export class Response {
       text.push(`- New console entries: ${tabSnapshot.consoleLink}`);
     if (tabSnapshot?.events.filter(event => event.type !== 'request').length) {
       for (const event of tabSnapshot.events) {
-        if (event.type === 'console' && this._context.config.outputMode !== 'file' && this._context.config.snapshot?.mode !== 'none') {
-          if (shouldIncludeMessage(this._context.config.console?.level, event.message.type))
-            text.push(`- ${trimMiddle(event.message.toString(), 100)}`);
-        } else if (event.type === 'download-start') {
+        if (event.type === 'download-start')
           text.push(`- Downloading file ${event.download.download.suggestedFilename()} ...`);
-        } else if (event.type === 'download-finish') {
+        else if (event.type === 'download-finish')
           text.push(`- Downloaded file ${event.download.download.suggestedFilename()} to "${this._computRelativeTo(event.download.outputFile)}"`);
-        }
       }
     }
     if (text.length)
@@ -275,12 +276,6 @@ export function renderTabsMarkdown(tabs: TabHeader[]): string[] {
   return lines;
 }
 
-function trimMiddle(text: string, maxLength: number) {
-  if (text.length <= maxLength)
-    return text;
-  return text.slice(0, Math.floor(maxLength / 2)) + '...' + text.slice(- 3 - Math.floor(maxLength / 2));
-}
-
 /**
  * Sanitizes a string to ensure it only contains well-formed Unicode.
  * Replaces lone surrogates with U+FFFD using String.prototype.toWellFormed().
@@ -306,7 +301,7 @@ function parseSections(text: string): Map<string, string> {
   return sections;
 }
 
-export function parseResponse(response: CallToolResult) {
+export function parseResponse(response: CallToolResult, cwd?: string) {
   if (response.content?.[0].type !== 'text')
     return undefined;
   const text = response.content[0].text;
@@ -317,13 +312,29 @@ export function parseResponse(response: CallToolResult) {
   const code = sections.get('Ran Playwright code');
   const tabs = sections.get('Open tabs');
   const page = sections.get('Page');
-  const snapshot = sections.get('Snapshot');
+  const snapshotSection = sections.get('Snapshot');
   const events = sections.get('Events');
   const modalState = sections.get('Modal state');
   const paused = sections.get('Paused');
   const codeNoFrame = code?.replace(/^```js\n/, '').replace(/\n```$/, '');
   const isError = response.isError;
   const attachments = response.content.length > 1 ? response.content.slice(1) : undefined;
+
+  let snapshot: string | undefined;
+  let inlineSnapshot: string | undefined;
+  if (snapshotSection) {
+    const match = snapshotSection.match(/\[Snapshot\]\(([^)]+)\)/);
+    if (match) {
+      if (cwd) {
+        try {
+          snapshot = fs.readFileSync(path.resolve(cwd, match[1]), 'utf-8');
+        } catch {
+        }
+      }
+    } else {
+      inlineSnapshot = snapshotSection.replace(/^```yaml\n?/, '').replace(/\n?```$/, '');
+    }
+  }
 
   return {
     result,
@@ -332,6 +343,7 @@ export function parseResponse(response: CallToolResult) {
     tabs,
     page,
     snapshot,
+    inlineSnapshot,
     events,
     modalState,
     paused,

--- a/packages/playwright-core/src/tools/backend/sessionLog.ts
+++ b/packages/playwright-core/src/tools/backend/sessionLog.ts
@@ -25,11 +25,13 @@ import type { ContextConfig } from './context';
 export class SessionLog {
   private _folder: string;
   private _file: string;
+  private _cwd: string;
   private _sessionFileQueue = Promise.resolve();
 
-  constructor(sessionFolder: string) {
+  constructor(sessionFolder: string, cwd: string) {
     this._folder = sessionFolder;
     this._file = path.join(this._folder, 'session.md');
+    this._cwd = cwd;
   }
 
   static async create(config: ContextConfig, cwd: string): Promise<SessionLog> {
@@ -37,11 +39,11 @@ export class SessionLog {
     await fs.promises.mkdir(sessionFolder, { recursive: true });
     // eslint-disable-next-line no-console
     console.error(`Session: ${sessionFolder}`);
-    return new SessionLog(sessionFolder);
+    return new SessionLog(sessionFolder, cwd);
   }
 
   logResponse(toolName: string, toolArgs: Record<string, any>, responseObject: any) {
-    const parsed = { ...parseResponse(responseObject), text: undefined };
+    const parsed = { ...parseResponse(responseObject, this._cwd), text: undefined };
     const lines: string[] = [''];
     lines.push(
         `### Tool call: ${toolName}`,

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -253,9 +253,8 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   private _handleConsoleMessage(message: ConsoleMessage) {
     const wallTime = message.timestamp;
     this._addLogEntry({ type: 'console', wallTime, message });
-    const level = consoleLevelForMessageType(message.type);
-    if (level === 'error' || level === 'warning')
-      this._consoleLog.appendLine(wallTime, () => message.toString());
+    if (shouldIncludeMessage(this.context.config.console?.level, message.type))
+      this._consoleLog.appendLine(wallTime, message.toString());
   }
 
   private _addLogEntry(entry: EventEntry) {

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -57,7 +57,7 @@ const open = declareCommand({
     profile: z.string().optional().describe('Use persistent browser profile, store profile in specified directory.'),
   }),
   toolName: ({ url }) => url ? 'browser_navigate' : 'browser_snapshot',
-  toolParams: ({ url }) => ({ url: url || 'about:blank' }),
+  toolParams: ({ url }) => url ? ({ url: url || 'about:blank' }) : { filename: '<auto>' },
 });
 
 const attach = declareCommand({
@@ -72,7 +72,7 @@ const attach = declareCommand({
     session: z.string().optional().describe('Session name alias (defaults to the attach target name)'),
   }),
   toolName: 'browser_snapshot',
-  toolParams: () => ({}),
+  toolParams: () => ({ filename: '<auto>' }),
 });
 
 const close = declareCommand({
@@ -361,8 +361,11 @@ const evaluate = declareCommand({
     func: z.string().describe('() => { /* code */ } or (element) => { /* code */ } when element is provided'),
     element: z.string().optional().describe('Exact target element reference from the page snapshot, or a unique element selector'),
   }),
+  options: z.object({
+    filename: z.string().optional().describe('Save evaluation result to a file instead of returning it in the response.'),
+  }),
   toolName: 'browser_evaluate',
-  toolParams: ({ func, element }) => ({ function: func, ...asRef(element) }),
+  toolParams: ({ func, element, filename }) => ({ function: func, filename, ...asRef(element) }),
 });
 
 const dialogAccept = declareCommand({

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -83,7 +83,6 @@ export async function resolveCLIConfig(clientInfo: ClientInfo, sessionName: stri
     headless: options.headed ? false : undefined,
     extension: options.extension,
     userDataDir: options.profile,
-    outputMode: 'file',
     snapshotMode: 'full',
   });
   daemonOverrides.browser!.remoteEndpoint = options.attach;

--- a/packages/playwright-core/src/tools/mcp/config.d.ts
+++ b/packages/playwright-core/src/tools/mcp/config.d.ts
@@ -154,11 +154,6 @@ export type Config = {
    */
   outputDir?: string;
 
-  /**
-   * Whether to save snapshots, console messages, network logs and other session logs to a file or to the standard output. Defaults to "stdout".
-   */
-  outputMode?: 'file' | 'stdout';
-
   console?: {
     /**
      * The level of console messages to return. Each level includes the messages of more severe levels. Defaults to "info".

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -58,7 +58,6 @@ export type CLIOptions = {
   imageResponses?: 'allow' | 'omit';
   sandbox?: boolean;
   outputDir?: string;
-  outputMode?: 'file' | 'stdout';
   port?: number;
   proxyBypass?: string;
   proxyServer?: string;
@@ -255,7 +254,6 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config & { configF
     secrets: cliOptions.secrets,
     sharedBrowserContext: cliOptions.sharedBrowserContext,
     snapshot: cliOptions.snapshotMode ? { mode: cliOptions.snapshotMode } : undefined,
-    outputMode: cliOptions.outputMode,
     outputDir: cliOptions.outputDir,
     imageResponses: cliOptions.imageResponses,
     testIdAttribute: cliOptions.testIdAttribute,

--- a/packages/playwright-core/src/tools/mcp/configIni.ts
+++ b/packages/playwright-core/src/tools/mcp/configIni.ts
@@ -162,7 +162,6 @@ const longhandTypes: Record<string, LonghandType> = {
   'saveVideo': 'size',
   'sharedBrowserContext': 'boolean',
   'outputDir': 'string',
-  'outputMode': 'string',
   'imageResponses': 'string',
   'allowUnrestrictedFileAccess': 'boolean',
   'codegen': 'string',

--- a/tests/mcp/cdp.spec.ts
+++ b/tests/mcp/cdp.spec.ts
@@ -55,9 +55,7 @@ test('cdp server reuse tab', async ({ cdpServer, startClient, server }) => {
   })).toHaveResponse({
     page: `- Page URL: ${server.HELLO_WORLD}
 - Page Title: Title`,
-    snapshot: `\`\`\`yaml
-- generic [active] [ref=e1]: Hello, world!
-\`\`\``,
+    inlineSnapshot: `- generic [active] [ref=e1]: Hello, world!`,
   });
 });
 

--- a/tests/mcp/cli-cdp.spec.ts
+++ b/tests/mcp/cli-cdp.spec.ts
@@ -32,6 +32,6 @@ browser.cdpEndpoint=${cdpServer.endpoint}
 browser.isolated=false
 `);
   await cli('open', `--config=${configPath}`);
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).toContain(`- generic [active] [ref=e1]: Hello, world!`);
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toContain(`- generic [active] [ref=e1]: Hello, world!`);
 });

--- a/tests/mcp/cli-core.spec.ts
+++ b/tests/mcp/cli-core.spec.ts
@@ -99,16 +99,16 @@ test('hover', async ({ cli, server }) => {
   server.setContent('/', eventsPage, 'text/html');
   await cli('open', server.PREFIX);
   await cli('hover', 'e2');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).toContain('mouse move 50 50');
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toContain('mouse move 50 50');
 });
 
 test('select', async ({ cli, server }) => {
   server.setContent('/', `<select><option value="1">One</option><option value="2">Two</option></select>`, 'text/html');
   await cli('open', server.PREFIX);
   await cli('select', 'e2', 'Two');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).toContain('- option "Two" [selected]');
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toContain('- option "Two" [selected]');
 });
 
 test('check', async ({ cli, server, mcpBrowser }) => {
@@ -116,8 +116,8 @@ test('check', async ({ cli, server, mcpBrowser }) => {
   server.setContent('/', `<input type="checkbox">`, 'text/html');
   await cli('open', server.PREFIX);
   await cli('check', 'e2');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).toContain(`- checkbox [checked] ${active}[ref=e2]`);
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toContain(`- checkbox [checked] ${active}[ref=e2]`);
 });
 
 test('uncheck', async ({ cli, server, mcpBrowser }) => {
@@ -125,8 +125,8 @@ test('uncheck', async ({ cli, server, mcpBrowser }) => {
   server.setContent('/', `<input type="checkbox" checked>`, 'text/html');
   await cli('open', server.PREFIX);
   await cli('uncheck', 'e2');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).toContain(`- checkbox ${active}[ref=e2]`);
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toContain(`- checkbox ${active}[ref=e2]`);
 });
 
 test('eval', async ({ cli, server }) => {
@@ -155,8 +155,8 @@ test('dialog-accept', async ({ cli, server }) => {
   expect(output).toContain('MyAlert');
   expect(output).toContain('["alert" dialog with message "MyAlert"]: can be handled by dialog-accept or dialog-dismiss');
   await cli('dialog-accept');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).not.toContain('MyAlert');
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).not.toContain('MyAlert');
 });
 
 test('dialog-dismiss', async ({ cli, server }) => {
@@ -165,8 +165,8 @@ test('dialog-dismiss', async ({ cli, server }) => {
   const { output } = await cli('click', 'e2');
   expect(output).toContain('MyAlert');
   await cli('dialog-dismiss');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).not.toContain('MyAlert');
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).not.toContain('MyAlert');
 });
 
 test('dialog-accept <prompt>', async ({ cli, server }) => {
@@ -174,8 +174,8 @@ test('dialog-accept <prompt>', async ({ cli, server }) => {
   await cli('open', server.PREFIX);
   await cli('click', 'e2');
   await cli('dialog-accept', 'my reply');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).toContain('my reply');
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toContain('my reply');
 });
 
 test('resize', async ({ cli, server }) => {
@@ -270,7 +270,7 @@ test('partial snapshot', async ({ cli, server }) => {
   expect(snapshot).toContain('- button "Submit" [ref=e2]');
   expect(snapshot).toContain('- button "Cancel" [ref=e3]');
 
-  const { snapshot: partialSnapshot } = await cli('snapshot', '#two');
+  const { inlineSnapshot: partialSnapshot } = await cli('snapshot', '#two');
   expect(partialSnapshot).toBe(`- button "Cancel" [ref=e3]`);
 
   const { output: strictError } = await cli('snapshot', 'button');
@@ -284,12 +284,12 @@ test('snapshot depth', async ({ cli, server }) => {
   server.setContent('/', `<ul><li><button id=one>Submit</button></li><li><button id=two>Cancel</button></li></ul>`, 'text/html');
   await cli('open', server.PREFIX);
 
-  const { snapshot: limitedSnapshot } = await cli('snapshot', '--depth=1');
+  const { inlineSnapshot: limitedSnapshot } = await cli('snapshot', '--depth=1');
   expect(limitedSnapshot).toBe(`- list [ref=e2]:
   - listitem [ref=e3]
   - listitem [ref=e5]`);
 
-  const { snapshot: fullSnapshot } = await cli('snapshot', '--depth=100');
+  const { inlineSnapshot: fullSnapshot } = await cli('snapshot', '--depth=100');
   expect(fullSnapshot).toBe(`- list [ref=e2]:
   - listitem [ref=e3]:
     - button "Submit" [ref=e4]

--- a/tests/mcp/cli-devtools.spec.ts
+++ b/tests/mcp/cli-devtools.spec.ts
@@ -21,47 +21,42 @@ import { test, expect } from './cli-fixtures';
 test('console', async ({ cli, server }) => {
   await cli('open', server.PREFIX);
   await cli('eval', 'console.log("Hello, world!")');
-  const { attachments } = await cli('console');
-  expect(attachments[0].name).toEqual('Console');
-  expect(attachments[0].data.toString()).toContain('Total messages: 1 (Errors: 0, Warnings: 0)');
-  expect(attachments[0].data.toString()).toContain('Hello, world!');
+  const { output } = await cli('console');
+  expect(output).toContain('Total messages: 1 (Errors: 0, Warnings: 0)');
+  expect(output).toContain('Hello, world!');
 });
 
 test('console error', async ({ cli, server }) => {
   await cli('open', server.PREFIX);
   await cli('eval', 'console.log("log-level")');
   await cli('eval', 'console.error("error-level")');
-  const { attachments } = await cli('console', 'error');
-  expect(attachments[0].name).toEqual('Console');
-  expect(attachments[0].data.toString()).toContain('Total messages: 2 (Errors: 1, Warnings: 0)');
-  expect(attachments[0].data.toString()).toContain('Returning 1 messages for level "error"');
-  expect(attachments[0].data.toString()).not.toContain('log-level');
-  expect(attachments[0].data.toString()).toContain('error-level');
+  const { output } = await cli('console', 'error');
+  expect(output).toContain('Total messages: 2 (Errors: 1, Warnings: 0)');
+  expect(output).toContain('Returning 1 messages for level "error"');
+  expect(output).not.toContain('log-level');
+  expect(output).toContain('error-level');
 });
 
 test('console --clear', async ({ cli, server }) => {
   await cli('open', server.PREFIX);
   await cli('eval', 'console.log("log-level")');
   await cli('console', '--clear');
-  const { attachments } = await cli('console');
-  expect(attachments[0].name).toEqual('Console');
-  expect(attachments[0].data.toString()).not.toContain('log-level');
+  const { output } = await cli('console');
+  expect(output).not.toContain('log-level');
 });
 
 test('network', async ({ cli, server }) => {
   await cli('open', server.PREFIX);
   await cli('eval', '() => fetch("/hello-world")');
-  const { attachments } = await cli('network');
-  expect(attachments[0].name).toEqual('Network');
-  expect(attachments[0].data.toString()).not.toContain(`[GET] ${`${server.PREFIX}/`} => [200] OK`);
-  expect(attachments[0].data.toString()).toContain(`[GET] ${`${server.PREFIX}/hello-world`} => [200] OK`);
+  const { output } = await cli('network');
+  expect(output).not.toContain(`[GET] ${`${server.PREFIX}/`} => [200] OK`);
+  expect(output).toContain(`[GET] ${`${server.PREFIX}/hello-world`} => [200] OK`);
 });
 
 test('network --static', async ({ cli, server }) => {
   await cli('open', server.PREFIX);
-  const { attachments } = await cli('network', '--static');
-  expect(attachments[0].name).toEqual('Network');
-  expect(attachments[0].data.toString()).toContain(`[GET] ${`${server.PREFIX}/`} => [200] OK`);
+  const { output } = await cli('network', '--static');
+  expect(output).toContain(`[GET] ${`${server.PREFIX}/`} => [200] OK`);
 });
 
 test('network --filter', async ({ cli, server }) => {
@@ -70,10 +65,10 @@ test('network --filter', async ({ cli, server }) => {
   </script>`, 'text/html');
   await cli('open', server.PREFIX);
 
-  const { attachments } = await cli('network', '--filter=/api/', '--static');
-  expect(attachments[0].data.toString()).toContain(`${server.PREFIX}/api/users`);
-  expect(attachments[0].data.toString()).toContain(`${server.PREFIX}/api/orders`);
-  expect(attachments[0].data.toString()).not.toContain(`${server.PREFIX}/static/image.png`);
+  const { output } = await cli('network', '--filter=/api/', '--static');
+  expect(output).toContain(`${server.PREFIX}/api/users`);
+  expect(output).toContain(`${server.PREFIX}/api/orders`);
+  expect(output).not.toContain(`${server.PREFIX}/static/image.png`);
 });
 
 test('network --request-body', async ({ cli, server }) => {
@@ -85,14 +80,14 @@ test('network --request-body', async ({ cli, server }) => {
   await cli('click', 'e2');
 
   {
-    const { attachments } = await cli('network');
-    expect(attachments[0].data.toString()).not.toContain('Request body:');
+    const { output } = await cli('network');
+    expect(output).not.toContain('Request body:');
   }
 
   {
-    const { attachments } = await cli('network', '--request-body');
-    expect(attachments[0].data.toString()).toContain(`[POST] ${server.PREFIX}/api => [200] OK`);
-    expect(attachments[0].data.toString()).toContain('Request body: {"key":"value"}');
+    const { output } = await cli('network', '--request-body');
+    expect(output).toContain(`[POST] ${server.PREFIX}/api => [200] OK`);
+    expect(output).toContain('Request body: {"key":"value"}');
   }
 });
 
@@ -105,15 +100,15 @@ test('network --request-headers', async ({ cli, server }) => {
   await cli('click', 'e2');
 
   {
-    const { attachments } = await cli('network');
-    expect(attachments[0].data.toString()).not.toContain('Request headers:');
+    const { output } = await cli('network');
+    expect(output).not.toContain('Request headers:');
   }
 
   {
-    const { attachments } = await cli('network', '--request-headers');
-    expect(attachments[0].data.toString()).toContain(`[GET] ${server.PREFIX}/api => [200] OK`);
-    expect(attachments[0].data.toString()).toContain('Request headers:');
-    expect(attachments[0].data.toString()).toContain('x-custom-header: test-value');
+    const { output } = await cli('network', '--request-headers');
+    expect(output).toContain(`[GET] ${server.PREFIX}/api => [200] OK`);
+    expect(output).toContain('Request headers:');
+    expect(output).toContain('x-custom-header: test-value');
   }
 });
 
@@ -121,9 +116,8 @@ test('network --clear', async ({ cli, server }) => {
   await cli('open', server.PREFIX);
   await cli('eval', '() => fetch("/hello-world")');
   await cli('network', '--clear');
-  const { attachments } = await cli('network');
-  expect(attachments[0].name).toEqual('Network');
-  expect(attachments[0].data.toString()).not.toContain(`[GET] ${`${server.PREFIX}/hello-world`} => [200] OK`);
+  const { output } = await cli('network');
+  expect(output).not.toContain(`[GET] ${`${server.PREFIX}/hello-world`} => [200] OK`);
 });
 
 test('tracing-start-stop', async ({ cli, server }, testInfo) => {

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -33,6 +33,7 @@ export const test = baseTest.extend<{
     output: string,
     error: string,
     exitCode: number | undefined,
+    inlineSnapshot?: string,
     snapshot?: string,
     attachments?: { name: string, data: Buffer | null }[],
     pid?: number,
@@ -114,8 +115,9 @@ async function runCli(childProcess: CommonFixtures['childProcess'], args: string
     });
 
     let snapshot: string | undefined;
+    let inlineSnapshot: string | undefined;
     if (cli.stdout.includes('### Snapshot'))
-      snapshot = await loadSnapshot(cli.stdout);
+      ({ snapshot, inlineSnapshot } = await loadSnapshot(cli.stdout));
     const attachments = loadAttachments(cli.stdout);
 
     const matches = cli.stdout.includes('### Browser') ? cli.stdout.match(/Browser `(.+)` opened with pid (\d+)\./) : undefined;
@@ -127,6 +129,7 @@ async function runCli(childProcess: CommonFixtures['childProcess'], args: string
       output: cli.stdout.trim(),
       error: cli.stderr.trim(),
       snapshot,
+      inlineSnapshot,
       attachments,
       pid: pid ? +pid : undefined,
     };
@@ -150,16 +153,19 @@ function loadAttachments(output: string) {
   });
 }
 
-async function loadSnapshot(output: string) {
+async function loadSnapshot(output: string): Promise<{ snapshot?: string, inlineSnapshot?: string }> {
   const lines = output.split('\n');
   if (!lines.includes('### Snapshot'))
     throw new Error('Snapshot file not found');
-  const fileLine = lines[lines.indexOf('### Snapshot') + 1];
+  const snapshotIndex = lines.indexOf('### Snapshot') + 1;
+  const fileLine = lines[snapshotIndex];
+  if (fileLine.startsWith('```yaml'))
+    return { inlineSnapshot: lines.slice(snapshotIndex + 1, lines.indexOf('```', snapshotIndex)).join('\n') };
   const fileName = fileLine.match(/- \[(.+)\]\((.+)\)/)![2];
   try {
-    return await fs.promises.readFile(test.info().outputPath(fileName), 'utf8').catch(() => undefined);
+    return { snapshot: await fs.promises.readFile(test.info().outputPath(fileName), 'utf8').catch(() => undefined) };
   } catch (e) {
-    return '';
+    return {};
   }
 }
 

--- a/tests/mcp/cli-keyboard.spec.ts
+++ b/tests/mcp/cli-keyboard.spec.ts
@@ -21,8 +21,8 @@ test('press', async ({ cli, server }) => {
   await cli('open', server.PREFIX);
   await cli('click', 'e2');
   await cli('press', 'h');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).toBe(`- textbox [active] [ref=e2]: h`);
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toBe(`- textbox [active] [ref=e2]: h`);
 });
 
 test('keydown keyup', async ({ cli, server }) => {
@@ -31,6 +31,6 @@ test('keydown keyup', async ({ cli, server }) => {
   await cli('click', 'e2');
   await cli('keydown', 'h');
   await cli('keyup', 'h');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).toBe(`- textbox [active] [ref=e2]: h`);
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toBe(`- textbox [active] [ref=e2]: h`);
 });

--- a/tests/mcp/cli-mouse.spec.ts
+++ b/tests/mcp/cli-mouse.spec.ts
@@ -20,8 +20,8 @@ test('mousemove', async ({ cli, server }) => {
   server.setContent('/', eventsPage, 'text/html');
   await cli('open', server.PREFIX);
   await cli('mousemove', '45', '35');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).toContain('mouse move 45 35');
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toContain('mouse move 45 35');
 });
 
 test('mousedown mouseup', async ({ cli, server }) => {
@@ -30,9 +30,9 @@ test('mousedown mouseup', async ({ cli, server }) => {
   await cli('mousemove', '45', '35');
   await cli('mousedown');
   await cli('mouseup');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).toContain('mouse down');
-  expect(snapshot).toContain('mouse up');
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toContain('mouse down');
+  expect(inlineSnapshot).toContain('mouse up');
 });
 
 test('mousewheel', async ({ cli, server }) => {
@@ -45,5 +45,5 @@ test('mousewheel', async ({ cli, server }) => {
 
   await cli('mousewheel', '10', '5');
 
-  await expect.poll(() => cli('snapshot').then(result => result.snapshot)).toContain('wheel 10 5');
+  await expect.poll(() => cli('snapshot').then(result => result.inlineSnapshot)).toContain('wheel 10 5');
 });

--- a/tests/mcp/cli-parsing.spec.ts
+++ b/tests/mcp/cli-parsing.spec.ts
@@ -65,6 +65,6 @@ test('should preserve leading zeros in string arguments', async ({ cli, server }
   await cli('open', server.PREFIX);
   await cli('click', 'e2');
   await cli('type', '0812345679');
-  const { snapshot } = await cli('snapshot');
-  expect(snapshot).toContain(`0812345679`);
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toContain(`0812345679`);
 });

--- a/tests/mcp/cli-test.spec.ts
+++ b/tests/mcp/cli-test.spec.ts
@@ -61,7 +61,7 @@ test('debug test and snapshot', async ({ cliEnv, cli, childProcess }) => {
   expect(stepOutput).toContain(`- Expect "toBeVisible" at subdir${path.sep}a.test.ts:5`);
 
   const snapshotResult = await cli(`--session=${session}`, 'snapshot');
-  expect(snapshotResult.snapshot).toContain('button "Submit"');
+  expect(snapshotResult.inlineSnapshot).toContain('button "Submit"');
 
   const { output: pauseAtOutput } = await cli(`--session=${session}`, 'pause-at', 'a.test.ts:7');
   expect(pauseAtOutput).toContain('### Paused');

--- a/tests/mcp/console.spec.ts
+++ b/tests/mcp/console.spec.ts
@@ -16,7 +16,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { test, expect, parseResponse } from './fixtures';
+import { test, expect, parseResponse, consoleEntries } from './fixtures';
 
 test('browser_console_messages', async ({ client, server }) => {
   server.setContent('/', `
@@ -78,7 +78,7 @@ test('browser_console_messages (page error)', async ({ client, server }) => {
   });
 });
 
-test('recent console messages', async ({ client, server }) => {
+test('recent console messages', async ({ client, server }, testInfo) => {
   server.setContent('/', `
     <!DOCTYPE html>
     <html>
@@ -93,20 +93,19 @@ test('recent console messages', async ({ client, server }) => {
     },
   });
 
-  const response = await client.callTool({
+  const response = parseResponse(await client.callTool({
     name: 'browser_click',
     arguments: {
       element: 'Click me',
       ref: 'e2',
     },
-  });
+  }));
 
-  expect(response).toHaveResponse({
-    events: expect.stringContaining(`- [LOG] Hello, world! @`),
-  });
+  const content = await consoleEntries(response);
+  expect(content).toContain('Hello, world!');
 });
 
-test('recent console messages filter', async ({ startClient, server }) => {
+test('recent console messages filter', async ({ startClient, server }, testInfo) => {
   server.setContent('/', `
     <!DOCTYPE html>
     <html>
@@ -128,8 +127,9 @@ test('recent console messages filter', async ({ startClient, server }) => {
     },
   }));
 
-  expect(response.events).toContain('console.error');
-  expect(response.events).not.toContain('console.log');
+  const content = await consoleEntries(response);
+  expect(content).toContain('console.error');
+  expect(content).not.toContain('console.log');
 });
 
 test('browser_console_messages default level', async ({ client, server }) => {
@@ -205,7 +205,7 @@ test('browser_console_messages errors only', async ({ client, server }) => {
 test('console log file is created on snapshot', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const { client } = await startClient({
-    config: { outputDir, outputMode: 'file' },
+    config: { outputDir },
   });
 
   server.setContent('/', `
@@ -241,7 +241,7 @@ test('console log file is created on snapshot', async ({ startClient, server }, 
 test('console log file shows correct entry count', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const { client } = await startClient({
-    config: { outputDir, outputMode: 'file' },
+    config: { outputDir },
   });
 
   server.setContent('/', `
@@ -266,7 +266,7 @@ test('console log file shows correct entry count', async ({ startClient, server 
 test('console log file shows singular entry', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const { client } = await startClient({
-    config: { outputDir, outputMode: 'file' },
+    config: { outputDir },
   });
 
   server.setContent('/', `
@@ -289,7 +289,7 @@ test('console log file shows singular entry', async ({ startClient, server }, te
 test('new console log file after navigation', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const { client } = await startClient({
-    config: { outputDir, outputMode: 'file' },
+    config: { outputDir },
   });
 
   server.setContent('/page1', `
@@ -335,7 +335,7 @@ test('new console log file after navigation', async ({ startClient, server }, te
 test('console log file appends on multiple snapshots', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const { client } = await startClient({
-    config: { outputDir, outputMode: 'file' },
+    config: { outputDir },
   });
 
   server.setContent('/', `
@@ -376,7 +376,7 @@ test('console log file appends on multiple snapshots', async ({ startClient, ser
 test('console log file stores message type and content', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const { client } = await startClient({
-    config: { outputDir, outputMode: 'file' },
+    config: { outputDir },
   });
 
   server.setContent('/', `
@@ -452,7 +452,7 @@ test('browser_console_messages all option for page errors', async ({ client, ser
 test('console log is updated without taking snapshots', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const { client } = await startClient({
-    config: { outputDir, outputMode: 'file' },
+    config: { outputDir },
   });
 
   // Navigate to the page (this takes a snapshot)

--- a/tests/mcp/core.spec.ts
+++ b/tests/mcp/core.spec.ts
@@ -26,9 +26,7 @@ test('browser_navigate', async ({ client, server }) => {
     code: `await page.goto('${server.HELLO_WORLD}');`,
     page: `- Page URL: ${server.HELLO_WORLD}
 - Page Title: Title`,
-    snapshot: `\`\`\`yaml
-- generic [active] [ref=e1]: Hello, world!
-\`\`\``,
+    snapshot: `- generic [active] [ref=e1]: Hello, world!`,
   });
 });
 
@@ -49,9 +47,7 @@ test('browser_navigate allows about:, data: and javascript: protocols', async ({
   })).toHaveResponse({
     code: `await page.goto('about:blank');`,
     page: `- Page URL: about:blank`,
-    snapshot: `\`\`\`yaml
-
-\`\`\``,
+    snapshot: ``,
   });
 
   expect(await client.callTool({
@@ -60,9 +56,7 @@ test('browser_navigate allows about:, data: and javascript: protocols', async ({
   })).toHaveResponse({
     code: `await page.goto('data:text/html,<h1>Hello</h1>');`,
     page: expect.stringContaining(`- Page URL: data:text/html,<h1>Hello</h1>`),
-    snapshot: `\`\`\`yaml
-- heading \"Hello\" [level=1] [ref=e2]
-\`\`\``,
+    snapshot: `- heading \"Hello\" [level=1] [ref=e2]`,
   });
 });
 
@@ -88,9 +82,7 @@ test('browser_navigate can navigate to file:// URLs allowUnrestrictedFileAccess 
     arguments: { url },
   })).toHaveResponse({
     page: `- Page URL: ${url}`,
-    snapshot: `\`\`\`yaml
-- generic [ref=e2]: Test file content
-\`\`\``,
+    snapshot: `- generic [ref=e2]: Test file content`,
   });
 });
 
@@ -116,11 +108,9 @@ test('browser_select_option', async ({ client, server }) => {
       values: ['bar'],
     },
   })).toHaveResponse({
-    snapshot: `\`\`\`yaml
-- <changed> combobox [ref=e2]:
+    snapshot: `- <changed> combobox [ref=e2]:
   - option "Foo"
-  - option "Bar" [selected]
-\`\`\``,
+  - option "Bar" [selected]`,
   });
 });
 
@@ -148,10 +138,8 @@ test('browser_select_option (multiple)', async ({ client, server }) => {
     },
   })).toHaveResponse({
     code: `await page.getByRole('listbox').selectOption(['bar', 'baz']);`,
-    snapshot: `\`\`\`yaml
-- <changed> option "Bar" [selected] [ref=e4]
-- <changed> option "Baz" [selected] [ref=e5]
-\`\`\``,
+    snapshot: `- <changed> option "Bar" [selected] [ref=e4]
+- <changed> option "Baz" [selected] [ref=e5]`,
   });
 });
 
@@ -180,7 +168,7 @@ test('browser_resize', async ({ client, server }) => {
     code: `await page.setViewportSize({ width: 390, height: 780 });`,
   });
   await expect.poll(() => client.callTool({ name: 'browser_snapshot' })).toHaveResponse({
-    snapshot: expect.stringContaining(`Window size: 390x780`),
+    inlineSnapshot: expect.stringContaining(`Window size: 390x780`),
   });
 });
 
@@ -243,7 +231,7 @@ test('visibility: hidden > visible should be shown', { annotation: { type: 'issu
   expect(await client.callTool({
     name: 'browser_snapshot'
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`- button "Button"`),
+    inlineSnapshot: expect.stringContaining(`- button "Button"`),
   });
 });
 
@@ -268,11 +256,9 @@ test('snapshot depth', async ({ client, server }) => {
       depth: 1,
     }
   })).toHaveResponse({
-    snapshot: `\`\`\`yaml
-- list [ref=e2]:
+    inlineSnapshot: `- list [ref=e2]:
   - listitem [ref=e3]: text
-  - listitem [ref=e4]
-\`\`\``,
+  - listitem [ref=e4]`,
   });
 
   expect(await client.callTool({
@@ -281,11 +267,9 @@ test('snapshot depth', async ({ client, server }) => {
       depth: 2,
     }
   })).toHaveResponse({
-    snapshot: `\`\`\`yaml
-- list [ref=e2]:
+    inlineSnapshot: `- list [ref=e2]:
   - listitem [ref=e3]: text
   - listitem [ref=e4]:
-    - button "Button" [ref=e5]
-\`\`\``,
+    - button "Button" [ref=e5]`,
   });
 });

--- a/tests/mcp/fixtures.ts
+++ b/tests/mcp/fixtures.ts
@@ -235,7 +235,7 @@ type Response = Awaited<ReturnType<Client['callTool']>>;
 
 export const expect = baseExpect.extend({
   toHaveResponse(response: Response, object: any) {
-    const parsed = parseResponse(response);
+    const parsed = parseResponse(response, test.info().outputPath());
     const text = parsed.text;
     const isNot = this.isNot;
 
@@ -348,4 +348,9 @@ export function formatLog(stderr: string) {
   for (const line of lines)
     object[line] = (object[line] || 0) + 1;
   return object;
+}
+
+export async function consoleEntries(response: any) {
+  const file = response.events?.match(/New console entries: (.+\.log)(#L\d+)?/)?.[1];
+  return await fs.promises.readFile(test.info().outputPath(file), 'utf-8');
 }

--- a/tests/mcp/form.spec.ts
+++ b/tests/mcp/form.spec.ts
@@ -106,18 +106,18 @@ await page.getByRole('checkbox', { name: 'Subscribe to newsletter' }).setChecked
     },
   });
   expect.soft(response).toHaveResponse({
-    snapshot: expect.stringMatching(/textbox "Name".*John Doe/),
+    inlineSnapshot: expect.stringMatching(/textbox "Name".*John Doe/),
   });
   expect.soft(response).toHaveResponse({
-    snapshot: expect.stringMatching(/textbox "Email".*john.doe@example.com/),
+    inlineSnapshot: expect.stringMatching(/textbox "Email".*john.doe@example.com/),
   });
   expect.soft(response).toHaveResponse({
-    snapshot: expect.stringMatching(/slider "Age".*"25"/),
+    inlineSnapshot: expect.stringMatching(/slider "Age".*"25"/),
   });
   expect.soft(response).toHaveResponse({
-    snapshot: expect.stringContaining('option \"United States\" [selected]'),
+    inlineSnapshot: expect.stringContaining('option \"United States\" [selected]'),
   });
   expect.soft(response).toHaveResponse({
-    snapshot: expect.stringContaining('checkbox \"Subscribe to newsletter\" [checked]'),
+    inlineSnapshot: expect.stringContaining('checkbox \"Subscribe to newsletter\" [checked]'),
   });
 });

--- a/tests/mcp/iframes.spec.ts
+++ b/tests/mcp/iframes.spec.ts
@@ -30,8 +30,7 @@ test('stitched aria frames', async ({ client }) => {
       - button "World" [ref=f1e2]
       - main [ref=f1e3]:
         - iframe [ref=f1e4]:
-          - paragraph [ref=f3e2]: Nested
-\`\`\``),
+          - paragraph [ref=f3e2]: Nested`),
   });
 
   expect(await client.callTool({

--- a/tests/mcp/init-page.spec.ts
+++ b/tests/mcp/init-page.spec.ts
@@ -32,7 +32,7 @@ test('--init-page', async ({ startClient }) => {
     name: 'browser_snapshot',
     arguments: {},
   })).toHaveResponse({
-    snapshot: expect.stringContaining('Hello world'),
+    inlineSnapshot: expect.stringContaining('Hello world'),
   });
 });
 

--- a/tests/mcp/request-blocking.spec.ts
+++ b/tests/mcp/request-blocking.spec.ts
@@ -20,27 +20,31 @@ import { test, expect } from './fixtures';
 const BLOCK_MESSAGE = /Blocked by Web Inspector|NS_ERROR_FAILURE|net::ERR_BLOCKED_BY_CLIENT/g;
 
 const fetchPage = async (client: Client, url: string) => {
-  const result = await client.callTool({
+  return await client.callTool({
     name: 'browser_navigate',
     arguments: {
       url,
     },
   });
+};
 
+const fetchPageText = async (client: Client, url: string) => {
+  const result = await fetchPage(client, url);
   return JSON.stringify(result, null, 2);
 };
 
 test('default to allow all', async ({ server, client }) => {
   server.setContent('/ppp', 'content:PPP', 'text/html');
-  const result = await fetchPage(client, server.PREFIX + '/ppp');
-  expect(result).toContain('content:PPP');
+  expect(await fetchPage(client, server.PREFIX + '/ppp')).toHaveResponse({
+    snapshot: expect.stringContaining('content:PPP'),
+  });
 });
 
 test('blocked works (hostname)', async ({ startClient }) => {
   const { client } = await startClient({
     args: ['--blocked-origins', 'microsoft.com;example.com;playwright.dev']
   });
-  const result = await fetchPage(client, 'https://example.com/');
+  const result = await fetchPageText(client, 'https://example.com/');
   expect(result).toMatch(BLOCK_MESSAGE);
 });
 
@@ -48,7 +52,7 @@ test('blocked works (origin)', async ({ startClient }) => {
   const { client } = await startClient({
     args: ['--blocked-origins', 'https://microsoft.com;https://example.com;https://playwright.dev']
   });
-  const result = await fetchPage(client, 'https://example.com/');
+  const result = await fetchPageText(client, 'https://example.com/');
   expect(result).toMatch(BLOCK_MESSAGE);
 });
 
@@ -57,8 +61,9 @@ test('allowed works (hostname)', async ({ server, startClient }) => {
   const { client } = await startClient({
     args: ['--allowed-origins', `microsoft.com;${new URL(server.PREFIX).host};playwright.dev`]
   });
-  const result = await fetchPage(client, server.PREFIX + '/ppp');
-  expect(result).toContain('content:PPP');
+  expect(await fetchPage(client, server.PREFIX + '/ppp')).toHaveResponse({
+    snapshot: expect.stringContaining('content:PPP'),
+  });
 });
 
 test('allowed works (origin)', async ({ server, startClient }) => {
@@ -66,8 +71,9 @@ test('allowed works (origin)', async ({ server, startClient }) => {
   const { client } = await startClient({
     args: ['--allowed-origins', `https://microsoft.com;${new URL(server.PREFIX).origin};https://playwright.dev`]
   });
-  const result = await fetchPage(client, server.PREFIX + '/ppp');
-  expect(result).toContain('content:PPP');
+  expect(await fetchPage(client, server.PREFIX + '/ppp')).toHaveResponse({
+    snapshot: expect.stringContaining('content:PPP'),
+  });
 });
 
 test('blocked takes precedence (hostname)', async ({ startClient }) => {
@@ -77,7 +83,7 @@ test('blocked takes precedence (hostname)', async ({ startClient }) => {
       '--allowed-origins', 'example.com',
     ],
   });
-  const result = await fetchPage(client, 'https://example.com/');
+  const result = await fetchPageText(client, 'https://example.com/');
   expect(result).toMatch(BLOCK_MESSAGE);
 });
 
@@ -88,7 +94,7 @@ test('blocked takes precedence (origin)', async ({ startClient }) => {
       '--allowed-origins', 'https://example.com',
     ],
   });
-  const result = await fetchPage(client, 'https://example.com/');
+  const result = await fetchPageText(client, 'https://example.com/');
   expect(result).toMatch(BLOCK_MESSAGE);
 });
 
@@ -96,7 +102,7 @@ test('allowed without blocked blocks all non-explicitly specified origins (hostn
   const { client } = await startClient({
     args: ['--allowed-origins', 'playwright.dev'],
   });
-  const result = await fetchPage(client, 'https://example.com/');
+  const result = await fetchPageText(client, 'https://example.com/');
   expect(result).toMatch(BLOCK_MESSAGE);
 });
 
@@ -104,7 +110,7 @@ test('allowed without blocked blocks all non-explicitly specified origins (origi
   const { client } = await startClient({
     args: ['--allowed-origins', 'https://playwright.dev'],
   });
-  const result = await fetchPage(client, 'https://example.com/');
+  const result = await fetchPageText(client, 'https://example.com/');
   expect(result).toMatch(BLOCK_MESSAGE);
 });
 
@@ -113,8 +119,9 @@ test('blocked without allowed allows non-explicitly specified origins (hostname)
   const { client } = await startClient({
     args: ['--blocked-origins', 'example.com'],
   });
-  const result = await fetchPage(client, server.PREFIX + '/ppp');
-  expect(result).toContain('content:PPP');
+  expect(await fetchPage(client, server.PREFIX + '/ppp')).toHaveResponse({
+    snapshot: expect.stringContaining('content:PPP'),
+  });
 });
 
 test('blocked without allowed allows non-explicitly specified origins (origin)', async ({ server, startClient }) => {
@@ -122,8 +129,9 @@ test('blocked without allowed allows non-explicitly specified origins (origin)',
   const { client } = await startClient({
     args: ['--blocked-origins', 'https://example.com'],
   });
-  const result = await fetchPage(client, server.PREFIX + '/ppp');
-  expect(result).toContain('content:PPP');
+  expect(await fetchPage(client, server.PREFIX + '/ppp')).toHaveResponse({
+    snapshot: expect.stringContaining('content:PPP'),
+  });
 });
 
 test('allowed works (wildcard port)', async ({ server, startClient }) => {
@@ -131,15 +139,16 @@ test('allowed works (wildcard port)', async ({ server, startClient }) => {
   const { client } = await startClient({
     args: ['--allowed-origins', 'http://localhost:*']
   });
-  const result = await fetchPage(client, server.PREFIX + '/ppp');
-  expect(result).toContain('content:PPP');
+  expect(await fetchPage(client, server.PREFIX + '/ppp')).toHaveResponse({
+    snapshot: expect.stringContaining('content:PPP'),
+  });
 });
 
 test('allowed blocks different hostname (wildcard port)', async ({ startClient }) => {
   const { client } = await startClient({
     args: ['--allowed-origins', 'http://localhost:*'],
   });
-  const result = await fetchPage(client, 'http://example.com/');
+  const result = await fetchPageText(client, 'http://example.com/');
   expect(result).toMatch(BLOCK_MESSAGE);
 });
 
@@ -147,7 +156,7 @@ test('allowed blocks different protocol (wildcard port)', async ({ startClient }
   const { client } = await startClient({
     args: ['--allowed-origins', 'http://localhost:*'],
   });
-  const result = await fetchPage(client, 'https://localhost:8080/');
+  const result = await fetchPageText(client, 'https://localhost:8080/');
   expect(result).toMatch(BLOCK_MESSAGE);
 });
 
@@ -156,6 +165,6 @@ test('blocked works (wildcard port)', async ({ server, startClient }) => {
   const { client } = await startClient({
     args: ['--blocked-origins', `http://${new URL(server.PREFIX).host.split(':')[0]}:*`]
   });
-  const result = await fetchPage(client, server.PREFIX + '/ppp');
+  const result = await fetchPageText(client, server.PREFIX + '/ppp');
   expect(result).toMatch(BLOCK_MESSAGE);
 });

--- a/tests/mcp/route.spec.ts
+++ b/tests/mcp/route.spec.ts
@@ -58,7 +58,7 @@ test('browser_route mocks response with JSON body', async ({ client, server }) =
   expect(await client.callTool({
     name: 'browser_snapshot',
   })).toHaveResponse({
-    snapshot: expect.stringContaining('Alice'),
+    inlineSnapshot: expect.stringContaining('Alice'),
   });
 });
 
@@ -96,7 +96,7 @@ test('browser_route mocks response with custom status', async ({ client, server 
   expect(await client.callTool({
     name: 'browser_snapshot',
   })).toHaveResponse({
-    snapshot: expect.stringContaining('Status: 404'),
+    inlineSnapshot: expect.stringContaining('Status: 404'),
   });
 });
 

--- a/tests/mcp/run-code.spec.ts
+++ b/tests/mcp/run-code.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect } from './fixtures';
+import { test, expect, parseResponse, consoleEntries } from './fixtures';
 
 test('browser_run_code', async ({ client, server }) => {
   server.setContent('/', `
@@ -26,15 +26,14 @@ test('browser_run_code', async ({ client, server }) => {
   });
 
   const code = 'async (page) => await page.getByRole("button", { name: "Submit" }).click()';
-  expect(await client.callTool({
+  const response = parseResponse(await client.callTool({
     name: 'browser_run_code',
     arguments: {
       code,
     },
-  })).toHaveResponse({
-    code: `await (${code})(page);`,
-    events: expect.stringContaining('- [LOG] Submit'),
-  });
+  }));
+  const content = await consoleEntries(response);
+  expect(content).toContain('[LOG] Submit');
 });
 
 test('browser_run_code block', async ({ client, server }) => {
@@ -46,15 +45,19 @@ test('browser_run_code block', async ({ client, server }) => {
     arguments: { url: server.PREFIX },
   });
 
-  expect(await client.callTool({
+  const response = parseResponse(await client.callTool({
     name: 'browser_run_code',
     arguments: {
       code: 'async (page) => { await page.getByRole("button", { name: "Submit" }).click(); await page.getByRole("button", { name: "Submit" }).click(); }',
     },
-  })).toHaveResponse({
+  }));
+
+  expect(response).toEqual(expect.objectContaining({
     code: expect.stringContaining(`await page.getByRole(\"button\", { name: \"Submit\" }).click()`),
-    events: expect.stringMatching(/\[LOG\] Submit.*\n.*\[LOG\] Submit/),
-  });
+  }));
+
+  const content = await consoleEntries(response);
+  expect(content).toMatch(/\[LOG\] Submit.*\n.*\[LOG\] Submit/);
 });
 
 test('browser_run_code no-require', async ({ client, server }) => {
@@ -87,14 +90,18 @@ test('browser_run_code return value', async ({ client, server }) => {
   });
 
   const code = 'async (page) => { await page.getByRole("button", { name: "Submit" }).click(); return { message: "Hello, world!" }; await page.getByRole("banner").click(); }';
-  expect(await client.callTool({
+
+  const response = parseResponse(await client.callTool({
     name: 'browser_run_code',
     arguments: {
       code,
     },
-  })).toHaveResponse({
+  }));
+  expect(response).toEqual(expect.objectContaining({
     code: `await (${code})(page);`,
-    events: expect.stringContaining('- [LOG] Submit'),
     result: '{"message":"Hello, world!"}',
-  });
+  }));
+
+  const content = await consoleEntries(response);
+  expect(content).toContain('[LOG] Submit');
 });

--- a/tests/mcp/secrets.spec.ts
+++ b/tests/mcp/secrets.spec.ts
@@ -123,6 +123,6 @@ await page.getByRole('textbox', { name: 'Password' }).fill(process.env['X-PASSWO
     name: 'browser_snapshot',
     arguments: {},
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`- textbox \"Password\" [active] [ref=e6]: <secret>X-PASSWORD</secret>`),
+    inlineSnapshot: expect.stringContaining(`- textbox \"Password\" [active] [ref=e6]: <secret>X-PASSWORD</secret>`),
   });
 });

--- a/tests/mcp/session-log.spec.ts
+++ b/tests/mcp/session-log.spec.ts
@@ -61,7 +61,7 @@ test('session log should record tool calls', async ({ startClient, server, mcpBr
 \\{
   "code": "await page.goto\\('http://localhost:${server.PORT}'\\);",
   "page": "- Page URL: http://localhost:${server.PORT}/\\\\n- Page Title: Title",
-  "snapshot": "\\\`\\\`\\\`yaml\\\\n- button \\\\"Submit\\\\" \\[ref=e2\\]\\\\n\\\`\\\`\\\`"
+  "snapshot": "- button \\\\"Submit\\\\" \\[ref=e2\\]"
 \\}
 \\\`\\\`\\\`
 
@@ -78,7 +78,7 @@ test('session log should record tool calls', async ({ startClient, server, mcpBr
 \\{
   "code": "await page.getByRole\\('button', \\{ name: 'Submit' \\}\\).click\\(\\);",
   "page": "- Page URL: http://localhost:${server.PORT}/\\\\n- Page Title: Title",
-  "snapshot": "\\\`\\\`\\\`yaml\\\\n- <changed> button \\\\"Submit\\\\" \\[active\\] \\[ref=e2\\]\\\\n\\\`\\\`\\\`"
+  "snapshot": "- <changed> button \\\\"Submit\\\\" \\[active\\] \\[ref=e2\\]"
 \\}
 \\\`\\\`\\\`
 `.trim()));

--- a/tests/mcp/snapshot-diff.spec.ts
+++ b/tests/mcp/snapshot-diff.spec.ts
@@ -50,8 +50,7 @@ test('should return aria snapshot diff', async ({ client, server }) => {
       url: server.PREFIX,
     },
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`
-  - button "Button 1" [ref=e2]
+    snapshot: expect.stringContaining(`- button "Button 1" [ref=e2]
   - button "Button 2" [active] [ref=e3]
   - list [ref=e4]:${listitems}`),
   });
@@ -63,9 +62,7 @@ test('should return aria snapshot diff', async ({ client, server }) => {
       ref: 'e3',
     },
   })).toHaveResponse({
-    snapshot: `\`\`\`yaml
-
-\`\`\``,
+    snapshot: ``,
   });
 
   expect(await client.callTool({
@@ -75,24 +72,20 @@ test('should return aria snapshot diff', async ({ client, server }) => {
       ref: 'e2',
     },
   })).toHaveResponse({
-    snapshot: `\`\`\`yaml
-- <changed> generic [ref=e1]:
+    snapshot: `- <changed> generic [ref=e1]:
   - button "Button 1" [active] [ref=e2]
   - button "Button 2new text" [ref=e105]
-  - ref=e4 [unchanged]
-\`\`\``,
+  - ref=e4 [unchanged]`,
   });
 
   // browser_snapshot forces a full snapshot.
   expect(await client.callTool({
     name: 'browser_snapshot',
   })).toHaveResponse({
-    snapshot: `\`\`\`yaml
-- generic [ref=e1]:
+    inlineSnapshot: `- generic [ref=e1]:
   - button "Button 1" [active] [ref=e2]
   - button "Button 2new text" [ref=e105]
-  - list [ref=e4]:${listitems}
-\`\`\``,
+  - list [ref=e4]:${listitems}`,
   });
 });
 
@@ -136,8 +129,7 @@ test('should reset aria snapshot diff upon navigation', async ({ client, server 
       url: server.PREFIX + '/before',
     },
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`
-  - button "Button 1" [ref=e2]
+    snapshot: expect.stringContaining(`- button "Button 1" [ref=e2]
   - button "Button 2" [active] [ref=e3]`),
   });
 
@@ -148,8 +140,7 @@ test('should reset aria snapshot diff upon navigation', async ({ client, server 
       ref: 'e2',
     },
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`
-  - button "Button 1" [ref=e2]
+    snapshot: expect.stringContaining(`- button "Button 1" [ref=e2]
   - button "Button 2" [active] [ref=e3]`),
   });
 });

--- a/tests/mcp/snapshot-mode.spec.ts
+++ b/tests/mcp/snapshot-mode.spec.ts
@@ -31,8 +31,7 @@ test('should respect --snapshot-mode=full', async ({ startClient, server }) => {
       url: server.PREFIX,
     },
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`
-- button "Button 1" [ref=e2]`),
+    snapshot: expect.stringContaining(`- button "Button 1" [ref=e2]`),
   });
 
   await client.callTool({
@@ -49,8 +48,7 @@ test('should respect --snapshot-mode=full', async ({ startClient, server }) => {
   expect(await client.callTool({
     name: 'browser_snapshot',
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`
-  - button "Button 1" [ref=e2]
+    inlineSnapshot: expect.stringContaining(`- button "Button 1" [ref=e2]
   - button "Button 2" [ref=e3]`),
   });
 });
@@ -69,8 +67,7 @@ test('should respect --snapshot-mode=incremental', async ({ startClient, server,
       url: server.PREFIX,
     },
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`
-- button "Button 1" [ref=e2]`),
+    snapshot: expect.stringContaining(`- button "Button 1" [ref=e2]`),
   });
 
   await client.callTool({
@@ -91,8 +88,7 @@ test('should respect --snapshot-mode=incremental', async ({ startClient, server,
       ref: 'e3',
     },
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`
-- <changed> generic [ref=e1]:
+    snapshot: expect.stringContaining(`- <changed> generic [ref=e1]:
   - ref=e2 [unchanged]
   - button \"Button 2\" [active] [ref=e3]`),
   });

--- a/tests/mcp/tabs.spec.ts
+++ b/tests/mcp/tabs.spec.ts
@@ -61,18 +61,14 @@ test('create new tab', async ({ client }) => {
   expect(await createTab(client, 'Tab one', 'Body one')).toHaveResponse({
     tabs: `- 0: [](about:blank)
 - 1: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
-    snapshot: `\`\`\`yaml
-- generic [active] [ref=e1]: Body one
-\`\`\``,
+    snapshot: `- generic [active] [ref=e1]: Body one`,
   });
 
   expect(await createTab(client, 'Tab two', 'Body two')).toHaveResponse({
     tabs: `- 0: [](about:blank)
 - 1: [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)
 - 2: (current) [Tab two](data:text/html,<title>Tab two</title><body>Body two</body>)`,
-    snapshot: `\`\`\`yaml
-- generic [active] [ref=e1]: Body two
-\`\`\``,
+    snapshot: `- generic [active] [ref=e1]: Body two`,
   });
   expect(await client.callTool({
     name: 'browser_snapshot',

--- a/tests/mcp/test-debug.spec.ts
+++ b/tests/mcp/test-debug.spec.ts
@@ -119,7 +119,7 @@ test('test_debug (browser_snapshot/network/console)', async ({ startClient, serv
   expect(await client.callTool({
     name: 'browser_snapshot',
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`generic [active] [ref=e1]: Hello, world!`),
+    inlineSnapshot: expect.stringContaining(`generic [active] [ref=e1]: Hello, world!`),
   });
 });
 
@@ -201,7 +201,7 @@ Try recovering from the error prior to continuing`);
   expect(await client.callTool({
     name: 'browser_snapshot',
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`- button \"Submit\" [ref=e2]`),
+    inlineSnapshot: expect.stringContaining(`- button \"Submit\" [ref=e2]`),
   });
 
   expect(await client.callTool({

--- a/tests/mcp/unicode-serialization.spec.ts
+++ b/tests/mcp/unicode-serialization.spec.ts
@@ -30,17 +30,6 @@ test.describe('unicode serialization', () => {
     expect(result.content[0].text).toContain('Page URL:');
   });
 
-  test('preserves valid emoji and surrogate pairs', async ({ client, server }) => {
-    server.setContent('/', 'Valid emoji: 💀 skull and text', 'text/html');
-
-    const result = await client.callTool({
-      name: 'browser_navigate',
-      arguments: { url: server.PREFIX },
-    });
-
-    expect(result.content[0].text).toContain('emoji');
-  });
-
   test('handles console messages with lone surrogates', async ({ startClient, server }) => {
     server.setContent('/', `<script>console.log('msg ${String.fromCharCode(0xD800)} surrog')</script>`, 'text/html');
 

--- a/tests/mcp/wait.spec.ts
+++ b/tests/mcp/wait.spec.ts
@@ -54,7 +54,7 @@ test('browser_wait_for(text)', async ({ client, server }) => {
   expect(await client.callTool({
     name: 'browser_snapshot',
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [ref=e3]: Text to appear`),
+    inlineSnapshot: expect.stringContaining(`- generic [ref=e3]: Text to appear`),
   });
 });
 
@@ -96,7 +96,7 @@ test('browser_wait_for(textGone)', async ({ client, server }) => {
   expect(await client.callTool({
     name: 'browser_snapshot',
   })).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [ref=e3]: Text to appear`),
+    inlineSnapshot: expect.stringContaining(`- generic [ref=e3]: Text to appear`),
   });
 });
 


### PR DESCRIPTION
## Summary
- Remove `outputMode` config option; snapshots go to files for non-explicit mode, inline for explicit (browser_snapshot)
- Centralize secret masking via `_redactSecrets` / `_writeFile` so all file writes are redacted
- Move console message filtering to tab level, simplify LogFile to accept strings directly
- Add `filename` parameter to evaluate tool for saving results to files
- Update `parseResponse` to read snapshot files and distinguish file vs inline snapshots