### PR TITLE
fix(mcp): write network.txt to output directory when specified

### DIFF
--- a/packages/playwright-core/src/tools/backend/network.ts
+++ b/packages/playwright-core/src/tools/backend/network.ts
@@ -50,7 +50,13 @@ const requests = defineTabTool({
       }
       text.push(await renderRequest(request, params.requestBody, params.requestHeaders));
     }
-    await response.addResult('Network', text.join('\n'), { prefix: 'network', ext: 'log', suggestedFilename: params.filename });
+    const template = { prefix: 'network', ext: 'log', suggestedFilename: params.filename };
+    if (params.filename) {
+      const resolvedFile = await response.resolveOutputFile(template, 'Network');
+      await response.addFileResult(resolvedFile, text.join('\n'));
+    } else {
+      await response.addResult('Network', text.join('\n'), template);
+    }
   },
 });
 

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -78,6 +78,13 @@ export class Response {
     return { fileName, relativeName, printableLink };
   }
 
+  async resolveOutputFile(template: FilenameTemplate, title: string): Promise<ResolvedFile> {
+    const fileName = await this._context.outputFile(template, { origin: 'llm' });
+    const relativeName = this._computRelativeTo(fileName);
+    const printableLink = `- [${title}](${relativeName})`;
+    return { fileName, relativeName, printableLink };
+  }
+
   async resolveClientFilename(filename: string): Promise<string> {
     return await this._context.workspaceFile(filename, this._clientWorkspace);
   }

--- a/tests/mcp/network.spec.ts
+++ b/tests/mcp/network.spec.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+import path from 'path';
 import { test, expect, parseResponse } from './fixtures';
 
 test('browser_network_requests', async ({ client, server }) => {
@@ -114,6 +116,32 @@ test('browser_network_requests includes request headers', async ({ client, serve
     expect(response.result).toContain('Request headers:');
     expect(response.result).toContain('x-custom-header: test-value');
   }
+});
+
+test('browser_network_requests saves file to output directory', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir },
+  });
+
+  server.setContent('/', `<script>fetch('/api')</script>`, 'text/html');
+  server.setContent('/api', '{}', 'application/json');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  await client.callTool({
+    name: 'browser_network_requests',
+    arguments: { filename: 'network.txt' },
+  });
+
+  // The file should be saved in the output directory, not in cwd.
+  const networkFile = path.join(outputDir, 'network.txt');
+  expect(fs.existsSync(networkFile)).toBe(true);
+  const content = fs.readFileSync(networkFile, 'utf-8');
+  expect(content).toContain(`${server.PREFIX}/api`);
 });
 
 test('browser_network_requests includes request payload', async ({ client, server }) => {


### PR DESCRIPTION
## Summary
- When `browser_network_requests` is called with a `filename` parameter, the network log file is now written to the configured output directory (`--output-dir`) instead of the current working directory
- Adds `resolveOutputFile` to the Response class, which always resolves file paths against the output directory
- The network tool uses this new method when a filename is provided, while still returning text inline when no filename is given

Fixes https://github.com/microsoft/playwright-mcp/issues/1484