### PR TITLE
fix(mcp): do not let empty cdpHeaders from env override config file

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -229,7 +229,7 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config & { configF
       launchOptions,
       contextOptions,
       cdpEndpoint: cliOptions.cdpEndpoint,
-      cdpHeaders: cliOptions.cdpHeader,
+      cdpHeaders: nonEmptyRecord(cliOptions.cdpHeader),
       cdpTimeout: cliOptions.cdpTimeout,
       initPage: cliOptions.initPage,
       initScript: cliOptions.initScript,
@@ -276,7 +276,9 @@ export function configFromEnv(): Config & { configFile?: string } {
   options.browser = envToString(process.env.PLAYWRIGHT_MCP_BROWSER);
   options.caps = commaSeparatedList(process.env.PLAYWRIGHT_MCP_CAPS);
   options.cdpEndpoint = envToString(process.env.PLAYWRIGHT_MCP_CDP_ENDPOINT);
-  options.cdpHeader = headerParser(process.env.PLAYWRIGHT_MCP_CDP_HEADERS, {});
+  const cdpHeadersEnv = process.env.PLAYWRIGHT_MCP_CDP_HEADERS?.trim();
+  if (cdpHeadersEnv)
+    options.cdpHeader = headerParser(cdpHeadersEnv, {});
   options.cdpTimeout = numberParser(process.env.PLAYWRIGHT_MCP_CDP_TIMEOUT);
   options.config = envToString(process.env.PLAYWRIGHT_MCP_CONFIG);
   if (process.env.PLAYWRIGHT_MCP_CONSOLE_LEVEL)
@@ -332,6 +334,12 @@ function pickDefined<T extends object>(obj: T | undefined): Partial<T> {
   return Object.fromEntries(
       Object.entries(obj ?? {}).filter(([_, v]) => v !== undefined)
   ) as Partial<T>;
+}
+
+function nonEmptyRecord(r: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!r || !Object.keys(r).length)
+    return undefined;
+  return r;
 }
 
 export function mergeConfig(base: FullConfig, overrides: Config): FullConfig {

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -229,7 +229,7 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config & { configF
       launchOptions,
       contextOptions,
       cdpEndpoint: cliOptions.cdpEndpoint,
-      cdpHeaders: nonEmptyRecord(cliOptions.cdpHeader),
+      cdpHeaders: cliOptions.cdpHeader,
       cdpTimeout: cliOptions.cdpTimeout,
       initPage: cliOptions.initPage,
       initScript: cliOptions.initScript,
@@ -276,9 +276,7 @@ export function configFromEnv(): Config & { configFile?: string } {
   options.browser = envToString(process.env.PLAYWRIGHT_MCP_BROWSER);
   options.caps = commaSeparatedList(process.env.PLAYWRIGHT_MCP_CAPS);
   options.cdpEndpoint = envToString(process.env.PLAYWRIGHT_MCP_CDP_ENDPOINT);
-  const cdpHeadersEnv = process.env.PLAYWRIGHT_MCP_CDP_HEADERS?.trim();
-  if (cdpHeadersEnv)
-    options.cdpHeader = headerParser(cdpHeadersEnv, {});
+  options.cdpHeader = headerParser(envToString(process.env.PLAYWRIGHT_MCP_CDP_HEADERS));
   options.cdpTimeout = numberParser(process.env.PLAYWRIGHT_MCP_CDP_TIMEOUT);
   options.config = envToString(process.env.PLAYWRIGHT_MCP_CONFIG);
   if (process.env.PLAYWRIGHT_MCP_CONSOLE_LEVEL)
@@ -334,12 +332,6 @@ function pickDefined<T extends object>(obj: T | undefined): Partial<T> {
   return Object.fromEntries(
       Object.entries(obj ?? {}).filter(([_, v]) => v !== undefined)
   ) as Partial<T>;
-}
-
-function nonEmptyRecord(r: Record<string, string> | undefined): Record<string, string> | undefined {
-  if (!r || !Object.keys(r).length)
-    return undefined;
-  return r;
 }
 
 export function mergeConfig(base: FullConfig, overrides: Config): FullConfig {
@@ -435,10 +427,10 @@ export function resolutionParser(name: string, value: string | undefined): Viewp
   throw new Error(`Invalid resolution format: use ${name}="800x600"`);
 }
 
-export function headerParser(arg: string | undefined, previous?: Record<string, string>): Record<string, string> {
+export function headerParser(arg: string | undefined, previous?: Record<string, string>): Record<string, string> | undefined {
   if (!arg)
-    return previous || {};
-  const result: Record<string, string> = previous || {};
+    return previous;
+  const result: Record<string, string> = { ...(previous ?? {}) };
   const colonIndex = arg.indexOf(':');
 
   const name = colonIndex === -1 ? arg.trim() : arg.substring(0, colonIndex).trim();

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -118,6 +118,29 @@ test('test sandbox configuration', async ({}) => {
   expect(await sandboxOption({ browser: 'msedge' })).toBe(true);
 });
 
+test('file browser.cdpHeaders preserved when PLAYWRIGHT_MCP_CDP_HEADERS unset', async ({}, testInfo) => {
+  const prev = process.env.PLAYWRIGHT_MCP_CDP_HEADERS;
+  delete process.env.PLAYWRIGHT_MCP_CDP_HEADERS;
+  try {
+    const config: Config = {
+      browser: {
+        cdpEndpoint: 'ws://example.invalid',
+        cdpHeaders: { Authorization: 'Bearer token-from-file' },
+      },
+    };
+    const configPath = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configPath, JSON.stringify(config, null, 2));
+
+    const resolved = await resolveCLIConfig({ config: configPath });
+    expect(resolved.browser.cdpHeaders).toEqual({ Authorization: 'Bearer token-from-file' });
+  } finally {
+    if (prev !== undefined)
+      process.env.PLAYWRIGHT_MCP_CDP_HEADERS = prev;
+    else
+      delete process.env.PLAYWRIGHT_MCP_CDP_HEADERS;
+  }
+});
+
 test('browser_get_config returns merged config from file, env and cli', async ({ startClient }) => {
   const { client } = await startClient({
     config: {


### PR DESCRIPTION
## Summary
- Preserve `browser.cdpHeaders` from config files when `PLAYWRIGHT_MCP_CDP_HEADERS` is unset.
- Avoid producing/merging empty `cdpHeaders` overrides from env parsing.
- Add regression test in `tests/mcp/config.spec.ts`.