### PR TITLE
chore: make sure `locator.ariaSnapshot()` behaves as before

### DIFF
--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -206,12 +206,16 @@ Below is the HTML markup and the respective ARIA snapshot:
     - link "About"
 ```
 
+An AI-optimized snapshot, controlled by [`option: Locator.ariaSnapshot.mode`], is different from a default snapshot:
+1. Includes element references `[ref=e2]`.
+2. Does not wait for an element matching the locator, and throws when no elements match.
+3. Includes snapshots of `<iframe>`s inside the target.
+
 ### option: Locator.ariaSnapshot.mode
 * since: v1.59
 - `mode` <[AriaSnapshotMode]<"ai"|"default">>
 
-When set to `"ai"`, returns a snapshot optimized for AI consumption with element references.
-Defaults to `"default"`.
+When set to `"ai"`, returns a snapshot optimized for AI consumption. Defaults to `"default"`. See details for more information.
 
 ### option: Locator.ariaSnapshot.timeout = %%-input-timeout-%%
 * since: v1.49

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -4242,7 +4242,7 @@ Captures the aria snapshot of the page. Read more about [aria snapshots](../aria
 * since: v1.59
 - `mode` <[AriaSnapshotMode]<"ai"|"default">>
 
-When set to `"ai"`, returns a snapshot optimized for AI consumption with element references. Defaults to `"default"`.
+When set to `"ai"`, returns a snapshot optimized for AI consumption: including element references like `[ref=e2]` and snapshots of `<iframe>`s. Defaults to `"default"`.
 
 ### option: Page.ariaSnapshot.timeout = %%-input-timeout-%%
 * since: v1.59

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -2110,8 +2110,8 @@ export interface Page {
     depth?: number;
 
     /**
-     * When set to `"ai"`, returns a snapshot optimized for AI consumption with element references. Defaults to
-     * `"default"`.
+     * When set to `"ai"`, returns a snapshot optimized for AI consumption: including element references like `[ref=e2]`
+     * and snapshots of `<iframe>`s. Defaults to `"default"`.
      */
     mode?: "ai"|"default";
 
@@ -12779,6 +12779,11 @@ export interface Locator {
    *     - link "About"
    * ```
    *
+   * An AI-optimized snapshot, controlled by
+   * [`mode`](https://playwright.dev/docs/api/class-locator#locator-aria-snapshot-option-mode), is different from a
+   * default snapshot:
+   * 1. Includes element references `[ref=e2]`. 2. Does not wait for an element matching the locator, and throws when
+   *    no elements match. 3. Includes snapshots of `<iframe>`s inside the target.
    * @param options
    */
   ariaSnapshot(options?: {
@@ -12788,8 +12793,8 @@ export interface Locator {
     depth?: number;
 
     /**
-     * When set to `"ai"`, returns a snapshot optimized for AI consumption with element references. Defaults to
-     * `"default"`.
+     * When set to `"ai"`, returns a snapshot optimized for AI consumption. Defaults to `"default"`. See details for more
+     * information.
      */
     mode?: "ai"|"default";
 

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1694,6 +1694,14 @@ export class Frame extends SdkObject<FrameEventMap> {
     if (options.selector && options.track)
       throw new Error('Cannot specify both selector and track options');
 
+    if (options.selector && options.mode !== 'ai') {
+      // Non-ai locator snapshot is auto-waiting and does not include iframes.
+      const snapshot = await this._retryWithProgressIfNotConnected(progress, options.selector, { strict: true, performActionPreChecks: true }, async handle => {
+        return await progress.race(handle.evaluateInUtility(([injected, element, opts]) => injected.ariaSnapshot(element, opts), { mode: 'default' as const, depth: options.depth }));
+      });
+      return { snapshot };
+    }
+
     let targetFrame: Frame;
     let info: SelectorInfo | undefined;
     if (options.selector) {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2110,8 +2110,8 @@ export interface Page {
     depth?: number;
 
     /**
-     * When set to `"ai"`, returns a snapshot optimized for AI consumption with element references. Defaults to
-     * `"default"`.
+     * When set to `"ai"`, returns a snapshot optimized for AI consumption: including element references like `[ref=e2]`
+     * and snapshots of `<iframe>`s. Defaults to `"default"`.
      */
     mode?: "ai"|"default";
 
@@ -12779,6 +12779,11 @@ export interface Locator {
    *     - link "About"
    * ```
    *
+   * An AI-optimized snapshot, controlled by
+   * [`mode`](https://playwright.dev/docs/api/class-locator#locator-aria-snapshot-option-mode), is different from a
+   * default snapshot:
+   * 1. Includes element references `[ref=e2]`. 2. Does not wait for an element matching the locator, and throws when
+   *    no elements match. 3. Includes snapshots of `<iframe>`s inside the target.
    * @param options
    */
   ariaSnapshot(options?: {
@@ -12788,8 +12793,8 @@ export interface Locator {
     depth?: number;
 
     /**
-     * When set to `"ai"`, returns a snapshot optimized for AI consumption with element references. Defaults to
-     * `"default"`.
+     * When set to `"ai"`, returns a snapshot optimized for AI consumption. Defaults to `"default"`. See details for more
+     * information.
      */
     mode?: "ai"|"default";
 

--- a/tests/page/page-aria-snapshot.spec.ts
+++ b/tests/page/page-aria-snapshot.spec.ts
@@ -695,3 +695,56 @@ it('match values both against regex and string', async ({ page }) => {
       - /url: /auth?r=/
   `);
 });
+
+it('auto-waits the locator and does not include iframes', async ({ page }) => {
+  await page.setContent(`
+    <div>Hello</div>
+  `);
+
+  const snapshotPromise = page.locator('#target').ariaSnapshot();
+  await page.waitForTimeout(2000);
+  await page.setContent(`
+    <div id=target>
+      Hello
+      <iframe srcdoc="<ul><li>Item 1</li><li>Item 2</li></ul>"></iframe>
+    </div>
+  `);
+  expect(await snapshotPromise).toContainYaml(`
+    - text: Hello
+  `);
+});
+
+it('should limit depth', async ({ page }) => {
+  await page.setContent(`
+    <ul id=target>
+      <li>item2</li>
+      <li>
+        <ul>
+          <li>item3</li>
+        </ul>
+      </li>
+    </ul>
+  `);
+
+  const snapshot = await page.locator('#target').ariaSnapshot({ depth: 1 });
+  expect(snapshot).toContainYaml(`
+    - list:
+      - listitem: item2
+      - listitem
+  `);
+});
+
+it('should snapshot a locator inside an iframe', async ({ page }) => {
+  await page.setContent(`
+    <h1>Main Page</h1>
+    <iframe srcdoc="<ul><li>Item 1</li><li>Item 2</li></ul>"></iframe>
+  `);
+
+  const list = page.frames()[1].locator('ul');
+  const snapshot = await list.ariaSnapshot();
+  expect(snapshot).toContainYaml(`
+    - list:
+      - listitem: Item 1
+      - listitem: Item 2
+  `);
+});


### PR DESCRIPTION
- Auto-waits for the element.
- Does not include iframes.
- Limits depth.
- When setting `mode: 'ai'`, does not auto-wait and does include iframes.