### PR TITLE
chore(cli): lazy-load command implementations to reduce startup time

### DIFF
--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -137,6 +137,7 @@ This project incorporates components from the projects listed below. The origina
 -	yazl@2.5.1 (https://github.com/thejoshwolfe/yazl)
 -	zod-to-json-schema@3.25.1 (https://github.com/StefanTerdell/zod-to-json-schema)
 -	zod@4.3.5 (https://github.com/colinhacks/zod)
+-	zod@4.3.6 (https://github.com/colinhacks/zod)
 
 %% @hono/node-server@1.19.11 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -3545,8 +3546,34 @@ SOFTWARE.
 =========================================
 END OF zod@4.3.5 AND INFORMATION
 
+%% zod@4.3.6 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+MIT License
+
+Copyright (c) 2025 Colin McDonnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF zod@4.3.6 AND INFORMATION
+
 SUMMARY BEGIN HERE
 =========================================
-Total Packages: 133
+Total Packages: 134
 =========================================
 END OF SUMMARY

--- a/packages/playwright-core/bundles/mcp/src/mcpBundleImpl.ts
+++ b/packages/playwright-core/bundles/mcp/src/mcpBundleImpl.ts
@@ -23,5 +23,4 @@ export { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 export { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 export { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 export { CallToolRequestSchema, ListRootsRequestSchema, ListToolsRequestSchema, PingRequestSchema, ProgressNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
-export * as z from 'zod';
 export { zodToJsonSchema } from 'zod-to-json-schema';

--- a/packages/playwright-core/bundles/zod/package-lock.json
+++ b/packages/playwright-core/bundles/zod/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "zod-bundle",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zod-bundle",
+      "version": "0.0.1",
+      "dependencies": {
+        "zod": "^4.3.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/playwright-core/bundles/zod/package.json
+++ b/packages/playwright-core/bundles/zod/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "zod-bundle",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "zod": "^4.3.5"
+  }
+}

--- a/packages/playwright-core/bundles/zod/src/zodBundleImpl.ts
+++ b/packages/playwright-core/bundles/zod/src/zodBundleImpl.ts
@@ -14,25 +14,4 @@
  * limitations under the License.
  */
 
-import { z } from '../../zodBundle';
-import { defineTool } from './tool';
-
-const configShow = defineTool({
-  capability: 'config',
-
-  schema: {
-    name: 'browser_get_config',
-    title: 'Get config',
-    description: 'Get the final resolved config after merging CLI options, environment variables and config file.',
-    inputSchema: z.object({}),
-    type: 'readOnly',
-  },
-
-  handle: async (context, params, response) => {
-    response.addTextResult(JSON.stringify(context.config, null, 2));
-  },
-});
-
-export default [
-  configShow,
-];
+export * as z from 'zod';

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -27,6 +27,7 @@
     "./lib/tools/cli-client/program": "./lib/tools/cli-client/program.js",
     "./lib/tools/mcp/program": "./lib/tools/mcp/program.js",
     "./lib/mcpBundle": "./lib/mcpBundle.js",
+    "./lib/zodBundle": "./lib/zodBundle.js",
     "./lib/tools/exports": "./lib/tools/exports.js",
     "./lib/remote/playwrightServer": "./lib/remote/playwrightServer.js",
     "./lib/server": "./lib/server/index.js",

--- a/packages/playwright-core/src/cli/installCommands.ts
+++ b/packages/playwright-core/src/cli/installCommands.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-console */
+
+import path from 'path';
+
+import { registry } from '../server';
+import { isLikelyNpxGlobal } from '../utils';
+import { wrapInASCIIBox } from '../server/utils/ascii';
+
+import type { BrowserInfo } from '../server';
+
+function printInstalledBrowsers(browsers: BrowserInfo[]) {
+  const browserPaths = new Set<string>();
+  for (const browser of browsers)
+    browserPaths.add(browser.browserPath);
+  console.log(`  Browsers:`);
+  for (const browserPath of [...browserPaths].sort())
+    console.log(`    ${browserPath}`);
+  console.log(`  References:`);
+
+  const references = new Set<string>();
+  for (const browser of browsers)
+    references.add(browser.referenceDir);
+  for (const reference of [...references].sort())
+    console.log(`    ${reference}`);
+}
+
+function printGroupedByPlaywrightVersion(browsers: BrowserInfo[]) {
+  const dirToVersion = new Map<string, string>();
+  for (const browser of browsers) {
+    if (dirToVersion.has(browser.referenceDir))
+      continue;
+    const packageJSON = require(path.join(browser.referenceDir, 'package.json'));
+    const version = packageJSON.version;
+    dirToVersion.set(browser.referenceDir, version);
+  }
+
+  const groupedByPlaywrightMinorVersion = new Map<string, BrowserInfo[]>();
+  for (const browser of browsers) {
+    const version = dirToVersion.get(browser.referenceDir)!;
+    let entries = groupedByPlaywrightMinorVersion.get(version);
+    if (!entries) {
+      entries = [];
+      groupedByPlaywrightMinorVersion.set(version, entries);
+    }
+    entries.push(browser);
+  }
+
+  const sortedVersions = [...groupedByPlaywrightMinorVersion.keys()].sort((a, b) => {
+    const aComponents = a.split('.');
+    const bComponents = b.split('.');
+    const aMajor = parseInt(aComponents[0], 10);
+    const bMajor = parseInt(bComponents[0], 10);
+    if (aMajor !== bMajor)
+      return aMajor - bMajor;
+    const aMinor = parseInt(aComponents[1], 10);
+    const bMinor = parseInt(bComponents[1], 10);
+    if (aMinor !== bMinor)
+      return aMinor - bMinor;
+    return aComponents.slice(2).join('.').localeCompare(bComponents.slice(2).join('.'));
+  });
+
+  for (const version of sortedVersions) {
+    console.log(`\nPlaywright version: ${version}`);
+    printInstalledBrowsers(groupedByPlaywrightMinorVersion.get(version)!);
+  }
+}
+
+export async function install(args: string[], options: { withDeps?: boolean, force?: boolean, dryRun?: boolean, list?: boolean, shell?: boolean, noShell?: boolean, onlyShell?: boolean }) {
+  if (isLikelyNpxGlobal()) {
+    console.error(wrapInASCIIBox([
+      `WARNING: It looks like you are running 'npx playwright install' without first`,
+      `installing your project's dependencies.`,
+      ``,
+      `To avoid unexpected behavior, please install your dependencies first, and`,
+      `then run Playwright's install command:`,
+      ``,
+      `    npm install`,
+      `    npx playwright install`,
+      ``,
+      `If your project does not yet depend on Playwright, first install the`,
+      `applicable npm package (most commonly @playwright/test), and`,
+      `then run Playwright's install command to download the browsers:`,
+      ``,
+      `    npm install @playwright/test`,
+      `    npx playwright install`,
+      ``,
+    ].join('\n'), 1));
+  }
+  if (options.shell === false && options.onlyShell)
+    throw new Error(`Only one of --no-shell and --only-shell can be specified`);
+  const shell = options.shell === false ? 'no' : options.onlyShell ? 'only' : undefined;
+  const executables = registry.resolveBrowsers(args, { shell });
+  if (options.withDeps)
+    await registry.installDeps(executables, !!options.dryRun);
+  if (options.dryRun && options.list)
+    throw new Error(`Only one of --dry-run and --list can be specified`);
+  if (options.dryRun) {
+    for (const executable of executables) {
+      console.log(registry.calculateDownloadTitle(executable));
+      console.log(`  Install location:    ${executable.directory ?? '<system>'}`);
+      if (executable.downloadURLs?.length) {
+        const [url, ...fallbacks] = executable.downloadURLs;
+        console.log(`  Download url:        ${url}`);
+        for (let i = 0; i < fallbacks.length; ++i)
+          console.log(`  Download fallback ${i + 1}: ${fallbacks[i]}`);
+      }
+      console.log(``);
+    }
+  } else if (options.list) {
+    const browsers = await registry.listInstalledBrowsers();
+    printGroupedByPlaywrightVersion(browsers);
+  } else {
+    await registry.install(executables, { force: options.force });
+    await registry.validateHostRequirementsForExecutablesIfNeeded(executables, process.env.PW_LANG_NAME || 'javascript').catch((e: Error) => {
+      e.name = 'Playwright Host validation warning';
+      console.error(e);
+    });
+  }
+}
+
+export async function uninstall(options: { all?: boolean }) {
+  delete process.env.PLAYWRIGHT_SKIP_BROWSER_GC;
+  await registry.uninstall(!!options.all).then(({ numberOfBrowsersLeft }) => {
+    if (!options.all && numberOfBrowsersLeft > 0) {
+      console.log('Successfully uninstalled Playwright browsers for the current Playwright installation.');
+      console.log(`There are still ${numberOfBrowsersLeft} browsers left, used by other Playwright installations.\nTo uninstall Playwright browsers for all installations, re-run with --all flag.`);
+    }
+  });
+}
+
+export async function installDeps(args: string[]) {
+  await registry.installDeps(registry.resolveBrowsers(args, {}), false);
+}
+
+export async function installDepsDryRun(args: string[]) {
+  await registry.installDeps(registry.resolveBrowsers(args, {}), true);
+}
+
+export function suggestedBrowsersToInstall(): string {
+  return registry.suggestedBrowsersToInstall();
+}

--- a/packages/playwright-core/src/cli/openCommands.ts
+++ b/packages/playwright-core/src/cli/openCommands.ts
@@ -1,0 +1,370 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-console */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import * as playwright from '../..';
+import { gracefullyProcessExitDoNotHang, ManualPromise } from '../utils';
+import { dotenv, program } from '../utilsBundle';
+
+import type { Browser } from '../client/browser';
+import type { BrowserContext } from '../client/browserContext';
+import type { BrowserType } from '../client/browserType';
+import type { Page } from '../client/page';
+import type { BrowserContextOptions, LaunchOptions } from '../client/types';
+
+export type Options = {
+  browser: string;
+  channel?: string;
+  colorScheme?: string;
+  device?: string;
+  geolocation?: string;
+  ignoreHttpsErrors?: boolean;
+  lang?: string;
+  loadStorage?: string;
+  proxyServer?: string;
+  proxyBypass?: string;
+  blockServiceWorkers?: boolean;
+  saveHar?: string;
+  saveHarGlob?: string;
+  saveStorage?: string;
+  timeout: string;
+  timezone?: string;
+  viewportSize?: string;
+  userAgent?: string;
+  userDataDir?: string;
+};
+
+export type CaptureOptions = {
+  waitForSelector?: string;
+  waitForTimeout?: string;
+  fullPage: boolean;
+  paperFormat?: string;
+};
+
+async function launchContext(options: Options, extraOptions: LaunchOptions): Promise<{ browser: Browser, browserName: string, launchOptions: LaunchOptions, contextOptions: BrowserContextOptions, context: BrowserContext, closeBrowser: () => Promise<void> }> {
+  validateOptions(options);
+  const browserType = lookupBrowserType(options);
+  const launchOptions: LaunchOptions = extraOptions;
+  if (options.channel)
+    launchOptions.channel = options.channel as any;
+  launchOptions.handleSIGINT = false;
+
+  const contextOptions: BrowserContextOptions =
+    // Copy the device descriptor since we have to compare and modify the options.
+    options.device ? { ...playwright.devices[options.device] } : {};
+
+  // In headful mode, use host device scale factor for things to look nice.
+  // In headless, keep things the way it works in Playwright by default.
+  // Assume high-dpi on MacOS. TODO: this is not perfect.
+  if (!extraOptions.headless)
+    contextOptions.deviceScaleFactor = os.platform() === 'darwin' ? 2 : 1;
+
+  // Work around the WebKit GTK scrolling issue.
+  if (browserType.name() === 'webkit' && process.platform === 'linux') {
+    delete contextOptions.hasTouch;
+    delete contextOptions.isMobile;
+  }
+
+  if (contextOptions.isMobile && browserType.name() === 'firefox')
+    contextOptions.isMobile = undefined;
+
+  if (options.blockServiceWorkers)
+    contextOptions.serviceWorkers = 'block';
+
+  // Proxy
+
+  if (options.proxyServer) {
+    launchOptions.proxy = {
+      server: options.proxyServer
+    };
+    if (options.proxyBypass)
+      launchOptions.proxy.bypass = options.proxyBypass;
+  }
+
+  // Viewport size
+  if (options.viewportSize) {
+    try {
+      const [width, height] = options.viewportSize.split(',').map(n => +n);
+      if (isNaN(width) || isNaN(height))
+        throw new Error('bad values');
+      contextOptions.viewport = { width, height };
+    } catch (e) {
+      throw new Error('Invalid viewport size format: use "width,height", for example --viewport-size="800,600"');
+    }
+  }
+
+  // Geolocation
+
+  if (options.geolocation) {
+    try {
+      const [latitude, longitude] = options.geolocation.split(',').map(n => parseFloat(n.trim()));
+      contextOptions.geolocation = {
+        latitude,
+        longitude
+      };
+    } catch (e) {
+      throw new Error('Invalid geolocation format, should be "lat,long". For example --geolocation="37.819722,-122.478611"');
+    }
+    contextOptions.permissions = ['geolocation'];
+  }
+
+  // User agent
+
+  if (options.userAgent)
+    contextOptions.userAgent = options.userAgent;
+
+  // Lang
+
+  if (options.lang)
+    contextOptions.locale = options.lang;
+
+  // Color scheme
+
+  if (options.colorScheme)
+    contextOptions.colorScheme = options.colorScheme as 'dark' | 'light';
+
+  // Timezone
+
+  if (options.timezone)
+    contextOptions.timezoneId = options.timezone;
+
+  // Storage
+
+  if (options.loadStorage)
+    contextOptions.storageState = options.loadStorage;
+
+  if (options.ignoreHttpsErrors)
+    contextOptions.ignoreHTTPSErrors = true;
+
+  // HAR
+
+  if (options.saveHar) {
+    contextOptions.recordHar = { path: path.resolve(process.cwd(), options.saveHar), mode: 'minimal' };
+    if (options.saveHarGlob)
+      contextOptions.recordHar.urlFilter = options.saveHarGlob;
+    contextOptions.serviceWorkers = 'block';
+  }
+
+  let browser: Browser;
+  let context: BrowserContext;
+
+  if (options.userDataDir) {
+    context = await browserType.launchPersistentContext(options.userDataDir, { ...launchOptions, ...contextOptions });
+    browser = context.browser()!;
+  } else {
+    browser = await browserType.launch(launchOptions);
+    context = await browser.newContext(contextOptions);
+  }
+
+  let closingBrowser = false;
+  async function closeBrowser() {
+    // We can come here multiple times. For example, saving storage creates
+    // a temporary page and we call closeBrowser again when that page closes.
+    if (closingBrowser)
+      return;
+    closingBrowser = true;
+    if (options.saveStorage)
+      await context.storageState({ path: options.saveStorage }).catch(e => null);
+    if (options.saveHar)
+      await context.close();
+    await browser.close();
+  }
+
+  context.on('page', page => {
+    page.on('dialog', () => {});  // Prevent dialogs from being automatically dismissed.
+    page.on('close', () => {
+      const hasPage = browser.contexts().some(context => context.pages().length > 0);
+      if (hasPage)
+        return;
+      // Avoid the error when the last page is closed because the browser has been closed.
+      closeBrowser().catch(() => {});
+    });
+  });
+  process.on('SIGINT', async () => {
+    await closeBrowser();
+    gracefullyProcessExitDoNotHang(130);
+  });
+
+  const timeout = options.timeout ? parseInt(options.timeout, 10) : 0;
+  context.setDefaultTimeout(timeout);
+  context.setDefaultNavigationTimeout(timeout);
+
+  // Omit options that we add automatically for presentation purpose.
+  delete launchOptions.headless;
+  delete launchOptions.executablePath;
+  delete launchOptions.handleSIGINT;
+  delete contextOptions.deviceScaleFactor;
+  return { browser, browserName: browserType.name(), context, contextOptions, launchOptions, closeBrowser };
+}
+
+async function openPage(context: BrowserContext, url: string | undefined): Promise<Page> {
+  let page = context.pages()[0];
+  if (!page)
+    page = await context.newPage();
+  if (url) {
+    if (fs.existsSync(url))
+      url = 'file://' + path.resolve(url);
+    else if (!url.startsWith('http') && !url.startsWith('file://') && !url.startsWith('about:') && !url.startsWith('data:'))
+      url = 'http://' + url;
+    await page.goto(url);
+  }
+  return page;
+}
+
+export async function open(options: Options, url: string | undefined) {
+  const { context } = await launchContext(options, { headless: !!process.env.PWTEST_CLI_HEADLESS, executablePath: process.env.PWTEST_CLI_EXECUTABLE_PATH });
+  await context._exposeConsoleApi();
+  await openPage(context, url);
+}
+
+export async function codegen(options: Options & { target: string, output?: string, testIdAttribute?: string }, url: string | undefined) {
+  const { target: language, output: outputFile, testIdAttribute: testIdAttributeName } = options;
+  const tracesDir = path.join(os.tmpdir(), `playwright-recorder-trace-${Date.now()}`);
+  const { context, browser, launchOptions, contextOptions, closeBrowser } = await launchContext(options, {
+    headless: !!process.env.PWTEST_CLI_HEADLESS,
+    executablePath: process.env.PWTEST_CLI_EXECUTABLE_PATH,
+    tracesDir,
+  });
+  const donePromise = new ManualPromise<void>();
+  maybeSetupTestHooks(browser, closeBrowser, donePromise);
+  dotenv.config({ path: 'playwright.env' });
+  await context._enableRecorder({
+    language,
+    launchOptions,
+    contextOptions,
+    device: options.device,
+    saveStorage: options.saveStorage,
+    mode: 'recording',
+    testIdAttributeName,
+    outputFile: outputFile ? path.resolve(outputFile) : undefined,
+    handleSIGINT: false,
+  });
+  await openPage(context, url);
+  donePromise.resolve();
+}
+
+async function maybeSetupTestHooks(browser: Browser, closeBrowser: () => Promise<void>, donePromise: Promise<void>) {
+  if (!process.env.PWTEST_CLI_IS_UNDER_TEST)
+    return;
+
+  // Make sure we exit abnormally when browser crashes.
+  const logs: string[] = [];
+  require('playwright-core/lib/utilsBundle').debug.log = (...args: any[]) => {
+    const line = require('util').format(...args) + '\n';
+    logs.push(line);
+    // eslint-disable-next-line no-restricted-properties
+    process.stderr.write(line);
+  };
+  browser.on('disconnected', () => {
+    const hasCrashLine = logs.some(line => line.includes('process did exit:') && !line.includes('process did exit: exitCode=0, signal=null'));
+    if (hasCrashLine) {
+      // eslint-disable-next-line no-restricted-properties
+      process.stderr.write('Detected browser crash.\n');
+      gracefullyProcessExitDoNotHang(1);
+    }
+  });
+
+  const close = async () => {
+    await donePromise;
+    await closeBrowser();
+  };
+
+  if (process.env.PWTEST_CLI_EXIT_AFTER_TIMEOUT) {
+    setTimeout(close, +process.env.PWTEST_CLI_EXIT_AFTER_TIMEOUT);
+    return;
+  }
+
+  // Note: we cannot use SIGINT, as it is not available on Windows.
+  let stdin = '';
+  process.stdin.on('data', data => {
+    stdin += data.toString();
+    if (stdin.startsWith('exit')) {
+      process.stdin.destroy();
+      close();
+    }
+  });
+}
+
+async function waitForPage(page: Page, captureOptions: CaptureOptions) {
+  if (captureOptions.waitForSelector) {
+    console.log(`Waiting for selector ${captureOptions.waitForSelector}...`);
+    await page.waitForSelector(captureOptions.waitForSelector);
+  }
+  if (captureOptions.waitForTimeout) {
+    console.log(`Waiting for timeout ${captureOptions.waitForTimeout}...`);
+    await page.waitForTimeout(parseInt(captureOptions.waitForTimeout, 10));
+  }
+}
+
+export async function screenshot(options: Options, captureOptions: CaptureOptions, url: string, path: string) {
+  const { context } = await launchContext(options, { headless: true });
+  console.log('Navigating to ' + url);
+  const page = await openPage(context, url);
+  await waitForPage(page, captureOptions);
+  console.log('Capturing screenshot into ' + path);
+  await page.screenshot({ path, fullPage: !!captureOptions.fullPage });
+  // launchContext takes care of closing the browser.
+  await page.close();
+}
+
+export async function pdf(options: Options, captureOptions: CaptureOptions, url: string, path: string) {
+  if (options.browser !== 'chromium')
+    throw new Error('PDF creation is only working with Chromium');
+  const { context } = await launchContext({ ...options, browser: 'chromium' }, { headless: true });
+  console.log('Navigating to ' + url);
+  const page = await openPage(context, url);
+  await waitForPage(page, captureOptions);
+  console.log('Saving as pdf into ' + path);
+  await page.pdf!({ path, format: captureOptions.paperFormat });
+  // launchContext takes care of closing the browser.
+  await page.close();
+}
+
+function lookupBrowserType(options: Options): BrowserType {
+  let name = options.browser;
+  if (options.device) {
+    const device = playwright.devices[options.device];
+    name = device.defaultBrowserType;
+  }
+  let browserType: any;
+  switch (name) {
+    case 'chromium': browserType = playwright.chromium; break;
+    case 'webkit': browserType = playwright.webkit; break;
+    case 'firefox': browserType = playwright.firefox; break;
+    case 'cr': browserType = playwright.chromium; break;
+    case 'wk': browserType = playwright.webkit; break;
+    case 'ff': browserType = playwright.firefox; break;
+  }
+  if (browserType)
+    return browserType;
+  program.help();
+}
+
+function validateOptions(options: Options) {
+  if (options.device && !(options.device in playwright.devices)) {
+    const lines = [`Device descriptor not found: '${options.device}', available devices are:`];
+    for (const name in playwright.devices)
+      lines.push(`  "${name}"`);
+    throw new Error(lines.join('\n'));
+  }
+  if (options.colorScheme && !['light', 'dark'].includes(options.colorScheme))
+    throw new Error('Invalid color scheme, should be one of "light", "dark"');
+}

--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -16,28 +16,11 @@
 
 /* eslint-disable no-console */
 
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-
-import * as playwright from '../..';
-import { launchBrowserServer, printApiJson, runDriver, runServer } from './driver';
-import { registry, writeDockerVersion } from '../server';
-import { gracefullyProcessExitDoNotHang, isLikelyNpxGlobal, ManualPromise } from '../utils';
-import { runTraceInBrowser, runTraceViewerApp } from '../server/trace/viewer/traceViewer';
+import { gracefullyProcessExitDoNotHang } from '../utils';
+import { getPackageManagerExecCommand } from '../utils';
+import { program } from '../utilsBundle';
 import { addTraceCommands } from '../tools/trace/traceCli';
-import { assert, getPackageManagerExecCommand } from '../utils';
-import { wrapInASCIIBox } from '../server/utils/ascii';
-import { dotenv, program } from '../utilsBundle';
-import { program as cliProgram } from '../tools/cli-client/program';
 
-import type { Browser } from '../client/browser';
-import type { BrowserContext } from '../client/browserContext';
-import type { BrowserType } from '../client/browserType';
-import type { Page } from '../client/page';
-import type { BrowserContextOptions, LaunchOptions } from '../client/types';
-import type { BrowserInfo } from '../server';
-import type { TraceViewerServerOptions } from '../server/trace/viewer/traceViewer';
 import type { Command } from '../utilsBundle';
 
 export { program } from '../utilsBundle';
@@ -53,12 +36,15 @@ program
     .description('mark docker image')
     .allowUnknownOption(true)
     .action(function(dockerImageNameTemplate) {
+      const { assert } = require('../utils');
+      const { writeDockerVersion } = require('../server');
       assert(dockerImageNameTemplate, 'dockerImageNameTemplate is required');
       writeDockerVersion(dockerImageNameTemplate).catch(logErrorAndExit);
     });
 
 commandWithOpenOptions('open [url]', 'open page in browser specified via -b, --browser', [])
     .action(function(url, options) {
+      const { open } = require('./openCommands');
       open(options, url).catch(logErrorAndExit);
     })
     .addHelpText('afterAll', `
@@ -72,71 +58,15 @@ commandWithOpenOptions('codegen [url]', 'open page and generate code for user ac
       ['-o, --output <file name>', 'saves the generated script to a file'],
       ['--target <language>', `language to generate, one of javascript, playwright-test, python, python-async, python-pytest, csharp, csharp-mstest, csharp-nunit, java, java-junit`, codegenId()],
       ['--test-id-attribute <attributeName>', 'use the specified attribute to generate data test ID selectors'],
-    ]).action(async function(url, options) {
-  await codegen(options, url);
+    ]).action(function(url, options) {
+  const { codegen } = require('./openCommands');
+  codegen(options, url);
 }).addHelpText('afterAll', `
 Examples:
 
   $ codegen
   $ codegen --target=python
   $ codegen -b webkit https://example.com`);
-
-function printInstalledBrowsers(browsers: BrowserInfo[]) {
-  const browserPaths = new Set<string>();
-  for (const browser of browsers)
-    browserPaths.add(browser.browserPath);
-  console.log(`  Browsers:`);
-  for (const browserPath of [...browserPaths].sort())
-    console.log(`    ${browserPath}`);
-  console.log(`  References:`);
-
-  const references = new Set<string>();
-  for (const browser of browsers)
-    references.add(browser.referenceDir);
-  for (const reference of [...references].sort())
-    console.log(`    ${reference}`);
-}
-
-function printGroupedByPlaywrightVersion(browsers: BrowserInfo[]) {
-  const dirToVersion = new Map<string, string>();
-  for (const browser of browsers) {
-    if (dirToVersion.has(browser.referenceDir))
-      continue;
-    const packageJSON = require(path.join(browser.referenceDir, 'package.json'));
-    const version = packageJSON.version;
-    dirToVersion.set(browser.referenceDir, version);
-  }
-
-  const groupedByPlaywrightMinorVersion = new Map<string, BrowserInfo[]>();
-  for (const browser of browsers) {
-    const version = dirToVersion.get(browser.referenceDir)!;
-    let entries = groupedByPlaywrightMinorVersion.get(version);
-    if (!entries) {
-      entries = [];
-      groupedByPlaywrightMinorVersion.set(version, entries);
-    }
-    entries.push(browser);
-  }
-
-  const sortedVersions = [...groupedByPlaywrightMinorVersion.keys()].sort((a, b) => {
-    const aComponents = a.split('.');
-    const bComponents = b.split('.');
-    const aMajor = parseInt(aComponents[0], 10);
-    const bMajor = parseInt(bComponents[0], 10);
-    if (aMajor !== bMajor)
-      return aMajor - bMajor;
-    const aMinor = parseInt(aComponents[1], 10);
-    const bMinor = parseInt(bComponents[1], 10);
-    if (aMinor !== bMinor)
-      return aMinor - bMinor;
-    return aComponents.slice(2).join('.').localeCompare(bComponents.slice(2).join('.'));
-  });
-
-  for (const version of sortedVersions) {
-    console.log(`\nPlaywright version: ${version}`);
-    printInstalledBrowsers(groupedByPlaywrightMinorVersion.get(version)!);
-  }
-}
 
 program
     .command('install [browser...]')
@@ -148,82 +78,32 @@ program
     .option('--only-shell', 'only install headless shell when installing chromium')
     .option('--no-shell', 'do not install chromium headless shell')
     .action(async function(args: string[], options: { withDeps?: boolean, force?: boolean, dryRun?: boolean, list?: boolean, shell?: boolean, noShell?: boolean, onlyShell?: boolean }) {
-      if (isLikelyNpxGlobal()) {
-        console.error(wrapInASCIIBox([
-          `WARNING: It looks like you are running 'npx playwright install' without first`,
-          `installing your project's dependencies.`,
-          ``,
-          `To avoid unexpected behavior, please install your dependencies first, and`,
-          `then run Playwright's install command:`,
-          ``,
-          `    npm install`,
-          `    npx playwright install`,
-          ``,
-          `If your project does not yet depend on Playwright, first install the`,
-          `applicable npm package (most commonly @playwright/test), and`,
-          `then run Playwright's install command to download the browsers:`,
-          ``,
-          `    npm install @playwright/test`,
-          `    npx playwright install`,
-          ``,
-        ].join('\n'), 1));
-      }
       try {
-        if (options.shell === false && options.onlyShell)
-          throw new Error(`Only one of --no-shell and --only-shell can be specified`);
-        const shell = options.shell === false ? 'no' : options.onlyShell ? 'only' : undefined;
-        const executables = registry.resolveBrowsers(args, { shell });
-        if (options.withDeps)
-          await registry.installDeps(executables, !!options.dryRun);
-        if (options.dryRun && options.list)
-          throw new Error(`Only one of --dry-run and --list can be specified`);
-        if (options.dryRun) {
-          for (const executable of executables) {
-            console.log(registry.calculateDownloadTitle(executable));
-            console.log(`  Install location:    ${executable.directory ?? '<system>'}`);
-            if (executable.downloadURLs?.length) {
-              const [url, ...fallbacks] = executable.downloadURLs;
-              console.log(`  Download url:        ${url}`);
-              for (let i = 0; i < fallbacks.length; ++i)
-                console.log(`  Download fallback ${i + 1}: ${fallbacks[i]}`);
-            }
-            console.log(``);
-          }
-        } else if (options.list) {
-          const browsers = await registry.listInstalledBrowsers();
-          printGroupedByPlaywrightVersion(browsers);
-        } else {
-          await registry.install(executables, { force: options.force });
-          await registry.validateHostRequirementsForExecutablesIfNeeded(executables, process.env.PW_LANG_NAME || 'javascript').catch((e: Error) => {
-            e.name = 'Playwright Host validation warning';
-            console.error(e);
-          });
-        }
+        const { install } = require('./installCommands');
+        await install(args, options);
       } catch (e) {
         console.log(`Failed to install browsers\n${e}`);
         gracefullyProcessExitDoNotHang(1);
       }
-    }).addHelpText('afterAll', `
+    }).addHelpText('afterAll', () => {
+      const { suggestedBrowsersToInstall } = require('./installCommands');
+      return `
 
 Examples:
   - $ install
     Install default browsers.
 
   - $ install chrome firefox
-    Install custom browsers, supports ${registry.suggestedBrowsersToInstall()}.`);
+    Install custom browsers, supports ${suggestedBrowsersToInstall()}.`;
+    });
 
 program
     .command('uninstall')
     .description('Removes browsers used by this installation of Playwright from the system (chromium, firefox, webkit, ffmpeg). This does not include branded channels.')
     .option('--all', 'Removes all browsers used by any Playwright installation from the system.')
     .action(async (options: { all?: boolean }) => {
-      delete process.env.PLAYWRIGHT_SKIP_BROWSER_GC;
-      await registry.uninstall(!!options.all).then(({ numberOfBrowsersLeft }) => {
-        if (!options.all && numberOfBrowsersLeft > 0) {
-          console.log('Successfully uninstalled Playwright browsers for the current Playwright installation.');
-          console.log(`There are still ${numberOfBrowsersLeft} browsers left, used by other Playwright installations.\nTo uninstall Playwright browsers for all installations, re-run with --all flag.`);
-        }
-      }).catch(logErrorAndExit);
+      const { uninstall } = require('./installCommands');
+      await uninstall(options).catch(logErrorAndExit);
     });
 
 program
@@ -232,18 +112,25 @@ program
     .option('--dry-run', 'Do not execute installation commands, only print them')
     .action(async function(args: string[], options: { dryRun?: boolean }) {
       try {
-        await registry.installDeps(registry.resolveBrowsers(args, {}), !!options.dryRun);
+        const { installDeps, installDepsDryRun } = require('./installCommands');
+        if (options.dryRun)
+          await installDepsDryRun(args);
+        else
+          await installDeps(args);
       } catch (e) {
         console.log(`Failed to install browser dependencies\n${e}`);
         gracefullyProcessExitDoNotHang(1);
       }
-    }).addHelpText('afterAll', `
+    }).addHelpText('afterAll', () => {
+      const { suggestedBrowsersToInstall } = require('./installCommands');
+      return `
 Examples:
   - $ install-deps
     Install dependencies for default browsers.
 
   - $ install-deps chrome firefox
-    Install dependencies for specific browsers, supports ${registry.suggestedBrowsersToInstall()}.`);
+    Install dependencies for specific browsers, supports ${suggestedBrowsersToInstall()}.`;
+    });
 
 const browsers = [
   { alias: 'cr', name: 'Chromium', type: 'chromium' },
@@ -254,6 +141,7 @@ const browsers = [
 for (const { alias, name, type } of browsers) {
   commandWithOpenOptions(`${alias} [url]`, `open page in ${name}`, [])
       .action(function(url, options) {
+        const { open } = require('./openCommands');
         open({ ...options, browser: type }, url).catch(logErrorAndExit);
       }).addHelpText('afterAll', `
 Examples:
@@ -267,6 +155,7 @@ commandWithOpenOptions('screenshot <url> <filename>', 'capture a page screenshot
       ['--wait-for-timeout <timeout>', 'wait for timeout in milliseconds before taking a screenshot'],
       ['--full-page', 'whether to take a full page screenshot (entire scrollable area)'],
     ]).action(function(url, filename, command) {
+  const { screenshot } = require('./openCommands');
   screenshot(command, command, url, filename).catch(logErrorAndExit);
 }).addHelpText('afterAll', `
 Examples:
@@ -279,6 +168,7 @@ commandWithOpenOptions('pdf <url> <filename>', 'save page as pdf',
       ['--wait-for-selector <selector>', 'wait for given selector before saving as pdf'],
       ['--wait-for-timeout <timeout>', 'wait for given timeout in milliseconds before saving as pdf'],
     ]).action(function(url, filename, options) {
+  const { pdf } = require('./openCommands');
   pdf(options, options, url, filename).catch(logErrorAndExit);
 }).addHelpText('afterAll', `
 Examples:
@@ -288,6 +178,7 @@ Examples:
 program
     .command('run-driver', { hidden: true })
     .action(function(options) {
+      const { runDriver } = require('./driver');
       runDriver();
     });
 
@@ -300,6 +191,7 @@ program
     .option('--mode <mode>', 'Server mode, either "default" or "extension"')
     .option('--artifacts-dir <artifactsDir>', 'Artifacts directory')
     .action(function(options) {
+      const { runServer } = require('./driver');
       runServer({
         port: options.port ? +options.port : undefined,
         host: options.host,
@@ -313,6 +205,7 @@ program
 program
     .command('print-api-json', { hidden: true })
     .action(function(options) {
+      const { printApiJson } = require('./driver');
       printApiJson();
     });
 
@@ -321,6 +214,7 @@ program
     .requiredOption('--browser <browserName>', 'Browser name, one of "chromium", "firefox" or "webkit"')
     .option('--config <path-to-config-file>', 'JSON file with launchServer options')
     .action(function(options) {
+      const { launchBrowserServer } = require('./driver');
       launchBrowserServer(options.browser, options.config);
     });
 
@@ -339,12 +233,13 @@ program
       if (options.browser === 'wk')
         options.browser = 'webkit';
 
-      const openOptions: TraceViewerServerOptions = {
+      const openOptions = {
         host: options.host,
         port: +options.port,
         isServer: !!options.stdin,
       };
 
+      const { runTraceInBrowser, runTraceViewerApp } = require('../server/trace/viewer/traceViewer');
       if (options.port !== undefined || options.host !== undefined)
         runTraceInBrowser(trace, openOptions).catch(logErrorAndExit);
       else
@@ -361,349 +256,11 @@ program
     .command('cli', { hidden: true })
     .allowExcessArguments(true)
     .allowUnknownOption(true)
-    .action(async options => {
+    .action(options => {
       process.argv.splice(process.argv.indexOf('cli'), 1);
+      const { program: cliProgram } = require('../tools/cli-client/program');
       cliProgram();
     });
-
-type Options = {
-  browser: string;
-  channel?: string;
-  colorScheme?: string;
-  device?: string;
-  geolocation?: string;
-  ignoreHttpsErrors?: boolean;
-  lang?: string;
-  loadStorage?: string;
-  proxyServer?: string;
-  proxyBypass?: string;
-  blockServiceWorkers?: boolean;
-  saveHar?: string;
-  saveHarGlob?: string;
-  saveStorage?: string;
-  timeout: string;
-  timezone?: string;
-  viewportSize?: string;
-  userAgent?: string;
-  userDataDir?: string;
-};
-
-type CaptureOptions = {
-  waitForSelector?: string;
-  waitForTimeout?: string;
-  fullPage: boolean;
-  paperFormat?: string;
-};
-
-async function launchContext(options: Options, extraOptions: LaunchOptions): Promise<{ browser: Browser, browserName: string, launchOptions: LaunchOptions, contextOptions: BrowserContextOptions, context: BrowserContext, closeBrowser: () => Promise<void> }> {
-  validateOptions(options);
-  const browserType = lookupBrowserType(options);
-  const launchOptions: LaunchOptions = extraOptions;
-  if (options.channel)
-    launchOptions.channel = options.channel as any;
-  launchOptions.handleSIGINT = false;
-
-  const contextOptions: BrowserContextOptions =
-    // Copy the device descriptor since we have to compare and modify the options.
-    options.device ? { ...playwright.devices[options.device] } : {};
-
-  // In headful mode, use host device scale factor for things to look nice.
-  // In headless, keep things the way it works in Playwright by default.
-  // Assume high-dpi on MacOS. TODO: this is not perfect.
-  if (!extraOptions.headless)
-    contextOptions.deviceScaleFactor = os.platform() === 'darwin' ? 2 : 1;
-
-  // Work around the WebKit GTK scrolling issue.
-  if (browserType.name() === 'webkit' && process.platform === 'linux') {
-    delete contextOptions.hasTouch;
-    delete contextOptions.isMobile;
-  }
-
-  if (contextOptions.isMobile && browserType.name() === 'firefox')
-    contextOptions.isMobile = undefined;
-
-  if (options.blockServiceWorkers)
-    contextOptions.serviceWorkers = 'block';
-
-  // Proxy
-
-  if (options.proxyServer) {
-    launchOptions.proxy = {
-      server: options.proxyServer
-    };
-    if (options.proxyBypass)
-      launchOptions.proxy.bypass = options.proxyBypass;
-  }
-
-  // Viewport size
-  if (options.viewportSize) {
-    try {
-      const [width, height] = options.viewportSize.split(',').map(n => +n);
-      if (isNaN(width) || isNaN(height))
-        throw new Error('bad values');
-      contextOptions.viewport = { width, height };
-    } catch (e) {
-      throw new Error('Invalid viewport size format: use "width,height", for example --viewport-size="800,600"');
-    }
-  }
-
-  // Geolocation
-
-  if (options.geolocation) {
-    try {
-      const [latitude, longitude] = options.geolocation.split(',').map(n => parseFloat(n.trim()));
-      contextOptions.geolocation = {
-        latitude,
-        longitude
-      };
-    } catch (e) {
-      throw new Error('Invalid geolocation format, should be "lat,long". For example --geolocation="37.819722,-122.478611"');
-    }
-    contextOptions.permissions = ['geolocation'];
-  }
-
-  // User agent
-
-  if (options.userAgent)
-    contextOptions.userAgent = options.userAgent;
-
-  // Lang
-
-  if (options.lang)
-    contextOptions.locale = options.lang;
-
-  // Color scheme
-
-  if (options.colorScheme)
-    contextOptions.colorScheme = options.colorScheme as 'dark' | 'light';
-
-  // Timezone
-
-  if (options.timezone)
-    contextOptions.timezoneId = options.timezone;
-
-  // Storage
-
-  if (options.loadStorage)
-    contextOptions.storageState = options.loadStorage;
-
-  if (options.ignoreHttpsErrors)
-    contextOptions.ignoreHTTPSErrors = true;
-
-  // HAR
-
-  if (options.saveHar) {
-    contextOptions.recordHar = { path: path.resolve(process.cwd(), options.saveHar), mode: 'minimal' };
-    if (options.saveHarGlob)
-      contextOptions.recordHar.urlFilter = options.saveHarGlob;
-    contextOptions.serviceWorkers = 'block';
-  }
-
-  let browser: Browser;
-  let context: BrowserContext;
-
-  if (options.userDataDir) {
-    context = await browserType.launchPersistentContext(options.userDataDir, { ...launchOptions, ...contextOptions });
-    browser = context.browser()!;
-  } else {
-    browser = await browserType.launch(launchOptions);
-    context = await browser.newContext(contextOptions);
-  }
-
-  let closingBrowser = false;
-  async function closeBrowser() {
-    // We can come here multiple times. For example, saving storage creates
-    // a temporary page and we call closeBrowser again when that page closes.
-    if (closingBrowser)
-      return;
-    closingBrowser = true;
-    if (options.saveStorage)
-      await context.storageState({ path: options.saveStorage }).catch(e => null);
-    if (options.saveHar)
-      await context.close();
-    await browser.close();
-  }
-
-  context.on('page', page => {
-    page.on('dialog', () => {});  // Prevent dialogs from being automatically dismissed.
-    page.on('close', () => {
-      const hasPage = browser.contexts().some(context => context.pages().length > 0);
-      if (hasPage)
-        return;
-      // Avoid the error when the last page is closed because the browser has been closed.
-      closeBrowser().catch(() => {});
-    });
-  });
-  process.on('SIGINT', async () => {
-    await closeBrowser();
-    gracefullyProcessExitDoNotHang(130);
-  });
-
-  const timeout = options.timeout ? parseInt(options.timeout, 10) : 0;
-  context.setDefaultTimeout(timeout);
-  context.setDefaultNavigationTimeout(timeout);
-
-  // Omit options that we add automatically for presentation purpose.
-  delete launchOptions.headless;
-  delete launchOptions.executablePath;
-  delete launchOptions.handleSIGINT;
-  delete contextOptions.deviceScaleFactor;
-  return { browser, browserName: browserType.name(), context, contextOptions, launchOptions, closeBrowser };
-}
-
-async function openPage(context: BrowserContext, url: string | undefined): Promise<Page> {
-  let page = context.pages()[0];
-  if (!page)
-    page = await context.newPage();
-  if (url) {
-    if (fs.existsSync(url))
-      url = 'file://' + path.resolve(url);
-    else if (!url.startsWith('http') && !url.startsWith('file://') && !url.startsWith('about:') && !url.startsWith('data:'))
-      url = 'http://' + url;
-    await page.goto(url);
-  }
-  return page;
-}
-
-async function open(options: Options, url: string | undefined) {
-  const { context } = await launchContext(options, { headless: !!process.env.PWTEST_CLI_HEADLESS, executablePath: process.env.PWTEST_CLI_EXECUTABLE_PATH });
-  await context._exposeConsoleApi();
-  await openPage(context, url);
-}
-
-async function codegen(options: Options & { target: string, output?: string, testIdAttribute?: string }, url: string | undefined) {
-  const { target: language, output: outputFile, testIdAttribute: testIdAttributeName } = options;
-  const tracesDir = path.join(os.tmpdir(), `playwright-recorder-trace-${Date.now()}`);
-  const { context, browser, launchOptions, contextOptions, closeBrowser } = await launchContext(options, {
-    headless: !!process.env.PWTEST_CLI_HEADLESS,
-    executablePath: process.env.PWTEST_CLI_EXECUTABLE_PATH,
-    tracesDir,
-  });
-  const donePromise = new ManualPromise<void>();
-  maybeSetupTestHooks(browser, closeBrowser, donePromise);
-  dotenv.config({ path: 'playwright.env' });
-  await context._enableRecorder({
-    language,
-    launchOptions,
-    contextOptions,
-    device: options.device,
-    saveStorage: options.saveStorage,
-    mode: 'recording',
-    testIdAttributeName,
-    outputFile: outputFile ? path.resolve(outputFile) : undefined,
-    handleSIGINT: false,
-  });
-  await openPage(context, url);
-  donePromise.resolve();
-}
-
-async function maybeSetupTestHooks(browser: Browser, closeBrowser: () => Promise<void>, donePromise: Promise<void>) {
-  if (!process.env.PWTEST_CLI_IS_UNDER_TEST)
-    return;
-
-  // Make sure we exit abnormally when browser crashes.
-  const logs: string[] = [];
-  require('playwright-core/lib/utilsBundle').debug.log = (...args: any[]) => {
-    const line = require('util').format(...args) + '\n';
-    logs.push(line);
-    // eslint-disable-next-line no-restricted-properties
-    process.stderr.write(line);
-  };
-  browser.on('disconnected', () => {
-    const hasCrashLine = logs.some(line => line.includes('process did exit:') && !line.includes('process did exit: exitCode=0, signal=null'));
-    if (hasCrashLine) {
-      // eslint-disable-next-line no-restricted-properties
-      process.stderr.write('Detected browser crash.\n');
-      gracefullyProcessExitDoNotHang(1);
-    }
-  });
-
-  const close = async () => {
-    await donePromise;
-    await closeBrowser();
-  };
-
-  if (process.env.PWTEST_CLI_EXIT_AFTER_TIMEOUT) {
-    setTimeout(close, +process.env.PWTEST_CLI_EXIT_AFTER_TIMEOUT);
-    return;
-  }
-
-  // Note: we cannot use SIGINT, as it is not available on Windows.
-  let stdin = '';
-  process.stdin.on('data', data => {
-    stdin += data.toString();
-    if (stdin.startsWith('exit')) {
-      process.stdin.destroy();
-      close();
-    }
-  });
-}
-
-async function waitForPage(page: Page, captureOptions: CaptureOptions) {
-  if (captureOptions.waitForSelector) {
-    console.log(`Waiting for selector ${captureOptions.waitForSelector}...`);
-    await page.waitForSelector(captureOptions.waitForSelector);
-  }
-  if (captureOptions.waitForTimeout) {
-    console.log(`Waiting for timeout ${captureOptions.waitForTimeout}...`);
-    await page.waitForTimeout(parseInt(captureOptions.waitForTimeout, 10));
-  }
-}
-
-async function screenshot(options: Options, captureOptions: CaptureOptions, url: string, path: string) {
-  const { context } = await launchContext(options, { headless: true });
-  console.log('Navigating to ' + url);
-  const page = await openPage(context, url);
-  await waitForPage(page, captureOptions);
-  console.log('Capturing screenshot into ' + path);
-  await page.screenshot({ path, fullPage: !!captureOptions.fullPage });
-  // launchContext takes care of closing the browser.
-  await page.close();
-}
-
-async function pdf(options: Options, captureOptions: CaptureOptions, url: string, path: string) {
-  if (options.browser !== 'chromium')
-    throw new Error('PDF creation is only working with Chromium');
-  const { context } = await launchContext({ ...options, browser: 'chromium' }, { headless: true });
-  console.log('Navigating to ' + url);
-  const page = await openPage(context, url);
-  await waitForPage(page, captureOptions);
-  console.log('Saving as pdf into ' + path);
-  await page.pdf!({ path, format: captureOptions.paperFormat });
-  // launchContext takes care of closing the browser.
-  await page.close();
-}
-
-function lookupBrowserType(options: Options): BrowserType {
-  let name = options.browser;
-  if (options.device) {
-    const device = playwright.devices[options.device];
-    name = device.defaultBrowserType;
-  }
-  let browserType: any;
-  switch (name) {
-    case 'chromium': browserType = playwright.chromium; break;
-    case 'webkit': browserType = playwright.webkit; break;
-    case 'firefox': browserType = playwright.firefox; break;
-    case 'cr': browserType = playwright.chromium; break;
-    case 'wk': browserType = playwright.webkit; break;
-    case 'ff': browserType = playwright.firefox; break;
-  }
-  if (browserType)
-    return browserType;
-  program.help();
-}
-
-function validateOptions(options: Options) {
-  if (options.device && !(options.device in playwright.devices)) {
-    const lines = [`Device descriptor not found: '${options.device}', available devices are:`];
-    for (const name in playwright.devices)
-      lines.push(`  "${name}"`);
-    throw new Error(lines.join('\n'));
-  }
-  if (options.colorScheme && !['light', 'dark'].includes(options.colorScheme))
-    throw new Error('Invalid color scheme, should be one of "light", "dark"');
-}
 
 function logErrorAndExit(e: Error) {
   if (process.env.PWDEBUGIMPL)

--- a/packages/playwright-core/src/client/platform.ts
+++ b/packages/playwright-core/src/client/platform.ts
@@ -59,7 +59,6 @@ export type Platform = {
   streamFile: (path: string, writable: Writable) => Promise<void>,
   streamReadable: (channel: channels.StreamChannel) => Readable,
   streamWritable: (channel: channels.WritableStreamChannel) => Writable,
-  zodToJsonSchema: (schema: any) => any,
   zones: { empty: Zone, current: () => Zone; };
 };
 
@@ -118,10 +117,6 @@ export const emptyPlatform: Platform = {
 
   streamWritable: (channel: channels.WritableStreamChannel) => {
     throw new Error('Streams are not available');
-  },
-
-  zodToJsonSchema: (schema: any) => {
-    throw new Error('Zod is not available');
   },
 
   zones: { empty: noopZone, current: () => noopZone },

--- a/packages/playwright-core/src/mcpBundle.ts
+++ b/packages/playwright-core/src/mcpBundle.ts
@@ -31,7 +31,6 @@ const ListRootsRequestSchema: typeof import('@modelcontextprotocol/sdk/types.js'
 const ProgressNotificationSchema: typeof import('@modelcontextprotocol/sdk/types.js').ProgressNotificationSchema = bundle.ProgressNotificationSchema;
 const ListToolsRequestSchema: typeof import('@modelcontextprotocol/sdk/types.js').ListToolsRequestSchema = bundle.ListToolsRequestSchema;
 const PingRequestSchema: typeof import('@modelcontextprotocol/sdk/types.js').PingRequestSchema = bundle.PingRequestSchema;
-const z: typeof import('zod') = bundle.z;
 
 export {
   zodToJsonSchema,
@@ -48,5 +47,4 @@ export {
   ListToolsRequestSchema,
   PingRequestSchema,
   ProgressNotificationSchema,
-  z,
 };

--- a/packages/playwright-core/src/server/utils/DEPS.list
+++ b/packages/playwright-core/src/server/utils/DEPS.list
@@ -1,5 +1,6 @@
 [*]
 ../../mcpBundle.ts
+../../zodBundle.ts
 ../../utils
 ../../utils/isomorphic
 ../../utilsBundle.ts

--- a/packages/playwright-core/src/server/utils/nodePlatform.ts
+++ b/packages/playwright-core/src/server/utils/nodePlatform.ts
@@ -25,9 +25,6 @@ import { colors } from '../../utilsBundle';
 import { debugLogger } from './debugLogger';
 import { currentZone, emptyZone } from './zones';
 import { debugMode, isUnderTest } from './debug';
-import { zodToJsonSchema as zodToJsonSchemaV3, z } from '../../mcpBundle';
-import type zod3 from 'zod/v3';
-import type zod4 from 'zod';
 
 import type { Platform, Zone } from '../../client/platform';
 import type { Zone as ZoneImpl } from './zones';
@@ -124,13 +121,6 @@ export const nodePlatform: Platform = {
 
   streamWritable: (channel: channels.WritableStreamChannel) => {
     return new WritableStreamImpl(channel);
-  },
-
-  zodToJsonSchema: (schema: zod3.Schema | zod4.Schema): any => {
-    // https://zod.dev/library-authors?id=how-to-support-zod-3-and-zod-4-simultaneously
-    if ('_zod' in schema)
-      return z.toJSONSchema(schema);
-    return zodToJsonSchemaV3(schema);
   },
 
   zones: {

--- a/packages/playwright-core/src/tools/backend/DEPS.list
+++ b/packages/playwright-core/src/tools/backend/DEPS.list
@@ -2,6 +2,7 @@
 ../../..
 ../..
 ../../mcpBundle.ts
+../../zodBundle.ts
 ../../server/utils/
 ../../utils/
 ../../utils/isomorphic/

--- a/packages/playwright-core/src/tools/backend/common.ts
+++ b/packages/playwright-core/src/tools/backend/common.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool, defineTool } from './tool';
 import { renderTabsMarkdown } from './response';
 

--- a/packages/playwright-core/src/tools/backend/console.ts
+++ b/packages/playwright-core/src/tools/backend/console.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 const console = defineTabTool({

--- a/packages/playwright-core/src/tools/backend/cookies.ts
+++ b/packages/playwright-core/src/tools/backend/cookies.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 const cookieList = defineTool({

--- a/packages/playwright-core/src/tools/backend/devtools.ts
+++ b/packages/playwright-core/src/tools/backend/devtools.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 const resume = defineTool({

--- a/packages/playwright-core/src/tools/backend/dialogs.ts
+++ b/packages/playwright-core/src/tools/backend/dialogs.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 export const handleDialog = defineTabTool({

--- a/packages/playwright-core/src/tools/backend/evaluate.ts
+++ b/packages/playwright-core/src/tools/backend/evaluate.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
 
 import { defineTabTool } from './tool';

--- a/packages/playwright-core/src/tools/backend/files.ts
+++ b/packages/playwright-core/src/tools/backend/files.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 export const uploadFile = defineTabTool({

--- a/packages/playwright-core/src/tools/backend/form.ts
+++ b/packages/playwright-core/src/tools/backend/form.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
 
 import { defineTabTool } from './tool';

--- a/packages/playwright-core/src/tools/backend/keyboard.ts
+++ b/packages/playwright-core/src/tools/backend/keyboard.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 import { elementSchema } from './snapshot';
 

--- a/packages/playwright-core/src/tools/backend/mouse.ts
+++ b/packages/playwright-core/src/tools/backend/mouse.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { formatObjectOrVoid } from '../../utils/isomorphic/stringUtils';
 import { defineTabTool } from './tool';
 

--- a/packages/playwright-core/src/tools/backend/navigate.ts
+++ b/packages/playwright-core/src/tools/backend/navigate.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool, defineTabTool } from './tool';
 
 const navigate = defineTool({

--- a/packages/playwright-core/src/tools/backend/network.ts
+++ b/packages/playwright-core/src/tools/backend/network.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool, defineTabTool } from './tool';
 
 import type * as playwright from '../../..';

--- a/packages/playwright-core/src/tools/backend/pdf.ts
+++ b/packages/playwright-core/src/tools/backend/pdf.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { formatObject } from '../../utils/isomorphic/stringUtils';
 
 import { defineTabTool } from './tool';

--- a/packages/playwright-core/src/tools/backend/route.ts
+++ b/packages/playwright-core/src/tools/backend/route.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 import type * as playwright from '../../..';

--- a/packages/playwright-core/src/tools/backend/runCode.ts
+++ b/packages/playwright-core/src/tools/backend/runCode.ts
@@ -19,7 +19,7 @@ import vm from 'vm';
 
 import { ManualPromise } from '../../utils/isomorphic/manualPromise';
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 const codeSchema = z.object({

--- a/packages/playwright-core/src/tools/backend/screenshot.ts
+++ b/packages/playwright-core/src/tools/backend/screenshot.ts
@@ -18,7 +18,7 @@ import { scaleImageToSize } from '../../utils/isomorphic/imageUtils';
 import { jpegjs, PNG } from '../../utilsBundle';
 import { formatObject } from '../../utils/isomorphic/stringUtils';
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 import type * as playwright from '../../..';

--- a/packages/playwright-core/src/tools/backend/snapshot.ts
+++ b/packages/playwright-core/src/tools/backend/snapshot.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { formatObject, formatObjectOrVoid } from '../../utils/isomorphic/stringUtils';
 
 import { defineTabTool, defineTool } from './tool';

--- a/packages/playwright-core/src/tools/backend/storage.ts
+++ b/packages/playwright-core/src/tools/backend/storage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 const storageState = defineTool({

--- a/packages/playwright-core/src/tools/backend/tabs.ts
+++ b/packages/playwright-core/src/tools/backend/tabs.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 import { renderTabsMarkdown } from './response';
 

--- a/packages/playwright-core/src/tools/backend/tools.ts
+++ b/packages/playwright-core/src/tools/backend/tools.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 
 import common from './common';
 import config from './config';

--- a/packages/playwright-core/src/tools/backend/tracing.ts
+++ b/packages/playwright-core/src/tools/backend/tracing.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 

--- a/packages/playwright-core/src/tools/backend/verify.ts
+++ b/packages/playwright-core/src/tools/backend/verify.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
 
 import { defineTabTool } from './tool';

--- a/packages/playwright-core/src/tools/backend/video.ts
+++ b/packages/playwright-core/src/tools/backend/video.ts
@@ -15,7 +15,7 @@
  */
 
 import path from 'path';
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 const startVideo = defineTool({

--- a/packages/playwright-core/src/tools/backend/wait.ts
+++ b/packages/playwright-core/src/tools/backend/wait.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 const wait = defineTool({

--- a/packages/playwright-core/src/tools/backend/webstorage.ts
+++ b/packages/playwright-core/src/tools/backend/webstorage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 const localStorageList = defineTabTool({

--- a/packages/playwright-core/src/tools/cli-daemon/DEPS.list
+++ b/packages/playwright-core/src/tools/cli-daemon/DEPS.list
@@ -6,5 +6,6 @@
 ../../utilsBundle.ts
 ../../utils/
 ../../mcpBundle.ts
+../../zodBundle.ts
 ../../server/utils/
 ../../serverRegistry.ts

--- a/packages/playwright-core/src/tools/cli-daemon/command.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/command.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 
 import type zodType from 'zod';
 

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { declareCommand } from './command';
 
 import type { AnyCommandSchema } from './command';

--- a/packages/playwright-core/src/tools/cli-daemon/helpGenerator.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/helpGenerator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 
 import { commands } from './commands';
 

--- a/packages/playwright-core/src/tools/trace/traceCli.ts
+++ b/packages/playwright-core/src/tools/trace/traceCli.ts
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-import { traceOpen } from './traceOpen';
-import { traceActions, traceAction } from './traceActions';
-import { traceRequests, traceRequest } from './traceRequests';
-import { traceConsole } from './traceConsole';
-import { traceErrors } from './traceErrors';
-import { traceSnapshot } from './traceSnapshot';
-import { traceScreenshot } from './traceScreenshot';
-import { traceAttachments, traceAttachment } from './traceAttachments';
-import { installSkill } from './installSkill';
-
 import type { Command } from '../../utilsBundle';
 
 export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) => void) {
@@ -35,6 +25,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .command('open <trace>')
       .description('extract trace file for inspection')
       .action((trace: string) => {
+        const { traceOpen } = require('./traceOpen');
         traceOpen(trace).catch(logErrorAndExit);
       });
 
@@ -44,6 +35,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .option('--grep <pattern>', 'filter actions by title pattern')
       .option('--errors-only', 'only show failed actions')
       .action((options: { grep?: string, errorsOnly?: boolean }) => {
+        const { traceActions } = require('./traceActions');
         traceActions(options).catch(logErrorAndExit);
       });
 
@@ -51,6 +43,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .command('action <action-id>')
       .description('show details of a specific action')
       .action((actionId: string) => {
+        const { traceAction } = require('./traceActions');
         traceAction(actionId).catch(logErrorAndExit);
       });
 
@@ -62,6 +55,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .option('--status <code>', 'filter by status code')
       .option('--failed', 'only show failed requests (status >= 400)')
       .action((options: { grep?: string, method?: string, status?: string, failed?: boolean }) => {
+        const { traceRequests } = require('./traceRequests');
         traceRequests(options).catch(logErrorAndExit);
       });
 
@@ -69,6 +63,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .command('request <request-id>')
       .description('show details of a specific network request')
       .action((requestId: string) => {
+        const { traceRequest } = require('./traceRequests');
         traceRequest(requestId).catch(logErrorAndExit);
       });
 
@@ -80,6 +75,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .option('--browser', 'only browser console messages')
       .option('--stdio', 'only stdout/stderr')
       .action((options: { errorsOnly?: boolean, warnings?: boolean, browser?: boolean, stdio?: boolean }) => {
+        const { traceConsole } = require('./traceConsole');
         traceConsole(options).catch(logErrorAndExit);
       });
 
@@ -87,6 +83,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .command('errors')
       .description('show errors with stack traces')
       .action(() => {
+        const { traceErrors } = require('./traceErrors');
         traceErrors().catch(logErrorAndExit);
       });
 
@@ -99,6 +96,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .allowExcessArguments(true)
       .action(async (actionId: string, options: { name?: string, serve?: boolean }, cmd: Command) => {
         try {
+          const { traceSnapshot } = require('./traceSnapshot');
           // Collect everything after '--' as the browser command.
           const browserArgs = cmd.args.slice(1);
           await traceSnapshot(actionId, { ...options, browserArgs });
@@ -112,6 +110,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .description('save screencast screenshot for an action')
       .option('-o, --output <path>', 'output file path')
       .action((actionId: string, options: { output?: string }) => {
+        const { traceScreenshot } = require('./traceScreenshot');
         traceScreenshot(actionId, options).catch(logErrorAndExit);
       });
 
@@ -119,6 +118,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .command('attachments')
       .description('list trace attachments')
       .action(() => {
+        const { traceAttachments } = require('./traceAttachments');
         traceAttachments().catch(logErrorAndExit);
       });
 
@@ -127,6 +127,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .description('extract a trace attachment by its number')
       .option('-o, --output <path>', 'output file path')
       .action((attachmentId: string, options: { output?: string }) => {
+        const { traceAttachment } = require('./traceAttachments');
         traceAttachment(attachmentId, options).catch(logErrorAndExit);
       });
 
@@ -134,6 +135,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .command('install-skill')
       .description('install SKILL.md for LLM integration')
       .action(() => {
+        const { installSkill } = require('./installSkill');
         installSkill().catch(logErrorAndExit);
       });
 }

--- a/packages/playwright-core/src/tools/utils/mcp/DEPS.list
+++ b/packages/playwright-core/src/tools/utils/mcp/DEPS.list
@@ -1,4 +1,5 @@
 [*]
 ../../../mcpBundle.ts
+../../../zodBundle.ts
 ../../../utilsBundle.ts
 ../../../server/utils/network.ts

--- a/packages/playwright-core/src/tools/utils/mcp/tool.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/tool.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z as zod } from '../../../mcpBundle';
+import { z as zod } from '../../../zodBundle';
 import type { z } from 'zod';
 import type * as mcpServer from './server';
 

--- a/packages/playwright-core/src/zodBundle.ts
+++ b/packages/playwright-core/src/zodBundle.ts
@@ -14,25 +14,4 @@
  * limitations under the License.
  */
 
-import { z } from '../../zodBundle';
-import { defineTool } from './tool';
-
-const configShow = defineTool({
-  capability: 'config',
-
-  schema: {
-    name: 'browser_get_config',
-    title: 'Get config',
-    description: 'Get the final resolved config after merging CLI options, environment variables and config file.',
-    inputSchema: z.object({}),
-    type: 'readOnly',
-  },
-
-  handle: async (context, params, response) => {
-    response.addTextResult(JSON.stringify(context.config, null, 2));
-  },
-});
-
-export default [
-  configShow,
-];
+export const z: typeof import('zod') = require('./zodBundleImpl').z;

--- a/packages/playwright/src/DEPS.list
+++ b/packages/playwright/src/DEPS.list
@@ -6,6 +6,18 @@ common/
 [program.ts]
 **
 
+[testCommand.ts]
+**
+
+[mergeReportsCommand.ts]
+**
+
+[mcpServerCommand.ts]
+**
+
+[initAgentsCommand.ts]
+**
+
 [index.ts]
 @testIsomorphic/**
 ./prompt.ts

--- a/packages/playwright/src/common/validators.ts
+++ b/packages/playwright/src/common/validators.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z as zod } from 'playwright-core/lib/mcpBundle';
+import { z as zod } from 'playwright-core/lib/zodBundle';
 
 import type { TestAnnotation, TestDetailsAnnotation } from '../../types/test';
 import type { Location } from '../../types/testReporter';

--- a/packages/playwright/src/initAgentsCommand.ts
+++ b/packages/playwright/src/initAgentsCommand.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { loadConfigFromFile } from './common/configLoader';
+import { ClaudeGenerator, OpencodeGenerator, VSCodeGenerator, CopilotGenerator } from './agents/generateAgents';
+
+export async function initAgents(opts: { [key: string]: any }) {
+  const config = await loadConfigFromFile(opts.config);
+  if (opts.loop === 'opencode') {
+    await OpencodeGenerator.init(config, opts.project, opts.prompts);
+  } else if (opts.loop === 'vscode-legacy') {
+    await VSCodeGenerator.init(config, opts.project);
+  } else if (opts.loop === 'claude') {
+    await ClaudeGenerator.init(config, opts.project, opts.prompts);
+  } else {
+    await CopilotGenerator.init(config, opts.project, opts.prompts);
+    return;
+  }
+}

--- a/packages/playwright/src/mcp/test/generatorTools.ts
+++ b/packages/playwright/src/mcp/test/generatorTools.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { z } from 'playwright-core/lib/mcpBundle';
+import { z } from 'playwright-core/lib/zodBundle';
 import { defineTestTool } from './testTool';
 import { GeneratorJournal } from './testContext';
 

--- a/packages/playwright/src/mcp/test/plannerTools.ts
+++ b/packages/playwright/src/mcp/test/plannerTools.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { z } from 'playwright-core/lib/mcpBundle';
+import { z } from 'playwright-core/lib/zodBundle';
 import { defineTestTool } from './testTool';
 
 export const setupPage = defineTestTool({

--- a/packages/playwright/src/mcp/test/testBackend.ts
+++ b/packages/playwright/src/mcp/test/testBackend.ts
@@ -16,7 +16,7 @@
 
 import EventEmitter from 'events';
 
-import { z as zod } from 'playwright-core/lib/mcpBundle';
+import { z as zod } from 'playwright-core/lib/zodBundle';
 import * as mcp from 'playwright-core/lib/tools/exports';
 import { browserTools } from 'playwright-core/lib/tools/exports';
 

--- a/packages/playwright/src/mcp/test/testTools.ts
+++ b/packages/playwright/src/mcp/test/testTools.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from 'playwright-core/lib/mcpBundle';
+import { z } from 'playwright-core/lib/zodBundle';
 import ListModeReporter from '../../reporters/listModeReporter';
 import { defineTestTool } from './testTool';
 

--- a/packages/playwright/src/mcpServerCommand.ts
+++ b/packages/playwright/src/mcpServerCommand.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as tools from 'playwright-core/lib/tools/exports';
+import { setupExitWatchdog } from 'playwright-core/lib/tools/exports';
+
+import { TestServerBackend, testServerBackendTools } from './mcp/test/testBackend';
+
+const packageJSON = require('../package.json');
+
+export async function runTestMCPServer(options: { config?: string, headless?: boolean, host?: string, port?: string }) {
+  setupExitWatchdog();
+  const factory: tools.ServerBackendFactory = {
+    name: 'Playwright Test Runner',
+    nameInConfig: 'playwright-test-runner',
+    version: packageJSON.version,
+    toolSchemas: testServerBackendTools.map(tool => tool.schema),
+    create: async () => new TestServerBackend(options.config, { muteConsole: options.port === undefined, headless: options.headless }),
+    disposed: async () => { }
+  };
+  // TODO: add all options from mcp.startHttpServer.
+  await tools.start(factory, { port: options.port === undefined ? undefined : +options.port, host: options.host });
+}

--- a/packages/playwright/src/mergeReportsCommand.ts
+++ b/packages/playwright/src/mergeReportsCommand.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { gracefullyProcessExitDoNotHang } from 'playwright-core/lib/utils';
+
+import { builtInReporters, defaultReporter } from './common/config';
+import { loadConfigFromFile, loadEmptyConfigForMergeReports } from './common/configLoader';
+import { createMergedReport } from './reporters/merge';
+
+import type { ReporterDescription } from '../types/test';
+
+export async function mergeReports(reportDir: string | undefined, opts: { [key: string]: any }) {
+  const configFile = opts.config;
+  const config = configFile ? await loadConfigFromFile(configFile) : await loadEmptyConfigForMergeReports();
+
+  const dir = path.resolve(process.cwd(), reportDir || '');
+  const dirStat = await fs.promises.stat(dir).catch(e => null);
+  if (!dirStat)
+    throw new Error('Directory does not exist: ' + dir);
+  if (!dirStat.isDirectory())
+    throw new Error(`"${dir}" is not a directory`);
+  let reporterDescriptions: ReporterDescription[] | undefined = resolveReporterOption(opts.reporter);
+  if (!reporterDescriptions && configFile)
+    reporterDescriptions = config.config.reporter;
+  if (!reporterDescriptions)
+    reporterDescriptions = [[defaultReporter]];
+  const rootDirOverride = configFile ? config.config.rootDir : undefined;
+  await createMergedReport(config, dir, reporterDescriptions!, rootDirOverride);
+  gracefullyProcessExitDoNotHang(0);
+}
+
+function resolveReporterOption(reporter?: string): ReporterDescription[] | undefined {
+  if (!reporter || !reporter.length)
+    return undefined;
+  return reporter.split(',').map((r: string) => [resolveReporter(r)]);
+}
+
+function resolveReporter(id: string) {
+  if (builtInReporters.includes(id as any))
+    return id;
+  const localPath = path.resolve(process.cwd(), id);
+  if (fs.existsSync(localPath))
+    return localPath;
+  return require.resolve(id, { paths: [process.cwd()] });
+}

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -16,34 +16,14 @@
 
 /* eslint-disable no-console */
 
-import fs from 'fs';
-import path from 'path';
-
 import { program } from 'playwright-core/lib/cli/program';
-import { gracefullyProcessExitDoNotHang, startProfiling, stopProfiling } from 'playwright-core/lib/utils';
-import * as tools from 'playwright-core/lib/tools/exports';
-import { setupExitWatchdog } from 'playwright-core/lib/tools/exports';
+import { gracefullyProcessExitDoNotHang } from 'playwright-core/lib/utils';
 
 import { builtInReporters, defaultReporter, defaultTimeout } from './common/config';
-import { loadConfigFromFile, loadEmptyConfigForMergeReports, resolveConfigLocation } from './common/configLoader';
 export { program } from 'playwright-core/lib/cli/program';
-import { terminalScreen } from './reporters/base';
-import { showHTMLReport } from './reporters/html';
-import { createMergedReport } from './reporters/merge';
-import { filterProjects } from './runner/projectUtils';
-import * as testServer from './runner/testServer';
-import { runWatchModeLoop } from './runner/watchMode';
-import { runAllTestsWithConfig, TestRunner } from './runner/testRunner';
-import { createErrorCollectingReporter } from './runner/reporters';
-import { TestServerBackend, testServerBackendTools } from './mcp/test/testBackend';
-import { ClaudeGenerator, OpencodeGenerator, VSCodeGenerator, CopilotGenerator } from './agents/generateAgents';
 
-import type { ConfigCLIOverrides } from './common/ipc';
 import type { TraceMode } from '../types/test';
-import type { ReporterDescription } from '../types/test';
 import type { Command } from 'playwright-core/lib/utilsBundle';
-
-const packageJSON = require('../package.json');
 
 function addTestCommand(program: Command) {
   const command = program.command('test [test-filter...]');
@@ -62,6 +42,7 @@ function addTestCommand(program: Command) {
   });
   command.action(async (args, opts) => {
     try {
+      const { runTests } = require('./testCommand');
       await runTests(args, opts);
     } catch (e) {
       console.error(e);
@@ -84,6 +65,10 @@ function addClearCacheCommand(program: Command) {
   command.description('clears build and test caches');
   command.option('-c, --config <file>', `Configuration file, or a test directory with optional "playwright.config.{m,c}?{js,ts}"`);
   command.action(async opts => {
+    const { resolveConfigLocation } = require('./common/configLoader');
+    const { TestRunner } = require('./runner/testRunner');
+    const { createErrorCollectingReporter } = require('./runner/reporters');
+    const { terminalScreen } = require('./reporters/base');
     const runner = new TestRunner(resolveConfigLocation(opts.config), {});
     const { status } = await runner.clearCache(createErrorCollectingReporter(terminalScreen));
     const exitCode = status === 'interrupted' ? 130 : (status === 'passed' ? 0 : 1);
@@ -96,6 +81,10 @@ function addDevServerCommand(program: Command) {
   command.description('start dev server');
   command.option('-c, --config <file>', `Configuration file, or a test directory with optional "playwright.config.{m,c}?{js,ts}"`);
   command.action(async options => {
+    const { resolveConfigLocation } = require('./common/configLoader');
+    const { TestRunner } = require('./runner/testRunner');
+    const { createErrorCollectingReporter } = require('./runner/reporters');
+    const { terminalScreen } = require('./reporters/base');
     const runner = new TestRunner(resolveConfigLocation(options.config), {});
     await runner.startDevServer(createErrorCollectingReporter(terminalScreen), 'in-process');
   });
@@ -107,13 +96,23 @@ function addTestServerCommand(program: Command) {
   command.option('-c, --config <file>', `Configuration file, or a test directory with optional "playwright.config.{m,c}?{js,ts}"`);
   command.option('--host <host>', 'Host to start the server on', 'localhost');
   command.option('--port <port>', 'Port to start the server on', '0');
-  command.action(opts => runTestServer(opts));
+  command.action(async opts => {
+    const testServer = require('./runner/testServer');
+    const host = opts.host;
+    const port = opts.port ? +opts.port : undefined;
+    const status = await testServer.runTestServer(opts.config, { }, { host, port });
+    const exitCode = status === 'interrupted' ? 130 : (status === 'passed' ? 0 : 1);
+    gracefullyProcessExitDoNotHang(exitCode);
+  });
 }
 
 function addShowReportCommand(program: Command) {
   const command = program.command('show-report [report]');
   command.description('show HTML report');
-  command.action((report, options) => showHTMLReport(report, options.host, +options.port));
+  command.action((report, options) => {
+    const { showHTMLReport } = require('./reporters/html');
+    showHTMLReport(report, options.host, +options.port);
+  });
   command.option('--host <host>', 'Host to serve report on', 'localhost');
   command.option('--port <port>', 'Port to serve report on', '9323');
   command.addHelpText('afterAll', `
@@ -130,6 +129,7 @@ function addMergeReportsCommand(program: Command) {
   command.description('merge multiple blob reports (for sharded tests) into a single report');
   command.action(async (dir, options) => {
     try {
+      const { mergeReports } = require('./mergeReportsCommand');
       await mergeReports(dir, options);
     } catch (e) {
       console.error(e);
@@ -154,17 +154,8 @@ function addTestMCPServerCommand(program: Command) {
   command.option('--host <host>', 'host to bind server to. Default is localhost. Use 0.0.0.0 to bind to all interfaces.');
   command.option('--port <port>', 'port to listen on for SSE transport.');
   command.action(async options => {
-    setupExitWatchdog();
-    const factory: tools.ServerBackendFactory = {
-      name: 'Playwright Test Runner',
-      nameInConfig: 'playwright-test-runner',
-      version: packageJSON.version,
-      toolSchemas: testServerBackendTools.map(tool => tool.schema),
-      create: async () => new TestServerBackend(options.config, { muteConsole: options.port === undefined, headless: options.headless }),
-      disposed: async () => { }
-    };
-    // TODO: add all options from mcp.startHttpServer.
-    await tools.start(factory, { port: options.port === undefined ? undefined : +options.port, host: options.host });
+    const { runTestMCPServer } = require('./mcpServerCommand');
+    await runTestMCPServer(options);
   });
 }
 
@@ -178,221 +169,9 @@ function addInitAgentsCommand(program: Command) {
   command.option('--project <project>', 'Project to use for seed test');
   command.option('--prompts', 'Whether to include prompts in the agent initialization');
   command.action(async opts => {
-    const config = await loadConfigFromFile(opts.config);
-    if (opts.loop === 'opencode') {
-      await OpencodeGenerator.init(config, opts.project, opts.prompts);
-    } else if (opts.loop === 'vscode-legacy') {
-      await VSCodeGenerator.init(config, opts.project);
-    } else if (opts.loop === 'claude') {
-      await ClaudeGenerator.init(config, opts.project, opts.prompts);
-    } else {
-      await CopilotGenerator.init(config, opts.project, opts.prompts);
-      return;
-    }
+    const { initAgents } = require('./initAgentsCommand');
+    await initAgents(opts);
   });
-}
-
-async function runTests(args: string[], opts: { [key: string]: any }) {
-  await startProfiling();
-  const cliOverrides = overridesFromOptions(opts);
-
-  const config = await loadConfigFromFile(opts.config, cliOverrides, opts.deps === false);
-  config.cliArgs = args;
-  config.cliGrep = opts.grep as string | undefined;
-  config.cliOnlyChanged = opts.onlyChanged === true ? 'HEAD' : opts.onlyChanged;
-  config.cliGrepInvert = opts.grepInvert as string | undefined;
-  config.cliListOnly = !!opts.list;
-  config.cliProjectFilter = opts.project || undefined;
-  config.cliPassWithNoTests = !!opts.passWithNoTests;
-  config.cliLastFailed = !!opts.lastFailed;
-  config.cliTestList = opts.testList ? path.resolve(process.cwd(), opts.testList) : undefined;
-  config.cliTestListInvert = opts.testListInvert ? path.resolve(process.cwd(), opts.testListInvert) : undefined;
-
-  // Evaluate project filters against config before starting execution. This enables a consistent error message across run modes
-  filterProjects(config.projects, config.cliProjectFilter);
-
-  if (opts.ui || opts.uiHost || opts.uiPort) {
-    if (opts.onlyChanged)
-      throw new Error(`--only-changed is not supported in UI mode. If you'd like that to change, see https://github.com/microsoft/playwright/issues/15075 for more details.`);
-
-    const status = await testServer.runUIMode(opts.config, cliOverrides, {
-      host: opts.uiHost,
-      port: opts.uiPort ? +opts.uiPort : undefined,
-      args,
-      grep: opts.grep as string | undefined,
-      grepInvert: opts.grepInvert as string | undefined,
-      project: opts.project || undefined,
-      reporter: Array.isArray(opts.reporter) ? opts.reporter : opts.reporter ? [opts.reporter] : undefined,
-    });
-    await stopProfiling('runner');
-    const exitCode = status === 'interrupted' ? 130 : (status === 'passed' ? 0 : 1);
-    gracefullyProcessExitDoNotHang(exitCode);
-    return;
-  }
-
-  if (process.env.PWTEST_WATCH) {
-    if (opts.onlyChanged)
-      throw new Error(`--only-changed is not supported in watch mode. If you'd like that to change, file an issue and let us know about your usecase for it.`);
-
-    const status = await runWatchModeLoop(
-        resolveConfigLocation(opts.config),
-        {
-          projects: opts.project,
-          files: args,
-          grep: opts.grep
-        }
-    );
-    await stopProfiling('runner');
-    const exitCode = status === 'interrupted' ? 130 : (status === 'passed' ? 0 : 1);
-    gracefullyProcessExitDoNotHang(exitCode);
-    return;
-  }
-
-  const status = await runAllTestsWithConfig(config);
-  await stopProfiling('runner');
-  const exitCode = status === 'interrupted' ? 130 : (status === 'passed' ? 0 : 1);
-  gracefullyProcessExitDoNotHang(exitCode);
-}
-
-async function runTestServer(opts: { [key: string]: any }) {
-  const host = opts.host;
-  const port = opts.port ? +opts.port : undefined;
-  const status = await testServer.runTestServer(opts.config, { }, { host, port });
-  const exitCode = status === 'interrupted' ? 130 : (status === 'passed' ? 0 : 1);
-  gracefullyProcessExitDoNotHang(exitCode);
-}
-
-async function mergeReports(reportDir: string | undefined, opts: { [key: string]: any }) {
-  const configFile = opts.config;
-  const config = configFile ? await loadConfigFromFile(configFile) : await loadEmptyConfigForMergeReports();
-
-  const dir = path.resolve(process.cwd(), reportDir || '');
-  const dirStat = await fs.promises.stat(dir).catch(e => null);
-  if (!dirStat)
-    throw new Error('Directory does not exist: ' + dir);
-  if (!dirStat.isDirectory())
-    throw new Error(`"${dir}" is not a directory`);
-  let reporterDescriptions: ReporterDescription[] | undefined = resolveReporterOption(opts.reporter);
-  if (!reporterDescriptions && configFile)
-    reporterDescriptions = config.config.reporter;
-  if (!reporterDescriptions)
-    reporterDescriptions = [[defaultReporter]];
-  const rootDirOverride = configFile ? config.config.rootDir : undefined;
-  await createMergedReport(config, dir, reporterDescriptions!, rootDirOverride);
-  gracefullyProcessExitDoNotHang(0);
-}
-
-function overridesFromOptions(options: { [key: string]: any }): ConfigCLIOverrides {
-  if (options.ui) {
-    options.debug = undefined;
-    options.trace = undefined;
-  }
-
-  const overrides: ConfigCLIOverrides = {
-    debug: options.debug,
-    failOnFlakyTests: options.failOnFlakyTests ? true : undefined,
-    forbidOnly: options.forbidOnly ? true : undefined,
-    fullyParallel: options.fullyParallel ? true : undefined,
-    globalTimeout: options.globalTimeout ? parseInt(options.globalTimeout, 10) : undefined,
-    maxFailures: options.x ? 1 : (options.maxFailures ? parseInt(options.maxFailures, 10) : undefined),
-    outputDir: options.output ? path.resolve(process.cwd(), options.output) : undefined,
-    pause: !!process.env.PWPAUSE,
-    quiet: options.quiet ? options.quiet : undefined,
-    repeatEach: options.repeatEach ? parseInt(options.repeatEach, 10) : undefined,
-    retries: options.retries ? parseInt(options.retries, 10) : undefined,
-    reporter: resolveReporterOption(options.reporter),
-    shard: resolveShardOption(options.shard),
-    shardWeights: resolveShardWeightsOption(),
-    timeout: options.timeout ? parseInt(options.timeout, 10) : undefined,
-    tsconfig: options.tsconfig ? path.resolve(process.cwd(), options.tsconfig) : undefined,
-    ignoreSnapshots: options.ignoreSnapshots ? !!options.ignoreSnapshots : undefined,
-    updateSnapshots: options.updateSnapshots,
-    updateSourceMethod: options.updateSourceMethod,
-    use: {
-      trace: options.trace,
-    },
-    workers: options.workers,
-  };
-
-  if (options.browser) {
-    const browserOpt = options.browser.toLowerCase();
-    if (!['all', 'chromium', 'firefox', 'webkit'].includes(browserOpt))
-      throw new Error(`Unsupported browser "${options.browser}", must be one of "all", "chromium", "firefox" or "webkit"`);
-    const browserNames = browserOpt === 'all' ? ['chromium', 'firefox', 'webkit'] : [browserOpt];
-    overrides.projects = browserNames.map(browserName => {
-      return {
-        name: browserName,
-        use: { browserName },
-      };
-    });
-  }
-
-  if (options.headed)
-    overrides.use.headless = false;
-  if (options.debug === 'inspector') {
-    overrides.use.headless = false;
-    process.env.PWDEBUG = '1';
-  }
-  if (overrides.tsconfig && !fs.existsSync(overrides.tsconfig))
-    throw new Error(`--tsconfig "${options.tsconfig}" does not exist`);
-
-  return overrides;
-}
-
-function resolveReporterOption(reporter?: string): ReporterDescription[] | undefined {
-  if (!reporter || !reporter.length)
-    return undefined;
-  return reporter.split(',').map((r: string) => [resolveReporter(r)]);
-}
-
-function resolveShardOption(shard?: string): ConfigCLIOverrides['shard'] {
-  if (!shard)
-    return undefined;
-
-  const shardPair = shard.split('/');
-
-  if (shardPair.length !== 2) {
-    throw new Error(
-        `--shard "${shard}", expected format is "current/all", 1-based, for example "3/5".`,
-    );
-  }
-
-  const current = parseInt(shardPair[0], 10);
-  const total = parseInt(shardPair[1], 10);
-
-  if (isNaN(total) || total < 1)
-    throw new Error(`--shard "${shard}" total must be a positive number`);
-
-
-  if (isNaN(current) || current < 1 || current > total) {
-    throw new Error(
-        `--shard "${shard}" current must be a positive number, not greater than shard total`,
-    );
-  }
-
-  return { current, total };
-}
-
-function resolveShardWeightsOption(): ConfigCLIOverrides['shardWeights'] {
-  const shardWeights = process.env.PWTEST_SHARD_WEIGHTS;
-  if (!shardWeights)
-    return undefined;
-
-  return shardWeights.split(':').map(w => {
-    const weight = parseInt(w, 10);
-    if (isNaN(weight) || weight < 0)
-      throw new Error(`PWTEST_SHARD_WEIGHTS="${shardWeights}" weights must be non-negative numbers`);
-    return weight;
-  });
-}
-
-function resolveReporter(id: string) {
-  if (builtInReporters.includes(id as any))
-    return id;
-  const localPath = path.resolve(process.cwd(), id);
-  if (fs.existsSync(localPath))
-    return localPath;
-  return require.resolve(id, { paths: [process.cwd()] });
 }
 
 const kTraceModes: TraceMode[] = ['on', 'off', 'on-first-retry', 'on-all-retries', 'retain-on-failure', 'retain-on-first-failure', 'retain-on-failure-and-retries'];

--- a/packages/playwright/src/testCommand.ts
+++ b/packages/playwright/src/testCommand.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { gracefullyProcessExitDoNotHang, startProfiling, stopProfiling } from 'playwright-core/lib/utils';
+
+import { loadConfigFromFile, resolveConfigLocation } from './common/configLoader';
+import { filterProjects } from './runner/projectUtils';
+import * as testServer from './runner/testServer';
+import { runWatchModeLoop } from './runner/watchMode';
+import { runAllTestsWithConfig } from './runner/testRunner';
+import { builtInReporters } from './common/config';
+
+import type { ConfigCLIOverrides } from './common/ipc';
+import type { ReporterDescription } from '../types/test';
+
+export async function runTests(args: string[], opts: { [key: string]: any }) {
+  await startProfiling();
+  const cliOverrides = overridesFromOptions(opts);
+
+  const config = await loadConfigFromFile(opts.config, cliOverrides, opts.deps === false);
+  config.cliArgs = args;
+  config.cliGrep = opts.grep as string | undefined;
+  config.cliOnlyChanged = opts.onlyChanged === true ? 'HEAD' : opts.onlyChanged;
+  config.cliGrepInvert = opts.grepInvert as string | undefined;
+  config.cliListOnly = !!opts.list;
+  config.cliProjectFilter = opts.project || undefined;
+  config.cliPassWithNoTests = !!opts.passWithNoTests;
+  config.cliLastFailed = !!opts.lastFailed;
+  config.cliTestList = opts.testList ? path.resolve(process.cwd(), opts.testList) : undefined;
+  config.cliTestListInvert = opts.testListInvert ? path.resolve(process.cwd(), opts.testListInvert) : undefined;
+
+  // Evaluate project filters against config before starting execution. This enables a consistent error message across run modes
+  filterProjects(config.projects, config.cliProjectFilter);
+
+  if (opts.ui || opts.uiHost || opts.uiPort) {
+    if (opts.onlyChanged)
+      throw new Error(`--only-changed is not supported in UI mode. If you'd like that to change, see https://github.com/microsoft/playwright/issues/15075 for more details.`);
+
+    const status = await testServer.runUIMode(opts.config, cliOverrides, {
+      host: opts.uiHost,
+      port: opts.uiPort ? +opts.uiPort : undefined,
+      args,
+      grep: opts.grep as string | undefined,
+      grepInvert: opts.grepInvert as string | undefined,
+      project: opts.project || undefined,
+      reporter: Array.isArray(opts.reporter) ? opts.reporter : opts.reporter ? [opts.reporter] : undefined,
+    });
+    await stopProfiling('runner');
+    const exitCode = status === 'interrupted' ? 130 : (status === 'passed' ? 0 : 1);
+    gracefullyProcessExitDoNotHang(exitCode);
+    return;
+  }
+
+  if (process.env.PWTEST_WATCH) {
+    if (opts.onlyChanged)
+      throw new Error(`--only-changed is not supported in watch mode. If you'd like that to change, file an issue and let us know about your usecase for it.`);
+
+    const status = await runWatchModeLoop(
+        resolveConfigLocation(opts.config),
+        {
+          projects: opts.project,
+          files: args,
+          grep: opts.grep
+        }
+    );
+    await stopProfiling('runner');
+    const exitCode = status === 'interrupted' ? 130 : (status === 'passed' ? 0 : 1);
+    gracefullyProcessExitDoNotHang(exitCode);
+    return;
+  }
+
+  const status = await runAllTestsWithConfig(config);
+  await stopProfiling('runner');
+  const exitCode = status === 'interrupted' ? 130 : (status === 'passed' ? 0 : 1);
+  gracefullyProcessExitDoNotHang(exitCode);
+}
+
+function overridesFromOptions(options: { [key: string]: any }): ConfigCLIOverrides {
+  if (options.ui) {
+    options.debug = undefined;
+    options.trace = undefined;
+  }
+
+  const overrides: ConfigCLIOverrides = {
+    debug: options.debug,
+    failOnFlakyTests: options.failOnFlakyTests ? true : undefined,
+    forbidOnly: options.forbidOnly ? true : undefined,
+    fullyParallel: options.fullyParallel ? true : undefined,
+    globalTimeout: options.globalTimeout ? parseInt(options.globalTimeout, 10) : undefined,
+    maxFailures: options.x ? 1 : (options.maxFailures ? parseInt(options.maxFailures, 10) : undefined),
+    outputDir: options.output ? path.resolve(process.cwd(), options.output) : undefined,
+    pause: !!process.env.PWPAUSE,
+    quiet: options.quiet ? options.quiet : undefined,
+    repeatEach: options.repeatEach ? parseInt(options.repeatEach, 10) : undefined,
+    retries: options.retries ? parseInt(options.retries, 10) : undefined,
+    reporter: resolveReporterOption(options.reporter),
+    shard: resolveShardOption(options.shard),
+    shardWeights: resolveShardWeightsOption(),
+    timeout: options.timeout ? parseInt(options.timeout, 10) : undefined,
+    tsconfig: options.tsconfig ? path.resolve(process.cwd(), options.tsconfig) : undefined,
+    ignoreSnapshots: options.ignoreSnapshots ? !!options.ignoreSnapshots : undefined,
+    updateSnapshots: options.updateSnapshots,
+    updateSourceMethod: options.updateSourceMethod,
+    use: {
+      trace: options.trace,
+    },
+    workers: options.workers,
+  };
+
+  if (options.browser) {
+    const browserOpt = options.browser.toLowerCase();
+    if (!['all', 'chromium', 'firefox', 'webkit'].includes(browserOpt))
+      throw new Error(`Unsupported browser "${options.browser}", must be one of "all", "chromium", "firefox" or "webkit"`);
+    const browserNames = browserOpt === 'all' ? ['chromium', 'firefox', 'webkit'] : [browserOpt];
+    overrides.projects = browserNames.map(browserName => {
+      return {
+        name: browserName,
+        use: { browserName },
+      };
+    });
+  }
+
+  if (options.headed)
+    overrides.use.headless = false;
+  if (options.debug === 'inspector') {
+    overrides.use.headless = false;
+    process.env.PWDEBUG = '1';
+  }
+  if (overrides.tsconfig && !fs.existsSync(overrides.tsconfig))
+    throw new Error(`--tsconfig "${options.tsconfig}" does not exist`);
+
+  return overrides;
+}
+
+function resolveReporterOption(reporter?: string): ReporterDescription[] | undefined {
+  if (!reporter || !reporter.length)
+    return undefined;
+  return reporter.split(',').map((r: string) => [resolveReporter(r)]);
+}
+
+function resolveShardOption(shard?: string): ConfigCLIOverrides['shard'] {
+  if (!shard)
+    return undefined;
+
+  const shardPair = shard.split('/');
+
+  if (shardPair.length !== 2) {
+    throw new Error(
+        `--shard "${shard}", expected format is "current/all", 1-based, for example "3/5".`,
+    );
+  }
+
+  const current = parseInt(shardPair[0], 10);
+  const total = parseInt(shardPair[1], 10);
+
+  if (isNaN(total) || total < 1)
+    throw new Error(`--shard "${shard}" total must be a positive number`);
+
+
+  if (isNaN(current) || current < 1 || current > total) {
+    throw new Error(
+        `--shard "${shard}" current must be a positive number, not greater than shard total`,
+    );
+  }
+
+  return { current, total };
+}
+
+function resolveShardWeightsOption(): ConfigCLIOverrides['shardWeights'] {
+  const shardWeights = process.env.PWTEST_SHARD_WEIGHTS;
+  if (!shardWeights)
+    return undefined;
+
+  return shardWeights.split(':').map(w => {
+    const weight = parseInt(w, 10);
+    if (isNaN(weight) || weight < 0)
+      throw new Error(`PWTEST_SHARD_WEIGHTS="${shardWeights}" weights must be non-negative numbers`);
+    return weight;
+  });
+}
+
+function resolveReporter(id: string) {
+  if (builtInReporters.includes(id as any))
+    return id;
+  const localPath = path.resolve(process.cwd(), id);
+  if (fs.existsSync(localPath))
+    return localPath;
+  return require.resolve(id, { paths: [process.cwd()] });
+}

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -276,6 +276,12 @@ bundles.push({
 });
 
 bundles.push({
+  modulePath: 'packages/playwright-core/bundles/zod',
+  outdir: 'packages/playwright-core/lib',
+  entryPoints: ['src/zodBundleImpl.ts'],
+});
+
+bundles.push({
   modulePath: 'packages/playwright-core/bundles/mcp',
   outfile: 'packages/playwright-core/lib/mcpBundleImpl/index.js',
   entryPoints: ['src/mcpBundleImpl.ts'],


### PR DESCRIPTION
## Summary
- Extract command handler bodies from `program.ts` into sibling files (`openCommands`, `installCommands`, `testCommand`, etc.) and lazy-load them via `require()` in action callbacks
- Make trace CLI sub-command actions lazy-load their implementations instead of importing at module level
- Split `zod` into a standalone bundle (`zodBundle`) separate from `mcpBundle` so `validators.ts` doesn't pull in the full MCP SDK