### PR TITLE
fix(clock): return fake entries for performance.{mark,measure}

### DIFF
--- a/packages/injected/src/clock.ts
+++ b/packages/injected/src/clock.ts
@@ -701,6 +701,24 @@ function getClearHandler(type: TimerType) {
   return `clear${type}`;
 }
 
+class FakePerformanceEntry {
+  name: string;
+  entryType: string;
+  startTime: number;
+  duration: number;
+
+  constructor(name: string, entryType: string, startTime: number, duration: number) {
+    this.name = name;
+    this.entryType = entryType;
+    this.startTime = startTime;
+    this.duration = duration;
+  }
+
+  toJSON() {
+    return JSON.stringify({ ...this });
+  }
+}
+
 function fakePerformance(clock: ClockController, performance: Builtins['performance']): Builtins['performance'] {
   const result: any = {
     now: () => clock.performanceNow(),
@@ -712,6 +730,10 @@ function fakePerformance(clock: ClockController, performance: Builtins['performa
       continue;
     if (key === 'getEntries' || key === 'getEntriesByName' || key === 'getEntriesByType')
       result[key] = () => [];
+    else if (key === 'mark')
+      result[key] = (name: string) => new FakePerformanceEntry(name, 'mark', 0, 0);
+    else if (key === 'measure')
+      result[key] = (name: string) => new FakePerformanceEntry(name, 'measure', 0, 50);
     else
       result[key] = () => {};
   }

--- a/tests/library/unit/clock.spec.ts
+++ b/tests/library/unit/clock.spec.ts
@@ -1179,6 +1179,26 @@ it.describe('stubTimers', () => {
     });
   });
 
+  it('should return PerformanceEntry-like objects from performance.mark and performance.measure', async ({ install }) => {
+    it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39816' });
+    it.skip(nodeMajorVersion < 20);
+    install();
+    const markEntry = performance.mark('foo');
+    const measureEntry = performance.measure('bar');
+    for (const entry of [markEntry, measureEntry]) {
+      expect(entry).toHaveProperty('startTime');
+      expect(entry).toHaveProperty('duration');
+      expect(entry).toHaveProperty('name');
+      expect(entry).toHaveProperty('entryType');
+      expect(typeof entry.toJSON()).toBe('string');
+    }
+    expect(markEntry.name).toBe('foo');
+    expect(markEntry.entryType).toBe('mark');
+    expect(measureEntry.name).toBe('bar');
+    expect(measureEntry.entryType).toBe('measure');
+    expect(measureEntry.duration).toBe(50);
+  });
+
   it('restores global property on uninstall if it was inherited onto the global object', ({}) => {
     // Give the global object an inherited 'setTimeout' method
     const proto = {


### PR DESCRIPTION
Fixes #39816.