### PR TITLE
feat(extension): support multi-tab - Playwright can open and control multiple tabs

### DIFF
--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -254,6 +254,12 @@ export class CDPRelayServer {
           else
             sessionId = [...this._tabSessions.keys()][0];
         }
+        // Clean up tab session when the target is destroyed.
+        if (params.method === 'Target.targetDestroyed') {
+          const destroyedSessionId = this._findSessionByTargetId(params.params?.targetId);
+          if (destroyedSessionId)
+            this._removeTabSession(destroyedSessionId);
+        }
         this._sendToPlaywright({
           sessionId,
           method: params.method,
@@ -334,12 +340,41 @@ export class CDPRelayServer {
           targetInfos: [...this._tabSessions.values()].map(s => ({ ...s.targetInfo, attached: true })),
         };
       }
+      case 'Target.closeTarget': {
+        const targetId = params?.targetId;
+        const tabSessionId = this._findSessionByTargetId(targetId);
+        if (tabSessionId) {
+          this._removeTabSession(tabSessionId);
+          this._sendToPlaywright({
+            method: 'Target.detachedFromTarget',
+            params: { sessionId: tabSessionId },
+          });
+        }
+        return { success: true };
+      }
       case 'Target.getTargetInfo': {
         const tabSession = sessionId ? this._tabSessions.get(sessionId) : undefined;
         return (tabSession ?? [...this._tabSessions.values()][0])?.targetInfo;
       }
     }
     return await this._forwardToExtension(method, params, sessionId);
+  }
+
+  private _removeTabSession(tabSessionId: string) {
+    const session = this._tabSessions.get(tabSessionId);
+    if (!session)
+      return;
+    this._tabSessions.delete(tabSessionId);
+    if (session.tabId !== undefined)
+      this._tabIdToSessionId.delete(session.tabId);
+  }
+
+  private _findSessionByTargetId(targetId: string): string | undefined {
+    for (const [sessionId, session] of this._tabSessions) {
+      if (session.targetInfo?.targetId === targetId)
+        return sessionId;
+    }
+    return undefined;
   }
 
   private async _forwardToExtension(method: string, params: any, sessionId: string | undefined): Promise<any> {

--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -344,11 +344,9 @@ export class CDPRelayServer {
         const targetId = params?.targetId;
         const tabSessionId = this._findSessionByTargetId(targetId);
         if (tabSessionId) {
-          const tabId = this._tabSessions.get(tabSessionId)!.tabId;
+          // Forward the close to the extension so the real browser tab is closed.
+          await this._forwardToExtension(method, params, tabSessionId);
           this._removeTabSession(tabSessionId);
-          // Forward the close to the extension so the actual browser tab is removed.
-          if (tabId !== undefined)
-            this._extensionConnection?.send('forwardCDPCommand', { tabId, method: 'Target.closeTarget', params }).catch(() => {});
           this._sendToPlaywright({
             method: 'Target.detachedFromTarget',
             params: { sessionId: tabSessionId, targetId },

--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -68,11 +68,10 @@ export class CDPRelayServer {
   private _wss: WebSocketServer;
   private _playwrightConnection: WebSocket | null = null;
   private _extensionConnection: ExtensionConnection | null = null;
-  private _connectedTabInfo: {
-    targetInfo: any;
-    // Page sessionId that should be used by this connection.
-    sessionId: string;
-  } | undefined;
+  // Map from relay sessionId (pw-tab-N) to tab info.
+  private _tabSessions = new Map<string, { targetInfo: any; tabId?: number }>();
+  // Map from extension tabId to relay sessionId, for routing CDP events.
+  private _tabIdToSessionId = new Map<number, string>();
   private _nextSessionId: number = 1;
   private _extensionConnectionPromise!: ManualPromise<void>;
 
@@ -214,7 +213,8 @@ export class CDPRelayServer {
   }
 
   private _resetExtensionConnection() {
-    this._connectedTabInfo = undefined;
+    this._tabSessions.clear();
+    this._tabIdToSessionId.clear();
     this._extensionConnection = null;
     this._extensionConnectionPromise = new ManualPromise();
     void this._extensionConnectionPromise.catch(logUnhandledError);
@@ -245,14 +245,22 @@ export class CDPRelayServer {
 
   private _handleExtensionMessage<M extends keyof ExtensionEvents>(method: M, params: ExtensionEvents[M]['params']) {
     switch (method) {
-      case 'forwardCDPEvent':
-        const sessionId = params.sessionId || this._connectedTabInfo?.sessionId;
+      case 'forwardCDPEvent': {
+        let sessionId = params.sessionId;
+        if (!sessionId) {
+          // Route event to the correct relay session by tabId, or fall back to the first session.
+          if (params.tabId !== undefined)
+            sessionId = this._tabIdToSessionId.get(params.tabId);
+          else
+            sessionId = [...this._tabSessions.keys()][0];
+        }
         this._sendToPlaywright({
           sessionId,
           method: params.method,
-          params: params.params
+          params: params.params,
         });
         break;
+      }
     }
   }
 
@@ -288,28 +296,47 @@ export class CDPRelayServer {
         // Forward child session handling.
         if (sessionId)
           break;
-        // Simulate auto-attach behavior with real target info
-        const { targetInfo } = await this._extensionConnection!.send('attachToTab', { });
-        this._connectedTabInfo = {
-          targetInfo,
-          sessionId: `pw-tab-${this._nextSessionId++}`,
-        };
+        // Simulate auto-attach behavior with real target info.
+        const { targetInfo, tabId } = await this._extensionConnection!.send('attachToTab', { });
+        const tabSessionId = `pw-tab-${this._nextSessionId++}`;
+        this._tabSessions.set(tabSessionId, { targetInfo, tabId });
+        if (tabId !== undefined)
+          this._tabIdToSessionId.set(tabId, tabSessionId);
         debugLogger('Simulating auto-attach');
         this._sendToPlaywright({
           method: 'Target.attachedToTarget',
           params: {
-            sessionId: this._connectedTabInfo.sessionId,
-            targetInfo: {
-              ...this._connectedTabInfo.targetInfo,
-              attached: true,
-            },
-            waitingForDebugger: false
+            sessionId: tabSessionId,
+            targetInfo: { ...targetInfo, attached: true },
+            waitingForDebugger: false,
           }
         });
         return { };
       }
+      case 'Target.createTarget': {
+        const { targetInfo, tabId } = await this._extensionConnection!.send('createTab', { url: params?.url });
+        const tabSessionId = `pw-tab-${this._nextSessionId++}`;
+        this._tabSessions.set(tabSessionId, { targetInfo, tabId });
+        if (tabId !== undefined)
+          this._tabIdToSessionId.set(tabId, tabSessionId);
+        this._sendToPlaywright({
+          method: 'Target.attachedToTarget',
+          params: {
+            sessionId: tabSessionId,
+            targetInfo: { ...targetInfo, attached: true },
+            waitingForDebugger: false,
+          }
+        });
+        return { targetId: targetInfo.targetId };
+      }
+      case 'Target.getTargets': {
+        return {
+          targetInfos: [...this._tabSessions.values()].map(s => ({ ...s.targetInfo, attached: true })),
+        };
+      }
       case 'Target.getTargetInfo': {
-        return this._connectedTabInfo?.targetInfo;
+        const tabSession = sessionId ? this._tabSessions.get(sessionId) : undefined;
+        return (tabSession ?? [...this._tabSessions.values()][0])?.targetInfo;
       }
     }
     return await this._forwardToExtension(method, params, sessionId);
@@ -318,10 +345,13 @@ export class CDPRelayServer {
   private async _forwardToExtension(method: string, params: any, sessionId: string | undefined): Promise<any> {
     if (!this._extensionConnection)
       throw new Error('Extension not connected');
-    // Top level sessionId is only passed between the relay and the client.
-    if (this._connectedTabInfo?.sessionId === sessionId)
+    // Relay sessionIds (pw-tab-N) are internal — resolve them to tabId for routing.
+    let tabId: number | undefined;
+    if (sessionId && this._tabSessions.has(sessionId)) {
+      tabId = this._tabSessions.get(sessionId)!.tabId;
       sessionId = undefined;
-    return await this._extensionConnection.send('forwardCDPCommand', { sessionId, method, params });
+    }
+    return await this._extensionConnection.send('forwardCDPCommand', { sessionId, tabId, method, params });
   }
 
   private _sendToPlaywright(message: CDPResponse): void {

--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -344,10 +344,14 @@ export class CDPRelayServer {
         const targetId = params?.targetId;
         const tabSessionId = this._findSessionByTargetId(targetId);
         if (tabSessionId) {
+          const tabId = this._tabSessions.get(tabSessionId)!.tabId;
           this._removeTabSession(tabSessionId);
+          // Forward the close to the extension so the actual browser tab is removed.
+          if (tabId !== undefined)
+            this._extensionConnection?.send('forwardCDPCommand', { tabId, method: 'Target.closeTarget', params }).catch(() => {});
           this._sendToPlaywright({
             method: 'Target.detachedFromTarget',
-            params: { sessionId: tabSessionId },
+            params: { sessionId: tabSessionId, targetId },
           });
         }
         return { success: true };

--- a/packages/playwright-core/src/tools/mcp/protocol.ts
+++ b/packages/playwright-core/src/tools/mcp/protocol.ts
@@ -16,16 +16,22 @@
 
 // Whenever the commands/events change, the version must be updated. The latest
 // extension version should be compatible with the old MCP clients.
-export const VERSION = 1;
+export const VERSION = 2;
 
 export type ExtensionCommand = {
   'attachToTab': {
     params: {};
   };
+  'createTab': {
+    params: {
+      url?: string;
+    };
+  };
   'forwardCDPCommand': {
     params: {
       method: string,
-      sessionId?: string
+      sessionId?: string,
+      tabId?: number,
       params?: any,
     };
   };
@@ -35,7 +41,8 @@ export type ExtensionEvents = {
   'forwardCDPEvent': {
     params: {
       method: string,
-      sessionId?: string
+      sessionId?: string,
+      tabId?: number,
       params?: any,
     };
   };


### PR DESCRIPTION
## Problem

When using \`--extension\` mode, \`CDPRelayServer\` only tracked a single tab via \`_connectedTabInfo\`. Opening a new page via \`browser.newPage()\` sent \`Target.createTarget\` to the relay, which forwarded it as a raw CDP command — the extension had no mechanism to create a real Chrome tab, so the call failed silently.

## Fix

### \`protocol.ts\`
- Add \`createTab\` command: \`{ url?: string }\` → \`{ tabId, targetInfo }\`
- Add \`tabId?: number\` to \`forwardCDPCommand\` params: routes CDP commands to the correct tab
- Add \`tabId?: number\` to \`forwardCDPEvent\` params: identifies which tab emitted the event
- Bump \`VERSION\` to 2

### \`cdpRelay.ts\`
- Replace \`_connectedTabInfo\` with \`_tabSessions: Map<sessionId, { targetInfo, tabId }>\` and \`_tabIdToSessionId: Map<tabId, sessionId>\` for bidirectional lookup
- Handle \`Target.createTarget\`: call \`createTab\` on the extension, register the new session, emit \`Target.attachedToTarget\` to Playwright
- Handle \`Target.getTargets\`: return all tracked tab sessions
- Update \`_forwardToExtension\`: resolve relay session IDs (\`pw-tab-N\`) to \`tabId\` before forwarding; pass \`tabId\` so the extension routes to the correct debuggee
- Update \`_handleExtensionMessage\` for \`forwardCDPEvent\`: route events back to Playwright using \`tabId → sessionId\` lookup

## How it works

\`\`\`
Playwright                    CDPRelayServer              Extension
    |                               |                         |
    |-- Target.setAutoAttach ------>|                         |
    |                               |-- attachToTab --------->|
    |                               |<-- { tabId, targetInfo }|
    |<-- Target.attachedToTarget ---|                         |
    |                               |                         |
    |-- Target.createTarget ------->|                         |
    |                               |-- createTab(url) ------>|
    |                               |  (chrome.tabs.create)   |
    |                               |<-- { tabId, targetInfo }|
    |<-- Target.attachedToTarget ---|                         |
    |                               |                         |
    |-- CDP cmd (sessionId=pw-tab-2)|                         |
    |                               |-- forwardCDPCommand  -->|
    |                               |   (tabId=456)           |
    |                               |  (routes to Tab 2)      |
\`\`\`

## Multi-client with HTTP Streamable (\`/mcp\`)

When running \`playwright-mcp --extension --port N\`, each \`POST /mcp\` session calls \`createExtensionBrowser()\` which creates a new \`CDPRelayServer\` with a unique UUID relay URL. The extension's multi-instance fix (microsoft/playwright-mcp#1478) isolates each relay connection independently:

\`\`\`
playwright-mcp --extension --port 4321   (one shared process)
  ├── Claude session A  →  CDPRelayServer (uuid-aaa)  →  extension ConnectionState A  →  Tab 1
  └── Claude session B  →  CDPRelayServer (uuid-bbb)  →  extension ConnectionState B  →  Tab 2
\`\`\`

Two simultaneous Claude sessions can each control their own tabs with no conflicts, as long as each session is connected to a different browser tab (Chrome only allows one debugger per tab).

## Related

- Extension changes: microsoft/playwright-mcp#1478