### PR TITLE
docs(ct): add Svelte hooks example

### DIFF
--- a/docs/src/test-components-js.md
+++ b/docs/src/test-components-js.md
@@ -424,6 +424,7 @@ You can use `beforeMount` and `afterMount` hooks to configure your app. This let
   values={[
     {label: 'React', value: 'react'},
     {label: 'Vue', value: 'vue'},
+    {label: 'Svelte', value: 'svelte'},
   ]
 }>
   <TabItem value="react">
@@ -483,6 +484,41 @@ You can use `beforeMount` and `afterMount` hooks to configure your app. This let
       hooksConfig: { enableRouting: true },
     });
     await expect(component.getByRole('link')).toHaveAttribute('href', '/products/42');
+  });
+  ```
+
+  </TabItem>
+
+  <TabItem value="svelte">
+
+  ```js title="playwright/index.ts"
+  import { beforeMount, afterMount } from '@playwright/experimental-ct-svelte/hooks';
+
+  export type HooksConfig = {
+    context?: string;
+  }
+
+  beforeMount<HooksConfig>(async ({ hooksConfig, App }) => {
+    return new App({
+      context: new Map([
+        ['context-key', hooksConfig?.context]
+      ]),
+    });
+  });
+  ```
+
+  ```js title="src/context.spec.ts"
+  import { test, expect } from '@playwright/experimental-ct-svelte';
+  import type { HooksConfig } from '../playwright';
+  import Context from './Context.svelte';
+
+  test('pass context via hooksConfig', async ({ mount }) => {
+    const component = await mount<HooksConfig>(Context, {
+      hooksConfig: {
+        context: 'context-value',
+      },
+    });
+    await expect(component).toContainText('context-value');
   });
   ```
 


### PR DESCRIPTION
## Summary
- Add a Svelte tab to the hooks section in the component testing docs
- Shows how to pass context to a Svelte component via `beforeMount` and `hooksConfig`
- Matches the existing React (BrowserRouter) and Vue (app.use router) examples in structure

The example uses `@playwright/experimental-ct-svelte/hooks` and demonstrates Svelte's context map pattern, based on the code provided in #31367 by @sand4rt.

Fixes https://github.com/microsoft/playwright/issues/31367

This contribution was developed with AI assistance (Claude Code + Codex).