### PR TITLE
chore(ci): overwrite blob reports from previous attempts on retry

### DIFF
--- a/.github/actions/upload-blob-report/action.yml
+++ b/.github/actions/upload-blob-report/action.yml
@@ -17,8 +17,9 @@ runs:
       run: find "${{ inputs.report_dir }}" -name "*.zip" -exec unzip -t {} \;
     - name: Upload blob report to GitHub
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: blob-report-${{ inputs.job_name }}
         path: ${{ inputs.report_dir }}/**
         retention-days: 7
+        overwrite: true


### PR DESCRIPTION
## Summary
- Upgrade `actions/upload-artifact` from v4 to v7 in the upload-blob-report action
- Add `overwrite: true` to avoid failures when an artifact with the same name already exists