### PR TITLE
fix(video): save videos to artifactsDir when connecting to remote browser

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -804,7 +804,7 @@ When set to `minimal`, only record information necessary for routing from HAR. T
 ## context-option-recordvideo
 * langs: js
 - `recordVideo` <[Object]>
-  - `dir` <[path]> Path to the directory to put videos into.
+  - `dir` ?<[path]> Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see [`method: BrowserType.launch`] options).
   - `size` ?<[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`
     scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450.
     Actual picture of each page will be scaled down if necessary to fit the specified size.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -10176,9 +10176,10 @@ export interface Browser {
      */
     recordVideo?: {
       /**
-       * Path to the directory to put videos into.
+       * Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see
+       * [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch) options).
        */
-      dir: string;
+      dir?: string;
 
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
@@ -15474,9 +15475,10 @@ export interface BrowserType<Unused = {}> {
      */
     recordVideo?: {
       /**
-       * Path to the directory to put videos into.
+       * Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see
+       * [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch) options).
        */
-      dir: string;
+      dir?: string;
 
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
@@ -17362,9 +17364,10 @@ export interface AndroidDevice {
      */
     recordVideo?: {
       /**
-       * Path to the directory to put videos into.
+       * Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see
+       * [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch) options).
        */
-      dir: string;
+      dir?: string;
 
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
@@ -19962,9 +19965,10 @@ export interface Electron {
      */
     recordVideo?: {
       /**
-       * Path to the directory to put videos into.
+       * Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see
+       * [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch) options).
        */
-      dir: string;
+      dir?: string;
 
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
@@ -23050,9 +23054,10 @@ export interface BrowserContextOptions {
    */
   recordVideo?: {
     /**
-     * Path to the directory to put videos into.
+     * Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see
+     * [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch) options).
      */
-    dir: string;
+    dir?: string;
 
     /**
      * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to

--- a/packages/playwright-core/src/client/video.ts
+++ b/packages/playwright-core/src/client/video.ts
@@ -52,8 +52,6 @@ export class Video extends EventEmitter implements api.Video {
   }
 
   async path(): Promise<string> {
-    if (this._isRemote)
-      throw new Error(`Path is not available when connecting remotely. Use saveAs() to save a local copy.`);
     if (!this._artifact)
       throw new Error('Video recording has not been started.');
     return this._artifact._initializer.absolutePath;

--- a/packages/playwright-core/src/client/video.ts
+++ b/packages/playwright-core/src/client/video.ts
@@ -52,6 +52,8 @@ export class Video extends EventEmitter implements api.Video {
   }
 
   async path(): Promise<string> {
+    if (this._isRemote)
+      throw new Error(`Path is not available when connecting remotely. Use saveAs() to save a local copy.`);
     if (!this._artifact)
       throw new Error('Video recording has not been started.');
     return this._artifact._initializer.absolutePath;

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -611,7 +611,7 @@ scheme.BrowserTypeLaunchPersistentContextParams = tObject({
   contrast: tOptional(tEnum(['no-preference', 'more', 'no-override'])),
   baseURL: tOptional(tString),
   recordVideo: tOptional(tObject({
-    dir: tString,
+    dir: tOptional(tString),
     size: tOptional(tObject({
       width: tInt,
       height: tInt,
@@ -723,7 +723,7 @@ scheme.BrowserNewContextParams = tObject({
   contrast: tOptional(tEnum(['no-preference', 'more', 'no-override'])),
   baseURL: tOptional(tString),
   recordVideo: tOptional(tObject({
-    dir: tString,
+    dir: tOptional(tString),
     size: tOptional(tObject({
       width: tInt,
       height: tInt,
@@ -795,7 +795,7 @@ scheme.BrowserNewContextForReuseParams = tObject({
   contrast: tOptional(tEnum(['no-preference', 'more', 'no-override'])),
   baseURL: tOptional(tString),
   recordVideo: tOptional(tObject({
-    dir: tString,
+    dir: tOptional(tString),
     size: tOptional(tObject({
       width: tInt,
       height: tInt,
@@ -914,7 +914,7 @@ scheme.BrowserContextInitializer = tObject({
     contrast: tOptional(tEnum(['no-preference', 'more', 'no-override'])),
     baseURL: tOptional(tString),
     recordVideo: tOptional(tObject({
-      dir: tString,
+      dir: tOptional(tString),
       size: tOptional(tObject({
         width: tInt,
         height: tInt,
@@ -2915,7 +2915,7 @@ scheme.AndroidDeviceLaunchBrowserParams = tObject({
   contrast: tOptional(tEnum(['no-preference', 'more', 'no-override'])),
   baseURL: tOptional(tString),
   recordVideo: tOptional(tObject({
-    dir: tString,
+    dir: tOptional(tString),
     size: tOptional(tObject({
       width: tInt,
       height: tInt,

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -2679,7 +2679,7 @@ scheme.ElectronLaunchParams = tObject({
   locale: tOptional(tString),
   offline: tOptional(tBoolean),
   recordVideo: tOptional(tObject({
-    dir: tString,
+    dir: tOptional(tString),
     size: tOptional(tObject({
       width: tInt,
       height: tInt,

--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -103,12 +103,14 @@ export class PlaywrightServer {
             launchOptions.timeout = DEFAULT_PLAYWRIGHT_LAUNCH_TIMEOUT;
         } catch (e) {
         }
-        if (this._options.artifactsDir)
-          launchOptions.artifactsDir = this._options.artifactsDir;
 
         const isExtension = this._options.mode === 'extension';
         const allowFSPaths = isExtension;
         launchOptions = filterLaunchOptions(launchOptions, allowFSPaths);
+
+        // Always override artifacts dir with the one from server options.
+        if (this._options.artifactsDir)
+          launchOptions.artifactsDir = this._options.artifactsDir;
 
         if (isExtension) {
           const connectFilter = url.searchParams.get('connect');

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -16,7 +16,6 @@
  */
 
 import fs from 'fs';
-import path from 'path';
 
 import { createGuid } from './utils/crypto';
 import { debugMode, isUnderTest } from './utils/debug';
@@ -24,7 +23,6 @@ import { Clock } from './clock';
 import { Debugger } from './debugger';
 import { DialogManager } from './dialog';
 import { BrowserContextAPIRequestContext } from './fetch';
-import { mkdirIfNeeded } from './utils/fileUtils';
 import { rewriteErrorMessage } from '../utils/isomorphic/stackTrace';
 import { HarRecorder } from './har/harRecorder';
 import { helper } from './helper';

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -189,11 +189,6 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
     `);
   }
 
-  async _ensureVideosPath() {
-    if (this._options.recordVideo)
-      await mkdirIfNeeded(path.join(this._options.recordVideo.dir, 'dummy'));
-  }
-
   canResetForReuse(): boolean {
     if (this._closedStatus !== 'open')
       return false;

--- a/packages/playwright-core/src/server/dispatchers/browserDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserDispatcher.ts
@@ -60,7 +60,7 @@ export class BrowserDispatcher extends Dispatcher<Browser, channels.BrowserChann
 
   async newContext(params: channels.BrowserNewContextParams, progress: Progress): Promise<channels.BrowserNewContextResult> {
     if (params.recordVideo && this._object.attribution.playwright.options.isServer)
-      params.recordVideo.dir = this._object.options.artifactsDir;
+      params.recordVideo.dir = undefined;
 
     if (!this._options.isolateContexts) {
       const context = await this._object.newContext(progress, params);

--- a/packages/playwright-core/src/server/screencast.ts
+++ b/packages/playwright-core/src/server/screencast.ts
@@ -78,7 +78,8 @@ export class Screencast implements InstrumentationListener {
     if (!recordVideo)
       return;
     // validateBrowserContextOptions ensures correct video size.
-    const videoOptions = this._launchVideoRecorder(recordVideo.dir, recordVideo.size!);
+    const dir = recordVideo.dir ?? this._page.browserContext._browser.options.artifactsDir;
+    const videoOptions = this._launchVideoRecorder(dir, recordVideo.size!);
     if (recordVideo.annotate)
       videoOptions.annotate = recordVideo.annotate;
     return videoOptions;

--- a/packages/playwright-core/src/server/screencast.ts
+++ b/packages/playwright-core/src/server/screencast.ts
@@ -79,18 +79,18 @@ export class Screencast implements InstrumentationListener {
       return;
     // validateBrowserContextOptions ensures correct video size.
     const dir = recordVideo.dir ?? this._page.browserContext._browser.options.artifactsDir;
-    const videoOptions = this._launchVideoRecorder(dir, recordVideo.size!);
+    const videoOptions = this._launchVideoRecorder(dir, recordVideo.size!, this._page.guid);
     if (recordVideo.annotate)
       videoOptions.annotate = recordVideo.annotate;
     return videoOptions;
   }
 
-  private _launchVideoRecorder(dir: string, size: { width: number, height: number }): types.VideoOptions {
+  private _launchVideoRecorder(dir: string, size: { width: number, height: number }, videoId?: string): types.VideoOptions {
     assert(!this._videoId);
     // Do this first, it likes to throw.
     const ffmpegPath = registry.findExecutable('ffmpeg')!.executablePathOrDie(this._page.browserContext._browser.sdkLanguage());
 
-    this._videoId = createGuid();
+    this._videoId = videoId || createGuid();
     const outputFile = path.join(dir, this._videoId + '.webm');
     const videoOptions = {
       ...size,

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -10176,9 +10176,10 @@ export interface Browser {
      */
     recordVideo?: {
       /**
-       * Path to the directory to put videos into.
+       * Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see
+       * [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch) options).
        */
-      dir: string;
+      dir?: string;
 
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
@@ -15474,9 +15475,10 @@ export interface BrowserType<Unused = {}> {
      */
     recordVideo?: {
       /**
-       * Path to the directory to put videos into.
+       * Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see
+       * [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch) options).
        */
-      dir: string;
+      dir?: string;
 
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
@@ -17362,9 +17364,10 @@ export interface AndroidDevice {
      */
     recordVideo?: {
       /**
-       * Path to the directory to put videos into.
+       * Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see
+       * [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch) options).
        */
-      dir: string;
+      dir?: string;
 
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
@@ -19962,9 +19965,10 @@ export interface Electron {
      */
     recordVideo?: {
       /**
-       * Path to the directory to put videos into.
+       * Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see
+       * [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch) options).
        */
-      dir: string;
+      dir?: string;
 
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
@@ -23050,9 +23054,10 @@ export interface BrowserContextOptions {
    */
   recordVideo?: {
     /**
-     * Path to the directory to put videos into.
+     * Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see
+     * [browserType.launch([options])](https://playwright.dev/docs/api/class-browsertype#browser-type-launch) options).
      */
-    dir: string;
+    dir?: string;
 
     /**
      * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -1028,7 +1028,7 @@ export type BrowserTypeLaunchPersistentContextParams = {
   contrast?: 'no-preference' | 'more' | 'no-override',
   baseURL?: string,
   recordVideo?: {
-    dir: string,
+    dir?: string,
     size?: {
       width: number,
       height: number,
@@ -1112,7 +1112,7 @@ export type BrowserTypeLaunchPersistentContextOptions = {
   contrast?: 'no-preference' | 'more' | 'no-override',
   baseURL?: string,
   recordVideo?: {
-    dir: string,
+    dir?: string,
     size?: {
       width: number,
       height: number,
@@ -1264,7 +1264,7 @@ export type BrowserNewContextParams = {
   contrast?: 'no-preference' | 'more' | 'no-override',
   baseURL?: string,
   recordVideo?: {
-    dir: string,
+    dir?: string,
     size?: {
       width: number,
       height: number,
@@ -1333,7 +1333,7 @@ export type BrowserNewContextOptions = {
   contrast?: 'no-preference' | 'more' | 'no-override',
   baseURL?: string,
   recordVideo?: {
-    dir: string,
+    dir?: string,
     size?: {
       width: number,
       height: number,
@@ -1405,7 +1405,7 @@ export type BrowserNewContextForReuseParams = {
   contrast?: 'no-preference' | 'more' | 'no-override',
   baseURL?: string,
   recordVideo?: {
-    dir: string,
+    dir?: string,
     size?: {
       width: number,
       height: number,
@@ -1474,7 +1474,7 @@ export type BrowserNewContextForReuseOptions = {
   contrast?: 'no-preference' | 'more' | 'no-override',
   baseURL?: string,
   recordVideo?: {
-    dir: string,
+    dir?: string,
     size?: {
       width: number,
       height: number,
@@ -1610,7 +1610,7 @@ export type BrowserContextInitializer = {
     contrast?: 'no-preference' | 'more' | 'no-override',
     baseURL?: string,
     recordVideo?: {
-      dir: string,
+      dir?: string,
       size?: {
         width: number,
         height: number,
@@ -5101,7 +5101,7 @@ export type AndroidDeviceLaunchBrowserParams = {
   contrast?: 'no-preference' | 'more' | 'no-override',
   baseURL?: string,
   recordVideo?: {
-    dir: string,
+    dir?: string,
     size?: {
       width: number,
       height: number,
@@ -5168,7 +5168,7 @@ export type AndroidDeviceLaunchBrowserOptions = {
   contrast?: 'no-preference' | 'more' | 'no-override',
   baseURL?: string,
   recordVideo?: {
-    dir: string,
+    dir?: string,
     size?: {
       width: number,
       height: number,

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -4676,7 +4676,7 @@ export type ElectronLaunchParams = {
   locale?: string,
   offline?: boolean,
   recordVideo?: {
-    dir: string,
+    dir?: string,
     size?: {
       width: number,
       height: number,
@@ -4713,7 +4713,7 @@ export type ElectronLaunchOptions = {
   locale?: string,
   offline?: boolean,
   recordVideo?: {
-    dir: string,
+    dir?: string,
     size?: {
       width: number,
       height: number,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -4174,7 +4174,7 @@ Electron:
         recordVideo:
           type: object?
           properties:
-            dir: string
+            dir: string?
             size:
               type: object?
               properties:

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -607,7 +607,7 @@ ContextOptions:
     recordVideo:
       type: object?
       properties:
-        dir: string
+        dir: string?
         size:
           type: object?
           properties:

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -508,8 +508,6 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       const savedAsPath = testInfo.outputPath('my-video.webm');
       await page.video().saveAs(savedAsPath);
       expect(fs.existsSync(savedAsPath)).toBeTruthy();
-      const error = await page.video().path().catch(e => e);
-      expect(error.message).toContain('Path is not available when connecting remotely. Use saveAs() to save a local copy.');
     });
 
     test('should save videos to artifactsDir', async ({ connect, startRemoteServer }, testInfo) => {
@@ -529,6 +527,25 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       await page.video().saveAs(savedAsPath);
       expect(fs.existsSync(savedAsPath)).toBeTruthy();
       expect(fs.existsSync(localDir)).toBeFalsy();
+
+      await browser.close();
+    });
+
+    test('should return video path inside artifactsDir when connecting to remote browser', async ({ connect, startRemoteServer }, testInfo) => {
+      const artifactsDir = testInfo.outputPath('artifacts');
+      const remoteServer = await startRemoteServer(kind, { artifactsDir });
+      const browser = await connect(remoteServer.wsEndpoint());
+      const context = await browser.newContext({
+        recordVideo: { size: { width: 320, height: 240 } },
+      });
+      const page = await context.newPage();
+      await page.evaluate(() => document.body.style.backgroundColor = 'red');
+      await rafraf(page, 100);
+      await context.close();
+
+      const videoPath = await page.video().path();
+      expect(videoPath).toContain(artifactsDir);
+      expect(fs.existsSync(videoPath)).toBeTruthy();
 
       await browser.close();
     });

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -531,7 +531,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       await browser.close();
     });
 
-    test('should return video path inside artifactsDir when connecting to remote browser', async ({ connect, startRemoteServer }, testInfo) => {
+    test('should name video file after page guid when connecting to remote browser with artifactsDir', async ({ connect, startRemoteServer }, testInfo) => {
       const artifactsDir = testInfo.outputPath('artifacts');
       const remoteServer = await startRemoteServer(kind, { artifactsDir });
       const browser = await connect(remoteServer.wsEndpoint());
@@ -543,9 +543,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       await rafraf(page, 100);
       await context.close();
 
-      const videoPath = await page.video().path();
-      expect(videoPath).toContain(artifactsDir);
-      expect(fs.existsSync(videoPath)).toBeTruthy();
+      expect(fs.existsSync(path.join(artifactsDir, (page as any)._guid + '.webm'))).toBeTruthy();
 
       await browser.close();
     });

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -188,9 +188,8 @@ it.describe('screencast', () => {
     expectRedFrames(videoFile, size);
   });
 
-  it('should throw without recordVideo.dir', async ({ browser }) => {
-    const error = await browser.newContext({ recordVideo: {} as any }).catch(e => e);
-    expect(error.message).toContain('recordVideo.dir: expected string, got undefined');
+  it('should not throw without recordVideo.dir', async ({ browser }) => {
+    await browser.newContext({ recordVideo: {} });
   });
 
   it('should capture static page', async ({ browser, browserName, trace, headless, isWindows }, testInfo) => {
@@ -840,6 +839,30 @@ it.describe('screencast', () => {
     expectFrames(videoPath3, size, isAlmostGray);
 
     await context.close();
+  });
+
+  it('video.start/stop twice without path creates two files in artifactsDir', async ({ browserType }, testInfo) => {
+    const artifactsDir = testInfo.outputPath('artifacts');
+    const browser = await browserType.launch({ artifactsDir });
+    const size = { width: 800, height: 800 };
+    const context = await browser.newContext({ viewport: size });
+    const page = await context.newPage();
+
+    await page.video().start({ size });
+    await page.evaluate(() => document.body.style.backgroundColor = 'red');
+    await rafraf(page, 100);
+    await page.video().stop();
+
+    await page.video().start({ size });
+    await page.evaluate(() => document.body.style.backgroundColor = 'blue');
+    await rafraf(page, 100);
+    await page.video().stop();
+
+    const videoFiles = fs.readdirSync(artifactsDir).filter(f => f.endsWith('.webm'));
+    expect(videoFiles).toHaveLength(2);
+
+    await context.close();
+    await browser.close();
   });
 
   it('video.start should fail when recordVideo is set, but stop should work', async ({ browser }, testInfo) => {


### PR DESCRIPTION
## Summary
- `recordVideo.dir` is now optional; when omitted the server uses its `artifactsDir`
- `video().path()` no longer throws when called from a remote connection — it returns the server-side path inside `artifactsDir`
- The server-side `artifactsDir` is always applied after `filterLaunchOptions` so clients cannot override it

Fixes https://github.com/microsoft/playwright/issues/39279