### PR TITLE
fix(reporter): use Screen in html reporter for PLAYWRIGHT_FORCE_TTY support

### DIFF
--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -113,7 +113,7 @@ function addTestServerCommand(program: Command) {
 function addShowReportCommand(program: Command) {
   const command = program.command('show-report [report]');
   command.description('show HTML report');
-  command.action((report, options) => showHTMLReport(report, options.host, +options.port));
+  command.action((report, options) => showHTMLReport(terminalScreen, report, options.host, +options.port));
   command.option('--host <host>', 'Host to serve report on', 'localhost');
   command.option('--port <port>', 'Port to serve report on', '9323');
   command.addHelpText('afterAll', `

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -47,10 +47,6 @@ const isHtmlReportOption = (type: string): type is HtmlReportOpenOption => {
   return htmlReportOptions.includes(type as HtmlReportOpenOption);
 };
 
-type ScreenOptions = {
-  screen?: TerminalScreen;
-};
-
 type MachineData = {
   config: api.FullConfig;
   result: api.FullResult;
@@ -72,7 +68,7 @@ class HtmlReporter implements ReporterV2 {
   private _reportConfigs = new Map<string, api.FullConfig>();
   private _machines: MachineData[] = [];
 
-  constructor(options: HtmlReporterConfigOptions & CommonReporterOptions & ScreenOptions) {
+  constructor(options: HtmlReporterConfigOptions & CommonReporterOptions & { screen?: TerminalScreen }) {
     this._options = options;
     this._screen = options.screen ?? terminalScreen;
   }
@@ -103,12 +99,12 @@ class HtmlReporter implements ReporterV2 {
         if (reportedWarnings.has(key))
           continue;
         reportedWarnings.add(key);
-        writeLine(this._screen, this._screen.colors.red(`Configuration Error: HTML reporter output folder clashes with the tests output folder:`));
-        writeLine(this._screen, `
+        this._writeLine(this._screen.colors.red(`Configuration Error: HTML reporter output folder clashes with the tests output folder:`));
+        this._writeLine(`
     html reporter folder: ${this._screen.colors.bold(outputFolder)}
     test results folder: ${this._screen.colors.bold(project.outputDir)}`);
-        writeLine(this._screen, '');
-        writeLine(this._screen, `HTML reporter will clear its output directory prior to being generated, which will lead to the artifact loss.
+        this._writeLine('');
+        this._writeLine(`HTML reporter will clear its output directory prior to being generated, which will lead to the artifact loss.
 `);
       }
     }
@@ -119,7 +115,7 @@ class HtmlReporter implements ReporterV2 {
     const outputFolder = reportFolderFromEnv() ?? resolveReporterOutputPath('playwright-report', this._options.configDir, this._options.outputFolder);
     return {
       outputFolder,
-      open: getHtmlReportOptionProcessEnv(this._screen) || this._options.open || 'on-failure',
+      open: this._getHtmlReportOptionProcessEnv() || this._options.open || 'on-failure',
       attachmentsBaseURL: process.env.PLAYWRIGHT_HTML_ATTACHMENTS_BASE_URL || this._options.attachmentsBaseURL || 'data/',
       host: process.env.PLAYWRIGHT_HTML_HOST || this._options.host,
       port: process.env.PLAYWRIGHT_HTML_PORT ? +process.env.PLAYWRIGHT_HTML_PORT : this._options.port,
@@ -183,12 +179,28 @@ class HtmlReporter implements ReporterV2 {
       const relativeReportPath = this._outputFolder === standaloneDefaultFolder() ? '' : ' ' + path.relative(process.cwd(), this._outputFolder);
       const hostArg = this._host ? ` --host ${this._host}` : '';
       const portArg = this._port ? ` --port ${this._port}` : '';
-      writeLine(this._screen, '');
-      writeLine(this._screen, 'To open last HTML report run:');
-      writeLine(this._screen, this._screen.colors.cyan(`
+      this._writeLine('');
+      this._writeLine('To open last HTML report run:');
+      this._writeLine(this._screen.colors.cyan(`
   ${packageManagerCommand} playwright show-report${relativeReportPath}${hostArg}${portArg}
 `));
     }
+  }
+
+  private _getHtmlReportOptionProcessEnv(): HtmlReportOpenOption | undefined {
+    // Note: PW_TEST_HTML_REPORT_OPEN is for backwards compatibility.
+    const htmlOpenEnv = process.env.PLAYWRIGHT_HTML_OPEN || process.env.PW_TEST_HTML_REPORT_OPEN;
+    if (!htmlOpenEnv)
+      return undefined;
+    if (!isHtmlReportOption(htmlOpenEnv)) {
+      this._writeLine(this._screen.colors.red(`Configuration Error: HTML reporter Invalid value for PLAYWRIGHT_HTML_OPEN: ${htmlOpenEnv}. Valid values are: ${htmlReportOptions.join(', ')}`));
+      return undefined;
+    }
+    return htmlOpenEnv;
+  }
+
+  private _writeLine(line: string) {
+    writeLine(this._screen, line);
   }
 }
 
@@ -196,18 +208,6 @@ function reportFolderFromEnv(): string | undefined {
   // Note: PLAYWRIGHT_HTML_REPORT is for backwards compatibility.
   const envValue = process.env.PLAYWRIGHT_HTML_OUTPUT_DIR || process.env.PLAYWRIGHT_HTML_REPORT;
   return envValue ? path.resolve(envValue) : undefined;
-}
-
-function getHtmlReportOptionProcessEnv(screen: TerminalScreen): HtmlReportOpenOption | undefined {
-  // Note: PW_TEST_HTML_REPORT_OPEN is for backwards compatibility.
-  const htmlOpenEnv = process.env.PLAYWRIGHT_HTML_OPEN || process.env.PW_TEST_HTML_REPORT_OPEN;
-  if (!htmlOpenEnv)
-    return undefined;
-  if (!isHtmlReportOption(htmlOpenEnv)) {
-    writeLine(screen, screen.colors.red(`Configuration Error: HTML reporter Invalid value for PLAYWRIGHT_HTML_OPEN: ${htmlOpenEnv}. Valid values are: ${htmlReportOptions.join(', ')}`));
-    return undefined;
-  }
-  return htmlOpenEnv;
 }
 
 function standaloneDefaultFolder(): string {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -24,7 +24,7 @@ import { open } from 'playwright-core/lib/utilsBundle';
 import { mime } from 'playwright-core/lib/utilsBundle';
 import { yazl } from 'playwright-core/lib/zipBundle';
 
-import { CommonReporterOptions, formatError, formatResultFailure, internalScreen } from './base';
+import { CommonReporterOptions, formatError, formatResultFailure, internalScreen, terminalScreen } from './base';
 import { codeFrameColumns } from '../transform/babelBundle';
 import { resolveReporterOutputPath, stripAnsiEscapes } from '../util';
 
@@ -169,10 +169,10 @@ class HtmlReporter implements ReporterV2 {
       return;
     const { ok, singleTestId } = this._buildResult;
     const isCodingAgent = !!process.env.CLAUDECODE || !!process.env.COPILOT_CLI;
-    const shouldOpen = !isCodingAgent && !!process.stdin.isTTY && (this._open === 'always' || (!ok && this._open === 'on-failure'));
+    const shouldOpen = !isCodingAgent && terminalScreen.isTTY && (this._open === 'always' || (!ok && this._open === 'on-failure'));
     if (shouldOpen) {
       await showHTMLReport(this._outputFolder, this._host, this._port, singleTestId);
-    } else if (this._options._mode === 'test' && !!process.stdin.isTTY) {
+    } else if (this._options._mode === 'test' && terminalScreen.isTTY) {
       const packageManagerCommand = getPackageManagerExecCommand();
       const relativeReportPath = this._outputFolder === standaloneDefaultFolder() ? '' : ' ' + path.relative(process.cwd(), this._outputFolder);
       const hostArg = this._host ? ` --host ${this._host}` : '';
@@ -741,8 +741,7 @@ function createErrorCodeframe(message: string, location: Location) {
 }
 
 function writeLine(line: string) {
-  // eslint-disable-next-line no-restricted-properties
-  process.stdout.write(line + '\n');
+  terminalScreen.stdout.write(line + '\n');
 }
 
 export default HtmlReporter;

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -19,7 +19,6 @@ import path from 'path';
 import { Transform } from 'stream';
 
 import { HttpServer, MultiMap, assert, calculateSha1, getPackageManagerExecCommand, copyFileAndMakeWritable, gracefullyProcessExitDoNotHang, removeFolders, sanitizeForFilePath, toPosixPath } from 'playwright-core/lib/utils';
-import { colors } from 'playwright-core/lib/utils';
 import { open } from 'playwright-core/lib/utilsBundle';
 import { mime } from 'playwright-core/lib/utilsBundle';
 import { yazl } from 'playwright-core/lib/zipBundle';
@@ -34,6 +33,7 @@ import type * as api from '../../types/testReporter';
 import type { HTMLReport, HTMLReportOptions, Location, Stats, TestAttachment, TestCase, TestCaseSummary, TestFile, TestFileSummary, TestResult, TestStep } from '@html-reporter/types';
 import type { ZipFile } from 'playwright-core/lib/zipBundle';
 import type { TransformCallback } from 'stream';
+import type { TerminalScreen } from './base';
 
 type TestEntry = {
   testCase: TestCase;
@@ -47,6 +47,10 @@ const isHtmlReportOption = (type: string): type is HtmlReportOpenOption => {
   return htmlReportOptions.includes(type as HtmlReportOpenOption);
 };
 
+type ScreenOptions = {
+  screen?: TerminalScreen;
+};
+
 type MachineData = {
   config: api.FullConfig;
   result: api.FullResult;
@@ -57,6 +61,7 @@ class HtmlReporter implements ReporterV2 {
   private config!: api.FullConfig;
   private suite!: api.Suite;
   private _options: HtmlReporterConfigOptions & CommonReporterOptions;
+  private _screen: TerminalScreen;
   private _outputFolder!: string;
   private _attachmentsBaseURL!: string;
   private _open: string | undefined;
@@ -67,8 +72,9 @@ class HtmlReporter implements ReporterV2 {
   private _reportConfigs = new Map<string, api.FullConfig>();
   private _machines: MachineData[] = [];
 
-  constructor(options: HtmlReporterConfigOptions & CommonReporterOptions) {
+  constructor(options: HtmlReporterConfigOptions & CommonReporterOptions & ScreenOptions) {
     this._options = options;
+    this._screen = options.screen ?? terminalScreen;
   }
 
   version(): 'v2' {
@@ -97,12 +103,12 @@ class HtmlReporter implements ReporterV2 {
         if (reportedWarnings.has(key))
           continue;
         reportedWarnings.add(key);
-        writeLine(colors.red(`Configuration Error: HTML reporter output folder clashes with the tests output folder:`));
-        writeLine(`
-    html reporter folder: ${colors.bold(outputFolder)}
-    test results folder: ${colors.bold(project.outputDir)}`);
-        writeLine('');
-        writeLine(`HTML reporter will clear its output directory prior to being generated, which will lead to the artifact loss.
+        writeLine(this._screen, this._screen.colors.red(`Configuration Error: HTML reporter output folder clashes with the tests output folder:`));
+        writeLine(this._screen, `
+    html reporter folder: ${this._screen.colors.bold(outputFolder)}
+    test results folder: ${this._screen.colors.bold(project.outputDir)}`);
+        writeLine(this._screen, '');
+        writeLine(this._screen, `HTML reporter will clear its output directory prior to being generated, which will lead to the artifact loss.
 `);
       }
     }
@@ -113,7 +119,7 @@ class HtmlReporter implements ReporterV2 {
     const outputFolder = reportFolderFromEnv() ?? resolveReporterOutputPath('playwright-report', this._options.configDir, this._options.outputFolder);
     return {
       outputFolder,
-      open: getHtmlReportOptionProcessEnv() || this._options.open || 'on-failure',
+      open: getHtmlReportOptionProcessEnv(this._screen) || this._options.open || 'on-failure',
       attachmentsBaseURL: process.env.PLAYWRIGHT_HTML_ATTACHMENTS_BASE_URL || this._options.attachmentsBaseURL || 'data/',
       host: process.env.PLAYWRIGHT_HTML_HOST || this._options.host,
       port: process.env.PLAYWRIGHT_HTML_PORT ? +process.env.PLAYWRIGHT_HTML_PORT : this._options.port,
@@ -169,17 +175,17 @@ class HtmlReporter implements ReporterV2 {
       return;
     const { ok, singleTestId } = this._buildResult;
     const isCodingAgent = !!process.env.CLAUDECODE || !!process.env.COPILOT_CLI;
-    const shouldOpen = !isCodingAgent && terminalScreen.isTTY && (this._open === 'always' || (!ok && this._open === 'on-failure'));
+    const shouldOpen = !isCodingAgent && this._screen.isTTY && (this._open === 'always' || (!ok && this._open === 'on-failure'));
     if (shouldOpen) {
-      await showHTMLReport(this._outputFolder, this._host, this._port, singleTestId);
-    } else if (this._options._mode === 'test' && terminalScreen.isTTY) {
+      await showHTMLReport(this._screen, this._outputFolder, this._host, this._port, singleTestId);
+    } else if (this._options._mode === 'test' && this._screen.isTTY) {
       const packageManagerCommand = getPackageManagerExecCommand();
       const relativeReportPath = this._outputFolder === standaloneDefaultFolder() ? '' : ' ' + path.relative(process.cwd(), this._outputFolder);
       const hostArg = this._host ? ` --host ${this._host}` : '';
       const portArg = this._port ? ` --port ${this._port}` : '';
-      writeLine('');
-      writeLine('To open last HTML report run:');
-      writeLine(colors.cyan(`
+      writeLine(this._screen, '');
+      writeLine(this._screen, 'To open last HTML report run:');
+      writeLine(this._screen, this._screen.colors.cyan(`
   ${packageManagerCommand} playwright show-report${relativeReportPath}${hostArg}${portArg}
 `));
     }
@@ -192,13 +198,13 @@ function reportFolderFromEnv(): string | undefined {
   return envValue ? path.resolve(envValue) : undefined;
 }
 
-function getHtmlReportOptionProcessEnv(): HtmlReportOpenOption | undefined {
+function getHtmlReportOptionProcessEnv(screen: TerminalScreen): HtmlReportOpenOption | undefined {
   // Note: PW_TEST_HTML_REPORT_OPEN is for backwards compatibility.
   const htmlOpenEnv = process.env.PLAYWRIGHT_HTML_OPEN || process.env.PW_TEST_HTML_REPORT_OPEN;
   if (!htmlOpenEnv)
     return undefined;
   if (!isHtmlReportOption(htmlOpenEnv)) {
-    writeLine(colors.red(`Configuration Error: HTML reporter Invalid value for PLAYWRIGHT_HTML_OPEN: ${htmlOpenEnv}. Valid values are: ${htmlReportOptions.join(', ')}`));
+    writeLine(screen, screen.colors.red(`Configuration Error: HTML reporter Invalid value for PLAYWRIGHT_HTML_OPEN: ${htmlOpenEnv}. Valid values are: ${htmlReportOptions.join(', ')}`));
     return undefined;
   }
   return htmlOpenEnv;
@@ -208,20 +214,20 @@ function standaloneDefaultFolder(): string {
   return reportFolderFromEnv() ?? resolveReporterOutputPath('playwright-report', process.cwd(), undefined);
 }
 
-export async function showHTMLReport(reportFolder: string | undefined, host: string = 'localhost', port?: number, testId?: string) {
+export async function showHTMLReport(screen: TerminalScreen, reportFolder: string | undefined, host: string = 'localhost', port?: number, testId?: string) {
   const folder = reportFolder ?? standaloneDefaultFolder();
   try {
     assert(fs.statSync(folder).isDirectory());
   } catch (e) {
-    writeLine(colors.red(`No report found at "${folder}"`));
+    writeLine(screen, screen.colors.red(`No report found at "${folder}"`));
     gracefullyProcessExitDoNotHang(1);
     return;
   }
   const server = startHtmlReportServer(folder);
   await server.start({ port, host, preferredPort: port ? undefined : 9323 });
   let url = server.urlPrefix('human-readable');
-  writeLine('');
-  writeLine(colors.cyan(`  Serving HTML report at ${url}. Press Ctrl+C to quit.`));
+  writeLine(screen, '');
+  writeLine(screen, screen.colors.cyan(`  Serving HTML report at ${url}. Press Ctrl+C to quit.`));
   if (testId)
     url += `#?testId=${testId}`;
   url = url.replace('0.0.0.0', 'localhost');
@@ -740,8 +746,8 @@ function createErrorCodeframe(message: string, location: Location) {
   );
 }
 
-function writeLine(line: string) {
-  terminalScreen.stdout.write(line + '\n');
+function writeLine(screen: TerminalScreen, line: string) {
+  screen.stdout.write(line + '\n');
 }
 
 export default HtmlReporter;


### PR DESCRIPTION
## Summary
- Replace direct `process.stdin.isTTY` checks in the HTML reporter with `terminalScreen.isTTY`, which respects the `PLAYWRIGHT_FORCE_TTY` environment variable
- Replace `process.stdout.write` in `writeLine` with `terminalScreen.stdout.write` for consistency

This fixes the regression introduced in #38044 where JetBrains IDEs (WebStorm, IntelliJ) stopped auto-opening the HTML report because their test runners don't set `process.stdin.isTTY`. Users can now set `PLAYWRIGHT_FORCE_TTY=1` to work around this.

Fixes https://github.com/microsoft/playwright/issues/39766