### PR TITLE
chore(screencast): remove annotate option from Screencast.start API

### DIFF
--- a/docs/src/api/class-screencast.md
+++ b/docs/src/api/class-screencast.md
@@ -42,15 +42,6 @@ If a screencast is already active (e.g. started by tracing or video recording), 
 
 Defaults to 800×800.
 
-### option: Screencast.start.annotate
-* since: v1.59
-- `annotate` ?<[Object]>
-  - `duration` ?<[float]> How long each annotation is displayed in milliseconds. Defaults to `500`.
-  - `position` ?<[AnnotatePosition]<"top-left"|"top"|"top-right"|"bottom-left"|"bottom"|"bottom-right">> Position of the action title overlay. Defaults to `"top-right"`.
-  - `fontSize` ?<[int]> Font size of the action title in pixels. Defaults to `24`.
-
-If specified, enables visual annotations on interacted elements during screencast. Interacted elements are highlighted with a semi-transparent blue box and click points are shown as red circles.
-
 ## async method: Screencast.stop
 * since: v1.59
 * langs: js

--- a/packages/playwright-core/src/client/screencast.ts
+++ b/packages/playwright-core/src/client/screencast.ts
@@ -16,7 +16,6 @@
 
 import { DisposableStub } from './disposable';
 
-import type { AnnotateOptions } from './types';
 import type * as api from '../../types/types';
 import type { Page } from './page';
 
@@ -31,7 +30,7 @@ export class Screencast implements api.Screencast {
     });
   }
 
-  async start(onFrame: (frame: { data: Buffer }) => Promise<any>|any, options: { preferredSize?: { width: number, height: number }, annotate?: AnnotateOptions } = {}): Promise<DisposableStub> {
+  async start(onFrame: (frame: { data: Buffer }) => Promise<any>|any, options: { preferredSize?: { width: number, height: number } } = {}): Promise<DisposableStub> {
     if (this._onFrame)
       throw new Error('Screencast is already started');
     this._onFrame = onFrame;

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1574,7 +1574,6 @@ scheme.PageStartScreencastParams = tObject({
     width: tInt,
     height: tInt,
   })),
-  annotate: tOptional(tType('AnnotateOptions')),
 });
 scheme.PageStartScreencastResult = tOptional(tObject({}));
 scheme.PageStopScreencastParams = tOptional(tObject({}));

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -379,7 +379,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     this._screencastListener = (frame: ScreencastFrame) => {
       this._dispatchEvent('screencastFrame', { data: frame.buffer });
     };
-    await this._page.screencast.startScreencast(this._screencastListener, { quality: 90, width: size.width, height: size.height, annotate: params.annotate });
+    await this._page.screencast.startScreencast(this._screencastListener, { quality: 90, width: size.width, height: size.height });
   }
 
   async stopScreencast(params: channels.PageStopScreencastParams, progress?: Progress): Promise<channels.PageStopScreencastResult> {

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -2722,14 +2722,12 @@ export type PageStartScreencastParams = {
     width: number,
     height: number,
   },
-  annotate?: AnnotateOptions,
 };
 export type PageStartScreencastOptions = {
   preferredSize?: {
     width: number,
     height: number,
   },
-  annotate?: AnnotateOptions,
 };
 export type PageStartScreencastResult = void;
 export type PageStopScreencastParams = {};

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -2146,7 +2146,6 @@ Page:
           properties:
             width: int
             height: int
-        annotate: AnnotateOptions?
 
     stopScreencast:
       title: Stop screencast

--- a/tests/library/overlay.spec.ts
+++ b/tests/library/overlay.spec.ts
@@ -132,23 +132,6 @@ test('should strip event handlers from overlay html', async ({ browser, server }
   await context.close();
 });
 
-test('should show action highlight and title on click', async ({ browser, server }) => {
-  const context = await browser.newContext();
-  const page = await context.newPage();
-  await page.goto(server.EMPTY_PAGE);
-  await page.setContent('<button id="btn">Click me</button>');
-
-  await page.screencast.start(() => {}, { annotate: { duration: 5000 } });
-  const clickPromise = page.locator('#btn').click();
-
-  await expect(page.locator('x-pw-highlight')).toBeVisible();
-  await expect(page.locator('x-pw-title')).toBeVisible();
-  await expect(page.locator('x-pw-title')).toHaveText(/click/i);
-
-  await clickPromise;
-  await context.close();
-});
-
 test('should auto-remove overlay after timeout', async ({ browser, server }) => {
   const context = await browser.newContext();
   const page = await context.newPage();


### PR DESCRIPTION
## Summary
- Remove the `annotate` option from `Screencast.start()` across docs, client, protocol, validator, and dispatcher