### PR TITLE
feat(cli): support global config file at ~/.playwright/cli.config.json

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -227,10 +227,13 @@ async function install(args: MinimistArgs) {
 }
 
 async function ensureConfiguredBrowserInstalled() {
-  if (fs.existsSync(defaultConfigFile())) {
+  const defaultPath = defaultConfigFile();
+  const globalPath = globalConfigFile();
+  const configFile = fs.existsSync(defaultPath) ? defaultPath :
+    fs.existsSync(globalPath) ? globalPath : undefined;
+  if (configFile) {
     const { registry } = await import('playwright-core/lib/server/registry/index');
-    // Config exists, ensure configured browser is installed
-    const data = await fs.promises.readFile(defaultConfigFile(), 'utf-8');
+    const data = await fs.promises.readFile(configFile, 'utf-8');
     const config = JSON.parse(data.charCodeAt(0) === 0xFEFF ? data.slice(1) : data) as Config;
     const browserName = config.browser?.browserName ?? 'chromium';
     const channel = config.browser?.launchOptions?.channel;
@@ -245,6 +248,10 @@ async function ensureConfiguredBrowserInstalled() {
     if (channel !== 'chrome')
       await createDefaultConfig(channel);
   }
+}
+
+function globalConfigFile(): string {
+  return path.join(os.homedir(), '.playwright', 'cli.config.json');
 }
 
 async function installBrowser() {

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -201,7 +201,7 @@ async function runInSession(entry: SessionFile, clientInfo: ClientInfo, args: Mi
 
 async function runInitWorkspace(args: MinimistArgs) {
   const cliPath = require.resolve('../cli-daemon/program.js');
-  const daemonArgs = [cliPath, args.skills ? '--init-workspace=skills' : '--init-workspace'];
+  const daemonArgs: string[] = [cliPath, '--init-workspace', ...(args.skills ? ['--init-skills', String(args.skills)] : [])];
   await new Promise<void>((resolve, reject) => {
     const child = spawn(process.execPath, daemonArgs, {
       stdio: 'inherit',

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -20,7 +20,6 @@
 import { execSync, spawn } from 'child_process';
 
 import crypto from 'crypto';
-import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { createClientInfo, explicitSessionName, Registry, resolveSessionName } from './registry';
@@ -28,7 +27,6 @@ import { Session, renderResolvedConfig } from './session';
 import { serverRegistry } from '../../serverRegistry';
 import { minimist } from './minimist';
 
-import type { Config } from '../mcp/config.d';
 import type { ClientInfo, SessionFile } from './registry';
 import type { BrowserDescriptor } from '../../serverRegistry';
 import type { MinimistArgs } from './minimist';
@@ -156,7 +154,7 @@ export async function program(options?: { embedderVersion?: string}) {
       await session.stop();
       return;
     case 'install':
-      await install(args);
+      await runInitWorkspace(args);
       return;
     case 'install-browser':
       await installBrowser();
@@ -201,97 +199,27 @@ async function runInSession(entry: SessionFile, clientInfo: ClientInfo, args: Mi
   console.log(result.text);
 }
 
-async function install(args: MinimistArgs) {
-  const cwd = process.cwd();
-
-  // Create .playwright folder to mark workspace root
-  const playwrightDir = path.join(cwd, '.playwright');
-  await fs.promises.mkdir(playwrightDir, { recursive: true });
-  console.log(`✅ Workspace initialized at \`${cwd}\`.`);
-
-  if (args.skills !== undefined) {
-    const target = args.skills === 'agents' ? 'agents' : 'claude';
-    const skillSourceDir = path.join(__dirname, 'skill');
-    const skillDestDir = path.join(cwd, `.${target}`, 'skills', 'playwright-cli');
-
-    if (!fs.existsSync(skillSourceDir)) {
-      console.error('❌ Skills source directory not found:', skillSourceDir);
-      process.exit(1);
-    }
-
-    await fs.promises.cp(skillSourceDir, skillDestDir, { recursive: true });
-    console.log(`✅ Skills installed to \`${path.relative(cwd, skillDestDir)}\`.`);
-  }
-
-  await ensureConfiguredBrowserInstalled();
-}
-
-async function ensureConfiguredBrowserInstalled() {
-  const defaultPath = defaultConfigFile();
-  const globalPath = globalConfigFile();
-  const configFile = fs.existsSync(defaultPath) ? defaultPath :
-    fs.existsSync(globalPath) ? globalPath : undefined;
-  if (configFile) {
-    const { registry } = await import('playwright-core/lib/server/registry/index');
-    const data = await fs.promises.readFile(configFile, 'utf-8');
-    const config = JSON.parse(data.charCodeAt(0) === 0xFEFF ? data.slice(1) : data) as Config;
-    const browserName = config.browser?.browserName ?? 'chromium';
-    const channel = config.browser?.launchOptions?.channel;
-    if (!channel || channel.startsWith('chromium')) {
-      const executable = registry.findExecutable(channel ?? browserName);
-      if (executable && !fs.existsSync(executable?.executablePath()!))
-        await registry.install([executable]);
-    }
-  } else {
-    // No config exists, detect or install a browser and create config
-    const channel = await findOrInstallDefaultBrowser();
-    if (channel !== 'chrome')
-      await createDefaultConfig(channel);
-  }
-}
-
-function globalConfigFile(): string {
-  return path.join(os.homedir(), '.playwright', 'cli.config.json');
+async function runInitWorkspace(args: MinimistArgs) {
+  const cliPath = require.resolve('../cli-daemon/program.js');
+  const daemonArgs = [cliPath, args.skills ? '--init-workspace=skills' : '--init-workspace'];
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(process.execPath, daemonArgs, {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    });
+    child.on('close', code => {
+      if (code === 0)
+        resolve();
+      else
+        reject(new Error(`Workspace initialization failed with exit code ${code}`));
+    });
+  });
 }
 
 async function installBrowser() {
   const { program } = require('../../cli/program');
   const argv = process.argv.map(arg => arg === 'install-browser' ? 'install' : arg);
   program.parse(argv);
-}
-
-async function createDefaultConfig(channel: string) {
-  const config: Config = {
-    browser: {
-      browserName: 'chromium',
-      launchOptions: {
-        channel,
-      },
-    },
-  };
-  await fs.promises.writeFile(defaultConfigFile(), JSON.stringify(config, null, 2));
-  console.log(`✅ Created default config for ${channel} at ${path.relative(process.cwd(), defaultConfigFile())}.`);
-}
-
-async function findOrInstallDefaultBrowser() {
-  const { registry } = await import('playwright-core/lib/server/registry/index');
-  const channels = ['chrome', 'msedge'];
-  for (const channel of channels) {
-    const executable = registry.findExecutable(channel);
-    if (!executable?.executablePath())
-      continue;
-    console.log(`✅ Found ${channel}, will use it as the default browser.`);
-    return channel;
-  }
-  const chromiumExecutable = registry.findExecutable('chromium');
-  // Unlike channels, chromium executable path is always valid, even if the browser is not installed.
-  if (!fs.existsSync(chromiumExecutable?.executablePath()!))
-    await registry.install([chromiumExecutable]);
-  return 'chromium';
-}
-
-function defaultConfigFile(): string {
-  return path.resolve('.playwright', 'cli.config.json');
 }
 
 async function killAllDaemons(): Promise<void> {

--- a/packages/playwright-core/src/tools/cli-daemon/DEPS.list
+++ b/packages/playwright-core/src/tools/cli-daemon/DEPS.list
@@ -6,5 +6,6 @@
 ../../utilsBundle.ts
 ../../utils/
 ../../zodBundle.ts
+../../server/registry/index.ts
 ../../server/utils/
 ../../serverRegistry.ts

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -26,6 +26,7 @@ import { createBrowserWithInfo } from '../mcp/browserFactory';
 import * as configUtils from '../mcp/config';
 import { ClientInfo, createClientInfo } from '../cli-client/registry';
 import { program } from '../../utilsBundle';
+import { registry as browserRegistry } from '../../server/registry/index';
 
 import type { FullConfig } from '../mcp/config';
 
@@ -37,8 +38,14 @@ program.argument('[session-name]', 'name of the session to create or connect to'
     .option('--profile <path>', 'path to the user data dir')
     .option('--config <path>', 'path to the config file; by default uses .playwright/cli.config.json in the project directory and ~/.playwright/cli.config.json as global config')
     .option('--attach <name-or-endpoint>', 'attach to a running Playwright browser by name or endpoint')
+    .option('--init-workspace [value]', 'initialize workspace; pass "skills" to also install Claude skills')
 
     .action(async (sessionName: string, options: any) => {
+      if (options.initWorkspace !== undefined) {
+        await initWorkspace(options.initWorkspace === 'skills');
+        return;
+      }
+
       setupExitWatchdog();
       const clientInfo = createClientInfo();
       const mcpConfig = await resolveCLIConfig(clientInfo, sessionName, options);
@@ -129,4 +136,70 @@ export async function resolveCLIConfig(clientInfo: ClientInfo, sessionName: stri
   await configUtils.validateConfig(result);
 
   return result;
+}
+
+async function initWorkspace(installSkills: boolean) {
+  const cwd = process.cwd();
+  const playwrightDir = path.join(cwd, '.playwright');
+  await fs.promises.mkdir(playwrightDir, { recursive: true });
+  console.log(`✅ Workspace initialized at \`${cwd}\`.`);
+
+  if (installSkills) {
+    const skillSourceDir = path.join(__dirname, '../cli-client/skill');
+    const skillDestDir = path.join(cwd, '.claude', 'skills', 'playwright-cli');
+    if (!fs.existsSync(skillSourceDir)) {
+      console.error('❌ Skills source directory not found:', skillSourceDir);
+      // eslint-disable-next-line no-restricted-properties
+      process.exit(1);
+    }
+    await fs.promises.cp(skillSourceDir, skillDestDir, { recursive: true });
+    console.log(`✅ Skills installed to \`${path.relative(cwd, skillDestDir)}\`.`);
+  }
+
+  await ensureConfiguredBrowserInstalled();
+}
+
+async function ensureConfiguredBrowserInstalled() {
+  if (fs.existsSync(defaultConfigFile()) || fs.existsSync(globalConfigFile())) {
+    // Config exists, ensure configured browser is installed
+    const clientInfo = createClientInfo();
+    const config = await resolveCLIConfig(clientInfo, 'default', {});
+    const browserName = config.browser.browserName;
+    const channel = config.browser.launchOptions.channel;
+    if (!channel || channel.startsWith('chromium')) {
+      const executable = browserRegistry.findExecutable(channel ?? browserName);
+      if (executable && !fs.existsSync(executable.executablePath()!))
+        await browserRegistry.install([executable]);
+    }
+  } else {
+    const channel = await findOrInstallDefaultBrowser();
+    if (channel !== 'chrome')
+      await createDefaultConfig(channel);
+  }
+}
+
+async function findOrInstallDefaultBrowser() {
+  const channels = ['chrome', 'msedge'];
+  for (const channel of channels) {
+    const executable = browserRegistry.findExecutable(channel);
+    if (!executable?.executablePath())
+      continue;
+    console.log(`✅ Found ${channel}, will use it as the default browser.`);
+    return channel;
+  }
+  const chromiumExecutable = browserRegistry.findExecutable('chromium');
+  if (!fs.existsSync(chromiumExecutable?.executablePath()!))
+    await browserRegistry.install([chromiumExecutable]);
+  return 'chromium';
+}
+
+async function createDefaultConfig(channel: string) {
+  const config = {
+    browser: {
+      browserName: 'chromium',
+      launchOptions: { channel },
+    },
+  };
+  await fs.promises.writeFile(defaultConfigFile(), JSON.stringify(config, null, 2));
+  console.log(`✅ Created default config for ${channel} at ${path.relative(process.cwd(), defaultConfigFile())}.`);
 }

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -79,7 +79,7 @@ function defaultConfigFile(): string {
 }
 
 function globalConfigFile(): string {
-  return path.join(os.homedir(), '.playwright', 'cli.config.json');
+  return path.join(process.env['PWTEST_CLI_GLOBAL_CONFIG'] ?? os.homedir(), '.playwright', 'cli.config.json');
 }
 
 export async function resolveCLIConfig(clientInfo: ClientInfo, sessionName: string, options: any): Promise<FullConfig> {

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -35,7 +35,7 @@ program.argument('[session-name]', 'name of the session to create or connect to'
     .option('--browser <name>', 'browser to use (chromium, chrome, firefox, webkit)')
     .option('--persistent', 'use a persistent browser context')
     .option('--profile <path>', 'path to the user data dir')
-    .option('--config <path>', 'path to the config file')
+    .option('--config <path>', 'path to the config file; by default uses .playwright/cli.config.json in the project directory and ~/.playwright/cli.config.json as global config')
     .option('--attach <name-or-endpoint>', 'attach to a running Playwright browser by name or endpoint')
 
     .action(async (sessionName: string, options: any) => {

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -17,6 +17,7 @@
 /* eslint-disable no-console */
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import { startCliDaemonServer } from './daemon';
@@ -69,6 +70,10 @@ function defaultConfigFile(): string {
   return path.resolve('.playwright', 'cli.config.json');
 }
 
+function globalConfigFile(): string {
+  return path.join(os.homedir(), '.playwright', 'cli.config.json');
+}
+
 export async function resolveCLIConfig(clientInfo: ClientInfo, sessionName: string, options: any): Promise<FullConfig> {
   const config = options.config ? path.resolve(options.config) : undefined;
   try {
@@ -90,6 +95,8 @@ export async function resolveCLIConfig(clientInfo: ClientInfo, sessionName: stri
   const envOverrides = configUtils.configFromEnv();
   const configFile = envOverrides.configFile ?? daemonOverrides.configFile;
   const configInFile = await configUtils.loadConfig(configFile);
+  const globalConfigPath = fs.existsSync(globalConfigFile()) ? globalConfigFile() : undefined;
+  const globalConfigInFile = await configUtils.loadConfig(globalConfigPath);
 
   let result = configUtils.mergeConfig(configUtils.defaultConfig, {
     browser: {
@@ -99,6 +106,7 @@ export async function resolveCLIConfig(clientInfo: ClientInfo, sessionName: stri
     }
   });
 
+  result = configUtils.mergeConfig(result, globalConfigInFile);
   result = configUtils.mergeConfig(result, configInFile);
   result = configUtils.mergeConfig(result, daemonOverrides);
   result = configUtils.mergeConfig(result, envOverrides);

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -38,11 +38,12 @@ program.argument('[session-name]', 'name of the session to create or connect to'
     .option('--profile <path>', 'path to the user data dir')
     .option('--config <path>', 'path to the config file; by default uses .playwright/cli.config.json in the project directory and ~/.playwright/cli.config.json as global config')
     .option('--attach <name-or-endpoint>', 'attach to a running Playwright browser by name or endpoint')
-    .option('--init-workspace [value]', 'initialize workspace; pass "skills" to also install Claude skills')
+    .option('--init-workspace', 'initialize workspace')
+    .option('--init-skills <value>', 'install skills for the given agent type ("claude" or "agents")')
 
     .action(async (sessionName: string, options: any) => {
-      if (options.initWorkspace !== undefined) {
-        await initWorkspace(options.initWorkspace === 'skills');
+      if (options.initWorkspace) {
+        await initWorkspace(options.initSkills);
         return;
       }
 
@@ -138,15 +139,16 @@ export async function resolveCLIConfig(clientInfo: ClientInfo, sessionName: stri
   return result;
 }
 
-async function initWorkspace(installSkills: boolean) {
+async function initWorkspace(initSkills: string | undefined) {
   const cwd = process.cwd();
   const playwrightDir = path.join(cwd, '.playwright');
   await fs.promises.mkdir(playwrightDir, { recursive: true });
   console.log(`✅ Workspace initialized at \`${cwd}\`.`);
 
-  if (installSkills) {
+  if (initSkills) {
     const skillSourceDir = path.join(__dirname, '../cli-client/skill');
-    const skillDestDir = path.join(cwd, '.claude', 'skills', 'playwright-cli');
+    const target = initSkills === 'agents' ? 'agents' : 'claude';
+    const skillDestDir = path.join(cwd, `.${target}`, 'skills', 'playwright-cli');
     if (!fs.existsSync(skillSourceDir)) {
       console.error('❌ Skills source directory not found:', skillSourceDir);
       // eslint-disable-next-line no-restricted-properties

--- a/tests/mcp/cli-config.spec.ts
+++ b/tests/mcp/cli-config.spec.ts
@@ -103,11 +103,10 @@ test('isolated', async ({ cli, server }, testInfo) => {
   expect(fs.existsSync(testInfo.outputPath('daemon', 'default-user-data'))).toBe(false);
 });
 
-test('global config', async ({ cli, server, mcpBrowser }, testInfo) => {
-  test.skip(mcpBrowser !== 'chrome', 'Overriden home does not contain bundled browsers');
-  const globalConfigDir = testInfo.outputPath('home', '.playwright');
-  await fs.promises.mkdir(globalConfigDir, { recursive: true });
-  await fs.promises.writeFile(path.join(globalConfigDir, 'cli.config.json'), JSON.stringify({
+test('global config', async ({ cli, server }, testInfo) => {
+  const fakeHome = testInfo.outputPath('home');
+  await fs.promises.mkdir(path.join(fakeHome, '.playwright'), { recursive: true });
+  await fs.promises.writeFile(path.join(fakeHome, '.playwright', 'cli.config.json'), JSON.stringify({
     browser: {
       contextOptions: {
         viewport: { width: 800, height: 600 },
@@ -115,17 +114,16 @@ test('global config', async ({ cli, server, mcpBrowser }, testInfo) => {
     },
   }, null, 2));
 
-  const env = { HOME: testInfo.outputPath('home'), USERPROFILE: testInfo.outputPath('home') };
+  const env = { PWTEST_CLI_GLOBAL_CONFIG: fakeHome };
   await cli('open', server.PREFIX, { env });
   const { output } = await cli('eval', 'window.innerWidth + "x" + window.innerHeight', { env });
   expect(output).toContain('800x600');
 });
 
-test('project config overrides global config', async ({ cli, server, mcpBrowser }, testInfo) => {
-  test.skip(mcpBrowser !== 'chrome', 'Overriden home does not contain bundled browsers');
-  const globalConfigDir = testInfo.outputPath('home', '.playwright');
-  await fs.promises.mkdir(globalConfigDir, { recursive: true });
-  await fs.promises.writeFile(path.join(globalConfigDir, 'cli.config.json'), JSON.stringify({
+test('project config overrides global config', async ({ cli, server }, testInfo) => {
+  const fakeHome = testInfo.outputPath('home');
+  await fs.promises.mkdir(path.join(fakeHome, '.playwright'), { recursive: true });
+  await fs.promises.writeFile(path.join(fakeHome, '.playwright', 'cli.config.json'), JSON.stringify({
     browser: {
       contextOptions: {
         viewport: { width: 800, height: 600 },
@@ -141,7 +139,7 @@ test('project config overrides global config', async ({ cli, server, mcpBrowser 
     },
   }, null, 2));
 
-  const env = { HOME: testInfo.outputPath('home'), USERPROFILE: testInfo.outputPath('home') };
+  const env = { PWTEST_CLI_GLOBAL_CONFIG: fakeHome };
   await cli('open', server.PREFIX, { env });
   const { output } = await cli('eval', 'window.innerWidth + "x" + window.innerHeight', { env });
   expect(output).toContain('1024x768');

--- a/tests/mcp/cli-config.spec.ts
+++ b/tests/mcp/cli-config.spec.ts
@@ -103,7 +103,8 @@ test('isolated', async ({ cli, server }, testInfo) => {
   expect(fs.existsSync(testInfo.outputPath('daemon', 'default-user-data'))).toBe(false);
 });
 
-test('global config', async ({ cli, server }, testInfo) => {
+test('global config', async ({ cli, server, mcpBrowser }, testInfo) => {
+  test.skip(mcpBrowser !== 'chrome', 'Overriden home does not contain bundled browsers');
   const globalConfigDir = testInfo.outputPath('home', '.playwright');
   await fs.promises.mkdir(globalConfigDir, { recursive: true });
   await fs.promises.writeFile(path.join(globalConfigDir, 'cli.config.json'), JSON.stringify({
@@ -120,7 +121,8 @@ test('global config', async ({ cli, server }, testInfo) => {
   expect(output).toContain('800x600');
 });
 
-test('project config overrides global config', async ({ cli, server }, testInfo) => {
+test('project config overrides global config', async ({ cli, server, mcpBrowser }, testInfo) => {
+  test.skip(mcpBrowser !== 'chrome', 'Overriden home does not contain bundled browsers');
   const globalConfigDir = testInfo.outputPath('home', '.playwright');
   await fs.promises.mkdir(globalConfigDir, { recursive: true });
   await fs.promises.writeFile(path.join(globalConfigDir, 'cli.config.json'), JSON.stringify({

--- a/tests/mcp/cli-config.spec.ts
+++ b/tests/mcp/cli-config.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import fs from 'fs';
+import path from 'path';
 import { test, expect } from './cli-fixtures';
 
 test('user-data-dir', async ({ cli, server }, testInfo) => {
@@ -100,4 +101,46 @@ test('isolated', async ({ cli, server }, testInfo) => {
   await fs.promises.writeFile(testInfo.outputPath('.playwright', 'cli.config.json'), JSON.stringify(config, null, 2));
   await cli('open', server.PREFIX);
   expect(fs.existsSync(testInfo.outputPath('daemon', 'default-user-data'))).toBe(false);
+});
+
+test('global config', async ({ cli, server }, testInfo) => {
+  const globalConfigDir = testInfo.outputPath('home', '.playwright');
+  await fs.promises.mkdir(globalConfigDir, { recursive: true });
+  await fs.promises.writeFile(path.join(globalConfigDir, 'cli.config.json'), JSON.stringify({
+    browser: {
+      contextOptions: {
+        viewport: { width: 800, height: 600 },
+      },
+    },
+  }, null, 2));
+
+  const env = { HOME: testInfo.outputPath('home'), USERPROFILE: testInfo.outputPath('home') };
+  await cli('open', server.PREFIX, { env });
+  const { output } = await cli('eval', 'window.innerWidth + "x" + window.innerHeight', { env });
+  expect(output).toContain('800x600');
+});
+
+test('project config overrides global config', async ({ cli, server }, testInfo) => {
+  const globalConfigDir = testInfo.outputPath('home', '.playwright');
+  await fs.promises.mkdir(globalConfigDir, { recursive: true });
+  await fs.promises.writeFile(path.join(globalConfigDir, 'cli.config.json'), JSON.stringify({
+    browser: {
+      contextOptions: {
+        viewport: { width: 800, height: 600 },
+      },
+    },
+  }, null, 2));
+
+  await fs.promises.writeFile(testInfo.outputPath('.playwright', 'cli.config.json'), JSON.stringify({
+    browser: {
+      contextOptions: {
+        viewport: { width: 1024, height: 768 },
+      },
+    },
+  }, null, 2));
+
+  const env = { HOME: testInfo.outputPath('home'), USERPROFILE: testInfo.outputPath('home') };
+  await cli('open', server.PREFIX, { env });
+  const { output } = await cli('eval', 'window.innerWidth + "x" + window.innerHeight', { env });
+  expect(output).toContain('1024x768');
 });


### PR DESCRIPTION
## Summary
- Load `~/.playwright/cli.config.json` as a global user-level config, merged before the project-level `.playwright/cli.config.json`
- Merge order: defaults → global config → project config → CLI flags → env vars

Fixes https://github.com/microsoft/playwright/issues/39828