### PR TITLE
chore: swallow TargetClosedErrors in beforeunload dialog.dismiss()

### DIFF
--- a/packages/playwright-core/src/client/dialog.ts
+++ b/packages/playwright-core/src/client/dialog.ts
@@ -16,6 +16,7 @@
 
 import { ChannelOwner } from './channelOwner';
 import { Page } from './page';
+import { isTargetClosedError } from './errors';
 
 import type * as api from '../../types/types';
 import type * as channels from '@protocol/channels';
@@ -56,6 +57,12 @@ export class Dialog extends ChannelOwner<channels.DialogChannel> implements api.
   }
 
   async dismiss() {
-    await this._channel.dismiss();
+    try {
+      await this._channel.dismiss();
+    } catch (e) {
+      if (isTargetClosedError(e))
+        return;
+      throw e;
+    }
   }
 }

--- a/tests/library/page-close.spec.ts
+++ b/tests/library/page-close.spec.ts
@@ -27,16 +27,6 @@ test('should close page with active dialog', async ({ page }) => {
   await page.close();
 });
 
-test('should not accept dialog after close', async ({ page, mode }) => {
-  test.fixme(mode.startsWith('service2'), 'Times out');
-  const promise = page.waitForEvent('dialog');
-  page.evaluate(() => alert()).catch(() => {});
-  const dialog = await promise;
-  await page.close();
-  const e = await dialog.dismiss().catch(e => e);
-  expect(e.message).toContain('Target page, context or browser has been closed');
-});
-
 test('expect should not print timed out error message when page closes', async ({ page }) => {
   await page.setContent('<div id=node>Text content</div>');
   const [error] = await Promise.all([


### PR DESCRIPTION
See https://github.com/microsoft/playwright/pull/39701#issuecomment-4097716831. ~This swallows TargetClosedErrors only for `beforeunload` dialogs because [this test](https://github.com/microsoft/playwright/blob/662e25ae6ed982522e6218a6c70f777fdcc54d56/tests/library/page-close.spec.ts#L30-L38) checks that `dialog.dismiss()` will throw for alert dialogs.~