### PR TITLE
Added to the docs: Playwright for .NET does not follow Semantic Versioning

### DIFF
--- a/docs/src/library-csharp.md
+++ b/docs/src/library-csharp.md
@@ -94,3 +94,6 @@ or:
   <PlaywrightPlatform>osx;linux</PlaywrightPlatform>
 </PropertyGroup>
 ```
+
+## Updating Playwright
+Please note that Playwright for .NET does not follow Semantic Versioning (also known as [Semver](https://semver.org/)) — minor versions may include breaking changes.


### PR DESCRIPTION
Not sure if this is the best place, but it would be great if it was documented somewhere. 