### PR TITLE
docs(cli): fix video-stop example to use --filename flag

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
@@ -156,7 +156,7 @@ playwright-cli run-code --filename=script.js
 playwright-cli tracing-start
 playwright-cli tracing-stop
 playwright-cli video-start
-playwright-cli video-stop video.webm
+playwright-cli video-stop --filename=video.webm
 ```
 
 ## Open parameters


### PR DESCRIPTION
## Summary
- Update `video-stop` skill doc example from positional arg to `--filename` flag

Fixes https://github.com/microsoft/playwright-cli/issues/322