### PR TITLE
chore(html): followup for step filter

### DIFF
--- a/packages/html-reporter/src/testResultView.css
+++ b/packages/html-reporter/src/testResultView.css
@@ -65,6 +65,10 @@
   min-width: 0;
 }
 
+.step-title-highlight {
+  background: var(--color-attention-subtle);
+}
+
 .step-spacer {
   flex: auto;
 }

--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -209,9 +209,11 @@ function pickDiffForError(error: string, diffs: ImageDiff[]): ImageDiff | undefi
 }
 
 function stepMatchesFilter(step: TestStep, filterText: string): boolean {
-  if (step.title.toLowerCase().includes(filterText.toLowerCase()))
-    return true;
-  return step.steps.some(s => stepMatchesFilter(s, filterText));
+  return step.title.toLowerCase().includes(filterText.toLowerCase());
+}
+
+function stepChildrenMatchFilter(step: TestStep, filterText: string): boolean {
+  return step.steps.some(s => stepMatchesFilter(s, filterText) || stepChildrenMatchFilter(s, filterText));
 }
 
 const StepTreeItem: React.FC<{
@@ -222,12 +224,36 @@ const StepTreeItem: React.FC<{
   filterText?: string,
 }> = ({ test, step, result, depth, filterText }) => {
   const searchParams = useSearchParams();
-  if (filterText && !stepMatchesFilter(step, filterText))
-    return null;
+
+  let expandByDefault = false;
+  let title: React.ReactNode = <span>{step.title}</span>;
+
+  if (filterText) {
+    const matchesFilter = !!filterText && stepMatchesFilter(step, filterText);
+    const childrenMatchFilter = !!filterText && stepChildrenMatchFilter(step, filterText);
+    if (!matchesFilter && !childrenMatchFilter)
+      return null;
+    expandByDefault = childrenMatchFilter;
+    if (matchesFilter) {
+      const unmatched = step.title.toLowerCase().split(filterText.toLowerCase());
+      const parts: React.ReactNode[] = [];
+      let index = 0;
+      for (let i = 0; i < unmatched.length; i++) {
+        if (i) {
+          parts.push(<span key={i} className='step-title-highlight'>{step.title.substring(index, index + filterText.length)}</span>);
+          index += filterText.length;
+        }
+        parts.push(unmatched[i]);
+        index += unmatched[i].length;
+      }
+      title = parts;
+    }
+  }
+
   return <TreeItem title={<div aria-label={step.title} className='step-title-container'>
     {statusIcon(step.error || step.duration === -1 ? 'failed' : (step.skipped ? 'skipped' : 'passed'))}
     <span className='step-title-text'>
-      <span>{step.title}</span>
+      {title}
       {step.count > 1 && <> ✕ <span className='test-result-counter'>{step.count}</span></>}
       {step.location && <span className='test-result-path'>— {step.location.file}:{step.location.line}</span>}
     </span>
@@ -244,7 +270,7 @@ const StepTreeItem: React.FC<{
     const snippet = step.snippet ? [<CodeSnippet testId='test-snippet' key='line' code={step.snippet} />] : [];
     const steps = step.steps.map((s, i) => <StepTreeItem key={i} step={s} depth={depth + 1} result={result} test={test} filterText={filterText} />);
     return snippet.concat(steps);
-  } : undefined} depth={depth} expandByDefault={!!filterText}/>;
+  } : undefined} depth={depth} expandByDefault={expandByDefault}/>;
 };
 
 type WorkerLists = Map<number, { tests: TestCaseSummary[], runs: number[] }>;

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -829,6 +829,10 @@ for (const useIntermediateMergeReport of [true, false] as const) {
           test('has steps', async ({}) => {
             await test.step('click button', async () => {});
             await test.step('fill form', async () => {
+              await test.step('enter username', async () => {});
+              await test.step('enter password', async () => {});
+            });
+            await test.step('another form', async () => {
               await test.step('fill username', async () => {});
               await test.step('fill password', async () => {});
             });
@@ -850,7 +854,10 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.locator('.tree-item-title', { hasText: 'fill form' })).toBeVisible();
       await expect(page.locator('.tree-item-title', { hasText: 'click button' })).toBeHidden();
       await expect(page.locator('.tree-item-title', { hasText: 'submit form' })).toBeHidden();
-      // matching parent is auto-expanded to show matching children (like trace viewer)
+      // matching parent is not auto-expanded when it has no matching children
+      await expect(page.locator('.tree-item-title', { hasText: 'enter username' })).toBeHidden();
+      await expect(page.locator('.tree-item-title', { hasText: 'enter password' })).toBeHidden();
+      // non-matching parent is auto-expanded when it has a matching child
       await expect(page.locator('.tree-item-title', { hasText: 'fill username' })).toBeVisible();
       await expect(page.locator('.tree-item-title', { hasText: 'fill password' })).toBeVisible();
 
@@ -858,7 +865,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await filterInput.clear();
       await expect(page.locator('.tree-item-title', { hasText: 'click button' })).toBeVisible();
       await expect(page.locator('.tree-item-title', { hasText: 'submit form' })).toBeVisible();
-      // children of fill form are collapsed again after clearing the filter
+      // children are collapsed again after clearing the filter
       await expect(page.locator('.tree-item-title', { hasText: 'fill username' })).toBeHidden();
       await expect(page.locator('.tree-item-title', { hasText: 'fill password' })).toBeHidden();
     });


### PR DESCRIPTION
- Do not auto-expand steps that have no children matching the filter.
- Highlight the matching part of the title.

<img width="1004" height="719" alt="html-filter-highlight" src="https://github.com/user-attachments/assets/2e424d70-636a-4cb3-96da-fe9526d1bc97" />

References #39595.