### PR TITLE
fix(chromium): continue internal redirects after regular redirects

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -254,7 +254,7 @@ export class CRNetworkManager {
       this._requestIdToRequestWillBeSentEvent.delete(requestId);
     } else {
       const existingRequest = this._requestIdToRequest.get(requestId);
-      const alreadyContinuedParams = existingRequest?._route?._alreadyContinuedParams;
+      const alreadyContinuedParams = existingRequest?._originalRequestRoute?._alreadyContinuedParams;
       if (alreadyContinuedParams && !event.redirectedRequestId) {
         // Sometimes Chromium network stack restarts the request internally.
         // For example, when no-cors request hits a "less public address space", it should be resent with cors.
@@ -385,7 +385,7 @@ export class CRNetworkManager {
         return Buffer.from(response.body, response.base64Encoded ? 'base64' : 'utf8');
 
       // Make sure no network requests sent while reading the body for fulfilled requests.
-      if (request._route?._fulfilled)
+      if (request._originalRequestRoute?._fulfilled)
         return Buffer.from('');
 
       // For <link prefetch we are going to receive empty body with non-empty content-length expectation. Reach out for the actual content.
@@ -567,7 +567,6 @@ class InterceptableRequest {
   readonly _documentId: string | undefined;
   readonly _timestamp: number;
   readonly _wallTime: number;
-  readonly _route: RouteImpl | null;
   // Only first request in the chain can be intercepted, so this will
   // store the first and only Route in the chain (if any).
   readonly _originalRequestRoute: RouteImpl | undefined;
@@ -592,7 +591,6 @@ class InterceptableRequest {
     this._requestId = requestWillBeSentEvent.requestId;
     this._interceptionId = requestPausedEvent && requestPausedEvent.requestId;
     this._documentId = documentId;
-    this._route = route;
     this._originalRequestRoute = route ?? redirectedFrom?._originalRequestRoute;
 
     const {


### PR DESCRIPTION
We already have the logic to continue internal redirects with "already continued params" when routing - see #27429.

However, if the internal redirect happens after regular redirect, the `_route` is wrong - we should use `_originalRequestRoute` (introduced in #28962) instead to gather continue params from the original request.

In fact, using `_route` anywhere is incorrect, so just remove it.

Fixes #39823. Fixes #39299.