### PR TITLE
feat(html-reporter): add doNotInlineAssets option for CSP-compatible reports

### DIFF
--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -254,7 +254,7 @@ HTML report supports the following configuration options and environment variabl
 | `PLAYWRIGHT_HTML_ATTACHMENTS_BASE_URL` | `attachmentsBaseURL` | A separate location where attachments from the `data` subdirectory are uploaded. Only needed when you upload report and `data` separately to different locations. | `data/`
 | `PLAYWRIGHT_HTML_NO_COPY_PROMPT` | `noCopyPrompt` | If true, disable rendering of the Copy prompt for errors. Supports `true`, `1`, `false`, and `0`. | `false`
 | `PLAYWRIGHT_HTML_NO_SNIPPETS` | `noSnippets` | If true, disable rendering code snippets in the action log. If there is a top level error, that report section with code snippet will still render. Supports `true`, `1`, `false`, and `0`. | `false`
-| `PLAYWRIGHT_HTML_SEPARATE_ASSETS` | `separateAssets` | If true, JavaScript, CSS and report data are written as separate files alongside `index.html` instead of being embedded inline. Use this when serving the report under a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) that disallows inline scripts and styles. Supports `true`, `1`, `false`, and `0`. | `false`
+| `PLAYWRIGHT_HTML_DO_NOT_INLINE_ASSETS` | `doNotInlineAssets` | If true, JavaScript, CSS and report data are written as separate files alongside `index.html` instead of being embedded inline. Use this when serving the report under a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) that disallows inline scripts and styles. Supports `true`, `1`, `false`, and `0`. | `false`
 
 ### Blob reporter
 

--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -254,6 +254,7 @@ HTML report supports the following configuration options and environment variabl
 | `PLAYWRIGHT_HTML_ATTACHMENTS_BASE_URL` | `attachmentsBaseURL` | A separate location where attachments from the `data` subdirectory are uploaded. Only needed when you upload report and `data` separately to different locations. | `data/`
 | `PLAYWRIGHT_HTML_NO_COPY_PROMPT` | `noCopyPrompt` | If true, disable rendering of the Copy prompt for errors. Supports `true`, `1`, `false`, and `0`. | `false`
 | `PLAYWRIGHT_HTML_NO_SNIPPETS` | `noSnippets` | If true, disable rendering code snippets in the action log. If there is a top level error, that report section with code snippet will still render. Supports `true`, `1`, `false`, and `0`. | `false`
+| `PLAYWRIGHT_HTML_SEPARATE_ASSETS` | `separateAssets` | If true, JavaScript, CSS and report data are written as separate files alongside `index.html` instead of being embedded inline. Use this when serving the report under a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) that disallows inline scripts and styles. Supports `true`, `1`, `false`, and `0`. | `false`
 
 ### Blob reporter
 

--- a/packages/html-reporter/bundle.ts
+++ b/packages/html-reporter/bundle.ts
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
-import path from 'path';
-import type { Plugin, UserConfig } from 'vite';
+import type { Plugin } from 'vite';
 
 export function bundle(): Plugin {
-  let config: UserConfig;
   return {
     name: 'playwright-bundle',
-    config(c) {
-      config = c;
-    },
     transformIndexHtml: {
       handler(html, ctx) {
         if (!ctx || !ctx.bundle)
@@ -32,15 +26,6 @@ export function bundle(): Plugin {
         // Strip the license comment block.
         return html.replace(/(?=<!--)([\s\S]*?)-->/, '');
       },
-    },
-    closeBundle: () => {
-      const outDir = config.build!.outDir!;
-      if (!fs.existsSync(path.join(outDir, 'index.html')))
-        return;
-      const targetDir = path.join(__dirname, '..', 'playwright-core', 'lib', 'vite', 'htmlReport');
-      fs.mkdirSync(targetDir, { recursive: true });
-      for (const file of ['index.html', 'report.js', 'report.css'])
-        fs.copyFileSync(path.join(outDir, file), path.join(targetDir, file));
     },
   };
 }

--- a/packages/html-reporter/bundle.ts
+++ b/packages/html-reporter/bundle.ts
@@ -42,13 +42,12 @@ export function bundle(): Plugin {
       },
     },
     closeBundle: () => {
-      if (fs.existsSync(path.join(config.build!.outDir!, 'index.html'))) {
-        const targetDir = path.join(__dirname, '..', 'playwright-core', 'lib', 'vite', 'htmlReport');
-        fs.mkdirSync(targetDir, { recursive: true });
-        fs.copyFileSync(
-            path.join(config.build!.outDir!, 'index.html'),
-            path.join(targetDir, 'index.html'));
-      }
+      const outDir = config.build!.outDir!;
+      if (!fs.existsSync(path.join(outDir, 'index.html')))
+        return;
+      const targetDir = path.join(__dirname, '..', 'playwright-core', 'lib', 'vite', 'htmlReport');
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.copyFileSync(path.join(outDir, 'index.html'), path.join(targetDir, 'index.html'));
     },
   };
 }

--- a/packages/html-reporter/bundle.ts
+++ b/packages/html-reporter/bundle.ts
@@ -29,16 +29,8 @@ export function bundle(): Plugin {
       handler(html, ctx) {
         if (!ctx || !ctx.bundle)
           return html;
-        html = html.replace(/(?=<!--)([\s\S]*?)-->/, '');
-        for (const [name, value] of Object.entries(ctx.bundle)) {
-          if (name.endsWith('.map'))
-            continue;
-          if ('code' in value)
-            html = html.replace(/<script type="module".*<\/script>/, () => `<script type="module">${value.code}</script>`);
-          else
-            html = html.replace(/<link rel="stylesheet"[^>]*>/, () => `<style type='text/css'>${value.source}</style>`);
-        }
-        return html;
+        // Strip the license comment block.
+        return html.replace(/(?=<!--)([\s\S]*?)-->/, '');
       },
     },
     closeBundle: () => {
@@ -47,7 +39,8 @@ export function bundle(): Plugin {
         return;
       const targetDir = path.join(__dirname, '..', 'playwright-core', 'lib', 'vite', 'htmlReport');
       fs.mkdirSync(targetDir, { recursive: true });
-      fs.copyFileSync(path.join(outDir, 'index.html'), path.join(targetDir, 'index.html'));
+      for (const file of ['index.html', 'report.js', 'report.css'])
+        fs.copyFileSync(path.join(outDir, file), path.join(targetDir, file));
     },
   };
 }

--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -38,17 +38,12 @@ document.head.appendChild(link);
 const ReportLoader: React.FC = () => {
   const [report, setReport] = React.useState<LoadedReport | undefined>();
   React.useEffect(() => {
-    if (document.getElementById('playwrightReportBase64')) {
-      const zipReport = new ZipReport();
-      zipReport.load().then(() => {
-        // Drop node after consumption
-        document.getElementById('playwrightReportBase64')?.remove();
-        setReport(zipReport);
-      });
-    } else {
-      const fetchReport = new FetchReport();
-      fetchReport.load().then(() => setReport(fetchReport));
-    }
+    const zipReport = new ZipReport();
+    zipReport.load().then(() => {
+      // Drop node after consumption
+      document.getElementById('playwrightReportBase64')?.remove();
+      setReport(zipReport);
+    });
   }, []);
   return <SearchParamsProvider>
     <ReportView report={report} />
@@ -81,24 +76,5 @@ class ZipReport implements LoadedReport {
     const writer = new zipjs.TextWriter() as zip.TextWriter;
     await reportEntry!.getData!(writer);
     return JSON.parse(await writer.getData());
-  }
-}
-
-class FetchReport implements LoadedReport {
-  private _json!: HTMLReport;
-
-  async load() {
-    this._json = await (await fetch('report.json')).json() as HTMLReport;
-  }
-
-  json(): HTMLReport {
-    return this._json;
-  }
-
-  async entry(name: string): Promise<Object | undefined> {
-    const response = await fetch(name);
-    if (!response.ok)
-      return undefined;
-    return response.json();
   }
 }

--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -60,8 +60,10 @@ class ZipReport implements LoadedReport {
   private _json!: HTMLReport;
 
   async load() {
-    const zipURI = document.getElementById('playwrightReportBase64')!.textContent;
-    const zipReader = new zipjs.ZipReader(new zipjs.Data64URIReader(zipURI), { useWebWorkers: false });
+    const zipDataElement = document.getElementById('playwrightReportBase64');
+    const zipReader = zipDataElement
+      ? new zipjs.ZipReader(new zipjs.Data64URIReader(zipDataElement.textContent!), { useWebWorkers: false })
+      : new zipjs.ZipReader(new zipjs.HttpReader(new URL('report.zip', location.href).href), { useWebWorkers: false });
     for (const entry of await zipReader.getEntries())
       this._entries.set(entry.filename, entry);
     this._json = await this.entry('report.json') as HTMLReport;

--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -60,10 +60,8 @@ class ZipReport implements LoadedReport {
   private _json!: HTMLReport;
 
   async load() {
-    const zipDataElement = document.getElementById('playwrightReportBase64');
-    const zipReader = zipDataElement
-      ? new zipjs.ZipReader(new zipjs.Data64URIReader(zipDataElement.textContent!), { useWebWorkers: false })
-      : new zipjs.ZipReader(new zipjs.HttpReader(new URL('report.zip', location.href).href), { useWebWorkers: false });
+    const zipURI = (document.getElementById('playwrightReportBase64') as HTMLTemplateElement).content.textContent;
+    const zipReader = new zipjs.ZipReader(new zipjs.Data64URIReader(zipURI), { useWebWorkers: false });
     for (const entry of await zipReader.getEntries())
       this._entries.set(entry.filename, entry);
     this._json = await this.entry('report.json') as HTMLReport;

--- a/packages/html-reporter/src/index.tsx
+++ b/packages/html-reporter/src/index.tsx
@@ -38,12 +38,17 @@ document.head.appendChild(link);
 const ReportLoader: React.FC = () => {
   const [report, setReport] = React.useState<LoadedReport | undefined>();
   React.useEffect(() => {
-    const zipReport = new ZipReport();
-    zipReport.load().then(() => {
-      // Drop node after consumption
-      document.getElementById('playwrightReportBase64')?.remove();
-      setReport(zipReport);
-    });
+    if (document.getElementById('playwrightReportBase64')) {
+      const zipReport = new ZipReport();
+      zipReport.load().then(() => {
+        // Drop node after consumption
+        document.getElementById('playwrightReportBase64')?.remove();
+        setReport(zipReport);
+      });
+    } else {
+      const fetchReport = new FetchReport();
+      fetchReport.load().then(() => setReport(fetchReport));
+    }
   }, []);
   return <SearchParamsProvider>
     <ReportView report={report} />
@@ -76,5 +81,24 @@ class ZipReport implements LoadedReport {
     const writer = new zipjs.TextWriter() as zip.TextWriter;
     await reportEntry!.getData!(writer);
     return JSON.parse(await writer.getData());
+  }
+}
+
+class FetchReport implements LoadedReport {
+  private _json!: HTMLReport;
+
+  async load() {
+    this._json = await (await fetch('report.json')).json() as HTMLReport;
+  }
+
+  json(): HTMLReport {
+    return this._json;
+  }
+
+  async entry(name: string): Promise<Object | undefined> {
+    const response = await fetch(name);
+    if (!response.ok)
+      return undefined;
+    return response.json();
   }
 }

--- a/packages/html-reporter/vite.config.ts
+++ b/packages/html-reporter/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: path.resolve(__dirname, 'dist'),
+    outDir: path.resolve(__dirname, '../playwright-core/lib/vite/htmlReport'),
     emptyOutDir: true,
     assetsInlineLimit: 100000000,
     chunkSizeWarningLimit: 100000000,

--- a/packages/html-reporter/vite.config.ts
+++ b/packages/html-reporter/vite.config.ts
@@ -21,6 +21,7 @@ import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '',
   plugins: [
     react(),
     bundle()
@@ -41,6 +42,8 @@ export default defineConfig({
       output: {
         manualChunks: undefined,
         inlineDynamicImports: true,
+        entryFileNames: 'report.js',
+        assetFileNames: (assetInfo) => assetInfo.names.some(n => n.endsWith('.css')) ? 'report.css' : '[name][extname]',
       },
     },
   },

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -337,9 +337,7 @@ class HtmlBuilder {
       singleTestId = testFile.tests[0].testId;
     }
 
-    // Copy app.
-    const appFolder = path.join(require.resolve('playwright-core'), '..', 'lib', 'vite', 'htmlReport');
-    await copyFileAndMakeWritable(path.join(appFolder, 'index.html'), path.join(this._reportFolder, 'index.html'));
+    const reportIndexFile = await this._copyApp();
 
     // Copy trace viewer.
     if (this._hasTraces) {
@@ -359,11 +357,32 @@ class HtmlBuilder {
       }
     }
 
-    await this._writeReportData(path.join(this._reportFolder, 'index.html'));
-    if (this._separateAssets)
-      await this._extractAssetsToSeparateFiles();
+    await this._writeReportData(reportIndexFile);
 
     return { ok, singleTestId };
+  }
+
+  private async _copyApp() {
+    const appFolder = path.join(require.resolve('playwright-core'), '..', 'lib', 'vite', 'htmlReport');
+    const reportIndexFile = path.join(this._reportFolder, 'index.html');
+    if (this._separateAssets) {
+      const html = await fs.promises.readFile(path.join(appFolder, 'index.html'), 'utf-8');
+      await Promise.all([
+        fs.promises.writeFile(reportIndexFile, html),
+        fs.promises.copyFile(path.join(appFolder, 'report.js'), path.join(this._reportFolder, 'report.js')),
+        fs.promises.copyFile(path.join(appFolder, 'report.css'), path.join(this._reportFolder, 'report.css')),
+      ]);
+    } else {
+      let html = await fs.promises.readFile(path.join(appFolder, 'index.html'), 'utf-8');
+      const [js, css] = await Promise.all([
+        fs.promises.readFile(path.join(appFolder, 'report.js'), 'utf-8'),
+        fs.promises.readFile(path.join(appFolder, 'report.css'), 'utf-8'),
+      ]);
+      html = html.replace(/<script type="module"[^>]*><\/script>/, () => `<script type="module">${js}</script>`);
+      html = html.replace(/<link rel="stylesheet"[^>]*>/, () => `<style type='text/css'>${css}</style>`);
+      await fs.promises.writeFile(reportIndexFile, html);
+    }
+    return reportIndexFile;
   }
 
   private async _writeReportData(filePath: string) {
@@ -380,36 +399,6 @@ class HtmlBuilder {
 
   private _addDataFile(fileName: string, data: any) {
     this._dataZipFile.addBuffer(Buffer.from(JSON.stringify(data)), fileName);
-  }
-
-  private async _extractAssetsToSeparateFiles() {
-    // Extract inlined JS and CSS on the fly to avoid shipping them twice in the playwright npm package.
-    const indexFile = path.join(this._reportFolder, 'index.html');
-    let html = await fs.promises.readFile(indexFile, 'utf-8');
-
-    const styleTag = `<style type='text/css'>`;
-    const styleStart = html.indexOf(styleTag);
-    const styleEnd = html.indexOf('</style>', styleStart);
-    const css = html.slice(styleStart + styleTag.length, styleEnd);
-
-    const scriptTag = `<script type="module">`;
-    const scriptStart = html.indexOf(scriptTag);
-    const scriptEnd = html.indexOf('</script>', scriptStart);
-    const js = html.slice(scriptStart + scriptTag.length, scriptEnd);
-
-    await Promise.all([
-      fs.promises.writeFile(path.join(this._reportFolder, 'report.css'), css),
-      fs.promises.writeFile(path.join(this._reportFolder, 'report.js'), js),
-    ]);
-
-    // Replace in reverse document order so earlier offsets stay valid after each replacement.
-    const replacements = [
-      { start: styleStart, end: styleEnd + '</style>'.length, text: `<link rel="stylesheet" href="report.css">` },
-      { start: scriptStart, end: scriptEnd + '</script>'.length, text: `<script type="module" src="report.js"></script>` },
-    ].sort((a, b) => b.start - a.start);
-    for (const { start, end, text } of replacements)
-      html = html.slice(0, start) + text + html.slice(end);
-    await fs.promises.writeFile(indexFile, html);
   }
 
   private _createEntryForSuite(data: DataMap, projectName: string, suite: api.Suite, fileName: string, deep: boolean) {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -337,7 +337,7 @@ class HtmlBuilder {
       singleTestId = testFile.tests[0].testId;
     }
 
-    const reportIndexFile = await this._copyApp();
+    const reportIndexFile = await this._writeAppStaticFiles();
 
     // Copy trace viewer.
     if (this._hasTraces) {
@@ -362,7 +362,7 @@ class HtmlBuilder {
     return { ok, singleTestId };
   }
 
-  private async _copyApp() {
+  private async _writeAppStaticFiles() {
     const appFolder = path.join(require.resolve('playwright-core'), '..', 'lib', 'vite', 'htmlReport');
     const reportIndexFile = path.join(this._reportFolder, 'index.html');
     if (this._separateAssets) {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -385,25 +385,16 @@ class HtmlBuilder {
     return reportIndexFile;
   }
 
-  private async _writeReportData(reportIndexFile: string) {
-    if (this._doNotInlineAssets) {
-      await new Promise(f => {
-        this._dataZipFile.end(undefined, () => {
-          this._dataZipFile.outputStream
-              .pipe(fs.createWriteStream(path.join(this._reportFolder, 'report.zip'))).on('close', f);
-        });
+  private async _writeReportData(filePath: string) {
+    fs.appendFileSync(filePath, '<template id="playwrightReportBase64">data:application/zip;base64,');
+    await new Promise(f => {
+      this._dataZipFile.end(undefined, () => {
+        this._dataZipFile.outputStream
+            .pipe(new Base64Encoder())
+            .pipe(fs.createWriteStream(filePath, { flags: 'a' })).on('close', f);
       });
-    } else {
-      fs.appendFileSync(reportIndexFile, '<script id="playwrightReportBase64" type="application/zip">data:application/zip;base64,');
-      await new Promise(f => {
-        this._dataZipFile.end(undefined, () => {
-          this._dataZipFile.outputStream
-              .pipe(new Base64Encoder())
-              .pipe(fs.createWriteStream(reportIndexFile, { flags: 'a' })).on('close', f);
-        });
-      });
-      fs.appendFileSync(reportIndexFile, '</script>');
-    }
+    });
+    fs.appendFileSync(filePath, '</template>');
   }
 
   private _addDataFile(fileName: string, data: any) {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -385,16 +385,25 @@ class HtmlBuilder {
     return reportIndexFile;
   }
 
-  private async _writeReportData(filePath: string) {
-    fs.appendFileSync(filePath, '<script id="playwrightReportBase64" type="application/zip">data:application/zip;base64,');
-    await new Promise(f => {
-      this._dataZipFile.end(undefined, () => {
-        this._dataZipFile.outputStream
-            .pipe(new Base64Encoder())
-            .pipe(fs.createWriteStream(filePath, { flags: 'a' })).on('close', f);
+  private async _writeReportData(reportIndexFile: string) {
+    if (this._doNotInlineAssets) {
+      await new Promise(f => {
+        this._dataZipFile.end(undefined, () => {
+          this._dataZipFile.outputStream
+              .pipe(fs.createWriteStream(path.join(this._reportFolder, 'report.zip'))).on('close', f);
+        });
       });
-    });
-    fs.appendFileSync(filePath, '</script>');
+    } else {
+      fs.appendFileSync(reportIndexFile, '<script id="playwrightReportBase64" type="application/zip">data:application/zip;base64,');
+      await new Promise(f => {
+        this._dataZipFile.end(undefined, () => {
+          this._dataZipFile.outputStream
+              .pipe(new Base64Encoder())
+              .pipe(fs.createWriteStream(reportIndexFile, { flags: 'a' })).on('close', f);
+        });
+      });
+      fs.appendFileSync(reportIndexFile, '</script>');
+    }
   }
 
   private _addDataFile(fileName: string, data: any) {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -249,99 +249,22 @@ export function startHtmlReportServer(folder: string): HttpServer {
 
 type DataMap = Map<string, { testFile: TestFile, testFileSummary: TestFileSummary }>;
 
-interface ReportWriter {
-  addDataFile(fileName: string, data: any): Promise<void>;
-  copyAppFiles(viteDir: string): Promise<void>;
-  finalize(): Promise<void>;
-}
-
-class EmbeddedReportWriter implements ReportWriter {
-  private _zipFile = new yazl.ZipFile();
-  private _indexFile: string;
-
-  constructor(reportFolder: string) {
-    this._indexFile = path.join(reportFolder, 'index.html');
-  }
-
-  async addDataFile(fileName: string, data: any) {
-    this._zipFile.addBuffer(Buffer.from(JSON.stringify(data)), fileName);
-  }
-
-  async copyAppFiles(viteDir: string) {
-    await copyFileAndMakeWritable(path.join(viteDir, 'htmlReport', 'index.html'), this._indexFile);
-  }
-
-  async finalize() {
-    await fs.promises.appendFile(this._indexFile, '<script id="playwrightReportBase64" type="application/zip">data:application/zip;base64,');
-    await new Promise(f => {
-      this._zipFile.end(undefined, () => {
-        this._zipFile.outputStream
-            .pipe(new Base64Encoder())
-            .pipe(fs.createWriteStream(this._indexFile, { flags: 'a' })).on('close', f);
-      });
-    });
-    await fs.promises.appendFile(this._indexFile, '</script>');
-  }
-}
-
-class SeparateReportWriter implements ReportWriter {
-  constructor(private readonly _reportFolder: string) {}
-
-  async addDataFile(fileName: string, data: any) {
-    await fs.promises.writeFile(path.join(this._reportFolder, fileName), JSON.stringify(data));
-  }
-
-  async copyAppFiles(viteDir: string) {
-    await copyFileAndMakeWritable(path.join(viteDir, 'htmlReport', 'index.html'), path.join(this._reportFolder, 'index.html'));
-  }
-
-  async finalize() {
-    // Extract inlined JS and CSS on the fly to avoid shipping them twice in the playwright npm package.
-    const indexFile = path.join(this._reportFolder, 'index.html');
-    const html = await fs.promises.readFile(indexFile, 'utf-8');
-
-    const styleTag = `<style type='text/css'>`;
-    const styleStart = html.indexOf(styleTag);
-    const styleEnd = html.indexOf('</style>', styleStart);
-    const css = html.slice(styleStart + styleTag.length, styleEnd);
-
-    const scriptTag = `<script type="module">`;
-    const scriptStart = html.indexOf(scriptTag);
-    const scriptEnd = html.indexOf('</script>', scriptStart);
-    const js = html.slice(scriptStart + scriptTag.length, scriptEnd);
-
-    await Promise.all([
-      fs.promises.writeFile(path.join(this._reportFolder, 'report.css'), css),
-      fs.promises.writeFile(path.join(this._reportFolder, 'report.js'), js),
-    ]);
-
-    // Replace in reverse document order so earlier offsets stay valid after each replacement.
-    const replacements = [
-      { start: styleStart, end: styleEnd + '</style>'.length, text: `<link rel="stylesheet" href="report.css">` },
-      { start: scriptStart, end: scriptEnd + '</script>'.length, text: `<script type="module" src="report.js"></script>` },
-    ].sort((a, b) => b.start - a.start);
-    let newHtml = html;
-    for (const { start, end, text } of replacements)
-      newHtml = newHtml.slice(0, start) + text + newHtml.slice(end);
-    await fs.promises.writeFile(indexFile, newHtml);
-  }
-}
-
 class HtmlBuilder {
   private _config: api.FullConfig;
   private _reportFolder: string;
   private _stepsInFile = new MultiMap<string, TestStep>();
-  private _reportWriter: ReportWriter;
+  private _dataZipFile = new yazl.ZipFile();
   private _hasTraces = false;
   private _attachmentsBaseURL: string;
   private _options: HTMLReportOptions;
+  private _separateAssets: boolean;
 
   constructor(config: api.FullConfig, outputDir: string, attachmentsBaseURL: string, separateAssets: boolean, options: HTMLReportOptions) {
     this._config = config;
     this._reportFolder = outputDir;
     this._options = options;
+    this._separateAssets = separateAssets;
     fs.mkdirSync(this._reportFolder, { recursive: true });
-    this._reportWriter = separateAssets ? new SeparateReportWriter(this._reportFolder) : new EmbeddedReportWriter(this._reportFolder);
     this._attachmentsBaseURL = attachmentsBaseURL;
   }
 
@@ -358,7 +281,6 @@ class HtmlBuilder {
       createSnippets(this._stepsInFile);
 
     let ok = true;
-    const fileDataWrites: Promise<void>[] = [];
     for (const [fileId, { testFile, testFileSummary }] of data) {
       const stats = testFileSummary.stats;
       for (const test of testFileSummary.tests) {
@@ -383,9 +305,8 @@ class HtmlBuilder {
       };
       testFileSummary.tests.sort(testCaseSummaryComparator);
 
-      fileDataWrites.push(this._reportWriter.addDataFile(fileId + '.json', testFile));
+      this._addDataFile(fileId + '.json', testFile);
     }
-    await Promise.all(fileDataWrites);
     const htmlReport: HTMLReport = {
       metadata,
       startTime: result.startTime.getTime(),
@@ -408,7 +329,7 @@ class HtmlBuilder {
       return w2 - w1;
     });
 
-    await this._reportWriter.addDataFile('report.json', htmlReport);
+    this._addDataFile('report.json', htmlReport);
 
     let singleTestId: string | undefined;
     if (htmlReport.stats.total === 1) {
@@ -417,8 +338,8 @@ class HtmlBuilder {
     }
 
     // Copy app.
-    const viteDir = path.join(require.resolve('playwright-core'), '..', 'lib', 'vite');
-    await this._reportWriter.copyAppFiles(viteDir);
+    const appFolder = path.join(require.resolve('playwright-core'), '..', 'lib', 'vite', 'htmlReport');
+    await copyFileAndMakeWritable(path.join(appFolder, 'index.html'), path.join(this._reportFolder, 'index.html'));
 
     // Copy trace viewer.
     if (this._hasTraces) {
@@ -438,9 +359,57 @@ class HtmlBuilder {
       }
     }
 
-    await this._reportWriter.finalize();
+    await this._writeReportData(path.join(this._reportFolder, 'index.html'));
+    if (this._separateAssets)
+      await this._extractAssetsToSeparateFiles();
 
     return { ok, singleTestId };
+  }
+
+  private async _writeReportData(filePath: string) {
+    fs.appendFileSync(filePath, '<script id="playwrightReportBase64" type="application/zip">data:application/zip;base64,');
+    await new Promise(f => {
+      this._dataZipFile.end(undefined, () => {
+        this._dataZipFile.outputStream
+            .pipe(new Base64Encoder())
+            .pipe(fs.createWriteStream(filePath, { flags: 'a' })).on('close', f);
+      });
+    });
+    fs.appendFileSync(filePath, '</script>');
+  }
+
+  private _addDataFile(fileName: string, data: any) {
+    this._dataZipFile.addBuffer(Buffer.from(JSON.stringify(data)), fileName);
+  }
+
+  private async _extractAssetsToSeparateFiles() {
+    // Extract inlined JS and CSS on the fly to avoid shipping them twice in the playwright npm package.
+    const indexFile = path.join(this._reportFolder, 'index.html');
+    let html = await fs.promises.readFile(indexFile, 'utf-8');
+
+    const styleTag = `<style type='text/css'>`;
+    const styleStart = html.indexOf(styleTag);
+    const styleEnd = html.indexOf('</style>', styleStart);
+    const css = html.slice(styleStart + styleTag.length, styleEnd);
+
+    const scriptTag = `<script type="module">`;
+    const scriptStart = html.indexOf(scriptTag);
+    const scriptEnd = html.indexOf('</script>', scriptStart);
+    const js = html.slice(scriptStart + scriptTag.length, scriptEnd);
+
+    await Promise.all([
+      fs.promises.writeFile(path.join(this._reportFolder, 'report.css'), css),
+      fs.promises.writeFile(path.join(this._reportFolder, 'report.js'), js),
+    ]);
+
+    // Replace in reverse document order so earlier offsets stay valid after each replacement.
+    const replacements = [
+      { start: styleStart, end: styleEnd + '</style>'.length, text: `<link rel="stylesheet" href="report.css">` },
+      { start: scriptStart, end: scriptEnd + '</script>'.length, text: `<script type="module" src="report.js"></script>` },
+    ].sort((a, b) => b.start - a.start);
+    for (const { start, end, text } of replacements)
+      html = html.slice(0, start) + text + html.slice(end);
+    await fs.promises.writeFile(indexFile, html);
   }
 
   private _createEntryForSuite(data: DataMap, projectName: string, suite: api.Suite, fileName: string, deep: boolean) {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -143,9 +143,9 @@ class HtmlReporter implements ReporterV2 {
     await removeFolders([this._outputFolder]);
     const noSnippets = parseBooleanEnvVar('PLAYWRIGHT_HTML_NO_SNIPPETS') ?? this._options.noSnippets;
     const noCopyPrompt = parseBooleanEnvVar('PLAYWRIGHT_HTML_NO_COPY_PROMPT') ?? this._options.noCopyPrompt;
-    const separateAssets = parseBooleanEnvVar('PLAYWRIGHT_HTML_SEPARATE_ASSETS') ?? this._options.separateAssets ?? false;
+    const doNotInlineAssets = parseBooleanEnvVar('PLAYWRIGHT_HTML_DO_NOT_INLINE_ASSETS') ?? this._options.doNotInlineAssets ?? false;
 
-    const builder = new HtmlBuilder(this.config, this._outputFolder, this._attachmentsBaseURL, separateAssets, {
+    const builder = new HtmlBuilder(this.config, this._outputFolder, this._attachmentsBaseURL, doNotInlineAssets, {
       title: process.env.PLAYWRIGHT_HTML_TITLE || this._options.title,
       noSnippets,
       noCopyPrompt,
@@ -257,13 +257,13 @@ class HtmlBuilder {
   private _hasTraces = false;
   private _attachmentsBaseURL: string;
   private _options: HTMLReportOptions;
-  private _separateAssets: boolean;
+  private _doNotInlineAssets: boolean;
 
-  constructor(config: api.FullConfig, outputDir: string, attachmentsBaseURL: string, separateAssets: boolean, options: HTMLReportOptions) {
+  constructor(config: api.FullConfig, outputDir: string, attachmentsBaseURL: string, doNotInlineAssets: boolean, options: HTMLReportOptions) {
     this._config = config;
     this._reportFolder = outputDir;
     this._options = options;
-    this._separateAssets = separateAssets;
+    this._doNotInlineAssets = doNotInlineAssets;
     fs.mkdirSync(this._reportFolder, { recursive: true });
     this._attachmentsBaseURL = attachmentsBaseURL;
   }
@@ -337,7 +337,7 @@ class HtmlBuilder {
       singleTestId = testFile.tests[0].testId;
     }
 
-    const reportIndexFile = await this._writeAppStaticFiles();
+    const reportIndexFile = await this._writeStaticAssets();
 
     // Copy trace viewer.
     if (this._hasTraces) {
@@ -362,10 +362,10 @@ class HtmlBuilder {
     return { ok, singleTestId };
   }
 
-  private async _writeAppStaticFiles() {
+  private async _writeStaticAssets() {
     const appFolder = path.join(require.resolve('playwright-core'), '..', 'lib', 'vite', 'htmlReport');
     const reportIndexFile = path.join(this._reportFolder, 'index.html');
-    if (this._separateAssets) {
+    if (this._doNotInlineAssets) {
       const html = await fs.promises.readFile(path.join(appFolder, 'index.html'), 'utf-8');
       await Promise.all([
         fs.promises.writeFile(reportIndexFile, html),

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -32,7 +32,6 @@ import type { ReportConfigureParams, ReportEndParams, ReporterV2 } from './repor
 import type { HtmlReporterOptions as HtmlReporterConfigOptions, Metadata, TestAnnotation } from '../../types/test';
 import type * as api from '../../types/testReporter';
 import type { HTMLReport, HTMLReportOptions, Location, Stats, TestAttachment, TestCase, TestCaseSummary, TestFile, TestFileSummary, TestResult, TestStep } from '@html-reporter/types';
-import type { ZipFile } from 'playwright-core/lib/zipBundle';
 import type { TransformCallback } from 'stream';
 
 type TestEntry = {
@@ -142,21 +141,11 @@ class HtmlReporter implements ReporterV2 {
   async onEnd(result: api.FullResult) {
     const projectSuites = this.suite.suites;
     await removeFolders([this._outputFolder]);
-    let noSnippets: boolean | undefined;
-    if (process.env.PLAYWRIGHT_HTML_NO_SNIPPETS === 'false' || process.env.PLAYWRIGHT_HTML_NO_SNIPPETS === '0')
-      noSnippets = false;
-    else if (process.env.PLAYWRIGHT_HTML_NO_SNIPPETS)
-      noSnippets = true;
-    noSnippets = noSnippets || this._options.noSnippets;
+    const noSnippets = parseBooleanEnvVar('PLAYWRIGHT_HTML_NO_SNIPPETS') ?? this._options.noSnippets;
+    const noCopyPrompt = parseBooleanEnvVar('PLAYWRIGHT_HTML_NO_COPY_PROMPT') ?? this._options.noCopyPrompt;
+    const separateAssets = parseBooleanEnvVar('PLAYWRIGHT_HTML_SEPARATE_ASSETS') ?? this._options.separateAssets ?? false;
 
-    let noCopyPrompt: boolean | undefined;
-    if (process.env.PLAYWRIGHT_HTML_NO_COPY_PROMPT === 'false' || process.env.PLAYWRIGHT_HTML_NO_COPY_PROMPT === '0')
-      noCopyPrompt = false;
-    else if (process.env.PLAYWRIGHT_HTML_NO_COPY_PROMPT)
-      noCopyPrompt = true;
-    noCopyPrompt = noCopyPrompt || this._options.noCopyPrompt;
-
-    const builder = new HtmlBuilder(this.config, this._outputFolder, this._attachmentsBaseURL, {
+    const builder = new HtmlBuilder(this.config, this._outputFolder, this._attachmentsBaseURL, separateAssets, {
       title: process.env.PLAYWRIGHT_HTML_TITLE || this._options.title,
       noSnippets,
       noCopyPrompt,
@@ -202,6 +191,15 @@ function getHtmlReportOptionProcessEnv(): HtmlReportOpenOption | undefined {
     return undefined;
   }
   return htmlOpenEnv;
+}
+
+function parseBooleanEnvVar(name: string): boolean | undefined {
+  const value = process.env[name];
+  if (value === 'false' || value === '0')
+    return false;
+  if (value)
+    return true;
+  return undefined;
 }
 
 function standaloneDefaultFolder(): string {
@@ -251,21 +249,99 @@ export function startHtmlReportServer(folder: string): HttpServer {
 
 type DataMap = Map<string, { testFile: TestFile, testFileSummary: TestFileSummary }>;
 
+interface ReportWriter {
+  addDataFile(fileName: string, data: any): Promise<void>;
+  copyAppFiles(viteDir: string): Promise<void>;
+  finalize(): Promise<void>;
+}
+
+class EmbeddedReportWriter implements ReportWriter {
+  private _zipFile = new yazl.ZipFile();
+  private _indexFile: string;
+
+  constructor(reportFolder: string) {
+    this._indexFile = path.join(reportFolder, 'index.html');
+  }
+
+  async addDataFile(fileName: string, data: any) {
+    this._zipFile.addBuffer(Buffer.from(JSON.stringify(data)), fileName);
+  }
+
+  async copyAppFiles(viteDir: string) {
+    await copyFileAndMakeWritable(path.join(viteDir, 'htmlReport', 'index.html'), this._indexFile);
+  }
+
+  async finalize() {
+    await fs.promises.appendFile(this._indexFile, '<script id="playwrightReportBase64" type="application/zip">data:application/zip;base64,');
+    await new Promise(f => {
+      this._zipFile.end(undefined, () => {
+        this._zipFile.outputStream
+            .pipe(new Base64Encoder())
+            .pipe(fs.createWriteStream(this._indexFile, { flags: 'a' })).on('close', f);
+      });
+    });
+    await fs.promises.appendFile(this._indexFile, '</script>');
+  }
+}
+
+class SeparateReportWriter implements ReportWriter {
+  constructor(private readonly _reportFolder: string) {}
+
+  async addDataFile(fileName: string, data: any) {
+    await fs.promises.writeFile(path.join(this._reportFolder, fileName), JSON.stringify(data));
+  }
+
+  async copyAppFiles(viteDir: string) {
+    await copyFileAndMakeWritable(path.join(viteDir, 'htmlReport', 'index.html'), path.join(this._reportFolder, 'index.html'));
+  }
+
+  async finalize() {
+    // Extract inlined JS and CSS on the fly to avoid shipping them twice in the playwright npm package.
+    const indexFile = path.join(this._reportFolder, 'index.html');
+    const html = await fs.promises.readFile(indexFile, 'utf-8');
+
+    const styleTag = `<style type='text/css'>`;
+    const styleStart = html.indexOf(styleTag);
+    const styleEnd = html.indexOf('</style>', styleStart);
+    const css = html.slice(styleStart + styleTag.length, styleEnd);
+
+    const scriptTag = `<script type="module">`;
+    const scriptStart = html.indexOf(scriptTag);
+    const scriptEnd = html.indexOf('</script>', scriptStart);
+    const js = html.slice(scriptStart + scriptTag.length, scriptEnd);
+
+    await Promise.all([
+      fs.promises.writeFile(path.join(this._reportFolder, 'report.css'), css),
+      fs.promises.writeFile(path.join(this._reportFolder, 'report.js'), js),
+    ]);
+
+    // Replace in reverse document order so earlier offsets stay valid after each replacement.
+    const replacements = [
+      { start: styleStart, end: styleEnd + '</style>'.length, text: `<link rel="stylesheet" href="report.css">` },
+      { start: scriptStart, end: scriptEnd + '</script>'.length, text: `<script type="module" src="report.js"></script>` },
+    ].sort((a, b) => b.start - a.start);
+    let newHtml = html;
+    for (const { start, end, text } of replacements)
+      newHtml = newHtml.slice(0, start) + text + newHtml.slice(end);
+    await fs.promises.writeFile(indexFile, newHtml);
+  }
+}
+
 class HtmlBuilder {
   private _config: api.FullConfig;
   private _reportFolder: string;
   private _stepsInFile = new MultiMap<string, TestStep>();
-  private _dataZipFile: ZipFile;
+  private _reportWriter: ReportWriter;
   private _hasTraces = false;
   private _attachmentsBaseURL: string;
   private _options: HTMLReportOptions;
 
-  constructor(config: api.FullConfig, outputDir: string, attachmentsBaseURL: string, options: HTMLReportOptions) {
+  constructor(config: api.FullConfig, outputDir: string, attachmentsBaseURL: string, separateAssets: boolean, options: HTMLReportOptions) {
     this._config = config;
     this._reportFolder = outputDir;
     this._options = options;
     fs.mkdirSync(this._reportFolder, { recursive: true });
-    this._dataZipFile = new yazl.ZipFile();
+    this._reportWriter = separateAssets ? new SeparateReportWriter(this._reportFolder) : new EmbeddedReportWriter(this._reportFolder);
     this._attachmentsBaseURL = attachmentsBaseURL;
   }
 
@@ -282,6 +358,7 @@ class HtmlBuilder {
       createSnippets(this._stepsInFile);
 
     let ok = true;
+    const fileDataWrites: Promise<void>[] = [];
     for (const [fileId, { testFile, testFileSummary }] of data) {
       const stats = testFileSummary.stats;
       for (const test of testFileSummary.tests) {
@@ -306,8 +383,9 @@ class HtmlBuilder {
       };
       testFileSummary.tests.sort(testCaseSummaryComparator);
 
-      this._addDataFile(fileId + '.json', testFile);
+      fileDataWrites.push(this._reportWriter.addDataFile(fileId + '.json', testFile));
     }
+    await Promise.all(fileDataWrites);
     const htmlReport: HTMLReport = {
       metadata,
       startTime: result.startTime.getTime(),
@@ -330,7 +408,7 @@ class HtmlBuilder {
       return w2 - w1;
     });
 
-    this._addDataFile('report.json', htmlReport);
+    await this._reportWriter.addDataFile('report.json', htmlReport);
 
     let singleTestId: string | undefined;
     if (htmlReport.stats.total === 1) {
@@ -339,8 +417,8 @@ class HtmlBuilder {
     }
 
     // Copy app.
-    const appFolder = path.join(require.resolve('playwright-core'), '..', 'lib', 'vite', 'htmlReport');
-    await copyFileAndMakeWritable(path.join(appFolder, 'index.html'), path.join(this._reportFolder, 'index.html'));
+    const viteDir = path.join(require.resolve('playwright-core'), '..', 'lib', 'vite');
+    await this._reportWriter.copyAppFiles(viteDir);
 
     // Copy trace viewer.
     if (this._hasTraces) {
@@ -360,26 +438,9 @@ class HtmlBuilder {
       }
     }
 
-    await this._writeReportData(path.join(this._reportFolder, 'index.html'));
-
+    await this._reportWriter.finalize();
 
     return { ok, singleTestId };
-  }
-
-  private async _writeReportData(filePath: string) {
-    fs.appendFileSync(filePath, '<script id="playwrightReportBase64" type="application/zip">data:application/zip;base64,');
-    await new Promise(f => {
-      this._dataZipFile!.end(undefined, () => {
-        this._dataZipFile!.outputStream
-            .pipe(new Base64Encoder())
-            .pipe(fs.createWriteStream(filePath, { flags: 'a' })).on('close', f);
-      });
-    });
-    fs.appendFileSync(filePath, '</script>');
-  }
-
-  private _addDataFile(fileName: string, data: any) {
-    this._dataZipFile.addBuffer(Buffer.from(JSON.stringify(data)), fileName);
   }
 
   private _createEntryForSuite(data: DataMap, projectName: string, suite: api.Suite, fileName: string, deep: boolean) {

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -31,6 +31,7 @@ export type HtmlReporterOptions = {
   title?: string;
   noSnippets?: boolean;
   noCopyPrompt?: boolean;
+  separateAssets?: boolean;
 };
 
 export type ReporterDescription = Readonly<

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -31,7 +31,7 @@ export type HtmlReporterOptions = {
   title?: string;
   noSnippets?: boolean;
   noCopyPrompt?: boolean;
-  separateAssets?: boolean;
+  doNotInlineAssets?: boolean;
 };
 
 export type ReporterDescription = Readonly<

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3134,11 +3134,14 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       const reportFolder = testInfo.outputPath('playwright-report');
       expect(fs.existsSync(path.join(reportFolder, 'report.js'))).toBe(true);
       expect(fs.existsSync(path.join(reportFolder, 'report.css'))).toBe(true);
+      expect(fs.existsSync(path.join(reportFolder, 'report.zip'))).toBe(true);
       const html = fs.readFileSync(path.join(reportFolder, 'index.html'), 'utf-8');
       expect(html).toContain('src="./report.js"');
       expect(html).toContain('href="./report.css"');
-      // Report data stays embedded in the zip within index.html (CSP-safe: type="application/zip" is not executed as JS).
-      expect(html).toContain('playwrightReportBase64');
+      expect(html).not.toContain('playwrightReportBase64');
+      // No inline scripts or styles (CSP-compatible).
+      expect(html).not.toMatch(/<script[^>]*>[^<\s]/);
+      expect(html).not.toMatch(/<style[\s>]/);
 
       await showReport();
       await expect(page.locator('.subnav-item:has-text("Passed") .counter')).toHaveText('1');

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3122,13 +3122,13 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.getByTestId('test-snippet')).not.toBeVisible();
     });
 
-    test('should generate unpacked report with separateAssets', async ({ runInlineTest, showReport, page }, testInfo) => {
+    test('should generate unpacked report with doNotInlineAssets', async ({ runInlineTest, showReport, page }, testInfo) => {
       const result = await runInlineTest({
         'example.spec.ts': `
           import { test, expect } from '@playwright/test';
           test('passes', async ({}) => {});
         `,
-      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never', PLAYWRIGHT_HTML_SEPARATE_ASSETS: '1' });
+      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never', PLAYWRIGHT_HTML_DO_NOT_INLINE_ASSETS: '1' });
       expect(result.exitCode).toBe(0);
 
       const reportFolder = testInfo.outputPath('playwright-report');

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3135,8 +3135,8 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       expect(fs.existsSync(path.join(reportFolder, 'report.js'))).toBe(true);
       expect(fs.existsSync(path.join(reportFolder, 'report.css'))).toBe(true);
       const html = fs.readFileSync(path.join(reportFolder, 'index.html'), 'utf-8');
-      expect(html).toContain('src="report.js"');
-      expect(html).toContain('href="report.css"');
+      expect(html).toContain('src="./report.js"');
+      expect(html).toContain('href="./report.css"');
       // Report data stays embedded in the zip within index.html (CSP-safe: type="application/zip" is not executed as JS).
       expect(html).toContain('playwrightReportBase64');
 

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3122,6 +3122,30 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.getByTestId('test-snippet')).not.toBeVisible();
     });
 
+    test('should generate unpacked report with separateAssets', async ({ runInlineTest, showReport, page }, testInfo) => {
+      const result = await runInlineTest({
+        'example.spec.ts': `
+          import { test, expect } from '@playwright/test';
+          test('passes', async ({}) => {});
+        `,
+      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never', PLAYWRIGHT_HTML_SEPARATE_ASSETS: '1' });
+      expect(result.exitCode).toBe(0);
+
+      const reportFolder = testInfo.outputPath('playwright-report');
+      expect(fs.existsSync(path.join(reportFolder, 'report.js'))).toBe(true);
+      expect(fs.existsSync(path.join(reportFolder, 'report.css'))).toBe(true);
+      expect(fs.existsSync(path.join(reportFolder, 'report.json'))).toBe(true);
+      const html = fs.readFileSync(path.join(reportFolder, 'index.html'), 'utf-8');
+      expect(html).toContain('src="report.js"');
+      expect(html).toContain('href="report.css"');
+      expect(html).not.toContain('playwrightReportBase64');
+
+      await showReport();
+      await expect(page.locator('.subnav-item:has-text("Passed") .counter')).toHaveText('1');
+      await page.getByRole('link', { name: 'passes' }).click();
+      await expect(page.getByText('example.spec.ts')).toBeVisible();
+    });
+
     test('worker test list', async ({ runInlineTest, showReport, page }) => {
       const result = await runInlineTest({
         'playwright.config.ts': `

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3134,11 +3134,11 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       const reportFolder = testInfo.outputPath('playwright-report');
       expect(fs.existsSync(path.join(reportFolder, 'report.js'))).toBe(true);
       expect(fs.existsSync(path.join(reportFolder, 'report.css'))).toBe(true);
-      expect(fs.existsSync(path.join(reportFolder, 'report.json'))).toBe(true);
       const html = fs.readFileSync(path.join(reportFolder, 'index.html'), 'utf-8');
       expect(html).toContain('src="report.js"');
       expect(html).toContain('href="report.css"');
-      expect(html).not.toContain('playwrightReportBase64');
+      // Report data stays embedded in the zip within index.html (CSP-safe: type="application/zip" is not executed as JS).
+      expect(html).toContain('playwrightReportBase64');
 
       await showReport();
       await expect(page.locator('.subnav-item:has-text("Passed") .counter')).toHaveText('1');

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3134,12 +3134,11 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       const reportFolder = testInfo.outputPath('playwright-report');
       expect(fs.existsSync(path.join(reportFolder, 'report.js'))).toBe(true);
       expect(fs.existsSync(path.join(reportFolder, 'report.css'))).toBe(true);
-      expect(fs.existsSync(path.join(reportFolder, 'report.zip'))).toBe(true);
       const html = fs.readFileSync(path.join(reportFolder, 'index.html'), 'utf-8');
       expect(html).toContain('src="./report.js"');
       expect(html).toContain('href="./report.css"');
-      expect(html).not.toContain('playwrightReportBase64');
-      // No inline scripts or styles (CSP-compatible).
+      // Report data is stored in a <template> element (not a <script>), so no inline scripts or styles.
+      expect(html).toContain('<template id="playwrightReportBase64">');
       expect(html).not.toMatch(/<script[^>]*>[^<\s]/);
       expect(html).not.toMatch(/<style[\s>]/);
 

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -30,6 +30,7 @@ export type HtmlReporterOptions = {
   title?: string;
   noSnippets?: boolean;
   noCopyPrompt?: boolean;
+  separateAssets?: boolean;
 };
 
 export type ReporterDescription = Readonly<

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -30,7 +30,7 @@ export type HtmlReporterOptions = {
   title?: string;
   noSnippets?: boolean;
   noCopyPrompt?: boolean;
-  separateAssets?: boolean;
+  doNotInlineAssets?: boolean;
 };
 
 export type ReporterDescription = Readonly<


### PR DESCRIPTION
## Summary
- adds `doNotInlineAssets` option (and `PLAYWRIGHT_HTML_DO_NOT_INLINE_ASSETS` env var) to the HTML reporter
- when enabled, JS and CSS are written as separate `report.js`/`report.css` files instead of being inlined into `index.html`
- report data (zip) is always embedded in `index.html`, but stored in a `<template>` element instead of a `<script>` tag, making it CSP-safe (`script-src` does not apply to template elements)

Fixes https://github.com/microsoft/playwright/issues/39748