### PR TITLE
chore(ci): run infra checks after dependabot rebuild commit

### DIFF
--- a/.github/workflows/dependabot_rebuild.yml
+++ b/.github/workflows/dependabot_rebuild.yml
@@ -38,3 +38,38 @@ jobs:
           else
             echo "No generated files changed, nothing to commit."
           fi
+
+  doc-and-lint:
+    name: "docs & lint"
+    needs: rebuild
+    runs-on: ubuntu-24.04
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'microsoft/playwright'
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.head_ref }}
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 20
+    - run: npm ci
+    - run: npm run build
+    - run: npx playwright install --with-deps
+    - run: npm run lint
+    - name: Verify clean tree
+      run: |
+        if [[ -n $(git status -s) ]]; then
+          echo "ERROR: tree is dirty after npm run build:"
+          git diff
+          exit 1
+        fi
+    - name: Audit prod NPM dependencies
+      run: node utils/check_audit.js
+      continue-on-error: true
+
+  lint-snippets:
+    name: "Lint snippets"
+    needs: rebuild
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'microsoft/playwright'
+    steps:
+    - run: echo "Skipped for dependabot PRs"


### PR DESCRIPTION
## Summary

- When `dependabot_rebuild` pushes generated files back to a dependabot PR using `GITHUB_TOKEN`, GitHub [does not retrigger workflow runs](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs) for that commit
- Using a PAT or GitHub App to push would bypass this restriction, but both are unavailable due to company policy
- To satisfy the required `docs & lint` and `Lint snippets` status checks, duplicate the `infra.yml` jobs inside `dependabot_rebuild.yml` so they run on the rebuilt commit; job names match exactly so branch protection rules are satisfied