### PR TITLE
chore(mcp): remove unnecessary waitForCompletion from non-navigating tools

### DIFF
--- a/packages/playwright-core/src/tools/backend/keyboard.ts
+++ b/packages/playwright-core/src/tools/backend/keyboard.ts
@@ -94,7 +94,7 @@ const type = defineTabTool({
     const { locator, resolved } = await tab.refLocator(params);
     const secret = tab.context.lookupSecret(params.text);
 
-    await tab.waitForCompletion(async () => {
+    const action = async () => {
       if (params.slowly) {
         response.setIncludeSnapshot();
         response.addCode(`await page.${resolved}.pressSequentially(${secret.code});`);
@@ -109,7 +109,12 @@ const type = defineTabTool({
         response.addCode(`await page.${resolved}.press('Enter');`);
         await locator.press('Enter', tab.actionTimeoutOptions);
       }
-    });
+    };
+
+    if (params.submit || params.slowly)
+      await tab.waitForCompletion(action);
+    else
+      await action();
   },
 });
 

--- a/packages/playwright-core/src/tools/backend/mouse.ts
+++ b/packages/playwright-core/src/tools/backend/mouse.ts
@@ -35,9 +35,7 @@ const mouseMove = defineTabTool({
     response.addCode(`// Move mouse to (${params.x}, ${params.y})`);
     response.addCode(`await page.mouse.move(${params.x}, ${params.y});`);
 
-    await tab.waitForCompletion(async () => {
-      await tab.page.mouse.move(params.x, params.y);
-    });
+    await tab.page.mouse.move(params.x, params.y);
   },
 });
 

--- a/packages/playwright-core/src/tools/backend/snapshot.ts
+++ b/packages/playwright-core/src/tools/backend/snapshot.ts
@@ -135,9 +135,7 @@ const hover = defineTabTool({
     const { locator, resolved } = await tab.refLocator(params);
     response.addCode(`await page.${resolved}.hover();`);
 
-    await tab.waitForCompletion(async () => {
-      await locator.hover(tab.actionTimeoutOptions);
-    });
+    await locator.hover(tab.actionTimeoutOptions);
   },
 });
 
@@ -161,9 +159,7 @@ const selectOption = defineTabTool({
     const { locator, resolved } = await tab.refLocator(params);
     response.addCode(`await page.${resolved}.selectOption(${formatObject(params.values)});`);
 
-    await tab.waitForCompletion(async () => {
-      await locator.selectOption(params.values, tab.actionTimeoutOptions);
-    });
+    await locator.selectOption(params.values, tab.actionTimeoutOptions);
   },
 });
 

--- a/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
@@ -35,7 +35,8 @@ playwright-cli goto https://playwright.dev
 playwright-cli type "search query"
 playwright-cli click e3
 playwright-cli dblclick e7
-playwright-cli fill e5 "user@example.com"
+# --submit presses Enter after filling the element
+playwright-cli fill e5 "user@example.com"  --submit
 playwright-cli drag e2 e8
 playwright-cli hover e4
 playwright-cli select e9 "option-value"


### PR DESCRIPTION
## Summary
- Remove `waitForCompletion` from `browser_type` (fill) unless `--submit` or `--slowly` is used
- Remove `waitForCompletion` from `browser_hover`, `browser_select_option`, and `browser_mouse_move_xy` — these actions don't cause navigation
- Update SKILL.md to document `--submit` flag for fill