### PR TITLE
docs: document that functions in object props are silently dropped during mount

### DIFF
--- a/docs/src/test-components-js.md
+++ b/docs/src/test-components-js.md
@@ -187,6 +187,18 @@ test('this will not work', async ({ mount }) => {
 });
 ```
 
+- Functions defined as properties of objects are silently dropped during serialization. This is a common source of confusion — no error is thrown, but the function will be `undefined` inside the component.
+
+```js
+test('this will not work', async ({ mount }) => {
+  // The `format` function will be undefined inside the component.
+  // Functions cannot be serialized across the Node.js / browser boundary.
+  const component = await mount(
+    <DataTable formatter={{ label: 'Price', format: (value) => `$${value}` }} />
+  );
+});
+```
+
 - You can't pass data to your component synchronously in a callback:
 
 ```js


### PR DESCRIPTION
## Summary

Closes #22194

When you pass a plain JavaScript object as a prop and that object has function-valued properties, those functions are silently removed during serialization across the Node.js / browser boundary. No error is thrown — the function is simply `undefined` inside the component. This trips up a lot of users and was called out by @pavelfeldman as a documentation gap.

The existing limitations section in `test-components-js.md` already covers:
- Can't pass complex Node objects (e.g. `process`)
- Can't use callbacks to return values synchronously

But it didn't cover the **function-in-object** case, which is the most common real-world pattern (e.g. a formatter, a comparator, a config object with methods).

## Change

Added one new bullet point and code example to the existing limitations list in `docs/src/test-components-js.md`.

## Test plan

- [ ] Read the updated docs section and confirm the new example clearly describes the behaviour
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)