### PR TITLE
fix(cli-daemon): close browser context on stop to prevent orphaned Chrome processes

### DIFF
--- a/packages/playwright-core/src/tools/cli-daemon/daemon.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/daemon.ts
@@ -64,6 +64,7 @@ export async function startCliDaemonServer(
 ): Promise<string> {
   const sessionConfig = createSessionConfig(clientInfo, sessionName, browserInfo, options);
   const { socketPath } = sessionConfig;
+  let isStoppingExplicitly = false;
 
   // Clean up existing socket file on Unix
   if (process.platform !== 'win32' && await socketExists(socketPath)) {
@@ -95,13 +96,21 @@ export async function startCliDaemonServer(
       try {
         daemonDebug('received command', method);
         if (method === 'stop') {
+          if (isStoppingExplicitly) {
+            await connection.send({ id, result: 'ok' }).catch(() => {});
+            return;
+          }
           daemonDebug('stop command received, shutting down');
+          isStoppingExplicitly = true;
           await deleteSessionFile(clientInfo, sessionConfig);
-          const sendAck = async () => connection.send({ id, result: 'ok' }).catch(() => {});
+          // Send ack before closing the browser so the client is not blocked
+          // waiting for browser teardown.
+          await connection.send({ id, result: 'ok' }).catch(() => {});
+          // Close the browser context to terminate the browser process before exiting.
+          // Without this, the browser process may outlive the daemon.
+          await browserContext.close().catch(e => daemonDebug('failed to close browser context', e));
           if (options?.exitOnClose)
-            gracefullyProcessExitDoNotHang(0, () => sendAck());
-          else
-            await sendAck();
+            gracefullyProcessExitDoNotHang(0);
         } else if (method === 'run') {
           const { toolName, toolParams } = parseCliCommand(params.args);
           if (params.cwd)
@@ -121,6 +130,8 @@ export async function startCliDaemonServer(
 
   decorateServer(server);
   browserContext.on('close', () => Promise.resolve().then(async () => {
+    if (isStoppingExplicitly)
+      return;
     await deleteSessionFile(clientInfo, sessionConfig);
     if (options?.exitOnClose)
       gracefullyProcessExitDoNotHang(0);

--- a/tests/mcp/cli-session.spec.ts
+++ b/tests/mcp/cli-session.spec.ts
@@ -42,6 +42,27 @@ test('close', async ({ cli, server }) => {
   expect(listOutput).toContain('(no browsers)');
 });
 
+test('close terminates daemon process', async ({ cli, server }) => {
+  const { pid } = await cli('open', server.HELLO_WORLD);
+  expect(pid).toBeTruthy();
+  const daemonPid = pid!;
+
+  // Verify the daemon process is running.
+  expect(() => process.kill(daemonPid, 0)).not.toThrow();
+
+  await cli('close');
+
+  // The daemon process (and its child browser process) should be gone.
+  await expect.poll(() => {
+    try {
+      process.kill(daemonPid, 0);
+      return false;
+    } catch {
+      return true;
+    }
+  }, { timeout: 10_000 }).toBe(true);
+});
+
 test('close named session', async ({ cli, server }) => {
   await cli('-s', 'mysession', 'open', server.HELLO_WORLD);
 


### PR DESCRIPTION
## Summary

- Close the browser context in the `stop` handler before the daemon exits, preventing orphaned browser processes
- Send ack before closing the browser so the client is not blocked waiting for teardown
- Add `isStoppingExplicitly` guard to prevent the `close` event handler from racing with the stop handler
- Add test verifying daemon process exits after close

## Problem

When the daemon receives a `stop` command, it calls `gracefullyProcessExitDoNotHang(0)` without closing the browser context first. The browser process outlives the daemon, holds the `userDataDir` lock, and prevents session reuse. Repeated restarts accumulate orphaned Chrome processes.

Fixes microsoft/playwright-cli#312