### PR TITLE
feat(cli): validate command flags using help.json

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -91,7 +91,7 @@ export async function program(options?: { embedderVersion?: string}) {
   const command = commandName && help.commands[commandName];
   if (args.help || args.h) {
     if (command) {
-      console.log(command);
+      console.log(command.help);
     } else {
       console.log('playwright-cli - run playwright mcp commands from terminal\n');
       console.log(help.global);
@@ -104,6 +104,8 @@ export async function program(options?: { embedderVersion?: string}) {
     console.log(help.global);
     process.exit(1);
   }
+
+  validateFlags(args, command);
 
   const registry = await Registry.load();
   const sessionName = resolveSessionName(args.session as string);
@@ -429,6 +431,24 @@ async function renderSessionStatus(clientInfo: ClientInfo, session: Session) {
   if (config.browser)
     text.push(...renderResolvedConfig(config));
   return text.join('\n');
+}
+
+function validateFlags(args: MinimistArgs, command: { flags: Record<string, 'boolean' | 'string'>, help: string }) {
+  const unknownFlags: string[] = [];
+  for (const key of Object.keys(args)) {
+    if (key === '_')
+      continue;
+    if ((globalOptions as readonly string[]).includes(key))
+      continue;
+    if (!(key in command.flags))
+      unknownFlags.push(key);
+  }
+  if (unknownFlags.length) {
+    console.error(`Unknown option${unknownFlags.length > 1 ? 's' : ''}: ${unknownFlags.map(f => `--${f}`).join(', ')}`);
+    console.log('');
+    console.log(command.help);
+    process.exit(1);
+  }
 }
 
 export function calculateSha1(buffer: Buffer | string): string {

--- a/packages/playwright-core/src/tools/cli-daemon/helpGenerator.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/helpGenerator.ts
@@ -154,27 +154,33 @@ function unwrapZodType(schema: zodType.ZodTypeAny): zodType.ZodTypeAny {
   return schema;
 }
 
+function isBooleanSchema(schema: zodType.ZodTypeAny): boolean {
+  return unwrapZodType(schema) instanceof z.ZodBoolean;
+}
+
 export function generateHelpJSON() {
   const booleanOptions = new Set<string>();
-  for (const command of Object.values(commands)) {
-    if (!command.options)
-      continue;
-    const optionsShape = (command.options as zodType.ZodObject<any>).shape;
-    for (const [name, schema] of Object.entries(optionsShape)) {
-      const innerSchema = unwrapZodType(schema as zodType.ZodTypeAny);
-      if (innerSchema instanceof z.ZodBoolean)
-        booleanOptions.add(name);
+
+  const commandEntries: Record<string, { help: string, flags: Record<string, 'boolean' | 'string'> }> = {};
+  for (const [name, command] of Object.entries(commands)) {
+    const flags: Record<string, 'boolean' | 'string'> = {};
+    if (command.options) {
+      const optionsShape = (command.options as zodType.ZodObject<any>).shape;
+      for (const [flagName, schema] of Object.entries(optionsShape)) {
+        const isBoolean = isBooleanSchema(schema as zodType.ZodTypeAny);
+        flags[flagName] = isBoolean ? 'boolean' : 'string';
+        if (isBoolean)
+          booleanOptions.add(flagName);
+      }
     }
+    commandEntries[name] = { help: generateCommandHelp(command), flags };
   }
 
-  const help = {
+  return {
     global: generateHelp(),
-    commands: Object.fromEntries(
-        Object.entries(commands).map(([name, command]) => [name, generateCommandHelp(command)])
-    ),
+    commands: commandEntries,
     booleanOptions: [...booleanOptions],
   };
-  return help;
 }
 
 function formatWithGap(prefix: string, text: string, threshold: number = 30) {

--- a/tests/mcp/cli-parsing.spec.ts
+++ b/tests/mcp/cli-parsing.spec.ts
@@ -19,7 +19,13 @@ import { test, expect } from './cli-fixtures';
 test('unknown option', async ({ cli, server }) => {
   const { error, exitCode } = await cli('open', '--some-option', 'value', 'about:blank');
   expect(exitCode).toBe(1);
-  expect(error).toContain(`error: unknown '--some-option' option`);
+  expect(error).toContain(`Unknown option: --some-option`);
+});
+
+test('unknown option typo', async ({ cli }) => {
+  const { error, exitCode } = await cli('install', '--skill');
+  expect(exitCode).toBe(1);
+  expect(error).toContain(`Unknown option: --skill`);
 });
 
 test('too many arguments', async ({ cli, server }) => {


### PR DESCRIPTION
## Summary
- Include per-command flag names and types (`boolean` | `string`) in generated `help.json`
- Validate flags in `program.ts` before command execution, reporting unknown options with help text