### PR TITLE
fix(mcp): validate file path in browser_set_storage_state tool

### DIFF
--- a/packages/playwright-core/src/tools/backend/storage.ts
+++ b/packages/playwright-core/src/tools/backend/storage.ts
@@ -55,7 +55,8 @@ const setStorageState = defineTool({
 
   handle: async (context, params, response) => {
     const browserContext = await context.ensureBrowserContext();
-    await browserContext.setStorageState(params.filename);
+    const resolvedFilename = await response.resolveClientFilename(params.filename);
+    await browserContext.setStorageState(resolvedFilename);
     response.addTextResult(`Storage state restored from ${params.filename}`);
     response.addCode(`await page.context().setStorageState('${params.filename}');`);
   },


### PR DESCRIPTION
## Summary
- `browser_set_storage_state` was passing the LLM-supplied filename directly to `browserContext.setStorageState()` without any path validation, allowing reads from arbitrary paths outside the workspace
- Fix resolves the filename through `response.resolveClientFilename()` which enforces the same `checkFile()` containment check used by all other file-access tools