### PR TITLE
chore(ci): retrigger infra checks via PR close/reopen after rebuild

### DIFF
--- a/.github/workflows/dependabot_rebuild.yml
+++ b/.github/workflows/dependabot_rebuild.yml
@@ -39,8 +39,7 @@ jobs:
             # Pushing with GITHUB_TOKEN does not retrigger workflow runs, see:
             # https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs
             # Close and reopen the PR to fire a pull_request reopened event, which
-            # retriggers infra.yml on the new commit. PATs and GitHub Apps are not
-            # available due to company policy.
+            # retriggers infra.yml on the new commit.
             # Remove labels first to avoid triggering bots on the close/reopen events.
             gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels -X DELETE
             gh pr close ${{ github.event.pull_request.number }}

--- a/.github/workflows/dependabot_rebuild.yml
+++ b/.github/workflows/dependabot_rebuild.yml
@@ -36,6 +36,12 @@ jobs:
             git add .
             git commit -m "chore: update generated files after dependency update"
             git push origin HEAD:${{ github.head_ref }}
+            # Pushing with GITHUB_TOKEN does not retrigger workflow runs, see:
+            # https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs
+            # Close and reopen the PR to fire a pull_request reopened event, which
+            # retriggers infra.yml on the new commit. PATs and GitHub Apps are not
+            # available due to company policy.
+            # Remove labels first to avoid triggering bots on the close/reopen events.
             gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels -X DELETE
             gh pr close ${{ github.event.pull_request.number }}
             gh pr reopen ${{ github.event.pull_request.number }}

--- a/.github/workflows/dependabot_rebuild.yml
+++ b/.github/workflows/dependabot_rebuild.yml
@@ -11,6 +11,7 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'microsoft/playwright'
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,41 +36,11 @@ jobs:
             git add .
             git commit -m "chore: update generated files after dependency update"
             git push origin HEAD:${{ github.head_ref }}
+            gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels -X DELETE
+            gh pr close ${{ github.event.pull_request.number }}
+            gh pr reopen ${{ github.event.pull_request.number }}
           else
             echo "No generated files changed, nothing to commit."
           fi
-
-  doc-and-lint:
-    name: "docs & lint"
-    needs: rebuild
-    runs-on: ubuntu-24.04
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'microsoft/playwright'
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        ref: ${{ github.head_ref }}
-    - uses: actions/setup-node@v6
-      with:
-        node-version: 20
-    - run: npm ci
-    - run: npm run build
-    - run: npx playwright install --with-deps
-    - run: npm run lint
-    - name: Verify clean tree
-      run: |
-        if [[ -n $(git status -s) ]]; then
-          echo "ERROR: tree is dirty after npm run build:"
-          git diff
-          exit 1
-        fi
-    - name: Audit prod NPM dependencies
-      run: node utils/check_audit.js
-      continue-on-error: true
-
-  lint-snippets:
-    name: "Lint snippets"
-    needs: rebuild
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'microsoft/playwright'
-    steps:
-    - run: echo "Skipped for dependabot PRs"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot_rebuild.yml
+++ b/.github/workflows/dependabot_rebuild.yml
@@ -40,9 +40,9 @@ jobs:
             # https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs
             # Close and reopen the PR to fire a pull_request reopened event, which
             # retriggers infra.yml on the new commit.
-            # Remove labels first to avoid triggering bots on the close/reopen events.
-            gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels -X DELETE
             gh pr close ${{ github.event.pull_request.number }}
+            # Remove labels after closing to avoid triggering bots that may rerun CI.
+            gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels -X DELETE
             gh pr reopen ${{ github.event.pull_request.number }}
           else
             echo "No generated files changed, nothing to commit."


### PR DESCRIPTION
## Summary

- When `dependabot_rebuild` pushes generated files back to a dependabot PR using `GITHUB_TOKEN`, GitHub [does not retrigger workflow runs](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs) for that commit
- Using a PAT or GitHub App to push would bypass this restriction, but both are unavailable due to company policy
- Close and reopen the PR after pushing — this fires a `pull_request` reopened event and retriggers `infra.yml` on the new commit
- Labels are removed before closing to avoid triggering bots on the close/reopen events