### PR TITLE
feat(electron): add artifactsDir option to electron.launch()

### DIFF
--- a/docs/src/api/class-electron.md
+++ b/docs/src/api/class-electron.md
@@ -140,5 +140,8 @@ Maximum time in milliseconds to wait for the application to start. Defaults to `
 ### option: Electron.launch.tracesDir = %%-browser-option-tracesdir-%%
 * since: v1.36
 
+### option: Electron.launch.artifactsDir = %%-browser-option-artifactsdir-%%
+* since: v1.59
+
 ### option: Electron.launch.chromiumSandbox = %%-browser-option-chromiumsandbox-%%
 * since: v1.59

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -19815,6 +19815,13 @@ export interface Electron {
     args?: Array<string>;
 
     /**
+     * If specified, artifacts (traces, videos, downloads, HAR files, etc.) are saved into this directory. The directory
+     * is not cleaned up when the browser closes. If not specified, a temporary directory is used and cleaned up when the
+     * browser closes.
+     */
+    artifactsDir?: string;
+
+    /**
      * Toggles bypassing page's Content-Security-Policy. Defaults to `false`.
      */
     bypassCSP?: boolean;

--- a/packages/playwright-core/src/client/electron.ts
+++ b/packages/playwright-core/src/client/electron.ts
@@ -61,6 +61,7 @@ export class Electron extends ChannelOwner<channels.ElectronChannel> implements 
       ...await prepareBrowserContextParams(this._platform, options),
       env: envObjectToArray(options.env ? options.env : this._platform.env),
       tracesDir: options.tracesDir,
+      artifactsDir: options.artifactsDir,
       timeout: new TimeoutSettings(this._platform).launchTimeout(options),
     };
     const app = ElectronApplication.from((await this._channel.launch(params)).electronApplication);

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -2689,6 +2689,7 @@ scheme.ElectronLaunchParams = tObject({
   strictSelectors: tOptional(tBoolean),
   timezoneId: tOptional(tString),
   tracesDir: tOptional(tString),
+  artifactsDir: tOptional(tString),
   selectorEngines: tOptional(tArray(tType('SelectorEngine'))),
   testIdAttributeName: tOptional(tString),
 });

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -164,7 +164,14 @@ export class Electron extends SdkObject {
         electronArguments.unshift('--no-sandbox');
     }
 
-    const artifactsDir = await progress.race(fs.promises.mkdtemp(ARTIFACTS_FOLDER));
+    let artifactsDir: string;
+    const tempDirectories: string[] = [];
+    if (options.artifactsDir) {
+      artifactsDir = options.artifactsDir;
+    } else {
+      artifactsDir = await progress.race(fs.promises.mkdtemp(ARTIFACTS_FOLDER));
+      tempDirectories.push(artifactsDir);
+    }
     const browserLogsCollector = new RecentLogsCollector();
     const env = options.env ? envArrayToObject(options.env) : process.env;
 
@@ -216,7 +223,7 @@ export class Electron extends SdkObject {
       shell,
       stdio: 'pipe',
       cwd: options.cwd,
-      tempDirectories: [artifactsDir],
+      tempDirectories,
       attemptToGracefullyClose: () => app!.close(),
       handleSIGINT: true,
       handleSIGTERM: true,

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -19815,6 +19815,13 @@ export interface Electron {
     args?: Array<string>;
 
     /**
+     * If specified, artifacts (traces, videos, downloads, HAR files, etc.) are saved into this directory. The directory
+     * is not cleaned up when the browser closes. If not specified, a temporary directory is used and cleaned up when the
+     * browser closes.
+     */
+    artifactsDir?: string;
+
+    /**
      * Toggles bypassing page's Content-Security-Policy. Defaults to `false`.
      */
     bypassCSP?: boolean;

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -4686,6 +4686,7 @@ export type ElectronLaunchParams = {
   strictSelectors?: boolean,
   timezoneId?: string,
   tracesDir?: string,
+  artifactsDir?: string,
   selectorEngines?: SelectorEngine[],
   testIdAttributeName?: string,
 };
@@ -4723,6 +4724,7 @@ export type ElectronLaunchOptions = {
   strictSelectors?: boolean,
   timezoneId?: string,
   tracesDir?: string,
+  artifactsDir?: string,
   selectorEngines?: SelectorEngine[],
   testIdAttributeName?: string,
 };

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -4184,6 +4184,7 @@ Electron:
         strictSelectors: boolean?
         timezoneId: string?
         tracesDir: string?
+        artifactsDir: string?
         selectorEngines:
           type: array?
           items: SelectorEngine

--- a/tests/electron/electron-app.spec.ts
+++ b/tests/electron/electron-app.spec.ts
@@ -339,3 +339,29 @@ test('should report downloads', async ({ launchElectronApp, electronMajorVersion
   expect(fs.readFileSync(path).toString()).toBe('Hello world');
   await app.close();
 });
+
+test('should save downloads to artifactsDir', async ({ launchElectronApp, electronMajorVersion, server }, testInfo) => {
+  server.setRoute('/download', (req, res) => {
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', 'attachment');
+    res.end(`Hello world`);
+  });
+
+  const artifactsDir = testInfo.outputPath('artifacts');
+  const app = await launchElectronApp('electron-window-app.js', [], {
+    acceptDownloads: true,
+    artifactsDir,
+  });
+  const window = await app.firstWindow();
+  await window.setContent(`<a href="${server.PREFIX}/download">download</a>`);
+  const [download] = await Promise.all([
+    window.waitForEvent('download'),
+    window.click('a')
+  ]);
+  const downloadPath = await download.path();
+  expect(downloadPath.startsWith(artifactsDir)).toBeTruthy();
+  expect(fs.existsSync(downloadPath)).toBeTruthy();
+  await app.close();
+  // User-provided artifactsDir should not be cleaned up.
+  expect(fs.existsSync(artifactsDir)).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- Add `artifactsDir` option to `electron.launch()`, mirroring the same option in `browserType.launch()`
- When specified, artifacts (downloads, traces, videos, etc.) are saved to the given directory and not cleaned up on close
- When not specified, a temporary directory is created and cleaned up as before