### PR TITLE
chore(build): vendor zod bundle and refactor CLI into action modules

### DIFF
--- a/.claude/skills/playwright-dev/tools.md
+++ b/.claude/skills/playwright-dev/tools.md
@@ -9,7 +9,7 @@ Create `packages/playwright-core/src/tools/backend/<your-tool>.ts`.
 Import zod from the MCP bundle and use `defineTool` or `defineTabTool`:
 
 ```typescript
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool, defineTabTool } from './tool';
 ```
 
@@ -201,7 +201,7 @@ Implement the corresponding MCP tool first (see section above). CLI commands cal
 In `packages/playwright-core/src/tools/cli-daemon/commands.ts`, use `declareCommand()`:
 
 ```typescript
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { declareCommand } from './command';
 
 const myCommand = declareCommand({

--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -5,7 +5,7 @@ THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 This project incorporates components from the projects listed below. The original copyright notices and the licenses under which Microsoft received such components are set forth below. Microsoft reserves all rights not expressly granted herein, whether by implication, estoppel or otherwise.
 
 -	@hono/node-server@1.19.11 (https://github.com/honojs/node-server)
--	@modelcontextprotocol/sdk@1.26.0 (https://github.com/modelcontextprotocol/typescript-sdk)
+-	@modelcontextprotocol/sdk@1.28.0 (https://github.com/modelcontextprotocol/typescript-sdk)
 -	accepts@2.0.0 (https://github.com/jshttp/accepts)
 -	agent-base@7.1.4 (https://github.com/TooTallNate/proxy-agents)
 -	ajv-formats@3.0.1 (https://github.com/ajv-validator/ajv-formats)
@@ -136,7 +136,6 @@ This project incorporates components from the projects listed below. The origina
 -	yauzl@3.2.0 (https://github.com/thejoshwolfe/yauzl)
 -	yazl@2.5.1 (https://github.com/thejoshwolfe/yazl)
 -	zod-to-json-schema@3.25.1 (https://github.com/StefanTerdell/zod-to-json-schema)
--	zod@4.3.5 (https://github.com/colinhacks/zod)
 -	zod@4.3.6 (https://github.com/colinhacks/zod)
 
 %% @hono/node-server@1.19.11 NOTICES AND INFORMATION BEGIN HERE
@@ -165,7 +164,7 @@ SOFTWARE.
 =========================================
 END OF @hono/node-server@1.19.11 AND INFORMATION
 
-%% @modelcontextprotocol/sdk@1.26.0 NOTICES AND INFORMATION BEGIN HERE
+%% @modelcontextprotocol/sdk@1.28.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 MIT License
 
@@ -189,7 +188,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 =========================================
-END OF @modelcontextprotocol/sdk@1.26.0 AND INFORMATION
+END OF @modelcontextprotocol/sdk@1.28.0 AND INFORMATION
 
 %% accepts@2.0.0 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -3520,32 +3519,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 =========================================
 END OF zod-to-json-schema@3.25.1 AND INFORMATION
 
-%% zod@4.3.5 NOTICES AND INFORMATION BEGIN HERE
-=========================================
-MIT License
-
-Copyright (c) 2025 Colin McDonnell
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-=========================================
-END OF zod@4.3.5 AND INFORMATION
-
 %% zod@4.3.6 NOTICES AND INFORMATION BEGIN HERE
 =========================================
 MIT License
@@ -3574,6 +3547,6 @@ END OF zod@4.3.6 AND INFORMATION
 
 SUMMARY BEGIN HERE
 =========================================
-Total Packages: 134
+Total Packages: 133
 =========================================
 END OF SUMMARY

--- a/packages/playwright-core/ThirdPartyNotices.txt
+++ b/packages/playwright-core/ThirdPartyNotices.txt
@@ -137,6 +137,7 @@ This project incorporates components from the projects listed below. The origina
 -	yazl@2.5.1 (https://github.com/thejoshwolfe/yazl)
 -	zod-to-json-schema@3.25.1 (https://github.com/StefanTerdell/zod-to-json-schema)
 -	zod@4.3.5 (https://github.com/colinhacks/zod)
+-	zod@4.3.6 (https://github.com/colinhacks/zod)
 
 %% @hono/node-server@1.19.11 NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -3545,8 +3546,34 @@ SOFTWARE.
 =========================================
 END OF zod@4.3.5 AND INFORMATION
 
+%% zod@4.3.6 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+MIT License
+
+Copyright (c) 2025 Colin McDonnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF zod@4.3.6 AND INFORMATION
+
 SUMMARY BEGIN HERE
 =========================================
-Total Packages: 133
+Total Packages: 134
 =========================================
 END OF SUMMARY

--- a/packages/playwright-core/bundles/mcp/package-lock.json
+++ b/packages/playwright-core/bundles/mcp/package-lock.json
@@ -8,8 +8,8 @@
       "name": "mcp-bundle",
       "version": "0.0.1",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
-        "zod": "^4.3.5",
+        "@modelcontextprotocol/sdk": "^1.28.0",
+        "zod": "^4.3.6",
         "zod-to-json-schema": "^3.25.1"
       }
     },
@@ -26,9 +26,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
+      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1115,9 +1115,10 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/playwright-core/bundles/mcp/package.json
+++ b/packages/playwright-core/bundles/mcp/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
-    "zod": "^4.3.5",
+    "@modelcontextprotocol/sdk": "^1.28.0",
+    "zod": "^4.3.6",
     "zod-to-json-schema": "^3.25.1"
   }
 }

--- a/packages/playwright-core/bundles/mcp/src/mcpBundleImpl.ts
+++ b/packages/playwright-core/bundles/mcp/src/mcpBundleImpl.ts
@@ -23,5 +23,4 @@ export { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 export { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 export { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 export { CallToolRequestSchema, ListRootsRequestSchema, ListToolsRequestSchema, PingRequestSchema, ProgressNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
-export * as z from 'zod';
 export { zodToJsonSchema } from 'zod-to-json-schema';

--- a/packages/playwright-core/bundles/zod/package-lock.json
+++ b/packages/playwright-core/bundles/zod/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "zod-bundle",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zod-bundle",
+      "version": "0.0.1",
+      "dependencies": {
+        "zod": "^4.3.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/playwright-core/bundles/zod/package-lock.json
+++ b/packages/playwright-core/bundles/zod/package-lock.json
@@ -8,7 +8,7 @@
       "name": "zod-bundle",
       "version": "0.0.1",
       "dependencies": {
-        "zod": "^4.3.5"
+        "zod": "^4.3.6"
       }
     },
     "node_modules/zod": {

--- a/packages/playwright-core/bundles/zod/package.json
+++ b/packages/playwright-core/bundles/zod/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "zod": "^4.3.5"
+    "zod": "^4.3.6"
   }
 }

--- a/packages/playwright-core/bundles/zod/package.json
+++ b/packages/playwright-core/bundles/zod/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "zod-bundle",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "zod": "^4.3.5"
+  }
+}

--- a/packages/playwright-core/bundles/zod/src/zodBundleImpl.ts
+++ b/packages/playwright-core/bundles/zod/src/zodBundleImpl.ts
@@ -14,25 +14,4 @@
  * limitations under the License.
  */
 
-import { z } from '../../zodBundle';
-import { defineTool } from './tool';
-
-const configShow = defineTool({
-  capability: 'config',
-
-  schema: {
-    name: 'browser_get_config',
-    title: 'Get config',
-    description: 'Get the final resolved config after merging CLI options, environment variables and config file.',
-    inputSchema: z.object({}),
-    type: 'readOnly',
-  },
-
-  handle: async (context, params, response) => {
-    response.addTextResult(JSON.stringify(context.config, null, 2));
-  },
-});
-
-export default [
-  configShow,
-];
+export * as z from 'zod';

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -27,6 +27,7 @@
     "./lib/tools/cli-client/program": "./lib/tools/cli-client/program.js",
     "./lib/tools/mcp/program": "./lib/tools/mcp/program.js",
     "./lib/mcpBundle": "./lib/mcpBundle.js",
+    "./lib/zodBundle": "./lib/zodBundle.js",
     "./lib/tools/exports": "./lib/tools/exports.js",
     "./lib/remote/playwrightServer": "./lib/remote/playwrightServer.js",
     "./lib/server": "./lib/server/index.js",

--- a/packages/playwright-core/src/client/platform.ts
+++ b/packages/playwright-core/src/client/platform.ts
@@ -59,7 +59,6 @@ export type Platform = {
   streamFile: (path: string, writable: Writable) => Promise<void>,
   streamReadable: (channel: channels.StreamChannel) => Readable,
   streamWritable: (channel: channels.WritableStreamChannel) => Writable,
-  zodToJsonSchema: (schema: any) => any,
   zones: { empty: Zone, current: () => Zone; };
 };
 
@@ -118,10 +117,6 @@ export const emptyPlatform: Platform = {
 
   streamWritable: (channel: channels.WritableStreamChannel) => {
     throw new Error('Streams are not available');
-  },
-
-  zodToJsonSchema: (schema: any) => {
-    throw new Error('Zod is not available');
   },
 
   zones: { empty: noopZone, current: () => noopZone },

--- a/packages/playwright-core/src/mcpBundle.ts
+++ b/packages/playwright-core/src/mcpBundle.ts
@@ -31,7 +31,6 @@ const ListRootsRequestSchema: typeof import('@modelcontextprotocol/sdk/types.js'
 const ProgressNotificationSchema: typeof import('@modelcontextprotocol/sdk/types.js').ProgressNotificationSchema = bundle.ProgressNotificationSchema;
 const ListToolsRequestSchema: typeof import('@modelcontextprotocol/sdk/types.js').ListToolsRequestSchema = bundle.ListToolsRequestSchema;
 const PingRequestSchema: typeof import('@modelcontextprotocol/sdk/types.js').PingRequestSchema = bundle.PingRequestSchema;
-const z: typeof import('zod') = bundle.z;
 
 export {
   zodToJsonSchema,
@@ -48,5 +47,4 @@ export {
   ListToolsRequestSchema,
   PingRequestSchema,
   ProgressNotificationSchema,
-  z,
 };

--- a/packages/playwright-core/src/server/utils/DEPS.list
+++ b/packages/playwright-core/src/server/utils/DEPS.list
@@ -1,5 +1,6 @@
 [*]
 ../../mcpBundle.ts
+../../zodBundle.ts
 ../../utils
 ../../utils/isomorphic
 ../../utilsBundle.ts

--- a/packages/playwright-core/src/server/utils/nodePlatform.ts
+++ b/packages/playwright-core/src/server/utils/nodePlatform.ts
@@ -25,9 +25,6 @@ import { colors } from '../../utilsBundle';
 import { debugLogger } from './debugLogger';
 import { currentZone, emptyZone } from './zones';
 import { debugMode, isUnderTest } from './debug';
-import { zodToJsonSchema as zodToJsonSchemaV3, z } from '../../mcpBundle';
-import type zod3 from 'zod/v3';
-import type zod4 from 'zod';
 
 import type { Platform, Zone } from '../../client/platform';
 import type { Zone as ZoneImpl } from './zones';
@@ -124,13 +121,6 @@ export const nodePlatform: Platform = {
 
   streamWritable: (channel: channels.WritableStreamChannel) => {
     return new WritableStreamImpl(channel);
-  },
-
-  zodToJsonSchema: (schema: zod3.Schema | zod4.Schema): any => {
-    // https://zod.dev/library-authors?id=how-to-support-zod-3-and-zod-4-simultaneously
-    if ('_zod' in schema)
-      return z.toJSONSchema(schema);
-    return zodToJsonSchemaV3(schema);
   },
 
   zones: {

--- a/packages/playwright-core/src/tools/backend/DEPS.list
+++ b/packages/playwright-core/src/tools/backend/DEPS.list
@@ -1,7 +1,7 @@
 [*]
 ../../..
 ../..
-../../mcpBundle.ts
+../../zodBundle.ts
 ../../server/utils/
 ../../utils/
 ../../utils/isomorphic/

--- a/packages/playwright-core/src/tools/backend/common.ts
+++ b/packages/playwright-core/src/tools/backend/common.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool, defineTool } from './tool';
 import { renderTabsMarkdown } from './response';
 

--- a/packages/playwright-core/src/tools/backend/console.ts
+++ b/packages/playwright-core/src/tools/backend/console.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 const console = defineTabTool({

--- a/packages/playwright-core/src/tools/backend/cookies.ts
+++ b/packages/playwright-core/src/tools/backend/cookies.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 const cookieList = defineTool({

--- a/packages/playwright-core/src/tools/backend/devtools.ts
+++ b/packages/playwright-core/src/tools/backend/devtools.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 const resume = defineTool({

--- a/packages/playwright-core/src/tools/backend/dialogs.ts
+++ b/packages/playwright-core/src/tools/backend/dialogs.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 export const handleDialog = defineTabTool({

--- a/packages/playwright-core/src/tools/backend/evaluate.ts
+++ b/packages/playwright-core/src/tools/backend/evaluate.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
 
 import { defineTabTool } from './tool';

--- a/packages/playwright-core/src/tools/backend/files.ts
+++ b/packages/playwright-core/src/tools/backend/files.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 export const uploadFile = defineTabTool({

--- a/packages/playwright-core/src/tools/backend/form.ts
+++ b/packages/playwright-core/src/tools/backend/form.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
 
 import { defineTabTool } from './tool';

--- a/packages/playwright-core/src/tools/backend/keyboard.ts
+++ b/packages/playwright-core/src/tools/backend/keyboard.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 import { elementSchema } from './snapshot';
 

--- a/packages/playwright-core/src/tools/backend/mouse.ts
+++ b/packages/playwright-core/src/tools/backend/mouse.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { formatObjectOrVoid } from '../../utils/isomorphic/stringUtils';
 import { defineTabTool } from './tool';
 

--- a/packages/playwright-core/src/tools/backend/navigate.ts
+++ b/packages/playwright-core/src/tools/backend/navigate.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool, defineTabTool } from './tool';
 
 const navigate = defineTool({

--- a/packages/playwright-core/src/tools/backend/network.ts
+++ b/packages/playwright-core/src/tools/backend/network.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool, defineTabTool } from './tool';
 
 import type * as playwright from '../../..';

--- a/packages/playwright-core/src/tools/backend/pdf.ts
+++ b/packages/playwright-core/src/tools/backend/pdf.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { formatObject } from '../../utils/isomorphic/stringUtils';
 
 import { defineTabTool } from './tool';

--- a/packages/playwright-core/src/tools/backend/route.ts
+++ b/packages/playwright-core/src/tools/backend/route.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 import type * as playwright from '../../..';

--- a/packages/playwright-core/src/tools/backend/runCode.ts
+++ b/packages/playwright-core/src/tools/backend/runCode.ts
@@ -19,7 +19,7 @@ import vm from 'vm';
 
 import { ManualPromise } from '../../utils/isomorphic/manualPromise';
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 const codeSchema = z.object({

--- a/packages/playwright-core/src/tools/backend/screenshot.ts
+++ b/packages/playwright-core/src/tools/backend/screenshot.ts
@@ -18,7 +18,7 @@ import { scaleImageToSize } from '../../utils/isomorphic/imageUtils';
 import { jpegjs, PNG } from '../../utilsBundle';
 import { formatObject } from '../../utils/isomorphic/stringUtils';
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 import type * as playwright from '../../..';

--- a/packages/playwright-core/src/tools/backend/snapshot.ts
+++ b/packages/playwright-core/src/tools/backend/snapshot.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { formatObject, formatObjectOrVoid } from '../../utils/isomorphic/stringUtils';
 
 import { defineTabTool, defineTool } from './tool';

--- a/packages/playwright-core/src/tools/backend/storage.ts
+++ b/packages/playwright-core/src/tools/backend/storage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 const storageState = defineTool({

--- a/packages/playwright-core/src/tools/backend/tabs.ts
+++ b/packages/playwright-core/src/tools/backend/tabs.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 import { renderTabsMarkdown } from './response';
 

--- a/packages/playwright-core/src/tools/backend/tools.ts
+++ b/packages/playwright-core/src/tools/backend/tools.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 
 import common from './common';
 import config from './config';

--- a/packages/playwright-core/src/tools/backend/tracing.ts
+++ b/packages/playwright-core/src/tools/backend/tracing.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 

--- a/packages/playwright-core/src/tools/backend/verify.ts
+++ b/packages/playwright-core/src/tools/backend/verify.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { escapeWithQuotes } from '../../utils/isomorphic/stringUtils';
 
 import { defineTabTool } from './tool';

--- a/packages/playwright-core/src/tools/backend/video.ts
+++ b/packages/playwright-core/src/tools/backend/video.ts
@@ -15,7 +15,7 @@
  */
 
 import path from 'path';
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 const startVideo = defineTool({

--- a/packages/playwright-core/src/tools/backend/wait.ts
+++ b/packages/playwright-core/src/tools/backend/wait.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTool } from './tool';
 
 const wait = defineTool({

--- a/packages/playwright-core/src/tools/backend/webstorage.ts
+++ b/packages/playwright-core/src/tools/backend/webstorage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { defineTabTool } from './tool';
 
 const localStorageList = defineTabTool({

--- a/packages/playwright-core/src/tools/cli-daemon/DEPS.list
+++ b/packages/playwright-core/src/tools/cli-daemon/DEPS.list
@@ -5,6 +5,6 @@
 ../mcp/
 ../../utilsBundle.ts
 ../../utils/
-../../mcpBundle.ts
+../../zodBundle.ts
 ../../server/utils/
 ../../serverRegistry.ts

--- a/packages/playwright-core/src/tools/cli-daemon/command.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/command.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 
 import type zodType from 'zod';
 

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 import { declareCommand } from './command';
 
 import type { AnyCommandSchema } from './command';

--- a/packages/playwright-core/src/tools/cli-daemon/helpGenerator.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/helpGenerator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from '../../mcpBundle';
+import { z } from '../../zodBundle';
 
 import { commands } from './commands';
 

--- a/packages/playwright-core/src/tools/utils/mcp/DEPS.list
+++ b/packages/playwright-core/src/tools/utils/mcp/DEPS.list
@@ -1,4 +1,5 @@
 [*]
 ../../../mcpBundle.ts
+../../../zodBundle.ts
 ../../../utilsBundle.ts
 ../../../server/utils/network.ts

--- a/packages/playwright-core/src/tools/utils/mcp/tool.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/tool.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z as zod } from '../../../mcpBundle';
+import { z as zod } from '../../../zodBundle';
 import type { z } from 'zod';
 import type * as mcpServer from './server';
 

--- a/packages/playwright-core/src/zodBundle.ts
+++ b/packages/playwright-core/src/zodBundle.ts
@@ -14,25 +14,11 @@
  * limitations under the License.
  */
 
-import { z } from '../../zodBundle';
-import { defineTool } from './tool';
+// @ts-ignore
+import * as bundle from './zodBundleImpl';
 
-const configShow = defineTool({
-  capability: 'config',
+const z: typeof import('zod') = bundle.z;
 
-  schema: {
-    name: 'browser_get_config',
-    title: 'Get config',
-    description: 'Get the final resolved config after merging CLI options, environment variables and config file.',
-    inputSchema: z.object({}),
-    type: 'readOnly',
-  },
-
-  handle: async (context, params, response) => {
-    response.addTextResult(JSON.stringify(context.config, null, 2));
-  },
-});
-
-export default [
-  configShow,
-];
+export {
+  z,
+};

--- a/packages/playwright/src/common/validators.ts
+++ b/packages/playwright/src/common/validators.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z as zod } from 'playwright-core/lib/mcpBundle';
+import { z as zod } from 'playwright-core/lib/zodBundle';
 
 import type { TestAnnotation, TestDetailsAnnotation } from '../../types/test';
 import type { Location } from '../../types/testReporter';

--- a/packages/playwright/src/mcp/test/generatorTools.ts
+++ b/packages/playwright/src/mcp/test/generatorTools.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { z } from 'playwright-core/lib/mcpBundle';
+import { z } from 'playwright-core/lib/zodBundle';
 import { defineTestTool } from './testTool';
 import { GeneratorJournal } from './testContext';
 

--- a/packages/playwright/src/mcp/test/plannerTools.ts
+++ b/packages/playwright/src/mcp/test/plannerTools.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { z } from 'playwright-core/lib/mcpBundle';
+import { z } from 'playwright-core/lib/zodBundle';
 import { defineTestTool } from './testTool';
 
 export const setupPage = defineTestTool({

--- a/packages/playwright/src/mcp/test/testBackend.ts
+++ b/packages/playwright/src/mcp/test/testBackend.ts
@@ -16,7 +16,7 @@
 
 import EventEmitter from 'events';
 
-import { z as zod } from 'playwright-core/lib/mcpBundle';
+import { z as zod } from 'playwright-core/lib/zodBundle';
 import * as mcp from 'playwright-core/lib/tools/exports';
 import { browserTools } from 'playwright-core/lib/tools/exports';
 

--- a/packages/playwright/src/mcp/test/testTools.ts
+++ b/packages/playwright/src/mcp/test/testTools.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from 'playwright-core/lib/mcpBundle';
+import { z } from 'playwright-core/lib/zodBundle';
 import ListModeReporter from '../../reporters/listModeReporter';
 import { defineTestTool } from './testTool';
 

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -69,6 +69,8 @@ const copyFiles = [];
 const watchMode = process.argv.slice(2).includes('--watch');
 const withSourceMaps = watchMode;
 const disableInstall = process.argv.slice(2).includes('--disable-install');
+const bundleFilterIndex = process.argv.indexOf('--bundle');
+const bundleFilter = bundleFilterIndex !== -1 ? process.argv[bundleFilterIndex + 1] : undefined;
 const ROOT = path.join(__dirname, '..', '..');
 
 /**
@@ -200,6 +202,19 @@ async function runWatch() {
     runOnChange(onChange);
 }
 
+/**
+ * @param {string} filter 
+ */
+async function runBundleOnly(filter) {
+  const matching = bundleSteps.filter((_, i) => bundles[i].modulePath.includes(filter));
+  if (!matching.length) {
+    console.error(`No bundles matching "${filter}". Available: ${bundles.map(b => b.modulePath).join(', ')}`);
+    process.exit(1);
+  }
+  for (const step of matching)
+    await step.run();
+}
+
 async function runBuild() {
   for (const { files, from, to, ignored } of copyFiles) {
     const watcher = chokidar.watch([filePath(files)], {
@@ -277,12 +292,18 @@ bundles.push({
 
 bundles.push({
   modulePath: 'packages/playwright-core/bundles/mcp',
-  outfile: 'packages/playwright-core/lib/mcpBundleImpl/index.js',
+  outfile: 'packages/playwright-core/lib/mcpBundleImpl.js',
   entryPoints: ['src/mcpBundleImpl.ts'],
   external: ['express', '@anthropic-ai/sdk'],
   alias: {
     'raw-body': 'raw-body.ts',
   },
+});
+
+bundles.push({
+  modulePath: 'packages/playwright-core/bundles/zod',
+  outfile: 'packages/playwright-core/lib/zodBundleImpl.js',
+  entryPoints: ['src/zodBundleImpl.ts'],
 });
 
 // @playwright/client
@@ -518,9 +539,12 @@ const pkgSizePlugin = {
 };
 
 // Build/watch bundles.
-for (const bundle of bundles) {
-  /** @type {import('esbuild').BuildOptions} */
-  const options = {
+/**
+ * @param {BundleOptions} bundle
+ * @returns {import('esbuild').BuildOptions}
+ */
+function bundleToEsbuildOptions(bundle) {
+  return {
     bundle: true,
     format: 'cjs',
     platform: 'node',
@@ -537,8 +561,12 @@ for (const bundle of bundles) {
     metafile: true,
     plugins: [pkgSizePlugin],
   };
-  steps.push(new EsbuildStep(options));
 }
+
+/** @type {EsbuildStep[]} */
+const bundleSteps = bundles.map(b => new EsbuildStep(bundleToEsbuildOptions(b)));
+for (const step of bundleSteps)
+  steps.push(step);
 
 // Build/watch trace viewer service worker.
 steps.push(new ProgramStep({
@@ -717,4 +745,4 @@ process.on('SIGINT', () => {
 });
 
 
-watchMode ? runWatch() : runBuild();
+bundleFilter ? runBundleOnly(bundleFilter) : watchMode ? runWatch() : runBuild();


### PR DESCRIPTION
## Summary
- Add a standalone `zod` bundle so MCP tools import zod from the vendored bundle instead of the MCP bundle
- Refactor `playwright-core` CLI `program.ts` into `browserActions.ts` and `installActions.ts`
- Refactor `playwright` CLI `program.ts` into `testActions.ts` and `reportActions.ts`
- Add `--bundle` filter flag to `build.js` for rebuilding individual bundles
- Add esbuild plugin to convert dynamic `import()` of relative paths to `require()`
- Bump MCP SDK to 1.28.0 and zod to 4.3.6