### PR TITLE
fix(webkit): enable WebGPU support on macOS (Issue #39762) 

### DIFF
--- a/browser_patches/webkit/embedder/Playwright/mac/AppDelegate.m
+++ b/browser_patches/webkit/embedder/Playwright/mac/AppDelegate.m
@@ -231,6 +231,8 @@ const NSActivityOptions ActivityOptions =
         configuration.preferences._developerExtrasEnabled = YES;
         configuration.preferences._mediaDevicesEnabled = YES;
         configuration.preferences._mockCaptureDevicesEnabled = YES;
+        // Enable WebGPU.
+        configuration.preferences._webGPUEnabled = YES;
         // Enable WebM support.
         configuration.preferences._hiddenPageDOMTimerThrottlingEnabled = NO;
         configuration.preferences._hiddenPageDOMTimerThrottlingAutoIncreases = NO;

--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -12492,6 +12492,9 @@ index 0000000000000000000000000000000000000000..13e45ef13e4d43dce84a8847bde2518a
 +    // TODO: allow to set preferences over the inspector protocol or find a better place for this.
 +    preferences.setJavaScriptCanOpenWindowsAutomatically(true);
 +
++    // Enable WebGPU.
++    preferences.setWebGPUEnabled(true);
++
 +    // Enable media stream.
 +    if (!preferences.mediaDevicesEnabled()) {
 +        preferences.setMediaDevicesEnabled(true);

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -120,6 +120,28 @@ it('should support webgl 2 @smoke', async ({ page, browserName, isWindows }) => 
   expect(hasWebGL2).toBe(true);
 });
 
+it('should support WebGPU in WebKit', {
+  annotation: {
+    type: 'issue',
+    description: 'https://github.com/microsoft/playwright/issues/39762'
+  }
+}, async ({ page, browserName, isMac, isFrozenWebkit }) => {
+  it.skip(browserName !== 'webkit', 'WebGPU fix targets WebKit only');
+  it.skip(!isMac, 'WebGPU is only available for WebKit on macOS');
+  it.skip(isFrozenWebkit, 'Frozen WebKit builds predate the WebGPU preference fix');
+
+  const result = await page.evaluate(async () => {
+    return {
+      hasNavigatorGPU: 'gpu' in navigator,
+      hasGPUBufferUsage: typeof (globalThis as any).GPUBufferUsage !== 'undefined',
+      hasGPUMapMode: typeof (globalThis as any).GPUMapMode !== 'undefined',
+    };
+  });
+  expect(result.hasNavigatorGPU).toBe(true);
+  expect(result.hasGPUBufferUsage).toBe(true);
+  expect(result.hasGPUMapMode).toBe(true);
+});
+
 it('should not crash on page with mp4 @smoke', async ({ page, server, platform, browserName }) => {
   it.fixme(browserName === 'webkit' && platform === 'win32', 'https://github.com/microsoft/playwright/issues/11009, times out in setContent');
   await page.setContent(`<video><source src="${server.PREFIX}/movie.mp4"/></video>`);


### PR DESCRIPTION
## Summary

My first PR to contribute to the Playwright project :) 

Summary of my changes: 

- Enable the `_webGPUEnabled` preference in the macOS WebKit embedder (`AppDelegate.m`), 
  following the same pattern used for `_mediaDevicesEnabled`. Without this, `navigator.gpu`
  is always null in Playwright's WebKit, even on macOS versions that support WebGPU natively.
- Set `preferences.setWebGPUEnabled(true)` in `adjustInspectedPagePreferences` 
  (bootstrap.diff) to keep the preference enabled when the Playwright inspector attaches.
- Added a test to `capabilities.spec.ts` that verifies `navigator.gpu`, `GPUBufferUsage`
  and `GPUMapMode` are exposed in WebKit on macOS.

Fixes https://github.com/microsoft/playwright/issues/39762